### PR TITLE
feat: add test job with PostgreSQL 16 to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,39 @@ jobs:
 
       - name: Lint code for consistent style
         run: bin/rubocop -f github
+
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      RAILS_ENV: test
+      DB_HOST: localhost
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8
+        with:
+          bundler-cache: true
+
+      - name: Set up database
+        run: bin/rails db:prepare
+
+      - name: Run tests
+        run: bin/rspec


### PR DESCRIPTION
Add RSpec test job to GitHub Actions that:
- Sets up PostgreSQL 16 service container with health checks
- Configures Ruby with bundler caching
- Prepares test database
- Runs RSpec tests with SimpleCov coverage enforcement (80% minimum)

Closes #7

https://claude.ai/code/session_01BHdWathbUuT8yUixi39rbX