### PR TITLE
Configure dependabot to group non-major updates and assign to viamin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,22 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  assignees:
+  - viamin
+  groups:
+    non-major:
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  assignees:
+  - viamin
+  groups:
+    non-major:
+      update-types:
+      - minor
+      - patch


### PR DESCRIPTION
- Group minor and patch updates together for both bundler and
  github-actions ecosystems so they create fewer PRs
- Major version updates and security updates remain as separate PRs
- Assign all dependabot PRs to viamin

https://claude.ai/code/session_01CZSnnAMjiSh2geEpSE6v2C