### PR TITLE
feat: add basic workflow monitoring to project UI

### DIFF
--- a/app/controllers/workflow_statuses_controller.rb
+++ b/app/controllers/workflow_statuses_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class WorkflowStatusesController < ApplicationController
+  def show
+    @project = policy_scope(Project).find(params[:project_id])
+    authorize @project, :show?
+
+    @poll_workflow = @project.workflow_states.find_by(
+      temporal_workflow_id: "github-poll-#{@project.id}"
+    )
+
+    @recent_workflows = @project.workflow_states
+      .where.not(workflow_type: "GitHubPoll")
+      .order(created_at: :desc)
+      .limit(10)
+  end
+end

--- a/app/helpers/workflow_helper.rb
+++ b/app/helpers/workflow_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module WorkflowHelper
+  WORKFLOW_STATUS_STYLES = {
+    "running" => { bg: "bg-blue-100", text: "text-blue-800" },
+    "completed" => { bg: "bg-green-100", text: "text-green-800" },
+    "failed" => { bg: "bg-red-100", text: "text-red-800" },
+    "cancelled" => { bg: "bg-gray-100", text: "text-gray-600" },
+    "timed_out" => { bg: "bg-orange-100", text: "text-orange-800" }
+  }.freeze
+
+  def workflow_status_class(status)
+    styles = WORKFLOW_STATUS_STYLES[status] || { bg: "bg-yellow-100", text: "text-yellow-800" }
+    "#{styles[:bg]} #{styles[:text]}"
+  end
+
+  def workflow_duration(workflow)
+    return "-" unless workflow.started_at
+
+    end_time = workflow.completed_at || Time.current
+    seconds = (end_time - workflow.started_at).to_i
+
+    if seconds < 60
+      "#{seconds}s"
+    elsif seconds < 3600
+      "#{seconds / 60}m #{seconds % 60}s"
+    else
+      "#{seconds / 3600}h #{(seconds % 3600) / 60}m"
+    end
+  end
+end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -104,6 +104,15 @@
   </div>
 
   <div class="mt-8">
+    <h2 class="text-lg font-medium text-gray-900">Workflow Status</h2>
+    <div class="mt-4">
+      <%= turbo_frame_tag "workflow-status", src: project_workflow_status_path(@project) do %>
+        <div class="animate-pulse bg-gray-100 h-24 rounded-lg"></div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-8">
     <div class="sm:flex sm:items-center sm:justify-between">
       <h2 class="text-lg font-medium text-gray-900">Recent Agent Runs</h2>
       <% if policy(@project).run_agent? %>

--- a/app/views/workflow_statuses/show.html.erb
+++ b/app/views/workflow_statuses/show.html.erb
@@ -1,0 +1,81 @@
+<%= turbo_frame_tag "workflow-status" do %>
+  <div class="space-y-4">
+    <div class="border rounded-lg p-4">
+      <div class="flex justify-between items-center">
+        <div>
+          <h3 class="font-semibold text-gray-900">GitHub Polling</h3>
+          <p class="text-sm text-gray-600">Monitoring for labeled issues</p>
+        </div>
+        <div class="flex items-center space-x-4">
+          <% if @poll_workflow&.running? %>
+            <span class="flex items-center text-green-600">
+              <span class="animate-pulse mr-2">&#9679;</span>
+              Active
+            </span>
+          <% elsif @poll_workflow %>
+            <span class="text-yellow-600"><%= @poll_workflow.status.capitalize %></span>
+          <% else %>
+            <span class="text-gray-500">Not started</span>
+          <% end %>
+
+          <a href="http://localhost:8080/namespaces/default/workflows/github-poll-<%= @project.id %>"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="text-indigo-600 hover:text-indigo-900 text-sm">
+            View in Temporal UI &rarr;
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <% if @recent_workflows.any? %>
+      <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+        <table class="min-w-full divide-y divide-gray-300">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Type</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Status</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Started</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Duration</th>
+              <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+                <span class="sr-only">Details</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% @recent_workflows.each do |workflow| %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 sm:pl-6"><%= workflow.workflow_type %></td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm">
+                  <span class="<%= workflow_status_class(workflow.status) %> inline-flex items-center rounded-md px-2 py-1 text-xs font-medium">
+                    <%= workflow.status.capitalize %>
+                  </span>
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  <%= workflow.started_at ? time_ago_in_words(workflow.started_at) + " ago" : "-" %>
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  <%= workflow_duration(workflow) %>
+                </td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <a href="http://localhost:8080/namespaces/default/workflows/<%= workflow.temporal_workflow_id %>"
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     class="text-indigo-600 hover:text-indigo-900">
+                    Details &rarr;
+                  </a>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <p class="text-gray-600 text-sm">No workflow executions yet.</p>
+    <% end %>
+  </div>
+
+  <% if @poll_workflow&.running? || @recent_workflows.any?(&:running?) %>
+    <meta http-equiv="refresh" content="5">
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,9 @@ Rails.application.routes.draw do
   resources :github_tokens, only: [ :index, :new, :create, :show, :destroy ]
 
   # Projects management
-  resources :projects
+  resources :projects do
+    resource :workflow_status, only: [ :show ]
+  end
 
   # Defines the root path route ("/")
   root "home#index"

--- a/spec/helpers/workflow_helper_spec.rb
+++ b/spec/helpers/workflow_helper_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkflowHelper do
+  describe "#workflow_status_class" do
+    it "returns blue classes for running status" do
+      expect(helper.workflow_status_class("running")).to eq("bg-blue-100 text-blue-800")
+    end
+
+    it "returns green classes for completed status" do
+      expect(helper.workflow_status_class("completed")).to eq("bg-green-100 text-green-800")
+    end
+
+    it "returns red classes for failed status" do
+      expect(helper.workflow_status_class("failed")).to eq("bg-red-100 text-red-800")
+    end
+
+    it "returns gray classes for cancelled status" do
+      expect(helper.workflow_status_class("cancelled")).to eq("bg-gray-100 text-gray-600")
+    end
+
+    it "returns orange classes for timed_out status" do
+      expect(helper.workflow_status_class("timed_out")).to eq("bg-orange-100 text-orange-800")
+    end
+
+    it "returns yellow classes for unknown status" do
+      expect(helper.workflow_status_class("unknown")).to eq("bg-yellow-100 text-yellow-800")
+    end
+  end
+
+  describe "#workflow_duration" do
+    it "returns dash when started_at is nil" do
+      workflow = build(:workflow_state, started_at: nil)
+      expect(helper.workflow_duration(workflow)).to eq("-")
+    end
+
+    it "returns seconds for short durations" do
+      workflow = build(:workflow_state, started_at: 30.seconds.ago, completed_at: Time.current)
+      expect(helper.workflow_duration(workflow)).to eq("30s")
+    end
+
+    it "returns minutes and seconds for medium durations" do
+      workflow = build(:workflow_state, started_at: 125.seconds.ago, completed_at: Time.current)
+      expect(helper.workflow_duration(workflow)).to eq("2m 5s")
+    end
+
+    it "returns hours and minutes for long durations" do
+      workflow = build(:workflow_state, started_at: 3725.seconds.ago, completed_at: Time.current)
+      expect(helper.workflow_duration(workflow)).to eq("1h 2m")
+    end
+
+    it "uses current time when completed_at is nil" do
+      workflow = build(:workflow_state, started_at: 10.seconds.ago, completed_at: nil)
+      result = helper.workflow_duration(workflow)
+      expect(result).to match(/\d+s/)
+    end
+  end
+end

--- a/spec/requests/workflow_statuses_spec.rb
+++ b/spec/requests/workflow_statuses_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "WorkflowStatuses" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+  let(:github_token) { create(:github_token, account: account) }
+  let(:project) { create(:project, account: account, github_token: github_token) }
+
+  describe "GET /projects/:project_id/workflow_status" do
+    context "when not authenticated" do
+      it "redirects to the sign in page" do
+        get project_workflow_status_path(project)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "renders the workflow status page" do
+        get project_workflow_status_path(project)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "shows the GitHub Polling section" do
+        get project_workflow_status_path(project)
+        expect(response.body).to include("GitHub Polling")
+      end
+
+      it "shows 'Not started' when no poll workflow exists" do
+        get project_workflow_status_path(project)
+        expect(response.body).to include("Not started")
+      end
+
+      it "shows 'Active' when poll workflow is running" do
+        create(:workflow_state,
+          project: project,
+          temporal_workflow_id: "github-poll-#{project.id}",
+          workflow_type: "GitHubPoll",
+          status: "running")
+
+        get project_workflow_status_path(project)
+        expect(response.body).to include("Active")
+      end
+
+      it "shows workflow status when poll workflow is not running" do
+        create(:workflow_state,
+          project: project,
+          temporal_workflow_id: "github-poll-#{project.id}",
+          workflow_type: "GitHubPoll",
+          status: "completed")
+
+        get project_workflow_status_path(project)
+        expect(response.body).to include("Completed")
+      end
+
+      it "shows recent non-poll workflows" do
+        create(:workflow_state, :with_project,
+          project: project,
+          workflow_type: "AgentExecutionWorkflow",
+          status: "completed")
+
+        get project_workflow_status_path(project)
+        expect(response.body).to include("AgentExecutionWorkflow")
+      end
+
+      it "excludes GitHubPoll workflows from the recent list" do
+        create(:workflow_state,
+          project: project,
+          temporal_workflow_id: "github-poll-#{project.id}",
+          workflow_type: "GitHubPoll",
+          status: "running")
+
+        get project_workflow_status_path(project)
+        # The table should not contain GitHubPoll rows
+        expect(response.body).not_to include("<td class=\"whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 sm:pl-6\">GitHubPoll</td>")
+      end
+
+      it "shows empty state when no workflows exist" do
+        get project_workflow_status_path(project)
+        expect(response.body).to include("No workflow executions yet.")
+      end
+
+      it "limits recent workflows to 10" do
+        12.times do |i|
+          create(:workflow_state,
+            project: project,
+            workflow_type: "AgentExecutionWorkflow",
+            status: "completed",
+            started_at: i.hours.ago,
+            completed_at: (i.hours.ago + 5.minutes))
+        end
+
+        get project_workflow_status_path(project)
+        expect(response.body.scan("AgentExecutionWorkflow").count).to eq(10)
+      end
+
+      it "includes Temporal UI links" do
+        get project_workflow_status_path(project)
+        expect(response.body).to include("View in Temporal UI")
+      end
+
+      it "includes auto-refresh meta tag when workflows are running" do
+        create(:workflow_state,
+          project: project,
+          workflow_type: "AgentExecutionWorkflow",
+          status: "running")
+
+        get project_workflow_status_path(project)
+        expect(response.body).to include('http-equiv="refresh" content="5"')
+      end
+
+      it "does not include auto-refresh when no workflows are running" do
+        create(:workflow_state,
+          project: project,
+          workflow_type: "AgentExecutionWorkflow",
+          status: "completed",
+          completed_at: Time.current)
+
+        get project_workflow_status_path(project)
+        expect(response.body).not_to include('http-equiv="refresh"')
+      end
+
+      it "does not allow viewing workflow status for other accounts' projects" do
+        other_account = create(:account)
+        other_token = create(:github_token, account: other_account)
+        other_project = create(:project, account: other_account, github_token: other_token)
+
+        get project_workflow_status_path(other_project)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "renders within a turbo_frame" do
+        get project_workflow_status_path(project)
+        expect(response.body).to include('turbo-frame id="workflow-status"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements [#21](https://github.com/viamin/paid/issues/21) - Add basic workflow monitoring to the project detail page.

- Adds a `WorkflowStatusesController` nested under projects (`GET /projects/:id/workflow_status`)
- Displays GitHub poll workflow status (active/completed/not started) with link to Temporal UI
- Shows a table of recent (non-poll) workflow executions with status badges, timing, and Temporal UI links
- Uses Turbo Frames for lazy loading and auto-refreshes every 5 seconds when workflows are running
- Adds `WorkflowHelper` with `workflow_status_class` and `workflow_duration` helpers
- Embeds the workflow status section in the project show page via turbo_frame

## Files Changed

- `config/routes.rb` - Added nested `workflow_status` resource under projects
- `app/controllers/workflow_statuses_controller.rb` - New controller with show action
- `app/helpers/workflow_helper.rb` - Status badge classes and duration formatting
- `app/views/workflow_statuses/show.html.erb` - Workflow status view with turbo_frame
- `app/views/projects/show.html.erb` - Added turbo_frame embed for workflow status
- `spec/requests/workflow_statuses_spec.rb` - 14 request specs (auth, status display, scoping, auto-refresh)
- `spec/helpers/workflow_helper_spec.rb` - 12 helper specs (status classes, duration formatting)

## Dependencies

- Depends on: #17 (Projects UI) - already merged
- Depends on: #19 (Temporal gem integration) - already merged

## Notes

- The Temporal UI link uses `localhost:8080` as noted in the issue; should be made configurable for production
- A more comprehensive dashboard with real-time streaming (Action Cable) is planned for Phase 2

## Test plan

- [x] All 26 new specs pass
- [x] Rubocop clean on all new files
- [ ] Verify workflow status section renders on project show page
- [ ] Verify turbo_frame lazy loads workflow status
- [ ] Verify status badges display correctly for each workflow state
- [ ] Verify auto-refresh meta tag appears when workflows are running

🤖 Generated with [Claude Code](https://claude.com/claude-code)