### PR TITLE
fix: address PR #68 review comments on worktree management

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -29,10 +29,6 @@ Rails.application.configure do
     log_retention: {
       cron: "0 3 * * *",
       class: "LogRetentionJob"
-    },
-    orphan_cleanup: {
-      cron: "0 * * * *",
-      class: "WorktreeOrphanCleanupJob"
     }
   }
 end


### PR DESCRIPTION
## Summary

Addresses all code review comments from PR #68 (worktree management implementation):

- **Credential redaction**: `run_git` error messages now redact `x-access-token` from GitHub URLs to prevent credential leakage into logs/error trackers
- **Process-wide mutex**: Replaced instance-scoped `Mutex.new` with class-level per-repo mutexes (`mutex_for(repo_path)`) so concurrent `WorktreeService` instances for the same repo are properly synchronized
- **Graceful missing directory handling**: `remove_worktree` now handles the case where the worktree directory is already gone - still marks the record as cleaned and attempts branch cleanup
- **push_branch validation**: Added validation for blank `branch_name`/`worktree_path` to prevent git commands from executing in the wrong directory
- **Targeted orphan cleanup**: `cleanup_worktree` now removes only the specific orphaned worktree via `git worktree remove` instead of calling `cleanup_stale_worktrees(older_than: 0.seconds)` which could inadvertently remove all active worktrees
- **prune_worktree_refs error handling**: Now checks return value from `git worktree prune` and logs warnings on failure
- **Duplicate cron entry removed**: Consolidated `WorktreeOrphanCleanupJob` to single `worktree_cleanup` cron entry (removed duplicate `orphan_cleanup` hourly entry)
- **YARD docs updated**: `create_worktree` docs now list all possible error types (`WorktreeError`, `CloneError`, `Error`)
- **Spec description fixed**: Updated "raises WorktreeError on git failure" to match the actual `Error` assertion

4 new specs added for the new validation and missing-directory behaviors.

Ref: PR #68, PR #71

## Test plan

- [x] All 35 worktree specs pass
- [x] RuboCop clean (0 offenses)
- [x] Brakeman clean (0 warnings)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)