### PR TITLE
fix: address PR #72 review comments on worktree cleanup

### DIFF
--- a/app/services/worktree_service.rb
+++ b/app/services/worktree_service.rb
@@ -113,7 +113,7 @@ class WorktreeService
   def remove_worktree(agent_run)
     worktree = agent_run.worktree
     return unless worktree&.active?
-    return unless agent_run.worktree_path
+    return if agent_run.worktree_path.blank?
 
     @mutex.synchronize do
       if Dir.exist?(agent_run.worktree_path)


### PR DESCRIPTION
## Summary

Addresses all 5 Copilot review comments from PR #72:

- **Distinct log message key**: Changed `worktree_cleanup.prune_failed` to `worktree_cleanup.prune_command_failed` in `prune_worktree_refs` to distinguish git command failures from exceptions in `prune_active_projects`
- **Blank path guard**: Changed `return unless agent_run.worktree_path` to `return if agent_run.worktree_path.blank?` in `remove_worktree` to catch empty strings, consistent with `push_branch` validations
- **Mock external deps only**: Updated new specs to stub `Open3.capture3` instead of `run_git`, per CLAUDE.md convention of mocking external dependencies only
- **Per-repo mutex in cleanup job**: Wrapped `cleanup_worktree` git operations in `WorktreeService.mutex_for(repo_path).synchronize` to prevent concurrent git operations racing with active agent runs
- **Check return values**: `cleanup_worktree` now checks `system` return values, logs warnings on failure (`worktree_cleanup.worktree_remove_failed`, `worktree_cleanup.branch_delete_failed`), and marks `cleanup_failed` when worktree removal fails instead of unconditionally marking cleaned

Ref: PR #72

## Test plan

- [x] All 32 worktree specs pass
- [x] RuboCop clean (0 offenses)
- [x] Brakeman clean (0 warnings)
- [ ] CI passes

**Note:** Existing specs throughout the file also stub `run_git` - a broader refactoring to use `Open3.capture3` stubs everywhere could be done as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)