### PR TITLE
feat: implement network allowlist for agent containers

### DIFF
--- a/app/services/network_policy.rb
+++ b/app/services/network_policy.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "docker-api"
+require "net/http"
+require "json"
+
+# Manages Docker network isolation for agent containers.
+#
+# Ensures the restricted agent network exists and applies firewall rules
+# to limit outbound traffic to only allowed destinations (secrets proxy, GitHub).
+#
+# @example Ensure network is ready before provisioning
+#   NetworkPolicy.ensure_network!
+#
+# @example Apply firewall rules inside a running container
+#   NetworkPolicy.apply_firewall_rules(container)
+#
+# @example Fetch current GitHub IP ranges
+#   ips = NetworkPolicy.fetch_github_ips
+#
+class NetworkPolicy
+  # Raised when network operations fail
+  class Error < StandardError; end
+
+  NETWORK_NAME = "paid_agent"
+
+  NETWORK_SUBNET = "172.28.0.0/16"
+
+  GITHUB_META_URL = "https://api.github.com/meta"
+
+  # Static fallback GitHub IP ranges (from https://api.github.com/meta)
+  DEFAULT_GITHUB_IPS = %w[
+    140.82.112.0/20
+    143.55.64.0/20
+    185.199.108.0/22
+    192.30.252.0/22
+    20.201.28.0/24
+  ].freeze
+
+  SECRETS_PROXY_PORT = 3001
+
+  class << self
+    # Ensures the agent Docker network exists. Creates it if missing.
+    #
+    # @return [Docker::Network] the agent network
+    # @raise [Error] if network creation fails
+    def ensure_network!
+      Docker::Network.get(NETWORK_NAME)
+    rescue Docker::Error::NotFoundError
+      create_network
+    end
+
+    # Checks whether the agent network exists.
+    #
+    # @return [Boolean]
+    def network_exists?
+      Docker::Network.get(NETWORK_NAME)
+      true
+    rescue Docker::Error::NotFoundError
+      false
+    end
+
+    # Applies iptables-based firewall rules inside a container to restrict
+    # outbound traffic. Only allows: secrets proxy, GitHub, and DNS.
+    #
+    # Requires NET_RAW capability on the container.
+    #
+    # @param container [Docker::Container] running container to apply rules to
+    # @param github_ips [Array<String>] GitHub CIDR ranges to allow
+    # @param proxy_host [String] hostname or IP of the secrets proxy
+    # @return [void]
+    # @raise [Error] if applying rules fails
+    def apply_firewall_rules(container, github_ips: nil, proxy_host: nil)
+      github_ips ||= DEFAULT_GITHUB_IPS
+      proxy_host ||= default_proxy_host
+
+      script = build_firewall_script(github_ips: github_ips, proxy_host: proxy_host)
+
+      _stdout, stderr, exit_code = container.exec([ "sh", "-c", script ])
+
+      return if exit_code == 0
+
+      raise Error, "Failed to apply firewall rules (exit #{exit_code}): #{stderr&.join}"
+    end
+
+    # Fetches current GitHub IP ranges from the GitHub API.
+    # Falls back to static defaults on failure.
+    #
+    # @return [Array<String>] CIDR ranges
+    def fetch_github_ips
+      uri = URI(GITHUB_META_URL)
+      response = Net::HTTP.get(uri)
+      data = JSON.parse(response)
+
+      %w[hooks git api web].flat_map { |key| data[key] || [] }.uniq
+    rescue StandardError => e
+      Rails.logger.warn(
+        message: "network_policy.fetch_github_ips.failed",
+        error: e.message
+      )
+      DEFAULT_GITHUB_IPS
+    end
+
+    private
+
+    def create_network
+      Rails.logger.info(
+        message: "network_policy.create_network",
+        network: NETWORK_NAME,
+        subnet: NETWORK_SUBNET
+      )
+
+      Docker::Network.create(
+        NETWORK_NAME,
+        "Driver" => "bridge",
+        "Internal" => true,
+        "Options" => {
+          "com.docker.network.bridge.enable_ip_masquerade" => "false"
+        },
+        "IPAM" => {
+          "Config" => [ { "Subnet" => NETWORK_SUBNET } ]
+        }
+      )
+    rescue Docker::Error::DockerError => e
+      raise Error, "Failed to create agent network: #{e.message}"
+    end
+
+    def default_proxy_host
+      # In Docker, the gateway IP of the agent network routes to the host
+      # where the secrets proxy runs.
+      network = Docker::Network.get(NETWORK_NAME)
+      gateway = network.info.dig("IPAM", "Config", 0, "Gateway")
+      gateway || "172.28.0.1"
+    rescue Docker::Error::NotFoundError
+      "172.28.0.1"
+    end
+
+    def build_firewall_script(github_ips:, proxy_host:)
+      github_rules = github_ips.flat_map do |cidr|
+        [
+          "iptables -A OUTPUT -d #{cidr} -p tcp --dport 443 -j ACCEPT",
+          "iptables -A OUTPUT -d #{cidr} -p tcp --dport 22 -j ACCEPT"
+        ]
+      end
+
+      <<~SCRIPT
+        # Default deny all outbound
+        iptables -P OUTPUT DROP
+
+        # Allow loopback
+        iptables -A OUTPUT -o lo -j ACCEPT
+
+        # Allow established connections (for responses)
+        iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+        # Allow DNS (for hostname resolution)
+        iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+        iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+        # Allow secrets proxy
+        iptables -A OUTPUT -d #{proxy_host} -p tcp --dport #{SECRETS_PROXY_PORT} -j ACCEPT
+
+        # Allow GitHub
+        #{github_rules.join("\n")}
+
+        # Log and drop everything else
+        iptables -A OUTPUT -j LOG --log-prefix "PAID_AGENT_BLOCK: " --log-level 4
+        iptables -A OUTPUT -j DROP
+      SCRIPT
+    end
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,14 @@
 # Docker Compose configuration for Paid development environment
 # Includes Rails, PostgreSQL, and Temporal for workflow orchestration
 
+# Networks:
+#   paid_internal - For Paid infrastructure services (Rails, Temporal, Postgres)
+#   paid_agent    - Restricted network for agent containers (no default internet access)
+#
+# Agent containers use paid_agent network with internal: true to prevent
+# default outbound access. Allowed egress (secrets proxy, GitHub) is
+# enforced via iptables rules applied by scripts/setup-agent-network.sh.
+
 services:
   postgres:
     image: postgres:16.1
@@ -15,6 +23,8 @@ services:
       POSTGRES_MULTIPLE_DATABASES: temporal,temporal_visibility
     ports:
       - "5432:5432"
+    networks:
+      - paid_internal
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U paid"]
       interval: 10s
@@ -32,6 +42,9 @@ services:
       - bundle-cache:/usr/local/bundle
     ports:
       - "3000:3000"
+    networks:
+      - paid_internal
+      - paid_agent
     environment:
       DATABASE_URL: postgres://paid:paid@postgres:5432/paid_development
       RAILS_ENV: development
@@ -56,6 +69,8 @@ services:
       - DYNAMIC_CONFIG_FILE_PATH=/etc/temporal/config/dynamicconfig/development-sql.yaml
     ports:
       - "7233:7233"
+    networks:
+      - paid_internal
     volumes:
       - ./config/temporal:/etc/temporal/config/dynamicconfig
     healthcheck:
@@ -75,6 +90,8 @@ services:
       - TEMPORAL_CORS_ORIGINS=http://localhost:3000
     ports:
       - "8080:8080"
+    networks:
+      - paid_internal
 
   temporal-admin-tools:
     image: temporalio/admin-tools:1.24
@@ -83,6 +100,8 @@ services:
         condition: service_healthy
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
+    networks:
+      - paid_internal
     stdin_open: true
     tty: true
 
@@ -102,6 +121,9 @@ services:
       - TEMPORAL_NAMESPACE=default
       - TEMPORAL_TASK_QUEUE=paid-tasks
       - RAILS_ENV=development
+    networks:
+      - paid_internal
+      - paid_agent
     volumes:
       - .:/workspaces/paid
       - bundle-cache:/usr/local/bundle
@@ -113,9 +135,27 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./agent-workspace:/workspace
+    networks:
+      - paid_agent
     profiles:
       - test
 
 volumes:
   postgres-data:
   bundle-cache:
+
+networks:
+  # Internal network for Paid infrastructure services
+  paid_internal:
+    driver: bridge
+
+  # Restricted network for agent containers
+  # internal: true disables default internet access
+  paid_agent:
+    driver: bridge
+    internal: true
+    driver_opts:
+      com.docker.network.bridge.enable_ip_masquerade: "false"
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/scripts/setup-agent-network.sh
+++ b/scripts/setup-agent-network.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# scripts/setup-agent-network.sh
+#
+# Configures iptables rules to restrict outbound traffic from the
+# paid_agent Docker network. Only allowed destinations:
+#   - Secrets proxy (for LLM API access)
+#   - GitHub (for git operations)
+#   - DNS (for hostname resolution)
+#
+# Prerequisites:
+#   - Docker network "paid_agent" must already exist
+#   - Must be run as root (iptables requires privileges)
+#
+# Usage:
+#   sudo scripts/setup-agent-network.sh
+#
+# Environment variables:
+#   SECRETS_PROXY_PORT - Port of the secrets proxy (default: 3001)
+#   DRY_RUN            - Set to "1" to print rules without applying (default: "")
+
+set -euo pipefail
+
+# Network name (must match docker-compose.yml)
+NETWORK_NAME="paid_agent"
+
+# Secrets proxy port
+SECRETS_PROXY_PORT="${SECRETS_PROXY_PORT:-3001}"
+
+# Dry run mode
+DRY_RUN="${DRY_RUN:-}"
+
+# GitHub IP ranges (from https://api.github.com/meta)
+# These should be refreshed periodically via NetworkPolicy.fetch_github_ips
+GITHUB_IPS=(
+    "140.82.112.0/20"
+    "143.55.64.0/20"
+    "185.199.108.0/22"
+    "192.30.252.0/22"
+    "20.201.28.0/24"
+)
+
+# Chain name for our rules
+CHAIN_NAME="PAID_AGENT"
+
+run_iptables() {
+    if [ -n "$DRY_RUN" ]; then
+        echo "[DRY RUN] iptables $*"
+    else
+        iptables "$@"
+    fi
+}
+
+echo "Setting up iptables rules for agent network '${NETWORK_NAME}'..."
+
+# Verify network exists
+if ! docker network inspect "${NETWORK_NAME}" > /dev/null 2>&1; then
+    echo "ERROR: Docker network '${NETWORK_NAME}' does not exist."
+    echo "Create it with: docker compose up (or docker network create --internal ${NETWORK_NAME})"
+    exit 1
+fi
+
+# Get the bridge interface for our network
+NETWORK_ID=$(docker network inspect "${NETWORK_NAME}" -f '{{.Id}}' | cut -c1-12)
+BRIDGE_IF="br-${NETWORK_ID}"
+
+echo "Bridge interface: ${BRIDGE_IF}"
+
+# Get the gateway IP (used as secrets proxy address since proxy runs on host)
+GATEWAY_IP=$(docker network inspect "${NETWORK_NAME}" -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}')
+if [ -z "$GATEWAY_IP" ]; then
+    GATEWAY_IP="172.28.0.1"
+    echo "WARNING: Could not detect gateway IP, using default: ${GATEWAY_IP}"
+fi
+
+echo "Gateway (proxy) IP: ${GATEWAY_IP}"
+
+# Clean up existing rules
+echo "Cleaning up existing rules..."
+run_iptables -D FORWARD -i "${BRIDGE_IF}" -j "${CHAIN_NAME}" 2>/dev/null || true
+run_iptables -F "${CHAIN_NAME}" 2>/dev/null || true
+run_iptables -X "${CHAIN_NAME}" 2>/dev/null || true
+
+# Create new chain
+echo "Creating iptables chain '${CHAIN_NAME}'..."
+run_iptables -N "${CHAIN_NAME}"
+
+# Allow established/related connections (for responses to allowed requests)
+run_iptables -A "${CHAIN_NAME}" -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow connections to secrets proxy (on gateway/host)
+echo "Allowing secrets proxy (${GATEWAY_IP}:${SECRETS_PROXY_PORT})..."
+run_iptables -A "${CHAIN_NAME}" -d "${GATEWAY_IP}" -p tcp --dport "${SECRETS_PROXY_PORT}" -j ACCEPT
+
+# Allow connections to GitHub
+echo "Allowing GitHub IP ranges..."
+for ip in "${GITHUB_IPS[@]}"; do
+    run_iptables -A "${CHAIN_NAME}" -d "${ip}" -p tcp --dport 443 -j ACCEPT
+    run_iptables -A "${CHAIN_NAME}" -d "${ip}" -p tcp --dport 22 -j ACCEPT
+done
+
+# Allow DNS (required for hostname resolution)
+echo "Allowing DNS..."
+run_iptables -A "${CHAIN_NAME}" -p udp --dport 53 -j ACCEPT
+run_iptables -A "${CHAIN_NAME}" -p tcp --dport 53 -j ACCEPT
+
+# Log dropped packets for debugging/auditing
+run_iptables -A "${CHAIN_NAME}" -j LOG --log-prefix "PAID_AGENT_BLOCK: " --log-level 4
+
+# Drop everything else
+run_iptables -A "${CHAIN_NAME}" -j DROP
+
+# Apply chain to forward traffic from agent network
+run_iptables -I FORWARD -i "${BRIDGE_IF}" -j "${CHAIN_NAME}"
+
+echo "Network rules configured successfully for '${NETWORK_NAME}'."
+echo ""
+echo "Allowed traffic:"
+echo "  - Secrets proxy: ${GATEWAY_IP}:${SECRETS_PROXY_PORT}"
+echo "  - GitHub: HTTPS (443) and SSH (22)"
+echo "  - DNS: UDP/TCP port 53"
+echo "  - All other outbound traffic: BLOCKED (logged as PAID_AGENT_BLOCK)"

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NetworkPolicy do
+  let(:mock_network) do
+    instance_double(
+      Docker::Network,
+      info: {
+        "IPAM" => {
+          "Config" => [ { "Subnet" => "172.28.0.0/16", "Gateway" => "172.28.0.1" } ]
+        }
+      }
+    )
+  end
+
+  let(:mock_container) do
+    instance_double(Docker::Container, id: "abc123", exec: [ [], [], 0 ])
+  end
+
+  describe ".ensure_network!" do
+    context "when network already exists" do
+      before do
+        allow(Docker::Network).to receive(:get)
+          .with(described_class::NETWORK_NAME)
+          .and_return(mock_network)
+      end
+
+      it "returns the existing network" do
+        result = described_class.ensure_network!
+        expect(result).to eq(mock_network)
+      end
+
+      it "does not create a new network" do
+        expect(Docker::Network).not_to receive(:create)
+        described_class.ensure_network!
+      end
+    end
+
+    context "when network does not exist" do
+      before do
+        allow(Docker::Network).to receive(:get)
+          .with(described_class::NETWORK_NAME)
+          .and_raise(Docker::Error::NotFoundError)
+        allow(Docker::Network).to receive(:create).and_return(mock_network)
+      end
+
+      it "creates the network with correct configuration" do
+        expect(Docker::Network).to receive(:create).with(
+          described_class::NETWORK_NAME,
+          hash_including(
+            "Driver" => "bridge",
+            "Internal" => true,
+            "Options" => hash_including(
+              "com.docker.network.bridge.enable_ip_masquerade" => "false"
+            ),
+            "IPAM" => hash_including(
+              "Config" => [ { "Subnet" => described_class::NETWORK_SUBNET } ]
+            )
+          )
+        ).and_return(mock_network)
+
+        described_class.ensure_network!
+      end
+
+      it "returns the newly created network" do
+        result = described_class.ensure_network!
+        expect(result).to eq(mock_network)
+      end
+    end
+
+    context "when network creation fails" do
+      before do
+        allow(Docker::Network).to receive(:get)
+          .with(described_class::NETWORK_NAME)
+          .and_raise(Docker::Error::NotFoundError)
+        allow(Docker::Network).to receive(:create)
+          .and_raise(Docker::Error::ServerError.new("Docker error"))
+      end
+
+      it "raises NetworkPolicy::Error" do
+        expect { described_class.ensure_network! }
+          .to raise_error(described_class::Error, /Failed to create agent network/)
+      end
+    end
+  end
+
+  describe ".network_exists?" do
+    context "when network exists" do
+      before do
+        allow(Docker::Network).to receive(:get)
+          .with(described_class::NETWORK_NAME)
+          .and_return(mock_network)
+      end
+
+      it "returns true" do
+        expect(described_class.network_exists?).to be true
+      end
+    end
+
+    context "when network does not exist" do
+      before do
+        allow(Docker::Network).to receive(:get)
+          .with(described_class::NETWORK_NAME)
+          .and_raise(Docker::Error::NotFoundError)
+      end
+
+      it "returns false" do
+        expect(described_class.network_exists?).to be false
+      end
+    end
+  end
+
+  describe ".apply_firewall_rules" do
+    before do
+      allow(Docker::Network).to receive(:get)
+        .with(described_class::NETWORK_NAME)
+        .and_return(mock_network)
+    end
+
+    context "when rules apply successfully" do
+      before do
+        allow(mock_container).to receive(:exec).and_return([ [], [], 0 ])
+      end
+
+      it "executes a shell script via exec" do
+        expect(mock_container).to receive(:exec) do |cmd|
+          expect(cmd.length).to eq(3)
+          expect(cmd[0]).to eq("sh")
+          expect(cmd[1]).to eq("-c")
+          expect(cmd[2]).to be_a(String)
+          [ [], [], 0 ]
+        end
+
+        described_class.apply_firewall_rules(mock_container)
+      end
+
+      it "includes all required iptables rules in the script" do
+        expect(mock_container).to receive(:exec) do |cmd|
+          script = cmd[2]
+          expect(script).to include("iptables -P OUTPUT DROP")
+          expect(script).to include("iptables -A OUTPUT -o lo -j ACCEPT")
+          expect(script).to include("ESTABLISHED,RELATED")
+          expect(script).to include("--dport 53")
+          expect(script).to include("--dport #{described_class::SECRETS_PROXY_PORT}")
+          expect(script).to include("PAID_AGENT_BLOCK")
+          [ [], [], 0 ]
+        end
+
+        described_class.apply_firewall_rules(mock_container)
+      end
+
+      it "includes GitHub IP rules" do
+        expect(mock_container).to receive(:exec) do |cmd|
+          script = cmd[2]
+          described_class::DEFAULT_GITHUB_IPS.each do |cidr|
+            expect(script).to include("-d #{cidr} -p tcp --dport 443")
+            expect(script).to include("-d #{cidr} -p tcp --dport 22")
+          end
+          [ [], [], 0 ]
+        end
+
+        described_class.apply_firewall_rules(mock_container)
+      end
+
+      it "accepts custom GitHub IPs" do
+        custom_ips = [ "10.0.0.0/8" ]
+
+        expect(mock_container).to receive(:exec) do |cmd|
+          script = cmd[2]
+          expect(script).to include("-d 10.0.0.0/8 -p tcp --dport 443")
+          expect(script).not_to include("140.82.112.0/20")
+          [ [], [], 0 ]
+        end
+
+        described_class.apply_firewall_rules(mock_container, github_ips: custom_ips)
+      end
+
+      it "accepts custom proxy host" do
+        expect(mock_container).to receive(:exec) do |cmd|
+          script = cmd[2]
+          expect(script).to include("-d 10.0.0.1 -p tcp --dport #{described_class::SECRETS_PROXY_PORT}")
+          [ [], [], 0 ]
+        end
+
+        described_class.apply_firewall_rules(mock_container, proxy_host: "10.0.0.1")
+      end
+    end
+
+    context "when rules fail to apply" do
+      before do
+        allow(mock_container).to receive(:exec)
+          .and_return([ [], [ "iptables: Permission denied" ], 1 ])
+      end
+
+      it "raises NetworkPolicy::Error" do
+        expect { described_class.apply_firewall_rules(mock_container) }
+          .to raise_error(described_class::Error, /Failed to apply firewall rules/)
+      end
+    end
+  end
+
+  describe ".fetch_github_ips" do
+    context "when GitHub API responds successfully" do
+      let(:github_meta_response) do
+        {
+          "hooks" => [ "192.30.252.0/22" ],
+          "git" => [ "140.82.112.0/20" ],
+          "api" => [ "140.82.112.0/20", "185.199.108.0/22" ],
+          "web" => [ "140.82.112.0/20" ]
+        }.to_json
+      end
+
+      before do
+        allow(Net::HTTP).to receive(:get).and_return(github_meta_response)
+      end
+
+      it "returns deduplicated IP ranges" do
+        result = described_class.fetch_github_ips
+
+        expect(result).to include("192.30.252.0/22")
+        expect(result).to include("140.82.112.0/20")
+        expect(result).to include("185.199.108.0/22")
+        expect(result.length).to eq(result.uniq.length)
+      end
+    end
+
+    context "when GitHub API fails" do
+      before do
+        allow(Net::HTTP).to receive(:get).and_raise(SocketError, "Connection refused")
+      end
+
+      it "returns default GitHub IPs" do
+        result = described_class.fetch_github_ips
+        expect(result).to eq(described_class::DEFAULT_GITHUB_IPS)
+      end
+
+      it "logs the failure" do
+        expect(Rails.logger).to receive(:warn).with(
+          hash_including(message: "network_policy.fetch_github_ips.failed")
+        )
+
+        described_class.fetch_github_ips
+      end
+    end
+  end
+
+  describe "constants" do
+    it "defines the network name" do
+      expect(described_class::NETWORK_NAME).to eq("paid_agent")
+    end
+
+    it "defines the network subnet" do
+      expect(described_class::NETWORK_SUBNET).to eq("172.28.0.0/16")
+    end
+
+    it "defines the secrets proxy port" do
+      expect(described_class::SECRETS_PROXY_PORT).to eq(3001)
+    end
+
+    it "defines default GitHub IP ranges" do
+      expect(described_class::DEFAULT_GITHUB_IPS).to be_a(Array)
+      expect(described_class::DEFAULT_GITHUB_IPS).not_to be_empty
+      expect(described_class::DEFAULT_GITHUB_IPS).to all(match(%r{\d+\.\d+\.\d+\.\d+/\d+}))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements network isolation for agent containers as specified in issue #25:

- **Docker network configuration**: Adds `paid_internal` and `paid_agent` networks to `docker-compose.yml`. The `paid_agent` network uses `internal: true` to disable default outbound internet access for agent containers.
- **NetworkPolicy service**: New `app/services/network_policy.rb` that ensures the agent Docker network exists and applies iptables-based firewall rules inside containers to restrict egress to only allowed destinations (secrets proxy, GitHub, DNS).
- **Container provisioning integration**: Updates `Containers::Provision` to ensure the network exists before provisioning and apply firewall rules after container start. Firewall failures are non-fatal in development but abort provisioning in production.
- **Host-level setup script**: Adds `scripts/setup-agent-network.sh` for configuring iptables rules at the Docker bridge level (defense-in-depth).

### Allowed traffic from agent containers:
- Secrets proxy (port 3001) for proxied LLM API access
- GitHub IP ranges (HTTPS 443, SSH 22) for git operations
- DNS (UDP/TCP port 53) for hostname resolution
- All other outbound traffic is blocked and logged (`PAID_AGENT_BLOCK` prefix)

## Test plan

- [x] RuboCop passes (0 offenses)
- [x] Brakeman passes (0 warnings)
- [x] All 70 specs pass (NetworkPolicy + updated Containers::Provision)
- [ ] Manual: verify agent-test container connects to paid_agent network via `docker compose --profile test up`
- [ ] Manual: verify iptables rules are applied inside container (requires NET_RAW capability)

## Notes

- GitHub IP ranges are hardcoded as static defaults with a `fetch_github_ips` method that can pull fresh ranges from `https://api.github.com/meta`
- The `paid_agent` network name was updated from `paid_agent_network` in `Containers::Provision::DEFAULTS` - this is backward compatible since the network is created on demand
- Future opportunity: Add package registry allowlisting (npm, RubyGems, PyPI) when agent CLIs need to install dependencies at runtime

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)