### PR TITLE
fix: address PR #70 review comments on RBAC documentation

### DIFF
--- a/docs/rdrs/RDR-001-web-framework-selection.md
+++ b/docs/rdrs/RDR-001-web-framework-selection.md
@@ -39,7 +39,7 @@ The team has Ruby expertise and values developer productivity. The application i
 - Database: PostgreSQL (decided separately in RDR-003)
 - Workflow engine: Temporal.io (decided separately in RDR-002)
 - Real-time requirements: Live agent status, interrupt capability
-- Authentication: Standard user auth with RBAC (membership tables + Pundit)
+- Authentication & authorization: Standard user auth with RBAC (membership tables + Pundit)
 
 ## Research Findings
 


### PR DESCRIPTION
## Summary

Addresses all 6 Copilot review comments from PR #70 (`docs: update authentication and role management references`):

- **RDR-001 line 42**: Renamed "Authentication" to "Authentication & authorization" to avoid conflating authentication with RBAC (authorization)
- **RDR-010 Pundit Scope**: Fixed `user.has_role?(:admin)` (global, no resource) to `user.has_any_role?(:owner, :admin, record.account)` so the scope example uses the membership-based API correctly
- **RDR-010 schema defaults**: Changed role `DEFAULT 1` (member) to `DEFAULT 0` (viewer) in both SQL schema examples and migration examples, matching DATA_MODEL.md and least-privilege principle
- **RDR-010 assign_owner_role_if_first_user**: Added default member role creation for all users before conditionally promoting the first user to owner, so `has_role?`/`has_any_role?` always find a membership row
- **RDR-010 user_in_account?**: Replaced direct `account_id` comparison with `has_any_account_role?(:owner, :admin, :member, :viewer)` so access checks go through membership tables consistently
- **RDR-010 consequences**: Changed "compile-time validation and database-level constraints" to "a constrained set of allowed role values with application-level validation" — Rails enums provide runtime validation, not compile-time

Addresses: #70

## Test plan

- [ ] Verify documentation reads consistently across RDR-001, RDR-010, and DATA_MODEL.md
- [ ] Confirm role defaults (0 = viewer) match everywhere
- [ ] Verify Pundit examples pass a resource to all role check methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)