### PR TITLE
feat: implement secrets proxy service (#26)

### DIFF
--- a/app/controllers/api/secrets_proxy_controller.rb
+++ b/app/controllers/api/secrets_proxy_controller.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Api
+  class SecretsProxyController < ActionController::API
+    before_action :validate_container_request
+    before_action :set_agent_run
+    before_action :check_rate_limit
+
+    # Maximum tokens per agent run before rate limiting kicks in
+    MAX_TOKENS_PER_RUN = 10_000_000
+
+    # POST /api/proxy/anthropic/*path
+    def anthropic
+      proxy_request(
+        base_url: "https://api.anthropic.com",
+        auth_header: "x-api-key",
+        api_key: fetch_api_key(:anthropic)
+      )
+    end
+
+    # POST /api/proxy/openai/*path
+    def openai
+      proxy_request(
+        base_url: "https://api.openai.com",
+        auth_header: "Authorization",
+        api_key: "Bearer #{fetch_api_key(:openai)}"
+      )
+    end
+
+    private
+
+    def validate_container_request
+      @agent_run_id = request.headers["X-Agent-Run-Id"]
+
+      unless @agent_run_id.present?
+        render json: { error: "Missing agent run ID" }, status: :unauthorized
+      end
+    end
+
+    def set_agent_run
+      @agent_run = AgentRun.find_by(id: @agent_run_id)
+
+      unless @agent_run&.running?
+        render json: { error: "Invalid or inactive agent run" }, status: :forbidden
+      end
+    end
+
+    def check_rate_limit
+      return unless @agent_run.total_tokens > MAX_TOKENS_PER_RUN
+
+      render json: { error: "Token limit exceeded for this agent run" }, status: :too_many_requests
+    end
+
+    def proxy_request(base_url:, auth_header:, api_key:)
+      path = params[:path] || ""
+      target_url = "#{base_url}/#{path}"
+
+      response = build_connection.run_request(
+        request.method.downcase.to_sym,
+        target_url,
+        request.body.read,
+        forwarded_headers.merge(auth_header => api_key)
+      )
+
+      track_usage(response)
+
+      render body: response.body, status: response.status,
+             content_type: response.headers["content-type"] || "application/json"
+    rescue Faraday::Error => e
+      log_error("secrets_proxy.forward_failed", e.message)
+      render json: { error: "Upstream request failed" }, status: :bad_gateway
+    end
+
+    def build_connection
+      Faraday.new do |f|
+        f.options.timeout = 300
+        f.options.open_timeout = 10
+      end
+    end
+
+    def forwarded_headers
+      %w[Content-Type Accept].each_with_object({}) do |header, hash|
+        value = request.headers[header]
+        hash[header] = value if value.present?
+      end
+    end
+
+    def track_usage(response)
+      return unless response.success?
+
+      body = parse_response_body(response.body)
+      return unless body.is_a?(Hash) && body["usage"]
+
+      usage = body["usage"]
+      TokenUsageTracker.track(
+        agent_run: @agent_run,
+        tokens_input: usage["input_tokens"] || usage["prompt_tokens"] || 0,
+        tokens_output: usage["output_tokens"] || usage["completion_tokens"] || 0
+      )
+    rescue => e
+      log_error("secrets_proxy.track_usage_failed", e.message)
+    end
+
+    def parse_response_body(body)
+      return body if body.is_a?(Hash)
+
+      JSON.parse(body)
+    rescue JSON::ParserError
+      nil
+    end
+
+    def fetch_api_key(provider)
+      key = Rails.application.credentials.dig(:llm, :"#{provider}_api_key")
+      key ||= ENV["#{provider.to_s.upcase}_API_KEY"]
+      raise "Missing API key for #{provider}" unless key
+
+      key
+    end
+
+    def log_error(message, error)
+      Rails.logger.error(
+        message: message,
+        agent_run_id: @agent_run&.id,
+        error: error
+      )
+    end
+  end
+end

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -312,8 +312,10 @@ module Containers
         "PROJECT_ID=#{project.id}",
         "AGENT_RUN_ID=#{agent_run.id}",
         "HOME=/home/agent",
-        "ANTHROPIC_BASE_URL=http://paid-proxy:3001/proxy/api.anthropic.com",
-        "OPENAI_BASE_URL=http://paid-proxy:3001/proxy/api.openai.com"
+        "ANTHROPIC_BASE_URL=http://paid-proxy:3001/api/proxy/anthropic",
+        "OPENAI_BASE_URL=http://paid-proxy:3001/api/proxy/openai",
+        "ANTHROPIC_HEADER_X_AGENT_RUN_ID=#{agent_run.id}",
+        "OPENAI_HEADER_X_AGENT_RUN_ID=#{agent_run.id}"
       ]
     end
 

--- a/app/services/token_usage_tracker.rb
+++ b/app/services/token_usage_tracker.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class TokenUsageTracker
+  # Default pricing per million tokens (Claude 3.5 Sonnet)
+  DEFAULT_INPUT_COST_PER_MILLION = 3.00
+  DEFAULT_OUTPUT_COST_PER_MILLION = 15.00
+
+  def self.track(agent_run:, tokens_input:, tokens_output:)
+    cost_cents = calculate_cost(tokens_input, tokens_output)
+
+    agent_run.with_lock do
+      agent_run.increment(:tokens_input, tokens_input)
+      agent_run.increment(:tokens_output, tokens_output)
+      agent_run.increment(:cost_cents, cost_cents)
+      agent_run.save!
+    end
+
+    agent_run.project.increment_metrics!(
+      cost_cents: cost_cents,
+      tokens_used: tokens_input + tokens_output
+    )
+
+    agent_run.log!("metric", {
+      tokens_input: tokens_input,
+      tokens_output: tokens_output,
+      cost_cents: cost_cents
+    }.to_json, metadata: { type: "token_usage" })
+  end
+
+  def self.calculate_cost(input_tokens, output_tokens)
+    input_cost = (input_tokens / 1_000_000.0) * DEFAULT_INPUT_COST_PER_MILLION
+    output_cost = (output_tokens / 1_000_000.0) * DEFAULT_OUTPUT_COST_PER_MILLION
+    ((input_cost + output_cost) * 100).round
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,12 @@ Rails.application.routes.draw do
     resource :workflow_status, only: [ :show ]
   end
 
+  # API endpoints for agent containers
+  namespace :api do
+    match "proxy/anthropic/*path", to: "secrets_proxy#anthropic", via: :all
+    match "proxy/openai/*path", to: "secrets_proxy#openai", via: :all
+  end
+
   # Defines the root path route ("/")
   root "home#index"
 end

--- a/spec/requests/api/secrets_proxy_spec.rb
+++ b/spec/requests/api/secrets_proxy_spec.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::SecretsProxy" do
+  let(:project) { create(:project) }
+  let(:agent_run) { create(:agent_run, :running, project: project) }
+
+  let(:anthropic_response_body) do
+    {
+      id: "msg_123",
+      type: "message",
+      model: "claude-3-5-sonnet-20241022",
+      usage: { input_tokens: 100, output_tokens: 50 },
+      content: [ { type: "text", text: "Hello!" } ]
+    }.to_json
+  end
+
+  let(:openai_response_body) do
+    {
+      id: "chatcmpl-123",
+      model: "gpt-4o",
+      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      choices: [ { message: { role: "assistant", content: "Hello!" } } ]
+    }.to_json
+  end
+
+  before do
+    allow(Rails.application.credentials).to receive(:dig).and_call_original
+    allow(Rails.application.credentials).to receive(:dig)
+      .with(:llm, :anthropic_api_key).and_return("sk-ant-test-key")
+    allow(Rails.application.credentials).to receive(:dig)
+      .with(:llm, :openai_api_key).and_return("sk-test-key")
+  end
+
+  describe "POST /api/proxy/anthropic/*path" do
+    let(:target_url) { "https://api.anthropic.com/v1/messages" }
+
+    before do
+      stub_request(:post, target_url)
+        .to_return(status: 200, body: anthropic_response_body, headers: { "Content-Type" => "application/json" })
+    end
+
+    context "with valid agent run" do
+      it "proxies the request to Anthropic and returns the response" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => agent_run.id.to_s
+          }
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["model"]).to eq("claude-3-5-sonnet-20241022")
+      end
+
+      it "injects the API key into the forwarded request" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => agent_run.id.to_s
+          }
+
+        expect(WebMock).to have_requested(:post, target_url)
+          .with(headers: { "x-api-key" => "sk-ant-test-key" })
+      end
+
+      it "tracks token usage on the agent run" do
+        expect {
+          post "/api/proxy/anthropic/v1/messages",
+            params: {}.to_json,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-Agent-Run-Id" => agent_run.id.to_s
+            }
+        }.to change { agent_run.reload.tokens_input }.by(100)
+          .and change { agent_run.reload.tokens_output }.by(50)
+      end
+
+      it "tracks cost on the agent run" do
+        # Use larger token counts to produce non-zero cost
+        large_response = {
+          id: "msg_123",
+          model: "claude-3-5-sonnet-20241022",
+          usage: { input_tokens: 100_000, output_tokens: 50_000 },
+          content: [ { type: "text", text: "Hello!" } ]
+        }.to_json
+
+        stub_request(:post, target_url)
+          .to_return(status: 200, body: large_response, headers: { "Content-Type" => "application/json" })
+
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => agent_run.id.to_s
+          }
+
+        agent_run.reload
+        expect(agent_run.cost_cents).to be > 0
+      end
+
+      it "updates project metrics" do
+        expect {
+          post "/api/proxy/anthropic/v1/messages",
+            params: {}.to_json,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-Agent-Run-Id" => agent_run.id.to_s
+            }
+        }.to change { project.reload.total_tokens_used }.by(150)
+      end
+
+      it "creates an agent run log entry" do
+        expect {
+          post "/api/proxy/anthropic/v1/messages",
+            params: {}.to_json,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-Agent-Run-Id" => agent_run.id.to_s
+            }
+        }.to change { agent_run.agent_run_logs.where(log_type: "metric").count }.by(1)
+      end
+    end
+
+    context "when upstream returns an error" do
+      before do
+        stub_request(:post, target_url)
+          .to_return(status: 500, body: { error: "Internal Server Error" }.to_json,
+                     headers: { "Content-Type" => "application/json" })
+      end
+
+      it "returns the upstream error status" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => agent_run.id.to_s
+          }
+
+        expect(response).to have_http_status(:internal_server_error)
+      end
+
+      it "does not track usage on error responses" do
+        expect {
+          post "/api/proxy/anthropic/v1/messages",
+            params: {}.to_json,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-Agent-Run-Id" => agent_run.id.to_s
+            }
+        }.not_to change { agent_run.reload.tokens_input }
+      end
+    end
+
+    context "when upstream connection fails" do
+      before do
+        stub_request(:post, target_url).to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+      end
+
+      it "returns bad gateway" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => agent_run.id.to_s
+          }
+
+        expect(response).to have_http_status(:bad_gateway)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("Upstream request failed")
+      end
+    end
+  end
+
+  describe "POST /api/proxy/openai/*path" do
+    let(:target_url) { "https://api.openai.com/v1/chat/completions" }
+
+    before do
+      stub_request(:post, target_url)
+        .to_return(status: 200, body: openai_response_body, headers: { "Content-Type" => "application/json" })
+    end
+
+    it "proxies the request to OpenAI and returns the response" do
+      post "/api/proxy/openai/v1/chat/completions",
+        params: { model: "gpt-4o" }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-Agent-Run-Id" => agent_run.id.to_s
+        }
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["model"]).to eq("gpt-4o")
+    end
+
+    it "injects the Bearer token into the forwarded request" do
+      post "/api/proxy/openai/v1/chat/completions",
+        params: {}.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-Agent-Run-Id" => agent_run.id.to_s
+        }
+
+      expect(WebMock).to have_requested(:post, target_url)
+        .with(headers: { "Authorization" => "Bearer sk-test-key" })
+    end
+
+    it "tracks token usage with OpenAI field names" do
+      expect {
+        post "/api/proxy/openai/v1/chat/completions",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => agent_run.id.to_s
+          }
+      }.to change { agent_run.reload.tokens_input }.by(100)
+        .and change { agent_run.reload.tokens_output }.by(50)
+    end
+  end
+
+  describe "authentication" do
+    before do
+      stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .to_return(status: 200, body: anthropic_response_body, headers: { "Content-Type" => "application/json" })
+    end
+
+    context "without X-Agent-Run-Id header" do
+      it "returns unauthorized" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: { "Content-Type" => "application/json" }
+
+        expect(response).to have_http_status(:unauthorized)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("Missing agent run ID")
+      end
+    end
+
+    context "with invalid agent run ID" do
+      it "returns forbidden" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => "999999"
+          }
+
+        expect(response).to have_http_status(:forbidden)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("Invalid or inactive agent run")
+      end
+    end
+
+    context "with non-running agent run" do
+      let(:completed_run) { create(:agent_run, :completed, project: project) }
+
+      it "returns forbidden for completed runs" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => completed_run.id.to_s
+          }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns forbidden for pending runs" do
+        pending_run = create(:agent_run, project: project, status: "pending")
+
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => pending_run.id.to_s
+          }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "rate limiting" do
+    before do
+      stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .to_return(status: 200, body: anthropic_response_body, headers: { "Content-Type" => "application/json" })
+    end
+
+    context "when agent run exceeds token limit" do
+      let(:agent_run) do
+        create(:agent_run, :running, project: project,
+          tokens_input: 9_000_000, tokens_output: 2_000_000)
+      end
+
+      it "returns too many requests" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => agent_run.id.to_s
+          }
+
+        expect(response).to have_http_status(:too_many_requests)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("Token limit exceeded for this agent run")
+      end
+    end
+
+    context "when agent run is within token limit" do
+      let(:agent_run) do
+        create(:agent_run, :running, project: project,
+          tokens_input: 1000, tokens_output: 500)
+      end
+
+      it "allows the request through" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Agent-Run-Id" => agent_run.id.to_s
+          }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -149,8 +149,10 @@ RSpec.describe Containers::Provision do
           expect(env).to include("PAID_PROXY_URL=http://paid-proxy:3001")
           expect(env).to include("PROJECT_ID=#{project.id}")
           expect(env).to include("AGENT_RUN_ID=#{agent_run.id}")
-          expect(env).to include("ANTHROPIC_BASE_URL=http://paid-proxy:3001/proxy/api.anthropic.com")
-          expect(env).to include("OPENAI_BASE_URL=http://paid-proxy:3001/proxy/api.openai.com")
+          expect(env).to include("ANTHROPIC_BASE_URL=http://paid-proxy:3001/api/proxy/anthropic")
+          expect(env).to include("OPENAI_BASE_URL=http://paid-proxy:3001/api/proxy/openai")
+          expect(env).to include("ANTHROPIC_HEADER_X_AGENT_RUN_ID=#{agent_run.id}")
+          expect(env).to include("OPENAI_HEADER_X_AGENT_RUN_ID=#{agent_run.id}")
           # Ensure no API keys are present
           expect(env.none? { |e| e.include?("API_KEY") }).to be true
           mock_container

--- a/spec/services/token_usage_tracker_spec.rb
+++ b/spec/services/token_usage_tracker_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TokenUsageTracker do
+  let(:project) { create(:project) }
+  let(:agent_run) { create(:agent_run, :running, project: project) }
+
+  describe ".track" do
+    it "increments tokens_input on the agent run" do
+      expect {
+        described_class.track(agent_run: agent_run, tokens_input: 1000, tokens_output: 500)
+      }.to change { agent_run.reload.tokens_input }.by(1000)
+    end
+
+    it "increments tokens_output on the agent run" do
+      expect {
+        described_class.track(agent_run: agent_run, tokens_input: 1000, tokens_output: 500)
+      }.to change { agent_run.reload.tokens_output }.by(500)
+    end
+
+    it "calculates and sets cost_cents on the agent run" do
+      described_class.track(agent_run: agent_run, tokens_input: 1_000_000, tokens_output: 1_000_000)
+
+      agent_run.reload
+      # $3/M input + $15/M output = $18 = 1800 cents
+      expect(agent_run.cost_cents).to eq(1800)
+    end
+
+    it "accumulates across multiple calls" do
+      described_class.track(agent_run: agent_run, tokens_input: 100, tokens_output: 50)
+      described_class.track(agent_run: agent_run, tokens_input: 200, tokens_output: 100)
+
+      agent_run.reload
+      expect(agent_run.tokens_input).to eq(300)
+      expect(agent_run.tokens_output).to eq(150)
+    end
+
+    it "updates project total_tokens_used" do
+      expect {
+        described_class.track(agent_run: agent_run, tokens_input: 1000, tokens_output: 500)
+      }.to change { project.reload.total_tokens_used }.by(1500)
+    end
+
+    it "updates project total_cost_cents" do
+      expect {
+        described_class.track(agent_run: agent_run, tokens_input: 1_000_000, tokens_output: 1_000_000)
+      }.to change { project.reload.total_cost_cents }.by(1800)
+    end
+
+    it "creates a metric log entry" do
+      expect {
+        described_class.track(agent_run: agent_run, tokens_input: 1000, tokens_output: 500)
+      }.to change { agent_run.agent_run_logs.where(log_type: "metric").count }.by(1)
+
+      log = agent_run.agent_run_logs.where(log_type: "metric").last
+      content = JSON.parse(log.content)
+      expect(content["tokens_input"]).to eq(1000)
+      expect(content["tokens_output"]).to eq(500)
+      expect(log.metadata).to eq({ "type" => "token_usage" })
+    end
+  end
+
+  describe ".calculate_cost" do
+    it "returns 0 for zero tokens" do
+      expect(described_class.calculate_cost(0, 0)).to eq(0)
+    end
+
+    it "calculates cost based on default pricing" do
+      # $3/M input, $15/M output
+      # 1M input = $3 = 300 cents
+      # 1M output = $15 = 1500 cents
+      expect(described_class.calculate_cost(1_000_000, 1_000_000)).to eq(1800)
+    end
+
+    it "handles small token counts" do
+      # 1000 input = $0.003 = 0.3 cents
+      # 500 output = $0.0075 = 0.75 cents
+      # Total = $0.0105 => 1.05 cents, rounded = 1
+      expect(described_class.calculate_cost(1000, 500)).to eq(1)
+    end
+
+    it "handles large token counts" do
+      # 10M input = $30 = 3000 cents
+      # 5M output = $75 = 7500 cents
+      expect(described_class.calculate_cost(10_000_000, 5_000_000)).to eq(10_500)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements the secrets proxy service as described in issue #26 and RDR-006. This creates a lightweight proxy that allows agent containers to make LLM API calls without having direct access to API keys.

- **`Api::SecretsProxyController`** - Receives unauthenticated requests from agent containers, validates them via `X-Agent-Run-Id` header, injects provider API keys, and forwards to Anthropic/OpenAI
- **`TokenUsageTracker`** service - Tracks token usage and cost per agent run, updates project-level metrics, logs usage as metric entries
- **Rate limiting** - Basic per-run token limit (10M tokens) to prevent runaway costs
- **Route mounting** - API namespace at `/api/proxy/anthropic/*path` and `/api/proxy/openai/*path`
- **Container env var update** - Updated `Containers::Provision` environment variables to match new proxy URL scheme

### Key design decisions

- Inherits from `ActionController::API` (not `ApplicationController`) to skip browser checks, CSRF, Devise auth, and Pundit - these are container-to-proxy requests, not browser requests
- API keys resolved from Rails credentials first, falling back to ENV vars
- Raw response passthrough (no double JSON encode/decode) for proper proxy behavior
- Cost calculation uses default Claude 3.5 Sonnet pricing ($3/M input, $15/M output) for MVP

### Files changed

| File | Description |
|------|-------------|
| `app/controllers/api/secrets_proxy_controller.rb` | New proxy controller |
| `app/services/token_usage_tracker.rb` | New token usage tracking service |
| `config/routes.rb` | Added API proxy routes |
| `app/services/containers/provision.rb` | Updated container env vars to match proxy URLs |
| `spec/requests/api/secrets_proxy_spec.rb` | 21 request specs |
| `spec/services/token_usage_tracker_spec.rb` | 8 unit specs |
| `spec/services/containers/provision_spec.rb` | Updated env var assertions |

### Future opportunities (not implemented)

- Add Google/Mistral provider support (straightforward extension)
- Source IP validation (restrict to container network 172.28.x.x)
- Streaming response support for real-time agent output
- Per-project quota/budget enforcement via `CostBudget` model
- Model-specific pricing lookup instead of default rates
- Standalone Rack app deployment on port 3001 for better isolation

## Test plan

- [x] 29 new specs pass (21 request + 8 service)
- [x] Existing container provision spec updated and passing
- [x] RuboCop clean
- [x] Brakeman: 0 warnings

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)