### PR TITLE
fix: address PR #69 review comments on GitHubPollWorkflow

### DIFF
--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -52,8 +52,7 @@ module Workflows
       Temporalio::Workflow.start_child_workflow(
         Workflows::AgentExecutionWorkflow,
         { project_id: project_id, issue_id: issue_id },
-        id: workflow_id,
-        task_queue: Paid.task_queue
+        id: workflow_id
       )
     end
   end


### PR DESCRIPTION
## Summary

Addresses all 5 code review comments from PR #69 (GitHubPollWorkflow and FetchIssuesActivity):

- **Race condition fix**: Changed `after_create` to `after_create_commit` in Project model so Temporal activities can safely call `Project.find` after the DB transaction commits
- **Active toggle hook**: Added `after_update_commit :toggle_github_polling, if: :saved_change_to_active?` so polling starts/stops when a project is activated/deactivated
- **Blank label filtering**: Changed `.compact` to `.compact_blank.uniq` in FetchIssuesActivity to filter blank strings from label mappings before GitHub API calls
- **Pagination**: Implemented page-by-page fetching in FetchIssuesActivity for repos with >100 matching open issues
- **Workflow determinism**: Removed `task_queue: Paid.task_queue` from child workflow start (reads ENV, non-deterministic on Temporal replay); child inherits parent queue by default

## Test plan

- [x] All 68 relevant specs pass (0 failures)
- [x] New specs for active toggle (activate/deactivate/no-op on other updates)
- [x] New specs for pagination (multi-page fetching)
- [x] New spec for blank label filtering
- [x] RuboCop clean (0 offenses)
- [x] Brakeman clean (0 warnings)

Addresses review comments from #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)