### PR TITLE
fix: address PR #67 review comments on workflow monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ RAILS_ENV=development
 
 # Temporal server address (used by Rails app to connect to Temporal)
 TEMPORAL_HOST=localhost:7233
+
+# Temporal UI base URL (used for workflow monitoring links)
+TEMPORAL_UI_URL=http://localhost:8080

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -106,7 +106,7 @@
   <div class="mt-8">
     <h2 class="text-lg font-medium text-gray-900">Workflow Status</h2>
     <div class="mt-4">
-      <%= turbo_frame_tag "workflow-status", src: project_workflow_status_path(@project) do %>
+      <%= turbo_frame_tag "workflow-status", src: project_workflow_status_path(@project), loading: :lazy do %>
         <div class="animate-pulse bg-gray-100 h-24 rounded-lg"></div>
       <% end %>
     </div>

--- a/app/views/workflow_statuses/show.html.erb
+++ b/app/views/workflow_statuses/show.html.erb
@@ -13,12 +13,12 @@
               Active
             </span>
           <% elsif @poll_workflow %>
-            <span class="text-yellow-600"><%= @poll_workflow.status.capitalize %></span>
+            <span class="text-yellow-600"><%= @poll_workflow.status.to_s.humanize %></span>
           <% else %>
             <span class="text-gray-500">Not started</span>
           <% end %>
 
-          <a href="http://localhost:8080/namespaces/default/workflows/github-poll-<%= @project.id %>"
+          <a href="<%= Paid.temporal_ui_url %>/namespaces/<%= Paid.temporal_namespace %>/workflows/github-poll-<%= @project.id %>"
              target="_blank"
              rel="noopener noreferrer"
              class="text-indigo-600 hover:text-indigo-900 text-sm">
@@ -48,7 +48,7 @@
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 sm:pl-6"><%= workflow.workflow_type %></td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm">
                   <span class="<%= workflow_status_class(workflow.status) %> inline-flex items-center rounded-md px-2 py-1 text-xs font-medium">
-                    <%= workflow.status.capitalize %>
+                    <%= workflow.status.to_s.humanize %>
                   </span>
                 </td>
                 <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
@@ -58,7 +58,7 @@
                   <%= workflow_duration(workflow) %>
                 </td>
                 <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                  <a href="http://localhost:8080/namespaces/default/workflows/<%= workflow.temporal_workflow_id %>"
+                  <a href="<%= Paid.temporal_ui_url %>/namespaces/<%= Paid.temporal_namespace %>/workflows/<%= workflow.temporal_workflow_id %>"
                      target="_blank"
                      rel="noopener noreferrer"
                      class="text-indigo-600 hover:text-indigo-900">
@@ -76,6 +76,17 @@
   </div>
 
   <% if @poll_workflow&.running? || @recent_workflows.any?(&:running?) %>
-    <meta http-equiv="refresh" content="5">
+    <script>
+      (function() {
+        setTimeout(function() {
+          var frame = document.getElementById("workflow-status");
+          if (frame && frame.src) {
+            frame.reload();
+          } else {
+            window.location.reload();
+          }
+        }, 5000);
+      })();
+    </script>
   <% end %>
 <% end %>

--- a/config/initializers/temporal.rb
+++ b/config/initializers/temporal.rb
@@ -47,6 +47,10 @@ module Paid
       ENV.fetch("TEMPORAL_NAMESPACE", "default")
     end
 
+    def temporal_ui_url
+      ENV.fetch("TEMPORAL_UI_URL", "http://localhost:8080")
+    end
+
     def task_queue
       ENV.fetch("TEMPORAL_TASK_QUEUE", "paid-tasks")
     end

--- a/spec/helpers/workflow_helper_spec.rb
+++ b/spec/helpers/workflow_helper_spec.rb
@@ -36,24 +36,29 @@ RSpec.describe WorkflowHelper do
     end
 
     it "returns seconds for short durations" do
-      workflow = build(:workflow_state, started_at: 30.seconds.ago, completed_at: Time.current)
+      current_time = Time.current
+      workflow = build(:workflow_state, started_at: current_time - 30.seconds, completed_at: current_time)
       expect(helper.workflow_duration(workflow)).to eq("30s")
     end
 
     it "returns minutes and seconds for medium durations" do
-      workflow = build(:workflow_state, started_at: 125.seconds.ago, completed_at: Time.current)
+      current_time = Time.current
+      workflow = build(:workflow_state, started_at: current_time - 125.seconds, completed_at: current_time)
       expect(helper.workflow_duration(workflow)).to eq("2m 5s")
     end
 
     it "returns hours and minutes for long durations" do
-      workflow = build(:workflow_state, started_at: 3725.seconds.ago, completed_at: Time.current)
+      current_time = Time.current
+      workflow = build(:workflow_state, started_at: current_time - 3725.seconds, completed_at: current_time)
       expect(helper.workflow_duration(workflow)).to eq("1h 2m")
     end
 
     it "uses current time when completed_at is nil" do
-      workflow = build(:workflow_state, started_at: 10.seconds.ago, completed_at: nil)
-      result = helper.workflow_duration(workflow)
-      expect(result).to match(/\d+s/)
+      freeze_time do
+        workflow = build(:workflow_state, started_at: 10.seconds.ago, completed_at: nil)
+        result = helper.workflow_duration(workflow)
+        expect(result).to eq("10s")
+      end
     end
   end
 end

--- a/spec/requests/workflow_statuses_spec.rb
+++ b/spec/requests/workflow_statuses_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe "WorkflowStatuses" do
           status: "running")
 
         get project_workflow_status_path(project)
-        # The table should not contain GitHubPoll rows
-        expect(response.body).not_to include("<td class=\"whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 sm:pl-6\">GitHubPoll</td>")
+        # The page should not display GitHubPoll workflows in the recent list
+        expect(response.body).not_to include("GitHubPoll")
       end
 
       it "shows empty state when no workflows exist" do
@@ -102,14 +102,14 @@ RSpec.describe "WorkflowStatuses" do
         expect(response.body).to include("View in Temporal UI")
       end
 
-      it "includes auto-refresh meta tag when workflows are running" do
+      it "includes auto-refresh script when workflows are running" do
         create(:workflow_state,
           project: project,
           workflow_type: "AgentExecutionWorkflow",
           status: "running")
 
         get project_workflow_status_path(project)
-        expect(response.body).to include('http-equiv="refresh" content="5"')
+        expect(response.body).to include("setTimeout")
       end
 
       it "does not include auto-refresh when no workflows are running" do
@@ -120,7 +120,7 @@ RSpec.describe "WorkflowStatuses" do
           completed_at: Time.current)
 
         get project_workflow_status_path(project)
-        expect(response.body).not_to include('http-equiv="refresh"')
+        expect(response.body).not_to include("setTimeout")
       end
 
       it "does not allow viewing workflow status for other accounts' projects" do


### PR DESCRIPTION
## Summary

Addresses all 6 Copilot review comments from PR #67 (workflow monitoring UI):

- **Brittle HTML assertion** (`spec/requests/workflow_statuses_spec.rb`): Replaced full `<td class=...>` HTML string assertion with semantic `not_to include("GitHubPoll")` check
- **Non-deterministic time tests** (`spec/helpers/workflow_helper_spec.rb`): Fixed off-by-one risk by using fixed timestamps (`current_time - N.seconds`) and `freeze_time` for deterministic assertions
- **Hardcoded Temporal UI URL** (`app/views/workflow_statuses/show.html.erb`): Extracted to configurable `Paid.temporal_ui_url` (reads `TEMPORAL_UI_URL` env var, defaults to `http://localhost:8080`). Also uses `Paid.temporal_namespace` instead of hardcoded `default`
- **`status.capitalize` on multi-word statuses** (`show.html.erb`): Changed to `.to_s.humanize` so `timed_out` renders as "Timed out" instead of "Timed_out"
- **Meta refresh in Turbo Frame** (`show.html.erb`): Replaced `<meta http-equiv="refresh">` (unreliable inside Turbo Frame body) with JS-based `setTimeout` that reloads the frame
- **Missing lazy loading** (`app/views/projects/show.html.erb`): Added `loading: :lazy` to `turbo_frame_tag` for true lazy loading

## References

- Addresses review comments on: #67
- Source issue: #21

## Test plan

- [x] All 11 workflow helper specs pass (deterministic now)
- [x] RuboCop clean on all changed files
- [x] Brakeman reports 0 warnings
- [ ] Verify workflow status renders correctly with new humanize formatting
- [ ] Verify Temporal UI links use configured URL

**Note**: Request specs have a pre-existing `Propshaft::MissingAssetError` (`application.js` not found in load path) unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)