### PR TITLE
feat: integrate agent-harness gem for agent CLI abstraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem "temporalio"
 # Docker API client [https://github.com/upserve/docker-api]
 gem "docker-api"
 
+# Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
+gem "agent-harness"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[windows jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    agent-harness (0.3.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.21)
@@ -488,6 +489,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  agent-harness
   bootsnap
   brakeman
   bundler-audit
@@ -538,6 +540,7 @@ CHECKSUMS
   activestorage (8.1.2) sha256=8a63a48c3999caeee26a59441f813f94681fc35cc41aba7ce1f836add04fba76
   activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
   addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  agent-harness (0.3.0) sha256=a9573580dd27af497428602100f28cfa1efc08ba3dd9c1035e30d4d705be6518
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.21) sha256=5964613d750a42c7ee5dc61f7b9336fb6caca429ba4ac9f2011609946e4a2dcf

--- a/app/services/agent_runs/execute.rb
+++ b/app/services/agent_runs/execute.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module AgentRuns
+  # Executes an agent run using the agent-harness gem.
+  #
+  # Maps agent-harness responses to AgentRun model fields, handles errors
+  # and timeouts, and tracks token usage.
+  #
+  # @example
+  #   result = AgentRuns::Execute.call(agent_run: agent_run, prompt: "Fix the bug")
+  #   result.success? # => true
+  #   result.response  # => AgentHarness::Response
+  class Execute
+    # Maps AgentRun agent_type values to agent-harness provider symbols
+    PROVIDER_MAP = {
+      "claude_code" => :claude,
+      "cursor" => :cursor,
+      "codex" => :codex,
+      "copilot" => :github_copilot,
+      "aider" => :aider,
+      "gemini" => :gemini,
+      "opencode" => :opencode,
+      "kilocode" => :kilocode
+    }.freeze
+
+    DEFAULT_TIMEOUT = 600
+
+    attr_reader :agent_run, :prompt, :timeout
+
+    def initialize(agent_run:, prompt:, timeout: DEFAULT_TIMEOUT)
+      @agent_run = agent_run
+      @prompt = prompt
+      @timeout = timeout
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      validate!
+      start_run
+      response = execute_agent
+      process_response(response)
+      Result.new(success: true, response: response)
+    rescue AgentHarness::TimeoutError => e
+      handle_timeout(e)
+    rescue AgentHarness::Error => e
+      handle_error(e)
+    end
+
+    private
+
+    def validate!
+      provider_name = PROVIDER_MAP[agent_run.agent_type]
+      raise ArgumentError, "Unsupported agent type: #{agent_run.agent_type}" unless provider_name
+    end
+
+    def start_run
+      agent_run.start!
+      agent_run.log!("system", "Starting #{agent_run.agent_type} agent")
+      agent_run.log!("system", "Prompt: #{prompt.truncate(500)}")
+    end
+
+    def execute_agent
+      provider_name = PROVIDER_MAP[agent_run.agent_type]
+
+      AgentHarness.send_message(
+        prompt,
+        provider: provider_name,
+        timeout: timeout,
+        dangerous_mode: true
+      )
+    end
+
+    def process_response(response)
+      agent_run.log!("stdout", response.output) if response.output.present?
+
+      if response.error.present?
+        agent_run.log!("stderr", response.error)
+      end
+
+      track_tokens(response)
+
+      if response.success?
+        agent_run.update!(
+          status: "completed",
+          completed_at: Time.current,
+          duration_seconds: response.duration&.round
+        )
+      else
+        agent_run.update!(
+          status: "failed",
+          completed_at: Time.current,
+          error_message: response.error || "Agent exited with code #{response.exit_code}",
+          duration_seconds: response.duration&.round
+        )
+      end
+    end
+
+    def track_tokens(response)
+      return unless response.tokens
+
+      input_tokens = response.input_tokens || 0
+      output_tokens = response.output_tokens || 0
+
+      agent_run.update!(
+        tokens_input: input_tokens,
+        tokens_output: output_tokens
+      )
+
+      agent_run.project.increment_metrics!(
+        cost_cents: 0,
+        tokens_used: input_tokens + output_tokens
+      )
+
+      agent_run.log!("metric", "token_usage", metadata: {
+        input_tokens: input_tokens,
+        output_tokens: output_tokens,
+        total_tokens: response.total_tokens,
+        model: response.model,
+        provider: response.provider.to_s
+      })
+    end
+
+    def handle_timeout(error)
+      agent_run.timeout!
+      agent_run.update!(error_message: "Agent execution timed out after #{timeout} seconds")
+      agent_run.log!("system", "Execution timed out")
+
+      Result.new(success: false, error: error)
+    end
+
+    def handle_error(error)
+      agent_run.fail!(error: error.message)
+      agent_run.log!("stderr", error.message)
+      agent_run.log!("system", "Execution failed: #{error.class.name}")
+
+      Result.new(success: false, error: error)
+    end
+
+    # Simple result object for execute outcomes
+    class Result
+      attr_reader :response, :error
+
+      def initialize(success:, response: nil, error: nil)
+        @success = success
+        @response = response
+        @error = error
+      end
+
+      def success?
+        @success
+      end
+
+      def failure?
+        !@success
+      end
+    end
+  end
+end

--- a/app/services/prompts/build_for_issue.rb
+++ b/app/services/prompts/build_for_issue.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Prompts
+  # Builds a prompt for an agent to work on a GitHub issue.
+  #
+  # @example
+  #   prompt = Prompts::BuildForIssue.call(issue: issue, project: project)
+  #   # => "# Task\n\nYou are working on..."
+  class BuildForIssue
+    LANGUAGE_TEST_COMMANDS = {
+      "ruby" => "bundle exec rspec",
+      "javascript" => "npm test",
+      "typescript" => "npm test",
+      "python" => "pytest",
+      "go" => "go test ./...",
+      "rust" => "cargo test"
+    }.freeze
+
+    LANGUAGE_LINT_COMMANDS = {
+      "ruby" => "bundle exec rubocop",
+      "javascript" => "npm run lint",
+      "typescript" => "npm run lint",
+      "python" => "ruff check .",
+      "go" => "golangci-lint run",
+      "rust" => "cargo clippy"
+    }.freeze
+
+    attr_reader :issue, :project
+
+    def initialize(issue:, project:)
+      @issue = issue
+      @project = project
+    end
+
+    def self.call(...)
+      new(...).build
+    end
+
+    def build
+      <<~PROMPT
+        # Task
+
+        You are working on the following GitHub issue:
+
+        **#{issue.title}** (##{issue.github_number})
+
+        #{issue.body}
+
+        # Instructions
+
+        1. Analyze the issue and understand what needs to be done
+        2. Make the necessary code changes
+        3. Ensure tests pass (run `#{test_command}` if available)
+        4. Ensure linting passes (run `#{lint_command}` if available)
+        5. Commit your changes with a descriptive message
+
+        # Important
+
+        - Work within the existing codebase style and conventions
+        - Do not modify unrelated files
+        - If you're unsure about something, leave a comment in the code
+        - Focus on completing the specific task in the issue
+
+        When you're done, commit all your changes. Do not push.
+      PROMPT
+    end
+
+    private
+
+    def test_command
+      LANGUAGE_TEST_COMMANDS.fetch(detected_language, "echo \"No test command configured\"")
+    end
+
+    def lint_command
+      LANGUAGE_LINT_COMMANDS.fetch(detected_language, "echo \"No lint command configured\"")
+    end
+
+    def detected_language
+      @detected_language ||= detect_language
+    end
+
+    def detect_language
+      return project.detected_language if project.respond_to?(:detected_language) && project.detected_language.present?
+
+      # Infer from project name or repo conventions
+      "ruby"
+    end
+  end
+end

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "agent_harness"
+
+AgentHarness.configure do |config|
+  config.default_provider = :claude
+  config.fallback_providers = %i[cursor aider]
+  config.default_timeout = ENV.fetch("AGENT_TIMEOUT", 600).to_i
+
+  config.provider(:claude) do |p|
+    p.enabled = true
+    p.priority = 10
+    p.timeout = ENV.fetch("AGENT_TIMEOUT", 600).to_i
+  end
+
+  config.provider(:cursor) do |p|
+    p.enabled = ENV.fetch("CURSOR_ENABLED", "false") == "true"
+    p.priority = 20
+  end
+
+  config.provider(:aider) do |p|
+    p.enabled = ENV.fetch("AIDER_ENABLED", "false") == "true"
+    p.priority = 30
+  end
+
+  config.orchestration do |orch|
+    orch.enabled = true
+    orch.auto_switch_on_error = true
+    orch.auto_switch_on_rate_limit = true
+
+    orch.circuit_breaker do |cb|
+      cb.enabled = true
+      cb.failure_threshold = 5
+      cb.timeout = 300
+    end
+
+    orch.retry do |r|
+      r.enabled = true
+      r.max_attempts = 3
+      r.base_delay = 1.0
+      r.max_delay = 60.0
+    end
+  end
+
+  config.logger = Rails.logger
+end

--- a/spec/factories/agent_runs.rb
+++ b/spec/factories/agent_runs.rb
@@ -77,6 +77,22 @@ FactoryBot.define do
       agent_type { "copilot" }
     end
 
+    trait :aider do
+      agent_type { "aider" }
+    end
+
+    trait :gemini do
+      agent_type { "gemini" }
+    end
+
+    trait :opencode do
+      agent_type { "opencode" }
+    end
+
+    trait :kilocode do
+      agent_type { "kilocode" }
+    end
+
     trait :api do
       agent_type { "api" }
     end

--- a/spec/services/agent_runs/execute_spec.rb
+++ b/spec/services/agent_runs/execute_spec.rb
@@ -1,0 +1,286 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRuns::Execute do
+  let(:project) { create(:project) }
+  let(:agent_run) { create(:agent_run, project: project, agent_type: "claude_code") }
+  let(:prompt) { "Fix the authentication bug" }
+
+  describe ".call" do
+    context "when agent execution succeeds" do
+      let(:response) do
+        AgentHarness::Response.new(
+          output: "Fixed the bug in auth.rb",
+          exit_code: 0,
+          duration: 45.2,
+          provider: :claude,
+          model: "claude-sonnet-4",
+          tokens: { input: 1500, output: 800, total: 2300 }
+        )
+      end
+
+      before do
+        allow(AgentHarness).to receive(:send_message).and_return(response)
+      end
+
+      it "returns a successful result" do
+        result = described_class.call(agent_run: agent_run, prompt: prompt)
+
+        expect(result).to be_success
+        expect(result.response).to eq(response)
+      end
+
+      it "marks the agent run as completed" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("completed")
+        expect(agent_run.completed_at).to be_present
+        expect(agent_run.duration_seconds).to eq(45)
+      end
+
+      it "tracks token usage on the agent run" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        agent_run.reload
+        expect(agent_run.tokens_input).to eq(1500)
+        expect(agent_run.tokens_output).to eq(800)
+      end
+
+      it "increments project metrics" do
+        expect(project).to receive(:increment_metrics!).with(
+          cost_cents: 0,
+          tokens_used: 2300
+        )
+
+        described_class.call(agent_run: agent_run, prompt: prompt)
+      end
+
+      it "logs agent output" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        logs = agent_run.agent_run_logs
+        system_logs = logs.where(log_type: "system")
+        stdout_logs = logs.where(log_type: "stdout")
+        metric_logs = logs.where(log_type: "metric")
+
+        expect(system_logs.pluck(:content)).to include(
+          "Starting claude_code agent",
+          match(/Prompt:/)
+        )
+        expect(stdout_logs.pluck(:content)).to include("Fixed the bug in auth.rb")
+        expect(metric_logs.count).to eq(1)
+      end
+
+      it "calls AgentHarness.send_message with correct parameters" do
+        expect(AgentHarness).to receive(:send_message).with(
+          prompt,
+          provider: :claude,
+          timeout: 600,
+          dangerous_mode: true
+        ).and_return(response)
+
+        described_class.call(agent_run: agent_run, prompt: prompt)
+      end
+    end
+
+    context "when agent execution fails (non-zero exit)" do
+      let(:response) do
+        AgentHarness::Response.new(
+          output: "Partial output",
+          exit_code: 1,
+          duration: 30.0,
+          provider: :claude,
+          error: "Compilation error in main.rb"
+        )
+      end
+
+      before do
+        allow(AgentHarness).to receive(:send_message).and_return(response)
+      end
+
+      it "marks the agent run as failed" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("failed")
+        expect(agent_run.error_message).to eq("Compilation error in main.rb")
+        expect(agent_run.completed_at).to be_present
+      end
+
+      it "returns a successful result (execution completed, agent failed)" do
+        result = described_class.call(agent_run: agent_run, prompt: prompt)
+
+        expect(result).to be_success
+        expect(result.response).to eq(response)
+      end
+
+      it "logs the error output" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        stderr_logs = agent_run.agent_run_logs.where(log_type: "stderr")
+        expect(stderr_logs.pluck(:content)).to include("Compilation error in main.rb")
+      end
+    end
+
+    context "when agent times out" do
+      before do
+        allow(AgentHarness).to receive(:send_message)
+          .and_raise(AgentHarness::TimeoutError.new("Timed out after 600s"))
+      end
+
+      it "marks the agent run as timeout" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("timeout")
+        expect(agent_run.error_message).to include("timed out")
+      end
+
+      it "returns a failure result" do
+        result = described_class.call(agent_run: agent_run, prompt: prompt)
+
+        expect(result).to be_failure
+        expect(result.error).to be_a(AgentHarness::TimeoutError)
+      end
+
+      it "logs the timeout" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        system_logs = agent_run.agent_run_logs.where(log_type: "system")
+        expect(system_logs.pluck(:content)).to include("Execution timed out")
+      end
+    end
+
+    context "when agent-harness raises an error" do
+      before do
+        allow(AgentHarness).to receive(:send_message)
+          .and_raise(AgentHarness::ProviderError.new("Provider unavailable"))
+      end
+
+      it "marks the agent run as failed" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("failed")
+        expect(agent_run.error_message).to eq("Provider unavailable")
+      end
+
+      it "returns a failure result" do
+        result = described_class.call(agent_run: agent_run, prompt: prompt)
+
+        expect(result).to be_failure
+        expect(result.error).to be_a(AgentHarness::ProviderError)
+      end
+
+      it "logs the error" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        stderr_logs = agent_run.agent_run_logs.where(log_type: "stderr")
+        system_logs = agent_run.agent_run_logs.where(log_type: "system")
+
+        expect(stderr_logs.pluck(:content)).to include("Provider unavailable")
+        expect(system_logs.pluck(:content)).to include("Execution failed: AgentHarness::ProviderError")
+      end
+    end
+
+    context "with unsupported agent type" do
+      let(:agent_run) { create(:agent_run, project: project, agent_type: "api") }
+
+      it "raises ArgumentError" do
+        expect {
+          described_class.call(agent_run: agent_run, prompt: prompt)
+        }.to raise_error(ArgumentError, /Unsupported agent type: api/)
+      end
+    end
+
+    context "with custom timeout" do
+      let(:response) do
+        AgentHarness::Response.new(
+          output: "Done",
+          exit_code: 0,
+          duration: 10.0,
+          provider: :claude
+        )
+      end
+
+      before do
+        allow(AgentHarness).to receive(:send_message).and_return(response)
+      end
+
+      it "passes custom timeout to agent-harness" do
+        expect(AgentHarness).to receive(:send_message).with(
+          prompt,
+          provider: :claude,
+          timeout: 1200,
+          dangerous_mode: true
+        ).and_return(response)
+
+        described_class.call(agent_run: agent_run, prompt: prompt, timeout: 1200)
+      end
+    end
+
+    context "when response has no tokens" do
+      let(:response) do
+        AgentHarness::Response.new(
+          output: "Done",
+          exit_code: 0,
+          duration: 10.0,
+          provider: :claude
+        )
+      end
+
+      before do
+        allow(AgentHarness).to receive(:send_message).and_return(response)
+      end
+
+      it "skips token tracking" do
+        expect(project).not_to receive(:increment_metrics!)
+
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        agent_run.reload
+        expect(agent_run.tokens_input).to eq(0)
+        expect(agent_run.tokens_output).to eq(0)
+      end
+    end
+  end
+
+  describe "provider mapping" do
+    let(:response) do
+      AgentHarness::Response.new(
+        output: "Done",
+        exit_code: 0,
+        duration: 5.0,
+        provider: :claude
+      )
+    end
+
+    before do
+      allow(AgentHarness).to receive(:send_message).and_return(response)
+    end
+
+    {
+      "claude_code" => :claude,
+      "cursor" => :cursor,
+      "codex" => :codex,
+      "copilot" => :github_copilot,
+      "aider" => :aider,
+      "gemini" => :gemini,
+      "opencode" => :opencode,
+      "kilocode" => :kilocode
+    }.each do |agent_type, expected_provider|
+      it "maps #{agent_type} to :#{expected_provider}" do
+        run = create(:agent_run, project: project, agent_type: agent_type)
+
+        expect(AgentHarness).to receive(:send_message).with(
+          prompt,
+          hash_including(provider: expected_provider)
+        ).and_return(response)
+
+        described_class.call(agent_run: run, prompt: prompt)
+      end
+    end
+  end
+end

--- a/spec/services/prompts/build_for_issue_spec.rb
+++ b/spec/services/prompts/build_for_issue_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Prompts::BuildForIssue do
+  let(:project) { create(:project) }
+  let(:issue) do
+    create(:issue,
+      project: project,
+      title: "Fix login redirect",
+      github_number: 42,
+      body: "Users are redirected to the wrong page after login.")
+  end
+
+  describe ".call" do
+    it "builds a prompt containing the issue title and number" do
+      prompt = described_class.call(issue: issue, project: project)
+
+      expect(prompt).to include("Fix login redirect")
+      expect(prompt).to include("#42")
+    end
+
+    it "includes the issue body" do
+      prompt = described_class.call(issue: issue, project: project)
+
+      expect(prompt).to include("Users are redirected to the wrong page after login.")
+    end
+
+    it "includes instructions for the agent" do
+      prompt = described_class.call(issue: issue, project: project)
+
+      expect(prompt).to include("Analyze the issue")
+      expect(prompt).to include("Make the necessary code changes")
+      expect(prompt).to include("commit all your changes")
+      expect(prompt).to include("Do not push")
+    end
+
+    it "includes test command for ruby projects" do
+      prompt = described_class.call(issue: issue, project: project)
+
+      expect(prompt).to include("bundle exec rspec")
+    end
+
+    it "includes lint command for ruby projects" do
+      prompt = described_class.call(issue: issue, project: project)
+
+      expect(prompt).to include("bundle exec rubocop")
+    end
+
+    context "when project responds to detected_language" do
+      let(:project_with_language) do
+        proj = create(:project)
+        proj.define_singleton_method(:detected_language) { "python" }
+        proj
+      end
+      let(:issue) do
+        create(:issue,
+          project: project_with_language,
+          title: "Fix login redirect",
+          github_number: 42,
+          body: "Users are redirected to the wrong page after login.")
+      end
+
+      it "uses the detected language for test commands" do
+        prompt = described_class.call(issue: issue, project: project_with_language)
+
+        expect(prompt).to include("pytest")
+      end
+
+      it "uses the detected language for lint commands" do
+        prompt = described_class.call(issue: issue, project: project_with_language)
+
+        expect(prompt).to include("ruff check .")
+      end
+    end
+
+    context "when project has unknown language" do
+      let(:project_with_language) do
+        proj = create(:project)
+        proj.define_singleton_method(:detected_language) { "haskell" }
+        proj
+      end
+      let(:issue) do
+        create(:issue,
+          project: project_with_language,
+          title: "Fix login redirect",
+          github_number: 42,
+          body: "Users are redirected to the wrong page after login.")
+      end
+
+      it "uses fallback commands" do
+        prompt = described_class.call(issue: issue, project: project_with_language)
+
+        expect(prompt).to include("No test command configured")
+        expect(prompt).to include("No lint command configured")
+      end
+    end
+
+    context "when issue body is nil" do
+      let(:issue) do
+        create(:issue,
+          project: project,
+          title: "Quick fix",
+          github_number: 99,
+          body: nil)
+      end
+
+      it "builds prompt without body content" do
+        prompt = described_class.call(issue: issue, project: project)
+
+        expect(prompt).to include("Quick fix")
+        expect(prompt).to include("#99")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #27

Integrates the [agent-harness](https://github.com/viamin/agent-harness) gem (v0.3.0) to provide a unified interface for running AI agent CLIs (Claude Code, Cursor, Aider, Gemini CLI, etc.).

- **Added `agent-harness` gem** to Gemfile
- **Created `AgentRuns::Execute` service** — wraps `AgentHarness.send_message`, maps responses to `AgentRun` model fields, handles errors/timeouts, and tracks token usage
- **Created `Prompts::BuildForIssue` service** — builds structured prompts from GitHub issues with language-aware test/lint commands
- **Added convenience methods to `AgentRun`** — `execute_agent` and `prompt_for_issue` delegate to the new services
- **Expanded `AGENT_TYPES`** — added `aider`, `gemini`, `opencode`, `kilocode` to align with all agent-harness providers
- **Created `AgentHarness` initializer** — configures default provider (`:claude`), fallback providers, orchestration settings, circuit breakers, and retries
- **Comprehensive specs** — 476 model/service specs pass (0 failures)

### Key design decisions

- **Provider mapping**: `AgentRuns::Execute::PROVIDER_MAP` maps internal agent_type strings (e.g. `"claude_code"`) to agent-harness provider symbols (e.g. `:claude`)
- **No `iterations` field on Response**: The gem executes a single CLI invocation per `send_message` call — iteration tracking would need to be built at the application layer
- **Token tracking**: Hooks into `AgentHarness::Response#tokens` to persist to `AgentRun` and increment `Project` metrics
- **`dangerous_mode: true`**: Enabled by default for agent execution (skips CLI permission prompts in non-interactive mode)
- **Follows existing patterns**: Plain Ruby classes matching `Containers::Provision`, `GithubClient`, etc. (Servo gem is documented but not yet installed)

### Opportunities noted (not implemented)

- Token usage callback via `AgentHarness.token_tracker.on_tokens_used` for real-time tracking
- Cost calculation per token by provider/model
- `detected_language` method on `Project` model for better prompt building
- Integration with Temporal `RunAgentActivity` for end-to-end workflow execution

## Test plan

- [x] RuboCop: 0 offenses on all new/modified files
- [x] Brakeman: 0 security warnings
- [x] RSpec: 476 model/service specs pass, 0 failures
- [x] Pre-existing request spec failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)