### PR TITLE
fix: address PR #80 review comments on workflow monitoring

### DIFF
--- a/app/views/workflow_statuses/show.html.erb
+++ b/app/views/workflow_statuses/show.html.erb
@@ -80,8 +80,14 @@
       (function() {
         setTimeout(function() {
           var frame = document.getElementById("workflow-status");
-          if (frame && frame.src) {
-            frame.reload();
+          if (frame) {
+            if (typeof frame.reload === "function") {
+              frame.reload();
+            } else if (frame.src) {
+              frame.src = frame.src;
+            } else {
+              window.location.reload();
+            }
           } else {
             window.location.reload();
           }

--- a/config/initializers/temporal.rb
+++ b/config/initializers/temporal.rb
@@ -48,7 +48,7 @@ module Paid
     end
 
     def temporal_ui_url
-      ENV.fetch("TEMPORAL_UI_URL", "http://localhost:8080")
+      ENV.fetch("TEMPORAL_UI_URL", "http://localhost:8080").sub(%r{/*$}, "")
     end
 
     def task_queue


### PR DESCRIPTION
## Summary

Addresses the 2 Copilot review comments from PR #80:

- **Trailing slash in `temporal_ui_url`** (`config/initializers/temporal.rb`): `temporal_ui_url` is concatenated with path segments in views. If `TEMPORAL_UI_URL` is configured with a trailing slash, this produces malformed double-slashed URLs. Now strips trailing slashes via `.sub(%r{/*$}, "")`.
- **Non-standard `frame.reload()` API** (`app/views/workflow_statuses/show.html.erb`): `reload()` is not a standard DOM API — it's a Turbo Frame method. Added `typeof frame.reload === "function"` guard with fallback to re-setting `frame.src` (which triggers a Turbo Frame reload), and a final fallback to `window.location.reload()`.

## References

- Addresses review comments on: #80
- Source issue: #21

## Test plan

- [x] All 11 workflow helper specs pass
- [x] RuboCop clean on changed Ruby files
- [ ] Verify Temporal UI links work with trailing-slash env vars
- [ ] Verify auto-refresh works when Turbo is loaded and when it isn't

**Note**: Request specs have a pre-existing `Propshaft::MissingAssetError` (`application.js` not found in load path) unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)