### PR TITLE
fix: address PR #81 review comments on agent-harness integration

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -120,10 +120,14 @@ class AgentRun < ApplicationRecord
   # Executes the agent for this run using agent-harness.
   #
   # @param prompt [String] The prompt to send to the agent
-  # @param timeout [Integer] Timeout in seconds (default 600)
+  # @param timeout [Integer, nil] Optional timeout in seconds; when nil, the
+  #   underlying AgentHarness configuration determines the default
   # @return [AgentRuns::Execute::Result] Result with success/failure and response
-  def execute_agent(prompt, timeout: AgentRuns::Execute::DEFAULT_TIMEOUT)
-    AgentRuns::Execute.call(agent_run: self, prompt: prompt, timeout: timeout)
+  def execute_agent(prompt, timeout: nil)
+    args = { agent_run: self, prompt: prompt }
+    args[:timeout] = timeout if timeout
+
+    AgentRuns::Execute.call(**args)
   end
 
   # Builds a prompt for this run's issue using the PromptBuilder.

--- a/app/services/prompts/build_for_issue.rb
+++ b/app/services/prompts/build_for_issue.rb
@@ -82,7 +82,7 @@ module Prompts
     def detect_language
       return project.detected_language if project.respond_to?(:detected_language) && project.detected_language.present?
 
-      # Infer from project name or repo conventions
+      # Default to Ruby when detected_language is unavailable
       "ruby"
     end
   end

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -2,15 +2,24 @@
 
 require "agent_harness"
 
+AGENT_TIMEOUT = begin
+  Integer(ENV.fetch("AGENT_TIMEOUT", 600))
+rescue ArgumentError
+  Rails.logger.warn(message: "agent_harness.invalid_timeout",
+    value: ENV["AGENT_TIMEOUT"],
+    fallback: 600)
+  600
+end
+
 AgentHarness.configure do |config|
   config.default_provider = :claude
   config.fallback_providers = %i[cursor aider]
-  config.default_timeout = ENV.fetch("AGENT_TIMEOUT", 600).to_i
+  config.default_timeout = [ AGENT_TIMEOUT, 1 ].max
 
   config.provider(:claude) do |p|
     p.enabled = true
     p.priority = 10
-    p.timeout = ENV.fetch("AGENT_TIMEOUT", 600).to_i
+    p.timeout = [ AGENT_TIMEOUT, 1 ].max
   end
 
   config.provider(:cursor) do |p|

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -383,19 +383,18 @@ RSpec.describe AgentRun do
         allow(AgentHarness).to receive(:send_message).and_return(response)
       end
 
-      it "delegates to AgentRuns::Execute" do
+      it "delegates to AgentRuns::Execute without timeout by default" do
         agent_run = create(:agent_run)
 
         expect(AgentRuns::Execute).to receive(:call).with(
           agent_run: agent_run,
-          prompt: "Fix the bug",
-          timeout: 600
+          prompt: "Fix the bug"
         ).and_call_original
 
         agent_run.execute_agent("Fix the bug")
       end
 
-      it "passes custom timeout" do
+      it "passes custom timeout when provided" do
         agent_run = create(:agent_run)
 
         expect(AgentRuns::Execute).to receive(:call).with(


### PR DESCRIPTION
## Summary

Addresses all 5 Copilot review comments from PR #81 (agent-harness integration):

- **Unified timeout configuration** — Removed `DEFAULT_TIMEOUT` constant from `AgentRuns::Execute`. Timeout now defaults to `nil`, letting `AgentHarness.config.default_timeout` apply. Only passes explicit `timeout:` when the caller overrides it. Updated `AgentRun#execute_agent` similarly.
- **Delegated token tracking to `TokenUsageTracker`** — Replaced inline token tracking (which hard-coded `cost_cents: 0`) with `TokenUsageTracker.track`, which calculates real cost and handles logging/metrics consistently.
- **Fixed misleading comment** — Changed `# Infer from project name or repo conventions` to `# Default to Ruby when detected_language is unavailable` to match actual behavior.
- **Validated `AGENT_TIMEOUT` env var** — Replaced `.to_i` (which silently coerces `"abc"` to `0`) with `Integer()` + `rescue ArgumentError`, logging a warning on invalid values and clamping to minimum 1.

Ref: #81

## Test plan

- [x] All 126 affected specs pass (0 failures)
- [x] RuboCop: 0 offenses on changed files
- [x] Changes are minimal and focused on review feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)