### PR TITLE
feat: add pre-commit hook for CI linter checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-commit checks..."
+
+echo "== Style: RuboCop =="
+bin/rubocop
+
+echo "== Security: Brakeman =="
+bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error
+
+echo "== Security: Gem audit =="
+bin/bundler-audit
+
+echo "== Security: Yarn audit =="
+yarn audit
+
+echo "All pre-commit checks passed."

--- a/bin/setup
+++ b/bin/setup
@@ -12,7 +12,10 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts "== Installing dependencies =="
+  puts "== Setting up git hooks =="
+  system! "git config core.hooksPath .githooks"
+
+  puts "\n== Installing dependencies =="
   system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies


### PR DESCRIPTION
## Summary

- Adds a `.githooks/pre-commit` hook that runs the same checks as the `lint` and `scan_ruby` CI jobs: RuboCop, Brakeman, bundler-audit, and yarn audit
- Updates `bin/setup` to configure `core.hooksPath` to `.githooks/` so hooks are activated automatically for all developers
- Hook script uses `set -euo pipefail` to fail fast on the first check failure

## Details

The pre-commit hook mirrors the CI checks from `.github/workflows/ci.yml`:

| CI Job | Pre-commit Check |
|--------|-----------------|
| `bin/rubocop -f github` | `bin/rubocop` |
| `bin/brakeman --no-pager` | `bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error` |
| `bin/bundler-audit` | `bin/bundler-audit` |
| (from config/ci.rb) | `yarn audit` |

**Note:** The existing codebase has 134 RuboCop offenses, so the pre-commit hook will currently block commits until those are resolved. This could be addressed separately by generating a `.rubocop_todo.yml` or by auto-fixing (`bin/rubocop -a`).

## Test plan

- [ ] Verify `.githooks/pre-commit` is executable and runs all four checks
- [ ] Verify `bin/setup` configures `core.hooksPath` to `.githooks`
- [ ] Verify a commit is blocked when RuboCop finds violations
- [ ] Verify `--no-verify` can bypass the hook when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)