### PR TITLE
fix: address PR #82 review comments on trailing-slash regex

### DIFF
--- a/config/initializers/temporal.rb
+++ b/config/initializers/temporal.rb
@@ -48,7 +48,7 @@ module Paid
     end
 
     def temporal_ui_url
-      ENV.fetch("TEMPORAL_UI_URL", "http://localhost:8080").sub(%r{/*$}, "")
+      ENV.fetch("TEMPORAL_UI_URL", "http://localhost:8080").sub(%r{/+\z}, "")
     end
 
     def task_queue


### PR DESCRIPTION
## Summary

- **Use `\z` anchor and `+` quantifier in `temporal_ui_url` regex** (`config/initializers/temporal.rb`): Changed `%r{/*$}` to `%r{/+\z}` so the regex requires at least one trailing slash to match. The `*` quantifier matched zero slashes, causing `sub` to always allocate a new string even when no normalization was needed. With `+`, the original string is returned unchanged when there are no trailing slashes.

## References

- Addresses review comment on: #82
- Source issue: #21

## Test plan

- [x] RuboCop clean on changed file
- [x] All 11 workflow helper specs pass
- [x] Regex behavior verified: `/+\z` requires at least one `/` to match, `\z` anchors to true end-of-string (not before newline like `$`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)