### PR TITLE
fix: address PR #83 review comments on destroy callback and pagination

### DIFF
--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -183,10 +183,15 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       it "stops after MAX_PAGES and logs a warning" do
+        allow(Rails.logger).to receive(:warn)
+
         result = activity.execute(project_id: project.id)
 
         expect(result[:issues].size).to eq(described_class::MAX_PAGES * 100)
         expect(github_client).to have_received(:issues).exactly(described_class::MAX_PAGES).times
+        expect(Rails.logger).to have_received(:warn).with(
+          hash_including(message: "github_sync.fetch_issues_page_limit")
+        )
       end
     end
 


### PR DESCRIPTION
## Summary

Addresses the 3 Copilot review comments from PR #83:

- **Pagination test missing log assertion**: The test "stops after MAX_PAGES and logs a warning" wasn't asserting the warning was actually logged. Added `Rails.logger.warn` expectation with `hash_including(message: "github_sync.fetch_issues_page_limit")`.

- **Stub external boundary, not application code**: Replaced `ProjectWorkflowManager` stubs with `Paid.temporal_client` / workflow handle stubs in the polling lifecycle hook specs. This follows the CLAUDE.md testing guidance to mock external dependencies only, not application code.

- **Rollback test for after_destroy_commit**: Added a spec that destroys inside a rolled-back transaction and asserts `cancel` is NOT called on the workflow handle, exercising the commit-safety behavior of `after_destroy_commit`.

## Test plan

- [x] All 54 examples pass (0 failures)
- [x] RuboCop clean (0 offenses)

Addresses review comments from #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)