### PR TITLE
fix: address PR #84 review comments on agent-harness integration

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -127,7 +127,7 @@ class AgentRun < ApplicationRecord
   # @return [AgentRuns::Execute::Result] Result with success/failure and response
   def execute_agent(prompt, timeout: nil)
     args = { agent_run: self, prompt: prompt }
-    args[:timeout] = timeout if timeout
+    args[:timeout] = timeout unless timeout.nil?
 
     AgentRuns::Execute.call(**args)
   end

--- a/app/services/agent_runs/execute.rb
+++ b/app/services/agent_runs/execute.rb
@@ -64,7 +64,7 @@ module AgentRuns
       provider_name = PROVIDER_MAP[agent_run.agent_type]
 
       options = { provider: provider_name, dangerous_mode: true }
-      options[:timeout] = timeout if timeout
+      options[:timeout] = timeout unless timeout.nil?
 
       AgentHarness.send_message(prompt, **options)
     end
@@ -108,8 +108,9 @@ module AgentRuns
     end
 
     def handle_timeout(error)
+      effective_timeout = timeout || AgentHarness.configuration.default_timeout
       agent_run.timeout!
-      agent_run.update!(error_message: "Agent execution timed out after #{timeout} seconds")
+      agent_run.update!(error_message: "Agent execution timed out after #{effective_timeout} seconds")
       agent_run.log!("system", "Execution timed out")
 
       Result.new(success: false, error: error)

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -2,7 +2,7 @@
 
 require "agent_harness"
 
-AGENT_TIMEOUT = begin
+agent_timeout = begin
   Integer(ENV.fetch("AGENT_TIMEOUT", 600))
 rescue ArgumentError
   Rails.logger.warn(message: "agent_harness.invalid_timeout",
@@ -11,15 +11,17 @@ rescue ArgumentError
   600
 end
 
+Rails.application.config.x.agent_timeout = [ agent_timeout, 1 ].max
+
 AgentHarness.configure do |config|
   config.default_provider = :claude
   config.fallback_providers = %i[cursor aider]
-  config.default_timeout = [ AGENT_TIMEOUT, 1 ].max
+  config.default_timeout = Rails.application.config.x.agent_timeout
 
   config.provider(:claude) do |p|
     p.enabled = true
     p.priority = 10
-    p.timeout = [ AGENT_TIMEOUT, 1 ].max
+    p.timeout = Rails.application.config.x.agent_timeout
   end
 
   config.provider(:cursor) do |p|


### PR DESCRIPTION
## Summary

Addresses all 3 Copilot review comments from PR #84 (agent-harness integration):

- **Explicit nil checks for timeout** — Changed `if timeout` to `unless timeout.nil?` in both `AgentRuns::Execute#execute_agent` and `AgentRun#execute_agent` so that `0` is treated as a valid timeout value rather than being silently dropped by a truthiness check.
- **Fixed empty timeout in error message** — `handle_timeout` now computes an effective timeout by falling back to `AgentHarness.configuration.default_timeout` when no explicit timeout was provided, preventing empty string interpolation (e.g., "timed out after  seconds").
- **Namespaced timeout configuration** — Replaced the top-level `AGENT_TIMEOUT` constant with a local variable, storing the validated value in `Rails.application.config.x.agent_timeout` to avoid global namespace pollution and potential constant redefinition warnings.

Ref: #84

## Test plan

- [x] All 106 affected specs pass (0 failures)
- [x] RuboCop: 0 offenses on changed files
- [x] Changes are minimal and focused on review feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)