### PR TITLE
fix: address PR #85 review comments on NetworkPolicy

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -302,7 +302,7 @@ module Containers
         "Binds" => [ "#{worktree_path}:#{options[:workspace_mount]}:rw" ],
         # Agent containers always use the restricted network.
         # ensure_network! guarantees the network exists before we reach here.
-        "NetworkMode" => NetworkPolicy::NETWORK_NAME
+        "NetworkMode" => options[:network]
       }
 
       config

--- a/app/services/network_policy.rb
+++ b/app/services/network_policy.rb
@@ -68,7 +68,7 @@ class NetworkPolicy
     #
     # @param container [Docker::Container] running container to apply rules to
     # @param github_ips [Array<String>] GitHub CIDR ranges to allow
-    # @param proxy_host [String] hostname or IP of the secrets proxy
+    # @param proxy_host [String] hostname or IPv4 address of the secrets proxy
     # @return [void]
     # @raise [Error] if applying rules fails
     def apply_firewall_rules(container, github_ips: nil, proxy_host: nil)
@@ -135,7 +135,7 @@ class NetworkPolicy
       raise Error, "Failed to create agent network: #{e.message}"
     end
 
-    # Validates a CIDR notation string. Returns the normalized string.
+    # Validates a CIDR notation string. Returns the validated string.
     def validate_cidr!(cidr)
       IPAddr.new(cidr)
       cidr
@@ -143,7 +143,7 @@ class NetworkPolicy
       raise Error, "Invalid CIDR: #{cidr.inspect}"
     end
 
-    # Validates a hostname or IP address. Rejects shell metacharacters.
+    # Validates a hostname or IPv4 address. Rejects shell metacharacters.
     def validate_host!(host)
       unless host.match?(/\A[a-zA-Z0-9.\-]+\z/)
         raise Error, "Invalid proxy host: #{host.inspect}"


### PR DESCRIPTION
## Summary

Addresses all 3 Copilot review comments (plus 1 suppressed) from PR #85:

- **Unused `options[:network]`** (comment #1): Restored `host_config` to use `options[:network]` instead of hardcoding `NetworkPolicy::NETWORK_NAME`. Since `DEFAULTS[:network]` is already set to `NetworkPolicy::NETWORK_NAME`, the behavior is unchanged but the `:network` option is now consistently usable as documented.
- **`validate_cidr!` comment accuracy** (comment #2): Updated docstring from "Returns the normalized string" to "Returns the validated string" since the method returns the original input unchanged.
- **`validate_host!` IPv6 scope** (comment #3): Tightened docstring from "hostname or IP address" to "hostname or IPv4 address" to accurately reflect the regex which excludes IPv6 literals. Also updated the `@param` tag in `apply_firewall_rules`.
- **Missing validation specs** (suppressed comment): Added specs for invalid `github_ips` (malformed CIDR, shell injection) and invalid `proxy_host` (shell metacharacters, backtick injection) to lock in injection-prevention behavior.

Fixes review comments on PR #85.

## Test plan

- [x] All 75 network/provision specs pass (4 new specs added)
- [x] RuboCop: 0 offenses
- [x] Brakeman: 0 security warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)