### PR TITLE
fix: address PR #86 review comments on secrets proxy

### DIFF
--- a/app/controllers/api/secrets_proxy_controller.rb
+++ b/app/controllers/api/secrets_proxy_controller.rb
@@ -54,8 +54,9 @@ module Api
 
     def verify_proxy_token
       provided_token = request.headers["X-Proxy-Token"]
+      stored_token = @agent_run.ensure_proxy_token!
 
-      unless provided_token.present? && ActiveSupport::SecurityUtils.secure_compare(provided_token, @agent_run.proxy_token.to_s)
+      unless provided_token.present? && ActiveSupport::SecurityUtils.secure_compare(provided_token, stored_token)
         render json: { error: "Invalid proxy token" }, status: :forbidden
       end
     end

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -205,6 +205,16 @@ class AgentRun < ApplicationRecord
     end
   end
 
+  # Lazily generates and persists a proxy token for runs that were created
+  # before the proxy_token column existed. Returns the token.
+  def ensure_proxy_token!
+    return proxy_token if proxy_token.present?
+
+    token = SecureRandom.hex(32)
+    update_column(:proxy_token, token)
+    self.proxy_token = token
+  end
+
   private
 
   def issue_belongs_to_same_project

--- a/db/migrate/20260208100000_add_proxy_token_to_agent_runs.rb
+++ b/db/migrate/20260208100000_add_proxy_token_to_agent_runs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddProxyTokenToAgentRuns < ActiveRecord::Migration[8.0]
+class AddProxyTokenToAgentRuns < ActiveRecord::Migration[8.1]
   def change
     add_column :agent_runs, :proxy_token, :string, limit: 64
     add_index :agent_runs, :proxy_token, unique: true

--- a/db/migrate/20260208120000_backfill_proxy_tokens_on_agent_runs.rb
+++ b/db/migrate/20260208120000_backfill_proxy_tokens_on_agent_runs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class BackfillProxyTokensOnAgentRuns < ActiveRecord::Migration[8.1]
+  def up
+    AgentRun.where(proxy_token: nil).find_each do |run|
+      run.update_column(:proxy_token, SecureRandom.hex(32))
+    end
+  end
+
+  def down
+    # No-op: removing tokens would break running agents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_08_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_08_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## Summary

Addresses the 2 Copilot review comments from PR #86 (secrets proxy):

- **Fix migration version** - Changed `ActiveRecord::Migration[8.0]` to `[8.1]` to match the rest of the codebase and `db/schema.rb`
- **Handle NULL proxy tokens** - Added a backfill migration that generates tokens for existing `agent_runs` with `NULL` `proxy_token`, plus an `ensure_proxy_token!` method on `AgentRun` as a runtime safety net that lazily generates and persists a token if one is missing

### Files changed

| File | Change |
|------|--------|
| `db/migrate/20260208100000_add_proxy_token_to_agent_runs.rb` | Fix migration version: `[8.0]` → `[8.1]` |
| `db/migrate/20260208120000_backfill_proxy_tokens_on_agent_runs.rb` | New migration: backfills `proxy_token` for existing rows |
| `app/models/agent_run.rb` | Add public `ensure_proxy_token!` method for lazy token generation |
| `app/controllers/api/secrets_proxy_controller.rb` | Use `ensure_proxy_token!` in `verify_proxy_token` instead of `.to_s` |
| `db/schema.rb` | Updated schema version |

## Test plan

- [x] All 103 secrets_proxy + agent_run specs pass (0 failures)
- [x] RuboCop: 0 offenses on changed files
- [x] No regressions in full suite (72 pre-existing failures unrelated to these changes)

Addresses review comments from #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)