### PR TITLE
fix: address PR #92 review comment on NetworkMode

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -302,7 +302,7 @@ module Containers
         "Binds" => [ "#{worktree_path}:#{options[:workspace_mount]}:rw" ],
         # Agent containers always use the restricted network.
         # ensure_network! guarantees the network exists before we reach here.
-        "NetworkMode" => options[:network]
+        "NetworkMode" => NetworkPolicy::NETWORK_NAME
       }
 
       config

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -246,6 +246,21 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
+      it "ignores custom :network option and uses the restricted network" do
+        custom_service = described_class.new(
+          agent_run: agent_run,
+          worktree_path: worktree_path,
+          network: "custom_network"
+        )
+
+        expect(Docker::Container).to receive(:create) do |config|
+          expect(config["HostConfig"]["NetworkMode"]).to eq(NetworkPolicy::NETWORK_NAME)
+          mock_container
+        end
+
+        custom_service.provision
+      end
+
       it "applies firewall rules after container start" do
         expect(mock_container).to receive(:start).ordered
         expect(NetworkPolicy).to receive(:apply_firewall_rules).with(mock_container).ordered


### PR DESCRIPTION
## Summary

- Pins `NetworkMode` in `Containers::Provision#host_config` to `NetworkPolicy::NETWORK_NAME` instead of `options[:network]`
- Addresses [PR #92 review comment](https://github.com/viamin/paid/pull/92) where `ensure_network!` only guarantees `NetworkPolicy::NETWORK_NAME` exists, but `options[:network]` could be overridden to a different (non-existent) network, causing provisioning failures or bypassing isolation
- Adds spec verifying that custom `:network` option is ignored in favor of the restricted network

## Test plan

- [x] All 52 existing provision specs pass
- [x] New spec confirms custom `:network` option does not change `NetworkMode`
- [x] RuboCop passes with no offenses

Ref: PR #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)