### PR TITLE
fix: address PR #95 review comments on :network option

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -60,7 +60,6 @@ module Containers
       tmpfs_tmp_size: 1024 * 1024 * 1024,        # 1GB for /tmp
       tmpfs_cache_size: 512 * 1024 * 1024,       # 512MB for /home/agent/.cache
       image: "paid-agent:latest",
-      network: NetworkPolicy::NETWORK_NAME,
       user: "agent",
       workspace_mount: "/workspace"
     }.freeze
@@ -75,8 +74,14 @@ module Containers
     # @option options [Integer] :pids_limit Maximum number of processes
     # @option options [Integer] :timeout_seconds Default command timeout
     # @option options [String] :image Docker image to use
-    # @option options [String] :network Docker network to attach to
     def initialize(agent_run:, worktree_path:, **options)
+      if options.key?(:network)
+        Rails.logger.warn(
+          message: "container_manager.network_option_ignored",
+          hint: "The :network option is ignored; containers always use #{NetworkPolicy::NETWORK_NAME}"
+        )
+        options.delete(:network)
+      end
       @agent_run = agent_run
       @worktree_path = worktree_path
       @options = DEFAULTS.merge(options)


### PR DESCRIPTION
## Summary

- Removes `:network` from `Containers::Provision::DEFAULTS` since `NetworkMode` is hardcoded to `NetworkPolicy::NETWORK_NAME`
- Removes the `@option :network` YARD doc from the initializer
- Adds a deprecation warning log when callers pass `:network`, then strips the option to prevent a misleading no-op configuration
- Updates specs to verify `:network` is absent from DEFAULTS and that the warning fires

Addresses [PR #95 review comment](https://github.com/viamin/paid/pull/95#discussion_r2778882937) from Copilot about the `:network` option being a silent no-op after `NetworkMode` was pinned.

## Test plan

- [x] All 52 existing provision specs pass
- [x] Updated spec verifies warning log + option removal when `:network` is provided
- [x] RuboCop passes with no offenses

Ref: PR #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)