### PR TITLE
fix: address PR #93 review comments on secrets proxy race conditions and tests

### DIFF
--- a/app/controllers/api/secrets_proxy_controller.rb
+++ b/app/controllers/api/secrets_proxy_controller.rb
@@ -54,9 +54,15 @@ module Api
 
     def verify_proxy_token
       provided_token = request.headers["X-Proxy-Token"]
+
+      unless provided_token.present?
+        render json: { error: "Invalid proxy token" }, status: :forbidden
+        return
+      end
+
       stored_token = @agent_run.ensure_proxy_token!
 
-      unless provided_token.present? && ActiveSupport::SecurityUtils.secure_compare(provided_token, stored_token)
+      unless ActiveSupport::SecurityUtils.secure_compare(provided_token, stored_token)
         render json: { error: "Invalid proxy token" }, status: :forbidden
       end
     end

--- a/db/migrate/20260208120000_backfill_proxy_tokens_on_agent_runs.rb
+++ b/db/migrate/20260208120000_backfill_proxy_tokens_on_agent_runs.rb
@@ -2,8 +2,14 @@
 
 class BackfillProxyTokensOnAgentRuns < ActiveRecord::Migration[8.1]
   def up
-    AgentRun.where(proxy_token: nil).find_each do |run|
-      run.update_column(:proxy_token, SecureRandom.hex(32))
+    agent_run_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "agent_runs"
+    end
+
+    agent_run_class.reset_column_information
+
+    agent_run_class.where(proxy_token: nil).find_each do |run|
+      agent_run_class.where(id: run.id, proxy_token: nil).update_all(proxy_token: SecureRandom.hex(32))
     end
   end
 


### PR DESCRIPTION
## Summary

Addresses all 5 Copilot review comments from PR #93 (secrets proxy):

- **Race-safe `ensure_proxy_token!`** — Replaced `update_column` with atomic `WHERE proxy_token IS NULL` conditional update. If another process wins the race, we reload to get the persisted value instead of overwriting it.
- **Early return in `verify_proxy_token`** — Returns forbidden immediately when `X-Proxy-Token` header is blank, before calling `ensure_proxy_token!`, to avoid generating tokens for clearly unauthorized requests.
- **Migration-local AR class** — Replaced direct `AgentRun` model reference in backfill migration with an anonymous `Class.new(ActiveRecord::Base)` to decouple from future model changes (callbacks, validations, renames).
- **Race-safe backfill** — Changed backfill migration to use conditional `WHERE id = ? AND proxy_token IS NULL` update to avoid overwriting tokens set concurrently.
- **Spec coverage** — Added 4 model specs for `ensure_proxy_token!` (existing token, nil token generation, idempotency, race condition) and 2 request specs (blank header doesn't trigger token generation, nil proxy_token lazy generation).

### Files changed

| File | Change |
|------|--------|
| `app/models/agent_run.rb` | Race-safe atomic `ensure_proxy_token!` |
| `app/controllers/api/secrets_proxy_controller.rb` | Early return when `X-Proxy-Token` header blank |
| `db/migrate/20260208120000_backfill_proxy_tokens_on_agent_runs.rb` | Migration-local AR class + conditional update |
| `spec/models/agent_run_spec.rb` | 4 new specs for `ensure_proxy_token!` |
| `spec/requests/api/secrets_proxy_spec.rb` | 2 new request specs for token edge cases |

## Test plan

- [x] All 108 specs pass (0 failures)
- [x] RuboCop: 0 offenses on changed files
- [x] Race condition spec validates atomic update behavior

Addresses review comments from #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)