### PR TITLE
fix: address PR #94 review comments on timeout fallback and tests

### DIFF
--- a/app/services/agent_runs/execute.rb
+++ b/app/services/agent_runs/execute.rb
@@ -108,7 +108,7 @@ module AgentRuns
     end
 
     def handle_timeout(error)
-      effective_timeout = timeout.nil? ? AgentHarness.configuration.default_timeout : timeout
+      effective_timeout = timeout || AgentHarness.configuration.default_timeout
       agent_run.timeout!
       agent_run.update!(error_message: "Agent execution timed out after #{effective_timeout} seconds")
       agent_run.log!("system", "Execution timed out")

--- a/spec/services/agent_runs/execute_spec.rb
+++ b/spec/services/agent_runs/execute_spec.rb
@@ -157,14 +157,14 @@ RSpec.describe AgentRuns::Execute do
       before do
         allow(AgentHarness).to receive(:send_message)
           .and_raise(AgentHarness::TimeoutError.new("Timed out"))
-        allow(AgentHarness.configuration).to receive(:default_timeout).and_return(600)
+        allow(AgentHarness.configuration).to receive(:default_timeout).and_return(601)
       end
 
       it "uses the configured default timeout in the error message" do
         described_class.call(agent_run: agent_run, prompt: prompt)
 
         agent_run.reload
-        expect(agent_run.error_message).to eq("Agent execution timed out after 600 seconds")
+        expect(agent_run.error_message).to eq("Agent execution timed out after 601 seconds")
       end
     end
 
@@ -174,6 +174,7 @@ RSpec.describe AgentRuns::Execute do
           .and_raise(AgentHarness::TimeoutError.new("Timed out"))
       end
 
+      # 0 is truthy in Ruby so `timeout || default` correctly preserves it
       it "uses 0 in the error message, not the default" do
         described_class.call(agent_run: agent_run, prompt: prompt, timeout: 0)
 


### PR DESCRIPTION
## Summary

Addresses 3 Copilot review comments from PR #94:

- **Revert `timeout.nil?` to `||`** — `0` is truthy in Ruby, so `timeout || default` already preserves `timeout: 0`. The `nil?` ternary only differed for `timeout: false`, which is not a valid input. Reverted to simpler `||` form.
- **Use distinct stub value (601)** — The nil-timeout test previously stubbed `default_timeout` to `600`, which coincidentally matched the real default. Changed to `601` so the test proves the fallback actually reads from the stubbed configuration.
- **Clarify `timeout: 0` test** — Added comment explaining that `0` is truthy in Ruby, so `||` correctly preserves it (the test documents expected behavior, not a regression guard).

Ref: #94

## Test plan

- [x] All 28 execute specs pass (0 failures)
- [x] RuboCop: 0 offenses on changed files
- [x] Changes are minimal and focused on review feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)