### PR TITLE
fix: address PR #97 review comments on :network option logging

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -77,7 +77,8 @@ module Containers
     def initialize(agent_run:, worktree_path:, **options)
       if options.key?(:network)
         Rails.logger.warn(
-          message: "container_manager.network_option_ignored",
+          message: "container_manager.container.network_option_ignored",
+          agent_run_id: agent_run.id,
           hint: "The :network option is ignored; containers always use #{NetworkPolicy::NETWORK_NAME}"
         )
         options.delete(:network)

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -248,7 +248,10 @@ RSpec.describe Containers::Provision do
 
       it "warns and ignores custom :network option" do
         expect(Rails.logger).to receive(:warn).with(
-          hash_including(message: "container_manager.network_option_ignored")
+          hash_including(
+            message: "container_manager.container.network_option_ignored",
+            agent_run_id: agent_run.id
+          )
         )
 
         custom_service = described_class.new(


### PR DESCRIPTION
## Summary

- Aligns the `:network` deprecation warning log message with the service's existing `container_manager.container.*` naming convention used by `log_system`
- Adds `agent_run_id` to the warning log for correlation with other container lifecycle logs
- Updates spec to assert both the corrected message namespace and the `agent_run_id` field

Addresses [PR #97 review comments](https://github.com/viamin/paid/pull/97#pullrequestreview-3769213166) from Copilot about log naming consistency and correlation fields.

## Test plan

- [x] All 52 existing provision specs pass
- [x] Updated spec verifies warning includes `container_manager.container.network_option_ignored` message and `agent_run_id`
- [x] RuboCop passes with no offenses

Ref: PR #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)