### PR TITLE
fix: address PR #98 review comment on misleading test description

### DIFF
--- a/spec/requests/api/secrets_proxy_spec.rb
+++ b/spec/requests/api/secrets_proxy_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe "Api::SecretsProxy" do
     context "with nil proxy_token on agent run" do
       let(:agent_run) { create(:agent_run, :running, project: project) }
 
-      it "lazily generates a token and authenticates successfully" do
+      it "lazily regenerates a proxy token and rejects the old token" do
         # Clear the token to simulate a pre-existing run
         token = agent_run.proxy_token
         agent_run.update_column(:proxy_token, nil)


### PR DESCRIPTION
## Summary

- **Renamed misleading spec description** — Changed `"lazily generates a token and authenticates successfully"` to `"lazily regenerates a proxy token and rejects the old token"` in `spec/requests/api/secrets_proxy_spec.rb`. The test actually asserts a `:forbidden` response (old token is rejected after lazy regeneration), not successful authentication.

### Files changed

| File | Change |
|------|--------|
| `spec/requests/api/secrets_proxy_spec.rb` | Renamed test description to match actual behavior |

## Test plan

- [x] All 24 secrets proxy specs pass (0 failures)
- [x] No code behavior changes, only spec description wording

Addresses review comment from #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)