### PR TITLE
feat: add -A autofix flag to bin/lint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ bin/rails server             # Start Rails server only
 bin/rails console            # Rails console
 
 # Code Quality
+bin/lint                     # Run all linters (RuboCop, markdownlint)
+bin/lint -A                  # Run all linters with auto-fix
 bin/rubocop                  # Run RuboCop (rubocop-rails-omakase style)
 bin/rubocop -a               # Auto-fix violations
 

--- a/bin/lint
+++ b/bin/lint
@@ -1,9 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+AUTOFIX=false
+for arg in "$@"; do
+  case "$arg" in
+    -A) AUTOFIX=true ;;
+    *)
+      echo "Usage: bin/lint [-A]"
+      echo "  -A  Auto-fix violations (rubocop -A, markdownlint --fix)"
+      exit 1
+      ;;
+  esac
+done
+
 RUBOCOP_ARGS=""
+MARKDOWNLINT_ARGS=""
+
 if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
   RUBOCOP_ARGS="-f github"
+fi
+
+if [ "$AUTOFIX" = true ]; then
+  RUBOCOP_ARGS="$RUBOCOP_ARGS -A"
+  MARKDOWNLINT_ARGS="--fix"
 fi
 
 echo "== Style: RuboCop =="
@@ -19,6 +38,6 @@ echo "== Security: Yarn audit =="
 yarn audit
 
 echo "== Markdown: markdownlint =="
-npx markdownlint-cli2 '**/*.md' '#node_modules' '#vendor'
+npx markdownlint-cli2 $MARKDOWNLINT_ARGS '**/*.md' '#node_modules' '#vendor'
 
 echo "All checks passed."


### PR DESCRIPTION
## Summary

- Adds `-A` flag to `bin/lint` that enables auto-fix mode for tools that support it
- RuboCop receives `-A` (unsafe + safe autocorrect)
- markdownlint-cli2 receives `--fix`
- Security scanners (brakeman, bundler-audit, yarn audit) are unaffected — they have no fix mode
- Documents `bin/lint` and `bin/lint -A` in CLAUDE.md

## Test plan

- [ ] `bin/lint` without flags runs all checks normally (no behavior change)
- [ ] `bin/lint -A` passes `-A` to rubocop and `--fix` to markdownlint-cli2
- [ ] `bin/lint --bad-flag` shows usage and exits with error
- [ ] CI (`GITHUB_ACTIONS=true`) still appends `-f github` to rubocop args

🤖 Generated with [Claude Code](https://claude.com/claude-code)