### PR TITLE
fix: address PR #99 review comments on CI workflow hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,20 @@ jobs:
           ruby-version: .tool-versions
           bundler-cache: true
 
+      - name: Read Node version from .tool-versions
+        id: node-version-lint
+        run: echo "version=$(grep '^nodejs' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
         with:
-          node-version: '22.12.0'
+          node-version: ${{ steps.node-version-lint.outputs.version }}
           cache: 'yarn'
 
       - name: Install JavaScript dependencies
-        run: yarn install --frozen-lockfile
+        run: |
+          corepack enable
+          yarn install --frozen-lockfile
 
       - name: Prepare RuboCop cache
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
@@ -73,14 +79,20 @@ jobs:
           ruby-version: .tool-versions
           bundler-cache: true
 
+      - name: Read Node version from .tool-versions
+        id: node-version-test
+        run: echo "version=$(grep '^nodejs' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
         with:
-          node-version: '22.12.0'
+          node-version: ${{ steps.node-version-test.outputs.version }}
           cache: 'yarn'
 
       - name: Install JavaScript dependencies
-        run: yarn install --frozen-lockfile
+        run: |
+          corepack enable
+          yarn install --frozen-lockfile
 
       - name: Build assets
         run: yarn build && yarn build:css


### PR DESCRIPTION
## Summary

Addresses the three review comments from PR #99 on the CI workflow:

- **Pin `actions/setup-node` to commit SHA** (`6044e13b`) for supply-chain hardening, consistent with how `actions/checkout` and `ruby/setup-ruby` are already pinned
- **Source Node version from `.tool-versions`** instead of hardcoding `22.12.0`, preventing drift between CI and local tooling
- **Enable Corepack** before `yarn install` to ensure the correct Yarn version (`1.22.22` per `package.json` `packageManager` field) is used in CI

Applied to both the `lint` and `test` jobs.

## References

- Review comments: PR #99

## Test plan

- [ ] CI lint job runs successfully with Node version sourced from `.tool-versions`
- [ ] CI test job runs successfully with Corepack-managed Yarn
- [ ] Verify `actions/setup-node` SHA resolves to v6

🤖 Generated with [Claude Code](https://claude.com/claude-code)