### PR TITLE
fix: address PR #99 review comments on CI Node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,17 @@ jobs:
           ruby-version: .tool-versions
           bundler-cache: true
 
-      - name: Read Node version from .tool-versions
-        id: node-version-lint
-        run: echo "version=$(grep '^nodejs' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
       - name: Set up Node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
-          node-version: ${{ steps.node-version-lint.outputs.version }}
+          node-version-file: .tool-versions
           cache: 'yarn'
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install JavaScript dependencies
-        run: |
-          corepack enable
-          yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - name: Prepare RuboCop cache
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
@@ -79,20 +76,17 @@ jobs:
           ruby-version: .tool-versions
           bundler-cache: true
 
-      - name: Read Node version from .tool-versions
-        id: node-version-test
-        run: echo "version=$(grep '^nodejs' .tool-versions | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-
       - name: Set up Node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
-          node-version: ${{ steps.node-version-test.outputs.version }}
+          node-version-file: .tool-versions
           cache: 'yarn'
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install JavaScript dependencies
-        run: |
-          corepack enable
-          yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - name: Build assets
         run: yarn build && yarn build:css


### PR DESCRIPTION
## Summary

Addresses the three Copilot review comments on PR #99, improving on the previous PR #106 approach:

- **Use `node-version-file` instead of shell extraction** ([comment](https://github.com/viamin/paid/pull/99#discussion_r2778894292)): Replaces the manual `grep`+`awk` step with `node-version-file: .tool-versions`, which `actions/setup-node` supports natively. Simpler and fewer moving parts.

- **Add `# v6` version comment to SHA pin** ([comment](https://github.com/viamin/paid/pull/99#discussion_r2778894288)): Adds human-readable version context next to the commit SHA for `actions/setup-node`.

- **Separate Corepack step** ([comment](https://github.com/viamin/paid/pull/99#discussion_r2778894297)): Moves `corepack enable` into its own named step instead of embedding it in the yarn install command, for better CI log readability.

Changes applied to both `lint` and `test` jobs.

References: PR #99, PR #106

## Test plan

- [ ] Verify CI workflow YAML is valid (validated locally with Ruby YAML parser)
- [ ] Verify `lint` job runs successfully with `node-version-file`
- [ ] Verify `test` job runs successfully with Corepack enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)