### PR TITLE
fix: address PR #102 review comment on scope note wording

### DIFF
--- a/docs/rdrs/RDR-010-multi-tenancy-rbac.md
+++ b/docs/rdrs/RDR-010-multi-tenancy-rbac.md
@@ -121,8 +121,8 @@ class ProjectPolicy < ApplicationPolicy
     user.has_any_role?(:owner, :admin, record.account)
   end
 
-  # Scope is inherited from ApplicationPolicy::Scope, which already
-  # scopes by account_id — no need to redefine it here.
+  # This example assumes the base policy already scopes records by
+  # account_id, so there is no need to redefine Scope here.
 end
 ```
 


### PR DESCRIPTION
## Summary

- **Reworded scope comment** in `docs/rdrs/RDR-010-multi-tenancy-rbac.md` (line 124-125): The previous comment referenced `ApplicationPolicy::Scope`, but the document's `ApplicationPolicy` example doesn't define a `Scope` class. This could confuse readers looking for the class definition. Reworded to describe the assumption generically without naming a specific undefined class, matching the exact suggestion from the Copilot review.

Addresses: Copilot review comment on #102

## Test plan

- [x] Verify the comment no longer references `ApplicationPolicy::Scope`
- [x] Verify markdownlint passes on the modified file
- [x] Verify the meaning is preserved (scope is inherited, no need to redefine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)