### PR TITLE
fix: address PR #111 review comments on AgentExecutionWorkflow

### DIFF
--- a/app/temporal/activities/update_issue_with_pr_activity.rb
+++ b/app/temporal/activities/update_issue_with_pr_activity.rb
@@ -12,6 +12,8 @@ module Activities
 
       issue.update!(paid_state: "completed")
 
+      post_pr_comment(agent_run, issue, pull_request_url)
+
       logger.info(
         message: "agent_execution.issue_updated",
         agent_run_id: agent_run_id,
@@ -20,6 +22,25 @@ module Activities
       )
 
       { agent_run_id: agent_run_id }
+    end
+
+    private
+
+    def post_pr_comment(agent_run, issue, pull_request_url)
+      return if pull_request_url.blank?
+
+      client = agent_run.project.github_token.client
+      client.add_comment(
+        agent_run.project.full_name,
+        issue.github_number,
+        "Pull request created: #{pull_request_url}"
+      )
+    rescue => e
+      logger.warn(
+        message: "agent_execution.issue_comment_failed",
+        agent_run_id: agent_run.id,
+        error: e.message
+      )
     end
   end
 end

--- a/db/migrate/20260208130000_add_container_id_to_agent_runs.rb
+++ b/db/migrate/20260208130000_add_container_id_to_agent_runs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddContainerIdToAgentRuns < ActiveRecord::Migration[8.0]
+  def change
+    add_column :agent_runs, :container_id, :string, limit: 128
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_08_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_08_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,6 +50,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_08_120000) do
     t.string "base_commit_sha", limit: 40
     t.string "branch_name", limit: 255
     t.datetime "completed_at"
+    t.string "container_id", limit: 128
     t.integer "cost_cents", default: 0
     t.datetime "created_at", null: false
     t.integer "duration_seconds"

--- a/spec/temporal/activities/update_issue_with_pr_activity_spec.rb
+++ b/spec/temporal/activities/update_issue_with_pr_activity_spec.rb
@@ -8,12 +8,37 @@ RSpec.describe Activities::UpdateIssueWithPrActivity do
   let(:issue) { create(:issue, :in_progress, project: project) }
   let(:agent_run) { create(:agent_run, :with_issue, project: project, issue: issue) }
   let(:pr_url) { "https://github.com/owner/repo/pull/42" }
+  let(:github_client) { instance_double(Octokit::Client) }
+  let(:github_token) { instance_double(GithubToken, client: github_client) }
+
+  before do
+    allow(project).to receive(:github_token).and_return(github_token)
+    allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+    allow(agent_run).to receive(:project).and_return(project)
+    allow(github_client).to receive(:add_comment)
+  end
 
   describe "#execute" do
     it "updates the issue paid_state to completed" do
       activity.execute(agent_run_id: agent_run.id, pull_request_url: pr_url)
 
       expect(issue.reload.paid_state).to eq("completed")
+    end
+
+    it "posts a comment on the GitHub issue with the PR link" do
+      expect(github_client).to receive(:add_comment).with(
+        project.full_name,
+        issue.github_number,
+        "Pull request created: #{pr_url}"
+      )
+
+      activity.execute(agent_run_id: agent_run.id, pull_request_url: pr_url)
+    end
+
+    it "does not post a comment when pull_request_url is blank" do
+      expect(github_client).not_to receive(:add_comment)
+
+      activity.execute(agent_run_id: agent_run.id, pull_request_url: "")
     end
 
     it "returns agent_run_id" do
@@ -24,13 +49,24 @@ RSpec.describe Activities::UpdateIssueWithPrActivity do
 
     it "handles agent runs without an issue" do
       agent_run_no_issue = create(:agent_run, project: project)
+      allow(AgentRun).to receive(:find).with(agent_run_no_issue.id).and_return(agent_run_no_issue)
 
       result = activity.execute(agent_run_id: agent_run_no_issue.id, pull_request_url: pr_url)
 
       expect(result[:agent_run_id]).to eq(agent_run_no_issue.id)
     end
 
+    it "does not fail when GitHub comment fails" do
+      allow(github_client).to receive(:add_comment).and_raise(Octokit::Error)
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id, pull_request_url: pr_url)
+      }.not_to raise_error
+    end
+
     it "raises ActiveRecord::RecordNotFound for invalid agent_run_id" do
+      allow(AgentRun).to receive(:find).and_call_original
+
       expect {
         activity.execute(agent_run_id: -1, pull_request_url: pr_url)
       }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
## Summary

Addresses all 7 Copilot review comments from PR #111 (`AgentExecutionWorkflow`):

- **Persist container_id** on `agent_runs` table so container state survives across Temporal activities. Previously `@container_service` was only in-memory and lost between activity invocations, causing cleanup to no-op and `execute_in_container` to always fail.
- **Add `Containers::Provision.reconnect`** class method to rehydrate a container service from a persisted Docker container ID.
- **Check `agent_result[:success]`** in workflow before branching on `has_changes`, preventing failed runs from being incorrectly marked as completed.
- **Wrap ensure cleanup in rescue blocks** so cleanup activity failures are logged but don't mask the primary workflow outcome.
- **Raise `ApplicationError` in `RunAgentActivity`** when agent execution fails, ensuring the workflow's rescue path runs.
- **Fix `check_for_changes`** to use `Open3.capture2e` git commands on the worktree path instead of `execute_in_container` (which required the unavailable in-memory container service).
- **Post GitHub issue comment** in `UpdateIssueWithPrActivity` with the PR link (was only logging the URL without persisting/using it).

## Files Changed

| File | Change |
|------|--------|
| `db/migrate/20260208130000_add_container_id_to_agent_runs.rb` | New migration adding `container_id` column |
| `app/models/agent_run.rb` | Persist container_id, add `ensure_container_service!` for rehydration |
| `app/services/containers/provision.rb` | Add `Containers::Provision.reconnect` class method |
| `app/temporal/workflows/agent_execution_workflow.rb` | Check success, rescue cleanup failures |
| `app/temporal/activities/run_agent_activity.rb` | Raise on failure, use Open3 for change detection |
| `app/temporal/activities/update_issue_with_pr_activity.rb` | Post GitHub comment with PR link |
| `spec/` | Updated specs for all changes (109 passing) |

## Test plan

- [x] All 109 affected specs pass
- [x] RuboCop passes with no offenses
- [ ] Verify container lifecycle works end-to-end in integration environment

Addresses review comments from #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)