### PR TITLE
fix: add agent_run_id to warning logs in activity rescue blocks

### DIFF
--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -26,7 +26,7 @@ module Activities
         pr_number: pr.number
       )
 
-      add_pr_labels(client, project, pr.number)
+      add_pr_labels(client, project, pr.number, agent_run_id)
 
       agent_run.log!("system", "PR created: #{pr.html_url}")
 
@@ -99,11 +99,12 @@ module Activities
       "$#{"%.2f" % (cents / 100.0)}"
     end
 
-    def add_pr_labels(client, project, pr_number)
+    def add_pr_labels(client, project, pr_number, agent_run_id)
       client.add_labels_to_issue(project.full_name, pr_number, [ PAID_GENERATED_LABEL ])
     rescue GithubClient::Error => e
       logger.warn(
         message: "agent_execution.add_pr_labels_failed",
+        agent_run_id: agent_run_id,
         pr_number: pr_number,
         error: e.message
       )


### PR DESCRIPTION
## Summary

- Adds `agent_run_id` to warning logs in `add_pr_labels`, `post_pr_comment`, and `remove_trigger_labels` rescue blocks
- Passes `agent_run_id` through method parameters so it's available in rescue scope
- Addresses all 3 Copilot review comments from PR #115

## Context

PR #115 was merged but had review feedback noting that warning logs in rescue blocks were missing `agent_run_id`, making it difficult to trace label/comment/label-removal failures back to the originating agent run. All other `agent_execution.*` logs include this field for consistency.

## Changes

- `CreatePullRequestActivity#add_pr_labels` — added `agent_run_id` parameter and log field
- `UpdateIssueWithPrActivity#post_pr_comment` — added `agent_run_id` parameter and log field
- `UpdateIssueWithPrActivity#remove_trigger_labels` — added `agent_run_id` parameter and log field

## Test plan

- [x] All 20 existing specs pass (no spec changes needed — tests exercise via `execute`)
- [x] RuboCop clean on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)