### PR TITLE
fix: address PR #117 review comments on AgentRunsController

### DIFF
--- a/app/policies/agent_run_policy.rb
+++ b/app/policies/agent_run_policy.rb
@@ -20,16 +20,10 @@ class AgentRunPolicy < ApplicationPolicy
   private
 
   def run_agent?
-    return false unless user_in_account?
-
-    has_any_account_role?(:owner, :admin, :member) || has_project_role?
-  end
-
-  def has_project_role?
     project = record.is_a?(AgentRun) ? record.project : record
-    return false unless user && project.is_a?(Project)
+    return false unless project.is_a?(Project)
 
-    user.has_any_role?(:project_admin, :project_member, project)
+    ProjectPolicy.new(user, project).run_agent?
   end
 
   def account_for_record

--- a/app/views/agent_runs/show.html.erb
+++ b/app/views/agent_runs/show.html.erb
@@ -116,11 +116,11 @@
     </div>
   <% end %>
 
-  <% if @agent_run.agent_run_logs.any? %>
+  <% if @logs.present? %>
     <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
       <h2 class="border-b border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-900">Execution Logs</h2>
       <div class="max-h-96 overflow-auto">
-        <% @agent_run.agent_run_logs.order(created_at: :asc).each do |log| %>
+        <% @logs.each do |log| %>
           <div class="border-b border-gray-100 px-4 py-2 font-mono text-xs last:border-b-0 <%= log.log_type == 'stderr' ? 'bg-red-50 text-red-800' : '' %> <%= log.log_type == 'system' ? 'bg-blue-50 text-blue-800' : '' %>">
             <span class="mr-2 text-gray-400"><%= log.created_at.strftime('%H:%M:%S') %></span>
             <span class="mr-2 rounded bg-gray-200 px-1 text-gray-600"><%= log.log_type %></span>

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -222,6 +222,15 @@ RSpec.describe "AgentRuns" do
           expect(response).to redirect_to(new_project_agent_run_path(project))
         end
 
+        it "rejects URLs from non-GitHub hosts" do
+          post project_agent_runs_path(project), params: {
+            issue_url: "https://notgithub.com/#{project.owner}/#{project.repo}/issues/42"
+          }
+          expect(response).to redirect_to(new_project_agent_run_path(project))
+          follow_redirect!
+          expect(response.body).to include("must be from")
+        end
+
         it "shows error when issue not synced" do
           post project_agent_runs_path(project), params: {
             issue_url: "https://github.com/#{project.owner}/#{project.repo}/issues/999"


### PR DESCRIPTION
## Summary

Addresses all 4 code review comments from Copilot on PR #117.

- **URL host validation**: Replace regex substring match with `URI.parse` + host validation to prevent accepting URLs like `notgithub.com` (also anchors path regex with `\A` and `\z`)
- **Policy delegation**: `AgentRunPolicy#run_agent?` now delegates to `ProjectPolicy#run_agent?` instead of duplicating the role-check logic, maintaining a single source of truth
- **Duplicate DB queries**: Preload ordered logs in the controller (`@logs`) with a 500-row limit, replacing the view's `any?` + `order()` double-query pattern
- **Deterministic workflow ID**: Remove `Time.now.to_i` from Temporal workflow ID so `WorkflowAlreadyStartedError` properly prevents duplicate concurrent runs; uses `id_conflict_policy: FAIL` to reject when already running

## Test Plan

- [x] Added spec for non-GitHub host URL rejection
- [x] Existing specs pass (pre-existing asset compilation issue unrelated to these changes)
- [x] RuboCop clean on all changed Ruby files

Addresses review comments on: #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)