### PR TITLE
docs: address PR #118 review comments on env loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,9 @@
 # Paid Development Environment Variables
 #
-# Copy this file to .env and fill in the values:
-#   cp .env.example .env
-#
-# NOTE: When using docker compose, DATABASE_URL, TEMPORAL_HOST, and RAILS_ENV
-# are configured directly in docker-compose.yml. This file serves as
-# documentation and for local (non-Docker) development.
+# NOTE: The default dev runner (bin/dev) disables automatic .env loading, and
+# when using docker compose, DATABASE_URL, TEMPORAL_HOST, and RAILS_ENV are
+# configured directly in docker-compose.yml. Treat this file primarily as
+# documentation and for workflows where you explicitly load .env.
 
 # =============================================================================
 # Required

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,11 @@ bundle install
 # Install JavaScript dependencies
 yarn install
 
-# Copy environment configuration
-cp .env.example .env
-# Edit .env to add your API keys (see README.md for details)
+# Review environment configuration
+# NOTE: bin/dev uses Foreman with --env /dev/null, which disables
+# automatic .env loading. Export variables in your shell instead,
+# or use direnv / dotenv to load them before running bin/dev.
+cp .env.example .env  # Use as a reference for required variables
 
 # Prepare the database
 bin/rails db:prepare
@@ -34,7 +36,7 @@ bin/rails db:prepare
 # Build frontend assets
 yarn build && yarn build:css
 
-# Start the development server
+# Export any needed env vars, then start the development server
 bin/dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
 # Clone and configure
 git clone <repo-url> && cd paid
 cp .env.example .env
-# Edit .env to add your ANTHROPIC_API_KEY
 
 # Start all services
 docker compose up
@@ -44,6 +43,8 @@ docker compose up
 # In another terminal, setup the database
 docker compose exec web bin/rails db:prepare
 ```
+
+> **Note**: Docker Compose sets `DATABASE_URL`, `TEMPORAL_HOST`, and `RAILS_ENV` directly in `docker-compose.yml`. Additional variables like `ANTHROPIC_API_KEY` (needed for agent execution) must be added to the `environment` section of the `web` and `worker` services, or loaded via `env_file: .env` in `docker-compose.yml`.
 
 ### Option 2: Dev Container
 
@@ -136,7 +137,7 @@ bin/rails server             # Start Rails server only
 bin/rails console            # Rails console
 
 # Testing
-bin/rspec                    # Run RSpec tests (904 examples, 92%+ coverage)
+bin/rspec                    # Run the full RSpec test suite
 
 # Code Quality
 bin/rubocop                  # Run RuboCop linter


### PR DESCRIPTION
## Summary

Addresses the 4 Copilot review comments from PR #118 about misleading `.env` documentation and hardcoded test metrics.

- **README.md**: Removed hardcoded test count (`904 examples, 92%+ coverage`) from `bin/rspec` comment to prevent drift — now says "Run the full RSpec test suite"
- **README.md**: Replaced misleading "Edit .env to add your ANTHROPIC_API_KEY" with a note explaining that Docker Compose doesn't auto-load `.env` and how to actually pass additional env vars
- **CONTRIBUTING.md**: Added note that `bin/dev` uses Foreman with `--env /dev/null`, disabling automatic `.env` loading, with guidance to export vars in shell or use direnv/dotenv
- **.env.example**: Updated header to clarify this file is primarily documentation, since neither `bin/dev` nor Docker Compose auto-load it

## Context

PR #118 was merged with 4 outstanding review comments. All comments related to the same theme: documentation implied `.env` would be automatically consumed, but:
- `bin/dev` explicitly disables it (`foreman start --env /dev/null`)
- `docker-compose.yml` has no `env_file` directive and doesn't interpolate `ANTHROPIC_API_KEY`

## Test plan

- [ ] Verify README quick start instructions are clear and accurate
- [ ] Verify CONTRIBUTING.md setup steps match actual behavior
- [ ] Verify .env.example header accurately describes its role

🤖 Generated with [Claude Code](https://claude.com/claude-code)