### PR TITLE
fix: address PR #119 Copilot review comments

### DIFF
--- a/app/controllers/agent_runs_controller.rb
+++ b/app/controllers/agent_runs_controller.rb
@@ -11,7 +11,7 @@ class AgentRunsController < ApplicationController
 
   def show
     authorize @agent_run
-    @logs = @agent_run.agent_run_logs.order(created_at: :asc).limit(500)
+    @logs = @agent_run.agent_run_logs.order(created_at: :asc).limit(500).load
   end
 
   def new
@@ -71,7 +71,7 @@ class AgentRunsController < ApplicationController
 
     unless uri&.host&.match?(/\A(www\.)?github\.com\z/)
       redirect_to new_project_agent_run_path(@project),
-        alert: "Issue URL must be from #{@project.full_name}."
+        alert: "Issue URL must be a github.com URL."
       return nil
     end
 

--- a/app/views/agent_runs/show.html.erb
+++ b/app/views/agent_runs/show.html.erb
@@ -116,7 +116,7 @@
     </div>
   <% end %>
 
-  <% if @logs.present? %>
+  <% if @logs.any? %>
     <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
       <h2 class="border-b border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-900">Execution Logs</h2>
       <div class="max-h-96 overflow-auto">

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -185,7 +185,11 @@ RSpec.describe "AgentRuns" do
         expect(temporal_client).to receive(:start_workflow).with(
           Workflows::AgentExecutionWorkflow,
           hash_including(project_id: project.id, issue_id: issue.id, agent_type: "claude_code"),
-          hash_including(task_queue: "paid-tasks")
+          hash_including(
+            id: "manual-#{project.id}-#{issue.id}",
+            id_conflict_policy: Temporalio::WorkflowIDConflictPolicy::FAIL,
+            task_queue: "paid-tasks"
+          )
         ).and_return(workflow_handle)
 
         post project_agent_runs_path(project), params: { issue_id: issue.id, agent_type: "claude_code" }
@@ -228,7 +232,7 @@ RSpec.describe "AgentRuns" do
           }
           expect(response).to redirect_to(new_project_agent_run_path(project))
           follow_redirect!
-          expect(response.body).to include("must be from")
+          expect(response.body).to include("must be a github.com URL")
         end
 
         it "shows error when issue not synced" do


### PR DESCRIPTION
## Summary

Addresses all 3 Copilot review comments from PR #119:

- **Eager-load `@logs` to avoid double query**: Added `.load` in the controller's `show` action so the relation is materialized once. Changed view from `@logs.present?` (which issues an `EXISTS?` query) to `@logs.any?` (which checks the already-loaded array in memory).
- **Clarify host validation error message**: Changed "Issue URL must be from {repo}" to "Issue URL must be a github.com URL." so users understand the issue is the host, not the repository.
- **Spec for workflow ID and conflict policy**: Extended the "starts workflow with correct parameters" spec to assert the deterministic `id: "manual-#{project.id}-#{issue.id}"` and `id_conflict_policy: Temporalio::WorkflowIDConflictPolicy::FAIL` values are passed to `start_workflow`.

## Test Plan

- [x] RuboCop clean on all changed Ruby files
- [x] Workflow parameters spec passes with new assertions
- [x] Pre-existing `application.js` asset issue causes unrelated test failures (same as PR #119)

Addresses review comments on: #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)