### PR TITLE
docs: address PR #120 review comments from Copilot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 # Paid Development Environment Variables
 #
 # NOTE: The default dev runner (bin/dev) disables automatic .env loading, and
-# when using docker compose, DATABASE_URL, TEMPORAL_HOST, and RAILS_ENV are
-# configured directly in docker-compose.yml. Treat this file primarily as
-# documentation and for workflows where you explicitly load .env.
+# when using docker compose, DATABASE_URL, the Temporal address (TEMPORAL_HOST
+# / TEMPORAL_ADDRESS), and RAILS_ENV are configured directly in
+# docker-compose.yml. Treat this file primarily as documentation and for
+# workflows where you explicitly load .env.
 
 # =============================================================================
 # Required

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ yarn install
 # Review environment configuration
 # NOTE: bin/dev uses Foreman with --env /dev/null, which disables
 # automatic .env loading. Export variables in your shell instead,
-# or use direnv / dotenv to load them before running bin/dev.
+# or use direnv or another shell env loader to load them before running bin/dev.
 cp .env.example .env  # Use as a reference for required variables
 
 # Prepare the database

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
 ```bash
 # Clone and configure
 git clone <repo-url> && cd paid
+# Optional: copy .env.example for local reference or if you add `env_file: .env` to docker-compose.yml
 cp .env.example .env
 
 # Start all services
@@ -44,7 +45,7 @@ docker compose up
 docker compose exec web bin/rails db:prepare
 ```
 
-> **Note**: Docker Compose sets `DATABASE_URL`, `TEMPORAL_HOST`, and `RAILS_ENV` directly in `docker-compose.yml`. Additional variables like `ANTHROPIC_API_KEY` (needed for agent execution) must be added to the `environment` section of the `web` and `worker` services, or loaded via `env_file: .env` in `docker-compose.yml`.
+> **Note**: Docker Compose sets `DATABASE_URL`, the Temporal address (via `TEMPORAL_HOST` on `web`, `TEMPORAL_ADDRESS` on `worker`), and `RAILS_ENV` directly in `docker-compose.yml`. Additional variables like `ANTHROPIC_API_KEY` (needed for agent execution) should be added to the `environment` section of the `web` service (which hosts the secrets proxy), or loaded via `env_file: .env` for whichever services actually require them.
 
 ### Option 2: Dev Container
 


### PR DESCRIPTION
## Summary

Addresses the 4 Copilot review comments from PR #120 about Docker Compose env var documentation accuracy.

- **README.md**: Added comment clarifying `cp .env.example .env` is optional in Docker Compose quick start since Compose doesn't auto-load `.env`
- **README.md**: Fixed Temporal address note to reflect that `web` uses `TEMPORAL_HOST` while `worker` uses `TEMPORAL_ADDRESS`; clarified `ANTHROPIC_API_KEY` only needs the `web` service (which hosts the secrets proxy)
- **CONTRIBUTING.md**: Replaced "direnv / dotenv" with "direnv or another shell env loader" since repo has no bundled dotenv dependency
- **.env.example**: Updated header to mention both `TEMPORAL_HOST` and `TEMPORAL_ADDRESS` to match actual `docker-compose.yml` config

## Context

PR #120 was merged with 4 outstanding Copilot review comments. All comments related to documentation accuracy:
1. `cp .env.example .env` presented as required but isn't needed for default Compose setup
2. Note incorrectly implied both `web` and `worker` use `TEMPORAL_HOST` (worker uses `TEMPORAL_ADDRESS`)
3. "dotenv" referenced as if it were available, but no dotenv gem/config exists in the repo
4. `.env.example` header only mentioned `TEMPORAL_HOST`, not `TEMPORAL_ADDRESS`

Verified against `docker-compose.yml`: `web` service uses `TEMPORAL_HOST: temporal:7233`, while `worker`, `temporal-ui`, and `temporal-admin-tools` all use `TEMPORAL_ADDRESS=temporal:7233`.

## Test plan

- [x] Verify README quick start instructions are clear about optional `.env` copy
- [x] Verify README note accurately describes Temporal address configuration per service
- [x] Verify CONTRIBUTING.md doesn't reference unavailable tools
- [x] Verify `.env.example` header matches actual `docker-compose.yml` variable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)