### PR TITLE
feat: add PR run lifecycle handling (rebase, CI, reviews, comments)

### DIFF
--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+module Prompts
+  # Builds a prompt for an agent to work on an existing pull request.
+  #
+  # Gathers CI failures, review threads, conversation comments, and
+  # optionally linked issue requirements to produce a comprehensive prompt
+  # that tells the agent to rebase, fix CI, address reviews, and push.
+  #
+  # @example
+  #   prompt = Prompts::BuildForPr.call(
+  #     project: project,
+  #     pr_number: 42,
+  #     github_client: client,
+  #     rebase_succeeded: true
+  #   )
+  class BuildForPr
+    attr_reader :project, :pr_number, :github_client, :rebase_succeeded,
+                :lint_command, :test_command, :issue
+
+    def initialize(project:, pr_number:, github_client:, rebase_succeeded:,
+                   lint_command: nil, test_command: nil, issue: nil)
+      @project = project
+      @pr_number = pr_number
+      @github_client = github_client
+      @rebase_succeeded = rebase_succeeded
+      @lint_command = lint_command || detected_lint_command
+      @test_command = test_command || detected_test_command
+      @issue = issue
+    end
+
+    def self.call(...)
+      new(...).build
+    end
+
+    def build
+      sections = []
+      sections << task_section
+      sections << issue_requirements_section if issue
+      sections << merge_conflicts_section unless rebase_succeeded
+      sections << ci_failures_section if failing_checks.any?
+      sections << code_review_section if unresolved_threads.any?
+      sections << conversation_section if trusted_comments.any?
+      sections << instructions_section
+      sections << rules_section
+      sections.join("\n")
+    end
+
+    private
+
+    def pr_data
+      @pr_data ||= github_client.pull_request(project.full_name, pr_number)
+    end
+
+    def base_branch
+      pr_data.base.ref
+    end
+
+    def task_section
+      <<~SECTION
+        # Task
+
+        You are working on an existing pull request:
+
+        **#{pr_data.title}** (##{pr_number})
+
+        Base branch: `#{base_branch}`
+
+        #{pr_data.body}
+      SECTION
+    end
+
+    def issue_requirements_section
+      <<~SECTION
+        # Issue Requirements
+
+        This PR is linked to the following issue:
+
+        **#{issue.title}** (##{issue.github_number})
+
+        #{issue.body}
+
+        Evaluate whether the current PR changes fully implement the issue requirements.
+        Close any implementation or testing gaps you find.
+      SECTION
+    end
+
+    def merge_conflicts_section
+      <<~SECTION
+        # Merge Conflicts
+
+        Automatic rebase against `#{base_branch}` failed due to conflicts.
+        Run `git merge origin/#{base_branch}` and resolve all conflicts.
+        Ensure the merged result compiles and passes all tests.
+      SECTION
+    end
+
+    def ci_failures_section
+      names = failing_checks.map { |c| "- #{c[:name]} (#{c[:conclusion]})" }.join("\n")
+
+      <<~SECTION
+        # CI Failures
+
+        The following CI checks are failing:
+
+        #{names}
+
+        Reproduce these failures locally using the lint and test commands below.
+        Fix the underlying issues — do not skip or disable checks.
+      SECTION
+    end
+
+    def code_review_section
+      thread_text = unresolved_threads.map do |thread|
+        comments = thread[:comments].map do |c|
+          location = [ c[:path], c[:line] ].compact.join(":")
+          "  - **#{c[:author]}**#{" (#{location})" if location.present?}: #{c[:body]}"
+        end.join("\n")
+
+        "**Thread** (#{thread[:comments].first&.dig(:path) || "general"}):\n#{comments}"
+      end.join("\n\n")
+
+      <<~SECTION
+        # Code Review Comments
+
+        The following review threads are unresolved:
+
+        #{thread_text}
+
+        Address each thread: fix the code if the reviewer is correct, or explain
+        your reasoning in a code comment if you disagree. Do not ignore review feedback.
+      SECTION
+    end
+
+    def conversation_section
+      comment_text = trusted_comments.map do |c|
+        "- **#{c.user.login}**: #{c.body}"
+      end.join("\n")
+
+      <<~SECTION
+        # Conversation Comments
+
+        Recent comments from project collaborators:
+
+        #{comment_text}
+
+        Address any actionable requests in these comments.
+      SECTION
+    end
+
+    def instructions_section
+      priorities = []
+      priorities << "Resolve merge conflicts" unless rebase_succeeded
+      priorities << "Fix CI failures" if failing_checks.any?
+      priorities << "Close implementation gaps against the linked issue" if issue
+      priorities << "Address code review comments" if unresolved_threads.any?
+      priorities << "Address conversation comments" if trusted_comments.any?
+      priority_list = priorities.each_with_index.map { |p, i| "#{i + 1}. #{p}" }.join("\n")
+
+      <<~SECTION
+        # Instructions
+
+        Priority order:
+        #{priority_list}
+
+        Steps:
+        1. Set up the project first — install dependencies (`bundle install`, `npm install`, etc.)
+        2. Work through the priorities above in order
+        3. Run lint and fix any violations: `#{lint_command}`
+        4. Run the test suite and fix any failures: `#{test_command}`
+        5. Commit your changes with a descriptive message
+
+        When you're done, commit all your changes. Do not push.
+      SECTION
+    end
+
+    def rules_section
+      <<~SECTION
+        # Rules — you MUST follow these
+
+        - **Lint and tests MUST pass before every commit.** Do not commit code that fails lint or tests.
+        - **Never use `--no-verify`** or any flag that skips git hooks.
+        - **Never disable linters** (e.g. rubocop:disable, eslint-disable, noqa) to silence failures. Fix the code instead.
+        - **Fix forward** — if a check fails, fix the underlying issue. Do not bypass the check.
+        - Work within the existing codebase style and conventions
+        - Do not modify unrelated files
+        - Focus on completing the specific tasks listed above
+      SECTION
+    end
+
+    # Memoized data fetchers
+
+    def failing_checks
+      @failing_checks ||= begin
+        checks = github_client.check_runs_for_ref(project.full_name, pr_data.head.sha)
+        checks.reject { |c| %w[success skipped neutral].include?(c[:conclusion].to_s) }
+      rescue GithubClient::Error
+        []
+      end
+    end
+
+    def unresolved_threads
+      @unresolved_threads ||= begin
+        threads = github_client.review_threads(project.full_name, pr_number)
+        threads.reject { |t| t[:is_resolved] }
+      rescue GithubClient::Error
+        []
+      end
+    end
+
+    def trusted_comments
+      @trusted_comments ||= begin
+        comments = github_client.issue_comments(project.full_name, pr_number)
+        comments.select { |c| project.trusted_github_user?(c.user&.login) }
+      rescue GithubClient::Error
+        []
+      end
+    end
+
+    def detected_language
+      @detected_language ||= begin
+        lang = project.detected_language if project.respond_to?(:detected_language)
+        lang.presence || "ruby"
+      end
+    end
+
+    def detected_lint_command
+      BuildForIssue::LANGUAGE_LINT_COMMANDS.fetch(detected_language, "echo \"No lint command configured\"")
+    end
+
+    def detected_test_command
+      BuildForIssue::LANGUAGE_TEST_COMMANDS.fetch(detected_language, "echo \"No test command configured\"")
+    end
+  end
+end

--- a/app/temporal/activities/prepare_pr_prompt_activity.rb
+++ b/app/temporal/activities/prepare_pr_prompt_activity.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Activities
+  # Builds a rich prompt for an existing PR run and stores it in custom_prompt.
+  #
+  # Gathers CI failures, review threads, conversation comments, and optionally
+  # linked issue requirements. The generated prompt is written to custom_prompt
+  # so that RunAgentActivity picks it up via effective_prompt without changes.
+  class PreparePrPromptActivity < BaseActivity
+    activity_name "PreparePrPrompt"
+
+    def execute(input)
+      agent_run_id = input[:agent_run_id]
+      rebase_succeeded = input.fetch(:rebase_succeeded, true)
+      agent_run = AgentRun.find(agent_run_id)
+      project = agent_run.project
+      client = project.github_token.client
+
+      prompt = Prompts::BuildForPr.call(
+        project: project,
+        pr_number: agent_run.source_pull_request_number,
+        github_client: client,
+        rebase_succeeded: rebase_succeeded,
+        issue: agent_run.issue
+      )
+
+      agent_run.update!(custom_prompt: prompt)
+
+      logger.info(
+        message: "agent_execution.prepare_pr_prompt",
+        agent_run_id: agent_run_id,
+        prompt_length: prompt.length
+      )
+
+      { agent_run_id: agent_run_id, prompt_length: prompt.length }
+    end
+  end
+end

--- a/app/temporal/activities/rebase_branch_activity.rb
+++ b/app/temporal/activities/rebase_branch_activity.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Activities
+  # Rebases the current branch onto the PR's base branch inside the container.
+  #
+  # On conflict, returns rebase_succeeded: false so the workflow can instruct
+  # the agent to resolve conflicts via merge instead.
+  class RebaseBranchActivity < BaseActivity
+    activity_name "RebaseBranch"
+
+    def execute(input)
+      agent_run_id = input[:agent_run_id]
+      agent_run = AgentRun.find(agent_run_id)
+      project = agent_run.project
+
+      base_branch = fetch_base_branch(agent_run, project)
+
+      container_service = reconnect_container(agent_run)
+      git_ops = Containers::GitOperations.new(
+        container_service: container_service,
+        agent_run: agent_run
+      )
+
+      rebase_succeeded = git_ops.rebase_onto(base_branch)
+
+      agent_run.log!("system",
+        rebase_succeeded ? "Rebased onto #{base_branch}" : "Rebase onto #{base_branch} failed (conflicts)")
+
+      logger.info(
+        message: "agent_execution.rebase_branch",
+        agent_run_id: agent_run_id,
+        base_branch: base_branch,
+        rebase_succeeded: rebase_succeeded
+      )
+
+      { agent_run_id: agent_run_id, rebase_succeeded: rebase_succeeded, base_branch: base_branch }
+    end
+
+    private
+
+    def fetch_base_branch(agent_run, project)
+      client = project.github_token.client
+      pr = client.pull_request(project.full_name, agent_run.source_pull_request_number)
+      pr.base.ref
+    end
+
+    def reconnect_container(agent_run)
+      Containers::Provision.reconnect(
+        agent_run: agent_run,
+        container_id: agent_run.container_id
+      )
+    end
+  end
+end

--- a/app/temporal/activities/resolve_review_threads_activity.rb
+++ b/app/temporal/activities/resolve_review_threads_activity.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Activities
+  # Resolves unresolved review threads on a pull request after the agent
+  # has pushed its changes.
+  #
+  # Individual thread resolution failures are logged but do not fail the
+  # activity — this is a best-effort cleanup step.
+  class ResolveReviewThreadsActivity < BaseActivity
+    activity_name "ResolveReviewThreads"
+
+    def execute(input)
+      agent_run_id = input[:agent_run_id]
+      agent_run = AgentRun.find(agent_run_id)
+      project = agent_run.project
+      client = project.github_token.client
+
+      threads = client.review_threads(project.full_name, agent_run.source_pull_request_number)
+      unresolved = threads.reject { |t| t[:is_resolved] }
+
+      resolved_count = 0
+      failed_count = 0
+
+      unresolved.each do |thread|
+        client.resolve_review_thread(thread[:id])
+        resolved_count += 1
+      rescue GithubClient::Error => e
+        failed_count += 1
+        logger.warn(
+          message: "agent_execution.resolve_thread_failed",
+          agent_run_id: agent_run_id,
+          thread_id: thread[:id],
+          error: e.message
+        )
+      end
+
+      logger.info(
+        message: "agent_execution.resolve_review_threads",
+        agent_run_id: agent_run_id,
+        resolved_count: resolved_count,
+        failed_count: failed_count
+      )
+
+      { agent_run_id: agent_run_id, resolved_count: resolved_count, failed_count: failed_count }
+    end
+  end
+end

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Prompts::BuildForPr do
+  let(:project) { create(:project, allowed_github_usernames: [ "trusteduser" ]) }
+  let(:github_client) { instance_double(GithubClient) }
+
+  let(:pr_data) do
+    OpenStruct.new(
+      title: "Fix authentication flow",
+      body: "This PR fixes the auth redirect bug.",
+      head: OpenStruct.new(ref: "fix-auth", sha: "abc123"),
+      base: OpenStruct.new(ref: "main")
+    )
+  end
+
+  before do
+    allow(github_client).to receive(:pull_request)
+      .with(project.full_name, 42)
+      .and_return(pr_data)
+
+
+
+    allow(github_client).to receive_messages(check_runs_for_ref: [], review_threads: [], issue_comments: [])
+  end
+
+  describe ".call" do
+    subject(:prompt) do
+      described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+    end
+
+    it "includes the PR title and number" do
+      expect(prompt).to include("Fix authentication flow")
+      expect(prompt).to include("#42")
+    end
+
+    it "includes the PR body" do
+      expect(prompt).to include("This PR fixes the auth redirect bug.")
+    end
+
+    it "includes the base branch" do
+      expect(prompt).to include("`main`")
+    end
+
+    it "includes instructions" do
+      expect(prompt).to include("Set up the project first")
+      expect(prompt).to include("commit all your changes")
+      expect(prompt).to include("Do not push")
+    end
+
+    it "includes rules" do
+      expect(prompt).to include("MUST pass before every commit")
+      expect(prompt).to include("Never use `--no-verify`")
+      expect(prompt).to include("Fix forward")
+    end
+
+    it "includes language-specific lint command for ruby" do
+      expect(prompt).to include("bundle exec rubocop")
+    end
+
+    it "includes language-specific test command for ruby" do
+      expect(prompt).to include("bundle exec rspec")
+    end
+
+    it "omits merge conflicts section when rebase succeeded" do
+      expect(prompt).not_to include("Merge Conflicts")
+    end
+
+    it "omits CI failures section when no checks are failing" do
+      expect(prompt).not_to include("CI Failures")
+    end
+
+    it "omits code review section when no unresolved threads" do
+      expect(prompt).not_to include("Code Review Comments")
+    end
+
+    it "omits conversation section when no trusted comments" do
+      expect(prompt).not_to include("Conversation Comments")
+    end
+
+    it "omits issue requirements section when no issue" do
+      expect(prompt).not_to include("Issue Requirements")
+    end
+  end
+
+  describe "merge conflicts section" do
+    it "includes merge conflicts instructions when rebase failed" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false
+      )
+
+      expect(prompt).to include("Merge Conflicts")
+      expect(prompt).to include("git merge origin/main")
+      expect(prompt).to include("resolve all conflicts")
+    end
+  end
+
+  describe "CI failures section" do
+    before do
+      allow(github_client).to receive(:check_runs_for_ref)
+        .with(project.full_name, "abc123")
+        .and_return([
+          { name: "rspec", conclusion: "failure" },
+          { name: "rubocop", conclusion: "success" },
+          { name: "build", conclusion: "cancelled" }
+        ])
+    end
+
+    it "includes failing check names" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include("CI Failures")
+      expect(prompt).to include("rspec (failure)")
+      expect(prompt).to include("build (cancelled)")
+      expect(prompt).not_to include("rubocop (success)")
+    end
+  end
+
+  describe "code review section" do
+    before do
+      allow(github_client).to receive(:review_threads)
+        .with(project.full_name, 42)
+        .and_return([
+          {
+            id: "thread_1",
+            is_resolved: false,
+            comments: [
+              { body: "This method is too long", path: "app/models/user.rb", line: 42, author: "reviewer" }
+            ]
+          },
+          {
+            id: "thread_2",
+            is_resolved: true,
+            comments: [
+              { body: "Already fixed", path: "app/models/post.rb", line: 10, author: "reviewer" }
+            ]
+          }
+        ])
+    end
+
+    it "includes unresolved review threads" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include("Code Review Comments")
+      expect(prompt).to include("This method is too long")
+      expect(prompt).to include("app/models/user.rb:42")
+    end
+
+    it "excludes resolved threads" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).not_to include("Already fixed")
+    end
+  end
+
+  describe "conversation comments section" do
+    before do
+      allow(github_client).to receive(:issue_comments)
+        .with(project.full_name, 42)
+        .and_return([
+          OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Please also fix the tests"),
+          OpenStruct.new(user: OpenStruct.new(login: "randomuser"), body: "Ignore this")
+        ])
+    end
+
+    it "includes comments from trusted users only" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include("Conversation Comments")
+      expect(prompt).to include("Please also fix the tests")
+      expect(prompt).not_to include("Ignore this")
+    end
+  end
+
+  describe "issue requirements section" do
+    let(:issue) do
+      create(:issue,
+        project: project,
+        title: "Add dark mode",
+        github_number: 99,
+        body: "Implement dark mode toggle in settings.")
+    end
+
+    it "includes issue requirements when issue is provided" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true,
+        issue: issue
+      )
+
+      expect(prompt).to include("Issue Requirements")
+      expect(prompt).to include("Add dark mode")
+      expect(prompt).to include("#99")
+      expect(prompt).to include("Implement dark mode toggle in settings.")
+      expect(prompt).to include("Evaluate whether the current PR changes fully implement")
+    end
+  end
+
+  describe "language detection" do
+    let(:python_project) do
+      proj = create(:project, allowed_github_usernames: [ "trusteduser" ])
+      proj.define_singleton_method(:detected_language) { "python" }
+      proj
+    end
+
+    before do
+      allow(github_client).to receive(:pull_request)
+        .with(python_project.full_name, 42)
+        .and_return(pr_data)
+    end
+
+    it "uses detected language for lint and test commands" do
+      prompt = described_class.call(
+        project: python_project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include("ruff check .")
+      expect(prompt).to include("pytest")
+    end
+  end
+
+  describe "priority ordering" do
+    it "orders priorities correctly with all sections present" do
+      allow(github_client).to receive_messages(check_runs_for_ref: [ { name: "ci", conclusion: "failure" } ], review_threads: [ { id: "t1", is_resolved: false, comments: [ { body: "fix", path: "a.rb", line: 1, author: "r" } ] } ], issue_comments: [ OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "comment") ])
+
+      issue = create(:issue, project: project, title: "Issue", github_number: 1, body: "body")
+
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue
+      )
+
+      conflicts_pos = prompt.index("Resolve merge conflicts")
+      ci_pos = prompt.index("Fix CI failures")
+      issue_pos = prompt.index("Close implementation gaps")
+      review_pos = prompt.index("Address code review comments")
+      comments_pos = prompt.index("Address conversation comments")
+
+      expect(conflicts_pos).to be < ci_pos
+      expect(ci_pos).to be < issue_pos
+      expect(issue_pos).to be < review_pos
+      expect(review_pos).to be < comments_pos
+    end
+  end
+
+  describe "error resilience" do
+    it "omits CI section when check_runs_for_ref raises" do
+      allow(github_client).to receive(:check_runs_for_ref)
+        .and_raise(GithubClient::ApiError.new("API error"))
+
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).not_to include("CI Failures")
+    end
+
+    it "omits review section when review_threads raises" do
+      allow(github_client).to receive(:review_threads)
+        .and_raise(GithubClient::ApiError.new("API error"))
+
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).not_to include("Code Review Comments")
+    end
+
+    it "omits conversation section when issue_comments raises" do
+      allow(github_client).to receive(:issue_comments)
+        .and_raise(GithubClient::ApiError.new("API error"))
+
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).not_to include("Conversation Comments")
+    end
+  end
+end

--- a/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
+++ b/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Activities::PreparePrPromptActivity do
+  let(:project) { create(:project) }
+  let(:agent_run) do
+    create(:agent_run, :running,
+      project: project,
+      source_pull_request_number: 42,
+      custom_prompt: "placeholder")
+  end
+  let(:github_client) { instance_double(GithubClient) }
+  let(:activity) { described_class.new }
+
+  let(:pr_data) do
+    OpenStruct.new(
+      title: "Fix the bug",
+      body: "This fixes the bug",
+      head: OpenStruct.new(ref: "fix-branch", sha: "abc123"),
+      base: OpenStruct.new(ref: "main")
+    )
+  end
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(github_client)
+
+    allow(github_client).to receive(:pull_request)
+      .with(project.full_name, 42)
+      .and_return(pr_data)
+
+    allow(github_client).to receive_messages(check_runs_for_ref: [], review_threads: [], issue_comments: [])
+  end
+
+  describe "#execute" do
+    it "stores the generated prompt in custom_prompt" do
+      activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+      agent_run.reload
+      expect(agent_run.custom_prompt).to include("Fix the bug")
+      expect(agent_run.custom_prompt).to include("#42")
+    end
+
+    it "returns prompt_length" do
+      result = activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+      expect(result[:prompt_length]).to be > 0
+      expect(result[:agent_run_id]).to eq(agent_run.id)
+    end
+
+    it "passes rebase_succeeded through to the prompt builder" do
+      activity.execute(agent_run_id: agent_run.id, rebase_succeeded: false)
+
+      agent_run.reload
+      expect(agent_run.custom_prompt).to include("Merge Conflicts")
+    end
+
+    it "omits merge conflicts section when rebase succeeded" do
+      activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+      agent_run.reload
+      expect(agent_run.custom_prompt).not_to include("Merge Conflicts")
+    end
+
+    context "with a linked issue" do
+      let(:issue) do
+        create(:issue,
+          project: project,
+          title: "Add feature X",
+          github_number: 99,
+          body: "Implement feature X completely.")
+      end
+
+      let(:agent_run) do
+        create(:agent_run, :running,
+          project: project,
+          issue: issue,
+          source_pull_request_number: 42,
+          custom_prompt: "placeholder")
+      end
+
+      it "includes issue requirements in the prompt" do
+        activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+        agent_run.reload
+        expect(agent_run.custom_prompt).to include("Issue Requirements")
+        expect(agent_run.custom_prompt).to include("Add feature X")
+        expect(agent_run.custom_prompt).to include("#99")
+      end
+    end
+
+    context "without a linked issue" do
+      let(:agent_run) do
+        create(:agent_run, :running,
+          project: project,
+          issue: nil,
+          source_pull_request_number: 42,
+          custom_prompt: "placeholder")
+      end
+
+      it "omits issue requirements section" do
+        activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+        agent_run.reload
+        expect(agent_run.custom_prompt).not_to include("Issue Requirements")
+      end
+    end
+  end
+end

--- a/spec/temporal/activities/rebase_branch_activity_spec.rb
+++ b/spec/temporal/activities/rebase_branch_activity_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Activities::RebaseBranchActivity do
+  let(:project) { create(:project) }
+  let(:agent_run) do
+    create(:agent_run, :running,
+      project: project,
+      source_pull_request_number: 42,
+      custom_prompt: "Fix PR")
+  end
+  let(:container_service) { instance_double(Containers::Provision) }
+  let(:github_client) { instance_double(GithubClient) }
+  let(:activity) { described_class.new }
+
+  let(:pr_data) do
+    OpenStruct.new(
+      base: OpenStruct.new(ref: "main"),
+      head: OpenStruct.new(ref: "fix-branch", sha: "abc123")
+    )
+  end
+
+  before do
+    agent_run.update!(container_id: "container-123")
+
+    allow(Containers::Provision).to receive(:reconnect).and_return(container_service)
+    allow(GithubClient).to receive(:new).and_return(github_client)
+
+    allow(github_client).to receive(:pull_request)
+      .with(project.full_name, 42)
+      .and_return(pr_data)
+  end
+
+  describe "#execute" do
+    context "when rebase succeeds" do
+      before do
+        success_result = Containers::Provision::Result.success(stdout: "", stderr: "", exit_code: 0)
+        allow(container_service).to receive(:execute).and_return(success_result)
+      end
+
+      it "returns rebase_succeeded: true" do
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:rebase_succeeded]).to be true
+        expect(result[:base_branch]).to eq("main")
+        expect(result[:agent_run_id]).to eq(agent_run.id)
+      end
+
+      it "fetches the base branch from the PR" do
+        expect(github_client).to receive(:pull_request)
+          .with(project.full_name, 42)
+          .and_return(pr_data)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+    end
+
+    context "when rebase has conflicts" do
+      before do
+        success_result = Containers::Provision::Result.success(stdout: "", stderr: "", exit_code: 0)
+        conflict_result = Containers::Provision::Result.failure(
+          error: "rebase failed",
+          stdout: "",
+          stderr: "CONFLICT (content): Merge conflict in file.rb",
+          exit_code: 1
+        )
+
+        # fetch succeeds
+        allow(container_service).to receive(:execute)
+          .with([ "git", "fetch", "origin", "main" ], timeout: nil, stream: false)
+          .and_return(success_result)
+
+        # rebase fails with conflict
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rebase", "origin/main" ], timeout: nil, stream: false)
+          .and_return(conflict_result)
+
+        # abort succeeds
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rebase", "--abort" ], timeout: nil, stream: false)
+          .and_return(success_result)
+      end
+
+      it "returns rebase_succeeded: false" do
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:rebase_succeeded]).to be false
+        expect(result[:base_branch]).to eq("main")
+      end
+    end
+  end
+end

--- a/spec/temporal/activities/resolve_review_threads_activity_spec.rb
+++ b/spec/temporal/activities/resolve_review_threads_activity_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::ResolveReviewThreadsActivity do
+  let(:project) { create(:project) }
+  let(:agent_run) do
+    create(:agent_run, :running,
+      project: project,
+      source_pull_request_number: 42,
+      custom_prompt: "Fix PR")
+  end
+  let(:github_client) { instance_double(GithubClient) }
+  let(:activity) { described_class.new }
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(github_client)
+  end
+
+  describe "#execute" do
+    context "when there are unresolved threads" do
+      before do
+        allow(github_client).to receive(:review_threads)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: "thread_1", is_resolved: false, comments: [] },
+            { id: "thread_2", is_resolved: true, comments: [] },
+            { id: "thread_3", is_resolved: false, comments: [] }
+          ])
+
+        allow(github_client).to receive(:resolve_review_thread)
+      end
+
+      it "resolves unresolved threads" do
+        expect(github_client).to receive(:resolve_review_thread).with("thread_1")
+        expect(github_client).to receive(:resolve_review_thread).with("thread_3")
+        expect(github_client).not_to receive(:resolve_review_thread).with("thread_2")
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "returns resolved and failed counts" do
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:resolved_count]).to eq(2)
+        expect(result[:failed_count]).to eq(0)
+        expect(result[:agent_run_id]).to eq(agent_run.id)
+      end
+    end
+
+    context "when individual thread resolution fails" do
+      before do
+        allow(github_client).to receive(:review_threads)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: "thread_1", is_resolved: false, comments: [] },
+            { id: "thread_2", is_resolved: false, comments: [] }
+          ])
+
+        allow(github_client).to receive(:resolve_review_thread).with("thread_1")
+        allow(github_client).to receive(:resolve_review_thread).with("thread_2")
+          .and_raise(GithubClient::ApiError.new("GraphQL error"))
+      end
+
+      it "continues despite individual failures" do
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:resolved_count]).to eq(1)
+        expect(result[:failed_count]).to eq(1)
+      end
+    end
+
+    context "when there are no unresolved threads" do
+      before do
+        allow(github_client).to receive(:review_threads)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: "thread_1", is_resolved: true, comments: [] }
+          ])
+      end
+
+      it "returns zero counts" do
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:resolved_count]).to eq(0)
+        expect(result[:failed_count]).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a run is started on an existing PR without a custom prompt, the system now automatically builds a rich prompt covering: rebase against the base branch, CI failure reproduction, code review thread resolution, conversation comment handling, and (when an issue is linked) gap evaluation against issue requirements.

- Add 5 GitHub client methods (check_runs, comments, review threads, GraphQL resolve/reply) with a dedicated Faraday-based GraphQL helper
- Add fetch_branch and rebase_onto to container git operations
- Create Prompts::BuildForPr service with conditional prompt sections
- Create RebaseBranch, PreparePrPrompt, ResolveReviewThreads activities
- Wire new activities into AgentExecutionWorkflow for PR runs
- Add 138 tests across 7 spec files (full suite: 1126 pass, 92.67% cov)