### PR TITLE
Fix GitHub issue/PR sync: per-label fetching, stale closure guard, paid-generated sync

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "statusLine": {
+    "type": "command",
+    "command": "bash /workspaces/paid/.claude/statusline-command.sh"
+  },
   "hooks": {
     "PreCompact": [
       {

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Claude Code status line: shows context usage as a progress bar
+
+input=$(cat)
+
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+remaining_pct=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
+model=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+dir=$(basename "$cwd")
+
+if [ -n "$used_pct" ]; then
+  # Build a 20-char progress bar
+  bar_width=20
+  filled=$(echo "$used_pct $bar_width" | awk '{printf "%d", ($1 / 100) * $2}')
+  empty=$((bar_width - filled))
+
+  bar=""
+  for i in $(seq 1 "$filled"); do bar="${bar}#"; done
+  for i in $(seq 1 "$empty"); do bar="${bar}-"; done
+
+  # Pick color based on usage
+  if [ "$(echo "$used_pct" | awk '{print ($1 >= 90)}')" = "1" ]; then
+    color="\033[31m"   # red
+  elif [ "$(echo "$used_pct" | awk '{print ($1 >= 70)}')" = "1" ]; then
+    color="\033[33m"   # yellow
+  else
+    color="\033[32m"   # green
+  fi
+  reset="\033[0m"
+
+  used_int=$(echo "$used_pct" | awk '{printf "%d", $1}')
+  printf "${color}[${bar}] ${used_int}%% ctx${reset}  %s  %s" "$model" "$dir"
+else
+  printf "%s  %s" "$model" "$dir"
+fi

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -6,6 +6,8 @@ module Activities
   # Returns a list of synced issue summaries for downstream processing.
   # Handles rate limiting by re-raising as a retryable Temporal error.
   class FetchIssuesActivity < BaseActivity
+    PAID_GENERATED_LABEL = "paid-generated"
+
     def execute(input)
       project_id = input[:project_id]
       project = Project.find_by(id: project_id)
@@ -14,6 +16,7 @@ module Activities
       client = project.github_token.client
 
       labels = project.label_mappings.values.compact_blank.uniq
+      labels = (labels + [ PAID_GENERATED_LABEL ]).uniq
       github_issues = fetch_all_issues(client, project.full_name, labels)
 
       synced_issues = github_issues.map { |gi| sync_issue(project, gi) }
@@ -38,14 +41,35 @@ module Activities
 
     MAX_PAGES = 10
 
+    # Fetches open issues for each label separately, then deduplicates.
+    # GitHub's API treats multiple labels as AND (all required), so we
+    # must query per-label to get OR behavior (any label matches).
     def fetch_all_issues(client, repo_full_name, labels)
+      return fetch_issues_for_label(client, repo_full_name, nil) if labels.empty?
+
+      seen_ids = Set.new
+      all_issues = []
+
+      labels.each do |label|
+        fetch_issues_for_label(client, repo_full_name, label).each do |issue|
+          next if seen_ids.include?(issue.id)
+
+          seen_ids.add(issue.id)
+          all_issues << issue
+        end
+      end
+
+      all_issues
+    end
+
+    def fetch_issues_for_label(client, repo_full_name, label)
       issues = []
       page = 1
 
       loop do
         page_issues = client.issues(
           repo_full_name,
-          labels: labels,
+          labels: label ? [ label ] : nil,
           state: "open",
           per_page: 100,
           page: page
@@ -62,6 +86,7 @@ module Activities
           logger.warn(
             message: "github_sync.fetch_issues_page_limit",
             repo: repo_full_name,
+            label: label,
             fetched_count: issues.size,
             max_pages: MAX_PAGES
           )
@@ -102,6 +127,8 @@ module Activities
     end
 
     def close_stale_issues(project, github_issues)
+      return 0 if github_issues.empty?
+
       fetched_github_ids = github_issues.map(&:id).to_set
       stale_issues = project.issues.where(github_state: "open").where.not(github_issue_id: fetched_github_ids)
       count = stale_issues.count

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -12,39 +12,52 @@ RSpec.describe Activities::FetchIssuesActivity do
     allow(GithubClient).to receive(:new).and_return(github_client)
   end
 
+  # Helper: route github_client.issues calls by label
+  def stub_issues_by_label(mapping)
+    allow(github_client).to receive(:issues) do |_repo, **opts|
+      label = Array(opts[:labels]).first
+      result = mapping[label] || []
+      result
+    end
+  end
+
   describe "#execute" do
     context "when issues are found" do
-      let(:github_issues) do
-        [
-          OpenStruct.new(
-            id: 1001,
-            number: 1,
-            title: "Build this feature",
-            body: "Please build it",
-            state: "open",
-            labels: [ OpenStruct.new(name: "paid-build") ],
-            pull_request: nil,
-            user: OpenStruct.new(login: "viamin"),
-            created_at: 2.days.ago,
-            updated_at: 1.day.ago
-          ),
-          OpenStruct.new(
-            id: 1002,
-            number: 2,
-            title: "Plan this feature",
-            body: "Please plan it",
-            state: "open",
-            labels: [ OpenStruct.new(name: "paid-plan"), OpenStruct.new(name: "enhancement") ],
-            pull_request: nil,
-            user: OpenStruct.new(login: "viamin"),
-            created_at: 1.day.ago,
-            updated_at: Time.current
-          )
-        ]
+      let(:build_issue) do
+        OpenStruct.new(
+          id: 1001,
+          number: 1,
+          title: "Build this feature",
+          body: "Please build it",
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-build") ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 2.days.ago,
+          updated_at: 1.day.ago
+        )
+      end
+
+      let(:plan_issue) do
+        OpenStruct.new(
+          id: 1002,
+          number: 2,
+          title: "Plan this feature",
+          body: "Please plan it",
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-plan"), OpenStruct.new(name: "enhancement") ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 1.day.ago,
+          updated_at: Time.current
+        )
       end
 
       before do
-        allow(github_client).to receive(:issues).and_return(github_issues)
+        stub_issues_by_label(
+          "paid-build" => [ build_issue ],
+          "paid-plan" => [ plan_issue ]
+        )
       end
 
       it "syncs issues to the database" do
@@ -79,6 +92,56 @@ RSpec.describe Activities::FetchIssuesActivity do
           expect(issue.is_pull_request).to be false
         end
       end
+
+      it "makes separate API calls for each label" do
+        activity.execute(project_id: project.id)
+
+        expect(github_client).to have_received(:issues).with(
+          project.full_name,
+          hash_including(labels: [ "paid-build" ])
+        ).at_least(:once)
+
+        expect(github_client).to have_received(:issues).with(
+          project.full_name,
+          hash_including(labels: [ "paid-plan" ])
+        ).at_least(:once)
+
+        expect(github_client).to have_received(:issues).with(
+          project.full_name,
+          hash_including(labels: [ "paid-generated" ])
+        ).at_least(:once)
+      end
+    end
+
+    context "when the same issue matches multiple labels" do
+      let(:shared_issue) do
+        OpenStruct.new(
+          id: 1001,
+          number: 1,
+          title: "Multi-label issue",
+          body: "Has both labels",
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-build"), OpenStruct.new(name: "paid-plan") ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 2.days.ago,
+          updated_at: 1.day.ago
+        )
+      end
+
+      before do
+        stub_issues_by_label(
+          "paid-build" => [ shared_issue ],
+          "paid-plan" => [ shared_issue ]
+        )
+      end
+
+      it "deduplicates issues by GitHub ID" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:issues].size).to eq(1)
+        expect(project.issues.count).to eq(1)
+      end
     end
 
     context "when results include pull requests" do
@@ -112,7 +175,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       before do
-        allow(github_client).to receive(:issues).and_return(github_items)
+        stub_issues_by_label("paid-build" => github_items)
       end
 
       it "correctly identifies pull requests" do
@@ -162,20 +225,24 @@ RSpec.describe Activities::FetchIssuesActivity do
         allow(github_client).to receive(:issues).and_return([])
       end
 
-      it "filters out blank and nil values" do
+      it "filters out blank and nil values and makes per-label calls" do
         activity.execute(project_id: project.id)
 
         expect(github_client).to have_received(:issues).with(
           project.full_name,
-          labels: [ "paid-build" ],
-          state: "open",
-          per_page: 100,
-          page: 1
-        )
+          hash_including(labels: [ "paid-build" ])
+        ).at_least(:once)
+
+        expect(github_client).to have_received(:issues).with(
+          project.full_name,
+          hash_including(labels: [ "paid-generated" ])
+        ).at_least(:once)
       end
     end
 
     context "when there are multiple pages of issues" do
+      let(:project) { create(:project, label_mappings: { "build" => "paid-build" }) }
+
       let(:page1_issues) do
         Array.new(100) do |i|
           OpenStruct.new(
@@ -211,38 +278,53 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       before do
-        allow(github_client).to receive(:issues).with(anything, hash_including(page: 1)).and_return(page1_issues)
-        allow(github_client).to receive(:issues).with(anything, hash_including(page: 2)).and_return(page2_issues)
+        allow(github_client).to receive(:issues) do |_repo, **opts|
+          label = Array(opts[:labels]).first
+          page = opts[:page] || 1
+          case label
+          when "paid-build"
+            page == 1 ? page1_issues : page2_issues
+          else
+            []
+          end
+        end
       end
 
       it "paginates through all pages" do
         result = activity.execute(project_id: project.id)
 
         expect(result[:issues].size).to eq(101)
-        expect(github_client).to have_received(:issues).twice
       end
     end
 
     context "when page limit is reached" do
-      let(:full_page) do
-        Array.new(100) do |i|
-          OpenStruct.new(
-            id: 4000 + i,
-            number: i + 1,
-            title: "Issue #{i + 1}",
-            body: "Body",
-            state: "open",
-            labels: [ OpenStruct.new(name: "paid-build") ],
-            pull_request: nil,
-            user: OpenStruct.new(login: "viamin"),
-            created_at: 2.days.ago,
-            updated_at: 1.day.ago
-          )
-        end
-      end
+      let(:project) { create(:project, label_mappings: { "build" => "paid-build" }) }
 
       before do
-        allow(github_client).to receive(:issues).and_return(full_page)
+        allow(github_client).to receive(:issues) do |_repo, **opts|
+          label = Array(opts[:labels]).first
+          page = opts[:page] || 1
+          if label == "paid-build"
+            # Return unique IDs per page to avoid deduplication
+            offset = (page - 1) * 100
+            Array.new(100) do |i|
+              OpenStruct.new(
+                id: 4000 + offset + i,
+                number: offset + i + 1,
+                title: "Issue #{offset + i + 1}",
+                body: "Body",
+                state: "open",
+                labels: [ OpenStruct.new(name: "paid-build") ],
+                pull_request: nil,
+                user: OpenStruct.new(login: "viamin"),
+                created_at: 2.days.ago,
+                updated_at: 1.day.ago
+              )
+            end
+          else
+            []
+          end
+        end
       end
 
       it "stops after MAX_PAGES and logs a warning" do
@@ -251,7 +333,6 @@ RSpec.describe Activities::FetchIssuesActivity do
         result = activity.execute(project_id: project.id)
 
         expect(result[:issues].size).to eq(described_class::MAX_PAGES * 100)
-        expect(github_client).to have_received(:issues).exactly(described_class::MAX_PAGES).times
         expect(Rails.logger).to have_received(:warn).with(
           hash_including(message: "github_sync.fetch_issues_page_limit")
         )
@@ -265,15 +346,12 @@ RSpec.describe Activities::FetchIssuesActivity do
         allow(github_client).to receive(:issues).and_return([])
       end
 
-      it "fetches with empty labels filter" do
+      it "still fetches issues with the paid-generated label" do
         activity.execute(project_id: project.id)
 
         expect(github_client).to have_received(:issues).with(
           project.full_name,
-          labels: [],
-          state: "open",
-          per_page: 100,
-          page: 1
+          hash_including(labels: [ "paid-generated" ])
         )
       end
     end
@@ -296,7 +374,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       before do
-        allow(github_client).to receive(:issues).and_return([ untrusted_issue ])
+        stub_issues_by_label("paid-build" => [ untrusted_issue ])
       end
 
       it "stores the issue without the body" do
@@ -347,7 +425,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       before do
-        allow(github_client).to receive(:issues).and_return([ trusted_issue ])
+        stub_issues_by_label("paid-build" => [ trusted_issue ])
       end
 
       it "stores the issue with the body" do
@@ -366,25 +444,23 @@ RSpec.describe Activities::FetchIssuesActivity do
     end
 
     context "when locally-open issues are no longer returned by GitHub" do
-      let(:github_issues) do
-        [
-          OpenStruct.new(
-            id: 1001,
-            number: 1,
-            title: "Still open",
-            body: "Body",
-            state: "open",
-            labels: [ OpenStruct.new(name: "paid-build") ],
-            pull_request: nil,
-            user: OpenStruct.new(login: "viamin"),
-            created_at: 2.days.ago,
-            updated_at: 1.day.ago
-          )
-        ]
+      let(:still_open_issue) do
+        OpenStruct.new(
+          id: 1001,
+          number: 1,
+          title: "Still open",
+          body: "Body",
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-build") ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 2.days.ago,
+          updated_at: 1.day.ago
+        )
       end
 
       before do
-        allow(github_client).to receive(:issues).and_return(github_issues)
+        stub_issues_by_label("paid-build" => [ still_open_issue ])
       end
 
       it "marks stale issues as closed" do
@@ -408,6 +484,53 @@ RSpec.describe Activities::FetchIssuesActivity do
         activity.execute(project_id: project.id)
 
         expect(closed.reload.github_state).to eq("closed")
+      end
+    end
+
+    context "when fetch returns empty results with existing open issues" do
+      before do
+        create(:issue, project: project, github_issue_id: 5000, github_number: 50, github_state: "open")
+        create(:issue, project: project, github_issue_id: 5001, github_number: 51, github_state: "open")
+
+        allow(github_client).to receive(:issues).and_return([])
+      end
+
+      it "does not mark existing open issues as closed" do
+        activity.execute(project_id: project.id)
+
+        expect(project.issues.where(github_state: "open").count).to eq(2)
+      end
+    end
+
+    context "when paid-generated PRs exist on GitHub" do
+      let(:project) { create(:project, label_mappings: { "build" => "paid-build" }) }
+      let(:paid_pr) do
+        OpenStruct.new(
+          id: 2001,
+          number: 10,
+          title: "Fix #5: Some fix",
+          body: "Auto-generated PR",
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-generated") ],
+          pull_request: OpenStruct.new(html_url: "https://github.com/owner/repo/pull/10"),
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 1.day.ago,
+          updated_at: Time.current
+        )
+      end
+
+      before do
+        stub_issues_by_label("paid-generated" => [ paid_pr ])
+      end
+
+      it "syncs paid-generated PRs to the database" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:issues].size).to eq(1)
+        issue = project.issues.find_by(github_issue_id: 2001)
+        expect(issue).to be_present
+        expect(issue.is_pull_request).to be true
+        expect(issue.labels).to include("paid-generated")
       end
     end
   end


### PR DESCRIPTION
## Summary

- **Multi-label AND logic**: `FetchIssuesActivity` passed all label_mappings values as a single comma-joined labels parameter to GitHub's API, which treats it as AND (all labels required). Projects with both "build" and "plan" labels returned zero results. Fixed by making separate per-label API calls with deduplication.
- **`close_stale_issues` wipes on empty fetch**: When no issues were fetched, `where.not(column: [])` matched ALL rows in Rails, closing every open issue/PR. Added an early return guard when fetch returns empty.
- **Paid-generated PRs never synced**: Agent-created PRs only get the `paid-generated` label (not label_mappings labels), so they were never fetched by `FetchIssuesActivity`. `ScanPaidPrsActivity` couldn't find them. Fixed by always including `paid-generated` in fetched labels.

## Test plan

- [x] All 23 `fetch_issues_activity_spec` tests pass (including new tests for deduplication, empty-fetch safety, paid-generated sync, per-label API calls)
- [x] Full suite: 1175 tests, 0 failures
- [x] Lint clean (`bin/lint --changed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)