### PR TITLE
fix: increase container memory from 2GB to 4GB to prevent OOM kills

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -70,7 +70,7 @@ module Containers
 
     # Default resource limits (per issue #23 requirements)
     DEFAULTS = {
-      memory_bytes: 2 * 1024 * 1024 * 1024,     # 2GB RAM
+      memory_bytes: Integer(ENV.fetch("CONTAINER_MEMORY_BYTES", 4 * 1024 * 1024 * 1024)), # 4GB RAM
       cpu_quota: 200_000,                        # 2 CPUs (100_000 per CPU)
       pids_limit: 500,                           # 500 process limit
       timeout_seconds: 1800,                     # 30 minutes default timeout

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Containers::Provision do
   end
 
   describe "constants" do
-    it "defines default memory limit of 2GB" do
-      expect(described_class::DEFAULTS[:memory_bytes]).to eq(2 * 1024 * 1024 * 1024)
+    it "defines default memory limit of 4GB" do
+      expect(described_class::DEFAULTS[:memory_bytes]).to eq(4 * 1024 * 1024 * 1024)
     end
 
     it "defines default CPU quota for 2 CPUs" do
@@ -118,8 +118,8 @@ RSpec.describe Containers::Provision do
       it "configures resource limits" do
         expect(Docker::Container).to receive(:create) do |config|
           host_config = config["HostConfig"]
-          expect(host_config["Memory"]).to eq(2 * 1024 * 1024 * 1024)
-          expect(host_config["MemorySwap"]).to eq(2 * 1024 * 1024 * 1024)
+          expect(host_config["Memory"]).to eq(4 * 1024 * 1024 * 1024)
+          expect(host_config["MemorySwap"]).to eq(4 * 1024 * 1024 * 1024)
           expect(host_config["CpuPeriod"]).to eq(100_000)
           expect(host_config["CpuQuota"]).to eq(200_000)
           expect(host_config["PidsLimit"]).to eq(500)


### PR DESCRIPTION
## Summary

- The last 3 agent runs (#59, #60, #61) all failed with **exit code 137 (SIGKILL)** due to Docker OOM (Out of Memory) kills
- `docker inspect` on the surviving container (#61) confirmed `"OOMKilled": true`
- Root cause: containers had a 2GB RAM limit with swap disabled (`MemorySwap == Memory`), which is insufficient for Claude Code + build operations (bundle install, rspec, native extensions)
- **Fix**: Increase default container memory from 2GB to 4GB
- **Bonus**: Memory is now configurable via `CONTAINER_MEMORY_BYTES` env var for environments with different resource profiles

## Test plan

- [x] All 68 container provision specs pass with 0 failures
- [x] RuboCop passes with 0 offenses
- [ ] Trigger a new agent run and verify it no longer OOM-kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)