### PR TITLE
fix: skip duplicate issue requirements when issue is the PR itself

### DIFF
--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -36,7 +36,7 @@ module Prompts
     def build
       sections = []
       sections << task_section
-      sections << issue_requirements_section if issue
+      sections << issue_requirements_section if linked_issue?
       sections << merge_conflicts_section unless rebase_succeeded
       sections << ci_failures_section if failing_checks.any?
       sections << code_review_section if unresolved_threads.any?
@@ -47,6 +47,13 @@ module Prompts
     end
 
     private
+
+    # Returns true when a separate issue is linked (not the PR's own Issue record).
+    # PR follow-up runs pass the PR's Issue as `issue`, which duplicates the
+    # PR body already present in task_section. Skip it in that case.
+    def linked_issue?
+      issue.present? && !issue.is_pull_request?
+    end
 
     def pr_data
       @pr_data ||= github_client.pull_request(project.full_name, pr_number)
@@ -152,7 +159,7 @@ module Prompts
       priorities = []
       priorities << "Resolve merge conflicts" unless rebase_succeeded
       priorities << "Fix CI failures" if failing_checks.any?
-      priorities << "Close implementation gaps against the linked issue" if issue
+      priorities << "Close implementation gaps against the linked issue" if linked_issue?
       priorities << "Address code review comments" if unresolved_threads.any?
       priorities << "Address conversation comments" if trusted_comments.any?
       priority_list = priorities.each_with_index.map { |p, i| "#{i + 1}. #{p}" }.join("\n")

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Prompts::BuildForPr do
         body: "Implement dark mode toggle in settings.")
     end
 
-    it "includes issue requirements when issue is provided" do
+    it "includes issue requirements when a linked issue is provided" do
       prompt = described_class.call(
         project: project,
         pr_number: 42,
@@ -225,6 +225,26 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("#99")
       expect(prompt).to include("Implement dark mode toggle in settings.")
       expect(prompt).to include("Evaluate whether the current PR changes fully implement")
+    end
+
+    it "omits issue requirements when issue is the PR itself" do
+      pr_issue = create(:issue, :pull_request,
+        project: project,
+        title: "Fix authentication flow",
+        github_number: 42,
+        body: "This PR fixes the auth redirect bug.")
+
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true,
+        issue: pr_issue
+      )
+
+      expect(prompt).not_to include("Issue Requirements")
+      expect(prompt).to include("# Task")
+      expect(prompt).to include("This PR fixes the auth redirect bug.")
     end
   end
 


### PR DESCRIPTION
## Summary

- PR follow-up runs pass the PR's own Issue record as the linked issue to `Prompts::BuildForPr`
- This caused the PR body to appear **twice** in the prompt — once in the `# Task` section (from `pr_data.body`) and again in `# Issue Requirements` (from `issue.body`)
- All 3 recent failed agent runs (59, 60, 61) had this duplication in their prompts
- **Fix**: Add `linked_issue?` helper that checks `issue.is_pull_request?` to skip the duplicate section when the "linked issue" is actually the PR itself

## Test plan

- [x] All 24 BuildForPr specs pass (including new test for PR-as-issue case)
- [x] RuboCop passes with 0 offenses
- [x] Existing test for linked issues still passes (non-PR issues still get the section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)