### PR TITLE
fix: reclaim stale active worktrees from finished agent runs

### DIFF
--- a/app/temporal/activities/clone_repo_activity.rb
+++ b/app/temporal/activities/clone_repo_activity.rb
@@ -97,6 +97,18 @@ module Activities
       elsif existing.active? && existing.agent_run_id == agent_run.id
         # Temporal retry — the previous attempt already created this record.
         existing
+      elsif existing.active? && existing.agent_run&.finished?
+        # The owning agent run finished (failed/completed) but cleanup never
+        # marked the worktree as cleaned. Reclaim the stale record.
+        existing.update!(
+          agent_run: agent_run,
+          path: "/workspace",
+          base_commit: agent_run.base_commit_sha,
+          pushed: false,
+          cleaned_at: nil,
+          created_at: Time.current
+        )
+        existing
       elsif existing.active?
         raise Temporalio::Error::ApplicationError.new(
           "Branch #{agent_run.branch_name} has an active worktree from agent run #{existing.agent_run_id}",

--- a/spec/temporal/activities/clone_repo_activity_spec.rb
+++ b/spec/temporal/activities/clone_repo_activity_spec.rb
@@ -133,7 +133,23 @@ RSpec.describe Activities::CloneRepoActivity do
         expect(worktree).to be_active
       end
 
-      it "raises WorktreeConflict when an active worktree belongs to a different agent_run" do
+      it "reclaims an active worktree when the owning agent_run has finished" do
+        failed_agent_run = create(:agent_run, :failed, project: project)
+        create(:worktree, :active, project: project, agent_run: failed_agent_run,
+          branch_name: "existing-feature-branch", created_at: 3.days.ago)
+
+        freeze_time do
+          activity.execute(agent_run_id: agent_run.id)
+
+          worktree = Worktree.find_by(project: project, branch_name: "existing-feature-branch")
+          expect(worktree.agent_run).to eq(agent_run)
+          expect(worktree).to be_active
+          expect(worktree.pushed).to be(false)
+          expect(worktree.created_at).to eq(Time.current)
+        end
+      end
+
+      it "raises WorktreeConflict when an active worktree belongs to a different running agent_run" do
         other_agent_run = create(:agent_run, :running, project: project)
         create(:worktree, :active, project: project, agent_run: other_agent_run, branch_name: "existing-feature-branch")
 


### PR DESCRIPTION
## Summary

- When an agent run fails (e.g. OOM kill) but cleanup doesn't mark its worktree record as cleaned, subsequent runs on the same branch hit a `WorktreeConflict` error and fail after 3 Temporal retries without ever starting the agent
- Added a check in `CloneRepoActivity#create_worktree_record` — if an active worktree's owning agent run has already `finished?` (failed/completed), the worktree is stale and gets reclaimed instead of raising a conflict
- The real `WorktreeConflict` now only fires for worktrees owned by still-running agent runs

## Test plan

- [x] Added spec: "reclaims an active worktree when the owning agent_run has finished"
- [x] Updated existing spec name to clarify it tests conflict with a *running* agent run
- [x] All 11 `clone_repo_activity_spec.rb` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)