### PR TITLE
fix: rebase conflict detection and retry cleanup

### DIFF
--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -234,7 +234,10 @@ module Containers
         return false
       end
 
-      raise Error, "Rebase failed: #{error_with_stderr(result)}" if result.failure?
+      if result.failure?
+        abort_rebase
+        raise Error, "Rebase failed: #{error_with_stderr(result)}"
+      end
 
       true
     end
@@ -242,7 +245,8 @@ module Containers
     private
 
     def rebase_conflict?(result)
-      result.failure? && result[:stderr].to_s.include?("CONFLICT")
+      result.failure? &&
+        (result[:stdout].to_s.include?("CONFLICT") || result[:stderr].to_s.include?("CONFLICT"))
     end
 
     def abort_rebase

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -436,8 +436,8 @@ RSpec.describe Containers::GitOperations do
       let(:conflict_result) do
         Containers::Provision::Result.failure(
           error: "rebase failed",
-          stdout: "",
-          stderr: "CONFLICT (content): Merge conflict in app/model.rb\nFailed to merge in the changes.",
+          stdout: "CONFLICT (content): Merge conflict in app/model.rb",
+          stderr: "Failed to merge in the changes.",
           exit_code: 1
         )
       end
@@ -479,10 +479,22 @@ RSpec.describe Containers::GitOperations do
         allow(container_service).to receive(:execute)
           .with([ "git", "rebase", "origin/main" ], timeout: nil, stream: false)
           .and_return(error_result)
+
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rebase", "--abort" ], timeout: nil, stream: false)
+          .and_return(success_result)
       end
 
       it "raises Error" do
         expect { git_ops.rebase_onto("main") }.to raise_error(described_class::Error, /Rebase failed/)
+      end
+
+      it "aborts the rebase before raising" do
+        expect(container_service).to receive(:execute)
+          .with([ "git", "rebase", "--abort" ], timeout: nil, stream: false)
+          .and_return(success_result)
+
+        expect { git_ops.rebase_onto("main") }.to raise_error(described_class::Error)
       end
     end
   end

--- a/spec/temporal/activities/rebase_branch_activity_spec.rb
+++ b/spec/temporal/activities/rebase_branch_activity_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe Activities::RebaseBranchActivity do
         success_result = Containers::Provision::Result.success(stdout: "", stderr: "", exit_code: 0)
         conflict_result = Containers::Provision::Result.failure(
           error: "rebase failed",
-          stdout: "",
-          stderr: "CONFLICT (content): Merge conflict in file.rb",
+          stdout: "CONFLICT (content): Merge conflict in file.rb",
+          stderr: "Failed to merge in the changes.",
           exit_code: 1
         )
 


### PR DESCRIPTION
## Summary

- **Fix conflict detection**: `git rebase` outputs `CONFLICT (content): ...` to **stdout**, not stderr. The `rebase_conflict?` check only looked at stderr, so conflicts were missed and treated as unexpected errors (raised exception instead of returning `false`).
- **Abort rebase before raising**: When rebase fails for non-conflict reasons, the code raised without aborting the in-progress rebase. On Temporal retry, the repo was stuck in a dirty rebase-in-progress state, causing all retries to fail.
- **Fix test fixtures**: Tests had "CONFLICT" in stderr which didn't match real git behavior. Moved to stdout so tests validate the actual fix.

## Test plan

- [x] `bin/rspec spec/services/containers/git_operations_spec.rb` — 43 examples, 0 failures
- [x] `bin/rspec spec/temporal/activities/rebase_branch_activity_spec.rb` — 12 examples, 0 failures
- [ ] Verify on a real agent run that encounters rebase conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)