### PR TITLE
fix: use Docker volumes for agent workspaces

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -81,13 +81,11 @@ module Containers
       workspace_mount: "/workspace"
     }.freeze
 
-    WORKSPACE_ROOT = ENV.fetch("WORKSPACE_ROOT", "/var/paid/workspaces")
-
     attr_reader :agent_run, :worktree_path, :container, :options, :workspace_volume
 
     # @param agent_run [AgentRun] The agent run to associate logs with
     # @param worktree_path [String, nil] Path to an existing worktree to bind-mount.
-    #   When nil, an empty per-run directory is auto-created for in-container git clone.
+    #   When nil, a Docker named volume is created for in-container git clone.
     # @param options [Hash] Override default container options
     # @option options [Integer] :memory_bytes Memory limit in bytes
     # @option options [Integer] :cpu_quota CPU quota (100_000 per CPU)
@@ -131,10 +129,12 @@ module Containers
     rescue Docker::Error::DockerError => e
       log_system("container.provision.failed", error: e.message)
       cleanup
+      cleanup_workspace_volume
       raise ProvisionError, "Docker error: #{e.message}"
     rescue StandardError => e
       log_system("container.provision.failed", error: e.message)
       cleanup
+      cleanup_workspace_volume
       raise
     end
 
@@ -413,23 +413,30 @@ module Containers
         raise ProvisionError, "Worktree path does not exist: #{worktree_path}" unless File.directory?(worktree_path)
       else
         @workspace_volume = "paid-workspace-#{agent_run.id}"
-        Docker::Volume.create(@workspace_volume)
+        begin
+          Docker::Volume.get(@workspace_volume)
+        rescue Docker::Error::NotFoundError
+          Docker::Volume.create(@workspace_volume)
+        end
       end
     end
 
     def cleanup_workspace_volume
-      return unless @workspace_volume
+      volume_name = @workspace_volume
+      volume_name ||= "paid-workspace-#{agent_run.id}" if worktree_path.blank?
+      return unless volume_name
 
-      Docker::Volume.get(@workspace_volume).remove
-      @workspace_volume = nil
+      Docker::Volume.get(volume_name).remove
     rescue Docker::Error::NotFoundError
-      @workspace_volume = nil
+      # Volume already removed
     rescue => e
       Rails.logger.warn(
         message: "container_manager.workspace_cleanup_failed",
         agent_run_id: agent_run.id,
         error: e.message
       )
+    ensure
+      @workspace_volume = nil
     end
 
     def create_container

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -553,9 +553,12 @@ RSpec.describe AgentRun do
         )
       end
 
+      let(:mock_volume) { instance_double(Docker::Volume, remove: true) }
+
       before do
         allow(Docker::Container).to receive(:create).and_return(mock_container)
         allow(Docker::Container).to receive(:get).and_raise(Docker::Error::NotFoundError)
+        allow(Docker::Volume).to receive_messages(create: mock_volume, get: mock_volume)
         allow(NetworkPolicy).to receive_messages(ensure_network!: instance_double(Docker::Network), apply_firewall_rules: nil)
       end
 
@@ -575,8 +578,6 @@ RSpec.describe AgentRun do
         end
 
         it "provisions container when worktree_path is blank" do
-          allow(FileUtils).to receive(:mkdir_p).and_call_original
-          allow(FileUtils).to receive(:mkdir_p).with(a_string_matching(%r{runs/})).and_return(nil)
           agent_run = create(:agent_run, worktree_path: nil)
 
           result = agent_run.provision_container
@@ -685,8 +686,6 @@ RSpec.describe AgentRun do
         end
 
         it "provisions container when worktree_path is blank" do
-          allow(FileUtils).to receive(:mkdir_p).and_call_original
-          allow(FileUtils).to receive(:mkdir_p).with(a_string_matching(%r{runs/})).and_return(nil)
           agent_run = create(:agent_run, worktree_path: nil)
 
           agent_run.with_container { |run| expect(run).to eq(agent_run) }

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Containers::Provision do
   before do
     allow(Docker::Container).to receive(:create).and_return(mock_container)
     allow(Docker::Container).to receive(:get).and_raise(Docker::Error::NotFoundError)
-    allow(Docker::Volume).to receive_messages(create: mock_volume, get: mock_volume)
+    allow(Docker::Volume).to receive(:create).and_return(mock_volume)
+    allow(Docker::Volume).to receive(:get).and_raise(Docker::Error::NotFoundError)
     allow(NetworkPolicy).to receive_messages(ensure_network!: mock_network, apply_firewall_rules: nil)
   end
 
@@ -199,25 +200,42 @@ RSpec.describe Containers::Provision do
       end
     end
 
-    context "when worktree path is invalid" do
-      it "auto-creates workspace volume for blank path" do
+    context "when worktree path is not provided" do
+      it "creates workspace volume for nil path" do
+        service = described_class.new(agent_run: agent_run)
+
+        result = service.provision
+
+        expect(result).to be_success
+        expect(service.workspace_volume).to eq("paid-workspace-#{agent_run.id}")
+      end
+
+      it "creates workspace volume for blank path" do
         service = described_class.new(agent_run: agent_run, worktree_path: "")
 
         result = service.provision
 
         expect(result).to be_success
-        expect(Docker::Volume).to have_received(:create).with("paid-workspace-#{agent_run.id}")
         expect(service.workspace_volume).to eq("paid-workspace-#{agent_run.id}")
       end
 
-      it "mounts workspace volume in container binds for blank path" do
+      it "reuses existing volume idempotently" do
+        allow(Docker::Volume).to receive(:get).with("paid-workspace-#{agent_run.id}").and_return(mock_volume)
+        service = described_class.new(agent_run: agent_run)
+
+        service.provision
+
+        expect(Docker::Volume).not_to have_received(:create)
+      end
+
+      it "mounts workspace volume in container binds" do
         expect(Docker::Container).to receive(:create) do |config|
           binds = config["HostConfig"]["Binds"]
           expect(binds).to include("paid-workspace-#{agent_run.id}:/workspace:rw")
           mock_container
         end
 
-        described_class.new(agent_run: agent_run, worktree_path: "").provision
+        described_class.new(agent_run: agent_run).provision
       end
 
       it "raises ProvisionError for non-existent path" do


### PR DESCRIPTION
## Summary

- Replace host bind mounts with Docker named volumes for auto-created agent workspaces, fixing `fatal: write error: No space left on device` (git exit code 128) failures since run #69
- In the DooD devcontainer setup, workspace dirs on the overlay filesystem resolve to the OrbStack VM root disk (8GB, 100% full) when bind-mounted — Docker volumes use the overlay2 disk (160GB) instead
- Worktree-based bind mounts (explicit `worktree_path`) are unchanged

## Test plan

- [x] `bin/rspec spec/services/containers/provision_spec.rb` — 69 examples, 0 failures
- [x] `bin/lint --changed` — no offenses
- [ ] Manual: trigger an agent run without a worktree path and confirm `git clone` succeeds inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)