### PR TITLE
Enable Turbo scroll position preservation on page refresh

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="min-h-screen bg-gray-50">
+  <body class="min-h-screen bg-gray-50" data-turbo-refresh-scroll="preserve">
     <nav class="bg-white shadow-sm">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 justify-between">


### PR DESCRIPTION
Add data-turbo-refresh-scroll="preserve" to the body tag so Turbo
maintains the user's scroll position across page refreshes.

https://claude.ai/code/session_01WUNTbNanZRrTSToXpX7N7p