### PR TITLE
fix: always enqueue ProcessRunQueueJob on agent run failure

### DIFF
--- a/app/temporal/activities/mark_agent_run_failed_activity.rb
+++ b/app/temporal/activities/mark_agent_run_failed_activity.rb
@@ -16,11 +16,13 @@ module Activities
       else
         agent_run.fail!(error: error)
         agent_run.log!("system", "Agent run failed: #{error}")
-
-        # Only trigger queue processing when this activity actually transitions the run,
-        # avoiding redundant enqueues when the run was already terminal (e.g. timeout).
-        ProcessRunQueueJob.perform_later
       end
+
+      # Always trigger queue processing so remaining queued runs get claimed.
+      # This is safe because ProcessRunQueueJob is idempotent (advisory lock +
+      # SKIP LOCKED). Without this, runs that were already marked failed by
+      # RunAgentActivity would skip queue processing entirely.
+      ProcessRunQueueJob.perform_later
 
       # Always update issue state so it doesn't stay stuck in "in_progress".
       if agent_run.issue && agent_run.issue.paid_state != "failed"

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -69,12 +69,12 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
         .to have_enqueued_job(ProcessRunQueueJob)
     end
 
-    it "does not enqueue ProcessRunQueueJob when run is already finished" do
+    it "enqueues ProcessRunQueueJob even when run is already finished" do
       agent_run = create(:agent_run, :running, project: project)
       agent_run.timeout!(error: "startup_timeout: No output received")
 
       expect { activity.execute(agent_run_id: agent_run.id, error: "Activity task failed") }
-        .not_to have_enqueued_job(ProcessRunQueueJob)
+        .to have_enqueued_job(ProcessRunQueueJob)
     end
 
     it "raises ActiveRecord::RecordNotFound for invalid agent_run_id" do


### PR DESCRIPTION
## Summary

- **Bug**: When `RunAgentActivity` detected an agent CLI failure (e.g., auth error), it called `agent_run.fail!` before raising an exception. `MarkAgentRunFailedActivity` then saw the run as already `finished?` and skipped `ProcessRunQueueJob.perform_later`, leaving queued runs permanently stuck.
- **Fix**: Moved `ProcessRunQueueJob.perform_later` outside the `if/else` in `MarkAgentRunFailedActivity` so it always fires regardless of whether the status transition happened. This is safe because the job is idempotent (PostgreSQL advisory lock + `FOR UPDATE SKIP LOCKED`).
- Also cleaned up stuck run 84 (zombie container) and triggered queue processing for runs 87/89.

## Test plan

- [x] Updated spec: `MarkAgentRunFailedActivity` now enqueues `ProcessRunQueueJob` even when the run is already finished
- [x] All 20 related specs pass (`mark_agent_run_failed_activity_spec`, `mark_agent_run_complete_activity_spec`, `process_run_queue_job_spec`)
- [ ] Verify queued runs get processed after a run fails with an agent-level error

🤖 Generated with [Claude Code](https://claude.com/claude-code)