### PR TITLE
Add ShellCheck linting to devcontainer and bin/lint

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   cmake \
   chromium \
+  shellcheck \
   tmux \
   libpq-dev \
   && rm -rf /var/lib/apt/lists/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ bin/rails server             # Start Rails server only
 bin/rails console            # Rails console
 
 # Code Quality
-bin/lint                     # Run linters (RuboCop, ESLint, markdownlint)
+bin/lint                     # Run linters (RuboCop, ESLint, markdownlint, ShellCheck)
 bin/lint -a                  # Run linters with safe auto-fix
 bin/lint -A                  # Run linters with auto-fix (including unsafe)
 bin/lint --changed           # Lint only changed files (staged + unstaged vs HEAD)

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 # If running the rails server then create or migrate existing database
+# shellcheck disable=SC2198 # ${@: -N:1} slices exactly one positional parameter
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare
 fi

--- a/bin/lint
+++ b/bin/lint
@@ -18,6 +18,8 @@ for arg in "$@"; do
       echo "  -A         Auto-fix all including unsafe (rubocop -A, eslint --fix, markdownlint --fix)"
       echo "  --changed  Lint only changed files (staged + unstaged vs HEAD)"
       echo "  --staged   Lint only staged files"
+      echo ""
+      echo "Linters: RuboCop, ESLint, markdownlint, ShellCheck"
       exit 0
       ;;
     *)
@@ -71,11 +73,13 @@ fi
 ruby_files=""
 js_files=""
 md_files=""
+sh_files=""
 
 if [ "$FILE_FILTER" = true ]; then
   ruby_files=$(echo "$FILES" | grep -E '\.rb$' || true)
   js_files=$(echo "$FILES" | grep -E '\.(js|ts|jsx|tsx)$' || true)
   md_files=$(echo "$FILES" | grep -E '\.md$' || true)
+  sh_files=$(echo "$FILES" | grep -E '\.sh$' || true)
 fi
 
 echo "== Style: RuboCop =="
@@ -115,6 +119,18 @@ if [ "$FILE_FILTER" = true ]; then
 else
   # shellcheck disable=SC2086
   npx markdownlint $MARKDOWNLINT_ARGS --ignore node_modules --ignore vendor '**/*.md'
+fi
+
+echo "== Shell: ShellCheck =="
+if [ "$FILE_FILTER" = true ]; then
+  if [ -n "$sh_files" ]; then
+    # shellcheck disable=SC2086
+    shellcheck $sh_files
+  else
+    echo "  No shell files to lint."
+  fi
+else
+  shellcheck scripts/*.sh .devcontainer/*.sh .githooks/* bin/audit bin/dev bin/docker-entrypoint bin/lint
 fi
 
 echo "All lint checks passed."

--- a/scripts/test-agent-image.sh
+++ b/scripts/test-agent-image.sh
@@ -77,11 +77,11 @@ if [ "$CURRENT_UID" -eq 0 ]; then
 fi
 
 if [ "$CURRENT_USER" != "agent" ]; then
-    echo "   ERROR: Running as '$CURRENT_USER', expected 'agent'"
+    echo "   ERROR: Running as ${CURRENT_USER}, expected agent"
     exit 1
 fi
 
-echo "   ✓ Running as non-root user 'agent'"
+echo "   ✓ Running as non-root user: agent"
 
 echo ""
 echo "9. Workspace directory:"


### PR DESCRIPTION
Install shellcheck in the devcontainer Dockerfile and add a ShellCheck
section to bin/lint that checks all shell scripts (bin/, scripts/,
.devcontainer/, .githooks/). Also fix existing shellcheck warnings in
scripts/test-agent-image.sh and bin/docker-entrypoint.

https://claude.ai/code/session_01LubhMWG4sjGMroekvHCbLR