### PR TITLE
fix: upgrade devcontainer to bookworm with CloudFront APT mirror

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,11 +20,16 @@ RUN set -e; \
     sed -i 's|http://deb.debian.org|http://cloudfront.debian.net|g' /etc/apt/sources.list && sources_modified=1; \
   fi; \
   if [ "$sources_modified" -eq 0 ]; then \
-    echo "Warning: no APT sources were updated to use the CloudFront mirror." >&2; \
+    echo "Info: no APT sources were updated to use the CloudFront mirror; this can be normal for some base images." >&2; \
   fi; \
   echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries \
   && apt-get update -qq \
-  && apt-get install -y build-essential cmake shellcheck tmux libpq-dev chromium \
+  && apt-get install -y build-essential cmake shellcheck tmux libpq-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install chromium separately for better layer caching (updates more frequently)
+RUN apt-get update -qq \
+  && apt-get install -y chromium \
   && rm -rf /var/lib/apt/lists/*
 
 # Install yarn


### PR DESCRIPTION
## Summary
- Upgrade base image from Debian bullseye to bookworm (3.4-bookworm)
- Add CloudFront mirror for Debian APT packages to avoid Fastly CDN connection drops experienced in OrbStack
- Add APT retry configuration (3 retries) for resilience
- Separate chromium install for better layer caching

## Test plan
- [ ] Rebuild the devcontainer and verify it builds successfully
- [ ] Verify `apt-get install` uses CloudFront mirrors
- [ ] Confirm all system dependencies (chromium, shellcheck, tmux, etc.) install correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)