### PR TITLE
fix: resolve tailwindcss 404 by loading only compiled stylesheet

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,8 +19,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 


### PR DESCRIPTION
## Summary
- `stylesheet_link_tag :app` was including **all** CSS files from propshaft's load paths, serving both the compiled `application.css` and the unprocessed source `application.tailwind.css`
- The browser loaded the source file, tried to resolve its `@import "tailwindcss"` as a network request to `/assets/tailwindcss`, and got a 404
- Changed to `stylesheet_link_tag "application"` to load only the compiled Tailwind CSS

## Test plan
- [x] Verified only one `<link>` tag in HTML output (`/assets/application-*.css`)
- [x] Verified zero console errors in browser
- [x] Verified page renders correctly with all Tailwind styles intact
- [ ] Verify on other pages (dashboard, projects) after sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)