### PR TITLE
Remove --ensure-latest from brakeman and update to 8.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -553,7 +553,7 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.2) sha256=7b02065ce8b1de93949cefd3f2ad78e8eb370e644b95c8556a32a912a782426a
+  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -4,6 +4,7 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
+# Rely on Dependabot to keep brakeman up to date (weekly PRs).
+# Actual findings are enforced via --exit-on-warn/--exit-on-error in bin/audit.
 
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
The --ensure-latest flag causes CI to fail when a newer brakeman version
is released, even when there are zero actual security findings. This is
counterproductive — the findings matter more than the version.

Brakeman is already kept up to date by Dependabot (weekly bundler PRs),
and actual security findings are still enforced via --exit-on-warn and
--exit-on-error in bin/audit.

https://claude.ai/code/session_01VzdQBU15p8WgLPxxmi4PEb