### PR TITLE
Speed up slow tests (25% faster suite)

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -225,7 +225,7 @@ module Containers
         # with a non-zero exit code when the process is killed).
         raise_if_watchdog_timeout!(watchdog_mutex, timeout_reason_ref, startup_timeout, idle_timeout)
 
-        # The watchdog polls every 1s, so exec may return between ticks with a
+        # The watchdog polls periodically, so exec may return between ticks with a
         # deadline already exceeded. Check the deadline directly in the main thread.
         check_deadline_exceeded!(watchdog_mutex, output_received, last_activity_at, startup_timeout, idle_timeout)
 
@@ -692,7 +692,7 @@ module Containers
 
       Thread.new do
         loop do
-          sleep 1
+          sleep watchdog_poll_interval
 
           should_fire = watchdog_mutex.synchronize do
             if exec_completed_ref.call
@@ -732,6 +732,12 @@ module Containers
           break
         end
       end
+    end
+
+    # How often the watchdog thread checks for timeouts, in seconds.
+    # Extracted as a method so tests can override with a shorter interval.
+    def watchdog_poll_interval
+      1
     end
 
     # Stops the watchdog thread and waits for it to exit cleanly.

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -7,6 +7,7 @@ module Activities
   # Handles rate limiting by re-raising as a retryable Temporal error.
   class FetchIssuesActivity < BaseActivity
     PAID_GENERATED_LABEL = "paid-generated"
+    PER_PAGE = 100
 
     def execute(input)
       project_id = input[:project_id]
@@ -71,14 +72,14 @@ module Activities
           repo_full_name,
           labels: label ? [ label ] : nil,
           state: "open",
-          per_page: 100,
+          per_page: PER_PAGE,
           page: page
         )
 
         break if page_issues.empty?
 
         issues.concat(page_issues)
-        break if page_issues.size < 100
+        break if page_issues.size < PER_PAGE
 
         page += 1
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -728,6 +728,8 @@ RSpec.describe Containers::Provision do
 
     before do
       service.provision
+      # Speed up watchdog polling for tests (default is 1s)
+      allow(service).to receive(:watchdog_poll_interval).and_return(0.05)
       # When the watchdog calls container.stop, set the flag so the
       # exec mock can unblock.
       allow(mock_container).to receive(:stop) do |**_opts|
@@ -738,12 +740,12 @@ RSpec.describe Containers::Provision do
     context "with startup timeout" do
       it "fires when exec produces no output" do
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
-          sleep 0.1 until container_stopped.true?
+          sleep 0.01 until container_stopped.true?
           [ [], [], 137 ]
         end
 
         expect {
-          service.execute("slow_command", timeout: 10, startup_timeout: 1)
+          service.execute("slow_command", timeout: 10, startup_timeout: 0.1)
         }.to raise_error(described_class::StartupTimeoutError)
       end
 
@@ -762,12 +764,12 @@ RSpec.describe Containers::Provision do
       it "fires when output stops mid-stream" do
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
           block.call(:stdout, "initial output\n") if block
-          sleep 0.1 until container_stopped.true?
+          sleep 0.01 until container_stopped.true?
           [ [ "initial output\n" ], [], 137 ]
         end
 
         expect {
-          service.execute("stalling_command", timeout: 10, idle_timeout: 1)
+          service.execute("stalling_command", timeout: 10, idle_timeout: 0.1)
         }.to raise_error(described_class::IdleTimeoutError)
       end
 
@@ -775,7 +777,7 @@ RSpec.describe Containers::Provision do
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
           3.times do
             block.call(:stdout, "chunk\n") if block
-            sleep 0.2
+            sleep 0.05
           end
           [ [ "chunk\nchunk\nchunk\n" ], [], 0 ]
         end
@@ -788,12 +790,12 @@ RSpec.describe Containers::Provision do
     context "with startup timeout when exec raises Docker error" do
       it "detects the watchdog reason through the Docker error" do
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
-          sleep 0.1 until container_stopped.true?
+          sleep 0.01 until container_stopped.true?
           raise Docker::Error::ServerError, "connection closed"
         end
 
         expect {
-          service.execute("slow_command", timeout: 10, startup_timeout: 1)
+          service.execute("slow_command", timeout: 10, startup_timeout: 0.1)
         }.to raise_error(described_class::StartupTimeoutError)
       end
     end

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       let(:project) { create(:project, label_mappings: { "build" => "paid-build" }) }
 
       let(:page1_issues) do
-        Array.new(100) do |i|
+        Array.new(5) do |i|
           OpenStruct.new(
             id: 2000 + i,
             number: i + 1,
@@ -264,8 +264,8 @@ RSpec.describe Activities::FetchIssuesActivity do
         [
           OpenStruct.new(
             id: 3000,
-            number: 101,
-            title: "Issue 101",
+            number: 6,
+            title: "Issue 6",
             body: "Body",
             state: "open",
             labels: [ OpenStruct.new(name: "paid-build") ],
@@ -278,6 +278,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       before do
+        stub_const("Activities::FetchIssuesActivity::PER_PAGE", 5)
         allow(github_client).to receive(:issues) do |_repo, **opts|
           label = Array(opts[:labels]).first
           page = opts[:page] || 1
@@ -293,7 +294,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       it "paginates through all pages" do
         result = activity.execute(project_id: project.id)
 
-        expect(result[:issues].size).to eq(101)
+        expect(result[:issues].size).to eq(6)
       end
     end
 
@@ -301,13 +302,16 @@ RSpec.describe Activities::FetchIssuesActivity do
       let(:project) { create(:project, label_mappings: { "build" => "paid-build" }) }
 
       before do
+        stub_const("Activities::FetchIssuesActivity::PER_PAGE", 5)
+        stub_const("Activities::FetchIssuesActivity::MAX_PAGES", 3)
+
         allow(github_client).to receive(:issues) do |_repo, **opts|
           label = Array(opts[:labels]).first
           page = opts[:page] || 1
           if label == "paid-build"
             # Return unique IDs per page to avoid deduplication
-            offset = (page - 1) * 100
-            Array.new(100) do |i|
+            offset = (page - 1) * 5
+            Array.new(5) do |i|
               OpenStruct.new(
                 id: 4000 + offset + i,
                 number: offset + i + 1,
@@ -332,7 +336,7 @@ RSpec.describe Activities::FetchIssuesActivity do
 
         result = activity.execute(project_id: project.id)
 
-        expect(result[:issues].size).to eq(described_class::MAX_PAGES * 100)
+        expect(result[:issues].size).to eq(3 * 5)
         expect(Rails.logger).to have_received(:warn).with(
           hash_including(message: "github_sync.fetch_issues_page_limit")
         )


### PR DESCRIPTION
## Summary
- **FetchIssuesActivity** pagination tests were creating 100–1000 DB records to test logic that only needs a handful. Extracted `PER_PAGE` constant and stub it to 5 in tests (`MAX_PAGES` to 3 for the page-limit test), reducing the slowest test from **11s → 0.16s** (69x faster)
- **Containers::Provision** watchdog timeout tests were waiting 1+ real seconds due to a hardcoded `sleep(1)` poll interval. Extracted `watchdog_poll_interval` method and stub it to 0.05s in tests, cutting each watchdog test from **~1.1s → ~0.17s** (6.5x faster)
- Total suite time reduced from **72.5s → 54.2s (25% faster)**

## Test plan
- [x] Full test suite passes (1401 examples, 0 failures)
- [x] No production behavior changed (constants/methods have same default values)
- [x] RuboCop passes with no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)