### PR TITLE
Fix regression: empty label_mappings stopped syncing all issues

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -16,7 +16,8 @@ module Activities
 
       client = project.github_token.client
 
-      labels = (project.label_mappings.values.compact_blank + [ PAID_GENERATED_LABEL ]).uniq
+      labels = project.label_mappings.values.compact_blank.uniq
+      labels = (labels + [ PAID_GENERATED_LABEL ]).uniq if labels.any?
       github_issues = fetch_all_issues(client, project.full_name, labels)
 
       synced_issues = github_issues.map { |gi| sync_issue(project, gi) }

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -350,12 +350,12 @@ RSpec.describe Activities::FetchIssuesActivity do
         allow(github_client).to receive(:issues).and_return([])
       end
 
-      it "still fetches paid-generated issues to track existing PRs" do
+      it "fetches all open issues without label filter" do
         activity.execute(project_id: project.id)
 
         expect(github_client).to have_received(:issues).with(
           project.full_name,
-          hash_including(labels: [ "paid-generated" ])
+          hash_including(labels: nil, state: "open")
         )
       end
     end


### PR DESCRIPTION
## Summary

- Bug 6 fix in #196 changed `FetchIssuesActivity` label construction to always append `"paid-generated"`, which broke the "fetch all open issues" fallback for projects with no configured label mappings
- All 8 active projects have empty `label_mappings`, so they all stopped syncing (logs show `issue_count: 0` every poll cycle)
- Restores the `if labels.any?` guard so `"paid-generated"` is only appended when other labels are already configured; projects with empty mappings resume fetching all open issues unfiltered

## Test plan

- [x] All 271 polling-related specs pass (temporal activities, workflows, health check, github client)
- [x] Linting passes
- [ ] Verify issue/PR sync resumes on next poll cycle after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)