### PR TITLE
Fix #210: When a failed agent run is retried, a new agent run is created and the old on stays in the failed status. I think we should have a new status “Retried” so the user can see which agent runs were retried and which ones were left failed

### DIFF
--- a/app/controllers/agent_runs_controller.rb
+++ b/app/controllers/agent_runs_controller.rb
@@ -86,6 +86,8 @@ class AgentRunsController < ApplicationController
       status: "queued"
     )
 
+    @agent_run.retry!
+
     ProcessRunQueueJob.perform_later
 
     redirect_to project_agent_run_path(@project, new_run),

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,8 @@ module ApplicationHelper
     "completed" => { bg: "bg-green-100", text: "text-green-700", label: "Completed" },
     "failed" => { bg: "bg-red-100", text: "text-red-700", label: "Failed" },
     "cancelled" => { bg: "bg-gray-100", text: "text-gray-600", label: "Cancelled" },
-    "timeout" => { bg: "bg-orange-100", text: "text-orange-700", label: "Timeout" }
+    "timeout" => { bg: "bg-orange-100", text: "text-orange-700", label: "Timeout" },
+    "retried" => { bg: "bg-purple-100", text: "text-purple-700", label: "Retried" }
   }.freeze
 
   def agent_run_status_badge(status)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AgentRun < ApplicationRecord
-  STATUSES = %w[queued pending running completed failed cancelled timeout].freeze
+  STATUSES = %w[queued pending running completed failed cancelled timeout retried].freeze
   AGENT_TYPES = %w[claude_code cursor codex copilot aider gemini opencode kilocode api].freeze
   GOALS = %w[create_pr create_issue].freeze
 
@@ -45,8 +45,9 @@ class AgentRun < ApplicationRecord
   scope :failed, -> { where(status: "failed") }
   scope :cancelled, -> { where(status: "cancelled") }
   scope :timeout, -> { where(status: "timeout") }
+  scope :retried, -> { where(status: "retried") }
   scope :active, -> { where(status: %w[pending running]) }
-  scope :finished, -> { where(status: %w[completed failed cancelled timeout]) }
+  scope :finished, -> { where(status: %w[completed failed cancelled timeout retried]) }
   scope :recent, -> { order(created_at: :desc) }
 
   def duration
@@ -106,7 +107,7 @@ class AgentRun < ApplicationRecord
   end
 
   def finished?
-    %w[completed failed cancelled timeout].include?(status)
+    %w[completed failed cancelled timeout retried].include?(status)
   end
 
   def successful?
@@ -162,6 +163,14 @@ class AgentRun < ApplicationRecord
       error_message: error,
       duration_seconds: duration
     )
+  end
+
+  def retried?
+    status == "retried"
+  end
+
+  def retry!
+    update!(status: "retried")
   end
 
   # Creates a log entry for this agent run.

--- a/spec/factories/agent_runs.rb
+++ b/spec/factories/agent_runs.rb
@@ -58,6 +58,13 @@ FactoryBot.define do
       duration_seconds { 3600 }
     end
 
+    trait :retried do
+      status { "retried" }
+      started_at { 10.minutes.ago }
+      completed_at { Time.current }
+      duration_seconds { 600 }
+    end
+
     trait :with_temporal do
       temporal_workflow_id { "workflow-#{SecureRandom.uuid}" }
       temporal_run_id { "run-#{SecureRandom.uuid}" }

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -148,6 +148,16 @@ RSpec.describe AgentRun do
       end
     end
 
+    describe ".retried" do
+      it "returns only retried runs" do
+        retried_run = create(:agent_run, :retried)
+        create(:agent_run)
+
+        expect(described_class.retried).to include(retried_run)
+        expect(described_class.retried.count).to eq(1)
+      end
+    end
+
     describe ".active" do
       it "includes pending and running runs but not queued" do
         pending_run = create(:agent_run)
@@ -162,16 +172,17 @@ RSpec.describe AgentRun do
     end
 
     describe ".finished" do
-      it "includes completed, failed, cancelled, and timeout runs" do
+      it "includes completed, failed, cancelled, timeout, and retried runs" do
         completed_run = create(:agent_run, :completed)
         failed_run = create(:agent_run, :failed)
         cancelled_run = create(:agent_run, :cancelled)
         timeout_run = create(:agent_run, :timeout)
+        retried_run = create(:agent_run, :retried)
         create(:agent_run)
 
         finished = described_class.finished
-        expect(finished).to include(completed_run, failed_run, cancelled_run, timeout_run)
-        expect(finished.count).to eq(4)
+        expect(finished).to include(completed_run, failed_run, cancelled_run, timeout_run, retried_run)
+        expect(finished.count).to eq(5)
       end
     end
 
@@ -308,12 +319,30 @@ RSpec.describe AgentRun do
         expect(build(:agent_run, :timeout).finished?).to be true
       end
 
+      it "returns true for retried status" do
+        expect(build(:agent_run, :retried).finished?).to be true
+      end
+
       it "returns false for pending status" do
         expect(build(:agent_run).finished?).to be false
       end
 
       it "returns false for running status" do
         expect(build(:agent_run, :running).finished?).to be false
+      end
+    end
+
+    describe "#retried?" do
+      it "returns true when status is retried" do
+        agent_run = build(:agent_run, :retried)
+
+        expect(agent_run.retried?).to be true
+      end
+
+      it "returns false when status is not retried" do
+        agent_run = build(:agent_run, :failed)
+
+        expect(agent_run.retried?).to be false
       end
     end
 
@@ -435,6 +464,16 @@ RSpec.describe AgentRun do
           expect(agent_run.completed_at).to eq(Time.current)
           expect(agent_run.duration_seconds).to eq((Time.current - started_time).to_i)
         end
+      end
+    end
+
+    describe "#retry!" do
+      it "sets status to retried" do
+        agent_run = create(:agent_run, :failed)
+
+        agent_run.retry!
+
+        expect(agent_run.status).to eq("retried")
       end
     end
 
@@ -808,7 +847,7 @@ RSpec.describe AgentRun do
 
   describe "constants" do
     it "defines valid STATUSES" do
-      expect(described_class::STATUSES).to eq(%w[queued pending running completed failed cancelled timeout])
+      expect(described_class::STATUSES).to eq(%w[queued pending running completed failed cancelled timeout retried])
     end
 
     it "defines valid AGENT_TYPES" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -336,6 +336,14 @@ RSpec.describe "AgentRuns" do
         expect(response).to redirect_to(project_agent_run_path(project, new_run))
       end
 
+      it "marks the original run as retried" do
+        agent_run = create(:agent_run, :failed, project: project)
+
+        post retry_project_agent_run_path(project, agent_run)
+
+        expect(agent_run.reload.status).to eq("retried")
+      end
+
       it "preserves custom_prompt from the original run" do
         agent_run = create(:agent_run, :failed, :with_custom_prompt, project: project)
 


### PR DESCRIPTION
All tasks are complete. Here's a summary of the changes made for issue #210:

## Changes Summary

**6 files changed, 74 insertions, 8 deletions**

### `app/models/agent_run.rb`
- Added `"retried"` to the `STATUSES` constant
- Added `.retried` scope
- Included `"retried"` in `.finished` scope and `#finished?` predicate
- Added `#retried?` predicate method
- Added `#retry!` transition method that sets status to `"retried"`

### `app/controllers/agent_runs_controller.rb`
- Updated the `retry` action to call `@agent_run.retry!` after creating the new queued run, marking the original run as "retried"

### `app/helpers/application_helper.rb`
- Added purple badge style for the "retried" status: `bg-purple-100` / `text-purple-700`

### `spec/factories/agent_runs.rb`
- Added `:retried` trait with appropriate attributes

### `spec/models/agent_run_spec.rb`
- Updated STATUSES constant test to include "retried"
- Added `.retried` scope test
- Updated `.finished` scope test to include retried runs (count 5 instead of 4)
- Added `#finished?` test for retried status
- Added `#retried?` predicate tests
- Added `#retry!` transition method test

### `spec/requests/agent_runs_spec.rb`
- Added test verifying the original run is marked as "retried" after retry

**Note:** Rubocop linting passed with 0 offenses. Tests could not be run because PostgreSQL is not available in this environment, but the test code is syntactically valid and follows existing patterns.

---

Closes #210