### PR TITLE
Add agent image build to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -38,6 +38,9 @@ FileUtils.chdir APP_ROOT do
   system! "bin/rails db:prepare"
   system! "bin/rails db:reset" if ARGV.include?("--reset")
 
+  puts "\n== Building agent container image =="
+  system! "docker compose --profile setup up agent-image --build"
+
   puts "\n== Removing old logs and tempfiles =="
   FileUtils.rm_f(Dir["log/*.log"])
   FileUtils.rm_rf(%w[tmp/cache tmp/pids tmp/sockets tmp/screenshots tmp/storage])


### PR DESCRIPTION
## Summary

- Add `docker compose --profile setup up agent-image --build` to `bin/setup` so the `paid-agent:latest` image is rebuilt whenever setup runs

**Context**: The agent container Dockerfile was updated to Ruby 3.4.8 in PR #191, but the local image was never rebuilt. Agents were running with Ruby 3.2.3, causing them to bypass pre-commit hooks and attempt to compile Ruby from source (creating `.tmp-build/` artifacts in PRs). The docker-compose `agent-image` service already existed for this purpose — this just wires it into the standard setup flow.

## Test plan

- [x] Verified `docker compose --profile setup up agent-image --build` rebuilds the image
- [x] Confirmed `paid-agent:latest` now has Ruby 3.4.8
- [ ] Run `bin/setup --skip-server` and verify agent image step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)