### PR TITLE
Add /.local/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ WORKLOG.md
 /pgdata/
 /.postgres/
 /.rubocop-cache/
+/.local/
 /.local-include/
 /.local-deps/
 /.libyaml-build/


### PR DESCRIPTION
## Summary

- Adds `/.local/` to `.gitignore` to prevent accidentally committing local data files
- PR #216 committed 3,055 PostgreSQL data files under `.local/pg-data/` because only `/.local-include/` and `/.local-deps/` were covered, not `/.local/` itself

## Test plan

- [x] Verify `.local/` directories are now ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)