### PR TITLE
Fix #229: Default sort order on projects index to paid activity descending

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,7 +9,7 @@ class ProjectsController < ApplicationController
   def index
     base_scope = policy_scope(Project).includes(:github_token, :agent_runs)
     @q = base_scope.ransack(params[:q])
-    @q.sorts = "created_at desc" if @q.sorts.empty?
+    @q.sorts = "last_agent_run_at desc" if @q.sorts.empty?
     @projects = apply_nulls_last_ordering(@q.result)
   end
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -128,9 +128,9 @@ RSpec.describe "Projects" do
         expect(response.body.index(active_project.name)).to be < response.body.index(null_project.name)
       end
 
-      it "defaults to created_at desc when no sort is specified" do
-        old_project = create(:project, account: account, github_token: github_token, name: "Older Project", created_at: 2.days.ago)
-        new_project = create(:project, account: account, github_token: github_token, name: "Newer Project", created_at: 1.hour.ago)
+      it "defaults to last_agent_run_at desc when no sort is specified" do
+        old_project = create(:project, account: account, github_token: github_token, name: "Older Project", last_agent_run_at: 2.days.ago)
+        new_project = create(:project, account: account, github_token: github_token, name: "Newer Project", last_agent_run_at: 1.hour.ago)
 
         get projects_path
 


### PR DESCRIPTION
Done. Here's a summary of what was changed:

**Changes made (2 files):**

1. **`app/controllers/projects_controller.rb`** (line 12): Changed the default Ransack sort from `"created_at desc"` to `"last_agent_run_at desc"`. This makes the projects index page default to sorting by paid activity (most recent first), with NULL values pushed to the end via the existing `apply_nulls_last_ordering` method.

2. **`spec/requests/projects_spec.rb`** (lines 131-138): Updated the default sort test to verify the new behavior — it now creates projects with different `last_agent_run_at` timestamps instead of `created_at` timestamps, and the test description reflects the new default.

The sort indicators in the UI will automatically show a `↓` arrow on "Paid Activity" by default, since the existing `sort_link_to` helper reads from `@q.sorts`.

---

Closes #229