### PR TITLE
Fix #230: Add issue completion statistics section to dashboard

### DIFF
--- a/app/services/dashboard/stats.rb
+++ b/app/services/dashboard/stats.rb
@@ -17,6 +17,7 @@ module Dashboard
         run_volume: run_volume,
         duration_percentiles: duration_percentiles,
         cost_and_tokens: cost_and_tokens,
+        issue_completion: issue_completion,
         runs_by_agent_type: runs_by_agent_type,
         runs_by_project: runs_by_project
       }
@@ -26,6 +27,76 @@ module Dashboard
 
     def agent_runs
       @agent_runs ||= AgentRun.joins(:project).where(projects: { account_id: account.id })
+    end
+
+    def issues
+      @issues ||= Issue.joins(:project).where(projects: { account_id: account.id })
+    end
+
+    def non_pr_issues
+      @non_pr_issues ||= issues.where(is_pull_request: false)
+    end
+
+    def issue_completion
+      total = non_pr_issues.count
+      completed = non_pr_issues.where(paid_state: "completed").count
+      aggs = issue_completion_aggregates
+
+      {
+        total_issues: total,
+        completed_count: completed,
+        failed_count: non_pr_issues.where(paid_state: "failed").count,
+        in_progress_count: non_pr_issues.where(paid_state: "in_progress").count,
+        completion_rate: total.zero? ? 0.0 : (completed.to_f / total * 100).round(1),
+        runs_per_issue: {
+          avg: aggs["avg_runs"].to_f.round(1),
+          min: aggs["min_runs"].to_i,
+          max: aggs["max_runs"].to_i,
+          median: aggs["median_runs"].to_f.round(1)
+        },
+        time_to_merge: {
+          avg: aggs["avg_wall_clock"].to_i,
+          p50: aggs["p50_wall_clock"].to_i,
+          p90: aggs["p90_wall_clock"].to_i
+        },
+        agent_minutes: {
+          avg: aggs["avg_agent_seconds"].to_i,
+          p50: aggs["p50_agent_seconds"].to_i,
+          p90: aggs["p90_agent_seconds"].to_i
+        }
+      }
+    end
+
+    def issue_completion_aggregates
+      sql = ActiveRecord::Base.sanitize_sql_array([ <<~SQL.squish, account.id ])
+        WITH per_issue AS (
+          SELECT ar.issue_id,
+            COUNT(*) AS run_count,
+            COALESCE(SUM(COALESCE(ar.duration_seconds, 0)), 0) AS total_agent_seconds,
+            EXTRACT(EPOCH FROM (MAX(i.updated_at) - MIN(ar.created_at))) AS wall_clock_seconds
+          FROM agent_runs ar
+          JOIN issues i ON i.id = ar.issue_id
+          JOIN projects p ON p.id = i.project_id
+          WHERE i.is_pull_request = false
+            AND i.paid_state = 'completed'
+            AND p.account_id = ?
+          GROUP BY ar.issue_id
+        )
+        SELECT
+          COALESCE(AVG(run_count), 0) AS avg_runs,
+          COALESCE(MIN(run_count), 0) AS min_runs,
+          COALESCE(MAX(run_count), 0) AS max_runs,
+          COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY run_count), 0) AS median_runs,
+          COALESCE(AVG(wall_clock_seconds), 0) AS avg_wall_clock,
+          COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY wall_clock_seconds), 0) AS p50_wall_clock,
+          COALESCE(percentile_cont(0.9) WITHIN GROUP (ORDER BY wall_clock_seconds), 0) AS p90_wall_clock,
+          COALESCE(AVG(total_agent_seconds), 0) AS avg_agent_seconds,
+          COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY total_agent_seconds), 0) AS p50_agent_seconds,
+          COALESCE(percentile_cont(0.9) WITHIN GROUP (ORDER BY total_agent_seconds), 0) AS p90_agent_seconds
+        FROM per_issue
+      SQL
+
+      ActiveRecord::Base.connection.select_one(sql)
     end
 
     def run_volume

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -145,6 +145,107 @@
     </div>
   </div>
 
+  <%# Issue Completion %>
+  <div class="mt-8">
+    <h2 class="text-lg font-semibold text-gray-900">Issue Completion</h2>
+    <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500">Total Issues</dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+          <%= number_with_delimiter(@stats[:issue_completion][:total_issues]) %>
+        </dd>
+      </div>
+      <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500">Completed</dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight text-green-600">
+          <%= number_with_delimiter(@stats[:issue_completion][:completed_count]) %>
+        </dd>
+      </div>
+      <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500">Failed</dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight text-red-600">
+          <%= number_with_delimiter(@stats[:issue_completion][:failed_count]) %>
+        </dd>
+      </div>
+      <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500">Completion Rate</dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+          <%= @stats[:issue_completion][:completion_rate] %>%
+        </dd>
+      </div>
+    </div>
+
+    <%# Runs per Issue %>
+    <div class="mt-4">
+      <h3 class="text-sm font-medium text-gray-500">Agent Runs per Completed Issue</h3>
+      <div class="mt-2 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <% { "Average" => :avg, "Median" => :median, "Min" => :min, "Max" => :max }.each do |label, key| %>
+          <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
+            <dt class="truncate text-sm font-medium text-gray-500"><%= label %></dt>
+            <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+              <% value = @stats[:issue_completion][:runs_per_issue][key] %>
+              <%= value > 0 ? value : "--" %>
+            </dd>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <%# Time-to-Merge %>
+    <div class="mt-4 grid grid-cols-1 gap-8 lg:grid-cols-2">
+      <div>
+        <h3 class="text-sm font-medium text-gray-500">Wall Clock Time to Merge</h3>
+        <div class="mt-2 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <% { "Average" => :avg, "Median (p50)" => :p50, "p90" => :p90 }.each do |label, key| %>
+            <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
+              <dt class="truncate text-sm font-medium text-gray-500"><%= label %></dt>
+              <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-900">
+                <% seconds = @stats[:issue_completion][:time_to_merge][key] %>
+                <% if seconds > 0 %>
+                  <% if seconds >= 86400 %>
+                    <%= seconds / 86400 %>d <%= (seconds % 86400) / 3600 %>h
+                  <% elsif seconds >= 3600 %>
+                    <%= seconds / 3600 %>h <%= (seconds % 3600) / 60 %>m
+                  <% elsif seconds >= 60 %>
+                    <%= seconds / 60 %>m <%= seconds % 60 %>s
+                  <% else %>
+                    <%= seconds %>s
+                  <% end %>
+                <% else %>
+                  --
+                <% end %>
+              </dd>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div>
+        <h3 class="text-sm font-medium text-gray-500">Agent Execution Time per Issue</h3>
+        <div class="mt-2 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <% { "Average" => :avg, "Median (p50)" => :p50, "p90" => :p90 }.each do |label, key| %>
+            <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
+              <dt class="truncate text-sm font-medium text-gray-500"><%= label %></dt>
+              <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-900">
+                <% seconds = @stats[:issue_completion][:agent_minutes][key] %>
+                <% if seconds > 0 %>
+                  <% if seconds >= 3600 %>
+                    <%= seconds / 3600 %>h <%= (seconds % 3600) / 60 %>m
+                  <% elsif seconds >= 60 %>
+                    <%= seconds / 60 %>m <%= seconds % 60 %>s
+                  <% else %>
+                    <%= seconds %>s
+                  <% end %>
+                <% else %>
+                  --
+                <% end %>
+              </dd>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
     <%# Runs by Agent Type %>
     <div>

--- a/spec/services/dashboard/stats_spec.rb
+++ b/spec/services/dashboard/stats_spec.rb
@@ -37,6 +37,22 @@ RSpec.describe Dashboard::Stats do
         expect(stats[:runs_by_agent_type]).to be_empty
         expect(stats[:runs_by_project]).to be_empty
       end
+
+      it "returns zero issue completion counts" do
+        completion = stats[:issue_completion]
+        expect(completion[:total_issues]).to eq(0)
+        expect(completion[:completed_count]).to eq(0)
+        expect(completion[:failed_count]).to eq(0)
+        expect(completion[:in_progress_count]).to eq(0)
+        expect(completion[:completion_rate]).to eq(0.0)
+      end
+
+      it "returns zero issue completion aggregates" do
+        completion = stats[:issue_completion]
+        expect(completion[:runs_per_issue]).to eq(avg: 0.0, min: 0, max: 0, median: 0.0)
+        expect(completion[:time_to_merge]).to eq(avg: 0, p50: 0, p90: 0)
+        expect(completion[:agent_minutes]).to eq(avg: 0, p50: 0, p90: 0)
+      end
     end
 
     context "with agent runs" do
@@ -141,6 +157,95 @@ RSpec.describe Dashboard::Stats do
         types = stats[:runs_by_agent_type]
         expect(types.first).to eq([ "cursor", 2 ])
         expect(types.last).to eq([ "claude_code", 1 ])
+      end
+    end
+
+    context "with completed issues" do
+      let(:first_issue) { create(:issue, :completed, project: project, updated_at: 1.day.ago) }
+      let(:second_issue) { create(:issue, :completed, project: project, updated_at: 2.days.ago) }
+      let(:failed_issue) { create(:issue, :failed, project: project) }
+      let(:in_progress_issue) { create(:issue, :in_progress, project: project) }
+
+      before do
+        # First issue: 2 agent runs, total 900s agent time
+        create(:agent_run, :completed, project: project, issue: first_issue,
+          duration_seconds: 600, created_at: 3.days.ago)
+        create(:agent_run, :completed, project: project, issue: first_issue,
+          duration_seconds: 300, created_at: 2.days.ago)
+
+        # Second issue: 1 agent run, 400s agent time
+        create(:agent_run, :completed, project: project, issue: second_issue,
+          duration_seconds: 400, created_at: 5.days.ago)
+
+        # Failed issue: has a run but should not be counted in completion aggregates
+        create(:agent_run, :failed, project: project, issue: failed_issue,
+          duration_seconds: 100, created_at: 1.day.ago)
+
+        # In-progress issue
+        create(:agent_run, :running, project: project, issue: in_progress_issue,
+          created_at: 1.hour.ago)
+      end
+
+      it "counts issues by state" do
+        completion = stats[:issue_completion]
+        expect(completion[:total_issues]).to eq(4)
+        expect(completion[:completed_count]).to eq(2)
+        expect(completion[:failed_count]).to eq(1)
+        expect(completion[:in_progress_count]).to eq(1)
+      end
+
+      it "calculates completion rate" do
+        # 2 completed / 4 total = 50.0%
+        expect(stats[:issue_completion][:completion_rate]).to eq(50.0)
+      end
+
+      it "calculates runs per completed issue" do
+        runs = stats[:issue_completion][:runs_per_issue]
+        # Issue 1: 2 runs, Issue 2: 1 run -> avg 1.5, median 1.5, min 1, max 2
+        expect(runs[:avg]).to eq(1.5)
+        expect(runs[:min]).to eq(1)
+        expect(runs[:max]).to eq(2)
+        expect(runs[:median]).to eq(1.5)
+      end
+
+      it "calculates agent execution time per issue" do
+        agent = stats[:issue_completion][:agent_minutes]
+        # Issue 1: 900s, Issue 2: 400s -> avg 650s
+        expect(agent[:avg]).to eq(650)
+        expect(agent[:p50]).to be > 0
+        expect(agent[:p90]).to be > 0
+      end
+
+      it "calculates time-to-merge stats" do
+        ttm = stats[:issue_completion][:time_to_merge]
+        expect(ttm[:avg]).to be > 0
+        expect(ttm[:p50]).to be > 0
+        expect(ttm[:p90]).to be > 0
+      end
+
+      it "excludes pull request issues from counts" do
+        create(:issue, :pull_request, :completed, project: project)
+        completion = stats[:issue_completion]
+        expect(completion[:total_issues]).to eq(4)
+        expect(completion[:completed_count]).to eq(2)
+      end
+    end
+
+    context "with issues from another account" do
+      let(:other_account) { create(:account) }
+      let(:other_project) { create(:project, account: other_account) }
+
+      before do
+        other_issue = create(:issue, :completed, project: other_project)
+        create(:agent_run, :completed, project: other_project, issue: other_issue)
+
+        my_issue = create(:issue, :completed, project: project)
+        create(:agent_run, :completed, project: project, issue: my_issue)
+      end
+
+      it "only includes issues from the specified account" do
+        expect(stats[:issue_completion][:total_issues]).to eq(1)
+        expect(stats[:issue_completion][:completed_count]).to eq(1)
       end
     end
 


### PR DESCRIPTION
The commit succeeded. Here's a summary of what was implemented:

## Changes Made

### 1. `app/services/dashboard/stats.rb`
- Added `issue_completion` key to the `call` return hash
- Added `issues` and `non_pr_issues` helper methods scoped to the account
- Added `issue_completion` method that returns:
  - **Issue state counts**: total, completed, failed, in-progress
  - **Completion rate**: percentage of completed issues
  - **Runs per issue**: avg, min, max, median (for completed issues only)
  - **Time to merge**: avg, p50, p90 wall clock seconds (from first agent run to issue completion)
  - **Agent minutes**: avg, p50, p90 total execution seconds per issue
- Added `issue_completion_aggregates` method using a single CTE query that:
  - Groups agent runs by issue for completed non-PR issues
  - Computes per-issue run count, total agent seconds, and wall clock seconds
  - Uses PostgreSQL `percentile_cont` for median and p90 calculations
  - Uses parameterized SQL via `sanitize_sql_array` for safety

### 2. `app/views/dashboard/show.html.erb`
Added a new "Issue Completion" section between Duration and Runs by Agent Type:
- **Summary cards**: Total Issues, Completed (green), Failed (red), Completion Rate
- **Agent Runs per Completed Issue**: Average, Median, Min, Max in a 4-column grid
- **Wall Clock Time to Merge**: Average, p50, p90 with human-readable time formatting (days/hours/minutes/seconds)
- **Agent Execution Time per Issue**: Average, p50, p90 with the same time formatting

### 3. `spec/services/dashboard/stats_spec.rb`
Added test coverage:
- Zero-state tests for issue completion counts and aggregates
- Tests with completed issues verifying state counts, completion rate, runs per issue, agent execution time, and time-to-merge
- Test that PR issues are excluded from counts
- Test for account isolation (issues from other accounts not included)

---

Closes #230