### PR TITLE
Fix #274: Move trigger run button to the top of the project page

### DIFF
--- a/app/views/projects/_agent_runs.html.erb
+++ b/app/views/projects/_agent_runs.html.erb
@@ -1,15 +1,7 @@
 <div id="<%= dom_id(project, :agent_runs) %>" class="mt-8">
-  <div class="sm:flex sm:items-center sm:justify-between">
-    <h2 class="text-lg font-medium text-gray-900">
-      <%= link_to "Recent Agent Runs", project_agent_runs_path(project), class: "hover:text-indigo-600" %>
-    </h2>
-    <%= link_to new_project_agent_run_path(project), class: "mt-4 inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 sm:mt-0", data: { action_button: true } do %>
-      <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM9.555 7.168A1 1 0 0 0 8 8v4a1 1 0 0 0 1.555.832l3-2a1 1 0 0 0 0-1.664l-3-2Z" clip-rule="evenodd" />
-      </svg>
-      Trigger Run
-    <% end %>
-  </div>
+  <h2 class="text-lg font-medium text-gray-900">
+    <%= link_to "Recent Agent Runs", project_agent_runs_path(project), class: "hover:text-indigo-600" %>
+  </h2>
 
   <% if recent_agent_runs.any? %>
     <div class="mt-4 flow-root">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -31,6 +31,14 @@
               Inactive
             </span>
           <% end %>
+          <% if policy(@project).run_agent? %>
+            <%= link_to new_project_agent_run_path(@project), class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500", data: { action_button: true } do %>
+              <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM9.555 7.168A1 1 0 0 0 8 8v4a1 1 0 0 0 1.555.832l3-2a1 1 0 0 0 0-1.664l-3-2Z" clip-rule="evenodd" />
+              </svg>
+              Trigger Run
+            <% end %>
+          <% end %>
           <% if policy(@project).update? %>
             <%= link_to edit_project_path(@project), class: "inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" do %>
               <svg class="-ml-0.5 mr-1.5 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
All done. Here's a summary of what was done:

**Changes made (2 files, net zero lines changed):**

1. **`app/views/projects/show.html.erb`** — Added the "Trigger Run" button to the project header area, positioned between the Active/Inactive badge and the Edit button. It's gated by `policy(@project).run_agent?` so it only appears for authorized users.

2. **`app/views/projects/_agent_runs.html.erb`** — Removed the "Trigger Run" button from the "Recent Agent Runs" section header, simplifying it to just the heading link.

The button is now immediately visible at the top of the project page without scrolling, placed in the natural action area alongside other project-level controls.

**Lint & Tests:**
- RuboCop: 243 files inspected, no offenses
- Pre-commit hook passed (lint + tests)
- Full RSpec suite could not run due to no database being available in this environment, but the changes are purely in ERB view templates with no logic changes

---

Closes #274