### PR TITLE
Fix create_issue agent runs hanging for 86+ minutes

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -10,6 +10,10 @@ module Activities
       "claude_code" => %w[claude --print --output-format=text --dangerously-skip-permissions -p]
     }.freeze
 
+    # Issue creation should complete quickly — use a shorter timeout than full PR runs.
+    ISSUE_GOAL_TIMEOUT = 600        # 10 minutes wall clock
+    ISSUE_GOAL_IDLE_TIMEOUT = 120   # 2 minutes without output = stuck
+
     def execute(input)
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
@@ -59,7 +63,10 @@ module Activities
       agent_run.log!("system", "Starting #{agent_run.agent_type} agent in container")
       agent_run.log!("system", "Prompt: #{prompt.truncate(500)}")
 
-      result = container_service.execute(command, timeout: agent_timeout)
+      effective_timeout = agent_run.create_issue_goal? ? ISSUE_GOAL_TIMEOUT : agent_timeout
+      effective_idle_timeout = agent_run.create_issue_goal? ? ISSUE_GOAL_IDLE_TIMEOUT : nil
+
+      result = container_service.execute(command, timeout: effective_timeout, idle_timeout: effective_idle_timeout)
 
       if result.success?
         # Stay in running status — the run is only marked completed after
@@ -171,7 +178,7 @@ module Activities
         You have access to the GitHub API via a proxy. Use curl to create the issue:
 
         ```bash
-        curl -X POST "$GITHUB_API_URL/repos/#{repo}/issues" \\
+        curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/#{repo}/issues" \\
           -H "Content-Type: application/json" \\
           -H "X-Agent-Run-Id: $AGENT_RUN_ID" \\
           -H "X-Proxy-Token: $PROXY_TOKEN" \\

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -74,10 +74,16 @@ module Workflows
         # Step 4: Run the agent (long timeout, no retry)
         # Timeout = agent_timeout + 300s safety buffer so Temporal doesn't
         # kill the activity before the in-process timeout fires.
-        agent_timeout = Rails.application.config.x.agent_timeout
+        # Issue goals use a shorter timeout since they only need to create
+        # a GitHub issue via curl, not write code.
+        activity_timeout = if goal == "create_issue"
+          Activities::RunAgentActivity::ISSUE_GOAL_TIMEOUT + 300
+        else
+          Rails.application.config.x.agent_timeout + 300
+        end
         agent_result = run_activity(Activities::RunAgentActivity,
           { agent_run_id: agent_run_id },
-          start_to_close_timeout: agent_timeout + 300, retry_policy: NO_RETRY)
+          start_to_close_timeout: activity_timeout, retry_policy: NO_RETRY)
 
         unless agent_result[:success]
           raise Temporalio::Error::ApplicationError.new(

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Activities::RunAgentActivity do
 
         expect(container_service).to receive(:execute).with(
           array_including("claude", "--print", "--output-format=text", "--dangerously-skip-permissions", "-p"),
-          timeout: anything
+          hash_including(timeout: anything)
         ).and_return(exec_success)
 
         activity.execute(agent_run_id: agent_run.id)
@@ -255,6 +255,54 @@ RSpec.describe Activities::RunAgentActivity do
       expect {
         activity.execute(agent_run_id: unsupported_run.id)
       }.to raise_error(Temporalio::Error::ApplicationError, /Unsupported agent type/)
+    end
+
+    context "when goal is create_issue" do
+      let(:agent_run) do
+        create(:agent_run, :create_issue_goal, :with_git_context,
+          project: project, container_id: "abc123")
+      end
+
+      before do
+        allow(container_service).to receive(:execute).and_return(exec_success)
+        allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+      end
+
+      it "uses the shorter issue goal timeout" do
+        expect(container_service).to receive(:execute).with(
+          anything,
+          timeout: described_class::ISSUE_GOAL_TIMEOUT,
+          idle_timeout: described_class::ISSUE_GOAL_IDLE_TIMEOUT
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "includes curl timeouts in the augmented prompt" do
+        expect(container_service).to receive(:execute) do |command, **_opts|
+          prompt = command.last
+          expect(prompt).to include("--connect-timeout 10")
+          expect(prompt).to include("--max-time 30")
+          exec_success
+        end
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+    end
+
+    context "when goal is create_pr" do
+      it "uses the default agent timeout without idle_timeout" do
+        allow(container_service).to receive(:execute).and_return(exec_success)
+        allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+
+        expect(container_service).to receive(:execute).with(
+          anything,
+          timeout: Rails.application.config.x.agent_timeout,
+          idle_timeout: nil
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
     end
   end
 end

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -75,6 +75,55 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
     end
   end
 
+  describe "activity timeout for create_issue goal" do
+    let(:input) { { project_id: 1, issue_id: 1, goal: "create_issue" } }
+
+    before do
+      allow(Temporalio::Workflow).to receive(:logger).and_return(Rails.logger)
+    end
+
+    it "uses shorter start_to_close_timeout for create_issue goals" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42 }
+        when "Activities::RunAgentActivity"
+          expected_timeout = Activities::RunAgentActivity::ISSUE_GOAL_TIMEOUT + 300
+          expect(opts[:start_to_close_timeout]).to eq(expected_timeout)
+          { success: true }
+        when "Activities::CompleteIssueGoalActivity"
+          { agent_run_id: 42, success: true, issue_created: true }
+        else {}
+        end
+      end
+
+      workflow.execute(input)
+    end
+  end
+
+  describe "activity timeout for create_pr goal" do
+    let(:input) { { project_id: 1, issue_id: 1, goal: "create_pr" } }
+
+    before do
+      allow(Rails.application.config.x).to receive(:agent_timeout).and_return(3600)
+      allow(Temporalio::Workflow).to receive(:logger).and_return(Rails.logger)
+    end
+
+    it "uses default agent_timeout for create_pr goals" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42 }
+        when "Activities::RunAgentActivity"
+          expect(opts[:start_to_close_timeout]).to eq(3900) # 3600 + 300
+          { success: true, has_changes: false }
+        when "Activities::MarkAgentRunCompleteActivity" then {}
+        else {}
+        end
+      end
+
+      workflow.execute(input)
+    end
+  end
+
   describe "#unwrap_error_message" do
     let(:workflow) { described_class.new }
 


### PR DESCRIPTION
## Summary

- Add `ISSUE_GOAL_TIMEOUT` (10 min) and `ISSUE_GOAL_IDLE_TIMEOUT` (2 min) constants for `create_issue` runs — these are much shorter than the default 1-hour agent timeout, so hangs are detected quickly instead of waiting ~86 minutes for the stale run detector
- Update Temporal workflow `start_to_close_timeout` to match the shorter timeout for issue goals
- Add `--connect-timeout 10 --max-time 30` to the curl example in the issue creation prompt to prevent the agent's HTTP calls from hanging indefinitely

## Test plan

- [x] `bin/rspec spec/temporal/activities/run_agent_activity_spec.rb` — 24 examples, 0 failures
- [x] `bin/rspec spec/temporal/workflows/agent_execution_workflow_spec.rb` — 14 examples, 0 failures
- [x] RuboCop passes on all changed files
- [ ] Manual: trigger a `create_issue` agent run and verify it uses the 10-minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)