### PR TITLE
Fix scroll position resetting on redirects

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= action_cable_meta_tag %>
+    <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
 
     <%= yield :head %>
 
@@ -23,7 +24,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="min-h-screen bg-gray-50" data-turbo-refresh-scroll="preserve">
+  <body class="min-h-screen bg-gray-50">
     <nav class="bg-white shadow-sm" data-controller="mobile-menu">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 justify-between">


### PR DESCRIPTION
## Summary
- Enable Turbo 8 morph refreshes by adding `turbo_refreshes_with method: :morph, scroll: :preserve` to the layout head
- Remove the redundant `data-turbo-refresh-scroll="preserve"` attribute from the body element, which had no effect without morphing enabled

The layout had `data-turbo-refresh-scroll="preserve"` on the `<body>`, but this attribute only works during Turbo morph refreshes. Without the `<meta name="turbo-refresh-method" content="morph">` tag, every `redirect_to` was a standard Turbo Drive visit that always scrolls to top. Now same-page redirects (e.g., updating a project, retrying validation) morph the DOM in-place and preserve scroll position.

## Test plan
- [x] All 1810 existing tests pass
- [ ] Verify scroll position is preserved when submitting forms that redirect back to the same page (e.g., edit project, retry token validation)
- [ ] Verify redirects to different pages still scroll to top as expected
- [ ] Verify Turbo Stream broadcasts still update correctly with morphing enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)