### PR TITLE
Pre-create ~/.local dirs in devcontainer to fix restart builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,6 +47,12 @@ RUN groupadd -f docker && usermod -aG docker vscode
 
 USER vscode
 
+# Pre-create ~/.local tree so bind mounts don't leave root-owned parents
+# (Docker creates missing mount-point parents as root, blocking vscode writes)
+RUN mkdir -p /home/vscode/.local/bin \
+             /home/vscode/.local/state \
+             /home/vscode/.local/share
+
 # Add rbenv to PATH
 ENV PATH="/home/vscode/.rbenv/shims:/home/vscode/.rbenv/bin:${PATH}"
 


### PR DESCRIPTION
## Summary

- Docker creates missing bind-mount parent directories as root, which blocks vscode user writes after a container restart
- Pre-create `~/.local/{bin,state,share}` in the Dockerfile so ownership stays with the vscode user

## Test plan

- [ ] Rebuild devcontainer from scratch
- [ ] Restart devcontainer and verify `~/.local` dirs are writable

🤖 Generated with [Claude Code](https://claude.com/claude-code)