### PR TITLE
Fix missing Settings link in mobile menu

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,6 +75,7 @@
             <%= link_to "Agent Runs", agent_runs_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>
             <%= link_to "Prompts", prompts_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>
             <%= link_to "Tokens", github_tokens_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>
+            <%= link_to "Settings", edit_user_settings_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>
             <div class="border-t border-gray-200 pt-3 mt-2">
               <p class="px-3 text-sm text-gray-700"><%= current_user.email %></p>
               <%= button_to "Sign out", destroy_user_session_path, method: :delete, class: "mt-1 block w-full rounded-md px-3 py-2 text-left text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe "Dashboard" do
         get dashboard_path
         expect(response.body).to include("Test Company")
       end
+
+      it "includes settings in the mobile menu" do
+        get dashboard_path
+
+        doc = Nokogiri::HTML(response.body)
+        mobile_settings_link = doc.at_css("#mobile-menu a[href='#{edit_user_settings_path}']")
+
+        expect(mobile_settings_link).to be_present
+        expect(mobile_settings_link.text.strip).to eq("Settings")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- add `Settings` link to the signed-in mobile navigation menu
- keep mobile menu close behavior on navigation consistent with other links
- add a request spec that asserts `Settings` appears inside `#mobile-menu` for authenticated users

## Testing
- `COVERAGE=false bin/rspec spec/requests/dashboard_spec.rb spec/requests/user_settings_spec.rb`