### PR TITLE
Fix null byte crash in PR prompt building

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -234,7 +234,7 @@ class AgentRun < ApplicationRecord
   def log!(type, content, metadata: nil)
     agent_run_logs.create!(
       log_type: type,
-      content: content,
+      content: content.to_s.delete("\x00"),
       metadata: metadata
     )
   end

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -47,7 +47,7 @@ module Prompts
       sections << rules_section
       sections << available_services_section
       sections << no_infrastructure_section
-      sections.join("\n")
+      sections.join("\n").delete("\x00")
     end
 
     private


### PR DESCRIPTION
## Summary

- Agent run #433 failed with `string contains null byte` because a Copilot review comment contained a literal `\x00` character (part of a regex pattern discussion). When `BuildForPr` included this in the prompt and saved it to PostgreSQL, the write was rejected.
- Strip null bytes from the assembled prompt in `Prompts::BuildForPr#build` before returning
- Strip null bytes from log content in `AgentRun#log!` to prevent the same class of failure in logging

## Test plan

- [x] `bin/rspec spec/services/prompts/build_for_pr_spec.rb` — 31 examples, 0 failures
- [x] `bin/rspec spec/models/agent_run_spec.rb` — 146 examples, 0 failures
- [ ] Re-run agent run #433 to verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)