### PR TITLE
Fix stale issues not closing when GitHub returns no open issues

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -128,10 +128,12 @@ module Activities
     end
 
     def close_stale_issues(project, github_issues)
-      return 0 if github_issues.empty?
-
       fetched_github_ids = github_issues.map(&:id).to_set
-      stale_issues = project.issues.where(github_state: "open").where.not(github_issue_id: fetched_github_ids)
+      stale_issues = if fetched_github_ids.empty?
+        project.issues.where(github_state: "open")
+      else
+        project.issues.where(github_state: "open").where.not(github_issue_id: fetched_github_ids)
+      end
       count = stale_issues.count
 
       if count > 0

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -517,10 +517,11 @@ RSpec.describe Activities::FetchIssuesActivity do
         allow(github_client).to receive(:issues).and_return([])
       end
 
-      it "does not mark existing open issues as closed" do
+      it "marks existing open issues as closed" do
         activity.execute(project_id: project.id)
 
-        expect(project.issues.where(github_state: "open").count).to eq(2)
+        expect(project.issues.where(github_state: "open").count).to eq(0)
+        expect(project.issues.where(github_state: "closed").count).to eq(2)
       end
     end
 


### PR DESCRIPTION
## Summary
- Fixed `close_stale_issues` in `FetchIssuesActivity` which had an early return when `github_issues` was empty, preventing locally-open issues from being marked closed
- This caused an infinite retry loop: merged PRs stayed `github_state: "open"` in the DB, `ScanPaidPrsActivity` kept triggering agent runs, and each run failed with "PR is closed; project resync needed"
- Updated test to match corrected behavior

## Test plan
- [x] Existing specs updated and passing (`bin/rspec spec/temporal/activities/fetch_issues_activity_spec.rb`)
- [ ] Verify on a project with no open GitHub issues that stale DB issues get closed
- [ ] Verify on a project with some open issues that only non-matching ones get closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)