### PR TITLE
Fix service container conflict detection by catching ConflictError

### DIFF
--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -183,7 +183,7 @@ module Containers
 
     def create_or_replace_container!(service_container)
       create_docker_container(service_container)
-    rescue Docker::Error::ServerError => e
+    rescue Docker::Error::ConflictError, Docker::Error::ServerError => e
       raise unless e.message&.include?("Conflict") && e.message&.include?("already in use")
 
       log_info("service_provisioner.container_name_conflict", name: service_container.name)

--- a/spec/services/containers/service_provisioner_spec.rb
+++ b/spec/services/containers/service_provisioner_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Containers::ServiceProvisioner do
         call_count = 0
         allow(Docker::Container).to receive(:create) do
           call_count += 1
-          raise Docker::Error::ServerError, "Conflict. The container name is already in use" if call_count == 1
+          raise Docker::Error::ConflictError, "Conflict. The container name is already in use" if call_count == 1
           new_container
         end
         allow(Docker::Container).to receive(:get).with("conflict-postgres").and_return(stale)
@@ -174,7 +174,7 @@ RSpec.describe Containers::ServiceProvisioner do
 
         allow(Docker::Image).to receive(:create)
         allow(Docker::Container).to receive(:create)
-          .and_raise(Docker::Error::ServerError, "Conflict. The container name is already in use")
+          .and_raise(Docker::Error::ConflictError, "Conflict. The container name is already in use")
         allow(Docker::Container).to receive(:get).with("conflict-postgres").and_return(existing)
         allow(existing).to receive_messages(json: running_json, stop: nil, delete: nil)
         allow(provisioner).to receive(:tcp_port_open?).and_return(true)
@@ -192,7 +192,7 @@ RSpec.describe Containers::ServiceProvisioner do
 
         allow(Docker::Image).to receive(:create)
         allow(Docker::Container).to receive(:create)
-          .and_raise(Docker::Error::ServerError, "Conflict. The container name is already in use")
+          .and_raise(Docker::Error::ConflictError, "Conflict. The container name is already in use")
         allow(Docker::Container).to receive(:get).with("conflict-postgres").and_return(stale)
         allow(stale).to receive(:json).and_return({ "Config" => { "Labels" => {} } })
 
@@ -206,7 +206,7 @@ RSpec.describe Containers::ServiceProvisioner do
 
         allow(Docker::Image).to receive(:create)
         allow(Docker::Container).to receive(:create)
-          .and_raise(Docker::Error::ServerError, "Conflict. The container name is already in use")
+          .and_raise(Docker::Error::ConflictError, "Conflict. The container name is already in use")
         allow(Docker::Container).to receive(:get).with("conflict-postgres").and_return(stale)
         allow(stale).to receive(:json).and_return({ "Config" => { "Labels" => wrong_labels } })
 


### PR DESCRIPTION
## Summary

- Docker raises `Docker::Error::ConflictError` for container name conflicts, but `create_or_replace_container!` only caught `Docker::Error::ServerError`. This meant the conflict resolution logic (adopt running containers, remove stale ones) was never invoked, causing all service-container-dependent agent runs to fail.
- Updated the rescue clause to catch both `ConflictError` and `ServerError`.
- Updated test stubs to use `ConflictError` to match real Docker behavior.

## Test plan

- [x] All 17 `service_provisioner_spec.rb` tests pass
- [x] RuboCop clean
- [ ] Deploy and verify agent runs with service containers succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)