### PR TITLE
fix(devcontainer): gracefully handle missing gh auth in signing setup

### DIFF
--- a/.devcontainer/enable-commit-signing.sh
+++ b/.devcontainer/enable-commit-signing.sh
@@ -25,19 +25,28 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Resolve the repo root from the script's location so validation works even
 # when the user runs this script from a subdirectory or outside the repo.
 REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
-bash "${SCRIPT_DIR}/setup-signing-key.sh"
+# Run setup-signing-key.sh from the repo root so its internal
+# `git rev-parse --show-toplevel` resolves correctly even when the user
+# invokes this wrapper from outside the repository.
+(cd "${REPO_ROOT}" && bash "${SCRIPT_DIR}/setup-signing-key.sh")
 
 echo
 
 # Validate that signing was actually configured (setup-signing-key.sh may
 # exit 0 without configuring anything if auth/scopes are missing).
-if [[ "$(git -C "${REPO_ROOT}" config --local --get commit.gpgsign 2>/dev/null)" == "true" ]] \
-  && [[ "$(git -C "${REPO_ROOT}" config --local --get gpg.format 2>/dev/null)" == "ssh" ]] \
-  && [[ -n "$(git -C "${REPO_ROOT}" config --local --get user.signingkey 2>/dev/null)" ]]; then
+# Use `|| true` to guard git-config reads: with `set -euo pipefail`, a missing
+# key causes `git config --get` to return non-zero which can abort the script
+# before reaching the else branch in some bash versions.
+gpgsign="$(git -C "${REPO_ROOT}" config --local --get commit.gpgsign 2>/dev/null || true)"
+gpgformat="$(git -C "${REPO_ROOT}" config --local --get gpg.format 2>/dev/null || true)"
+signingkey="$(git -C "${REPO_ROOT}" config --local --get user.signingkey 2>/dev/null || true)"
+if [[ "${gpgsign}" == "true" ]] \
+  && [[ "${gpgformat}" == "ssh" ]] \
+  && [[ -n "${signingkey}" ]]; then
   echo "Commit signing is enabled for this repo. Current git settings:"
-  echo "  gpg.format      = $(git -C "${REPO_ROOT}" config --local --get gpg.format)"
-  echo "  user.signingkey  = $(git -C "${REPO_ROOT}" config --local --get user.signingkey)"
-  echo "  commit.gpgsign   = $(git -C "${REPO_ROOT}" config --local --get commit.gpgsign)"
+  echo "  gpg.format      = ${gpgformat}"
+  echo "  user.signingkey  = ${signingkey}"
+  echo "  commit.gpgsign   = ${gpgsign}"
 else
   echo "ERROR: Commit signing was not configured." >&2
   echo "  The signing key setup did not complete successfully." >&2

--- a/.devcontainer/enable-commit-signing.sh
+++ b/.devcontainer/enable-commit-signing.sh
@@ -44,12 +44,20 @@ echo
 gpgsign="$(git -C "${REPO_ROOT}" config --local --get commit.gpgsign 2>/dev/null || true)"
 gpgformat="$(git -C "${REPO_ROOT}" config --local --get gpg.format 2>/dev/null || true)"
 signingkey="$(git -C "${REPO_ROOT}" config --local --get user.signingkey 2>/dev/null || true)"
+# Resolve the signing key path (expand leading ~) so we can verify the file
+# actually exists and is readable, not just that the config points to it.
+resolved_signingkey="${signingkey}"
+if [[ -n "${resolved_signingkey}" && "${resolved_signingkey}" == "~"* ]]; then
+  resolved_signingkey="${HOME}${resolved_signingkey:1}"
+fi
 if [[ "${gpgsign}" == "true" ]] \
   && [[ "${gpgformat}" == "ssh" ]] \
-  && [[ -n "${signingkey}" ]]; then
+  && [[ -n "${signingkey}" ]] \
+  && [[ -r "${resolved_signingkey}" ]]; then
   echo "Commit signing is enabled for this repo. Current git settings:"
   echo "  gpg.format      = ${gpgformat}"
   echo "  user.signingkey  = ${signingkey}"
+  echo "  signing key file = ${resolved_signingkey} (readable)"
   echo "  commit.gpgsign   = ${gpgsign}"
 else
   echo "ERROR: Commit signing was not configured." >&2

--- a/.devcontainer/enable-commit-signing.sh
+++ b/.devcontainer/enable-commit-signing.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Enable Git SSH commit signing inside the devcontainer.
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) is not installed in this environment." >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: git is not installed in this environment." >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated. Starting login..."
+  gh auth login -h github.com
+fi
+
+echo "Ensuring token has admin:ssh_signing_key scope..."
+gh auth refresh -h github.com -s admin:ssh_signing_key
+
+echo "Configuring SSH commit signing for this repository..."
+bash "$(dirname "$0")/setup-signing-key.sh"
+
+echo
+
+echo "Commit signing is enabled for this repo. Current git settings:"
+git config --local --get gpg.format || true
+git config --local --get user.signingkey || true
+git config --local --get commit.gpgsign || true

--- a/.devcontainer/enable-commit-signing.sh
+++ b/.devcontainer/enable-commit-signing.sh
@@ -24,7 +24,11 @@ echo "Configuring SSH commit signing for this repository..."
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Resolve the repo root from the script's location so validation works even
 # when the user runs this script from a subdirectory or outside the repo.
-REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+if ! REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "Error: this script must be run from within a checked-out repository." >&2
+  echo "  Could not find a git repository at or above: ${SCRIPT_DIR}" >&2
+  exit 1
+fi
 # Run setup-signing-key.sh from the repo root so its internal
 # `git rev-parse --show-toplevel` resolves correctly even when the user
 # invokes this wrapper from outside the repository.

--- a/.devcontainer/enable-commit-signing.sh
+++ b/.devcontainer/enable-commit-signing.sh
@@ -22,19 +22,22 @@ gh auth refresh -h github.com -s admin:ssh_signing_key
 
 echo "Configuring SSH commit signing for this repository..."
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve the repo root from the script's location so validation works even
+# when the user runs this script from a subdirectory or outside the repo.
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
 bash "${SCRIPT_DIR}/setup-signing-key.sh"
 
 echo
 
 # Validate that signing was actually configured (setup-signing-key.sh may
 # exit 0 without configuring anything if auth/scopes are missing).
-if [[ "$(git config --local --get commit.gpgsign 2>/dev/null)" == "true" ]] \
-  && [[ "$(git config --local --get gpg.format 2>/dev/null)" == "ssh" ]] \
-  && [[ -n "$(git config --local --get user.signingkey 2>/dev/null)" ]]; then
+if [[ "$(git -C "${REPO_ROOT}" config --local --get commit.gpgsign 2>/dev/null)" == "true" ]] \
+  && [[ "$(git -C "${REPO_ROOT}" config --local --get gpg.format 2>/dev/null)" == "ssh" ]] \
+  && [[ -n "$(git -C "${REPO_ROOT}" config --local --get user.signingkey 2>/dev/null)" ]]; then
   echo "Commit signing is enabled for this repo. Current git settings:"
-  echo "  gpg.format      = $(git config --local --get gpg.format)"
-  echo "  user.signingkey  = $(git config --local --get user.signingkey)"
-  echo "  commit.gpgsign   = $(git config --local --get commit.gpgsign)"
+  echo "  gpg.format      = $(git -C "${REPO_ROOT}" config --local --get gpg.format)"
+  echo "  user.signingkey  = $(git -C "${REPO_ROOT}" config --local --get user.signingkey)"
+  echo "  commit.gpgsign   = $(git -C "${REPO_ROOT}" config --local --get commit.gpgsign)"
 else
   echo "ERROR: Commit signing was not configured." >&2
   echo "  The signing key setup did not complete successfully." >&2

--- a/.devcontainer/enable-commit-signing.sh
+++ b/.devcontainer/enable-commit-signing.sh
@@ -21,7 +21,8 @@ echo "Ensuring token has admin:ssh_signing_key scope..."
 gh auth refresh -h github.com -s admin:ssh_signing_key
 
 echo "Configuring SSH commit signing for this repository..."
-bash "$(dirname "$0")/setup-signing-key.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "${SCRIPT_DIR}/setup-signing-key.sh"
 
 echo
 

--- a/.devcontainer/enable-commit-signing.sh
+++ b/.devcontainer/enable-commit-signing.sh
@@ -25,7 +25,18 @@ bash "$(dirname "$0")/setup-signing-key.sh"
 
 echo
 
-echo "Commit signing is enabled for this repo. Current git settings:"
-git config --local --get gpg.format || true
-git config --local --get user.signingkey || true
-git config --local --get commit.gpgsign || true
+# Validate that signing was actually configured (setup-signing-key.sh may
+# exit 0 without configuring anything if auth/scopes are missing).
+if [[ "$(git config --local --get commit.gpgsign 2>/dev/null)" == "true" ]] \
+  && [[ "$(git config --local --get gpg.format 2>/dev/null)" == "ssh" ]] \
+  && [[ -n "$(git config --local --get user.signingkey 2>/dev/null)" ]]; then
+  echo "Commit signing is enabled for this repo. Current git settings:"
+  echo "  gpg.format      = $(git config --local --get gpg.format)"
+  echo "  user.signingkey  = $(git config --local --get user.signingkey)"
+  echo "  commit.gpgsign   = $(git config --local --get commit.gpgsign)"
+else
+  echo "ERROR: Commit signing was not configured." >&2
+  echo "  The signing key setup did not complete successfully." >&2
+  echo "  Check the output above for warnings and follow the suggested steps." >&2
+  exit 1
+fi

--- a/.devcontainer/enable-commit-signing.sh
+++ b/.devcontainer/enable-commit-signing.sh
@@ -12,8 +12,8 @@ if ! command -v git >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! gh auth status >/dev/null 2>&1; then
-  echo "GitHub CLI is not authenticated. Starting login..."
+if ! gh auth status -h github.com >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated for github.com. Starting login..."
   gh auth login -h github.com
 fi
 

--- a/.devcontainer/setup-signing-key.sh
+++ b/.devcontainer/setup-signing-key.sh
@@ -29,12 +29,19 @@ if ! gh auth status -h github.com >/dev/null 2>&1; then
   exit 0
 fi
 
-if ! gh api /user/ssh_signing_keys --method GET --paginate --jq '.' >/dev/null 2>&1; then
-  echo "WARNING: GitHub token lacks the 'admin:ssh_signing_key' scope." >&2
-  echo "  Commit signing will be disabled. To enable it, run:" >&2
-  echo "    bash .devcontainer/enable-commit-signing.sh" >&2
+scope_output=$(gh api /user/ssh_signing_keys --method GET --paginate --jq '.' 2>&1) || {
+  if echo "$scope_output" | grep -qiE "insufficient.scope|403|missing.*scope"; then
+    echo "WARNING: GitHub token lacks the 'admin:ssh_signing_key' scope." >&2
+    echo "  Commit signing will be disabled. To enable it, run:" >&2
+    echo "    bash .devcontainer/enable-commit-signing.sh" >&2
+  else
+    echo "WARNING: Failed to verify SSH signing key scope (API call failed)." >&2
+    echo "  This may be due to a network issue, rate limiting, or missing scope." >&2
+    echo "  Commit signing will be disabled. To enable it, run:" >&2
+    echo "    bash .devcontainer/enable-commit-signing.sh" >&2
+  fi
   exit 0
-fi
+}
 
 # 1. Generate key (overwrite any leftover from a previous build)
 echo "Generating SSH signing key..."

--- a/.devcontainer/setup-signing-key.sh
+++ b/.devcontainer/setup-signing-key.sh
@@ -29,7 +29,7 @@ if ! gh auth status -h github.com >/dev/null 2>&1; then
   exit 0
 fi
 
-scope_error=$(gh api /user/ssh_signing_keys --method GET --paginate --jq '.' 2>&1 >/dev/null) || {
+scope_error=$({ gh api /user/ssh_signing_keys --method GET --paginate --jq '.' >/dev/null; } 2>&1) || {
   if echo "$scope_error" | grep -qiE "insufficient.scope|Resource not accessible by|missing.*scope"; then
     echo "WARNING: GitHub token lacks the 'admin:ssh_signing_key' scope." >&2
     echo "  Commit signing will be disabled. To enable it, run:" >&2

--- a/.devcontainer/setup-signing-key.sh
+++ b/.devcontainer/setup-signing-key.sh
@@ -19,10 +19,10 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 0
 fi
 
-if ! gh auth status >/dev/null 2>&1; then
-  echo "WARNING: GitHub CLI is not authenticated; skipping commit signing setup." >&2
+if ! gh auth status -h github.com >/dev/null 2>&1; then
+  echo "WARNING: GitHub CLI is not authenticated for github.com; skipping commit signing setup." >&2
   echo "  To enable it, run:" >&2
-  echo "    gh auth login" >&2
+  echo "    gh auth login -h github.com" >&2
   echo "  Then re-run: bash .devcontainer/setup-signing-key.sh" >&2
   exit 0
 fi

--- a/.devcontainer/setup-signing-key.sh
+++ b/.devcontainer/setup-signing-key.sh
@@ -12,10 +12,19 @@ KEY_PATH="$KEY_DIR/id_ed25519"
 TITLE_PREFIX="devcontainer-signing:"
 KEY_TITLE="$TITLE_PREFIX $(hostname)"
 
-# 0. Verify GitHub CLI authentication and required scope
+# 0. Verify GitHub CLI authentication and required scope.
+# This is best-effort in devcontainers; lack of auth should not fail setup.
+if ! command -v gh >/dev/null 2>&1; then
+  echo "WARNING: GitHub CLI is not installed; skipping commit signing setup." >&2
+  exit 0
+fi
+
 if ! gh auth status >/dev/null 2>&1; then
-  echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' first." >&2
-  exit 1
+  echo "WARNING: GitHub CLI is not authenticated; skipping commit signing setup." >&2
+  echo "  To enable it, run:" >&2
+  echo "    gh auth login" >&2
+  echo "  Then re-run: bash .devcontainer/setup-signing-key.sh" >&2
+  exit 0
 fi
 
 if ! gh api /user/ssh_signing_keys --method GET --paginate --jq '.' >/dev/null 2>&1; then

--- a/.devcontainer/setup-signing-key.sh
+++ b/.devcontainer/setup-signing-key.sh
@@ -14,6 +14,8 @@ KEY_TITLE="$TITLE_PREFIX $(hostname)"
 
 # 0. Verify GitHub CLI authentication and required scope.
 # This is best-effort in devcontainers; lack of auth should not fail setup.
+# Ensure all gh commands target github.com (not an enterprise host).
+export GH_HOST="github.com"
 if ! command -v gh >/dev/null 2>&1; then
   echo "WARNING: GitHub CLI is not installed; skipping commit signing setup." >&2
   exit 0

--- a/.devcontainer/setup-signing-key.sh
+++ b/.devcontainer/setup-signing-key.sh
@@ -25,15 +25,14 @@ if ! gh auth status -h github.com >/dev/null 2>&1; then
   echo "WARNING: GitHub CLI is not authenticated for github.com; skipping commit signing setup." >&2
   echo "  To enable it, run:" >&2
   echo "    gh auth login -h github.com" >&2
-  echo "  Then re-run: bash .devcontainer/setup-signing-key.sh" >&2
+  echo "  Then re-run: bash .devcontainer/enable-commit-signing.sh" >&2
   exit 0
 fi
 
 if ! gh api /user/ssh_signing_keys --method GET --paginate --jq '.' >/dev/null 2>&1; then
   echo "WARNING: GitHub token lacks the 'admin:ssh_signing_key' scope." >&2
   echo "  Commit signing will be disabled. To enable it, run:" >&2
-  echo "    gh auth refresh -h github.com -s admin:ssh_signing_key" >&2
-  echo "  Then re-run: bash .devcontainer/setup-signing-key.sh" >&2
+  echo "    bash .devcontainer/enable-commit-signing.sh" >&2
   exit 0
 fi
 
@@ -77,7 +76,7 @@ if ! output=$(gh ssh-key add "$KEY_PATH.pub" --type signing --title "$KEY_TITLE"
   echo "    - Network issues or GitHub availability problems" >&2
   echo "    - API rate limits or other GitHub API errors" >&2
   echo "    - A signing key with the same title already exists" >&2
-  echo "  After resolving the issue, re-run: bash .devcontainer/setup-signing-key.sh" >&2
+  echo "  After resolving the issue, re-run: bash .devcontainer/enable-commit-signing.sh" >&2
   exit 0
 fi
 

--- a/.devcontainer/setup-signing-key.sh
+++ b/.devcontainer/setup-signing-key.sh
@@ -29,8 +29,8 @@ if ! gh auth status -h github.com >/dev/null 2>&1; then
   exit 0
 fi
 
-scope_output=$(gh api /user/ssh_signing_keys --method GET --paginate --jq '.' 2>&1) || {
-  if echo "$scope_output" | grep -qiE "insufficient.scope|403|missing.*scope"; then
+scope_error=$(gh api /user/ssh_signing_keys --method GET --paginate --jq '.' 2>&1 >/dev/null) || {
+  if echo "$scope_error" | grep -qiE "insufficient.scope|Resource not accessible by|missing.*scope"; then
     echo "WARNING: GitHub token lacks the 'admin:ssh_signing_key' scope." >&2
     echo "  Commit signing will be disabled. To enable it, run:" >&2
     echo "    bash .devcontainer/enable-commit-signing.sh" >&2

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config and vendored gems.
 /.bundle
+/.bundle-install
 /vendor/bundle
 
 # Ignore vendored gems

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker compose exec web bin/rails db:prepare
 
 Open in VS Code with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, or use GitHub Codespaces. The `.devcontainer/` configuration provides a complete development environment.
 
-#### Enable Commit Signing In Devcontainer
+#### Enable Commit Signing in Dev Container
 
 If commit signing is not configured automatically, run:
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ docker compose exec web bin/rails db:prepare
 
 Open in VS Code with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, or use GitHub Codespaces. The `.devcontainer/` configuration provides a complete development environment.
 
+#### Enable Commit Signing In Devcontainer
+
+If commit signing is not configured automatically, run:
+
+```bash
+bash .devcontainer/enable-commit-signing.sh
+```
+
+This script will:
+
+1. Authenticate GitHub CLI if needed (`gh auth login`)
+2. Request the required `admin:ssh_signing_key` scope
+3. Create/register a container-local SSH signing key
+4. Configure repo-local git signing settings
+
+If you prefer to run commands manually:
+
+```bash
+gh auth login -h github.com
+gh auth refresh -h github.com -s admin:ssh_signing_key
+bash .devcontainer/setup-signing-key.sh
+```
+
 ### Option 3: Local Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ bash .devcontainer/enable-commit-signing.sh
 
 This script will:
 
-1. Authenticate GitHub CLI if needed (`gh auth login`)
+1. Authenticate GitHub CLI if needed (`gh auth login -h github.com`)
 2. Request the required `admin:ssh_signing_key` scope
 3. Create/register a container-local SSH signing key
 4. Configure repo-local git signing settings


### PR DESCRIPTION
## Summary

- **`setup-signing-key.sh`**: Warns and exits 0 (instead of hard-failing) when `gh` is missing or unauthenticated, so devcontainer creation doesn't break for users who haven't logged in yet.
- **`enable-commit-signing.sh`** (new): One-command wrapper that handles `gh auth login`, scope refresh, and key setup.
- **README**: Documents both the easy and manual commit-signing flows.

## Test plan

- [ ] Open a new devcontainer without `gh` authenticated — setup should complete with a warning, not fail
- [ ] Run `bash .devcontainer/enable-commit-signing.sh` and verify it walks through auth + key setup
- [ ] Verify signed commits work after running the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)