### PR TITLE
perf: enable gzip compression via Rack::Deflater

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,14 +41,7 @@ module Paid
     # Don't generate system test files.
     config.generators.system_tests = nil
 
-    # Enable gzip compression for static assets and API responses.
-    # Inserted after Rack::Sendfile (always present) so it works regardless of
-    # whether ActionDispatch::Static is in the stack.
-    # HTML is excluded to avoid BREACH-style attacks on pages with CSRF tokens.
-    config.middleware.insert_after Rack::Sendfile, Rack::Deflater,
-      include: %w[application/javascript text/javascript text/css application/json image/svg+xml]
-
-# Use GoodJob for background jobs across environments.
+    # Use GoodJob for background jobs across environments.
     config.active_job.queue_adapter = :good_job
   end
 end

--- a/config/initializers/compression.rb
+++ b/config/initializers/compression.rb
@@ -10,8 +10,6 @@ deflater_options = {
   include: %w[application/javascript text/javascript text/css application/json image/svg+xml]
 }
 
-if Rails.configuration.public_file_server.enabled
-  Rails.configuration.middleware.insert_before ActionDispatch::Static, Rack::Deflater, deflater_options
-else
-  Rails.configuration.middleware.use Rack::Deflater, deflater_options
-end
+# Insert after Rack::Sendfile (always present) so compression works regardless
+# of whether ActionDispatch::Static is in the middleware stack.
+Rails.configuration.middleware.insert_after Rack::Sendfile, Rack::Deflater, deflater_options

--- a/spec/requests/compression_spec.rb
+++ b/spec/requests/compression_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe "Gzip compression" do
     context "with HTML responses" do
       it "excludes text/html from compression to mitigate BREACH attacks" do
         deflater = Rails.application.config.middleware.detect { |m| m.name == "Rack::Deflater" }
-        options = deflater.args.detect { |a| a.is_a?(Hash) } || {}
+        expect(deflater).not_to be_nil, "Rack::Deflater middleware not found in stack"
 
+        options = deflater.args.detect { |a| a.is_a?(Hash) } || {}
         expect(options[:include]).not_to include("text/html")
       end
     end


### PR DESCRIPTION
## Summary
- Adds `Rack::Deflater` middleware to compress eligible responses (JS, CSS, JSON, SVG) when the client supports gzip
- Reduces asset transfer sizes by ~78% (e.g. `application.js`: 369 KB → 77 KB)
- Excludes HTML from compression to mitigate BREACH-style attacks on pages with CSRF tokens
- Guards middleware insertion to handle environments where `ActionDispatch::Static` is disabled

## Details
The server was sending all responses uncompressed. Over localhost this was imperceptible, but over Tailscale connections with added latency, the large uncompressed assets on first load caused noticeably slow page loads.

| Asset | Before | After (gzip) | Reduction |
|-------|--------|--------------|-----------|
| `application.js` | 369 KB | 77 KB | 79% |
| `application.css` | 39 KB | ~8 KB | ~80% |

HTML responses are intentionally **not** compressed to avoid BREACH-style compression attacks on pages containing CSRF tokens.

## Test plan
- [x] Verified `Rack::Deflater` appears in middleware stack via `bin/rails middleware`
- [x] Verified `Content-Encoding: gzip` header in JSON responses via curl
- [x] Verified transfer size reduction with Playwright performance API
- [x] Spec validates gzip body inflates to valid JSON
- [x] Spec verifies text/html is excluded from compression config
- [ ] Confirm improved load times over Tailscale connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)