### PR TITLE
fix(agent-runs): use rev-parse HEAD for clone idempotency check

### DIFF
--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -356,7 +356,12 @@ module Containers
       # Idempotent: skip clone if a previous attempt already populated /workspace.
       # This prevents failures on Temporal retries when the clone succeeded but a
       # later step (e.g. DB update) failed.
-      check = execute_git("rev-parse", "--is-inside-work-tree")
+      #
+      # We check rev-parse HEAD (not --is-inside-work-tree) because a partial
+      # clone can leave a .git dir with no commits — --is-inside-work-tree
+      # would return true, skipping the clone and causing head_sha to fail
+      # with "ambiguous argument 'HEAD'".
+      check = execute_git("rev-parse", "HEAD")
       return if check.success?
 
       project = agent_run.project

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -18,16 +18,12 @@ RSpec.describe Containers::GitOperations do
     before do
       allow(container_service).to receive(:execute).and_return(success_result)
 
-      # The clone is skipped when rev-parse succeeds (idempotency guard),
-      # so return failure to indicate /workspace is not yet a repo.
-      allow(container_service).to receive(:execute)
-        .with([ "git", "rev-parse", "--is-inside-work-tree" ], timeout: nil, stream: false)
-        .and_return(not_a_repo_result)
-
+      # The clone is skipped when rev-parse HEAD succeeds (idempotency guard),
+      # so return failure first (triggering clone), then success (for head_sha).
       sha_result = Containers::Provision::Result.success(stdout: "#{head_sha}\n", stderr: "", exit_code: 0)
       allow(container_service).to receive(:execute)
         .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
-        .and_return(sha_result)
+        .and_return(not_a_repo_result, sha_result)
     end
 
     it "clones the repository inside the container" do
@@ -106,7 +102,7 @@ RSpec.describe Containers::GitOperations do
       allow(container_service).to receive(:execute).and_return(success_result)
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "rev-parse", "--is-inside-work-tree" ], timeout: nil, stream: false)
+        .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
         .and_return(not_a_repo_result)
 
       allow(container_service).to receive(:execute)


### PR DESCRIPTION
## Summary

- **Bug**: `clone_repo` used `git rev-parse --is-inside-work-tree` as its idempotency guard, which returns `true` even in a repo with zero commits (e.g. after a partial clone creates `.git/` but fails to fetch objects). On Temporal retry, the clone was skipped and `head_sha` failed with `fatal: ambiguous argument 'HEAD'`.
- **Fix**: Changed the idempotency check to `git rev-parse HEAD` so partial clones are re-attempted on retry.
- Affected agent runs: 1403, 1444.

## Test plan

- [x] All 64 `git_operations_spec.rb` examples pass
- [ ] Manually trigger an agent run and verify clone + branch setup succeeds
- [ ] Simulate a partial clone (Temporal retry after `.git/` created but no objects fetched) and confirm the clone is re-attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)