### PR TITLE
fix(ci): allow dependabot PRs in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,3 +43,4 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: 'dependabot[bot]'


### PR DESCRIPTION
## Summary
- The `claude-code-action` rejects PRs from bot actors by default, causing the `claude-review` check to fail on all Dependabot PRs (e.g. #353)
- Adds `allowed_bots: 'dependabot[bot]'` to the workflow config so claude-review runs on Dependabot PRs

## Test plan
- [ ] Verify existing Dependabot PRs no longer show `claude-review` as failed
- [ ] Re-run the `claude-review` check on #353 to confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)