### PR TITLE
Fix #247: Auto-detect project service needs from repository files

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -97,9 +97,8 @@ class ProjectsController < ApplicationController
     result = Projects::DetectServices.call(project: @project)
 
     if result.any_detected?
-      added = apply_detected_services(result.matched)
-      notice = build_detection_notice(added, result)
-      redirect_to edit_project_path(@project), notice: notice
+      added = result.apply(@project)
+      redirect_to edit_project_path(@project), notice: result.notice_message(added)
     else
       redirect_to edit_project_path(@project), notice: "No service dependencies detected in repository files."
     end
@@ -133,26 +132,6 @@ class ProjectsController < ApplicationController
       :poll_interval_seconds, :github_id, :default_branch,
       :owner_reviewer_login, :merge_method, :max_draft_review_rounds, :auto_pick_enabled,
       allowed_github_usernames: [])
-  end
-
-  def apply_detected_services(containers)
-    added = []
-    containers.each do |container|
-      psc = @project.project_service_containers.find_or_create_by!(service_container: container)
-      added << container.name if psc.previously_new_record?
-    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
-      next
-    end
-    added
-  end
-
-  def build_detection_notice(added, result)
-    parts = []
-    parts << "Added #{added.join(', ')}." if added.any?
-    parts << "#{result.unmatched.map { |d| d[:service] }.join(', ')} detected but no matching service container exists." if result.unmatched.any?
-    already_count = result.matched.size - added.size
-    parts << "#{already_count} already associated." if already_count > 0
-    parts.join(" ").presence || "All detected services are already associated."
   end
 
   def parse_usernames_csv

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectsController < ApplicationController
-  before_action :set_project, only: [ :show, :edit, :update, :destroy, :toggle_auto_pick ]
+  before_action :set_project, only: [ :show, :edit, :update, :destroy, :toggle_auto_pick, :detect_services ]
   skip_after_action :verify_authorized, only: :index
 
   NULLS_LAST_SORT_ATTRIBUTES = %w[last_agent_run_at last_github_activity_at].freeze
@@ -91,6 +91,22 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def detect_services
+    authorize @project, :update?
+
+    result = Projects::DetectServices.call(project: @project)
+
+    if result.any_detected?
+      added = apply_detected_services(result.matched)
+      notice = build_detection_notice(added, result)
+      redirect_to edit_project_path(@project), notice: notice
+    else
+      redirect_to edit_project_path(@project), notice: "No service dependencies detected in repository files."
+    end
+  rescue GithubClient::Error => e
+    redirect_to edit_project_path(@project), alert: "Could not detect services: #{e.message}"
+  end
+
   def destroy
     authorize @project
     @project.destroy!
@@ -117,6 +133,26 @@ class ProjectsController < ApplicationController
       :poll_interval_seconds, :github_id, :default_branch,
       :owner_reviewer_login, :merge_method, :max_draft_review_rounds, :auto_pick_enabled,
       allowed_github_usernames: [])
+  end
+
+  def apply_detected_services(containers)
+    added = []
+    containers.each do |container|
+      psc = @project.project_service_containers.find_or_create_by(service_container: container)
+      added << container.name if psc.previously_new_record?
+    rescue ActiveRecord::RecordNotUnique
+      next
+    end
+    added
+  end
+
+  def build_detection_notice(added, result)
+    parts = []
+    parts << "Added #{added.join(', ')}." if added.any?
+    parts << "#{result.unmatched.map { |d| d[:service] }.join(', ')} detected but no matching service container exists." if result.unmatched.any?
+    already_count = result.matched.size - added.size
+    parts << "#{already_count} already associated." if already_count > 0
+    parts.join(" ").presence || "All detected services are already associated."
   end
 
   def parse_usernames_csv

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -102,7 +102,7 @@ class ProjectsController < ApplicationController
     else
       redirect_to edit_project_path(@project), notice: "No service dependencies detected in repository files."
     end
-  rescue GithubClient::Error, Octokit::Error => e
+  rescue GithubClient::Error => e
     redirect_to edit_project_path(@project), alert: "Could not detect services: #{e.message}"
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -103,7 +103,7 @@ class ProjectsController < ApplicationController
     else
       redirect_to edit_project_path(@project), notice: "No service dependencies detected in repository files."
     end
-  rescue GithubClient::Error => e
+  rescue GithubClient::Error, Octokit::Error => e
     redirect_to edit_project_path(@project), alert: "Could not detect services: #{e.message}"
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -138,9 +138,9 @@ class ProjectsController < ApplicationController
   def apply_detected_services(containers)
     added = []
     containers.each do |container|
-      psc = @project.project_service_containers.find_or_create_by(service_container: container)
+      psc = @project.project_service_containers.find_or_create_by!(service_container: container)
       added << container.name if psc.previously_new_record?
-    rescue ActiveRecord::RecordNotUnique
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
       next
     end
     added

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -101,6 +101,17 @@ class GithubClient
     handle_errors { client.repository(repo) }
   end
 
+  # Fetches file contents from a repository.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param path [String] File path within the repository
+  # @return [Sawyer::Resource] File content data (Base64-encoded)
+  # @raise [NotFoundError] if the file does not exist
+  # @raise [AuthenticationError] if access is denied
+  def contents(repo, path:)
+    handle_errors { client.contents(repo, path: path) }
+  end
+
   # Lists repositories the token has push access to.
   # Filters by permissions.push to exclude repos where the token only
   # has metadata access (relevant for fine-grained PATs with selected repos).

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -288,8 +288,11 @@ module Projects
     end
 
     def match_compose_service_name(name)
+      return nil if name.blank?
+
+      name_str = name.to_s
       COMPOSE_IMAGE_PATTERNS.each do |pattern, service|
-        return service if name.match?(pattern)
+        return service if name_str.match?(pattern)
       end
       nil
     end

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -118,11 +118,9 @@ module Projects
 
     def fetch_file(path)
       client = project.github_token.client
-      response = client.client.contents("#{project.owner}/#{project.repo}", path: path)
+      response = client.contents("#{project.owner}/#{project.repo}", path: path)
       decode_content(response)
-    rescue GithubClient::NotFoundError, Octokit::NotFound
-      nil
-    rescue GithubClient::Error
+    rescue GithubClient::NotFoundError
       nil
     end
 
@@ -174,10 +172,15 @@ module Projects
     end
 
     def detect_from_docker_compose
-      content = fetch_file("docker-compose.yml") || fetch_file("compose.yml")
+      source_file = "docker-compose.yml"
+      content = fetch_file(source_file)
+      unless content
+        source_file = "compose.yml"
+        content = fetch_file(source_file)
+      end
       return [] unless content
 
-      data = YAML.safe_load(content, permitted_classes: [ Symbol ])
+      data = YAML.safe_load(content)
       return [] unless data.is_a?(Hash)
 
       services = data["services"]
@@ -191,20 +194,26 @@ module Projects
         matched_service = match_compose_image(image) || match_compose_service_name(service_name)
         next unless matched_service
 
-        detections << { service: matched_service, source: "docker-compose.yml", dependency: image.presence || service_name }
+        detections << { service: matched_service, source: source_file, dependency: image.presence || service_name }
       end
       detections
     rescue Psych::SyntaxError
       []
     end
 
+    # Maximum size for database.yml content to mitigate YAML alias expansion DoS
+    DATABASE_YML_MAX_SIZE = 64_000
+
     def detect_from_database_yml
       content = fetch_file("config/database.yml")
       return [] unless content
+      return [] if content.bytesize > DATABASE_YML_MAX_SIZE
 
-      # Parse YAML but handle ERB-style templates by stripping them
+      # Parse YAML but handle ERB-style templates by stripping them.
+      # Aliases are enabled because database.yml conventionally uses YAML
+      # anchors (e.g., &default / <<: *default) to share config across environments.
       sanitized = content.gsub(/<%.*?%>/, '""')
-      data = YAML.safe_load(sanitized, permitted_classes: [ Symbol ], aliases: true)
+      data = YAML.safe_load(sanitized, aliases: true)
       return [] unless data.is_a?(Hash)
 
       detections = []

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -95,7 +95,8 @@ module Projects
       detections.concat(detect_from_database_yml)
 
       unique_services = detections.uniq { |d| d[:service] }
-      containers = ServiceContainer.all.index_by(&:name)
+      detected_names = unique_services.map { |d| d[:service] }
+      containers = ServiceContainer.where(name: detected_names).index_by(&:name)
 
       matched = []
       unmatched = []
@@ -129,7 +130,7 @@ module Projects
     def decode_content(response)
       return nil unless response&.content
 
-      Base64.decode64(response.content).force_encoding("UTF-8")
+      Base64.decode64(response.content).force_encoding("UTF-8").scrub
     end
 
     def detect_from_gemfile
@@ -181,6 +182,7 @@ module Projects
         content = fetch_file(source_file)
       end
       return [] unless content
+      return [] if content.bytesize > YAML_MAX_SIZE
 
       data = YAML.safe_load(content, aliases: true)
       return [] unless data.is_a?(Hash)
@@ -203,13 +205,15 @@ module Projects
       []
     end
 
-    # Maximum size for database.yml content to mitigate YAML alias expansion DoS
-    DATABASE_YML_MAX_SIZE = 64_000
+    # Maximum size for YAML content to mitigate YAML alias expansion DoS.
+    # Applied to both docker-compose and database.yml since both support
+    # YAML aliases that can cause exponential memory expansion.
+    YAML_MAX_SIZE = 64_000
 
     def detect_from_database_yml
       content = fetch_file("config/database.yml")
       return [] unless content
-      return [] if content.bytesize > DATABASE_YML_MAX_SIZE
+      return [] if content.bytesize > YAML_MAX_SIZE
 
       # Parse YAML but handle ERB-style templates by stripping them.
       # Aliases are enabled because database.yml conventionally uses YAML
@@ -219,10 +223,7 @@ module Projects
       return [] unless data.is_a?(Hash)
 
       detections = []
-      data.each_value do |config|
-        next unless config.is_a?(Hash)
-
-        adapter = config["adapter"]
+      extract_adapters(data) do |adapter|
         service = DATABASE_ADAPTER_MAP[adapter]
         next unless service
 
@@ -231,6 +232,23 @@ module Projects
       detections
     rescue Psych::Exception
       []
+    end
+
+    # Recursively walks a YAML hash to find all "adapter" values.
+    # Handles both single-db (adapter at top level of each env) and
+    # multi-db (adapter nested under primary/secondary sub-keys) configs.
+    def extract_adapters(hash, &block)
+      return unless hash.is_a?(Hash)
+
+      hash.each_value do |value|
+        next unless value.is_a?(Hash)
+
+        if value.key?("adapter")
+          yield value["adapter"]
+        else
+          extract_adapters(value, &block)
+        end
+      end
     end
 
     def match_compose_image(image)

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -79,6 +79,15 @@ module Projects
       "mongo" => "mongodb"
     }.freeze
 
+    # Maximum size for YAML content to limit parsing of untrusted files.
+    YAML_MAX_SIZE = 64_000
+
+    # Maximum number of YAML alias nodes allowed. Limits exponential
+    # expansion from small "YAML bomb" payloads that use nested aliases
+    # (e.g., &a [*b,*b] chains). Checked via Psych AST before converting
+    # to Ruby objects.
+    MAX_YAML_ALIASES = 100
+
     attr_reader :project
 
     def initialize(project:)
@@ -125,7 +134,7 @@ module Projects
       client = project.github_token.client
       response = client.contents("#{project.owner}/#{project.repo}", path: path)
       decode_content(response)
-    rescue GithubClient::NotFoundError
+    rescue GithubClient::Error
       nil
     end
 
@@ -206,15 +215,6 @@ module Projects
     rescue Psych::Exception
       []
     end
-
-    # Maximum size for YAML content to limit parsing of untrusted files.
-    YAML_MAX_SIZE = 64_000
-
-    # Maximum number of YAML alias nodes allowed. Limits exponential
-    # expansion from small "YAML bomb" payloads that use nested aliases
-    # (e.g., &a [*b,*b] chains). Checked via Psych AST before converting
-    # to Ruby objects.
-    MAX_YAML_ALIASES = 100
 
     def detect_from_database_yml
       content = fetch_file("config/database.yml")

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "base64"
+require "json"
+require "yaml"
 
 module Projects
   # Inspects repository files to detect required service dependencies.
@@ -184,7 +186,7 @@ module Projects
       return [] unless content
       return [] if content.bytesize > YAML_MAX_SIZE
 
-      data = YAML.safe_load(content, aliases: true)
+      data = safe_yaml_load(content)
       return [] unless data.is_a?(Hash)
 
       services = data["services"]
@@ -205,10 +207,14 @@ module Projects
       []
     end
 
-    # Maximum size for YAML content to mitigate YAML alias expansion DoS.
-    # Applied to both docker-compose and database.yml since both support
-    # YAML aliases that can cause exponential memory expansion.
+    # Maximum size for YAML content to limit parsing of untrusted files.
     YAML_MAX_SIZE = 64_000
+
+    # Maximum number of YAML alias nodes allowed. Limits exponential
+    # expansion from small "YAML bomb" payloads that use nested aliases
+    # (e.g., &a [*b,*b] chains). Checked via Psych AST before converting
+    # to Ruby objects.
+    MAX_YAML_ALIASES = 100
 
     def detect_from_database_yml
       content = fetch_file("config/database.yml")
@@ -219,7 +225,7 @@ module Projects
       # Aliases are enabled because database.yml conventionally uses YAML
       # anchors (e.g., &default / <<: *default) to share config across environments.
       sanitized = content.gsub(/<%.*?%>/m, '""')
-      data = YAML.safe_load(sanitized, aliases: true)
+      data = safe_yaml_load(sanitized)
       return [] unless data.is_a?(Hash)
 
       detections = []
@@ -251,6 +257,27 @@ module Projects
       end
     end
 
+    # Parses YAML via Psych AST with an alias count limit to prevent
+    # exponential expansion from YAML bomb payloads. Returns nil if the
+    # alias count exceeds MAX_YAML_ALIASES.
+    def safe_yaml_load(content)
+      tree = Psych.parse(content)
+      return nil unless tree
+
+      alias_count = count_yaml_aliases(tree)
+      return nil if alias_count > MAX_YAML_ALIASES
+
+      tree.to_ruby
+    end
+
+    def count_yaml_aliases(node)
+      count = node.is_a?(Psych::Nodes::Alias) ? 1 : 0
+      if node.respond_to?(:children) && node.children
+        node.children.each { |child| count += count_yaml_aliases(child) }
+      end
+      count
+    end
+
     def match_compose_image(image)
       return nil if image.blank?
 
@@ -279,6 +306,31 @@ module Projects
 
       def any_detected?
         detected.any?
+      end
+
+      # Associates matched service containers with the project.
+      # Returns the names of newly added associations.
+      def apply(project)
+        added = []
+        matched.each do |container|
+          psc = project.project_service_containers.find_or_create_by!(service_container: container)
+          added << container.name if psc.previously_new_record?
+        rescue ActiveRecord::RecordNotUnique
+          next
+        end
+        added
+      end
+
+      def notice_message(added)
+        parts = []
+        parts << "Added #{added.join(', ')}." if added.any?
+        if unmatched.any?
+          names = unmatched.map { |d| d[:service] }.join(", ")
+          parts << "#{names} detected but no matching service container exists."
+        end
+        already_count = matched.size - added.size
+        parts << "#{already_count} already associated." if already_count > 0
+        parts.join(" ").presence || "All detected services are already associated."
       end
     end
   end

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+module Projects
+  # Inspects repository files to detect required service dependencies.
+  #
+  # Parses Gemfile, package.json, docker-compose.yml, and config/database.yml
+  # to identify services like PostgreSQL, Redis, Elasticsearch, etc.
+  # Maps detected dependencies to existing ServiceContainer records.
+  #
+  # @example
+  #   result = Projects::DetectServices.call(project: project)
+  #   result.detected   # => [{ service: "postgres", source: "Gemfile", ... }]
+  #   result.matched     # => [#<ServiceContainer name: "postgres">]
+  #   result.unmatched   # => [{ service: "elasticsearch", source: "docker-compose.yml" }]
+  class DetectServices
+    # Maps dependency identifiers to canonical service names.
+    # Keys are patterns found in Gemfile/package.json/docker-compose.
+    # Values are canonical service names matching ServiceContainer.name.
+    DEPENDENCY_MAP = {
+      # PostgreSQL
+      "pg" => "postgres",
+      "postgres" => "postgres",
+      "postgresql" => "postgres",
+      # Redis
+      "redis" => "redis",
+      "redis-rb" => "redis",
+      "ioredis" => "redis",
+      "bull" => "redis",
+      "sidekiq" => "redis",
+      # MySQL
+      "mysql2" => "mysql",
+      "mysql" => "mysql",
+      # MongoDB
+      "mongoid" => "mongodb",
+      "mongo" => "mongodb",
+      "mongoose" => "mongodb",
+      "mongodb" => "mongodb",
+      # Elasticsearch
+      "elasticsearch" => "elasticsearch",
+      "elastic-apm" => "elasticsearch",
+      "searchkick" => "elasticsearch",
+      "@elastic/elasticsearch" => "elasticsearch",
+      # Memcached
+      "dalli" => "memcached",
+      "memcached" => "memcached",
+      "memjs" => "memcached",
+      # Selenium
+      "selenium" => "selenium",
+      "selenium-webdriver" => "selenium"
+    }.freeze
+
+    # Gemfile gem patterns that indicate service dependencies.
+    GEMFILE_PATTERNS = /^\s*gem\s+["']([^"']+)["']/.freeze
+
+    # package.json dependency keys to inspect.
+    PACKAGE_JSON_DEPENDENCY_KEYS = %w[dependencies devDependencies].freeze
+
+    # docker-compose service image patterns mapped to canonical names.
+    COMPOSE_IMAGE_PATTERNS = {
+      /postgres/ => "postgres",
+      /redis/ => "redis",
+      /mysql|mariadb/ => "mysql",
+      /mongo/ => "mongodb",
+      /elasticsearch|opensearch/ => "elasticsearch",
+      /memcache/ => "memcached",
+      /selenium/ => "selenium"
+    }.freeze
+
+    # database.yml adapter patterns.
+    DATABASE_ADAPTER_MAP = {
+      "postgresql" => "postgres",
+      "postgis" => "postgres",
+      "mysql2" => "mysql",
+      "trilogy" => "mysql",
+      "mongo" => "mongodb"
+    }.freeze
+
+    attr_reader :project
+
+    def initialize(project:)
+      @project = project
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      detections = []
+      detections.concat(detect_from_gemfile)
+      detections.concat(detect_from_package_json)
+      detections.concat(detect_from_docker_compose)
+      detections.concat(detect_from_database_yml)
+
+      unique_services = detections.uniq { |d| d[:service] }
+      containers = ServiceContainer.all.index_by(&:name)
+
+      matched = []
+      unmatched = []
+
+      unique_services.each do |detection|
+        container = containers[detection[:service]]
+        if container
+          matched << container
+        else
+          unmatched << detection
+        end
+      end
+
+      Result.new(
+        detected: unique_services,
+        matched: matched.uniq,
+        unmatched: unmatched
+      )
+    end
+
+    private
+
+    def fetch_file(path)
+      client = project.github_token.client
+      response = client.client.contents("#{project.owner}/#{project.repo}", path: path)
+      decode_content(response)
+    rescue GithubClient::NotFoundError, Octokit::NotFound
+      nil
+    rescue GithubClient::Error
+      nil
+    end
+
+    def decode_content(response)
+      return nil unless response&.content
+
+      Base64.decode64(response.content).force_encoding("UTF-8")
+    end
+
+    def detect_from_gemfile
+      content = fetch_file("Gemfile")
+      return [] unless content
+
+      detections = []
+      content.each_line do |line|
+        match = line.match(GEMFILE_PATTERNS)
+        next unless match
+
+        gem_name = match[1]
+        service = DEPENDENCY_MAP[gem_name]
+        next unless service
+
+        detections << { service: service, source: "Gemfile", dependency: gem_name }
+      end
+      detections
+    end
+
+    def detect_from_package_json
+      content = fetch_file("package.json")
+      return [] unless content
+
+      data = JSON.parse(content)
+      detections = []
+
+      PACKAGE_JSON_DEPENDENCY_KEYS.each do |key|
+        deps = data[key]
+        next unless deps.is_a?(Hash)
+
+        deps.each_key do |dep_name|
+          service = DEPENDENCY_MAP[dep_name]
+          next unless service
+
+          detections << { service: service, source: "package.json", dependency: dep_name }
+        end
+      end
+      detections
+    rescue JSON::ParserError
+      []
+    end
+
+    def detect_from_docker_compose
+      content = fetch_file("docker-compose.yml") || fetch_file("compose.yml")
+      return [] unless content
+
+      data = YAML.safe_load(content, permitted_classes: [ Symbol ])
+      return [] unless data.is_a?(Hash)
+
+      services = data["services"]
+      return [] unless services.is_a?(Hash)
+
+      detections = []
+      services.each do |service_name, config|
+        next unless config.is_a?(Hash)
+
+        image = config["image"].to_s
+        matched_service = match_compose_image(image) || match_compose_service_name(service_name)
+        next unless matched_service
+
+        detections << { service: matched_service, source: "docker-compose.yml", dependency: image.presence || service_name }
+      end
+      detections
+    rescue Psych::SyntaxError
+      []
+    end
+
+    def detect_from_database_yml
+      content = fetch_file("config/database.yml")
+      return [] unless content
+
+      # Parse YAML but handle ERB-style templates by stripping them
+      sanitized = content.gsub(/<%.*?%>/, '""')
+      data = YAML.safe_load(sanitized, permitted_classes: [ Symbol ], aliases: true)
+      return [] unless data.is_a?(Hash)
+
+      detections = []
+      data.each_value do |config|
+        next unless config.is_a?(Hash)
+
+        adapter = config["adapter"]
+        service = DATABASE_ADAPTER_MAP[adapter]
+        next unless service
+
+        detections << { service: service, source: "config/database.yml", dependency: adapter }
+      end
+      detections
+    rescue Psych::SyntaxError
+      []
+    end
+
+    def match_compose_image(image)
+      return nil if image.blank?
+
+      COMPOSE_IMAGE_PATTERNS.each do |pattern, service|
+        return service if image.match?(pattern)
+      end
+      nil
+    end
+
+    def match_compose_service_name(name)
+      COMPOSE_IMAGE_PATTERNS.each do |pattern, service|
+        return service if name.match?(pattern)
+      end
+      nil
+    end
+
+    # Result object returned by DetectServices.
+    class Result
+      attr_reader :detected, :matched, :unmatched
+
+      def initialize(detected:, matched:, unmatched:)
+        @detected = detected
+        @matched = matched
+        @unmatched = unmatched
+      end
+
+      def any_detected?
+        detected.any?
+      end
+    end
+  end
+end

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -134,7 +134,7 @@ module Projects
       client = project.github_token.client
       response = client.contents("#{project.owner}/#{project.repo}", path: path)
       decode_content(response)
-    rescue GithubClient::Error
+    rescue GithubClient::NotFoundError
       nil
     end
 

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "base64"
+
 module Projects
   # Inspects repository files to detect required service dependencies.
   #
@@ -180,7 +182,7 @@ module Projects
       end
       return [] unless content
 
-      data = YAML.safe_load(content)
+      data = YAML.safe_load(content, aliases: true)
       return [] unless data.is_a?(Hash)
 
       services = data["services"]
@@ -197,7 +199,7 @@ module Projects
         detections << { service: matched_service, source: source_file, dependency: image.presence || service_name }
       end
       detections
-    rescue Psych::SyntaxError
+    rescue Psych::Exception
       []
     end
 
@@ -212,7 +214,7 @@ module Projects
       # Parse YAML but handle ERB-style templates by stripping them.
       # Aliases are enabled because database.yml conventionally uses YAML
       # anchors (e.g., &default / <<: *default) to share config across environments.
-      sanitized = content.gsub(/<%.*?%>/, '""')
+      sanitized = content.gsub(/<%.*?%>/m, '""')
       data = YAML.safe_load(sanitized, aliases: true)
       return [] unless data.is_a?(Hash)
 
@@ -227,7 +229,7 @@ module Projects
         detections << { service: service, source: "config/database.yml", dependency: adapter }
       end
       detections
-    rescue Psych::SyntaxError
+    rescue Psych::Exception
       []
     end
 

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -164,10 +164,15 @@
   <%# Service Containers section %>
   <div class="mt-6 bg-white shadow sm:rounded-lg">
     <div class="px-4 py-5 sm:p-6">
-      <h2 class="text-lg font-semibold text-gray-900">Service Containers</h2>
-      <p class="mt-1 text-sm text-gray-500">
-        Associate service containers with this project. Agents will receive connection environment variables (e.g. <code class="rounded bg-gray-100 px-1 py-0.5 text-xs">DATABASE_URL</code>) during runs.
-      </p>
+      <div class="flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-gray-900">Service Containers</h2>
+          <p class="mt-1 text-sm text-gray-500">
+            Associate service containers with this project. Agents will receive connection environment variables (e.g. <code class="rounded bg-gray-100 px-1 py-0.5 text-xs">DATABASE_URL</code>) during runs.
+          </p>
+        </div>
+        <%= button_to "Detect from Repo", detect_services_project_path(@project), method: :post, class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
+      </div>
 
       <% project_service_containers = @project.project_service_containers.includes(:service_container).to_a %>
       <% if project_service_containers.any? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
       post :quick_create, on: :collection
     end
     resources :project_service_containers, only: [ :create, :destroy ], controller: "projects/service_containers"
+    post :detect_services, on: :member
   end
 
   # API endpoints for agent containers

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -694,7 +694,7 @@ RSpec.describe "Projects" do
       end
 
       context "when services are detected and matched" do
-        let(:postgres_container) { create(:service_container, name: "postgres") }
+        let(:postgres_container) { ServiceContainer.find_by(name: "postgres") || create(:service_container, name: "postgres") }
         let(:detect_result) do
           Projects::DetectServices::Result.new(
             detected: [ { service: "postgres", source: "Gemfile", dependency: "pg" } ],

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -663,6 +663,109 @@ RSpec.describe "Projects" do
     end
   end
 
+  describe "POST /projects/:id/detect_services" do
+    context "when not authenticated" do
+      it "redirects to the sign in page" do
+        project = create(:project, account: account, github_token: github_token)
+        post detect_services_project_path(project)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as owner" do
+      let(:project) { create(:project, account: account, github_token: github_token) }
+      let(:detect_result) do
+        Projects::DetectServices::Result.new(detected: [], matched: [], unmatched: [])
+      end
+
+      before do
+        sign_in user
+        allow(Projects::DetectServices).to receive(:call).and_return(detect_result)
+      end
+
+      it "redirects to the edit page" do
+        post detect_services_project_path(project)
+        expect(response).to redirect_to(edit_project_path(project))
+      end
+
+      it "shows a notice when no services are detected" do
+        post detect_services_project_path(project)
+        expect(flash[:notice]).to include("No service dependencies detected")
+      end
+
+      context "when services are detected and matched" do
+        let(:postgres_container) { create(:service_container, name: "postgres") }
+        let(:detect_result) do
+          Projects::DetectServices::Result.new(
+            detected: [ { service: "postgres", source: "Gemfile", dependency: "pg" } ],
+            matched: [ postgres_container ],
+            unmatched: []
+          )
+        end
+
+        it "creates project service container associations" do
+          expect {
+            post detect_services_project_path(project)
+          }.to change(ProjectServiceContainer, :count).by(1)
+        end
+
+        it "shows a notice with added services" do
+          post detect_services_project_path(project)
+          expect(flash[:notice]).to include("postgres")
+        end
+
+        it "does not duplicate existing associations" do
+          create(:project_service_container, project: project, service_container: postgres_container)
+          expect {
+            post detect_services_project_path(project)
+          }.not_to change(ProjectServiceContainer, :count)
+        end
+      end
+
+      context "when services are detected but unmatched" do
+        let(:detect_result) do
+          Projects::DetectServices::Result.new(
+            detected: [ { service: "elasticsearch", source: "Gemfile", dependency: "searchkick" } ],
+            matched: [],
+            unmatched: [ { service: "elasticsearch", source: "Gemfile", dependency: "searchkick" } ]
+          )
+        end
+
+        it "shows a notice about unmatched services" do
+          post detect_services_project_path(project)
+          expect(flash[:notice]).to include("elasticsearch")
+          expect(flash[:notice]).to include("no matching service container")
+        end
+      end
+
+      context "when GitHub API returns an error" do
+        before do
+          allow(Projects::DetectServices).to receive(:call)
+            .and_raise(GithubClient::ApiError.new("API rate limit exceeded"))
+        end
+
+        it "redirects with an alert" do
+          post detect_services_project_path(project)
+          expect(response).to redirect_to(edit_project_path(project))
+          expect(flash[:alert]).to include("Could not detect services")
+        end
+      end
+    end
+
+    context "when authenticated as viewer" do
+      let(:viewer_user) { create(:user, :viewer, account: account) }
+
+      before { sign_in viewer_user }
+
+      it "redirects with authorization error" do
+        project = create(:project, account: account, github_token: github_token)
+        post detect_services_project_path(project)
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("not authorized")
+      end
+    end
+  end
+
   describe "DELETE /projects/:id" do
     context "when not authenticated" do
       it "redirects to the sign in page" do

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -5,11 +5,15 @@ require "rails_helper"
 RSpec.describe Issues::ParseDependencies do
   let(:project) { create(:project) }
 
+  # Use high github_numbers (9000+) for dependency targets to avoid collisions
+  # with FactoryBot's global github_number sequence (which starts at 1 and
+  # increments across all tests in the suite).
+
   describe ".call" do
     it "parses dependencies from a Dependencies section" do
-      dep1 = create(:issue, project: project, github_number: 101)
-      dep2 = create(:issue, project: project, github_number: 102)
-      issue = create(:issue, project: project, body: "## Dependencies\n- #101\n- #102\n")
+      dep1 = create(:issue, project: project, github_number: 9101)
+      dep2 = create(:issue, project: project, github_number: 9102)
+      issue = create(:issue, project: project, body: "## Dependencies\n- #9101\n- #9102\n")
 
       described_class.call(issue: issue)
 
@@ -17,8 +21,8 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "parses 'Depends on' inline references" do
-      dep = create(:issue, project: project, github_number: 50)
-      issue = create(:issue, project: project, body: "This issue depends on #50.")
+      dep = create(:issue, project: project, github_number: 9050)
+      issue = create(:issue, project: project, body: "This issue depends on #9050.")
 
       described_class.call(issue: issue)
 
@@ -26,8 +30,8 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "parses 'Depends on:' with colon" do
-      dep = create(:issue, project: project, github_number: 10)
-      issue = create(:issue, project: project, body: "Depends on: #10")
+      dep = create(:issue, project: project, github_number: 9010)
+      issue = create(:issue, project: project, body: "Depends on: #9010")
 
       described_class.call(issue: issue)
 
@@ -35,8 +39,8 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "parses 'Blocked by' references" do
-      dep = create(:issue, project: project, github_number: 42)
-      issue = create(:issue, project: project, body: "Blocked by #42")
+      dep = create(:issue, project: project, github_number: 9042)
+      issue = create(:issue, project: project, body: "Blocked by #9042")
 
       described_class.call(issue: issue)
 
@@ -44,10 +48,10 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "parses multiple comma-separated references" do
-      dep1 = create(:issue, project: project, github_number: 1)
-      dep2 = create(:issue, project: project, github_number: 2)
-      dep3 = create(:issue, project: project, github_number: 3)
-      issue = create(:issue, project: project, body: "Depends on #1, #2, #3")
+      dep1 = create(:issue, project: project, github_number: 9001)
+      dep2 = create(:issue, project: project, github_number: 9002)
+      dep3 = create(:issue, project: project, github_number: 9003)
+      issue = create(:issue, project: project, body: "Depends on #9001, #9002, #9003")
 
       described_class.call(issue: issue)
 
@@ -55,7 +59,7 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "ignores references to non-existent issues" do
-      issue = create(:issue, project: project, body: "Depends on #999")
+      issue = create(:issue, project: project, body: "Depends on #9999")
 
       described_class.call(issue: issue)
 
@@ -63,7 +67,7 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "ignores self-references" do
-      issue = create(:issue, project: project, github_number: 5, body: "Depends on #5")
+      issue = create(:issue, project: project, github_number: 9005, body: "Depends on #9005")
 
       described_class.call(issue: issue)
 
@@ -71,8 +75,8 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "ignores references to pull requests" do
-      create(:issue, :pull_request, project: project, github_number: 7)
-      issue = create(:issue, project: project, body: "Depends on #7")
+      create(:issue, :pull_request, project: project, github_number: 9007)
+      issue = create(:issue, project: project, body: "Depends on #9007")
 
       described_class.call(issue: issue)
 
@@ -86,8 +90,8 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "removes all dependencies when body becomes blank" do
-      dep = create(:issue, project: project, github_number: 10)
-      issue = create(:issue, project: project, body: "Depends on #10")
+      dep = create(:issue, project: project, github_number: 9010)
+      issue = create(:issue, project: project, body: "Depends on #9010")
 
       described_class.call(issue: issue)
       expect(issue.dependencies.reload).to contain_exactly(dep)
@@ -98,8 +102,8 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "removes all dependencies when dependency section is cleared" do
-      dep = create(:issue, project: project, github_number: 10)
-      issue = create(:issue, project: project, body: "Depends on #10")
+      dep = create(:issue, project: project, github_number: 9010)
+      issue = create(:issue, project: project, body: "Depends on #9010")
 
       described_class.call(issue: issue)
       expect(issue.dependencies.reload).to contain_exactly(dep)
@@ -110,43 +114,43 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "removes stale dependencies when body changes" do
-      dep1 = create(:issue, project: project, github_number: 10)
-      dep2 = create(:issue, project: project, github_number: 20)
-      issue = create(:issue, project: project, body: "Depends on #10, #20")
+      dep1 = create(:issue, project: project, github_number: 9010)
+      dep2 = create(:issue, project: project, github_number: 9020)
+      issue = create(:issue, project: project, body: "Depends on #9010, #9020")
 
       described_class.call(issue: issue)
       expect(issue.dependencies.reload).to contain_exactly(dep1, dep2)
 
-      issue.update!(body: "Depends on #10")
+      issue.update!(body: "Depends on #9010")
       described_class.call(issue: issue)
       expect(issue.dependencies.reload).to contain_exactly(dep1)
     end
 
     it "is idempotent" do
-      create(:issue, project: project, github_number: 10)
-      issue = create(:issue, project: project, body: "Depends on #10")
+      create(:issue, project: project, github_number: 9010)
+      issue = create(:issue, project: project, body: "Depends on #9010")
 
       described_class.call(issue: issue)
       expect { described_class.call(issue: issue) }.not_to change(IssueDependency, :count)
     end
 
     it "skips dependencies that would create a cycle" do
-      issue_a = create(:issue, project: project, github_number: 1)
-      issue_b = create(:issue, project: project, github_number: 2,
-                       body: "Depends on #1")
+      issue_a = create(:issue, project: project, github_number: 9001)
+      issue_b = create(:issue, project: project, github_number: 9002,
+                       body: "Depends on #9001")
 
       described_class.call(issue: issue_b)
       expect(issue_b.dependencies).to contain_exactly(issue_a)
 
-      issue_a.update!(body: "Depends on #2")
+      issue_a.update!(body: "Depends on #9002")
       described_class.call(issue: issue_a)
       expect(issue_a.dependencies.reload).to be_empty
     end
 
     it "parses dependencies from a section followed by another heading" do
-      dep = create(:issue, project: project, github_number: 101)
-      create(:issue, project: project, github_number: 999)
-      body = "## Dependencies\n- #101\n\n## Notes\nSome notes mentioning #999\n"
+      dep = create(:issue, project: project, github_number: 9101)
+      create(:issue, project: project, github_number: 9999)
+      body = "## Dependencies\n- #9101\n\n## Notes\nSome notes mentioning #9999\n"
       issue = create(:issue, project: project, body: body)
 
       described_class.call(issue: issue)
@@ -155,8 +159,8 @@ RSpec.describe Issues::ParseDependencies do
     end
 
     it "parses checklist items with issue references" do
-      dep = create(:issue, project: project, github_number: 15)
-      body = "## Dependencies\n- [ ] #15 complete the setup\n"
+      dep = create(:issue, project: project, github_number: 9015)
+      body = "## Dependencies\n- [ ] #9015 complete the setup\n"
       issue = create(:issue, project: project, body: body)
 
       described_class.call(issue: issue)

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -308,6 +308,20 @@ RSpec.describe Projects::DetectServices do
       end
     end
 
+    context "when a GitHub API error occurs for one file" do
+      it "continues detection from other files" do
+        allow(github_client).to receive(:contents)
+          .with("test-owner/test-repo", path: "Gemfile")
+          .and_raise(GithubClient::RateLimitError.new)
+        stub_file("config/database.yml", "default:\n  adapter: postgresql")
+
+        result = described_class.call(project: project)
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres")
+      end
+    end
+
     context "when files contain invalid content" do
       it "handles invalid JSON gracefully" do
         stub_file("package.json", "not valid json {{{")

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Projects::DetectServices do
+  let(:octokit_client) { instance_double(Octokit::Client) }
+  let(:project_owner) { "test-owner" }
+  let(:project_repo) { "test-repo" }
+  let(:service) { described_class.new(project: project_stub) }
+  let(:project_stub) do
+    github_token_stub = OpenStruct.new(
+      client: OpenStruct.new(client: octokit_client)
+    )
+    OpenStruct.new(owner: project_owner, repo: project_repo, github_token: github_token_stub)
+  end
+
+  before do
+    # Default: all files return 404
+    allow(octokit_client).to receive(:contents).and_raise(Octokit::NotFound.new)
+  end
+
+  def stub_file(path, content)
+    encoded = Base64.encode64(content)
+    response = OpenStruct.new(content: encoded)
+    allow(octokit_client).to receive(:contents)
+      .with("test-owner/test-repo", path: path)
+      .and_return(response)
+  end
+
+  # Override the service's call to use a stubbed container lookup instead of hitting the DB.
+  def call_with_containers(containers_by_name = {})
+    result_detections = []
+    result_detections.concat(service.send(:detect_from_gemfile))
+    result_detections.concat(service.send(:detect_from_package_json))
+    result_detections.concat(service.send(:detect_from_docker_compose))
+    result_detections.concat(service.send(:detect_from_database_yml))
+
+    unique_services = result_detections.uniq { |d| d[:service] }
+
+    matched = []
+    unmatched = []
+
+    unique_services.each do |detection|
+      container = containers_by_name[detection[:service]]
+      if container
+        matched << container
+      else
+        unmatched << detection
+      end
+    end
+
+    described_class::Result.new(
+      detected: unique_services,
+      matched: matched.uniq,
+      unmatched: unmatched
+    )
+  end
+
+  describe ".call" do
+    context "when Gemfile contains pg and redis gems" do
+      before do
+        stub_file("Gemfile", <<~GEMFILE)
+          source "https://rubygems.org"
+          gem "rails"
+          gem "pg"
+          gem "redis"
+          gem "sidekiq"
+        GEMFILE
+      end
+
+      it "detects postgres and redis services" do
+        result = call_with_containers
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres", "redis")
+      end
+
+      it "deduplicates redis from both redis gem and sidekiq" do
+        result = call_with_containers
+
+        service_names = result.detected.map { |d| d[:service] }
+        expect(service_names.count("redis")).to eq(1)
+      end
+
+      it "reports the source as Gemfile" do
+        result = call_with_containers
+
+        postgres_detection = result.detected.find { |d| d[:service] == "postgres" }
+        expect(postgres_detection[:source]).to eq("Gemfile")
+      end
+
+      context "when matching containers exist" do
+        let(:postgres_container) { OpenStruct.new(name: "postgres") }
+        let(:redis_container) { OpenStruct.new(name: "redis") }
+
+        it "returns matched containers" do
+          result = call_with_containers("postgres" => postgres_container, "redis" => redis_container)
+
+          expect(result.matched).to contain_exactly(postgres_container, redis_container)
+        end
+
+        it "returns no unmatched" do
+          result = call_with_containers("postgres" => postgres_container, "redis" => redis_container)
+
+          expect(result.unmatched).to be_empty
+        end
+      end
+
+      context "when no matching containers exist" do
+        it "returns unmatched detections" do
+          result = call_with_containers
+
+          expect(result.unmatched).to be_present
+          unmatched_services = result.unmatched.map { |d| d[:service] }
+          expect(unmatched_services).to include("postgres", "redis")
+        end
+      end
+    end
+
+    context "when package.json contains database dependencies" do
+      before do
+        stub_file("package.json", <<~JSON)
+          {
+            "name": "my-app",
+            "dependencies": {
+              "express": "^4.18.0",
+              "pg": "^8.11.0",
+              "ioredis": "^5.3.0"
+            },
+            "devDependencies": {
+              "@elastic/elasticsearch": "^8.0.0"
+            }
+          }
+        JSON
+      end
+
+      it "detects postgres, redis, and elasticsearch" do
+        result = call_with_containers
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres", "redis", "elasticsearch")
+      end
+
+      it "reports the source as package.json" do
+        result = call_with_containers
+
+        result.detected.each do |detection|
+          expect(detection[:source]).to eq("package.json")
+        end
+      end
+    end
+
+    context "when docker-compose.yml declares services" do
+      before do
+        stub_file("docker-compose.yml", <<~YAML)
+          version: "3.8"
+          services:
+            db:
+              image: postgres:16
+              ports:
+                - "5432:5432"
+            cache:
+              image: redis:7-alpine
+              ports:
+                - "6379:6379"
+            search:
+              image: elasticsearch:8.11.0
+        YAML
+      end
+
+      it "detects services from compose images" do
+        result = call_with_containers
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres", "redis", "elasticsearch")
+      end
+
+      it "reports the source as docker-compose.yml" do
+        result = call_with_containers
+
+        result.detected.each do |detection|
+          expect(detection[:source]).to eq("docker-compose.yml")
+        end
+      end
+    end
+
+    context "when compose.yml is used instead of docker-compose.yml" do
+      before do
+        stub_file("compose.yml", <<~YAML)
+          services:
+            postgres:
+              image: postgres:16
+        YAML
+      end
+
+      it "falls back to compose.yml" do
+        result = call_with_containers
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres")
+      end
+    end
+
+    context "when config/database.yml specifies an adapter" do
+      before do
+        stub_file("config/database.yml", <<~YAML)
+          default: &default
+            adapter: postgresql
+            encoding: unicode
+            pool: 5
+
+          development:
+            <<: *default
+            database: myapp_development
+
+          test:
+            <<: *default
+            database: myapp_test
+        YAML
+      end
+
+      it "detects postgres from the adapter" do
+        result = call_with_containers
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres")
+      end
+
+      it "reports the source as config/database.yml" do
+        result = call_with_containers
+
+        db_detection = result.detected.find { |d| d[:source] == "config/database.yml" }
+        expect(db_detection).to be_present
+        expect(db_detection[:dependency]).to eq("postgresql")
+      end
+    end
+
+    context "when config/database.yml contains ERB" do
+      before do
+        stub_file("config/database.yml", <<~YAML)
+          default: &default
+            adapter: postgresql
+            encoding: unicode
+            pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+            url: <%= ENV["DATABASE_URL"] %>
+
+          production:
+            <<: *default
+        YAML
+      end
+
+      it "handles ERB templates gracefully" do
+        result = call_with_containers
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres")
+      end
+    end
+
+    context "when multiple sources detect the same service" do
+      before do
+        stub_file("Gemfile", <<~GEMFILE)
+          gem "pg"
+        GEMFILE
+        stub_file("config/database.yml", <<~YAML)
+          default:
+            adapter: postgresql
+        YAML
+      end
+
+      it "deduplicates across sources" do
+        result = call_with_containers
+
+        postgres_detections = result.detected.select { |d| d[:service] == "postgres" }
+        expect(postgres_detections.size).to eq(1)
+      end
+    end
+
+    context "when no files are found" do
+      it "returns empty results" do
+        result = call_with_containers
+
+        expect(result.detected).to be_empty
+        expect(result.matched).to be_empty
+        expect(result.unmatched).to be_empty
+        expect(result.any_detected?).to be false
+      end
+    end
+
+    context "when files contain invalid content" do
+      it "handles invalid JSON gracefully" do
+        stub_file("package.json", "not valid json {{{")
+
+        result = call_with_containers
+        expect(result.detected).to be_empty
+      end
+
+      it "handles invalid YAML gracefully" do
+        stub_file("docker-compose.yml", "invalid: yaml: content: [}")
+
+        result = call_with_containers
+        expect(result.detected).to be_empty
+      end
+    end
+
+    context "when docker-compose.yml uses service names without explicit images" do
+      before do
+        stub_file("docker-compose.yml", <<~YAML)
+          services:
+            postgres:
+              environment:
+                POSTGRES_PASSWORD: secret
+            redis:
+              command: redis-server
+        YAML
+      end
+
+      it "detects services from service names" do
+        result = call_with_containers
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres", "redis")
+      end
+    end
+  end
+end

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "base64"
 require "ostruct"
 
 RSpec.describe Projects::DetectServices do

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -4,57 +4,45 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe Projects::DetectServices do
-  let(:octokit_client) { instance_double(Octokit::Client) }
-  let(:project_owner) { "test-owner" }
-  let(:project_repo) { "test-repo" }
-  let(:service) { described_class.new(project: project_stub) }
-  let(:project_stub) do
-    github_token_stub = OpenStruct.new(
-      client: OpenStruct.new(client: octokit_client)
-    )
-    OpenStruct.new(owner: project_owner, repo: project_repo, github_token: github_token_stub)
+  let(:github_client) { instance_double(GithubClient) }
+
+  # Use lightweight stubs for AR models to avoid DB connections during class loading
+  let(:github_token_stub) { Struct.new(:client).new(github_client) }
+  let(:project) { Struct.new(:owner, :repo, :github_token).new("test-owner", "test-repo", github_token_stub) }
+
+  let(:service_container_class) do
+    Class.new do
+      def self.all
+        raise "stub me"
+      end
+    end
   end
 
   before do
-    # Default: all files return 404
-    allow(octokit_client).to receive(:contents).and_raise(Octokit::NotFound.new)
+    stub_const("ServiceContainer", service_container_class)
+    # Default: all files return NotFound
+    allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError)
+    # Default: no service containers exist
+    allow(service_container_class).to receive(:all).and_return([])
+    allow([]).to receive(:index_by).and_return({})
   end
 
   def stub_file(path, content)
     encoded = Base64.encode64(content)
     response = OpenStruct.new(content: encoded)
-    allow(octokit_client).to receive(:contents)
+    allow(github_client).to receive(:contents)
       .with("test-owner/test-repo", path: path)
       .and_return(response)
   end
 
-  # Override the service's call to use a stubbed container lookup instead of hitting the DB.
-  def call_with_containers(containers_by_name = {})
-    result_detections = []
-    result_detections.concat(service.send(:detect_from_gemfile))
-    result_detections.concat(service.send(:detect_from_package_json))
-    result_detections.concat(service.send(:detect_from_docker_compose))
-    result_detections.concat(service.send(:detect_from_database_yml))
-
-    unique_services = result_detections.uniq { |d| d[:service] }
-
-    matched = []
-    unmatched = []
-
-    unique_services.each do |detection|
-      container = containers_by_name[detection[:service]]
-      if container
-        matched << container
-      else
-        unmatched << detection
-      end
+  def stub_containers(*names)
+    containers_by_name = names.each_with_object({}) do |name, hash|
+      hash[name] = Struct.new(:name).new(name)
     end
-
-    described_class::Result.new(
-      detected: unique_services,
-      matched: matched.uniq,
-      unmatched: unmatched
-    )
+    container_list = containers_by_name.values
+    allow(service_container_class).to receive(:all).and_return(container_list)
+    allow(container_list).to receive(:index_by).and_return(containers_by_name)
+    containers_by_name
   end
 
   describe ".call" do
@@ -70,38 +58,37 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "detects postgres and redis services" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         services = result.detected.map { |d| d[:service] }
         expect(services).to include("postgres", "redis")
       end
 
       it "deduplicates redis from both redis gem and sidekiq" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         service_names = result.detected.map { |d| d[:service] }
         expect(service_names.count("redis")).to eq(1)
       end
 
       it "reports the source as Gemfile" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         postgres_detection = result.detected.find { |d| d[:service] == "postgres" }
         expect(postgres_detection[:source]).to eq("Gemfile")
       end
 
       context "when matching containers exist" do
-        let(:postgres_container) { OpenStruct.new(name: "postgres") }
-        let(:redis_container) { OpenStruct.new(name: "redis") }
-
         it "returns matched containers" do
-          result = call_with_containers("postgres" => postgres_container, "redis" => redis_container)
+          containers = stub_containers("postgres", "redis")
+          result = described_class.call(project: project)
 
-          expect(result.matched).to contain_exactly(postgres_container, redis_container)
+          expect(result.matched).to contain_exactly(containers["postgres"], containers["redis"])
         end
 
         it "returns no unmatched" do
-          result = call_with_containers("postgres" => postgres_container, "redis" => redis_container)
+          stub_containers("postgres", "redis")
+          result = described_class.call(project: project)
 
           expect(result.unmatched).to be_empty
         end
@@ -109,7 +96,7 @@ RSpec.describe Projects::DetectServices do
 
       context "when no matching containers exist" do
         it "returns unmatched detections" do
-          result = call_with_containers
+          result = described_class.call(project: project)
 
           expect(result.unmatched).to be_present
           unmatched_services = result.unmatched.map { |d| d[:service] }
@@ -136,14 +123,14 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "detects postgres, redis, and elasticsearch" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         services = result.detected.map { |d| d[:service] }
         expect(services).to include("postgres", "redis", "elasticsearch")
       end
 
       it "reports the source as package.json" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         result.detected.each do |detection|
           expect(detection[:source]).to eq("package.json")
@@ -170,14 +157,14 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "detects services from compose images" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         services = result.detected.map { |d| d[:service] }
         expect(services).to include("postgres", "redis", "elasticsearch")
       end
 
       it "reports the source as docker-compose.yml" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         result.detected.each do |detection|
           expect(detection[:source]).to eq("docker-compose.yml")
@@ -194,11 +181,14 @@ RSpec.describe Projects::DetectServices do
         YAML
       end
 
-      it "falls back to compose.yml" do
-        result = call_with_containers
+      it "falls back to compose.yml and reports correct source" do
+        result = described_class.call(project: project)
 
         services = result.detected.map { |d| d[:service] }
         expect(services).to include("postgres")
+
+        detection = result.detected.find { |d| d[:service] == "postgres" }
+        expect(detection[:source]).to eq("compose.yml")
       end
     end
 
@@ -221,14 +211,14 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "detects postgres from the adapter" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         services = result.detected.map { |d| d[:service] }
         expect(services).to include("postgres")
       end
 
       it "reports the source as config/database.yml" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         db_detection = result.detected.find { |d| d[:source] == "config/database.yml" }
         expect(db_detection).to be_present
@@ -251,7 +241,7 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "handles ERB templates gracefully" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         services = result.detected.map { |d| d[:service] }
         expect(services).to include("postgres")
@@ -270,7 +260,7 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "deduplicates across sources" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         postgres_detections = result.detected.select { |d| d[:service] == "postgres" }
         expect(postgres_detections.size).to eq(1)
@@ -279,7 +269,7 @@ RSpec.describe Projects::DetectServices do
 
     context "when no files are found" do
       it "returns empty results" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         expect(result.detected).to be_empty
         expect(result.matched).to be_empty
@@ -292,14 +282,14 @@ RSpec.describe Projects::DetectServices do
       it "handles invalid JSON gracefully" do
         stub_file("package.json", "not valid json {{{")
 
-        result = call_with_containers
+        result = described_class.call(project: project)
         expect(result.detected).to be_empty
       end
 
       it "handles invalid YAML gracefully" do
         stub_file("docker-compose.yml", "invalid: yaml: content: [}")
 
-        result = call_with_containers
+        result = described_class.call(project: project)
         expect(result.detected).to be_empty
       end
     end
@@ -317,7 +307,7 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "detects services from service names" do
-        result = call_with_containers
+        result = described_class.call(project: project)
 
         services = result.detected.map { |d| d[:service] }
         expect(services).to include("postgres", "redis")

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -347,17 +347,17 @@ RSpec.describe Projects::DetectServices do
         expect(services).to include("postgres")
       end
 
-      it "handles YAML with disallowed classes in docker-compose.yml" do
-        allow(Psych).to receive(:parse).and_raise(Psych::DisallowedClass.new("action", "Symbol"))
-        stub_file("docker-compose.yml", "services: {}")
+      it "handles Psych errors during docker-compose.yml parsing" do
+        # Psych.parse raises SyntaxError on truly malformed YAML (e.g., bare
+        # tab characters). This exercises the Psych::Exception rescue clause.
+        stub_file("docker-compose.yml", "services:\n\t- invalid")
 
         result = described_class.call(project: project)
         expect(result.detected).to be_empty
       end
 
-      it "handles YAML with disallowed classes in database.yml" do
-        allow(Psych).to receive(:parse).and_raise(Psych::DisallowedClass.new("action", "Symbol"))
-        stub_file("config/database.yml", "default:\n  adapter: postgresql")
+      it "handles Psych errors during database.yml parsing" do
+        stub_file("config/database.yml", "default:\n\t- invalid")
 
         result = described_class.call(project: project)
         expect(result.detected).to be_empty

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Projects::DetectServices do
 
   let(:service_container_class) do
     Class.new do
-      def self.all
+      def self.where(name:)
         raise "stub me"
       end
     end
@@ -23,7 +23,7 @@ RSpec.describe Projects::DetectServices do
     # Default: all files return NotFound
     allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError)
     # Default: no service containers exist
-    allow(service_container_class).to receive(:all).and_return([])
+    allow(service_container_class).to receive(:where).and_return(double(index_by: {}))
   end
 
   def stub_file(path, content)
@@ -38,9 +38,8 @@ RSpec.describe Projects::DetectServices do
     containers_by_name = names.each_with_object({}) do |name, hash|
       hash[name] = Struct.new(:name).new(name)
     end
-    container_list = containers_by_name.values
-    allow(service_container_class).to receive(:all).and_return(container_list)
-    allow(container_list).to receive(:index_by).and_return(containers_by_name)
+    relation = double(index_by: containers_by_name)
+    allow(service_container_class).to receive(:where).and_return(relation)
     containers_by_name
   end
 
@@ -247,6 +246,27 @@ RSpec.describe Projects::DetectServices do
       end
     end
 
+    context "when config/database.yml uses multi-db nested structure" do
+      before do
+        stub_file("config/database.yml", <<~YAML)
+          production:
+            primary:
+              adapter: postgresql
+              database: myapp_production
+            cache:
+              adapter: postgresql
+              database: myapp_cache
+        YAML
+      end
+
+      it "detects postgres from nested adapter keys" do
+        result = described_class.call(project: project)
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres")
+      end
+    end
+
     context "when multiple sources detect the same service" do
       before do
         stub_file("Gemfile", <<~GEMFILE)
@@ -263,6 +283,17 @@ RSpec.describe Projects::DetectServices do
 
         postgres_detections = result.detected.select { |d| d[:service] == "postgres" }
         expect(postgres_detections.size).to eq(1)
+      end
+    end
+
+    context "when docker-compose.yml exceeds size limit" do
+      it "returns empty results" do
+        oversized = "services:\n  db:\n    image: postgres:16\n" + ("x" * 65_000)
+        stub_file("docker-compose.yml", oversized)
+
+        result = described_class.call(project: project)
+        compose_detections = result.detected.select { |d| d[:source] == "docker-compose.yml" }
+        expect(compose_detections).to be_empty
       end
     end
 
@@ -290,6 +321,20 @@ RSpec.describe Projects::DetectServices do
 
         result = described_class.call(project: project)
         expect(result.detected).to be_empty
+      end
+
+      it "handles invalid UTF-8 content gracefully" do
+        # Simulate a file with invalid UTF-8 bytes
+        invalid_utf8 = "gem \"pg\"\ngem \"\xFF\xFE\"".b
+        encoded = Base64.encode64(invalid_utf8)
+        response = OpenStruct.new(content: encoded)
+        allow(github_client).to receive(:contents)
+          .with("test-owner/test-repo", path: "Gemfile")
+          .and_return(response)
+
+        result = described_class.call(project: project)
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres")
       end
 
       it "handles YAML with disallowed classes in docker-compose.yml" do

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Projects::DetectServices do
     allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError)
     # Default: no service containers exist
     allow(service_container_class).to receive(:all).and_return([])
-    allow([]).to receive(:index_by).and_return({})
   end
 
   def stub_file(path, content)
@@ -291,6 +290,72 @@ RSpec.describe Projects::DetectServices do
 
         result = described_class.call(project: project)
         expect(result.detected).to be_empty
+      end
+
+      it "handles YAML with disallowed classes in docker-compose.yml" do
+        allow(YAML).to receive(:safe_load).and_raise(Psych::DisallowedClass.new("action", "Symbol"))
+        stub_file("docker-compose.yml", "services: {}")
+
+        result = described_class.call(project: project)
+        expect(result.detected).to be_empty
+      end
+
+      it "handles YAML with disallowed classes in database.yml" do
+        allow(YAML).to receive(:safe_load).and_raise(Psych::DisallowedClass.new("action", "Symbol"))
+        stub_file("config/database.yml", "default:\n  adapter: postgresql")
+
+        result = described_class.call(project: project)
+        expect(result.detected).to be_empty
+      end
+    end
+
+    context "when config/database.yml contains multi-line ERB" do
+      before do
+        stub_file("config/database.yml", <<~YAML)
+          default: &default
+            adapter: postgresql
+            pool: <%
+              if ENV["RAILS_MAX_THREADS"]
+                ENV["RAILS_MAX_THREADS"]
+              else
+                5
+              end
+            %>
+
+          production:
+            <<: *default
+        YAML
+      end
+
+      it "handles multi-line ERB templates gracefully" do
+        result = described_class.call(project: project)
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres")
+      end
+    end
+
+    context "when docker-compose.yml uses YAML anchors" do
+      before do
+        stub_file("docker-compose.yml", <<~YAML)
+          x-common: &common
+            restart: always
+
+          services:
+            db:
+              <<: *common
+              image: postgres:16
+            cache:
+              <<: *common
+              image: redis:7
+        YAML
+      end
+
+      it "detects services from compose files with anchors" do
+        result = described_class.call(project: project)
+
+        services = result.detected.map { |d| d[:service] }
+        expect(services).to include("postgres", "redis")
       end
     end
 

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -308,17 +308,13 @@ RSpec.describe Projects::DetectServices do
       end
     end
 
-    context "when a GitHub API error occurs for one file" do
-      it "continues detection from other files" do
+    context "when a non-NotFound GitHub API error occurs" do
+      it "propagates the error instead of silently swallowing it" do
         allow(github_client).to receive(:contents)
           .with("test-owner/test-repo", path: "Gemfile")
           .and_raise(GithubClient::RateLimitError.new)
-        stub_file("config/database.yml", "default:\n  adapter: postgresql")
 
-        result = described_class.call(project: project)
-
-        services = result.detected.map { |d| d[:service] }
-        expect(services).to include("postgres")
+        expect { described_class.call(project: project) }.to raise_error(GithubClient::RateLimitError)
       end
     end
 

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "handles YAML with disallowed classes in docker-compose.yml" do
-        allow(YAML).to receive(:safe_load).and_raise(Psych::DisallowedClass.new("action", "Symbol"))
+        allow(Psych).to receive(:parse).and_raise(Psych::DisallowedClass.new("action", "Symbol"))
         stub_file("docker-compose.yml", "services: {}")
 
         result = described_class.call(project: project)
@@ -346,7 +346,7 @@ RSpec.describe Projects::DetectServices do
       end
 
       it "handles YAML with disallowed classes in database.yml" do
-        allow(YAML).to receive(:safe_load).and_raise(Psych::DisallowedClass.new("action", "Symbol"))
+        allow(Psych).to receive(:parse).and_raise(Psych::DisallowedClass.new("action", "Symbol"))
         stub_file("config/database.yml", "default:\n  adapter: postgresql")
 
         result = described_class.call(project: project)
@@ -404,6 +404,22 @@ RSpec.describe Projects::DetectServices do
       end
     end
 
+    context "when docker-compose.yml exceeds alias limit" do
+      it "returns empty results to prevent YAML bomb expansion" do
+        # Build a YAML payload with aliases exceeding MAX_YAML_ALIASES
+        lines = [ "x-base: &base\n  restart: always\n" ]
+        lines << "services:\n"
+        110.times do |i|
+          lines << "  svc#{i}:\n    <<: *base\n    image: postgres:16\n"
+        end
+        stub_file("docker-compose.yml", lines.join)
+
+        result = described_class.call(project: project)
+        compose_detections = result.detected.select { |d| d[:source] == "docker-compose.yml" }
+        expect(compose_detections).to be_empty
+      end
+    end
+
     context "when docker-compose.yml uses service names without explicit images" do
       before do
         stub_file("docker-compose.yml", <<~YAML)
@@ -421,6 +437,42 @@ RSpec.describe Projects::DetectServices do
 
         services = result.detected.map { |d| d[:service] }
         expect(services).to include("postgres", "redis")
+      end
+    end
+  end
+
+  describe Projects::DetectServices::Result do
+    describe "#notice_message" do
+      it "reports added services" do
+        result = described_class.new(
+          detected: [ { service: "postgres", source: "Gemfile", dependency: "pg" } ],
+          matched: [ double(name: "postgres") ],
+          unmatched: []
+        )
+        expect(result.notice_message(%w[postgres])).to eq("Added postgres.")
+      end
+
+      it "reports unmatched services" do
+        result = described_class.new(
+          detected: [ { service: "elasticsearch", source: "Gemfile", dependency: "searchkick" } ],
+          matched: [],
+          unmatched: [ { service: "elasticsearch", source: "Gemfile" } ]
+        )
+        expect(result.notice_message([])).to include("elasticsearch detected but no matching service container exists")
+      end
+
+      it "reports already associated count" do
+        result = described_class.new(
+          detected: [ { service: "postgres", source: "Gemfile", dependency: "pg" } ],
+          matched: [ double(name: "postgres") ],
+          unmatched: []
+        )
+        expect(result.notice_message([])).to include("1 already associated")
+      end
+
+      it "returns fallback when no changes" do
+        result = described_class.new(detected: [], matched: [], unmatched: [])
+        expect(result.notice_message([])).to eq("All detected services are already associated.")
       end
     end
   end


### PR DESCRIPTION
All done. Here's a summary of what was implemented:

## Changes

### New: `app/services/projects/detect_services.rb`
Service that inspects repository files via the GitHub API to detect service dependencies:
- **Gemfile** - detects gems like `pg`, `redis`, `sidekiq`, `mysql2`, `mongoid`, `elasticsearch`, `dalli`, `selenium-webdriver`
- **package.json** - detects npm packages like `pg`, `ioredis`, `mongoose`, `@elastic/elasticsearch`
- **docker-compose.yml / compose.yml** - detects services from image names and service names
- **config/database.yml** - detects database adapter (handles ERB templates and YAML aliases)

Maps detected dependencies to canonical service names (e.g., `sidekiq` -> `redis`, `pg` -> `postgres`) and matches them against existing `ServiceContainer` records. Returns a `Result` with `detected`, `matched`, and `unmatched` collections.

### Modified: `app/controllers/projects_controller.rb`
- Added `detect_services` action that calls the service, auto-associates matched containers, and reports results via flash notice
- Handles both detected+matched and unmatched scenarios with informative messages

### Modified: `config/routes.rb`
- Added `post :detect_services, on: :member` route for projects

### Modified: `app/views/projects/edit.html.erb`
- Added "Detect from Repo" button in the Service Containers section header

### New: `spec/services/projects/detect_services_spec.rb`
19 test cases covering Gemfile parsing, package.json parsing, docker-compose.yml parsing, database.yml parsing, ERB handling, deduplication, invalid file handling, and empty results.

---

Closes #247