### PR TITLE
fix(containers): label paid workspace volumes

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -416,7 +416,7 @@ module Containers
         begin
           Docker::Volume.get(@workspace_volume)
         rescue Docker::Error::NotFoundError
-          Docker::Volume.create(@workspace_volume)
+          Docker::Volume.create(@workspace_volume, volume_options)
         end
       end
     end
@@ -437,6 +437,17 @@ module Containers
       )
     ensure
       @workspace_volume = nil
+    end
+
+    def volume_options
+      {
+        "Labels" => {
+          "paid.managed" => "true",
+          "paid.resource" => "workspace_volume",
+          "paid.agent_run_id" => agent_run.id.to_s,
+          "paid.project_id" => agent_run.project_id.to_s
+        }
+      }
     end
 
     def create_container

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -210,6 +210,24 @@ RSpec.describe Containers::Provision do
         expect(service.workspace_volume).to eq("paid-workspace-#{agent_run.id}")
       end
 
+      it "labels created workspace volumes for paid ownership" do
+        service = described_class.new(agent_run: agent_run)
+
+        service.provision
+
+        expect(Docker::Volume).to have_received(:create).with(
+          "paid-workspace-#{agent_run.id}",
+          {
+            "Labels" => {
+              "paid.managed" => "true",
+              "paid.resource" => "workspace_volume",
+              "paid.agent_run_id" => agent_run.id.to_s,
+              "paid.project_id" => project.id.to_s
+            }
+          }
+        )
+      end
+
       it "creates workspace volume for blank path" do
         service = described_class.new(agent_run: agent_run, worktree_path: "")
 


### PR DESCRIPTION
## Summary
- label named `paid-workspace-*` Docker volumes when they are created
- include `paid.managed`, `paid.resource`, `paid.agent_run_id`, and `paid.project_id`
- add coverage for the labeled volume creation path

## Testing
- `bin/rspec spec/services/containers/provision_spec.rb`
- `bin/lint` (via pre-commit hook during commit)

## Notes
- leaves the existing orphan cleanup job unchanged for now
