### PR TITLE
feat(containers): use shallow clone to speed up repo cloning

### DIFF
--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -367,18 +367,13 @@ module Containers
     # No-op if the repo is already unshallow. Needed before operations
     # that require commit ancestry (e.g. rebase).
     def unshallow
-      result = execute_git("fetch", "--unshallow", timeout: CLONE_TIMEOUT)
-      # --unshallow fails with "fatal: --unshallow on a complete repository"
-      # when already unshallow — that's fine, ignore it.
-      return if result.success? || result[:stderr].to_s.include?("complete repository")
+      check = execute_git("rev-parse", "--is-shallow-repository")
+      return if check.success? && check[:stdout].to_s.strip == "false"
 
-      Rails.logger.warn(
-        message: "container_git.unshallow_failed",
-        agent_run_id: agent_run.id,
-        project_id: agent_run.project_id,
-        exit_code: result[:exit_code],
-        stderr: result[:stderr].to_s.truncate(200)
-      )
+      result = execute_git("fetch", "--unshallow", timeout: CLONE_TIMEOUT)
+      return if result.success?
+
+      raise Error, "Failed to unshallow repository: #{error_with_stderr(result)}"
     end
 
     def clone_repo

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -165,11 +165,21 @@ RSpec.describe Containers::GitOperations do
       expect(agent_run.base_commit_sha).to eq(merge_base_sha)
     end
 
-    it "skips fetch when branch already exists locally (idempotent retry)" do
-      # Switch succeeds immediately — no fetch needed
+    it "skips clone and fetch when branch already exists locally (idempotent retry)" do
+      # On Temporal retry, rev-parse HEAD succeeds (clone already done)
+      # and switch succeeds (branch already checked out).
+      sha_result = Containers::Provision::Result.success(stdout: "#{head_sha}\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
+        .and_return(sha_result)
+
       allow(container_service).to receive(:execute)
         .with([ "git", "switch", "--", "fix-bug-branch" ], timeout: nil, stream: false)
         .and_return(success_result)
+
+      expect(container_service).not_to receive(:execute)
+        .with([ "git", "clone", "--depth", "1", "https://github.com/#{project.full_name}.git", "." ],
+              timeout: described_class::CLONE_TIMEOUT, stream: false)
 
       expect(container_service).not_to receive(:execute)
         .with([ "git", "fetch", "--depth", "1", "origin", "fix-bug-branch" ], timeout: nil, stream: false)
@@ -531,8 +541,13 @@ RSpec.describe Containers::GitOperations do
 
   describe "#rebase_onto" do
     let(:fetch_result) { success_result }
+    let(:shallow_true_result) { Containers::Provision::Result.success(stdout: "true\n", stderr: "", exit_code: 0) }
 
     before do
+      allow(container_service).to receive(:execute)
+        .with([ "git", "rev-parse", "--is-shallow-repository" ], timeout: nil, stream: false)
+        .and_return(shallow_true_result)
+
       allow(container_service).to receive(:execute)
         .with([ "git", "fetch", "--unshallow" ], timeout: described_class::CLONE_TIMEOUT, stream: false)
         .and_return(success_result)
@@ -553,7 +568,12 @@ RSpec.describe Containers::GitOperations do
         expect(git_ops.rebase_onto("main")).to be true
       end
 
-      it "unshallows then fetches the branch before rebasing" do
+      it "checks shallow status, unshallows, then fetches before rebasing" do
+        expect(container_service).to receive(:execute)
+          .with([ "git", "rev-parse", "--is-shallow-repository" ], timeout: nil, stream: false)
+          .and_return(shallow_true_result)
+          .ordered
+
         expect(container_service).to receive(:execute)
           .with([ "git", "fetch", "--unshallow" ], timeout: described_class::CLONE_TIMEOUT, stream: false)
           .and_return(success_result)
@@ -636,6 +656,40 @@ RSpec.describe Containers::GitOperations do
           .and_return(success_result)
 
         expect { git_ops.rebase_onto("main") }.to raise_error(described_class::Error)
+      end
+    end
+
+    context "when repo is not shallow" do
+      let(:shallow_false_result) { Containers::Provision::Result.success(stdout: "false\n", stderr: "", exit_code: 0) }
+
+      before do
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rev-parse", "--is-shallow-repository" ], timeout: nil, stream: false)
+          .and_return(shallow_false_result)
+
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rebase", "origin/main" ], timeout: nil, stream: false)
+          .and_return(success_result)
+      end
+
+      it "skips unshallow and proceeds with rebase" do
+        expect(container_service).not_to receive(:execute)
+          .with([ "git", "fetch", "--unshallow" ], timeout: described_class::CLONE_TIMEOUT, stream: false)
+
+        expect(git_ops.rebase_onto("main")).to be true
+      end
+    end
+
+    context "when unshallow fails" do
+      before do
+        allow(container_service).to receive(:execute)
+          .with([ "git", "fetch", "--unshallow" ], timeout: described_class::CLONE_TIMEOUT, stream: false)
+          .and_return(failure_result)
+      end
+
+      it "raises Error with unshallow details" do
+        expect { git_ops.rebase_onto("main") }
+          .to raise_error(described_class::Error, /Failed to unshallow/)
       end
     end
   end

--- a/spec/temporal/activities/rebase_branch_activity_spec.rb
+++ b/spec/temporal/activities/rebase_branch_activity_spec.rb
@@ -67,7 +67,11 @@ RSpec.describe Activities::RebaseBranchActivity do
           exit_code: 1
         )
 
-        # unshallow (shallow clone -> full history)
+        # unshallow check + fetch (shallow clone -> full history)
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rev-parse", "--is-shallow-repository" ], timeout: nil, stream: false)
+          .and_return(Containers::Provision::Result.success(stdout: "true\n", stderr: "", exit_code: 0))
+
         allow(container_service).to receive(:execute)
           .with([ "git", "fetch", "--unshallow" ], timeout: Containers::GitOperations::CLONE_TIMEOUT, stream: false)
           .and_return(success_result)


### PR DESCRIPTION
## Summary

- Use `git clone --depth 1` instead of full clone in agent containers
- Add shallow fetch of target branch before checkout for existing PR runs
- Avoids downloading ~1.9GB of accidentally committed build artifacts in git history

The merge-base fallback already handles shallow clone limitations gracefully (falls back to HEAD SHA when histories don't connect).

## Context

Agent runs were timing out during `CloneRepo` because 3 concurrent full clones were competing for bandwidth to download the bloated history. This is the immediate fix; a companion PR (#TBD) adds a script to permanently purge the artifacts from history.

## Test plan

- [x] All 66 git_operations specs pass with updated expectations
- [ ] Verify agent runs clone successfully in dev
- [ ] Monitor clone times in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)