### PR TITLE
chore: add script to purge build artifacts from git history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ config.log
 
 # Ignore downloaded packages
 *.deb
+*.txz
 
 # Node corepack cache (created by corepack enable / yarn install)
 /.corepack/
@@ -80,6 +81,8 @@ config.log
 # PostgreSQL installation directory (created by bin/setup on some hosts)
 /.pg-install/
 /.pg-local/
+/.pg-src/
+/.pg.jar
 
 # APT cache and cached package extracts (created during container setup)
 /.apt-cache/
@@ -103,6 +106,7 @@ config.log
 /.mise-cache/
 /.mise-data/
 /.mise-home/
+/.bundle-install/
 /.bundle_path/
 /.cache/
 /.tmp/
@@ -131,3 +135,7 @@ config.log
 /.tmp_pg.tar.bz2
 /.tmp_ruby.tar.gz
 /.tmp_yaml.tar.gz
+
+# Python virtual environments and caches
+/.venv/
+__pycache__/

--- a/bin/purge-history
+++ b/bin/purge-history
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# frozen_string_literal: false
+# shellcheck disable=SC2059
+set -euo pipefail
+
+# bin/purge-history — Remove accidentally committed build artifacts from git history.
+#
+# This script uses git-filter-repo to permanently rewrite history, removing
+# large directories and files that were committed and later deleted. After
+# running, a force-push is required and all collaborators must re-clone.
+#
+# Usage:
+#   bin/purge-history          # interactive confirmation
+#   bin/purge-history --yes    # skip confirmation prompt
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# ---------------------------------------------------------------------------
+# Verify we are at the repo root
+# ---------------------------------------------------------------------------
+if [[ ! -f "Gemfile" || ! -d ".git" ]]; then
+  printf "${RED}ERROR:${NC} This script must be run from the repository root.\n" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Verify git-filter-repo is available
+# ---------------------------------------------------------------------------
+if ! command -v git-filter-repo &>/dev/null; then
+  printf "${RED}ERROR:${NC} git-filter-repo is not installed.\n" >&2
+  printf "Install it with: pip install git-filter-repo\n" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Warning and confirmation
+# ---------------------------------------------------------------------------
+printf "${RED}╔══════════════════════════════════════════════════════════════╗${NC}\n"
+printf "${RED}║  WARNING: DESTRUCTIVE OPERATION                            ║${NC}\n"
+printf "${RED}╠══════════════════════════════════════════════════════════════╣${NC}\n"
+printf "${RED}║                                                            ║${NC}\n"
+printf "${RED}║  This will permanently rewrite git history to remove       ║${NC}\n"
+printf "${RED}║  ~1.9 GB of build artifacts. This operation:              ║${NC}\n"
+printf "${RED}║                                                            ║${NC}\n"
+printf "${RED}║  • Rewrites ALL commits that touched these paths           ║${NC}\n"
+printf "${RED}║  • Changes commit SHAs throughout the history              ║${NC}\n"
+printf "${RED}║  • Requires a force-push to update the remote              ║${NC}\n"
+printf "${RED}║  • Requires all collaborators to re-clone                  ║${NC}\n"
+printf "${RED}║                                                            ║${NC}\n"
+printf "${RED}╚══════════════════════════════════════════════════════════════╝${NC}\n"
+printf "\n"
+
+if [[ "${1:-}" != "--yes" ]]; then
+  printf "${YELLOW}Type 'yes' to proceed:${NC} "
+  read -r confirmation
+  if [[ "$confirmation" != "yes" ]]; then
+    printf "Aborted.\n"
+    exit 0
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Record before size
+# ---------------------------------------------------------------------------
+printf "\n${GREEN}Measuring repository size before purge...${NC}\n"
+before_size=$(du -sh .git | cut -f1)
+printf "  .git size before: %s\n" "$before_size"
+
+# ---------------------------------------------------------------------------
+# Run git filter-repo
+# ---------------------------------------------------------------------------
+printf "\n${GREEN}Running git filter-repo to remove build artifacts...${NC}\n\n"
+
+git filter-repo \
+  --path .xdg-cache/ \
+  --path .bundle-install/ \
+  --path .pg-data/ \
+  --path .local/ \
+  --path .postgres/ \
+  --path .pg-local/ \
+  --path .mise-data/ \
+  --path .mise-home/ \
+  --path .build/ \
+  --path .pg-src/ \
+  --path .apt-cache/ \
+  --path .pgdata/ \
+  --path .tmp-build/ \
+  --path .pg-install/ \
+  --path .pg.jar \
+  --path .gem/ \
+  --path .cache-pkg/ \
+  --path .venv/ \
+  --path __pycache__/ \
+  --path postgresql-16_16.2-1ubuntu4_arm64.deb \
+  --path postgres-linux-arm_64.txz \
+  --path libicu74_74.2-1ubuntu3.1_arm64.deb \
+  --invert-paths \
+  --force
+
+# ---------------------------------------------------------------------------
+# Record after size and run gc
+# ---------------------------------------------------------------------------
+printf "\n${GREEN}Running garbage collection...${NC}\n"
+git reflog expire --expire=now --all
+git gc --prune=now --aggressive
+
+after_size=$(du -sh .git | cut -f1)
+
+printf "\n${GREEN}════════════════════════════════════════${NC}\n"
+printf "  .git size before: %s\n" "$before_size"
+printf "  .git size after:  %s\n" "$after_size"
+printf "${GREEN}════════════════════════════════════════${NC}\n"
+
+# ---------------------------------------------------------------------------
+# Next steps
+# ---------------------------------------------------------------------------
+printf "\n${YELLOW}Next steps:${NC}\n"
+printf "  1. Verify the repo works:  bin/rspec (or run your test suite)\n"
+printf "  2. Force-push all branches:\n"
+printf "       git remote add origin <url>   # filter-repo removes remotes\n"
+printf "       git push --force --all origin\n"
+printf "       git push --force --tags origin\n"
+printf "  3. All collaborators must re-clone (git pull will NOT work):\n"
+printf "       git clone <url>\n"
+printf "\n"


### PR DESCRIPTION
## Summary

- Add `bin/purge-history` script using `git-filter-repo` to permanently remove ~1.9GB of build artifacts from git history
- Update `.gitignore` with missing entries to prevent future accidental commits

Artifacts being removed: PostgreSQL binaries/data/source (`.pg-data/`, `.postgres/`, `.pg-local/`, `.pg-src/`, etc.), bundled gems (`.bundle-install/`), caches (`.xdg-cache/`, `.apt-cache/`), tool data (`.mise-data/`, `.mise-home/`), loose `.deb`/`.txz` packages, and more.

## Usage

```bash
# Install git-filter-repo first
pip install git-filter-repo

# Run the purge (interactive confirmation)
bin/purge-history

# Or skip confirmation
bin/purge-history --yes
```

After running: force-push all branches and have all collaborators re-clone.

## Test plan

- [ ] Run `bin/purge-history` on a fresh clone and verify repo shrinks from ~1.9GB to reasonable size
- [ ] Verify `.gitignore` additions don't exclude any tracked source files
- [ ] Coordinate force-push timing with team

🤖 Generated with [Claude Code](https://claude.com/claude-code)