### PR TITLE
fix(prompts): move proactive scan into action steps for visibility

### DIFF
--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -142,12 +142,6 @@ module Prompts
 
         Address each thread: fix the code if the reviewer is correct, or explain
         your reasoning in a code comment if you disagree. Do not ignore review feedback.
-
-        After addressing the explicit feedback, proactively scan the rest of the PR diff
-        for the same classes of issues the reviewers raised. For example, if a reviewer
-        flagged a missing guard clause or input validation, look for similar unguarded
-        calls elsewhere in your changes. Fix any instances you find — the goal is zero
-        new review rounds for problems you could have caught yourself.
       SECTION
     end
 
@@ -186,10 +180,11 @@ module Prompts
         1. Install dependencies (`bundle install`, `yarn install`, etc.)
         #{setup_database_instruction}
         2. Work through the priorities above in order
-        3. Self-review: Before running checks, review the changes you are about to
-           commit as a critical code reviewer would. Look for missing guard clauses,
+        3. Proactive scan: After making your changes, review the **entire diff** you are
+           about to commit#{review_scan_instruction}. Look for missing guard clauses,
            insufficient input validation, unhandled edge cases, missing tests, unclear
-           naming, and style inconsistencies. Fix anything you find.
+           naming, and style inconsistencies. Fix every issue you find — the goal is
+           zero new review rounds for problems you could have caught yourself.
         4. Run lint and fix any violations: `#{lint_command}`
         5. Run the test suite and fix any failures: `#{test_command}`
         6. Commit your changes with a descriptive message
@@ -214,6 +209,16 @@ module Prompts
         - Do not modify unrelated files
         - Focus on completing the specific tasks listed above
       SECTION
+    end
+
+    # When reviewers have flagged specific issues, tell the agent to scan for
+    # the same class of problem across the whole diff — not just the flagged lines.
+    def review_scan_instruction
+      return "" unless unresolved_threads.any?
+
+      ". Pay special attention to the same classes of issues the reviewers " \
+        "raised — if they flagged one instance, scan for similar problems " \
+        "elsewhere in your changes"
     end
 
     # Memoized data fetchers

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("Do not push")
     end
 
-    it "includes self-review step" do
-      expect(prompt).to include("Self-review")
-      expect(prompt).to include("review the changes you are about to")
+    it "includes proactive scan step" do
+      expect(prompt).to include("Proactive scan")
+      expect(prompt).to include("review the **entire diff**")
     end
 
     it "includes rules" do
@@ -82,9 +82,12 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).not_to include("CI Failures")
     end
 
-    it "omits code review section and proactive scanning when no unresolved threads" do
+    it "omits code review section when no unresolved threads" do
       expect(prompt).not_to include("Code Review Comments")
-      expect(prompt).not_to include("proactively scan the rest of the PR diff")
+    end
+
+    it "omits review-specific scan instruction when no unresolved threads" do
+      expect(prompt).not_to include("same classes of issues the reviewers")
     end
 
     it "omits conversation section when no trusted comments" do
@@ -172,7 +175,7 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("app/models/user.rb:42")
     end
 
-    it "includes proactive scanning instruction" do
+    it "includes review-specific scan instruction in the proactive scan step" do
       prompt = described_class.call(
         project: project,
         pr_number: 42,
@@ -180,7 +183,8 @@ RSpec.describe Prompts::BuildForPr do
         rebase_succeeded: true
       )
 
-      expect(prompt).to include("proactively scan the rest of the PR diff")
+      expect(prompt).to include("same classes of issues the reviewers")
+      expect(prompt).to include("Proactive scan")
     end
 
     it "excludes resolved threads" do


### PR DESCRIPTION
## Summary

- Moves the proactive scanning instruction from the `code_review_section` data block into the numbered `instructions_section` as step 3 ("Proactive scan"), so agents treat it as an explicit action rather than context they can skip
- Conditionally injects review-specific guidance ("same classes of issues the reviewers raised") into the step only when unresolved review threads exist
- Strengthens the language: "review the **entire diff**" and "zero new review rounds"

Follows up on #368 — the self-review instructions were present but not effective because the proactive scanning text was buried after review thread data, while the action steps only had generic self-review language.

## Test plan

- [x] All 34 `build_for_pr_spec.rb` specs pass
- [ ] Verify that a PR followup run with review comments includes the review-specific scan instruction in step 3
- [ ] Verify that a PR followup run without review comments includes the generic proactive scan step but omits review-specific language

🤖 Generated with [Claude Code](https://claude.com/claude-code)