### PR TITLE
Fix #362: Prioritize Create Issue agent runs over PR agent runs at same priority level

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -130,8 +130,11 @@ class AgentRun < ApplicationRecord
   #   0 = manual runs (highest)
   #   1 = automatic runs fixing a PR (auto-continue)
   #   2 = automatic runs from auto-pick (lowest)
-  # Within each tier, runs are processed FIFO by created_at, with id
-  # as a stable tiebreaker for runs created in the same timestamp.
+  # Within each tier, create_issue runs are prioritized over create_pr
+  # runs because issue creation is lighter-weight and often unblocks
+  # downstream PR work.
+  # Within each goal type, runs are processed FIFO by created_at, with
+  # id as a stable tiebreaker for runs created in the same timestamp.
   QUEUE_PRIORITY_SQL = Arel.sql(<<~SQL.squish).freeze
     CASE
       WHEN trigger_type = 'manual' THEN 0
@@ -139,7 +142,13 @@ class AgentRun < ApplicationRecord
       ELSE 2
     END
   SQL
-  QUEUE_ORDER = [ QUEUE_PRIORITY_SQL, { created_at: :asc, id: :asc } ].freeze
+  GOAL_PRIORITY_SQL = Arel.sql(<<~SQL.squish).freeze
+    CASE
+      WHEN goal = 'create_issue' THEN 0
+      ELSE 1
+    END
+  SQL
+  QUEUE_ORDER = [ QUEUE_PRIORITY_SQL, GOAL_PRIORITY_SQL, { created_at: :asc, id: :asc } ].freeze
 
   def self.next_queued_run
     queued.order(QUEUE_ORDER).first

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -1111,7 +1111,14 @@ RSpec.describe AgentRun do
       expect(described_class.next_queued_run).to eq(auto_continue)
     end
 
-    it "uses FIFO within the same priority tier" do
+    it "prioritizes create_issue over create_pr within the same priority tier" do
+      pr_run = create(:agent_run, :queued, trigger_type: "manual", goal: "create_pr", created_at: 2.minutes.ago)
+      issue_run = create(:agent_run, :queued, trigger_type: "manual", goal: "create_issue", created_at: 1.minute.ago)
+
+      expect(described_class.next_queued_run).to eq(issue_run)
+    end
+
+    it "uses FIFO within the same priority tier and goal type" do
       newer_manual = create(:agent_run, :queued, trigger_type: "manual", created_at: 1.minute.ago)
       older_manual = create(:agent_run, :queued, trigger_type: "manual", created_at: 2.minutes.ago)
 


### PR DESCRIPTION
Commit succeeded. Here's what I did:

**Changes made:**

1. **`app/models/agent_run.rb`** — Added `GOAL_PRIORITY_SQL` as a secondary sort key in `QUEUE_ORDER`. Within the same trigger-type priority tier, `create_issue` runs (priority 0) are now ordered before `create_pr` runs (priority 1).

2. **`spec/models/agent_run_spec.rb`** — Added a test verifying that `create_issue` runs are prioritized over `create_pr` runs at the same priority level, and updated the existing FIFO test description to clarify it applies within the same goal type.

Note: The database wasn't reachable in this environment so I couldn't run the test suite, but lint passed cleanly and the pre-commit hook succeeded.

---

Closes #362