### PR TITLE
docs: require rails generate for database migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ Never skip pre-commit hooks (`--no-verify`), never disable linters, never ignore
 - UUIDs for external-facing IDs, bigints for internal foreign keys
 - Always add foreign key constraints
 - Index all foreign keys and frequently queried columns
+- **Always use `rails generate migration`** to create migrations — never create migration files manually. The generator ensures correct timestamps, naming conventions, and boilerplate.
 
 ## Release Management
 


### PR DESCRIPTION
## Summary
- Adds a note to the Database section of CLAUDE.md requiring `rails generate migration` instead of manually creating migration files
- Ensures AI assistants and contributors use the generator for correct timestamps, naming conventions, and boilerplate

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)