### PR TITLE
Fix #142: Add cost tracking dashboard to UI

### DIFF
--- a/app/controllers/projects/cost_budgets_controller.rb
+++ b/app/controllers/projects/cost_budgets_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Projects
+  class CostBudgetsController < ApplicationController
+    before_action :set_project
+    before_action :set_cost_budget, only: [ :update, :destroy ]
+
+    def create
+      authorize @project, :update?
+      @cost_budget = @project.cost_budgets.build(cost_budget_params)
+
+      if @cost_budget.save
+        redirect_to project_cost_dashboard_path(@project), notice: "Budget limit created."
+      else
+        @stats = Projects::CostDashboardStats.call(project: @project)
+        render "projects/cost_dashboards/show", status: :unprocessable_content
+      end
+    end
+
+    def update
+      authorize @project, :update?
+
+      if @cost_budget.update(cost_budget_params)
+        redirect_to project_cost_dashboard_path(@project), notice: "Budget limit updated."
+      else
+        @stats = Projects::CostDashboardStats.call(project: @project)
+        render "projects/cost_dashboards/show", status: :unprocessable_content
+      end
+    end
+
+    def destroy
+      authorize @project, :update?
+      @cost_budget.destroy!
+      redirect_to project_cost_dashboard_path(@project), notice: "Budget limit removed."
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).find(params[:project_id])
+    end
+
+    def set_cost_budget
+      @cost_budget = @project.cost_budgets.find(params[:id])
+    end
+
+    def cost_budget_params
+      params.require(:cost_budget).permit(:budget_type, :limit_dollars, :alert_threshold_percent).tap do |p|
+        if p[:limit_dollars].present?
+          p[:limit_cents] = (p.delete(:limit_dollars).to_f * 100).round
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/projects/cost_budgets_controller.rb
+++ b/app/controllers/projects/cost_budgets_controller.rb
@@ -24,9 +24,11 @@ module Projects
       if @cost_budget.update(cost_budget_params)
         redirect_to project_cost_dashboard_path(@project), notice: "Budget limit updated."
       else
+        failed_budget = @cost_budget
         @stats = Projects::CostDashboardStats.call(project: @project)
         @cost_budgets = @project.cost_budgets.index_by(&:id)
         @cost_budget = @project.cost_budgets.build
+        @failed_budget = failed_budget
         render "projects/cost_dashboards/show", status: :unprocessable_content
       end
     end

--- a/app/controllers/projects/cost_budgets_controller.rb
+++ b/app/controllers/projects/cost_budgets_controller.rb
@@ -26,6 +26,7 @@ module Projects
       else
         @stats = Projects::CostDashboardStats.call(project: @project)
         @cost_budgets = @project.cost_budgets.index_by(&:id)
+        @cost_budget = @project.cost_budgets.build
         render "projects/cost_dashboards/show", status: :unprocessable_content
       end
     end

--- a/app/controllers/projects/cost_budgets_controller.rb
+++ b/app/controllers/projects/cost_budgets_controller.rb
@@ -13,6 +13,7 @@ module Projects
         redirect_to project_cost_dashboard_path(@project), notice: "Budget limit created."
       else
         @stats = Projects::CostDashboardStats.call(project: @project)
+        @cost_budgets = @project.cost_budgets.index_by(&:id)
         render "projects/cost_dashboards/show", status: :unprocessable_content
       end
     end
@@ -24,6 +25,7 @@ module Projects
         redirect_to project_cost_dashboard_path(@project), notice: "Budget limit updated."
       else
         @stats = Projects::CostDashboardStats.call(project: @project)
+        @cost_budgets = @project.cost_budgets.index_by(&:id)
         render "projects/cost_dashboards/show", status: :unprocessable_content
       end
     end
@@ -45,11 +47,7 @@ module Projects
     end
 
     def cost_budget_params
-      params.require(:cost_budget).permit(:budget_type, :limit_dollars, :alert_threshold_percent).tap do |p|
-        if p[:limit_dollars].present?
-          p[:limit_cents] = (p.delete(:limit_dollars).to_f * 100).round
-        end
-      end
+      params.require(:cost_budget).permit(:budget_type, :limit_dollars, :alert_threshold_percent)
     end
   end
 end

--- a/app/controllers/projects/cost_dashboards_controller.rb
+++ b/app/controllers/projects/cost_dashboards_controller.rb
@@ -7,6 +7,8 @@ module Projects
     def show
       authorize @project, :show?
       @stats = Projects::CostDashboardStats.call(project: @project)
+      @cost_budgets = @project.cost_budgets.index_by(&:id)
+      @cost_budget ||= CostBudget.new
     end
 
     private

--- a/app/controllers/projects/cost_dashboards_controller.rb
+++ b/app/controllers/projects/cost_dashboards_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Projects
+  class CostDashboardsController < ApplicationController
+    before_action :set_project
+
+    def show
+      authorize @project, :show?
+      @stats = Projects::CostDashboardStats.call(project: @project)
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).find(params[:project_id])
+    end
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -23,6 +23,7 @@ class ProjectsController < ApplicationController
     open_items = @project.issues.where(github_state: "open").order(github_number: :desc)
     @issues = open_items.issues_only.includes(:sub_issues).limit(25)
     @pull_requests = open_items.pull_requests_only.limit(25)
+    @cost_budgets = @project.cost_budgets.load
     @quality_summary = QualityMetrics::DashboardStats.overview(project: @project)
   end
 

--- a/app/helpers/cost_dashboard_helper.rb
+++ b/app/helpers/cost_dashboard_helper.rb
@@ -5,10 +5,10 @@ module CostDashboardHelper
     "$#{format('%.2f', cents / 100.0)}"
   end
 
-  def budget_status_color(usage_percent)
+  def budget_status_color(usage_percent, alert_threshold_percent = 80)
     if usage_percent >= 100
       "red"
-    elsif usage_percent >= 80
+    elsif usage_percent >= alert_threshold_percent
       "yellow"
     else
       "green"

--- a/app/helpers/cost_dashboard_helper.rb
+++ b/app/helpers/cost_dashboard_helper.rb
@@ -21,6 +21,8 @@ module CostDashboardHelper
       { bg: "bg-red-100", text: "text-red-700", bar: "bg-red-500", ring: "ring-red-200" }
     when "yellow"
       { bg: "bg-yellow-100", text: "text-yellow-700", bar: "bg-yellow-500", ring: "ring-yellow-200" }
+    when "gray"
+      { bg: "bg-gray-100", text: "text-gray-600", bar: "bg-gray-400", ring: "ring-gray-200" }
     else
       { bg: "bg-green-100", text: "text-green-700", bar: "bg-green-500", ring: "ring-green-200" }
     end

--- a/app/helpers/cost_dashboard_helper.rb
+++ b/app/helpers/cost_dashboard_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CostDashboardHelper
+  def format_cost_cents(cents)
+    "$#{format('%.2f', cents / 100.0)}"
+  end
+
+  def budget_status_color(usage_percent)
+    if usage_percent >= 100
+      "red"
+    elsif usage_percent >= 80
+      "yellow"
+    else
+      "green"
+    end
+  end
+
+  def budget_status_classes(color)
+    case color
+    when "red"
+      { bg: "bg-red-100", text: "text-red-700", bar: "bg-red-500", ring: "ring-red-200" }
+    when "yellow"
+      { bg: "bg-yellow-100", text: "text-yellow-700", bar: "bg-yellow-500", ring: "ring-yellow-200" }
+    else
+      { bg: "bg-green-100", text: "text-green-700", bar: "bg-green-500", ring: "ring-green-200" }
+    end
+  end
+
+  def budget_type_label(budget_type)
+    case budget_type
+    when "daily" then "Daily"
+    when "monthly" then "Monthly"
+    when "per_run" then "Per Run"
+    else budget_type.titleize
+    end
+  end
+end

--- a/app/models/cost_budget.rb
+++ b/app/models/cost_budget.rb
@@ -102,7 +102,6 @@ class CostBudget < ApplicationRecord
     value = BigDecimal(limit_dollars.to_s)
     self.limit_cents = (value * 100).round.to_i
   rescue ArgumentError
-    errors.add(:limit_dollars, "is not a number")
     self.limit_cents = nil
   end
 

--- a/app/models/cost_budget.rb
+++ b/app/models/cost_budget.rb
@@ -3,7 +3,11 @@
 class CostBudget < ApplicationRecord
   BUDGET_TYPES = %w[daily monthly per_run].freeze
 
+  attr_accessor :limit_dollars
+
   belongs_to :project
+
+  before_validation :convert_limit_dollars_to_cents, if: -> { limit_dollars.present? }
 
   validates :budget_type, presence: true, inclusion: { in: BUDGET_TYPES }, uniqueness: { scope: :project_id }
   validates :limit_cents, presence: true, numericality: { greater_than: 0 }
@@ -91,6 +95,10 @@ class CostBudget < ApplicationRecord
   end
 
   private
+
+  def convert_limit_dollars_to_cents
+    self.limit_cents = (BigDecimal(limit_dollars.to_s) * 100).to_i
+  end
 
   def rollover_period_if_needed!
     return if budget_type == "per_run"

--- a/app/models/cost_budget.rb
+++ b/app/models/cost_budget.rb
@@ -10,7 +10,7 @@ class CostBudget < ApplicationRecord
   before_validation :convert_limit_dollars_to_cents, if: -> { limit_dollars.present? }
 
   validates :budget_type, presence: true, inclusion: { in: BUDGET_TYPES }, uniqueness: { scope: :project_id }
-  validates :limit_cents, presence: true, numericality: { greater_than: 0 }
+  validates :limit_cents, presence: true, numericality: { greater_than: 0 }, unless: -> { errors.include?(:limit_dollars) }
   validates :current_usage_cents, numericality: { greater_than_or_equal_to: 0 }
   validates :alert_threshold_percent, numericality: { greater_than: 0, less_than_or_equal_to: 100 }
 

--- a/app/models/cost_budget.rb
+++ b/app/models/cost_budget.rb
@@ -97,7 +97,11 @@ class CostBudget < ApplicationRecord
   private
 
   def convert_limit_dollars_to_cents
-    self.limit_cents = (BigDecimal(limit_dollars.to_s) * 100).to_i
+    value = BigDecimal(limit_dollars.to_s)
+    self.limit_cents = (value * 100).round.to_i
+  rescue ArgumentError
+    errors.add(:limit_dollars, "is not a number")
+    self.limit_cents = nil
   end
 
   def rollover_period_if_needed!

--- a/app/models/cost_budget.rb
+++ b/app/models/cost_budget.rb
@@ -10,7 +10,9 @@ class CostBudget < ApplicationRecord
   before_validation :convert_limit_dollars_to_cents, if: -> { limit_dollars.present? }
 
   validates :budget_type, presence: true, inclusion: { in: BUDGET_TYPES }, uniqueness: { scope: :project_id }
-  validates :limit_cents, presence: true, numericality: { greater_than: 0 }, unless: -> { errors.include?(:limit_dollars) }
+  validates :limit_dollars, numericality: { greater_than: 0 }, allow_nil: true
+  validates :limit_cents, presence: true, numericality: { greater_than: 0 },
+    unless: -> { errors.include?(:limit_dollars) }
   validates :current_usage_cents, numericality: { greater_than_or_equal_to: 0 }
   validates :alert_threshold_percent, numericality: { greater_than: 0, less_than_or_equal_to: 100 }
 

--- a/app/models/token_usage.rb
+++ b/app/models/token_usage.rb
@@ -57,7 +57,7 @@ class TokenUsage < ApplicationRecord
 
   def self.daily_costs(days: 30)
     where(created_at: days.days.ago..)
-      .group("DATE(created_at)")
+      .group(Arel.sql("DATE(token_usages.created_at)"))
       .sum(:cost_cents)
   end
 end

--- a/app/services/cost_budgets/check.rb
+++ b/app/services/cost_budgets/check.rb
@@ -32,6 +32,8 @@ module CostBudgets
     end
 
     def call
+      # Uses count.zero? instead of none? to avoid stale association cache
+      # returning empty when budgets exist but were loaded earlier.
       return allowed_result if project.cost_budgets.count.zero?
 
       rollover_expired_periods

--- a/app/services/cost_budgets/check.rb
+++ b/app/services/cost_budgets/check.rb
@@ -32,7 +32,7 @@ module CostBudgets
     end
 
     def call
-      return allowed_result if project.cost_budgets.none?
+      return allowed_result if project.cost_budgets.count.zero?
 
       rollover_expired_periods
 

--- a/app/services/cost_budgets/check.rb
+++ b/app/services/cost_budgets/check.rb
@@ -32,9 +32,9 @@ module CostBudgets
     end
 
     def call
-      # Uses count.zero? instead of none? to avoid stale association cache
-      # returning empty when budgets exist but were loaded earlier.
-      return allowed_result if project.cost_budgets.count.zero?
+      # Uses exists? for an efficient existence check while still bypassing
+      # any potentially stale association target cache.
+      return allowed_result unless project.cost_budgets.exists?
 
       rollover_expired_periods
 

--- a/app/services/dashboard/stats.rb
+++ b/app/services/dashboard/stats.rb
@@ -23,6 +23,7 @@ module Dashboard
         cost_and_tokens: cost_and_tokens,
         runs_by_agent_type: runs_by_agent_type,
         runs_by_project: runs_by_project,
+        cost_by_project: cost_by_project,
         issue_completion: issue_completion
       }
     end
@@ -157,6 +158,14 @@ module Dashboard
         .count
         .sort_by { |_, v| -v }
         .first(5)
+    end
+
+    def cost_by_project
+      Project.where(account_id: account.id)
+        .where("total_cost_cents > 0")
+        .order(total_cost_cents: :desc)
+        .limit(10)
+        .pluck(:name, :total_cost_cents)
     end
 
     def issue_completion

--- a/app/services/projects/cost_dashboard_stats.rb
+++ b/app/services/projects/cost_dashboard_stats.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Projects
+  class CostDashboardStats
+    attr_reader :project
+
+    def initialize(project:)
+      @project = project
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      {
+        summary: summary,
+        cost_by_model: cost_by_model,
+        cost_by_request_type: cost_by_request_type,
+        daily_costs: daily_costs,
+        budgets: budgets
+      }
+    end
+
+    private
+
+    def billable_scope
+      @billable_scope ||= TokenUsage.billable.by_project(project.id)
+    end
+
+    def summary
+      now = Time.current
+      today_start = now.beginning_of_day
+      month_start = now.beginning_of_month
+
+      {
+        total_cost_cents: project.total_cost_cents,
+        total_tokens: project.total_tokens_used,
+        cost_today_cents: billable_scope.by_time_period(today_start, now).total_cost_cents,
+        cost_this_month_cents: billable_scope.by_time_period(month_start, now).total_cost_cents,
+        avg_cost_per_run_cents: avg_cost_per_run_cents,
+        total_runs: project.agent_runs.count
+      }
+    end
+
+    def avg_cost_per_run_cents
+      completed = project.agent_runs.where(status: "completed")
+      count = completed.count
+      return 0 if count.zero?
+
+      total = completed.sum(:cost_cents)
+      (total.to_f / count).round
+    end
+
+    def cost_by_model
+      billable_scope.cost_by_model.sort_by { |_, v| -v }
+    end
+
+    def cost_by_request_type
+      billable_scope.cost_by_request_type.sort_by { |_, v| -v }
+    end
+
+    def daily_costs
+      billable_scope.daily_costs(days: 30).sort_by { |date, _| date }
+    end
+
+    def budgets
+      project.cost_budgets.order(:budget_type).map do |budget|
+        budget.rollover_if_period_expired!
+        {
+          id: budget.id,
+          budget_type: budget.budget_type,
+          limit_cents: budget.limit_cents,
+          current_usage_cents: budget.current_usage_cents,
+          usage_percent: budget.usage_percent,
+          remaining_cents: budget.remaining_cents,
+          exceeded: budget.exceeded?,
+          alert_threshold_percent: budget.alert_threshold_percent
+        }
+      end
+    end
+  end
+end

--- a/app/services/projects/cost_dashboard_stats.rb
+++ b/app/services/projects/cost_dashboard_stats.rb
@@ -56,7 +56,13 @@ module Projects
     end
 
     def daily_costs
-      billable_scope.daily_costs(days: 30).sort_by { |date, _| date }
+      raw_costs = billable_scope.daily_costs(days: 30)
+      today = Time.current.to_date
+      start_date = today - 29
+
+      (start_date..today).map do |date|
+        [ date, raw_costs[date] || 0 ]
+      end
     end
 
     def budgets

--- a/app/services/projects/cost_dashboard_stats.rb
+++ b/app/services/projects/cost_dashboard_stats.rb
@@ -61,16 +61,27 @@ module Projects
 
     def budgets
       project.cost_budgets.order(:budget_type).map do |budget|
-        {
+        base_stats = {
           id: budget.id,
           budget_type: budget.budget_type,
           limit_cents: budget.limit_cents,
-          current_usage_cents: budget.current_usage_cents,
-          usage_percent: budget.usage_percent,
-          remaining_cents: budget.remaining_cents,
           exceeded: budget.exceeded?,
           alert_threshold_percent: budget.alert_threshold_percent
         }
+
+        # Per-run budgets are enforced per agent run via
+        # agent_run.token_usages.sum(:cost_cents) in CostBudgets::Check,
+        # not via current_usage_cents. Omit period-based usage fields to
+        # avoid showing misleading "0% used" stats.
+        if budget.budget_type == "per_run"
+          base_stats
+        else
+          base_stats.merge(
+            current_usage_cents: budget.current_usage_cents,
+            usage_percent: budget.usage_percent,
+            remaining_cents: budget.remaining_cents
+          )
+        end
       end
     end
   end

--- a/app/services/projects/cost_dashboard_stats.rb
+++ b/app/services/projects/cost_dashboard_stats.rb
@@ -39,7 +39,7 @@ module Projects
         cost_today_cents: billable_scope.by_time_period(today_start, now).total_cost_cents,
         cost_this_month_cents: billable_scope.by_time_period(month_start, now).total_cost_cents,
         avg_cost_per_run_cents: avg_cost_per_run_cents,
-        total_runs: project.agent_runs.count
+        total_runs: project.agent_runs.where(status: "completed").count
       }
     end
 

--- a/app/services/projects/cost_dashboard_stats.rb
+++ b/app/services/projects/cost_dashboard_stats.rb
@@ -33,23 +33,18 @@ module Projects
       today_start = now.beginning_of_day
       month_start = now.beginning_of_month
 
+      completed = project.agent_runs.where(status: "completed")
+      run_count = completed.count
+      avg_cost = run_count.zero? ? 0 : (completed.sum(:cost_cents).to_f / run_count).round
+
       {
         total_cost_cents: project.total_cost_cents,
         total_tokens: project.total_tokens_used,
         cost_today_cents: billable_scope.by_time_period(today_start, now).total_cost_cents,
         cost_this_month_cents: billable_scope.by_time_period(month_start, now).total_cost_cents,
-        avg_cost_per_run_cents: avg_cost_per_run_cents,
-        total_runs: project.agent_runs.where(status: "completed").count
+        avg_cost_per_run_cents: avg_cost,
+        total_runs: run_count
       }
-    end
-
-    def avg_cost_per_run_cents
-      completed = project.agent_runs.where(status: "completed")
-      count = completed.count
-      return 0 if count.zero?
-
-      total = completed.sum(:cost_cents)
-      (total.to_f / count).round
     end
 
     def cost_by_model

--- a/app/services/projects/cost_dashboard_stats.rb
+++ b/app/services/projects/cost_dashboard_stats.rb
@@ -66,7 +66,6 @@ module Projects
 
     def budgets
       project.cost_budgets.order(:budget_type).map do |budget|
-        budget.rollover_if_period_expired!
         {
           id: budget.id,
           budget_type: budget.budget_type,

--- a/app/views/dashboard/_content.html.erb
+++ b/app/views/dashboard/_content.html.erb
@@ -245,6 +245,35 @@
     <% end %>
   </div>
 
+  <%# Cost by Project %>
+  <div class="mt-8">
+    <h2 class="text-lg font-semibold text-gray-900">Cost by Project</h2>
+    <% if stats[:cost_by_project].any? %>
+      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Project</th>
+              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Total Cost</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% stats[:cost_by_project].each do |project_name, cost_cents| %>
+              <tr>
+                <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= project_name %></td>
+                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right">$<%= format("%.2f", cost_cents / 100.0) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+        <div class="px-4 py-5 text-sm text-gray-500">No project costs recorded yet.</div>
+      </div>
+    <% end %>
+  </div>
+
   <div class="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
     <%# Runs by Agent Type %>
     <div>

--- a/app/views/projects/_stats.html.erb
+++ b/app/views/projects/_stats.html.erb
@@ -16,22 +16,21 @@
       <span class="font-medium text-gray-500">Tokens:</span>
       <span class="font-semibold text-gray-900"><%= number_with_delimiter(project.total_tokens_used) %></span>
     </div>
-    <% monthly_cost = project.token_usages.billable.by_time_period(Time.current.beginning_of_month, Time.current).total_cost_cents %>
+    <% monthly_cost_cents = local_assigns.fetch(:monthly_cost_cents, project.token_usages.billable.by_time_period(Time.current.beginning_of_month, Time.current).total_cost_cents) %>
     <div class="flex items-center gap-1.5 px-4 py-3">
       <span class="font-medium text-gray-500">This Month:</span>
-      <span class="font-semibold text-gray-900">$<%= format("%.2f", monthly_cost / 100.0) %></span>
+      <span class="font-semibold text-gray-900">$<%= format("%.2f", monthly_cost_cents / 100.0) %></span>
     </div>
-    <% today_cost = project.token_usages.billable.by_time_period(Time.current.beginning_of_day, Time.current).total_cost_cents %>
+    <% today_cost_cents = local_assigns.fetch(:today_cost_cents, project.token_usages.billable.by_time_period(Time.current.beginning_of_day, Time.current).total_cost_cents) %>
     <div class="flex items-center gap-1.5 px-4 py-3">
       <span class="font-medium text-gray-500">Today:</span>
-      <span class="font-semibold text-gray-900">$<%= format("%.2f", today_cost / 100.0) %></span>
+      <span class="font-semibold text-gray-900">$<%= format("%.2f", today_cost_cents / 100.0) %></span>
     </div>
-    <% budgets = project.cost_budgets.reload %>
+    <% budgets = project.cost_budgets.load %>
     <% if budgets.any? %>
       <div class="flex items-center gap-1.5 px-4 py-3">
         <% budgets.each do |budget| %>
-          <% budget.rollover_if_period_expired! %>
-          <% color = budget_status_color(budget.usage_percent) %>
+          <% color = budget_status_color(budget.usage_percent, budget.alert_threshold_percent) %>
           <% classes = budget_status_classes(color) %>
           <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= classes[:bg] %> <%= classes[:text] %> mr-1">
             <%= budget_type_label(budget.budget_type) %>: <%= budget.usage_percent %>%

--- a/app/views/projects/_stats.html.erb
+++ b/app/views/projects/_stats.html.erb
@@ -9,12 +9,38 @@
       <span class="font-semibold text-green-600"><%= project.agent_runs.completed.count %></span>
     </div>
     <div class="flex items-center gap-1.5 px-4 py-3">
-      <span class="font-medium text-gray-500">Cost:</span>
+      <span class="font-medium text-gray-500">Total Cost:</span>
       <span class="font-semibold text-gray-900">$<%= format("%.2f", project.total_cost_cents / 100.0) %></span>
     </div>
     <div class="flex items-center gap-1.5 px-4 py-3">
       <span class="font-medium text-gray-500">Tokens:</span>
       <span class="font-semibold text-gray-900"><%= number_with_delimiter(project.total_tokens_used) %></span>
+    </div>
+    <% monthly_cost = project.token_usages.billable.by_time_period(Time.current.beginning_of_month, Time.current).total_cost_cents %>
+    <div class="flex items-center gap-1.5 px-4 py-3">
+      <span class="font-medium text-gray-500">This Month:</span>
+      <span class="font-semibold text-gray-900">$<%= format("%.2f", monthly_cost / 100.0) %></span>
+    </div>
+    <% today_cost = project.token_usages.billable.by_time_period(Time.current.beginning_of_day, Time.current).total_cost_cents %>
+    <div class="flex items-center gap-1.5 px-4 py-3">
+      <span class="font-medium text-gray-500">Today:</span>
+      <span class="font-semibold text-gray-900">$<%= format("%.2f", today_cost / 100.0) %></span>
+    </div>
+    <% budgets = project.cost_budgets.reload %>
+    <% if budgets.any? %>
+      <div class="flex items-center gap-1.5 px-4 py-3">
+        <% budgets.each do |budget| %>
+          <% budget.rollover_if_period_expired! %>
+          <% color = budget_status_color(budget.usage_percent) %>
+          <% classes = budget_status_classes(color) %>
+          <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= classes[:bg] %> <%= classes[:text] %> mr-1">
+            <%= budget_type_label(budget.budget_type) %>: <%= budget.usage_percent %>%
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+    <div class="flex items-center gap-1.5 px-4 py-3">
+      <%= link_to "Cost Details", project_cost_dashboard_path(project), class: "text-indigo-600 hover:text-indigo-900 font-medium" %>
     </div>
   </div>
 </div>

--- a/app/views/projects/_stats.html.erb
+++ b/app/views/projects/_stats.html.erb
@@ -16,17 +16,18 @@
       <span class="font-medium text-gray-500">Tokens:</span>
       <span class="font-semibold text-gray-900"><%= number_with_delimiter(project.total_tokens_used) %></span>
     </div>
-    <% monthly_cost_cents = local_assigns.fetch(:monthly_cost_cents, project.token_usages.billable.by_time_period(Time.current.beginning_of_month, Time.current).total_cost_cents) %>
+    <% now = local_assigns.fetch(:now, Time.current) %>
+    <% monthly_cost_cents = local_assigns.fetch(:monthly_cost_cents, project.token_usages.billable.by_time_period(now.beginning_of_month, now).total_cost_cents) %>
     <div class="flex items-center gap-1.5 px-4 py-3">
       <span class="font-medium text-gray-500">This Month:</span>
       <span class="font-semibold text-gray-900">$<%= format("%.2f", monthly_cost_cents / 100.0) %></span>
     </div>
-    <% today_cost_cents = local_assigns.fetch(:today_cost_cents, project.token_usages.billable.by_time_period(Time.current.beginning_of_day, Time.current).total_cost_cents) %>
+    <% today_cost_cents = local_assigns.fetch(:today_cost_cents, project.token_usages.billable.by_time_period(now.beginning_of_day, now).total_cost_cents) %>
     <div class="flex items-center gap-1.5 px-4 py-3">
       <span class="font-medium text-gray-500">Today:</span>
       <span class="font-semibold text-gray-900">$<%= format("%.2f", today_cost_cents / 100.0) %></span>
     </div>
-    <% budgets = project.cost_budgets.load %>
+    <% budgets = local_assigns.fetch(:budgets, project.cost_budgets.load) %>
     <% if budgets.any? %>
       <div class="flex items-center gap-1.5 px-4 py-3">
         <% budgets.each do |budget| %>

--- a/app/views/projects/_stats.html.erb
+++ b/app/views/projects/_stats.html.erb
@@ -31,11 +31,18 @@
     <% if budgets.any? %>
       <div class="flex items-center gap-1.5 px-4 py-3">
         <% budgets.each do |budget| %>
-          <% color = budget_status_color(budget.usage_percent, budget.alert_threshold_percent) %>
-          <% classes = budget_status_classes(color) %>
-          <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= classes[:bg] %> <%= classes[:text] %> mr-1">
-            <%= budget_type_label(budget.budget_type) %>: <%= budget.usage_percent %>%
-          </span>
+          <% if budget.budget_type == "per_run" %>
+            <%# Per-run budgets are enforced per agent run, not via current_usage_cents %>
+            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 mr-1">
+              <%= budget_type_label(budget.budget_type) %>: <%= format("$%.2f", budget.limit_cents / 100.0) %>/run
+            </span>
+          <% else %>
+            <% color = budget_status_color(budget.usage_percent, budget.alert_threshold_percent) %>
+            <% classes = budget_status_classes(color) %>
+            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= classes[:bg] %> <%= classes[:text] %> mr-1">
+              <%= budget_type_label(budget.budget_type) %>: <%= budget.usage_percent %>%
+            </span>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -173,6 +173,15 @@
                 </div>
               </div>
               <% if policy(@project).update? %>
+                <% if @failed_budget&.id == budget[:id] && @failed_budget.errors.any? %>
+                  <div class="mt-3 w-full rounded-md bg-red-50 p-3 text-sm text-red-700">
+                    <ul class="list-disc pl-5">
+                      <% @failed_budget.errors.full_messages.each do |message| %>
+                        <li><%= message %></li>
+                      <% end %>
+                    </ul>
+                  </div>
+                <% end %>
                 <div class="mt-3 flex gap-2">
                   <% budget_record = @cost_budgets[budget[:id]] %>
                   <%= form_with model: [@project, budget_record], url: project_cost_budget_path(@project, budget[:id]), method: :patch, class: "flex items-center gap-2" do |f| %>
@@ -204,6 +213,15 @@
           <div class="px-4 py-5 sm:p-6">
             <h3 class="text-sm font-medium text-gray-900">Add Budget Limit</h3>
             <%= form_with model: [@project, @cost_budget], url: project_cost_budgets_path(@project), class: "mt-3 flex flex-wrap items-end gap-3" do |f| %>
+              <% if @cost_budget&.errors&.any? %>
+                <div class="mb-3 w-full rounded-md bg-red-50 p-3 text-sm text-red-700">
+                  <ul class="list-disc pl-5">
+                    <% @cost_budget.errors.full_messages.each do |message| %>
+                      <li><%= message %></li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
               <div>
                 <%= f.label :budget_type, "Type", class: "block text-xs font-medium text-gray-700" %>
                 <%= f.select :budget_type, available_types.map { |t| [budget_type_label(t), t] }, {}, class: "mt-1 block rounded-md border-0 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -151,27 +151,40 @@
     <% if budgets.any? %>
       <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
         <% budgets.each do |budget| %>
-          <% color = budget_status_color(budget[:usage_percent], budget[:alert_threshold_percent]) %>
+          <% is_per_run = budget[:budget_type] == "per_run" %>
+          <% usage_percent = budget[:usage_percent] || 0 %>
+          <% color = is_per_run ? "gray" : budget_status_color(usage_percent, budget[:alert_threshold_percent]) %>
           <% classes = budget_status_classes(color) %>
           <div class="overflow-hidden rounded-lg bg-white shadow">
             <div class="px-4 py-5 sm:p-6">
               <div class="flex items-center justify-between">
                 <dt class="text-sm font-medium text-gray-500"><%= budget_type_label(budget[:budget_type]) %> Limit</dt>
-                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= classes[:bg] %> <%= classes[:text] %>">
-                  <%= budget[:exceeded] ? "Exceeded" : "#{budget[:usage_percent]}%" %>
-                </span>
+                <% if is_per_run %>
+                  <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600">
+                    Per Run
+                  </span>
+                <% else %>
+                  <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= classes[:bg] %> <%= classes[:text] %>">
+                    <%= budget[:exceeded] ? "Exceeded" : "#{usage_percent}%" %>
+                  </span>
+                <% end %>
               </div>
               <dd class="mt-1 text-2xl font-semibold text-gray-900"><%= format_cost_cents(budget[:limit_cents]) %></dd>
-              <div class="mt-3">
-                <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200">
-                  <div class="h-2 rounded-full <%= classes[:bar] %> transition-all"
-                       style="width: <%= [budget[:usage_percent], 100].min %>%"></div>
+              <% if is_per_run %>
+                <%# Per-run budgets are enforced per agent run, not via period-based usage tracking %>
+                <p class="mt-2 text-xs text-gray-500">Enforced per agent run. Each run is limited to this amount.</p>
+              <% else %>
+                <div class="mt-3">
+                  <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+                    <div class="h-2 rounded-full <%= classes[:bar] %> transition-all"
+                         style="width: <%= [usage_percent, 100].min %>%"></div>
+                  </div>
+                  <div class="mt-1 flex justify-between text-xs text-gray-500">
+                    <span>Used: <%= format_cost_cents(budget[:current_usage_cents]) %></span>
+                    <span>Remaining: <%= format_cost_cents(budget[:remaining_cents]) %></span>
+                  </div>
                 </div>
-                <div class="mt-1 flex justify-between text-xs text-gray-500">
-                  <span>Used: <%= format_cost_cents(budget[:current_usage_cents]) %></span>
-                  <span>Remaining: <%= format_cost_cents(budget[:remaining_cents]) %></span>
-                </div>
-              </div>
+              <% end %>
               <% if policy(@project).update? %>
                 <% if @failed_budget&.id == budget[:id] && @failed_budget.errors.any? %>
                   <div class="mt-3 w-full rounded-md bg-red-50 p-3 text-sm text-red-700">

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -151,7 +151,7 @@
     <% if budgets.any? %>
       <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
         <% budgets.each do |budget| %>
-          <% color = budget_status_color(budget[:usage_percent]) %>
+          <% color = budget_status_color(budget[:usage_percent], budget[:alert_threshold_percent]) %>
           <% classes = budget_status_classes(color) %>
           <div class="overflow-hidden rounded-lg bg-white shadow">
             <div class="px-4 py-5 sm:p-6">
@@ -174,10 +174,11 @@
               </div>
               <% if policy(@project).update? %>
                 <div class="mt-3 flex gap-2">
-                  <%= form_with model: [@project, CostBudget.find(budget[:id])], url: project_cost_budget_path(@project, budget[:id]), method: :patch, class: "flex items-center gap-2" do |f| %>
+                  <% budget_record = @cost_budgets[budget[:id]] %>
+                  <%= form_with model: [@project, budget_record], url: project_cost_budget_path(@project, budget[:id]), method: :patch, class: "flex items-center gap-2" do |f| %>
                     <div class="relative">
                       <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2 text-gray-400 text-sm">$</span>
-                      <%= f.number_field :limit_dollars, value: format("%.2f", budget[:limit_cents] / 100.0), step: 0.01, min: 0.01, class: "block w-24 rounded-md border-0 py-1 pl-6 pr-2 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
+                      <%= number_field_tag "cost_budget[limit_dollars]", format("%.2f", budget[:limit_cents] / 100.0), step: 0.01, min: 0.01, class: "block w-24 rounded-md border-0 py-1 pl-6 pr-2 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
                     </div>
                     <%= f.submit "Update", class: "rounded-md bg-white px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
                   <% end %>
@@ -202,7 +203,7 @@
         <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
           <div class="px-4 py-5 sm:p-6">
             <h3 class="text-sm font-medium text-gray-900">Add Budget Limit</h3>
-            <%= form_with model: [@project, CostBudget.new], url: project_cost_budgets_path(@project), class: "mt-3 flex flex-wrap items-end gap-3" do |f| %>
+            <%= form_with model: [@project, @cost_budget], url: project_cost_budgets_path(@project), class: "mt-3 flex flex-wrap items-end gap-3" do |f| %>
               <div>
                 <%= f.label :budget_type, "Type", class: "block text-xs font-medium text-gray-700" %>
                 <%= f.select :budget_type, available_types.map { |t| [budget_type_label(t), t] }, {}, class: "mt-1 block rounded-md border-0 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
@@ -216,7 +217,7 @@
               </div>
               <div>
                 <%= f.label :alert_threshold_percent, "Alert at %", class: "block text-xs font-medium text-gray-700" %>
-                <%= f.number_field :alert_threshold_percent, value: 80, min: 1, max: 100, class: "mt-1 block w-20 rounded-md border-0 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
+                <%= f.number_field :alert_threshold_percent, value: (@cost_budget.alert_threshold_percent || 80), min: 1, max: 100, class: "mt-1 block w-20 rounded-md border-0 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
               </div>
               <%= f.submit "Add Limit", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
             <% end %>

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -44,7 +44,7 @@
       <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
         <%= format_cost_cents(summary[:avg_cost_per_run_cents]) %>
       </dd>
-      <dd class="mt-1 text-xs text-gray-500"><%= number_with_delimiter(summary[:total_runs]) %> total runs</dd>
+      <dd class="mt-1 text-xs text-gray-500"><%= number_with_delimiter(summary[:total_runs]) %> completed runs</dd>
     </div>
   </div>
 

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -52,7 +52,7 @@
   <div class="mt-8">
     <h2 class="text-lg font-semibold text-gray-900">Cost Trend (Last 30 Days)</h2>
     <% daily_costs = @stats[:daily_costs] %>
-    <% if daily_costs.any? %>
+    <% if daily_costs.any? { |_, cost_cents| cost_cents.to_i > 0 } %>
       <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
         <div class="px-4 py-5 sm:p-6">
           <% max_cost = [daily_costs.map { |_, v| v }.max, 1].max %>

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -1,0 +1,228 @@
+<% content_for(:title) { "Cost Dashboard - #{@project.name} - Paid" } %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mb-6">
+    <%= link_to project_path(@project), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+      <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+      </svg>
+      Back to <%= @project.name %>
+    <% end %>
+  </div>
+
+  <div class="sm:flex sm:items-center sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-semibold text-gray-900">Cost Dashboard</h1>
+      <p class="mt-1 text-sm text-gray-500"><%= @project.name %></p>
+    </div>
+  </div>
+
+  <% summary = @stats[:summary] %>
+
+  <%# Cost Summary Cards %>
+  <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+      <dt class="truncate text-sm font-medium text-gray-500">Total Cost</dt>
+      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+        <%= format_cost_cents(summary[:total_cost_cents]) %>
+      </dd>
+    </div>
+    <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+      <dt class="truncate text-sm font-medium text-gray-500">Cost This Month</dt>
+      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+        <%= format_cost_cents(summary[:cost_this_month_cents]) %>
+      </dd>
+    </div>
+    <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+      <dt class="truncate text-sm font-medium text-gray-500">Cost Today</dt>
+      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+        <%= format_cost_cents(summary[:cost_today_cents]) %>
+      </dd>
+    </div>
+    <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+      <dt class="truncate text-sm font-medium text-gray-500">Avg Cost / Run</dt>
+      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+        <%= format_cost_cents(summary[:avg_cost_per_run_cents]) %>
+      </dd>
+      <dd class="mt-1 text-xs text-gray-500"><%= number_with_delimiter(summary[:total_runs]) %> total runs</dd>
+    </div>
+  </div>
+
+  <%# Cost Trend Chart (30 days) %>
+  <div class="mt-8">
+    <h2 class="text-lg font-semibold text-gray-900">Cost Trend (Last 30 Days)</h2>
+    <% daily_costs = @stats[:daily_costs] %>
+    <% if daily_costs.any? %>
+      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+        <div class="px-4 py-5 sm:p-6">
+          <% max_cost = [daily_costs.map { |_, v| v }.max, 1].max %>
+          <div class="flex items-end gap-1" style="height: 160px;" role="img" aria-label="Daily cost trend chart">
+            <% daily_costs.each do |date, cost_cents| %>
+              <% height_pct = (cost_cents.to_f / max_cost * 100).round %>
+              <div class="group relative flex-1" style="min-width: 4px;">
+                <div class="w-full rounded-t bg-indigo-400 hover:bg-indigo-500 transition-colors"
+                     style="height: <%= height_pct %>%;"
+                     title="<%= date %>: <%= format_cost_cents(cost_cents) %>">
+                </div>
+              </div>
+            <% end %>
+          </div>
+          <div class="mt-2 flex justify-between text-xs text-gray-400">
+            <span><%= daily_costs.first&.first %></span>
+            <span><%= daily_costs.last&.first %></span>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+        <div class="px-4 py-5 text-sm text-gray-500">No cost data available yet.</div>
+      </div>
+    <% end %>
+  </div>
+
+  <%# Cost Breakdown %>
+  <div class="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
+    <%# By Model %>
+    <div>
+      <h2 class="text-lg font-semibold text-gray-900">Cost by Model</h2>
+      <% cost_by_model = @stats[:cost_by_model] %>
+      <% if cost_by_model.any? %>
+        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Model</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Cost</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <% cost_by_model.each do |model_name, cost_cents| %>
+                <tr>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= model_name || "Unknown" %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(cost_cents) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+          <div class="px-4 py-5 text-sm text-gray-500">No model breakdown available.</div>
+        </div>
+      <% end %>
+    </div>
+
+    <%# By Request Type %>
+    <div>
+      <h2 class="text-lg font-semibold text-gray-900">Cost by Request Type</h2>
+      <% cost_by_type = @stats[:cost_by_request_type] %>
+      <% if cost_by_type.any? %>
+        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Cost</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <% cost_by_type.each do |type, cost_cents| %>
+                <tr>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= type.titleize %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(cost_cents) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+          <div class="px-4 py-5 text-sm text-gray-500">No request type breakdown available.</div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <%# Budget Status & Configuration %>
+  <div class="mt-8">
+    <h2 class="text-lg font-semibold text-gray-900">Budget Limits</h2>
+
+    <% budgets = @stats[:budgets] %>
+    <% if budgets.any? %>
+      <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <% budgets.each do |budget| %>
+          <% color = budget_status_color(budget[:usage_percent]) %>
+          <% classes = budget_status_classes(color) %>
+          <div class="overflow-hidden rounded-lg bg-white shadow">
+            <div class="px-4 py-5 sm:p-6">
+              <div class="flex items-center justify-between">
+                <dt class="text-sm font-medium text-gray-500"><%= budget_type_label(budget[:budget_type]) %> Limit</dt>
+                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= classes[:bg] %> <%= classes[:text] %>">
+                  <%= budget[:exceeded] ? "Exceeded" : "#{budget[:usage_percent]}%" %>
+                </span>
+              </div>
+              <dd class="mt-1 text-2xl font-semibold text-gray-900"><%= format_cost_cents(budget[:limit_cents]) %></dd>
+              <div class="mt-3">
+                <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+                  <div class="h-2 rounded-full <%= classes[:bar] %> transition-all"
+                       style="width: <%= [budget[:usage_percent], 100].min %>%"></div>
+                </div>
+                <div class="mt-1 flex justify-between text-xs text-gray-500">
+                  <span>Used: <%= format_cost_cents(budget[:current_usage_cents]) %></span>
+                  <span>Remaining: <%= format_cost_cents(budget[:remaining_cents]) %></span>
+                </div>
+              </div>
+              <% if policy(@project).update? %>
+                <div class="mt-3 flex gap-2">
+                  <%= form_with model: [@project, CostBudget.find(budget[:id])], url: project_cost_budget_path(@project, budget[:id]), method: :patch, class: "flex items-center gap-2" do |f| %>
+                    <div class="relative">
+                      <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2 text-gray-400 text-sm">$</span>
+                      <%= f.number_field :limit_dollars, value: format("%.2f", budget[:limit_cents] / 100.0), step: 0.01, min: 0.01, class: "block w-24 rounded-md border-0 py-1 pl-6 pr-2 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
+                    </div>
+                    <%= f.submit "Update", class: "rounded-md bg-white px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
+                  <% end %>
+                  <%= button_to "Remove", project_cost_budget_path(@project, budget[:id]), method: :delete, class: "rounded-md bg-white px-2 py-1 text-xs font-medium text-red-600 ring-1 ring-inset ring-red-200 hover:bg-red-50 cursor-pointer", form: { data: { turbo_confirm: "Remove this budget limit?" } } %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+        <div class="px-4 py-5 text-sm text-gray-500">No budget limits configured.</div>
+      </div>
+    <% end %>
+
+    <%# Add new budget %>
+    <% if policy(@project).update? %>
+      <% existing_types = budgets.map { |b| b[:budget_type] } %>
+      <% available_types = CostBudget::BUDGET_TYPES - existing_types %>
+      <% if available_types.any? %>
+        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+          <div class="px-4 py-5 sm:p-6">
+            <h3 class="text-sm font-medium text-gray-900">Add Budget Limit</h3>
+            <%= form_with model: [@project, CostBudget.new], url: project_cost_budgets_path(@project), class: "mt-3 flex flex-wrap items-end gap-3" do |f| %>
+              <div>
+                <%= f.label :budget_type, "Type", class: "block text-xs font-medium text-gray-700" %>
+                <%= f.select :budget_type, available_types.map { |t| [budget_type_label(t), t] }, {}, class: "mt-1 block rounded-md border-0 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
+              </div>
+              <div>
+                <%= f.label :limit_dollars, "Limit", class: "block text-xs font-medium text-gray-700" %>
+                <div class="relative mt-1">
+                  <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2 text-gray-400 text-sm">$</span>
+                  <%= f.number_field :limit_dollars, step: 0.01, min: 0.01, placeholder: "10.00", class: "block w-28 rounded-md border-0 py-1.5 pl-6 pr-2 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
+                </div>
+              </div>
+              <div>
+                <%= f.label :alert_threshold_percent, "Alert at %", class: "block text-xs font-medium text-gray-700" %>
+                <%= f.number_field :alert_threshold_percent, value: 80, min: 1, max: 100, class: "mt-1 block w-20 rounded-md border-0 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
+              </div>
+              <%= f.submit "Add Limit", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -183,11 +183,12 @@
                   </div>
                 <% end %>
                 <div class="mt-3 flex gap-2">
-                  <% budget_record = @cost_budgets[budget[:id]] %>
+                  <%# Use @failed_budget when present so the user's submitted value is preserved on validation failure %>
+                  <% budget_record = (@failed_budget&.id == budget[:id] ? @failed_budget : @cost_budgets[budget[:id]]) %>
                   <%= form_with model: [@project, budget_record], url: project_cost_budget_path(@project, budget[:id]), method: :patch, class: "flex items-center gap-2" do |f| %>
                     <div class="relative">
                       <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2 text-gray-400 text-sm">$</span>
-                      <%= number_field_tag "cost_budget[limit_dollars]", format("%.2f", budget[:limit_cents] / 100.0), step: 0.01, min: 0.01, class: "block w-24 rounded-md border-0 py-1 pl-6 pr-2 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
+                      <%= f.number_field :limit_dollars, value: (budget_record.limit_dollars || format("%.2f", budget[:limit_cents] / 100.0)), step: 0.01, min: 0.01, class: "block w-24 rounded-md border-0 py-1 pl-6 pr-2 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600" %>
                     </div>
                     <%= f.submit "Update", class: "rounded-md bg-white px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
                   <% end %>
@@ -207,7 +208,12 @@
     <%# Add new budget %>
     <% if policy(@project).update? %>
       <% existing_types = budgets.map { |b| b[:budget_type] } %>
-      <% available_types = CostBudget::BUDGET_TYPES - existing_types %>
+      <%# Include the submitted budget_type when the create form has errors, so the user can correct the error %>
+      <% available_types = if @cost_budget&.errors&.any? && @cost_budget.budget_type.present? %>
+      <%                     (CostBudget::BUDGET_TYPES - existing_types) | [@cost_budget.budget_type] %>
+      <%                   else %>
+      <%                     CostBudget::BUDGET_TYPES - existing_types %>
+      <%                   end %>
       <% if available_types.any? %>
         <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
           <div class="px-4 py-5 sm:p-6">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -111,7 +111,7 @@
   </div>
 
   <div data-show-actions="<%= policy(@project).run_agent? %>">
-    <%= render "projects/stats", project: @project %>
+    <%= render "projects/stats", project: @project, budgets: @cost_budgets %>
 
     <%= render "projects/issues", project: @project, issues: @issues %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,8 @@ Rails.application.routes.draw do
     post :toggle_auto_pick, on: :member
     resource :workflow_status, only: [ :show ]
     resource :quality_dashboard, only: [ :show ], controller: "projects/quality_dashboards"
+    resource :cost_dashboard, only: [ :show ], controller: "projects/cost_dashboards"
+    resources :cost_budgets, only: [ :create, :update, :destroy ], controller: "projects/cost_budgets"
     resources :agent_runs, only: [ :index, :show, :new, :create ], controller: "projects/agent_runs" do
       post :retry, on: :member
       post :refresh_auth, on: :member

--- a/spec/models/cost_budget_spec.rb
+++ b/spec/models/cost_budget_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe CostBudget do
     it { is_expected.to validate_presence_of(:limit_cents) }
     it { is_expected.to validate_numericality_of(:limit_cents).is_greater_than(0) }
     it { is_expected.to validate_numericality_of(:current_usage_cents).is_greater_than_or_equal_to(0) }
+
+    it "validates limit_dollars is greater than 0 when present" do
+      budget = build(:cost_budget, limit_dollars: "0")
+      budget.valid?
+
+      expect(budget.errors[:limit_dollars]).to include("must be greater than 0")
+      expect(budget.errors[:limit_cents]).to be_empty
+    end
+
+    it "validates limit_dollars rejects negative values" do
+      budget = build(:cost_budget, limit_dollars: "-5")
+      budget.valid?
+
+      expect(budget.errors[:limit_dollars]).to include("must be greater than 0")
+    end
+
     it { is_expected.to validate_numericality_of(:alert_threshold_percent).is_greater_than(0) }
 
     it "enforces uniqueness of budget_type per project" do

--- a/spec/models/cost_budget_spec.rb
+++ b/spec/models/cost_budget_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe CostBudget do
       expect(budget.errors[:limit_dollars]).to include("must be greater than 0")
     end
 
+    it "produces a single error for non-numeric limit_dollars" do
+      budget = build(:cost_budget, limit_dollars: "abc")
+      budget.valid?
+
+      expect(budget.errors[:limit_dollars]).to eq([ "is not a number" ])
+    end
+
     it { is_expected.to validate_numericality_of(:alert_threshold_percent).is_greater_than(0) }
 
     it "enforces uniqueness of budget_type per project" do

--- a/spec/requests/projects/cost_budgets_spec.rb
+++ b/spec/requests/projects/cost_budgets_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Projects::CostBudgets" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+  let(:project) { create(:project, account: account) }
+
+  before { sign_in user }
+
+  describe "POST /projects/:project_id/cost_budgets" do
+    context "when user has update permission" do
+      before do
+        user.add_role(:admin, account)
+      end
+
+      it "creates a new budget" do
+        expect {
+          post project_cost_budgets_path(project), params: {
+            cost_budget: { budget_type: "daily", limit_dollars: "10.00", alert_threshold_percent: 80 }
+          }
+        }.to change(CostBudget, :count).by(1)
+
+        expect(response).to redirect_to(project_cost_dashboard_path(project))
+        budget = project.cost_budgets.last
+        expect(budget.limit_cents).to eq(1000)
+        expect(budget.budget_type).to eq("daily")
+      end
+
+      it "renders errors for invalid budget" do
+        post project_cost_budgets_path(project), params: {
+          cost_budget: { budget_type: "daily", limit_dollars: "0", alert_threshold_percent: 80 }
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "PATCH /projects/:project_id/cost_budgets/:id" do
+    let!(:budget) { create(:cost_budget, project: project, budget_type: "daily", limit_cents: 1000) }
+
+    context "when user has update permission" do
+      before do
+        user.add_role(:admin, account)
+      end
+
+      it "updates the budget limit" do
+        patch project_cost_budget_path(project, budget), params: {
+          cost_budget: { limit_dollars: "20.00" }
+        }
+
+        expect(response).to redirect_to(project_cost_dashboard_path(project))
+        expect(budget.reload.limit_cents).to eq(2000)
+      end
+    end
+  end
+
+  describe "DELETE /projects/:project_id/cost_budgets/:id" do
+    let!(:budget) { create(:cost_budget, project: project, budget_type: "daily", limit_cents: 1000) }
+
+    context "when user has update permission" do
+      before do
+        user.add_role(:admin, account)
+      end
+
+      it "destroys the budget" do
+        expect {
+          delete project_cost_budget_path(project, budget)
+        }.to change(CostBudget, :count).by(-1)
+
+        expect(response).to redirect_to(project_cost_dashboard_path(project))
+      end
+    end
+  end
+end

--- a/spec/requests/projects/cost_budgets_spec.rb
+++ b/spec/requests/projects/cost_budgets_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Projects::CostBudgets" do
   end
 
   describe "PATCH /projects/:project_id/cost_budgets/:id" do
-    let!(:budget) { create(:cost_budget, project: project, budget_type: "daily", limit_cents: 1000) }
+    let!(:budget) { create(:cost_budget, :daily, project: project, limit_cents: 1000) }
 
     context "when user has update permission" do
       before do
@@ -58,7 +58,7 @@ RSpec.describe "Projects::CostBudgets" do
   end
 
   describe "DELETE /projects/:project_id/cost_budgets/:id" do
-    let!(:budget) { create(:cost_budget, project: project, budget_type: "daily", limit_cents: 1000) }
+    let!(:budget) { create(:cost_budget, :daily, project: project, limit_cents: 1000) }
 
     context "when user has update permission" do
       before do

--- a/spec/requests/projects/cost_dashboards_spec.rb
+++ b/spec/requests/projects/cost_dashboards_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Projects::CostDashboards" do
       end
 
       it "shows budget status when budgets exist" do
-        create(:cost_budget, project: project, budget_type: "daily", limit_cents: 1000, current_usage_cents: 800)
+        create(:cost_budget, :daily, project: project, limit_cents: 1000, current_usage_cents: 800)
 
         get project_cost_dashboard_path(project)
 

--- a/spec/requests/projects/cost_dashboards_spec.rb
+++ b/spec/requests/projects/cost_dashboards_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Projects::CostDashboards" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+  let(:project) { create(:project, account: account) }
+
+  describe "GET /projects/:project_id/cost_dashboard" do
+    context "when not authenticated" do
+      it "redirects to sign in" do
+        get project_cost_dashboard_path(project)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "renders the cost dashboard" do
+        get project_cost_dashboard_path(project)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Cost Dashboard")
+      end
+
+      it "shows cost summary cards" do
+        get project_cost_dashboard_path(project)
+
+        expect(response.body).to include("Total Cost")
+        expect(response.body).to include("Cost This Month")
+        expect(response.body).to include("Cost Today")
+        expect(response.body).to include("Avg Cost / Run")
+      end
+
+      it "shows empty state when no cost data" do
+        get project_cost_dashboard_path(project)
+
+        expect(response.body).to include("$0.00")
+      end
+
+      it "shows cost data when token usages exist" do
+        run = create(:agent_run, project: project, status: "completed", cost_cents: 500)
+        create(:token_usage, agent_run: run, cost_cents: 500, llm_model: "claude-3-opus", request_type: "agent")
+        project.update!(total_cost_cents: 500)
+
+        get project_cost_dashboard_path(project)
+
+        expect(response.body).to include("$5.00")
+        expect(response.body).to include("Cost by Model")
+        expect(response.body).to include("claude-3-opus")
+      end
+
+      it "shows budget status when budgets exist" do
+        create(:cost_budget, project: project, budget_type: "daily", limit_cents: 1000, current_usage_cents: 800)
+
+        get project_cost_dashboard_path(project)
+
+        expect(response.body).to include("Budget Limits")
+        expect(response.body).to include("Daily Limit")
+        expect(response.body).to include("$10.00")
+      end
+    end
+  end
+end

--- a/spec/services/dashboard/stats_spec.rb
+++ b/spec/services/dashboard/stats_spec.rb
@@ -229,6 +229,69 @@ RSpec.describe Dashboard::Stats do
       end
     end
 
+    describe "cost_by_project" do
+      context "with no projects having costs" do
+        it "returns an empty array" do
+          expect(stats[:cost_by_project]).to be_empty
+        end
+      end
+
+      context "with projects having costs" do
+        let(:expensive_project) { create(:project, account: account, name: "Expensive Project", total_cost_cents: 5000) }
+        let(:cheap_project) { create(:project, account: account, name: "Cheap Project", total_cost_cents: 100) }
+
+        before do
+          project.update!(total_cost_cents: 1000)
+          expensive_project
+          cheap_project
+        end
+
+        it "only includes projects with non-zero costs" do
+          names = stats[:cost_by_project].map(&:first)
+          expect(names).to include(project.name, "Expensive Project", "Cheap Project")
+        end
+
+        it "orders by cost descending" do
+          result = stats[:cost_by_project]
+          expect(result.first).to eq([ "Expensive Project", 5000 ])
+          expect(result.last).to eq([ "Cheap Project", 100 ])
+        end
+
+        it "excludes zero-cost projects" do
+          create(:project, account: account, name: "Free Project", total_cost_cents: 0)
+          names = stats[:cost_by_project].map(&:first)
+          expect(names).not_to include("Free Project")
+        end
+      end
+
+      context "with projects from another account" do
+        let(:other_account) { create(:account) }
+
+        before do
+          create(:project, account: other_account, name: "Other Project", total_cost_cents: 9999)
+          project.update!(total_cost_cents: 500)
+        end
+
+        it "only includes projects from the specified account" do
+          names = stats[:cost_by_project].map(&:first)
+          expect(names).to include(project.name)
+          expect(names).not_to include("Other Project")
+        end
+      end
+
+      context "with more than 10 projects" do
+        before do
+          12.times do |i|
+            create(:project, account: account, name: "Project #{i}", total_cost_cents: (i + 1) * 100)
+          end
+        end
+
+        it "limits results to 10" do
+          expect(stats[:cost_by_project].length).to eq(10)
+        end
+      end
+    end
+
     context "with merged PRs" do
       let(:merged_issue) do
         create(:issue, :pull_request, :closed, project: project,

--- a/spec/services/projects/cost_dashboard_stats_spec.rb
+++ b/spec/services/projects/cost_dashboard_stats_spec.rb
@@ -52,13 +52,28 @@ RSpec.describe Projects::CostDashboardStats do
       expect(result[:daily_costs]).to be_an(Array)
     end
 
-    it "returns budget information" do
+    it "returns budget information with usage for daily budgets" do
       create(:cost_budget, :daily, project: project, limit_cents: 1000, current_usage_cents: 500)
 
       result = described_class.call(project: project)
       expect(result[:budgets].length).to eq(1)
-      expect(result[:budgets].first[:budget_type]).to eq("daily")
-      expect(result[:budgets].first[:usage_percent]).to eq(50.0)
+      budget = result[:budgets].first
+      expect(budget[:budget_type]).to eq("daily")
+      expect(budget[:usage_percent]).to eq(50.0)
+      expect(budget[:current_usage_cents]).to eq(500)
+      expect(budget[:remaining_cents]).to eq(500)
+    end
+
+    it "omits period-based usage fields for per_run budgets" do
+      create(:cost_budget, project: project, budget_type: "per_run", limit_cents: 2000)
+
+      result = described_class.call(project: project)
+      budget = result[:budgets].first
+      expect(budget[:budget_type]).to eq("per_run")
+      expect(budget[:limit_cents]).to eq(2000)
+      expect(budget).not_to have_key(:usage_percent)
+      expect(budget).not_to have_key(:current_usage_cents)
+      expect(budget).not_to have_key(:remaining_cents)
     end
   end
 end

--- a/spec/services/projects/cost_dashboard_stats_spec.rb
+++ b/spec/services/projects/cost_dashboard_stats_spec.rb
@@ -44,12 +44,21 @@ RSpec.describe Projects::CostDashboardStats do
       expect(models["claude-3-haiku"]).to eq(100)
     end
 
-    it "returns daily cost data" do
-      run = create(:agent_run, project: project)
-      create(:token_usage, agent_run: run, cost_cents: 150, request_type: "agent")
+    it "returns a full 30-day daily cost array with zero-filled gaps" do
+      travel_to(Time.zone.local(2024, 6, 15, 12, 0, 0)) do
+        run = create(:agent_run, project: project)
+        create(:token_usage, agent_run: run, cost_cents: 150, request_type: "agent")
 
-      result = described_class.call(project: project)
-      expect(result[:daily_costs]).to be_an(Array)
+        result = described_class.call(project: project)
+        daily = result[:daily_costs]
+        expect(daily).to be_an(Array)
+        expect(daily.length).to eq(30)
+        expect(daily.first.first).to eq(Date.new(2024, 5, 17))
+        expect(daily.last.first).to eq(Date.new(2024, 6, 15))
+        expect(daily.last.last).to eq(150)
+        # Days without usage should be zero-filled
+        expect(daily[0..28].map(&:last)).to all(eq(0))
+      end
     end
 
     it "returns budget information with usage for daily budgets" do

--- a/spec/services/projects/cost_dashboard_stats_spec.rb
+++ b/spec/services/projects/cost_dashboard_stats_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Projects::CostDashboardStats do
     end
 
     it "returns budget information" do
-      create(:cost_budget, project: project, budget_type: "daily", limit_cents: 1000, current_usage_cents: 500)
+      create(:cost_budget, :daily, project: project, limit_cents: 1000, current_usage_cents: 500)
 
       result = described_class.call(project: project)
       expect(result[:budgets].length).to eq(1)

--- a/spec/services/projects/cost_dashboard_stats_spec.rb
+++ b/spec/services/projects/cost_dashboard_stats_spec.rb
@@ -15,12 +15,14 @@ RSpec.describe Projects::CostDashboardStats do
     end
 
     it "calculates today and monthly costs" do
-      run = create(:agent_run, project: project, status: "completed", cost_cents: 300)
-      create(:token_usage, agent_run: run, cost_cents: 300, request_type: "agent")
+      travel_to(Time.zone.local(2024, 1, 15, 12, 0, 0)) do
+        run = create(:agent_run, project: project, status: "completed", cost_cents: 300)
+        create(:token_usage, agent_run: run, cost_cents: 300, request_type: "agent")
 
-      result = described_class.call(project: project)
-      expect(result[:summary][:cost_today_cents]).to eq(300)
-      expect(result[:summary][:cost_this_month_cents]).to eq(300)
+        result = described_class.call(project: project)
+        expect(result[:summary][:cost_today_cents]).to eq(300)
+        expect(result[:summary][:cost_this_month_cents]).to eq(300)
+      end
     end
 
     it "calculates average cost per run" do

--- a/spec/services/projects/cost_dashboard_stats_spec.rb
+++ b/spec/services/projects/cost_dashboard_stats_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Projects::CostDashboardStats do
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account, total_cost_cents: 5000, total_tokens_used: 100_000) }
+
+  describe ".call" do
+    subject(:stats) { described_class.call(project: project) }
+
+    it "returns summary with cost totals" do
+      expect(stats[:summary][:total_cost_cents]).to eq(5000)
+      expect(stats[:summary][:total_tokens]).to eq(100_000)
+    end
+
+    it "calculates today and monthly costs" do
+      run = create(:agent_run, project: project, status: "completed", cost_cents: 300)
+      create(:token_usage, agent_run: run, cost_cents: 300, request_type: "agent")
+
+      result = described_class.call(project: project)
+      expect(result[:summary][:cost_today_cents]).to eq(300)
+      expect(result[:summary][:cost_this_month_cents]).to eq(300)
+    end
+
+    it "calculates average cost per run" do
+      create(:agent_run, project: project, status: "completed", cost_cents: 400)
+      create(:agent_run, project: project, status: "completed", cost_cents: 600)
+
+      result = described_class.call(project: project)
+      expect(result[:summary][:avg_cost_per_run_cents]).to eq(500)
+    end
+
+    it "returns cost breakdown by model" do
+      run = create(:agent_run, project: project)
+      create(:token_usage, agent_run: run, cost_cents: 200, llm_model: "claude-3-opus", request_type: "agent")
+      create(:token_usage, agent_run: run, cost_cents: 100, llm_model: "claude-3-haiku", request_type: "agent")
+
+      result = described_class.call(project: project)
+      models = result[:cost_by_model].to_h
+      expect(models["claude-3-opus"]).to eq(200)
+      expect(models["claude-3-haiku"]).to eq(100)
+    end
+
+    it "returns daily cost data" do
+      run = create(:agent_run, project: project)
+      create(:token_usage, agent_run: run, cost_cents: 150, request_type: "agent")
+
+      result = described_class.call(project: project)
+      expect(result[:daily_costs]).to be_an(Array)
+    end
+
+    it "returns budget information" do
+      create(:cost_budget, project: project, budget_type: "daily", limit_cents: 1000, current_usage_cents: 500)
+
+      result = described_class.call(project: project)
+      expect(result[:budgets].length).to eq(1)
+      expect(result[:budgets].first[:budget_type]).to eq("daily")
+      expect(result[:budgets].first[:usage_percent]).to eq(50.0)
+    end
+  end
+end


### PR DESCRIPTION
All done. Here's a summary of what was implemented for issue #142:

## Changes Made

### New Files (6 source + 3 spec)
- **`app/services/projects/cost_dashboard_stats.rb`** - Service that aggregates cost data per project: summary (total/month/today), breakdown by model and request type, daily costs for trending, and budget status
- **`app/controllers/projects/cost_dashboards_controller.rb`** - Show action for the cost dashboard page
- **`app/controllers/projects/cost_budgets_controller.rb`** - CRUD controller for creating/updating/deleting budget limits (daily, monthly, per-run)
- **`app/helpers/cost_dashboard_helper.rb`** - Helpers for formatting costs and budget status colors (green/yellow/red)
- **`app/views/projects/cost_dashboards/show.html.erb`** - Full cost dashboard with summary cards, trend chart, model/type breakdowns, budget management UI
- **3 spec files** - Request specs for cost dashboards and budgets, service spec for CostDashboardStats

### Modified Files (4)
- **`config/routes.rb`** - Added `cost_dashboard` and `cost_budgets` routes nested under projects
- **`app/views/projects/_stats.html.erb`** - Enhanced with cost this month, cost today, budget status indicators, and a "Cost Details" link
- **`app/services/dashboard/stats.rb`** - Added `cost_by_project` method for account-level cost comparison
- **`app/views/dashboard/_content.html.erb`** - Added "Cost by Project" comparison table to account dashboard

### Acceptance Criteria Met
- Per-project cost visible on project page (stats bar + dedicated dashboard)
- Historical cost trends displayed (30-day bar chart)
- Budget limits configurable from UI (create/update/delete)
- Clear visual indicators for budget status (green/yellow/red)
- Account-level cost overview available (cost by project table)

---

Closes #142