### PR TITLE
fix(agent-image): pin codex to a published version

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -135,7 +135,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash \
 
 # Install OpenAI Codex CLI
 # Pin version for reproducible builds; update intentionally when upgrading Codex.
-RUN npm install -g @openai/codex@0.2.4
+RUN npm install -g @openai/codex@0.116.0
 
 # Install git credential helper for proxy-based authentication.
 # This allows git clone/push inside the container without exposing GitHub tokens.


### PR DESCRIPTION
## Summary
- replace the invalid `@openai/codex@0.2.4` pin with published version `0.116.0`
- restore reproducible agent image builds during `bin/setup`

## Validation
- `docker build -t paid-agent:test -f docker/agent/Dockerfile docker/agent`
- `docker compose --profile setup up agent-image --build`

## Context
`npm` returned a 404 for `@openai/codex@0.2.4`, which caused the agent image build to fail inside `bin/setup`.