### PR TITLE
fix(providers): patch agent-harness CLI argument syntax for test agent

### DIFF
--- a/config/initializers/agent_harness_cli_fixes.rb
+++ b/config/initializers/agent_harness_cli_fixes.rb
@@ -10,52 +10,86 @@
 # Remove once agent-harness ships corrected build_command implementations.
 
 Rails.application.config.after_initialize do
+  spec = Gem.loaded_specs["agent-harness"]
+  version = spec&.version
+
+  unless version == Gem::Version.new("0.5.0")
+    Rails.logger.info(
+      "[agent_harness_cli_fixes] Skipping patches: agent-harness #{version || 'not installed'} " \
+      "(only 0.5.0 needs patching)"
+    )
+    next
+  end
+
   # --- Anthropic (Claude Code CLI) -------------------------------------------
-  if defined?(AgentHarness::Providers::Anthropic)
-    AgentHarness::Providers::Anthropic.class_eval do
+  begin
+    # Reference the constant to trigger autoload if needed
+    provider = AgentHarness::Providers::Anthropic
+
+    provider.class_eval do
+      alias_method :original_build_command, :build_command
+
       protected
 
       def build_command(prompt, options)
-        cmd = [ self.class.binary_name ]
+        cmd = original_build_command(prompt, options)
 
-        cmd += [ "--print", "--output-format=json" ]
-
-        if @config.model && !@config.model.empty?
-          cmd += [ "--model", @config.model ]
+        # Replace --prompt <text> with positional prompt argument
+        if (idx = cmd.index("--prompt"))
+          cmd.delete_at(idx) # remove --prompt flag
+          cmd.delete_at(idx) # remove the prompt value that followed it
         end
 
-        if options[:dangerous_mode] && supports_dangerous_mode?
-          cmd += dangerous_mode_flags
-        end
-
-        cmd += @config.default_flags if @config.default_flags&.any?
-
-        # Prompt is a positional argument, not --prompt
         cmd << prompt
-
         cmd
       end
     end
+
+    Rails.logger.info("[agent_harness_cli_fixes] Patched AgentHarness::Providers::Anthropic#build_command")
+  rescue NameError
+    Rails.logger.info(
+      "[agent_harness_cli_fixes] Skipping Anthropic patch: provider constant not defined"
+    )
+  rescue StandardError => e
+    Rails.logger.warn(
+      "[agent_harness_cli_fixes] Failed to patch Anthropic: #{e.class}: #{e.message}"
+    )
   end
 
   # --- Codex -----------------------------------------------------------------
-  if defined?(AgentHarness::Providers::Codex)
-    AgentHarness::Providers::Codex.class_eval do
+  begin
+    provider = AgentHarness::Providers::Codex
+
+    provider.class_eval do
+      alias_method :original_build_command, :build_command
+
       protected
 
       def build_command(prompt, options)
-        # Use `codex exec` subcommand for non-interactive execution
-        cmd = [ self.class.binary_name, "exec" ]
+        cmd = original_build_command(prompt, options)
 
-        if options[:session]
-          cmd += session_flags(options[:session])
+        # Insert `exec` subcommand after binary name for non-interactive execution
+        cmd.insert(1, "exec") unless cmd[1] == "exec"
+
+        # Replace --prompt <text> with positional prompt argument
+        if (idx = cmd.index("--prompt"))
+          cmd.delete_at(idx) # remove --prompt flag
+          cmd.delete_at(idx) # remove the prompt value that followed it
         end
 
-        # Prompt is a positional argument, not --prompt
         cmd << prompt
-
         cmd
       end
     end
+
+    Rails.logger.info("[agent_harness_cli_fixes] Patched AgentHarness::Providers::Codex#build_command")
+  rescue NameError
+    Rails.logger.info(
+      "[agent_harness_cli_fixes] Skipping Codex patch: provider constant not defined"
+    )
+  rescue StandardError => e
+    Rails.logger.warn(
+      "[agent_harness_cli_fixes] Failed to patch Codex: #{e.class}: #{e.message}"
+    )
   end
 end


### PR DESCRIPTION
## Summary

- The "Test Agent" button on the providers index page was broken for all providers due to agent-harness 0.5.0 passing `--prompt` as a CLI flag, which neither Claude Code nor Codex CLIs support
- Added a monkey-patch initializer that corrects the `build_command` methods to pass the prompt as a positional argument instead
- Claude CLI: `claude --print --output-format=json "<prompt>"` (was `--prompt`)
- Codex CLI: `codex exec "<prompt>"` (was `--prompt`)

## Test plan

- [x] Verified Claude "Test Agent" returns "Agent is healthy" via Playwright
- [x] Verified Codex "Test Agent" completes successfully (200 OK) via server logs
- [x] Verified Gemini/Kilocode correctly report "CLI not installed" (expected)
- [x] All 31 existing specs pass (providers request + test_agent service)
- [ ] Confirm upstream agent-harness gem fix is filed

🤖 Generated with [Claude Code](https://claude.com/claude-code)