### PR TITLE
fix(auto-merge): allow self-authored owner PRs

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -173,7 +173,7 @@ module Activities
 
       if project.auto_merge_enabled? &&
           pr_data.present? &&
-          owner_approved_from_reviews?(project, reviews) &&
+          owner_approved_or_self_authored?(project, reviews, pr_data) &&
           checks.present? &&
           all_checks_green?(checks) &&
           mergeable == true
@@ -251,7 +251,7 @@ module Activities
       {
         issue_id: issue.id,
         pr_number: issue.github_number,
-        triggers: [ { type: "owner_approved", details: "Owner approved PR" } ],
+        triggers: [ { type: "owner_approved", details: "Owner approval requirement satisfied" } ],
         phase: "ready"
       }
     end
@@ -509,6 +509,12 @@ module Activities
 
     # --- Owner approval check ---
 
+    def owner_approved_or_self_authored?(project, reviews, pr_data)
+      return true if owner_is_pr_author?(project, pr_data)
+
+      owner_approved_from_reviews?(project, reviews)
+    end
+
     def owner_approved_from_reviews?(project, reviews)
       return false if reviews.nil?
 
@@ -520,6 +526,15 @@ module Activities
 
       latest = owner_reviews.max_by { |r| r[:submitted_at] || Time.at(0) }
       latest[:state] == "APPROVED"
+    end
+
+    def owner_is_pr_author?(project, pr_data)
+      owner_login = project.owner_reviewer_login
+      author_login = pr_data&.user&.login
+
+      return false if owner_login.blank? || author_login.blank?
+
+      owner_login.casecmp?(author_login)
     end
 
     # --- Helpers ---

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1145,6 +1145,44 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when owner reviewer is also the PR author" do
+      before do
+        project.update!(owner_reviewer_login: "viamin", auto_merge_enabled: true)
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated" ],
+          pr_review_phase: "ready",
+          paid_state: "completed")
+        stub_github_for_pr(author_login: "viamin", reviews: default_clean_copilot_review)
+      end
+
+      it "returns owner_approved without a separate owner approval review" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("owner_approved")
+      end
+    end
+
+    context "when the PR author is not the owner reviewer" do
+      before do
+        project.update!(owner_reviewer_login: "viamin", auto_merge_enabled: true)
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated" ],
+          pr_review_phase: "ready",
+          paid_state: "completed")
+        stub_github_for_pr(author_login: "someone-else", reviews: default_clean_copilot_review)
+      end
+
+      it "still requires an owner approval review" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
     context "when ready PR has unresolved review bot threads" do
       before do
         create(:issue, :pull_request,
@@ -1415,12 +1453,18 @@ RSpec.describe Activities::ScanPaidPrsActivity do
   def stub_github_for_pr(
     mergeable: true,
     draft: false,
+    author_login: "someone-else",
     checks: [ { name: "ci", conclusion: "success" } ],
     review_threads: [],
     issue_comments: [],
     reviews: default_clean_copilot_review
   )
-    pr_data = OpenStruct.new(head: OpenStruct.new(sha: "abc123"), mergeable: mergeable, draft: draft)
+    pr_data = OpenStruct.new(
+      head: OpenStruct.new(sha: "abc123"),
+      mergeable: mergeable,
+      draft: draft,
+      user: OpenStruct.new(login: author_login)
+    )
 
     allow(github_client).to receive(:pull_request)
       .with(project.full_name, 42)


### PR DESCRIPTION
## Summary
- allow the auto-merge owner gate to pass when the configured owner reviewer is also the PR author
- keep the existing approval requirement for all other ready PRs
- add ready-phase specs for both self-authored and non-self-authored paths

## Testing
- COVERAGE=false bin/rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb
- bin/rubocop app/temporal/activities/scan_paid_prs_activity.rb spec/temporal/activities/scan_paid_prs_activity_spec.rb