### PR TITLE
fix(agent-image): restore bin/setup Kilocode install

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -143,7 +143,7 @@ RUN npm install -g @google/gemini-cli@0.5.5
 
 # Install Kilocode CLI
 # Pin version for reproducible builds; update intentionally when upgrading Kilocode.
-RUN npm install -g @nicepkg/kilocode@0.0.14
+RUN npm install -g @kilocode/cli@7.1.3
 
 # Install git credential helper for proxy-based authentication.
 # This allows git clone/push inside the container without exposing GitHub tokens.


### PR DESCRIPTION
## Summary
- replace the removed `@nicepkg/kilocode@0.0.14` package in the agent image
- pin Kilocode to the current published `@kilocode/cli@7.1.3` package, which still exposes the `kilo` binary
- restore `bin/setup` so the Docker agent image build completes again

## Verification
- ran `bin/setup --skip-server`
