### PR TITLE
fix(github): avoid nil commit_message in PR merges

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -491,7 +491,9 @@ class GithubClient
     options = { merge_method: merge_method }
     options[:commit_title] = commit_title if commit_title
     options[:commit_message] = commit_message if commit_message
-    handle_errors { client.merge_pull_request(repo, number, nil, **options) }
+
+    path = "#{Octokit::Repository.path repo}/pulls/#{number}/merge"
+    handle_errors { client.put(path, options) }
   end
 
   # Gets the remaining rate limit.

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -158,6 +158,53 @@ RSpec.describe GithubClient do
     end
   end
 
+  describe "#merge_pull_request" do
+    let(:repo) { "owner/repo" }
+    let(:merge_url) { "#{api_base}/repos/#{repo}/pulls/42/merge" }
+
+    it "omits commit_message when none is provided" do
+      stub = stub_request(:put, merge_url)
+        .with do |request|
+          body = JSON.parse(request.body)
+
+          expect(body).to include("merge_method" => "squash")
+          expect(body).not_to have_key("commit_message")
+        end
+        .to_return(
+          status: 200,
+          body: { merged: true }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      client.merge_pull_request(repo, 42, merge_method: "squash")
+
+      expect(stub).to have_been_requested.once
+    end
+
+    it "includes commit_message when provided" do
+      stub = stub_request(:put, merge_url)
+        .with do |request|
+          body = JSON.parse(request.body)
+
+          expect(body).to include(
+            "merge_method" => "squash",
+            "commit_message" => "Custom merge message"
+          )
+        end
+        .to_return(
+          status: 200,
+          body: { merged: true }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      client.merge_pull_request(repo, 42,
+        merge_method: "squash",
+        commit_message: "Custom merge message")
+
+      expect(stub).to have_been_requested.once
+    end
+  end
+
   describe "#repositories" do
     let(:repo_with_push) do
       { id: 1, full_name: "owner/repo1", name: "repo1", private: false,


### PR DESCRIPTION
## Summary
Fixes Paid auto-merge failures caused by sending an invalid `commit_message: nil` payload to GitHub when merging PRs.

## Changes
- send merge requests directly to GitHub with only the fields that are actually present
- add regression coverage for merge requests with and without a custom commit message

## Verification
- targeted RSpec: GithubClient + MergePullRequestActivity specs
- RuboCop on the touched files
- manually retried MergePullRequestActivity for PR #449 and confirmed it merged successfully
