### PR TITLE
Fix #325: Show PR/issue reference instead of branch name in agent runs table

### DIFF
--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -20,8 +20,14 @@
     <% end %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <% if agent_run.branch_name.present? %>
-      <code class="rounded bg-gray-100 px-1 py-0.5 text-xs"><%= agent_run.branch_name %></code>
+    <% context = agent_run_context(agent_run) %>
+    <% case context[:type] %>
+    <% when :link %>
+      <%= link_to context[:label], context[:url], target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
+    <% when :text %>
+      <span class="<%= context[:classes] %>"><%= context[:label] %></span>
+    <% when :pending %>
+      <span class="italic text-gray-500">Creating issue&hellip;</span>
     <% else %>
       <span class="text-gray-400">-</span>
     <% end %>

--- a/app/views/projects/_agent_runs.html.erb
+++ b/app/views/projects/_agent_runs.html.erb
@@ -15,7 +15,7 @@
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Trigger</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Priority</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Goal</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Branch</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Context</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Duration</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Started</th>
                   <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">


### PR DESCRIPTION
Commit successful. Here's a summary of the changes:

**Files changed:**
- `app/views/projects/_agent_runs.html.erb` - Renamed "Branch" column header to "Context"
- `app/views/projects/_agent_run.html.erb` - Replaced the branch name display with the `agent_run_context` helper, which shows:
  - For `create_pr` runs: the linked issue number (e.g., `#123`), source PR number, or result PR number
  - For `create_issue` runs: the created issue link, or "Creating issue..." while pending
  - For `review` runs: the source PR number
  - Fallback: a dash (`-`) placeholder

This reuses the existing `agent_run_context` helper that was already powering the dashboard's "Context" column in `_index_table.html.erb`, ensuring consistent display across views. Queued and pending runs now show their associated issue/PR reference instead of a blank cell.

---

Closes #325