### PR TITLE
fix(auto-pick): add periodic cron trigger for ProcessRunQueueJob

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -37,6 +37,11 @@ Rails.application.configure do
       cron: "0 */4 * * *",
       class: "AbTestAnalysisCheckJob",
       description: "Check running A/B tests for auto-completion"
+    },
+    process_run_queue: {
+      cron: "*/5 * * * *",
+      class: "ProcessRunQueueJob",
+      description: "Process queued agent runs and auto-pick eligible issues"
     }
   }
 end


### PR DESCRIPTION
## Summary
- `ProcessRunQueueJob` was only triggered reactively (run completions, auto-pick toggle, stale run detection). If the system went idle with no triggering events, auto-pick would never re-evaluate eligible issues — leaving agents idle for hours.
- Adds a 5-minute GoodJob cron entry to periodically trigger the job, matching the cadence of `stale_run_detector` and `poll_workflow_health_check`.
- Safe due to the job's existing PostgreSQL advisory lock — concurrent invocations are no-ops.

## Test plan
- [x] Existing `ProcessRunQueueJob` specs pass (17 examples, 0 failures)
- [ ] Verify in staging that the job runs on schedule via GoodJob dashboard
- [ ] Confirm auto-pick issues get picked up when system is idle with eligible issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)