### PR TITLE
Fix #490: fix(agent-runs): configure Gemini CLI sandboxing in agent containers

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -713,10 +713,16 @@ module Containers
       # Google proxy env vars are always set so Gemini CLI can route through
       # the secrets proxy. Gemini CLI has no native login equivalent to
       # `claude login`, so it always needs the proxy for auth.
+      #
+      # GEMINI_SANDBOX=false disables Gemini CLI's built-in sandbox layer.
+      # The agent already runs inside an isolated Docker container, so an
+      # inner sandbox is unnecessary and fails because neither Docker nor
+      # Podman is available inside the agent image.
       env.concat([
         "GOOGLE_GENAI_BASE_URL=#{proxy_base}/api/proxy/google",
         "GOOGLE_HEADER_X_AGENT_RUN_ID=#{agent_run.id}",
-        "GOOGLE_HEADER_X_PROXY_TOKEN=#{agent_run.proxy_token}"
+        "GOOGLE_HEADER_X_PROXY_TOKEN=#{agent_run.proxy_token}",
+        "GEMINI_SANDBOX=false"
       ])
 
       if subscription_auth?

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -255,6 +255,16 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
+      it "disables Gemini CLI sandbox since the container is already isolated" do
+        expect(Docker::Container).to receive(:create) do |config|
+          env = config["Env"]
+          expect(env).to include("GEMINI_SANDBOX=false")
+          mock_container
+        end
+
+        service.provision
+      end
+
       it "does not include API keys in environment variables" do
         expect(Docker::Container).to receive(:create) do |config|
           env = config["Env"]


### PR DESCRIPTION
Done. Here's a summary of the changes:

**`app/services/containers/provision.rb`** — Added `GEMINI_SANDBOX=false` to the container environment variables alongside the existing Google proxy config. This disables Gemini CLI's built-in sandbox auto-detection (which tries to find Docker/Podman inside the container and fails), since the agent already runs inside an isolated Docker container.

**`spec/services/containers/provision_spec.rb`** — Added a regression test verifying that `GEMINI_SANDBOX=false` is set in the container environment, preventing this from silently breaking again.

---

Closes #490