### PR TITLE
Fix #487: fix(agent-runs): update Codex CLI invocation for current codex version

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -16,7 +16,7 @@ module Activities
     AGENT_COMMANDS = {
       "claude_code" => %w[claude --print --output-format=text --dangerously-skip-permissions -p],
       "claude" => %w[claude --print --output-format=text --dangerously-skip-permissions -p],
-      "codex" => %w[codex exec --full-auto],
+      "codex" => %w[codex exec --full-auto --],
       "gemini" => %w[gemini -s],
       "kilocode" => %w[kilo run],
       "opencode" => %w[opencode --non-interactive --message],

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe Activities::RunAgentActivity do
 
     it "uses codex exec subcommand for non-interactive mode" do
       cmd = described_class::AGENT_COMMANDS["codex"]
-      expect(cmd).to eq(%w[codex exec --full-auto])
+      expect(cmd).to start_with("codex", "exec", "--full-auto")
+      expect(cmd).to include("--")
     end
 
     it "includes a command mapping for gemini" do


### PR DESCRIPTION
The background setup agent confirmed what we already found — PostgreSQL isn't reachable in this environment, but the fix is committed successfully. The commit passed lint (RuboCop, ESLint, markdownlint, ShellCheck) via the pre-commit hook.

---

Closes #487