### PR TITLE
Fix #502: Remove trigger column from agent runs table

### DIFF
--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -12,9 +12,6 @@
                   <%= sort_link_to "Status", :status, q %>
                 </th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                  Trigger
-                </th>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
                   Priority
                 </th>
                 <% if show_project %>
@@ -39,9 +36,6 @@
                 <tr>
                   <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
                     <%= agent_run_status_badge(run.status) %>
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <%= agent_run_trigger_badge(run.trigger_type) %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <%= agent_run_priority_badge(run) %>

--- a/app/views/agent_runs/_table.html.erb
+++ b/app/views/agent_runs/_table.html.erb
@@ -9,7 +9,6 @@
               <thead class="bg-gray-50">
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Status</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Trigger</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Priority</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Context</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Duration</th>
@@ -24,9 +23,6 @@
                   <tr>
                     <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
                       <%= agent_run_status_badge(run.status) %>
-                    </td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      <%= agent_run_trigger_badge(run.trigger_type) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <%= agent_run_priority_badge(run) %>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -3,9 +3,6 @@
     <%= agent_run_status_badge(agent_run.status) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <%= agent_run_trigger_badge(agent_run.trigger_type) %>
-  </td>
-  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
     <%= agent_run_priority_badge(agent_run) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/app/views/projects/_agent_runs.html.erb
+++ b/app/views/projects/_agent_runs.html.erb
@@ -12,7 +12,6 @@
               <thead class="bg-gray-50">
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Status</th>
-                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Trigger</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Priority</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Goal</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Context</th>


### PR DESCRIPTION
Done. The commit `a762b5a` removes the trigger column from all four agent runs table views:

- `app/views/agent_runs/_table.html.erb` — removed trigger header and cell
- `app/views/agent_runs/_index_table.html.erb` — removed trigger header and cell
- `app/views/projects/_agent_runs.html.erb` — removed trigger header
- `app/views/projects/_agent_run.html.erb` — removed trigger cell

The `agent_run_trigger_badge` helper and all filtering/model logic remain intact, so trigger-based filtering continues to work. The priority column is unchanged.

---

Closes #502