### PR TITLE
Fix #256: Analytical Collectors — ruby-maat Churn/Hotspots + scc Language Stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem "devise"
 # Authorization [https://github.com/varvet/pundit]
 gem "pundit"
 
+# CSV parsing (bundled gem since Ruby 3.4)
+gem "csv"
+
 # GitHub API client [https://github.com/octokit/octokit.rb]
 gem "octokit"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.5)
     cuprite (0.17)
       capybara (~> 3.0)
       ferrum (~> 0.17.0)
@@ -510,6 +511,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   cssbundling-rails
+  csv
   cuprite
   debug
   devise
@@ -576,6 +578,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cssbundling-rails (1.4.3) sha256=53aecd5a7d24ac9c8fcd92975acd0e830fead4ee4583d3d3d49bb64651946e41
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   cuprite (0.17) sha256=b140d5dc70d08b97ad54bcf45cd95d0bd430e291e9dffe76fff851fddd57c12b
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -39,12 +39,12 @@ module Knowledge
       path.exist? ? path.to_s : nil
     end
 
-    def run_command(command, timeout: 30)
+    def run_command(*argv, timeout: 30)
       stdout_str = +""
       stderr_str = +""
       status = nil
 
-      Open3.popen3(command, pgroup: true) do |stdin, stdout, stderr, wait_thr|
+      Open3.popen3(*argv, pgroup: true) do |stdin, stdout, stderr, wait_thr|
         stdin&.close
 
         out_thread = Thread.new { stdout_str << stdout.read.to_s }
@@ -58,9 +58,11 @@ module Knowledge
           end
         rescue Timeout::Error
           kill_process_group(wait_thr.pid)
-          out_thread.join(1)
-          err_thread.join(1)
-          raise Timeout::Error, "Command timed out after #{timeout} seconds: #{command}"
+          stdout.close unless stdout.closed?
+          stderr.close unless stderr.closed?
+          out_thread.join
+          err_thread.join
+          raise Timeout::Error, "Command timed out after #{timeout} seconds: #{argv.join(' ')}"
         ensure
           stdout.close unless stdout.closed?
           stderr.close unless stderr.closed?

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -87,7 +87,7 @@ module Knowledge
       end
 
       unless status&.success?
-        raise "Command failed (exit #{status&.exitstatus}): #{stderr_str.first(500)}"
+        raise "Command failed (exit #{status&.exitstatus}) for `#{argv.join(' ')}`: #{stderr_str.first(500)}"
       end
 
       stdout_str

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "open3"
+require "timeout"
+
 module Knowledge
   class BaseCollector
     attr_reader :project, :project_version, :collector_run
@@ -23,6 +26,61 @@ module Knowledge
 
     def tool_version
       nil
+    end
+
+    private
+
+    def resolve_repo_path
+      project.worktrees.order(created_at: :desc).first&.path || default_repo_path
+    end
+
+    def default_repo_path
+      path = Rails.root.join("tmp", "repos", project.id.to_s)
+      path.exist? ? path.to_s : nil
+    end
+
+    def run_command(command, timeout: 30)
+      stdout_str = +""
+      stderr_str = +""
+      status = nil
+
+      Open3.popen3(command, pgroup: true) do |stdin, stdout, stderr, wait_thr|
+        stdin&.close
+
+        out_thread = Thread.new { stdout_str << stdout.read.to_s }
+        err_thread = Thread.new { stderr_str << stderr.read.to_s }
+
+        begin
+          Timeout.timeout(timeout) do
+            status = wait_thr.value
+            out_thread.join
+            err_thread.join
+          end
+        rescue Timeout::Error
+          kill_process_group(wait_thr.pid)
+          out_thread.join(1)
+          err_thread.join(1)
+          raise Timeout::Error, "Command timed out after #{timeout} seconds: #{command}"
+        ensure
+          stdout.close unless stdout.closed?
+          stderr.close unless stderr.closed?
+        end
+      end
+
+      unless status&.success?
+        raise "Command failed (exit #{status&.exitstatus}): #{stderr_str.first(500)}"
+      end
+
+      stdout_str
+    end
+
+    def kill_process_group(pid)
+      pgid = Process.getpgid(pid)
+      Process.kill("TERM", -pgid)
+      sleep 1
+      Process.kill("KILL", -pgid)
+    rescue Errno::ESRCH, Errno::EPERM
+      # Process already exited or cannot be signaled
     end
   end
 end

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -58,11 +58,16 @@ module Knowledge
           end
         rescue Timeout::Error
           kill_process_group(wait_thr.pid)
-          wait_thr.value # reap the child process to avoid zombies
+          # Reap with a short timeout to avoid blocking forever if the process
+          # cannot be signaled (e.g. EPERM from kill_process_group).
+          reap_thread = Thread.new { wait_thr.value }
+          unless reap_thread.join(5)
+            reap_thread.kill
+          end
           stdout.close unless stdout.closed?
           stderr.close unless stderr.closed?
-          out_thread.join
-          err_thread.join
+          out_thread.join(5)
+          err_thread.join(5)
           raise Timeout::Error, "Command timed out after #{timeout} seconds: #{argv.join(' ')}"
         ensure
           stdout.close unless stdout.closed?

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -77,8 +77,14 @@ module Knowledge
           end
           stdout.close unless stdout.closed?
           stderr.close unless stderr.closed?
-          out_thread.join(5)
-          err_thread.join(5)
+          out_thread.join(5) || begin
+            out_thread.kill
+            out_thread.join
+          end
+          err_thread.join(5) || begin
+            err_thread.kill
+            err_thread.join
+          end
           raise Timeout::Error, "Command timed out after #{timeout} seconds: #{argv.join(' ')}"
         ensure
           stdout.close unless stdout.closed?

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -58,6 +58,7 @@ module Knowledge
           end
         rescue Timeout::Error
           kill_process_group(wait_thr.pid)
+          wait_thr.value # reap the child process to avoid zombies
           stdout.close unless stdout.closed?
           stderr.close unless stderr.closed?
           out_thread.join

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -78,6 +78,8 @@ module Knowledge
     end
 
     def kill_process_group(pid)
+      # Errno::ESRCH from getpgid (process already exited) is caught by the
+      # method-level rescue below, keeping timeout cleanup deterministic.
       pgid = Process.getpgid(pid)
       Process.kill("TERM", -pgid)
       sleep 1

--- a/app/services/knowledge/collectors/churn_hotspot_collector.rb
+++ b/app/services/knowledge/collectors/churn_hotspot_collector.rb
@@ -99,7 +99,7 @@ module Knowledge
           revs = revision_map.fetch(file, 0)
           complexity = hotspot_map.fetch(file, 0)
           { file: file, revisions: revs, complexity: complexity, score: revs * complexity }
-        end.sort_by { |e| -e[:score] }
+        end.sort_by { |e| [ -e[:score], -e[:revisions], -e[:complexity], e[:file] ] }
       end
 
       def build_artifact(entry, rank)

--- a/app/services/knowledge/collectors/churn_hotspot_collector.rb
+++ b/app/services/knowledge/collectors/churn_hotspot_collector.rb
@@ -2,6 +2,7 @@
 
 require "open3"
 require "shellwords"
+require "timeout"
 
 module Knowledge
   module Collectors
@@ -34,7 +35,7 @@ module Knowledge
       private
 
       def resolve_repo_path
-        project.worktrees.order(created_at: :desc).first&.host_path || default_repo_path
+        project.worktrees.order(created_at: :desc).first&.path || default_repo_path
       end
 
       def default_repo_path
@@ -59,7 +60,7 @@ module Knowledge
       end
 
       def run_command(command, timeout: 30)
-        stdout, stderr, status = Open3.capture3(command, timeout: timeout)
+        stdout, stderr, status = Timeout.timeout(timeout) { Open3.capture3(command) }
         unless status.success?
           raise "Command failed (exit #{status.exitstatus}): #{stderr.first(500)}"
         end

--- a/app/services/knowledge/collectors/churn_hotspot_collector.rb
+++ b/app/services/knowledge/collectors/churn_hotspot_collector.rb
@@ -123,8 +123,14 @@ module Knowledge
         traits << "#{revisions} revisions" if revisions > 0
         traits << "complexity #{complexity}" if complexity > 0
 
-        if traits.any?
+        if revisions > 0 && complexity > 0
+          "#{file} has high churn and complexity (#{traits.join(', ')}, rank ##{rank}). " \
+            "Changes here need careful review."
+        elsif revisions > 0
           "#{file} is a high-churn file (#{traits.join(', ')}, rank ##{rank}). " \
+            "Changes here need careful review."
+        elsif complexity > 0
+          "#{file} is a complexity hotspot (#{traits.join(', ')}, rank ##{rank}). " \
             "Changes here need careful review."
         else
           "#{file} (rank ##{rank}): no significant churn or complexity detected."

--- a/app/services/knowledge/collectors/churn_hotspot_collector.rb
+++ b/app/services/knowledge/collectors/churn_hotspot_collector.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "open3"
+require "csv"
 require "shellwords"
-require "timeout"
 
 module Knowledge
   module Collectors
@@ -34,15 +33,6 @@ module Knowledge
 
       private
 
-      def resolve_repo_path
-        project.worktrees.order(created_at: :desc).first&.path || default_repo_path
-      end
-
-      def default_repo_path
-        path = Rails.root.join("tmp", "repos", project.id.to_s)
-        path.exist? ? path.to_s : nil
-      end
-
       def run_maat(repo_path, analysis)
         output = run_command(
           "maat -c git2 -l #{Shellwords.escape(repo_path)} -a #{analysis}",
@@ -59,27 +49,13 @@ module Knowledge
         []
       end
 
-      def run_command(command, timeout: 30)
-        stdout, stderr, status = Timeout.timeout(timeout) { Open3.capture3(command) }
-        unless status.success?
-          raise "Command failed (exit #{status.exitstatus}): #{stderr.first(500)}"
-        end
-        stdout
-      end
-
       def parse_csv(output)
         return [] if output.blank?
 
-        lines = output.strip.split("\n")
-        return [] if lines.size < 2
-
-        headers = lines.first.split(",").map(&:strip)
-        lines.drop(1).filter_map do |line|
-          values = line.split(",").map(&:strip)
-          next if values.size < headers.size
-
-          headers.zip(values).to_h
-        end
+        rows = CSV.parse(output, headers: true)
+        rows.map(&:to_h)
+      rescue CSV::MalformedCSVError
+        []
       end
 
       def build_artifacts(revisions, hotspots)
@@ -135,12 +111,24 @@ module Knowledge
           chunks: [
             {
               chunk_type: "summary",
-              content: "#{file} is a high-churn file (#{revisions} revisions, rank ##{rank}). " \
-                       "Changes here need careful review.",
+              content: build_chunk_text(file, revisions, complexity, rank),
               scope_tags: [ "churn", "hotspot" ]
             }
           ]
         }
+      end
+
+      def build_chunk_text(file, revisions, complexity, rank)
+        traits = []
+        traits << "#{revisions} revisions" if revisions > 0
+        traits << "complexity #{complexity}" if complexity > 0
+
+        if traits.any?
+          "#{file} is a high-churn file (#{traits.join(', ')}, rank ##{rank}). " \
+            "Changes here need careful review."
+        else
+          "#{file} (rank ##{rank}): no significant churn or complexity detected."
+        end
       end
     end
   end

--- a/app/services/knowledge/collectors/churn_hotspot_collector.rb
+++ b/app/services/knowledge/collectors/churn_hotspot_collector.rb
@@ -53,7 +53,13 @@ module Knowledge
 
         rows = CSV.parse(output, headers: true)
         rows.map(&:to_h)
-      rescue CSV::MalformedCSVError
+      rescue CSV::MalformedCSVError => e
+        Rails.logger.warn(
+          message: "knowledge.churn_hotspot_collector.malformed_csv",
+          project_id: project.id,
+          error: e.message,
+          output_snippet: output.to_s.first(200)
+        )
         []
       end
 

--- a/app/services/knowledge/collectors/churn_hotspot_collector.rb
+++ b/app/services/knowledge/collectors/churn_hotspot_collector.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "open3"
+require "shellwords"
+
+module Knowledge
+  module Collectors
+    class ChurnHotspotCollector < BaseCollector
+      MAAT_TIMEOUT = 120 # seconds
+
+      def collect
+        repo_path = resolve_repo_path
+        return [] unless repo_path
+
+        revisions = run_maat(repo_path, "revisions")
+        hotspots = run_maat(repo_path, "hotspots")
+
+        return [] if revisions.empty? && hotspots.empty?
+
+        build_artifacts(revisions, hotspots)
+      end
+
+      def collector_type
+        "churn_hotspot"
+      end
+
+      def tool_version
+        version_output = run_command("maat --version")
+        version_output.strip.presence
+      rescue StandardError
+        nil
+      end
+
+      private
+
+      def resolve_repo_path
+        project.worktrees.order(created_at: :desc).first&.host_path || default_repo_path
+      end
+
+      def default_repo_path
+        path = Rails.root.join("tmp", "repos", project.id.to_s)
+        path.exist? ? path.to_s : nil
+      end
+
+      def run_maat(repo_path, analysis)
+        output = run_command(
+          "maat -c git2 -l #{Shellwords.escape(repo_path)} -a #{analysis}",
+          timeout: MAAT_TIMEOUT
+        )
+        parse_csv(output)
+      rescue StandardError => e
+        Rails.logger.warn(
+          message: "knowledge.churn_hotspot_collector.maat_failed",
+          analysis: analysis,
+          project_id: project.id,
+          error: e.message
+        )
+        []
+      end
+
+      def run_command(command, timeout: 30)
+        stdout, stderr, status = Open3.capture3(command, timeout: timeout)
+        unless status.success?
+          raise "Command failed (exit #{status.exitstatus}): #{stderr.first(500)}"
+        end
+        stdout
+      end
+
+      def parse_csv(output)
+        return [] if output.blank?
+
+        lines = output.strip.split("\n")
+        return [] if lines.size < 2
+
+        headers = lines.first.split(",").map(&:strip)
+        lines.drop(1).filter_map do |line|
+          values = line.split(",").map(&:strip)
+          next if values.size < headers.size
+
+          headers.zip(values).to_h
+        end
+      end
+
+      def build_artifacts(revisions, hotspots)
+        revision_map = build_revision_map(revisions)
+        hotspot_map = build_hotspot_map(hotspots)
+
+        all_files = (revision_map.keys + hotspot_map.keys).uniq
+        ranked = rank_files(all_files, revision_map, hotspot_map)
+
+        ranked.each_with_index.map do |entry, index|
+          rank = index + 1
+          build_artifact(entry, rank)
+        end
+      end
+
+      def build_revision_map(revisions)
+        revisions.each_with_object({}) do |row, map|
+          entity = row["entity"]
+          next unless entity
+
+          map[entity] = (row["n-revs"] || row["revisions"] || "0").to_i
+        end
+      end
+
+      def build_hotspot_map(hotspots)
+        hotspots.each_with_object({}) do |row, map|
+          entity = row["entity"] || row["module"]
+          next unless entity
+
+          map[entity] = (row["code"] || row["complexity"] || "0").to_i
+        end
+      end
+
+      def rank_files(files, revision_map, hotspot_map)
+        files.map do |file|
+          revs = revision_map.fetch(file, 0)
+          complexity = hotspot_map.fetch(file, 0)
+          { file: file, revisions: revs, complexity: complexity, score: revs * complexity }
+        end.sort_by { |e| -e[:score] }
+      end
+
+      def build_artifact(entry, rank)
+        file = entry[:file]
+        revisions = entry[:revisions]
+        complexity = entry[:complexity]
+
+        {
+          artifact_type: "churn_hotspot",
+          scope_path: file,
+          identifier: file,
+          content: "Churn hotspot: #{file} — #{revisions} revisions, complexity score #{complexity}",
+          metadata: { revisions: revisions, complexity: complexity, rank: rank },
+          chunks: [
+            {
+              chunk_type: "summary",
+              content: "#{file} is a high-churn file (#{revisions} revisions, rank ##{rank}). " \
+                       "Changes here need careful review.",
+              scope_tags: [ "churn", "hotspot" ]
+            }
+          ]
+        }
+      end
+    end
+  end
+end

--- a/app/services/knowledge/collectors/churn_hotspot_collector.rb
+++ b/app/services/knowledge/collectors/churn_hotspot_collector.rb
@@ -121,7 +121,12 @@ module Knowledge
         traits = []
         traits << "#{revisions} revisions" if revisions > 0
         traits << "complexity score #{complexity}" if complexity > 0
-        "Churn hotspot: #{file} — #{traits.join(', ')}"
+
+        if traits.empty?
+          "Churn hotspot: #{file} — no significant churn or complexity detected."
+        else
+          "Churn hotspot: #{file} — #{traits.join(', ')}"
+        end
       end
 
       def build_chunk_text(file, revisions, complexity, rank)

--- a/app/services/knowledge/collectors/churn_hotspot_collector.rb
+++ b/app/services/knowledge/collectors/churn_hotspot_collector.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "csv"
-require "shellwords"
 
 module Knowledge
   module Collectors
@@ -25,7 +24,7 @@ module Knowledge
       end
 
       def tool_version
-        version_output = run_command("maat --version")
+        version_output = run_command("maat", "--version")
         version_output.strip.presence
       rescue StandardError
         nil
@@ -35,7 +34,7 @@ module Knowledge
 
       def run_maat(repo_path, analysis)
         output = run_command(
-          "maat -c git2 -l #{Shellwords.escape(repo_path)} -a #{analysis}",
+          "maat", "-c", "git2", "-l", repo_path, "-a", analysis,
           timeout: MAAT_TIMEOUT
         )
         parse_csv(output)
@@ -106,7 +105,7 @@ module Knowledge
           artifact_type: "churn_hotspot",
           scope_path: file,
           identifier: file,
-          content: "Churn hotspot: #{file} — #{revisions} revisions, complexity score #{complexity}",
+          content: build_content(file, revisions, complexity),
           metadata: { revisions: revisions, complexity: complexity, rank: rank },
           chunks: [
             {
@@ -116,6 +115,13 @@ module Knowledge
             }
           ]
         }
+      end
+
+      def build_content(file, revisions, complexity)
+        traits = []
+        traits << "#{revisions} revisions" if revisions > 0
+        traits << "complexity score #{complexity}" if complexity > 0
+        "Churn hotspot: #{file} — #{traits.join(', ')}"
       end
 
       def build_chunk_text(file, revisions, complexity, rank)

--- a/app/services/knowledge/collectors/language_stats_collector.rb
+++ b/app/services/knowledge/collectors/language_stats_collector.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
-require "open3"
 require "shellwords"
-require "timeout"
 
 module Knowledge
   module Collectors
@@ -33,15 +31,6 @@ module Knowledge
 
       private
 
-      def resolve_repo_path
-        project.worktrees.order(created_at: :desc).first&.path || default_repo_path
-      end
-
-      def default_repo_path
-        path = Rails.root.join("tmp", "repos", project.id.to_s)
-        path.exist? ? path.to_s : nil
-      end
-
       def run_scc(repo_path)
         output = run_command(
           "scc --format json #{Shellwords.escape(repo_path)}",
@@ -55,14 +44,6 @@ module Knowledge
           error: e.message
         )
         []
-      end
-
-      def run_command(command, timeout: 30)
-        stdout, stderr, status = Timeout.timeout(timeout) { Open3.capture3(command) }
-        unless status.success?
-          raise "Command failed (exit #{status.exitstatus}): #{stderr.first(500)}"
-        end
-        stdout
       end
 
       def parse_scc_json(output)

--- a/app/services/knowledge/collectors/language_stats_collector.rb
+++ b/app/services/knowledge/collectors/language_stats_collector.rb
@@ -3,6 +3,7 @@
 require "json"
 require "open3"
 require "shellwords"
+require "timeout"
 
 module Knowledge
   module Collectors
@@ -33,7 +34,7 @@ module Knowledge
       private
 
       def resolve_repo_path
-        project.worktrees.order(created_at: :desc).first&.host_path || default_repo_path
+        project.worktrees.order(created_at: :desc).first&.path || default_repo_path
       end
 
       def default_repo_path
@@ -57,7 +58,7 @@ module Knowledge
       end
 
       def run_command(command, timeout: 30)
-        stdout, stderr, status = Open3.capture3(command, timeout: timeout)
+        stdout, stderr, status = Timeout.timeout(timeout) { Open3.capture3(command) }
         unless status.success?
           raise "Command failed (exit #{status.exitstatus}): #{stderr.first(500)}"
         end

--- a/app/services/knowledge/collectors/language_stats_collector.rb
+++ b/app/services/knowledge/collectors/language_stats_collector.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "json"
-require "shellwords"
 
 module Knowledge
   module Collectors
@@ -23,7 +22,7 @@ module Knowledge
       end
 
       def tool_version
-        output = run_command("scc --version")
+        output = run_command("scc", "--version")
         output.strip.presence
       rescue StandardError
         nil
@@ -33,7 +32,7 @@ module Knowledge
 
       def run_scc(repo_path)
         output = run_command(
-          "scc --format json #{Shellwords.escape(repo_path)}",
+          "scc", "--format", "json", repo_path,
           timeout: SCC_TIMEOUT
         )
         parse_scc_json(output)
@@ -72,7 +71,10 @@ module Knowledge
           artifact_type: "language_stat",
           scope_path: nil,
           identifier: lang[:name],
-          content: "#{lang[:name]}: #{number_with_delimiter(lang[:code])} lines of code across #{lang[:files]} files",
+          content: "#{lang[:name]}: #{number_with_delimiter(lang[:code])} lines of code, " \
+                   "#{number_with_delimiter(lang[:comments])} comments, " \
+                   "#{number_with_delimiter(lang[:blanks])} blanks, " \
+                   "#{number_with_delimiter(lang[:lines])} total lines across #{lang[:files]} files",
           metadata: {
             files: lang[:files],
             lines: lang[:lines],

--- a/app/services/knowledge/collectors/language_stats_collector.rb
+++ b/app/services/knowledge/collectors/language_stats_collector.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "shellwords"
+
+module Knowledge
+  module Collectors
+    class LanguageStatsCollector < BaseCollector
+      SCC_TIMEOUT = 60 # seconds
+
+      def collect
+        repo_path = resolve_repo_path
+        return [] unless repo_path
+
+        languages = run_scc(repo_path)
+        return [] if languages.empty?
+
+        languages.map { |lang| build_artifact(lang) }
+      end
+
+      def collector_type
+        "language_stat"
+      end
+
+      def tool_version
+        output = run_command("scc --version")
+        output.strip.presence
+      rescue StandardError
+        nil
+      end
+
+      private
+
+      def resolve_repo_path
+        project.worktrees.order(created_at: :desc).first&.host_path || default_repo_path
+      end
+
+      def default_repo_path
+        path = Rails.root.join("tmp", "repos", project.id.to_s)
+        path.exist? ? path.to_s : nil
+      end
+
+      def run_scc(repo_path)
+        output = run_command(
+          "scc --format json #{Shellwords.escape(repo_path)}",
+          timeout: SCC_TIMEOUT
+        )
+        parse_scc_json(output)
+      rescue StandardError => e
+        Rails.logger.warn(
+          message: "knowledge.language_stats_collector.scc_failed",
+          project_id: project.id,
+          error: e.message
+        )
+        []
+      end
+
+      def run_command(command, timeout: 30)
+        stdout, stderr, status = Open3.capture3(command, timeout: timeout)
+        unless status.success?
+          raise "Command failed (exit #{status.exitstatus}): #{stderr.first(500)}"
+        end
+        stdout
+      end
+
+      def parse_scc_json(output)
+        return [] if output.blank?
+
+        data = JSON.parse(output)
+        return [] unless data.is_a?(Array)
+
+        data.filter_map do |entry|
+          name = entry["Name"]
+          next unless name
+
+          {
+            name: name,
+            files: entry["Count"] || 0,
+            lines: entry["Lines"] || 0,
+            code: entry["Code"] || 0,
+            comments: entry["Comment"] || 0,
+            blanks: entry["Blank"] || 0
+          }
+        end
+      end
+
+      def build_artifact(lang)
+        {
+          artifact_type: "language_stat",
+          scope_path: nil,
+          identifier: lang[:name],
+          content: "#{lang[:name]}: #{number_with_delimiter(lang[:code])} lines of code across #{lang[:files]} files",
+          metadata: {
+            files: lang[:files],
+            lines: lang[:lines],
+            code: lang[:code],
+            comments: lang[:comments],
+            blanks: lang[:blanks]
+          },
+          chunks: [
+            {
+              chunk_type: "summary",
+              content: "The project contains #{lang[:name]} code: " \
+                       "#{number_with_delimiter(lang[:code])} lines of code, " \
+                       "#{number_with_delimiter(lang[:comments])} comments, " \
+                       "across #{lang[:files]} files.",
+              scope_tags: [ "language", "stats" ]
+            }
+          ]
+        }
+      end
+
+      def number_with_delimiter(number)
+        number.to_s.reverse.scan(/\d{1,3}/).join(",").reverse
+      end
+    end
+  end
+end

--- a/config/initializers/knowledge_collectors.rb
+++ b/config/initializers/knowledge_collectors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  Knowledge::CollectorRunner.register("churn_hotspot", Knowledge::Collectors::ChurnHotspotCollector)
+  Knowledge::CollectorRunner.register("language_stat", Knowledge::Collectors::LanguageStatsCollector)
+end

--- a/config/initializers/knowledge_collectors.rb
+++ b/config/initializers/knowledge_collectors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Rails.application.config.after_initialize do
+Rails.application.config.to_prepare do
   Knowledge::CollectorRunner.register("churn_hotspot", Knowledge::Collectors::ChurnHotspotCollector)
   Knowledge::CollectorRunner.register("language_stat", Knowledge::Collectors::LanguageStatsCollector)
 end

--- a/spec/fixtures/files/knowledge/maat_hotspots.csv
+++ b/spec/fixtures/files/knowledge/maat_hotspots.csv
@@ -1,0 +1,5 @@
+entity,code
+app/models/agent_run.rb,23
+app/models/project.rb,15
+app/controllers/projects_controller.rb,42
+config/routes.rb,3

--- a/spec/fixtures/files/knowledge/maat_revisions.csv
+++ b/spec/fixtures/files/knowledge/maat_revisions.csv
@@ -1,0 +1,5 @@
+entity,n-revs
+app/models/agent_run.rb,47
+app/models/project.rb,32
+app/controllers/projects_controller.rb,18
+lib/utils/helper.rb,5

--- a/spec/fixtures/files/knowledge/scc_output.json
+++ b/spec/fixtures/files/knowledge/scc_output.json
@@ -1,0 +1,26 @@
+[
+  {
+    "Name": "Ruby",
+    "Count": 187,
+    "Lines": 15234,
+    "Code": 12456,
+    "Comment": 1890,
+    "Blank": 888
+  },
+  {
+    "Name": "JavaScript",
+    "Count": 45,
+    "Lines": 3200,
+    "Code": 2800,
+    "Comment": 200,
+    "Blank": 200
+  },
+  {
+    "Name": "YAML",
+    "Count": 12,
+    "Lines": 450,
+    "Code": 400,
+    "Comment": 30,
+    "Blank": 20
+  }
+]

--- a/spec/lib/dev_script_spec.rb
+++ b/spec/lib/dev_script_spec.rb
@@ -5,8 +5,10 @@ require "fileutils"
 require "open3"
 require "socket"
 require "tmpdir"
+require_relative "../support/exec_tmpdir"
 
 RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
+  include ExecTmpdir
   let(:script_source) { File.expand_path("../../bin/dev", __dir__) }
 
   it "removes a stale Overmind socket before starting overmind" do
@@ -64,18 +66,5 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
     UNIXServer.open(socket_path) { |server| server.close }
     expect(File.socket?(socket_path)).to be(true)
     socket_path
-  end
-
-  def exec_tmpdir
-    %w[/tmp /workspace/tmp].find { |d| File.directory?(d) && exec_allowed?(d) }
-  end
-
-  def exec_allowed?(dir)
-    Dir.mktmpdir(nil, dir) do |d|
-      f = File.join(d, "t.sh")
-      File.write(f, "#!/bin/sh\nexit 0\n")
-      File.chmod(0o755, f)
-      system(f, out: File::NULL, err: File::NULL)
-    end
   end
 end

--- a/spec/lib/dev_script_spec.rb
+++ b/spec/lib/dev_script_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
   let(:script_source) { File.expand_path("../../bin/dev", __dir__) }
 
   it "removes a stale Overmind socket before starting overmind" do
-    Dir.mktmpdir("dev-script-spec") do |dir|
+    Dir.mktmpdir("dev-script-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir)
       socket_path = create_stale_socket(dir)
 
@@ -64,5 +64,18 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
     UNIXServer.open(socket_path) { |server| server.close }
     expect(File.socket?(socket_path)).to be(true)
     socket_path
+  end
+
+  def exec_tmpdir
+    %w[/tmp /workspace/tmp].find { |d| File.directory?(d) && exec_allowed?(d) }
+  end
+
+  def exec_allowed?(dir)
+    Dir.mktmpdir(nil, dir) do |d|
+      f = File.join(d, "t.sh")
+      File.write(f, "#!/bin/sh\nexit 0\n")
+      File.chmod(0o755, f)
+      system(f, out: File::NULL, err: File::NULL)
+    end
   end
 end

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -6,8 +6,10 @@ require "open3"
 require "socket"
 require "tmpdir"
 require "timeout"
+require_relative "../support/exec_tmpdir"
 
 RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
+  include ExecTmpdir
   let(:script_source) { File.expand_path("../../bin/dev-update", __dir__) }
 
   it "removes a stale Overmind socket before restarting the dev environment" do
@@ -108,18 +110,5 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     UNIXServer.open(socket_path) { |server| server.close }
     expect(File.socket?(socket_path)).to be(true)
     socket_path
-  end
-
-  def exec_tmpdir
-    %w[/tmp /workspace/tmp].find { |d| File.directory?(d) && exec_allowed?(d) }
-  end
-
-  def exec_allowed?(dir)
-    Dir.mktmpdir(nil, dir) do |d|
-      f = File.join(d, "t.sh")
-      File.write(f, "#!/bin/sh\nexit 0\n")
-      File.chmod(0o755, f)
-      system(f, out: File::NULL, err: File::NULL)
-    end
   end
 end

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
   let(:script_source) { File.expand_path("../../bin/dev-update", __dir__) }
 
   it "removes a stale Overmind socket before restarting the dev environment" do
-    Dir.mktmpdir("dev-update-spec") do |dir|
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir)
       socket_path = create_stale_socket(dir)
 
@@ -108,5 +108,18 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     UNIXServer.open(socket_path) { |server| server.close }
     expect(File.socket?(socket_path)).to be(true)
     socket_path
+  end
+
+  def exec_tmpdir
+    %w[/tmp /workspace/tmp].find { |d| File.directory?(d) && exec_allowed?(d) }
+  end
+
+  def exec_allowed?(dir)
+    Dir.mktmpdir(nil, dir) do |d|
+      f = File.join(d, "t.sh")
+      File.write(f, "#!/bin/sh\nexit 0\n")
+      File.chmod(0o755, f)
+      system(f, out: File::NULL, err: File::NULL)
+    end
   end
 end

--- a/spec/services/knowledge/base_collector_spec.rb
+++ b/spec/services/knowledge/base_collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Knowledge::BaseCollector do
+RSpec.describe Knowledge::BaseCollector, :no_db do
   subject(:collector) do
     described_class.new(
       project: project,
@@ -11,10 +11,9 @@ RSpec.describe Knowledge::BaseCollector do
     )
   end
 
-  let(:project) { build(:project) }
-  let(:project_version) { build(:project_version, project: project) }
-  let(:collector_run) { build(:collector_run, project_version: project_version) }
-
+  let(:project) { Struct.new(:id).new(1) }
+  let(:project_version) { Struct.new(:id).new(1) }
+  let(:collector_run) { Struct.new(:id).new(1) }
 
   describe "#collect" do
     it "raises NotImplementedError" do
@@ -31,6 +30,46 @@ RSpec.describe Knowledge::BaseCollector do
   describe "#tool_version" do
     it "returns nil by default" do
       expect(collector.tool_version).to be_nil
+    end
+  end
+
+  describe "#run_command" do
+    it "returns stdout on success" do
+      result = collector.send(:run_command, "echo", "hello", timeout: 5)
+
+      expect(result.strip).to eq("hello")
+    end
+
+    it "raises on non-zero exit status with stderr in message" do
+      expect do
+        collector.send(:run_command, "sh", "-c", "echo oops >&2; exit 1", timeout: 5)
+      end.to raise_error(RuntimeError, /exit 1.*oops/)
+    end
+
+    it "raises Timeout::Error when command exceeds timeout" do
+      expect do
+        collector.send(:run_command, "sleep", "60", timeout: 1)
+      end.to raise_error(Timeout::Error, /timed out after 1 seconds/i)
+    end
+
+    it "closes stdout and stderr even on timeout" do
+      # Verify that the process is cleaned up by checking that no zombie
+      # processes are left. We just need this to not hang.
+      expect do
+        collector.send(:run_command, "sleep", "60", timeout: 1)
+      end.to raise_error(Timeout::Error)
+    end
+
+    it "includes command in non-zero exit error message" do
+      expect do
+        collector.send(:run_command, "sh", "-c", "exit 42", timeout: 5)
+      end.to raise_error(RuntimeError, /sh -c exit 42/)
+    end
+
+    it "includes command in timeout error message" do
+      expect do
+        collector.send(:run_command, "sleep", "60", timeout: 1)
+      end.to raise_error(Timeout::Error, /sleep 60/)
     end
   end
 end

--- a/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
+++ b/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
         expect(identifiers).to include("config/routes.rb")
       end
 
-      it "does not describe revision-only files as high-churn when complexity is 0" do
+      it "omits complexity from revision-only file summaries" do
         artifact = collector.collect.find { |a| a[:identifier] == "lib/utils/helper.rb" }
         chunk = artifact[:chunks].first
 

--- a/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
+++ b/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
+  subject(:collector) do
+    described_class.new(
+      project: project,
+      project_version: project_version,
+      collector_run: collector_run
+    )
+  end
+
+  let(:project) { build(:project) }
+  let(:project_version) { build(:project_version, project: project) }
+  let(:collector_run) { build(:collector_run, project_version: project_version) }
+
+  let(:revisions_csv) { file_fixture("knowledge/maat_revisions.csv").read }
+  let(:hotspots_csv) { file_fixture("knowledge/maat_hotspots.csv").read }
+  let(:repo_path) { "/tmp/test-repo" }
+  let(:worktree) { instance_double(Worktree, host_path: repo_path) }
+  let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: worktree) }
+
+  before do
+    allow(project).to receive(:worktrees).and_return(
+      instance_double(ActiveRecord::Relation, order: worktrees_relation)
+    )
+  end
+
+  describe "#collector_type" do
+    it "returns 'churn_hotspot'" do
+      expect(collector.collector_type).to eq("churn_hotspot")
+    end
+  end
+
+  describe "#tool_version" do
+    it "returns maat version when available" do
+      allow(Open3).to receive(:capture3)
+        .with("maat --version", timeout: 30)
+        .and_return([ "maat 1.0.4\n", "", instance_double(Process::Status, success?: true) ])
+
+      expect(collector.tool_version).to eq("maat 1.0.4")
+    end
+
+    it "returns nil when maat is not installed" do
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+
+      expect(collector.tool_version).to be_nil
+    end
+  end
+
+  describe "#collect" do
+    context "when maat produces valid output" do
+      before do
+        allow(Open3).to receive(:capture3)
+          .with("maat -c git2 -l /tmp/test-repo -a revisions", timeout: 120)
+          .and_return([ revisions_csv, "", instance_double(Process::Status, success?: true) ])
+        allow(Open3).to receive(:capture3)
+          .with("maat -c git2 -l /tmp/test-repo -a hotspots", timeout: 120)
+          .and_return([ hotspots_csv, "", instance_double(Process::Status, success?: true) ])
+      end
+
+      it "returns artifacts sorted by score (revisions * complexity)" do
+        artifacts = collector.collect
+
+        expect(artifacts.size).to eq(5)
+        expect(artifacts.first[:identifier]).to eq("app/controllers/projects_controller.rb")
+      end
+
+      it "produces artifacts with correct structure" do
+        artifact = collector.collect.find { |a| a[:identifier] == "app/models/agent_run.rb" }
+
+        expect(artifact[:artifact_type]).to eq("churn_hotspot")
+        expect(artifact[:scope_path]).to eq("app/models/agent_run.rb")
+        expect(artifact[:content]).to include("47 revisions")
+        expect(artifact[:content]).to include("complexity score 23")
+      end
+
+      it "populates metadata with revisions, complexity, and rank" do
+        artifact = collector.collect.find { |a| a[:identifier] == "app/models/agent_run.rb" }
+
+        expect(artifact[:metadata][:revisions]).to eq(47)
+        expect(artifact[:metadata][:complexity]).to eq(23)
+        expect(artifact[:metadata][:rank]).to be_a(Integer)
+      end
+
+      it "includes summary chunks" do
+        artifact = collector.collect.find { |a| a[:identifier] == "app/models/agent_run.rb" }
+        chunk = artifact[:chunks].first
+
+        expect(chunk[:chunk_type]).to eq("summary")
+        expect(chunk[:content]).to include("47 revisions")
+        expect(chunk[:scope_tags]).to eq([ "churn", "hotspot" ])
+      end
+
+      it "ranks files by score descending" do
+        artifacts = collector.collect
+        scores = artifacts.map { |a| a[:metadata][:revisions] * a[:metadata][:complexity] }
+
+        expect(scores).to eq(scores.sort.reverse)
+      end
+
+      it "includes files that appear in only one analysis" do
+        artifacts = collector.collect
+        identifiers = artifacts.map { |a| a[:identifier] }
+
+        expect(identifiers).to include("lib/utils/helper.rb")
+        expect(identifiers).to include("config/routes.rb")
+      end
+    end
+
+    context "when no repo path is available" do
+      let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: nil) }
+
+      before do
+        allow(Rails.root).to receive(:join).and_return(Pathname.new("/nonexistent/path"))
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+
+    context "when maat fails" do
+      before do
+        allow(Open3).to receive(:capture3).and_return(
+          [ "", "error", instance_double(Process::Status, success?: false, exitstatus: 1) ]
+        )
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+
+    context "when maat produces empty output" do
+      before do
+        allow(Open3).to receive(:capture3).and_return(
+          [ "", "", instance_double(Process::Status, success?: true) ]
+        )
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+
+    context "when maat produces header-only output" do
+      before do
+        allow(Open3).to receive(:capture3).and_return(
+          [ "entity,n-revs\n", "", instance_double(Process::Status, success?: true) ]
+        )
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
+++ b/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
   let(:revisions_csv) { file_fixture("knowledge/maat_revisions.csv").read }
   let(:hotspots_csv) { file_fixture("knowledge/maat_hotspots.csv").read }
   let(:repo_path) { "/tmp/test-repo" }
-  let(:worktree) { instance_double(Worktree, host_path: repo_path) }
+  let(:worktree) { instance_double(Worktree, path: repo_path) }
   let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: worktree) }
 
   before do
@@ -36,7 +36,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
   describe "#tool_version" do
     it "returns maat version when available" do
       allow(Open3).to receive(:capture3)
-        .with("maat --version", timeout: 30)
+        .with("maat --version")
         .and_return([ "maat 1.0.4\n", "", instance_double(Process::Status, success?: true) ])
 
       expect(collector.tool_version).to eq("maat 1.0.4")
@@ -53,10 +53,10 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
     context "when maat produces valid output" do
       before do
         allow(Open3).to receive(:capture3)
-          .with("maat -c git2 -l /tmp/test-repo -a revisions", timeout: 120)
+          .with("maat -c git2 -l /tmp/test-repo -a revisions")
           .and_return([ revisions_csv, "", instance_double(Process::Status, success?: true) ])
         allow(Open3).to receive(:capture3)
-          .with("maat -c git2 -l /tmp/test-repo -a hotspots", timeout: 120)
+          .with("maat -c git2 -l /tmp/test-repo -a hotspots")
           .and_return([ hotspots_csv, "", instance_double(Process::Status, success?: true) ])
       end
 

--- a/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
+++ b/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
     )
   end
 
+  # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status
+  def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
+    status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
+    wait_thr = instance_double(Thread, pid: 12345, value: status)
+    stdin_io = instance_double(IO, close: nil)
+    stdout_io = instance_double(IO, "read": stdout, closed?: false, close: nil)
+    stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
+
+    matcher = command_pattern.is_a?(Regexp) ? command_pattern : eq(command_pattern)
+    allow(Open3).to receive(:popen3).with(matcher, pgroup: true) do |*, &block|
+      block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+    end
+  end
+
   describe "#collector_type" do
     it "returns 'churn_hotspot'" do
       expect(collector.collector_type).to eq("churn_hotspot")
@@ -35,15 +49,13 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
 
   describe "#tool_version" do
     it "returns maat version when available" do
-      allow(Open3).to receive(:capture3)
-        .with("maat --version")
-        .and_return([ "maat 1.0.4\n", "", instance_double(Process::Status, success?: true) ])
+      stub_popen3("maat --version", stdout: "maat 1.0.4\n")
 
       expect(collector.tool_version).to eq("maat 1.0.4")
     end
 
     it "returns nil when maat is not installed" do
-      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+      allow(Open3).to receive(:popen3).and_raise(Errno::ENOENT)
 
       expect(collector.tool_version).to be_nil
     end
@@ -52,19 +64,15 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
   describe "#collect" do
     context "when maat produces valid output" do
       before do
-        allow(Open3).to receive(:capture3)
-          .with("maat -c git2 -l /tmp/test-repo -a revisions")
-          .and_return([ revisions_csv, "", instance_double(Process::Status, success?: true) ])
-        allow(Open3).to receive(:capture3)
-          .with("maat -c git2 -l /tmp/test-repo -a hotspots")
-          .and_return([ hotspots_csv, "", instance_double(Process::Status, success?: true) ])
+        stub_popen3("maat -c git2 -l /tmp/test-repo -a revisions", stdout: revisions_csv)
+        stub_popen3("maat -c git2 -l /tmp/test-repo -a hotspots", stdout: hotspots_csv)
       end
 
       it "returns artifacts sorted by score (revisions * complexity)" do
         artifacts = collector.collect
 
         expect(artifacts.size).to eq(5)
-        expect(artifacts.first[:identifier]).to eq("app/controllers/projects_controller.rb")
+        expect(artifacts.first[:identifier]).to eq("app/models/agent_run.rb")
       end
 
       it "produces artifacts with correct structure" do
@@ -107,6 +115,22 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
         expect(identifiers).to include("lib/utils/helper.rb")
         expect(identifiers).to include("config/routes.rb")
       end
+
+      it "does not describe revision-only files as high-churn when complexity is 0" do
+        artifact = collector.collect.find { |a| a[:identifier] == "lib/utils/helper.rb" }
+        chunk = artifact[:chunks].first
+
+        expect(chunk[:content]).to include("5 revisions")
+        expect(chunk[:content]).not_to include("complexity")
+      end
+
+      it "does not mention revisions for hotspot-only files" do
+        artifact = collector.collect.find { |a| a[:identifier] == "config/routes.rb" }
+        chunk = artifact[:chunks].first
+
+        expect(chunk[:content]).to include("complexity 3")
+        expect(chunk[:content]).not_to include("revisions")
+      end
     end
 
     context "when no repo path is available" do
@@ -123,9 +147,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
 
     context "when maat fails" do
       before do
-        allow(Open3).to receive(:capture3).and_return(
-          [ "", "error", instance_double(Process::Status, success?: false, exitstatus: 1) ]
-        )
+        stub_popen3(/maat/, stdout: "", stderr: "error", success: false, exit_code: 1)
       end
 
       it "returns empty array" do
@@ -135,9 +157,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
 
     context "when maat produces empty output" do
       before do
-        allow(Open3).to receive(:capture3).and_return(
-          [ "", "", instance_double(Process::Status, success?: true) ]
-        )
+        stub_popen3(/maat/, stdout: "")
       end
 
       it "returns empty array" do
@@ -147,9 +167,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
 
     context "when maat produces header-only output" do
       before do
-        allow(Open3).to receive(:capture3).and_return(
-          [ "entity,n-revs\n", "", instance_double(Process::Status, success?: true) ]
-        )
+        stub_popen3(/maat/, stdout: "entity,n-revs\n")
       end
 
       it "returns empty array" do

--- a/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
+++ b/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Knowledge::Collectors::ChurnHotspotCollector, type: :service do
+RSpec.describe Knowledge::Collectors::ChurnHotspotCollector, :no_db do
   subject(:collector) do
     described_class.new(
       project: project,
@@ -11,20 +11,19 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector, type: :service do
     )
   end
 
-  let(:project) { build(:project) }
-  let(:project_version) { build(:project_version, project: project) }
-  let(:collector_run) { build(:collector_run, project_version: project_version) }
+  let(:project) { Struct.new(:id, :worktrees).new(1, worktrees_stub) }
+  let(:project_version) { Struct.new(:id).new(1) }
+  let(:collector_run) { Struct.new(:id).new(1) }
 
   let(:revisions_csv) { file_fixture("knowledge/maat_revisions.csv").read }
   let(:hotspots_csv) { file_fixture("knowledge/maat_hotspots.csv").read }
   let(:repo_path) { "/tmp/test-repo" }
-  let(:worktree) { instance_double(Worktree, path: repo_path) }
-  let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: worktree) }
-
-  before do
-    allow(project).to receive(:worktrees).and_return(
-      instance_double(ActiveRecord::Relation, order: worktrees_relation)
-    )
+  let(:worktree_entry) { Struct.new(:path).new(repo_path) }
+  let(:worktrees_stub) do
+    ordered = Struct.new(:first).new(worktree_entry)
+    Struct.new(:ordered).new(ordered).tap do |stub|
+      stub.define_singleton_method(:order) { |*| ordered }
+    end
   end
 
   describe "#collector_type" do
@@ -121,7 +120,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector, type: :service do
     end
 
     context "when no repo path is available" do
-      let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: nil) }
+      let(:worktree_entry) { nil }
 
       before do
         allow(Rails.root).to receive(:join).and_return(Pathname.new("/nonexistent/path"))

--- a/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
+++ b/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
     )
   end
 
-  # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status
+  # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status.
+  # Accepts either an argv array or a Regexp to match against the full argument list.
   def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
     status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
     wait_thr = instance_double(Thread, pid: 12345, value: status)
@@ -35,9 +36,16 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
     stdout_io = instance_double(IO, "read": stdout, closed?: false, close: nil)
     stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
 
-    matcher = command_pattern.is_a?(Regexp) ? command_pattern : eq(command_pattern)
-    allow(Open3).to receive(:popen3).with(matcher, pgroup: true) do |*, &block|
-      block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+    if command_pattern.is_a?(Regexp)
+      allow(Open3).to receive(:popen3) do |*args, **_kwargs, &block|
+        if args.join(" ").match?(command_pattern)
+          block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+        end
+      end
+    else
+      allow(Open3).to receive(:popen3).with(*command_pattern, pgroup: true) do |*, &block|
+        block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+      end
     end
   end
 
@@ -49,7 +57,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
 
   describe "#tool_version" do
     it "returns maat version when available" do
-      stub_popen3("maat --version", stdout: "maat 1.0.4\n")
+      stub_popen3(%w[maat --version], stdout: "maat 1.0.4\n")
 
       expect(collector.tool_version).to eq("maat 1.0.4")
     end
@@ -64,8 +72,8 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
   describe "#collect" do
     context "when maat produces valid output" do
       before do
-        stub_popen3("maat -c git2 -l /tmp/test-repo -a revisions", stdout: revisions_csv)
-        stub_popen3("maat -c git2 -l /tmp/test-repo -a hotspots", stdout: hotspots_csv)
+        stub_popen3(%w[maat -c git2 -l /tmp/test-repo -a revisions], stdout: revisions_csv)
+        stub_popen3(%w[maat -c git2 -l /tmp/test-repo -a hotspots], stdout: hotspots_csv)
       end
 
       it "returns artifacts sorted by score (revisions * complexity)" do
@@ -82,6 +90,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
         expect(artifact[:scope_path]).to eq("app/models/agent_run.rb")
         expect(artifact[:content]).to include("47 revisions")
         expect(artifact[:content]).to include("complexity score 23")
+        expect(artifact[:content]).to start_with("Churn hotspot: app/models/agent_run.rb")
       end
 
       it "populates metadata with revisions, complexity, and rank" do
@@ -167,7 +176,7 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
 
     context "when maat produces header-only output" do
       before do
-        stub_popen3(/maat/, stdout: "entity,n-revs\n")
+        stub_popen3(/maat/, stdout: "entity,n-revs\n") # header-only CSV
       end
 
       it "returns empty array" do

--- a/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
+++ b/spec/services/knowledge/collectors/churn_hotspot_collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
+RSpec.describe Knowledge::Collectors::ChurnHotspotCollector, type: :service do
   subject(:collector) do
     described_class.new(
       project: project,
@@ -25,28 +25,6 @@ RSpec.describe Knowledge::Collectors::ChurnHotspotCollector do
     allow(project).to receive(:worktrees).and_return(
       instance_double(ActiveRecord::Relation, order: worktrees_relation)
     )
-  end
-
-  # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status.
-  # Accepts either an argv array or a Regexp to match against the full argument list.
-  def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
-    status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
-    wait_thr = instance_double(Thread, pid: 12345, value: status)
-    stdin_io = instance_double(IO, close: nil)
-    stdout_io = instance_double(IO, "read": stdout, closed?: false, close: nil)
-    stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
-
-    if command_pattern.is_a?(Regexp)
-      allow(Open3).to receive(:popen3) do |*args, **_kwargs, &block|
-        if args.join(" ").match?(command_pattern)
-          block.call(stdin_io, stdout_io, stderr_io, wait_thr)
-        end
-      end
-    else
-      allow(Open3).to receive(:popen3).with(*command_pattern, pgroup: true) do |*, &block|
-        block.call(stdin_io, stdout_io, stderr_io, wait_thr)
-      end
-    end
   end
 
   describe "#collector_type" do

--- a/spec/services/knowledge/collectors/language_stats_collector_spec.rb
+++ b/spec/services/knowledge/collectors/language_stats_collector_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
+  subject(:collector) do
+    described_class.new(
+      project: project,
+      project_version: project_version,
+      collector_run: collector_run
+    )
+  end
+
+  let(:project) { build(:project) }
+  let(:project_version) { build(:project_version, project: project) }
+  let(:collector_run) { build(:collector_run, project_version: project_version) }
+
+  let(:scc_json) { file_fixture("knowledge/scc_output.json").read }
+  let(:repo_path) { "/tmp/test-repo" }
+  let(:worktree) { instance_double(Worktree, host_path: repo_path) }
+  let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: worktree) }
+
+  before do
+    allow(project).to receive(:worktrees).and_return(
+      instance_double(ActiveRecord::Relation, order: worktrees_relation)
+    )
+  end
+
+  describe "#collector_type" do
+    it "returns 'language_stat'" do
+      expect(collector.collector_type).to eq("language_stat")
+    end
+  end
+
+  describe "#tool_version" do
+    it "returns scc version when available" do
+      allow(Open3).to receive(:capture3)
+        .with("scc --version", timeout: 30)
+        .and_return([ "scc version 3.6.0\n", "", instance_double(Process::Status, success?: true) ])
+
+      expect(collector.tool_version).to eq("scc version 3.6.0")
+    end
+
+    it "returns nil when scc is not installed" do
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+
+      expect(collector.tool_version).to be_nil
+    end
+  end
+
+  describe "#collect" do
+    context "when scc produces valid output" do
+      before do
+        allow(Open3).to receive(:capture3)
+          .with("scc --format json /tmp/test-repo", timeout: 60)
+          .and_return([ scc_json, "", instance_double(Process::Status, success?: true) ])
+      end
+
+      it "returns one artifact per language" do
+        artifacts = collector.collect
+
+        expect(artifacts.size).to eq(3)
+      end
+
+      it "produces artifacts with correct structure" do
+        artifact = collector.collect.first
+
+        expect(artifact[:artifact_type]).to eq("language_stat")
+        expect(artifact[:identifier]).to eq("Ruby")
+        expect(artifact[:content]).to include("12,456 lines of code")
+        expect(artifact[:content]).to include("187 files")
+      end
+
+      it "populates metadata with file and line counts" do
+        artifact = collector.collect.first
+
+        expect(artifact[:metadata]).to eq(
+          files: 187,
+          lines: 15234,
+          code: 12456,
+          comments: 1890,
+          blanks: 888
+        )
+      end
+
+      it "includes summary chunks" do
+        artifact = collector.collect.first
+        chunk = artifact[:chunks].first
+
+        expect(chunk[:chunk_type]).to eq("summary")
+        expect(chunk[:content]).to include("Ruby")
+        expect(chunk[:content]).to include("12,456 lines of code")
+        expect(chunk[:content]).to include("1,890 comments")
+        expect(chunk[:scope_tags]).to eq([ "language", "stats" ])
+      end
+
+      it "sets scope_path to nil" do
+        artifact = collector.collect.first
+
+        expect(artifact[:scope_path]).to be_nil
+      end
+    end
+
+    context "when no repo path is available" do
+      let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: nil) }
+
+      before do
+        allow(Rails.root).to receive(:join).and_return(Pathname.new("/nonexistent/path"))
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+
+    context "when scc fails" do
+      before do
+        allow(Open3).to receive(:capture3).and_return(
+          [ "", "error", instance_double(Process::Status, success?: false, exitstatus: 1) ]
+        )
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+
+    context "when scc produces empty output" do
+      before do
+        allow(Open3).to receive(:capture3).and_return(
+          [ "", "", instance_double(Process::Status, success?: true) ]
+        )
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+
+    context "when scc produces empty JSON array" do
+      before do
+        allow(Open3).to receive(:capture3).and_return(
+          [ "[]", "", instance_double(Process::Status, success?: true) ]
+        )
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+
+    context "when scc produces invalid JSON" do
+      before do
+        allow(Open3).to receive(:capture3).and_return(
+          [ "not json", "", instance_double(Process::Status, success?: true) ]
+        )
+      end
+
+      it "returns empty array" do
+        expect(collector.collect).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/knowledge/collectors/language_stats_collector_spec.rb
+++ b/spec/services/knowledge/collectors/language_stats_collector_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
 
   let(:scc_json) { file_fixture("knowledge/scc_output.json").read }
   let(:repo_path) { "/tmp/test-repo" }
-  let(:worktree) { instance_double(Worktree, host_path: repo_path) }
+  let(:worktree) { instance_double(Worktree, path: repo_path) }
   let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: worktree) }
 
   before do
@@ -35,7 +35,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
   describe "#tool_version" do
     it "returns scc version when available" do
       allow(Open3).to receive(:capture3)
-        .with("scc --version", timeout: 30)
+        .with("scc --version")
         .and_return([ "scc version 3.6.0\n", "", instance_double(Process::Status, success?: true) ])
 
       expect(collector.tool_version).to eq("scc version 3.6.0")
@@ -52,7 +52,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
     context "when scc produces valid output" do
       before do
         allow(Open3).to receive(:capture3)
-          .with("scc --format json /tmp/test-repo", timeout: 60)
+          .with("scc --format json /tmp/test-repo")
           .and_return([ scc_json, "", instance_double(Process::Status, success?: true) ])
       end
 

--- a/spec/services/knowledge/collectors/language_stats_collector_spec.rb
+++ b/spec/services/knowledge/collectors/language_stats_collector_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
     )
   end
 
+  # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status
+  def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
+    status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
+    wait_thr = instance_double(Thread, pid: 12345, value: status)
+    stdin_io = instance_double(IO, close: nil)
+    stdout_io = instance_double(IO, "read": stdout, closed?: false, close: nil)
+    stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
+
+    matcher = command_pattern.is_a?(Regexp) ? command_pattern : eq(command_pattern)
+    allow(Open3).to receive(:popen3).with(matcher, pgroup: true) do |*, &block|
+      block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+    end
+  end
+
   describe "#collector_type" do
     it "returns 'language_stat'" do
       expect(collector.collector_type).to eq("language_stat")
@@ -34,15 +48,13 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
 
   describe "#tool_version" do
     it "returns scc version when available" do
-      allow(Open3).to receive(:capture3)
-        .with("scc --version")
-        .and_return([ "scc version 3.6.0\n", "", instance_double(Process::Status, success?: true) ])
+      stub_popen3("scc --version", stdout: "scc version 3.6.0\n")
 
       expect(collector.tool_version).to eq("scc version 3.6.0")
     end
 
     it "returns nil when scc is not installed" do
-      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+      allow(Open3).to receive(:popen3).and_raise(Errno::ENOENT)
 
       expect(collector.tool_version).to be_nil
     end
@@ -51,9 +63,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
   describe "#collect" do
     context "when scc produces valid output" do
       before do
-        allow(Open3).to receive(:capture3)
-          .with("scc --format json /tmp/test-repo")
-          .and_return([ scc_json, "", instance_double(Process::Status, success?: true) ])
+        stub_popen3("scc --format json /tmp/test-repo", stdout: scc_json)
       end
 
       it "returns one artifact per language" do
@@ -115,9 +125,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
 
     context "when scc fails" do
       before do
-        allow(Open3).to receive(:capture3).and_return(
-          [ "", "error", instance_double(Process::Status, success?: false, exitstatus: 1) ]
-        )
+        stub_popen3(/scc/, stdout: "", stderr: "error", success: false, exit_code: 1)
       end
 
       it "returns empty array" do
@@ -127,9 +135,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
 
     context "when scc produces empty output" do
       before do
-        allow(Open3).to receive(:capture3).and_return(
-          [ "", "", instance_double(Process::Status, success?: true) ]
-        )
+        stub_popen3(/scc/, stdout: "")
       end
 
       it "returns empty array" do
@@ -139,9 +145,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
 
     context "when scc produces empty JSON array" do
       before do
-        allow(Open3).to receive(:capture3).and_return(
-          [ "[]", "", instance_double(Process::Status, success?: true) ]
-        )
+        stub_popen3(/scc/, stdout: "[]")
       end
 
       it "returns empty array" do
@@ -151,9 +155,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
 
     context "when scc produces invalid JSON" do
       before do
-        allow(Open3).to receive(:capture3).and_return(
-          [ "not json", "", instance_double(Process::Status, success?: true) ]
-        )
+        stub_popen3(/scc/, stdout: "not json")
       end
 
       it "returns empty array" do

--- a/spec/services/knowledge/collectors/language_stats_collector_spec.rb
+++ b/spec/services/knowledge/collectors/language_stats_collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Knowledge::Collectors::LanguageStatsCollector, type: :service do
+RSpec.describe Knowledge::Collectors::LanguageStatsCollector, :no_db do
   subject(:collector) do
     described_class.new(
       project: project,
@@ -11,19 +11,18 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector, type: :service do
     )
   end
 
-  let(:project) { build(:project) }
-  let(:project_version) { build(:project_version, project: project) }
-  let(:collector_run) { build(:collector_run, project_version: project_version) }
+  let(:project) { Struct.new(:id, :worktrees).new(1, worktrees_stub) }
+  let(:project_version) { Struct.new(:id).new(1) }
+  let(:collector_run) { Struct.new(:id).new(1) }
 
   let(:scc_json) { file_fixture("knowledge/scc_output.json").read }
   let(:repo_path) { "/tmp/test-repo" }
-  let(:worktree) { instance_double(Worktree, path: repo_path) }
-  let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: worktree) }
-
-  before do
-    allow(project).to receive(:worktrees).and_return(
-      instance_double(ActiveRecord::Relation, order: worktrees_relation)
-    )
+  let(:worktree_entry) { Struct.new(:path).new(repo_path) }
+  let(:worktrees_stub) do
+    ordered = Struct.new(:first).new(worktree_entry)
+    Struct.new(:ordered).new(ordered).tap do |stub|
+      stub.define_singleton_method(:order) { |*| ordered }
+    end
   end
 
   describe "#collector_type" do
@@ -101,7 +100,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector, type: :service do
     end
 
     context "when no repo path is available" do
-      let(:worktrees_relation) { instance_double(ActiveRecord::Relation, first: nil) }
+      let(:worktree_entry) { nil }
 
       before do
         allow(Rails.root).to receive(:join).and_return(Pathname.new("/nonexistent/path"))

--- a/spec/services/knowledge/collectors/language_stats_collector_spec.rb
+++ b/spec/services/knowledge/collectors/language_stats_collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
+RSpec.describe Knowledge::Collectors::LanguageStatsCollector, type: :service do
   subject(:collector) do
     described_class.new(
       project: project,
@@ -24,28 +24,6 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
     allow(project).to receive(:worktrees).and_return(
       instance_double(ActiveRecord::Relation, order: worktrees_relation)
     )
-  end
-
-  # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status.
-  # Accepts either an argv array or a Regexp to match against the full argument list.
-  def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
-    status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
-    wait_thr = instance_double(Thread, pid: 12345, value: status)
-    stdin_io = instance_double(IO, close: nil)
-    stdout_io = instance_double(IO, "read": stdout, closed?: false, close: nil)
-    stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
-
-    if command_pattern.is_a?(Regexp)
-      allow(Open3).to receive(:popen3) do |*args, **_kwargs, &block|
-        if args.join(" ").match?(command_pattern)
-          block.call(stdin_io, stdout_io, stderr_io, wait_thr)
-        end
-      end
-    else
-      allow(Open3).to receive(:popen3).with(*command_pattern, pgroup: true) do |*, &block|
-        block.call(stdin_io, stdout_io, stderr_io, wait_thr)
-      end
-    end
   end
 
   describe "#collector_type" do

--- a/spec/services/knowledge/collectors/language_stats_collector_spec.rb
+++ b/spec/services/knowledge/collectors/language_stats_collector_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
     )
   end
 
-  # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status
+  # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status.
+  # Accepts either an argv array or a Regexp to match against the full argument list.
   def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
     status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
     wait_thr = instance_double(Thread, pid: 12345, value: status)
@@ -34,9 +35,16 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
     stdout_io = instance_double(IO, "read": stdout, closed?: false, close: nil)
     stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
 
-    matcher = command_pattern.is_a?(Regexp) ? command_pattern : eq(command_pattern)
-    allow(Open3).to receive(:popen3).with(matcher, pgroup: true) do |*, &block|
-      block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+    if command_pattern.is_a?(Regexp)
+      allow(Open3).to receive(:popen3) do |*args, **_kwargs, &block|
+        if args.join(" ").match?(command_pattern)
+          block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+        end
+      end
+    else
+      allow(Open3).to receive(:popen3).with(*command_pattern, pgroup: true) do |*, &block|
+        block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+      end
     end
   end
 
@@ -48,7 +56,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
 
   describe "#tool_version" do
     it "returns scc version when available" do
-      stub_popen3("scc --version", stdout: "scc version 3.6.0\n")
+      stub_popen3(%w[scc --version], stdout: "scc version 3.6.0\n")
 
       expect(collector.tool_version).to eq("scc version 3.6.0")
     end
@@ -63,7 +71,7 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
   describe "#collect" do
     context "when scc produces valid output" do
       before do
-        stub_popen3("scc --format json /tmp/test-repo", stdout: scc_json)
+        stub_popen3(%w[scc --format json /tmp/test-repo], stdout: scc_json)
       end
 
       it "returns one artifact per language" do
@@ -78,6 +86,9 @@ RSpec.describe Knowledge::Collectors::LanguageStatsCollector do
         expect(artifact[:artifact_type]).to eq("language_stat")
         expect(artifact[:identifier]).to eq("Ruby")
         expect(artifact[:content]).to include("12,456 lines of code")
+        expect(artifact[:content]).to include("1,890 comments")
+        expect(artifact[:content]).to include("888 blanks")
+        expect(artifact[:content]).to include("15,234 total lines")
         expect(artifact[:content]).to include("187 files")
       end
 

--- a/spec/support/exec_tmpdir.rb
+++ b/spec/support/exec_tmpdir.rb
@@ -33,5 +33,7 @@ module ExecTmpdir
       File.chmod(0o755, f)
       system(f, out: File::NULL, err: File::NULL)
     end
+  rescue StandardError
+    false
   end
 end

--- a/spec/support/exec_tmpdir.rb
+++ b/spec/support/exec_tmpdir.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Shared helper for specs that need to create executable scripts in a tmpdir.
+# Some CI environments mount /tmp as noexec, so we probe for a usable directory.
+module ExecTmpdir
+  def exec_tmpdir
+    %w[/tmp /workspace/tmp].find { |d| File.directory?(d) && exec_allowed?(d) } || Dir.tmpdir
+  end
+
+  def exec_allowed?(dir)
+    Dir.mktmpdir(nil, dir) do |d|
+      f = File.join(d, "t.sh")
+      File.write(f, "#!/bin/sh\nexit 0\n")
+      File.chmod(0o755, f)
+      system(f, out: File::NULL, err: File::NULL)
+    end
+  end
+end

--- a/spec/support/exec_tmpdir.rb
+++ b/spec/support/exec_tmpdir.rb
@@ -1,12 +1,29 @@
 # frozen_string_literal: true
 
 require "tmpdir"
+require "fileutils"
 
 # Shared helper for specs that need to create executable scripts in a tmpdir.
 # Some CI environments mount /tmp as noexec, so we probe for a usable directory.
 module ExecTmpdir
   def exec_tmpdir
-    %w[/tmp /workspace/tmp].find { |d| File.directory?(d) && exec_allowed?(d) } || Dir.tmpdir
+    candidates = %w[/tmp /workspace/tmp]
+
+    if (dir = candidates.find { |d| File.directory?(d) && exec_allowed?(d) })
+      return dir
+    end
+
+    if exec_allowed?(Dir.tmpdir)
+      return Dir.tmpdir
+    end
+
+    project_tmp = File.join(Dir.pwd, "tmp")
+    FileUtils.mkdir_p(project_tmp) unless File.directory?(project_tmp)
+
+    return project_tmp if exec_allowed?(project_tmp)
+
+    checked = (candidates + [ Dir.tmpdir, project_tmp ]).uniq
+    raise "ExecTmpdir: no executable tmpdir found; checked: #{checked.join(', ')}"
   end
 
   def exec_allowed?(dir)

--- a/spec/support/exec_tmpdir.rb
+++ b/spec/support/exec_tmpdir.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+
 # Shared helper for specs that need to create executable scripts in a tmpdir.
 # Some CI environments mount /tmp as noexec, so we probe for a usable directory.
 module ExecTmpdir

--- a/spec/support/popen3_stub.rb
+++ b/spec/support/popen3_stub.rb
@@ -15,6 +15,8 @@ module Popen3Stub
       allow(Open3).to receive(:popen3) do |*args, **_kwargs, &block|
         if args.join(" ").match?(command_pattern)
           block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+        else
+          raise "Unexpected Open3.popen3 invocation: #{args.inspect} did not match #{command_pattern.inspect}"
         end
       end
     else

--- a/spec/support/popen3_stub.rb
+++ b/spec/support/popen3_stub.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "open3"
+
 # Shared helper for stubbing Open3.popen3 in collector specs.
 # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status.
 # Accepts either an argv array (exact match) or a Regexp to match against the full argument list.

--- a/spec/support/popen3_stub.rb
+++ b/spec/support/popen3_stub.rb
@@ -6,12 +6,35 @@ require "open3"
 # Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status.
 # Accepts either an argv array (exact match) or a Regexp to match against the full argument list.
 module Popen3Stub
+  # Lightweight fake IO that tracks closed state, matching real IO semantics
+  # so code paths relying on closed? (e.g., BaseCollector timeout/ensure cleanup)
+  # behave correctly.
+  class FakeIO
+    def initialize(read_content = "")
+      @read_content = read_content
+      @closed = false
+    end
+
+    def read(*_args)
+      @read_content
+    end
+
+    def close
+      @closed = true
+      nil
+    end
+
+    def closed?
+      @closed
+    end
+  end
+
   def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
     status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
     wait_thr = instance_double(Thread, pid: 12345, value: status)
-    stdin_io = instance_double(IO, close: nil)
-    stdout_io = instance_double(IO, "read": stdout, closed?: false, close: nil)
-    stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
+    stdin_io = FakeIO.new
+    stdout_io = FakeIO.new(stdout)
+    stderr_io = FakeIO.new(stderr)
 
     if command_pattern.is_a?(Regexp)
       allow(Open3).to receive(:popen3).and_wrap_original do |original, *args, **kwargs, &block|

--- a/spec/support/popen3_stub.rb
+++ b/spec/support/popen3_stub.rb
@@ -31,7 +31,7 @@ module Popen3Stub
 
   def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
     status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
-    wait_thr = instance_double(Thread, pid: 12345, value: status)
+    wait_thr = instance_double(Process::Waiter, pid: 12345, value: status)
     stdin_io = FakeIO.new
     stdout_io = FakeIO.new(stdout)
     stderr_io = FakeIO.new(stderr)
@@ -54,4 +54,5 @@ end
 
 RSpec.configure do |config|
   config.include Popen3Stub, type: :service
+  config.include Popen3Stub, :no_db
 end

--- a/spec/support/popen3_stub.rb
+++ b/spec/support/popen3_stub.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Shared helper for stubbing Open3.popen3 in collector specs.
+# Simulates Open3.popen3 yielding a completed process with given stdout/stderr/status.
+# Accepts either an argv array (exact match) or a Regexp to match against the full argument list.
+module Popen3Stub
+  def stub_popen3(command_pattern, stdout:, stderr: "", success: true, exit_code: 0)
+    status = instance_double(Process::Status, success?: success, exitstatus: exit_code)
+    wait_thr = instance_double(Thread, pid: 12345, value: status)
+    stdin_io = instance_double(IO, close: nil)
+    stdout_io = instance_double(IO, "read": stdout, closed?: false, close: nil)
+    stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
+
+    if command_pattern.is_a?(Regexp)
+      allow(Open3).to receive(:popen3) do |*args, **_kwargs, &block|
+        if args.join(" ").match?(command_pattern)
+          block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+        end
+      end
+    else
+      allow(Open3).to receive(:popen3).with(*command_pattern, pgroup: true) do |*, &block|
+        block.call(stdin_io, stdout_io, stderr_io, wait_thr)
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Popen3Stub, type: :service
+end

--- a/spec/support/popen3_stub.rb
+++ b/spec/support/popen3_stub.rb
@@ -14,11 +14,11 @@ module Popen3Stub
     stderr_io = instance_double(IO, "read": stderr, closed?: false, close: nil)
 
     if command_pattern.is_a?(Regexp)
-      allow(Open3).to receive(:popen3) do |*args, **_kwargs, &block|
+      allow(Open3).to receive(:popen3).and_wrap_original do |original, *args, **kwargs, &block|
         if args.join(" ").match?(command_pattern)
           block.call(stdin_io, stdout_io, stderr_io, wait_thr)
         else
-          raise "Unexpected Open3.popen3 invocation: #{args.inspect} did not match #{command_pattern.inspect}"
+          original.call(*args, **kwargs, &block)
         end
       end
     else


### PR DESCRIPTION
Commit succeeded. All lint checks passed.

Here's a summary of what was implemented:

**New files:**

1. **`app/services/knowledge/collectors/churn_hotspot_collector.rb`** — Runs `maat` (ruby-maat) to get revision counts and hotspot data, merges them, and produces artifacts ranked by `revisions × complexity` score. Each artifact includes a summary chunk for semantic search.

2. **`app/services/knowledge/collectors/language_stats_collector.rb`** — Runs `scc --format json` to get language statistics, producing one artifact per language with code/comment/blank line counts and file counts.

3. **`config/initializers/knowledge_collectors.rb`** — Registers both collectors in the `CollectorRunner` registry.

4. **Specs** (`spec/services/knowledge/collectors/`) — 26 examples covering:
   - Correct artifact structure and metadata
   - Ranking by score
   - Files appearing in only one analysis (revisions or hotspots)
   - Tool version detection
   - Graceful handling of: missing repo path, tool failures, empty output, header-only output, invalid JSON

5. **Fixtures** (`spec/fixtures/files/knowledge/`) — Sample maat CSV and scc JSON output for tests.

---

Closes #256