### PR TITLE
fix(devcontainer): set PAID_REPO_FULL_NAME so auto-update triggers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
     // LLM CLI tools - dangerous/auto-approve mode (container only)
     "CODEX_APPROVAL_POLICY": "never",
     "CODEX_SANDBOX_MODE": "danger-full-access",
-    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
+    "PAID_REPO_FULL_NAME": "viamin/paid"
   },
   "remoteEnv": {
     "AIDER_NO_BROWSER": "1",


### PR DESCRIPTION
## Summary
- Sets `PAID_REPO_FULL_NAME=viamin/paid` in devcontainer `containerEnv`
- Without this, `TriggerDevEnvironmentUpdateActivity#self_repo?` always returns `false`, so `bin/dev-update` never runs automatically after PR merges
- The dev environment was never auto-updating — `log/dev_update.log` didn't even exist

## Test plan
- [ ] Rebuild devcontainer and verify `echo $PAID_REPO_FULL_NAME` outputs `viamin/paid`
- [ ] Merge a PR on the Paid repo and confirm `log/dev_update.log` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)