### PR TITLE
feat(agent-runs): queue auto-pick work ahead of spare capacity

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -22,6 +22,7 @@ class ProcessRunQueueJob < ApplicationJob
   # Prevents unbounded scanning when a large queue has many runs that
   # can't start due to per-user capacity limits.
   MAX_ITERATIONS_PER_PERFORM = 100
+  AUTO_PICK_RESERVED_SLOTS = 1
 
   def perform
     # Use a PostgreSQL advisory lock to ensure only one job processes the queue at a time.
@@ -36,6 +37,8 @@ class ProcessRunQueueJob < ApplicationJob
       skipped_ids = Set.new
       @user_capacity = {}  # { user_id => { active: count, max: limit } }
 
+      seed_auto_pick_queue
+
       loop do
         iterations += 1
         break if iterations > MAX_ITERATIONS_PER_PERFORM
@@ -45,17 +48,7 @@ class ProcessRunQueueJob < ApplicationJob
         # associated broadcasts/metrics) for runs that can't start yet.
         next_run = AgentRun.peek_next_queued_run(exclude_ids: skipped_ids.to_a)
 
-        # When the queue is truly empty (not just all skipped), auto-pick
-        # unblocked issues to keep agents productive. Skip auto-pick when
-        # every queued run was skipped due to capacity limits — scanning
-        # projects and creating more runs would be wasteful.
-        unless next_run
-          if skipped_ids.empty? && auto_pick_unblocked_issues
-            next
-          else
-            break
-          end
-        end
+        break unless next_run
 
         # Resolve the project owner for capacity checks. If the owner
         # can't be resolved, fail the run immediately rather than
@@ -69,7 +62,7 @@ class ProcessRunQueueJob < ApplicationJob
           next
         end
 
-        unless user_has_capacity?(user)
+        unless user_has_capacity?(user, next_run)
           skipped_ids.add(next_run.id)
           next
         end
@@ -104,12 +97,12 @@ class ProcessRunQueueJob < ApplicationJob
   # Checks per-user capacity using an in-memory cache. The active count
   # is fetched from the DB on first access per user, then updated
   # in-memory as runs are started, avoiding repeated COUNT queries.
-  def user_has_capacity?(user)
+  def user_has_capacity?(user, run)
     cap = @user_capacity[user.id] ||= {
       active: AgentRun.active_count_for_user(user),
       max: user.settings.max_concurrent_runs
     }
-    cap[:active] < cap[:max]
+    cap[:active] < start_capacity_limit(cap[:max], run)
   end
 
   # Updates the in-memory capacity tracker after a run is started.
@@ -118,40 +111,26 @@ class ProcessRunQueueJob < ApplicationJob
     cap[:active] += 1 if cap
   end
 
-  # Auto-picks unblocked issues for active projects, creating new queued
-  # agent runs. Picks at most one project per invocation, favoring
-  # projects with fewer active auto-pick runs and then the oldest
-  # prior auto-pick assignment. This preserves round-robin fairness
-  # across job invocations while still allowing a single busy project
-  # to fill otherwise idle slots. Returns true if a run exists or was
-  # enqueued so the main loop can attempt to process it through the
-  # normal claim-and-start flow.
-  def auto_pick_unblocked_issues
-    # If the last auto-pick pass created no runs, skip further attempts to
-    # avoid spinning when no eligible issues exist.
-    if defined?(@auto_pick_last_created_any) && @auto_pick_last_created_any == false
-      return false
+  # Seeds the queue with all currently auto-pickable issues before run
+  # selection. Priorities still determine what starts next, but keeping
+  # low-priority auto-pick work queued makes latent work visible and ready
+  # to consume spare capacity.
+  def seed_auto_pick_queue
+    loop do
+      created_in_pass = false
+
+      ordered_auto_pick_projects.each do |project|
+        next unless project.effective_owner
+
+        run = Issues::AutoPick.new(project).call
+        next unless run
+
+        created_in_pass = true
+        @ordered_auto_pick_projects = nil
+      end
+
+      break unless created_in_pass
     end
-
-    projects = ordered_auto_pick_projects
-    return @auto_pick_last_created_any = false if projects.empty?
-
-    projects.each do |project|
-      user = project.effective_owner
-      next unless user
-      next unless user_has_capacity?(user)
-
-      run = Issues::AutoPick.new(project, allow_concurrent_runs: true).call
-      next unless run
-
-      # Invalidate the memoized project ordering so the next pass
-      # reflects the newly created run in its active counts.
-      @ordered_auto_pick_projects = nil
-      @auto_pick_last_created_any = true
-      return true
-    end
-
-    @auto_pick_last_created_any = false
   end
 
   # Memoized within a single perform so repeated auto-pick passes
@@ -192,6 +171,17 @@ class ProcessRunQueueJob < ApplicationJob
         ]
       end
     end
+  end
+
+  def start_capacity_limit(max_concurrent_runs, run)
+    return max_concurrent_runs unless auto_pick_run?(run)
+
+    reserved = max_concurrent_runs > AUTO_PICK_RESERVED_SLOTS ? AUTO_PICK_RESERVED_SLOTS : 0
+    max_concurrent_runs - reserved
+  end
+
+  def auto_pick_run?(run)
+    run.automatic? && !run.existing_pr?
   end
 
   def start_claimed_run(agent_run)

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -22,6 +22,7 @@ class ProcessRunQueueJob < ApplicationJob
   # Prevents unbounded scanning when a large queue has many runs that
   # can't start due to per-user capacity limits.
   MAX_ITERATIONS_PER_PERFORM = 100
+  MAX_SEEDS_PER_PERFORM = 20
   AUTO_PICK_RESERVED_SLOTS = 1
 
   def perform
@@ -36,8 +37,6 @@ class ProcessRunQueueJob < ApplicationJob
       iterations = 0
       skipped_ids = Set.new
       @user_capacity = {}  # { user_id => { active: count, max: limit } }
-
-      seed_auto_pick_queue
 
       loop do
         iterations += 1
@@ -87,6 +86,8 @@ class ProcessRunQueueJob < ApplicationJob
           break if consecutive_failures >= MAX_CONSECUTIVE_FAILURES
         end
       end
+
+      seed_auto_pick_queue
     ensure
       ActiveRecord::Base.connection.execute("SELECT pg_advisory_unlock(#{ADVISORY_LOCK_KEY})") if acquired
     end
@@ -116,15 +117,22 @@ class ProcessRunQueueJob < ApplicationJob
   # low-priority auto-pick work queued makes latent work visible and ready
   # to consume spare capacity.
   def seed_auto_pick_queue
+    seeds_count = 0
+
     loop do
+      break if seeds_count >= MAX_SEEDS_PER_PERFORM
+
       created_in_pass = false
 
       ordered_auto_pick_projects.each do |project|
+        break if seeds_count >= MAX_SEEDS_PER_PERFORM
+
         next unless project.effective_owner
 
         run = Issues::AutoPick.new(project).call
         next unless run
 
+        seeds_count += 1
         created_in_pass = true
         @ordered_auto_pick_projects = nil
       end
@@ -137,7 +145,7 @@ class ProcessRunQueueJob < ApplicationJob
   # don't re-query the project list and aggregate stats each time.
   def ordered_auto_pick_projects
     @ordered_auto_pick_projects ||= begin
-      projects = Project.active.where(auto_pick_enabled: true).order(:id).to_a
+      projects = Project.active.where(auto_pick_enabled: true).includes(:created_by, :account).order(:id).to_a
       return projects if projects.empty?
 
       project_ids = projects.map(&:id)
@@ -181,7 +189,7 @@ class ProcessRunQueueJob < ApplicationJob
   end
 
   def auto_pick_run?(run)
-    run.automatic? && !run.existing_pr?
+    run.auto_pick?
   end
 
   def start_claimed_run(agent_run)

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -38,6 +38,8 @@ class ProcessRunQueueJob < ApplicationJob
       skipped_ids = Set.new
       @user_capacity = {}  # { user_id => { active: count, max: limit } }
 
+      seed_auto_pick_queue
+
       loop do
         iterations += 1
         break if iterations > MAX_ITERATIONS_PER_PERFORM
@@ -87,7 +89,6 @@ class ProcessRunQueueJob < ApplicationJob
         end
       end
 
-      seed_auto_pick_queue
     ensure
       ActiveRecord::Base.connection.execute("SELECT pg_advisory_unlock(#{ADVISORY_LOCK_KEY})") if acquired
     end
@@ -188,8 +189,13 @@ class ProcessRunQueueJob < ApplicationJob
     max_concurrent_runs - reserved
   end
 
+  # Treat a run as auto-pick if it is explicitly marked via the auto_pick
+  # column, or if it matches the legacy inference used elsewhere in the
+  # scheduler (automatic trigger with no source pull request).  The legacy
+  # check keeps reserved-slot behavior consistent until all historical
+  # rows are backfilled.
   def auto_pick_run?(run)
-    run.auto_pick?
+    run.auto_pick? || (run.trigger_type == "automatic" && run.source_pull_request_number.nil?)
   end
 
   def start_claimed_run(agent_run)

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -2,13 +2,11 @@
 
 module Issues
   # Selects the next unblocked, eligible issue for a project and creates
-  # a queued agent run for it. Used when the run queue is empty and the
-  # system has capacity, keeping agents productive without manual intervention.
+  # a queued agent run for it. Used by queue seeding to surface latent
+  # auto-pick work ahead of time so spare capacity can be consumed
+  # without waiting for another project scan.
   #
   # Guards (checked before issue selection):
-  # - Project must not have any active/queued agent runs (default; the
-  #   scheduler can override this via +allow_concurrent_runs: true+ to
-  #   fill idle owner capacity across projects)
   # - Project must not have open PRs needing attention (finish before start)
   #
   # Selection criteria:
@@ -60,14 +58,12 @@ module Issues
       end
     end
 
-    def initialize(project, allow_concurrent_runs: false)
+    def initialize(project)
       @project = project
-      @allow_concurrent_runs = allow_concurrent_runs
     end
 
     def call
       return nil unless @project.auto_pick_enabled?
-      return nil if project_has_active_runs? && !@allow_concurrent_runs
       return nil if project_has_prs_needing_attention?
 
       issue = find_next_eligible_issue
@@ -115,15 +111,6 @@ module Issues
     end
 
     private
-
-    # Returns true if the project already has any active or queued agent
-    # runs. By default limits auto-pick to one concurrent run per project
-    # so agents focus on finishing work before starting new issues. The
-    # scheduler bypasses this guard via +allow_concurrent_runs+ when
-    # distributing idle capacity across projects.
-    def project_has_active_runs?
-      AgentRun.where(project: @project, status: %w[queued pending running]).exists?
-    end
 
     # Returns true if the project has open pull requests that still need
     # Paid's attention. Performs up to two lightweight EXISTS-style queries

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -219,7 +219,8 @@ module Issues
         issue: issue,
         agent_type: resolve_agent_type,
         status: "queued",
-        trigger_type: "automatic"
+        trigger_type: "automatic",
+        auto_pick: true
       )
     end
 

--- a/db/migrate/20260327000516_add_auto_pick_to_agent_runs.rb
+++ b/db/migrate/20260327000516_add_auto_pick_to_agent_runs.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
 class AddAutoPickToAgentRuns < ActiveRecord::Migration[8.1]
-  def change
+  def up
     add_column :agent_runs, :auto_pick, :boolean, default: false, null: false
+
+    execute <<~SQL
+      UPDATE agent_runs
+      SET auto_pick = TRUE
+      WHERE trigger_type = 'automatic'
+        AND source_pull_request_number IS NULL
+        AND issue_id IS NOT NULL;
+    SQL
+  end
+
+  def down
+    remove_column :agent_runs, :auto_pick
   end
 end

--- a/db/migrate/20260327000516_add_auto_pick_to_agent_runs.rb
+++ b/db/migrate/20260327000516_add_auto_pick_to_agent_runs.rb
@@ -1,0 +1,5 @@
+class AddAutoPickToAgentRuns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :agent_runs, :auto_pick, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260327000516_add_auto_pick_to_agent_runs.rb
+++ b/db/migrate/20260327000516_add_auto_pick_to_agent_runs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAutoPickToAgentRuns < ActiveRecord::Migration[8.1]
   def change
     add_column :agent_runs, :auto_pick, :boolean, default: false, null: false

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe ProcessRunQueueJob do
     it "starts multiple queued runs up to user capacity" do
       project = create(:project)
       project.created_by.settings.update!(max_concurrent_runs: 2)
-      older = create(:agent_run, :queued, project: project, created_at: 2.minutes.ago)
-      newer = create(:agent_run, :queued, project: project, created_at: 1.minute.ago)
+      older = create(:agent_run, :queued, project: project, trigger_type: "manual", created_at: 2.minutes.ago)
+      newer = create(:agent_run, :queued, project: project, trigger_type: "manual", created_at: 1.minute.ago)
 
       expect(temporal_client).to receive(:start_workflow).twice.and_return(workflow_handle)
 
@@ -178,21 +178,21 @@ RSpec.describe ProcessRunQueueJob do
       user = project.created_by
       user.settings.update!(max_concurrent_runs: 1)
       create(:agent_run, :running, project: project)
-      create(:agent_run, :queued, project: project)
-
-      expect(Issues::AutoPick).not_to receive(:new)
+      queued_run = create(:agent_run, :queued, project: project)
 
       described_class.new.perform
+
+      expect(queued_run.reload.status).to eq("queued")
     end
 
-    context "when queue is empty with capacity available" do
-      it "calls auto-pick and starts newly queued runs" do
+    context "when seeding auto-pick work" do
+      it "queues eligible auto-pick runs and starts them" do
         project = create(:project, auto_pick_enabled: true)
         issue = create(:issue, project: project)
 
         auto_pick_service = instance_double(Issues::AutoPick)
         allow(Issues::AutoPick).to receive(:new)
-          .with(having_attributes(id: project.id), allow_concurrent_runs: true)
+          .with(having_attributes(id: project.id))
           .and_return(auto_pick_service)
         call_count = 0
         allow(auto_pick_service).to receive(:call) do
@@ -203,16 +203,16 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
 
         expect(Issues::AutoPick).to have_received(:new)
-          .with(having_attributes(id: project.id), allow_concurrent_runs: true).at_least(:once)
+          .with(having_attributes(id: project.id)).at_least(:once)
         expect(AgentRun.last.status).to eq("pending")
       end
 
-      it "stops auto-picking when no new runs are created" do
+      it "stops seeding when no new runs are created" do
         project = create(:project, auto_pick_enabled: true)
 
         auto_pick_service = instance_double(Issues::AutoPick)
         allow(Issues::AutoPick).to receive(:new)
-          .with(having_attributes(id: project.id), allow_concurrent_runs: true)
+          .with(having_attributes(id: project.id))
           .and_return(auto_pick_service)
         allow(auto_pick_service).to receive(:call).and_return(nil)
 
@@ -236,12 +236,13 @@ RSpec.describe ProcessRunQueueJob do
 
         4.times { create(:issue, project: project) }
 
-        expect(temporal_client).to receive(:start_workflow).exactly(4).times.and_return(workflow_handle)
+        expect(temporal_client).to receive(:start_workflow).exactly(3).times.and_return(workflow_handle)
 
         described_class.new.perform
 
         expect(project.agent_runs.where(trigger_type: "automatic").count).to eq(4)
-        expect(project.agent_runs.pending.count).to eq(4)
+        expect(project.agent_runs.pending.count).to eq(3)
+        expect(project.agent_runs.queued.count).to eq(1)
       end
 
       it "round robins auto-pick runs across projects before giving one project extra capacity" do
@@ -263,10 +264,42 @@ RSpec.describe ProcessRunQueueJob do
 
         described_class.new.perform
 
-        expected_order = [ first_project, second_project, first_project, second_project ].map(&:id)
+        expected_order = [ first_project, second_project, first_project ].map(&:id)
         expect(started_projects).to eq(expected_order)
         expect(first_project.agent_runs.pending.count).to eq(2)
-        expect(second_project.agent_runs.pending.count).to eq(2)
+        expect(second_project.agent_runs.pending.count).to eq(1)
+      end
+
+      it "reserves one active slot from being consumed by auto-pick runs" do
+        project = create(:project, auto_pick_enabled: true)
+        user = project.created_by
+        user.settings.update!(max_concurrent_runs: 4)
+
+        4.times { create(:issue, project: project) }
+
+        described_class.new.perform
+
+        expect(project.agent_runs.pending.count).to eq(3)
+        expect(project.agent_runs.queued.count).to eq(1)
+      end
+
+      it "still starts a manual run with one slot reserved from auto-pick" do
+        project = create(:project)
+        user = project.created_by
+        user.settings.update!(max_concurrent_runs: 4)
+
+        3.times { create(:agent_run, :running, project: project, trigger_type: "automatic") }
+        manual_run = create(:agent_run, :queued, project: project, trigger_type: "manual")
+
+        expect(temporal_client).to receive(:start_workflow).with(
+          Workflows::AgentExecutionWorkflow,
+          hash_including(agent_run_id: manual_run.id),
+          hash_including(task_queue: "paid-tasks")
+        ).and_return(workflow_handle)
+
+        described_class.new.perform
+
+        expect(manual_run.reload.status).to eq("pending")
       end
     end
 

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe ProcessRunQueueJob do
       expect(eligible_run.reload.status).to eq("pending")
     end
 
-    it "skips auto-pick when all queued runs are at capacity" do
+    it "does not start queued runs when user is at capacity" do
       project = create(:project, auto_pick_enabled: true)
       user = project.created_by
       user.settings.update!(max_concurrent_runs: 1)

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Issues::AutoPick do
     end
 
     it "returns existing run when RecordNotUnique is raised and active run exists" do
-      issue = create(:issue, project: project)
+      create(:issue, project: project)
 
       service = described_class.new(project)
       # Simulate a race: another process creates a run between our SELECT

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -125,14 +125,25 @@ RSpec.describe Issues::AutoPick do
       expect(result).to be_nil
     end
 
-    it "returns nil when an issue already has an active agent run (per-project concurrency)" do
+    it "picks another eligible issue when the project already has an active run" do
       issue_with_run = create(:issue, project: project)
       create(:agent_run, :queued, project: project, issue: issue_with_run)
-      create(:issue, project: project)
+      eligible = create(:issue, project: project)
 
       result = described_class.new(project).call
 
-      expect(result).to be_nil
+      expect(result.issue).to eq(eligible)
+    end
+
+    it "queues another auto-pick run when a different issue is already queued" do
+      first = create(:issue, project: project, github_number: 1)
+      second = create(:issue, project: project, github_number: 2)
+      create(:agent_run, :queued, project: project, issue: first, trigger_type: "automatic")
+
+      result = described_class.new(project).call
+
+      expect(result.issue).to eq(second)
+      expect(project.agent_runs.queued.where(trigger_type: "automatic").count).to eq(2)
     end
 
     it "picks the issue with the lowest github_number first (no dependencies)" do
@@ -324,32 +335,32 @@ RSpec.describe Issues::AutoPick do
       )
     end
 
-    context "with per-project concurrency limit" do
-      it "returns nil when project has a queued agent run" do
+    context "with concurrent auto-pick runs" do
+      it "queues another run when project already has a queued agent run" do
         create(:agent_run, :queued, project: project)
-        create(:issue, project: project)
+        issue = create(:issue, project: project)
 
         result = described_class.new(project).call
 
-        expect(result).to be_nil
+        expect(result.issue).to eq(issue)
       end
 
-      it "returns nil when project has a running agent run" do
+      it "queues another run when project already has a running agent run" do
         create(:agent_run, :running, project: project)
-        create(:issue, project: project)
+        issue = create(:issue, project: project)
 
         result = described_class.new(project).call
 
-        expect(result).to be_nil
+        expect(result.issue).to eq(issue)
       end
 
-      it "returns nil when project has a pending agent run" do
+      it "queues another run when project already has a pending agent run" do
         create(:agent_run, project: project, status: "pending")
-        create(:issue, project: project)
+        issue = create(:issue, project: project)
 
         result = described_class.new(project).call
 
-        expect(result).to be_nil
+        expect(result.issue).to eq(issue)
       end
 
       it "picks an issue when all project runs are finished" do
@@ -370,16 +381,6 @@ RSpec.describe Issues::AutoPick do
         issue = create(:issue, project: project)
 
         result = described_class.new(project).call
-
-        expect(result).to be_a(AgentRun)
-        expect(result.issue).to eq(issue)
-      end
-
-      it "can allow concurrent runs when explicitly enabled by the scheduler" do
-        create(:agent_run, :running, project: project)
-        issue = create(:issue, project: project)
-
-        result = described_class.new(project, allow_concurrent_runs: true).call
 
         expect(result).to be_a(AgentRun)
         expect(result.issue).to eq(issue)
@@ -466,13 +467,11 @@ RSpec.describe Issues::AutoPick do
         expect(result).to be_nil
       end
 
-      it "returns nil when open PRs already have active agent runs (per-project concurrency limit)" do
+      it "returns nil when open PRs already need attention even if a run is already active" do
         pr = create(:issue, :pull_request, :in_progress, project: project)
         create(:agent_run, :running, project: project, issue: pr)
         create(:issue, project: project)
 
-        # Project has an active run, so it should return nil due to
-        # per-project concurrency limit (not PR check)
         result = described_class.new(project).call
 
         expect(result).to be_nil
@@ -515,8 +514,7 @@ RSpec.describe Issues::AutoPick do
         create(:agent_run, :queued, project: project, issue: issue_with_run)
         eligible = create(:issue, project: project)
 
-        # Use allow_concurrent_runs so project-level guard doesn't block
-        result = described_class.new(project, allow_concurrent_runs: true).call
+        result = described_class.new(project).call
 
         expect(result.issue).to eq(eligible)
       end


### PR DESCRIPTION
## Summary
- queue all currently auto-pickable issues instead of blocking on existing in-project runs
- reserve one active slot from low-priority auto-pick starts so manual and auto-continue work can still start quickly
- update scheduler specs to cover eager queue seeding, fairness, and the reserved-slot behavior

## Review
- focused `ProcessRunQueueJob` and `Issues::AutoPick` review completed before opening
- no functional blockers found after the reserved-slot design was in place

## Verification
- `bin/rubocop app/services/issues/auto_pick.rb app/jobs/process_run_queue_job.rb spec/services/issues/auto_pick_spec.rb spec/jobs/process_run_queue_job_spec.rb`
- `bin/rspec spec/services/issues/auto_pick_spec.rb spec/jobs/process_run_queue_job_spec.rb` (examples green; partial run still exits non-zero because SimpleCov enforces 80% global coverage)
