### PR TITLE
fix(setup): make solid cable setup idempotent

### DIFF
--- a/db/cable_migrate/20260301000001_create_solid_cable_tables.rb
+++ b/db/cable_migrate/20260301000001_create_solid_cable_tables.rb
@@ -2,7 +2,7 @@
 
 class CreateSolidCableTables < ActiveRecord::Migration[8.1]
   def change
-    create_table :solid_cable_messages do |t|
+    create_table :solid_cable_messages, if_not_exists: true do |t|
       t.binary :channel, limit: 1024, null: false
       t.binary :payload, limit: 536870912, null: false
       t.datetime :created_at, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_26_180754) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_27_000516) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -120,6 +120,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_26_180754) do
   create_table "agent_runs", force: :cascade do |t|
     t.string "agent_type", limit: 50, null: false
     t.string "auth_provider", limit: 50
+    t.boolean "auto_pick", default: false, null: false
     t.float "avg_cpu_percent"
     t.decimal "avg_memory_bytes", precision: 20, scale: 4
     t.string "base_commit_sha", limit: 40


### PR DESCRIPTION
## Summary
- make the Solid Cable migration idempotent so `bin/setup` / `db:prepare` can recover when the cable table already exists
- reconcile `db/schema.rb` with the checked-in `AddAutoPickToAgentRuns` migration
- avoid committing local schema drift that is not backed by migrations

## Testing
- `ruby -c db/cable_migrate/20260301000001_create_solid_cable_tables.rb`
- `ruby -c db/schema.rb`
- `bin/rubocop db/cable_migrate/20260301000001_create_solid_cable_tables.rb db/schema.rb db/cable_schema.rb`