### PR TITLE
fix(dev-update): preserve restart diagnostics across setup

### DIFF
--- a/app/temporal/activities/trigger_dev_environment_update_activity.rb
+++ b/app/temporal/activities/trigger_dev_environment_update_activity.rb
@@ -48,7 +48,8 @@ module Activities
       changed_files = fetch_changed_files(project, pr_number)
       return { triggered: false, reason: "no_changed_files" } if changed_files.empty?
 
-      mode = determine_update_mode(changed_files)
+      restart_trigger_files = full_restart_trigger_files(changed_files)
+      mode = determine_update_mode(restart_trigger_files)
       return { triggered: false, reason: "spawn_failed" } unless trigger_update(mode)
 
       logger.info(
@@ -56,7 +57,9 @@ module Activities
         project_id: project.id,
         pr_number: pr_number,
         mode: mode,
-        changed_files_count: changed_files.size
+        changed_files_count: changed_files.size,
+        changed_files: changed_files,
+        restart_trigger_files: restart_trigger_files
       )
 
       { triggered: true, mode: mode, changed_files_count: changed_files.size }
@@ -84,25 +87,28 @@ module Activities
       []
     end
 
-    def determine_update_mode(changed_files)
-      needs_full_restart = changed_files.any? do |file|
+    def determine_update_mode(restart_trigger_files)
+      restart_trigger_files.any? ? "full" : "lightweight"
+    end
+
+    def full_restart_trigger_files(changed_files)
+      changed_files.select do |file|
         FULL_RESTART_PATTERNS.any? { |pattern| pattern.match?(file) }
       end
-
-      needs_full_restart ? "full" : "lightweight"
     end
 
     def trigger_update(mode)
       script = File.expand_path("../../../bin/dev-update", __dir__)
       flag = mode == "full" ? "--full" : "--lightweight"
-      log_path = Rails.root.join("log", "dev_update.log").to_s
+      log_path = Rails.root.join("log", "dev-update", "dev-update.log")
+      log_path.dirname.mkpath
 
       # Spawn detached so the Temporal worker (which runs under Overmind)
       # is not the parent — setsid creates a new session.
       pid = Process.spawn(
         "setsid", script, flag,
-        out: [ log_path, "a" ],
-        err: [ log_path, "a" ]
+        out: [ log_path.to_s, "a" ],
+        err: [ log_path.to_s, "a" ]
       )
       Process.detach(pid)
 
@@ -110,7 +116,7 @@ module Activities
         message: "dev_update.process_spawned",
         pid: pid,
         mode: mode,
-        log_path: log_path
+        log_path: log_path.to_s
       )
 
       true

--- a/bin/dev-update
+++ b/bin/dev-update
@@ -26,7 +26,8 @@ cd "$APP_ROOT"
 MODE="${1:---lightweight}"
 LOG_PREFIX="[dev-update]"
 OVERMIND_SOCKET="${OVERMIND_SOCKET:-.overmind.sock}"
-START_DEV_LOG="log/dev_start.log"
+SCRIPT_LOG="log/dev-update/dev-update.log"
+START_DEV_LOG="log/dev-update/dev-start.log"
 STOPPED_OVERMIND=0
 OVERMIND_STOP_POLL_COUNT="${DEV_UPDATE_OVERMIND_STOP_POLL_COUNT:-10}"
 OVERMIND_START_POLL_COUNT="${DEV_UPDATE_OVERMIND_START_POLL_COUNT:-15}"
@@ -34,6 +35,26 @@ OVERMIND_POLL_INTERVAL="${DEV_UPDATE_OVERMIND_POLL_INTERVAL:-1}"
 
 log() {
   echo "$LOG_PREFIX $(date '+%Y-%m-%d %H:%M:%S') $*"
+}
+
+configure_logging() {
+  mkdir -p "$(dirname "$SCRIPT_LOG")"
+
+  if [ -t 1 ]; then
+    exec > >(tee -a "$SCRIPT_LOG") 2>&1
+  else
+    exec >>"$SCRIPT_LOG" 2>&1
+  fi
+}
+
+log_command_output() {
+  local label="$1"
+  local output="$2"
+  [ -z "$output" ] && return
+
+  while IFS= read -r line; do
+    log "${label}: ${line}"
+  done <<< "$output"
 }
 
 fail() {
@@ -92,9 +113,11 @@ stop_overmind() {
     log "Stopping Overmind (detached)..."
     # Use setsid to run overmind quit in a new session so that stopping
     # Overmind does not kill this script (which may be a child of Overmind).
-    if ! setsid overmind quit &>/dev/null; then
+    local quit_output
+    if ! quit_output="$(setsid overmind quit 2>&1)"; then
       log "Warning: overmind quit returned a non-zero exit status."
     fi
+    log_command_output "overmind quit" "$quit_output"
     STOPPED_OVERMIND=1
 
     # Give Overmind a moment to shut down gracefully and release its socket.
@@ -129,7 +152,9 @@ start_dev() {
 
   if overmind_running; then
     log "Overmind is already running, restarting processes."
-    overmind restart
+    local restart_output
+    restart_output="$(overmind restart 2>&1)"
+    log_command_output "overmind restart" "$restart_output"
     log "Overmind process restart requested."
     return 0
   fi
@@ -172,6 +197,7 @@ recover_dev_if_needed() {
 }
 
 run_full_restart() {
+  configure_logging
   log "Starting full restart update..."
   ensure_on_main
   pull_latest
@@ -192,6 +218,7 @@ run_full_restart() {
 
 case "$MODE" in
   --lightweight)
+    configure_logging
     log "Starting lightweight update..."
     ensure_on_main
     pull_latest

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -26,13 +26,14 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
 
       env = poll_env.merge("PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}")
       stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+      updater_log = read_updater_log(dir)
 
       expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
       expect(File.exist?(socket_path)).to be(false)
       expect(File.exist?(File.join(dir, "overmind-quit-ran"))).to be(false)
       expect(File.exist?(File.join(dir, "setup-ran"))).to be(true)
-      expect(stdout).to include("Overmind is healthy after restart.")
-      expect(stdout).to include("Streaming detached bin/dev output to log/dev_start.log")
+      expect(updater_log).to include("Overmind is healthy after restart.")
+      expect(updater_log).to include("Streaming detached bin/dev output to log/dev-update/dev-start.log")
       expect(wait_for_dev_start_log(dir)).to include("bin/dev booted")
 
       Timeout.timeout(5) do
@@ -48,14 +49,15 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
 
       env = poll_env.merge("PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}")
       stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+      updater_log = read_updater_log(dir)
 
       expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
       expect(File.exist?(File.join(dir, "overmind-quit-ran"))).to be(true)
       expect(File.exist?(File.join(dir, "dev-ran"))).to be(true)
-      expect(stdout).to include("Setup failed after Overmind stop.")
-      expect(stdout).to include("Attempting recovery start because Overmind was stopped during this update.")
-      expect(stdout).to include("Recovery start succeeded.")
-      expect(stdout).to include("ERROR: Full restart aborted because bin/setup --skip-server failed.")
+      expect(updater_log).to include("Setup failed after Overmind stop.")
+      expect(updater_log).to include("Attempting recovery start because Overmind was stopped during this update.")
+      expect(updater_log).to include("Recovery start succeeded.")
+      expect(updater_log).to include("ERROR: Full restart aborted because bin/setup --skip-server failed.")
     end
   end
 
@@ -65,12 +67,13 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
 
       env = poll_env.merge("PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}")
       stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+      updater_log = read_updater_log(dir)
 
       expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
       expect(File.exist?(File.join(dir, "setup-ran"))).to be(true)
       expect(File.exist?(File.join(dir, "dev-ran"))).to be(true)
-      expect(stdout).to include("Inspect log/dev_start.log for detached bin/dev output.")
-      expect(stdout).to include("ERROR: Full restart completed setup but failed to restore a healthy Overmind session.")
+      expect(updater_log).to include("Inspect log/dev-update/dev-start.log for detached bin/dev output.")
+      expect(updater_log).to include("ERROR: Full restart completed setup but failed to restore a healthy Overmind session.")
     end
   end
 
@@ -80,13 +83,33 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
 
       env = poll_env.merge("PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}")
       stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+      updater_log = read_updater_log(dir)
 
       expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
       expect(File.exist?(File.join(dir, "setup-ran"))).to be(true)
       expect(File.exist?(File.join(dir, "overmind-restart-ran"))).to be(true)
       expect(File.exist?(File.join(dir, "dev-ran"))).to be(false)
-      expect(stdout).to include("Overmind is already running, restarting processes.")
-      expect(stdout).to include("Overmind process restart requested.")
+      expect(updater_log).to include("overmind restart: overmind restarted processes")
+      expect(updater_log).to include("Overmind is already running, restarting processes.")
+      expect(updater_log).to include("Overmind process restart requested.")
+    end
+  end
+
+  it "keeps a persistent updater log outside the files bin/setup deletes" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+
+      env = poll_env.merge("PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}")
+      stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      updater_log_path = File.join(dir, "log", "dev-update", "dev-update.log")
+      dev_start_log_path = File.join(dir, "log", "dev-update", "dev-start.log")
+      expect(File.exist?(updater_log_path)).to be(true)
+      expect(File.exist?(dev_start_log_path)).to be(true)
+      expect(File.read(updater_log_path)).to include("Starting full restart update...")
+      expect(File.read(updater_log_path)).to include("Full restart update complete.")
+      expect(File.read(dev_start_log_path)).to include("bin/dev booted")
     end
   end
 
@@ -95,12 +118,16 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     FileUtils.chmod("+x", path)
   end
 
+  def read_updater_log(dir)
+    File.read(File.join(dir, "log", "dev-update", "dev-update.log"))
+  end
+
   def wait_for_dev_start_log(dir)
     dev_start_log = nil
 
     Timeout.timeout(5) do
       loop do
-        dev_start_log_path = File.join(dir, "log", "dev_start.log")
+        dev_start_log_path = File.join(dir, "log", "dev-update", "dev-start.log")
         dev_start_log = File.read(dev_start_log_path) if File.exist?(dev_start_log_path)
         break if dev_start_log&.include?("bin/dev booted")
 
@@ -178,6 +205,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
             ;;
           restart)
             touch "#{dir}/overmind-restart-ran"
+            echo "overmind restarted processes"
             exit 0
             ;;
           *)

--- a/spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb
+++ b/spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
         it "spawns the dev-update script with --lightweight" do
           activity.execute(project_id: project.id, pr_number: 42)
 
-          log_path = Rails.root.join("log", "dev_update.log").to_s
+          log_path = Rails.root.join("log", "dev-update", "dev-update.log").to_s
           expect(Process).to have_received(:spawn).with(
             "setsid", /bin\/dev-update/, "--lightweight",
             hash_including(out: [ log_path, "a" ], err: [ log_path, "a" ])
@@ -92,7 +92,7 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
         it "spawns the dev-update script with --full" do
           activity.execute(project_id: project.id, pr_number: 42)
 
-          log_path = Rails.root.join("log", "dev_update.log").to_s
+          log_path = Rails.root.join("log", "dev-update", "dev-update.log").to_s
           expect(Process).to have_received(:spawn).with(
             "setsid", /bin\/dev-update/, "--full",
             hash_including(out: [ log_path, "a" ], err: [ log_path, "a" ])


### PR DESCRIPTION
## Summary
- preserve dev-update logs across `bin/setup` by writing updater output under `log/dev-update/`
- move detached `bin/dev` output to the same durable directory and capture Overmind command output
- log the changed files and the specific restart-trigger files that forced a full restart

## Review Findings Fixed
- `TriggerDevEnvironmentUpdateActivity` was changed to write to `log/dev-update/dev-update.log`, but it did not create the parent directory before `Process.spawn`; that could cause the auto-update trigger itself to fail. This PR creates the directory first.
- The first logging patch mirrored output with `tee` unconditionally, which can duplicate lines when the activity already redirects stdout/stderr to the same log file. This PR only uses `tee` for interactive runs and appends directly when stdout is already redirected.
- `dev_start.log` still lived under `log/*.log`, so `bin/setup` could delete it during later runs. This PR moves it under `log/dev-update/dev-start.log` so both diagnostic logs survive setup cleanup.

## Testing
- `COVERAGE=false bundle exec rspec spec/lib/dev_update_spec.rb spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb`
- `bundle exec rubocop app/temporal/activities/trigger_dev_environment_update_activity.rb spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb spec/lib/dev_update_spec.rb`
- `shellcheck bin/dev-update`
