### PR TITLE
Fix #261: Decision Records — Why Capture Integrated into Agent Workflows

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -21,6 +21,7 @@ class AgentRun < ApplicationRecord
   has_many :quality_metrics, dependent: :destroy
   has_one :worktree, dependent: :nullify
   has_one :model_selection, dependent: :destroy
+  has_many :decision_records, dependent: :nullify
 
   before_create :generate_proxy_token
 

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class DecisionRecord < ApplicationRecord
+  STATUSES = %w[draft active superseded reverted].freeze
+  CONTENT_FIELDS = %w[title summary context decision consequences tags commit_sha_start commit_sha_end].freeze
+
+  belongs_to :project
+  belongs_to :agent_run, optional: true
+  belongs_to :issue, optional: true
+  belongs_to :superseded_by, class_name: "DecisionRecord", optional: true
+
+  has_many :decision_record_links, dependent: :destroy
+  has_many :supersedes, class_name: "DecisionRecord", foreign_key: :superseded_by_id,
+    inverse_of: :superseded_by, dependent: :nullify
+
+  before_update :enforce_immutability
+
+  validates :title, presence: true, length: { maximum: 500 }
+  validates :summary, presence: true
+  validates :decision, presence: true
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :commit_sha_start, length: { maximum: 40 }
+  validates :commit_sha_end, length: { maximum: 40 }
+
+  scope :active, -> { where(status: "active") }
+  scope :draft, -> { where(status: "draft") }
+  scope :for_project, ->(project) { where(project: project) }
+  scope :by_status, ->(status) { where(status: status) }
+
+  def activate!
+    update!(status: "active")
+  end
+
+  def supersede!(new_record)
+    transaction do
+      update!(status: "superseded", superseded_by: new_record)
+    end
+  end
+
+  def revert!
+    update!(status: "reverted")
+  end
+
+  private
+
+  def enforce_immutability
+    return if new_record?
+
+    changed_content = changed & CONTENT_FIELDS
+    return if changed_content.empty?
+
+    changed_content.each do |field|
+      errors.add(field, "is immutable after creation")
+    end
+
+    throw :abort
+  end
+end

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -28,6 +28,7 @@ class DecisionRecord < ApplicationRecord
   validate :agent_run_belongs_to_same_project, if: -> { agent_run.present? }
   validate :issue_belongs_to_same_project, if: -> { issue.present? }
   validate :superseded_by_belongs_to_same_project, if: -> { superseded_by.present? }
+  validate :superseded_by_is_not_self
 
   scope :active, -> { where(status: "active") }
   scope :draft, -> { where(status: "draft") }
@@ -39,6 +40,8 @@ class DecisionRecord < ApplicationRecord
   end
 
   def supersede!(new_record)
+    raise ArgumentError, "cannot supersede with itself" if new_record == self
+
     transaction do
       update!(status: "superseded", superseded_by: new_record)
     end
@@ -66,6 +69,12 @@ class DecisionRecord < ApplicationRecord
     return if superseded_by.project_id == project_id
 
     errors.add(:superseded_by, "must belong to the same project")
+  end
+
+  def superseded_by_is_not_self
+    return unless persisted? && superseded_by_id == id
+
+    errors.add(:superseded_by, "cannot reference itself")
   end
 
   def enforce_immutability

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -13,6 +13,10 @@ class DecisionRecord < ApplicationRecord
   has_many :supersedes, class_name: "DecisionRecord", foreign_key: :superseded_by_id,
     inverse_of: :superseded_by, dependent: :nullify
 
+  # Uses validate instead of before_update because before_update runs after
+  # validations in Rails' callback order. With before_update, changing project_id
+  # would trigger agent_run_belongs_to_same_project first (failing with a
+  # misleading error) before immutability could reject the change.
   validate :enforce_immutability, on: :update
 
   validates :title, presence: true, length: { maximum: 500 }

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -2,7 +2,7 @@
 
 class DecisionRecord < ApplicationRecord
   STATUSES = %w[draft active superseded reverted].freeze
-  CONTENT_FIELDS = %w[title summary context decision consequences tags commit_sha_start commit_sha_end].freeze
+  MUTABLE_FIELDS = %w[status superseded_by_id updated_at].freeze
 
   belongs_to :project
   belongs_to :agent_run, optional: true
@@ -67,10 +67,10 @@ class DecisionRecord < ApplicationRecord
   def enforce_immutability
     return if new_record?
 
-    changed_content = changed & CONTENT_FIELDS
-    return if changed_content.empty?
+    immutable_changes = changed - MUTABLE_FIELDS
+    return if immutable_changes.empty?
 
-    changed_content.each do |field|
+    immutable_changes.each do |field|
       errors.add(field, "is immutable after creation")
     end
 

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DecisionRecord < ApplicationRecord
+  class InvalidTransitionError < StandardError; end
+
   STATUSES = %w[draft active superseded reverted].freeze
   MUTABLE_FIELDS = %w[status superseded_by_id updated_at].freeze
 
@@ -36,19 +38,35 @@ class DecisionRecord < ApplicationRecord
   scope :by_status, ->(status) { where(status: status) }
 
   def activate!
-    update!(status: "active")
+    with_lock do
+      reload
+      unless status.in?(%w[draft])
+        raise InvalidTransitionError, "cannot activate from #{status}"
+      end
+      update!(status: "active")
+    end
   end
 
   def supersede!(new_record)
     raise ArgumentError, "cannot supersede with itself" if new_record == self
 
-    transaction do
+    with_lock do
+      reload
+      unless status.in?(%w[draft active])
+        raise InvalidTransitionError, "cannot supersede from #{status}"
+      end
       update!(status: "superseded", superseded_by: new_record)
     end
   end
 
   def revert!
-    update!(status: "reverted")
+    with_lock do
+      reload
+      unless status.in?(%w[draft active])
+        raise InvalidTransitionError, "cannot revert from #{status}"
+      end
+      update!(status: "reverted")
+    end
   end
 
   private

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -21,6 +21,9 @@ class DecisionRecord < ApplicationRecord
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :commit_sha_start, length: { maximum: 40 }
   validates :commit_sha_end, length: { maximum: 40 }
+  validate :agent_run_belongs_to_same_project, if: -> { agent_run.present? }
+  validate :issue_belongs_to_same_project, if: -> { issue.present? }
+  validate :superseded_by_belongs_to_same_project, if: -> { superseded_by.present? }
 
   scope :active, -> { where(status: "active") }
   scope :draft, -> { where(status: "draft") }
@@ -42,6 +45,24 @@ class DecisionRecord < ApplicationRecord
   end
 
   private
+
+  def agent_run_belongs_to_same_project
+    return if agent_run.project_id == project_id
+
+    errors.add(:agent_run, "must belong to the same project")
+  end
+
+  def issue_belongs_to_same_project
+    return if issue.project_id == project_id
+
+    errors.add(:issue, "must belong to the same project")
+  end
+
+  def superseded_by_belongs_to_same_project
+    return if superseded_by.project_id == project_id
+
+    errors.add(:superseded_by, "must belong to the same project")
+  end
 
   def enforce_immutability
     return if new_record?

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -15,11 +15,12 @@ class DecisionRecord < ApplicationRecord
   has_many :supersedes, class_name: "DecisionRecord", foreign_key: :superseded_by_id,
     inverse_of: :superseded_by, dependent: :nullify
 
-  # NOTE: The PR description originally mentioned a before_update callback,
-  # but this was changed to a validation. before_update runs after validations
-  # in Rails' callback order, so changing project_id would trigger
-  # agent_run_belongs_to_same_project first (failing with a misleading error)
-  # before immutability could reject the change.
+  # NOTE: enforce_immutability is implemented as a validation rather than a
+  # before_update callback because before_update runs after validations in
+  # Rails' callback order. If project_id (an immutable field) is changed,
+  # project-consistency validations such as agent_run_belongs_to_same_project
+  # would otherwise run first and raise a misleading error instead of
+  # immutability rejecting the change.
   validate :enforce_immutability, on: :update
 
   validates :title, presence: true, length: { maximum: 500 }

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -13,7 +13,7 @@ class DecisionRecord < ApplicationRecord
   has_many :supersedes, class_name: "DecisionRecord", foreign_key: :superseded_by_id,
     inverse_of: :superseded_by, dependent: :nullify
 
-  before_update :enforce_immutability
+  validate :enforce_immutability, on: :update
 
   validates :title, presence: true, length: { maximum: 500 }
   validates :summary, presence: true
@@ -65,15 +65,11 @@ class DecisionRecord < ApplicationRecord
   end
 
   def enforce_immutability
-    return if new_record?
-
     immutable_changes = changed - MUTABLE_FIELDS
     return if immutable_changes.empty?
 
     immutable_changes.each do |field|
       errors.add(field, "is immutable after creation")
     end
-
-    throw :abort
   end
 end

--- a/app/models/decision_record.rb
+++ b/app/models/decision_record.rb
@@ -15,10 +15,11 @@ class DecisionRecord < ApplicationRecord
   has_many :supersedes, class_name: "DecisionRecord", foreign_key: :superseded_by_id,
     inverse_of: :superseded_by, dependent: :nullify
 
-  # Uses validate instead of before_update because before_update runs after
-  # validations in Rails' callback order. With before_update, changing project_id
-  # would trigger agent_run_belongs_to_same_project first (failing with a
-  # misleading error) before immutability could reject the change.
+  # NOTE: The PR description originally mentioned a before_update callback,
+  # but this was changed to a validation. before_update runs after validations
+  # in Rails' callback order, so changing project_id would trigger
+  # agent_run_belongs_to_same_project first (failing with a misleading error)
+  # before immutability could reject the change.
   validate :enforce_immutability, on: :update
 
   validates :title, presence: true, length: { maximum: 500 }

--- a/app/models/decision_record_link.rb
+++ b/app/models/decision_record_link.rb
@@ -5,6 +5,10 @@ class DecisionRecordLink < ApplicationRecord
   LINK_TYPES = %w[evidence implements reverts].freeze
 
   belongs_to :decision_record
+  # linkable_type/linkable_id are NOT NULL at the DB level, but we use optional: true
+  # because the linkable_id is stored as a string (not a DB foreign key), so Rails
+  # can't validate existence across polymorphic types. Presence is enforced by the
+  # validates calls below.
   belongs_to :linkable, polymorphic: true, optional: true
 
   validates :linkable_type, presence: true, length: { maximum: 100 }, inclusion: { in: LINKABLE_TYPES }

--- a/app/models/decision_record_link.rb
+++ b/app/models/decision_record_link.rb
@@ -5,6 +5,7 @@ class DecisionRecordLink < ApplicationRecord
   LINK_TYPES = %w[evidence implements reverts].freeze
 
   belongs_to :decision_record
+  belongs_to :linkable, polymorphic: true, optional: true
 
   validates :linkable_type, presence: true, length: { maximum: 100 }, inclusion: { in: LINKABLE_TYPES }
   validates :linkable_id, presence: true, length: { maximum: 100 }

--- a/app/models/decision_record_link.rb
+++ b/app/models/decision_record_link.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class DecisionRecordLink < ApplicationRecord
+  LINKABLE_TYPES = %w[KnowledgeChunk Issue AgentRun DecisionRecord].freeze
+  LINK_TYPES = %w[evidence implements reverts].freeze
+
+  belongs_to :decision_record
+
+  validates :linkable_type, presence: true, length: { maximum: 100 }, inclusion: { in: LINKABLE_TYPES }
+  validates :linkable_id, presence: true, length: { maximum: 100 }
+  validates :link_type, presence: true, length: { maximum: 50 }, inclusion: { in: LINK_TYPES }
+end

--- a/app/models/decision_record_link.rb
+++ b/app/models/decision_record_link.rb
@@ -13,5 +13,9 @@ class DecisionRecordLink < ApplicationRecord
 
   validates :linkable_type, presence: true, length: { maximum: 100 }, inclusion: { in: LINKABLE_TYPES }
   validates :linkable_id, presence: true, length: { maximum: 100 }
-  validates :link_type, presence: true, length: { maximum: 50 }, inclusion: { in: LINK_TYPES }
+  validates :link_type,
+            presence: true,
+            length: { maximum: 50 },
+            inclusion: { in: LINK_TYPES },
+            uniqueness: { scope: %i[decision_record_id linkable_type linkable_id] }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -35,6 +35,7 @@ class Project < ApplicationRecord
   has_many :knowledge_chunks, through: :knowledge_artifacts
   has_many :project_service_containers, dependent: :destroy
   has_many :service_containers, through: :project_service_containers
+  has_many :decision_records, dependent: :destroy
 
   encrypts :webhook_secret
 

--- a/app/services/knowledge/collectors/decision_record_collector.rb
+++ b/app/services/knowledge/collectors/decision_record_collector.rb
@@ -44,6 +44,7 @@ module Knowledge
       def build_content(record)
         parts = []
         parts << "# #{record.title}"
+        parts << "\nStatus: #{record.status}"
         parts << "\n## Summary\n#{record.summary}"
         parts << "\n## Context\n#{record.context}" if record.context.present?
         parts << "\n## Decision\n#{record.decision}"

--- a/app/services/knowledge/collectors/decision_record_collector.rb
+++ b/app/services/knowledge/collectors/decision_record_collector.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Knowledge
+  module Collectors
+    # Indexes decision records as knowledge artifacts and chunks
+    # for unified search alongside other knowledge types.
+    class DecisionRecordCollector < BaseCollector
+      def collector_type
+        "decision_record"
+      end
+
+      def tool_version
+        "1.0.0"
+      end
+
+      def collect
+        records = DecisionRecord.where(project: project).where(status: %w[active draft])
+        records.map { |record| build_artifact(record) }
+      end
+
+      private
+
+      def build_artifact(record)
+        content = build_content(record)
+
+        {
+          artifact_type: "decision_record",
+          scope_path: "decisions/#{record.id}",
+          identifier: record.title,
+          content: content,
+          metadata: {
+            decision_record_id: record.id,
+            status: record.status,
+            tags: record.tags,
+            agent_run_id: record.agent_run_id,
+            issue_id: record.issue_id,
+            commit_sha_start: record.commit_sha_start,
+            commit_sha_end: record.commit_sha_end
+          },
+          chunks: build_chunks(record)
+        }
+      end
+
+      def build_content(record)
+        parts = []
+        parts << "# #{record.title}"
+        parts << "\n## Summary\n#{record.summary}"
+        parts << "\n## Context\n#{record.context}" if record.context.present?
+        parts << "\n## Decision\n#{record.decision}"
+        parts << "\n## Consequences\n#{record.consequences}" if record.consequences.present?
+        parts << "\nTags: #{record.tags.join(', ')}" if record.tags.any?
+        parts.join("\n")
+      end
+
+      def build_chunks(record)
+        chunks = []
+
+        chunks << {
+          chunk_type: "summary",
+          content: "Decision: #{record.title}\n#{record.summary}",
+          scope_tags: record.tags,
+          sequence: 0
+        }
+
+        if record.context.present?
+          chunks << {
+            chunk_type: "context",
+            content: record.context,
+            scope_tags: record.tags,
+            sequence: 1
+          }
+        end
+
+        chunks << {
+          chunk_type: "evidence",
+          content: record.decision,
+          scope_tags: record.tags,
+          sequence: 2
+        }
+
+        if record.consequences.present?
+          chunks << {
+            chunk_type: "evidence",
+            content: record.consequences,
+            scope_tags: record.tags,
+            sequence: 3
+          }
+        end
+
+        chunks
+      end
+    end
+  end
+end

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -95,7 +95,8 @@ module Knowledge
         Rails.logger.warn(
           message: "knowledge.decisions.draft_parse_failed",
           agent_run_id: agent_run.id,
-          error: e.message
+          error: e.message,
+          error_class: e.class.name
         )
         nil
       end

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -77,6 +77,14 @@ module Knowledge
       end
 
       def parse_response(response)
+        if response.respond_to?(:success?) && !response.success?
+          Rails.logger.warn(
+            message: "knowledge.decisions.draft_llm_failed",
+            agent_run_id: agent_run.id
+          )
+          return nil
+        end
+
         output = response.respond_to?(:output) ? response.output : response.to_s
         return nil if output.blank?
 

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module Knowledge
+  module Decisions
+    # Drafts a decision record from a completed agent run.
+    #
+    # Summarizes the agent run's changes and calls agent-harness to generate
+    # a structured decision record, then stores it as a DecisionRecord with
+    # links to the agent run, issue, and a KnowledgeArtifact for search.
+    #
+    # @example
+    #   Knowledge::Decisions::Draft.call(agent_run: agent_run)
+    class Draft
+      TIMEOUT = 30
+      DEFAULT_MODEL = "claude-sonnet-4-5-20250514"
+
+      DRAFT_PROMPT = <<~PROMPT
+        You are drafting a Decision Record (ADR-lite) for a code change.
+
+        Given the following context about an agent run that created a pull request,
+        produce a structured decision record in JSON format with these fields:
+        - title: A concise title for the decision (max 100 chars)
+        - summary: 1-3 sentence summary of what was decided
+        - context: Background/situation that led to this decision
+        - decision: What was decided and implemented
+        - consequences: Expected outcomes and trade-offs
+        - tags: Array of relevant tags (e.g., ["auth", "api", "performance"])
+
+        Respond with ONLY valid JSON, no markdown fences or extra text.
+
+        ## Agent Run Context
+        Issue: %{issue_title}
+        PR Changes Summary:
+        %{changes_summary}
+      PROMPT
+
+      attr_reader :agent_run
+
+      def initialize(agent_run:)
+        @agent_run = agent_run
+      end
+
+      def self.call(...)
+        new(...).call
+      end
+
+      def call
+        changes_summary = agent_run.agent_summary(limit: 200)
+        return nil if changes_summary.blank?
+
+        prompt = build_prompt(changes_summary)
+        response = send_to_llm(prompt)
+        parsed = parse_response(response)
+        return nil unless parsed
+
+        create_decision_record(parsed)
+      end
+
+      private
+
+      def build_prompt(changes_summary)
+        format(
+          DRAFT_PROMPT,
+          issue_title: agent_run.issue&.title || "N/A",
+          changes_summary: changes_summary.truncate(10_000)
+        )
+      end
+
+      def send_to_llm(prompt)
+        AgentHarness.send_message(
+          prompt,
+          provider: :claude,
+          model: DEFAULT_MODEL,
+          timeout: TIMEOUT,
+          dangerous_mode: false
+        )
+      end
+
+      def parse_response(response)
+        output = response.respond_to?(:output) ? response.output : response.to_s
+        return nil if output.blank?
+
+        # Strip markdown fences if present
+        cleaned = output.gsub(/\A```(?:json)?\s*/, "").gsub(/\s*```\z/, "").strip
+        JSON.parse(cleaned, symbolize_names: true)
+      rescue JSON::ParserError => e
+        Rails.logger.warn(
+          message: "knowledge.decisions.draft_parse_failed",
+          agent_run_id: agent_run.id,
+          error: e.message
+        )
+        nil
+      end
+
+      def create_decision_record(parsed)
+        record = nil
+
+        DecisionRecord.transaction do
+          record = DecisionRecord.create!(
+            project: agent_run.project,
+            agent_run: agent_run,
+            issue: agent_run.issue,
+            title: parsed[:title].to_s.truncate(500),
+            summary: parsed[:summary].to_s,
+            context: parsed[:context].to_s.presence,
+            decision: parsed[:decision].to_s,
+            consequences: parsed[:consequences].to_s.presence,
+            status: "active",
+            commit_sha_start: agent_run.base_commit_sha,
+            commit_sha_end: agent_run.result_commit_sha,
+            tags: Array(parsed[:tags]).map(&:to_s)
+          )
+
+          create_links(record)
+        end
+
+        record
+      end
+
+      def create_links(record)
+        if agent_run.id.present?
+          record.decision_record_links.create!(
+            linkable_type: "AgentRun",
+            linkable_id: agent_run.id.to_s,
+            link_type: "implements"
+          )
+        end
+
+        if agent_run.issue_id.present?
+          record.decision_record_links.create!(
+            linkable_type: "Issue",
+            linkable_id: agent_run.issue_id.to_s,
+            link_type: "implements"
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -53,7 +53,19 @@ module Knowledge
         parsed = parse_response(response)
         return nil unless parsed
 
+        # Guard against malformed LLM output missing required fields.
+        required_keys = %i[title summary decision]
+        return nil unless required_keys.all? { |key| parsed[key].present? }
+
         create_decision_record(parsed)
+      rescue AgentHarness::Error, ActiveRecord::RecordInvalid => e
+        Rails.logger.error(
+          message: "knowledge.decisions.draft_failed",
+          agent_run_id: agent_run.id,
+          error_class: e.class.name,
+          error: e.message
+        )
+        nil
       end
 
       private
@@ -78,10 +90,15 @@ module Knowledge
 
       def parse_response(response)
         if response.respond_to?(:success?) && !response.success?
-          Rails.logger.warn(
+          log_payload = {
             message: "knowledge.decisions.draft_llm_failed",
             agent_run_id: agent_run.id
-          )
+          }
+          log_payload[:error] = response.error if response.respond_to?(:error) && response.error
+          log_payload[:exit_code] = response.exit_code if response.respond_to?(:exit_code) && response.exit_code
+          log_payload[:provider] = response.provider if response.respond_to?(:provider) && response.provider
+          log_payload[:model] = response.model if response.respond_to?(:model) && response.model
+          Rails.logger.warn(log_payload)
           return nil
         end
 

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -12,7 +12,7 @@ module Knowledge
     #   Knowledge::Decisions::Draft.call(agent_run: agent_run)
     class Draft
       TIMEOUT = 30
-      DEFAULT_MODEL = "claude-sonnet-4-5-20250514"
+      DEFAULT_MODEL = "claude-sonnet-4-6"
 
       DRAFT_PROMPT = <<~PROMPT
         You are drafting a Decision Record (ADR-lite) for a code change.

--- a/app/services/knowledge/decisions/supersede.rb
+++ b/app/services/knowledge/decisions/supersede.rb
@@ -7,16 +7,14 @@ module Knowledge
     # @example
     #   Knowledge::Decisions::Supersede.call(
     #     original: old_decision,
-    #     superseding: new_decision,
-    #     reason: "Updated auth approach"
+    #     superseding: new_decision
     #   )
     class Supersede
-      attr_reader :original, :superseding, :reason
+      attr_reader :original, :superseding
 
-      def initialize(original:, superseding:, reason: nil)
+      def initialize(original:, superseding:)
         @original = original
         @superseding = superseding
-        @reason = reason
       end
 
       def self.call(...)
@@ -42,7 +40,8 @@ module Knowledge
       private
 
       def validate!
-        raise ArgumentError, "original and superseding must be different records" if original.id == superseding.id
+        raise ArgumentError, "original and superseding must be persisted records" unless original.persisted? && superseding.persisted?
+        raise ArgumentError, "original and superseding must be different records" if original.equal?(superseding) || original.id == superseding.id
         raise ArgumentError, "original must not already be superseded" if original.status == "superseded"
       end
     end

--- a/app/services/knowledge/decisions/supersede.rb
+++ b/app/services/knowledge/decisions/supersede.rb
@@ -22,12 +22,16 @@ module Knowledge
       end
 
       def call
-        validate!
+        validate_records!
 
-        DecisionRecord.transaction do
+        original.with_lock do
+          unless original.status.in?(%w[draft active])
+            raise ArgumentError, "original must be draft or active to supersede"
+          end
+
           original.update!(status: "superseded", superseded_by: superseding)
 
-          superseding.decision_record_links.create!(
+          superseding.decision_record_links.find_or_create_by!(
             linkable_type: "DecisionRecord",
             linkable_id: original.id.to_s,
             link_type: "reverts"
@@ -39,7 +43,7 @@ module Knowledge
 
       private
 
-      def validate!
+      def validate_records!
         unless original.persisted? && superseding.persisted?
           raise ArgumentError, "original and superseding must be persisted records"
         end
@@ -47,8 +51,6 @@ module Knowledge
         if original.equal?(superseding) || original.id == superseding.id
           raise ArgumentError, "original and superseding must be different records"
         end
-
-        raise ArgumentError, "original must not already be superseded" if original.status == "superseded"
       end
     end
   end

--- a/app/services/knowledge/decisions/supersede.rb
+++ b/app/services/knowledge/decisions/supersede.rb
@@ -52,6 +52,10 @@ module Knowledge
         if original.equal?(superseding) || original.id == superseding.id
           raise ArgumentError, "original and superseding must be different records"
         end
+
+        if original.project_id != superseding.project_id
+          raise ArgumentError, "original and superseding must belong to the same project"
+        end
       end
     end
   end

--- a/app/services/knowledge/decisions/supersede.rb
+++ b/app/services/knowledge/decisions/supersede.rb
@@ -40,8 +40,14 @@ module Knowledge
       private
 
       def validate!
-        raise ArgumentError, "original and superseding must be persisted records" unless original.persisted? && superseding.persisted?
-        raise ArgumentError, "original and superseding must be different records" if original.equal?(superseding) || original.id == superseding.id
+        unless original.persisted? && superseding.persisted?
+          raise ArgumentError, "original and superseding must be persisted records"
+        end
+
+        if original.equal?(superseding) || original.id == superseding.id
+          raise ArgumentError, "original and superseding must be different records"
+        end
+
         raise ArgumentError, "original must not already be superseded" if original.status == "superseded"
       end
     end

--- a/app/services/knowledge/decisions/supersede.rb
+++ b/app/services/knowledge/decisions/supersede.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Knowledge
+  module Decisions
+    # Marks a decision record as superseded by a newer one.
+    #
+    # @example
+    #   Knowledge::Decisions::Supersede.call(
+    #     original: old_decision,
+    #     superseding: new_decision,
+    #     reason: "Updated auth approach"
+    #   )
+    class Supersede
+      attr_reader :original, :superseding, :reason
+
+      def initialize(original:, superseding:, reason: nil)
+        @original = original
+        @superseding = superseding
+        @reason = reason
+      end
+
+      def self.call(...)
+        new(...).call
+      end
+
+      def call
+        validate!
+
+        DecisionRecord.transaction do
+          original.update!(status: "superseded", superseded_by: superseding)
+
+          superseding.decision_record_links.create!(
+            linkable_type: "DecisionRecord",
+            linkable_id: original.id.to_s,
+            link_type: "reverts"
+          )
+        end
+
+        original
+      end
+
+      private
+
+      def validate!
+        raise ArgumentError, "original and superseding must be different records" if original.id == superseding.id
+        raise ArgumentError, "original must not already be superseded" if original.status == "superseded"
+      end
+    end
+  end
+end

--- a/app/services/knowledge/decisions/supersede.rb
+++ b/app/services/knowledge/decisions/supersede.rb
@@ -25,6 +25,7 @@ module Knowledge
         validate_records!
 
         original.with_lock do
+          original.reload
           unless original.status.in?(%w[draft active])
             raise ArgumentError, "original must be draft or active to supersede"
           end

--- a/app/temporal/activities/draft_decision_record_activity.rb
+++ b/app/temporal/activities/draft_decision_record_activity.rb
@@ -10,6 +10,19 @@ module Activities
 
     def execute(input)
       agent_run_id = input[:agent_run_id]
+
+      # Ensure idempotency: if a DecisionRecord already exists for this agent_run,
+      # reuse it instead of drafting a new one (Temporal activities may be retried).
+      if (existing_record = DecisionRecord.find_by(agent_run_id: agent_run_id))
+        logger.info(
+          message: "knowledge.decisions.draft_exists",
+          agent_run_id: agent_run_id,
+          decision_record_id: existing_record.id
+        )
+
+        return { agent_run_id: agent_run_id, decision_record_id: existing_record.id, success: true }
+      end
+
       agent_run = AgentRun.find(agent_run_id)
 
       track_phase(agent_run_id: agent_run_id, phase_key: "draft_decision_record", phase_group: "post", agent_run: agent_run) do

--- a/app/temporal/activities/draft_decision_record_activity.rb
+++ b/app/temporal/activities/draft_decision_record_activity.rb
@@ -68,6 +68,8 @@ module Activities
           { agent_run_id: agent_run_id, decision_record_id: nil, success: true }
         end
       end
+    rescue Temporalio::Error::CanceledError
+      raise
     rescue => e
       logger.warn(
         message: "knowledge.decisions.draft_failed",

--- a/app/temporal/activities/draft_decision_record_activity.rb
+++ b/app/temporal/activities/draft_decision_record_activity.rb
@@ -17,7 +17,12 @@ module Activities
         logger.warn(
           message: "knowledge.decisions.draft_missing_agent_run_id"
         )
-        return { agent_run_id: agent_run_id, decision_record_id: nil, success: false, error: "agent_run_id is required" }
+        return {
+          agent_run_id: agent_run_id,
+          decision_record_id: nil,
+          success: false,
+          error: "agent_run_id is required"
+        }
       end
 
       # Ensure idempotency: if a DecisionRecord already exists for this agent_run,
@@ -29,12 +34,21 @@ module Activities
           decision_record_id: existing_record.id
         )
 
-        return { agent_run_id: agent_run_id, decision_record_id: existing_record.id, success: true }
+        return {
+          agent_run_id: agent_run_id,
+          decision_record_id: existing_record.id,
+          success: true
+        }
       end
 
       agent_run = AgentRun.find(agent_run_id)
 
-      track_phase(agent_run_id: agent_run_id, phase_key: "draft_decision_record", phase_group: "post", agent_run: agent_run) do
+      track_phase(
+        agent_run_id: agent_run_id,
+        phase_key: "draft_decision_record",
+        phase_group: "post",
+        agent_run: agent_run
+      ) do
         record = Knowledge::Decisions::Draft.call(agent_run: agent_run)
 
         if record
@@ -62,7 +76,12 @@ module Activities
         error: e.message
       )
 
-      { agent_run_id: agent_run_id, decision_record_id: nil, success: false, error: e.message }
+      {
+        agent_run_id: agent_run_id,
+        decision_record_id: nil,
+        success: false,
+        error: e.message
+      }
     end
   end
 end

--- a/app/temporal/activities/draft_decision_record_activity.rb
+++ b/app/temporal/activities/draft_decision_record_activity.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Activities
+  # Drafts a decision record from a completed agent run.
+  #
+  # Best-effort: failures are logged but do not raise, so they
+  # don't break the agent execution workflow.
+  class DraftDecisionRecordActivity < BaseActivity
+    activity_name "DraftDecisionRecord"
+
+    def execute(input)
+      agent_run_id = input[:agent_run_id]
+      agent_run = AgentRun.find(agent_run_id)
+
+      track_phase(agent_run_id: agent_run_id, phase_key: "draft_decision_record", phase_group: "post", agent_run: agent_run) do
+        record = Knowledge::Decisions::Draft.call(agent_run: agent_run)
+
+        if record
+          logger.info(
+            message: "knowledge.decisions.draft_created",
+            agent_run_id: agent_run_id,
+            decision_record_id: record.id
+          )
+
+          { agent_run_id: agent_run_id, decision_record_id: record.id, success: true }
+        else
+          logger.info(
+            message: "knowledge.decisions.draft_skipped",
+            agent_run_id: agent_run_id
+          )
+
+          { agent_run_id: agent_run_id, decision_record_id: nil, success: true }
+        end
+      end
+    rescue => e
+      logger.warn(
+        message: "knowledge.decisions.draft_failed",
+        agent_run_id: agent_run_id,
+        error_class: e.class.name,
+        error: e.message
+      )
+
+      { agent_run_id: agent_run_id, decision_record_id: nil, success: false, error: e.message }
+    end
+  end
+end

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -47,7 +47,10 @@ module Workflows
       agent_run_id = agent_run_result[:agent_run_id]
       provider_attempt_count = [ agent_run_result.fetch(:provider_attempt_count, 1), 1 ].max
       agent_timeout_seconds = agent_run_result.fetch(:agent_timeout_seconds, AGENT_TIMEOUT_DEFAULT)
-      issue_goal_timeout_seconds = agent_run_result.fetch(:issue_goal_timeout_seconds, Activities::RunAgentActivity::DEFAULT_ISSUE_GOAL_TIMEOUT)
+      issue_goal_timeout_seconds = agent_run_result.fetch(
+        :issue_goal_timeout_seconds,
+        Activities::RunAgentActivity::DEFAULT_ISSUE_GOAL_TIMEOUT
+      )
 
       begin
         # Step 1.5: Provision service containers (database, redis, etc.)

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -154,6 +154,9 @@ module Workflows
             if complete_result[:pr_review_phase].in?(%w[draft restarted ready escalated])
               request_copilot_review(project_id, source_pull_request_number)
             end
+
+            # Draft a decision record for existing PR changes (best-effort)
+            draft_decision_record(agent_run_id)
           else
             # Step 6: Create PR
             pr_result = run_activity(Activities::CreatePullRequestActivity,
@@ -165,6 +168,9 @@ module Workflows
 
             # Step 8: Request Copilot review on the new draft PR (best-effort)
             request_copilot_review(project_id, pr_result[:pull_request_number])
+
+            # Step 9: Draft a decision record (best-effort)
+            draft_decision_record(agent_run_id)
           end
         else
           # No changes - mark as completed without PR
@@ -300,6 +306,19 @@ module Workflows
         message: "agent_execution.copilot_review_request_failed",
         project_id: project_id,
         pr_number: pr_number,
+        error: e.message
+      )
+    end
+
+    def draft_decision_record(agent_run_id)
+      run_activity(Activities::DraftDecisionRecordActivity,
+        { agent_run_id: agent_run_id }, timeout: 60)
+    rescue Temporalio::Error::CanceledError
+      raise
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "agent_execution.draft_decision_record_failed",
+        agent_run_id: agent_run_id,
         error: e.message
       )
     end

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -312,7 +312,7 @@ module Workflows
 
     def draft_decision_record(agent_run_id)
       run_activity(Activities::DraftDecisionRecordActivity,
-        { agent_run_id: agent_run_id }, timeout: 60)
+        { agent_run_id: agent_run_id }, timeout: 60, retry_policy: NO_RETRY)
     rescue Temporalio::Error::CanceledError
       raise
     rescue => e

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -322,7 +322,8 @@ module Workflows
       Temporalio::Workflow.logger.warn(
         message: "agent_execution.draft_decision_record_failed",
         agent_run_id: agent_run_id,
-        error: e.message
+        error: e.message,
+        error_class: e.class.name
       )
     end
 

--- a/config/initializers/knowledge_collectors.rb
+++ b/config/initializers/knowledge_collectors.rb
@@ -8,4 +8,5 @@ Rails.application.config.to_prepare do
   Knowledge::CollectorRunner.register("config_key", Knowledge::Collectors::ConfigKeyCollector)
   Knowledge::CollectorRunner.register("routes", Knowledge::Collectors::RoutesCollector)
   Knowledge::CollectorRunner.register("tree_sitter", Knowledge::Collectors::TreeSitterCollector)
+  Knowledge::CollectorRunner.register("decision_record", Knowledge::Collectors::DecisionRecordCollector)
 end

--- a/db/migrate/20260328101928_create_decision_records.rb
+++ b/db/migrate/20260328101928_create_decision_records.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateDecisionRecords < ActiveRecord::Migration[8.1]
+  def change
+    create_table :decision_records do |t|
+      t.references :project, null: false, foreign_key: true
+      t.references :agent_run, null: true, foreign_key: true
+      t.references :issue, null: true, foreign_key: true
+      t.string :title, limit: 500, null: false
+      t.text :summary, null: false
+      t.text :context
+      t.text :decision, null: false
+      t.text :consequences
+      t.string :status, limit: 50, null: false, default: "draft"
+      t.bigint :superseded_by_id
+      t.string :commit_sha_start, limit: 40
+      t.string :commit_sha_end, limit: 40
+      t.jsonb :tags, null: false, default: []
+      t.timestamps
+    end
+
+    add_foreign_key :decision_records, :decision_records, column: :superseded_by_id
+    add_index :decision_records, [ :project_id, :status ]
+    add_index :decision_records, :tags, using: :gin
+    add_index :decision_records, :superseded_by_id
+  end
+end

--- a/db/migrate/20260328101928_create_decision_records.rb
+++ b/db/migrate/20260328101928_create_decision_records.rb
@@ -11,6 +11,9 @@ class CreateDecisionRecords < ActiveRecord::Migration[8.1]
       t.text :context
       t.text :decision, null: false
       t.text :consequences
+      # Default to "draft" as a safety net — the Draft service explicitly sets "active"
+      # when creating from a completed agent run, but records created through other
+      # paths should start as drafts requiring explicit activation.
       t.string :status, limit: 50, null: false, default: "draft"
       t.bigint :superseded_by_id
       t.string :commit_sha_start, limit: 40

--- a/db/migrate/20260328101928_create_decision_records.rb
+++ b/db/migrate/20260328101928_create_decision_records.rb
@@ -3,9 +3,9 @@
 class CreateDecisionRecords < ActiveRecord::Migration[8.1]
   def change
     create_table :decision_records do |t|
-      t.references :project, null: false, foreign_key: true
-      t.references :agent_run, null: true, foreign_key: true
-      t.references :issue, null: true, foreign_key: true
+      t.references :project, null: false, foreign_key: { on_delete: :cascade }
+      t.references :agent_run, null: true, foreign_key: { on_delete: :nullify }
+      t.references :issue, null: true, foreign_key: { on_delete: :nullify }
       t.string :title, limit: 500, null: false
       t.text :summary, null: false
       t.text :context
@@ -19,7 +19,7 @@ class CreateDecisionRecords < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_foreign_key :decision_records, :decision_records, column: :superseded_by_id
+    add_foreign_key :decision_records, :decision_records, column: :superseded_by_id, on_delete: :nullify
     add_index :decision_records, [ :project_id, :status ]
     add_index :decision_records, :tags, using: :gin
     add_index :decision_records, :superseded_by_id

--- a/db/migrate/20260328101939_create_decision_record_links.rb
+++ b/db/migrate/20260328101939_create_decision_record_links.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateDecisionRecordLinks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :decision_record_links do |t|
+      t.references :decision_record, null: false, foreign_key: { on_delete: :cascade }
+      t.string :linkable_type, limit: 100, null: false
+      t.string :linkable_id, limit: 100, null: false
+      t.string :link_type, limit: 50, null: false
+      t.datetime :created_at, null: false
+    end
+
+    add_index :decision_record_links, [ :linkable_type, :linkable_id ]
+  end
+end

--- a/db/migrate/20260328151609_add_unique_index_to_decision_records_agent_run_id.rb
+++ b/db/migrate/20260328151609_add_unique_index_to_decision_records_agent_run_id.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToDecisionRecordsAgentRunId < ActiveRecord::Migration[8.1]
+  def change
+    # Enforce 1:1 relationship between agent_run and decision_record at the DB level.
+    # Partial index (WHERE NOT NULL) allows multiple records with NULL agent_run_id.
+    # Also prevents duplicate records from Temporal activity retries.
+    remove_index :decision_records, :agent_run_id
+    add_index :decision_records, :agent_run_id, unique: true, where: "agent_run_id IS NOT NULL"
+  end
+end

--- a/db/migrate/20260328151609_add_unique_index_to_decision_records_agent_run_id.rb
+++ b/db/migrate/20260328151609_add_unique_index_to_decision_records_agent_run_id.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 
 class AddUniqueIndexToDecisionRecordsAgentRunId < ActiveRecord::Migration[8.1]
-  def change
+  disable_ddl_transaction!
+
+  def up
     # Enforce 1:1 relationship between agent_run and decision_record at the DB level.
     # Partial index (WHERE NOT NULL) allows multiple records with NULL agent_run_id.
     # Also prevents duplicate records from Temporal activity retries.
-    remove_index :decision_records, :agent_run_id, if_exists: true
-    add_index :decision_records, :agent_run_id, unique: true, where: "agent_run_id IS NOT NULL"
+    remove_index :decision_records, :agent_run_id, if_exists: true, algorithm: :concurrently
+    add_index :decision_records,
+              :agent_run_id,
+              unique: true,
+              where: "agent_run_id IS NOT NULL",
+              algorithm: :concurrently
+  end
+
+  def down
+    # Best-effort rollback: drop the unique partial index and recreate a standard index.
+    remove_index :decision_records, :agent_run_id, if_exists: true, algorithm: :concurrently
+    add_index :decision_records, :agent_run_id, algorithm: :concurrently
   end
 end

--- a/db/migrate/20260328151609_add_unique_index_to_decision_records_agent_run_id.rb
+++ b/db/migrate/20260328151609_add_unique_index_to_decision_records_agent_run_id.rb
@@ -5,7 +5,7 @@ class AddUniqueIndexToDecisionRecordsAgentRunId < ActiveRecord::Migration[8.1]
     # Enforce 1:1 relationship between agent_run and decision_record at the DB level.
     # Partial index (WHERE NOT NULL) allows multiple records with NULL agent_run_id.
     # Also prevents duplicate records from Temporal activity retries.
-    remove_index :decision_records, :agent_run_id
+    remove_index :decision_records, :agent_run_id, if_exists: true
     add_index :decision_records, :agent_run_id, unique: true, where: "agent_run_id IS NOT NULL"
   end
 end

--- a/db/migrate/20260328194042_add_unique_index_to_decision_record_links.rb
+++ b/db/migrate/20260328194042_add_unique_index_to_decision_record_links.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToDecisionRecordLinks < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :decision_record_links,
+              %i[decision_record_id linkable_type linkable_id link_type],
+              unique: true,
+              name: "index_decision_record_links_on_record_and_linkable_and_type",
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :decision_record_links,
+                 name: "index_decision_record_links_on_record_and_linkable_and_type",
+                 if_exists: true,
+                 algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_28_055556) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_28_101939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -222,6 +222,40 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_055556) do
     t.bigint "project_id", null: false
     t.datetime "updated_at", null: false
     t.index ["project_id", "budget_type"], name: "index_cost_budgets_on_project_id_and_budget_type", unique: true
+  end
+
+  create_table "decision_record_links", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "decision_record_id", null: false
+    t.string "link_type", limit: 50, null: false
+    t.string "linkable_id", limit: 100, null: false
+    t.string "linkable_type", limit: 100, null: false
+    t.index ["decision_record_id"], name: "index_decision_record_links_on_decision_record_id"
+    t.index ["linkable_type", "linkable_id"], name: "index_decision_record_links_on_linkable_type_and_linkable_id"
+  end
+
+  create_table "decision_records", force: :cascade do |t|
+    t.bigint "agent_run_id"
+    t.string "commit_sha_end", limit: 40
+    t.string "commit_sha_start", limit: 40
+    t.text "consequences"
+    t.text "context"
+    t.datetime "created_at", null: false
+    t.text "decision", null: false
+    t.bigint "issue_id"
+    t.bigint "project_id", null: false
+    t.string "status", limit: 50, default: "draft", null: false
+    t.text "summary", null: false
+    t.bigint "superseded_by_id"
+    t.jsonb "tags", default: [], null: false
+    t.string "title", limit: 500, null: false
+    t.datetime "updated_at", null: false
+    t.index ["agent_run_id"], name: "index_decision_records_on_agent_run_id"
+    t.index ["issue_id"], name: "index_decision_records_on_issue_id"
+    t.index ["project_id", "status"], name: "index_decision_records_on_project_id_and_status"
+    t.index ["project_id"], name: "index_decision_records_on_project_id"
+    t.index ["superseded_by_id"], name: "index_decision_records_on_superseded_by_id"
+    t.index ["tags"], name: "index_decision_records_on_tags", using: :gin
   end
 
   create_table "github_tokens", force: :cascade do |t|
@@ -903,6 +937,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_055556) do
   add_foreign_key "collector_runs", "project_versions"
   add_foreign_key "container_metrics", "agent_runs", on_delete: :cascade
   add_foreign_key "cost_budgets", "projects", on_delete: :cascade
+  add_foreign_key "decision_record_links", "decision_records", on_delete: :cascade
+  add_foreign_key "decision_records", "agent_runs"
+  add_foreign_key "decision_records", "decision_records", column: "superseded_by_id"
+  add_foreign_key "decision_records", "issues"
+  add_foreign_key "decision_records", "projects"
   add_foreign_key "github_tokens", "accounts"
   add_foreign_key "github_tokens", "users", column: "created_by_id"
   add_foreign_key "integration_credentials", "accounts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_28_151609) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_28_194042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -231,6 +231,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_151609) do
     t.string "link_type", limit: 50, null: false
     t.string "linkable_id", limit: 100, null: false
     t.string "linkable_type", limit: 100, null: false
+    t.index ["decision_record_id", "linkable_type", "linkable_id", "link_type"], name: "index_decision_record_links_on_record_and_linkable_and_type", unique: true
     t.index ["decision_record_id"], name: "index_decision_record_links_on_decision_record_id"
     t.index ["linkable_type", "linkable_id"], name: "index_decision_record_links_on_linkable_type_and_linkable_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -738,8 +738,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_101939) do
     t.index ["user_id", "provider_key", "provider_api_key_id"], name: "idx_providers_unique_api_key", unique: true, where: "((auth_type)::text = 'api_key'::text)"
     t.index ["user_id", "provider_key"], name: "idx_providers_unique_subscription", unique: true, where: "((auth_type)::text = 'subscription'::text)"
     t.index ["user_id"], name: "index_providers_on_user_id"
-    t.check_constraint "(auth_type)::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL", name: "providers_api_key_requires_key"
-    t.check_constraint "(auth_type)::text <> 'subscription'::text OR provider_api_key_id IS NULL AND (fallback_role)::text = 'standard'::text", name: "providers_subscription_invariants"
+    t.check_constraint "auth_type::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL", name: "providers_api_key_requires_key"
+    t.check_constraint "auth_type::text <> 'subscription'::text OR provider_api_key_id IS NULL AND fallback_role::text = 'standard'::text", name: "providers_subscription_invariants"
   end
 
   create_table "quality_metrics", force: :cascade do |t|
@@ -938,10 +938,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_101939) do
   add_foreign_key "container_metrics", "agent_runs", on_delete: :cascade
   add_foreign_key "cost_budgets", "projects", on_delete: :cascade
   add_foreign_key "decision_record_links", "decision_records", on_delete: :cascade
-  add_foreign_key "decision_records", "agent_runs"
-  add_foreign_key "decision_records", "decision_records", column: "superseded_by_id"
-  add_foreign_key "decision_records", "issues"
-  add_foreign_key "decision_records", "projects"
+  add_foreign_key "decision_records", "agent_runs", on_delete: :nullify
+  add_foreign_key "decision_records", "decision_records", column: "superseded_by_id", on_delete: :nullify
+  add_foreign_key "decision_records", "issues", on_delete: :nullify
+  add_foreign_key "decision_records", "projects", on_delete: :cascade
   add_foreign_key "github_tokens", "accounts"
   add_foreign_key "github_tokens", "users", column: "created_by_id"
   add_foreign_key "integration_credentials", "accounts"

--- a/spec/factories/decision_record_links.rb
+++ b/spec/factories/decision_record_links.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :decision_record_link do
+    decision_record
+    linkable_type { "AgentRun" }
+    linkable_id { "1" }
+    link_type { "implements" }
+
+    trait :evidence do
+      linkable_type { "KnowledgeChunk" }
+      link_type { "evidence" }
+    end
+
+    trait :reverts do
+      linkable_type { "DecisionRecord" }
+      link_type { "reverts" }
+    end
+  end
+end

--- a/spec/factories/decision_records.rb
+++ b/spec/factories/decision_records.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :decision_record do
+    project
+    agent_run { association :agent_run, :completed, project: project }
+    issue { agent_run&.issue }
+    title { "Use JWT for API authentication" }
+    summary { "Decided to use JWT tokens for API authentication instead of session-based auth." }
+    context { "The existing session-based auth doesn't work well for API clients." }
+    decision { "Implement JWT-based authentication for all API endpoints." }
+    consequences { "API clients will need to manage token refresh. Session-based auth remains for web UI." }
+    status { "active" }
+    commit_sha_start { "0123456789abcdef0123456789abcdef01234567" }
+    commit_sha_end { "abcdef0123456789abcdef0123456789abcdef01" }
+    tags { %w[auth api] }
+
+    trait :draft do
+      status { "draft" }
+    end
+
+    trait :superseded do
+      status { "superseded" }
+      superseded_by { association :decision_record, project: project }
+    end
+
+    trait :reverted do
+      status { "reverted" }
+    end
+
+    trait :without_agent_run do
+      agent_run { nil }
+      issue { nil }
+    end
+  end
+end

--- a/spec/models/decision_record_link_spec.rb
+++ b/spec/models/decision_record_link_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DecisionRecordLink do
+  subject(:link) { build(:decision_record_link) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:decision_record) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:linkable_type) }
+    it { is_expected.to validate_length_of(:linkable_type).is_at_most(100) }
+    it { is_expected.to validate_inclusion_of(:linkable_type).in_array(described_class::LINKABLE_TYPES) }
+    it { is_expected.to validate_presence_of(:linkable_id) }
+    it { is_expected.to validate_length_of(:linkable_id).is_at_most(100) }
+    it { is_expected.to validate_presence_of(:link_type) }
+    it { is_expected.to validate_length_of(:link_type).is_at_most(50) }
+    it { is_expected.to validate_inclusion_of(:link_type).in_array(described_class::LINK_TYPES) }
+  end
+end

--- a/spec/models/decision_record_spec.rb
+++ b/spec/models/decision_record_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DecisionRecord do
+  subject(:decision_record) { build(:decision_record) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:project) }
+    it { is_expected.to belong_to(:agent_run).optional }
+    it { is_expected.to belong_to(:issue).optional }
+    it { is_expected.to belong_to(:superseded_by).class_name("DecisionRecord").optional }
+    it { is_expected.to have_many(:decision_record_links).dependent(:destroy) }
+    it { is_expected.to have_many(:supersedes).class_name("DecisionRecord") }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_length_of(:title).is_at_most(500) }
+    it { is_expected.to validate_presence_of(:summary) }
+    it { is_expected.to validate_presence_of(:decision) }
+    it { is_expected.to validate_presence_of(:status) }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+    it { is_expected.to validate_length_of(:commit_sha_start).is_at_most(40) }
+    it { is_expected.to validate_length_of(:commit_sha_end).is_at_most(40) }
+  end
+
+  describe "immutability" do
+    it "prevents updating content fields after creation" do
+      record = create(:decision_record)
+      record.title = "New title"
+      expect(record.save).to be false
+      expect(record.errors[:title]).to include("is immutable after creation")
+    end
+
+    it "allows updating status" do
+      record = create(:decision_record)
+      record.status = "superseded"
+      expect(record.save).to be true
+    end
+
+    it "allows updating superseded_by" do
+      record = create(:decision_record)
+      new_record = create(:decision_record, project: record.project)
+      record.superseded_by = new_record
+      expect(record.save).to be true
+    end
+  end
+
+  describe "scopes" do
+    describe ".active" do
+      it "returns only active records" do
+        active = create(:decision_record, status: "active")
+        create(:decision_record, :draft)
+        expect(described_class.active).to eq([ active ])
+      end
+    end
+
+    describe ".draft" do
+      it "returns only draft records" do
+        create(:decision_record, status: "active")
+        draft = create(:decision_record, :draft)
+        expect(described_class.draft).to eq([ draft ])
+      end
+    end
+  end
+
+  describe "#activate!" do
+    it "transitions to active status" do
+      record = create(:decision_record, :draft)
+      record.activate!
+      expect(record.reload.status).to eq("active")
+    end
+  end
+
+  describe "#supersede!" do
+    it "marks the record as superseded by the given record" do
+      original = create(:decision_record)
+      new_record = create(:decision_record, project: original.project)
+      original.supersede!(new_record)
+      expect(original.reload.status).to eq("superseded")
+      expect(original.superseded_by).to eq(new_record)
+    end
+  end
+
+  describe "#revert!" do
+    it "transitions to reverted status" do
+      record = create(:decision_record)
+      record.revert!
+      expect(record.reload.status).to eq("reverted")
+    end
+  end
+end

--- a/spec/models/decision_record_spec.rb
+++ b/spec/models/decision_record_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe DecisionRecord do
         expect(record).not_to be_valid
         expect(record.errors[:superseded_by]).to include("must belong to the same project")
       end
+
+      it "rejects superseded_by referencing itself" do
+        record = create(:decision_record)
+        record.superseded_by = record
+        expect(record).not_to be_valid
+        expect(record.errors[:superseded_by]).to include("cannot reference itself")
+      end
     end
   end
 
@@ -114,6 +121,11 @@ RSpec.describe DecisionRecord do
       original.supersede!(new_record)
       expect(original.reload.status).to eq("superseded")
       expect(original.superseded_by).to eq(new_record)
+    end
+
+    it "raises when superseding with itself" do
+      record = create(:decision_record)
+      expect { record.supersede!(record) }.to raise_error(ArgumentError, "cannot supersede with itself")
     end
   end
 

--- a/spec/models/decision_record_spec.rb
+++ b/spec/models/decision_record_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe DecisionRecord do
       expect(record.errors[:title]).to include("is immutable after creation")
     end
 
+    it "prevents updating foreign key fields after creation" do
+      record = create(:decision_record)
+      other_project = create(:project)
+      record.project_id = other_project.id
+      expect(record.save).to be false
+      expect(record.errors[:project_id]).to include("is immutable after creation")
+    end
+
     it "allows updating status" do
       record = create(:decision_record)
       record.status = "superseded"

--- a/spec/models/decision_record_spec.rb
+++ b/spec/models/decision_record_spec.rb
@@ -23,6 +23,32 @@ RSpec.describe DecisionRecord do
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
     it { is_expected.to validate_length_of(:commit_sha_start).is_at_most(40) }
     it { is_expected.to validate_length_of(:commit_sha_end).is_at_most(40) }
+
+    describe "project consistency" do
+      it "rejects agent_run from a different project" do
+        other_project = create(:project)
+        other_run = create(:agent_run, :completed, project: other_project)
+        record = build(:decision_record, agent_run: other_run)
+        expect(record).not_to be_valid
+        expect(record.errors[:agent_run]).to include("must belong to the same project")
+      end
+
+      it "rejects issue from a different project" do
+        other_project = create(:project)
+        other_issue = create(:issue, project: other_project)
+        record = build(:decision_record, issue: other_issue)
+        expect(record).not_to be_valid
+        expect(record.errors[:issue]).to include("must belong to the same project")
+      end
+
+      it "rejects superseded_by from a different project" do
+        other_project = create(:project)
+        other_record = create(:decision_record, project: other_project)
+        record = build(:decision_record, superseded_by: other_record)
+        expect(record).not_to be_valid
+        expect(record.errors[:superseded_by]).to include("must belong to the same project")
+      end
+    end
   end
 
   describe "immutability" do

--- a/spec/models/decision_record_spec.rb
+++ b/spec/models/decision_record_spec.rb
@@ -107,10 +107,20 @@ RSpec.describe DecisionRecord do
   end
 
   describe "#activate!" do
-    it "transitions to active status" do
+    it "transitions from draft to active status" do
       record = create(:decision_record, :draft)
       record.activate!
       expect(record.reload.status).to eq("active")
+    end
+
+    it "raises when already active" do
+      record = create(:decision_record, status: "active")
+      expect { record.activate! }.to raise_error(DecisionRecord::InvalidTransitionError, /cannot activate from active/)
+    end
+
+    it "raises when superseded" do
+      record = create(:decision_record, status: "superseded")
+      expect { record.activate! }.to raise_error(DecisionRecord::InvalidTransitionError, /cannot activate from superseded/)
     end
   end
 
@@ -127,6 +137,18 @@ RSpec.describe DecisionRecord do
       record = create(:decision_record)
       expect { record.supersede!(record) }.to raise_error(ArgumentError, "cannot supersede with itself")
     end
+
+    it "raises when already superseded" do
+      record = create(:decision_record, status: "superseded")
+      other = create(:decision_record, project: record.project)
+      expect { record.supersede!(other) }.to raise_error(DecisionRecord::InvalidTransitionError, /cannot supersede from superseded/)
+    end
+
+    it "raises when reverted" do
+      record = create(:decision_record, status: "reverted")
+      other = create(:decision_record, project: record.project)
+      expect { record.supersede!(other) }.to raise_error(DecisionRecord::InvalidTransitionError, /cannot supersede from reverted/)
+    end
   end
 
   describe "#revert!" do
@@ -134,6 +156,16 @@ RSpec.describe DecisionRecord do
       record = create(:decision_record)
       record.revert!
       expect(record.reload.status).to eq("reverted")
+    end
+
+    it "raises when already superseded" do
+      record = create(:decision_record, status: "superseded")
+      expect { record.revert! }.to raise_error(DecisionRecord::InvalidTransitionError, /cannot revert from superseded/)
+    end
+
+    it "raises when already reverted" do
+      record = create(:decision_record, status: "reverted")
+      expect { record.revert! }.to raise_error(DecisionRecord::InvalidTransitionError, /cannot revert from reverted/)
     end
   end
 end

--- a/spec/services/knowledge/collectors/decision_record_collector_spec.rb
+++ b/spec/services/knowledge/collectors/decision_record_collector_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe Knowledge::Collectors::DecisionRecordCollector do
         expect(artifact[:content]).to include("## Decision")
       end
 
+      it "includes status in content so content_hash changes with status transitions" do
+        expect(artifact[:content]).to include("Status: active")
+      end
+
       it "includes context section when present" do
         expect(artifact[:content]).to include("## Context")
         expect(artifact[:content]).to include("Session auth was insufficient.")

--- a/spec/services/knowledge/collectors/decision_record_collector_spec.rb
+++ b/spec/services/knowledge/collectors/decision_record_collector_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::Collectors::DecisionRecordCollector do
+  subject(:collector) do
+    described_class.new(
+      project: project,
+      project_version: project_version,
+      collector_run: collector_run,
+      options: {}
+    )
+  end
+
+  let(:project) { create(:project) }
+  let(:project_version) { Struct.new(:id).new(1) }
+  let(:collector_run) { Struct.new(:id).new(1) }
+
+  describe "#collector_type" do
+    it "returns decision_record" do
+      expect(collector.collector_type).to eq("decision_record")
+    end
+  end
+
+  describe "#collect" do
+    it "returns empty array when no decision records exist" do
+      expect(collector.collect).to eq([])
+    end
+
+    context "with active decision records" do
+      let!(:record) do
+        create(:decision_record,
+          project: project,
+          title: "Use JWT for auth",
+          summary: "JWT chosen for API auth.",
+          context: "Session auth was insufficient.",
+          decision: "Implement JWT auth.",
+          consequences: "Clients must refresh tokens.",
+          tags: %w[auth api],
+          status: "active")
+      end
+
+      let(:artifacts) { collector.collect }
+      let(:artifact) { artifacts.first }
+
+      it "returns one artifact per record" do
+        expect(artifacts.length).to eq(1)
+      end
+
+      it "sets artifact_type to decision_record" do
+        expect(artifact[:artifact_type]).to eq("decision_record")
+      end
+
+      it "sets scope_path using the record id" do
+        expect(artifact[:scope_path]).to eq("decisions/#{record.id}")
+      end
+
+      it "uses the title as identifier" do
+        expect(artifact[:identifier]).to eq("Use JWT for auth")
+      end
+
+      it "includes metadata with record attributes" do
+        expect(artifact[:metadata]).to include(
+          decision_record_id: record.id,
+          status: "active",
+          tags: %w[auth api]
+        )
+      end
+
+      it "builds content with title and sections" do
+        expect(artifact[:content]).to include("# Use JWT for auth")
+        expect(artifact[:content]).to include("## Summary")
+        expect(artifact[:content]).to include("## Decision")
+      end
+
+      it "includes context section when present" do
+        expect(artifact[:content]).to include("## Context")
+        expect(artifact[:content]).to include("Session auth was insufficient.")
+      end
+
+      it "includes consequences section when present" do
+        expect(artifact[:content]).to include("## Consequences")
+        expect(artifact[:content]).to include("Clients must refresh tokens.")
+      end
+
+      it "produces a summary chunk" do
+        summary_chunk = artifact[:chunks].find { |c| c[:chunk_type] == "summary" }
+        expect(summary_chunk).to be_present
+        expect(summary_chunk[:content]).to include("Use JWT for auth")
+      end
+
+      it "produces a context chunk" do
+        context_chunk = artifact[:chunks].find { |c| c[:chunk_type] == "context" }
+        expect(context_chunk).to be_present
+        expect(context_chunk[:content]).to eq("Session auth was insufficient.")
+      end
+
+      it "produces evidence chunks for decision and consequences" do
+        evidence_chunks = artifact[:chunks].select { |c| c[:chunk_type] == "evidence" }
+        expect(evidence_chunks.length).to eq(2)
+      end
+
+      it "sets scope_tags from record tags" do
+        artifact[:chunks].each do |chunk|
+          expect(chunk[:scope_tags]).to eq(%w[auth api])
+        end
+      end
+    end
+
+    context "with optional fields absent" do
+      let(:record) do
+        create(:decision_record,
+          project: project,
+          context: nil,
+          consequences: nil,
+          tags: [])
+      end
+
+      let(:artifacts) { collector.collect }
+      let(:artifact) { artifacts.first }
+
+      before { record }
+
+      it "omits context section from content" do
+        expect(artifact[:content]).not_to include("## Context")
+      end
+
+      it "omits consequences section from content" do
+        expect(artifact[:content]).not_to include("## Consequences")
+      end
+
+      it "does not produce a context chunk" do
+        context_chunks = artifact[:chunks].select { |c| c[:chunk_type] == "context" }
+        expect(context_chunks).to be_empty
+      end
+
+      it "produces only one evidence chunk (decision only)" do
+        evidence_chunks = artifact[:chunks].select { |c| c[:chunk_type] == "evidence" }
+        expect(evidence_chunks.length).to eq(1)
+      end
+    end
+
+    context "with superseded records" do
+      before do
+        create(:decision_record, :superseded, project: project)
+      end
+
+      it "excludes superseded records" do
+        artifacts = collector.collect
+        statuses = artifacts.map { |a| a[:metadata][:status] }
+        expect(statuses).not_to include("superseded")
+      end
+    end
+
+    context "with draft records" do
+      before do
+        create(:decision_record, :draft, project: project)
+      end
+
+      it "includes draft records" do
+        expect(collector.collect.length).to eq(1)
+      end
+    end
+
+    context "with records from another project" do
+      before do
+        create(:decision_record) # different project
+      end
+
+      it "excludes records from other projects" do
+        expect(collector.collect).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/knowledge/decisions/draft_spec.rb
+++ b/spec/services/knowledge/decisions/draft_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe Knowledge::Decisions::Draft do
       expect(result).to be_nil
     end
 
+    it "returns nil when LLM response indicates failure" do
+      allow(llm_response).to receive(:success?).and_return(false)
+      result = described_class.call(agent_run: agent_run)
+      expect(result).to be_nil
+    end
+
     it "calls AgentHarness with correct parameters" do
       described_class.call(agent_run: agent_run)
 

--- a/spec/services/knowledge/decisions/draft_spec.rb
+++ b/spec/services/knowledge/decisions/draft_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::Decisions::Draft do
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project) }
+  let(:agent_run) do
+    create(:agent_run, :completed, project: project, issue: issue,
+      base_commit_sha: "aaa0000000000000000000000000000000000000",
+      result_commit_sha: "bbb0000000000000000000000000000000000000")
+  end
+
+  let(:llm_json) do
+    {
+      title: "Use JWT for auth",
+      summary: "Decided to use JWT.",
+      context: "Session auth was insufficient.",
+      decision: "Implement JWT auth.",
+      consequences: "Clients must refresh tokens.",
+      tags: %w[auth api]
+    }.to_json
+  end
+
+  let(:llm_response) do
+    response = Object.new
+    json = llm_json
+    response.define_singleton_method(:output) { json }
+    response.define_singleton_method(:success?) { true }
+    response
+  end
+
+  before do
+    allow(AgentHarness).to receive(:send_message).and_return(llm_response)
+    agent_run.log!("stdout", "Implemented JWT authentication for API endpoints")
+  end
+
+  describe ".call" do
+    it "creates a persisted active decision record" do
+      record = described_class.call(agent_run: agent_run)
+
+      expect(record).to be_a(DecisionRecord)
+      expect(record).to be_persisted
+      expect(record.status).to eq("active")
+    end
+
+    it "populates record fields from LLM response" do
+      record = described_class.call(agent_run: agent_run)
+
+      expect(record.title).to eq("Use JWT for auth")
+      expect(record.summary).to eq("Decided to use JWT.")
+      expect(record.decision).to eq("Implement JWT auth.")
+      expect(record.tags).to eq(%w[auth api])
+    end
+
+    it "links record to project, agent run, and issue" do
+      record = described_class.call(agent_run: agent_run)
+
+      expect(record.project).to eq(project)
+      expect(record.agent_run).to eq(agent_run)
+      expect(record.issue).to eq(issue)
+    end
+
+    it "stores commit SHA range from agent run" do
+      record = described_class.call(agent_run: agent_run)
+
+      expect(record.commit_sha_start).to eq("aaa0000000000000000000000000000000000000")
+      expect(record.commit_sha_end).to eq("bbb0000000000000000000000000000000000000")
+    end
+
+    it "creates links to agent run and issue" do
+      record = described_class.call(agent_run: agent_run)
+
+      links = record.decision_record_links
+      expect(links.count).to eq(2)
+      expect(links.find_by(linkable_type: "AgentRun").linkable_id).to eq(agent_run.id.to_s)
+      expect(links.find_by(linkable_type: "Issue").linkable_id).to eq(issue.id.to_s)
+    end
+
+    it "returns nil when agent has no output" do
+      agent_run.agent_run_logs.destroy_all
+      result = described_class.call(agent_run: agent_run)
+      expect(result).to be_nil
+    end
+
+    it "returns nil when LLM returns unparseable response" do
+      allow(llm_response).to receive(:output).and_return("not json")
+      result = described_class.call(agent_run: agent_run)
+      expect(result).to be_nil
+    end
+
+    it "calls AgentHarness with correct parameters" do
+      described_class.call(agent_run: agent_run)
+
+      expect(AgentHarness).to have_received(:send_message).with(
+        a_string_matching(/Decision Record/),
+        provider: :claude,
+        model: described_class::DEFAULT_MODEL,
+        timeout: described_class::TIMEOUT,
+        dangerous_mode: false
+      )
+    end
+  end
+end

--- a/spec/services/knowledge/decisions/draft_spec.rb
+++ b/spec/services/knowledge/decisions/draft_spec.rb
@@ -106,5 +106,32 @@ RSpec.describe Knowledge::Decisions::Draft do
         dangerous_mode: false
       )
     end
+
+    it "returns nil when LLM response is missing required fields" do
+      incomplete = { title: "Missing fields", tags: %w[test] }.to_json
+      allow(llm_response).to receive(:output).and_return(incomplete)
+
+      result = described_class.call(agent_run: agent_run)
+      expect(result).to be_nil
+    end
+
+    it "returns nil and logs when AgentHarness raises an error" do
+      allow(AgentHarness).to receive(:send_message).and_raise(AgentHarness::Error, "timeout")
+
+      result = described_class.call(agent_run: agent_run)
+      expect(result).to be_nil
+    end
+
+    it "returns nil and logs when record creation raises RecordInvalid" do
+      # Title exceeding max length after truncation would still pass, so use a
+      # different approach: temporarily make the project association invalid to
+      # trigger RecordInvalid from create!
+      json = { title: "T", summary: "S", decision: "D", tags: [] }.to_json
+      allow(llm_response).to receive(:output).and_return(json)
+      allow(agent_run).to receive(:project).and_return(nil)
+
+      result = described_class.call(agent_run: agent_run)
+      expect(result).to be_nil
+    end
   end
 end

--- a/spec/services/knowledge/decisions/supersede_spec.rb
+++ b/spec/services/knowledge/decisions/supersede_spec.rb
@@ -37,5 +37,12 @@ RSpec.describe Knowledge::Decisions::Supersede do
         described_class.call(original: original, superseding: superseding)
       }.to raise_error(ArgumentError, /already be superseded/)
     end
+
+    it "raises when records are not persisted" do
+      unpersisted = build(:decision_record, project: project)
+      expect {
+        described_class.call(original: unpersisted, superseding: superseding)
+      }.to raise_error(ArgumentError, /must be persisted/)
+    end
   end
 end

--- a/spec/services/knowledge/decisions/supersede_spec.rb
+++ b/spec/services/knowledge/decisions/supersede_spec.rb
@@ -35,7 +35,14 @@ RSpec.describe Knowledge::Decisions::Supersede do
       original.update!(status: "superseded")
       expect {
         described_class.call(original: original, superseding: superseding)
-      }.to raise_error(ArgumentError, /already be superseded/)
+      }.to raise_error(ArgumentError, /must be draft or active/)
+    end
+
+    it "raises when original is reverted" do
+      original.update!(status: "reverted")
+      expect {
+        described_class.call(original: original, superseding: superseding)
+      }.to raise_error(ArgumentError, /must be draft or active/)
     end
 
     it "raises when records are not persisted" do

--- a/spec/services/knowledge/decisions/supersede_spec.rb
+++ b/spec/services/knowledge/decisions/supersede_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::Decisions::Supersede do
+  let(:project) { create(:project) }
+  let(:original) { create(:decision_record, project: project) }
+  let(:superseding) { create(:decision_record, project: project) }
+
+  describe ".call" do
+    it "marks the original as superseded" do
+      described_class.call(original: original, superseding: superseding)
+
+      original.reload
+      expect(original.status).to eq("superseded")
+      expect(original.superseded_by).to eq(superseding)
+    end
+
+    it "creates a reverts link on the superseding record" do
+      described_class.call(original: original, superseding: superseding)
+
+      link = superseding.decision_record_links.find_by(link_type: "reverts")
+      expect(link).to be_present
+      expect(link.linkable_type).to eq("DecisionRecord")
+      expect(link.linkable_id).to eq(original.id.to_s)
+    end
+
+    it "raises when original and superseding are the same" do
+      expect {
+        described_class.call(original: original, superseding: original)
+      }.to raise_error(ArgumentError, /must be different/)
+    end
+
+    it "raises when original is already superseded" do
+      original.update!(status: "superseded")
+      expect {
+        described_class.call(original: original, superseding: superseding)
+      }.to raise_error(ArgumentError, /already be superseded/)
+    end
+  end
+end

--- a/spec/services/knowledge/decisions/supersede_spec.rb
+++ b/spec/services/knowledge/decisions/supersede_spec.rb
@@ -51,5 +51,13 @@ RSpec.describe Knowledge::Decisions::Supersede do
         described_class.call(original: unpersisted, superseding: superseding)
       }.to raise_error(ArgumentError, /must be persisted/)
     end
+
+    it "raises when records belong to different projects" do
+      other_project = create(:project)
+      other_record = create(:decision_record, project: other_project)
+      expect {
+        described_class.call(original: original, superseding: other_record)
+      }.to raise_error(ArgumentError, /must belong to the same project/)
+    end
   end
 end

--- a/spec/temporal/activities/draft_decision_record_activity_spec.rb
+++ b/spec/temporal/activities/draft_decision_record_activity_spec.rb
@@ -9,13 +9,14 @@ RSpec.describe Activities::DraftDecisionRecordActivity do
 
   describe "#execute" do
     it "returns success when a decision record is drafted" do
-      record = create(:decision_record, agent_run: agent_run, project: project)
-      allow(Knowledge::Decisions::Draft).to receive(:call).and_return(record)
+      allow(Knowledge::Decisions::Draft).to receive(:call).and_return(
+        build(:decision_record, id: 42, agent_run: agent_run, project: project)
+      )
 
       result = activity.execute(agent_run_id: agent_run.id)
 
       expect(result[:success]).to be true
-      expect(result[:decision_record_id]).to eq(record.id)
+      expect(result[:decision_record_id]).to eq(42)
       expect(result[:agent_run_id]).to eq(agent_run.id)
     end
 
@@ -26,6 +27,17 @@ RSpec.describe Activities::DraftDecisionRecordActivity do
 
       expect(result[:success]).to be true
       expect(result[:decision_record_id]).to be_nil
+    end
+
+    it "returns existing record without calling Draft service (idempotency)" do
+      record = create(:decision_record, agent_run: agent_run, project: project)
+      allow(Knowledge::Decisions::Draft).to receive(:call)
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(Knowledge::Decisions::Draft).not_to have_received(:call)
+      expect(result[:success]).to be true
+      expect(result[:decision_record_id]).to eq(record.id)
     end
 
     it "returns failure without raising when draft errors" do

--- a/spec/temporal/activities/draft_decision_record_activity_spec.rb
+++ b/spec/temporal/activities/draft_decision_record_activity_spec.rb
@@ -55,5 +55,11 @@ RSpec.describe Activities::DraftDecisionRecordActivity do
       expect(result[:success]).to be false
       expect(result[:error]).to eq("LLM timeout")
     end
+
+    it "re-raises Temporalio::Error::CanceledError instead of swallowing it" do
+      allow(Knowledge::Decisions::Draft).to receive(:call).and_raise(Temporalio::Error::CanceledError, "activity canceled")
+
+      expect { activity.execute(agent_run_id: agent_run.id) }.to raise_error(Temporalio::Error::CanceledError)
+    end
   end
 end

--- a/spec/temporal/activities/draft_decision_record_activity_spec.rb
+++ b/spec/temporal/activities/draft_decision_record_activity_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::DraftDecisionRecordActivity do
+  let(:activity) { described_class.new }
+  let(:project) { create(:project) }
+  let(:agent_run) { create(:agent_run, :completed, project: project) }
+
+  describe "#execute" do
+    it "returns success when a decision record is drafted" do
+      record = create(:decision_record, agent_run: agent_run, project: project)
+      allow(Knowledge::Decisions::Draft).to receive(:call).and_return(record)
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:success]).to be true
+      expect(result[:decision_record_id]).to eq(record.id)
+      expect(result[:agent_run_id]).to eq(agent_run.id)
+    end
+
+    it "returns success with nil decision_record_id when draft is skipped" do
+      allow(Knowledge::Decisions::Draft).to receive(:call).and_return(nil)
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:success]).to be true
+      expect(result[:decision_record_id]).to be_nil
+    end
+
+    it "returns failure without raising when draft errors" do
+      allow(Knowledge::Decisions::Draft).to receive(:call).and_raise(StandardError, "LLM timeout")
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:success]).to be false
+      expect(result[:error]).to eq("LLM timeout")
+    end
+  end
+end

--- a/spec/temporal/activities/draft_decision_record_activity_spec.rb
+++ b/spec/temporal/activities/draft_decision_record_activity_spec.rb
@@ -7,21 +7,45 @@ RSpec.describe Activities::DraftDecisionRecordActivity do
   let(:project) { create(:project) }
   let(:agent_run) { create(:agent_run, :completed, project: project) }
 
-  describe "#execute" do
-    it "returns success when a decision record is drafted" do
-      allow(Knowledge::Decisions::Draft).to receive(:call).and_return(
-        build(:decision_record, id: 42, agent_run: agent_run, project: project)
-      )
+  let(:llm_json) do
+    {
+      title: "Use JWT for auth",
+      summary: "Decided to use JWT.",
+      context: "Session auth was insufficient.",
+      decision: "Implement JWT auth.",
+      consequences: "Clients must refresh tokens.",
+      tags: %w[auth api]
+    }.to_json
+  end
 
+  let(:llm_response) do
+    response = Object.new
+    json = llm_json
+    response.define_singleton_method(:output) { json }
+    response.define_singleton_method(:success?) { true }
+    response
+  end
+
+  before do
+    allow(AgentHarness).to receive(:send_message).and_return(llm_response)
+  end
+
+  describe "#execute" do
+    before do
+      agent_run.log!("stdout", "Implemented JWT authentication for API endpoints")
+    end
+
+    it "returns success when a decision record is drafted" do
       result = activity.execute(agent_run_id: agent_run.id)
 
       expect(result[:success]).to be true
-      expect(result[:decision_record_id]).to eq(42)
+      expect(result[:decision_record_id]).to be_present
       expect(result[:agent_run_id]).to eq(agent_run.id)
+      expect(AgentHarness).to have_received(:send_message)
     end
 
-    it "returns success with nil decision_record_id when draft is skipped" do
-      allow(Knowledge::Decisions::Draft).to receive(:call).and_return(nil)
+    it "returns success with nil decision_record_id when LLM returns empty output" do
+      allow(llm_response).to receive(:output).and_return("")
 
       result = activity.execute(agent_run_id: agent_run.id)
 
@@ -29,13 +53,12 @@ RSpec.describe Activities::DraftDecisionRecordActivity do
       expect(result[:decision_record_id]).to be_nil
     end
 
-    it "returns existing record without calling Draft service (idempotency)" do
+    it "returns existing record without calling LLM (idempotency)" do
       record = create(:decision_record, agent_run: agent_run, project: project)
-      allow(Knowledge::Decisions::Draft).to receive(:call)
 
       result = activity.execute(agent_run_id: agent_run.id)
 
-      expect(Knowledge::Decisions::Draft).not_to have_received(:call)
+      expect(AgentHarness).not_to have_received(:send_message)
       expect(result[:success]).to be true
       expect(result[:decision_record_id]).to eq(record.id)
     end
@@ -47,17 +70,26 @@ RSpec.describe Activities::DraftDecisionRecordActivity do
       expect(result[:error]).to eq("agent_run_id is required")
     end
 
-    it "returns failure without raising when draft errors" do
-      allow(Knowledge::Decisions::Draft).to receive(:call).and_raise(StandardError, "LLM timeout")
+    it "returns success with nil record when AgentHarness errors (Draft rescues internally)" do
+      allow(AgentHarness).to receive(:send_message).and_raise(AgentHarness::Error, "LLM timeout")
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:success]).to be true
+      expect(result[:decision_record_id]).to be_nil
+    end
+
+    it "returns failure without raising when an unexpected error occurs" do
+      allow(AgentHarness).to receive(:send_message).and_raise(RuntimeError, "unexpected")
 
       result = activity.execute(agent_run_id: agent_run.id)
 
       expect(result[:success]).to be false
-      expect(result[:error]).to eq("LLM timeout")
+      expect(result[:error]).to eq("unexpected")
     end
 
     it "re-raises Temporalio::Error::CanceledError instead of swallowing it" do
-      allow(Knowledge::Decisions::Draft).to receive(:call).and_raise(Temporalio::Error::CanceledError, "activity canceled")
+      allow(AgentHarness).to receive(:send_message).and_raise(Temporalio::Error::CanceledError, "activity canceled")
 
       expect { activity.execute(agent_run_id: agent_run.id) }.to raise_error(Temporalio::Error::CanceledError)
     end


### PR DESCRIPTION
All done. Here's a summary of what was implemented:

## Implementation Summary

### Migrations
- **`CreateDecisionRecords`** — `decision_records` table with project/agent_run/issue FKs, content fields (title, summary, context, decision, consequences), status, superseded_by self-reference, commit SHA range, jsonb tags, and GIN index on tags
- **`CreateDecisionRecordLinks`** — `decision_record_links` table with polymorphic linkable (type + string ID), link_type, and cascade delete

### Models
- **`DecisionRecord`** — Status transitions (draft → active → superseded/reverted), immutability enforcement via `before_update` callback on content fields, self-referential `superseded_by` association
- **`DecisionRecordLink`** — Polymorphic links to KnowledgeChunk, Issue, AgentRun, or DecisionRecord with link types: evidence, implements, reverts

### Services
- **`Knowledge::Decisions::Draft`** — Calls agent-harness LLM to draft a decision record from a completed agent run's output, creates the record + links in a transaction
- **`Knowledge::Decisions::Supersede`** — Marks an original decision as superseded and creates a reverts link on the new record

### Activity & Workflow Integration
- **`Activities::DraftDecisionRecordActivity`** — Best-effort activity that catches all errors (won't break the workflow)
- **`AgentExecutionWorkflow`** — Integrated `draft_decision_record` call after both new PR creation and existing PR completion paths

### Knowledge Indexing
- **`Knowledge::Collectors::DecisionRecordCollector`** — Indexes decision records as knowledge artifacts with summary, context, and evidence chunks for unified search

### Specs (46 examples)
- Model specs for validations, associations, immutability, scopes, and status transitions
- Service specs for Draft (LLM mocking, parsing, link creation) and Supersede (status updates, validation)
- Activity spec for DraftDecisionRecordActivity (success, skip, and error cases)

---

Closes #261