### PR TITLE
Fix #580: Show PR link instead of quick run button for synced issues with active PRs

### DIFF
--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -79,7 +79,7 @@ module Projects
         return
       end
 
-      if issue&.has_associated_pull_requests?
+      if issue&.associated_pull_request
         redirect_to project_path(@project),
           alert: "This issue already has an associated pull request."
         return

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -111,19 +111,15 @@ class Issue < ApplicationRecord
 
   def associated_pull_request
     if sub_issues.loaded?
-      prs = sub_issues.select(&:is_pull_request?)
-      return nil if prs.empty?
+      open_prs = sub_issues.select { |si| si.is_pull_request? && si.github_state == "open" }
+      return nil if open_prs.empty?
 
-      open_prs = prs.select { |pr| pr.github_state == "open" }
-      candidates = open_prs.any? ? open_prs : prs
-
-      candidates.max_by { |pr| pr.github_updated_at || pr.updated_at || Time.at(0) }
+      open_prs.max_by { |pr| pr.github_updated_at || pr.updated_at || Time.at(0) }
     else
-      scope = sub_issues.pull_requests_only
-      open_scope = scope.where(github_state: "open")
-
-      open_scope.order(github_updated_at: :desc, updated_at: :desc).first ||
-        scope.order(github_updated_at: :desc, updated_at: :desc).first
+      sub_issues.pull_requests_only
+        .where(github_state: "open")
+        .order(github_updated_at: :desc, updated_at: :desc)
+        .first
     end
   end
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -114,7 +114,9 @@ class Issue < ApplicationRecord
       open_prs = sub_issues.select { |si| si.is_pull_request? && si.github_state == "open" }
       return nil if open_prs.empty?
 
-      open_prs.max_by { |pr| pr.github_updated_at || pr.updated_at || Time.at(0) }
+      open_prs.max_by do |pr|
+        [ pr.github_updated_at || Time.at(0), pr.updated_at || Time.at(0) ]
+      end
     else
       sub_issues.pull_requests_only
         .where(github_state: "open")

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -109,6 +109,14 @@ class Issue < ApplicationRecord
     end
   end
 
+  def associated_pull_request
+    if sub_issues.loaded?
+      sub_issues.find(&:is_pull_request?)
+    else
+      sub_issues.pull_requests_only.first
+    end
+  end
+
   def draft_phase?
     pr_review_phase.in?(%w[draft restarted])
   end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -111,9 +111,19 @@ class Issue < ApplicationRecord
 
   def associated_pull_request
     if sub_issues.loaded?
-      sub_issues.find(&:is_pull_request?)
+      prs = sub_issues.select(&:is_pull_request?)
+      return nil if prs.empty?
+
+      open_prs = prs.select { |pr| pr.github_state == "open" }
+      candidates = open_prs.any? ? open_prs : prs
+
+      candidates.max_by { |pr| pr.github_updated_at || pr.updated_at || Time.at(0) }
     else
-      sub_issues.pull_requests_only.first
+      scope = sub_issues.pull_requests_only
+      open_scope = scope.where(github_state: "open")
+
+      open_scope.order(github_updated_at: :desc, updated_at: :desc).first ||
+        scope.order(github_updated_at: :desc, updated_at: :desc).first
     end
   end
 

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -31,7 +31,7 @@
                   target: "_blank",
                   rel: "noopener noreferrer",
                   class: "inline-flex items-center space-x-1 text-xs font-medium text-indigo-600 hover:text-indigo-900" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3.5 w-3.5" role="img" aria-label="Pull request">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3.5 w-3.5" aria-hidden="true">
           <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/>
         </svg>
         <span>PR #<%= pr.github_number %></span>

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -25,7 +25,17 @@
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= paid_state_badge(issue.paid_state) %>
-    <% unless issue.has_associated_pull_requests? %>
+    <% if (pr = issue.associated_pull_request) %>
+      <%= link_to pr.github_url,
+                  target: "_blank",
+                  rel: "noopener noreferrer",
+                  class: "inline-flex items-center space-x-1 text-xs font-medium text-indigo-600 hover:text-indigo-900" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3.5 w-3.5" role="img" aria-label="Pull request">
+          <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/>
+        </svg>
+        <span>PR #<%= pr.github_number %></span>
+      <% end %>
+    <% else %>
       <%= button_to "Quick Run",
                     quick_create_project_agent_runs_path(project, issue_id: issue.id),
                     method: :post,

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -26,7 +26,8 @@
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= paid_state_badge(issue.paid_state) %>
     <% if (pr = issue.associated_pull_request) %>
-      <%= link_to pr.github_url,
+      <%# Build URL from the parent issue's project to avoid N+1 on sub_issues: :project %>
+      <%= link_to "#{project.github_url}/pull/#{pr.github_number}",
                   target: "_blank",
                   rel: "noopener noreferrer",
                   class: "inline-flex items-center space-x-1 text-xs font-medium text-indigo-600 hover:text-indigo-900" do %>

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -304,6 +304,52 @@ RSpec.describe Issue do
     end
   end
 
+  describe "#associated_pull_request" do
+    let(:project) { create(:project) }
+
+    it "returns the pull request sub-issue when one exists" do
+      issue = create(:issue, project: project)
+      pr = create(:issue, :pull_request, project: project, parent_issue: issue)
+
+      expect(issue.associated_pull_request).to eq(pr)
+    end
+
+    it "returns nil when no sub-issues exist" do
+      issue = create(:issue, project: project)
+
+      expect(issue.associated_pull_request).to be_nil
+    end
+
+    it "returns nil when sub-issues are not pull requests" do
+      issue = create(:issue, project: project)
+      create(:issue, project: project, parent_issue: issue)
+
+      expect(issue.associated_pull_request).to be_nil
+    end
+
+    context "when sub_issues are preloaded" do
+      it "returns the pull request from preloaded sub-issues" do
+        issue = create(:issue, project: project)
+        pr = create(:issue, :pull_request, project: project, parent_issue: issue)
+
+        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+        expect(preloaded_issue.sub_issues).to be_loaded
+        expect(preloaded_issue.associated_pull_request).to eq(pr)
+      end
+
+      it "returns nil when preloaded sub-issues have no pull requests" do
+        issue = create(:issue, project: project)
+        create(:issue, project: project, parent_issue: issue)
+
+        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+        expect(preloaded_issue.sub_issues).to be_loaded
+        expect(preloaded_issue.associated_pull_request).to be_nil
+      end
+    end
+  end
+
   describe "#ready_to_work?" do
     let(:project) { create(:project) }
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -302,117 +302,117 @@ RSpec.describe Issue do
         end
       end
     end
-  end
 
-  describe "#associated_pull_request" do
-    let(:project) { create(:project) }
+    describe "#associated_pull_request" do
+      let(:project) { create(:project) }
 
-    it "returns the pull request sub-issue when one exists" do
-      issue = create(:issue, project: project)
-      pr = create(:issue, :pull_request, project: project, parent_issue: issue)
-
-      expect(issue.associated_pull_request).to eq(pr)
-    end
-
-    it "returns nil when no sub-issues exist" do
-      issue = create(:issue, project: project)
-
-      expect(issue.associated_pull_request).to be_nil
-    end
-
-    it "returns nil when sub-issues are not pull requests" do
-      issue = create(:issue, project: project)
-      create(:issue, project: project, parent_issue: issue)
-
-      expect(issue.associated_pull_request).to be_nil
-    end
-
-    it "prefers an open PR over a closed PR" do
-      issue = create(:issue, project: project)
-      create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
-             github_updated_at: 2.days.ago)
-      open_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
-                       github_updated_at: 3.days.ago)
-
-      expect(issue.associated_pull_request).to eq(open_pr)
-    end
-
-    it "returns the most recently updated open PR when multiple exist" do
-      issue = create(:issue, project: project)
-      create(:issue, :pull_request, project: project, parent_issue: issue,
-             github_updated_at: 2.days.ago)
-      newest_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
-                         github_updated_at: 1.hour.ago)
-
-      expect(issue.associated_pull_request).to eq(newest_pr)
-    end
-
-    it "returns nil when only closed PRs exist" do
-      issue = create(:issue, project: project)
-      create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
-             github_updated_at: 2.days.ago)
-      create(:issue, :pull_request, :closed, project: project,
-             parent_issue: issue, github_updated_at: 1.hour.ago)
-
-      expect(issue.associated_pull_request).to be_nil
-    end
-
-    context "when sub_issues are preloaded" do
-      it "returns the pull request from preloaded sub-issues" do
+      it "returns the pull request sub-issue when one exists" do
         issue = create(:issue, project: project)
         pr = create(:issue, :pull_request, project: project, parent_issue: issue)
 
-        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
-
-        expect(preloaded_issue.sub_issues).to be_loaded
-        expect(preloaded_issue.associated_pull_request).to eq(pr)
+        expect(issue.associated_pull_request).to eq(pr)
       end
 
-      it "returns nil when preloaded sub-issues have no pull requests" do
+      it "returns nil when no sub-issues exist" do
+        issue = create(:issue, project: project)
+
+        expect(issue.associated_pull_request).to be_nil
+      end
+
+      it "returns nil when sub-issues are not pull requests" do
         issue = create(:issue, project: project)
         create(:issue, project: project, parent_issue: issue)
 
-        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
-
-        expect(preloaded_issue.sub_issues).to be_loaded
-        expect(preloaded_issue.associated_pull_request).to be_nil
+        expect(issue.associated_pull_request).to be_nil
       end
 
-      it "prefers an open PR over a closed PR with preloaded data" do
+      it "prefers an open PR over a closed PR" do
         issue = create(:issue, project: project)
         create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
                github_updated_at: 2.days.ago)
         open_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
                          github_updated_at: 3.days.ago)
 
-        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
-
-        expect(preloaded_issue.sub_issues).to be_loaded
-        expect(preloaded_issue.associated_pull_request).to eq(open_pr)
+        expect(issue.associated_pull_request).to eq(open_pr)
       end
 
-      it "returns nil when only closed PRs exist with preloaded data" do
-        issue = create(:issue, project: project)
-        create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
-               github_updated_at: 2.days.ago)
-
-        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
-
-        expect(preloaded_issue.sub_issues).to be_loaded
-        expect(preloaded_issue.associated_pull_request).to be_nil
-      end
-
-      it "returns the most recently updated open PR with preloaded data" do
+      it "returns the most recently updated open PR when multiple exist" do
         issue = create(:issue, project: project)
         create(:issue, :pull_request, project: project, parent_issue: issue,
                github_updated_at: 2.days.ago)
         newest_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
                            github_updated_at: 1.hour.ago)
 
-        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+        expect(issue.associated_pull_request).to eq(newest_pr)
+      end
 
-        expect(preloaded_issue.sub_issues).to be_loaded
-        expect(preloaded_issue.associated_pull_request).to eq(newest_pr)
+      it "returns nil when only closed PRs exist" do
+        issue = create(:issue, project: project)
+        create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+               github_updated_at: 2.days.ago)
+        create(:issue, :pull_request, :closed, project: project,
+               parent_issue: issue, github_updated_at: 1.hour.ago)
+
+        expect(issue.associated_pull_request).to be_nil
+      end
+
+      context "when sub_issues are preloaded" do
+        it "returns the pull request from preloaded sub-issues" do
+          issue = create(:issue, project: project)
+          pr = create(:issue, :pull_request, project: project, parent_issue: issue)
+
+          preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+          expect(preloaded_issue.sub_issues).to be_loaded
+          expect(preloaded_issue.associated_pull_request).to eq(pr)
+        end
+
+        it "returns nil when preloaded sub-issues have no pull requests" do
+          issue = create(:issue, project: project)
+          create(:issue, project: project, parent_issue: issue)
+
+          preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+          expect(preloaded_issue.sub_issues).to be_loaded
+          expect(preloaded_issue.associated_pull_request).to be_nil
+        end
+
+        it "prefers an open PR over a closed PR with preloaded data" do
+          issue = create(:issue, project: project)
+          create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+                 github_updated_at: 2.days.ago)
+          open_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
+                           github_updated_at: 3.days.ago)
+
+          preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+          expect(preloaded_issue.sub_issues).to be_loaded
+          expect(preloaded_issue.associated_pull_request).to eq(open_pr)
+        end
+
+        it "returns nil when only closed PRs exist with preloaded data" do
+          issue = create(:issue, project: project)
+          create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+                 github_updated_at: 2.days.ago)
+
+          preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+          expect(preloaded_issue.sub_issues).to be_loaded
+          expect(preloaded_issue.associated_pull_request).to be_nil
+        end
+
+        it "returns the most recently updated open PR with preloaded data" do
+          issue = create(:issue, project: project)
+          create(:issue, :pull_request, project: project, parent_issue: issue,
+                 github_updated_at: 2.days.ago)
+          newest_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
+                             github_updated_at: 1.hour.ago)
+
+          preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+          expect(preloaded_issue.sub_issues).to be_loaded
+          expect(preloaded_issue.associated_pull_request).to eq(newest_pr)
+        end
       end
     end
   end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -347,14 +347,14 @@ RSpec.describe Issue do
       expect(issue.associated_pull_request).to eq(newest_pr)
     end
 
-    it "falls back to the most recently updated closed PR when no open PRs exist" do
+    it "returns nil when only closed PRs exist" do
       issue = create(:issue, project: project)
       create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
              github_updated_at: 2.days.ago)
-      newest_closed_pr = create(:issue, :pull_request, :closed, project: project,
-                                parent_issue: issue, github_updated_at: 1.hour.ago)
+      create(:issue, :pull_request, :closed, project: project,
+             parent_issue: issue, github_updated_at: 1.hour.ago)
 
-      expect(issue.associated_pull_request).to eq(newest_closed_pr)
+      expect(issue.associated_pull_request).to be_nil
     end
 
     context "when sub_issues are preloaded" do
@@ -389,6 +389,17 @@ RSpec.describe Issue do
 
         expect(preloaded_issue.sub_issues).to be_loaded
         expect(preloaded_issue.associated_pull_request).to eq(open_pr)
+      end
+
+      it "returns nil when only closed PRs exist with preloaded data" do
+        issue = create(:issue, project: project)
+        create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+               github_updated_at: 2.days.ago)
+
+        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+        expect(preloaded_issue.sub_issues).to be_loaded
+        expect(preloaded_issue.associated_pull_request).to be_nil
       end
 
       it "returns the most recently updated open PR with preloaded data" do

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -327,6 +327,36 @@ RSpec.describe Issue do
       expect(issue.associated_pull_request).to be_nil
     end
 
+    it "prefers an open PR over a closed PR" do
+      issue = create(:issue, project: project)
+      create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+             github_updated_at: 2.days.ago)
+      open_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
+                       github_updated_at: 3.days.ago)
+
+      expect(issue.associated_pull_request).to eq(open_pr)
+    end
+
+    it "returns the most recently updated open PR when multiple exist" do
+      issue = create(:issue, project: project)
+      create(:issue, :pull_request, project: project, parent_issue: issue,
+             github_updated_at: 2.days.ago)
+      newest_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
+                         github_updated_at: 1.hour.ago)
+
+      expect(issue.associated_pull_request).to eq(newest_pr)
+    end
+
+    it "falls back to the most recently updated closed PR when no open PRs exist" do
+      issue = create(:issue, project: project)
+      create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+             github_updated_at: 2.days.ago)
+      newest_closed_pr = create(:issue, :pull_request, :closed, project: project,
+                                parent_issue: issue, github_updated_at: 1.hour.ago)
+
+      expect(issue.associated_pull_request).to eq(newest_closed_pr)
+    end
+
     context "when sub_issues are preloaded" do
       it "returns the pull request from preloaded sub-issues" do
         issue = create(:issue, project: project)
@@ -346,6 +376,32 @@ RSpec.describe Issue do
 
         expect(preloaded_issue.sub_issues).to be_loaded
         expect(preloaded_issue.associated_pull_request).to be_nil
+      end
+
+      it "prefers an open PR over a closed PR with preloaded data" do
+        issue = create(:issue, project: project)
+        create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+               github_updated_at: 2.days.ago)
+        open_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
+                         github_updated_at: 3.days.ago)
+
+        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+        expect(preloaded_issue.sub_issues).to be_loaded
+        expect(preloaded_issue.associated_pull_request).to eq(open_pr)
+      end
+
+      it "returns the most recently updated open PR with preloaded data" do
+        issue = create(:issue, project: project)
+        create(:issue, :pull_request, project: project, parent_issue: issue,
+               github_updated_at: 2.days.ago)
+        newest_pr = create(:issue, :pull_request, project: project, parent_issue: issue,
+                           github_updated_at: 1.hour.ago)
+
+        preloaded_issue = described_class.includes(:sub_issues).find(issue.id)
+
+        expect(preloaded_issue.sub_issues).to be_loaded
+        expect(preloaded_issue.associated_pull_request).to eq(newest_pr)
       end
     end
   end


### PR DESCRIPTION
Commit succeeded. Here's a summary of the changes:

**`app/models/issue.rb`** - Added `#associated_pull_request` method that returns the first PR sub-issue (using preloaded data when available, same pattern as `has_associated_pull_requests?`).

**`app/views/projects/_issue.html.erb`** - Replaced the blank space (when an issue has an associated PR) with a clickable link showing a GitHub PR icon and "PR #N" that opens the PR on GitHub in a new tab. The Quick Run button is still shown when there's no associated PR.

**`spec/models/issue_spec.rb`** - Added 5 tests for the new `#associated_pull_request` method covering: PR exists, no sub-issues, non-PR sub-issues, and preloaded variants.

---

Closes #580