### PR TITLE
fix(dev): recover from dead overmind processes

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -20,12 +20,30 @@ then
   gem install overmind
 fi
 
-if [ -S "$OVERMIND_SOCKET" ] && ! dev_supervisor_run_overmind overmind status &>/dev/null; then
-  echo "Removing stale Overmind socket..."
-  rm -f "$OVERMIND_SOCKET"
+dev_supervisor_prepare_logging
+
+if [ -S "$OVERMIND_SOCKET" ]; then
+  if ! status_output="$(dev_supervisor_overmind_status_output)"; then
+    echo "Removing stale Overmind socket..."
+    rm -f "$OVERMIND_SOCKET"
+  elif dev_supervisor_overmind_has_dead_processes "$status_output" || dev_supervisor_tmux_has_dead_panes; then
+    echo "Detected unhealthy Overmind session with dead processes. Restarting it..."
+    dev_supervisor_snapshot_state "bin-dev-unhealthy-overmind"
+    if ! dev_supervisor_run_overmind overmind quit >> "$(dev_supervisor_overmind_log)" 2>&1; then
+      echo "Warning: overmind quit returned a non-zero exit status. Continuing recovery..."
+    fi
+    sleep 1
+    if [ -S "$OVERMIND_SOCKET" ] && ! dev_supervisor_run_overmind overmind status &>/dev/null; then
+      rm -f "$OVERMIND_SOCKET"
+    fi
+  else
+    echo "Overmind is already running and healthy."
+    echo "Use 'overmind connect web' to attach, or 'overmind restart' to restart processes."
+    printf '%s\n' "$status_output"
+    exit 0
+  fi
 fi
 
-dev_supervisor_prepare_logging
 dev_supervisor_cleanup_stale_tmux_sockets
 
 # Let the debug gem allow remote connections,

--- a/bin/lib/dev_supervisor.sh
+++ b/bin/lib/dev_supervisor.sh
@@ -45,6 +45,15 @@ dev_supervisor_run_overmind() {
     "$@"
 }
 
+dev_supervisor_overmind_status_output() {
+  dev_supervisor_run_overmind overmind status 2>&1
+}
+
+dev_supervisor_overmind_has_dead_processes() {
+  local output="$1"
+  printf '%s\n' "$output" | awk 'NR > 1 { print $3 }' | grep -qx 'dead'
+}
+
 dev_supervisor_log_line() {
   local file="$1"
   shift
@@ -117,4 +126,44 @@ dev_supervisor_cleanup_stale_tmux_sockets() {
   if [ "$found" -eq 0 ]; then
     dev_supervisor_log_line "$(dev_supervisor_tmux_log)" "No overmind tmux sockets found in $socket_dir"
   fi
+}
+
+dev_supervisor_tmux_sockets() {
+  local socket_dir
+  socket_dir="$(dev_supervisor_tmux_socket_dir)"
+
+  [ -d "$socket_dir" ] || return 0
+
+  local socket
+  for socket in "$socket_dir"/overmind-"$(dev_supervisor_app_name)"-*; do
+    [ -S "$socket" ] || continue
+    printf '%s\n' "$socket"
+  done
+}
+
+dev_supervisor_tmux_has_dead_panes() {
+  local socket
+  local output
+
+  while IFS= read -r socket; do
+    [ -n "$socket" ] || continue
+
+    if ! tmux -S "$socket" ls >> "$(dev_supervisor_tmux_log)" 2>&1; then
+      dev_supervisor_log_line "$(dev_supervisor_tmux_log)" "Treating tmux socket $socket as unhealthy because tmux ls failed"
+      return 0
+    fi
+
+    if ! output="$(tmux -S "$socket" list-panes -a -F '#{pane_dead} #{session_name}:#{window_name}.#{pane_index} #{pane_current_command}' 2>> "$(dev_supervisor_tmux_log)")"; then
+      dev_supervisor_log_line "$(dev_supervisor_tmux_log)" "Treating tmux socket $socket as unhealthy because list-panes failed"
+      return 0
+    fi
+
+    if printf '%s\n' "$output" | grep -q '^1 '; then
+      dev_supervisor_log_line "$(dev_supervisor_tmux_log)" "Detected dead tmux panes on $socket"
+      printf '%s\n' "$output" >> "$(dev_supervisor_tmux_log)"
+      return 0
+    fi
+  done < <(dev_supervisor_tmux_sockets)
+
+  return 1
 }

--- a/spec/lib/dev_script_spec.rb
+++ b/spec/lib/dev_script_spec.rb
@@ -70,21 +70,66 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "exits cleanly when overmind is already running and healthy" do
+    Dir.mktmpdir("dev-script-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, overmind_running: true, tmux_pane_dead: false)
+
+      env = {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "SKIP_DEV_CLEANUP" => "1",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_SUPERVISOR_TMUX_SOCKET_DIR" => File.join(dir, "tmux")
+      }
+      stdout, stderr, status = Open3.capture3(env, script_path, chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Overmind is already running and healthy.")
+      expect(stdout).to include("web       12345     running")
+      expect(File.exist?(File.join(dir, "overmind-start-ran"))).to be(false)
+      expect(File.exist?(File.join(dir, "overmind-quit-ran"))).to be(false)
+    end
+  end
+
+  it "restarts an unhealthy overmind session with dead processes from overmind status" do
+    Dir.mktmpdir("dev-script-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, overmind_running: true, overmind_process_dead: true, tmux_pane_dead: false)
+
+      env = {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "SKIP_DEV_CLEANUP" => "1",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_SUPERVISOR_TMUX_SOCKET_DIR" => File.join(dir, "tmux")
+      }
+      stdout, stderr, status = Open3.capture3(env, script_path, chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Detected unhealthy Overmind session with dead processes. Restarting it...")
+      expect(File.exist?(File.join(dir, "overmind-quit-ran"))).to be(true)
+      expect(File.exist?(File.join(dir, "overmind-start-ran"))).to be(true)
+      expect(Dir.glob(File.join(dir, "log", "dev-update", "diagnostics", "*bin-dev-unhealthy-overmind.log"))).not_to be_empty
+    end
+  end
+
   def write_executable(path, contents)
     File.write(path, contents)
     FileUtils.chmod("+x", path)
   end
 
-  def prepare_script_fixture(dir)
+  def prepare_script_fixture(dir, overmind_running: false, overmind_process_dead: false, tmux_pane_dead: false)
     FileUtils.mkdir_p(File.join(dir, "stubbin"))
     FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
     FileUtils.mkdir_p(File.join(dir, "config"))
+    FileUtils.mkdir_p(File.join(dir, "tmux"))
 
     script_path = File.join(dir, "bin", "dev")
     FileUtils.cp(script_source, script_path)
     FileUtils.chmod("+x", script_path)
     FileUtils.cp(File.expand_path("../../bin/lib/dev_supervisor.sh", __dir__), File.join(dir, "bin", "lib", "dev_supervisor.sh"))
     FileUtils.cp(File.expand_path("../../config/overmind.tmux.conf", __dir__), File.join(dir, "config", "overmind.tmux.conf"))
+
+    FileUtils.touch(File.join(dir, "overmind-running")) if overmind_running
+    create_socket(File.join(dir, ".overmind.sock")) if overmind_running
+    create_socket(File.join(dir, "tmux", "overmind-#{File.basename(dir)}-active")) if overmind_running
 
     write_executable(
       File.join(dir, "stubbin", "overmind"),
@@ -97,10 +142,25 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
         } >> "#{dir}/stubbin/overmind-env.log"
         case "$1" in
           status)
+            if [ -e "#{dir}/overmind-running" ]; then
+              echo "PROCESS   PID       STATUS"
+              if [ "#{overmind_process_dead ? 1 : 0}" = "1" ]; then
+                echo "web       12345     dead"
+              else
+                echo "web       12345     running"
+              fi
+              exit 0
+            fi
             exit 1
             ;;
           start)
             touch "#{dir}/overmind-start-ran"
+            touch "#{dir}/overmind-running"
+            exit 0
+            ;;
+          quit)
+            touch "#{dir}/overmind-quit-ran"
+            rm -f "#{dir}/overmind-running" "#{dir}/.overmind.sock"
             exit 0
             ;;
           *)
@@ -116,7 +176,19 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
       <<~BASH
         #!/usr/bin/env bash
         if [ "$1" = "-S" ] && [ "$3" = "ls" ]; then
+          if [ -e "#{dir}/overmind-running" ]; then
+            exit 0
+          fi
           exit 1
+        fi
+
+        if [ "$1" = "-S" ] && [ "$3" = "list-panes" ]; then
+          if [ "#{tmux_pane_dead ? 1 : 0}" = "1" ]; then
+            echo "1 paid:web.0 ruby"
+          else
+            echo "0 paid:web.0 ruby"
+          fi
+          exit 0
         fi
         echo "unexpected tmux command: $*" >&2
         exit 1


### PR DESCRIPTION
## Summary
- detect unhealthy existing Overmind sessions by parsing `overmind status` for `dead` processes
- keep tmux dead-pane detection as a fallback and capture diagnostics before recovery
- exit cleanly when Overmind is already healthy instead of surfacing a misleading startup failure

## Verification
- `bin/rspec spec/lib/dev_script_spec.rb spec/lib/dev_update_spec.rb` (examples passed; command exits non-zero because partial runs trip the repo's SimpleCov threshold)
- `bin/rubocop spec/lib/dev_script_spec.rb spec/lib/dev_update_spec.rb`
- `shellcheck bin/dev bin/dev-update bin/lib/dev_supervisor.sh`
