### PR TITLE
Fix #592: Add a comment when auto-merging a PR

### DIFF
--- a/app/temporal/activities/merge_pull_request_activity.rb
+++ b/app/temporal/activities/merge_pull_request_activity.rb
@@ -47,7 +47,7 @@ module Activities
         # already-merged PRs may have been merged manually by a human.
         unless pr_data.merged_at
           add_phase_label(client, project, pr_number, PAID_AUTO_MERGED_LABEL)
-          client.add_comment(project.full_name, pr_number, AUTO_MERGE_COMMENT)
+          add_merge_comment(client, project, pr_number)
         end
       end
 
@@ -55,6 +55,17 @@ module Activities
     end
 
     private
+
+    def add_merge_comment(client, project, pr_number)
+      client.add_comment(project.full_name, pr_number, AUTO_MERGE_COMMENT)
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "pr_review.add_comment_failed",
+        project_id: project.id,
+        pr_number: pr_number,
+        error: e.message
+      )
+    end
 
     def attempt_merge(client, project, pr_number)
       client.merge_pull_request(

--- a/spec/temporal/activities/merge_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/merge_pull_request_activity_spec.rb
@@ -141,6 +141,27 @@ RSpec.describe Activities::MergePullRequestActivity do
       end
     end
 
+    context "when commenting fails after merge" do
+      let(:pr_data) { double("pr_data", merged_at: nil) } # rubocop:disable RSpec/VerifiedDoubles
+
+      before do
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, 42)
+          .and_return(pr_data)
+        allow(github_client).to receive(:merge_pull_request)
+        allow(github_client).to receive(:add_labels_to_issue)
+        allow(github_client).to receive(:add_comment)
+          .and_raise(GithubClient::ApiError.new("Not found", status: 404))
+      end
+
+      it "does not raise and still returns merged: true" do
+        result = activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
+
+        expect(result[:merged]).to be true
+        expect(github_client).to have_received(:add_comment)
+      end
+    end
+
     context "when merge fails with expected error (409 conflict)" do
       let(:pr_data) { double("pr_data", merged_at: nil) } # rubocop:disable RSpec/VerifiedDoubles
 


### PR DESCRIPTION
## Summary

Add a comment to PRs when paid's auto-merge feature performs the merge, providing a clear audit trail that distinguishes automatic merges from manual ones.

## Changes

- **Merge activity** (`app/temporal/activities/merge_pull_request_activity.rb`):
  - Added `AUTO_MERGE_COMMENT` constant with the comment text
  - Post a comment on the PR after a successful merge, only when paid actually performed the merge (not when the PR was already merged by a human)
- **Tests** (`spec/temporal/activities/merge_pull_request_activity_spec.rb`):
  - Added test verifying the comment is posted when paid merges a PR
  - Added test verifying the comment is **not** posted when the PR was already merged manually
  - Updated existing test contexts with the `add_comment` stub

## Design Decisions

- The comment is only posted when paid performs the merge, matching the existing behavior for the `paid-auto-merged` label. This avoids incorrectly attributing manual merges to paid's auto-merge feature.

---

Closes #592