### PR TITLE
fix(containers): normalize git push error encoding

### DIFF
--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -693,9 +693,19 @@ module Containers
     # Without this, errors only show "Command exited with code N" which
     # makes debugging impossible.
     def error_with_stderr(result)
-      parts = [ result.error ]
-      parts << result[:stderr] if result[:stderr].present?
+      parts = [ normalize_output(result.error) ]
+      stderr = normalize_output(result[:stderr])
+      parts << stderr if stderr.present?
       parts.join(" — ")
+    end
+
+    def normalize_output(value)
+      return "" if value.nil?
+
+      text = value.to_s
+      return text if text.encoding == Encoding::UTF_8 && text.valid_encoding?
+
+      text.dup.force_encoding(Encoding::UTF_8).scrub
     end
   end
 end

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -443,6 +443,25 @@ RSpec.describe Containers::GitOperations do
       expect { git_ops.push_branch }.to raise_error(described_class::PushError, /error/)
     end
 
+    it "raises PushError when stderr is binary encoded" do
+      binary_stderr = "fatal: remote rejected push \xFF".b
+      binary_failure = Containers::Provision::Result.failure(
+        error: "Command exited with code 1",
+        stdout: "",
+        stderr: binary_stderr,
+        exit_code: 1
+      )
+
+      allow(container_service).to receive(:execute)
+        .with(array_including("push"), anything)
+        .and_return(binary_failure)
+
+      expect { git_ops.push_branch }.to raise_error(
+        described_class::PushError,
+        /Command exited with code 1.*fatal: remote rejected push/
+      )
+    end
+
     it "treats a new-branch retry as success when the remote branch already exists at HEAD" do
       branch_exists_result = Containers::Provision::Result.failure(
         error: "Command exited with code 1",


### PR DESCRIPTION
## Summary
- normalize git push error text before composing `PushError` messages
- prevent binary `stderr` from raising `Encoding::CompatibilityError` during failed push handling
- add regression coverage for binary-encoded push `stderr`

## Why
Agent runs `#3329` and `#3333` both completed the agent step successfully, then failed in `push_branch` because Ruby tried to join UTF-8 text with binary Docker exec output while formatting the git error.

## Testing
- `COVERAGE=false bundle exec rspec spec/services/containers/git_operations_spec.rb`

## Follow-up
- Filed #609 for selective failed-run container retention with a short TTL for diagnostics and salvage.