### PR TITLE
Fix #626: Provider table is not horizontally scrollable on mobile

### DIFF
--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -18,7 +18,7 @@
     <% end %>
   </div>
 
-  <div class="overflow-hidden rounded-lg bg-white shadow">
+  <div class="overflow-x-auto rounded-lg bg-white shadow">
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>


### PR DESCRIPTION
## Summary

Enable horizontal scrolling on the providers table so mobile users can view all columns instead of having content clipped off-screen.

## Changes

- **UI (`app/views/providers/index.html.erb`)**: Changed the table container's CSS class from `overflow-hidden` to `overflow-x-auto`, allowing horizontal scroll on narrow viewports

## Screenshots

> **Note:** Please attach before/after screenshots on a mobile-width viewport before merging.

---

Closes #626