### PR TITLE
fix(knowledge): remove empty Qdrant API key that blocks dev connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,8 +131,6 @@ services:
       - "6333:6333"
     volumes:
       - qdrant-data:/qdrant/storage
-    environment:
-      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}
     networks:
       - paid_internal
     healthcheck:


### PR DESCRIPTION
## Summary

- `docker-compose.yml` sets `QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}` which passes an empty string when `QDRANT_API_KEY` is unset
- Qdrant interprets an empty string as "auth enabled with empty key", not "auth disabled"
- The Rails app's `qdrant_api_key` returns `nil` in dev (no credentials, no env var), so all requests fail with 401
- Removes the env var from the qdrant service; operators who want auth can set it via `.env` or docker-compose override

## Test plan

- [ ] `docker compose up -d qdrant` starts without auth
- [ ] `curl http://qdrant:6333/collections` returns 200 without API key header
- [ ] Setting `QDRANT_API_KEY` in `.env` and adding `QDRANT__SERVICE__API_KEY` back via override still works for production-like setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)