### PR TITLE
fix(db): use correct pool key and raise default to 20

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,7 +17,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", 20) } %>
   <% if ENV["DB_HOST"] %>
   host: <%= ENV["DB_HOST"] %>
   username: postgres


### PR DESCRIPTION
## Summary
- **Renames `max_connections` to `pool`** in `database.yml` — `max_connections` is not a recognized ActiveRecord key, so Rails silently ignored it and used the default pool size of 5
- **Raises default pool from 5 to 20** to accommodate concurrent Temporal poll workflows (9 active projects), GoodJob async jobs, and web requests
- **Adds `DB_POOL` env var** for per-process override (e.g. `DB_POOL=30` for the Temporal worker)

### Root cause
All poll workflows were crash-looping with `"could not obtain a connection from the pool within 5 seconds"`. The health check job restarted them every 5 minutes, but they immediately exhausted the pool and failed again.

## Test plan
- [ ] Verify `ActiveRecord::Base.connection_pool.size` returns 20 after restart
- [ ] Confirm poll workflows stay running after `overmind restart web worker`
- [ ] Verify `DB_POOL` env var overrides the default when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)