### PR TITLE
Fix #695: feat(orchestration): create sub-issues in GitHub from decomposed plan

### DIFF
--- a/app/temporal/activities/create_sub_issues_activity.rb
+++ b/app/temporal/activities/create_sub_issues_activity.rb
@@ -75,6 +75,8 @@ module Activities
           sub_issue_number: gh_issue.number
         )
       end
+    rescue Temporalio::Error::CanceledError
+      raise
     rescue StandardError => e
       raise e if created_issues.empty?
 

--- a/spec/temporal/activities/create_sub_issues_activity_spec.rb
+++ b/spec/temporal/activities/create_sub_issues_activity_spec.rb
@@ -230,6 +230,24 @@ RSpec.describe Activities::CreateSubIssuesActivity do
       end
     end
 
+    context "when a CanceledError is raised after partial success" do
+      it "propagates the cancellation instead of wrapping it" do
+        call_count = 0
+        allow(github_client).to receive(:create_issue) do |*_args|
+          call_count += 1
+          if call_count == 1
+            gh_issue_response(number: 101, id: 200_001, title: "Implement authentication", body: "body1")
+          else
+            raise Temporalio::Error::CanceledError, "activity canceled"
+          end
+        end
+
+        expect {
+          activity.execute(project_id: project.id, parent_issue_id: parent_issue.id, sub_tasks: sub_tasks)
+        }.to raise_error(Temporalio::Error::CanceledError)
+      end
+    end
+
     context "when sync_issue_record fails" do
       it "continues creating remaining issues and returns nil issue_id" do
         parent_issue # ensure created before stubbing


### PR DESCRIPTION
## Summary

Automates the creation of GitHub sub-issues from a decomposed plan, enabling `PlanningWorkflow` to break down feature requests into trackable, independently-assignable sub-tasks that are automatically picked up for execution.

## Changes

**Temporal Activity**
- Added `Activities::CreateSubIssuesActivity` that creates GitHub issues via the API for each sub-task in a decomposed plan
- Each sub-issue body includes the task description and a "Sub-issue of #N" back-reference to the parent issue for traceability
- Returns structured metadata (github_number, github_issue_id, issue_id, title) for downstream workflow use

**Issue Relationships & Labels**
- Establishes parent-child relationships by linking each created issue to the parent via `parent_issue_id`
- Applies the project's `automation_label_name` (when automation is enabled) so sub-issues are automatically picked up by agent runs
- Applies `generated_label_name` (when auto-add labels is enabled) to distinguish machine-created issues

**Error Handling**
- If syncing a sub-issue to the local database fails, logs a warning and continues creating remaining issues rather than failing the entire activity

**Tests**
- Added 15 RSpec examples covering issue creation, parent-child linking, label configuration, empty task lists, error handling, and invalid input validation

## Design Decisions

- **Partial failure tolerance**: The activity continues creating remaining sub-issues if one fails to sync locally, since the GitHub issue was already created and losing that reference is worse than blocking all subsequent issues. Failures are logged for observability.
- **Label reuse over hard-coding**: Rather than adding a dedicated `paid-build` label, the activity uses the project's existing `automation_label_name` and `generated_label_name` settings, keeping label configuration centralized and consistent with the rest of the system.

---

Closes #695