### PR TITLE
Fix #703: feat(guardrails): add execution time limits for agent runs

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -104,6 +104,7 @@ class Project < ApplicationRecord
   validates :security_severity_threshold, inclusion: { in: Issue::SEVERITY_ORDER }
   validates :code_scanning_interval_hours, numericality: { greater_than_or_equal_to: 24 }
   validates :knowledge_status, inclusion: { in: KNOWLEDGE_STATUSES }
+  validates :max_execution_seconds, numericality: { only_integer: true, greater_than_or_equal_to: 60, less_than_or_equal_to: 86_400 }
   validate :allowed_github_usernames_not_empty
   validate :agent_co_author_trailer_is_single_line
   validate :owner_reviewer_login_is_trusted, if: -> { owner_reviewer_login.present? }

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -101,6 +101,7 @@ module Activities
           provider_attempt_count: provider_attempt_count_for(agent_run, user_settings),
           agent_timeout_seconds: user_settings&.agent_timeout_seconds || AGENT_TIMEOUT_DEFAULT,
           issue_goal_timeout_seconds: user_settings&.issue_goal_timeout_seconds || Activities::RunAgentActivity::DEFAULT_ISSUE_GOAL_TIMEOUT,
+          max_execution_seconds: project.max_execution_seconds,
           scope_analysis: scope_result ? {
             should_decompose: scope_result.should_decompose?,
             confidence: scope_result.confidence,
@@ -143,7 +144,8 @@ module Activities
         agent_run_id: agent_run.id,
         provider_attempt_count: provider_attempt_count_for(agent_run, user_settings),
         agent_timeout_seconds: user_settings&.agent_timeout_seconds || AGENT_TIMEOUT_DEFAULT,
-        issue_goal_timeout_seconds: user_settings&.issue_goal_timeout_seconds || Activities::RunAgentActivity::DEFAULT_ISSUE_GOAL_TIMEOUT
+        issue_goal_timeout_seconds: user_settings&.issue_goal_timeout_seconds || Activities::RunAgentActivity::DEFAULT_ISSUE_GOAL_TIMEOUT,
+        max_execution_seconds: agent_run.project.max_execution_seconds
       }
     end
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -104,7 +104,15 @@ module Activities
         rate_limit_reset_at = nil
         skipped_rate_limited_count = 0
 
+        max_execution_seconds = agent_run.project.max_execution_seconds
+
         providers.each_with_index do |provider_candidate, index|
+          # Check if the project's execution time limit has been exceeded
+          if max_execution_seconds && agent_run.started_at && (Time.current - agent_run.started_at).to_i >= max_execution_seconds
+            timeout_error = "Execution time limit of #{max_execution_seconds}s exceeded"
+            break
+          end
+
           # Skip routing keys whose provider entry has been deleted — attempting
           # execution would fail with "Unsupported provider" and leak internal
           # identifiers in user-visible error messages.
@@ -394,6 +402,16 @@ module Activities
       else
         user_settings&.agent_timeout_seconds || agent_timeout
       end
+
+      # Cap timeout by the project's max execution time limit.
+      # Uses started_at to compute remaining budget so the limit covers
+      # the full run, not just a single provider attempt.
+      max_exec = agent_run.project.max_execution_seconds
+      if max_exec && agent_run.started_at
+        remaining = (max_exec - (Time.current - agent_run.started_at).to_i).clamp(1, max_exec)
+        effective_timeout = [ effective_timeout, remaining ].min
+      end
+
       effective_idle_timeout = if agent_run.create_issue_goal?
         user_settings&.issue_goal_idle_timeout_seconds || DEFAULT_ISSUE_GOAL_IDLE_TIMEOUT
       elsif agent_run.review_goal?

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -99,6 +99,7 @@ module Workflows
         :issue_goal_timeout_seconds,
         Activities::RunAgentActivity::DEFAULT_ISSUE_GOAL_TIMEOUT
       )
+      max_execution_seconds = agent_run_result[:max_execution_seconds]
 
       agent_step_succeeded = false
       workflow_error = nil
@@ -160,6 +161,14 @@ module Workflows
           agent_timeout_seconds
         end
         activity_timeout = (per_provider_timeout * provider_attempt_count) + 300
+
+        # Cap the activity timeout by the project's max execution time limit
+        # (plus a buffer for Temporal overhead). This ensures runs are terminated
+        # even when the per-provider timeout budget is larger.
+        if max_execution_seconds
+          execution_limit = max_execution_seconds + 300
+          activity_timeout = [ activity_timeout, execution_limit ].min
+        end
         agent_result = run_activity(Activities::RunAgentActivity,
           { agent_run_id: agent_run_id },
           start_to_close_timeout: activity_timeout,

--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -67,10 +67,21 @@
       <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
         <dt class="truncate text-sm font-medium text-gray-500">Duration</dt>
         <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
-          <% if agent_run.duration_seconds.present? %>
-            <%= agent_run.duration_seconds %>s
-          <% elsif agent_run.running? && agent_run.started_at.present? %>
-            <%= (Time.current - agent_run.started_at).to_i %>s
+          <% elapsed = if agent_run.duration_seconds.present?
+               agent_run.duration_seconds
+             elsif agent_run.running? && agent_run.started_at.present?
+               (Time.current - agent_run.started_at).to_i
+             end %>
+          <% if elapsed %>
+            <%= elapsed %>s
+            <% max_exec = agent_run.project.max_execution_seconds %>
+            <% if max_exec %>
+              <span class="text-sm font-normal text-gray-500">/ <%= max_exec %>s</span>
+              <% pct = (elapsed * 100.0 / max_exec).clamp(0, 100) %>
+              <div class="mt-2 h-1.5 w-full rounded-full bg-gray-200">
+                <div class="h-1.5 rounded-full <%= pct >= 90 ? 'bg-red-500' : pct >= 75 ? 'bg-yellow-500' : 'bg-indigo-600' %>" style="width: <%= pct.round %>%"></div>
+              </div>
+            <% end %>
           <% else %>
             -
           <% end %>
@@ -190,7 +201,17 @@
     </div>
   <% end %>
 
-  <% if agent_run.rate_limited? %>
+  <% if agent_run.status == "timeout" %>
+    <div class="mt-6 rounded-lg border border-yellow-200 bg-yellow-50 p-4">
+      <h2 class="text-sm font-semibold text-yellow-800">Execution Timed Out</h2>
+      <p class="mt-1 text-sm text-yellow-700">
+        This run exceeded the maximum execution time of <strong><%= agent_run.project.max_execution_seconds %>s</strong>.
+        <% if agent_run.error_message.present? %>
+          <br><span class="text-yellow-600"><%= agent_run.error_message %></span>
+        <% end %>
+      </p>
+    </div>
+  <% elsif agent_run.rate_limited? %>
     <div class="mt-6 rounded-lg border border-orange-200 bg-orange-50 p-4">
       <h2 class="text-sm font-semibold text-orange-800">Rate Limited</h2>
       <p class="mt-1 text-sm text-orange-700">

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -30,10 +30,17 @@
     <% end %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <% if agent_run.duration_seconds.present? %>
-      <%= agent_run.duration_seconds %>s
-    <% elsif agent_run.running? && agent_run.started_at.present? %>
-      <%= (Time.current - agent_run.started_at).to_i %>s
+    <% elapsed = if agent_run.duration_seconds.present?
+         agent_run.duration_seconds
+       elsif agent_run.running? && agent_run.started_at.present?
+         (Time.current - agent_run.started_at).to_i
+       end %>
+    <% if elapsed %>
+      <%= elapsed %>s
+      <% max_exec = agent_run.project.max_execution_seconds %>
+      <% if max_exec %>
+        <span class="text-gray-400">/ <%= max_exec %>s</span>
+      <% end %>
     <% else %>
       <span class="text-gray-400">-</span>
     <% end %>

--- a/db/migrate/20260402082402_add_max_execution_seconds_to_projects.rb
+++ b/db/migrate/20260402082402_add_max_execution_seconds_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMaxExecutionSecondsToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :max_execution_seconds, :integer, default: 1800, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_02_050141) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_02_082402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -81,6 +81,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_050141) do
 
   create_table "accounts", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "default_max_tokens_per_run", default: 10000000, null: false
     t.string "name", null: false
     t.string "slug", null: false
     t.datetime "updated_at", null: false
@@ -166,6 +167,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_050141) do
     t.string "status", limit: 50, default: "pending", null: false
     t.string "temporal_run_id", limit: 255
     t.string "temporal_workflow_id", limit: 255
+    t.string "token_limit_status", limit: 50
     t.integer "tokens_input", default: 0
     t.integer "tokens_output", default: 0
     t.string "trigger_type", limit: 50, default: "automatic", null: false
@@ -226,6 +228,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_050141) do
     t.string "budget_type", limit: 50, null: false
     t.datetime "created_at", null: false
     t.integer "current_usage_cents", default: 0, null: false
+    t.string "enforcement_mode", limit: 20, default: "alert", null: false
+    t.integer "grace_buffer_percent", default: 0, null: false
     t.integer "limit_cents", null: false
     t.datetime "period_started_at"
     t.bigint "project_id", null: false
@@ -699,7 +703,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_050141) do
     t.datetime "last_github_activity_at"
     t.datetime "last_polled_at"
     t.integer "max_draft_review_rounds", default: 10, null: false
+    t.integer "max_execution_seconds", default: 1800, null: false
     t.integer "max_pr_followup_runs", default: 8, null: false
+    t.integer "max_tokens_per_run"
     t.string "merge_method", default: "squash", null: false
     t.jsonb "model_preferences", default: {}, null: false
     t.string "name", null: false
@@ -711,6 +717,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_050141) do
     t.jsonb "review_settings", default: {}, null: false
     t.jsonb "security_alert_types", default: ["code_scanning"], null: false
     t.string "security_severity_threshold", default: "high", null: false
+    t.integer "token_limit_warning_threshold", default: 80, null: false
     t.bigint "total_cost_cents", default: 0, null: false
     t.bigint "total_tokens_used", default: 0, null: false
     t.datetime "updated_at", null: false

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe Project do
     it { is_expected.to validate_presence_of(:github_id) }
     it { is_expected.to validate_uniqueness_of(:github_id).scoped_to(:account_id) }
     it { is_expected.to validate_numericality_of(:poll_interval_seconds).is_greater_than_or_equal_to(60) }
+    it { is_expected.to validate_numericality_of(:max_execution_seconds).only_integer.is_greater_than_or_equal_to(60).is_less_than_or_equal_to(86_400) }
+
+    it "defaults max_execution_seconds to 1800" do
+      project = build(:project)
+      expect(project.max_execution_seconds).to eq(1800)
+    end
 
     it "validates knowledge_status inclusion" do
       project = build(:project)

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(agent_run.agent_type).to eq("claude_code")
     end
 
+    it "returns the project max_execution_seconds in the result" do
+      project.update!(max_execution_seconds: 900)
+      result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+      expect(result[:max_execution_seconds]).to eq(900)
+    end
+
+    it "returns default max_execution_seconds when not customized" do
+      result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+      expect(result[:max_execution_seconds]).to eq(1800)
+    end
+
     it "accepts a custom agent_type" do
       result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "aider")
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -663,6 +663,7 @@ RSpec.describe Activities::RunAgentActivity do
 
     context "when goal is create_pr" do
       it "uses the default agent timeout without idle_timeout" do
+        project.update!(max_execution_seconds: 86_400)
         allow(container_service).to receive(:execute).and_return(exec_success)
         allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
 
@@ -899,6 +900,38 @@ RSpec.describe Activities::RunAgentActivity do
           activity.execute(agent_run_id: orphan_run.id)
         }.to raise_error(Temporalio::Error::ApplicationError, /No user available/)
       end
+    end
+  end
+
+  describe "max_execution_seconds enforcement" do
+    before do
+      allow(container_service).to receive(:execute).and_return(exec_success)
+      allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+    end
+
+    it "caps effective_timeout by remaining execution time" do
+      project.update!(max_execution_seconds: 600)
+      agent_run.update!(started_at: 5.minutes.ago, status: "running")
+
+      expect(container_service).to receive(:execute).with(
+        anything,
+        hash_including(timeout: a_value <= 300)
+      ).and_return(exec_success)
+
+      activity.execute(agent_run_id: agent_run.id)
+    end
+
+    it "times out when execution time limit is exceeded" do
+      project.update!(max_execution_seconds: 60)
+      agent_run.update!(started_at: 2.minutes.ago, status: "running")
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError)
+
+      agent_run.reload
+      expect(agent_run.status).to eq("timeout")
+      expect(agent_run.error_message).to include("Execution time limit")
     end
   end
 end

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -243,6 +243,66 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
     end
   end
 
+  describe "max_execution_seconds timeout capping" do
+    let(:input) { { project_id: 1, issue_id: 1, goal: "create_pr" } }
+
+    before do
+      allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger, patched: true)
+    end
+
+    it "caps activity timeout by max_execution_seconds when it is smaller" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity"
+          { agent_run_id: 42, provider_attempt_count: 3, agent_timeout_seconds: 3600, max_execution_seconds: 1800 }
+        when "Activities::RunAgentActivity"
+          # Without cap: (3600 * 3) + 300 = 11_100
+          # With cap: 1800 + 300 = 2100
+          expect(opts[:start_to_close_timeout]).to eq(2100)
+          { success: true, has_changes: false }
+        when "Activities::MarkAgentRunCompleteActivity" then {}
+        else {}
+        end
+      end
+
+      workflow.execute(input)
+    end
+
+    it "does not cap when max_execution_seconds is larger than computed timeout" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity"
+          { agent_run_id: 42, provider_attempt_count: 1, agent_timeout_seconds: 1800, max_execution_seconds: 86_400 }
+        when "Activities::RunAgentActivity"
+          # Computed: (1800 * 1) + 300 = 2100
+          # Cap: 86_400 + 300 = 86_700 (larger, so no cap)
+          expect(opts[:start_to_close_timeout]).to eq(2100)
+          { success: true, has_changes: false }
+        when "Activities::MarkAgentRunCompleteActivity" then {}
+        else {}
+        end
+      end
+
+      workflow.execute(input)
+    end
+
+    it "does not cap when max_execution_seconds is nil" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity"
+          { agent_run_id: 42, provider_attempt_count: 1, agent_timeout_seconds: 3600, max_execution_seconds: nil }
+        when "Activities::RunAgentActivity"
+          expect(opts[:start_to_close_timeout]).to eq(3900)
+          { success: true, has_changes: false }
+        when "Activities::MarkAgentRunCompleteActivity" then {}
+        else {}
+        end
+      end
+
+      workflow.execute(input)
+    end
+  end
+
   describe "existing PR follow-up reviews" do
     let(:input) { { project_id: 1, issue_id: 1, source_pull_request_number: 42 } }
 


### PR DESCRIPTION
## Summary

Enforce configurable maximum execution time per agent run to prevent runaway agents from consuming unbounded resources. Projects get a `max_execution_seconds` setting (default: 30 minutes) that gracefully terminates agents exceeding the limit while preserving partial results and surfacing timeout status distinctly in the UI.

## Changes

### Database
- Add `max_execution_seconds` integer column to `projects` table with a default of 1800 seconds (30 minutes) and a NOT NULL constraint

### Model
- Add numericality validation on `Project#max_execution_seconds` constraining values to 60–86400 seconds (1 minute to 24 hours)

### Orchestration
- **`CreateAgentRunActivity`** — propagates `max_execution_seconds` from the project in both new-run and resume-queued-run paths
- **`AgentExecutionWorkflow`** — caps the `RunAgentActivity` Temporal timeout to `max_execution_seconds + 300s` buffer for Temporal overhead
- **`RunAgentActivity`** — two enforcement points:
  - Checks elapsed time at the start of each provider loop iteration; breaks with timeout status if limit exceeded
  - Caps per-provider `effective_timeout` by remaining execution budget so individual providers cannot exceed the overall limit

### UI
- **Agent run detail view** — displays duration as "elapsed / limit" with a color-coded progress bar (green → yellow at 75% → red at 90%) and a dedicated "Execution Timed Out" banner for timeout status
- **Agent run table row** — shows duration as "elapsed / limit" inline

### Tests
- Project validation specs for numericality and default value
- `CreateAgentRunActivity` spec verifying `max_execution_seconds` propagation
- `AgentExecutionWorkflow` specs for timeout capping behavior (smaller limit, larger limit, nil)
- `RunAgentActivity` specs for timeout capping and execution time limit exceeded

## Design Decisions

- **300-second buffer on Temporal timeout**: The Temporal activity timeout is set to `max_execution_seconds + 300` rather than the exact limit. This avoids Temporal killing the activity before the application-level timeout logic can run, which would prevent graceful shutdown and partial result preservation.
- **Two-layer enforcement in RunAgentActivity**: Checking both at loop iteration boundaries and capping per-provider timeouts ensures the limit is respected even if a single provider call runs long, while still allowing clean exit with partial results when possible.
- **Timeout as a distinct status**: Timeouts are distinguished from other failure modes in `AgentRun` status rather than being lumped into a generic failure, enabling filtered views and targeted debugging.

## Screenshots

> ⚠️ **Author**: please attach before/after screenshots of the agent run detail view showing the progress bar and timeout banner.

---

Closes #703