### PR TITLE
Fix #756: Clicking timeframe buttons on dashboard resets page scroll position

### DIFF
--- a/app/views/dashboard/_metrics.html.erb
+++ b/app/views/dashboard/_metrics.html.erb
@@ -3,7 +3,7 @@
   <div class="mb-6 flex flex-wrap gap-2">
     <% Dashboard::Stats::TIME_RANGES.each do |range| %>
       <%= link_to time_range_label(range),
-            dashboard_metrics_path(time_range: range),
+            dashboard_path(time_range: range),
             class: filter_button_classes(time_range == range),
             data: { turbo_frame: "dashboard-metrics" } %>
     <% end %>

--- a/app/views/dashboard/_performance.html.erb
+++ b/app/views/dashboard/_performance.html.erb
@@ -6,7 +6,7 @@
       <span class="text-sm font-medium text-gray-500 mr-1">Status:</span>
       <% Dashboard::Stats::VALID_STATUSES.each do |s| %>
         <%= link_to DashboardHelper::STATUS_FILTER_LABELS[s],
-              dashboard_performance_path(status: s, goal: goal_filter, time_range: time_range),
+              dashboard_path(status: s, goal: goal_filter, time_range: time_range),
               class: filter_button_classes(status_filter == s),
               data: { turbo_frame: "dashboard-performance" } %>
       <% end %>
@@ -17,7 +17,7 @@
       <span class="text-sm font-medium text-gray-500 mr-1">Type:</span>
       <% Dashboard::Stats::VALID_GOALS.each do |g| %>
         <%= link_to DashboardHelper::GOAL_FILTER_LABELS[g],
-              dashboard_performance_path(status: status_filter, goal: g, time_range: time_range),
+              dashboard_path(status: status_filter, goal: g, time_range: time_range),
               class: filter_button_classes(goal_filter == g),
               data: { turbo_frame: "dashboard-performance" } %>
       <% end %>


### PR DESCRIPTION
That was the earlier failed commit attempt (before assets were built). The fix has since been successfully committed as `64756b2`. Everything is done.

---

Closes #756