### PR TITLE
Fix #708: feat(evolution): implement prompt mutation agent

### DIFF
--- a/app/services/prompt_evolution/mutate.rb
+++ b/app/services/prompt_evolution/mutate.rb
@@ -154,14 +154,14 @@ module PromptEvolution
     end
 
     def variables_preservation_instruction
-      names = variable_names
+      names = required_variable_names
       return "" if names.empty?
 
       "- Preserve all template variables (#{names.join(', ')}) — use the exact {{variable_name}} syntax\n        "
     end
 
     def variables_section
-      names = variable_names
+      names = required_variable_names
       return "" if names.empty?
 
       "## Template Variables\n#{names.join(', ')}\n"
@@ -327,16 +327,14 @@ module PromptEvolution
       required = required_variable_names
       return true if required.empty?
 
-      generated_variables = extract_template_variables(template)
-      required.all? { |var| generated_variables.include?(var) }
+      required.all? { |var| template.include?("{{#{var}}}") }
     end
 
     def required_variable_names
-      names = variable_names
-      return names if names.any?
+      metadata_names = variable_names
+      template_names = extract_template_variables(@prompt.current_version.template.to_s)
 
-      # Fall back to extracting {{...}} placeholders from the current template
-      extract_template_variables(@prompt.current_version.template.to_s)
+      (metadata_names + template_names).uniq
     end
 
     def extract_template_variables(template)

--- a/spec/services/prompt_evolution/mutate_spec.rb
+++ b/spec/services/prompt_evolution/mutate_spec.rb
@@ -411,6 +411,34 @@ RSpec.describe PromptEvolution::Mutate do
       expect(mutations.size).to eq(1)
     end
 
+    it "rejects mutations that only preserve variables with spaced placeholder syntax" do
+      prompt_no_vars_metadata = create(:prompt, :global)
+      prompt_no_vars_metadata.create_version!(template: "Do {{task}} for {{repo}}", variables: [])
+
+      response = JSON.generate("mutations" => [ { "template" => "Complete {{ task }} in {{ repo }} carefully",
+                                     "strategy" => "expansion",
+                                     "reasoning" => "test", "expected_improvement" => "test" } ])
+      allow(harness_response).to receive(:output).and_return(response)
+
+      mutations = described_class.call(prompt: prompt_no_vars_metadata)
+
+      expect(mutations).to be_empty
+    end
+
+    it "rejects mutations missing template placeholders not listed in metadata" do
+      prompt_with_partial_metadata = create(:prompt, :global)
+      prompt_with_partial_metadata.create_version!(template: "Do {{task}} for {{repo}}", variables: [ "task" ])
+
+      response = JSON.generate("mutations" => [ { "template" => "Do {{task}} only",
+                                     "strategy" => "simplification",
+                                     "reasoning" => "test", "expected_improvement" => "test" } ])
+      allow(harness_response).to receive(:output).and_return(response)
+
+      mutations = described_class.call(prompt: prompt_with_partial_metadata)
+
+      expect(mutations).to be_empty
+    end
+
     it "rejects mutations exceeding max template length" do
       response = JSON.generate("mutations" => [ { "template" => "x" * 50_001, "strategy" => "expansion",
                                      "reasoning" => "test", "expected_improvement" => "test" } ])
@@ -476,7 +504,10 @@ RSpec.describe PromptEvolution::Mutate do
 
   describe "variable preservation instruction" do
     it "omits variable preservation instruction when there are no variables" do
-      described_class.call(prompt: prompt)
+      prompt_without_vars = create(:prompt, :global)
+      prompt_without_vars.create_version!(template: "Do the work", variables: [])
+
+      described_class.call(prompt: prompt_without_vars)
 
       expect(AgentHarness).to have_received(:send_message) do |prompt_text, **_opts|
         expect(prompt_text).not_to include("Preserve all template variables")
@@ -491,6 +522,30 @@ RSpec.describe PromptEvolution::Mutate do
 
       expect(AgentHarness).to have_received(:send_message).with(
         a_string_including("Preserve all template variables (task, repo)"),
+        hash_including(provider: :claude)
+      )
+    end
+
+    it "includes inferred template variables when metadata is empty" do
+      prompt_no_vars_metadata = create(:prompt, :global)
+      prompt_no_vars_metadata.create_version!(template: "Do {{task}} for {{repo}}", variables: [])
+
+      described_class.call(prompt: prompt_no_vars_metadata)
+
+      expect(AgentHarness).to have_received(:send_message).with(
+        a_string_including("Preserve all template variables (task, repo)", "## Template Variables\ntask, repo"),
+        hash_including(provider: :claude)
+      )
+    end
+
+    it "includes the union of metadata and template variables" do
+      prompt_with_partial_metadata = create(:prompt, :global)
+      prompt_with_partial_metadata.create_version!(template: "Do {{task}} for {{repo}}", variables: [ "task" ])
+
+      described_class.call(prompt: prompt_with_partial_metadata)
+
+      expect(AgentHarness).to have_received(:send_message).with(
+        a_string_including("Preserve all template variables (task, repo)", "## Template Variables\ntask, repo"),
         hash_including(provider: :claude)
       )
     end


### PR DESCRIPTION
## Summary

Implement an LLM-based prompt mutation agent that analyzes performance data from sampled runs and generates improved prompt variants. This enables the prompt evolution pipeline to automatically produce targeted improvements based on what's working and what isn't, closing the loop on data-driven prompt optimization.

## Changes

### Services
- **`app/services/prompt_evolution/mutate.rb`** — New Servo service that accepts a prompt version with quality metrics, sample outputs, and failure modes, then calls AgentHarness (claude-sonnet-4-6) to generate N validated variant prompts
- Supports four mutation strategies: refinement, restructuring, simplification, expansion
- Returns `Mutation` structs containing template, strategy, reasoning, and expected improvement
- Validates each generated mutation: non-blank template, valid strategy, all required template variables preserved, and length within limits

### Tests
- **`spec/services/prompt_evolution/mutate_spec.rb`** — 27 specs covering mutation generation, quality metrics integration, failure mode analysis, sample output handling, validation rules, error handling, and output normalization

## Design Decisions

- **LLM errors return empty arrays instead of raising** — Since mutations are an optimization step (not a critical path), graceful degradation with structured logging avoids disrupting the broader evolution pipeline
- **Mutation count clamping and strategy filtering** — Prevents runaway generation and ensures only requested strategies are returned, keeping the mutation cycle predictable
- **Template variable preservation as a hard validation** — Rejects any mutation that drops required variables, preventing downstream rendering failures even if the LLM produces an otherwise high-quality variant
- **Sample output truncation** — Bounds the context window cost of including real outputs in the analysis prompt while still giving the LLM enough signal to reason about quality

---

Closes #708