### PR TITLE
Fix #707: feat(evolution): random sampling of completed runs for prompt evaluation

### DIFF
--- a/app/services/prompt_evolution/sample_runs.rb
+++ b/app/services/prompt_evolution/sample_runs.rb
@@ -69,12 +69,24 @@ module PromptEvolution
       end
       return AgentRun.none if grouped.empty?
 
-      per_stratum = [ sample_size / grouped.size, 1 ].max
-      sampled_ids = grouped.flat_map do |_key, stratum_runs|
-        stratum_runs.sample(per_stratum).map(&:first)
+      strata = grouped.to_a.shuffle
+      base_allocation, remainder = sample_size.divmod(strata.size)
+      sampled_ids = []
+      leftover_ids = []
+
+      strata.each_with_index do |(_key, stratum_runs), index|
+        allocation = [ base_allocation + (index < remainder ? 1 : 0), 1 ].max
+        shuffled_runs = stratum_runs.shuffle
+
+        sampled_ids.concat(shuffled_runs.first(allocation).map(&:first))
+        leftover_ids.concat(shuffled_runs.drop(allocation).map(&:first))
       end
 
-      AgentRun.where(id: sampled_ids.shuffle.first(sample_size))
+      if sampled_ids.size < sample_size
+        sampled_ids.concat(leftover_ids.shuffle.first(sample_size - sampled_ids.size))
+      end
+
+      AgentRun.where(id: sampled_ids.first(sample_size))
     end
 
     def quality_bucket(score)

--- a/spec/services/prompt_evolution/sample_runs_spec.rb
+++ b/spec/services/prompt_evolution/sample_runs_spec.rb
@@ -140,6 +140,18 @@ RSpec.describe PromptEvolution::SampleRuns do
       expect(all_selected_project_ids.size).to be > 3
     end
 
+    it "returns exactly sample_size when enough runs exist and strata don't divide evenly" do
+      # 3 strata with 4 runs each = 12 runs, sample_size = 10, 10 % 3 != 0
+      3.times do |i|
+        proj = create(:project)
+        4.times { create_completed_run(project: proj, goal: "create_pr") }
+      end
+
+      result = described_class.call(sample_size: 10, days: 7)
+
+      expect(result.samples.size).to eq(10)
+    end
+
     it "respects sample_size limit" do
       8.times { create_completed_run }
 


### PR DESCRIPTION
The background task notification is for the earlier failed commit attempt — that's already been resolved. The commit succeeded in the subsequent attempt (commit `838730c`), with all 15 tests passing and lint clean.

---

Closes #707