### PR TITLE
feat(projects): show recently merged pull requests

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -30,6 +30,23 @@ class ProjectsController < ApplicationController
     @pr_numbers_with_active_runs = @project.pr_numbers_with_active_runs
     @cost_budgets = @project.cost_budgets.load
     @quality_summary = QualityMetrics::DashboardStats.overview(project: @project)
+    if @project.auto_merge_enabled?
+      @recent_merged_pull_requests = @project.issues
+        .pull_requests_only
+        .where(github_state: "closed", pr_review_phase: "merged")
+        .includes(:parent_issue)
+        .order(github_updated_at: :desc, updated_at: :desc)
+        .limit(10)
+
+      closing_issue_numbers = @recent_merged_pull_requests.flat_map(&:closing_referenced_issue_numbers).uniq
+      @merged_pull_request_closed_issues_by_number = @project.issues
+        .issues_only
+        .where(github_number: closing_issue_numbers)
+        .index_by(&:github_number)
+    else
+      @recent_merged_pull_requests = Issue.none
+      @merged_pull_request_closed_issues_by_number = {}
+    end
     @collector_runs = CollectorRun
       .joins(:project_version)
       .where(project_versions: { project_id: @project.id })

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -39,10 +39,15 @@ class ProjectsController < ApplicationController
         .limit(10)
 
       closing_issue_numbers = @recent_merged_pull_requests.flat_map(&:closing_referenced_issue_numbers).uniq
-      @merged_pull_request_closed_issues_by_number = @project.issues
-        .issues_only
-        .where(github_number: closing_issue_numbers)
-        .index_by(&:github_number)
+      @merged_pull_request_closed_issues_by_number =
+        if closing_issue_numbers.any?
+          @project.issues
+            .issues_only
+            .where(github_number: closing_issue_numbers)
+            .index_by(&:github_number)
+        else
+          {}
+        end
     else
       @recent_merged_pull_requests = Issue.none
       @merged_pull_request_closed_issues_by_number = {}

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -133,7 +133,7 @@ class Issue < ApplicationRecord
       .scan(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b([^.\n\r]*)/i)
       .flatten
       .flat_map do |clause|
-        clause.scan(/(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+))?#(?<number>\d+)/).filter_map do |owner, repo, number|
+        clause.scan(/(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+)|(?<!\w))#(?<number>\d+)/).filter_map do |owner, repo, number|
           next if owner.present? && !owner.casecmp?(project.owner)
           next if repo.present? && !repo.casecmp?(project.repo)
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -127,20 +127,7 @@ class Issue < ApplicationRecord
   end
 
   def closing_referenced_issue_numbers
-    return [] if body.blank?
-
-    body.to_s
-      .scan(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b([^.\n\r]*)/i)
-      .flatten
-      .flat_map do |clause|
-        clause.scan(/(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+)|(?<!\w))#(?<number>\d+)/).filter_map do |owner, repo, number|
-          next if owner.present? && !owner.casecmp?(project.owner)
-          next if repo.present? && !repo.casecmp?(project.repo)
-
-          number.to_i
-        end
-      end
-      .uniq
+    @closing_referenced_issue_numbers ||= parse_closing_references
   end
 
   def closed_issue(referenced_issues_by_number = {})
@@ -260,6 +247,32 @@ class Issue < ApplicationRecord
   end
 
   private
+
+  CLOSING_KEYWORD_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b/i
+  CLOSING_REF_RE = /\G\s*(?:,\s*)?(?:and\s+)?(?:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)|(?<!\w))#(\d+)/
+
+  # Parses closing issue references that immediately follow a closing keyword,
+  # consuming only chained references (separated by "," or "and"). Stops at the
+  # first non-reference token so that e.g. "Closes #12, related to #14" only
+  # returns [12].
+  def parse_closing_references
+    return [] if body.blank?
+
+    numbers = []
+    text = body.to_s
+    text.scan(CLOSING_KEYWORD_RE) do
+      pos = Regexp.last_match.end(0)
+      while (m = CLOSING_REF_RE.match(text, pos))
+        owner, repo, number = m[1], m[2], m[3]
+        unless (owner.present? && !owner.casecmp?(project.owner)) ||
+               (repo.present? && !repo.casecmp?(project.repo))
+          numbers << number.to_i
+        end
+        pos = m.end(0)
+      end
+    end
+    numbers.uniq
+  end
 
   def parent_issue_belongs_to_same_project
     return if parent_issue.project_id == project_id

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -126,6 +126,32 @@ class Issue < ApplicationRecord
     body.to_s.scan(/(?<!\w)#(\d+)/).flatten.map(&:to_i).uniq
   end
 
+  def closing_referenced_issue_numbers
+    return [] if body.blank?
+
+    body.to_s
+      .scan(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b([^.\n\r]*)/i)
+      .flatten
+      .flat_map do |clause|
+        clause.scan(/(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+))?#(?<number>\d+)/).filter_map do |owner, repo, number|
+          next if owner.present? && !owner.casecmp?(project.owner)
+          next if repo.present? && !repo.casecmp?(project.repo)
+
+          number.to_i
+        end
+      end
+      .uniq
+  end
+
+  def closed_issue(referenced_issues_by_number = {})
+    closing_referenced_issue_numbers.each do |github_number|
+      issue = referenced_issues_by_number[github_number]
+      return issue if issue.present?
+    end
+
+    parent_issue
+  end
+
   def has_associated_pull_requests?
     if sub_issues.loaded?
       sub_issues.any?(&:is_pull_request?)

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -266,10 +266,11 @@ class Issue < ApplicationRecord
       pos += 1 if text[pos] == ":"
       while (m = CLOSING_REF_RE.match(text, pos))
         owner, repo, number = m[1], m[2], m[3]
-        unless (owner.present? && !owner.casecmp?(project.owner)) ||
-               (repo.present? && !repo.casecmp?(project.repo))
-          numbers << number.to_i
-        end
+        same_repo_reference =
+          (owner.blank? || owner.casecmp?(project.owner)) &&
+          (repo.blank? || repo.casecmp?(project.repo))
+
+        numbers << number.to_i if same_repo_reference
         pos = m.end(0)
       end
     end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -262,6 +262,8 @@ class Issue < ApplicationRecord
     text = body.to_s
     text.scan(CLOSING_KEYWORD_RE) do
       pos = Regexp.last_match.end(0)
+      # Skip optional colon after keyword (e.g. "Fixes: #123", "Closes: #123")
+      pos += 1 if text[pos] == ":"
       while (m = CLOSING_REF_RE.match(text, pos))
         owner, repo, number = m[1], m[2], m[3]
         unless (owner.present? && !owner.casecmp?(project.owner)) ||

--- a/app/views/projects/_recent_merged_pull_requests.html.erb
+++ b/app/views/projects/_recent_merged_pull_requests.html.erb
@@ -9,7 +9,7 @@
           <thead class="bg-gray-50">
             <tr>
               <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">PR</th>
-              <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Closed Issue</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Linked Issue</th>
               <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Last GitHub Activity</th>
             </tr>
           </thead>

--- a/app/views/projects/_recent_merged_pull_requests.html.erb
+++ b/app/views/projects/_recent_merged_pull_requests.html.erb
@@ -1,0 +1,63 @@
+<div class="mt-8">
+  <h2 class="text-lg font-medium text-gray-900">Recently Merged PRs</h2>
+  <p class="mt-1 text-sm text-gray-500">Merged pull requests cached locally for projects with auto-merge enabled. Issue links come from cached closing references or Paid's parent-issue relationship; rows are ordered by latest synced GitHub activity.</p>
+
+  <% if pull_requests.any? %>
+    <div class="mt-4 overflow-hidden bg-white shadow sm:rounded-lg">
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">PR</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Closed Issue</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Last GitHub Activity</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% pull_requests.each do |pull_request| %>
+              <% closed_issue = pull_request.closed_issue(closed_issues_by_number) %>
+              <tr id="<%= dom_id(pull_request, :recent_merge) %>">
+                <td class="px-4 py-3 text-sm text-gray-900">
+                  <div class="flex flex-col gap-1">
+                    <div>
+                      <%= link_to "##{pull_request.github_number}",
+                            pull_request.github_url,
+                            target: "_blank",
+                            rel: "noopener noreferrer",
+                            class: "font-medium text-indigo-600 hover:text-indigo-900" %>
+                    </div>
+                    <div class="text-gray-600"><%= pull_request.title %></div>
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-900">
+                  <% if closed_issue.present? %>
+                    <div class="flex flex-col gap-1">
+                      <div>
+                        <%= link_to "##{closed_issue.github_number}",
+                              closed_issue.github_url,
+                              target: "_blank",
+                              rel: "noopener noreferrer",
+                              class: "font-medium text-indigo-600 hover:text-indigo-900" %>
+                      </div>
+                      <div class="text-gray-600"><%= closed_issue.title %></div>
+                    </div>
+                  <% else %>
+                    <span class="text-gray-400">Unknown</span>
+                  <% end %>
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-600">
+                  <%= local_time(pull_request.github_updated_at, format: :short) %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% else %>
+    <div class="mt-4 rounded-lg border-2 border-dashed border-gray-300 p-8 text-center">
+      <h3 class="text-sm font-semibold text-gray-900">No recently merged PRs</h3>
+      <p class="mt-1 text-sm text-gray-500">Merged pull requests will appear here once they are synced from GitHub.</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -183,6 +183,13 @@
     <%= render "projects/agent_runs", project: @project, recent_agent_runs: @recent_agent_runs %>
 
     <%= render "projects/knowledge", project: @project, collector_runs: @collector_runs, failed_collector_runs: @latest_failed_collector_runs %>
+
+    <% if @project.auto_merge_enabled? %>
+      <%= render "projects/recent_merged_pull_requests",
+                 project: @project,
+                 pull_requests: @recent_merged_pull_requests,
+                 closed_issues_by_number: @merged_pull_request_closed_issues_by_number %>
+    <% end %>
   </div>
 
 </div>

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -824,6 +824,12 @@ RSpec.describe Issue do
       expect(issue.closing_referenced_issue_numbers).to eq([ 12 ])
     end
 
+    it "ignores repo-only qualified references like repo#123" do
+      issue = build(:issue, project: project, body: "Closes widget#42 and #12")
+
+      expect(issue.closing_referenced_issue_numbers).to eq([ 12 ])
+    end
+
     it "ignores non-closing references" do
       issue = build(:issue, project: project, body: "Related to #12. Depends on #14.")
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -803,6 +803,55 @@ RSpec.describe Issue do
     end
   end
 
+  describe "#closing_referenced_issue_numbers" do
+    let(:project) { build(:project, owner: "acme", repo: "widget") }
+
+    it "extracts same-repo closing references from the body" do
+      issue = build(:issue, project: project, body: "Closes #12. Fixes #14 and #15.")
+
+      expect(issue.closing_referenced_issue_numbers).to eq([ 12, 14, 15 ])
+    end
+
+    it "includes fully-qualified references for the same repo" do
+      issue = build(:issue, project: project, body: "Resolves acme/widget#42")
+
+      expect(issue.closing_referenced_issue_numbers).to eq([ 42 ])
+    end
+
+    it "ignores references for other repos" do
+      issue = build(:issue, project: project, body: "Closes other/repo#9 and #12")
+
+      expect(issue.closing_referenced_issue_numbers).to eq([ 12 ])
+    end
+
+    it "ignores non-closing references" do
+      issue = build(:issue, project: project, body: "Related to #12. Depends on #14.")
+
+      expect(issue.closing_referenced_issue_numbers).to eq([])
+    end
+  end
+
+  describe "#closed_issue" do
+    let(:project) { create(:project, owner: "acme", repo: "widget") }
+
+    it "prefers a cached closing reference over parent_issue" do
+      parent_issue = create(:issue, project: project, github_number: 12, title: "Parent issue")
+      closed_issue = create(:issue, project: project, github_number: 42, title: "Actually closed")
+      pr = create(:issue, :pull_request, project: project, parent_issue: parent_issue,
+        body: "Closes #42")
+
+      expect(pr.closed_issue(42 => closed_issue)).to eq(closed_issue)
+    end
+
+    it "falls back to parent_issue when no cached closing reference is available" do
+      parent_issue = create(:issue, project: project, github_number: 12, title: "Parent issue")
+      pr = create(:issue, :pull_request, project: project, parent_issue: parent_issue,
+        body: "Related to #42")
+
+      expect(pr.closed_issue).to eq(parent_issue)
+    end
+  end
+
   describe ".lifecycle_statuses" do
     let(:project) { create(:project) }
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -836,6 +836,12 @@ RSpec.describe Issue do
       expect(issue.closing_referenced_issue_numbers).to eq([])
     end
 
+    it "handles colon after closing keyword" do
+      issue = build(:issue, project: project, body: "Fixes: #123")
+
+      expect(issue.closing_referenced_issue_numbers).to eq([ 123 ])
+    end
+
     it "stops at non-reference tokens so unrelated refs in the same clause are excluded" do
       issue = build(:issue, project: project, body: "Closes #12, related to #14")
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -825,15 +825,21 @@ RSpec.describe Issue do
     end
 
     it "ignores repo-only qualified references like repo#123" do
-      issue = build(:issue, project: project, body: "Closes widget#42 and #12")
+      issue = build(:issue, project: project, body: "Closes widget#42")
 
-      expect(issue.closing_referenced_issue_numbers).to eq([ 12 ])
+      expect(issue.closing_referenced_issue_numbers).to eq([])
     end
 
     it "ignores non-closing references" do
       issue = build(:issue, project: project, body: "Related to #12. Depends on #14.")
 
       expect(issue.closing_referenced_issue_numbers).to eq([])
+    end
+
+    it "stops at non-reference tokens so unrelated refs in the same clause are excluded" do
+      issue = build(:issue, project: project, body: "Closes #12, related to #14")
+
+      expect(issue.closing_referenced_issue_numbers).to eq([ 12 ])
     end
   end
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -527,6 +527,7 @@ RSpec.describe "Projects" do
         expect(response.body).to include(%(id="recent_merge_issue_#{pr.id}"))
 
         recent_merge_row = response.body.match(/<tr[^>]*id="recent_merge_issue_#{pr.id}"[^>]*>.*?<\/tr>/m)&.[](0)
+        expect(recent_merge_row).to be_present, "expected to find a <tr> with id='recent_merge_issue_#{pr.id}'"
 
         expect(recent_merge_row).to include(">#34<")
         expect(recent_merge_row).to include(">Fix flaky spec in CI<")
@@ -547,6 +548,7 @@ RSpec.describe "Projects" do
         expect(response.body).to include(%(id="recent_merge_issue_#{pr.id}"))
 
         recent_merge_row = response.body.match(/<tr[^>]*id="recent_merge_issue_#{pr.id}"[^>]*>.*?<\/tr>/m)&.[](0)
+        expect(recent_merge_row).to be_present, "expected to find a <tr> with id='recent_merge_issue_#{pr.id}'"
 
         expect(recent_merge_row).to include(">#34<")
         expect(recent_merge_row).to include(">Fix flaky spec in CI<")

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -514,6 +514,56 @@ RSpec.describe "Projects" do
         expect(response.body).to include("Quick Run")
       end
 
+      it "shows recently merged PRs with linked closed issues when auto-merge is enabled" do
+        project = create(:project, account: account, github_token: github_token, auto_merge_enabled: true)
+        issue = create(:issue, project: project, github_number: 21, title: "Fix flaky spec")
+        create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+          github_number: 34, title: "Fix flaky spec in CI", pr_review_phase: "merged",
+          github_updated_at: Time.utc(2026, 4, 1, 12, 0, 0))
+
+        get project_path(project)
+
+        expect(response.body).to include("Recently Merged PRs")
+        expect(response.body).to include(">#34<")
+        expect(response.body).to include(">Fix flaky spec in CI<")
+        expect(response.body).to include(">#21<")
+        expect(response.body).to include(">Fix flaky spec<")
+      end
+
+      it "shows the issue from cached closing references when parent_issue is absent" do
+        project = create(:project, account: account, github_token: github_token, auto_merge_enabled: true)
+        create(:issue, project: project, github_number: 21, title: "Fix flaky spec")
+        create(:issue, :pull_request, :closed, project: project,
+          github_number: 34, title: "Fix flaky spec in CI", pr_review_phase: "merged",
+          body: "Closes #21")
+
+        get project_path(project)
+
+        expect(response.body).to include("Recently Merged PRs")
+        expect(response.body).to include(">#21<")
+        expect(response.body).to include(">Fix flaky spec<")
+      end
+
+      it "shows the empty recent merged PR state when auto-merge is enabled but nothing has merged" do
+        project = create(:project, account: account, github_token: github_token, auto_merge_enabled: true)
+
+        get project_path(project)
+
+        expect(response.body).to include("Recently Merged PRs")
+        expect(response.body).to include("No recently merged PRs")
+      end
+
+      it "hides the recent merged PR section when auto-merge is disabled" do
+        project = create(:project, account: account, github_token: github_token, auto_merge_enabled: false)
+        issue = create(:issue, project: project, github_number: 21, title: "Fix flaky spec")
+        create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+          github_number: 34, title: "Fix flaky spec in CI", pr_review_phase: "merged")
+
+        get project_path(project)
+
+        expect(response.body).not_to include("Recently Merged PRs")
+      end
+
       it "shows pause button for PRs with automation label" do
         project = create(:project, account: account, github_token: github_token)
         pr = create(:issue, :pull_request, project: project, github_number: 10, title: "Automated PR",

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -517,31 +517,41 @@ RSpec.describe "Projects" do
       it "shows recently merged PRs with linked closed issues when auto-merge is enabled" do
         project = create(:project, account: account, github_token: github_token, auto_merge_enabled: true)
         issue = create(:issue, project: project, github_number: 21, title: "Fix flaky spec")
-        create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
+        pr = create(:issue, :pull_request, :closed, project: project, parent_issue: issue,
           github_number: 34, title: "Fix flaky spec in CI", pr_review_phase: "merged",
           github_updated_at: Time.utc(2026, 4, 1, 12, 0, 0))
 
         get project_path(project)
 
         expect(response.body).to include("Recently Merged PRs")
-        expect(response.body).to include(">#34<")
-        expect(response.body).to include(">Fix flaky spec in CI<")
-        expect(response.body).to include(">#21<")
-        expect(response.body).to include(">Fix flaky spec<")
+        expect(response.body).to include(%(id="recent_merge_issue_#{pr.id}"))
+
+        recent_merge_row = response.body.match(/<tr[^>]*id="recent_merge_issue_#{pr.id}"[^>]*>.*?<\/tr>/m)&.[](0)
+
+        expect(recent_merge_row).to include(">#34<")
+        expect(recent_merge_row).to include(">Fix flaky spec in CI<")
+        expect(recent_merge_row).to match(/<a [^>]*>#21<\/a>/)
+        expect(recent_merge_row).to include(">Fix flaky spec<")
       end
 
       it "shows the issue from cached closing references when parent_issue is absent" do
         project = create(:project, account: account, github_token: github_token, auto_merge_enabled: true)
         create(:issue, project: project, github_number: 21, title: "Fix flaky spec")
-        create(:issue, :pull_request, :closed, project: project,
+        pr = create(:issue, :pull_request, :closed, project: project,
           github_number: 34, title: "Fix flaky spec in CI", pr_review_phase: "merged",
           body: "Closes #21")
 
         get project_path(project)
 
         expect(response.body).to include("Recently Merged PRs")
-        expect(response.body).to include(">#21<")
-        expect(response.body).to include(">Fix flaky spec<")
+        expect(response.body).to include(%(id="recent_merge_issue_#{pr.id}"))
+
+        recent_merge_row = response.body.match(/<tr[^>]*id="recent_merge_issue_#{pr.id}"[^>]*>.*?<\/tr>/m)&.[](0)
+
+        expect(recent_merge_row).to include(">#34<")
+        expect(recent_merge_row).to include(">Fix flaky spec in CI<")
+        expect(recent_merge_row).to match(/<a [^>]*>#21<\/a>/)
+        expect(recent_merge_row).to include(">Fix flaky spec<")
       end
 
       it "shows the empty recent merged PR state when auto-merge is enabled but nothing has merged" do


### PR DESCRIPTION
## Summary
- add a recently merged PR table to project pages with auto-merge enabled
- link merged PRs to cached closed issues using closing keywords or parent issues
- clarify that ordering uses latest synced GitHub activity and add request/model coverage

## Testing
- bin/rspec spec/models/issue_spec.rb spec/requests/projects_spec.rb
- bin/rubocop app/models/issue.rb app/controllers/projects_controller.rb spec/models/issue_spec.rb spec/requests/projects_spec.rb