### PR TITLE
fix(dev): force temporal worker shutdown after grace period

### DIFF
--- a/bin/temporal_worker
+++ b/bin/temporal_worker
@@ -31,6 +31,13 @@ activity_task_polls = ENV.fetch("TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS", a
 puts "Temporal concurrency: workflows=#{workflow_slots} activities=#{activity_slots} " \
      "local_activities=#{local_activity_slots} activity_polls=#{activity_task_polls}"
 
+shutdown_cancellation, request_shutdown = Temporalio::Cancellation.new
+shutdown_state_mutex = Mutex.new
+shutdown_started = false
+forced_exit_buffer = ENV.fetch("TEMPORAL_FORCE_EXIT_BUFFER_SECONDS", "10").to_i
+forced_exit_timeout = graceful_shutdown + forced_exit_buffer
+force_exit_thread = nil
+
 worker = Temporalio::Worker.new(
   client: Paid.temporal_client,
   task_queue: Paid.task_queue,
@@ -45,4 +52,31 @@ worker = Temporalio::Worker.new(
   graceful_shutdown_period: graceful_shutdown
 )
 
-worker.run(shutdown_signals: %w[INT TERM])
+%w[INT TERM].each do |signal|
+  Signal.trap(signal) do
+    force_exit_now = shutdown_state_mutex.synchronize do
+      if shutdown_started
+        true
+      else
+        shutdown_started = true
+        false
+      end
+    end
+
+    if force_exit_now
+      warn "Received #{signal} during shutdown, forcing Temporal worker exit"
+      exit! 1
+    end
+
+    warn "Received #{signal}, shutting down Temporal worker gracefully"
+    request_shutdown.call(reason: "#{signal} received")
+
+    force_exit_thread ||= Thread.new do
+      sleep(forced_exit_timeout)
+      warn "Temporal worker did not exit within #{forced_exit_timeout}s, forcing exit"
+      exit! 1
+    end
+  end
+end
+
+worker.run(cancellation: shutdown_cancellation)


### PR DESCRIPTION
## Summary
- replace Temporal SDK signal traps in `bin/temporal_worker` with an explicit cancellation-driven shutdown path
- force the worker to exit on a second signal or if graceful shutdown hangs past the configured grace period
- make Overmind sessions stop cleanly instead of leaving the worker pane running after `overmind stop`

## Testing
- `ruby -c bin/temporal_worker`
