### PR TITLE
fix(dev): harden auto-update overmind recovery

### DIFF
--- a/app/temporal/activities/trigger_dev_environment_update_activity.rb
+++ b/app/temporal/activities/trigger_dev_environment_update_activity.rb
@@ -50,7 +50,13 @@ module Activities
 
       restart_trigger_files = full_restart_trigger_files(changed_files)
       mode = determine_update_mode(restart_trigger_files)
-      return { triggered: false, reason: "spawn_failed" } unless trigger_update(mode)
+      return { triggered: false, reason: "spawn_failed" } unless trigger_update(
+        mode: mode,
+        project_id: project.id,
+        pr_number: pr_number,
+        changed_files: changed_files,
+        restart_trigger_files: restart_trigger_files
+      )
 
       logger.info(
         message: "dev_update.triggered",
@@ -97,7 +103,7 @@ module Activities
       end
     end
 
-    def trigger_update(mode)
+    def trigger_update(mode:, project_id:, pr_number:, changed_files:, restart_trigger_files:)
       script = File.expand_path("../../../bin/dev-update", __dir__)
       flag = mode == "full" ? "--full" : "--lightweight"
       log_path = Rails.root.join("log", "dev-update", "dev-update.log")
@@ -106,6 +112,14 @@ module Activities
       # Spawn detached so the Temporal worker (which runs under Overmind)
       # is not the parent — setsid creates a new session.
       pid = Process.spawn(
+        {
+          "DEV_UPDATE_TRIGGER_SOURCE" => self.class.name,
+          "DEV_UPDATE_TRIGGER_MODE" => mode,
+          "DEV_UPDATE_PROJECT_ID" => project_id.to_s,
+          "DEV_UPDATE_PR_NUMBER" => pr_number.to_s,
+          "DEV_UPDATE_CHANGED_FILES" => changed_files.join("\n"),
+          "DEV_UPDATE_RESTART_TRIGGER_FILES" => restart_trigger_files.join("\n")
+        },
         "setsid", script, flag,
         out: [ log_path.to_s, "a" ],
         err: [ log_path.to_s, "a" ]
@@ -116,7 +130,11 @@ module Activities
         message: "dev_update.process_spawned",
         pid: pid,
         mode: mode,
-        log_path: log_path.to_s
+        log_path: log_path.to_s,
+        project_id: project_id,
+        pr_number: pr_number,
+        changed_files: changed_files,
+        restart_trigger_files: restart_trigger_files
       )
 
       true

--- a/bin/dev
+++ b/bin/dev
@@ -25,6 +25,7 @@ dev_supervisor_log_line "$(dev_supervisor_overmind_log)" \
   "bin/dev starting pid=$$ ppid=$PPID tty=$(dev_supervisor_tty) term=${TERM:-} cwd=$PWD"
 
 DEV_SUPERVISOR_EXIT_SNAPSHOT_TAKEN=0
+DEV_SUPERVISOR_MONITOR_PID=""
 
 dev_supervisor_snapshot_once() {
   local label="$1"
@@ -47,6 +48,10 @@ dev_supervisor_handle_signal() {
 
 dev_supervisor_handle_exit() {
   local exit_code="$1"
+  if [ -n "${DEV_SUPERVISOR_MONITOR_PID:-}" ] && kill -0 "$DEV_SUPERVISOR_MONITOR_PID" >/dev/null 2>&1; then
+    kill "$DEV_SUPERVISOR_MONITOR_PID" >/dev/null 2>&1 || true
+    wait "$DEV_SUPERVISOR_MONITOR_PID" 2>/dev/null || true
+  fi
   dev_supervisor_log_line "$(dev_supervisor_overmind_log)" \
     "bin/dev exiting code=${exit_code} pid=$$ ppid=$PPID tty=$(dev_supervisor_tty) term=${TERM:-}"
   if [ "$exit_code" -ne 0 ]; then
@@ -102,7 +107,13 @@ fi
 
 dev_supervisor_snapshot_state "bin-dev-before-start"
 
+dev_supervisor_monitor_overmind "$$" "bin-dev-monitor" &
+DEV_SUPERVISOR_MONITOR_PID=$!
+dev_supervisor_log_line "$(dev_supervisor_overmind_log)" \
+  "started overmind monitor pid=${DEV_SUPERVISOR_MONITOR_PID}"
+
 if dev_supervisor_run_overmind overmind start -f Procfile.dev -F "$(dev_supervisor_tmux_config)" "$@" \
+  > >(tee -a "$(dev_supervisor_overmind_log)") \
   2> >(tee -a "$(dev_supervisor_overmind_log)" >&2); then
   :
 else

--- a/bin/dev-update
+++ b/bin/dev-update
@@ -43,6 +43,43 @@ OVERMIND_START_POLL_COUNT="${DEV_UPDATE_OVERMIND_START_POLL_COUNT:-15}"
 OVERMIND_POLL_INTERVAL="${DEV_UPDATE_OVERMIND_POLL_INTERVAL:-1}"
 STARTUP_CLEANUP_GRACE_PERIOD="${DEV_UPDATE_STARTUP_CLEANUP_GRACE_PERIOD:-300}"
 
+newline_list_to_csv() {
+  printf '%s' "${1:-}" | tr '\n' ',' | sed 's/,$//'
+}
+
+restart_required_for_file() {
+  local file="$1"
+
+  case "$file" in
+    app/temporal/*|config/*|db/migrate/*|bin/*|lib/*|Procfile*)
+      return 0
+      ;;
+    Gemfile|Gemfile.lock|package.json|package-lock.json|yarn.lock)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+restart_required_from_trigger_context() {
+  local file
+
+  if [ -n "${DEV_UPDATE_RESTART_TRIGGER_FILES:-}" ]; then
+    return 0
+  fi
+
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    if restart_required_for_file "$file"; then
+      return 0
+    fi
+  done <<< "${DEV_UPDATE_CHANGED_FILES:-}"
+
+  return 1
+}
+
 log() {
   echo "$LOG_PREFIX $(date '+%Y-%m-%d %H:%M:%S') $*"
 }
@@ -78,6 +115,28 @@ configure_logging() {
     exec > >(tee -a "$SCRIPT_LOG") 2>&1
   else
     exec >>"$SCRIPT_LOG" 2>&1
+  fi
+}
+
+log_trigger_context() {
+  log "Trigger source: ${DEV_UPDATE_TRIGGER_SOURCE:-unknown}"
+  log "Requested mode: ${DEV_UPDATE_TRIGGER_MODE:-unknown}"
+  log "Project ID: ${DEV_UPDATE_PROJECT_ID:-unknown}"
+  log "PR number: ${DEV_UPDATE_PR_NUMBER:-unknown}"
+
+  local changed_files_csv
+  changed_files_csv="$(newline_list_to_csv "${DEV_UPDATE_CHANGED_FILES:-}")"
+  local restart_files_csv
+  restart_files_csv="$(newline_list_to_csv "${DEV_UPDATE_RESTART_TRIGGER_FILES:-}")"
+
+  [ -z "$changed_files_csv" ] || log "Changed files: $changed_files_csv"
+  [ -z "$restart_files_csv" ] || log "Restart trigger files: $restart_files_csv"
+}
+
+enforce_safe_mode() {
+  if [ "$MODE" = "--lightweight" ] && restart_required_from_trigger_context; then
+    log "Restart-worthy files were provided with a lightweight request; upgrading to full restart."
+    MODE="--full"
   fi
 }
 
@@ -244,7 +303,6 @@ recover_dev_if_needed() {
 }
 
 run_full_restart() {
-  configure_logging
   log "Starting full restart update..."
   ensure_on_main
   pull_latest
@@ -266,12 +324,20 @@ run_full_restart() {
 case "$MODE" in
   --lightweight)
     configure_logging
+    log_trigger_context
+    enforce_safe_mode
+    if [ "$MODE" = "--full" ]; then
+      run_full_restart
+      exit 0
+    fi
     log "Starting lightweight update..."
     ensure_on_main
     pull_latest
     log "Lightweight update complete. Rails will autoload changes."
     ;;
   --full)
+    configure_logging
+    log_trigger_context
     run_full_restart
     ;;
   *)

--- a/bin/lib/dev_supervisor.sh
+++ b/bin/lib/dev_supervisor.sh
@@ -106,6 +106,44 @@ dev_supervisor_append_command() {
   } >> "$file"
 }
 
+dev_supervisor_append_tmux_details() {
+  local file="$1"
+  local socket
+  local panes
+
+  while IFS= read -r socket; do
+    [ -n "$socket" ] || continue
+
+    {
+      printf '== tmux socket details: %s ==\n' "$socket"
+      tmux -S "$socket" display-message -p \
+        'session=#{session_name} attached=#{session_attached} windows=#{session_windows} created=#{session_created_string}' 2>&1 || true
+      printf '\n'
+    } >> "$file"
+
+    panes="$(tmux -S "$socket" list-panes -a -F \
+      '#{session_name}|#{window_name}|#{pane_index}|#{pane_id}|#{pane_pid}|#{pane_dead}|#{pane_current_command}|#{pane_start_command}|#{pane_current_path}' 2>&1 || true)"
+
+    {
+      printf '== tmux panes: %s ==\n' "$socket"
+      printf '%s\n' "$panes"
+      printf '\n'
+    } >> "$file"
+
+    while IFS='|' read -r session_name window_name pane_index pane_id pane_pid pane_dead pane_current_command _pane_start_command _pane_current_path; do
+      [ -n "${pane_id:-}" ] || continue
+      [ "${pane_id#%}" != "$pane_id" ] || continue
+
+      {
+        printf '== tmux pane capture: %s %s:%s.%s pid=%s dead=%s cmd=%s ==\n' \
+          "$socket" "$session_name" "$window_name" "$pane_index" "$pane_pid" "$pane_dead" "$pane_current_command"
+        tmux -S "$socket" capture-pane -p -t "$pane_id" -S -200 2>&1 || true
+        printf '\n'
+      } >> "$file"
+    done <<< "$panes"
+  done < <(dev_supervisor_tmux_sockets)
+}
+
 dev_supervisor_snapshot_state() {
   dev_supervisor_prepare_logging
 
@@ -130,6 +168,7 @@ dev_supervisor_snapshot_state() {
   dev_supervisor_append_command "$file" "tmux sockets" sh -c "ls -la '$(dev_supervisor_tmux_socket_dir)' 2>/dev/null"
   dev_supervisor_append_command "$file" "overmind socket" sh -c "ls -la '${OVERMIND_SOCKET:-.overmind.sock}' 2>/dev/null"
   dev_supervisor_append_command "$file" "tmux sessions" sh -c "for socket in '$(dev_supervisor_tmux_socket_dir)'/overmind-$(dev_supervisor_app_name)-*; do [ -S \"\$socket\" ] || continue; echo \"-- \$socket --\"; tmux -S \"\$socket\" ls 2>&1 || true; done"
+  dev_supervisor_append_tmux_details "$file"
   dev_supervisor_append_command "$file" "processes" sh -c "if command -v rg >/dev/null 2>&1; then ps -ef | rg 'overmind|tmux|bin/dev|bin/rails server|bin/temporal_worker|yarn build --watch|build:css --watch|esbuild' -S; else ps -ef | grep -E 'overmind|tmux|bin/dev|bin/rails server|bin/temporal_worker|yarn build --watch|build:css --watch|esbuild' | grep -v grep; fi 2>&1 || true"
   dev_supervisor_append_command "$file" "overmind temp files" sh -c "ls -la /tmp/overmind-* 2>/dev/null || true"
 
@@ -202,4 +241,36 @@ dev_supervisor_tmux_has_dead_panes() {
   done < <(dev_supervisor_tmux_sockets)
 
   return 1
+}
+
+dev_supervisor_monitor_overmind() {
+  local parent_pid="$1"
+  local label_prefix="${2:-bin-dev-monitor}"
+  local interval="${DEV_SUPERVISOR_MONITOR_INTERVAL:-2}"
+  local started=0
+  local status_output
+
+  while kill -0 "$parent_pid" >/dev/null 2>&1; do
+    if [ -S "${OVERMIND_SOCKET:-}" ]; then
+      started=1
+    fi
+
+    if [ "$started" -eq 1 ]; then
+      if ! status_output="$(dev_supervisor_overmind_status_output)"; then
+        dev_supervisor_log_line "$(dev_supervisor_overmind_log)" \
+          "${label_prefix} detected unhealthy overmind status: ${status_output//$'\n'/ | }"
+        dev_supervisor_snapshot_state "${label_prefix}-status-failed"
+        return 0
+      fi
+
+      if dev_supervisor_tmux_has_dead_panes; then
+        dev_supervisor_log_line "$(dev_supervisor_overmind_log)" \
+          "${label_prefix} detected dead tmux panes"
+        dev_supervisor_snapshot_state "${label_prefix}-dead-pane"
+        return 0
+      fi
+    fi
+
+    sleep "$interval"
+  done
 }

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -166,6 +166,50 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "logs trigger context passed from the activity" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+      stdout, stderr, status = Open3.capture3(
+        trigger_context_env(dir,
+          "DEV_UPDATE_TRIGGER_MODE" => "full",
+          "DEV_UPDATE_PROJECT_ID" => "12",
+          "DEV_UPDATE_PR_NUMBER" => "42",
+          "DEV_UPDATE_CHANGED_FILES" => "app/models/user.rb\nbin/dev",
+          "DEV_UPDATE_RESTART_TRIGGER_FILES" => "bin/dev"),
+        script_path,
+        "--full",
+        chdir: dir
+      )
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect_trigger_context_log(dir)
+    end
+  end
+
+  it "upgrades lightweight mode to full restart when restart-worthy files are provided" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+
+      stdout, stderr, status = Open3.capture3(
+        trigger_context_env(dir,
+          "DEV_UPDATE_TRIGGER_MODE" => "lightweight",
+          "DEV_UPDATE_CHANGED_FILES" => "bin/dev\napp/models/user.rb"),
+        script_path,
+        "--lightweight",
+        chdir: dir
+      )
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(File.exist?(File.join(dir, "setup-ran"))).to be(true)
+      expect(File.exist?(File.join(dir, "dev-ran"))).to be(true)
+
+      updater_log = read_updater_log(dir)
+      expect(updater_log).to include("Restart-worthy files were provided with a lightweight request; upgrading to full restart.")
+      expect(updater_log).to include("Starting full restart update...")
+      expect(updater_log).not_to include("Lightweight update complete. Rails will autoload changes.")
+    end
+  end
+
   it "passes a startup cleanup grace period to bin/setup during full restart" do
     Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, capture_startup_cleanup_grace_period_in_dev: true)
@@ -241,6 +285,26 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
 
   def read_updater_log(dir)
     File.read(File.join(dir, "log", "dev-update", "dev-update.log"))
+  end
+
+  def expect_trigger_context_log(dir)
+    updater_log = read_updater_log(dir)
+    expect(updater_log).to include("Trigger source: Activities::TriggerDevEnvironmentUpdateActivity")
+    expect(updater_log).to include("Requested mode: full")
+    expect(updater_log).to include("Project ID: 12")
+    expect(updater_log).to include("PR number: 42")
+    expect(updater_log).to include("Changed files: app/models/user.rb,bin/dev")
+    expect(updater_log).to include("Restart trigger files: bin/dev")
+  end
+
+  def trigger_context_env(dir, overrides = {})
+    poll_env.merge(
+      {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_UPDATE_TRIGGER_SOURCE" => "Activities::TriggerDevEnvironmentUpdateActivity"
+      }.merge(overrides)
+    )
   end
 
   def wait_for_dev_start_log(dir)

--- a/spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb
+++ b/spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
 
           log_path = Rails.root.join("log", "dev-update", "dev-update.log").to_s
           expect(Process).to have_received(:spawn).with(
+            hash_including(
+              "DEV_UPDATE_TRIGGER_SOURCE" => "Activities::TriggerDevEnvironmentUpdateActivity",
+              "DEV_UPDATE_TRIGGER_MODE" => "lightweight",
+              "DEV_UPDATE_PROJECT_ID" => project.id.to_s,
+              "DEV_UPDATE_PR_NUMBER" => "42",
+              "DEV_UPDATE_CHANGED_FILES" => "app/models/user.rb\napp/controllers/projects_controller.rb",
+              "DEV_UPDATE_RESTART_TRIGGER_FILES" => ""
+            ),
             "setsid", /bin\/dev-update/, "--lightweight",
             hash_including(out: [ log_path, "a" ], err: [ log_path, "a" ])
           )
@@ -94,6 +102,14 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
 
           log_path = Rails.root.join("log", "dev-update", "dev-update.log").to_s
           expect(Process).to have_received(:spawn).with(
+            hash_including(
+              "DEV_UPDATE_TRIGGER_SOURCE" => "Activities::TriggerDevEnvironmentUpdateActivity",
+              "DEV_UPDATE_TRIGGER_MODE" => "full",
+              "DEV_UPDATE_PROJECT_ID" => project.id.to_s,
+              "DEV_UPDATE_PR_NUMBER" => "42",
+              "DEV_UPDATE_CHANGED_FILES" => "app/temporal/activities/new_activity.rb\napp/models/user.rb",
+              "DEV_UPDATE_RESTART_TRIGGER_FILES" => "app/temporal/activities/new_activity.rb"
+            ),
             "setsid", /bin\/dev-update/, "--full",
             hash_including(out: [ log_path, "a" ], err: [ log_path, "a" ])
           )


### PR DESCRIPTION
## Summary
- add richer auto-update trigger context so dev-update logs which workflow call requested the update and which files drove mode selection
- harden `bin/dev-update` so a lightweight request is automatically upgraded to a full restart when restart-worthy files are present
- add earlier Overmind/tmux diagnostics in `bin/dev` and the supervisor so future shutdowns leave actionable snapshots

## Why
The recent Overmind shutdowns appear correlated with the auto-update path. During investigation we found a suspicious case where restart-worthy file changes under `bin/` were pulled via a logged lightweight update. This change makes that path auditable and prevents a lightweight run from proceeding when the changed files require a restart.

## Testing
- `bash -n bin/dev-update`
- `bundle exec rspec spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb spec/lib/dev_update_spec.rb`
- `bundle exec rspec spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb spec/lib/dev_update_spec.rb spec/lib/dev_script_spec.rb` was also exercised during the debugging work; focused examples passed, but repo-wide SimpleCov still forces a non-zero exit in focused runs because the global 80% threshold is enforced
