### PR TITLE
fix(providers): restore codex sandbox bypass for test agent

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -20,7 +20,7 @@ module Activities
     AGENT_COMMANDS = {
       "claude_code" => %w[claude --print --output-format=text --dangerously-skip-permissions -p],
       "claude" => %w[claude --print --output-format=text --dangerously-skip-permissions -p],
-      "codex" => %w[codex exec --full-auto --sandbox none --],
+      "codex" => %w[codex exec --dangerously-bypass-approvals-and-sandbox --],
       "gemini" => %w[gemini -y -p],
       "kilocode" => %w[kilo run --auto],
       "opencode" => %w[opencode run],

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -154,12 +154,22 @@ RSpec.describe Providers::TestAgent do
       end
 
       it "adds the skip git repo check flag" do
+        service = described_class.new(provider: provider)
+        base_command = Providers::TestAgent::CONTAINER_COMMANDS.fetch("codex")
+        codex_command = service.send(
+          :command_with_flags_before_separator,
+          base_command,
+          "--skip-git-repo-check",
+          "--output-last-message",
+          "$tmp_output"
+        ).join(" ")
+
         described_class.call(provider: provider)
 
         expect(test_run).to have_received(:execute_in_container).with(
           a_string_including('if [ "$PAID_CODEX_SUBSCRIPTION_AUTH" = "1" ]')
             .and(include("-u OPENAI_API_KEY"))
-            .and(include("codex exec --full-auto --sandbox none --skip-git-repo-check --output-last-message")),
+            .and(include(codex_command)),
           timeout: 60,
           stream: false,
           env: {}

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Activities::RunAgentActivity do
 
     it "includes upstream sandbox bypass flags for codex" do
       cmd = described_class::AGENT_COMMANDS["codex"]
-      expect(cmd).to start_with("codex", "exec", "--full-auto", "--sandbox", "none")
+      expect(cmd).to start_with("codex", "exec", "--dangerously-bypass-approvals-and-sandbox")
       expect(cmd).to include("--")
     end
 
@@ -247,11 +247,12 @@ RSpec.describe Activities::RunAgentActivity do
       )
       command = activity.send(:build_command, context, "say 'hi'")
       script = command[2]
+      codex_command = described_class::AGENT_COMMANDS.fetch("codex").join(" ")
 
       expect(command[0..1]).to eq(%w[sh -c])
       expect(script).to include('if [ "$PAID_CODEX_SUBSCRIPTION_AUTH" = "1" ]')
       expect(script).to include("-u OPENAI_API_KEY")
-      expect(script).to include("codex exec --full-auto --sandbox none --")
+      expect(script).to include(codex_command)
       expect(command[3]).to eq("--")
       expect(command[4]).to eq("say 'hi'")
     end


### PR DESCRIPTION
## Summary

Restores a working Codex container command for the current Codex CLI by replacing the invalid `--full-auto --sandbox none` invocation with `--dangerously-bypass-approvals-and-sandbox`.

This fixes the Codex Test Agent regression tracked in #782 and also protects the shared runtime command path used for containerized Codex execution.

## What Changed

- updated `Activities::RunAgentActivity::AGENT_COMMANDS["codex"]` to use the current CLI-compatible sandbox bypass flag
- updated the Codex command expectations in the activity and provider specs
- tightened the provider spec to derive the expected assembled Codex command from the same shared command source used in production, so future flag changes are less likely to drift silently

## Regression Context

The regression appears to come from [#629](https://github.com/viamin/paid/pull/629), which switched Codex back to `--full-auto --sandbox none` on March 30, 2026. In the current environment (`codex-cli 0.117.0`), `codex exec --help` accepts `read-only`, `workspace-write`, and `danger-full-access`, but not `none`.

This is not only a Paid-local bug. The installed `agent-harness` gem (`0.5.6`) also still maps externally sandboxed Codex runs to `--sandbox none`, which is now tracked upstream in [viamin/agent-harness#59](https://github.com/viamin/agent-harness/issues/59).

Broader follow-up work to move `RunAgentActivity` off raw provider command strings is tracked in:
- [#784](https://github.com/viamin/paid/issues/784)
- [viamin/agent-harness#60](https://github.com/viamin/agent-harness/issues/60)
- [viamin/agent-harness#61](https://github.com/viamin/agent-harness/issues/61)
- [viamin/agent-harness#62](https://github.com/viamin/agent-harness/issues/62)

## Verification

- `codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --output-last-message /tmp/codex-test-output "reply with ok"`
- `bundle exec rubocop app/temporal/activities/run_agent_activity.rb app/services/providers/test_agent.rb spec/temporal/activities/run_agent_activity_spec.rb spec/services/providers/test_agent_spec.rb`
- `COVERAGE=false bundle exec rspec spec/temporal/activities/run_agent_activity_spec.rb spec/services/providers/test_agent_spec.rb`

Closes #782
