### PR TITLE
Fix #781: enhancement(agent-runs): unify agent scheduling behind a single queue

### DIFF
--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -58,6 +58,8 @@ module Activities
         issue_id: issue_id
       )
 
+      ProcessRunQueueJob.perform_later
+
       { agent_run_id: agent_run.id, queued: true }
     end
 

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -146,30 +146,10 @@ module Workflows
       )
     end
 
-    # When at capacity, queues an AgentRun record (no child workflow). ProcessRunQueueJob
-    # will start the workflow when a slot opens. This asymmetry is intentional: queued
-    # runs don't need workflow-level monitoring since the DB record tracks their state.
-    def start_agent_workflow(project_id, issue_id, prefix: "agent", source_pull_request_number: nil)
-      capacity = run_activity(Activities::CheckRunCapacityActivity, { project_id: project_id }, timeout: 10)
-
-      unless capacity[:has_capacity]
-        queue_input = { project_id: project_id, issue_id: issue_id }
-        queue_input[:source_pull_request_number] = source_pull_request_number if source_pull_request_number
-        run_activity(Activities::QueueAgentRunActivity, queue_input, timeout: 30)
-        return
-      end
-
-      workflow_id = "#{prefix}-#{project_id}-#{issue_id}-#{Temporalio::Workflow.now.to_i}"
-
-      child_input = { project_id: project_id, issue_id: issue_id }
-      child_input[:source_pull_request_number] = source_pull_request_number if source_pull_request_number
-
-      Temporalio::Workflow.start_child_workflow(
-        Workflows::AgentExecutionWorkflow,
-        child_input,
-        id: workflow_id,
-        parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON
-      )
+    def start_agent_workflow(project_id, issue_id, source_pull_request_number: nil)
+      queue_input = { project_id: project_id, issue_id: issue_id }
+      queue_input[:source_pull_request_number] = source_pull_request_number if source_pull_request_number
+      run_activity(Activities::QueueAgentRunActivity, queue_input, timeout: 30)
     end
 
     def handle_pr_scan_results(scan_result, project_id)
@@ -291,44 +271,20 @@ module Workflows
       issue_id = pr_data[:issue_id]
       pr_number = pr_data[:pr_number]
 
-      capacity = run_activity(Activities::CheckRunCapacityActivity, { project_id: project_id }, timeout: 10)
-
       draft_input = {
         issue_id: issue_id,
         expected_draft_review_count: pr_data[:current_draft_review_count]
       }
 
-      unless capacity[:has_capacity]
-        run_activity(Activities::QueueAgentRunActivity,
-          { project_id: project_id, issue_id: issue_id,
-            source_pull_request_number: pr_number }, timeout: 30)
-
-        run_activity(Activities::RecordDraftReviewActivity, draft_input, timeout: 30)
-        return
-      end
-
-      timestamp = Temporalio::Workflow.now.to_i
-      workflow_id = "draft-followup-#{project_id}-#{pr_number}-#{timestamp}"
-
-      Temporalio::Workflow.start_child_workflow(
-        Workflows::AgentExecutionWorkflow,
-        {
-          project_id: project_id,
-          issue_id: issue_id,
-          source_pull_request_number: pr_number
-        },
-        id: workflow_id,
-        parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON
-      )
-
+      run_activity(Activities::QueueAgentRunActivity,
+        { project_id: project_id, issue_id: issue_id,
+          source_pull_request_number: pr_number }, timeout: 30)
       run_activity(Activities::RecordDraftReviewActivity, draft_input, timeout: 30)
     end
 
     def start_pr_followup_workflow(project_id, pr_data)
       issue_id = pr_data[:issue_id]
       pr_number = pr_data[:pr_number]
-
-      capacity = run_activity(Activities::CheckRunCapacityActivity, { project_id: project_id }, timeout: 10)
 
       followup_input = {
         project_id: project_id,
@@ -337,29 +293,9 @@ module Workflows
         expected_followup_count: pr_data[:current_followup_count]
       }
 
-      unless capacity[:has_capacity]
-        run_activity(Activities::QueueAgentRunActivity,
-          { project_id: project_id, issue_id: issue_id,
-            source_pull_request_number: pr_number }, timeout: 30)
-
-        run_activity(Activities::RecordPrFollowupActivity, followup_input, timeout: 30)
-        return
-      end
-
-      timestamp = Temporalio::Workflow.now.to_i
-      workflow_id = "pr-followup-#{project_id}-#{pr_number}-#{timestamp}"
-
-      Temporalio::Workflow.start_child_workflow(
-        Workflows::AgentExecutionWorkflow,
-        {
-          project_id: project_id,
-          issue_id: issue_id,
-          source_pull_request_number: pr_number
-        },
-        id: workflow_id,
-        parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON
-      )
-
+      run_activity(Activities::QueueAgentRunActivity,
+        { project_id: project_id, issue_id: issue_id,
+          source_pull_request_number: pr_number }, timeout: 30)
       run_activity(Activities::RecordPrFollowupActivity, followup_input, timeout: 30)
     end
   end

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -112,6 +112,27 @@ RSpec.describe ProcessRunQueueJob do
       expect(auto.reload.status).to eq("queued")
     end
 
+    it "starts an older queued manual run before a later auto-continue followup" do
+      project = create(:project)
+      project.created_by.settings.update!(max_concurrent_runs: 1)
+      manual = create(:agent_run, :queued, :manual, project: project, created_at: 2.minutes.ago)
+      followup_issue = create(:issue, project: project)
+      auto_continue = create(:agent_run, :queued, :automatic, :existing_pr,
+        project: project, issue: followup_issue, created_at: 1.minute.ago)
+
+      started_ids = []
+      allow(temporal_client).to receive(:start_workflow) do |_wf, input, **_opts|
+        started_ids << input[:agent_run_id]
+        workflow_handle
+      end
+
+      described_class.new.perform
+
+      expect(started_ids).to eq([ manual.id ])
+      expect(manual.reload.status).to eq("pending")
+      expect(auto_continue.reload.status).to eq("queued")
+    end
+
     it "marks run as failed and continues when workflow start fails" do
       failing_run = create(:agent_run, :queued, created_at: 2.minutes.ago)
       good_run = create(:agent_run, :queued, created_at: 1.minute.ago)

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -3,16 +3,31 @@
 require "rails_helper"
 
 RSpec.describe Activities::QueueAgentRunActivity do
+  include ActiveJob::TestHelper
+
   let(:activity) { described_class.new }
   let(:project) { create(:project) }
   let(:issue) { create(:issue, project: project) }
 
   describe "#execute" do
+    around do |example|
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      clear_enqueued_jobs
+      clear_performed_jobs
+      example.run
+    ensure
+      clear_enqueued_jobs
+      clear_performed_jobs
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+
     it "creates an agent run with queued status" do
       result = activity.execute(project_id: project.id, issue_id: issue.id)
 
       expect(result[:agent_run_id]).to be_present
       expect(result[:queued]).to be true
+      expect(ProcessRunQueueJob).to have_been_enqueued
 
       agent_run = AgentRun.find(result[:agent_run_id])
       expect(agent_run.status).to eq("queued")
@@ -61,6 +76,7 @@ RSpec.describe Activities::QueueAgentRunActivity do
         expect(result[:agent_run_id]).to eq(existing.id)
         expect(result[:duplicate]).to be true
         expect(AgentRun.where(project: project, issue: issue).count).to eq(1)
+        expect(ProcessRunQueueJob).not_to have_been_enqueued
       end
 
       it "returns existing run when an active run exists for the same issue" do
@@ -70,6 +86,7 @@ RSpec.describe Activities::QueueAgentRunActivity do
 
         expect(result[:agent_run_id]).to eq(existing.id)
         expect(result[:duplicate]).to be true
+        expect(ProcessRunQueueJob).not_to have_been_enqueued
       end
 
       it "returns existing run when a queued run exists for the same PR" do
@@ -84,6 +101,7 @@ RSpec.describe Activities::QueueAgentRunActivity do
 
         expect(result[:agent_run_id]).to eq(existing.id)
         expect(result[:duplicate]).to be true
+        expect(ProcessRunQueueJob).not_to have_been_enqueued
       end
 
       it "allows queueing when no active/queued run exists for the issue" do

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -105,26 +105,28 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
     before do
       allow(workflow).to receive(:run_activity)
-        .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
-        .and_return({ has_capacity: true })
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
       allow(Temporalio::Workflow).to receive(:start_child_workflow)
-      allow(Temporalio::Workflow).to receive(:now).and_return(Time.now)
     end
 
-    it "starts execute_agent child workflow with ABANDON parent close policy" do
+    it "queues execute_agent runs instead of starting them directly" do
       detection = { action: "execute_agent", issue_id: 10 }
 
       workflow.send(:handle_detection, detection, project_id)
 
-      expect(Temporalio::Workflow).to have_received(:start_child_workflow).with(
-        Workflows::AgentExecutionWorkflow,
-        hash_including(project_id: project_id, issue_id: 10),
-        hash_including(parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON)
-      )
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, { project_id: project_id, issue_id: 10 }, timeout: 30)
+      expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
     it "starts PlanningWorkflow for start_planning action" do
       detection = { action: "start_planning", issue_id: 20 }
+
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
+        .and_return({ has_capacity: true })
+      allow(Temporalio::Workflow).to receive(:now).and_return(Time.now)
 
       workflow.send(:handle_detection, detection, project_id)
 
@@ -164,6 +166,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
     before do
       allow(workflow).to receive(:run_activity).and_return({})
+      allow(Temporalio::Workflow).to receive(:start_child_workflow)
     end
 
     it "routes ready_for_owner to MarkPrReadyActivity and RequestReviewActivity" do
@@ -240,11 +243,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     end
 
     it "routes draft phase triggers to draft followup workflow" do
-      allow(Temporalio::Workflow).to receive(:start_child_workflow)
-      allow(Temporalio::Workflow).to receive(:now).and_return(Time.now)
       allow(workflow).to receive(:run_activity)
-        .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
-        .and_return({ has_capacity: true })
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
 
       pr_data = {
         issue_id: 10, pr_number: 42, phase: "draft",
@@ -255,20 +256,15 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       workflow.send(:handle_pr_trigger, project_id, pr_data)
 
       expect(workflow).to have_received(:run_activity)
-        .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
-      expect(Temporalio::Workflow).to have_received(:start_child_workflow).with(
-        Workflows::AgentExecutionWorkflow,
-        hash_including(project_id: project_id, issue_id: 10, source_pull_request_number: 42),
-        hash_including(parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON)
-      )
+        .with(Activities::QueueAgentRunActivity,
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 }, timeout: 30)
+      expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
     it "routes ready phase triggers to PR followup workflow" do
-      allow(Temporalio::Workflow).to receive(:start_child_workflow)
-      allow(Temporalio::Workflow).to receive(:now).and_return(Time.now)
       allow(workflow).to receive(:run_activity)
-        .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
-        .and_return({ has_capacity: true })
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
 
       pr_data = {
         issue_id: 10, pr_number: 42, phase: "ready",
@@ -279,12 +275,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       workflow.send(:handle_pr_trigger, project_id, pr_data)
 
       expect(workflow).to have_received(:run_activity)
-        .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
-      expect(Temporalio::Workflow).to have_received(:start_child_workflow).with(
-        Workflows::AgentExecutionWorkflow,
-        hash_including(project_id: project_id, issue_id: 10, source_pull_request_number: 42),
-        hash_including(parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON)
-      )
+        .with(Activities::QueueAgentRunActivity,
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 }, timeout: 30)
+      expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
     it "routes review_bot_review_pending to RequestReviewActivity with copilot" do
@@ -302,11 +295,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     end
 
     it "defers review request and dispatches followup when other triggers present" do
-      allow(Temporalio::Workflow).to receive(:start_child_workflow)
-      allow(Temporalio::Workflow).to receive(:now).and_return(Time.now)
       allow(workflow).to receive(:run_activity)
-        .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
-        .and_return({ has_capacity: true })
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
 
       pr_data = {
         issue_id: 10, pr_number: 42, phase: "draft",
@@ -323,7 +314,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::RequestReviewActivity,
           hash_including(reviewers: array_including(Activities::RequestReviewActivity::COPILOT_LOGIN)), timeout: anything)
-      expect(Temporalio::Workflow).to have_received(:start_child_workflow)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 }, timeout: 30)
     end
 
     it "does not start followup workflow when review_bot_review_pending is the only trigger" do


### PR DESCRIPTION
Poll-triggered agent runs now always enter the DB-backed queue before execution. In [git_hub_poll_workflow.rb](/workspace/app/temporal/workflows/git_hub_poll_workflow.rb), the direct-start paths for issue execution, draft followups, and PR followups were removed so `QueueAgentRunActivity` is always the admission path; in [queue_agent_run_activity.rb](/workspace/app/temporal/activities/queue_agent_run_activity.rb), new queued runs now immediately enqueue `ProcessRunQueueJob`, which matches the collaborator guidance for low-latency wakeups while keeping dedup intact.

The specs were updated to assert queueing instead of direct `start_child_workflow`, and [process_run_queue_job_spec.rb](/workspace/spec/jobs/process_run_queue_job_spec.rb) now covers the regression where an older queued manual run must start before a later auto-continue followup.

Verification: `RAILS_ENV=test bundle exec bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec` all passed. The suite finished with `5204 examples, 0 failures, 2 pending` (the existing Qdrant live-spec pendings). Commit: `87fd619` with message `fix(agent-runs): unify poll-triggered scheduling behind queue`.

---

Closes #781