### PR TITLE
fix(agent-runs): honor provider routing and primary selection

### DIFF
--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -14,8 +14,8 @@ module Activities
       project_id = input[:project_id]
       issue_id = input[:issue_id]
       custom_prompt = input[:custom_prompt]
-      agent_type = input.fetch(:agent_type, "claude_code")
       provider_id = input[:provider_id]
+      agent_type = resolve_agent_type(input[:agent_type], provider_id)
       goal = input.fetch(:goal, "create_pr")
       source_pull_request_number = input[:source_pull_request_number]
 
@@ -113,10 +113,40 @@ module Activities
 
     private
 
+    def resolve_agent_type(requested_agent_type, provider_id)
+      provider = Provider.find_by(id: provider_id) if provider_id.present?
+      return Provider.agent_type_for(provider.provider_key) if provider
+
+      requested_agent_type || "claude_code"
+    end
+
+    def default_provider_for(project)
+      owner = project.effective_owner
+      return unless owner
+
+      settings = AgentRuns::UserSettingsResolver.call(project: project, strict: false)
+      return Provider.ensure_default_for(owner) unless settings
+
+      Provider.for_identifier(settings.user, settings.default_provider_identifier) || Provider.ensure_default_for(settings.user)
+    end
+
+    def refresh_queued_run_provider!(agent_run)
+      return unless agent_run.automatic?
+
+      provider = default_provider_for(agent_run.project)
+      return unless provider
+
+      agent_run.update!(
+        provider: provider,
+        agent_type: Provider.agent_type_for(provider.provider_key)
+      )
+    end
+
     def resume_queued_run(agent_run_id)
       agent_run = AgentRun.find(agent_run_id)
 
       if agent_run.queued?
+        refresh_queued_run_provider!(agent_run)
         agent_run.update!(status: "pending")
       elsif agent_run.status != "pending"
         # "pending" is expected — ProcessRunQueueJob claims runs (queued→pending)

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -8,12 +8,19 @@ module Activities
       project_id = input[:project_id]
       issue_id = input[:issue_id]
       custom_prompt = input[:custom_prompt]
-      agent_type = input.fetch(:agent_type, "claude_code")
+      requested_agent_type = input[:agent_type]
       provider_id = input[:provider_id]
       source_pull_request_number = input[:source_pull_request_number]
 
       project = Project.find(project_id)
       issue = issue_id ? Issue.find(issue_id) : nil
+      provider_id, agent_type = resolve_provider_selection(
+        project: project,
+        requested_agent_type: requested_agent_type,
+        requested_provider_id: provider_id,
+        agent_type_provided: input.key?(:agent_type),
+        provider_id_provided: input.key?(:provider_id)
+      )
 
       # Use a transaction with row-level locking to prevent duplicate
       # queued/active runs for the same issue or PR under concurrency.
@@ -64,6 +71,41 @@ module Activities
     end
 
     private
+
+    def resolve_provider_selection(project:, requested_agent_type:, requested_provider_id:, agent_type_provided:, provider_id_provided:)
+      if provider_id_provided || agent_type_provided
+        provider = provider_for_id(requested_provider_id)
+        resolved_agent_type =
+          if provider
+            Provider.agent_type_for(provider.provider_key)
+          else
+            requested_agent_type || "claude_code"
+          end
+
+        return [ requested_provider_id, resolved_agent_type ]
+      end
+
+      provider = default_provider_for(project)
+      return [ provider&.id, Provider.agent_type_for(provider.provider_key) ] if provider
+
+      [ nil, "claude_code" ]
+    end
+
+    def default_provider_for(project)
+      owner = project.effective_owner
+      return unless owner
+
+      settings = AgentRuns::UserSettingsResolver.call(project: project, strict: false)
+      return Provider.ensure_default_for(owner) unless settings
+
+      Provider.for_identifier(settings.user, settings.default_provider_identifier) || Provider.ensure_default_for(settings.user)
+    end
+
+    def provider_for_id(provider_id)
+      return if provider_id.blank?
+
+      Provider.find_by(id: provider_id)
+    end
 
     # Returns nil for custom-prompt-only runs (no issue or PR) intentionally:
     # custom prompts are unique by definition and cannot be meaningfully deduplicated.

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -315,17 +315,20 @@ module Activities
           providers.concat(user_settings.fallback_priority_for(primary_provider: agent_run.provider.routing_key, identifiers: true))
         end
       else
-        fallback_providers = user_settings.fallback_priority_for(
-          primary_provider: canonical_provider(agent_run.agent_type),
-          identifiers: true
-        ).map do |identifier|
-          Provider.for_identifier(user_settings.user, identifier)&.provider_key || identifier
-        end
-        providers = self.class.provider_order(
-          agent_type: agent_run.agent_type,
-          fallback_enabled: user_settings.fallback_enabled,
-          fallback_providers: fallback_providers
-        )
+        providers =
+          if user_settings.fallback_enabled
+            fallback_providers = user_settings.fallback_priority_for(
+              primary_provider: canonical_provider(agent_run.agent_type),
+              identifiers: true
+            )
+            deduplicate_provider_candidates(
+              primary_provider: agent_run.agent_type,
+              fallback_providers: fallback_providers,
+              user: user_settings.user
+            )
+          else
+            [ agent_run.agent_type ].select { |provider| self.class::AGENT_COMMANDS.key?(provider) }
+          end
       end
 
       @rate_limit_fallback_keys = UserSetting.rate_limit_fallback_providers(user_settings.user).to_set
@@ -667,6 +670,30 @@ module Activities
       return @provider_entry_cache[cache_key] if @provider_entry_cache.key?(cache_key)
 
       @provider_entry_cache[cache_key] = Provider.for_identifier(user, provider_candidate)
+    end
+
+    def deduplicate_provider_candidates(primary_provider:, fallback_providers:, user:)
+      providers = [ primary_provider ]
+      seen = Set.new([ canonical_provider_candidate(primary_provider, user) ])
+
+      Array(fallback_providers).each do |provider_candidate|
+        canonical_candidate = canonical_provider_candidate(provider_candidate, user)
+        next if seen.include?(canonical_candidate)
+
+        seen << canonical_candidate
+        providers << provider_candidate
+      end
+
+      providers.select do |provider_candidate|
+        self.class::AGENT_COMMANDS.key?(provider_command_key(provider_candidate, nil, user))
+      end
+    end
+
+    def canonical_provider_candidate(provider_candidate, user)
+      provider_entry = provider_entry_for(provider_candidate, user)
+      return provider_entry.provider_key if provider_entry
+
+      canonical_provider(provider_candidate)
     end
 
     # Returns a per-entry identifier suitable for persisting in

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(result[:provider_attempt_count]).to eq(1)
     end
 
+    it "derives agent_type from provider_id when only a provider is supplied" do
+      provider = create(:provider, user: project.created_by, provider_key: "cursor")
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id, provider_id: provider.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(provider)
+      expect(agent_run.agent_type).to eq("cursor")
+    end
+
     it "persists the goal when provided" do
       result = activity.execute(
         project_id: project.id,
@@ -346,6 +356,50 @@ RSpec.describe Activities::CreateAgentRunActivity do
 
         expect(result[:agent_run_id]).to eq(pending_run.id)
         expect(pending_run.reload.status).to eq("pending")
+      end
+
+      it "refreshes automatic queued runs to the current primary provider before starting" do
+        claude_provider = project.created_by.providers.find_by!(provider_key: "claude")
+        codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
+        queued_run = create(
+          :agent_run,
+          :queued,
+          project: project,
+          issue: issue,
+          trigger_type: "automatic",
+          provider: claude_provider,
+          agent_type: "claude_code"
+        )
+        project.created_by.settings.update!(default_agent_provider: codex_provider.routing_key)
+
+        activity.execute(agent_run_id: queued_run.id, project_id: project.id)
+
+        queued_run.reload
+        expect(queued_run.status).to eq("pending")
+        expect(queued_run.provider).to eq(codex_provider)
+        expect(queued_run.agent_type).to eq("codex")
+      end
+
+      it "preserves manual queued runs when resuming" do
+        claude_provider = project.created_by.providers.find_by!(provider_key: "claude")
+        codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
+        queued_run = create(
+          :agent_run,
+          :queued,
+          project: project,
+          issue: issue,
+          trigger_type: "manual",
+          provider: claude_provider,
+          agent_type: "claude_code"
+        )
+        project.created_by.settings.update!(default_agent_provider: codex_provider.routing_key)
+
+        activity.execute(agent_run_id: queued_run.id, project_id: project.id)
+
+        queued_run.reload
+        expect(queued_run.status).to eq("pending")
+        expect(queued_run.provider).to eq(claude_provider)
+        expect(queued_run.agent_type).to eq("claude_code")
       end
     end
   end

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Activities::QueueAgentRunActivity do
   include ActiveJob::TestHelper
 
   let(:activity) { described_class.new }
-  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+  let(:project) { create(:project, account: user.account, created_by: user) }
   let(:issue) { create(:issue, project: project) }
 
   describe "#execute" do
@@ -34,6 +35,7 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.project).to eq(project)
       expect(agent_run.issue).to eq(issue)
       expect(agent_run.agent_type).to eq("claude_code")
+      expect(agent_run.provider).to eq(user.providers.find_by!(provider_key: "claude"))
     end
 
     it "accepts a custom agent_type" do
@@ -41,6 +43,28 @@ RSpec.describe Activities::QueueAgentRunActivity do
 
       agent_run = AgentRun.find(result[:agent_run_id])
       expect(agent_run.agent_type).to eq("aider")
+      expect(agent_run.provider_id).to be_nil
+    end
+
+    it "derives agent_type from provider_id when only a provider is supplied" do
+      codex_provider = user.providers.find_or_create_by!(provider_key: "codex", auth_type: "subscription")
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id, provider_id: codex_provider.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(codex_provider)
+      expect(agent_run.agent_type).to eq("codex")
+    end
+
+    it "uses the configured primary provider when agent type is omitted" do
+      codex_provider = user.providers.find_or_create_by!(provider_key: "codex", auth_type: "subscription")
+      user.settings.update!(default_agent_provider: codex_provider.routing_key)
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(codex_provider)
+      expect(agent_run.agent_type).to eq("codex")
     end
 
     it "stores custom_prompt and source_pull_request_number" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -336,6 +336,23 @@ RSpec.describe Activities::RunAgentActivity do
     end
   end
 
+  describe "#build_provider_order" do
+    it "preserves routing-key fallback entries for agent-type runs" do
+      api_key = create(:provider_api_key, user: user, api_service_type: "openrouter")
+      opencode_provider = create_opencode_provider_entry(
+        user: user,
+        api_key: api_key,
+        name: "Kimi K2.5",
+        model: "moonshotai/kimi-k2-0905"
+      )
+      user.settings.update!(fallback_enabled: true, fallback_providers: [ opencode_provider.routing_key ])
+
+      providers = activity.send(:build_provider_order, agent_run, user.settings)
+
+      expect(providers).to eq([ "claude_code", opencode_provider.routing_key ])
+    end
+  end
+
   def build_opencode_context(user)
     api_key = create(:provider_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret")
     provider = create_opencode_provider_entry(user: user, api_key: api_key, name: nil, model: "moonshotai/kimi-k2-0905")
@@ -346,6 +363,28 @@ RSpec.describe Activities::RunAgentActivity do
       command_prefix: described_class::AGENT_COMMANDS["opencode"],
       user: user
     )
+  end
+
+  def expect_opencode_fallback_execution(opencode_provider)
+    call_count = 0
+    expect(container_service).to receive(:execute).twice do |command, **opts|
+      call_count += 1
+      if call_count == 1
+        rate_limit_failure
+      else
+        expect(command[0..1]).to eq(%w[sh -lc])
+        expect(command[2]).to include('printf \'%s\' "$PAID_OPENCODE_CONFIG_B64" | base64 -d')
+        expect(command[2]).to include('opencode run "$1"')
+        expect(opts[:env]).to include("PAID_OPENCODE_CONFIG_B64")
+        exec_success
+      end
+    end
+
+    result = activity.execute(agent_run_id: agent_run.id)
+
+    expect(result[:success]).to be true
+    expect(result[:final_provider]).to eq(opencode_provider.routing_key)
+    expect(agent_run.reload.final_provider).to eq(opencode_provider.routing_key)
   end
 
   def create_opencode_provider_entry(user:, api_key:, name:, model:)
@@ -858,6 +897,20 @@ RSpec.describe Activities::RunAgentActivity do
         labels = activity.send(:provider_attempt_labels, [ kimi.routing_key, opus.routing_key ], agent_run, user)
 
         expect(labels).to eq([ "Kimi K2.5", "Opus via OpenCode" ])
+      end
+
+      it "executes routing-key fallbacks with the provider entry config intact" do
+        allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[claude cursor aider opencode])
+        api_key = create(:provider_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret")
+        opencode_provider = create_opencode_provider_entry(
+          user: user,
+          api_key: api_key,
+          name: "Kimi K2.5",
+          model: "moonshotai/kimi-k2-0905"
+        )
+        user.settings.update!(fallback_enabled: true, fallback_providers: [ opencode_provider.routing_key ])
+
+        expect_opencode_fallback_execution(opencode_provider)
       end
 
       it "marks run as rate_limited when all providers are already rate limited in ProviderState" do


### PR DESCRIPTION
## Summary

This PR fixes three provider-selection bugs in agent execution:

- preserves routing-key-backed fallback provider entries during execution
- makes automatically queued runs honor the configured primary provider instead of defaulting to `claude_code`
- refreshes automatic queued runs to the current primary provider when they leave the queue and start

## Linked Issues

Closes #808
Closes #809
Closes #810

## Testing

- `SIMPLECOV_DISABLE=1 bundle exec rspec spec/temporal/activities/run_agent_activity_spec.rb`
- `SIMPLECOV_DISABLE=1 bundle exec rspec spec/temporal/activities/queue_agent_run_activity_spec.rb spec/temporal/activities/create_agent_run_activity_spec.rb`
- `SIMPLECOV_DISABLE=1 bundle exec rspec spec/temporal/workflows/git_hub_poll_workflow_spec.rb spec/jobs/process_run_queue_job_spec.rb spec/services/issues/auto_pick_spec.rb`
- `SIMPLECOV_DISABLE=1 bundle exec rspec spec/requests/agent_runs_spec.rb`

## Notes

Parts of this work are relevant to #778 because queued automatic runs now refresh to the current configured primary provider right before execution starts, which tightens the semantics around provider selection that issue is reshaping in the UI and settings model.