### PR TITLE
fix(agent-runs): ignore echoed prompts in rate limit detection

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -450,10 +450,11 @@ module Activities
       end
 
       output = (result[:stderr].presence || result[:stdout]).to_s.strip
+      rate_limit_output = strip_prompt_echo(output, prompt)
 
       # Check if this is a rate limit error
-      if rate_limit_error?(output)
-        reset_at = parse_rate_limit_reset(output)
+      if rate_limit_error?(rate_limit_output)
+        reset_at = parse_rate_limit_reset(rate_limit_output)
         raise ProviderRateLimitError.new("Rate limited by #{provider}", reset_at: reset_at)
       end
 
@@ -480,6 +481,30 @@ module Activities
       return false if output.blank?
 
       RATE_LIMIT_PATTERNS.any? { |pattern| output.match?(pattern) }
+    end
+
+    def strip_prompt_echo(output, prompt)
+      return output if output.blank? || prompt.blank?
+
+      sanitized_output = output.gsub(prompt, "")
+      prompt_lines = prompt.each_line.map { |line| normalize_output_line(line, strip_prompt_prefixes: true) }.reject(&:blank?).to_set
+
+      sanitized_output.each_line.filter_map do |line|
+        normalized_line = normalize_output_line(line, strip_prompt_prefixes: true)
+        next if normalized_line.blank? || prompt_lines.include?(normalized_line)
+
+        line.rstrip
+      end.join("\n").strip
+    end
+
+    def normalize_output_line(line, strip_prompt_prefixes: false)
+      normalized_line = line.to_s.strip
+      if strip_prompt_prefixes
+        normalized_line = normalized_line.sub(/\A(?:user|assistant|system)\s*[:|-]?\s*/i, "")
+        normalized_line = normalized_line.sub(/\A(?:>\s*)+/, "")
+      end
+
+      normalized_line.gsub(/\s+/, " ")
     end
 
     # Attempts to parse a rate limit reset time from the output.

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -535,6 +535,24 @@ RSpec.describe Activities::RunAgentActivity do
         )
       end
 
+      def expect_prompt_echo_to_fail_without_rate_limit!(prompt:, output:)
+        allow(agent_run).to receive(:effective_prompt).and_return(prompt)
+        allow(container_service).to receive(:execute).and_return(output)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+
+        expect(agent_run.status).to eq("failed")
+        expect(agent_run.error_message).to include("All providers exhausted")
+        expect(agent_run.error_message).not_to include("rate limited")
+
+        provider_state = user.provider_states.find_by(provider_name: "claude")
+        expect(provider_state&.rate_limited_until).to be_nil
+      end
+
       before do
         allow(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")
         allow(container_service).to receive(:execute).and_return(rate_limit_output)
@@ -557,6 +575,37 @@ RSpec.describe Activities::RunAgentActivity do
         }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
 
         expect(agent_run.reload.status).to eq("rate_limited")
+      end
+
+      it "does not classify echoed prompt text as a rate limit" do
+        echoed_prompt = <<~PROMPT
+          Investigate why the secrets proxy returns 429 for token usage limits.
+          Confirm whether the provider itself is actually rate limited.
+        PROMPT
+        prompt_echo_output = Containers::Provision::Result.failure(
+          error: "killed", stdout: "", stderr: echoed_prompt, exit_code: 137
+        )
+
+        expect_prompt_echo_to_fail_without_rate_limit!(prompt: echoed_prompt, output: prompt_echo_output)
+      end
+
+      it "ignores prompt echoes wrapped in common prefixes" do
+        echoed_prompt = <<~PROMPT
+          Investigate why the secrets proxy returns 429 for token usage limits.
+          Confirm whether the provider itself is actually rate limited.
+        PROMPT
+        prefixed_prompt_echo_output = Containers::Provision::Result.failure(
+          error: "killed",
+          stdout: "",
+          stderr: <<~OUTPUT,
+            user
+            > Investigate why the secrets proxy returns 429 for token usage limits.
+            > Confirm whether the provider itself is actually rate limited.
+          OUTPUT
+          exit_code: 137
+        )
+
+        expect_prompt_echo_to_fail_without_rate_limit!(prompt: echoed_prompt, output: prefixed_prompt_echo_output)
       end
     end
 


### PR DESCRIPTION
## Summary

- ignore prompt-echoed text before classifying provider rate-limit failures
- cover both exact prompt echoes and wrapped echo formats in the activity spec
- prevent false-positive Codex rate-limit state from poisoning later fallback decisions

## Testing

- `bundle exec rubocop app/temporal/activities/run_agent_activity.rb spec/temporal/activities/run_agent_activity_spec.rb`
- `COVERAGE=false bundle exec rspec spec/temporal/activities/run_agent_activity_spec.rb`

Closes #817