### PR TITLE
feat(providers): add z.ai to DIRECT_OUTBOUND_API_PROVIDERS

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -23,7 +23,9 @@ class Provider < ApplicationRecord
     "inception" => { label: "InceptionLabs", base_url: "https://api.inceptionlabs.ai/v1", service_type: "inception" },
     "deepseek" => { label: "DeepSeek", base_url: "https://api.deepseek.com/v1", service_type: "deepseek" },
     "mistral" => { label: "Mistral", base_url: "https://api.mistral.ai/v1", service_type: "mistral" },
-    "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai" }
+    "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai" },
+    "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai" },
+    "zai_coding" => { label: "z.ai (Coding Plan)", base_url: "https://api.z.ai/api/coding/paas/v4", service_type: "zai_coding" }
   }.freeze
 
   DIRECT_OUTBOUND_SERVICE_TYPES = DIRECT_OUTBOUND_API_PROVIDERS.values.map { |c| c[:service_type] }.to_set.freeze


### PR DESCRIPTION
## Summary

- Adds `"zai"` and `"zai_coding"` entries to `DIRECT_OUTBOUND_API_PROVIDERS` in `app/models/provider.rb`
- Z.ai's API is OpenAI-compatible, so no adapter hints needed — the default `openai-compatible` adapter works
- Derived constants (`DIRECT_OUTBOUND_SERVICE_TYPES`, `OPENCODE_API_PROVIDER_KEYS`, `KILOCODE_API_PROVIDER_KEYS`) auto-update, so z.ai appears in OpenCode/KiloCode dropdowns and passes `compatible_with?` checks

## Why

Z.ai was added to `API_SERVICE_TYPES` in #844 so users can store API keys, but without entries in `DIRECT_OUTBOUND_API_PROVIDERS` those keys can't be used with OpenCode or KiloCode providers. The original issue #843 was based on the incorrect assumption that z.ai is not OpenAI-compatible — [their docs confirm it is](https://docs.z.ai/guides/develop/openai/python).

## References

- Z.ai OpenAI-compatible API: https://docs.z.ai/guides/develop/openai/python
- Z.ai + KiloCode: https://docs.z.ai/scenario-example/develop-tools/kilo.md
- Z.ai + OpenCode: https://docs.z.ai/devpack/tool/opencode

Closes #845