### PR TITLE
Fix #865: fix(github-client): add retry middleware to GraphQL connection

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -815,7 +815,11 @@ class GithubClient
   end
 
   def graphql_request(query, **variables)
-    response = graphql_connection.post("/graphql") do |req|
+    # Mutations are not idempotent — retrying them after a transient failure
+    # (where the server may have applied the mutation before returning 5xx)
+    # can cause duplicate side effects. Only retry read-only queries.
+    conn = graphql_mutation?(query) ? graphql_connection_base : graphql_connection
+    response = conn.post("/graphql") do |req|
       req.headers["Authorization"] = "token #{client.access_token}"
       req.body = { query: query, variables: variables }
     end
@@ -826,27 +830,41 @@ class GithubClient
     raise ApiError.new(e.message)
   end
 
+  def graphql_mutation?(query)
+    query.strip.start_with?("mutation")
+  end
+
   def graphql_connection
-    @graphql_connection ||= Faraday.new(url: "https://api.github.com") do |f|
+    @graphql_connection ||= build_graphql_connection(with_retry: true)
+  end
+
+  def graphql_connection_base
+    @graphql_connection_base ||= build_graphql_connection(with_retry: false)
+  end
+
+  def build_graphql_connection(with_retry:)
+    Faraday.new(url: "https://api.github.com") do |f|
       f.request :json
-      f.request :retry,
-        max: 3,
-        interval: 0.5,
-        interval_randomness: 0.5,
-        backoff_factor: 2,
-        methods: %i[post],
-        retry_statuses: [ 429, 500, 502, 503, 504 ],
-        exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS +
-          [ Faraday::ServerError, Faraday::TooManyRequestsError ],
-        retry_block: ->(env:, options:, retry_count:, exception:, will_retry_in:) {
-          Rails.logger.warn(
-            message: "github_client.graphql_retry",
-            url: env[:url].to_s,
-            retry_count: retry_count,
-            will_retry_in: will_retry_in,
-            exception: exception&.class&.name
-          )
-        }
+      if with_retry
+        f.request :retry,
+          max: 3,
+          interval: 0.5,
+          interval_randomness: 0.5,
+          backoff_factor: 2,
+          methods: %i[post],
+          retry_statuses: [ 429, 500, 502, 503, 504 ],
+          exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS +
+            [ Faraday::ServerError, Faraday::TooManyRequestsError ],
+          retry_block: ->(env:, options:, retry_count:, exception:, will_retry_in:) {
+            Rails.logger.warn(
+              message: "github_client.graphql_retry",
+              url: env[:url].to_s,
+              retry_count: retry_count,
+              will_retry_in: will_retry_in,
+              exception: exception&.class&.name
+            )
+          }
+      end
       f.response :json
       f.response :raise_error
       f.adapter Faraday.default_adapter

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -1336,6 +1336,14 @@ RSpec.describe GithubClient do
 
       expect { client.review_threads(repo, 1) }.to raise_error(GithubClient::ApiError)
     end
+
+    it "does not retry mutations" do
+      stub = stub_request(:post, "#{api_base}/graphql")
+        .to_return(status: 503, body: "Service Unavailable")
+
+      expect { client.resolve_review_thread("thread_id") }.to raise_error(GithubClient::ApiError)
+      expect(stub).to have_been_requested.once
+    end
   end
 
   describe "#rate_limit_remaining" do


### PR DESCRIPTION
## Summary

Adds retry middleware to the GitHub GraphQL Faraday connection so transient failures (429/5xx) are retried with exponential backoff, matching the existing REST client behavior. This prevents unnecessary escalation to Temporal workflow-level retries for recoverable errors.

## Changes

- **Services (`app/services/github_client.rb`)**: Added `Faraday::Retry::Middleware` to `graphql_connection` with the same configuration as the REST client — max 3 retries, exponential backoff (0.5s base, 2x factor, 0.5 randomness), retrying on 429/500/502/503/504. Includes structured logging on each retry using the `github_client.graphql_retry` component.

## Design Decisions

- **Parity with REST client**: Uses identical retry parameters rather than introducing GraphQL-specific tuning. This keeps behavior predictable and simplifies future changes to retry policy.
- **HTTP-level retry only**: Retries are triggered by HTTP status codes (429/5xx), not by inspecting GraphQL response bodies for `rateLimit` fields. This is sufficient because GitHub returns HTTP 429 for rate limiting and HTTP 5xx for server errors, even on the GraphQL endpoint.

---

Closes #865