### PR TITLE
Fix #864: perf(github-sync): skip unchanged issues when fetching comments in FetchIssuesActivity

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -121,14 +121,20 @@ module Activities
     end
 
     # TODO(#430): Fetching comments per issue is an N+1 API call pattern that
-    # increases sync time and rate-limit pressure. Consider skipping unchanged
-    # issues (via github_updated_at) or batching comment fetches.
+    # increases sync time and rate-limit pressure. Mitigated by skipping
+    # unchanged issues (via github_updated_at vs last_comment_sync_at).
     def parse_issue_relationships(project, synced_issues)
       synced_issue_ids = synced_issues.filter_map { |si| si[:id] }
       issues_relation = project.issues.where(
         id: synced_issue_ids,
         github_state: "open",
         is_pull_request: false
+      )
+      # Only fetch comments for issues whose github_updated_at has changed
+      # since the last successful comment sync. Issues that haven't been
+      # updated on GitHub since we last synced their comments are skipped.
+      issues_relation = issues_relation.where(
+        "last_comment_sync_at IS NULL OR github_updated_at > last_comment_sync_at"
       )
 
       client = project.github_token.client
@@ -148,6 +154,7 @@ module Activities
 
         Issues::ParseDependencies.call(issue: issue, adjacency: adjacency, comments: comment_bodies)
         parent_child_changed |= Issues::ParseParentChild.call(issue: issue, comments: comment_bodies)
+        issue.update_column(:last_comment_sync_at, Time.current)
       rescue GithubClient::RateLimitError
         raise
       rescue => e

--- a/db/migrate/20260407082352_add_last_comment_sync_at_to_issues.rb
+++ b/db/migrate/20260407082352_add_last_comment_sync_at_to_issues.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastCommentSyncAtToIssues < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issues, :last_comment_sync_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_04_161335) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_07_082352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -461,6 +461,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_04_161335) do
     t.datetime "github_updated_at", null: false
     t.boolean "is_pull_request", default: false, null: false
     t.jsonb "labels", default: [], null: false
+    t.datetime "last_comment_sync_at"
+    t.datetime "last_pr_scan_at"
     t.string "paid_state", default: "new", null: false
     t.bigint "parent_issue_id"
     t.integer "pr_followup_count", default: 0, null: false
@@ -587,12 +589,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_04_161335) do
     t.boolean "supports_json_output", default: false, null: false
     t.boolean "supports_tools", default: false, null: false
     t.boolean "supports_vision", default: false, null: false
+    t.string "tier", limit: 10
     t.datetime "updated_at", null: false
     t.index ["active"], name: "index_llm_models_on_active"
     t.index ["category"], name: "index_llm_models_on_category"
     t.index ["model_id"], name: "index_llm_models_on_model_id", unique: true
     t.index ["provider", "active"], name: "index_llm_models_on_provider_and_active"
     t.index ["provider"], name: "index_llm_models_on_provider"
+    t.index ["tier"], name: "index_llm_models_on_tier"
+    t.check_constraint "tier IS NULL OR (tier::text = ANY (ARRAY['low'::character varying::text, 'mid'::character varying::text, 'high'::character varying::text]))", name: "llm_models_tier_check"
   end
 
   create_table "mcp_server_definitions", force: :cascade do |t|
@@ -848,10 +853,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_04_161335) do
     t.string "name", limit: 100, default: "", null: false
     t.bigint "provider_api_key_id"
     t.string "provider_key", limit: 50, null: false
+    t.jsonb "tier_model_ids", default: {}, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["auth_type"], name: "index_providers_on_auth_type"
     t.index ["provider_api_key_id"], name: "index_providers_on_provider_api_key_id"
+    t.index ["tier_model_ids"], name: "index_providers_on_tier_model_ids", using: :gin
     t.index ["user_id", "provider_key", "provider_api_key_id", "name"], name: "idx_providers_unique_api_key", unique: true, where: "((auth_type)::text = 'api_key'::text)"
     t.index ["user_id", "provider_key"], name: "idx_providers_unique_subscription", unique: true, where: "((auth_type)::text = 'subscription'::text)"
     t.index ["user_id"], name: "index_providers_on_user_id"

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -521,6 +521,85 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
     end
 
+    context "when skipping unchanged issues for comment fetching" do
+      let(:project) { create(:project, label_mappings: { "build" => "paid-build" }, allowed_github_usernames: %w[viamin]) }
+      let(:unchanged_time) { 2.days.ago }
+      let(:updated_time) { 1.hour.ago }
+
+      let(:unchanged_github_issue) do
+        OpenStruct.new(
+          id: 8001,
+          number: 80,
+          title: "Unchanged issue",
+          body: "No changes",
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-build") ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 5.days.ago,
+          updated_at: unchanged_time
+        )
+      end
+
+      let(:updated_github_issue) do
+        OpenStruct.new(
+          id: 8002,
+          number: 81,
+          title: "Updated issue",
+          body: "Has changes",
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-build") ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 5.days.ago,
+          updated_at: updated_time
+        )
+      end
+
+      before do
+        stub_issues_by_label(nil => [ unchanged_github_issue, updated_github_issue ])
+      end
+
+      it "skips comment fetching for issues unchanged since last sync" do
+        # Pre-create the unchanged issue with last_comment_sync_at after github_updated_at
+        create(:issue, project: project, github_issue_id: 8001, github_number: 80,
+               github_updated_at: unchanged_time, last_comment_sync_at: unchanged_time + 1.minute)
+
+        activity.execute(project_id: project.id)
+
+        # Comments should only be fetched for the updated issue (number 81), not the unchanged one (80)
+        expect(github_client).to have_received(:issue_comments).with(project.full_name, 81)
+        expect(github_client).not_to have_received(:issue_comments).with(project.full_name, 80)
+      end
+
+      it "fetches comments for issues that have never been synced" do
+        activity.execute(project_id: project.id)
+
+        # Both issues are new (no last_comment_sync_at), so both should be fetched
+        expect(github_client).to have_received(:issue_comments).with(project.full_name, 80)
+        expect(github_client).to have_received(:issue_comments).with(project.full_name, 81)
+      end
+
+      it "sets last_comment_sync_at after successful comment fetch" do
+        activity.execute(project_id: project.id)
+
+        issue = project.issues.find_by(github_issue_id: 8002)
+        expect(issue.last_comment_sync_at).to be_present
+      end
+
+      it "does not set last_comment_sync_at when comment fetch fails" do
+        allow(github_client).to receive(:issue_comments)
+          .with(project.full_name, 80).and_raise(GithubClient::Error.new("API error"))
+        allow(github_client).to receive(:issue_comments)
+          .with(project.full_name, 81).and_return([])
+
+        activity.execute(project_id: project.id)
+
+        unchanged_issue = project.issues.find_by(github_issue_id: 8001)
+        expect(unchanged_issue.last_comment_sync_at).to be_nil
+      end
+    end
+
     context "when fetching comment dependencies" do
       let(:project) { create(:project, label_mappings: { "build" => "paid-build" }, allowed_github_usernames: %w[viamin trusted-dev]) }
       let(:github_issue) do


### PR DESCRIPTION
Commit succeeded. Here's a summary of the changes:

**Migration:** Added `last_comment_sync_at` datetime column to `issues` table to track when comments were last successfully synced.

**FetchIssuesActivity changes:**
- `parse_issue_relationships` now filters `issues_relation` to only include issues where `last_comment_sync_at IS NULL OR github_updated_at > last_comment_sync_at` — skipping issues that haven't changed on GitHub since their comments were last fetched
- After successful comment fetch + dependency parsing, sets `last_comment_sync_at` via `update_column` to avoid triggering callbacks
- First sync (no `last_comment_sync_at`) always fetches comments; subsequent syncs only fetch for updated issues

**Tests:** Added 4 new specs covering:
- Skipping comment fetching for unchanged issues
- Fetching comments for never-synced issues
- Setting `last_comment_sync_at` after successful fetch
- Not setting `last_comment_sync_at` on fetch failure

---

Closes #864