### PR TITLE
Fix #870: use recent_issue_comments instead of auto-paginated issue_comments

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -382,9 +382,15 @@ class GithubClient
     handle_errors do
       first_page = client.issue_comments(repo, number, per_page: 100, page: 1)
       last_rel = client.last_response&.rels&.dig(:last)
-      return first_page if last_rel.nil?
 
-      client.get(last_rel.href)
+      unless last_rel
+        first_page.define_singleton_method(:multi_page?) { false }
+        return first_page
+      end
+
+      last_page = client.get(last_rel.href)
+      last_page.define_singleton_method(:multi_page?) { true }
+      last_page
     end
   end
 

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -384,15 +384,11 @@ class GithubClient
       last_rel = client.last_response&.rels&.dig(:last)
 
       unless last_rel
-        first_page.instance_variable_set(:@multi_page, false)
-        first_page.define_singleton_method(:multi_page?) { @multi_page }
-        return first_page
+        return tag_multi_page(first_page, false)
       end
 
       last_page = client.get(last_rel.href)
-      last_page.instance_variable_set(:@multi_page, true)
-      last_page.define_singleton_method(:multi_page?) { @multi_page }
-      last_page
+      tag_multi_page(last_page, true)
     end
   end
 
@@ -788,6 +784,12 @@ class GithubClient
   end
 
   private
+
+  def tag_multi_page(page, multi)
+    page.instance_variable_set(:@multi_page, multi)
+    page.define_singleton_method(:multi_page?) { @multi_page }
+    page
+  end
 
   def configure_middleware
     client.middleware = Faraday::RackBuilder.new do |builder|

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -384,12 +384,14 @@ class GithubClient
       last_rel = client.last_response&.rels&.dig(:last)
 
       unless last_rel
-        first_page.define_singleton_method(:multi_page?) { false }
+        first_page.instance_variable_set(:@multi_page, false)
+        first_page.define_singleton_method(:multi_page?) { @multi_page }
         return first_page
       end
 
       last_page = client.get(last_rel.href)
-      last_page.define_singleton_method(:multi_page?) { true }
+      last_page.instance_variable_set(:@multi_page, true)
+      last_page.define_singleton_method(:multi_page?) { @multi_page }
       last_page
     end
   end

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -678,7 +678,7 @@ module Activities
 
       # Treat nil created_at as newer than cutoff (safe: triggers fallback to
       # full pagination rather than silently missing comments).
-      if cutoff && comments.multi_page? &&
+      if cutoff && comments.multi_page? && comments.any? &&
           comments.all? { |c| c.created_at.nil? || c.created_at > cutoff }
         client.issue_comments(project.full_name, issue.github_number)
       else

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -644,21 +644,22 @@ module Activities
     end
 
     def check_conversation_comments(client, project, issue, last_run)
-      comments = client.issue_comments(project.full_name, issue.github_number)
+      comments = client.recent_issue_comments(project.full_name, issue.github_number)
       cutoff = last_run&.completed_at
 
-      relevant = comments.select do |c|
-        login = c.user&.login
-        next false if bot_user?(login)
-        next false unless project.trusted_github_user?(login)
-        next false if cutoff && c.created_at <= cutoff
-        next false if system_generated_comment?(c.body)
-        next false if c.body.to_s.strip.length < MIN_COMMENT_LENGTH
+      relevant = comments.filter_map do |c|
+        break if cutoff && c.created_at && c.created_at <= cutoff
 
-        true
+        login = c.user&.login
+        next if bot_user?(login)
+        next unless project.trusted_github_user?(login)
+        next if system_generated_comment?(c.body)
+        next if c.body.to_s.strip.length < MIN_COMMENT_LENGTH
+
+        c
       end
 
-      return [] if relevant.empty?
+      return [] if relevant.nil? || relevant.empty?
 
       [ { type: "conversation_comments", details: "#{relevant.size} new comment(s)" } ]
     rescue GithubClient::Error => e

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -651,6 +651,7 @@ module Activities
         login = c.user&.login
         next false if bot_user?(login)
         next false unless project.trusted_github_user?(login)
+        # Defensive: treat nil created_at as potentially relevant (include it)
         next false if cutoff && c.created_at && c.created_at <= cutoff
         next false if system_generated_comment?(c.body)
         next false if c.body.to_s.strip.length < MIN_COMMENT_LENGTH
@@ -675,7 +676,9 @@ module Activities
     def fetch_conversation_comments(client, project, issue, cutoff)
       comments = client.recent_issue_comments(project.full_name, issue.github_number)
 
-      if cutoff && comments.respond_to?(:multi_page?) && comments.multi_page? &&
+      # Treat nil created_at as newer than cutoff (safe: triggers fallback to
+      # full pagination rather than silently missing comments).
+      if cutoff && comments.multi_page? &&
           comments.all? { |c| c.created_at.nil? || c.created_at > cutoff }
         client.issue_comments(project.full_name, issue.github_number)
       else

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -644,14 +644,8 @@ module Activities
     end
 
     def check_conversation_comments(client, project, issue, last_run)
-      # recent_issue_comments returns the most recent page (up to 100) of
-      # comments via GithubClient's Link: last follow-up — see the note on
-      # that helper for why we cannot rely on sort/direction params. Within
-      # the returned page, GitHub's /issues/:n/comments endpoint lists
-      # comments in ascending order by id, so we cannot short-circuit on
-      # the first older-than-cutoff comment — we must scan the whole page.
-      comments = client.recent_issue_comments(project.full_name, issue.github_number)
       cutoff = last_run&.completed_at
+      comments = fetch_conversation_comments(client, project, issue, cutoff)
 
       relevant = comments.select do |c|
         login = c.user&.login
@@ -670,6 +664,21 @@ module Activities
     rescue GithubClient::Error => e
       log_signal_error("conversation_comments", project, issue, e)
       []
+    end
+
+    # Fetches conversation comments, preferring the lightweight single-page
+    # recent_issue_comments call. Falls back to full auto-paginated
+    # issue_comments when the cutoff window extends beyond the returned page
+    # (i.e., every comment on the page is newer than the cutoff, meaning
+    # older post-cutoff comments may exist on earlier pages).
+    def fetch_conversation_comments(client, project, issue, cutoff)
+      comments = client.recent_issue_comments(project.full_name, issue.github_number)
+
+      if cutoff && comments.size >= 100 && comments.all? { |c| c.created_at.nil? || c.created_at > cutoff }
+        client.issue_comments(project.full_name, issue.github_number)
+      else
+        comments
+      end
     end
 
     def fetch_reviews(client, project, issue)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -668,13 +668,15 @@ module Activities
 
     # Fetches conversation comments, preferring the lightweight single-page
     # recent_issue_comments call. Falls back to full auto-paginated
-    # issue_comments when the cutoff window extends beyond the returned page
-    # (i.e., every comment on the page is newer than the cutoff, meaning
-    # older post-cutoff comments may exist on earlier pages).
+    # issue_comments when the returned page is from a multi-page result and
+    # the cutoff window extends beyond it (i.e., every comment on the page
+    # is newer than the cutoff, meaning older post-cutoff comments may exist
+    # on earlier pages).
     def fetch_conversation_comments(client, project, issue, cutoff)
       comments = client.recent_issue_comments(project.full_name, issue.github_number)
 
-      if cutoff && comments.size >= 100 && comments.all? { |c| c.created_at.nil? || c.created_at > cutoff }
+      if cutoff && comments.respond_to?(:multi_page?) && comments.multi_page? &&
+          comments.all? { |c| c.created_at.nil? || c.created_at > cutoff }
         client.issue_comments(project.full_name, issue.github_number)
       else
         comments

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -644,22 +644,27 @@ module Activities
     end
 
     def check_conversation_comments(client, project, issue, last_run)
+      # recent_issue_comments returns the most recent page (up to 100) of
+      # comments via GithubClient's Link: last follow-up — see the note on
+      # that helper for why we cannot rely on sort/direction params. Within
+      # the returned page, GitHub's /issues/:n/comments endpoint lists
+      # comments in ascending order by id, so we cannot short-circuit on
+      # the first older-than-cutoff comment — we must scan the whole page.
       comments = client.recent_issue_comments(project.full_name, issue.github_number)
       cutoff = last_run&.completed_at
 
-      relevant = comments.filter_map do |c|
-        break if cutoff && c.created_at && c.created_at <= cutoff
-
+      relevant = comments.select do |c|
         login = c.user&.login
-        next if bot_user?(login)
-        next unless project.trusted_github_user?(login)
-        next if system_generated_comment?(c.body)
-        next if c.body.to_s.strip.length < MIN_COMMENT_LENGTH
+        next false if bot_user?(login)
+        next false unless project.trusted_github_user?(login)
+        next false if cutoff && c.created_at && c.created_at <= cutoff
+        next false if system_generated_comment?(c.body)
+        next false if c.body.to_s.strip.length < MIN_COMMENT_LENGTH
 
-        c
+        true
       end
 
-      return [] if relevant.nil? || relevant.empty?
+      return [] if relevant.empty?
 
       [ { type: "conversation_comments", details: "#{relevant.size} new comment(s)" } ]
     rescue GithubClient::Error => e

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_09_231400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -22,10 +22,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "created_at", null: false
     t.decimal "quality_score", precision: 5, scale: 4
     t.datetime "updated_at", null: false
-    t.index [ "ab_test_id", "agent_run_id" ], name: "index_ab_test_assignments_unique", unique: true
-    t.index [ "ab_test_id" ], name: "index_ab_test_assignments_on_ab_test_id"
-    t.index [ "ab_test_variant_id" ], name: "index_ab_test_assignments_on_ab_test_variant_id"
-    t.index [ "agent_run_id" ], name: "index_ab_test_assignments_on_agent_run_id"
+    t.index ["ab_test_id", "agent_run_id"], name: "index_ab_test_assignments_unique", unique: true
+    t.index ["ab_test_id"], name: "index_ab_test_assignments_on_ab_test_id"
+    t.index ["ab_test_variant_id"], name: "index_ab_test_assignments_on_ab_test_variant_id"
+    t.index ["agent_run_id"], name: "index_ab_test_assignments_on_agent_run_id"
   end
 
   create_table "ab_test_variants", force: :cascade do |t|
@@ -37,11 +37,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "sample_count", default: 0, null: false
     t.decimal "total_quality_score", precision: 10, scale: 4, default: "0.0", null: false
     t.datetime "updated_at", null: false
-    t.index [ "ab_test_id", "is_control" ], name: "index_ab_test_variants_on_test_and_control"
-    t.index [ "ab_test_id", "prompt_version_id" ], name: "index_ab_test_variants_on_test_and_prompt_version", unique: true
-    t.index [ "ab_test_id" ], name: "index_ab_test_variants_on_ab_test_id"
-    t.index [ "ab_test_id" ], name: "index_ab_test_variants_on_control_per_test", unique: true, where: "(is_control = true)"
-    t.index [ "prompt_version_id" ], name: "index_ab_test_variants_on_prompt_version_id"
+    t.index ["ab_test_id", "is_control"], name: "index_ab_test_variants_on_test_and_control"
+    t.index ["ab_test_id", "prompt_version_id"], name: "index_ab_test_variants_on_test_and_prompt_version", unique: true
+    t.index ["ab_test_id"], name: "index_ab_test_variants_on_ab_test_id"
+    t.index ["ab_test_id"], name: "index_ab_test_variants_on_control_per_test", unique: true, where: "(is_control = true)"
+    t.index ["prompt_version_id"], name: "index_ab_test_variants_on_prompt_version_id"
   end
 
   create_table "ab_tests", force: :cascade do |t|
@@ -59,12 +59,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "status", limit: 50, default: "draft", null: false
     t.datetime "updated_at", null: false
     t.bigint "winner_variant_id"
-    t.index [ "control_version_id" ], name: "index_ab_tests_on_control_version_id"
-    t.index [ "prompt_id", "status" ], name: "index_ab_tests_on_prompt_id_and_status"
-    t.index [ "prompt_id" ], name: "index_ab_tests_on_prompt_id"
-    t.index [ "prompt_id" ], name: "index_ab_tests_one_running_per_prompt", unique: true, where: "((status)::text = 'running'::text)"
-    t.index [ "status" ], name: "index_ab_tests_on_status"
-    t.index [ "winner_variant_id" ], name: "index_ab_tests_on_winner_variant_id"
+    t.index ["control_version_id"], name: "index_ab_tests_on_control_version_id"
+    t.index ["prompt_id", "status"], name: "index_ab_tests_on_prompt_id_and_status"
+    t.index ["prompt_id"], name: "index_ab_tests_on_prompt_id"
+    t.index ["prompt_id"], name: "index_ab_tests_one_running_per_prompt", unique: true, where: "((status)::text = 'running'::text)"
+    t.index ["status"], name: "index_ab_tests_on_status"
+    t.index ["winner_variant_id"], name: "index_ab_tests_on_winner_variant_id"
   end
 
   create_table "account_memberships", force: :cascade do |t|
@@ -73,10 +73,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "role", default: 0, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index [ "account_id", "role" ], name: "index_account_memberships_on_account_id_and_role"
-    t.index [ "account_id" ], name: "index_account_memberships_on_account_id"
-    t.index [ "user_id", "account_id" ], name: "index_account_memberships_on_user_id_and_account_id", unique: true
-    t.index [ "user_id" ], name: "index_account_memberships_on_user_id"
+    t.index ["account_id", "role"], name: "index_account_memberships_on_account_id_and_role"
+    t.index ["account_id"], name: "index_account_memberships_on_account_id"
+    t.index ["user_id", "account_id"], name: "index_account_memberships_on_user_id_and_account_id", unique: true
+    t.index ["user_id"], name: "index_account_memberships_on_user_id"
   end
 
   create_table "accounts", force: :cascade do |t|
@@ -85,7 +85,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "name", null: false
     t.string "slug", null: false
     t.datetime "updated_at", null: false
-    t.index [ "slug" ], name: "index_accounts_on_slug", unique: true
+    t.index ["slug"], name: "index_accounts_on_slug", unique: true
   end
 
   create_table "agent_run_anomalies", force: :cascade do |t|
@@ -101,11 +101,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.bigint "project_id", null: false
     t.string "severity", limit: 20, null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_run_id", "metric_name" ], name: "index_agent_run_anomalies_on_agent_run_id_and_metric_name", unique: true
-    t.index [ "agent_run_id" ], name: "index_agent_run_anomalies_on_agent_run_id"
-    t.index [ "anomaly_type" ], name: "index_agent_run_anomalies_on_anomaly_type"
-    t.index [ "project_id", "created_at" ], name: "index_agent_run_anomalies_on_project_id_and_created_at"
-    t.index [ "project_id" ], name: "index_agent_run_anomalies_on_project_id"
+    t.index ["agent_run_id", "metric_name"], name: "index_agent_run_anomalies_on_agent_run_id_and_metric_name", unique: true
+    t.index ["agent_run_id"], name: "index_agent_run_anomalies_on_agent_run_id"
+    t.index ["anomaly_type"], name: "index_agent_run_anomalies_on_anomaly_type"
+    t.index ["project_id", "created_at"], name: "index_agent_run_anomalies_on_project_id_and_created_at"
+    t.index ["project_id"], name: "index_agent_run_anomalies_on_project_id"
   end
 
   create_table "agent_run_logs", force: :cascade do |t|
@@ -114,9 +114,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "created_at", null: false
     t.string "log_type", limit: 50, null: false
     t.jsonb "metadata"
-    t.index [ "agent_run_id", "log_type" ], name: "index_agent_run_logs_on_agent_run_id_and_log_type"
-    t.index [ "agent_run_id" ], name: "index_agent_run_logs_on_agent_run_id"
-    t.index [ "created_at" ], name: "index_agent_run_logs_on_created_at"
+    t.index ["agent_run_id", "log_type"], name: "index_agent_run_logs_on_agent_run_id_and_log_type"
+    t.index ["agent_run_id"], name: "index_agent_run_logs_on_agent_run_id"
+    t.index ["created_at"], name: "index_agent_run_logs_on_created_at"
   end
 
   create_table "agent_run_phases", force: :cascade do |t|
@@ -130,10 +130,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "started_at", null: false
     t.string "status", limit: 50, default: "completed", null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_run_id", "started_at" ], name: "index_agent_run_phases_on_agent_run_id_and_started_at"
-    t.index [ "agent_run_id" ], name: "index_agent_run_phases_on_agent_run_id"
-    t.index [ "phase_group", "started_at" ], name: "index_agent_run_phases_on_phase_group_and_started_at"
-    t.index [ "phase_key", "started_at" ], name: "index_agent_run_phases_on_phase_key_and_started_at"
+    t.index ["agent_run_id", "started_at"], name: "index_agent_run_phases_on_agent_run_id_and_started_at"
+    t.index ["agent_run_id"], name: "index_agent_run_phases_on_agent_run_id"
+    t.index ["phase_group", "started_at"], name: "index_agent_run_phases_on_phase_group_and_started_at"
+    t.index ["phase_key", "started_at"], name: "index_agent_run_phases_on_phase_key_and_started_at"
     t.check_constraint "duration_seconds >= 0", name: "agent_run_phases_duration_seconds_non_negative"
     t.check_constraint "finished_at >= started_at", name: "agent_run_phases_finished_at_after_started_at"
   end
@@ -196,21 +196,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "trigger_type", limit: 50, default: "automatic", null: false
     t.datetime "updated_at", null: false
     t.string "worktree_path", limit: 500
-    t.index [ "created_at" ], name: "index_agent_runs_on_created_at"
-    t.index [ "guardrail_violation_type" ], name: "index_agent_runs_on_guardrail_violation_type", where: "(guardrail_violation_type IS NOT NULL)"
-    t.index [ "issue_id" ], name: "index_agent_runs_on_issue_id"
-    t.index [ "parent_workflow_id" ], name: "index_agent_runs_on_parent_workflow_id"
-    t.index [ "project_id", "goal" ], name: "index_agent_runs_on_project_id_and_goal"
-    t.index [ "project_id", "issue_id" ], name: "idx_agent_runs_unique_active_issue", unique: true, where: "((issue_id IS NOT NULL) AND ((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('pending'::character varying)::text, ('running'::character varying)::text, ('paused'::character varying)::text])))"
-    t.index [ "project_id", "source_pull_request_number" ], name: "idx_agent_runs_unique_active_pr", unique: true, where: "((source_pull_request_number IS NOT NULL) AND ((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('pending'::character varying)::text, ('running'::character varying)::text, ('paused'::character varying)::text])))"
-    t.index [ "project_id", "status", "completed_at" ], name: "index_agent_runs_on_project_status_completed_at"
-    t.index [ "project_id", "status" ], name: "index_agent_runs_on_project_id_and_status"
-    t.index [ "project_id" ], name: "index_agent_runs_on_project_id"
-    t.index [ "prompt_version_id" ], name: "index_agent_runs_on_prompt_version_id"
-    t.index [ "provider_id" ], name: "index_agent_runs_on_provider_id"
-    t.index [ "proxy_token" ], name: "index_agent_runs_on_proxy_token", unique: true
-    t.index [ "status" ], name: "index_agent_runs_on_status"
-    t.index [ "temporal_workflow_id" ], name: "index_agent_runs_on_temporal_workflow_id"
+    t.index ["created_at"], name: "index_agent_runs_on_created_at"
+    t.index ["guardrail_violation_type"], name: "index_agent_runs_on_guardrail_violation_type", where: "(guardrail_violation_type IS NOT NULL)"
+    t.index ["issue_id"], name: "index_agent_runs_on_issue_id"
+    t.index ["parent_workflow_id"], name: "index_agent_runs_on_parent_workflow_id"
+    t.index ["project_id", "goal"], name: "index_agent_runs_on_project_id_and_goal"
+    t.index ["project_id", "issue_id"], name: "idx_agent_runs_unique_active_issue", unique: true, where: "((issue_id IS NOT NULL) AND ((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('pending'::character varying)::text, ('running'::character varying)::text, ('paused'::character varying)::text])))"
+    t.index ["project_id", "source_pull_request_number"], name: "idx_agent_runs_unique_active_pr", unique: true, where: "((source_pull_request_number IS NOT NULL) AND ((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('pending'::character varying)::text, ('running'::character varying)::text, ('paused'::character varying)::text])))"
+    t.index ["project_id", "status", "completed_at"], name: "index_agent_runs_on_project_status_completed_at"
+    t.index ["project_id", "status"], name: "index_agent_runs_on_project_id_and_status"
+    t.index ["project_id"], name: "index_agent_runs_on_project_id"
+    t.index ["prompt_version_id"], name: "index_agent_runs_on_prompt_version_id"
+    t.index ["provider_id"], name: "index_agent_runs_on_provider_id"
+    t.index ["proxy_token"], name: "index_agent_runs_on_proxy_token", unique: true
+    t.index ["status"], name: "index_agent_runs_on_status"
+    t.index ["temporal_workflow_id"], name: "index_agent_runs_on_temporal_workflow_id"
   end
 
   create_table "collector_runs", force: :cascade do |t|
@@ -226,9 +226,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "status", limit: 50, default: "pending", null: false
     t.string "tool_version", limit: 100
     t.datetime "updated_at", null: false
-    t.index [ "project_version_id", "collector_type" ], name: "index_collector_runs_on_project_version_id_and_collector_type", unique: true
-    t.index [ "project_version_id" ], name: "index_collector_runs_on_project_version_id"
-    t.index [ "status" ], name: "index_collector_runs_on_status"
+    t.index ["project_version_id", "collector_type"], name: "index_collector_runs_on_project_version_id_and_collector_type", unique: true
+    t.index ["project_version_id"], name: "index_collector_runs_on_project_version_id"
+    t.index ["status"], name: "index_collector_runs_on_status"
   end
 
   create_table "container_metrics", force: :cascade do |t|
@@ -242,9 +242,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "pids_count"
     t.datetime "recorded_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_run_id", "recorded_at" ], name: "index_container_metrics_on_run_and_recorded"
-    t.index [ "container_id" ], name: "index_container_metrics_on_container_id"
-    t.index [ "recorded_at" ], name: "index_container_metrics_on_recorded_at"
+    t.index ["agent_run_id", "recorded_at"], name: "index_container_metrics_on_run_and_recorded"
+    t.index ["container_id"], name: "index_container_metrics_on_container_id"
+    t.index ["recorded_at"], name: "index_container_metrics_on_recorded_at"
   end
 
   create_table "cost_budgets", force: :cascade do |t|
@@ -259,7 +259,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "period_started_at"
     t.bigint "project_id", null: false
     t.datetime "updated_at", null: false
-    t.index [ "project_id", "budget_type" ], name: "index_cost_budgets_on_project_id_and_budget_type", unique: true
+    t.index ["project_id", "budget_type"], name: "index_cost_budgets_on_project_id_and_budget_type", unique: true
   end
 
   create_table "decision_record_links", force: :cascade do |t|
@@ -268,9 +268,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "link_type", limit: 50, null: false
     t.string "linkable_id", limit: 100, null: false
     t.string "linkable_type", limit: 100, null: false
-    t.index [ "decision_record_id", "linkable_type", "linkable_id", "link_type" ], name: "index_decision_record_links_on_record_and_linkable_and_type", unique: true
-    t.index [ "decision_record_id" ], name: "index_decision_record_links_on_decision_record_id"
-    t.index [ "linkable_type", "linkable_id" ], name: "index_decision_record_links_on_linkable_type_and_linkable_id"
+    t.index ["decision_record_id", "linkable_type", "linkable_id", "link_type"], name: "index_decision_record_links_on_record_and_linkable_and_type", unique: true
+    t.index ["decision_record_id"], name: "index_decision_record_links_on_decision_record_id"
+    t.index ["linkable_type", "linkable_id"], name: "index_decision_record_links_on_linkable_type_and_linkable_id"
   end
 
   create_table "decision_records", force: :cascade do |t|
@@ -289,12 +289,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.jsonb "tags", default: [], null: false
     t.string "title", limit: 500, null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_run_id" ], name: "index_decision_records_on_agent_run_id", unique: true, where: "(agent_run_id IS NOT NULL)"
-    t.index [ "issue_id" ], name: "index_decision_records_on_issue_id"
-    t.index [ "project_id", "status" ], name: "index_decision_records_on_project_id_and_status"
-    t.index [ "project_id" ], name: "index_decision_records_on_project_id"
-    t.index [ "superseded_by_id" ], name: "index_decision_records_on_superseded_by_id"
-    t.index [ "tags" ], name: "index_decision_records_on_tags", using: :gin
+    t.index ["agent_run_id"], name: "index_decision_records_on_agent_run_id", unique: true, where: "(agent_run_id IS NOT NULL)"
+    t.index ["issue_id"], name: "index_decision_records_on_issue_id"
+    t.index ["project_id", "status"], name: "index_decision_records_on_project_id_and_status"
+    t.index ["project_id"], name: "index_decision_records_on_project_id"
+    t.index ["superseded_by_id"], name: "index_decision_records_on_superseded_by_id"
+    t.index ["tags"], name: "index_decision_records_on_tags", using: :gin
   end
 
   create_table "github_tokens", force: :cascade do |t|
@@ -313,11 +313,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "updated_at", null: false
     t.text "validation_error"
     t.string "validation_status", limit: 50, default: "pending", null: false
-    t.index [ "account_id", "name" ], name: "index_github_tokens_on_account_id_and_name", unique: true
-    t.index [ "account_id" ], name: "index_github_tokens_on_account_id"
-    t.index [ "created_by_id" ], name: "index_github_tokens_on_created_by_id"
-    t.index [ "revoked_at" ], name: "index_github_tokens_on_revoked_at"
-    t.index [ "validation_status" ], name: "index_github_tokens_on_validation_status"
+    t.index ["account_id", "name"], name: "index_github_tokens_on_account_id_and_name", unique: true
+    t.index ["account_id"], name: "index_github_tokens_on_account_id"
+    t.index ["created_by_id"], name: "index_github_tokens_on_created_by_id"
+    t.index ["revoked_at"], name: "index_github_tokens_on_revoked_at"
+    t.index ["validation_status"], name: "index_github_tokens_on_validation_status"
   end
 
   create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -350,8 +350,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "scheduled_at"
     t.jsonb "serialized_params"
     t.datetime "updated_at", null: false
-    t.index [ "active_job_id", "created_at" ], name: "index_good_job_executions_on_active_job_id_and_created_at"
-    t.index [ "process_id", "created_at" ], name: "index_good_job_executions_on_process_id_and_created_at"
+    t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
+    t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
   end
 
   create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -366,7 +366,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.text "key"
     t.datetime "updated_at", null: false
     t.jsonb "value"
-    t.index [ "key" ], name: "index_good_job_settings_on_key", unique: true
+    t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
   create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -393,22 +393,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "scheduled_at"
     t.jsonb "serialized_params"
     t.datetime "updated_at", null: false
-    t.index [ "active_job_id", "created_at" ], name: "index_good_jobs_on_active_job_id_and_created_at"
-    t.index [ "batch_callback_id" ], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
-    t.index [ "batch_id" ], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
-    t.index [ "concurrency_key", "created_at" ], name: "index_good_jobs_on_concurrency_key_and_created_at"
-    t.index [ "concurrency_key" ], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
-    t.index [ "cron_key", "created_at" ], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
-    t.index [ "cron_key", "cron_at" ], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
-    t.index [ "finished_at" ], name: "index_good_jobs_jobs_on_finished_at_only", where: "(finished_at IS NOT NULL)"
-    t.index [ "job_class" ], name: "index_good_jobs_on_job_class"
-    t.index [ "labels" ], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
-    t.index [ "locked_by_id" ], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
-    t.index [ "priority", "created_at" ], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
-    t.index [ "priority", "created_at" ], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
-    t.index [ "priority", "scheduled_at" ], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
-    t.index [ "queue_name", "scheduled_at" ], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
-    t.index [ "scheduled_at" ], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
+    t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
+    t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
+    t.index ["concurrency_key", "created_at"], name: "index_good_jobs_on_concurrency_key_and_created_at"
+    t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
+    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
+    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at_only", where: "(finished_at IS NOT NULL)"
+    t.index ["job_class"], name: "index_good_jobs_on_job_class"
+    t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
+    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
+    t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
   create_table "integration_credentials", force: :cascade do |t|
@@ -425,12 +425,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.text "secret", null: false
     t.string "service_key", null: false
     t.datetime "updated_at", null: false
-    t.index [ "account_id", "category" ], name: "index_integration_credentials_on_account_id_and_category"
-    t.index [ "account_id", "revoked_at" ], name: "index_integration_credentials_on_account_id_and_revoked_at"
-    t.index [ "account_id", "service_key", "name" ], name: "idx_on_account_id_service_key_name_e4c03e1ea7", unique: true
-    t.index [ "account_id", "service_key" ], name: "index_integration_credentials_on_account_id_and_service_key"
-    t.index [ "account_id" ], name: "index_integration_credentials_on_account_id"
-    t.index [ "created_by_id" ], name: "index_integration_credentials_on_created_by_id"
+    t.index ["account_id", "category"], name: "index_integration_credentials_on_account_id_and_category"
+    t.index ["account_id", "revoked_at"], name: "index_integration_credentials_on_account_id_and_revoked_at"
+    t.index ["account_id", "service_key", "name"], name: "idx_on_account_id_service_key_name_e4c03e1ea7", unique: true
+    t.index ["account_id", "service_key"], name: "index_integration_credentials_on_account_id_and_service_key"
+    t.index ["account_id"], name: "index_integration_credentials_on_account_id"
+    t.index ["created_by_id"], name: "index_integration_credentials_on_created_by_id"
   end
 
   create_table "issue_dependencies", force: :cascade do |t|
@@ -441,10 +441,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "depends_on_repo"
     t.bigint "issue_id", null: false
     t.datetime "updated_at", null: false
-    t.index [ "depends_on_issue_id" ], name: "index_issue_dependencies_on_depends_on_issue_id"
-    t.index [ "issue_id", "depends_on_issue_id" ], name: "idx_issue_dependencies_unique", unique: true
-    t.index [ "issue_id", "depends_on_owner", "depends_on_repo", "depends_on_number" ], name: "idx_issue_deps_external_unique", unique: true, where: "(depends_on_owner IS NOT NULL)"
-    t.index [ "issue_id" ], name: "index_issue_dependencies_on_issue_id"
+    t.index ["depends_on_issue_id"], name: "index_issue_dependencies_on_depends_on_issue_id"
+    t.index ["issue_id", "depends_on_issue_id"], name: "idx_issue_dependencies_unique", unique: true
+    t.index ["issue_id", "depends_on_owner", "depends_on_repo", "depends_on_number"], name: "idx_issue_deps_external_unique", unique: true, where: "(depends_on_owner IS NOT NULL)"
+    t.index ["issue_id"], name: "index_issue_dependencies_on_issue_id"
     t.check_constraint "depends_on_issue_id IS NOT NULL AND depends_on_owner IS NULL AND depends_on_repo IS NULL AND depends_on_number IS NULL OR depends_on_issue_id IS NULL AND NULLIF(depends_on_owner::text, ''::text) IS NOT NULL AND NULLIF(depends_on_repo::text, ''::text) IS NOT NULL AND depends_on_number > 0", name: "issue_dependencies_depends_on_xor"
   end
 
@@ -470,18 +470,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "source", default: "github", null: false
     t.string "title", limit: 1000, null: false
     t.datetime "updated_at", null: false
-    t.index [ "github_creator_login" ], name: "index_issues_on_github_creator_login"
-    t.index [ "labels" ], name: "index_issues_on_labels_gin_open_issues", where: "((is_pull_request = false) AND ((github_state)::text = 'open'::text))", using: :gin
-    t.index [ "labels" ], name: "index_issues_on_labels_gin_open_prs", where: "((is_pull_request = true) AND ((github_state)::text = 'open'::text))", using: :gin
-    t.index [ "parent_issue_id" ], name: "index_issues_on_parent_issue_id"
-    t.index [ "project_id", "github_issue_id" ], name: "index_issues_on_project_id_and_github_issue_id", unique: true
-    t.index [ "project_id", "github_number" ], name: "index_issues_on_project_id_and_github_number"
-    t.index [ "project_id", "paid_state" ], name: "index_issues_on_project_id_and_paid_state"
-    t.index [ "project_id", "pr_review_phase" ], name: "idx_issues_pr_review_phase", where: "((is_pull_request = true) AND ((github_state)::text = 'open'::text))"
-    t.index [ "project_id", "source", "github_state" ], name: "idx_issues_on_project_source_state"
-    t.index [ "project_id" ], name: "index_issues_on_project_id"
-    t.index [ "relationships_parsed_at" ], name: "index_issues_on_relationships_parsed_at"
-    t.index [ "source" ], name: "index_issues_on_source"
+    t.index ["github_creator_login"], name: "index_issues_on_github_creator_login"
+    t.index ["labels"], name: "index_issues_on_labels_gin_open_issues", where: "((is_pull_request = false) AND ((github_state)::text = 'open'::text))", using: :gin
+    t.index ["labels"], name: "index_issues_on_labels_gin_open_prs", where: "((is_pull_request = true) AND ((github_state)::text = 'open'::text))", using: :gin
+    t.index ["parent_issue_id"], name: "index_issues_on_parent_issue_id"
+    t.index ["project_id", "github_issue_id"], name: "index_issues_on_project_id_and_github_issue_id", unique: true
+    t.index ["project_id", "github_number"], name: "index_issues_on_project_id_and_github_number"
+    t.index ["project_id", "paid_state"], name: "index_issues_on_project_id_and_paid_state"
+    t.index ["project_id", "pr_review_phase"], name: "idx_issues_pr_review_phase", where: "((is_pull_request = true) AND ((github_state)::text = 'open'::text))"
+    t.index ["project_id", "source", "github_state"], name: "idx_issues_on_project_source_state"
+    t.index ["project_id"], name: "index_issues_on_project_id"
+    t.index ["relationships_parsed_at"], name: "index_issues_on_relationships_parsed_at"
+    t.index ["source"], name: "index_issues_on_source"
   end
 
   create_table "knowledge_artifacts", force: :cascade do |t|
@@ -497,13 +497,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "scope_path", limit: 1000
     t.string "status", limit: 50, default: "active", null: false
     t.datetime "updated_at", null: false
-    t.index [ "collector_run_id", "content_hash" ], name: "index_knowledge_artifacts_on_collector_run_id_and_content_hash", unique: true
-    t.index [ "collector_run_id" ], name: "index_knowledge_artifacts_on_collector_run_id"
-    t.index [ "identifier" ], name: "index_knowledge_artifacts_on_identifier_trgm", opclass: :gin_trgm_ops, using: :gin
-    t.index [ "project_id", "artifact_type", "scope_path", "identifier", "collector_type", "status" ], name: "idx_knowledge_artifacts_on_project_type_scope_id_ctype_status"
-    t.index [ "project_id", "artifact_type", "scope_path", "identifier", "collector_type" ], name: "idx_knowledge_artifacts_active_unique", unique: true, where: "((status)::text = 'active'::text)"
-    t.index [ "project_id" ], name: "index_knowledge_artifacts_on_project_id"
-    t.index [ "status" ], name: "index_knowledge_artifacts_on_status"
+    t.index ["collector_run_id", "content_hash"], name: "index_knowledge_artifacts_on_collector_run_id_and_content_hash", unique: true
+    t.index ["collector_run_id"], name: "index_knowledge_artifacts_on_collector_run_id"
+    t.index ["identifier"], name: "index_knowledge_artifacts_on_identifier_trgm", opclass: :gin_trgm_ops, using: :gin
+    t.index ["project_id", "artifact_type", "scope_path", "identifier", "collector_type", "status"], name: "idx_knowledge_artifacts_on_project_type_scope_id_ctype_status"
+    t.index ["project_id", "artifact_type", "scope_path", "identifier", "collector_type"], name: "idx_knowledge_artifacts_active_unique", unique: true, where: "((status)::text = 'active'::text)"
+    t.index ["project_id"], name: "index_knowledge_artifacts_on_project_id"
+    t.index ["status"], name: "index_knowledge_artifacts_on_status"
   end
 
   create_table "knowledge_audit_events", force: :cascade do |t|
@@ -515,11 +515,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.bigint "project_id", null: false
     t.string "target_id", limit: 100
     t.string "target_type", limit: 100
-    t.index [ "created_at" ], name: "idx_knowledge_audit_events_on_created_at", using: :brin
-    t.index [ "event_type" ], name: "index_knowledge_audit_events_on_event_type"
-    t.index [ "project_id", "created_at", "id" ], name: "idx_knowledge_audit_events_on_project_created_at_id", order: { created_at: :desc, id: :desc }
-    t.index [ "project_id" ], name: "index_knowledge_audit_events_on_project_id"
-    t.index [ "target_type", "target_id" ], name: "index_knowledge_audit_events_on_target_type_and_target_id"
+    t.index ["created_at"], name: "idx_knowledge_audit_events_on_created_at", using: :brin
+    t.index ["event_type"], name: "index_knowledge_audit_events_on_event_type"
+    t.index ["project_id", "created_at", "id"], name: "idx_knowledge_audit_events_on_project_created_at_id", order: { created_at: :desc, id: :desc }
+    t.index ["project_id"], name: "index_knowledge_audit_events_on_project_id"
+    t.index ["target_type", "target_id"], name: "index_knowledge_audit_events_on_target_type_and_target_id"
   end
 
   create_table "knowledge_chunks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -536,11 +536,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "sequence", default: 0
     t.string "status", limit: 50, default: "active", null: false
     t.datetime "updated_at", null: false
-    t.index [ "content_hash" ], name: "index_knowledge_chunks_on_content_hash"
-    t.index [ "content_tsvector" ], name: "index_knowledge_chunks_on_content_tsvector", using: :gin
-    t.index [ "knowledge_artifact_id" ], name: "index_knowledge_chunks_on_knowledge_artifact_id"
-    t.index [ "project_id", "status" ], name: "index_knowledge_chunks_on_project_id_and_status"
-    t.index [ "project_id" ], name: "index_knowledge_chunks_on_project_id"
+    t.index ["content_hash"], name: "index_knowledge_chunks_on_content_hash"
+    t.index ["content_tsvector"], name: "index_knowledge_chunks_on_content_tsvector", using: :gin
+    t.index ["knowledge_artifact_id"], name: "index_knowledge_chunks_on_knowledge_artifact_id"
+    t.index ["project_id", "status"], name: "index_knowledge_chunks_on_project_id_and_status"
+    t.index ["project_id"], name: "index_knowledge_chunks_on_project_id"
   end
 
   create_table "knowledge_links", force: :cascade do |t|
@@ -550,9 +550,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.uuid "source_chunk_id", null: false
     t.uuid "target_chunk_id", null: false
     t.decimal "weight", precision: 5, scale: 3, default: "1.0"
-    t.index [ "link_type" ], name: "index_knowledge_links_on_link_type"
-    t.index [ "source_chunk_id", "target_chunk_id", "link_type" ], name: "idx_knowledge_links_uniqueness", unique: true
-    t.index [ "target_chunk_id" ], name: "index_knowledge_links_on_target_chunk_id"
+    t.index ["link_type"], name: "index_knowledge_links_on_link_type"
+    t.index ["source_chunk_id", "target_chunk_id", "link_type"], name: "idx_knowledge_links_uniqueness", unique: true
+    t.index ["target_chunk_id"], name: "index_knowledge_links_on_target_chunk_id"
   end
 
   create_table "linear_tokens", force: :cascade do |t|
@@ -567,10 +567,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "updated_at", null: false
     t.string "validation_error"
     t.string "validation_status", default: "pending", null: false
-    t.index [ "account_id", "name" ], name: "index_linear_tokens_on_account_id_and_name", unique: true
-    t.index [ "account_id" ], name: "index_linear_tokens_on_account_id"
-    t.index [ "created_by_id" ], name: "index_linear_tokens_on_created_by_id"
-    t.index [ "revoked_at" ], name: "index_linear_tokens_on_revoked_at"
+    t.index ["account_id", "name"], name: "index_linear_tokens_on_account_id_and_name", unique: true
+    t.index ["account_id"], name: "index_linear_tokens_on_account_id"
+    t.index ["created_by_id"], name: "index_linear_tokens_on_created_by_id"
+    t.index ["revoked_at"], name: "index_linear_tokens_on_revoked_at"
   end
 
   create_table "llm_models", force: :cascade do |t|
@@ -592,13 +592,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.boolean "supports_vision", default: false, null: false
     t.string "tier", limit: 10
     t.datetime "updated_at", null: false
-    t.index [ "active" ], name: "index_llm_models_on_active"
-    t.index [ "category" ], name: "index_llm_models_on_category"
-    t.index [ "model_id" ], name: "index_llm_models_on_model_id", unique: true
-    t.index [ "provider", "active" ], name: "index_llm_models_on_provider_and_active"
-    t.index [ "provider" ], name: "index_llm_models_on_provider"
-    t.index [ "tier" ], name: "index_llm_models_on_tier"
-    t.check_constraint "tier IS NULL OR (tier::text = ANY (ARRAY['low'::character varying, 'mid'::character varying, 'high'::character varying]::text[]))", name: "llm_models_tier_check"
+    t.index ["active"], name: "index_llm_models_on_active"
+    t.index ["category"], name: "index_llm_models_on_category"
+    t.index ["model_id"], name: "index_llm_models_on_model_id", unique: true
+    t.index ["provider", "active"], name: "index_llm_models_on_provider_and_active"
+    t.index ["provider"], name: "index_llm_models_on_provider"
+    t.index ["tier"], name: "index_llm_models_on_tier"
+    t.check_constraint "tier IS NULL OR (tier::text = ANY (ARRAY['low'::character varying::text, 'mid'::character varying::text, 'high'::character varying::text]))", name: "llm_models_tier_check"
   end
 
   create_table "mcp_server_definitions", force: :cascade do |t|
@@ -615,9 +615,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "transport", limit: 50, null: false
     t.datetime "updated_at", null: false
     t.string "url", limit: 2048
-    t.index [ "account_id", "enabled" ], name: "index_mcp_server_definitions_on_account_id_and_enabled"
-    t.index [ "account_id", "name" ], name: "index_mcp_server_definitions_on_account_id_and_name", unique: true
-    t.index [ "account_id" ], name: "index_mcp_server_definitions_on_account_id"
+    t.index ["account_id", "enabled"], name: "index_mcp_server_definitions_on_account_id_and_enabled"
+    t.index ["account_id", "name"], name: "index_mcp_server_definitions_on_account_id_and_name", unique: true
+    t.index ["account_id"], name: "index_mcp_server_definitions_on_account_id"
   end
 
   create_table "model_selections", force: :cascade do |t|
@@ -631,9 +631,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "selection_duration_ms"
     t.string "selector_type", limit: 50, null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_run_id" ], name: "index_model_selections_on_agent_run_id", unique: true
-    t.index [ "llm_model_id" ], name: "index_model_selections_on_llm_model_id"
-    t.index [ "selector_type" ], name: "index_model_selections_on_selector_type"
+    t.index ["agent_run_id"], name: "index_model_selections_on_agent_run_id", unique: true
+    t.index ["llm_model_id"], name: "index_model_selections_on_llm_model_id"
+    t.index ["selector_type"], name: "index_model_selections_on_selector_type"
   end
 
   create_table "pre_commit_requirements", force: :cascade do |t|
@@ -649,15 +649,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.bigint "project_id"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.index [ "account_id", "name" ], name: "idx_pre_commit_requirements_account_name_unique", unique: true, where: "((project_id IS NULL) AND (user_id IS NULL))"
-    t.index [ "account_id", "position" ], name: "idx_pre_commit_requirements_account_position", where: "((project_id IS NULL) AND (user_id IS NULL))"
-    t.index [ "account_id" ], name: "index_pre_commit_requirements_on_account_id"
-    t.index [ "project_id", "name" ], name: "idx_pre_commit_requirements_project_name_unique", unique: true, where: "(project_id IS NOT NULL)"
-    t.index [ "project_id", "position" ], name: "idx_pre_commit_requirements_project_position", where: "(project_id IS NOT NULL)"
-    t.index [ "project_id" ], name: "index_pre_commit_requirements_on_project_id"
-    t.index [ "user_id", "name" ], name: "idx_pre_commit_requirements_user_name_unique", unique: true, where: "((user_id IS NOT NULL) AND (project_id IS NULL))"
-    t.index [ "user_id", "position" ], name: "idx_pre_commit_requirements_user_position", where: "(user_id IS NOT NULL)"
-    t.index [ "user_id" ], name: "index_pre_commit_requirements_on_user_id"
+    t.index ["account_id", "name"], name: "idx_pre_commit_requirements_account_name_unique", unique: true, where: "((project_id IS NULL) AND (user_id IS NULL))"
+    t.index ["account_id", "position"], name: "idx_pre_commit_requirements_account_position", where: "((project_id IS NULL) AND (user_id IS NULL))"
+    t.index ["account_id"], name: "index_pre_commit_requirements_on_account_id"
+    t.index ["project_id", "name"], name: "idx_pre_commit_requirements_project_name_unique", unique: true, where: "(project_id IS NOT NULL)"
+    t.index ["project_id", "position"], name: "idx_pre_commit_requirements_project_position", where: "(project_id IS NOT NULL)"
+    t.index ["project_id"], name: "index_pre_commit_requirements_on_project_id"
+    t.index ["user_id", "name"], name: "idx_pre_commit_requirements_user_name_unique", unique: true, where: "((user_id IS NOT NULL) AND (project_id IS NULL))"
+    t.index ["user_id", "position"], name: "idx_pre_commit_requirements_user_position", where: "(user_id IS NOT NULL)"
+    t.index ["user_id"], name: "index_pre_commit_requirements_on_user_id"
     t.check_constraint "NOT (project_id IS NOT NULL AND user_id IS NOT NULL)", name: "chk_pre_commit_requirements_exclusive_scope"
   end
 
@@ -671,8 +671,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "sample_count", default: 0, null: false
     t.float "standard_deviation", default: 0.0, null: false
     t.datetime "updated_at", null: false
-    t.index [ "project_id", "metric_name" ], name: "index_project_baselines_on_project_id_and_metric_name", unique: true
-    t.index [ "project_id" ], name: "index_project_baselines_on_project_id"
+    t.index ["project_id", "metric_name"], name: "index_project_baselines_on_project_id_and_metric_name", unique: true
+    t.index ["project_id"], name: "index_project_baselines_on_project_id"
   end
 
   create_table "project_mcp_servers", force: :cascade do |t|
@@ -680,9 +680,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.bigint "mcp_server_definition_id", null: false
     t.bigint "project_id", null: false
     t.datetime "updated_at", null: false
-    t.index [ "mcp_server_definition_id" ], name: "index_project_mcp_servers_on_mcp_server_definition_id"
-    t.index [ "project_id", "mcp_server_definition_id" ], name: "idx_project_mcp_servers_unique", unique: true
-    t.index [ "project_id" ], name: "index_project_mcp_servers_on_project_id"
+    t.index ["mcp_server_definition_id"], name: "index_project_mcp_servers_on_mcp_server_definition_id"
+    t.index ["project_id", "mcp_server_definition_id"], name: "idx_project_mcp_servers_unique", unique: true
+    t.index ["project_id"], name: "index_project_mcp_servers_on_project_id"
   end
 
   create_table "project_memberships", force: :cascade do |t|
@@ -691,10 +691,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "role", default: 0, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index [ "project_id", "role" ], name: "index_project_memberships_on_project_id_and_role"
-    t.index [ "project_id" ], name: "index_project_memberships_on_project_id"
-    t.index [ "user_id", "project_id" ], name: "index_project_memberships_on_user_id_and_project_id", unique: true
-    t.index [ "user_id" ], name: "index_project_memberships_on_user_id"
+    t.index ["project_id", "role"], name: "index_project_memberships_on_project_id_and_role"
+    t.index ["project_id"], name: "index_project_memberships_on_project_id"
+    t.index ["user_id", "project_id"], name: "index_project_memberships_on_user_id_and_project_id", unique: true
+    t.index ["user_id"], name: "index_project_memberships_on_user_id"
   end
 
   create_table "project_service_containers", force: :cascade do |t|
@@ -702,9 +702,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.bigint "project_id", null: false
     t.bigint "service_container_id", null: false
     t.datetime "updated_at", null: false
-    t.index [ "project_id", "service_container_id" ], name: "idx_project_service_containers_unique", unique: true
-    t.index [ "project_id" ], name: "index_project_service_containers_on_project_id"
-    t.index [ "service_container_id" ], name: "index_project_service_containers_on_service_container_id"
+    t.index ["project_id", "service_container_id"], name: "idx_project_service_containers_unique", unique: true
+    t.index ["project_id"], name: "index_project_service_containers_on_project_id"
+    t.index ["service_container_id"], name: "index_project_service_containers_on_service_container_id"
   end
 
   create_table "project_versions", force: :cascade do |t|
@@ -716,9 +716,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "parent_sha", limit: 40
     t.bigint "project_id", null: false
     t.datetime "updated_at", null: false
-    t.index [ "project_id", "commit_sha" ], name: "index_project_versions_on_project_id_and_commit_sha", unique: true
-    t.index [ "project_id", "committed_at" ], name: "index_project_versions_on_project_id_and_committed_at", order: { committed_at: :desc }
-    t.index [ "project_id" ], name: "index_project_versions_on_project_id"
+    t.index ["project_id", "commit_sha"], name: "index_project_versions_on_project_id_and_commit_sha", unique: true
+    t.index ["project_id", "committed_at"], name: "index_project_versions_on_project_id_and_committed_at", order: { committed_at: :desc }
+    t.index ["project_id"], name: "index_project_versions_on_project_id"
   end
 
   create_table "projects", force: :cascade do |t|
@@ -763,21 +763,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.jsonb "priority_labels", default: {"P1" => "P1", "P2" => "P2", "P3" => "P3"}, null: false
     t.string "repo", null: false
     t.jsonb "review_settings", default: {}, null: false
-    t.jsonb "security_alert_types", default: [ "code_scanning" ], null: false
+    t.jsonb "security_alert_types", default: ["code_scanning"], null: false
     t.string "security_severity_threshold", default: "high", null: false
     t.integer "token_limit_warning_threshold", default: 80, null: false
     t.bigint "total_cost_cents", default: 0, null: false
     t.bigint "total_tokens_used", default: 0, null: false
     t.datetime "updated_at", null: false
     t.text "webhook_secret"
-    t.index [ "account_id", "active" ], name: "index_projects_on_account_id_and_active"
-    t.index [ "account_id", "github_id" ], name: "index_projects_on_account_id_and_github_id", unique: true
-    t.index [ "account_id", "last_agent_run_at" ], name: "index_projects_on_account_id_and_last_agent_run_at"
-    t.index [ "account_id", "last_github_activity_at" ], name: "index_projects_on_account_id_and_last_github_activity_at"
-    t.index [ "account_id" ], name: "index_projects_on_account_id"
-    t.index [ "created_by_id" ], name: "index_projects_on_created_by_id"
-    t.index [ "github_token_id" ], name: "index_projects_on_github_token_id"
-    t.index [ "owner", "repo" ], name: "index_projects_on_owner_and_repo"
+    t.index ["account_id", "active"], name: "index_projects_on_account_id_and_active"
+    t.index ["account_id", "github_id"], name: "index_projects_on_account_id_and_github_id", unique: true
+    t.index ["account_id", "last_agent_run_at"], name: "index_projects_on_account_id_and_last_agent_run_at"
+    t.index ["account_id", "last_github_activity_at"], name: "index_projects_on_account_id_and_last_github_activity_at"
+    t.index ["account_id"], name: "index_projects_on_account_id"
+    t.index ["created_by_id"], name: "index_projects_on_created_by_id"
+    t.index ["github_token_id"], name: "index_projects_on_github_token_id"
+    t.index ["owner", "repo"], name: "index_projects_on_owner_and_repo"
   end
 
   create_table "prompt_versions", force: :cascade do |t|
@@ -794,10 +794,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "usage_count", default: 0, null: false
     t.jsonb "variables", default: [], null: false
     t.integer "version", null: false
-    t.index [ "created_by_user_id" ], name: "index_prompt_versions_on_created_by_user_id"
-    t.index [ "parent_version_id" ], name: "index_prompt_versions_on_parent_version_id"
-    t.index [ "prompt_id", "version" ], name: "index_prompt_versions_on_prompt_id_and_version", unique: true
-    t.index [ "prompt_id" ], name: "index_prompt_versions_on_prompt_id"
+    t.index ["created_by_user_id"], name: "index_prompt_versions_on_created_by_user_id"
+    t.index ["parent_version_id"], name: "index_prompt_versions_on_parent_version_id"
+    t.index ["prompt_id", "version"], name: "index_prompt_versions_on_prompt_id_and_version", unique: true
+    t.index ["prompt_id"], name: "index_prompt_versions_on_prompt_id"
   end
 
   create_table "prompts", force: :cascade do |t|
@@ -811,14 +811,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.bigint "project_id"
     t.string "slug", limit: 100, null: false
     t.datetime "updated_at", null: false
-    t.index [ "account_id" ], name: "index_prompts_on_account_id"
-    t.index [ "active" ], name: "index_prompts_on_active"
-    t.index [ "category" ], name: "index_prompts_on_category"
-    t.index [ "current_version_id" ], name: "index_prompts_on_current_version_id"
-    t.index [ "project_id" ], name: "index_prompts_on_project_id"
-    t.index [ "slug", "account_id" ], name: "index_prompts_on_slug_account", unique: true, where: "((account_id IS NOT NULL) AND (project_id IS NULL))"
-    t.index [ "slug", "project_id" ], name: "index_prompts_on_slug_project", unique: true, where: "(project_id IS NOT NULL)"
-    t.index [ "slug" ], name: "index_prompts_on_slug_global", unique: true, where: "((account_id IS NULL) AND (project_id IS NULL))"
+    t.index ["account_id"], name: "index_prompts_on_account_id"
+    t.index ["active"], name: "index_prompts_on_active"
+    t.index ["category"], name: "index_prompts_on_category"
+    t.index ["current_version_id"], name: "index_prompts_on_current_version_id"
+    t.index ["project_id"], name: "index_prompts_on_project_id"
+    t.index ["slug", "account_id"], name: "index_prompts_on_slug_account", unique: true, where: "((account_id IS NOT NULL) AND (project_id IS NULL))"
+    t.index ["slug", "project_id"], name: "index_prompts_on_slug_project", unique: true, where: "(project_id IS NOT NULL)"
+    t.index ["slug"], name: "index_prompts_on_slug_global", unique: true, where: "((account_id IS NULL) AND (project_id IS NULL))"
     t.check_constraint "project_id IS NULL OR account_id IS NOT NULL", name: "chk_prompts_scope_consistency"
   end
 
@@ -829,9 +829,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "name", limit: 100, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index [ "user_id", "api_service_type" ], name: "index_provider_api_keys_on_user_id_and_api_service_type"
-    t.index [ "user_id", "name" ], name: "index_provider_api_keys_on_user_id_and_name", unique: true
-    t.index [ "user_id" ], name: "index_provider_api_keys_on_user_id"
+    t.index ["user_id", "api_service_type"], name: "index_provider_api_keys_on_user_id_and_api_service_type"
+    t.index ["user_id", "name"], name: "index_provider_api_keys_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_provider_api_keys_on_user_id"
   end
 
   create_table "provider_states", force: :cascade do |t|
@@ -843,7 +843,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "rate_limited_until"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index [ "user_id", "provider_name" ], name: "index_provider_states_on_user_id_and_provider_name", unique: true
+    t.index ["user_id", "provider_name"], name: "index_provider_states_on_user_id_and_provider_name", unique: true
   end
 
   create_table "providers", force: :cascade do |t|
@@ -859,12 +859,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.jsonb "tier_model_ids", default: {}, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index [ "auth_type" ], name: "index_providers_on_auth_type"
-    t.index [ "provider_api_key_id" ], name: "index_providers_on_provider_api_key_id"
-    t.index [ "tier_model_ids" ], name: "index_providers_on_tier_model_ids", using: :gin
-    t.index [ "user_id", "provider_key", "provider_api_key_id", "name" ], name: "idx_providers_unique_api_key", unique: true, where: "((auth_type)::text = 'api_key'::text)"
-    t.index [ "user_id", "provider_key" ], name: "idx_providers_unique_subscription", unique: true, where: "((auth_type)::text = 'subscription'::text)"
-    t.index [ "user_id" ], name: "index_providers_on_user_id"
+    t.index ["auth_type"], name: "index_providers_on_auth_type"
+    t.index ["provider_api_key_id"], name: "index_providers_on_provider_api_key_id"
+    t.index ["tier_model_ids"], name: "index_providers_on_tier_model_ids", using: :gin
+    t.index ["user_id", "provider_key", "provider_api_key_id", "name"], name: "idx_providers_unique_api_key", unique: true, where: "((auth_type)::text = 'api_key'::text)"
+    t.index ["user_id", "provider_key"], name: "idx_providers_unique_subscription", unique: true, where: "((auth_type)::text = 'subscription'::text)"
+    t.index ["user_id"], name: "index_providers_on_user_id"
     t.check_constraint "auth_type::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL", name: "providers_api_key_requires_key"
     t.check_constraint "auth_type::text <> 'subscription'::text OR provider_api_key_id IS NULL AND fallback_role::text = 'standard'::text", name: "providers_subscription_invariants"
   end
@@ -879,13 +879,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.bigint "prompt_version_id"
     t.jsonb "scores", default: {}, null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_run_id", "metric_type" ], name: "index_quality_metrics_on_agent_run_and_type", unique: true
-    t.index [ "agent_run_id" ], name: "index_quality_metrics_on_agent_run_id"
-    t.index [ "composite_score" ], name: "index_quality_metrics_on_composite_score"
-    t.index [ "created_at" ], name: "index_quality_metrics_on_created_at"
-    t.index [ "metric_type" ], name: "index_quality_metrics_on_metric_type"
-    t.index [ "prompt_version_id", "created_at" ], name: "index_quality_metrics_on_prompt_version_and_created_at"
-    t.index [ "prompt_version_id" ], name: "index_quality_metrics_on_prompt_version_id"
+    t.index ["agent_run_id", "metric_type"], name: "index_quality_metrics_on_agent_run_and_type", unique: true
+    t.index ["agent_run_id"], name: "index_quality_metrics_on_agent_run_id"
+    t.index ["composite_score"], name: "index_quality_metrics_on_composite_score"
+    t.index ["created_at"], name: "index_quality_metrics_on_created_at"
+    t.index ["metric_type"], name: "index_quality_metrics_on_metric_type"
+    t.index ["prompt_version_id", "created_at"], name: "index_quality_metrics_on_prompt_version_and_created_at"
+    t.index ["prompt_version_id"], name: "index_quality_metrics_on_prompt_version_id"
   end
 
   create_table "service_container_metrics", force: :cascade do |t|
@@ -899,10 +899,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "recorded_at", null: false
     t.bigint "service_container_id", null: false
     t.datetime "updated_at", null: false
-    t.index [ "container_id" ], name: "index_service_container_metrics_on_container_id"
-    t.index [ "recorded_at" ], name: "index_service_container_metrics_on_recorded_at"
-    t.index [ "service_container_id", "recorded_at" ], name: "index_service_container_metrics_on_container_and_recorded"
-    t.index [ "service_container_id" ], name: "index_service_container_metrics_on_service_container_id"
+    t.index ["container_id"], name: "index_service_container_metrics_on_container_id"
+    t.index ["recorded_at"], name: "index_service_container_metrics_on_recorded_at"
+    t.index ["service_container_id", "recorded_at"], name: "index_service_container_metrics_on_container_and_recorded"
+    t.index ["service_container_id"], name: "index_service_container_metrics_on_service_container_id"
   end
 
   create_table "service_containers", force: :cascade do |t|
@@ -919,7 +919,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "port", null: false
     t.string "status", default: "stopped", null: false
     t.datetime "updated_at", null: false
-    t.index [ "name" ], name: "index_service_containers_on_name", unique: true
+    t.index ["name"], name: "index_service_containers_on_name", unique: true
   end
 
   create_table "style_guides", force: :cascade do |t|
@@ -933,13 +933,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.bigint "project_id"
     t.text "raw_content", null: false
     t.datetime "updated_at", null: false
-    t.index [ "account_id" ], name: "index_style_guides_on_account_id"
-    t.index [ "active" ], name: "index_style_guides_on_active"
-    t.index [ "language" ], name: "index_style_guides_on_language"
-    t.index [ "name", "account_id" ], name: "index_style_guides_on_name_account", unique: true, where: "((account_id IS NOT NULL) AND (project_id IS NULL))"
-    t.index [ "name", "project_id" ], name: "index_style_guides_on_name_project", unique: true, where: "(project_id IS NOT NULL)"
-    t.index [ "name" ], name: "index_style_guides_on_name_global", unique: true, where: "((account_id IS NULL) AND (project_id IS NULL))"
-    t.index [ "project_id" ], name: "index_style_guides_on_project_id"
+    t.index ["account_id"], name: "index_style_guides_on_account_id"
+    t.index ["active"], name: "index_style_guides_on_active"
+    t.index ["language"], name: "index_style_guides_on_language"
+    t.index ["name", "account_id"], name: "index_style_guides_on_name_account", unique: true, where: "((account_id IS NOT NULL) AND (project_id IS NULL))"
+    t.index ["name", "project_id"], name: "index_style_guides_on_name_project", unique: true, where: "(project_id IS NOT NULL)"
+    t.index ["name"], name: "index_style_guides_on_name_global", unique: true, where: "((account_id IS NULL) AND (project_id IS NULL))"
+    t.index ["project_id"], name: "index_style_guides_on_project_id"
     t.check_constraint "project_id IS NULL OR account_id IS NOT NULL", name: "chk_style_guides_scope_consistency"
   end
 
@@ -953,15 +953,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "output_tokens", default: 0, null: false
     t.string "request_type", limit: 50, null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_run_id", "request_type" ], name: "index_token_usages_on_agent_run_id_and_request_type"
-    t.index [ "created_at" ], name: "index_token_usages_on_created_at"
-    t.index [ "llm_model" ], name: "index_token_usages_on_llm_model"
-    t.index [ "request_type" ], name: "index_token_usages_on_request_type"
+    t.index ["agent_run_id", "request_type"], name: "index_token_usages_on_agent_run_id_and_request_type"
+    t.index ["created_at"], name: "index_token_usages_on_created_at"
+    t.index ["llm_model"], name: "index_token_usages_on_llm_model"
+    t.index ["request_type"], name: "index_token_usages_on_request_type"
   end
 
   create_table "user_settings", force: :cascade do |t|
     t.integer "agent_timeout_seconds", default: 3600, null: false
-    t.jsonb "allowed_service_images", default: [ "postgres:16", "redis:7-alpine", "selenium/standalone-chromium:latest" ]
+    t.jsonb "allowed_service_images", default: ["postgres:16", "redis:7-alpine", "selenium/standalone-chromium:latest"]
     t.integer "circuit_breaker_failure_threshold", default: 5, null: false
     t.integer "circuit_breaker_timeout_seconds", default: 300, null: false
     t.bigint "container_memory_bytes", default: 4294967296, null: false
@@ -981,8 +981,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "issue_goal_timeout_seconds", default: 600, null: false
     t.integer "max_comment_length", default: 2000, null: false
     t.integer "max_concurrent_runs", default: 2, null: false
+    t.integer "max_issues_per_page", default: 50, null: false
     t.integer "max_parallel_agents_per_project", default: 3, null: false
     t.integer "max_prompt_comments", default: 20, null: false
+    t.integer "max_prs_per_page", default: 50, null: false
     t.integer "max_tokens_per_run", default: 10000000, null: false
     t.float "retry_base_delay", default: 1.0, null: false
     t.integer "retry_max_attempts", default: 3, null: false
@@ -994,7 +996,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.integer "token_validation_stale_minutes", default: 2, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index [ "user_id" ], name: "index_user_settings_on_user_id", unique: true
+    t.index ["user_id"], name: "index_user_settings_on_user_id", unique: true
+    t.check_constraint "max_issues_per_page >= 5 AND max_issues_per_page <= 200", name: "chk_max_issues_per_page_bounds"
+    t.check_constraint "max_prs_per_page >= 5 AND max_prs_per_page <= 200", name: "chk_max_prs_per_page_bounds"
   end
 
   create_table "users", force: :cascade do |t|
@@ -1007,9 +1011,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.datetime "updated_at", null: false
-    t.index [ "account_id" ], name: "index_users_on_account_id"
-    t.index [ "email" ], name: "index_users_on_email", unique: true
-    t.index [ "reset_password_token" ], name: "index_users_on_reset_password_token", unique: true
+    t.index ["account_id"], name: "index_users_on_account_id"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "workflow_states", force: :cascade do |t|
@@ -1025,9 +1029,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.string "temporal_workflow_id", null: false
     t.datetime "updated_at", null: false
     t.string "workflow_type", limit: 100, null: false
-    t.index [ "project_id" ], name: "index_workflow_states_on_project_id"
-    t.index [ "status" ], name: "index_workflow_states_on_status"
-    t.index [ "temporal_workflow_id" ], name: "index_workflow_states_on_temporal_workflow_id", unique: true
+    t.index ["project_id"], name: "index_workflow_states_on_project_id"
+    t.index ["status"], name: "index_workflow_states_on_status"
+    t.index ["temporal_workflow_id"], name: "index_workflow_states_on_temporal_workflow_id", unique: true
   end
 
   create_table "worktrees", force: :cascade do |t|
@@ -1041,10 +1045,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_004407) do
     t.boolean "pushed", default: false, null: false
     t.string "status", limit: 50, default: "active", null: false
     t.datetime "updated_at", null: false
-    t.index [ "agent_run_id" ], name: "index_worktrees_on_agent_run_id"
-    t.index [ "project_id", "branch_name" ], name: "index_worktrees_on_project_id_and_branch_name", unique: true
-    t.index [ "project_id" ], name: "index_worktrees_on_project_id"
-    t.index [ "status" ], name: "index_worktrees_on_status"
+    t.index ["agent_run_id"], name: "index_worktrees_on_agent_run_id"
+    t.index ["project_id", "branch_name"], name: "index_worktrees_on_project_id_and_branch_name", unique: true
+    t.index ["project_id"], name: "index_worktrees_on_project_id"
+    t.index ["status"], name: "index_worktrees_on_status"
   end
 
   add_foreign_key "ab_test_assignments", "ab_test_variants", on_delete: :cascade

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -839,6 +839,12 @@ RSpec.describe GithubClient do
         expect(result.map(&:body)).to contain_exactly("First comment", "Second comment")
         expect(client.client.auto_paginate).to be false
       end
+
+      it "marks the result as single-page" do
+        result = client.recent_issue_comments(repo, 42)
+
+        expect(result.multi_page?).to be false
+      end
     end
 
     context "when the comment list spans multiple pages" do
@@ -876,6 +882,12 @@ RSpec.describe GithubClient do
         expect(result.size).to eq(2)
         expect(result.map(&:body)).to contain_exactly("Newer comment", "Newest comment")
         expect(result.map(&:body)).not_to include("Very old comment")
+      end
+
+      it "marks the result as multi-page" do
+        result = client.recent_issue_comments(repo, 42)
+
+        expect(result.multi_page?).to be true
       end
     end
   end

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -383,6 +383,51 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         # issue_comments (full pagination) includes the human comment on an earlier page.
         stub_github_for_pr(
           recent_issue_comments: recent_page,
+          recent_multi_page: true,
+          issue_comments: [ human_comment ] + recent_page
+        )
+      end
+
+      it "falls back to full pagination and detects the earlier comment" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("conversation_comments")
+      end
+    end
+
+    context "when partial last page has all comments newer than cutoff" do
+      # When a multi-page PR has a last page with fewer than 100 comments
+      # (e.g., 150 total -> last page has 50), and all are newer than the
+      # cutoff, the scanner must still fall back to full pagination.
+      let(:recent_page) do
+        Array.new(50) do |i|
+          OpenStruct.new(
+            user: OpenStruct.new(login: "bot-user"),
+            body: "Automated update ##{i}",
+            created_at: (25 - (i / 2)).minutes.ago
+          )
+        end
+      end
+      let(:human_comment) do
+        OpenStruct.new(
+          user: OpenStruct.new(login: "viamin"),
+          body: "Please also address the logging around the parser fallback path",
+          created_at: 55.minutes.ago
+        )
+      end
+
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+        create(:agent_run, :completed,
+          project: project, source_pull_request_number: 42,
+          completed_at: 2.hours.ago)
+        stub_github_for_pr(
+          recent_issue_comments: recent_page,
+          recent_multi_page: true,
           issue_comments: [ human_comment ] + recent_page
         )
       end
@@ -2249,6 +2294,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     review_threads: [],
     issue_comments: [],
     recent_issue_comments: nil,
+    recent_multi_page: false,
     reviews: default_clean_copilot_review
   )
     pr_data = OpenStruct.new(
@@ -2257,6 +2303,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       draft: draft,
       user: OpenStruct.new(login: author_login)
     )
+
+    recent = recent_issue_comments || issue_comments
+    recent.define_singleton_method(:multi_page?) { recent_multi_page }
 
     allow(github_client).to receive(:pull_request)
       .with(project.full_name, 42)
@@ -2269,7 +2318,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       .and_return(review_threads)
     allow(github_client).to receive(:recent_issue_comments)
       .with(project.full_name, 42)
-      .and_return(recent_issue_comments || issue_comments)
+      .and_return(recent)
     allow(github_client).to receive(:issue_comments)
       .with(project.full_name, 42)
       .and_return(issue_comments)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -351,6 +351,51 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when cutoff window exceeds the recent comments page" do
+      # When the last page has 100+ comments all newer than the cutoff,
+      # earlier post-cutoff comments may exist on previous pages. The
+      # scanner should fall back to full pagination to avoid missing them.
+      let(:recent_page) do
+        Array.new(100) do |i|
+          OpenStruct.new(
+            user: OpenStruct.new(login: "bot-user"),
+            body: "Automated update ##{i}",
+            created_at: (50 - (i / 2)).minutes.ago
+          )
+        end
+      end
+      let(:human_comment) do
+        OpenStruct.new(
+          user: OpenStruct.new(login: "viamin"),
+          body: "Please also address the logging around the parser fallback path",
+          created_at: 55.minutes.ago
+        )
+      end
+
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+        create(:agent_run, :completed,
+          project: project, source_pull_request_number: 42,
+          completed_at: 2.hours.ago)
+        # recent_issue_comments returns only the last page (all newer than cutoff).
+        # issue_comments (full pagination) includes the human comment on an earlier page.
+        stub_github_for_pr(
+          recent_issue_comments: recent_page,
+          issue_comments: [ human_comment ] + recent_page
+        )
+      end
+
+      it "falls back to full pagination and detects the earlier comment" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("conversation_comments")
+      end
+    end
+
     context "when the new comment is a paid agent update" do
       let(:comment) do
         OpenStruct.new(
@@ -2225,6 +2270,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     allow(github_client).to receive(:recent_issue_comments)
       .with(project.full_name, 42)
       .and_return(recent_issue_comments || issue_comments)
+    allow(github_client).to receive(:issue_comments)
+      .with(project.full_name, 42)
+      .and_return(issue_comments)
     allow(github_client).to receive(:pull_request_reviews)
       .with(project.full_name, 42)
       .and_return(reviews)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -2181,7 +2181,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     allow(github_client).to receive(:review_threads)
       .with(project.full_name, 42)
       .and_return(review_threads)
-    allow(github_client).to receive(:issue_comments)
+    allow(github_client).to receive(:recent_issue_comments)
       .with(project.full_name, 42)
       .and_return(issue_comments)
     allow(github_client).to receive(:recent_issue_comments)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -351,93 +351,49 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
-    context "when cutoff window exceeds the recent comments page" do
-      # When the last page has 100+ comments all newer than the cutoff,
-      # earlier post-cutoff comments may exist on previous pages. The
-      # scanner should fall back to full pagination to avoid missing them.
-      let(:recent_page) do
-        Array.new(100) do |i|
+    [ 100, 50 ].each do |page_size|
+      context "when multi-page recent comments (#{page_size} per page) are all newer than cutoff" do
+        # When every comment on the last page is newer than the cutoff,
+        # earlier post-cutoff comments may exist on previous pages. The
+        # scanner should fall back to full pagination to avoid missing them.
+        let(:recent_page) do
+          Array.new(page_size) do |i|
+            OpenStruct.new(
+              user: OpenStruct.new(login: "bot-user"),
+              body: "Automated update ##{i}",
+              created_at: (50 - (i / 2)).minutes.ago
+            )
+          end
+        end
+        let(:human_comment) do
           OpenStruct.new(
-            user: OpenStruct.new(login: "bot-user"),
-            body: "Automated update ##{i}",
-            created_at: (50 - (i / 2)).minutes.ago
+            user: OpenStruct.new(login: "viamin"),
+            body: "Please also address the logging around the parser fallback path",
+            created_at: 55.minutes.ago
           )
         end
-      end
-      let(:human_comment) do
-        OpenStruct.new(
-          user: OpenStruct.new(login: "viamin"),
-          body: "Please also address the logging around the parser fallback path",
-          created_at: 55.minutes.ago
-        )
-      end
 
-      before do
-        create(:issue, :pull_request,
-          project: project, github_number: 42,
-          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
-        create(:agent_run, :completed,
-          project: project, source_pull_request_number: 42,
-          completed_at: 2.hours.ago)
-        # recent_issue_comments returns only the last page (all newer than cutoff).
-        # issue_comments (full pagination) includes the human comment on an earlier page.
-        stub_github_for_pr(
-          recent_issue_comments: recent_page,
-          recent_multi_page: true,
-          issue_comments: [ human_comment ] + recent_page
-        )
-      end
-
-      it "falls back to full pagination and detects the earlier comment" do
-        result = activity.execute(project_id: project.id)
-
-        expect(result[:prs_to_trigger].size).to eq(1)
-        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
-        expect(trigger_types).to include("conversation_comments")
-      end
-    end
-
-    context "when partial last page has all comments newer than cutoff" do
-      # When a multi-page PR has a last page with fewer than 100 comments
-      # (e.g., 150 total -> last page has 50), and all are newer than the
-      # cutoff, the scanner must still fall back to full pagination.
-      let(:recent_page) do
-        Array.new(50) do |i|
-          OpenStruct.new(
-            user: OpenStruct.new(login: "bot-user"),
-            body: "Automated update ##{i}",
-            created_at: (25 - (i / 2)).minutes.ago
+        before do
+          create(:issue, :pull_request,
+            project: project, github_number: 42,
+            labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+          create(:agent_run, :completed,
+            project: project, source_pull_request_number: 42,
+            completed_at: 2.hours.ago)
+          stub_github_for_pr(
+            recent_issue_comments: recent_page,
+            recent_multi_page: true,
+            issue_comments: [ human_comment ] + recent_page
           )
         end
-      end
-      let(:human_comment) do
-        OpenStruct.new(
-          user: OpenStruct.new(login: "viamin"),
-          body: "Please also address the logging around the parser fallback path",
-          created_at: 55.minutes.ago
-        )
-      end
 
-      before do
-        create(:issue, :pull_request,
-          project: project, github_number: 42,
-          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
-        create(:agent_run, :completed,
-          project: project, source_pull_request_number: 42,
-          completed_at: 2.hours.ago)
-        stub_github_for_pr(
-          recent_issue_comments: recent_page,
-          recent_multi_page: true,
-          issue_comments: [ human_comment ] + recent_page
-        )
-      end
+        it "falls back to full pagination and detects the earlier comment" do
+          result = activity.execute(project_id: project.id)
 
-      it "falls back to full pagination and detects the earlier comment" do
-        result = activity.execute(project_id: project.id)
-
-        expect(result[:prs_to_trigger].size).to eq(1)
-        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
-        expect(trigger_types).to include("conversation_comments")
+          expect(result[:prs_to_trigger].size).to eq(1)
+          trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+          expect(trigger_types).to include("conversation_comments")
+        end
       end
     end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -2305,7 +2305,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     )
 
     recent = recent_issue_comments || issue_comments
-    recent.define_singleton_method(:multi_page?) { recent_multi_page }
+    multi_page = recent_multi_page
+    recent.define_singleton_method(:multi_page?) { multi_page }
 
     allow(github_client).to receive(:pull_request)
       .with(project.full_name, 42)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -310,6 +310,47 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when the recent comment page starts with an older-than-cutoff comment" do
+      # Regression: GithubClient#recent_issue_comments returns comments in
+      # ascending order within the page, so a newer-than-cutoff comment can
+      # appear AFTER an older-than-cutoff comment in the same response. The
+      # scanner must scan the full page, not short-circuit on the first
+      # older entry.
+      let(:old_comment) do
+        OpenStruct.new(
+          user: OpenStruct.new(login: "viamin"),
+          body: "This comment is older than the last agent run — should be ignored",
+          created_at: 2.hours.ago
+        )
+      end
+      let(:new_comment) do
+        OpenStruct.new(
+          user: OpenStruct.new(login: "viamin"),
+          body: "Please also address the logging around the parser fallback path",
+          created_at: 20.minutes.ago
+        )
+      end
+
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+        create(:agent_run, :completed,
+          project: project, source_pull_request_number: 42,
+          completed_at: 1.hour.ago)
+        # Ascending order within the page — the older comment comes first.
+        stub_github_for_pr(issue_comments: [ old_comment, new_comment ])
+      end
+
+      it "still detects the newer comment that follows an older-than-cutoff entry" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("conversation_comments")
+      end
+    end
+
     context "when the new comment is a paid agent update" do
       let(:comment) do
         OpenStruct.new(
@@ -2181,9 +2222,6 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     allow(github_client).to receive(:review_threads)
       .with(project.full_name, 42)
       .and_return(review_threads)
-    allow(github_client).to receive(:recent_issue_comments)
-      .with(project.full_name, 42)
-      .and_return(issue_comments)
     allow(github_client).to receive(:recent_issue_comments)
       .with(project.full_name, 42)
       .and_return(recent_issue_comments || issue_comments)


### PR DESCRIPTION
## Summary

- Replace auto-paginating `client.issue_comments` with `client.recent_issue_comments` in `ScanPaidPrsActivity#check_conversation_comments`
- Adds early `break` when iterating newest-first comments older than the cutoff timestamp

## Problem

`check_conversation_comments` called `client.issue_comments` which auto-paginates **all** comments. On long-lived PRs with hundreds of comments, this makes multiple pages of API calls per PR per poll cycle. Since the method filters by `last_run.completed_at`, only recent comments are relevant.

## Impact

For 20 PRs with an average of 3 pages of comments, reduces ~60 API calls to ~20 per poll cycle (~67% reduction for this specific call).

Closes #870
Part of #879