### PR TITLE
fix(pr-review): detect codex body-only reviews as unaddressed feedback

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -480,9 +480,12 @@ module Activities
             # resolution cannot gate re-review. Use submitted_at vs the
             # last agent run's completed_at as the anti-loop guard — a
             # review post-dating the last run is unaddressed feedback.
+            # The "(body-only)" suffix on review_bot_comments lets
+            # structured-log consumers distinguish this path from the
+            # thread-based Copilot flow above.
             [
               { type: "review_bot_review_pending", details: "Latest review bot review was not clean" },
-              { type: "review_bot_comments", details: "Latest review bot review generated comments" }
+              { type: "review_bot_comments", details: "Latest review bot review generated comments (body-only)" }
             ]
           else
             # Thread-based bot with all bot threads resolved, or body-only

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -660,6 +660,28 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when copilot review had comments but all threads resolved (body-only regression)" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 0)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
+                       body: "I found some issues.", submitted_at: 1.hour.ago } ],
+          review_threads: []
+        )
+      end
+
+      it "still treats Copilot resolved-threads as clean and does not trigger" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
     context "when codex posted a body-only review with no last agent run" do
       before do
         create(:issue, :pull_request,


### PR DESCRIPTION
Fixes #901. Refs #807.

## Summary

`ScanPaidPrsActivity#check_review_bot_status` was designed for Copilot's thread-based review model and silently dropped codex body-only reviews, causing PRs with unaddressed codex feedback to stall indefinitely. This is why viamin/paid#807 has had codex reviews since 2026-04-05 and \`pr_followup_count = 0\` despite dozens of poll cycles.

## Root cause (walked through for #807)

1. \`review_bot_review_status\` sees a codex review, matches its body against \`REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i\`, doesn't match → returns \`:has_comments\`.
2. \`:has_comments\` branch calls \`review_bot_thread_triggers\` looking for unresolved bot-authored inline threads.
3. Codex posts everything in the top-level review body with **zero inline threads** → \`review_bot_thread_triggers\` returns \`[]\`.
4. Falls through to the \"all bot threads resolved → treat as effectively clean\" branch that was designed to prevent Copilot re-review loops. Returns \`[]\` every time.

Net: every poll emits zero triggers, no follow-up run is queued.

## Fix

Distinguish two bot review models in the \`:has_comments\` branch:

- **Thread-based bots (Copilot):** existing behavior — emit triggers when bot threads are unresolved, suppress when all resolved. Unchanged.
- **Body-only bots (Codex):** new path. When there are no bot threads AND the latest allowed bot review's login is in a known body-only set, use the bot review's \`submitted_at\` vs the last agent run's \`completed_at\` as the anti-loop guard. If the review post-dates the last run (or either timestamp is missing), emit \`review_bot_review_pending\` + \`review_bot_comments\` triggers so the workflow queues a follow-up.

Implementation notes:
- \`BODY_ONLY_REVIEW_BOT_LOGINS\` is built from \`ProviderSupport::PROVIDER_BOT_USERNAMES[\"codex\"]\` so the single source of truth for bot identities stays in \`provider_support.rb\`.
- \`check_review_bot_status\` gains a \`last_run:\` keyword arg. Propagated at the three call sites: two in \`scan_draft_pr\`, one in \`detect_ready_triggers\`. In \`scan_draft_pr\`, \`last_run\` is computed once at the top of the method instead of lazily inside the conversation-comment branch so it's available before the first \`check_review_bot_status\` call.
- Extracted \`latest_allowed_bot_review\` as a shared helper, used by both \`review_bot_review_status\` and the new body-only guard.
- Missing timestamps are treated conservatively as \"needs follow-up\" to avoid silently dropping actionable feedback.

## Deliberately out of scope

- **Codex 👍 clean signal via reaction.** Codex's documented clean signal is a thumbs-up reaction, not a review. Paid only queries \`pull_request_reviews\`, so a truly-clean codex PR matches \`:no_review\` and (after #898) will post an unnecessary \`@codex review\` comment. Codex re-confirms clean — annoying but not broken. Needs a reactions-API path; filing separately.
- **Non-codex body-only bots.** The \`BODY_ONLY_REVIEW_BOT_LOGINS\` set currently contains only codex logins. Adding other body-only bots is a one-line edit when they appear.

## Test plan

- [x] Three new specs in \`scan_paid_prs_activity_spec.rb\`:
  - codex body-only review, no last_run → emits triggers
  - codex body-only review, last_run completed after the review → returns [] (addressed)
  - codex body-only review, last_run completed before the review → emits triggers
- [x] Existing \"Copilot with all threads resolved → effectively clean\" spec still passes (regression check for the anti-loop guard behavior).
- [x] \`scan_paid_prs_activity_spec.rb\` + \`git_hub_poll_workflow_spec.rb\`: **104 examples, 0 failures**.
- [x] \`bin/rubocop\` clean on the two touched files.

## Related

- viamin/paid#807 — example PR stalled by this bug
- viamin/paid#897 / viamin/paid#898 — codex review **request** path (orthogonal, both needed for end-to-end codex)
- viamin/paid#895 — draft-review circuit breaker (orthogonal)
- viamin/paid#848 — heartbeat-based liveness (longer-term)