### PR TITLE
fix(pr-review): detect codex clean signal posted as an issue comment

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -466,7 +466,7 @@ module Activities
       # clean regardless of any older non-clean review. Without this check,
       # the @codex review trigger loop would re-emit pending triggers
       # forever and wedge codex-only PRs in draft.
-      if client && issue && body_only_bot_clean_comment_present?(client, project, issue, latest)
+      if client && issue && body_only_bot_clean_comment_present?(client, project, issue, latest, allowed)
         return []
       end
 
@@ -537,13 +537,27 @@ module Activities
     end
 
     # Returns true when the most recent issue comment authored by a body-only
-    # review bot (e.g. Codex) matches the clean signal pattern AND is at
-    # least as recent as that bot's latest review on this PR. The
-    # comment-vs-review timestamp comparison prevents an older "Bravo"
+    # review bot (e.g. Codex) matches the clean signal pattern AND can speak
+    # authoritatively for the project's review configuration AND is at least
+    # as recent as that bot's latest review on this PR.
+    #
+    # The override is restricted to projects whose enabled review bots are
+    # ALL body-only — i.e. no thread-based bot like Copilot is also enabled.
+    # A clean codex comment cannot speak for an outstanding Copilot review
+    # whose unresolved threads are tracked separately, so in mixed
+    # configurations we defer to the existing classification path.
+    #
+    # The comment-vs-review timestamp comparison prevents an older "Bravo"
     # comment from masking a newer non-clean review on a subsequent commit.
-    def body_only_bot_clean_comment_present?(client, project, issue, latest_review)
+    def body_only_bot_clean_comment_present?(client, project, issue, latest_review, allowed_bot_logins)
+      return false if allowed_bot_logins.nil? || allowed_bot_logins.empty?
+      return false unless allowed_bot_logins.subset?(BODY_ONLY_REVIEW_BOT_LOGINS)
+
       comments = client.recent_issue_comments(project.full_name, issue.github_number)
-      bot_comments = comments.select { |c| body_only_review_bot?(c.user&.login) }
+      bot_comments = comments.select do |c|
+        login = c.user&.login&.downcase
+        login && allowed_bot_logins.include?(login)
+      end
       return false if bot_comments.empty?
 
       latest_bot_comment = bot_comments.max_by { |c| c.created_at || Time.at(0) }

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -24,6 +24,23 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     })
   end
 
+  def enable_codex_review!(proj = project)
+    proj.update!(review_settings: {
+      "enabled" => true,
+      "methods" => { "codex" => { "enabled" => true } }
+    })
+  end
+
+  def enable_copilot_and_codex_review!(proj = project)
+    proj.update!(review_settings: {
+      "enabled" => true,
+      "methods" => {
+        "copilot" => { "enabled" => true },
+        "codex" => { "enabled" => true }
+      }
+    })
+  end
+
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
   end
@@ -695,6 +712,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
     context "when codex posted a clean signal as an issue comment with no prior review" do
       before do
+        enable_codex_review!
         create(:issue, :pull_request,
           project: project, github_number: 42,
           labels: [ "paid-generated", "paid-automation" ],
@@ -723,6 +741,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
     context "when a codex clean comment supersedes an older non-clean codex review" do
       before do
+        enable_codex_review!
         create(:issue, :pull_request,
           project: project, github_number: 42,
           labels: [ "paid-generated", "paid-automation" ],
@@ -751,8 +770,50 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when a project enables both Copilot and Codex and Copilot has unresolved threads" do
+      before do
+        enable_copilot_and_codex_review!
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        clean_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector[bot]"),
+          body: "Codex Review: Didn't find any major issues. Bravo.",
+          created_at: 5.minutes.ago
+        )
+        # Copilot reviewed the PR with findings; the unresolved Copilot thread
+        # must NOT be silently dropped just because Codex separately commented
+        # clean. The two bots' state is independent.
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
+                       body: "Copilot reviewed 5 out of 5 changed files and generated 2 comments.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: [
+            {
+              id: "thread_1",
+              is_resolved: false,
+              comments: [ { body: "Fix this", path: "app/model.rb", line: 10,
+                            author: "copilot-pull-request-reviewer[bot]" } ]
+            }
+          ],
+          recent_issue_comments: [ clean_comment ]
+        )
+      end
+
+      it "still emits review_bot_threads from Copilot — codex's clean comment cannot speak for Copilot" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).to include("review_bot_threads", "review_bot_review_pending")
+      end
+    end
+
     context "when an older codex clean comment is followed by a newer non-clean codex review" do
       before do
+        enable_codex_review!
         create(:issue, :pull_request,
           project: project, github_number: 42,
           labels: [ "paid-generated", "paid-automation" ],


### PR DESCRIPTION
Fixes #910.

Follow-up to viamin/paid#902 (already merged) and viamin/paid#898 (already merged), which together established the @codex review trigger path and the body-only review detection. This PR closes the last remaining gap that would wedge codex-only PRs in the draft phase.

## Problem

Codex's documented clean signal — when triggered via `@codex review` — is an **issue comment** (not a review) with body text like:

> Codex Review: Didn't find any major issues. Bravo.

The scanner is blind to it for two compounding reasons:

1. `REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i` matches Copilot's clean-review body. "Didn't find any major issues" doesn't contain that substring.
2. Even if the regex matched, `check_review_bot_status` only inspects `pull_request_reviews` — it never queries `issue_comments`.

So once #898's trigger path is live, every poll on a codex-only PR with no actionable findings re-classifies as `:no_review`, re-emits a pending trigger, and wedges the draft phase forever — even though codex has already responded "all clear." The author-gated marker check from #898 prevents *additional* trigger comments per HEAD, but it cannot unwedge the scanner.

This was called out as "deferred follow-up" in #901's body and #902's PR description, when I thought codex's clean signal was only a 👍 reaction. Closer inspection of [the actual codex comment on #898](https://github.com/viamin/paid/pull/898#issuecomment-4201064971) shows the issue-comment path is the real failure mode.

See #910 for the full root-cause analysis.

## Fix

Add a body-only-bot clean-comment short-circuit at the top of `check_review_bot_status`. Before classifying via `pull_request_reviews`, fetch `recent_issue_comments` and look for the most recent body-only-review-bot-authored comment matching `BODY_ONLY_BOT_CLEAN_COMMENT_PATTERN` (the literal phrase "didn't find any (major) issues"). If that comment is at least as recent as the bot's latest review on the PR, treat the bot as clean and return `[]` immediately.

The comment-vs-review timestamp comparison prevents an older "Bravo" comment from masking a newer non-clean review on a subsequent commit.

### Why this lands cleanly on top of #898 and #902

- #898 already fixed `recent_issue_comments` to follow the `Link: last` header, so this fix actually inspects the newest comments rather than the oldest.
- #902's existing `BODY_ONLY_REVIEW_BOT_LOGINS` set and `body_only_review_bot?` helper are reused — no new bot-identification mechanism.
- `check_review_bot_status` already takes `project:` and `last_run:` kwargs; adding `client:` and `issue:` is consistent with that pattern.

### Spec coverage

Three new contexts in `scan_paid_prs_activity_spec.rb`:
- Codex clean comment present, no prior codex review → no triggers
- Codex clean comment newer than non-clean codex review → no triggers (newer signal wins)
- Codex clean comment older than non-clean codex review → triggers still emitted (newer signal wins)

The shared `stub_github_for_pr` helper now stubs `recent_issue_comments` alongside `issue_comments`, defaulting to the same payload when no override is given.

## Test plan

- [x] `spec/temporal/activities/scan_paid_prs_activity_spec.rb` — **82 examples, 0 failures** (3 new specs above + existing tests for Copilot, Claude, body-only with findings).
- [x] `bin/rubocop` clean on the two touched files.

## Related

- #910 — tracking issue (fixed by this PR)
- #901 — original tracking issue for the body-only detection cohort
- #902 — body-only review detection (merged)
- #898 — codex `@codex review` request path + `recent_issue_comments` fix (merged)
- #807 — example PR that motivated the whole investigation