### PR TITLE
Fix #918: feat(scanner): no clean signal detection for paid_agent reviews

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -28,6 +28,14 @@ module Activities
     # wording changes.
     BODY_ONLY_BOT_CLEAN_COMMENT_PATTERN = /didn'?t find any (?:major )?issues/i
 
+    # paid_agent reviews are posted from regular GitHub accounts (not bot
+    # logins registered in PROVIDER_BOT_USERNAMES), so they are invisible
+    # to review_bot? and enabled_review_bot_logins. The agent includes a
+    # machine-readable HTML comment marker when no major findings remain.
+    # A human-readable pattern is also accepted for robustness.
+    PAID_REVIEW_CLEAN_MARKER = "<!-- paid-review-clean -->"
+    PAID_REVIEW_CLEAN_PATTERN = /no\s+(?:major\s+)?(?:issues|findings|concerns)\s+remaining/i
+
     def execute(input)
       project_id = input[:project_id]
       project = Project.find_by(id: project_id)
@@ -509,6 +517,20 @@ module Activities
         return []
       end
 
+      # paid_agent reviews are authored by regular GitHub accounts, not
+      # bot logins registered in PROVIDER_BOT_USERNAMES. When paid_agent
+      # is enabled and any review contains the clean marker, treat the
+      # review cycle as complete — the agent has signaled "no major
+      # findings remaining." Only bypass when no registered bot method
+      # could produce independent triggers; in mixed configurations
+      # (e.g. paid_agent + copilot), each bot's status is evaluated
+      # independently below.
+      if project&.review_method_enabled?("paid_agent") &&
+          paid_agent_clean_review_present?(reviews) &&
+          (allowed.nil? || allowed.empty?)
+        return []
+      end
+
       status = review_bot_review_status_from(reviews, latest)
 
       case status
@@ -765,6 +787,18 @@ module Activities
 
     def review_bot?(login)
       ProviderSupport.provider_bot_username?(login)
+    end
+
+    def paid_agent_review_clean?(body)
+      return false if body.nil?
+
+      body.include?(PAID_REVIEW_CLEAN_MARKER) || PAID_REVIEW_CLEAN_PATTERN.match?(body)
+    end
+
+    def paid_agent_clean_review_present?(reviews)
+      return false if reviews.nil?
+
+      reviews.any? { |r| paid_agent_review_clean?(r[:body]) }
     end
 
     def extract_actionable_labels(triggers)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -525,6 +525,14 @@ module Activities
       # could produce independent triggers; in mixed configurations
       # (e.g. paid_agent + copilot), each bot's status is evaluated
       # independently below.
+      #
+      # Today the existing flow already returns [] for paid_agent-only
+      # configs (no bot login → :no_review → nil login → []), so this
+      # early return is functionally redundant. It becomes load-bearing
+      # if paid_agent ever registers a bot login in PROVIDER_BOT_USERNAMES,
+      # which would cause `allowed` to be non-empty and the :no_review /
+      # :has_comments branches to fire. The explicit check keeps that
+      # future transition safe and documents the intended semantics.
       if project&.review_method_enabled?("paid_agent") &&
          paid_agent_clean_review_present?(reviews) &&
          (allowed.nil? || allowed.empty?)
@@ -795,11 +803,11 @@ module Activities
       body.include?(PAID_REVIEW_CLEAN_MARKER)
     end
 
-    # NOTE: paid_agent posts reviews from regular GitHub accounts — there is
+    # TODO(#918): paid_agent posts reviews from regular GitHub accounts — there is
     # no dedicated bot login to filter by. This method checks the latest
     # review from *any* author. The HTML marker (<!-- paid-review-clean -->)
-    # is unlikely to appear in human-authored reviews, but if the project
-    # later stores the paid_agent's GitHub login, this should filter by it.
+    # is unlikely to appear in human-authored reviews, but once the project
+    # stores the paid_agent's GitHub login, this should filter by it.
     def paid_agent_clean_review_present?(reviews)
       return false if reviews.nil? || reviews.empty?
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -32,9 +32,9 @@ module Activities
     # logins registered in PROVIDER_BOT_USERNAMES), so they are invisible
     # to review_bot? and enabled_review_bot_logins. The agent includes a
     # machine-readable HTML comment marker when no major findings remain.
-    # A human-readable pattern is also accepted for robustness.
+    # Only the marker is used for detection — no text patterns — to avoid
+    # false positives from human reviewers writing similar phrases.
     PAID_REVIEW_CLEAN_MARKER = "<!-- paid-review-clean -->"
-    PAID_REVIEW_CLEAN_PATTERN = /no\s+(?:major\s+)?(?:issues|findings|concerns)\s+remaining/i
 
     def execute(input)
       project_id = input[:project_id]
@@ -526,8 +526,8 @@ module Activities
       # (e.g. paid_agent + copilot), each bot's status is evaluated
       # independently below.
       if project&.review_method_enabled?("paid_agent") &&
-          paid_agent_clean_review_present?(reviews) &&
-          (allowed.nil? || allowed.empty?)
+         paid_agent_clean_review_present?(reviews) &&
+         (allowed.nil? || allowed.empty?)
         return []
       end
 
@@ -792,9 +792,14 @@ module Activities
     def paid_agent_review_clean?(body)
       return false if body.nil?
 
-      body.include?(PAID_REVIEW_CLEAN_MARKER) || PAID_REVIEW_CLEAN_PATTERN.match?(body)
+      body.include?(PAID_REVIEW_CLEAN_MARKER)
     end
 
+    # NOTE: paid_agent posts reviews from regular GitHub accounts — there is
+    # no dedicated bot login to filter by. This method checks the latest
+    # review from *any* author. The HTML marker (<!-- paid-review-clean -->)
+    # is unlikely to appear in human-authored reviews, but if the project
+    # later stores the paid_agent's GitHub login, this should filter by it.
     def paid_agent_clean_review_present?(reviews)
       return false if reviews.nil? || reviews.empty?
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -519,9 +519,9 @@ module Activities
 
       # paid_agent reviews are authored by regular GitHub accounts, not
       # bot logins registered in PROVIDER_BOT_USERNAMES. When paid_agent
-      # is enabled and any review contains the clean marker, treat the
-      # review cycle as complete — the agent has signaled "no major
-      # findings remaining." Only bypass when no registered bot method
+      # is enabled and the most recent review contains the clean marker,
+      # treat the review cycle as complete — the agent has signaled "no
+      # major findings remaining." Only bypass when no registered bot method
       # could produce independent triggers; in mixed configurations
       # (e.g. paid_agent + copilot), each bot's status is evaluated
       # independently below.
@@ -796,9 +796,10 @@ module Activities
     end
 
     def paid_agent_clean_review_present?(reviews)
-      return false if reviews.nil?
+      return false if reviews.nil? || reviews.empty?
 
-      reviews.any? { |r| paid_agent_review_clean?(r[:body]) }
+      latest = reviews.max_by { |r| r[:submitted_at] || Time.at(0) }
+      paid_agent_review_clean?(latest[:body])
     end
 
     def extract_actionable_labels(triggers)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -31,13 +31,6 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     })
   end
 
-  def enable_paid_agent_review!(proj = project)
-    proj.update!(review_settings: {
-      "enabled" => true,
-      "methods" => { "paid_agent" => { "enabled" => true } }
-    })
-  end
-
   def enable_copilot_and_codex_review!(proj = project)
     proj.update!(review_settings: {
       "enabled" => true,
@@ -1285,30 +1278,6 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
-    context "when paid_agent review body matches the clean pattern" do
-      before do
-        enable_paid_agent_review!
-        create(:issue, :pull_request,
-          project: project, github_number: 42,
-          labels: [ "paid-generated", "paid-automation" ],
-          pr_review_phase: "draft",
-          draft_review_count: 0)
-        stub_github_for_pr(
-          reviews: [ { id: 1, user_login: "human-reviewer", state: "COMMENTED",
-                       body: "Review complete. No major issues remaining.",
-                       submitted_at: 1.hour.ago } ],
-          review_threads: []
-        )
-      end
-
-      it "treats the review as clean via the text pattern" do
-        result = activity.execute(project_id: project.id)
-
-        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
-        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
-      end
-    end
-
     context "when paid_agent review does not include a clean signal" do
       before do
         enable_paid_agent_review!
@@ -1326,11 +1295,14 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         )
       end
 
-      it "does not treat the review as clean" do
+      it "proceeds through normal flow instead of bypassing via clean signal" do
         result = activity.execute(project_id: project.id)
 
         trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
-        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
+        # With CI green, no bot issues, and owner_reviewer_login set, the
+        # draft scanner emits ready_for_owner — proving the non-clean review
+        # did not trigger the paid_agent clean signal bypass.
+        expect(trigger_types).to include("ready_for_owner")
       end
     end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1334,6 +1334,36 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when a newer non-clean review follows an older clean paid_agent review" do
+      before do
+        enable_paid_agent_review!
+        project.update!(owner_reviewer_login: "viamin")
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          reviews: [
+            { id: 1, user_login: "human-reviewer", state: "COMMENTED",
+              body: "Looks good. <!-- paid-review-clean -->",
+              submitted_at: 2.hours.ago },
+            { id: 2, user_login: "human-reviewer", state: "COMMENTED",
+              body: "Found new issues after the latest push.",
+              submitted_at: 1.hour.ago }
+          ],
+          review_threads: []
+        )
+      end
+
+      it "does not treat the review as clean because the latest review is non-clean" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("review_bot_comments")
+      end
+    end
+
     context "when paid_agent is enabled alongside copilot and copilot has unresolved threads" do
       before do
         proj = project

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     })
   end
 
+  def enable_paid_agent_review!(proj = project)
+    proj.update!(review_settings: {
+      "enabled" => true,
+      "methods" => { "paid_agent" => { "enabled" => true } }
+    })
+  end
+
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
   end
@@ -1251,6 +1258,146 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         trigger_types = trigger[:triggers].map { |t| t[:type] }
         expect(trigger_types).to include("review_bot_comments")
         expect(trigger_types).to include("review_bot_threads")
+      end
+    end
+
+    context "when paid_agent review includes the clean marker" do
+      before do
+        enable_paid_agent_review!
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          reviews: [ { id: 1, user_login: "human-reviewer", state: "COMMENTED",
+                       body: "Looks good. <!-- paid-review-clean -->",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: []
+        )
+      end
+
+      it "treats the review as clean and emits no review_bot triggers" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
+      end
+    end
+
+    context "when paid_agent review body matches the clean pattern" do
+      before do
+        enable_paid_agent_review!
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          reviews: [ { id: 1, user_login: "human-reviewer", state: "COMMENTED",
+                       body: "Review complete. No major issues remaining.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: []
+        )
+      end
+
+      it "treats the review as clean via the text pattern" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
+      end
+    end
+
+    context "when paid_agent review does not include a clean signal" do
+      before do
+        enable_paid_agent_review!
+        project.update!(owner_reviewer_login: "viamin")
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          reviews: [ { id: 1, user_login: "human-reviewer", state: "COMMENTED",
+                       body: "Found a few things to fix in the error handling.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: []
+        )
+      end
+
+      it "does not treat the review as clean" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
+      end
+    end
+
+    context "when paid_agent is enabled alongside copilot and copilot has unresolved threads" do
+      before do
+        proj = project
+        proj.update!(review_settings: {
+          "enabled" => true,
+          "methods" => {
+            "paid_agent" => { "enabled" => true },
+            "copilot" => { "enabled" => true }
+          }
+        })
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          reviews: [
+            { id: 1, user_login: "human-reviewer", state: "COMMENTED",
+              body: "Looks good. <!-- paid-review-clean -->",
+              submitted_at: 30.minutes.ago },
+            { id: 2, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
+              body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
+              submitted_at: 1.hour.ago }
+          ],
+          review_threads: [
+            {
+              id: "thread_1",
+              is_resolved: false,
+              comments: [ { body: "Fix this", path: "app/model.rb", line: 10,
+                            author: "copilot-pull-request-reviewer[bot]" } ]
+            }
+          ]
+        )
+      end
+
+      it "still emits review_bot_threads from Copilot — paid_agent clean signal cannot suppress other bots" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).to include("review_bot_threads", "review_bot_review_pending")
+      end
+    end
+
+    context "when paid_agent clean signal present but paid_agent is not enabled" do
+      before do
+        project.update!(owner_reviewer_login: "viamin")
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          reviews: [ { id: 1, user_login: "human-reviewer", state: "COMMENTED",
+                       body: "Looks good. <!-- paid-review-clean -->",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: []
+        )
+      end
+
+      it "ignores the clean signal because paid_agent is not an enabled review method" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
       end
     end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1271,6 +1271,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
 
       it "treats the review as clean and emits no review_bot triggers" do
+        # Verify the bypass short-circuits before review_bot_review_status_from
+        # is reached — without this spy, the test would pass trivially because
+        # paid_agent-only configs already return [] via the :no_review path.
+        expect(activity).not_to receive(:review_bot_review_status_from)
+
         result = activity.execute(project_id: project.id)
 
         trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
@@ -1332,7 +1337,10 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         result = activity.execute(project_id: project.id)
 
         trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
-        expect(trigger_types).not_to include("review_bot_comments")
+        # With CI green, no bot issues, and owner_reviewer_login set, the
+        # draft scanner reaches the normal flow and emits ready_for_owner —
+        # proving the clean signal bypass was skipped.
+        expect(trigger_types).to include("ready_for_owner")
       end
     end
 


### PR DESCRIPTION
You've hit your limit · resets 11pm (UTC)

Let me read the key sections of the files I need to modify.

Now let me read the test file to understand the test structure around review bot status:

Now I have a thorough understanding of the codebase. Let me implement the changes.

First, add the constants after the existing pattern constants:

Now add the helper methods in the helpers section:

Now integrate the paid_agent clean signal check into `check_review_bot_status`. I'll add it after the body-only bot check:

Let me verify the changes look correct:

Good. Now let me verify the helper methods:

Now add the test helper and test cases. First, add the `enable_paid_agent_review!` helper:

Now I need to find the right place to add the test contexts. Let me look at where the review bot status tests end:

I'll add the paid_agent test cases after the "when review bot review has non-clean body" context (line 1231), before "when draft PR has CI green and no Copilot threads":

Now let me also add unit tests for the helper methods. Let me find where the describe block for helpers might be:

Good - the existing tests exercise methods through `execute`, and my integration tests follow the same pattern. Let me run lint and tests:

Good, database is prepared. Now run lint and tests:

Lint passes. Now run the tests:

I need to fix two tests that had wrong expectations. The draft phase scanner naturally produces `ready_for_owner` when CI is green and there are no bot issues. Let me fix both:

Now run the tests again:

All 89 tests pass. Let me also verify lint is still clean:

Now let me commit. First check the state:

Done. Here's a summary of the changes:

**`app/temporal/activities/scan_paid_prs_activity.rb`:**
- Added `PAID_REVIEW_CLEAN_MARKER` (`<!-- paid-review-clean -->`) and `PAID_REVIEW_CLEAN_PATTERN` (`/no\s+(?:major\s+)?(?:issues|findings|concerns)\s+remaining/i`) constants
- Added `paid_agent_review_clean?(body)` and `paid_agent_clean_review_present?(reviews)` helper methods for marker-based detection
- Added a parallel detection path in `check_review_bot_status` that bypasses review triggers when `paid_agent` is enabled and a clean signal is found, restricted to configurations where no registered bot method could produce independent triggers (safe for mixed configs like paid_agent + copilot)

**`spec/temporal/activities/scan_paid_prs_activity_spec.rb`:**
- Added `enable_paid_agent_review!` test helper
- Added 5 test contexts: clean marker detection, text pattern detection, non-clean review, mixed config with copilot (clean signal doesn't suppress copilot threads), and disabled paid_agent (signal ignored)

---

Closes #918