### PR TITLE
Fix #917: fix(scanner): ready phase auto-merge bypasses new review feedback without re-checking

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -188,7 +188,8 @@ module Activities
           owner_approved_or_self_authored?(project, reviews, pr_data) &&
           checks.present? &&
           all_checks_green?(checks) &&
-          mergeable == true
+          mergeable == true &&
+          no_outstanding_review_feedback?(project, client, issue, reviews)
         return owner_approved_trigger(issue)
       end
 
@@ -705,6 +706,24 @@ module Activities
       return false if owner_login.blank? || author_login.blank?
 
       owner_login.casecmp?(author_login)
+    end
+
+    # --- Review feedback gate for auto-merge ---
+
+    # Returns true when there is no outstanding review feedback that should
+    # block auto-merge. Checks the same review signals that detect_ready_triggers
+    # would evaluate, so owner approval cannot bypass new findings.
+    def no_outstanding_review_feedback?(project, client, issue, reviews)
+      last_run = last_completed_run(project, issue)
+      unresolved_threads = fetch_unresolved_threads(client, project, issue)
+
+      return false if human_review_thread_triggers(project, unresolved_threads).any?
+      return false if check_review_bot_status(reviews, unresolved_threads,
+        project: project, last_run: last_run, client: client, issue: issue).any?
+      return false if changes_requested_from_reviews(project, reviews, last_run).any?
+      return false if check_conversation_comments(client, project, issue, last_run).any?
+
+      true
     end
 
     # --- Helpers ---

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1635,6 +1635,104 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when owner approved but unresolved human review threads exist" do
+      before do
+        project.update!(owner_reviewer_login: "viamin", auto_merge_enabled: true)
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          paid_state: "completed")
+        stub_github_for_pr(
+          reviews: default_clean_copilot_review + [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
+          ],
+          review_threads: [
+            {
+              id: "thread_1",
+              is_resolved: false,
+              comments: [ { body: "Critical security vulnerability", path: "app/model.rb", line: 10, author: "viamin" } ]
+            }
+          ]
+        )
+      end
+
+      it "does not auto-merge and emits review thread triggers instead" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        trigger_types = trigger[:triggers].map { |t| t[:type] }
+        expect(trigger_types).not_to include("owner_approved")
+        expect(trigger_types).to include("review_threads")
+      end
+    end
+
+    context "when owner approved but changes_requested exists from trusted user" do
+      before do
+        project.update!(owner_reviewer_login: "viamin", auto_merge_enabled: true,
+          allowed_github_usernames: [ "viamin", "reviewer" ])
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          paid_state: "completed")
+        stub_github_for_pr(
+          reviews: default_clean_copilot_review + [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "", submitted_at: 1.hour.ago },
+            { id: 2, user_login: "reviewer", state: "CHANGES_REQUESTED", body: "Needs work",
+              submitted_at: Time.current }
+          ]
+        )
+      end
+
+      it "does not auto-merge" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        trigger_types = trigger[:triggers].map { |t| t[:type] }
+        expect(trigger_types).not_to include("owner_approved")
+        expect(trigger_types).to include("changes_requested")
+      end
+    end
+
+    context "when owner approved but new conversation comment from trusted user" do
+      before do
+        project.update!(owner_reviewer_login: "viamin", auto_merge_enabled: true)
+        issue = create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          paid_state: "completed")
+        create(:agent_run, project: project, issue: issue,
+          pull_request_number: 42, status: "completed",
+          completed_at: 2.hours.ago)
+        stub_github_for_pr(
+          reviews: default_clean_copilot_review + [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
+          ],
+          issue_comments: [
+            OpenStruct.new(
+              user: OpenStruct.new(login: "viamin"),
+              body: "This has a critical security vulnerability that needs to be fixed",
+              created_at: 1.hour.ago
+            )
+          ]
+        )
+      end
+
+      it "does not auto-merge" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        trigger_types = trigger[:triggers].map { |t| t[:type] }
+        expect(trigger_types).not_to include("owner_approved")
+        expect(trigger_types).to include("conversation_comments")
+      end
+    end
+
     context "when owner reviewer is also the PR author" do
       before do
         project.update!(owner_reviewer_login: "viamin", auto_merge_enabled: true)


### PR DESCRIPTION
Commit succeeded — lint passed, pre-commit hook passed.

Here's a summary of the changes:

**Problem:** In `scan_ready_pr`, the auto-merge check (owner approved + CI green + mergeable) returned `owner_approved_trigger` immediately, before `detect_ready_triggers` could evaluate review feedback signals. This meant unresolved review threads, `changes_requested` reviews, and new conversation comments from trusted users were silently bypassed.

**Fix:** Added a `no_outstanding_review_feedback?` method that checks the same review signals `detect_ready_triggers` would evaluate:
- Unresolved human review threads from trusted users
- Review bot status (unresolved bot threads, body-only bot findings)
- `CHANGES_REQUESTED` reviews from trusted users (post-dating last run)
- New conversation comments from trusted users (post-dating last run)

This method is called as an additional condition in the auto-merge gate at `scan_paid_prs_activity.rb:193`. If any outstanding review feedback exists, auto-merge is blocked and the PR falls through to `detect_ready_triggers` for normal signal processing.

**Tests added:** 3 new specs covering:
1. Owner approved but unresolved human review threads exist → blocks auto-merge, emits `review_threads`
2. Owner approved but `changes_requested` from trusted user → blocks auto-merge, emits `changes_requested`
3. Owner approved but new conversation comment from trusted user → blocks auto-merge, emits `conversation_comments`

---

Closes #917