### PR TITLE
Fix #916: fix(scanner): stale bot reviews from previously-enabled methods interfere with paid_agent-only config

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -455,7 +455,7 @@ module Activities
       .freeze
 
     def check_review_bot_status(reviews, unresolved_threads, project: nil, last_run: nil, client: nil, issue: nil)
-      allowed = project&.review_enabled? ? project.enabled_review_bot_logins.presence : nil
+      allowed = project&.review_enabled? ? (project.enabled_review_bot_logins.presence || Set.new) : nil
       latest = latest_allowed_bot_review(reviews, allowed)
 
       # Body-only bots (Codex) can post their CLEAN signal as an issue

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     })
   end
 
+  def enable_paid_agent_review!(proj = project)
+    proj.update!(review_settings: {
+      "enabled" => true,
+      "methods" => { "paid_agent" => { "enabled" => true } }
+    })
+  end
+
   def enable_copilot_and_codex_review!(proj = project)
     proj.update!(review_settings: {
       "enabled" => true,
@@ -1094,6 +1101,30 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
         expect(trigger_types).not_to include("review_bot_review_pending")
+      end
+    end
+
+    context "when paid_agent is the only review method and stale copilot reviews exist" do
+      before do
+        enable_paid_agent_review!
+        project.update!(owner_reviewer_login: "viamin")
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          reviews: [ { id: 100, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
+                       body: "Copilot found issues.", submitted_at: 1.day.ago } ],
+          checks: [ { name: "ci", conclusion: "success" } ]
+        )
+      end
+
+      it "ignores stale copilot reviews and does not emit review_bot triggers" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |tr| tr[:type] } }
+        expect(trigger_types).not_to include("review_bot_comments", "review_bot_threads")
       end
     end
 


### PR DESCRIPTION
Commit succeeded. Here's a summary of the changes:

**Root cause:** In `check_review_bot_status`, when `paid_agent` is the only enabled review method, `enabled_review_bot_logins` returns an empty `Set` (since `paid_agent` has no bot usernames in `PROVIDER_BOT_USERNAMES`). `.presence` converted this empty set to `nil`, which `latest_allowed_bot_review` interpreted as "accept all bots" — picking up stale Copilot/Codex reviews.

**Fix** (`scan_paid_prs_activity.rb:458`): Changed `.presence` fallback from `nil` to `Set.new`:
```ruby
allowed = project&.review_enabled? ? (project.enabled_review_bot_logins.presence || Set.new) : nil
```

Now `allowed` is:
- `nil` — reviews globally disabled (accept all, doesn't matter)
- Empty `Set` — reviews enabled but no bot logins (paid_agent-only) → no bot reviews match → `:no_review`
- Populated `Set` — bot methods enabled → only matching bot reviews accepted

**Test added:** Verifies that stale Copilot reviews are ignored when `paid_agent` is the only review method.

---

Closes #916