### PR TITLE
fix(dev-cleanup): don't trip provider circuit breaker when cleanup kills runs

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -14,6 +14,14 @@ class AgentRun < ApplicationRecord
   TOKEN_LIMIT_STATUSES = %w[ok warning exceeded].freeze
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000_000
 
+  # Sentinel prefix written into AgentRun#error_message by `bin/rails dev:cleanup`
+  # when it forcibly times out an in-flight run because the host process is being
+  # restarted (e.g. `bin/setup --skip-server`). Code that observes a run failing
+  # while marked with this prefix should treat the failure as caused by the
+  # cleanup, not by the provider — in particular, do not increment provider
+  # circuit-breaker counters on its behalf.
+  STALE_CLEANUP_ERROR_PREFIX = "Marked stale on startup"
+
   belongs_to :project
   belongs_to :issue, optional: true
   belongs_to :prompt_version, optional: true
@@ -649,6 +657,15 @@ class AgentRun < ApplicationRecord
       error_message: error,
       duration_seconds: duration
     )
+  end
+
+  # True when this run was force-timed-out by `dev:cleanup` (typically because
+  # `bin/setup --skip-server` is restarting the host process and stopping the
+  # run's container out from under the in-flight Temporal activity). Used by
+  # RunAgentActivity to suppress provider circuit-breaker bookkeeping for
+  # failures that the cleanup itself induced.
+  def cancelled_by_cleanup?
+    status == "timeout" && error_message.to_s.start_with?(STALE_CLEANUP_ERROR_PREFIX)
   end
 
   def retried?

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -296,6 +296,7 @@ module Activities
           agent_run.timeout!(error: timeout_error) unless agent_run.finished?
           # Skip queue processing when cleanup killed the run — the timeout
           # was not a real provider issue, so there is nothing to re-schedule.
+          # (agent_run was reloaded above, so the model method sees current state)
           ProcessRunQueueJob.perform_later unless agent_run.cancelled_by_cleanup?
         elsif !agent_run.finished? && (last_error == "rate_limited" || all_skipped_rate_limited)
           provider_list = providers.any? ? provider_attempt_labels(providers, agent_run, user_settings.user).join(", ") : "none"

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -294,7 +294,9 @@ module Activities
         # ProcessRunQueueJob to re-schedule work.
         if timeout_error.present?
           agent_run.timeout!(error: timeout_error) unless agent_run.finished?
-          ProcessRunQueueJob.perform_later
+          # Skip queue processing when cleanup killed the run — the timeout
+          # was not a real provider issue, so there is nothing to re-schedule.
+          ProcessRunQueueJob.perform_later unless agent_run.cancelled_by_cleanup?
         elsif !agent_run.finished? && (last_error == "rate_limited" || all_skipped_rate_limited)
           provider_list = providers.any? ? provider_attempt_labels(providers, agent_run, user_settings.user).join(", ") : "none"
           agent_run.rate_limit!(

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -248,12 +248,20 @@ module Activities
           rescue ProviderTimeoutError => e
             last_error = "timeout"
             timeout_error ||= e.message
+            if cancelled_by_cleanup?(agent_run)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, provider, e)
+              break
+            end
             record_provider_failure(user_settings, provider_state_name, provider_states)
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "timeout")
             logger.warn(message: "agent_execution.provider_timeout", provider: provider, agent_run_id: agent_run.id, error: e.message)
             break
           rescue ProviderExecutionError => e
             last_error = "error"
+            if cancelled_by_cleanup?(agent_run)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, provider, e)
+              break
+            end
             record_provider_failure(user_settings, provider_state_name, provider_states)
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "error")
             logger.warn(message: "agent_execution.provider_failed", provider: provider, agent_run_id: agent_run.id, error: e.message)
@@ -404,6 +412,31 @@ module Activities
     def record_provider_failure(user_settings, provider_state_name, provider_states)
       state = provider_state_for(user_settings, provider_state_name, provider_states)
       state.record_failure!(threshold: user_settings.circuit_breaker_failure_threshold)
+    end
+
+    # True when the agent run we're executing has already been force-timed-out
+    # by `dev:cleanup` (e.g. `bin/setup --skip-server` killed our container).
+    # In that case the failure we just rescued was caused by the cleanup, not
+    # by the provider, so we must not penalize the provider's circuit breaker.
+    def cancelled_by_cleanup?(agent_run)
+      agent_run.reload
+      agent_run.cancelled_by_cleanup?
+    rescue ActiveRecord::RecordNotFound
+      false
+    end
+
+    # Mirror of the failed-attempt bookkeeping for the cleanup-cancelled case:
+    # records the attempt with a distinct error_type so the UI can show what
+    # happened, but skips both record_provider_failure and the standard warn
+    # log (which would imply a real provider problem).
+    def record_cleanup_cancelled_attempt(agent_run, attempt_label, provider, error)
+      agent_run.record_provider_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup")
+      logger.info(
+        message: "agent_execution.cancelled_by_cleanup",
+        provider: provider,
+        agent_run_id: agent_run.id,
+        error: error.message
+      )
     end
 
     # Returns the canonical settings-level provider name for a given agent type.

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -225,9 +225,13 @@ module Activities
               )
             end
           rescue InfiniteLoopError => e
+            last_error = "infinite_loop"
+            if cancelled_by_cleanup?(agent_run)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, provider, e)
+              break
+            end
             record_provider_failure(user_settings, provider_state_name, provider_states)
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "infinite_loop")
-            last_error = "infinite_loop"
             logger.warn(message: "agent_execution.infinite_loop_detected", agent_run_id: agent_run.id, reason: e.message)
 
             result = Guardrails::ViolationHandler.call(

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -57,7 +57,7 @@ namespace :dev do
         next if run.finished?
 
         if grace.zero? || run.updated_at < grace.ago
-          run.timeout!(error: "Marked stale on startup: process was restarted")
+          run.timeout!(error: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted")
           run.log!("system", "Run marked as timed out during startup cleanup")
           run.issue&.update!(paid_state: "failed") unless run.issue&.paid_state == "failed"
           stale_container_ids << run.container_id if run.container_id.present?

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -505,6 +505,34 @@ RSpec.describe AgentRun do
       end
     end
 
+    describe "#cancelled_by_cleanup?" do
+      it "returns true when status is timeout and error_message starts with the sentinel prefix" do
+        agent_run = build(:agent_run, status: "timeout",
+          error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted")
+
+        expect(agent_run.cancelled_by_cleanup?).to be true
+      end
+
+      it "returns false when error_message lacks the sentinel prefix" do
+        agent_run = build(:agent_run, status: "timeout", error_message: "Provider timed out")
+
+        expect(agent_run.cancelled_by_cleanup?).to be false
+      end
+
+      it "returns false when status is not timeout even if the prefix is present" do
+        agent_run = build(:agent_run, :failed,
+          error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted")
+
+        expect(agent_run.cancelled_by_cleanup?).to be false
+      end
+
+      it "returns false when error_message is nil" do
+        agent_run = build(:agent_run, status: "timeout", error_message: nil)
+
+        expect(agent_run.cancelled_by_cleanup?).to be false
+      end
+    end
+
     describe "#total_tokens" do
       it "returns sum of input and output tokens" do
         agent_run = build(:agent_run, tokens_input: 1000, tokens_output: 500)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -544,6 +544,78 @@ RSpec.describe Activities::RunAgentActivity do
       end
     end
 
+    context "when the run is cancelled by dev:cleanup mid-execution" do
+      before do
+        allow(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")
+        # Simulate dev:cleanup force-timing-out the run from a *different*
+        # process while the container call is in flight. We mutate via
+        # `update_columns` so the in-memory `agent_run` instance held by the
+        # activity stays stale — only the `reload` inside `cancelled_by_cleanup?`
+        # will surface the cleanup mark, which is what happens in production
+        # where the rake task and the Temporal worker are separate processes.
+        allow(container_service).to receive(:execute) do
+          AgentRun.where(id: agent_run.id).update_all(
+            status: "timeout",
+            error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted",
+            completed_at: Time.current
+          )
+          exec_failure
+        end
+      end
+
+      it "does not increment the provider circuit-breaker failure_count" do
+        state = user.provider_states.create!(provider_name: "claude", failure_count: 0, circuit_state: "closed")
+
+        begin
+          activity.execute(agent_run_id: agent_run.id)
+        rescue Temporalio::Error::ApplicationError
+          # Expected: AllProvidersExhausted is still raised (the run is dead),
+          # but the breaker must remain untouched.
+        end
+
+        expect(state.reload.failure_count).to eq(0)
+        expect(state.circuit_state).to eq("closed")
+      end
+
+      it "records the provider attempt as cancelled_by_cleanup" do
+        begin
+          activity.execute(agent_run_id: agent_run.id)
+        rescue Temporalio::Error::ApplicationError
+          # expected
+        end
+
+        attempts = agent_run.reload.providers_attempted
+        expect(attempts.last["error_type"]).to eq("cancelled_by_cleanup")
+        expect(attempts.last["success"]).to be false
+      end
+
+      it "preserves the cleanup error_message and timeout status on the run" do
+        begin
+          activity.execute(agent_run_id: agent_run.id)
+        rescue Temporalio::Error::ApplicationError
+          # expected
+        end
+
+        agent_run.reload
+        expect(agent_run.status).to eq("timeout")
+        expect(agent_run.error_message).to start_with(AgentRun::STALE_CLEANUP_ERROR_PREFIX)
+      end
+
+      it "stops iterating providers instead of attempting fallbacks" do
+        user.settings.update!(fallback_enabled: true)
+
+        begin
+          activity.execute(agent_run_id: agent_run.id)
+        rescue Temporalio::Error::ApplicationError
+          # expected
+        end
+
+        # Exactly one provider attempt should be recorded (the one that was
+        # mid-flight when cleanup struck) — not one per configured fallback.
+        expect(agent_run.reload.providers_attempted.size).to eq(1)
+      end
+    end
+
     context "when agent hits rate limit (single provider)" do
       let(:rate_limit_output) do
         Containers::Provision::Result.failure(

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -614,6 +614,16 @@ RSpec.describe Activities::RunAgentActivity do
         # mid-flight when cleanup struck) — not one per configured fallback.
         expect(agent_run.reload.providers_attempted.size).to eq(1)
       end
+
+      it "does not enqueue ProcessRunQueueJob" do
+        expect(ProcessRunQueueJob).not_to receive(:perform_later)
+
+        begin
+          activity.execute(agent_run_id: agent_run.id)
+        rescue Temporalio::Error::ApplicationError
+          # expected
+        end
+      end
     end
 
     context "when agent hits rate limit (single provider)" do


### PR DESCRIPTION
Fixes #931

## Summary

- `bin/rails dev:cleanup` now tags force-timed-out runs with `AgentRun::STALE_CLEANUP_ERROR_PREFIX`.
- `RunAgentActivity` rescue branches reload the run and skip `record_provider_failure` (and break out of the providers loop) when `cancelled_by_cleanup?` — so killing in-flight runs no longer poisons healthy providers' circuit breakers.
- Cleanup-induced failures are recorded as `error_type: "cancelled_by_cleanup"` so they remain visible in the UI without implying a real provider problem.

## Test plan

- [x] New specs in `spec/temporal/activities/run_agent_activity_spec.rb`:
  - breaker `failure_count` stays at 0 when cleanup races with an in-flight run
  - the attempt is recorded as `cancelled_by_cleanup`
  - the cleanup-set `status: "timeout"` and `error_message` are preserved
  - with `fallback_enabled: true`, the activity stops after one attempt instead of cascading through fallbacks
- [x] Tests use `update_all` to mutate the run from "another process," so the `reload` inside `cancelled_by_cleanup?` is genuinely exercised
- [x] Full `run_agent_activity_spec.rb` (84 examples) green
- [x] `agent_run_spec.rb` and `dev_rake_spec.rb` (256 examples combined) green
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)