### PR TITLE
Fix #923: Add UI fields for configuring priority label names per project

### DIFF
--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -402,7 +402,7 @@
                 <label for="project_priority_labels_<%= tier %>" class="block text-sm font-medium leading-6 text-gray-900">Priority Label (<%= tier %>)</label>
                 <div class="mt-2">
                   <input type="text" name="project[priority_labels][<%= tier %>]" id="project_priority_labels_<%= tier %>"
-                    value="<%= @project.priority_labels&.dig(tier) || Project::DEFAULT_PRIORITY_LABELS[tier] %>"
+                    value="<%= @project.effective_priority_labels[tier] %>"
                     class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" />
                 </div>
                 <p class="mt-1 text-xs text-gray-500">GitHub label name for <%= tier %> priority issues.</p>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -396,6 +396,18 @@
               </div>
               <p class="mt-1 text-xs text-gray-500">Label that triggers automatic agent runs when added to issues or PRs.</p>
             </div>
+
+            <% %w[P1 P2 P3].each do |tier| %>
+              <div>
+                <label for="project_priority_labels_<%= tier %>" class="block text-sm font-medium leading-6 text-gray-900">Priority Label (<%= tier %>)</label>
+                <div class="mt-2">
+                  <input type="text" name="project[priority_labels][<%= tier %>]" id="project_priority_labels_<%= tier %>"
+                    value="<%= @project.priority_labels&.dig(tier) || Project::DEFAULT_PRIORITY_LABELS[tier] %>"
+                    class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" />
+                </div>
+                <p class="mt-1 text-xs text-gray-500">GitHub label name for <%= tier %> priority issues.</p>
+              </div>
+            <% end %>
           </fieldset>
 
           <fieldset id="automation" class="space-y-4">

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -399,7 +399,7 @@
 
             <% %w[P1 P2 P3].each do |tier| %>
               <div>
-                <label for="project_priority_labels_<%= tier %>" class="block text-sm font-medium leading-6 text-gray-900">Priority Label (<%= tier %>)</label>
+                <%= form.label "priority_labels_#{tier}", "Priority Label (#{tier})", class: "block text-sm font-medium leading-6 text-gray-900" %>
                 <div class="mt-2">
                   <input type="text" name="project[priority_labels][<%= tier %>]" id="project_priority_labels_<%= tier %>"
                     value="<%= @project.effective_priority_labels[tier] %>"
@@ -407,6 +407,11 @@
                 </div>
                 <p class="mt-1 text-xs text-gray-500">GitHub label name for <%= tier %> priority issues.</p>
               </div>
+            <% end %>
+            <% if @project.errors[:priority_labels].any? %>
+              <% @project.errors[:priority_labels].each do |msg| %>
+                <p class="mt-1 text-xs text-red-600"><%= msg %></p>
+              <% end %>
             <% end %>
           </fieldset>
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -882,6 +882,14 @@ RSpec.describe "Projects" do
         expect(project.reload.priority_labels).to eq("P1" => "P1", "P2" => "P2", "P3" => "P3")
       end
 
+      it "preserves priority labels when param is omitted" do
+        project = create(:project, account: account, github_token: github_token,
+          priority_labels: { "P1" => "urgent", "P2" => "normal", "P3" => "low" })
+        patch project_path(project), params: { project: { generated_label_name: "ai-gen" } }
+        expect(response).to redirect_to(project)
+        expect(project.reload.priority_labels).to eq("P1" => "urgent", "P2" => "normal", "P3" => "low")
+      end
+
       it "allows updating security scanning settings" do
         project = create(:project, account: account, github_token: github_token,
           auto_scan_security: false, security_severity_threshold: "high")

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -868,15 +868,18 @@ RSpec.describe "Projects" do
         patch project_path(project), params: {
           project: { priority_labels: { "P1" => "urgent", "P2" => "normal", "P3" => "low" } }
         }
+        expect(response).to redirect_to(project)
         expect(project.reload.priority_labels).to eq("P1" => "urgent", "P2" => "normal", "P3" => "low")
       end
 
       it "rejects blank priority label values" do
-        project = create(:project, account: account, github_token: github_token)
+        project = create(:project, account: account, github_token: github_token,
+          priority_labels: { "P1" => "P1", "P2" => "P2", "P3" => "P3" })
         patch project_path(project), params: {
           project: { priority_labels: { "P1" => "", "P2" => "normal", "P3" => "low" } }
         }
-        expect(project.reload.priority_labels).not_to eq("P1" => "", "P2" => "normal", "P3" => "low")
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(project.reload.priority_labels).to eq("P1" => "P1", "P2" => "P2", "P3" => "P3")
       end
 
       it "allows updating security scanning settings" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -863,6 +863,22 @@ RSpec.describe "Projects" do
         expect(project.reload.auto_fix_merge_conflicts).to be true
       end
 
+      it "allows updating priority label names" do
+        project = create(:project, account: account, github_token: github_token)
+        patch project_path(project), params: {
+          project: { priority_labels: { "P1" => "urgent", "P2" => "normal", "P3" => "low" } }
+        }
+        expect(project.reload.priority_labels).to eq("P1" => "urgent", "P2" => "normal", "P3" => "low")
+      end
+
+      it "rejects blank priority label values" do
+        project = create(:project, account: account, github_token: github_token)
+        patch project_path(project), params: {
+          project: { priority_labels: { "P1" => "", "P2" => "normal", "P3" => "low" } }
+        }
+        expect(project.reload.priority_labels).not_to eq("P1" => "", "P2" => "normal", "P3" => "low")
+      end
+
       it "allows updating security scanning settings" do
         project = create(:project, account: account, github_token: github_token,
           auto_scan_security: false, security_severity_threshold: "high")


### PR DESCRIPTION
Based on the issue context and agent output, here's the PR description:

## Summary

Allow project owners to customize the GitHub label names used for P1/P2/P3 priority tiers via the project edit form. Previously, `priority_labels` were stored in the database (#922) but had no UI for configuration, so projects with non-default label names (e.g., `critical` instead of `P1`) couldn't use the priority system without manual database edits.

## Changes

**Database**
- Added `priority_labels` jsonb column to `projects` with default `{"P1":"P1","P2":"P2","P3":"P3"}`

**Model (`app/models/project.rb`)**
- Added `DEFAULT_PRIORITY_LABELS` constant and `effective_priority_labels` method that merges defaults with any user-customized values
- Added `priority_labels_valid` custom validation rejecting unknown keys and blank values

**Controller (`app/controllers/projects_controller.rb`)**
- Permitted `priority_labels: %i[P1 P2 P3]` in strong params to allow the nested hash through

**View (`app/views/projects/edit.html.erb`)**
- Added three text inputs for P1, P2, and P3 label names within the existing Labels fieldset, pre-filled with current or default values
- Validation errors from the model are surfaced inline

**Tests (`spec/requests/projects_spec.rb`)**
- Added request spec for successfully updating priority label names
- Added request spec for rejecting blank priority label values

## Design Decisions

- **Blank fields fall back to defaults** — `effective_priority_labels` merges user input over `DEFAULT_PRIORITY_LABELS`, so users only need to override the tiers they've renamed. The validation still rejects explicitly blank *submitted* values to avoid confusion.
- **No auto-creation of GitHub labels** — the issue mentioned optional auto-creation of missing labels on the GitHub repo; this is deferred to keep the change focused on the UI plumbing. A follow-up could add a warning or auto-create via the GitHub client.

## Screenshots

> **Author**: please attach before/after screenshots of the project edit form showing the new priority label fields.

---

Closes #923