### PR TITLE
Fix #931: dev:cleanup trips provider circuit breakers when killing in-flight runs

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -13,6 +13,7 @@ class AgentRun < ApplicationRecord
   AUTO_PICK_BLOCKING_STATUSES = UNFINISHED_STATUSES
   TOKEN_LIMIT_STATUSES = %w[ok warning exceeded].freeze
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000_000
+  STALE_CLEANUP_ERROR_PREFIX = "[cleanup] "
 
   belongs_to :project
   belongs_to :issue, optional: true
@@ -510,6 +511,10 @@ class AgentRun < ApplicationRecord
       error_message: error,
       duration_seconds: duration
     )
+  end
+
+  def cancelled_by_cleanup?
+    status == "timeout" && error_message&.start_with?(STALE_CLEANUP_ERROR_PREFIX)
   end
 
   def retried?

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -225,6 +225,12 @@ module Activities
               )
             end
           rescue InfiniteLoopError => e
+            agent_run.reload
+            if agent_run.cancelled_by_cleanup?
+              agent_run.record_provider_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup")
+              logger.info(message: "agent_execution.cancelled_by_cleanup", provider: provider, agent_run_id: agent_run.id)
+              break
+            end
             record_provider_failure(user_settings, provider_state_name, provider_states)
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "infinite_loop")
             last_error = "infinite_loop"
@@ -246,6 +252,12 @@ module Activities
               non_retryable: true
             )
           rescue ProviderTimeoutError => e
+            agent_run.reload
+            if agent_run.cancelled_by_cleanup?
+              agent_run.record_provider_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup")
+              logger.info(message: "agent_execution.cancelled_by_cleanup", provider: provider, agent_run_id: agent_run.id)
+              break
+            end
             last_error = "timeout"
             timeout_error ||= e.message
             record_provider_failure(user_settings, provider_state_name, provider_states)
@@ -253,6 +265,12 @@ module Activities
             logger.warn(message: "agent_execution.provider_timeout", provider: provider, agent_run_id: agent_run.id, error: e.message)
             break
           rescue ProviderExecutionError => e
+            agent_run.reload
+            if agent_run.cancelled_by_cleanup?
+              agent_run.record_provider_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup")
+              logger.info(message: "agent_execution.cancelled_by_cleanup", provider: provider, agent_run_id: agent_run.id)
+              break
+            end
             last_error = "error"
             record_provider_failure(user_settings, provider_state_name, provider_states)
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "error")

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -57,7 +57,7 @@ namespace :dev do
         next if run.finished?
 
         if grace.zero? || run.updated_at < grace.ago
-          run.timeout!(error: "Marked stale on startup: process was restarted")
+          run.timeout!(error: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}Marked stale on startup: process was restarted")
           run.log!("system", "Run marked as timed out during startup cleanup")
           run.issue&.update!(paid_state: "failed") unless run.issue&.paid_state == "failed"
           stale_container_ids << run.container_id if run.container_id.present?

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -491,6 +491,33 @@ RSpec.describe AgentRun do
       end
     end
 
+    describe "#cancelled_by_cleanup?" do
+      it "returns true when status is timeout with cleanup prefix" do
+        agent_run = build(:agent_run, status: "timeout",
+          error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}Marked stale on startup: process was restarted")
+
+        expect(agent_run.cancelled_by_cleanup?).to be true
+      end
+
+      it "returns false when status is timeout without cleanup prefix" do
+        agent_run = build(:agent_run, status: "timeout", error_message: "Provider timed out")
+
+        expect(agent_run.cancelled_by_cleanup?).to be false
+      end
+
+      it "returns false when status is not timeout" do
+        agent_run = build(:agent_run, :failed, error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}something")
+
+        expect(agent_run.cancelled_by_cleanup?).to be false
+      end
+
+      it "returns false when error_message is nil" do
+        agent_run = build(:agent_run, status: "timeout", error_message: nil)
+
+        expect(agent_run).not_to be_cancelled_by_cleanup
+      end
+    end
+
     describe "#successful?" do
       it "returns true when status is completed" do
         agent_run = build(:agent_run, :completed)

--- a/spec/tasks/dev_rake_spec.rb
+++ b/spec/tasks/dev_rake_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe "dev:cleanup" do
 
     running_run.reload
     expect(running_run.status).to eq("timeout")
+    expect(running_run.error_message).to start_with(AgentRun::STALE_CLEANUP_ERROR_PREFIX)
     expect(running_run.error_message).to include("process was restarted")
     expect(running_run.completed_at).to be_present
+    expect(running_run.cancelled_by_cleanup?).to be true
   end
 
   it "times out runs stuck in pending" do
@@ -45,6 +47,7 @@ RSpec.describe "dev:cleanup" do
 
     pending_run.reload
     expect(pending_run.status).to eq("timeout")
+    expect(pending_run.error_message).to start_with(AgentRun::STALE_CLEANUP_ERROR_PREFIX)
     expect(pending_run.error_message).to include("process was restarted")
   end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1146,6 +1146,50 @@ RSpec.describe Activities::RunAgentActivity do
     end
   end
 
+  describe "cleanup cancellation detection" do
+    before do
+      allow(container_service).to receive(:execute).and_return(exec_success)
+      allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+    end
+
+    it "skips circuit breaker on InfiniteLoopError when run was cancelled by cleanup" do
+      call_count = 0
+      allow(activity).to receive(:run_agent_with_provider) do
+        call_count += 1
+        agent_run.update!(status: "timeout",
+          error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}Marked stale on startup: process was restarted",
+          completed_at: Time.current)
+        raise described_class::InfiniteLoopError, "loop detected"
+      end
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError, "All providers exhausted")
+
+      expect(call_count).to eq(1)
+    end
+
+    it "skips circuit breaker on ProviderExecutionError when run was cancelled by cleanup" do
+      call_count = 0
+      allow(activity).to receive(:run_agent_with_provider) do
+        call_count += 1
+        # On first call, simulate cleanup happening then provider error
+        if call_count == 1
+          agent_run.update!(status: "timeout",
+            error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}Marked stale on startup: process was restarted",
+            completed_at: Time.current)
+        end
+        raise described_class::ProviderExecutionError, "execution failed"
+      end
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError, "All providers exhausted")
+
+      expect(call_count).to eq(1)
+    end
+  end
+
   describe "paused run protection after provider exhaustion" do
     before do
       allow(container_service).to receive(:execute).and_return(exec_failure)


### PR DESCRIPTION
## Summary

dev:cleanup trips provider circuit breakers when killing in-flight runs

See #931 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #931