### PR TITLE
Fix #935: fix(auto-merge): check affected files when clearing body-only review feedback

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -189,6 +189,19 @@ class GithubClient
     end.map(&:filename)
   end
 
+  # Compares two commits and returns the list of changed file paths.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param base [String] Base commit SHA
+  # @param head [String] Head commit SHA
+  # @return [Array<String>] File paths changed between the two commits
+  def compare_files(repo, base, head)
+    handle_errors do
+      comparison = client.compare(repo, base, head)
+      (comparison.files || []).map(&:filename)
+    end
+  end
+
   # Creates an issue on a repository.
   #
   # @param repo [String] Repository in "owner/name" format
@@ -463,7 +476,8 @@ class GithubClient
           user_login: r.user&.login,
           state: r.state,
           body: r.body.to_s,
-          submitted_at: parse_timestamp(r.submitted_at)
+          submitted_at: parse_timestamp(r.submitted_at),
+          commit_id: r.commit_id
         }
       end
     end
@@ -709,7 +723,7 @@ class GithubClient
   # @param number [Integer] Pull request number
   # @param per_page [Integer, nil] When set, fetches a single page of this size
   #   (no auto-pagination). When nil, auto-paginates all comments.
-  # @return [Array<Hash>] Comments with :id, :user_login, :body, :created_at keys
+  # @return [Array<Hash>] Comments with :id, :user_login, :body, :created_at, :path keys
   def pull_request_review_comments(repo, number, per_page: nil)
     handle_errors do
       comments = if per_page
@@ -724,7 +738,8 @@ class GithubClient
           id: c.id,
           user_login: c.user&.login,
           body: c.body.to_s,
-          created_at: parse_timestamp(c.created_at)
+          created_at: parse_timestamp(c.created_at),
+          path: c.path
         }
       end
     end

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -545,12 +545,19 @@ module Activities
             triggers.concat(bot_thread_triggers)
             triggers
           elsif body_only_review_bot?(latest&.dig(:user_login)) &&
-              body_only_review_needs_followup?(latest, last_run)
+              (body_only_review_needs_followup?(latest, last_run) ||
+               !body_only_review_affected_files_changed?(client, project, issue, latest))
             # Body-only bots (e.g. Codex): the review feedback lives in
             # the top-level review body with no inline threads, so thread
-            # resolution cannot gate re-review. Use submitted_at vs the
-            # last agent run's completed_at as the anti-loop guard — a
-            # review post-dating the last run is unaddressed feedback.
+            # resolution cannot gate re-review. Two guards must both pass
+            # before clearing feedback:
+            #   1. Timestamp: the last agent run must have completed after
+            #      the review was submitted.
+            #   2. Affected files: the diff between the reviewed commit and
+            #      the current HEAD must touch at least one file mentioned
+            #      in the review's inline comments. This prevents unrelated
+            #      changes (e.g. db/schema.rb) from clearing findings on
+            #      files the agent never modified.
             # The "(body-only)" suffix on review_bot_comments lets
             # structured-log consumers distinguish this path from the
             # thread-based Copilot flow above.
@@ -560,9 +567,10 @@ module Activities
             ]
           else
             # Thread-based bot with all bot threads resolved, or body-only
-            # review already addressed by a subsequent agent run. Treat as
-            # effectively clean to avoid re-requesting reviews that would
-            # produce no new comments.
+            # review already addressed by a subsequent agent run that
+            # touched at least one reviewed file. Treat as effectively
+            # clean to avoid re-requesting reviews that would produce no
+            # new comments.
             []
           end
         end
@@ -629,6 +637,43 @@ module Activities
       return true if cutoff.nil?
 
       submitted_at > cutoff
+    end
+
+    # Checks whether the diff between the reviewed commit and the current
+    # PR HEAD touches at least one file mentioned in the review's inline
+    # comments. Returns true (safe to clear) when:
+    #   - the review has no commit_id or the client/project/issue is nil
+    #     (falls back to timestamp-only behavior)
+    #   - no inline review comments with paths exist (falls back)
+    #   - the interceding diff includes at least one reviewed file
+    # Returns false when the diff does not touch any reviewed file,
+    # preventing unrelated changes from clearing review findings.
+    def body_only_review_affected_files_changed?(client, project, issue, latest_review)
+      return true if client.nil? || project.nil? || issue.nil?
+
+      review_commit = latest_review&.dig(:commit_id)
+      return true if review_commit.nil?
+
+      pr_data = client.pull_request(project.full_name, issue.github_number)
+      head_sha = pr_data&.head&.sha
+      return true if head_sha.nil? || head_sha == review_commit
+
+      review_comments = client.pull_request_review_comments(
+        project.full_name, issue.github_number
+      )
+      review_bot_login = latest_review[:user_login]&.downcase
+      reviewed_paths = review_comments
+        .select { |c| c[:user_login]&.downcase == review_bot_login && c[:path].present? }
+        .map { |c| c[:path] }
+        .uniq
+
+      return true if reviewed_paths.empty?
+
+      changed_files = client.compare_files(project.full_name, review_commit, head_sha)
+      (reviewed_paths & changed_files).any?
+    rescue GithubClient::Error => e
+      log_signal_error("body_only_review_affected_files", project, issue, e)
+      true
     end
 
     def review_bot_thread_triggers(unresolved_threads)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -989,6 +989,113 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when codex review was addressed but agent only changed unrelated files" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "review_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
+              created_at: 2.hours.ago, path: "app/activities/fetch_issues_activity.rb" }
+          ])
+        allow(github_client).to receive(:compare_files)
+          .with(project.full_name, "review_sha", "abc123")
+          .and_return([ "db/schema.rb" ])
+      end
+
+      it "still emits triggers because the reviewed file was not changed" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("review_bot_comments", "review_bot_review_pending")
+      end
+    end
+
+    context "when codex review was addressed and agent changed a reviewed file" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "review_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
+              created_at: 2.hours.ago, path: "app/activities/fetch_issues_activity.rb" }
+          ])
+        allow(github_client).to receive(:compare_files)
+          .with(project.full_name, "review_sha", "abc123")
+          .and_return([ "app/activities/fetch_issues_activity.rb", "db/schema.rb" ])
+      end
+
+      it "treats the review as addressed and does not trigger" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
+    context "when codex review has no inline comments (body-only feedback)" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "review_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([])
+        allow(github_client).to receive(:compare_files)
+          .with(project.full_name, "review_sha", "abc123")
+          .and_return([ "db/schema.rb" ])
+      end
+
+      it "falls back to timestamp behavior and treats as addressed" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
     context "when PR is in draft phase with Claude review threads" do
       before do
         create(:issue, :pull_request,


### PR DESCRIPTION
## Summary

Prevent auto-merge from clearing review feedback when the agent's latest changes don't touch any files mentioned in the review. This closes a loophole where an unrelated CI fix (e.g., `db/schema.rb`) could satisfy the timestamp-based anti-loop guard and inadvertently dismiss a P1 review on a completely different file.

## Changes

**Models / Services**
- `github_client.rb`: Added `compare_files` method to retrieve the list of changed files between two commits. Included `commit_id` in review response payloads and `path` in review comment responses to support file-level cross-referencing.

**Workflow Activities**
- `scan_paid_prs_activity.rb`: Introduced `body_only_review_affected_files_changed?` heuristic that compares inline review comment paths against the diff between the reviewed commit and the current HEAD. Updated `check_review_bot_status` so that clearing body-only review feedback now requires **both** the existing timestamp guard **and** the new affected-file guard to pass.

**Tests**
- Added three test cases covering: unrelated file changes do not clear feedback, matching file changes do clear feedback, and fallback to timestamp-only behavior when no inline comments are present.

## Design Decisions

- **Dual guard (timestamp + file overlap):** Rather than replacing the timestamp check, the file-overlap heuristic is layered on top as defense-in-depth. This avoids regressions in the existing anti-loop logic while closing the identified gap.
- **Graceful fallback:** When inline comments can't be fetched or contain no file paths, the system falls back to the existing timestamp-only behavior, keeping the change backward-compatible and resilient to API failures.
- **Minimal API surface:** `compare_files` returns only the file list from the GitHub compare endpoint rather than full diff content, keeping the payload small and the heuristic fast.

---

Closes #935