### PR TITLE
Fix #931: dev:cleanup trips provider circuit breakers when killing in-flight runs

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -10,6 +10,7 @@ class AgentRun < ApplicationRecord
   FAILURE_STATUSES = %w[failed timeout auth_expired rate_limited].freeze
   UNFINISHED_STATUSES = %w[queued pending running paused].freeze
   GUARDRAIL_VIOLATION_TYPES = %w[loop_detected token_limit cost_limit time_limit anomaly].freeze
+  STALE_CLEANUP_ERROR_PREFIX = "[cleanup] "
   AUTO_PICK_BLOCKING_STATUSES = UNFINISHED_STATUSES
   TOKEN_LIMIT_STATUSES = %w[ok warning exceeded].freeze
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000_000
@@ -482,6 +483,10 @@ class AgentRun < ApplicationRecord
 
   def successful?
     status == "completed"
+  end
+
+  def cancelled_by_cleanup?
+    error_message.to_s.start_with?(STALE_CLEANUP_ERROR_PREFIX)
   end
 
   def total_tokens

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -225,6 +225,13 @@ module Activities
               )
             end
           rescue InfiniteLoopError => e
+            agent_run.reload
+            if agent_run.cancelled_by_cleanup?
+              agent_run.record_provider_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup")
+              logger.info(message: "agent_execution.cancelled_by_cleanup", agent_run_id: agent_run.id)
+              break
+            end
+
             record_provider_failure(user_settings, provider_state_name, provider_states)
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "infinite_loop")
             last_error = "infinite_loop"
@@ -246,6 +253,13 @@ module Activities
               non_retryable: true
             )
           rescue ProviderTimeoutError => e
+            agent_run.reload
+            if agent_run.cancelled_by_cleanup?
+              agent_run.record_provider_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup")
+              logger.info(message: "agent_execution.cancelled_by_cleanup", agent_run_id: agent_run.id)
+              break
+            end
+
             last_error = "timeout"
             timeout_error ||= e.message
             record_provider_failure(user_settings, provider_state_name, provider_states)
@@ -253,6 +267,13 @@ module Activities
             logger.warn(message: "agent_execution.provider_timeout", provider: provider, agent_run_id: agent_run.id, error: e.message)
             break
           rescue ProviderExecutionError => e
+            agent_run.reload
+            if agent_run.cancelled_by_cleanup?
+              agent_run.record_provider_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup")
+              logger.info(message: "agent_execution.cancelled_by_cleanup", agent_run_id: agent_run.id)
+              break
+            end
+
             last_error = "error"
             record_provider_failure(user_settings, provider_state_name, provider_states)
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "error")

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -57,7 +57,7 @@ namespace :dev do
         next if run.finished?
 
         if grace.zero? || run.updated_at < grace.ago
-          run.timeout!(error: "Marked stale on startup: process was restarted")
+          run.timeout!(error: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}Marked stale on startup: process was restarted")
           run.log!("system", "Run marked as timed out during startup cleanup")
           run.issue&.update!(paid_state: "failed") unless run.issue&.paid_state == "failed"
           stale_container_ids << run.container_id if run.container_id.present?

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -505,6 +505,26 @@ RSpec.describe AgentRun do
       end
     end
 
+    describe "#cancelled_by_cleanup?" do
+      it "returns true when error_message starts with the cleanup prefix" do
+        agent_run = build(:agent_run, error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}Marked stale on startup")
+
+        expect(agent_run.cancelled_by_cleanup?).to be true
+      end
+
+      it "returns false for a normal error message" do
+        agent_run = build(:agent_run, error_message: "Provider timed out")
+
+        expect(agent_run.cancelled_by_cleanup?).to be false
+      end
+
+      it "returns false when error_message is nil" do
+        agent_run = build(:agent_run, error_message: nil)
+
+        expect(agent_run.cancelled_by_cleanup?).to be false
+      end
+    end
+
     describe "#total_tokens" do
       it "returns sum of input and output tokens" do
         agent_run = build(:agent_run, tokens_input: 1000, tokens_output: 500)

--- a/spec/tasks/dev_rake_spec.rb
+++ b/spec/tasks/dev_rake_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe "dev:cleanup" do
 
     running_run.reload
     expect(running_run.status).to eq("timeout")
+    expect(running_run.error_message).to start_with(AgentRun::STALE_CLEANUP_ERROR_PREFIX)
     expect(running_run.error_message).to include("process was restarted")
     expect(running_run.completed_at).to be_present
+    expect(running_run).to be_cancelled_by_cleanup
   end
 
   it "times out runs stuck in pending" do
@@ -45,6 +47,7 @@ RSpec.describe "dev:cleanup" do
 
     pending_run.reload
     expect(pending_run.status).to eq("timeout")
+    expect(pending_run.error_message).to start_with(AgentRun::STALE_CLEANUP_ERROR_PREFIX)
     expect(pending_run.error_message).to include("process was restarted")
   end
 


### PR DESCRIPTION
## Summary

Prevent dev:cleanup from tripping provider circuit breakers by tagging cleanup-induced timeouts with a sentinel prefix and skipping failure recording for those runs. This fixes an issue where killing in-flight agent runs during setup would penalize healthy providers, causing subsequent runs to unnecessarily fall back to inferior providers.

## Changes

**Model (`app/models/agent_run.rb`)**
- Added `STALE_CLEANUP_ERROR_PREFIX` constant (`"[cleanup] "`) and `cancelled_by_cleanup?` predicate that checks whether the error message carries the cleanup sentinel

**Rake task (`lib/tasks/dev.rake`)**
- Prepended the cleanup prefix to the timeout error message set during `dev:cleanup`, making cleanup-killed runs distinguishable from genuine timeouts

**Temporal activity (`app/temporal/activities/run_agent_activity.rb`)**
- In all three rescue branches (`InfiniteLoopError`, `ProviderTimeoutError`, `ProviderExecutionError`), added a reload + `cancelled_by_cleanup?` guard that records the attempt as `error_type: "cancelled_by_cleanup"` and breaks out of the provider fallback loop **without** calling `record_provider_failure`

**Tests**
- Added specs for `cancelled_by_cleanup?` in the AgentRun model spec
- Updated dev:cleanup spec to verify the sentinel prefix is present on cleanup-killed runs

## Design Decisions

- **Sentinel prefix on `error_message` rather than a dedicated column**: avoids a migration for a narrow concern; the prefix is a stable contract between the rake task and the activity, and `cancelled_by_cleanup?` encapsulates the check cleanly.
- **Reload before checking**: the activity runs in a separate Temporal worker process, so the `AgentRun` record must be reloaded to see the cleanup prefix written by the rake task.
- **Break instead of `next`**: once cleanup has killed the container, retrying on a fallback provider is pointless — the run is already terminal. Breaking out avoids wasting fallback attempts and prevents cascading circuit breaker hits across multiple providers.

---

Closes #931