### PR TITLE
Fix #943: fix(quality): webhook feedback misses review-goal agent runs

### DIFF
--- a/app/controllers/api/github_webhooks_controller.rb
+++ b/app/controllers/api/github_webhooks_controller.rb
@@ -111,6 +111,10 @@ module Api
       head :ok
     end
 
+    # Shared lookup used by all three event handlers (pull_request_review,
+    # pull_request, issue_comment). The review-goal fallback intentionally
+    # applies to every event type: a merged PR or issue comment on a PR that
+    # was reviewed by an agent should still attribute the signal.
     def find_agent_run(pr_number)
       return nil unless @project && pr_number
 
@@ -123,6 +127,9 @@ module Api
       # CollectReviewReactionFeedback, which queries source_pull_request_number
       # directly for review-goal runs.
       #
+      # NOTE: the existing partial unique index on (project_id,
+      # source_pull_request_number) covers active runs only and does not help
+      # this completed-status query. At current volume that is fine.
       # TODO(#943): if review-goal feedback volume grows, consider a composite
       # index on (project_id, source_pull_request_number, status).
       @project.agent_runs

--- a/app/controllers/api/github_webhooks_controller.rb
+++ b/app/controllers/api/github_webhooks_controller.rb
@@ -119,6 +119,12 @@ module Api
       #
       # Review-goal runs set source_pull_request_number (the PR they reviewed)
       # instead of pull_request_number, so fall back to that lookup.
+      # The HumanFeedbackCollectionJob side already handles this via
+      # CollectReviewReactionFeedback, which queries source_pull_request_number
+      # directly for review-goal runs.
+      #
+      # TODO(#943): if review-goal feedback volume grows, consider a composite
+      # index on (project_id, source_pull_request_number, status).
       @project.agent_runs
         .where(pull_request_number: pr_number, status: "completed")
         .order(created_at: :desc)

--- a/app/controllers/api/github_webhooks_controller.rb
+++ b/app/controllers/api/github_webhooks_controller.rb
@@ -116,10 +116,17 @@ module Api
 
       # Only record feedback for successful (completed) runs to avoid skewing
       # metrics — mirrors the guard in HumanFeedbackCollectionJob#perform.
+      #
+      # Review-goal runs set source_pull_request_number (the PR they reviewed)
+      # instead of pull_request_number, so fall back to that lookup.
       @project.agent_runs
         .where(pull_request_number: pr_number, status: "completed")
         .order(created_at: :desc)
-        .first
+        .first ||
+        @project.agent_runs
+          .where(source_pull_request_number: pr_number, goal: "review", status: "completed")
+          .order(created_at: :desc)
+          .first
     end
 
     def find_agent_run_by_issue(issue_number)

--- a/spec/requests/api/github_webhooks_spec.rb
+++ b/spec/requests/api/github_webhooks_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe "Api::GithubWebhooks" do
       end
 
       it "attributes feedback to the review-goal run, not the create_pr run" do
-        # Create a create_pr run on the same PR to ensure the review run is preferred
-        # when no create_pr run matches
+        # No create_pr run exists for PR 77, so the fallback to
+        # source_pull_request_number should find the review-goal run.
         body, signature = sign_payload(payload, project.webhook_secret)
 
         expect {

--- a/spec/requests/api/github_webhooks_spec.rb
+++ b/spec/requests/api/github_webhooks_spec.rb
@@ -65,6 +65,67 @@ RSpec.describe "Api::GithubWebhooks" do
       end
     end
 
+    context "with pull_request_review event for a review-goal run" do
+      let(:review_run) do
+        create(:agent_run, :with_review, project: project, source_pull_request_number: 77)
+      end
+
+      let(:payload) do
+        {
+          action: "submitted",
+          review: {
+            state: "approved",
+            user: { login: "reviewer" },
+            body: "Review looks good!"
+          },
+          pull_request: {
+            number: review_run.source_pull_request_number
+          },
+          repository: {
+            id: project.github_id,
+            full_name: project.full_name
+          }
+        }
+      end
+
+      it "attributes feedback to the review-goal run, not the create_pr run" do
+        # Create a create_pr run on the same PR to ensure the review run is preferred
+        # when no create_pr run matches
+        body, signature = sign_payload(payload, project.webhook_secret)
+
+        expect {
+          post webhook_url,
+            params: body,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-GitHub-Event" => "pull_request_review",
+              "X-Hub-Signature-256" => signature
+            }
+        }.to change { review_run.quality_metrics.human.count }.by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "prefers the create_pr run when both exist for the same PR number" do
+        pr_run = create(:agent_run, :completed, project: project, pull_request_number: 77)
+
+        body, signature = sign_payload(payload, project.webhook_secret)
+
+        expect {
+          post webhook_url,
+            params: body,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-GitHub-Event" => "pull_request_review",
+              "X-Hub-Signature-256" => signature
+            }
+        }.to change { pr_run.quality_metrics.human.count }.by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(review_run.quality_metrics.human.count).to eq(0)
+      end
+    end
+
     context "with signature verification" do
       let(:payload) do
         {


### PR DESCRIPTION
## Summary

fix(quality): webhook feedback misses review-goal agent runs

See #943 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #943