### PR TITLE
Fix #935: fix(auto-merge): check affected files when clearing body-only review feedback

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -191,6 +191,12 @@ class GithubClient
 
   # Compares two commits and returns the list of changed file paths.
   #
+  # NOTE: GitHub's compare API returns a maximum of 300 files per response.
+  # For very large diffs (e.g., a rebase onto a distant base), the result
+  # may be silently truncated. This is unlikely for the narrow
+  # commit-to-HEAD diffs this method currently serves, but callers doing
+  # broader comparisons should be aware of the limit.
+  #
   # @param repo [String] Repository in "owner/name" format
   # @param base [String] Base commit SHA
   # @param head [String] Head commit SHA

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -189,6 +189,19 @@ class GithubClient
     end.map(&:filename)
   end
 
+  # Compares two commits and returns the list of changed file paths.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param base [String] Base commit SHA
+  # @param head [String] Head commit SHA
+  # @return [Array<String>] File paths changed between base and head
+  def compare_changed_files(repo, base, head)
+    handle_errors do
+      comparison = client.compare(repo, base, head)
+      (comparison.files || []).map(&:filename)
+    end
+  end
+
   # Creates an issue on a repository.
   #
   # @param repo [String] Repository in "owner/name" format
@@ -452,7 +465,7 @@ class GithubClient
   #
   # @param repo [String] Repository in "owner/name" format
   # @param number [Integer] Pull request number
-  # @return [Array<Hash>] Reviews with :id, :user_login, :state, :body, :submitted_at keys (:body is always a String)
+  # @return [Array<Hash>] Reviews with :id, :user_login, :state, :body, :submitted_at, :commit_id keys (:body is always a String)
   # @raise [NotFoundError] if the pull request does not exist
   def pull_request_reviews(repo, number)
     handle_errors do
@@ -463,7 +476,8 @@ class GithubClient
           user_login: r.user&.login,
           state: r.state,
           body: r.body.to_s,
-          submitted_at: parse_timestamp(r.submitted_at)
+          submitted_at: parse_timestamp(r.submitted_at),
+          commit_id: r.commit_id
         }
       end
     end
@@ -709,7 +723,7 @@ class GithubClient
   # @param number [Integer] Pull request number
   # @param per_page [Integer, nil] When set, fetches a single page of this size
   #   (no auto-pagination). When nil, auto-paginates all comments.
-  # @return [Array<Hash>] Comments with :id, :user_login, :body, :created_at keys
+  # @return [Array<Hash>] Comments with :id, :user_login, :body, :created_at, :path, :pull_request_review_id keys
   def pull_request_review_comments(repo, number, per_page: nil)
     handle_errors do
       comments = if per_page
@@ -724,7 +738,9 @@ class GithubClient
           id: c.id,
           user_login: c.user&.login,
           body: c.body.to_s,
-          created_at: parse_timestamp(c.created_at)
+          created_at: parse_timestamp(c.created_at),
+          path: c.path,
+          pull_request_review_id: c.pull_request_review_id
         }
       end
     end

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -537,6 +537,10 @@ module Activities
           [ { type: "review_bot_review_pending", details: "Latest review bot review was not clean" } ]
         else
           bot_thread_triggers = review_bot_thread_triggers(unresolved_threads)
+          body_only_pending_triggers = [
+            { type: "review_bot_review_pending", details: "Latest review bot review was not clean" },
+            { type: "review_bot_comments", details: "Latest review bot review generated comments (body-only)" }
+          ]
           if bot_thread_triggers.any?
             # Thread-based bots (e.g. Copilot) with at least one unresolved
             # bot thread: emit review_bot_comments + the thread triggers.
@@ -554,10 +558,7 @@ module Activities
             # The "(body-only)" suffix on review_bot_comments lets
             # structured-log consumers distinguish this path from the
             # thread-based Copilot flow above.
-            [
-              { type: "review_bot_review_pending", details: "Latest review bot review was not clean" },
-              { type: "review_bot_comments", details: "Latest review bot review generated comments (body-only)" }
-            ]
+            body_only_pending_triggers
           elsif body_only_review_bot?(latest&.dig(:user_login)) &&
               !review_diff_touches_reviewed_files?(client, project, issue, latest)
             # Body-only bot whose review pre-dates the last agent run
@@ -565,10 +566,7 @@ module Activities
             # touch any file mentioned in the review's inline comments.
             # Treat as still-unaddressed to prevent unrelated changes
             # (e.g. a CI schema fix) from clearing review findings.
-            [
-              { type: "review_bot_review_pending", details: "Latest review bot review was not clean" },
-              { type: "review_bot_comments", details: "Latest review bot review generated comments (body-only)" }
-            ]
+            body_only_pending_triggers
           else
             # Thread-based bot with all bot threads resolved, or body-only
             # review already addressed by a subsequent agent run whose diff
@@ -672,6 +670,11 @@ module Activities
       # clauses so it only fires when all other conditions align. Passing
       # pr_data through would avoid this call but adds complexity to
       # check_review_bot_status's already long keyword-arg list.
+      #
+      # pr_data returns a Sawyer::Resource, so `.head.sha` uses method
+      # dispatch. If pull_request is ever changed to return a plain Hash,
+      # this would need to switch to dig-style access. The nil guard below
+      # keeps this safe in either case.
       pr_data = client.pull_request(project.full_name, issue.github_number)
       head_sha = pr_data&.head&.sha
       return true if head_sha.nil? || head_sha == reviewed_commit

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -654,6 +654,10 @@ module Activities
       reviewed_commit = review[:commit_id]
       return true if review_id.nil? || reviewed_commit.nil?
 
+      # NOTE: The GitHub API does not support filtering review comments by
+      # review ID server-side, so we fetch all comments for the PR and
+      # filter client-side. This is O(total comments) rather than
+      # O(comments on this review), which is fine for typical PR sizes.
       comments = client.pull_request_review_comments(
         project.full_name, issue.github_number
       )
@@ -663,6 +667,11 @@ module Activities
         .to_set
       return true if reviewed_paths.empty?
 
+      # NOTE: pr_data is already fetched in scan_pr, but check_review_bot_status
+      # does not receive it. This extra API call is behind multiple guard
+      # clauses so it only fires when all other conditions align. Passing
+      # pr_data through would avoid this call but adds complexity to
+      # check_review_bot_status's already long keyword-arg list.
       pr_data = client.pull_request(project.full_name, issue.github_number)
       head_sha = pr_data&.head&.sha
       return true if head_sha.nil? || head_sha == reviewed_commit

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -558,11 +558,23 @@ module Activities
               { type: "review_bot_review_pending", details: "Latest review bot review was not clean" },
               { type: "review_bot_comments", details: "Latest review bot review generated comments (body-only)" }
             ]
+          elsif body_only_review_bot?(latest&.dig(:user_login)) &&
+              !review_diff_touches_reviewed_files?(client, project, issue, latest)
+            # Body-only bot whose review pre-dates the last agent run
+            # (timestamp guard passed), but the interceding diff did not
+            # touch any file mentioned in the review's inline comments.
+            # Treat as still-unaddressed to prevent unrelated changes
+            # (e.g. a CI schema fix) from clearing review findings.
+            [
+              { type: "review_bot_review_pending", details: "Latest review bot review was not clean" },
+              { type: "review_bot_comments", details: "Latest review bot review generated comments (body-only)" }
+            ]
           else
             # Thread-based bot with all bot threads resolved, or body-only
-            # review already addressed by a subsequent agent run. Treat as
-            # effectively clean to avoid re-requesting reviews that would
-            # produce no new comments.
+            # review already addressed by a subsequent agent run whose diff
+            # touches at least one reviewed file. Treat as effectively clean
+            # to avoid re-requesting reviews that would produce no new
+            # comments.
             []
           end
         end
@@ -629,6 +641,39 @@ module Activities
       return true if cutoff.nil?
 
       submitted_at > cutoff
+    end
+
+    # Returns true when the diff between the review's commit and the PR
+    # HEAD touches at least one file mentioned in the review's inline
+    # comments. Falls back to true (assumes addressed) when inline
+    # comments have no file paths or the comparison cannot be fetched.
+    def review_diff_touches_reviewed_files?(client, project, issue, review)
+      return true if client.nil? || project.nil? || issue.nil?
+
+      review_id = review[:id]
+      reviewed_commit = review[:commit_id]
+      return true if review_id.nil? || reviewed_commit.nil?
+
+      comments = client.pull_request_review_comments(
+        project.full_name, issue.github_number
+      )
+      reviewed_paths = comments
+        .select { |c| c[:pull_request_review_id] == review_id }
+        .filter_map { |c| c[:path] }
+        .to_set
+      return true if reviewed_paths.empty?
+
+      pr_data = client.pull_request(project.full_name, issue.github_number)
+      head_sha = pr_data&.head&.sha
+      return true if head_sha.nil? || head_sha == reviewed_commit
+
+      changed_files = client.compare_changed_files(
+        project.full_name, reviewed_commit, head_sha
+      )
+      changed_files.any? { |f| reviewed_paths.include?(f) }
+    rescue GithubClient::Error => e
+      log_signal_error("review_diff_check", project, issue, e)
+      true
     end
 
     def review_bot_thread_triggers(unresolved_threads)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1095,6 +1095,43 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when codex review pre-dates last run and compare API raises GithubClient::Error" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
+              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+              pull_request_review_id: 1 }
+          ])
+        allow(github_client).to receive(:compare_changed_files)
+          .with(project.full_name, "rev_sha", "abc123")
+          .and_raise(GithubClient::Error, "Not Found")
+      end
+
+      it "falls back to treating the review as addressed" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
     context "when PR is in draft phase with Claude review threads" do
       before do
         create(:issue, :pull_request,

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -989,6 +989,112 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when codex review pre-dates last run but diff does not touch reviewed files" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
+              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+              pull_request_review_id: 1 }
+          ])
+        allow(github_client).to receive(:compare_changed_files)
+          .with(project.full_name, "rev_sha", "abc123")
+          .and_return([ "db/schema.rb" ])
+      end
+
+      it "treats the review as unaddressed because the changed files are unrelated" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("review_bot_comments", "review_bot_review_pending")
+      end
+    end
+
+    context "when codex review pre-dates last run and diff touches a reviewed file" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
+              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+              pull_request_review_id: 1 }
+          ])
+        allow(github_client).to receive(:compare_changed_files)
+          .with(project.full_name, "rev_sha", "abc123")
+          .and_return([ "app/services/fetch_issues_activity.rb", "db/schema.rb" ])
+      end
+
+      it "treats the review as addressed because the diff touches the reviewed file" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
+    context "when codex review pre-dates last run and has no inline comments" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([])
+      end
+
+      it "falls back to treating the review as addressed" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
     context "when PR is in draft phase with Claude review threads" do
       before do
         create(:issue, :pull_request,


### PR DESCRIPTION
## Summary

Prevents auto-merge from clearing review feedback when the agent's latest changes don't touch any files mentioned in the review. This closes a gap where unrelated commits (e.g., a CI schema fix) could satisfy the timestamp-based anti-loop guard and inadvertently dismiss review findings on untouched files.

## Changes

**GitHub API surface** (`app/services/github_client.rb`):
- Exposed `commit_id` on `pull_request_reviews` and `path`/`pull_request_review_id` on `pull_request_review_comments` return hashes
- Added `compare_changed_files` method to retrieve the file list between two commits

**Review clearance logic** (`app/temporal/activities/scan_paid_prs_activity.rb`):
- Added `review_diff_touches_reviewed_files?` heuristic that cross-references inline comment paths against the diff between the reviewed commit and PR HEAD
- Gated the body-only review clearance path: even when the timestamp guard passes, feedback is only cleared if at least one reviewed file appears in the subsequent diff
- Falls back to existing timestamp-only behavior when `commit_id` is nil, no inline comments exist, or the compare API call fails

**Tests** (`spec/temporal/activities/scan_paid_prs_activity_spec.rb`):
- Three new cases covering unrelated diff (feedback retained), related diff (feedback cleared), and no inline comments (fallback to clear)

## Design Decisions

- **Graceful fallback to timestamp behavior**: when the review has no inline comments or the commit comparison fails, the existing timestamp-based logic applies unchanged. This keeps the change additive — it can only make clearance stricter, never block it where it previously succeeded.
- **File-path granularity, not line-level**: the heuristic checks whether any file from the review's inline comments appears in the diff, rather than verifying line-level overlap. This is intentionally coarse — it catches the "completely unrelated commit" case (like `db/schema.rb` vs `fetch_issues_activity.rb`) without introducing brittle line-range intersection logic.

---

Closes #935