### PR TITLE
Fix #942: chore(auto-pick): add 'planning' label to EXCLUDED_LABELS for documentation issues

### DIFF
--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -23,7 +23,7 @@ module Issues
   class AutoPick
     NoRunnableProviderError = Class.new(StandardError)
 
-    # Each label here must also be created as a GitHub label in the repo to take effect.
+    # Each label here must also exist as a GitHub label in the repo so it can be applied to issues.
     EXCLUDED_LABELS = %w[planning research waiting tracking epic needs-manual-setup].freeze
     PAID_READY_LABEL = "paid-ready"
 

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -13,7 +13,7 @@ module Issues
   # - Open, non-PR issues with all dependencies satisfied
   # - No existing unfinished (queued/pending/running/paused) agent run
   # - Not labeled with excluded labels (planning, research, waiting,
-  #   tracking, epic)
+  #   tracking, epic, needs-manual-setup)
   # - Not a parent/tracking issue (has sub-issues)
   # - Ordered by priority: issues in partially-complete dependency trees
   #   first, then by unblock count (how many open issues depend on this
@@ -23,7 +23,7 @@ module Issues
   class AutoPick
     NoRunnableProviderError = Class.new(StandardError)
 
-    EXCLUDED_LABELS = %w[planning research waiting tracking epic].freeze
+    EXCLUDED_LABELS = %w[planning research waiting tracking epic needs-manual-setup].freeze
     PAID_READY_LABEL = "paid-ready"
 
     # SQL ILIKE patterns used to pre-filter potential tracker issues before

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -23,6 +23,7 @@ module Issues
   class AutoPick
     NoRunnableProviderError = Class.new(StandardError)
 
+    # Each label here must also be created as a GitHub label in the repo to take effect.
     EXCLUDED_LABELS = %w[planning research waiting tracking epic needs-manual-setup].freeze
     PAID_READY_LABEL = "paid-ready"
 

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -172,6 +172,14 @@ RSpec.describe Issues::AutoPick do
       expect(result).to be_nil
     end
 
+    it "skips issues labeled needs-manual-setup" do
+      create(:issue, project: project, labels: [ "needs-manual-setup" ])
+
+      result = described_class.new(project).call
+
+      expect(result).to be_nil
+    end
+
     context "with tracker/meta issues" do
       it "skips a tracker issue when its body references open issues" do
         tracker = create(:issue, project: project, github_number: 100,


### PR DESCRIPTION
## Summary

Prevent issues requiring manual human intervention (e.g., bot account setup, GitHub App creation) from being auto-picked by agents, by adding a `needs-manual-setup` label to the exclusion list.

## Changes

- **Services**: Added `needs-manual-setup` to `Issues::AutoPick::EXCLUDED_LABELS` in `app/services/issues/auto_pick.rb`, ensuring issues with this label are skipped during auto-pick eligibility checks
- **Process**: Introduces a semantically clear label for issues that require manual GitHub admin work (creating apps, generating tokens, etc.) and should never be assigned to an agent

## Design Decisions

- **New label rather than reusing existing ones** — While `planning` already exists, it doesn't clearly communicate "this issue requires manual human steps." The `needs-manual-setup` label is self-documenting and specific to the use case of issues that cannot be completed by an agent.
- **Additive change** — The existing `EXCLUDED_LABELS` list is preserved; `needs-manual-setup` is appended alongside the current labels (`planning`, `research`, `waiting`, `tracking`, `epic`).

---

Closes #942