### PR TITLE
fix(workflow): make CreatePullRequestActivity idempotent (#964)

### DIFF
--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -12,7 +12,8 @@ module Activities
         issue = agent_run.issue
 
         client = project.github_token.client
-        pr = client.create_pull_request(
+        pr = find_existing_pull_request(client, project, agent_run.branch_name, agent_run_id: agent_run_id)
+        pr ||= client.create_pull_request(
           project.full_name,
           base: project.default_branch,
           head: agent_run.branch_name,
@@ -42,6 +43,33 @@ module Activities
     end
 
     private
+
+    # Look up an open PR already opened for this branch. Makes the activity
+    # idempotent: if a previous attempt created the PR but crashed before
+    # `agent_run.complete!` persisted, the retry reuses the existing PR
+    # instead of 422-ing on "A pull request already exists".
+    def find_existing_pull_request(client, project, branch_name, agent_run_id:)
+      owner = project.full_name.split("/").first
+      existing = client.pull_requests(project.full_name, state: "open", head: "#{owner}:#{branch_name}")
+      pr = Array(existing).first
+      return nil unless pr
+
+      logger.info(
+        message: "agent_execution.pull_request_reused",
+        agent_run_id: agent_run_id,
+        pull_request_url: pr.html_url,
+        pull_request_number: pr.number
+      )
+      pr
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "agent_execution.pull_request_lookup_failed",
+        agent_run_id: agent_run_id,
+        branch: branch_name,
+        error: e.message
+      )
+      nil
+    end
 
     def pr_title(issue)
       return "Agent changes" unless issue

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Activities::CreatePullRequestActivity do
 
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
-    allow(github_client).to receive(:create_pull_request).and_return(pr_response)
+    allow(github_client).to receive_messages(create_pull_request: pr_response, pull_requests: [])
     allow(github_client).to receive(:add_labels_to_issue)
     # Stub external agent harness so Llm::GeneratePrDescription runs without real external calls.
     # By default, return a failed response so the activity falls back to raw summary.
@@ -103,6 +103,42 @@ RSpec.describe Activities::CreatePullRequestActivity do
 
       result = activity.execute(agent_run_id: agent_run_no_issue.id)
       expect(result[:pull_request_url]).to eq("https://github.com/owner/repo/pull/42")
+    end
+
+    context "when an open PR already exists for the branch (retry after partial failure)" do
+      let(:existing_pr) { Struct.new(:html_url, :number).new("https://github.com/owner/repo/pull/77", 77) }
+
+      before do
+        allow(github_client).to receive(:pull_requests).with(
+          project.full_name,
+          state: "open",
+          head: "#{project.full_name.split('/').first}:#{agent_run.branch_name}"
+        ).and_return([ existing_pr ])
+      end
+
+      it "reuses the existing PR instead of creating a new one" do
+        expect(github_client).not_to receive(:create_pull_request)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:pull_request_number]).to eq(77)
+        expect(result[:pull_request_url]).to eq("https://github.com/owner/repo/pull/77")
+      end
+
+      it "marks the agent run as completed against the reused PR" do
+        activity.execute(agent_run_id: agent_run.id)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("completed")
+        expect(agent_run.pull_request_number).to eq(77)
+      end
+    end
+
+    it "falls through to create_pull_request when the lookup itself errors" do
+      allow(github_client).to receive(:pull_requests).and_raise(GithubClient::ApiError.new("boom"))
+      expect(github_client).to receive(:create_pull_request).and_return(pr_response)
+
+      expect { activity.execute(agent_run_id: agent_run.id) }.not_to raise_error
     end
 
     it "does not fail when label addition fails" do


### PR DESCRIPTION
## Summary
- Look up an existing open PR for the head branch before calling `create_pull_request`, so retries after a partial failure reuse the existing PR instead of hitting GitHub's "A pull request already exists" 422.
- Adds regression specs for the reuse path and for a lookup-failure fallthrough.

Fixes #964.

## Why
When `Activities::CreatePullRequestActivity` crashes between GitHub creating the PR and `agent_run.complete!` persisting (DB blip, worker restart, transient error in post-processing), Temporal retries the activity. The retry currently re-calls `create_pull_request`, GitHub returns 422, the workflow `rescue` marks the run **failed**, and the branch is left orphaned on the remote with no link back to the AgentRun. See #964 for the full root-cause writeup.

## Test plan
- [x] `bin/rspec spec/temporal/activities/create_pull_request_activity_spec.rb` (22 examples, 0 failures)
- [ ] CI green