### PR TITLE
Fix #959: Duration columns should not display max duration/timeout values

### DIFF
--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -74,14 +74,6 @@
              end %>
           <% if elapsed %>
             <%= elapsed %>s
-            <% max_exec = agent_run.project.max_execution_seconds %>
-            <% if max_exec %>
-              <span class="text-sm font-normal text-gray-500">/ <%= max_exec %>s</span>
-              <% pct = (elapsed * 100.0 / max_exec).clamp(0, 100) %>
-              <div class="mt-2 h-1.5 w-full rounded-full bg-gray-200">
-                <div class="h-1.5 rounded-full <%= pct >= 90 ? 'bg-red-500' : pct >= 75 ? 'bg-yellow-500' : 'bg-indigo-600' %>" style="width: <%= pct.round %>%"></div>
-              </div>
-            <% end %>
           <% else %>
             -
           <% end %>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -37,10 +37,6 @@
        end %>
     <% if elapsed %>
       <%= elapsed %>s
-      <% max_exec = agent_run.project.max_execution_seconds %>
-      <% if max_exec %>
-        <span class="text-gray-400">/ <%= max_exec %>s</span>
-      <% end %>
     <% else %>
       <span class="text-gray-400">-</span>
     <% end %>


### PR DESCRIPTION
## Summary

Clean up duration columns by removing max duration/timeout values that add unnecessary clutter, so users see only the actual elapsed time.

## Changes

- **Views (`_detail.html.erb`)** — Removed the `/ <max_exec>s` suffix, percentage calculation, and color-coded progress bar from the Duration card on the agent run detail page
- **Views (`_agent_run.html.erb`)** — Removed the `/ <max_exec>s` suffix from the duration column in the project's agent run table row

Duration values now display as simple elapsed time (e.g., `45s`) without the max execution time reference.

## Screenshots

> **Author**: please attach before/after screenshots of the agent run detail page and project agent run table showing the simplified duration display.

Closes #<!-- issue number -->

---

Closes #959