### PR TITLE
Fix #964: fix(workflow): CreatePullRequestActivity is not idempotent — retries leave orphan branches

### DIFF
--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -12,7 +12,12 @@ module Activities
         issue = agent_run.issue
 
         client = project.github_token.client
-        pr = client.create_pull_request(
+
+        # Idempotency: reuse an existing PR for this branch if one was
+        # already created (e.g. by a prior attempt that failed after the
+        # GitHub API call but before the activity returned).
+        pr = find_existing_pr(client, project, agent_run.branch_name)
+        pr ||= client.create_pull_request(
           project.full_name,
           base: project.default_branch,
           head: agent_run.branch_name,
@@ -21,15 +26,19 @@ module Activities
           draft: true
         )
 
+        # Persist completion as the very first step after obtaining the PR,
+        # before any best-effort post-processing. This ensures a retry
+        # cannot overwrite status via MarkAgentRunFailedActivity.
         agent_run.complete!(
           result_commit: agent_run.result_commit_sha,
           pr_url: pr.html_url,
           pr_number: pr.number
         )
 
-        add_pr_labels(client, project, pr.number, agent_run_id, issue: issue)
-
-        agent_run.log!("system", "PR created: #{pr.html_url}")
+        # Best-effort post-processing — failures here must not cause the
+        # activity to be retried now that the run is already completed.
+        best_effort(agent_run_id) { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
+        best_effort(agent_run_id) { agent_run.log!("system", "PR created: #{pr.html_url}") }
 
         logger.info(
           message: "agent_execution.pull_request_created",
@@ -42,6 +51,26 @@ module Activities
     end
 
     private
+
+    def find_existing_pr(client, project, branch_name)
+      existing = client.pull_requests(
+        project.full_name,
+        head: "#{project.owner}:#{branch_name}",
+        state: "open"
+      )
+      existing.first
+    end
+
+    def best_effort(agent_run_id)
+      yield
+    rescue StandardError => e
+      logger.warn(
+        message: "agent_execution.post_processing_failed",
+        agent_run_id: agent_run_id,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
 
     def pr_title(issue)
       return "Agent changes" unless issue

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -16,8 +16,8 @@ module Activities
         # Idempotency: reuse an existing PR for this branch if one was
         # already created (e.g. by a prior attempt that failed after the
         # GitHub API call but before the activity returned).
-        pr = find_existing_pr(client, project, agent_run.branch_name, agent_run_id: agent_run_id)
-        pr ||= client.create_pull_request(
+        existing_pr = find_existing_pr(client, project, agent_run.branch_name, agent_run_id: agent_run_id)
+        pr = existing_pr || client.create_pull_request(
           project.full_name,
           base: project.default_branch,
           head: agent_run.branch_name,
@@ -25,6 +25,7 @@ module Activities
           body: pr_body(issue, agent_run),
           draft: true
         )
+        pr_action = existing_pr ? "reused" : "created"
 
         # Persist completion as the very first step after obtaining the PR,
         # before any best-effort post-processing. This ensures a retry
@@ -38,10 +39,10 @@ module Activities
         # Best-effort post-processing — failures here must not cause the
         # activity to be retried now that the run is already completed.
         best_effort(agent_run_id) { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
-        best_effort(agent_run_id) { agent_run.log!("system", "PR created: #{pr.html_url}") }
+        best_effort(agent_run_id) { agent_run.log!("system", "PR #{pr_action}: #{pr.html_url}") }
 
         logger.info(
-          message: "agent_execution.pull_request_created",
+          message: "agent_execution.pull_request_#{pr_action}",
           agent_run_id: agent_run_id,
           pull_request_url: pr.html_url
         )
@@ -59,10 +60,11 @@ module Activities
         state: "open"
       )
       existing.first
-    rescue GithubClient::Error => e
-      # Lookup is best-effort: a transient failure here must not become a
-      # new failure mode introduced by the idempotency fix. Fall through
-      # to create_pull_request and let GitHub be the source of truth.
+    rescue StandardError => e
+      # Lookup is best-effort: a transient failure (including network-level
+      # errors like Faraday::TimeoutError) must not become a new failure
+      # mode introduced by the idempotency fix. Fall through to
+      # create_pull_request and let GitHub be the source of truth.
       logger.warn(
         message: "agent_execution.pull_request_lookup_failed",
         agent_run_id: agent_run_id,
@@ -169,13 +171,6 @@ module Activities
       return if labels.empty?
 
       client.add_labels_to_issue(project.full_name, pr_number, labels)
-    rescue GithubClient::Error => e
-      logger.warn(
-        message: "agent_execution.add_pr_labels_failed",
-        agent_run_id: agent_run_id,
-        pr_number: pr_number,
-        error: e.message
-      )
     end
   end
 end

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -38,14 +38,16 @@ module Activities
 
         # Best-effort post-processing — failures here must not cause the
         # activity to be retried now that the run is already completed.
-        best_effort(agent_run_id) { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
-        best_effort(agent_run_id) { agent_run.log!("system", "PR #{pr_action}: #{pr.html_url}") }
+        best_effort(agent_run_id, context: "add_pr_labels") { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
+        best_effort(agent_run_id, context: "log_pr_action") { agent_run.log!("system", "PR #{pr_action}: #{pr.html_url}") }
 
-        logger.info(
-          message: "agent_execution.pull_request_#{pr_action}",
-          agent_run_id: agent_run_id,
-          pull_request_url: pr.html_url
-        )
+        best_effort(agent_run_id, context: "structured_log") do
+          logger.info(
+            message: "agent_execution.pull_request_#{pr_action}",
+            agent_run_id: agent_run_id,
+            pull_request_url: pr.html_url
+          )
+        end
 
         { agent_run_id: agent_run_id, pull_request_url: pr.html_url, pull_request_number: pr.number }
       end
@@ -74,12 +76,13 @@ module Activities
       nil
     end
 
-    def best_effort(agent_run_id)
+    def best_effort(agent_run_id, context: nil)
       yield
     rescue StandardError => e
       logger.warn(
         message: "agent_execution.post_processing_failed",
         agent_run_id: agent_run_id,
+        context: context,
         error_class: e.class.name,
         error: e.message
       )

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -16,7 +16,7 @@ module Activities
         # Idempotency: reuse an existing PR for this branch if one was
         # already created (e.g. by a prior attempt that failed after the
         # GitHub API call but before the activity returned).
-        pr = find_existing_pr(client, project, agent_run.branch_name)
+        pr = find_existing_pr(client, project, agent_run.branch_name, agent_run_id: agent_run_id)
         pr ||= client.create_pull_request(
           project.full_name,
           base: project.default_branch,
@@ -52,13 +52,24 @@ module Activities
 
     private
 
-    def find_existing_pr(client, project, branch_name)
+    def find_existing_pr(client, project, branch_name, agent_run_id:)
       existing = client.pull_requests(
         project.full_name,
         head: "#{project.owner}:#{branch_name}",
         state: "open"
       )
       existing.first
+    rescue GithubClient::Error => e
+      # Lookup is best-effort: a transient failure here must not become a
+      # new failure mode introduced by the idempotency fix. Fall through
+      # to create_pull_request and let GitHub be the source of truth.
+      logger.warn(
+        message: "agent_execution.pull_request_lookup_failed",
+        agent_run_id: agent_run_id,
+        branch: branch_name,
+        error: e.message
+      )
+      nil
     end
 
     def best_effort(agent_run_id)

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -324,6 +324,14 @@ RSpec.describe Activities::CreatePullRequestActivity do
         expect(result[:pull_request_number]).to eq(99)
       end
 
+      it "falls through to create_pull_request when the lookup itself errors" do
+        allow(github_client).to receive(:pull_requests).and_raise(GithubClient::ApiError.new("boom"))
+
+        expect { activity.execute(agent_run_id: agent_run.id) }.not_to raise_error
+        expect(github_client).to have_received(:create_pull_request)
+        expect(agent_run.reload.status).to eq("completed")
+      end
+
       it "does not produce orphan branches when log! raises after completion" do
         allow(github_client).to receive(:pull_requests).and_return([])
         # agent_run.log! is called in best_effort, so even if it raises,

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Activities::CreatePullRequestActivity do
 
       log = agent_run.agent_run_logs.last
       expect(log.log_type).to eq("system")
+      expect(log.content).to include("PR created:")
       expect(log.content).to include("https://github.com/owner/repo/pull/42")
     end
 
@@ -312,20 +313,42 @@ RSpec.describe Activities::CreatePullRequestActivity do
         expect(result[:pull_request_url]).to eq("https://github.com/owner/repo/pull/42")
       end
 
-      it "reuses existing PR on retry after partial failure" do
-        # Simulate: first attempt created the PR but failed after complete!
-        # On retry, the PR already exists on GitHub.
+      it "reuses existing PR on retry after partial failure with already-completed run" do
+        # Simulate: first attempt created the PR and called complete!, but
+        # the activity raised during post-processing. On retry, both the PR
+        # and the completed status already exist.
+        agent_run.complete!(
+          result_commit: agent_run.result_commit_sha,
+          pr_url: existing_pr.html_url,
+          pr_number: existing_pr.number
+        )
         allow(github_client).to receive(:pull_requests).and_return([ existing_pr ])
 
         result = activity.execute(agent_run_id: agent_run.id)
 
         expect(github_client).not_to have_received(:create_pull_request)
-        expect(agent_run.reload.status).to eq("completed")
         expect(result[:pull_request_number]).to eq(99)
       end
 
-      it "falls through to create_pull_request when the lookup itself errors" do
+      it "logs 'reused' when an existing PR is found" do
+        allow(github_client).to receive(:pull_requests).and_return([ existing_pr ])
+
+        activity.execute(agent_run_id: agent_run.id)
+
+        log = agent_run.reload.agent_run_logs.last
+        expect(log.content).to include("PR reused:")
+      end
+
+      it "falls through to create_pull_request when the lookup raises GithubClient::ApiError" do
         allow(github_client).to receive(:pull_requests).and_raise(GithubClient::ApiError.new("boom"))
+
+        expect { activity.execute(agent_run_id: agent_run.id) }.not_to raise_error
+        expect(github_client).to have_received(:create_pull_request)
+        expect(agent_run.reload.status).to eq("completed")
+      end
+
+      it "falls through to create_pull_request when the lookup raises GithubClient::RateLimitError" do
+        allow(github_client).to receive(:pull_requests).and_raise(GithubClient::RateLimitError.new)
 
         expect { activity.execute(agent_run_id: agent_run.id) }.not_to raise_error
         expect(github_client).to have_received(:create_pull_request)

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Activities::CreatePullRequestActivity do
 
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
-    allow(github_client).to receive(:create_pull_request).and_return(pr_response)
+    allow(github_client).to receive_messages(pull_requests: [], create_pull_request: pr_response)
     allow(github_client).to receive(:add_labels_to_issue)
     # Stub external agent harness so Llm::GeneratePrDescription runs without real external calls.
     # By default, return a failed response so the activity falls back to raw summary.
@@ -35,6 +35,16 @@ RSpec.describe Activities::CreatePullRequestActivity do
 
       expect(result[:pull_request_url]).to eq("https://github.com/owner/repo/pull/42")
       expect(result[:pull_request_number]).to eq(42)
+    end
+
+    it "checks for an existing PR before creating a new one" do
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(github_client).to have_received(:pull_requests).with(
+        project.full_name,
+        head: "#{project.owner}:#{agent_run.branch_name}",
+        state: "open"
+      )
     end
 
     it "marks the agent run as completed with PR details" do
@@ -275,6 +285,57 @@ RSpec.describe Activities::CreatePullRequestActivity do
       expect {
         activity.execute(agent_run_id: -1)
       }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "with idempotent retries" do
+      let(:existing_pr) { Struct.new(:html_url, :number).new("https://github.com/owner/repo/pull/99", 99) }
+
+      it "reuses an existing open PR instead of creating a new one" do
+        allow(github_client).to receive(:pull_requests).and_return([ existing_pr ])
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(github_client).not_to have_received(:create_pull_request)
+        expect(result[:pull_request_url]).to eq("https://github.com/owner/repo/pull/99")
+        expect(result[:pull_request_number]).to eq(99)
+        expect(agent_run.reload.status).to eq("completed")
+        expect(agent_run.pull_request_url).to eq("https://github.com/owner/repo/pull/99")
+      end
+
+      it "still marks the run completed when post-processing raises" do
+        allow(github_client).to receive(:add_labels_to_issue)
+          .and_raise(StandardError.new("transient failure"))
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(agent_run.reload.status).to eq("completed")
+        expect(result[:pull_request_url]).to eq("https://github.com/owner/repo/pull/42")
+      end
+
+      it "reuses existing PR on retry after partial failure" do
+        # Simulate: first attempt created the PR but failed after complete!
+        # On retry, the PR already exists on GitHub.
+        allow(github_client).to receive(:pull_requests).and_return([ existing_pr ])
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(github_client).not_to have_received(:create_pull_request)
+        expect(agent_run.reload.status).to eq("completed")
+        expect(result[:pull_request_number]).to eq(99)
+      end
+
+      it "does not produce orphan branches when log! raises after completion" do
+        allow(github_client).to receive(:pull_requests).and_return([])
+        # agent_run.log! is called in best_effort, so even if it raises,
+        # the run should be completed
+        allow(agent_run).to receive(:log!).and_raise(StandardError.new("DB hiccup"))
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(agent_run.reload.status).to eq("completed")
+        expect(agent_run.pull_request_url).to eq("https://github.com/owner/repo/pull/42")
+        expect(result[:pull_request_url]).to eq("https://github.com/owner/repo/pull/42")
+      end
     end
   end
 end


### PR DESCRIPTION
Based on the current code and the issue/agent output, I can write the PR description. The changes are clear from the issue and agent output.

## Summary

Make `CreatePullRequestActivity` idempotent so that Temporal retries after partial failures reuse an existing GitHub PR instead of hitting a 422 error, which previously left orphan branches and incorrectly failed agent runs.

## Changes

**Activity idempotency (`app/temporal/activities/create_pull_request_activity.rb`):**
- Add `find_existing_pr` method that checks for an open PR matching the branch via `client.pull_requests(repo, head: "owner:branch", state: 'open')` before attempting to create one
- On retry, if a PR already exists for the branch, reuse it instead of calling `create_pull_request` again — eliminates the GitHub 422 ("A pull request already exists") failure path
- Persist `agent_run.complete!` with PR URL/number immediately after PR creation/lookup, before any post-processing

**Best-effort post-processing:**
- Wrap `add_pr_labels` and `agent_run.log!` in a `best_effort` helper that rescues `StandardError` and logs a warning
- Failures in labeling or logging no longer cause the activity to raise after `complete!` has run, preventing Temporal from retrying into a non-idempotent state

**Tests (`spec/temporal/activities/create_pull_request_activity_spec.rb`):**
- PR creation checks for existing PR before creating a new one
- Existing open PR is reused without calling `create_pull_request`
- Agent run is marked completed even when post-processing raises
- Retry after partial failure (PR created but activity didn't return) reuses the existing PR
- No orphan branches produced when `log!` raises after completion

## Design Decisions

- **Check-then-create over rescue-and-retry**: Rather than catching the 422 and then looking up the PR, we proactively check for an existing PR first. This avoids relying on GitHub error response parsing and makes the idempotency explicit in the happy path.
- **Best-effort wrapper instead of separate activities**: Post-processing steps (labels, logging) are wrapped in-place rather than extracted into separate Temporal activities. This keeps the workflow definition simple while still isolating failures — a separate activity would add retry/timeout configuration overhead for operations that are purely cosmetic.
- **`complete!` as the commit point**: Once `complete!` succeeds, the activity treats everything after as best-effort. This ensures the agent run state is consistent even if the activity is never retried (e.g., workflow cancellation).

---

Closes #964