### PR TITLE
Fix #971: feat(workflow): reap remote branches abandoned by retried/timeout/failed AgentRuns

### DIFF
--- a/app/jobs/orphan_branch_reaper_job.rb
+++ b/app/jobs/orphan_branch_reaper_job.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# Deletes remote branches left behind by AgentRuns that pushed a branch but
+# never created a pull request — typically due to timeout, retry, or failure.
+#
+# Scheduled via GoodJob cron every hour. A 1-hour grace period prevents races
+# with active workflows or the idempotent CreatePullRequestActivity recovery.
+class OrphanBranchReaperJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :maintenance
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: "orphan_branch_reaper"
+  )
+
+  REAPABLE_STATUSES = %w[retried timeout failed].freeze
+  GRACE_PERIOD = 1.hour
+
+  def perform
+    deleted = 0
+    skipped = 0
+    missing = 0
+    errored = 0
+
+    candidate_runs.find_each do |agent_run|
+      result = reap_branch(agent_run)
+
+      case result
+      when :deleted then deleted += 1
+      when :skipped then skipped += 1
+      when :missing then missing += 1
+      when :error   then errored += 1
+      end
+    end
+
+    Rails.logger.info(
+      message: "branch_reaper.completed",
+      deleted: deleted,
+      skipped: skipped,
+      missing: missing,
+      errored: errored
+    )
+  end
+
+  private
+
+  def candidate_runs
+    AgentRun
+      .where(status: REAPABLE_STATUSES)
+      .where(pull_request_url: nil)
+      .where.not(branch_name: [ nil, "" ])
+      .where("agent_runs.updated_at < ?", GRACE_PERIOD.ago)
+      .preload(project: :github_token)
+  end
+
+  def reap_branch(agent_run)
+    client = agent_run.project.github_token&.client
+    unless client
+      Rails.logger.warn(
+        message: "branch_reaper.no_github_token",
+        agent_run_id: agent_run.id,
+        project_id: agent_run.project_id
+      )
+      return :error
+    end
+
+    repo = agent_run.project.full_name
+    branch = agent_run.branch_name
+
+    unless remote_branch_exists?(client, repo, branch)
+      return :missing
+    end
+
+    if open_pr_references_branch?(client, repo, agent_run.project.owner, branch)
+      Rails.logger.info(
+        message: "branch_reaper.skipped_open_pr",
+        agent_run_id: agent_run.id,
+        repo: repo,
+        branch: branch
+      )
+      return :skipped
+    end
+
+    client.delete_ref(repo, "heads/#{branch}")
+
+    Rails.logger.info(
+      message: "branch_reaper.deleted",
+      agent_run_id: agent_run.id,
+      repo: repo,
+      branch: branch
+    )
+
+    :deleted
+  rescue GithubClient::Error => e
+    Rails.logger.error(
+      message: "branch_reaper.error",
+      agent_run_id: agent_run.id,
+      error_class: e.class.name,
+      error: e.message
+    )
+    :error
+  end
+
+  def remote_branch_exists?(client, repo, branch)
+    client.ref(repo, "heads/#{branch}")
+    true
+  rescue GithubClient::NotFoundError
+    false
+  end
+
+  def open_pr_references_branch?(client, repo, owner, branch)
+    prs = client.pull_requests(repo, state: "open", head: "#{owner}:#{branch}")
+    prs.any?
+  end
+end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -133,6 +133,11 @@ Rails.application.configure do
       cron: "0 * * * *",
       class: "DelayedHumanFeedbackCollectionJob",
       description: "Collect delayed human feedback (reactions, reviews) for recent agent runs"
+    },
+    orphan_branch_reaper: {
+      cron: "0 * * * *",
+      class: "OrphanBranchReaperJob",
+      description: "Delete remote branches abandoned by retried/timeout/failed agent runs"
     }
   }
 end

--- a/spec/jobs/orphan_branch_reaper_job_spec.rb
+++ b/spec/jobs/orphan_branch_reaper_job_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrphanBranchReaperJob do
+  describe "#perform" do
+    let(:project) { create(:project, owner: "viamin", repo: "paid") }
+    let(:github_client) { instance_double(GithubClient) }
+
+    before do
+      allow(GithubClient).to receive(:new).and_return(github_client)
+    end
+
+    def create_orphan_run(status:, branch_name: "paid/123-feature-abc123", updated_at: 2.hours.ago, **attrs)
+      create(:agent_run,
+        status: status,
+        project: project,
+        branch_name: branch_name,
+        pull_request_url: nil,
+        pull_request_number: nil,
+        updated_at: updated_at,
+        **attrs)
+    end
+
+    context "when branch exists on remote with no open PR" do
+      before do
+        allow(github_client).to receive(:ref)
+        allow(github_client).to receive(:pull_requests).and_return([])
+        allow(github_client).to receive(:delete_ref)
+      end
+
+      it "deletes the branch for a timed-out run" do
+        create_orphan_run(status: "timeout")
+
+        described_class.perform_now
+
+        expect(github_client).to have_received(:delete_ref)
+          .with("viamin/paid", "heads/paid/123-feature-abc123")
+      end
+
+      it "deletes the branch for a retried run" do
+        create_orphan_run(status: "retried")
+
+        described_class.perform_now
+
+        expect(github_client).to have_received(:delete_ref)
+          .with("viamin/paid", "heads/paid/123-feature-abc123")
+      end
+
+      it "deletes the branch for a failed run" do
+        create_orphan_run(status: "failed")
+
+        described_class.perform_now
+
+        expect(github_client).to have_received(:delete_ref)
+          .with("viamin/paid", "heads/paid/123-feature-abc123")
+      end
+    end
+
+    context "when branch is already gone from remote" do
+      before do
+        allow(github_client).to receive(:ref)
+          .and_raise(GithubClient::NotFoundError.new)
+        allow(github_client).to receive(:delete_ref)
+      end
+
+      it "does not attempt deletion" do
+        create_orphan_run(status: "timeout")
+
+        described_class.perform_now
+
+        expect(github_client).not_to have_received(:delete_ref)
+      end
+    end
+
+    context "when branch has an open PR" do
+      before do
+        allow(github_client).to receive(:ref)
+        allow(github_client).to receive(:pull_requests)
+          .and_return([ instance_double(Sawyer::Resource) ])
+        allow(github_client).to receive(:delete_ref)
+      end
+
+      it "skips deletion" do
+        create_orphan_run(status: "timeout")
+
+        described_class.perform_now
+
+        expect(github_client).to have_received(:pull_requests)
+          .with("viamin/paid", state: "open", head: "viamin:paid/123-feature-abc123")
+        expect(github_client).not_to have_received(:delete_ref)
+      end
+    end
+
+    context "when AgentRun status is completed" do
+      before do
+        allow(github_client).to receive(:ref)
+      end
+
+      it "is not selected as a candidate" do
+        create(:agent_run, :completed,
+          project: project,
+          branch_name: "paid/456-other-branch",
+          updated_at: 2.hours.ago)
+
+        described_class.perform_now
+
+        expect(github_client).not_to have_received(:ref)
+      end
+    end
+
+    context "when AgentRun is within the grace period" do
+      before do
+        allow(github_client).to receive(:ref)
+        allow(github_client).to receive(:pull_requests).and_return([])
+        allow(github_client).to receive(:delete_ref)
+      end
+
+      it "is excluded from candidates" do
+        create_orphan_run(status: "timeout", updated_at: 30.minutes.ago)
+
+        described_class.perform_now
+
+        expect(github_client).not_to have_received(:ref)
+      end
+    end
+
+    context "when a GitHub API error occurs" do
+      before do
+        allow(github_client).to receive(:ref)
+        allow(github_client).to receive(:pull_requests).and_return([])
+        allow(github_client).to receive(:delete_ref)
+          .and_raise(GithubClient::ApiError.new("Server Error", status: 500))
+      end
+
+      it "logs the error and continues" do
+        create_orphan_run(status: "failed")
+
+        expect { described_class.perform_now }.not_to raise_error
+      end
+    end
+
+    context "with multiple candidate runs" do
+      before do
+        allow(github_client).to receive(:ref)
+        allow(github_client).to receive(:pull_requests).and_return([])
+        allow(github_client).to receive(:delete_ref)
+      end
+
+      it "processes each independently" do
+        create_orphan_run(status: "timeout", branch_name: "paid/1-branch-a")
+        create_orphan_run(status: "retried", branch_name: "paid/2-branch-b")
+        create_orphan_run(status: "failed", branch_name: "paid/3-branch-c")
+
+        described_class.perform_now
+
+        expect(github_client).to have_received(:delete_ref).exactly(3).times
+      end
+    end
+
+    context "when AgentRun already has a pull_request_url" do
+      before do
+        allow(github_client).to receive(:ref)
+      end
+
+      it "is not selected as a candidate" do
+        create(:agent_run, :completed,
+          project: project,
+          branch_name: "paid/789-feature",
+          pull_request_url: "https://github.com/viamin/paid/pull/42",
+          pull_request_number: 42,
+          updated_at: 2.hours.ago)
+
+        described_class.perform_now
+
+        expect(github_client).not_to have_received(:ref)
+      end
+    end
+
+    context "when AgentRun has no branch_name" do
+      before do
+        allow(github_client).to receive(:ref)
+      end
+
+      it "is not selected as a candidate" do
+        create_orphan_run(status: "failed", branch_name: nil)
+
+        described_class.perform_now
+
+        expect(github_client).not_to have_received(:ref)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

feat(workflow): reap remote branches abandoned by retried/timeout/failed AgentRuns

See #971 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #971