### PR TITLE
Fix #971: feat(workflow): reap remote branches abandoned by retried/timeout/failed AgentRuns

### DIFF
--- a/app/jobs/orphan_branch_reaper_job.rb
+++ b/app/jobs/orphan_branch_reaper_job.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Deletes remote branches left behind by AgentRuns that pushed a branch but
+# never created a pull request — typically because the run was retried,
+# timed out, or failed after push but before PR creation.
+#
+# The job is idempotent: re-running is a no-op once branches are gone.
+# A one-hour grace period prevents racing with active workflows or with
+# the idempotent CreatePullRequestActivity recovery on still-retrying runs.
+#
+# Scheduled via GoodJob cron every hour.
+class OrphanBranchReaperJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :maintenance
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: "orphan_branch_reaper"
+  )
+
+  # How long after an AgentRun's last update before we consider its branch
+  # eligible for reaping. Prevents racing with active workflows and with
+  # the idempotent CreatePullRequestActivity retry path (#965).
+  GRACE_PERIOD = 1.hour
+
+  # Only inspect runs from the last 30 days to keep the query bounded.
+  CANDIDATE_WINDOW = 30.days
+
+  REAPABLE_STATUSES = %w[retried timeout failed].freeze
+
+  def perform
+    job_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    deleted = 0
+    skipped = 0
+    missing = 0
+    errored = 0
+
+    candidate_runs.find_each do |agent_run|
+      result = reap_branch(agent_run)
+
+      case result
+      when :deleted  then deleted += 1
+      when :skipped  then skipped += 1
+      when :missing  then missing += 1
+      when :errored  then errored += 1
+      end
+    rescue => e
+      errored += 1
+      Rails.logger.error(
+        message: "branch_reaper.unexpected_error",
+        agent_run_id: agent_run.id,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+
+    duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - job_started_at) * 1000).round
+    Rails.logger.info(
+      message: "branch_reaper.completed",
+      deleted: deleted,
+      skipped: skipped,
+      missing: missing,
+      errored: errored,
+      duration_ms: duration_ms
+    )
+  end
+
+  private
+
+  # AgentRuns that pushed a branch but never opened a PR, in a terminal
+  # failure state, and past the grace period.
+  def candidate_runs
+    AgentRun
+      .where(status: REAPABLE_STATUSES)
+      .where.not(branch_name: [ nil, "" ])
+      .where(pull_request_url: [ nil, "" ])
+      .where("agent_runs.updated_at < ?", GRACE_PERIOD.ago)
+      .where("agent_runs.created_at >= ?", CANDIDATE_WINDOW.ago)
+      .preload(project: :github_token)
+  end
+
+  def reap_branch(agent_run)
+    project = agent_run.project
+    client = project.github_token.client
+    repo = project.full_name
+    branch_name = agent_run.branch_name
+
+    # Check whether the branch still exists on the remote.
+    unless remote_branch_exists?(client, repo, branch_name)
+      return :missing
+    end
+
+    # Never delete a branch that has any open PR referencing it.
+    if open_pr_exists?(client, repo, project.owner, branch_name)
+      Rails.logger.info(
+        message: "branch_reaper.skipped_open_pr",
+        agent_run_id: agent_run.id,
+        project_id: project.id,
+        branch_name: branch_name
+      )
+      return :skipped
+    end
+
+    client.delete_ref(repo, "heads/#{branch_name}")
+
+    Rails.logger.info(
+      message: "branch_reaper.branch_deleted",
+      agent_run_id: agent_run.id,
+      project_id: project.id,
+      branch_name: branch_name
+    )
+
+    :deleted
+  rescue GithubClient::NotFoundError
+    # Branch was deleted between our check and the delete call — idempotent.
+    :missing
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "branch_reaper.delete_failed",
+      agent_run_id: agent_run.id,
+      project_id: project.id,
+      branch_name: branch_name,
+      error: e.message
+    )
+    :errored
+  end
+
+  def remote_branch_exists?(client, repo, branch_name)
+    client.ref(repo, "heads/#{branch_name}")
+    true
+  rescue GithubClient::NotFoundError
+    false
+  end
+
+  def open_pr_exists?(client, repo, owner, branch_name)
+    prs = client.pull_requests(repo, state: "open", head: "#{owner}:#{branch_name}")
+    prs.any?
+  end
+end

--- a/app/jobs/orphan_branch_reaper_job.rb
+++ b/app/jobs/orphan_branch_reaper_job.rb
@@ -83,7 +83,18 @@ class OrphanBranchReaperJob < ApplicationJob
 
   def reap_branch(agent_run)
     project = agent_run.project
-    client = project.github_token.client
+    token = project&.github_token
+
+    unless token
+      Rails.logger.warn(
+        message: "branch_reaper.missing_token",
+        agent_run_id: agent_run.id,
+        project_id: project&.id
+      )
+      return :errored
+    end
+
+    client = token.client
     repo = project.full_name
     branch_name = agent_run.branch_name
 
@@ -93,6 +104,10 @@ class OrphanBranchReaperJob < ApplicationJob
     end
 
     # Never delete a branch that has any open PR referencing it.
+    # Note: there is a small TOCTOU window between this check and delete_ref
+    # below — a PR could be opened after we check. The 1-hour grace period
+    # makes this very unlikely, and the worst case is deleting a branch whose
+    # PR will then show as "branch deleted" on GitHub.
     if open_pr_exists?(client, repo, project.owner, branch_name)
       Rails.logger.info(
         message: "branch_reaper.skipped_open_pr",

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -126,6 +126,11 @@ Rails.application.configure do
       class: "KnowledgeAuditRetentionJob",
       description: "Delete knowledge audit events older than 90 days"
     },
+    orphan_branch_reaper: {
+      cron: "0 * * * *",
+      class: "OrphanBranchReaperJob",
+      description: "Delete remote branches orphaned by retried/timeout/failed agent runs"
+    },
     delayed_human_feedback: {
       # Runs hourly, but the job itself skips runs polled within the last 12 hours
       # (SWEEP_INTERVAL). Hourly ticks prevent the scenario where a poll just

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ApplicationJob do
         AgentRunResourceJanitorJob
         DockerOrphanCleanupJob
         KnowledgeAuditRetentionJob
+        OrphanBranchReaperJob
         PollWorkflowHealthCheckJob
         RecoverMissingPullRequestLabelsJob
         ServiceContainerReconciliationJob

--- a/spec/jobs/orphan_branch_reaper_job_spec.rb
+++ b/spec/jobs/orphan_branch_reaper_job_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrphanBranchReaperJob do
+  let(:project) { create(:project) }
+  let(:github_client) { instance_double(GithubClient) }
+  let(:job) { described_class.new }
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(github_client)
+    allow(github_client).to receive(:ref)
+    allow(github_client).to receive(:pull_requests).and_return([])
+    allow(github_client).to receive(:delete_ref)
+  end
+
+  def stub_branch_exists(branch_name)
+    allow(github_client).to receive(:ref)
+      .with(project.full_name, "heads/#{branch_name}")
+      .and_return(instance_double(Sawyer::Resource))
+  end
+
+  def stub_branch_missing(branch_name)
+    allow(github_client).to receive(:ref)
+      .with(project.full_name, "heads/#{branch_name}")
+      .and_raise(GithubClient::NotFoundError)
+  end
+
+  def stub_no_open_prs(branch_name)
+    allow(github_client).to receive(:pull_requests)
+      .with(project.full_name, state: "open", head: "#{project.owner}:#{branch_name}")
+      .and_return([])
+  end
+
+  def stub_open_pr_exists(branch_name)
+    allow(github_client).to receive(:pull_requests)
+      .with(project.full_name, state: "open", head: "#{project.owner}:#{branch_name}")
+      .and_return([ instance_double(Sawyer::Resource) ])
+  end
+
+  describe "#perform" do
+    it "deletes a remote branch for a timed-out run with no PR" do
+      create(:agent_run, :timeout,
+        project: project,
+        branch_name: "paid/262-feature-202f06",
+        pull_request_url: nil,
+        updated_at: 2.hours.ago)
+
+      stub_branch_exists("paid/262-feature-202f06")
+      stub_no_open_prs("paid/262-feature-202f06")
+      allow(github_client).to receive(:delete_ref)
+
+      job.perform
+
+      expect(github_client).to have_received(:delete_ref)
+        .with(project.full_name, "heads/paid/262-feature-202f06")
+    end
+
+    it "deletes a remote branch for a retried run with no PR" do
+      create(:agent_run, :retried,
+        project: project,
+        branch_name: "paid/487-feature-d76f14",
+        pull_request_url: nil,
+        updated_at: 2.hours.ago)
+
+      stub_branch_exists("paid/487-feature-d76f14")
+      stub_no_open_prs("paid/487-feature-d76f14")
+      allow(github_client).to receive(:delete_ref)
+
+      job.perform
+
+      expect(github_client).to have_received(:delete_ref)
+        .with(project.full_name, "heads/paid/487-feature-d76f14")
+    end
+
+    it "deletes a remote branch for a failed run with no PR" do
+      create(:agent_run, :failed,
+        project: project,
+        branch_name: "paid/100-feature-abc123",
+        pull_request_url: nil,
+        updated_at: 2.hours.ago)
+
+      stub_branch_exists("paid/100-feature-abc123")
+      stub_no_open_prs("paid/100-feature-abc123")
+      allow(github_client).to receive(:delete_ref)
+
+      job.perform
+
+      expect(github_client).to have_received(:delete_ref)
+        .with(project.full_name, "heads/paid/100-feature-abc123")
+    end
+
+    it "skips runs whose branch has an open PR" do
+      create(:agent_run, :timeout,
+        project: project,
+        branch_name: "paid/262-feature-202f06",
+        pull_request_url: nil,
+        updated_at: 2.hours.ago)
+
+      stub_branch_exists("paid/262-feature-202f06")
+      stub_open_pr_exists("paid/262-feature-202f06")
+
+      job.perform
+
+      expect(github_client).not_to have_received(:delete_ref)
+    end
+
+    it "skips runs whose branch is already missing on the remote" do
+      create(:agent_run, :retried,
+        project: project,
+        branch_name: "paid/488-feature-59e4fd",
+        pull_request_url: nil,
+        updated_at: 2.hours.ago)
+
+      stub_branch_missing("paid/488-feature-59e4fd")
+
+      job.perform
+
+      expect(github_client).not_to have_received(:pull_requests)
+    end
+
+    it "skips completed runs" do
+      create(:agent_run, :completed,
+        project: project,
+        branch_name: "paid/200-feature-fff000",
+        updated_at: 2.hours.ago)
+
+      job.perform
+
+      expect(github_client).not_to have_received(:ref)
+    end
+
+    it "skips runs still within the grace period" do
+      create(:agent_run, :timeout,
+        project: project,
+        branch_name: "paid/300-feature-aaa111",
+        pull_request_url: nil,
+        updated_at: 30.minutes.ago)
+
+      job.perform
+
+      expect(github_client).not_to have_received(:ref)
+    end
+
+    it "skips runs that have a pull_request_url" do
+      create(:agent_run, :failed,
+        project: project,
+        branch_name: "paid/400-feature-bbb222",
+        pull_request_url: "https://github.com/example/repo/pull/99",
+        updated_at: 2.hours.ago)
+
+      job.perform
+
+      expect(github_client).not_to have_received(:ref)
+    end
+
+    it "handles GitHub API errors gracefully and continues" do
+      create(:agent_run, :timeout, project: project,
+        branch_name: "paid/500-error-branch", pull_request_url: nil, updated_at: 2.hours.ago)
+      create(:agent_run, :failed, project: project,
+        branch_name: "paid/501-good-branch", pull_request_url: nil, updated_at: 2.hours.ago)
+
+      allow(github_client).to receive(:ref) do |_repo, ref|
+        raise GithubClient::ApiError.new("Server error", status: 500) if ref.include?("500-error")
+        instance_double(Sawyer::Resource)
+      end
+      stub_no_open_prs("paid/501-good-branch")
+      allow(github_client).to receive(:delete_ref)
+
+      job.perform
+
+      expect(github_client).to have_received(:delete_ref)
+        .with(project.full_name, "heads/paid/501-good-branch")
+    end
+
+    it "is idempotent when branches are already deleted" do
+      create(:agent_run, :timeout,
+        project: project,
+        branch_name: "paid/600-already-gone",
+        pull_request_url: nil,
+        updated_at: 2.hours.ago)
+
+      stub_branch_missing("paid/600-already-gone")
+
+      2.times { job.perform }
+
+      expect(github_client).not_to have_received(:delete_ref)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Prevent remote branches from accumulating when AgentRuns end in `retried`, `timeout`, or `failed` states after pushing a branch but before creating a pull request. A periodic reaper job detects these orphaned branches and deletes them from the remote, closing a cleanup gap that #965's idempotent retry fix does not cover.

Refs #964, #965.

## Changes

**Jobs**
- Added `OrphanBranchReaperJob` that selects AgentRuns matching the orphan predicate (`branch_name` present, `pull_request_url` nil, status in `retried`/`timeout`/`failed`, `updated_at` older than 1 hour)
- For each candidate, verifies the remote branch still exists and confirms no open PR references it before deleting the ref via the GitHub API
- Handles `NotFoundError` gracefully so re-runs are idempotent once branches are already gone
- Structured logging under component `branch_reaper` with AgentRun ID for auditability

**Infrastructure**
- Registered the reaper on an hourly cron schedule (`0 * * * *`) in `config/initializers/good_job.rb`

**Tests**
- 10 specs covering: branch missing on remote, branch present with open PR (skip), branch present with no PR (delete), `completed` status (skip), grace-period exclusion, error handling, and idempotency

## Design Decisions

- **Periodic job over state-transition hook** — the transition itself can crash partway through; a self-healing reaper that runs hourly is more resilient than inline cleanup that may never execute.
- **1-hour grace period** — avoids racing with active workflows or with #965's idempotent recovery on a still-retrying activity.
- **Skips branches with _any_ open PR** — not just Paid-created PRs. This ensures the reaper never deletes a branch a human is independently working on.

---

Closes #971