### PR TITLE
fix(knowledge): handle EOF in archive_in_stream chunker

### DIFF
--- a/app/services/knowledge/containerized_runner.rb
+++ b/app/services/knowledge/containerized_runner.rb
@@ -227,7 +227,7 @@ module Knowledge
     def stream_repo_tar_to_container!
       Open3.popen3("tar", "-cf", "-", "-C", @host_repo_dir, ".") do |_stdin, stdout, stderr, wait_thr|
         stdout.binmode
-        @container.archive_in_stream(options[:workspace_mount]) { stdout.read(8192) }
+        @container.archive_in_stream(options[:workspace_mount]) { stdout.read(8192).to_s }
         status = wait_thr.value
         unless status.success?
           error_output = stderr.read.to_s.strip


### PR DESCRIPTION
## Summary
- `stream_repo_tar_to_container!` passed `stdout.read(8192)` to `archive_in_stream`, which returns `nil` at EOF
- Excon's chunked writer then calls `.encoding` on the chunk, raising `Excon::Error::Socket (undefined method 'encoding' for nil)` and failing every `RunCollectorsJob`
- Coerce to `""` so Excon sees a clean end-of-stream

## Test plan
- [ ] Run a collector against a real project and confirm `RunCollectorsJob` completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)