### PR TITLE
fix(dev): add --detach mode and clean stale overmind tmp dirs

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -20,7 +20,34 @@ then
   gem install overmind
 fi
 
+# Parse our own flags before they're handed to overmind. --detach (or -d, or
+# DEV_DETACH=1) re-execs bin/dev under setsid+nohup so it survives the parent
+# terminal being hung up — important in devcontainers where the host laptop
+# sleeping or the editor reconnecting sends SIGHUP to the foreground process
+# group and kills overmind+tmux. See log/dev-update/diagnostics for the
+# previous crash pattern that motivated this.
+DEV_DETACH_FLAG="${DEV_DETACH:-0}"
+DEV_PASSTHRU_ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --detach|-d) DEV_DETACH_FLAG=1 ;;
+    *) DEV_PASSTHRU_ARGS+=("$arg") ;;
+  esac
+done
+set -- ${DEV_PASSTHRU_ARGS[@]+"${DEV_PASSTHRU_ARGS[@]}"}
+
 dev_supervisor_prepare_logging
+
+if [ "$DEV_DETACH_FLAG" = "1" ] && [ -z "${DEV_DETACHED:-}" ]; then
+  log_path="$(dev_supervisor_overmind_log)"
+  echo "Detaching bin/dev — output streams to ${log_path}"
+  DEV_DETACHED=1 setsid nohup "$0" ${1+"$@"} </dev/null >>"$log_path" 2>&1 &
+  detached_pid=$!
+  disown "$detached_pid" 2>/dev/null || true
+  echo "bin/dev detached (pid=${detached_pid}). Use 'overmind connect' to attach."
+  exit 0
+fi
+
 dev_supervisor_log_line "$(dev_supervisor_overmind_log)" \
   "bin/dev starting pid=$$ ppid=$PPID tty=$(dev_supervisor_tty) term=${TERM:-} cwd=$PWD"
 
@@ -88,6 +115,7 @@ if [ -S "$OVERMIND_SOCKET" ]; then
 fi
 
 dev_supervisor_cleanup_stale_tmux_sockets
+dev_supervisor_cleanup_stale_overmind_tmp_dirs
 
 # Let the debug gem allow remote connections,
 # but avoid loading until `debugger` is called

--- a/bin/dev
+++ b/bin/dev
@@ -42,9 +42,12 @@ if [ "$DEV_DETACH_FLAG" = "1" ] && [ -z "${DEV_DETACHED:-}" ]; then
   log_path="$(dev_supervisor_overmind_log)"
   echo "Detaching bin/dev — output streams to ${log_path}"
   DEV_DETACHED=1 setsid nohup "$0" ${1+"$@"} </dev/null >>"$log_path" 2>&1 &
+  # $! is the setsid wrapper PID, not overmind itself. Killing this PID still
+  # propagates to the session, so it's useful for teardown; it just won't match
+  # the overmind PID you'd see in `ps` or `overmind status`.
   detached_pid=$!
   disown "$detached_pid" 2>/dev/null || true
-  echo "bin/dev detached (pid=${detached_pid}). Use 'overmind connect' to attach."
+  echo "bin/dev detached (setsid pid=${detached_pid}). Use 'overmind connect' to attach."
   exit 0
 fi
 

--- a/bin/dev
+++ b/bin/dev
@@ -20,7 +20,7 @@ then
   gem install overmind
 fi
 
-# Parse our own flags before they're handed to overmind. --detach (or -d, or
+# Parse our own flags before they're handed to overmind. --detach (or -D, or
 # DEV_DETACH=1) re-execs bin/dev under setsid+nohup so it survives the parent
 # terminal being hung up — important in devcontainers where the host laptop
 # sleeping or the editor reconnecting sends SIGHUP to the foreground process
@@ -30,7 +30,7 @@ DEV_DETACH_FLAG="${DEV_DETACH:-0}"
 DEV_PASSTHRU_ARGS=()
 for arg in "$@"; do
   case "$arg" in
-    --detach|-d) DEV_DETACH_FLAG=1 ;;
+    --detach|-D) DEV_DETACH_FLAG=1 ;;
     *) DEV_PASSTHRU_ARGS+=("$arg") ;;
   esac
 done
@@ -41,7 +41,7 @@ dev_supervisor_prepare_logging
 if [ "$DEV_DETACH_FLAG" = "1" ] && [ -z "${DEV_DETACHED:-}" ]; then
   log_path="$(dev_supervisor_overmind_log)"
   echo "Detaching bin/dev — output streams to ${log_path}"
-  DEV_DETACHED=1 setsid nohup "$0" ${1+"$@"} </dev/null >>"$log_path" 2>&1 &
+  DEV_DETACHED=1 setsid nohup "${APP_ROOT}/bin/dev" ${1+"$@"} </dev/null >>"$log_path" 2>&1 &
   # $! is the setsid wrapper PID, not overmind itself. Killing this PID still
   # propagates to the session, so it's useful for teardown; it just won't match
   # the overmind PID you'd see in `ps` or `overmind status`.

--- a/bin/lib/dev_supervisor.sh
+++ b/bin/lib/dev_supervisor.sh
@@ -203,6 +203,36 @@ dev_supervisor_cleanup_stale_tmux_sockets() {
   fi
 }
 
+dev_supervisor_cleanup_stale_overmind_tmp_dirs() {
+  dev_supervisor_prepare_logging
+
+  local app
+  app="$(dev_supervisor_app_name)"
+  local socket_dir
+  socket_dir="$(dev_supervisor_tmux_socket_dir)"
+
+  local dir
+  local found=0
+  for dir in /tmp/overmind-"${app}"-*; do
+    [ -d "$dir" ] || continue
+    found=1
+
+    local suffix="${dir##*/overmind-"${app}"-}"
+    local socket="${socket_dir}/overmind-${app}-${suffix}"
+    if [ -S "$socket" ] && tmux -S "$socket" ls >/dev/null 2>&1; then
+      dev_supervisor_log_line "$(dev_supervisor_overmind_log)" "Keeping active overmind tmp dir $dir"
+      continue
+    fi
+
+    dev_supervisor_log_line "$(dev_supervisor_overmind_log)" "Removing stale overmind tmp dir $dir"
+    rm -rf "$dir"
+  done
+
+  if [ "$found" -eq 0 ]; then
+    dev_supervisor_log_line "$(dev_supervisor_overmind_log)" "No overmind tmp dirs found in /tmp"
+  fi
+}
+
 dev_supervisor_tmux_sockets() {
   local socket_dir
   socket_dir="$(dev_supervisor_tmux_socket_dir)"

--- a/bin/setup
+++ b/bin/setup
@@ -59,7 +59,7 @@ FileUtils.chdir APP_ROOT do
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
     STDOUT.flush # flush the output before exec(2) so that it displays
-    exec "bin/dev"
+    exec "bin/dev", "--detach"
   end
 
   puts "\n== Setup complete! =="

--- a/bin/setup
+++ b/bin/setup
@@ -58,6 +58,7 @@ FileUtils.chdir APP_ROOT do
 
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
+    puts "   (detaching — use 'overmind connect web' to see logs, Ctrl-C to detach)"
     STDOUT.flush # flush the output before exec(2) so that it displays
     # --detach forks bin/dev into a new session and returns immediately, so
     # bin/setup exits back to the prompt instead of staying attached to the

--- a/bin/setup
+++ b/bin/setup
@@ -59,6 +59,9 @@ FileUtils.chdir APP_ROOT do
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
     STDOUT.flush # flush the output before exec(2) so that it displays
+    # --detach forks bin/dev into a new session and returns immediately, so
+    # bin/setup exits back to the prompt instead of staying attached to the
+    # dev server output. Use `overmind connect` to re-attach.
     exec "bin/dev", "--detach"
   end
 


### PR DESCRIPTION
## Summary
- `bin/dev` runs as a foreground process group attached to pts/0. When the controlling terminal disappears (devcontainer reconnect, host sleep/resume, ssh drop), SIGHUP propagates to overmind+tmux and the whole dev stack dies. `log/dev-update/diagnostics/` shows this repeating overnight, leaving defunct tmux servers (PID 1 in this devcontainer is `sleep infinity` and never reaps them) and orphaned `/tmp/overmind-paid-*` dirs.
- Add a `--detach` / `-d` flag (also `DEV_DETACH=1`) that re-execs `bin/dev` under `setsid nohup` with stdin closed and output appended to `log/dev-update/overmind.log`. The detached child has no controlling tty so a vanishing pts can't SIGHUP it.
- Add `dev_supervisor_cleanup_stale_overmind_tmp_dirs` and call it on startup, mirroring the existing stale-tmux-socket cleanup, so leaked `/tmp/overmind-<app>-*` dirs from prior crashes get reaped.

Does not touch the underlying PID-1-isn't-an-init devcontainer issue (defunct tmux zombies) — that's worth a separate change to set `"init": true` in `.devcontainer/devcontainer.json`.

## Test plan
- [ ] `bin/dev --detach` returns immediately, prints the detached pid, and `overmind connect web` attaches to the running session
- [ ] After running `bin/dev --detach`, closing the launching terminal does not kill overmind
- [ ] `bin/dev` (no flag) behaves exactly as before
- [ ] Stale `/tmp/overmind-paid-*` dirs left from prior crashes are removed on next `bin/dev` start, while an active session's dir is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)