### PR TITLE
Fix #919: fix(scanner): draft exit and ready detection ignore manual and ci_action review methods

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -52,6 +52,7 @@ class Project < ApplicationRecord
       },
       "manual" => {
         "enabled" => false,
+        "reviewer_login" => nil,
         "termination" => {
           "max_review_rounds" => nil,
           "stop_when_no_comments" => false,
@@ -628,6 +629,11 @@ class Project < ApplicationRecord
       # ci_action requires an action_name so the system knows which GitHub Action to invoke
       if method_name == "ci_action" && config["action_name"].blank?
         errors.add(:review_settings, "ci_action requires a non-blank action_name when enabled")
+      end
+
+      # manual requires a reviewer_login so the system knows who to request review from
+      if method_name == "manual" && config["reviewer_login"].blank?
+        errors.add(:review_settings, "manual requires a non-blank reviewer_login when enabled")
       end
 
       termination = config["termination"]

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -167,7 +167,7 @@ module Activities
         # and only after a clean review-bot review is present.
         if checks.present? && all_checks_green?(checks)
           # Check non-bot review gates (manual reviewer, ci_action) before advancing.
-          reviews ||= fetch_reviews(client, project, issue)
+          reviews ||= fetch_reviews(client, project, issue) # safety: reviews already fetched above
           gate_triggers = non_bot_review_gate_triggers(project, reviews, checks)
           if gate_triggers.any?
             all_pending = pending_triggers + gate_triggers
@@ -464,6 +464,9 @@ module Activities
       reviewer_reviews = reviews.select { |r| r[:user_login]&.downcase == reviewer_login.downcase }
       return false if reviewer_reviews.empty?
 
+      # Time.at(0) fallback: reviews with nil timestamps sort oldest, so any
+      # review with a real timestamp will win. GitHub always populates
+      # submitted_at in practice, so this is purely defensive.
       latest = reviewer_reviews.max_by { |r| r[:submitted_at] || Time.at(0) }
       latest[:state] == "APPROVED"
     end
@@ -472,7 +475,7 @@ module Activities
       return false if checks.nil? || checks.empty?
 
       matching = checks.find { |c| c[:name] == action_name }
-      matching && matching[:conclusion] == "success"
+      matching&.dig(:conclusion) == "success"
     end
 
     # --- Review checks ---
@@ -803,6 +806,11 @@ module Activities
     # Returns true when there is no outstanding review feedback that should
     # block auto-merge. Checks the same review signals that detect_ready_triggers
     # would evaluate, so owner approval cannot bypass new findings.
+    #
+    # NOTE: When `checks` is nil (the default), an empty array is passed to
+    # non_bot_review_gate_triggers, causing ci_action_succeeded? to return
+    # false — conservatively blocking auto-merge if ci_action is enabled.
+    # Callers that have check data available should always pass it.
     def no_outstanding_review_feedback?(project, client, issue, reviews, checks: nil)
       last_run = last_completed_run(project, issue)
       unresolved_threads = fetch_unresolved_threads(client, project, issue)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -166,6 +166,15 @@ module Activities
         # all_checks_green? implicitly rejects nil conclusions (pending checks),
         # and only after a clean review-bot review is present.
         if checks.present? && all_checks_green?(checks)
+          # Check non-bot review gates (manual reviewer, ci_action) before advancing.
+          reviews ||= fetch_reviews(client, project, issue)
+          gate_triggers = non_bot_review_gate_triggers(project, reviews, checks)
+          if gate_triggers.any?
+            all_pending = pending_triggers + gate_triggers
+            log_triggers(project, issue, all_pending)
+            return draft_trigger_payload(issue, all_pending)
+          end
+
           return ready_for_owner_trigger(issue)
         end
 
@@ -195,7 +204,7 @@ module Activities
           checks.present? &&
           all_checks_green?(checks) &&
           mergeable == true &&
-          no_outstanding_review_feedback?(project, client, issue, reviews)
+          no_outstanding_review_feedback?(project, client, issue, reviews, checks: checks)
         return owner_approved_trigger(issue)
       end
 
@@ -305,6 +314,7 @@ module Activities
       triggers.concat(changes_requested_from_reviews(project, reviews, last_run))
       triggers.concat(check_actionable_labels(project, issue))
       triggers.concat(check_merge_conflicts(project, pr_data))
+      triggers.concat(non_bot_review_gate_triggers(project, reviews, checks))
 
       triggers
     end
@@ -418,6 +428,51 @@ module Activities
       return true if checks.empty?
 
       checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
+    end
+
+    # Returns pending-style triggers when an enabled non-bot review method
+    # (manual or ci_action) has not yet been satisfied. These gates prevent
+    # the scanner from advancing a PR when a human reviewer or a specific
+    # CI action has not approved/completed.
+    def non_bot_review_gate_triggers(project, reviews, checks)
+      return [] unless project.review_enabled?
+
+      triggers = []
+
+      if project.review_method_enabled?("manual")
+        reviewer = project.review_method_config("manual")["reviewer_login"]
+        if reviewer.present? && !manual_reviewer_approved?(reviews, reviewer)
+          triggers << { type: "manual_review_pending", reviewer_login: reviewer,
+                        details: "Awaiting approval from #{reviewer}" }
+        end
+      end
+
+      if project.review_method_enabled?("ci_action")
+        action_name = project.review_method_config("ci_action")["action_name"]
+        if action_name.present? && !ci_action_succeeded?(checks, action_name)
+          triggers << { type: "ci_action_pending", action_name: action_name,
+                        details: "Awaiting successful #{action_name} check" }
+        end
+      end
+
+      triggers
+    end
+
+    def manual_reviewer_approved?(reviews, reviewer_login)
+      return false if reviews.nil?
+
+      reviewer_reviews = reviews.select { |r| r[:user_login]&.downcase == reviewer_login.downcase }
+      return false if reviewer_reviews.empty?
+
+      latest = reviewer_reviews.max_by { |r| r[:submitted_at] || Time.at(0) }
+      latest[:state] == "APPROVED"
+    end
+
+    def ci_action_succeeded?(checks, action_name)
+      return false if checks.nil? || checks.empty?
+
+      matching = checks.find { |c| c[:name] == action_name }
+      matching && matching[:conclusion] == "success"
     end
 
     # --- Review checks ---
@@ -748,7 +803,7 @@ module Activities
     # Returns true when there is no outstanding review feedback that should
     # block auto-merge. Checks the same review signals that detect_ready_triggers
     # would evaluate, so owner approval cannot bypass new findings.
-    def no_outstanding_review_feedback?(project, client, issue, reviews)
+    def no_outstanding_review_feedback?(project, client, issue, reviews, checks: nil)
       last_run = last_completed_run(project, issue)
       unresolved_threads = fetch_unresolved_threads(client, project, issue)
 
@@ -757,6 +812,7 @@ module Activities
         project: project, last_run: last_run, client: client, issue: issue).any?
       return false if changes_requested_from_reviews(project, reviews, last_run).any?
       return false if check_conversation_comments(client, project, issue, last_run).any?
+      return false if non_bot_review_gate_triggers(project, reviews, checks || []).any?
 
       true
     end

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -461,7 +461,7 @@ module Activities
     def manual_reviewer_approved?(reviews, reviewer_login)
       return false if reviews.nil?
 
-      reviewer_reviews = reviews.select { |r| r[:user_login]&.downcase == reviewer_login.downcase }
+      reviewer_reviews = reviews.select { |r| r[:user_login]&.downcase == reviewer_login.strip.downcase }
       return false if reviewer_reviews.empty?
 
       # Time.at(0) fallback: reviews with nil timestamps sort oldest, so any
@@ -474,7 +474,7 @@ module Activities
     def ci_action_succeeded?(checks, action_name)
       return false if checks.nil? || checks.empty?
 
-      matching = checks.find { |c| c[:name] == action_name }
+      matching = checks.find { |c| c[:name] == action_name.strip }
       matching&.dig(:conclusion) == "success"
     end
 
@@ -820,7 +820,15 @@ module Activities
         project: project, last_run: last_run, client: client, issue: issue).any?
       return false if changes_requested_from_reviews(project, reviews, last_run).any?
       return false if check_conversation_comments(client, project, issue, last_run).any?
-      return false if non_bot_review_gate_triggers(project, reviews, checks || []).any?
+      effective_checks = checks || []
+      if checks.nil?
+        logger.debug(
+          message: "pr_scanner.no_outstanding_review_feedback_nil_checks",
+          project_id: project.id,
+          pr_number: issue.github_number
+        )
+      end
+      return false if non_bot_review_gate_triggers(project, reviews, effective_checks).any?
 
       true
     end

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -195,6 +195,10 @@ module Workflows
       elsif trigger_types.include?("review_bot_review_pending")
         handle_review_bot_review_pending(project_id, pr_data, trigger_types)
       elsif trigger_types.include?("manual_review_pending") || trigger_types.include?("ci_action_pending")
+        # NOTE: when both review_bot_review_pending and manual/ci_action triggers
+        # are present, the bot handler above runs first and the non-bot handler is
+        # deferred to the next scan cycle. This is intentional — bot review
+        # completes before requesting human review or awaiting CI actions.
         handle_non_bot_review_pending(project_id, pr_data, trigger_types)
       elsif pr_data[:phase].in?(%w[draft restarted])
         start_draft_followup_workflow(project_id, pr_data)

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -194,6 +194,8 @@ module Workflows
         handle_owner_approved(project_id, pr_data)
       elsif trigger_types.include?("review_bot_review_pending")
         handle_review_bot_review_pending(project_id, pr_data, trigger_types)
+      elsif trigger_types.include?("manual_review_pending") || trigger_types.include?("ci_action_pending")
+        handle_non_bot_review_pending(project_id, pr_data, trigger_types)
       elsif pr_data[:phase].in?(%w[draft restarted])
         start_draft_followup_workflow(project_id, pr_data)
       else
@@ -249,6 +251,32 @@ module Workflows
         end
         return
       end
+
+      if pr_data[:phase].in?(%w[draft restarted])
+        start_draft_followup_workflow(project_id, pr_data)
+      else
+        start_pr_followup_workflow(project_id, pr_data)
+      end
+    end
+
+    def handle_non_bot_review_pending(project_id, pr_data, trigger_types)
+      # For manual_review_pending, request a review from the configured reviewer.
+      # For ci_action_pending, there is nothing to dispatch — the PR stays
+      # in its current phase until the configured action posts a result.
+      manual_trigger = (pr_data[:triggers] || []).find { |t| t[:type] == "manual_review_pending" }
+      if manual_trigger
+        login = manual_trigger[:reviewer_login]
+        if login.present?
+          request_review(project_id, pr_data[:pr_number],
+            [ login ],
+            log_key: "pr_review.request_manual_review_failed")
+        end
+      end
+
+      # If there are other actionable triggers beyond the non-bot gates,
+      # start a followup workflow to address them.
+      other_triggers = trigger_types - %w[manual_review_pending ci_action_pending]
+      return if other_triggers.empty?
 
       if pr_data[:phase].in?(%w[draft restarted])
         start_draft_followup_workflow(project_id, pr_data)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1372,6 +1372,43 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when draft PR manual reviewer posts CHANGES_REQUESTED after earlier APPROVED" do
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          review_settings: {
+            "enabled" => true,
+            "methods" => { "manual" => { "enabled" => true, "reviewer_login" => "alice" } }
+          }
+        )
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [
+            { id: 1, user_login: "alice", state: "APPROVED", body: "LGTM",
+              submitted_at: 2.hours.ago },
+            { id: 2, user_login: "alice", state: "CHANGES_REQUESTED", body: "Actually, needs fixes",
+              submitted_at: 1.hour.ago }
+          ],
+          review_threads: []
+        )
+      end
+
+      it "uses latest review state and emits manual_review_pending" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        types = trigger[:triggers].map { |t| t[:type] }
+        expect(types).to include("manual_review_pending")
+        expect(types).not_to include("ready_for_owner")
+      end
+    end
+
     context "when draft PR has ci_action-only review and configured action is missing from checks" do
       before do
         project.update!(

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1305,6 +1305,215 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when draft PR has manual-only review and CI is green but reviewer has not approved" do
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          review_settings: {
+            "enabled" => true,
+            "methods" => { "manual" => { "enabled" => true, "reviewer_login" => "alice" } }
+          }
+        )
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [],
+          review_threads: []
+        )
+      end
+
+      it "does not emit ready_for_owner; emits manual_review_pending" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        types = trigger[:triggers].map { |t| t[:type] }
+        expect(types).to include("manual_review_pending")
+        expect(types).not_to include("ready_for_owner")
+        pending_trigger = trigger[:triggers].find { |t| t[:type] == "manual_review_pending" }
+        expect(pending_trigger[:reviewer_login]).to eq("alice")
+      end
+    end
+
+    context "when draft PR has manual-only review and configured reviewer has approved" do
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          review_settings: {
+            "enabled" => true,
+            "methods" => { "manual" => { "enabled" => true, "reviewer_login" => "alice" } }
+          }
+        )
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [
+            { id: 1, user_login: "alice", state: "APPROVED", body: "LGTM",
+              submitted_at: 1.hour.ago }
+          ],
+          review_threads: []
+        )
+      end
+
+      it "emits ready_for_owner when reviewer has approved" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("ready_for_owner")
+      end
+    end
+
+    context "when draft PR has ci_action-only review and configured action is missing from checks" do
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          review_settings: {
+            "enabled" => true,
+            "methods" => { "ci_action" => { "enabled" => true, "action_name" => "e2e-suite" } }
+          }
+        )
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [],
+          review_threads: []
+        )
+      end
+
+      it "does not advance; emits ci_action_pending" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        types = trigger[:triggers].map { |t| t[:type] }
+        expect(types).to include("ci_action_pending")
+        expect(types).not_to include("ready_for_owner")
+        pending_trigger = trigger[:triggers].find { |t| t[:type] == "ci_action_pending" }
+        expect(pending_trigger[:action_name]).to eq("e2e-suite")
+      end
+    end
+
+    context "when draft PR has ci_action-only review and configured action succeeded" do
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          review_settings: {
+            "enabled" => true,
+            "methods" => { "ci_action" => { "enabled" => true, "action_name" => "e2e-suite" } }
+          }
+        )
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0)
+        stub_github_for_pr(
+          checks: [
+            { name: "ci", conclusion: "success" },
+            { name: "e2e-suite", conclusion: "success" }
+          ],
+          reviews: [],
+          review_threads: []
+        )
+      end
+
+      it "advances to ready_for_owner" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("ready_for_owner")
+      end
+    end
+
+    context "when ready PR has manual review pending and auto-merge is enabled" do
+      let(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 0)
+      end
+
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          auto_merge_enabled: true,
+          review_settings: {
+            "enabled" => true,
+            "methods" => { "manual" => { "enabled" => true, "reviewer_login" => "alice" } }
+          }
+        )
+        pr_issue
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "Approved",
+              submitted_at: 1.hour.ago }
+          ],
+          review_threads: []
+        )
+      end
+
+      it "does not auto-merge when manual reviewer has not approved" do
+        result = activity.execute(project_id: project.id)
+
+        if result[:prs_to_trigger].any?
+          trigger = result[:prs_to_trigger].first
+          types = trigger[:triggers].map { |t| t[:type] }
+          expect(types).not_to include("owner_approved")
+        end
+      end
+    end
+
+    context "when detect_ready_triggers includes non-bot review gates" do
+      let(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 0)
+      end
+
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          review_settings: {
+            "enabled" => true,
+            "methods" => { "ci_action" => { "enabled" => true, "action_name" => "e2e-suite" } }
+          }
+        )
+        pr_issue
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [],
+          review_threads: []
+        )
+      end
+
+      it "includes ci_action_pending in ready-phase triggers" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        types = trigger[:triggers].map { |t| t[:type] }
+        expect(types).to include("ci_action_pending")
+      end
+    end
+
     context "when draft PR has some green checks but others still pending" do
       before do
         project.update!(owner_reviewer_login: "viamin")

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1508,11 +1508,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       it "does not auto-merge when manual reviewer has not approved" do
         result = activity.execute(project_id: project.id)
 
-        if result[:prs_to_trigger].any?
-          trigger = result[:prs_to_trigger].first
-          types = trigger[:triggers].map { |t| t[:type] }
-          expect(types).not_to include("owner_approved")
-        end
+        expect(result[:prs_to_trigger]).not_to be_empty
+        trigger = result[:prs_to_trigger].first
+        types = trigger[:triggers].map { |t| t[:type] }
+        expect(types).to include("manual_review_pending")
+        expect(types).not_to include("owner_approved")
       end
     end
 

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -462,6 +462,49 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::TriggerDevEnvironmentUpdateActivity, anything, timeout: anything)
     end
 
+    it "routes manual_review_pending to RequestReviewActivity with configured reviewer" do
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "draft",
+        triggers: [ { type: "manual_review_pending", reviewer_login: "alice" } ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::RequestReviewActivity,
+          hash_including(reviewers: [ "alice" ]), timeout: anything)
+    end
+
+    it "does not start a followup workflow for ci_action_pending alone" do
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "draft",
+        triggers: [ { type: "ci_action_pending", action_name: "e2e-suite" } ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
+    end
+
+    it "starts followup when manual_review_pending is combined with other triggers" do
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "draft",
+        triggers: [
+          { type: "manual_review_pending", reviewer_login: "alice" },
+          { type: "ci_failure", details: [ "rspec" ] }
+        ],
+        current_draft_review_count: 0
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::RequestReviewActivity,
+          hash_including(reviewers: [ "alice" ]), timeout: anything)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+    end
+
     it "skips owner review request when owner_reviewer_login is blank" do
       allow(workflow).to receive(:run_activity)
         .with(Activities::MarkPrReadyActivity, anything, timeout: anything)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -501,8 +501,13 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(workflow).to have_received(:run_activity)
         .with(Activities::RequestReviewActivity,
           hash_including(reviewers: [ "alice" ]), timeout: anything)
+      # Verify draft followup specifically (not ready followup) via
+      # RecordDraftReviewActivity which only start_draft_followup_workflow calls.
       expect(workflow).to have_received(:run_activity)
         .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::RecordDraftReviewActivity,
+          hash_including(expected_draft_review_count: 0), timeout: anything)
     end
 
     it "skips owner review request when owner_reviewer_login is blank" do


### PR DESCRIPTION
## Summary

Prevent draft PRs from silently bypassing `manual` and `ci_action` review gates by adding non-bot review gating to the PR scanner. Previously, projects configured with only these review methods would advance draft PRs to `paid-ready` on CI-green alone, because the #898 rework removed bot-based triggers without adding complementary checks for human reviewer approval or named GitHub Actions completion.

## Changes

**Scanner gating (`app/temporal/activities/scan_paid_prs_activity.rb`)**
- Added `non_bot_review_gate_triggers` that emits `manual_review_pending` when the configured reviewer hasn't posted an approval, or `ci_action_pending` when the named action hasn't succeeded
- Added `manual_reviewer_approved?` and `ci_action_succeeded?` helpers to inspect review and check-run state
- Integrated gating into `scan_draft_pr` (before `ready_for_owner` emission), `detect_ready_triggers` (ready/escalated phases), and `no_outstanding_review_feedback?` (auto-merge gate)

**Workflow handling (`app/temporal/workflows/git_hub_poll_workflow.rb`)**
- Added `handle_non_bot_review_pending` handler that requests review from the configured manual reviewer and optionally starts followup workflows for other triggers

**Model validation (`app/models/project.rb`)**
- Added `reviewer_login` to manual method defaults
- Added validation requiring `reviewer_login` when the manual review method is enabled

**Tests**
- 9 new test cases covering manual-pending, ci-action-pending, and combined gate scenarios across scanner and workflow specs

## Design Decisions

- **Gate placement mirrors existing bot-review pattern**: non-bot triggers are checked at the same three integration points where bot triggers are already evaluated, keeping the control flow consistent rather than introducing a separate pathway.
- **Missing check ≠ green check**: `ci_action_succeeded?` requires the named action to be present and successful, closing the gap where `all_checks_green?` only evaluates checks that actually posted a status (a never-dispatched action was invisible).
- **Validation enforced at model level**: requiring `reviewer_login` when `manual` is enabled prevents misconfiguration from silently degrading to no-gate behavior at runtime.

---

Closes #919