### PR TITLE
feat(prompts): migrate all agent prompts into the prompts table

### DIFF
--- a/app/models/prompt_version.rb
+++ b/app/models/prompt_version.rb
@@ -18,14 +18,14 @@ class PromptVersion < ApplicationRecord
 
   validate :immutable_content_after_creation, on: :update
 
-  # Renders the template by interpolating variables.
+  # Renders the template by interpolating variables in a single pass.
+  # Values that themselves contain `{{other_var}}` substrings are NOT
+  # re-substituted (no gsub-ordering bug).
   #
   # @param vars [Hash] Variable name-value pairs to interpolate
   # @return [String] The rendered template
   def render(vars = {})
-    vars.reduce(template) do |result, (key, value)|
-      result.gsub("{{#{key}}}", value.to_s)
-    end
+    Prompts::Render.interpolate(template, vars)
   end
 
   private

--- a/app/services/agent_runs/diagnose_error.rb
+++ b/app/services/agent_runs/diagnose_error.rb
@@ -147,7 +147,7 @@ module AgentRuns
         slug: PROMPT_SLUG,
         project: @project,
         variables: vars,
-        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
       ).strip
     end
 

--- a/app/services/agent_runs/diagnose_error.rb
+++ b/app/services/agent_runs/diagnose_error.rb
@@ -100,38 +100,55 @@ module AgentRuns
       gh_issue.html_url
     end
 
+    PROMPT_SLUG = "diagnostics.agent_run_failure"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
+      You are diagnosing a failed agent run. Analyze the error and logs below, then provide:
+      1. A brief summary of what went wrong
+      2. The root cause of the failure
+      3. A suggested fix or workaround
+
+      Be concise and actionable. Format your response in Markdown.
+
+      ## Context
+      - Agent type: {{agent_type}}
+      - Goal: {{goal}}
+      - Task: {{task}}
+      - Status: {{status}}
+      - Duration: {{duration}}s
+
+      ## Error Message
+      ```
+      {{error_text}}
+      ```
+
+      ## Recent Logs
+      ```
+      {{logs_text}}
+      ```
+    PROMPT
+
     def diagnosis_prompt
-      error_text = redact_secrets(@agent_run.error_message.to_s).truncate(MAX_ERROR_INPUT, omission: "")
-      logs_text = redact_secrets(recent_logs.to_s).truncate(MAX_LOG_INPUT, omission: "")
-      issue_context = redact_secrets(@agent_run.issue&.title.to_s).truncate(MAX_ERROR_INPUT, omission: "").presence ||
-                      redact_secrets(@agent_run.custom_prompt.to_s).presence ||
-                      "N/A"
+      vars = {
+        agent_type: @agent_run.agent_type,
+        goal: @agent_run.goal,
+        task: redact_secrets(@agent_run.issue&.title.to_s).truncate(MAX_ERROR_INPUT, omission: "").presence ||
+              redact_secrets(@agent_run.custom_prompt.to_s).presence ||
+              "N/A",
+        status: @agent_run.status,
+        duration: @agent_run.duration_seconds || "N/A",
+        error_text: redact_secrets(@agent_run.error_message.to_s).truncate(MAX_ERROR_INPUT, omission: ""),
+        logs_text: redact_secrets(recent_logs.to_s).truncate(MAX_LOG_INPUT, omission: "")
+      }
 
-      <<~PROMPT.strip
-        You are diagnosing a failed agent run. Analyze the error and logs below, then provide:
-        1. A brief summary of what went wrong
-        2. The root cause of the failure
-        3. A suggested fix or workaround
-
-        Be concise and actionable. Format your response in Markdown.
-
-        ## Context
-        - Agent type: #{@agent_run.agent_type}
-        - Goal: #{@agent_run.goal}
-        - Task: #{issue_context}
-        - Status: #{@agent_run.status}
-        - Duration: #{@agent_run.duration_seconds || "N/A"}s
-
-        ## Error Message
-        ```
-        #{error_text}
-        ```
-
-        ## Recent Logs
-        ```
-        #{logs_text}
-        ```
-      PROMPT
+      Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        project: @project,
+        variables: vars,
+        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+      ).strip
     end
 
     def recent_logs

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -84,7 +84,7 @@ module Knowledge
           slug: PROMPT_SLUG,
           project: agent_run.project,
           variables: vars,
-          fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+          fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
         )
       end
 

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -14,7 +14,11 @@ module Knowledge
       TIMEOUT = 30
       DEFAULT_MODEL = "claude-sonnet-4-6"
 
-      DRAFT_PROMPT = <<~PROMPT
+      PROMPT_SLUG = "knowledge.draft_decision"
+
+      # Fallback used only if the seeded prompt is missing or deactivated.
+      # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+      FALLBACK_PROMPT = <<~PROMPT
         You are drafting a Decision Record (ADR-lite) for a code change.
 
         Given the following context about an agent run that created a pull request,
@@ -29,9 +33,9 @@ module Knowledge
         Respond with ONLY valid JSON, no markdown fences or extra text.
 
         ## Agent Run Context
-        Issue: %{issue_title}
+        Issue: {{issue_title}}
         PR Changes Summary:
-        %{changes_summary}
+        {{changes_summary}}
       PROMPT
 
       attr_reader :agent_run
@@ -71,10 +75,16 @@ module Knowledge
       private
 
       def build_prompt(changes_summary)
-        format(
-          DRAFT_PROMPT,
+        vars = {
           issue_title: agent_run.issue&.title || "N/A",
           changes_summary: changes_summary.truncate(10_000)
+        }
+
+        Prompts::Render.call(
+          slug: PROMPT_SLUG,
+          project: agent_run.project,
+          variables: vars,
+          fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
         )
       end
 

--- a/app/services/llm/generate_issue_title.rb
+++ b/app/services/llm/generate_issue_title.rb
@@ -65,6 +65,8 @@ module Llm
         summary: @summary.truncate(MAX_SUMMARY_INPUT, omission: "")
       }
 
+      # No project: passed — callers don't always have project context, and
+      # this prompt is unlikely to need project-level overrides.
       Prompts::Render.call(
         slug: PROMPT_SLUG,
         variables: vars,

--- a/app/services/llm/generate_issue_title.rb
+++ b/app/services/llm/generate_issue_title.rb
@@ -49,13 +49,27 @@ module Llm
       clean_title(response.output)
     end
 
-    def prompt
-      truncated = @summary.truncate(MAX_SUMMARY_INPUT, omission: "")
-      <<~PROMPT.strip
-        Generate a concise GitHub issue title for the following agent output. Respond with ONLY the title text — no quotes, no prefix, no explanation. Keep it under #{MAX_TITLE_LENGTH} characters.
+    PROMPT_SLUG = "generation.issue_title"
 
-        #{truncated}
-      PROMPT
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
+      Generate a concise GitHub issue title for the following agent output. Respond with ONLY the title text — no quotes, no prefix, no explanation. Keep it under {{max_title_length}} characters.
+
+      {{summary}}
+    PROMPT
+
+    def prompt
+      vars = {
+        max_title_length: MAX_TITLE_LENGTH,
+        summary: @summary.truncate(MAX_SUMMARY_INPUT, omission: "")
+      }
+
+      Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        variables: vars,
+        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+      ).strip
     end
 
     def clean_title(text)

--- a/app/services/llm/generate_issue_title.rb
+++ b/app/services/llm/generate_issue_title.rb
@@ -68,7 +68,7 @@ module Llm
       Prompts::Render.call(
         slug: PROMPT_SLUG,
         variables: vars,
-        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
       ).strip
     end
 

--- a/app/services/llm/generate_pr_description.rb
+++ b/app/services/llm/generate_pr_description.rb
@@ -24,7 +24,11 @@ module Llm
     MAX_ISSUE_BODY_INPUT = 4_000
     TIMEOUT = 30
 
-    PROMPT_TEMPLATE = <<~PROMPT
+    PROMPT_SLUG = "generation.pr_description"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
       You are writing a pull request description for a code change. Write a clear, well-structured PR description following these rules:
 
       1. **Lead with "why"** — the first sentence must frame the goal and expected outcome, not implementation details.
@@ -39,12 +43,12 @@ module Llm
       Respond with ONLY the PR description markdown — no preamble, no wrapping quotes, no explanation.
 
       ## Issue Context
-      Title: %{issue_title}
+      Title: {{issue_title}}
       Body:
-      %{issue_body}
+      {{issue_body}}
 
       ## Agent Output
-      %{agent_summary}
+      {{agent_summary}}
     PROMPT
 
     class << self
@@ -101,11 +105,16 @@ module Llm
     end
 
     def prompt
-      format(
-        PROMPT_TEMPLATE,
+      vars = {
         issue_title: @issue_title.presence || "N/A",
         issue_body: truncated_issue_body,
         agent_summary: @agent_summary.truncate(MAX_SUMMARY_INPUT, omission: "")
+      }
+
+      Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        variables: vars,
+        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
       )
     end
 

--- a/app/services/llm/generate_pr_description.rb
+++ b/app/services/llm/generate_pr_description.rb
@@ -114,7 +114,7 @@ module Llm
       Prompts::Render.call(
         slug: PROMPT_SLUG,
         variables: vars,
-        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
       )
     end
 

--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -187,7 +187,7 @@ module Models
         slug: PROMPT_SLUG,
         project: project,
         variables: vars,
-        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
       ).strip
     end
 

--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -141,35 +141,54 @@ module Models
       text
     end
 
+    PROMPT_SLUG = "planning.model_selection"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
+      Select the best LLM model for this development task.
+
+      ## Task
+      Goal: {{goal}}
+      {{task_details}}
+
+      ## Project
+      Repository: {{repository}}
+      {{budget_context}}
+
+      ## Available Models
+      {{candidates}}
+
+      ## Instructions
+      Consider task complexity, reasoning requirements, cost-effectiveness, and any budget constraints.
+      Simple tasks (typo fixes, small edits) should use cheaper models.
+      Complex tasks (architecture, multi-file refactors) need the most capable models.
+      If budget is limited, prefer cost-effective models unless the task clearly requires high capability.
+
+      Respond with ONLY a JSON object:
+      {"model": "model-id", "reasoning": "brief explanation", "complexity_score": 5.0}
+
+      complexity_score must be a number from 1.0 (trivial) to 10.0 (extremely complex).
+    PROMPT
+
     def build_prompt(candidates)
       issue = agent_run.issue
       project = agent_run.project
 
-      <<~PROMPT.strip
-        Select the best LLM model for this development task.
+      vars = {
+        goal: agent_run.goal,
+        task_details: task_details(issue),
+        repository: project.full_name,
+        budget_context: budget_context(project),
+        candidates: format_candidates(candidates)
+      }
 
-        ## Task
-        Goal: #{agent_run.goal}
-        #{task_details(issue)}
-
-        ## Project
-        Repository: #{project.full_name}
-        #{budget_context(project)}
-
-        ## Available Models
-        #{format_candidates(candidates)}
-
-        ## Instructions
-        Consider task complexity, reasoning requirements, cost-effectiveness, and any budget constraints.
-        Simple tasks (typo fixes, small edits) should use cheaper models.
-        Complex tasks (architecture, multi-file refactors) need the most capable models.
-        If budget is limited, prefer cost-effective models unless the task clearly requires high capability.
-
-        Respond with ONLY a JSON object:
-        {"model": "model-id", "reasoning": "brief explanation", "complexity_score": 5.0}
-
-        complexity_score must be a number from 1.0 (trivial) to 10.0 (extremely complex).
-      PROMPT
+      Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        project: project,
+        variables: vars,
+        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+      ).strip
     end
 
     def task_details(issue)

--- a/app/services/prompt_evolution/mutate.rb
+++ b/app/services/prompt_evolution/mutate.rb
@@ -108,30 +108,54 @@ module PromptEvolution
       Knowledge::Redaction::Redactor.call(text: text).clean_text
     end
 
+    PROMPT_SLUG = "evolution.mutate_prompt"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
+      You are a prompt engineering expert. Analyze the following prompt and its performance data, then generate {{mutation_count}} improved variant(s).
+
+      ## Current Prompt Template
+      ```
+      {{current_template}}
+      ```
+
+      {{variables_section}}
+      {{system_prompt_section}}
+      {{performance_section}}
+      {{sample_outputs_section}}
+      {{strategies_section}}
+
+      ## Instructions
+      Generate exactly {{mutation_count}} improved prompt variant(s). Each variant must:
+      {{variables_preservation_instruction}}- Be a complete, standalone prompt template (not a diff or partial edit)
+      - Apply one of the requested strategies: {{strategies_csv}}
+      - Address specific weaknesses identified in the performance data
+
+      Respond with ONLY valid JSON in this exact format (no markdown fences, no explanation):
+      {"mutations":[{"template":"improved prompt text","strategy":"one of {{strategies_pipe}}","reasoning":"what problem this addresses","expected_improvement":"why this should perform better"}]}
+    PROMPT
+
     def build_prompt
-      <<~PROMPT
-        You are a prompt engineering expert. Analyze the following prompt and its performance data, then generate #{@mutation_count} improved variant(s).
+      vars = {
+        mutation_count: @mutation_count,
+        current_template: current_template,
+        variables_section: variables_section,
+        system_prompt_section: system_prompt_section,
+        performance_section: performance_section,
+        sample_outputs_section: sample_outputs_section,
+        strategies_section: strategies_section,
+        variables_preservation_instruction: variables_preservation_instruction,
+        strategies_csv: @strategies.join(", "),
+        strategies_pipe: @strategies.join("/")
+      }
 
-        ## Current Prompt Template
-        ```
-        #{current_template}
-        ```
-
-        #{variables_section}
-        #{system_prompt_section}
-        #{performance_section}
-        #{sample_outputs_section}
-        #{strategies_section}
-
-        ## Instructions
-        Generate exactly #{@mutation_count} improved prompt variant(s). Each variant must:
-        #{variables_preservation_instruction}- Be a complete, standalone prompt template (not a diff or partial edit)
-        - Apply one of the requested strategies: #{@strategies.join(', ')}
-        - Address specific weaknesses identified in the performance data
-
-        Respond with ONLY valid JSON in this exact format (no markdown fences, no explanation):
-        {"mutations":[{"template":"improved prompt text","strategy":"one of #{@strategies.join('/')}","reasoning":"what problem this addresses","expected_improvement":"why this should perform better"}]}
-      PROMPT
+      Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        project: @prompt.project,
+        variables: vars,
+        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+      )
     end
 
     def current_template

--- a/app/services/prompt_evolution/mutate.rb
+++ b/app/services/prompt_evolution/mutate.rb
@@ -154,7 +154,7 @@ module PromptEvolution
         slug: PROMPT_SLUG,
         project: @prompt.project,
         variables: vars,
-        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
       )
     end
 

--- a/app/services/prompts/build_for_issue.rb
+++ b/app/services/prompts/build_for_issue.rb
@@ -72,8 +72,11 @@ module Prompts
       new(...).build
     end
 
-    def self.service_environment_section_for(project:)
-      ServiceContainerSections.service_environment_section_for(project: project)
+    def self.service_environment_section_for(project:, include_setup_instruction: true)
+      ServiceContainerSections.service_environment_section_for(
+        project: project,
+        include_setup_instruction: include_setup_instruction
+      )
     end
 
     def build
@@ -92,7 +95,7 @@ module Prompts
         slug: PROMPT_SLUG,
         project: project,
         variables: vars,
-        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
       )
 
       # Dynamic sections are composed in code and appended to the rendered

--- a/app/services/prompts/build_for_issue.rb
+++ b/app/services/prompts/build_for_issue.rb
@@ -11,6 +11,46 @@ module Prompts
 
     class UntrustedIssueError < StandardError; end
 
+    PROMPT_SLUG = "coding.issue_implementation"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~'PROMPT'
+      # Task
+
+      You are working on the following GitHub issue:
+
+      **{{title}}** (#{{issue_number}})
+
+      {{body}}
+
+      # Instructions
+
+      1. Install dependencies (`bundle install`, `yarn install`, etc.)
+      {{setup_database_instruction}}
+      2. Analyze the issue and understand what needs to be done
+      3. Make the necessary code changes
+      4. Run lint and fix any violations: `{{lint_command}}`
+      5. Run the test suite and fix any failures: `{{test_command}}`
+      6. Commit your changes with a descriptive message
+
+      **Important:** Git pre-commit hooks will automatically run lint and tests when you commit.
+      If the commit is rejected, read the error output carefully, fix the issues, and commit again.
+      Keep iterating until the commit succeeds. Do not leave uncommitted changes.
+
+      # Rules — you MUST follow these
+
+      - **Lint and tests MUST pass before every commit.** Do not commit code that fails lint or tests.
+      - **Never use `--no-verify`** or any flag that skips git hooks.
+      - **Never disable linters** (e.g. rubocop:disable, eslint-disable, noqa) to silence failures. Fix the code instead.
+      - **Fix forward** — if a check fails, fix the underlying issue. Do not bypass the check.
+      - Work within the existing codebase style and conventions
+      - Do not modify unrelated files
+      - Focus on completing the specific task in the issue
+
+      When you're done, commit all your changes. Do not push.
+    PROMPT
+
     # Kept for backwards compatibility with existing references
     LANGUAGE_TEST_COMMANDS = LanguageCommands::LANGUAGE_TEST_COMMANDS
     LANGUAGE_LINT_COMMANDS = LanguageCommands::LANGUAGE_LINT_COMMANDS
@@ -39,42 +79,29 @@ module Prompts
     def build
       raise UntrustedIssueError, "Cannot build prompt for issue from untrusted user: #{issue.github_creator_login}" unless issue.trusted?
 
-      base_prompt = <<~PROMPT
-        # Task
+      vars = {
+        title: issue.title,
+        issue_number: issue.github_number.to_s,
+        body: issue.body.to_s,
+        lint_command: lint_command,
+        test_command: test_command,
+        setup_database_instruction: setup_database_instruction
+      }
 
-        You are working on the following GitHub issue:
+      rendered = Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        project: project,
+        variables: vars,
+        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+      )
 
-        **#{issue.title}** (##{issue.github_number})
-
-        #{issue.body}
-
-        # Instructions
-
-        1. Install dependencies (`bundle install`, `yarn install`, etc.)
-        #{setup_database_instruction}
-        2. Analyze the issue and understand what needs to be done
-        3. Make the necessary code changes
-        4. Run lint and fix any violations: `#{lint_command}`
-        5. Run the test suite and fix any failures: `#{test_command}`
-        6. Commit your changes with a descriptive message
-
-        **Important:** Git pre-commit hooks will automatically run lint and tests when you commit.
-        If the commit is rejected, read the error output carefully, fix the issues, and commit again.
-        Keep iterating until the commit succeeds. Do not leave uncommitted changes.
-        #{conversation_section}
-        # Rules — you MUST follow these
-
-        - **Lint and tests MUST pass before every commit.** Do not commit code that fails lint or tests.
-        - **Never use `--no-verify`** or any flag that skips git hooks.
-        - **Never disable linters** (e.g. rubocop:disable, eslint-disable, noqa) to silence failures. Fix the code instead.
-        - **Fix forward** — if a check fails, fix the underlying issue. Do not bypass the check.
-        - Work within the existing codebase style and conventions
-        - Do not modify unrelated files
-        - Focus on completing the specific task in the issue
-
-        When you're done, commit all your changes. Do not push.
-        #{service_environment_section}
-      PROMPT
+      # Dynamic sections are composed in code and appended to the rendered
+      # template so the template stays readable in the prompts UI.
+      base_prompt = [
+        rendered,
+        conversation_section.presence,
+        service_environment_section.presence
+      ].compact.join("\n\n")
 
       with_knowledge = inject_knowledge_context(base_prompt)
       StyleGuides::InjectIntoPrompt.call(prompt: with_knowledge, project: project)

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -39,7 +39,7 @@ module Prompts
 
     # Fallback used only if the seeded prompt is missing or deactivated.
     # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
-    FALLBACK_PROMPT = <<~PROMPT
+    FALLBACK_PROMPT = <<~'PROMPT'
       # Instructions
 
       Priority order:
@@ -105,7 +105,7 @@ module Prompts
         slug: PROMPT_SLUG,
         project: project,
         variables: vars,
-        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
       )
     end
 

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -35,6 +35,46 @@ module Prompts
       new(...).build
     end
 
+    PROMPT_SLUG = "coding.pr_review_rebase"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
+      # Instructions
+
+      Priority order:
+      {{priority_list}}
+
+      Steps:
+      1. Install dependencies (`bundle install`, `yarn install`, etc.)
+      {{setup_database_instruction}}
+      2. Work through the priorities above in order
+      3. Proactive scan: After making your changes, review the **entire diff** you are
+         about to commit{{review_scan_instruction}}. Look for missing guard clauses,
+         insufficient input validation, unhandled edge cases, missing tests, unclear
+         naming, and style inconsistencies. Fix every issue you find — the goal is
+         zero new review rounds for problems you could have caught yourself.
+      4. Run lint and fix any violations: `{{lint_command}}`
+      5. Run the test suite and fix any failures: `{{test_command}}`
+      6. Commit your changes with a descriptive message
+
+      **Important:** Git pre-commit hooks will automatically run lint and tests when you commit.
+      If the commit is rejected, read the error output carefully, fix the issues, and commit again.
+      Keep iterating until the commit succeeds. Do not leave uncommitted changes.
+
+      When you're done, commit all your changes. Do not push.
+
+      # Rules — you MUST follow these
+
+      - **Lint and tests MUST pass before every commit.** Do not commit code that fails lint or tests.
+      - **Never use `--no-verify`** or any flag that skips git hooks.
+      - **Never disable linters** (e.g. rubocop:disable, eslint-disable, noqa) to silence failures. Fix the code instead.
+      - **Fix forward** — if a check fails, fix the underlying issue. Do not bypass the check.
+      - Work within the existing codebase style and conventions
+      - Do not modify unrelated files
+      - Focus on completing the specific tasks listed above
+    PROMPT
+
     def build
       sections = []
       sections << task_section
@@ -43,8 +83,7 @@ module Prompts
       sections << ci_failures_section if failing_checks.any?
       sections << code_review_section if unresolved_threads.any?
       sections << conversation_section if trusted_comments.any?
-      sections << instructions_section
-      sections << rules_section
+      sections << instructions_and_rules_shell
       sections << service_environment_section
       base_prompt = sections.join("\n").delete("\x00")
 
@@ -52,6 +91,33 @@ module Prompts
     end
 
     private
+
+    def instructions_and_rules_shell
+      vars = {
+        priority_list: priority_list,
+        setup_database_instruction: setup_database_instruction,
+        review_scan_instruction: review_scan_instruction,
+        lint_command: lint_command,
+        test_command: test_command
+      }
+
+      Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        project: project,
+        variables: vars,
+        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+      )
+    end
+
+    def priority_list
+      priorities = []
+      priorities << "Resolve merge conflicts" unless rebase_succeeded
+      priorities << "Fix CI failures" if failing_checks.any?
+      priorities << "Close implementation gaps against the linked issue" if linked_issue?
+      priorities << "Address code review comments" if unresolved_threads.any?
+      priorities << "Address conversation comments" if trusted_comments.any?
+      priorities.each_with_index.map { |p, i| "#{i + 1}. #{p}" }.join("\n")
+    end
 
     # Returns true when a separate issue is linked (not the PR's own Issue record).
     # PR follow-up runs pass the PR's Issue as `issue`, which duplicates the
@@ -157,56 +223,6 @@ module Prompts
         #{comment_text}
 
         Address any actionable requests in these comments.
-      SECTION
-    end
-
-    def instructions_section
-      priorities = []
-      priorities << "Resolve merge conflicts" unless rebase_succeeded
-      priorities << "Fix CI failures" if failing_checks.any?
-      priorities << "Close implementation gaps against the linked issue" if linked_issue?
-      priorities << "Address code review comments" if unresolved_threads.any?
-      priorities << "Address conversation comments" if trusted_comments.any?
-      priority_list = priorities.each_with_index.map { |p, i| "#{i + 1}. #{p}" }.join("\n")
-
-      <<~SECTION
-        # Instructions
-
-        Priority order:
-        #{priority_list}
-
-        Steps:
-        1. Install dependencies (`bundle install`, `yarn install`, etc.)
-        #{setup_database_instruction}
-        2. Work through the priorities above in order
-        3. Proactive scan: After making your changes, review the **entire diff** you are
-           about to commit#{review_scan_instruction}. Look for missing guard clauses,
-           insufficient input validation, unhandled edge cases, missing tests, unclear
-           naming, and style inconsistencies. Fix every issue you find — the goal is
-           zero new review rounds for problems you could have caught yourself.
-        4. Run lint and fix any violations: `#{lint_command}`
-        5. Run the test suite and fix any failures: `#{test_command}`
-        6. Commit your changes with a descriptive message
-
-        **Important:** Git pre-commit hooks will automatically run lint and tests when you commit.
-        If the commit is rejected, read the error output carefully, fix the issues, and commit again.
-        Keep iterating until the commit succeeds. Do not leave uncommitted changes.
-
-        When you're done, commit all your changes. Do not push.
-      SECTION
-    end
-
-    def rules_section
-      <<~SECTION
-        # Rules — you MUST follow these
-
-        - **Lint and tests MUST pass before every commit.** Do not commit code that fails lint or tests.
-        - **Never use `--no-verify`** or any flag that skips git hooks.
-        - **Never disable linters** (e.g. rubocop:disable, eslint-disable, noqa) to silence failures. Fix the code instead.
-        - **Fix forward** — if a check fails, fix the underlying issue. Do not bypass the check.
-        - Work within the existing codebase style and conventions
-        - Do not modify unrelated files
-        - Focus on completing the specific tasks listed above
       SECTION
     end
 

--- a/app/services/prompts/render.rb
+++ b/app/services/prompts/render.rb
@@ -49,6 +49,7 @@ module Prompts
     # left in place so callers can spot drift.
     def self.interpolate(template, vars)
       return template.to_s if template.nil?
+      return template.to_s if vars.empty?
 
       template.to_s.gsub(/\{\{(\w+)\}\}/) do
         key = Regexp.last_match(1)

--- a/app/services/prompts/render.rb
+++ b/app/services/prompts/render.rb
@@ -16,11 +16,11 @@ module Prompts
   #     fallback: -> { legacy_inline_prompt }
   #   )
   class Render
-    def self.call(slug:, variables: {}, project: nil, fallback:)
+    def self.call(slug:, fallback:, project: nil, variables: {})
       prompt = if project
         Prompt.resolve(slug, project: project)
       else
-        Prompt.active.global.find_by(slug: slug)
+        Prompt.global.active.find_by(slug: slug)
       end
 
       version = prompt&.current_version
@@ -35,6 +35,28 @@ module Prompts
       end
 
       version.render(variables)
+    end
+
+    # Single-pass `{{var}}` interpolation. Unlike a sequence of `gsub` calls,
+    # values that themselves contain `{{other_var}}` are *not* re-substituted on
+    # later iterations — important when the values come from arbitrary content
+    # like other prompt templates or agent log output.
+    #
+    # Accepts vars with either string or symbol keys. Unknown placeholders are
+    # left in place so callers can spot drift.
+    def self.interpolate(template, vars)
+      return template.to_s if template.nil?
+
+      template.to_s.gsub(/\{\{(\w+)\}\}/) do
+        key = Regexp.last_match(1)
+        if vars.key?(key.to_sym)
+          vars[key.to_sym].to_s
+        elsif vars.key?(key)
+          vars[key].to_s
+        else
+          Regexp.last_match(0)
+        end
+      end
     end
   end
 end

--- a/app/services/prompts/render.rb
+++ b/app/services/prompts/render.rb
@@ -17,6 +17,8 @@ module Prompts
   #   )
   class Render
     def self.call(slug:, fallback:, project: nil, variables: {})
+      # Prompt.resolve includes global scope as a fallback (project > account > global),
+      # so passing a project for a global-only slug still finds the prompt.
       prompt = if project
         Prompt.resolve(slug, project: project)
       else
@@ -42,6 +44,7 @@ module Prompts
     # later iterations — important when the values come from arbitrary content
     # like other prompt templates or agent log output.
     #
+    # Variable names must match `\w+` (letters, digits, underscores only).
     # Accepts vars with either string or symbol keys. Unknown placeholders are
     # left in place so callers can spot drift.
     def self.interpolate(template, vars)

--- a/app/services/prompts/render.rb
+++ b/app/services/prompts/render.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Prompts
+  # Resolves a prompt slug, renders it with variables, and falls back to an
+  # in-code default if no active prompt is found. Always returns a String.
+  #
+  # During rollout we prefer falling back + warning over raising, so a
+  # mis-seeded or deactivated prompt cannot break agent execution. Once the
+  # database-backed prompts are stable, callers can switch to raising on miss.
+  #
+  # @example
+  #   Prompts::Render.call(
+  #     slug: "diagnostics.agent_run_failure",
+  #     project: project,
+  #     variables: { error_text: "...", logs_text: "..." },
+  #     fallback: -> { legacy_inline_prompt }
+  #   )
+  class Render
+    def self.call(slug:, variables: {}, project: nil, fallback:)
+      prompt = if project
+        Prompt.resolve(slug, project: project)
+      else
+        Prompt.active.global.find_by(slug: slug)
+      end
+
+      version = prompt&.current_version
+      if version.nil?
+        Rails.logger.warn(
+          message: "prompts.render_fallback",
+          slug: slug,
+          project_id: project&.id,
+          reason: "no_active_version"
+        )
+        return fallback.call
+      end
+
+      version.render(variables)
+    end
+  end
+end

--- a/app/services/prompts/service_container_sections.rb
+++ b/app/services/prompts/service_container_sections.rb
@@ -40,10 +40,11 @@ module Prompts
       sections = []
 
       if include_setup_instruction
+        language = Prompts::LanguageCommands.detected_language(project)
         sections << <<~SECTION
           # Service Environment
 
-          #{setup_database_instruction_for(project: project)}
+          #{build_database_instruction(has_db: has_db, language: language)}
         SECTION
       end
 

--- a/app/services/prompts/service_container_sections.rb
+++ b/app/services/prompts/service_container_sections.rb
@@ -9,6 +9,27 @@ module Prompts
     # project without requiring a full BuildForIssue/BuildForPr instance.
     # Used by CreateAgentRunActivity to append service guidance to rendered
     # PromptVersion custom_prompts.
+    # Public module method: returns the indented database setup instruction
+    # line that goes between the install-deps step and the analyze step in
+    # the issue prompt. Used by both BuildForIssue and CreateAgentRunActivity
+    # so the prompt template can carry a {{setup_database_instruction}} slot.
+    def self.setup_database_instruction_for(project:)
+      containers = project.service_containers.to_a
+      has_db = containers.any? { |sc| sc.image.include?("postgres") }
+      language = Prompts::LanguageCommands.detected_language(project)
+
+      if has_db
+        if language == "ruby"
+          "   Run `bin/rails db:prepare` to set up the database (`DATABASE_URL` will be configured for you)."
+        else
+          "   A database service will be available via the `DATABASE_URL` environment variable." \
+          " Use your framework's standard command to create and migrate the database schema."
+        end
+      else
+        "   Do NOT run `bin/setup`, `db:prepare`, or `db:migrate` — no database is available in this environment."
+      end
+    end
+
     def self.service_environment_section_for(project:)
       containers = project.service_containers.to_a
       has_db = containers.any? { |sc| sc.image.include?("postgres") }

--- a/app/services/prompts/service_container_sections.rb
+++ b/app/services/prompts/service_container_sections.rb
@@ -17,7 +17,10 @@ module Prompts
       containers = project.service_containers.to_a
       has_db = containers.any? { |sc| sc.image.include?("postgres") }
       language = Prompts::LanguageCommands.detected_language(project)
+      build_database_instruction(has_db: has_db, language: language)
+    end
 
+    def self.build_database_instruction(has_db:, language:)
       if has_db
         if language == "ruby"
           "   Run `bin/rails db:prepare` to set up the database (`DATABASE_URL` will be configured for you)."
@@ -96,16 +99,10 @@ module Prompts
     private
 
     def setup_database_instruction
-      if has_database_container?
-        if detected_language == "ruby"
-          "   Run `bin/rails db:prepare` to set up the database (`DATABASE_URL` will be configured for you)."
-        else
-          "   A database service will be available via the `DATABASE_URL` environment variable." \
-          " Use your framework's standard command to create and migrate the database schema."
-        end
-      else
-        "   Do NOT run `bin/setup`, `db:prepare`, or `db:migrate` — no database is available in this environment."
-      end
+      ServiceContainerSections.build_database_instruction(
+        has_db: has_database_container?,
+        language: detected_language
+      )
     end
 
     def service_environment_section(include_setup_instruction: false)

--- a/app/services/prompts/service_container_sections.rb
+++ b/app/services/prompts/service_container_sections.rb
@@ -5,10 +5,6 @@ module Prompts
   # Included by both BuildForIssue and BuildForPr to provide
   # consistent database/infrastructure guardrails across all agent prompts.
   module ServiceContainerSections
-    # Public module method: generates the service-environment text for a
-    # project without requiring a full BuildForIssue/BuildForPr instance.
-    # Used by CreateAgentRunActivity to append service guidance to rendered
-    # PromptVersion custom_prompts.
     # Public module method: returns the indented database setup instruction
     # line that goes between the install-deps step and the analyze step in
     # the issue prompt. Used by both BuildForIssue and CreateAgentRunActivity

--- a/app/services/prompts/service_container_sections.rb
+++ b/app/services/prompts/service_container_sections.rb
@@ -30,30 +30,19 @@ module Prompts
       end
     end
 
-    def self.service_environment_section_for(project:)
+    def self.service_environment_section_for(project:, include_setup_instruction: true)
       containers = project.service_containers.to_a
       has_db = containers.any? { |sc| sc.image.include?("postgres") }
-      language = Prompts::LanguageCommands.detected_language(project)
 
       sections = []
 
-      # Setup instruction
-      setup = if has_db
-        if language == "ruby"
-          "   Run `bin/rails db:prepare` to set up the database (`DATABASE_URL` will be configured for you)."
-        else
-          "   A database service will be available via the `DATABASE_URL` environment variable." \
-          " Use your framework's standard command to create and migrate the database schema."
-        end
-      else
-        "   Do NOT run `bin/setup`, `db:prepare`, or `db:migrate` — no database is available in this environment."
+      if include_setup_instruction
+        sections << <<~SECTION
+          # Service Environment
+
+          #{setup_database_instruction_for(project: project)}
+        SECTION
       end
-
-      sections << <<~SECTION
-        # Service Environment
-
-        #{setup}
-      SECTION
 
       if containers.any?
         lines = containers.map { |sc| service_description(sc) }

--- a/app/services/style_guides/compress.rb
+++ b/app/services/style_guides/compress.rb
@@ -18,7 +18,11 @@ module StyleGuides
     # Overridden by UserSetting#style_guide_max_raw_bytes at runtime.
     DEFAULT_MAX_RAW_BYTES = 100_000
 
-    COMPRESSION_PROMPT = <<~PROMPT
+    PROMPT_SLUG = "style.compress_guide"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
       You are a technical writing assistant. Compress the following coding style guide into a concise, LLM-friendly format.
 
       Rules:
@@ -63,8 +67,14 @@ module StyleGuides
       @max_raw_bytes_used = max_bytes
       raw = raw.byteslice(0, max_bytes).scrub("") if @truncated
 
+      header = Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        project: style_guide.project,
+        fallback: -> { FALLBACK_PROMPT }
+      )
+
       response = AgentHarness.send_message(
-        "#{COMPRESSION_PROMPT}\n\n#{raw}",
+        "#{header}\n\n#{raw}",
         provider: :claude,
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,

--- a/app/services/style_guides/extract.rb
+++ b/app/services/style_guides/extract.rb
@@ -26,8 +26,12 @@ module StyleGuides
       "rust" => "Rust"
     }.freeze
 
-    EXTRACTION_PROMPT = <<~PROMPT
-      You are a senior software engineer. Analyze the following code samples from a %{language} codebase and extract the coding style conventions you observe.
+    PROMPT_SLUG = "style.extract_guide"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
+      You are a senior software engineer. Analyze the following code samples from a {{language}} codebase and extract the coding style conventions you observe.
 
       Output a concise style guide covering:
       - Naming conventions (variables, methods, classes, files)
@@ -88,7 +92,12 @@ module StyleGuides
     end
 
     def build_prompt(language, file_samples)
-      header = format(EXTRACTION_PROMPT, language: language)
+      header = Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        project: project,
+        variables: { language: language },
+        fallback: -> { FALLBACK_PROMPT.gsub("{{language}}", language) }
+      )
       body = file_samples.map { |s| "## #{s[:path]}\n```\n#{s[:content]}\n```" }.join("\n\n")
       "#{header}\n\n#{body}"
     end

--- a/app/services/style_guides/extract.rb
+++ b/app/services/style_guides/extract.rb
@@ -96,7 +96,7 @@ module StyleGuides
         slug: PROMPT_SLUG,
         project: project,
         variables: { language: language },
-        fallback: -> { FALLBACK_PROMPT.gsub("{{language}}", language) }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, { language: language }) }
       )
       body = file_samples.map { |s| "## #{s[:path]}\n```\n#{s[:content]}\n```" }.join("\n\n")
       "#{header}\n\n#{body}"

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -34,7 +34,8 @@ module Activities
             issue_number: issue.github_number.to_s,
             body: issue.body.to_s,
             test_command: test_command_for(project),
-            lint_command: lint_command_for(project)
+            lint_command: lint_command_for(project),
+            setup_database_instruction: Prompts::ServiceContainerSections.setup_database_instruction_for(project: project)
           )
           custom_prompt = [
             rendered_prompt,

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -29,13 +29,18 @@ module Activities
       if custom_prompt.blank? && issue.present? && issue.trusted?
         prompt_version = Prompts::Resolve.call(slug: "coding.issue_implementation", project: project)
         if prompt_version
+          # The activity appends a full `# Service Environment` section after
+          # the rendered template (see below), so we suppress the inline
+          # `{{setup_database_instruction}}` slot to avoid duplicating the
+          # database setup line. BuildForIssue uses the opposite split: it
+          # fills the inline slot and skips the header in the appended block.
           rendered_prompt = prompt_version.render(
             title: issue.title,
             issue_number: issue.github_number.to_s,
             body: issue.body.to_s,
             test_command: test_command_for(project),
             lint_command: lint_command_for(project),
-            setup_database_instruction: Prompts::ServiceContainerSections.setup_database_instruction_for(project: project)
+            setup_database_instruction: ""
           )
           custom_prompt = [
             rendered_prompt,

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -100,7 +100,7 @@ module Activities
         slug: PROMPT_SLUG,
         project: issue.project,
         variables: vars,
-        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
       ).strip
     end
 

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -50,42 +50,58 @@ module Activities
       parse_tasks(response.output)
     end
 
+    PROMPT_SLUG = "planning.decompose_feature"
+
+    # Fallback used only if the seeded prompt is missing or deactivated.
+    # The active template lives in db/seeds/prompts.rb under PROMPT_SLUG.
+    FALLBACK_PROMPT = <<~PROMPT
+      You are a software architect. Analyze the following feature request and decompose it into smaller, independently-implementable sub-tasks.
+
+      ## Feature Request
+      **Title:** {{title}}
+      **Description:**
+      {{body}}
+
+      {{knowledge_section}}
+
+      ## Instructions
+      - Each sub-task should be independently implementable and testable
+      - Order tasks by dependency (tasks that others depend on come first)
+      - Mark tasks that can be worked on in parallel (no dependencies between them)
+      - If this is a simple feature that doesn't need decomposition, return a single task
+      - Keep task descriptions clear and actionable
+      - Include acceptance criteria for each task
+      - Maximum {{max_tasks}} tasks
+
+      ## Output Format
+      Respond with ONLY a JSON array. Each element must have these fields:
+      - "title": concise task title (string)
+      - "description": detailed description with acceptance criteria (string)
+      - "dependencies": array of task indices (0-based) this task depends on (array of integers)
+      - "parallel_group": integer grouping tasks that can run in parallel (tasks with the same group number have no dependencies on each other)
+
+      Example:
+      [
+        {"title": "Add database migration for X", "description": "Create migration to add...", "dependencies": [], "parallel_group": 0},
+        {"title": "Implement model for X", "description": "Create ActiveRecord model...", "dependencies": [0], "parallel_group": 1},
+        {"title": "Add API endpoint for X", "description": "Create controller action...", "dependencies": [1], "parallel_group": 2}
+      ]
+    PROMPT
+
     def build_prompt(issue, context)
-      knowledge_section = build_knowledge_section(context[:knowledge_snippets])
+      vars = {
+        title: issue.title,
+        body: issue.body.to_s.truncate(8000),
+        knowledge_section: build_knowledge_section(context[:knowledge_snippets]),
+        max_tasks: MAX_TASKS
+      }
 
-      <<~PROMPT.strip
-        You are a software architect. Analyze the following feature request and decompose it into smaller, independently-implementable sub-tasks.
-
-        ## Feature Request
-        **Title:** #{issue.title}
-        **Description:**
-        #{issue.body.to_s.truncate(8000)}
-
-        #{knowledge_section}
-
-        ## Instructions
-        - Each sub-task should be independently implementable and testable
-        - Order tasks by dependency (tasks that others depend on come first)
-        - Mark tasks that can be worked on in parallel (no dependencies between them)
-        - If this is a simple feature that doesn't need decomposition, return a single task
-        - Keep task descriptions clear and actionable
-        - Include acceptance criteria for each task
-        - Maximum #{MAX_TASKS} tasks
-
-        ## Output Format
-        Respond with ONLY a JSON array. Each element must have these fields:
-        - "title": concise task title (string)
-        - "description": detailed description with acceptance criteria (string)
-        - "dependencies": array of task indices (0-based) this task depends on (array of integers)
-        - "parallel_group": integer grouping tasks that can run in parallel (tasks with the same group number have no dependencies on each other)
-
-        Example:
-        [
-          {"title": "Add database migration for X", "description": "Create migration to add...", "dependencies": [], "parallel_group": 0},
-          {"title": "Implement model for X", "description": "Create ActiveRecord model...", "dependencies": [0], "parallel_group": 1},
-          {"title": "Add API endpoint for X", "description": "Create controller action...", "dependencies": [1], "parallel_group": 2}
-        ]
-      PROMPT
+      Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        project: issue.project,
+        variables: vars,
+        fallback: -> { vars.reduce(FALLBACK_PROMPT) { |acc, (k, v)| acc.gsub("{{#{k}}}", v.to_s) } }
+      ).strip
     end
 
     def build_knowledge_section(snippets)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -923,135 +923,188 @@ module Activities
       end
     end
 
+    # Goal-augmentation prompts.
+    #
+    # The active templates live in db/seeds/prompts.rb under the slugs
+    # `goal.create_github_issue` and `goal.review_pull_request`. The
+    # FALLBACK_* constants below are the safety net used when the seeded
+    # row is missing or deactivated; they must stay in sync with the seeds.
+    #
+    # Note on the "Generated no new comments." phrase in the review template:
+    # this string is matched (case-insensitive) by
+    # ScanPaidPrsActivity::REVIEW_BOT_CLEAN_PATTERN
+    #   = /generated no (?:new )?comments/i
+    # which is how Paid recognizes a clean review and stops the review loop.
+    # If the matcher pattern changes, update both the seed and this constant.
+    ISSUE_GOAL_PROMPT_SLUG = "goal.create_github_issue"
+
+    FALLBACK_ISSUE_GOAL_PROMPT = <<~'AUGMENTED'
+      {{base_prompt}}
+
+      ---
+      IMPORTANT: Your goal is to CREATE A GITHUB ISSUE, not to write code or create a PR.
+
+      You have access to the GitHub API via a proxy. Use curl to create the issue.
+
+      IMPORTANT: Do NOT pass JSON inline with a single-quoted -d '...'. The body will contain
+      markdown with apostrophes (single quotes) and possibly newlines that break shell quoting.
+      Instead, write the JSON payload to a temporary file and use --data-binary @file:
+
+      ```bash
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'ISSUE_JSON'
+      {
+        "title": "Issue title",
+        "body": "Issue description with `code` and apostrophes",
+        "labels": []
+      }
+      ISSUE_JSON
+      curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/issues" \
+        -H "Content-Type: application/json" \
+        -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+        -H "X-Proxy-Token: $PROXY_TOKEN" \
+        --data-binary @"$tmpfile"
+      rm -f "$tmpfile"
+      ```
+
+      Available endpoints:
+      - GET  $GITHUB_API_URL/repos/{{repo}}/issues — list issues
+      - GET  $GITHUB_API_URL/repos/{{repo}}/issues/{number} — get issue
+      - POST $GITHUB_API_URL/repos/{{repo}}/issues — create issue
+      - PATCH $GITHUB_API_URL/repos/{{repo}}/issues/{number} — update issue
+      - POST $GITHUB_API_URL/repos/{{repo}}/issues/{number}/comments — add comment
+      - POST $GITHUB_API_URL/repos/{{repo}}/issues/{number}/labels — add labels
+
+      Do NOT push code or create a pull request. Only create the GitHub issue.
+    AUGMENTED
+
+    REVIEW_GOAL_PROMPT_SLUG = "goal.review_pull_request"
+
+    FALLBACK_REVIEW_GOAL_PROMPT = <<~'AUGMENTED'
+      {{base_prompt}}
+
+      ---
+      IMPORTANT: Your goal is to REVIEW A PULL REQUEST, not to write code, create issues, or create PRs.
+
+      Review PR #{{pr_number}} in {{repo}}. Examine the code changes and post a review on the PR.
+
+      You have access to the repository code (already cloned). To examine the code changes, either:
+      - Use the GitHub API (via the proxy) to retrieve the PR's `/pulls/{{pr_number}}/files` patches and review those diffs; or
+      - From the cloned repo, run an explicit diff against the PR base, for example:
+        `git fetch origin` then `git diff "$(git merge-base HEAD origin/main)"...HEAD`
+        (replace `main` with the PR's actual base branch if different).
+      You also have access to the GitHub API via a proxy for posting review comments.
+
+      Review the code for:
+      1. **Performance** — inefficient algorithms, N+1 queries, unnecessary allocations, missing caching
+      2. **Security** — SQL injection, XSS, insecure deserialization, secrets in code
+      3. **Best practices** — language/framework idioms, error handling, naming
+      4. **Project code style** — adherence to existing conventions, indentation, file organization
+      5. **Scope violations** — changes unrelated to the linked issue, unnecessary refactoring, feature creep
+      6. **Issue linkage** — verify the PR actually addresses the issue it claims to fix
+
+      # Comment policy — read carefully
+
+      Inline comments are reserved **exclusively for actionable changes**: security,
+      correctness, performance, scope, or style problems that require the author to
+      edit code. Do **not** post praise-only comments, "looks good" notes, "nice
+      refactor" remarks, or any inline comment that does not request a concrete
+      change. If you have nothing actionable to say about a hunk, do not comment on it.
+
+      A clean PR with zero issues is a valid and expected outcome. Do not invent
+      nitpicks to justify having posted a review.
+
+      Use GitHub's suggestion block syntax for concrete fixes:
+      ````
+      ```suggestion
+      corrected code here
+      ```
+      ````
+
+      Post your review using the GitHub API proxy:
+
+      ```bash
+      # Get PR details (metadata and links)
+      curl -s --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}" \
+        -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+        -H "X-Proxy-Token: $PROXY_TOKEN"
+
+      # Get PR files
+      curl -s --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/files" \
+        -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+        -H "X-Proxy-Token: $PROXY_TOKEN"
+
+      # Case A — actionable issues found: post a review with inline comments.
+      # Note: "side" must be "RIGHT" (new code) or "LEFT" (deleted code).
+      curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews" \
+        -H "Content-Type: application/json" \
+        -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+        -H "X-Proxy-Token: $PROXY_TOKEN" \
+        -d '{
+          "body": "Overall summary of the actionable issues found",
+          "event": "COMMENT",
+          "comments": [
+            {
+              "path": "file.rb",
+              "line": 10,
+              "side": "RIGHT",
+              "body": "Actionable change request on this line"
+            }
+          ]
+        }'
+
+      # Case B — clean PR, no actionable issues: post a single review with an EMPTY
+      # comments array and a body that begins with the EXACT phrase
+      # "Generated no new comments." This phrase is the signal Paid uses to mark
+      # the review as clean and stop the review loop. Do NOT paraphrase it.
+      curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews" \
+        -H "Content-Type: application/json" \
+        -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+        -H "X-Proxy-Token: $PROXY_TOKEN" \
+        -d '{
+          "body": "Generated no new comments. The PR looks ready as-is.",
+          "event": "COMMENT",
+          "comments": []
+        }'
+      ```
+
+      IMPORTANT: You MUST post exactly one PR review via the
+      `/pulls/{{pr_number}}/reviews` endpoint — either Case A (with inline
+      actionable comments) or Case B (clean review). This is how your review is
+      tracked as complete. Standalone PR comments via
+      `/issues/{{pr_number}}/comments` do NOT satisfy the review requirement.
+
+      Available endpoints:
+      - GET  $GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}} — get PR details
+      - GET  $GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/files — list changed files
+      - POST $GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews — create review (REQUIRED, exactly once)
+      - GET  $GITHUB_API_URL/repos/{{repo}}/issues/{number} — get linked issue details
+
+      Do NOT push code, create issues, or create new pull requests. Only post the review on PR #{{pr_number}}.
+    AUGMENTED
+
     def augment_prompt_for_issue_goal(agent_run, prompt)
-      repo = validated_repo_name(agent_run)
-      <<~AUGMENTED
-        #{prompt}
-
-        ---
-        IMPORTANT: Your goal is to CREATE A GITHUB ISSUE, not to write code or create a PR.
-
-        You have access to the GitHub API via a proxy. Use curl to create the issue.
-
-        IMPORTANT: Do NOT pass JSON inline with a single-quoted -d '...'. The body will contain
-        markdown with apostrophes (single quotes) and possibly newlines that break shell quoting.
-        Instead, write the JSON payload to a temporary file and use --data-binary @file:
-
-        ```bash
-        tmpfile=$(mktemp)
-        cat > "$tmpfile" <<'ISSUE_JSON'
-        {
-          "title": "Issue title",
-          "body": "Issue description with `code` and apostrophes",
-          "labels": []
-        }
-        ISSUE_JSON
-        curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/#{repo}/issues" \\
-          -H "Content-Type: application/json" \\
-          -H "X-Agent-Run-Id: $AGENT_RUN_ID" \\
-          -H "X-Proxy-Token: $PROXY_TOKEN" \\
-          --data-binary @"$tmpfile"
-        rm -f "$tmpfile"
-        ```
-
-        Available endpoints:
-        - GET  $GITHUB_API_URL/repos/#{repo}/issues — list issues
-        - GET  $GITHUB_API_URL/repos/#{repo}/issues/{number} — get issue
-        - POST $GITHUB_API_URL/repos/#{repo}/issues — create issue
-        - PATCH $GITHUB_API_URL/repos/#{repo}/issues/{number} — update issue
-        - POST $GITHUB_API_URL/repos/#{repo}/issues/{number}/comments — add comment
-        - POST $GITHUB_API_URL/repos/#{repo}/issues/{number}/labels — add labels
-
-        Do NOT push code or create a pull request. Only create the GitHub issue.
-      AUGMENTED
+      vars = { base_prompt: prompt, repo: validated_repo_name(agent_run) }
+      Prompts::Render.call(
+        slug: ISSUE_GOAL_PROMPT_SLUG,
+        project: agent_run.project,
+        variables: vars,
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_ISSUE_GOAL_PROMPT, vars) }
+      )
     end
 
     def augment_prompt_for_review_goal(agent_run, prompt)
-      repo = validated_repo_name(agent_run)
-      pr_number = agent_run.source_pull_request_number
-      <<~AUGMENTED
-        #{prompt}
-
-        ---
-        IMPORTANT: Your goal is to REVIEW A PULL REQUEST, not to write code, create issues, or create PRs.
-
-        Review PR ##{pr_number} in #{repo}. Examine the code changes and post review comments on the PR.
-
-        You have access to the repository code (already cloned). To examine the code changes, either:
-        - Use the GitHub API (via the proxy) to retrieve the PR's `/pulls/#{pr_number}/files` patches and review those diffs; or
-        - From the cloned repo, run an explicit diff against the PR base, for example:
-          `git fetch origin` then `git diff "$(git merge-base HEAD origin/main)"...HEAD`
-          (replace `main` with the PR's actual base branch if different).
-        You also have access to the GitHub API via a proxy for posting review comments.
-
-        Review the code for:
-        1. **Performance** — inefficient algorithms, N+1 queries, unnecessary allocations, missing caching
-        2. **Security** — SQL injection, XSS, insecure deserialization, secrets in code
-        3. **Best practices** — language/framework idioms, error handling, naming
-        4. **Project code style** — adherence to existing conventions, indentation, file organization
-        5. **Scope violations** — changes unrelated to the linked issue, unnecessary refactoring, feature creep
-        6. **Issue linkage** — verify the PR actually addresses the issue it claims to fix
-
-        Use GitHub's suggestion block syntax for concrete fixes:
-        ````
-        ```suggestion
-        corrected code here
-        ```
-        ````
-
-        Post your review using the GitHub API proxy:
-
-        ```bash
-        # Get PR details (metadata and links)
-        curl -s --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/#{repo}/pulls/#{pr_number}" \\
-          -H "X-Agent-Run-Id: $AGENT_RUN_ID" \\
-          -H "X-Proxy-Token: $PROXY_TOKEN"
-
-        # Get PR files
-        curl -s --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/#{repo}/pulls/#{pr_number}/files" \\
-          -H "X-Agent-Run-Id: $AGENT_RUN_ID" \\
-          -H "X-Proxy-Token: $PROXY_TOKEN"
-
-        # Post a review with inline comments
-        # Note: "side" must be "RIGHT" (new code) or "LEFT" (deleted code) for inline comments.
-        curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/#{repo}/pulls/#{pr_number}/reviews" \\
-          -H "Content-Type: application/json" \\
-          -H "X-Agent-Run-Id: $AGENT_RUN_ID" \\
-          -H "X-Proxy-Token: $PROXY_TOKEN" \\
-          -d '{
-            "body": "Overall summary of the review",
-            "event": "COMMENT",
-            "comments": [
-              {
-                "path": "file.rb",
-                "line": 10,
-                "side": "RIGHT",
-                "body": "Review comment on this line"
-              }
-            ]
-          }'
-
-        # Post a standalone comment on the PR (optional, supplementary only)
-        curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/#{repo}/issues/#{pr_number}/comments" \\
-          -H "Content-Type: application/json" \\
-          -H "X-Agent-Run-Id: $AGENT_RUN_ID" \\
-          -H "X-Proxy-Token: $PROXY_TOKEN" \\
-          -d '{"body": "Summary review comment"}'
-        ```
-
-        IMPORTANT: You MUST post at least one PR review via the `/pulls/#{pr_number}/reviews`
-        endpoint. This is how your review is tracked as complete. Standalone PR comments
-        via `/issues/#{pr_number}/comments` are optional and do NOT satisfy the review requirement.
-
-        Available endpoints:
-        - GET  $GITHUB_API_URL/repos/#{repo}/pulls/#{pr_number} — get PR details
-        - GET  $GITHUB_API_URL/repos/#{repo}/pulls/#{pr_number}/files — list changed files
-        - POST $GITHUB_API_URL/repos/#{repo}/pulls/#{pr_number}/reviews — create review with inline comments (REQUIRED)
-        - POST $GITHUB_API_URL/repos/#{repo}/issues/#{pr_number}/comments — post PR comment (optional)
-        - GET  $GITHUB_API_URL/repos/#{repo}/issues/{number} — get linked issue details
-
-        Do NOT push code, create issues, or create new pull requests. Only post review comments on PR ##{pr_number}.
-      AUGMENTED
+      vars = {
+        base_prompt: prompt,
+        repo: validated_repo_name(agent_run),
+        pr_number: agent_run.source_pull_request_number.to_s
+      }
+      Prompts::Render.call(
+        slug: REVIEW_GOAL_PROMPT_SLUG,
+        project: agent_run.project,
+        variables: vars,
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_REVIEW_GOAL_PROMPT, vars) }
+      )
     end
 
     def validated_repo_name(agent_run)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1095,10 +1095,17 @@ module Activities
     end
 
     def augment_prompt_for_review_goal(agent_run, prompt)
+      pr_number = agent_run.source_pull_request_number
+      raise Temporalio::Error::ApplicationError.new(
+        "Review goal requires source_pull_request_number",
+        type: "MissingPRNumber",
+        non_retryable: true
+      ) unless pr_number
+
       vars = {
         base_prompt: prompt,
         repo: validated_repo_name(agent_run),
-        pr_number: agent_run.source_pull_request_number.to_s
+        pr_number: pr_number.to_s
       }
       Prompts::Render.call(
         slug: REVIEW_GOAL_PROMPT_SLUG,

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -929,13 +929,7 @@ module Activities
     # `goal.create_github_issue` and `goal.review_pull_request`. The
     # FALLBACK_* constants below are the safety net used when the seeded
     # row is missing or deactivated; they must stay in sync with the seeds.
-    #
-    # Note on the "Generated no new comments." phrase in the review template:
-    # this string is matched (case-insensitive) by
-    # ScanPaidPrsActivity::REVIEW_BOT_CLEAN_PATTERN
-    #   = /generated no (?:new )?comments/i
-    # which is how Paid recognizes a clean review and stops the review loop.
-    # If the matcher pattern changes, update both the seed and this constant.
+    # spec/db/seeds_prompts_spec.rb asserts both pairs match.
     ISSUE_GOAL_PROMPT_SLUG = "goal.create_github_issue"
 
     FALLBACK_ISSUE_GOAL_PROMPT = <<~'AUGMENTED'
@@ -980,6 +974,13 @@ module Activities
 
     REVIEW_GOAL_PROMPT_SLUG = "goal.review_pull_request"
 
+    # The "Generated no new comments." phrase in the template below is
+    # matched (case-insensitive) by
+    #   ScanPaidPrsActivity::REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i
+    # which is how Paid recognizes a clean review and stops the review loop.
+    # spec/db/seeds_prompts_spec.rb has a coupling spec — if you change the
+    # matcher pattern, update the seed AND this constant together or the spec
+    # will fail.
     FALLBACK_REVIEW_GOAL_PROMPT = <<~'AUGMENTED'
       {{base_prompt}}
 

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -493,3 +493,181 @@ upsert_global_prompt.call(
     var.call("changes_summary", "Truncated PR changes summary")
   ]
 )
+
+# ----------------------------------------------------------------------------
+# goal.create_github_issue — Augment a base prompt for the create-issue goal
+# Used by: Activities::RunAgentActivity#augment_prompt_for_issue_goal
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "goal.create_github_issue",
+  name: "Goal: Create GitHub Issue",
+  description: "Augments a base prompt with instructions to create a GitHub issue via the API proxy. Used when an agent run's goal is to file an issue rather than open a PR.",
+  category: "planning",
+  template: <<~'TEMPLATE',
+    {{base_prompt}}
+
+    ---
+    IMPORTANT: Your goal is to CREATE A GITHUB ISSUE, not to write code or create a PR.
+
+    You have access to the GitHub API via a proxy. Use curl to create the issue.
+
+    IMPORTANT: Do NOT pass JSON inline with a single-quoted -d '...'. The body will contain
+    markdown with apostrophes (single quotes) and possibly newlines that break shell quoting.
+    Instead, write the JSON payload to a temporary file and use --data-binary @file:
+
+    ```bash
+    tmpfile=$(mktemp)
+    cat > "$tmpfile" <<'ISSUE_JSON'
+    {
+      "title": "Issue title",
+      "body": "Issue description with `code` and apostrophes",
+      "labels": []
+    }
+    ISSUE_JSON
+    curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/issues" \
+      -H "Content-Type: application/json" \
+      -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+      -H "X-Proxy-Token: $PROXY_TOKEN" \
+      --data-binary @"$tmpfile"
+    rm -f "$tmpfile"
+    ```
+
+    Available endpoints:
+    - GET  $GITHUB_API_URL/repos/{{repo}}/issues — list issues
+    - GET  $GITHUB_API_URL/repos/{{repo}}/issues/{number} — get issue
+    - POST $GITHUB_API_URL/repos/{{repo}}/issues — create issue
+    - PATCH $GITHUB_API_URL/repos/{{repo}}/issues/{number} — update issue
+    - POST $GITHUB_API_URL/repos/{{repo}}/issues/{number}/comments — add comment
+    - POST $GITHUB_API_URL/repos/{{repo}}/issues/{number}/labels — add labels
+
+    Do NOT push code or create a pull request. Only create the GitHub issue.
+  TEMPLATE
+  variables: [
+    var.call("base_prompt", "The base prompt this augmentation extends"),
+    var.call("repo", "Repository full_name (owner/repo)")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# goal.review_pull_request — Augment a base prompt for the review-PR goal
+# Used by: Activities::RunAgentActivity#augment_prompt_for_review_goal
+#
+# IMPORTANT: This template instructs the agent to post a clean-review body
+# starting with the EXACT phrase "Generated no new comments." which matches
+# ScanPaidPrsActivity::REVIEW_BOT_CLEAN_PATTERN. If that matcher pattern
+# changes, update this template AND the FALLBACK constant in
+# Activities::RunAgentActivity together.
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "goal.review_pull_request",
+  name: "Goal: Review Pull Request",
+  description: "Augments a base prompt with instructions to review an existing PR. Forbids praise-only inline comments and requires the clean-PR signal phrase Paid uses to stop the review loop.",
+  category: "review",
+  template: <<~'TEMPLATE',
+    {{base_prompt}}
+
+    ---
+    IMPORTANT: Your goal is to REVIEW A PULL REQUEST, not to write code, create issues, or create PRs.
+
+    Review PR #{{pr_number}} in {{repo}}. Examine the code changes and post a review on the PR.
+
+    You have access to the repository code (already cloned). To examine the code changes, either:
+    - Use the GitHub API (via the proxy) to retrieve the PR's `/pulls/{{pr_number}}/files` patches and review those diffs; or
+    - From the cloned repo, run an explicit diff against the PR base, for example:
+      `git fetch origin` then `git diff "$(git merge-base HEAD origin/main)"...HEAD`
+      (replace `main` with the PR's actual base branch if different).
+    You also have access to the GitHub API via a proxy for posting review comments.
+
+    Review the code for:
+    1. **Performance** — inefficient algorithms, N+1 queries, unnecessary allocations, missing caching
+    2. **Security** — SQL injection, XSS, insecure deserialization, secrets in code
+    3. **Best practices** — language/framework idioms, error handling, naming
+    4. **Project code style** — adherence to existing conventions, indentation, file organization
+    5. **Scope violations** — changes unrelated to the linked issue, unnecessary refactoring, feature creep
+    6. **Issue linkage** — verify the PR actually addresses the issue it claims to fix
+
+    # Comment policy — read carefully
+
+    Inline comments are reserved **exclusively for actionable changes**: security,
+    correctness, performance, scope, or style problems that require the author to
+    edit code. Do **not** post praise-only comments, "looks good" notes, "nice
+    refactor" remarks, or any inline comment that does not request a concrete
+    change. If you have nothing actionable to say about a hunk, do not comment on it.
+
+    A clean PR with zero issues is a valid and expected outcome. Do not invent
+    nitpicks to justify having posted a review.
+
+    Use GitHub's suggestion block syntax for concrete fixes:
+    ````
+    ```suggestion
+    corrected code here
+    ```
+    ````
+
+    Post your review using the GitHub API proxy:
+
+    ```bash
+    # Get PR details (metadata and links)
+    curl -s --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}" \
+      -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+      -H "X-Proxy-Token: $PROXY_TOKEN"
+
+    # Get PR files
+    curl -s --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/files" \
+      -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+      -H "X-Proxy-Token: $PROXY_TOKEN"
+
+    # Case A — actionable issues found: post a review with inline comments.
+    # Note: "side" must be "RIGHT" (new code) or "LEFT" (deleted code).
+    curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews" \
+      -H "Content-Type: application/json" \
+      -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+      -H "X-Proxy-Token: $PROXY_TOKEN" \
+      -d '{
+        "body": "Overall summary of the actionable issues found",
+        "event": "COMMENT",
+        "comments": [
+          {
+            "path": "file.rb",
+            "line": 10,
+            "side": "RIGHT",
+            "body": "Actionable change request on this line"
+          }
+        ]
+      }'
+
+    # Case B — clean PR, no actionable issues: post a single review with an EMPTY
+    # comments array and a body that begins with the EXACT phrase
+    # "Generated no new comments." This phrase is the signal Paid uses to mark
+    # the review as clean and stop the review loop. Do NOT paraphrase it.
+    curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews" \
+      -H "Content-Type: application/json" \
+      -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+      -H "X-Proxy-Token: $PROXY_TOKEN" \
+      -d '{
+        "body": "Generated no new comments. The PR looks ready as-is.",
+        "event": "COMMENT",
+        "comments": []
+      }'
+    ```
+
+    IMPORTANT: You MUST post exactly one PR review via the
+    `/pulls/{{pr_number}}/reviews` endpoint — either Case A (with inline
+    actionable comments) or Case B (clean review). This is how your review is
+    tracked as complete. Standalone PR comments via
+    `/issues/{{pr_number}}/comments` do NOT satisfy the review requirement.
+
+    Available endpoints:
+    - GET  $GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}} — get PR details
+    - GET  $GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/files — list changed files
+    - POST $GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews — create review (REQUIRED, exactly once)
+    - GET  $GITHUB_API_URL/repos/{{repo}}/issues/{number} — get linked issue details
+
+    Do NOT push code, create issues, or create new pull requests. Only post the review on PR #{{pr_number}}.
+  TEMPLATE
+  variables: [
+    var.call("base_prompt", "The base prompt this augmentation extends"),
+    var.call("repo", "Repository full_name (owner/repo)"),
+    var.call("pr_number", "Pull request number")
+  ]
+)

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -22,7 +22,7 @@ upsert_global_prompt = ->(slug:, name:, description:, category:, template:, vari
       active: true
     )
   else
-    prompt.name ||= name
+    prompt.name ||= name         # preserve user edits; only fill when blank
     prompt.description ||= description
     prompt.category ||= category
     prompt.active = true if prompt.active.nil?

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -11,7 +11,7 @@
 # version (versions are immutable). Use `db:seed:replant` during development
 # if you want to reset history.
 
-upsert_global_prompt = ->(slug:, name:, description:, category:, template:, variables:) do
+upsert_global_prompt = lambda do |slug:, name:, description:, category:, template:, variables:|
   prompt = Prompt.find_or_initialize_by(slug: slug, account_id: nil, project_id: nil)
 
   if prompt.new_record?

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -1,100 +1,499 @@
 # frozen_string_literal: true
 
-# Seed default prompts for coding tasks.
-# Migrates logic from Prompts::BuildForIssue into the database.
+# Seed default prompts used by Paid agents and supporting services.
+#
+# Each entry represents a global prompt template that can be:
+#   - Resolved at runtime via Prompts::Render or Prompts::Resolve
+#   - Iterated on via the PromptsController UI
+#   - Versioned, A/B tested, and tracked for cost/quality metrics
+#
+# When a prompt's template or variables change here, the seed creates a new
+# version (versions are immutable). Use `db:seed:replant` during development
+# if you want to reset history.
 
-# Use local variables to avoid constant-redefinition warnings when seeds
-# are loaded multiple times in the same process (e.g. tests or console).
-coding_issue_template = <<~'TEMPLATE'
-  # Task
+# rubocop:disable Metrics/BlockLength
 
-  You are working on the following GitHub issue:
+upsert_global_prompt = ->(slug:, name:, description:, category:, template:, variables:) do
+  prompt = Prompt.find_or_initialize_by(slug: slug, account_id: nil, project_id: nil)
 
-  **{{title}}** (#{{issue_number}})
-
-  {{body}}
-
-  # Instructions
-
-  1. Set up the project first — install dependencies (`bundle install`, `npm install`, etc.)
-  2. Analyze the issue and understand what needs to be done
-  3. Make the necessary code changes
-  4. Run lint and fix any violations: `{{lint_command}}`
-  5. Run the test suite and fix any failures: `{{test_command}}`
-  6. Commit your changes with a descriptive message
-
-  **Important:** Git pre-commit hooks will automatically run lint and tests when you commit.
-  If the commit is rejected, read the error output carefully, fix the issues, and commit again.
-  Keep iterating until the commit succeeds. Do not leave uncommitted changes.
-
-  # Rules — you MUST follow these
-
-  - **Lint and tests MUST pass before every commit.** Do not commit code that fails lint or tests.
-  - **Never use `--no-verify`** or any flag that skips git hooks.
-  - **Never disable linters** (e.g. rubocop:disable, eslint-disable, noqa) to silence failures. Fix the code instead.
-  - **Fix forward** — if a check fails, fix the underlying issue. Do not bypass the check.
-  - Work within the existing codebase style and conventions
-  - Do not modify unrelated files
-  - Focus on completing the specific task in the issue
-
-  When you're done, commit all your changes. Do not push.
-TEMPLATE
-
-coding_issue_variables = [
-  { "name" => "title", "required" => true, "description" => "Issue title" },
-  { "name" => "issue_number", "required" => true, "description" => "GitHub issue number" },
-  { "name" => "body", "required" => true, "description" => "Issue body/description" },
-  { "name" => "test_command", "required" => false, "description" => "Test command for the project language" },
-  { "name" => "lint_command", "required" => false, "description" => "Lint command for the project language" }
-]
-
-prompt = Prompt.find_or_initialize_by(slug: "coding.issue_implementation", account_id: nil, project_id: nil)
-
-if prompt.new_record?
-  # On first creation, set all default attributes.
-  prompt.assign_attributes(
-    name: "Issue Implementation",
-    description: "Default prompt for implementing a GitHub issue. Includes task description, instructions, and coding guidelines.",
-    category: "coding",
-    active: true
-  )
-else
-  # For existing prompts, avoid overwriting operator changes.
-  prompt.name ||= "Issue Implementation"
-  prompt.description ||= "Default prompt for implementing a GitHub issue. Includes task description, instructions, and coding guidelines."
-  prompt.category ||= "coding"
-  prompt.active = true if prompt.active.nil?
-end
-
-prompt.save!
-
-current = prompt.current_version
-
-# NOTE: A new version is only created when the template or variables actually
-# change. To avoid version proliferation from trivial whitespace edits,
-# we compare templates using a normalized form (stripping leading/trailing
-# whitespace). However, if you are iterating on the template during development,
-# each meaningful change will still mint a new version. This is by design —
-# versions are immutable and the history is intentional. In production the
-# template should stabilize quickly; in development you can reset with
-# `db:seed:replant`.
-normalize_template = ->(template) { template.to_s.strip }
-
-if current.nil? ||
-   normalize_template.call(current.template) != normalize_template.call(coding_issue_template) ||
-   current.variables != coding_issue_variables
-  change_notes = if current.nil?
-    "Initial version migrated from Prompts::BuildForIssue"
+  if prompt.new_record?
+    prompt.assign_attributes(
+      name: name,
+      description: description,
+      category: category,
+      active: true
+    )
   else
-    "Updated from seeds: template and/or variables changed"
+    prompt.name ||= name
+    prompt.description ||= description
+    prompt.category ||= category
+    prompt.active = true if prompt.active.nil?
   end
 
-  prompt.create_version!(
-    template: coding_issue_template,
-    variables: coding_issue_variables,
-    created_by: "seed",
-    change_notes: change_notes
-  )
+  prompt.save!
 
-  Rails.logger.info(message: "seeds.created_prompt", slug: "coding.issue_implementation")
+  current = prompt.current_version
+  normalize = ->(t) { t.to_s.strip }
+
+  if current.nil? ||
+     normalize.call(current.template) != normalize.call(template) ||
+     current.variables != variables
+    change_notes = current.nil? ? "Initial version from seeds" : "Updated from seeds: template and/or variables changed"
+
+    prompt.create_version!(
+      template: template,
+      variables: variables,
+      created_by: "seed",
+      change_notes: change_notes
+    )
+
+    Rails.logger.info(message: "seeds.created_prompt", slug: slug)
+  end
 end
+
+var = ->(name, description, required: true) { { "name" => name, "required" => required, "description" => description } }
+
+# ----------------------------------------------------------------------------
+# coding.issue_implementation — Default prompt for implementing a GitHub issue
+# Used by: Prompts::BuildForIssue, Activities::CreateAgentRunActivity
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "coding.issue_implementation",
+  name: "Issue Implementation",
+  description: "Default prompt for implementing a GitHub issue. Includes task description, instructions, and coding guidelines.",
+  category: "coding",
+  template: <<~'TEMPLATE',
+    # Task
+
+    You are working on the following GitHub issue:
+
+    **{{title}}** (#{{issue_number}})
+
+    {{body}}
+
+    # Instructions
+
+    1. Install dependencies (`bundle install`, `yarn install`, etc.)
+    {{setup_database_instruction}}
+    2. Analyze the issue and understand what needs to be done
+    3. Make the necessary code changes
+    4. Run lint and fix any violations: `{{lint_command}}`
+    5. Run the test suite and fix any failures: `{{test_command}}`
+    6. Commit your changes with a descriptive message
+
+    **Important:** Git pre-commit hooks will automatically run lint and tests when you commit.
+    If the commit is rejected, read the error output carefully, fix the issues, and commit again.
+    Keep iterating until the commit succeeds. Do not leave uncommitted changes.
+
+    # Rules — you MUST follow these
+
+    - **Lint and tests MUST pass before every commit.** Do not commit code that fails lint or tests.
+    - **Never use `--no-verify`** or any flag that skips git hooks.
+    - **Never disable linters** (e.g. rubocop:disable, eslint-disable, noqa) to silence failures. Fix the code instead.
+    - **Fix forward** — if a check fails, fix the underlying issue. Do not bypass the check.
+    - Work within the existing codebase style and conventions
+    - Do not modify unrelated files
+    - Focus on completing the specific task in the issue
+
+    When you're done, commit all your changes. Do not push.
+  TEMPLATE
+  variables: [
+    var.call("title", "Issue title"),
+    var.call("issue_number", "GitHub issue number"),
+    var.call("body", "Issue body/description"),
+    var.call("test_command", "Test command for the project language", required: false),
+    var.call("lint_command", "Lint command for the project language", required: false),
+    var.call("setup_database_instruction", "Optional database setup line for projects with service containers", required: false)
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# coding.pr_review_rebase — Instructions+rules shell for PR follow-up runs
+# Used by: Prompts::BuildForPr (dynamic CI/review/conflict sections are
+# composed in code and prepended to this rendered shell).
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "coding.pr_review_rebase",
+  name: "PR Review & Rebase",
+  description: "Instructions and rules section for an agent working on an existing pull request. Dynamic sections (task, conflicts, CI failures, code review, conversation) are composed in code by Prompts::BuildForPr and prepended to this rendered shell.",
+  category: "coding",
+  template: <<~'TEMPLATE',
+    # Instructions
+
+    Priority order:
+    {{priority_list}}
+
+    Steps:
+    1. Install dependencies (`bundle install`, `yarn install`, etc.)
+    {{setup_database_instruction}}
+    2. Work through the priorities above in order
+    3. Proactive scan: After making your changes, review the **entire diff** you are
+       about to commit{{review_scan_instruction}}. Look for missing guard clauses,
+       insufficient input validation, unhandled edge cases, missing tests, unclear
+       naming, and style inconsistencies. Fix every issue you find — the goal is
+       zero new review rounds for problems you could have caught yourself.
+    4. Run lint and fix any violations: `{{lint_command}}`
+    5. Run the test suite and fix any failures: `{{test_command}}`
+    6. Commit your changes with a descriptive message
+
+    **Important:** Git pre-commit hooks will automatically run lint and tests when you commit.
+    If the commit is rejected, read the error output carefully, fix the issues, and commit again.
+    Keep iterating until the commit succeeds. Do not leave uncommitted changes.
+
+    When you're done, commit all your changes. Do not push.
+
+    # Rules — you MUST follow these
+
+    - **Lint and tests MUST pass before every commit.** Do not commit code that fails lint or tests.
+    - **Never use `--no-verify`** or any flag that skips git hooks.
+    - **Never disable linters** (e.g. rubocop:disable, eslint-disable, noqa) to silence failures. Fix the code instead.
+    - **Fix forward** — if a check fails, fix the underlying issue. Do not bypass the check.
+    - Work within the existing codebase style and conventions
+    - Do not modify unrelated files
+    - Focus on completing the specific tasks listed above
+  TEMPLATE
+  variables: [
+    var.call("priority_list", "Numbered priority list assembled from PR state"),
+    var.call("setup_database_instruction", "Optional database setup line", required: false),
+    var.call("review_scan_instruction", "Extra clause emphasizing same-class issues when reviewers flagged something", required: false),
+    var.call("lint_command", "Project lint command"),
+    var.call("test_command", "Project test command")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# diagnostics.agent_run_failure — Failure diagnosis for failed agent runs
+# Used by: AgentRuns::DiagnoseError
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "diagnostics.agent_run_failure",
+  name: "Agent Run Failure Diagnosis",
+  description: "Analyzes a failed agent run's error and recent logs and produces a Markdown diagnosis (summary, root cause, suggested fix).",
+  category: "review",
+  template: <<~'TEMPLATE',
+    You are diagnosing a failed agent run. Analyze the error and logs below, then provide:
+    1. A brief summary of what went wrong
+    2. The root cause of the failure
+    3. A suggested fix or workaround
+
+    Be concise and actionable. Format your response in Markdown.
+
+    ## Context
+    - Agent type: {{agent_type}}
+    - Goal: {{goal}}
+    - Task: {{task}}
+    - Status: {{status}}
+    - Duration: {{duration}}s
+
+    ## Error Message
+    ```
+    {{error_text}}
+    ```
+
+    ## Recent Logs
+    ```
+    {{logs_text}}
+    ```
+  TEMPLATE
+  variables: [
+    var.call("agent_type", "Agent type (e.g. claude_code)"),
+    var.call("goal", "Agent run goal"),
+    var.call("task", "Linked issue title or custom prompt"),
+    var.call("status", "Final status of the agent run"),
+    var.call("duration", "Duration in seconds"),
+    var.call("error_text", "Redacted, truncated error message"),
+    var.call("logs_text", "Redacted, truncated tail of agent run logs")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# planning.decompose_feature — Break a feature into independently shippable tasks
+# Used by: Activities::DecomposeFeatureActivity
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "planning.decompose_feature",
+  name: "Feature Decomposition",
+  description: "Decomposes a feature request into independently implementable sub-tasks with dependencies and parallel groups.",
+  category: "planning",
+  template: <<~'TEMPLATE',
+    You are a software architect. Analyze the following feature request and decompose it into smaller, independently-implementable sub-tasks.
+
+    ## Feature Request
+    **Title:** {{title}}
+    **Description:**
+    {{body}}
+
+    {{knowledge_section}}
+
+    ## Instructions
+    - Each sub-task should be independently implementable and testable
+    - Order tasks by dependency (tasks that others depend on come first)
+    - Mark tasks that can be worked on in parallel (no dependencies between them)
+    - If this is a simple feature that doesn't need decomposition, return a single task
+    - Keep task descriptions clear and actionable
+    - Include acceptance criteria for each task
+    - Maximum {{max_tasks}} tasks
+
+    ## Output Format
+    Respond with ONLY a JSON array. Each element must have these fields:
+    - "title": concise task title (string)
+    - "description": detailed description with acceptance criteria (string)
+    - "dependencies": array of task indices (0-based) this task depends on (array of integers)
+    - "parallel_group": integer grouping tasks that can run in parallel (tasks with the same group number have no dependencies on each other)
+
+    Example:
+    [
+      {"title": "Add database migration for X", "description": "Create migration to add...", "dependencies": [], "parallel_group": 0},
+      {"title": "Implement model for X", "description": "Create ActiveRecord model...", "dependencies": [0], "parallel_group": 1},
+      {"title": "Add API endpoint for X", "description": "Create controller action...", "dependencies": [1], "parallel_group": 2}
+    ]
+  TEMPLATE
+  variables: [
+    var.call("title", "Issue title"),
+    var.call("body", "Issue body, truncated"),
+    var.call("knowledge_section", "Optional ## Codebase Context block from semantic search", required: false),
+    var.call("max_tasks", "Maximum number of tasks to emit")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# planning.model_selection — Pick the best LLM for a development task
+# Used by: Models::MetaAgentSelector
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "planning.model_selection",
+  name: "Meta-Agent Model Selection",
+  description: "Asks an LLM to choose the best available model for a development task based on complexity, cost, and budget context.",
+  category: "planning",
+  template: <<~'TEMPLATE',
+    Select the best LLM model for this development task.
+
+    ## Task
+    Goal: {{goal}}
+    {{task_details}}
+
+    ## Project
+    Repository: {{repository}}
+    {{budget_context}}
+
+    ## Available Models
+    {{candidates}}
+
+    ## Instructions
+    Consider task complexity, reasoning requirements, cost-effectiveness, and any budget constraints.
+    Simple tasks (typo fixes, small edits) should use cheaper models.
+    Complex tasks (architecture, multi-file refactors) need the most capable models.
+    If budget is limited, prefer cost-effective models unless the task clearly requires high capability.
+
+    Respond with ONLY a JSON object:
+    {"model": "model-id", "reasoning": "brief explanation", "complexity_score": 5.0}
+
+    complexity_score must be a number from 1.0 (trivial) to 10.0 (extremely complex).
+  TEMPLATE
+  variables: [
+    var.call("goal", "Agent run goal"),
+    var.call("task_details", "Title + truncated body of the linked issue, or 'No linked issue'"),
+    var.call("repository", "Project full_name (owner/repo)"),
+    var.call("budget_context", "Optional budget summary line", required: false),
+    var.call("candidates", "Newline-separated list of available models with costs")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# evolution.mutate_prompt — Generate improved variants of an existing prompt
+# Used by: PromptEvolution::Mutate
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "evolution.mutate_prompt",
+  name: "Prompt Mutation",
+  description: "Asks an LLM to generate N improved variants of a prompt template using configurable strategies (refinement, restructuring, simplification, expansion).",
+  category: "planning",
+  template: <<~'TEMPLATE',
+    You are a prompt engineering expert. Analyze the following prompt and its performance data, then generate {{mutation_count}} improved variant(s).
+
+    ## Current Prompt Template
+    ```
+    {{current_template}}
+    ```
+
+    {{variables_section}}
+    {{system_prompt_section}}
+    {{performance_section}}
+    {{sample_outputs_section}}
+    {{strategies_section}}
+
+    ## Instructions
+    Generate exactly {{mutation_count}} improved prompt variant(s). Each variant must:
+    {{variables_preservation_instruction}}- Be a complete, standalone prompt template (not a diff or partial edit)
+    - Apply one of the requested strategies: {{strategies_csv}}
+    - Address specific weaknesses identified in the performance data
+
+    Respond with ONLY valid JSON in this exact format (no markdown fences, no explanation):
+    {"mutations":[{"template":"improved prompt text","strategy":"one of {{strategies_pipe}}","reasoning":"what problem this addresses","expected_improvement":"why this should perform better"}]}
+  TEMPLATE
+  variables: [
+    var.call("mutation_count", "Number of variants to generate"),
+    var.call("current_template", "Redacted current prompt template"),
+    var.call("variables_section", "Optional ## Template Variables block", required: false),
+    var.call("system_prompt_section", "Optional ## System Prompt block", required: false),
+    var.call("performance_section", "## Performance Data block"),
+    var.call("sample_outputs_section", "Optional ## Sample Outputs block", required: false),
+    var.call("strategies_section", "## Mutation Strategies block"),
+    var.call("variables_preservation_instruction", "Instruction line about preserving {{var}} placeholders", required: false),
+    var.call("strategies_csv", "Comma-separated strategies"),
+    var.call("strategies_pipe", "Slash-separated strategies for the JSON example")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# style.extract_guide — Extract a coding style guide from code samples
+# Used by: StyleGuides::Extract
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "style.extract_guide",
+  name: "Style Guide Extraction",
+  description: "Extracts coding style conventions from a set of representative code samples in a given language. Code samples are appended after the rendered prompt.",
+  category: "review",
+  template: <<~'TEMPLATE',
+    You are a senior software engineer. Analyze the following code samples from a {{language}} codebase and extract the coding style conventions you observe.
+
+    Output a concise style guide covering:
+    - Naming conventions (variables, methods, classes, files)
+    - Formatting patterns (indentation, line length, spacing)
+    - Code organization (module structure, imports, file layout)
+    - Common patterns and idioms used
+    - Error handling conventions
+    - Testing patterns (if test files are included)
+
+    Rules:
+    - Only document conventions actually present in the code — do not invent rules
+    - Use terse bullet points grouped by category
+    - Include short code snippets only when they clarify a pattern
+    - Output plain text with markdown formatting
+    - Keep the guide under 3000 words
+
+    Code samples:
+  TEMPLATE
+  variables: [
+    var.call("language", "Programming language (e.g. ruby, typescript)")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# style.compress_guide — Compress a verbose style guide into LLM-friendly form
+# Used by: StyleGuides::Compress
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "style.compress_guide",
+  name: "Style Guide Compression",
+  description: "Compresses a raw style guide into a terse, LLM-friendly format. The raw guide content is appended after the rendered prompt.",
+  category: "review",
+  template: <<~'TEMPLATE',
+    You are a technical writing assistant. Compress the following coding style guide into a concise, LLM-friendly format.
+
+    Rules:
+    - Keep all concrete rules (naming conventions, formatting, patterns to use/avoid)
+    - Remove verbose explanations, examples that restate the rule, and motivational text
+    - Use terse bullet points grouped by category
+    - Preserve code snippets only when they define a pattern (e.g. preferred import style)
+    - Target roughly 30-50% of the original length
+    - Output plain text with markdown formatting
+
+    Style guide to compress:
+  TEMPLATE
+  variables: []
+)
+
+# ----------------------------------------------------------------------------
+# generation.issue_title — Generate a concise issue title from agent output
+# Used by: Llm::GenerateIssueTitle
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "generation.issue_title",
+  name: "Issue Title Generation",
+  description: "Generates a single concise GitHub issue title from agent output. Returns the title text only, no quotes or prefix.",
+  category: "review",
+  template: <<~'TEMPLATE',
+    Generate a concise GitHub issue title for the following agent output. Respond with ONLY the title text — no quotes, no prefix, no explanation. Keep it under {{max_title_length}} characters.
+
+    {{summary}}
+  TEMPLATE
+  variables: [
+    var.call("max_title_length", "Maximum title length in characters"),
+    var.call("summary", "Truncated agent output to summarize")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# generation.pr_description — Generate a structured PR description
+# Used by: Llm::GeneratePrDescription
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "generation.pr_description",
+  name: "PR Description Generation",
+  description: "Generates a structured PR description that leads with 'why', summarizes scope, and surfaces design decisions. Used after an agent run completes.",
+  category: "review",
+  template: <<~'TEMPLATE',
+    You are writing a pull request description for a code change. Write a clear, well-structured PR description following these rules:
+
+    1. **Lead with "why"** — the first sentence must frame the goal and expected outcome, not implementation details.
+    2. **Summarize the full scope** — describe all changes organized by concern (e.g., database, models, services, UI, infrastructure).
+    3. **Surface design decisions** — call out important trade-offs, constraints, or choices a reviewer should understand.
+    4. **Scale depth to complexity** — keep it concise for small changes; use structured sections for large cross-cutting changes.
+    5. **Mention operational concerns** — note any deployment steps, migration notes, or infrastructure changes if relevant.
+    6. **Include visuals for UI changes** — if the agent output indicates user-facing UI changes, add a ## Screenshots section with a placeholder reminding the author to attach before/after screenshots.
+
+    Use markdown formatting. Start with a ## Summary section containing 1-3 sentences explaining the purpose. Then add a ## Changes section with a bulleted breakdown organized by concern. If there are notable design decisions, add a ## Design Decisions section. Do NOT include a test plan section.
+
+    Respond with ONLY the PR description markdown — no preamble, no wrapping quotes, no explanation.
+
+    ## Issue Context
+    Title: {{issue_title}}
+    Body:
+    {{issue_body}}
+
+    ## Agent Output
+    {{agent_summary}}
+  TEMPLATE
+  variables: [
+    var.call("issue_title", "Linked issue title or 'N/A'"),
+    var.call("issue_body", "Truncated linked issue body or 'N/A'"),
+    var.call("agent_summary", "Truncated agent output")
+  ]
+)
+
+# ----------------------------------------------------------------------------
+# knowledge.draft_decision — Draft an ADR-lite decision record from an agent run
+# Used by: Knowledge::Decisions::Draft
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "knowledge.draft_decision",
+  name: "Decision Record Drafting",
+  description: "Drafts an ADR-lite decision record (title, summary, context, decision, consequences, tags) from a completed agent run's PR changes.",
+  category: "review",
+  template: <<~'TEMPLATE',
+    You are drafting a Decision Record (ADR-lite) for a code change.
+
+    Given the following context about an agent run that created a pull request,
+    produce a structured decision record in JSON format with these fields:
+    - title: A concise title for the decision (max 100 chars)
+    - summary: 1-3 sentence summary of what was decided
+    - context: Background/situation that led to this decision
+    - decision: What was decided and implemented
+    - consequences: Expected outcomes and trade-offs
+    - tags: Array of relevant tags (e.g., ["auth", "api", "performance"])
+
+    Respond with ONLY valid JSON, no markdown fences or extra text.
+
+    ## Agent Run Context
+    Issue: {{issue_title}}
+    PR Changes Summary:
+    {{changes_summary}}
+  TEMPLATE
+  variables: [
+    var.call("issue_title", "Linked issue title or 'N/A'"),
+    var.call("changes_summary", "Truncated PR changes summary")
+  ]
+)
+
+# rubocop:enable Metrics/BlockLength

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -11,8 +11,6 @@
 # version (versions are immutable). Use `db:seed:replant` during development
 # if you want to reset history.
 
-# rubocop:disable Metrics/BlockLength
-
 upsert_global_prompt = ->(slug:, name:, description:, category:, template:, variables:) do
   prompt = Prompt.find_or_initialize_by(slug: slug, account_id: nil, project_id: nil)
 
@@ -495,5 +493,3 @@ upsert_global_prompt.call(
     var.call("changes_summary", "Truncated PR changes summary")
   ]
 )
-
-# rubocop:enable Metrics/BlockLength

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -10,26 +10,28 @@ require "rails_helper"
 # This is the regression net for the "all prompts in the table" migration —
 # if a caller adds a new {{var}} to its template without declaring it in the
 # seed metadata, this spec will fail.
-EXPECTED_SEEDED_PROMPT_SLUGS = %w[
-  coding.issue_implementation
-  coding.pr_review_rebase
-  diagnostics.agent_run_failure
-  planning.decompose_feature
-  planning.model_selection
-  evolution.mutate_prompt
-  style.extract_guide
-  style.compress_guide
-  generation.issue_title
-  generation.pr_description
-  knowledge.draft_decision
-].freeze
+module SeedsPromptsSpec
+  EXPECTED_SLUGS = %w[
+    coding.issue_implementation
+    coding.pr_review_rebase
+    diagnostics.agent_run_failure
+    planning.decompose_feature
+    planning.model_selection
+    evolution.mutate_prompt
+    style.extract_guide
+    style.compress_guide
+    generation.issue_title
+    generation.pr_description
+    knowledge.draft_decision
+  ].freeze
+end
 
 RSpec.describe Prompt, type: :model do
   before do
     load Rails.root.join("db/seeds/prompts.rb").to_s
   end
 
-  EXPECTED_SEEDED_PROMPT_SLUGS.each do |slug|
+  SeedsPromptsSpec::EXPECTED_SLUGS.each do |slug|
     describe "prompt #{slug}" do
       let(:prompt) { described_class.global.find_by(slug: slug) }
       let(:version) { prompt&.current_version }
@@ -51,11 +53,19 @@ RSpec.describe Prompt, type: :model do
         expect(unresolved).to be_empty,
           "expected no unresolved placeholders in #{slug}, got: #{unresolved.inspect}"
       end
+
+      it "declares every {{placeholder}} that appears in its template" do
+        declared = Array(version.variables).map { |v| v.is_a?(Hash) ? (v["name"] || v[:name]) : v.to_s }
+        used = version.template.scan(/\{\{(\w+)\}\}/).flatten.uniq
+        missing = used - declared
+        expect(missing).to be_empty,
+          "template references undeclared variables: #{missing.inspect}"
+      end
     end
   end
 
   it "covers every expected slug exactly" do
-    actual = described_class.global.where(slug: EXPECTED_SEEDED_PROMPT_SLUGS).pluck(:slug).sort
-    expect(actual).to eq(EXPECTED_SEEDED_PROMPT_SLUGS.sort)
+    actual = described_class.global.where(slug: SeedsPromptsSpec::EXPECTED_SLUGS).pluck(:slug).sort
+    expect(actual).to eq(SeedsPromptsSpec::EXPECTED_SLUGS.sort)
   end
 end

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Loads db/seeds/prompts.rb and verifies that every seeded prompt:
+#   1. Creates a Prompt + current PromptVersion row
+#   2. Renders without leaving any unresolved {{variable}} placeholders
+#      when given the variables declared in its `variables` metadata
+#
+# This is the regression net for the "all prompts in the table" migration —
+# if a caller adds a new {{var}} to its template without declaring it in the
+# seed metadata, this spec will fail.
+EXPECTED_SEEDED_PROMPT_SLUGS = %w[
+  coding.issue_implementation
+  coding.pr_review_rebase
+  diagnostics.agent_run_failure
+  planning.decompose_feature
+  planning.model_selection
+  evolution.mutate_prompt
+  style.extract_guide
+  style.compress_guide
+  generation.issue_title
+  generation.pr_description
+  knowledge.draft_decision
+].freeze
+
+RSpec.describe Prompt, type: :model do
+  before do
+    load Rails.root.join("db/seeds/prompts.rb").to_s
+  end
+
+  EXPECTED_SEEDED_PROMPT_SLUGS.each do |slug|
+    describe "prompt #{slug}" do
+      let(:prompt) { described_class.global.find_by(slug: slug) }
+      let(:version) { prompt&.current_version }
+
+      it "exists with an active current version" do
+        expect(prompt).to be_present
+        expect(prompt.active).to be true
+        expect(version).to be_present
+      end
+
+      it "renders without leaving unresolved {{variables}}" do
+        vars = Array(version.variables).each_with_object({}) do |v, h|
+          name = v.is_a?(Hash) ? (v["name"] || v[:name]) : v.to_s
+          h[name.to_sym] = "X"
+        end
+
+        rendered = version.render(vars)
+        unresolved = rendered.scan(/\{\{[^{}]+\}\}/)
+        expect(unresolved).to be_empty,
+          "expected no unresolved placeholders in #{slug}, got: #{unresolved.inspect}"
+      end
+    end
+  end
+
+  it "covers every expected slug exactly" do
+    actual = described_class.global.where(slug: EXPECTED_SEEDED_PROMPT_SLUGS).pluck(:slug).sort
+    expect(actual).to eq(EXPECTED_SEEDED_PROMPT_SLUGS.sort)
+  end
+end

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Prompt, type: :model do
         end
 
         rendered = version.render(vars)
-        unresolved = rendered.scan(/\{\{[^{}]+\}\}/)
+        unresolved = rendered.scan(/\{\{\w+\}\}/)
         expect(unresolved).to be_empty,
           "expected no unresolved placeholders in #{slug}, got: #{unresolved.inspect}"
       end

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -23,6 +23,8 @@ module SeedsPromptsSpec
     generation.issue_title
     generation.pr_description
     knowledge.draft_decision
+    goal.create_github_issue
+    goal.review_pull_request
   ].freeze
 end
 

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -70,4 +70,21 @@ RSpec.describe Prompt, type: :model do
     actual = described_class.global.where(slug: SeedsPromptsSpec::EXPECTED_SLUGS).pluck(:slug).sort
     expect(actual).to eq(SeedsPromptsSpec::EXPECTED_SLUGS.sort)
   end
+
+  describe "goal.review_pull_request clean-PR phrase coupling" do
+    # If ScanPaidPrsActivity::REVIEW_BOT_CLEAN_PATTERN ever changes, the
+    # seeded review template AND the FALLBACK_REVIEW_GOAL_PROMPT in
+    # RunAgentActivity must be updated together or clean reviews will
+    # silently fail to terminate the review loop.
+    let(:pattern) { Activities::ScanPaidPrsActivity::REVIEW_BOT_CLEAN_PATTERN }
+
+    it "seeded template body matches the clean-review pattern" do
+      template = described_class.global.find_by(slug: "goal.review_pull_request").current_version.template
+      expect(template).to match(pattern)
+    end
+
+    it "FALLBACK_REVIEW_GOAL_PROMPT matches the clean-review pattern" do
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT).to match(pattern)
+    end
+  end
 end

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -1249,14 +1249,14 @@ RSpec.describe AgentRun do
     end
 
     it "prioritizes manual runs over automatic runs" do
-      auto = create(:agent_run, :queued, trigger_type: "automatic", created_at: 2.minutes.ago)
+      create(:agent_run, :queued, trigger_type: "automatic", created_at: 2.minutes.ago)
       manual = create(:agent_run, :queued, trigger_type: "manual", created_at: 1.minute.ago)
 
       expect(described_class.next_queued_run).to eq(manual)
     end
 
     it "prioritizes auto-continue (PR) runs over auto-picked runs" do
-      auto_picked = create(:agent_run, :queued, trigger_type: "automatic", created_at: 2.minutes.ago)
+      create(:agent_run, :queued, trigger_type: "automatic", created_at: 2.minutes.ago)
       auto_continue = create(:agent_run, :queued, trigger_type: "automatic",
         source_pull_request_number: 42, created_at: 1.minute.ago)
 
@@ -1264,14 +1264,14 @@ RSpec.describe AgentRun do
     end
 
     it "prioritizes create_issue over create_pr within the same priority tier" do
-      pr_run = create(:agent_run, :queued, trigger_type: "manual", goal: "create_pr", created_at: 2.minutes.ago)
+      create(:agent_run, :queued, trigger_type: "manual", goal: "create_pr", created_at: 2.minutes.ago)
       issue_run = create(:agent_run, :queued, trigger_type: "manual", goal: "create_issue", created_at: 1.minute.ago)
 
       expect(described_class.next_queued_run).to eq(issue_run)
     end
 
     it "uses FIFO within the same priority tier and goal type" do
-      newer_manual = create(:agent_run, :queued, trigger_type: "manual", created_at: 1.minute.ago)
+      create(:agent_run, :queued, trigger_type: "manual", created_at: 1.minute.ago)
       older_manual = create(:agent_run, :queued, trigger_type: "manual", created_at: 2.minutes.ago)
 
       expect(described_class.next_queued_run).to eq(older_manual)
@@ -1280,7 +1280,7 @@ RSpec.describe AgentRun do
 
   describe ".peek_next_queued_run" do
     it "returns the highest-priority queued run without changing status" do
-      auto = create(:agent_run, :queued, trigger_type: "automatic", created_at: 2.minutes.ago)
+      create(:agent_run, :queued, trigger_type: "automatic", created_at: 2.minutes.ago)
       manual = create(:agent_run, :queued, trigger_type: "manual", created_at: 1.minute.ago)
 
       peeked = described_class.peek_next_queued_run

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Prompt do
 
   describe "scopes" do
     before do
-      # Remove seeded prompts so scope tests have a clean slate
-      described_class.where(slug: "coding.issue_implementation").destroy_all
+      # Remove all existing prompts (including seeds) so scope tests have a clean slate
+      described_class.destroy_all
     end
 
     describe ".active" do

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Prompt do
 
   describe "scopes" do
     before do
-      # Remove all existing prompts (including seeds) so scope tests have a clean slate
-      described_class.destroy_all
+      # Remove all seeded (global) prompts so scope tests have a clean slate
+      described_class.global.destroy_all
     end
 
     describe ".active" do

--- a/spec/services/llm/generate_issue_title_spec.rb
+++ b/spec/services/llm/generate_issue_title_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Llm::GenerateIssueTitle do
       allow(AgentHarness).to receive(:send_message)
         .and_raise(AgentHarness::ProviderError.new("Provider unavailable"))
 
+      allow(Rails.logger).to receive(:warn).with(hash_including(message: "prompts.render_fallback"))
       expect(Rails.logger).to receive(:warn).with(hash_including(
         message: "agent_execution.llm_generate_issue_title_failed"
       ))
@@ -98,6 +99,7 @@ RSpec.describe Llm::GenerateIssueTitle do
       allow(AgentHarness).to receive(:send_message)
         .and_raise(AgentHarness::TimeoutError.new("Timed out"))
 
+      allow(Rails.logger).to receive(:warn).with(hash_including(message: "prompts.render_fallback"))
       expect(Rails.logger).to receive(:warn).with(hash_including(
         message: "agent_execution.llm_generate_issue_title_failed"
       ))

--- a/spec/services/prompt_evolution/mutate_spec.rb
+++ b/spec/services/prompt_evolution/mutate_spec.rb
@@ -233,6 +233,7 @@ RSpec.describe PromptEvolution::Mutate do
       failed_response = instance_double(AgentHarness::Response, success?: false, exit_code: 1, error: long_error)
       allow(AgentHarness).to receive(:send_message).and_return(failed_response)
 
+      allow(Rails.logger).to receive(:warn).with(hash_including(message: "prompts.render_fallback"))
       expect(Rails.logger).to receive(:warn).with(hash_including(
         message: "prompt_evolution.mutate_unsuccessful_response",
         error_detail: a_string_matching(/\[truncated\]/)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,8 +32,9 @@ RSpec.configure do |config|
   # Limits the available syntax to the non-monkey patched syntax.
   config.disable_monkey_patching!
 
-  # This setting enables warnings.
-  config.warnings = true
+  # Warnings from third-party gems are noisy and not actionable.
+  # Run with RUBYOPT="-W1" to surface warnings locally when needed.
+  config.warnings = false
 
   # Print the 10 slowest examples at the end of the spec run.
   config.profile_examples = 10 if config.files_to_run.one?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,9 +32,8 @@ RSpec.configure do |config|
   # Limits the available syntax to the non-monkey patched syntax.
   config.disable_monkey_patching!
 
-  # Warnings from third-party gems are noisy and not actionable.
-  # Run with RUBYOPT="-W1" to surface warnings locally when needed.
-  config.warnings = false
+  # This setting enables warnings.
+  config.warnings = true
 
   # Print the 10 slowest examples at the end of the spec run.
   config.profile_examples = 10 if config.files_to_run.one?


### PR DESCRIPTION
## Summary

- Migrates 13 LLM prompts that were scattered across services, activities, and prompt builders into the existing `prompts` / `prompt_versions` table so they can be versioned, A/B tested, iterated on in the controller UI, and tracked for cost/quality.
- Adds `Prompts::Render`, a slug resolver + single-pass `{{var}}` interpolator. `PromptVersion#render` now delegates to it. Each caller keeps its old template as a `FALLBACK_PROMPT` constant used only when the seeded row is missing or deactivated (warn + use fallback during rollout; we can flip to raising once stable).
- Fixes a real gsub-ordering bug in `PromptEvolution::Mutate` where `current_template` (an arbitrary prompt) routinely contains `{{...}}` tokens that the old reduce loop would clobber.
- **Behavior change in the PR review prompt** (`goal.review_pull_request`): forbids praise-only / "looks good" inline comments. Inline comments are now reserved exclusively for actionable changes. A clean PR with zero issues is a valid outcome — the agent posts a single review with empty `comments` and a body beginning with the exact phrase **"Generated no new comments."**, which matches `ScanPaidPrsActivity::REVIEW_BOT_CLEAN_PATTERN` and stops the review loop the same way a clean Copilot review does. Drops the standalone-PR-comments curl example and the optional `/issues/:n/comments` endpoint from the docs.

## Prompts migrated (13)

| Slug | Source | Category |
|---|---|---|
| `coding.issue_implementation` | `Prompts::BuildForIssue` | coding |
| `coding.pr_review_rebase` | `Prompts::BuildForPr` | coding |
| `diagnostics.agent_run_failure` | `AgentRuns::DiagnoseError` | review |
| `planning.decompose_feature` | `Activities::DecomposeFeatureActivity` | planning |
| `planning.model_selection` | `Models::MetaAgentSelector` | planning |
| `evolution.mutate_prompt` | `PromptEvolution::Mutate` | planning |
| `style.extract_guide` | `StyleGuides::Extract` | review |
| `style.compress_guide` | `StyleGuides::Compress` | review |
| `generation.issue_title` | `Llm::GenerateIssueTitle` | review |
| `generation.pr_description` | `Llm::GeneratePrDescription` | review |
| `knowledge.draft_decision` | `Knowledge::Decisions::Draft` | review |
| `goal.create_github_issue` | `RunAgentActivity#augment_prompt_for_issue_goal` | planning |
| `goal.review_pull_request` | `RunAgentActivity#augment_prompt_for_review_goal` | review |

## Notable design choices

- **Fallback safety net**: every caller keeps its template inline as `FALLBACK_PROMPT`. If `Prompts::Render` can't find an active seeded version it logs `prompts.render_fallback` and uses the in-code template. This means a missed seed run, a deactivated prompt, or a fresh test DB never breaks agent execution. Once the seeded prompts stabilize in production we can flip the behavior to raise.
- **`BuildForIssue` / `BuildForPr` keep dynamic section composition in Ruby**; only the static instructional shell moves into the templated prompt, so the prompt stays readable in the controller UI while per-request data (CI failures, conflicts, conversation comments, service environment) is appended in code.
- **`Prompts::Render.interpolate`** is a single-pass regex substitution rather than `vars.reduce(template) { gsub }`, so values that themselves contain `{{other_var}}` (e.g. `Mutate#current_template`) are never re-substituted on later iterations.
- **`coding.issue_implementation`** got a new `{{setup_database_instruction}}` variable + `ServiceContainerSections.setup_database_instruction_for` so `BuildForIssue` and `CreateAgentRunActivity` render the exact same template. They had drifted slightly. To avoid duplicating the database setup line, the activity passes `""` for the inline slot and continues to append the full `# Service Environment` block, while `BuildForIssue` does the opposite split (inline slot filled, header skipped).
- **Clean-review phrase coupling**: `spec/db/seeds_prompts_spec.rb` asserts both the seeded `goal.review_pull_request` template AND `RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT` match `ScanPaidPrsActivity::REVIEW_BOT_CLEAN_PATTERN`. If the matcher pattern ever changes without updating the prompts, the spec fails instead of the review loop wedging silently.

## Test plan

- [ ] `bin/rails db:seed` against a fresh DB and confirm all 13 prompts appear in `/prompts`
- [ ] Re-run `bin/rails db:seed` against an existing DB and confirm no duplicate `PromptVersion` rows are minted (idempotency)
- [ ] Run `bin/rspec spec/db/seeds_prompts_spec.rb spec/services/prompts spec/services/style_guides spec/services/agent_runs/diagnose_error_spec.rb spec/services/models/meta_agent_selector_spec.rb spec/services/llm spec/services/prompt_evolution spec/services/knowledge/decisions/draft_spec.rb spec/temporal/activities/decompose_feature_activity_spec.rb spec/temporal/activities/create_agent_run_activity_spec.rb spec/temporal/activities/run_agent_activity_spec.rb` — all green locally
- [ ] Smoke-test a real agent run (issue goal) and confirm the rendered prompt matches expectations and that `prompts.render_fallback` does NOT appear in logs after seeding
- [ ] Smoke-test a real PR review run on a clean PR and confirm the agent posts a single review with `comments: []` and a body matching `REVIEW_BOT_CLEAN_PATTERN`, and that the review loop terminates

🤖 Generated with [Claude Code](https://claude.com/claude-code)