### PR TITLE
feat(agent-runs): add no_output status for unproductive create_pr runs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,7 @@ module ApplicationHelper
     "pending" => { bg: "bg-yellow-100", text: "text-yellow-800", label: "Pending" },
     "running" => { bg: "bg-blue-100", text: "text-blue-700", label: "Running" },
     "completed" => { bg: "bg-green-100", text: "text-green-700", label: "Completed" },
+    "no_output" => { bg: "bg-slate-100", text: "text-slate-600", label: "No Output" },
     "failed" => { bg: "bg-red-100", text: "text-red-700", label: "Failed" },
     "cancelled" => { bg: "bg-gray-100", text: "text-gray-600", label: "Cancelled" },
     "timeout" => { bg: "bg-orange-100", text: "text-orange-700", label: "Timeout" },

--- a/app/javascript/controllers/agent_run_actions_controller.js
+++ b/app/javascript/controllers/agent_run_actions_controller.js
@@ -14,6 +14,7 @@ import { Controller } from "@hotwired/stimulus"
 const ACTIVE_STATUSES = ["pending", "running"]
 const FINISHED_STATUSES = [
   "completed",
+  "no_output",
   "failed",
   "cancelled",
   "timeout",

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class AgentRun < ApplicationRecord
-  STATUSES = %w[queued pending running paused completed failed cancelled timeout retried auth_expired rate_limited].freeze
+  STATUSES = %w[queued pending running paused completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
   AGENT_TYPES = %w[claude_code cursor codex copilot aider gemini opencode kilocode api].freeze
   GOALS = %w[create_pr create_issue review].freeze
   TRIGGER_TYPES = %w[manual automatic].freeze
   ACTIVE_STATUSES = %w[pending running].freeze
-  FINISHED_STATUSES = %w[completed failed cancelled timeout retried auth_expired rate_limited].freeze
+  FINISHED_STATUSES = %w[completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
   FAILURE_STATUSES = %w[failed timeout auth_expired rate_limited].freeze
   UNFINISHED_STATUSES = %w[queued pending running paused].freeze
   GUARDRAIL_VIOLATION_TYPES = %w[loop_detected token_limit cost_limit time_limit anomaly].freeze
@@ -81,6 +81,7 @@ class AgentRun < ApplicationRecord
   scope :pending, -> { where(status: "pending") }
   scope :running, -> { where(status: "running") }
   scope :completed, -> { where(status: "completed") }
+  scope :no_output, -> { where(status: "no_output") }
   scope :failed, -> { where(status: "failed") }
   scope :cancelled, -> { where(status: "cancelled") }
   scope :timeout, -> { where(status: "timeout") }
@@ -578,6 +579,15 @@ class AgentRun < ApplicationRecord
       pull_request_number: pr_number,
       created_issue_url: issue_url,
       created_issue_number: issue_number,
+      duration_seconds: duration
+    )
+  end
+
+  def complete_no_output!(reason: "no_changes")
+    update!(
+      status: "no_output",
+      completed_at: Time.current,
+      error_message: reason,
       duration_seconds: duration
     )
   end

--- a/app/temporal/activities/mark_agent_run_complete_activity.rb
+++ b/app/temporal/activities/mark_agent_run_complete_activity.rb
@@ -9,10 +9,14 @@ module Activities
       reason = input.fetch(:reason, "no_changes")
       agent_run = AgentRun.find(agent_run_id)
       track_phase(agent_run_id: agent_run_id, phase_key: "mark_agent_run_complete", phase_group: "post", agent_run: agent_run, metadata: { reason: reason }) do
-        agent_run.complete!
-        agent_run.log!("system", "Completed without PR: #{reason}")
+        if agent_run.goal == "create_pr"
+          agent_run.complete_no_output!(reason: reason)
+        else
+          agent_run.complete!
+        end
+        agent_run.log!("system", "Completed without output: #{reason}")
 
-        if agent_run.issue
+        if agent_run.issue && agent_run.status != "no_output"
           agent_run.issue.update!(paid_state: "completed")
         end
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -343,10 +343,13 @@ module Activities
     end
 
     # Circuit breaker: if the last N automatic draft follow-up runs on
-    # this PR all ended without producing any output (timeout/failed/
-    # cancelled with zero iterations), stop requeueing to prevent
-    # infinite retry loops. Scoped to automatic create_pr runs so that
-    # manual runs or review-phase followups don't trip the breaker.
+    # this PR all ended without producing any output, stop requeueing
+    # to prevent infinite retry loops. A run is "unproductive" if it
+    # finished as no_output (completed with zero commits), or if it
+    # failed/cancelled/timed out with zero iterations. Runs that did
+    # real work before failing don't trip the breaker. Scoped to
+    # automatic create_pr runs so that manual runs or review-phase
+    # followups don't trip the breaker.
     #
     # The draft_review_count guard ensures we only consider runs from the
     # current draft phase. maybe_restart_draft resets draft_review_count
@@ -367,7 +370,7 @@ module Activities
       return false if recent_runs.size < MAX_CONSECUTIVE_DRAFT_FAILURES
 
       recent_runs.all? do |run|
-        unproductive_statuses.include?(run.status)
+        unproductive_statuses.include?(run.status) && (run.status == "no_output" || run.iterations.to_i.zero?)
       end
     end
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -355,7 +355,7 @@ module Activities
     def consecutive_draft_failures_breaker?(project, issue)
       return false if issue.draft_review_count < MAX_CONSECUTIVE_DRAFT_FAILURES
 
-      failure_statuses = AgentRun::FAILURE_STATUSES + %w[cancelled]
+      unproductive_statuses = AgentRun::FAILURE_STATUSES + %w[cancelled no_output]
 
       recent_runs = project.agent_runs
         .where(source_pull_request_number: issue.github_number)
@@ -367,7 +367,7 @@ module Activities
       return false if recent_runs.size < MAX_CONSECUTIVE_DRAFT_FAILURES
 
       recent_runs.all? do |run|
-        failure_statuses.include?(run.status) && run.iterations.to_i.zero?
+        unproductive_statuses.include?(run.status)
       end
     end
 

--- a/app/temporal/activities/track_parallel_progress_activity.rb
+++ b/app/temporal/activities/track_parallel_progress_activity.rb
@@ -16,6 +16,7 @@ module Activities
       counts_by_status = runs.group(:status).count
 
       completed = counts_by_status["completed"].to_i
+      no_output = counts_by_status["no_output"].to_i
       failed = AgentRun::FAILURE_STATUSES.sum { |status| counts_by_status[status].to_i }
       cancelled = counts_by_status["cancelled"].to_i
       active = AgentRun::ACTIVE_STATUSES.sum { |status| counts_by_status[status].to_i }
@@ -27,13 +28,14 @@ module Activities
       missing = agent_run_ids.size - found_count
       total = found_count
 
-      all_finished = (completed + failed + cancelled) == total && total > 0
+      all_finished = (completed + no_output + failed + cancelled) == total && total > 0
 
       logger.info(
         message: "parallel_execution.progress",
         parent_workflow_id: parent_workflow_id,
         total: total,
         completed: completed,
+        no_output: no_output,
         failed: failed,
         cancelled: cancelled,
         active: active,
@@ -45,6 +47,7 @@ module Activities
       {
         total: total,
         completed: completed,
+        no_output: no_output,
         failed: failed,
         cancelled: cancelled,
         active: active,

--- a/app/views/dashboard/_content.html.erb
+++ b/app/views/dashboard/_content.html.erb
@@ -34,13 +34,14 @@
       <div class="px-4 py-5 sm:p-6">
         <h3 class="text-sm font-medium text-gray-500">Status Breakdown</h3>
         <div class="mt-3 flex flex-wrap gap-4 text-sm">
-          <% %w[completed failed cancelled timeout queued pending running].each do |status| %>
+          <% %w[completed no_output failed cancelled timeout queued pending running].each do |status| %>
             <% count = stats[:run_volume][:by_status][status] || 0 %>
             <% next if count.zero? %>
             <div class="flex items-center gap-1.5">
               <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
                 <%= case status
                     when 'completed' then 'bg-green-100 text-green-700'
+                    when 'no_output' then 'bg-slate-100 text-slate-600'
                     when 'failed' then 'bg-red-100 text-red-700'
                     when 'cancelled' then 'bg-gray-100 text-gray-700'
                     when 'timeout' then 'bg-yellow-100 text-yellow-700'
@@ -48,7 +49,7 @@
                     when 'pending' then 'bg-purple-100 text-purple-700'
                     when 'queued' then 'bg-indigo-100 text-indigo-700'
                     end %>">
-                <%= status.capitalize %>
+                <%= status.titleize %>
               </span>
               <span class="font-semibold text-gray-900"><%= number_with_delimiter(count) %></span>
             </div>

--- a/app/views/dashboard/_metrics.html.erb
+++ b/app/views/dashboard/_metrics.html.erb
@@ -44,13 +44,14 @@
       <div class="px-4 py-5 sm:p-6">
         <h3 class="text-sm font-medium text-gray-500">Status Breakdown</h3>
         <div class="mt-3 flex flex-wrap gap-4 text-sm">
-          <% %w[completed failed cancelled timeout queued pending running].each do |status| %>
+          <% %w[completed no_output failed cancelled timeout queued pending running].each do |status| %>
             <% count = stats[:run_volume][:by_status][status] || 0 %>
             <% next if count.zero? %>
             <div class="flex items-center gap-1.5">
               <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
                 <%= case status
                     when 'completed' then 'bg-green-100 text-green-700'
+                    when 'no_output' then 'bg-slate-100 text-slate-600'
                     when 'failed' then 'bg-red-100 text-red-700'
                     when 'cancelled' then 'bg-gray-100 text-gray-700'
                     when 'timeout' then 'bg-yellow-100 text-yellow-700'
@@ -58,7 +59,7 @@
                     when 'pending' then 'bg-purple-100 text-purple-700'
                     when 'queued' then 'bg-indigo-100 text-indigo-700'
                     end %>">
-                <%= status.capitalize %>
+                <%= status.titleize %>
               </span>
               <span class="font-semibold text-gray-900"><%= number_with_delimiter(count) %></span>
             </div>

--- a/spec/factories/agent_runs.rb
+++ b/spec/factories/agent_runs.rb
@@ -36,6 +36,14 @@ FactoryBot.define do
       pull_request_number { 1 }
     end
 
+    trait :no_output do
+      status { "no_output" }
+      started_at { 10.minutes.ago }
+      completed_at { Time.current }
+      duration_seconds { 600 }
+      error_message { "no_changes" }
+    end
+
     trait :failed do
       status { "failed" }
       started_at { 10.minutes.ago }

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -1460,7 +1460,7 @@ RSpec.describe AgentRun do
 
   describe "constants" do
     it "defines valid STATUSES" do
-      expect(described_class::STATUSES).to eq(%w[queued pending running paused completed failed cancelled timeout retried auth_expired rate_limited])
+      expect(described_class::STATUSES).to eq(%w[queued pending running paused completed no_output failed cancelled timeout retried auth_expired rate_limited])
     end
 
     it "defines valid AGENT_TYPES" do

--- a/spec/temporal/activities/mark_agent_run_complete_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_complete_activity_spec.rb
@@ -7,12 +7,32 @@ RSpec.describe Activities::MarkAgentRunCompleteActivity do
   let(:project) { create(:project) }
 
   describe "#execute" do
-    it "marks the agent run as completed" do
-      agent_run = create(:agent_run, :running, project: project)
+    context "when goal is create_pr" do
+      it "marks the agent run as no_output" do
+        agent_run = create(:agent_run, :running, project: project)
 
-      activity.execute(agent_run_id: agent_run.id)
+        activity.execute(agent_run_id: agent_run.id)
 
-      expect(agent_run.reload.status).to eq("completed")
+        expect(agent_run.reload.status).to eq("no_output")
+      end
+
+      it "stores the reason in error_message" do
+        agent_run = create(:agent_run, :running, project: project)
+
+        activity.execute(agent_run_id: agent_run.id, reason: "no_changes")
+
+        expect(agent_run.reload.error_message).to eq("no_changes")
+      end
+    end
+
+    context "when goal is not create_pr" do
+      it "marks the agent run as completed" do
+        agent_run = create(:agent_run, :running, :create_issue_goal, project: project)
+
+        activity.execute(agent_run_id: agent_run.id)
+
+        expect(agent_run.reload.status).to eq("completed")
+      end
     end
 
     it "logs the completion reason" do
@@ -26,13 +46,22 @@ RSpec.describe Activities::MarkAgentRunCompleteActivity do
       expect(log.content).to include("no_changes")
     end
 
-    it "updates issue paid_state to completed when issue exists" do
+    it "updates issue paid_state to completed for non-PR goals" do
+      issue = create(:issue, :in_progress, project: project)
+      agent_run = create(:agent_run, :running, :create_issue_goal, project: project, issue: issue)
+
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(issue.reload.paid_state).to eq("completed")
+    end
+
+    it "does not update issue paid_state for no_output create_pr runs" do
       issue = create(:issue, :in_progress, project: project)
       agent_run = create(:agent_run, :running, project: project, issue: issue)
 
       activity.execute(agent_run_id: agent_run.id)
 
-      expect(issue.reload.paid_state).to eq("completed")
+      expect(issue.reload.paid_state).to eq("in_progress")
     end
 
     it "enqueues ProcessRunQueueJob" do

--- a/spec/temporal/activities/track_parallel_progress_activity_spec.rb
+++ b/spec/temporal/activities/track_parallel_progress_activity_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Activities::TrackParallelProgressActivity do
       expect(result[:all_finished]).to be true
     end
 
+    it "counts no_output runs toward finished" do
+      project = create(:project)
+      no_output_run = create(:agent_run, :no_output, project: project, parent_workflow_id: "test-wf")
+
+      result = activity.execute({
+        parent_workflow_id: "test-wf",
+        agent_run_ids: [ no_output_run.id ]
+      })
+
+      expect(result[:total]).to eq(1)
+      expect(result[:no_output]).to eq(1)
+      expect(result[:all_finished]).to be true
+    end
+
     it "scopes runs by parent_workflow_id when provided" do
       project = create(:project)
       matching_run = create(:agent_run, :completed, project: project, parent_workflow_id: "parent-wf-1")


### PR DESCRIPTION
## Summary

- Adds a new `no_output` status for `create_pr` agent runs that complete without producing any commits, distinguishing them from truly successful `completed` runs
- Updates the draft circuit breaker to trip on consecutive `no_output` runs, preventing infinite auto-continue loops (e.g. when CI fails due to a seed-dependent test ordering issue the agent can't reproduce)
- Fixes `TrackParallelProgressActivity` to count `no_output` runs toward `all_finished`, preventing parallel workflows from hanging
- Skips `paid_state: "completed"` update for `no_output` runs so the issue correctly stays `in_progress`

## Context

Observed 9+ consecutive auto-triggered runs on PR #981 that each ran for ~25 minutes, produced nothing, were marked "completed", and re-triggered because:
1. `complete!` doesn't distinguish "ran successfully" from "ran but did nothing"
2. The circuit breaker only checks `FAILURE_STATUSES`, so "completed" runs never trip it
3. `pr_followup_count` wasn't incrementing (draft phase uses a different counter)

## Test plan

- [x] `MarkAgentRunCompleteActivity` spec: create_pr → `no_output`, create_issue → `completed`
- [x] `MarkAgentRunCompleteActivity` spec: `paid_state` unchanged for `no_output` runs
- [x] `TrackParallelProgressActivity` spec: `no_output` counted in `all_finished`
- [x] All existing specs pass (no regressions)
- [x] Lint clean
- [ ] Verify UI badge renders correctly for `no_output` status
- [ ] Verify dashboard status breakdown shows "No Output" when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)