### PR TITLE
fix(agent-runs): PR review table invisible on trigger form

### DIFF
--- a/app/views/shared/_pr_review_table.html.erb
+++ b/app/views/shared/_pr_review_table.html.erb
@@ -1,7 +1,7 @@
 <%# Multi-select table for review goal %>
-<div data-goal-toggle-target="prTable" class="hidden">
+<div data-goal-toggle-target="prTable" hidden>
   <p class="block text-sm font-medium text-gray-700 mb-2">Select PRs to review:</p>
-  <div class="overflow-hidden rounded-md border border-gray-200">
+  <div class="overflow-x-auto rounded-md border border-gray-200">
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -396,6 +396,11 @@ RSpec.describe "AgentRuns" do
         expect(body).to include('data-goal-toggle-target="issueSection"')
         expect(body).to include('data-goal-toggle-target="prSection"')
         expect(body).to include('data-goal-toggle-target="prTable"')
+
+        doc = Nokogiri::HTML(body)
+        pr_table = doc.at_css('[data-goal-toggle-target="prTable"]')
+        expect(pr_table).not_to be_nil
+        expect(pr_table["class"].to_s).not_to include("hidden")
       end
 
       it "shows all open issues in dropdown regardless of paid_state" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -388,12 +388,14 @@ RSpec.describe "AgentRuns" do
       end
 
       it "includes goal-toggle Stimulus wiring" do
+        create(:issue, :pull_request, project: project, github_number: 20, title: "Wiring PR")
         get new_project_agent_run_path(project)
         body = response.body
         expect(body).to include('data-controller="goal-toggle"')
         expect(body).to include('data-action="change->goal-toggle#toggle"')
         expect(body).to include('data-goal-toggle-target="issueSection"')
         expect(body).to include('data-goal-toggle-target="prSection"')
+        expect(body).to include('data-goal-toggle-target="prTable"')
       end
 
       it "shows all open issues in dropdown regardless of paid_state" do


### PR DESCRIPTION
## Summary
- Fix PR review table not appearing when selecting "PR Code Review" goal on the Trigger Agent Run form
- The partial used Tailwind's `class="hidden"` but the Stimulus controller toggles the HTML `hidden` attribute — both independently apply `display: none`, so removing the attribute still left the CSS class hiding the element
- Make the table horizontally scrollable on narrow screens (`overflow-x-auto`)
- Add `prTable` Stimulus target assertion to existing wiring test

## Test plan
- [x] Reproduced bug with Playwright: selecting PR Code Review showed blank section
- [x] Verified fix with Playwright: PR table now displays with checkboxes, priority, review rounds
- [x] Verified switching back to Create/Edit PR hides the table correctly
- [x] Existing request specs pass (`bin/rspec spec/requests/agent_runs_spec.rb -e "GET /projects/:project_id/agent_runs/new"` — 9 examples, 0 failures)
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)