### PR TITLE
Fix #982: fix(knowledge): ArtifactStore RecordNotUnique rescue fails when content_hash collides across different scope_paths

### DIFF
--- a/app/services/knowledge/artifact_store.rb
+++ b/app/services/knowledge/artifact_store.rb
@@ -47,8 +47,11 @@ module Knowledge
             mark_prior_stale(data)
             create_artifact(data, content_hash)
           end
-        rescue ActiveRecord::RecordNotUnique
+        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+          raise unless content_hash_conflict?(e)
+
           existing_after_conflict = find_existing_artifact(data, content_hash)
+          existing_after_conflict ||= find_by_run_and_hash(content_hash)
 
           if existing_after_conflict
             reassign_to_current_run(existing_after_conflict)
@@ -71,6 +74,18 @@ module Knowledge
           status: "active"
         )
         .first
+    end
+
+    # Broadened lookup using only the columns covered by the unique index
+    # (collector_run_id, content_hash). This handles cross-scope hash
+    # collisions where a different scope_path/identifier produced the same
+    # content_hash within the same collector run.
+    def find_by_run_and_hash(content_hash)
+      KnowledgeArtifact.find_by(
+        collector_run: collector_run,
+        content_hash: content_hash,
+        status: "active"
+      )
     end
 
     def reassign_to_current_run(artifact)
@@ -161,6 +176,17 @@ module Knowledge
           sequence: chunk[:sequence] || index,
           status: "active"
         )
+      end
+    end
+
+    def content_hash_conflict?(exception)
+      case exception
+      when ActiveRecord::RecordNotUnique
+        true
+      when ActiveRecord::RecordInvalid
+        exception.record.errors[:content_hash].any?
+      else
+        false
       end
     end
 

--- a/app/services/knowledge/collectors/config_key_collector.rb
+++ b/app/services/knowledge/collectors/config_key_collector.rb
@@ -81,7 +81,9 @@ module Knowledge
       end
 
       def deduplicate(artifacts)
-        artifacts.uniq { |a| [ a[:identifier], a[:scope_path] ] }
+        artifacts
+          .uniq { |a| [ a[:identifier], a[:scope_path] ] }
+          .uniq { |a| Digest::SHA256.hexdigest(a[:content].to_s) }
       end
 
       def ast_grep_log_component

--- a/app/services/knowledge/collectors/symbol_index_collector.rb
+++ b/app/services/knowledge/collectors/symbol_index_collector.rb
@@ -56,7 +56,7 @@ module Knowledge
           end
         end
 
-        artifacts
+        deduplicate_by_content(artifacts)
       end
 
       def collector_type
@@ -156,6 +156,13 @@ module Knowledge
         else
           "#{file_path}::#{qualified_name}"
         end
+      end
+
+      # Prevent content_hash collisions within a single collector run.
+      # The unique index on [collector_run_id, content_hash] rejects
+      # duplicates, so keep only the first artifact per content hash.
+      def deduplicate_by_content(artifacts)
+        artifacts.uniq { |a| Digest::SHA256.hexdigest(a[:content].to_s) }
       end
 
       def ast_grep_log_component

--- a/app/services/knowledge/collectors/tree_sitter_collector.rb
+++ b/app/services/knowledge/collectors/tree_sitter_collector.rb
@@ -67,7 +67,7 @@ module Knowledge
         LANGUAGE_CONFIG.each do |language, config|
           artifacts.concat(collect_language(language, config))
         end
-        artifacts
+        deduplicate_by_content(artifacts)
       end
 
       def collector_type
@@ -203,6 +203,13 @@ module Knowledge
             }
           ]
         }
+      end
+
+      # Prevent content_hash collisions within a single collector run.
+      # The unique index on [collector_run_id, content_hash] rejects
+      # duplicates, so keep only the first artifact per content hash.
+      def deduplicate_by_content(artifacts)
+        artifacts.uniq { |a| Digest::SHA256.hexdigest(a[:content].to_s) }
       end
 
       def ast_grep_log_component

--- a/spec/services/knowledge/artifact_store_spec.rb
+++ b/spec/services/knowledge/artifact_store_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe Knowledge::ArtifactStore do
       end
     end
 
+    context "when two artifacts have the same content but different scope_path" do
+      let(:duplicate_data) do
+        artifact_data.merge(
+          scope_path: "config/other_routes.rb",
+          identifier: "GET /api/users (alt)"
+        )
+      end
+
+      it "does not raise RecordNotUnique" do
+        expect { store.store_all([ artifact_data, duplicate_data ]) }.not_to raise_error
+      end
+
+      it "stores only one artifact (content_hash is unique per run)" do
+        store.store_all([ artifact_data, duplicate_data ])
+        expect(KnowledgeArtifact.count).to eq(1)
+      end
+    end
+
     context "when content changes (different hash)" do
       let(:new_version) { create(:project_version, project: project) }
       let(:new_run) { create(:collector_run, project_version: new_version, collector_type: "test") }


### PR DESCRIPTION
## Summary

fix(knowledge): ArtifactStore RecordNotUnique rescue fails when content_hash collides across different scope_paths

See #982 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #982