### PR TITLE
Fix #1006: feat(scanner): define post-escalation behavior after max_review_rounds reached

### DIFF
--- a/app/temporal/activities/dismiss_escalation_activity.rb
+++ b/app/temporal/activities/dismiss_escalation_activity.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Activities
+  # Transitions a PR from "escalated" back to "ready" when the owner
+  # dismisses the escalation (e.g. by adding the paid-dismiss-escalation
+  # label). Removes the escalation label and the dismiss trigger label.
+  class DismissEscalationActivity < BaseActivity
+    activity_name "DismissEscalation"
+
+    PAID_ESCALATED_LABEL = "paid-escalated"
+    DISMISS_ESCALATION_LABEL = "paid-dismiss-escalation"
+
+    def execute(input)
+      issue = Issue.find_by(id: input[:issue_id])
+      return { dismissed: false } unless issue
+      return { dismissed: false } unless issue.escalated_phase?
+
+      project = issue.project
+      client = project.github_token.client
+
+      issue.update!(pr_review_phase: "ready")
+
+      remove_label(client, project, issue, DISMISS_ESCALATION_LABEL)
+      remove_label(client, project, issue, PAID_ESCALATED_LABEL)
+
+      logger.info(
+        message: "pr_review.escalation_dismissed",
+        issue_id: issue.id,
+        pr_number: issue.github_number
+      )
+
+      { dismissed: true }
+    end
+
+    private
+
+    def remove_label(client, project, issue, label)
+      client.remove_label_from_issue(project.full_name, issue.github_number, label)
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "pr_review.remove_label_failed",
+        issue_id: issue.id,
+        pr_number: issue.github_number,
+        label: label,
+        error: e.message
+      )
+    end
+  end
+end

--- a/app/temporal/activities/mark_escalated_activity.rb
+++ b/app/temporal/activities/mark_escalated_activity.rb
@@ -76,13 +76,16 @@ module Activities
 
     def build_escalation_comment(reason, project, issue)
       reason = default_reason(project, issue) if reason.blank?
+      owner = project.owner_reviewer_login
 
       lines = [ COMMENT_MARKER, "**Escalation Note**", "" ]
       lines << "This has been escalated because #{reason}."
+      lines << "@#{owner} — manual review is required." if owner.present?
       lines << ""
-      lines << "**Questions:**"
-      lines << "- Are there specific changes you'd like to see in the pull request?"
-      lines << "- Should the automated review cycle be restarted with different guidance?"
+      lines << "**How to resolve:**"
+      lines << "- **Approve** this PR to allow auto-merge (if enabled)"
+      lines << "- **Add the `paid-dismiss-escalation` label** to move back to the `ready` phase without merging"
+      lines << "- **Convert to draft** on GitHub to restart the automated review cycle"
       lines.join("\n")
     end
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -257,7 +257,33 @@ module Activities
 
     # --- Escalated phase scanning ---
 
+    DISMISS_ESCALATION_LABEL = "paid-dismiss-escalation"
+
     def scan_escalated_pr(project, client, issue, pr_data: nil)
+      pr_data ||= fetch_pr_data(client, project, issue)
+
+      # Owner can dismiss escalation by adding the dismiss label.
+      if issue.has_label?(DISMISS_ESCALATION_LABEL)
+        return dismiss_escalation_trigger(issue)
+      end
+
+      # Owner approval on an escalated PR unblocks auto-merge.
+      if project.auto_merge_enabled? && pr_data.present?
+        checks = fetch_check_runs(client, project, pr_data)
+        reviews = fetch_reviews(client, project, issue)
+        mergeable = pr_data[:mergeable]
+
+        if owner_approved_or_self_authored?(project, reviews, pr_data) &&
+            checks.present? &&
+            all_checks_green?(checks) &&
+            mergeable == true &&
+            no_outstanding_review_feedback?(project, client, issue, reviews, checks: checks) &&
+            all_blocking_review_methods_complete?(project, reviews, checks) &&
+            !review_stale_for_head?(client, project, issue, pr_data, reviews)
+          return owner_approved_trigger(issue)
+        end
+      end
+
       return nil if followup_limit_reached?(project, issue)
 
       triggers = detect_ready_triggers(project, client, issue, pr_data: pr_data)
@@ -299,6 +325,18 @@ module Activities
         triggers: [ { type: "escalate_to_owner", details: reason } ],
         phase: issue.pr_review_phase,
         current_draft_review_count: issue.draft_review_count,
+        owner_reviewer_login: issue.project.owner_reviewer_login
+      }
+    end
+
+    def dismiss_escalation_trigger(issue)
+      log_triggers(issue.project, issue, [ { type: "dismiss_escalation" } ])
+
+      {
+        issue_id: issue.id,
+        pr_number: issue.github_number,
+        triggers: [ { type: "dismiss_escalation", details: "Owner dismissed escalation via label" } ],
+        phase: "escalated",
         owner_reviewer_login: issue.project.owner_reviewer_login
       }
     end

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -190,6 +190,8 @@ module Workflows
         handle_ready_for_owner(project_id, pr_data)
       elsif trigger_types.include?("escalate_to_owner")
         handle_escalate_to_owner(project_id, pr_data)
+      elsif trigger_types.include?("dismiss_escalation")
+        handle_dismiss_escalation(project_id, pr_data)
       elsif trigger_types.include?("owner_approved")
         handle_owner_approved(project_id, pr_data)
       elsif trigger_types.include?("review_bot_review_pending")
@@ -224,6 +226,12 @@ module Workflows
         timeout: 30)
 
       request_owner_review(project_id, pr_data)
+    end
+
+    def handle_dismiss_escalation(project_id, pr_data)
+      run_activity(Activities::DismissEscalationActivity,
+        { issue_id: pr_data[:issue_id] },
+        timeout: 30)
     end
 
     def request_owner_review(project_id, pr_data)

--- a/spec/temporal/activities/dismiss_escalation_activity_spec.rb
+++ b/spec/temporal/activities/dismiss_escalation_activity_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::DismissEscalationActivity do
+  let(:activity) { described_class.new }
+  let(:github_client) { instance_double(GithubClient) }
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(github_client)
+  end
+
+  describe "#execute" do
+    context "when issue is in escalated phase" do
+      let(:issue) do
+        create(:issue, :pull_request,
+          pr_review_phase: "escalated",
+          labels: [ "paid-generated", "paid-escalated", "paid-dismiss-escalation" ])
+      end
+
+      before do
+        allow(github_client).to receive(:remove_label_from_issue)
+      end
+
+      it "transitions pr_review_phase to ready" do
+        activity.execute(issue_id: issue.id)
+
+        expect(issue.reload.pr_review_phase).to eq("ready")
+      end
+
+      it "removes the paid-dismiss-escalation label" do
+        activity.execute(issue_id: issue.id)
+
+        expect(github_client).to have_received(:remove_label_from_issue)
+          .with(issue.project.full_name, issue.github_number, "paid-dismiss-escalation")
+      end
+
+      it "removes the paid-escalated label" do
+        activity.execute(issue_id: issue.id)
+
+        expect(github_client).to have_received(:remove_label_from_issue)
+          .with(issue.project.full_name, issue.github_number, "paid-escalated")
+      end
+
+      it "returns dismissed: true" do
+        result = activity.execute(issue_id: issue.id)
+
+        expect(result[:dismissed]).to be true
+      end
+    end
+
+    context "when label removal fails" do
+      let(:issue) do
+        create(:issue, :pull_request, pr_review_phase: "escalated")
+      end
+
+      before do
+        allow(github_client).to receive(:remove_label_from_issue)
+          .and_raise(GithubClient::Error, "Not found")
+      end
+
+      it "still transitions the phase" do
+        activity.execute(issue_id: issue.id)
+
+        expect(issue.reload.pr_review_phase).to eq("ready")
+      end
+
+      it "still returns dismissed: true" do
+        result = activity.execute(issue_id: issue.id)
+
+        expect(result[:dismissed]).to be true
+      end
+    end
+
+    context "when issue is not in escalated phase" do
+      let(:issue) do
+        create(:issue, :pull_request, pr_review_phase: "ready")
+      end
+
+      it "returns dismissed: false" do
+        result = activity.execute(issue_id: issue.id)
+
+        expect(result[:dismissed]).to be false
+      end
+
+      it "does not change the phase" do
+        activity.execute(issue_id: issue.id)
+
+        expect(issue.reload.pr_review_phase).to eq("ready")
+      end
+    end
+
+    context "when issue is missing" do
+      it "returns dismissed: false" do
+        result = activity.execute(issue_id: -1)
+
+        expect(result[:dismissed]).to be false
+      end
+    end
+  end
+end

--- a/spec/temporal/activities/mark_escalated_activity_spec.rb
+++ b/spec/temporal/activities/mark_escalated_activity_spec.rb
@@ -51,11 +51,27 @@ RSpec.describe Activities::MarkEscalatedActivity do
           .with(anything, anything, a_string_including("automated draft review limit"))
       end
 
-      it "includes questions in the escalation comment" do
+      it "includes resolution instructions in the escalation comment" do
         activity.execute(issue_id: issue.id)
 
         expect(github_client).to have_received(:add_comment)
-          .with(anything, anything, a_string_including("**Questions:**"))
+          .with(anything, anything, a_string_including("**How to resolve:**"))
+      end
+
+      it "mentions the owner in the escalation comment" do
+        issue.project.update!(owner_reviewer_login: "viamin")
+
+        activity.execute(issue_id: issue.id)
+
+        expect(github_client).to have_received(:add_comment)
+          .with(anything, anything, a_string_including("@viamin"))
+      end
+
+      it "includes the dismiss label instruction" do
+        activity.execute(issue_id: issue.id)
+
+        expect(github_client).to have_received(:add_comment)
+          .with(anything, anything, a_string_including("paid-dismiss-escalation"))
       end
 
       it "includes the hidden comment marker for future identification" do

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -3094,6 +3094,58 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when owner has approved an escalated PR with auto_merge enabled" do
+      before do
+        project.update!(owner_reviewer_login: "viamin", auto_merge_enabled: true)
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "escalated",
+          paid_state: "completed")
+        stub_github_for_pr(
+          reviews: default_clean_copilot_review + [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
+          ]
+        )
+      end
+
+      it "returns owner_approved trigger" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("owner_approved")
+      end
+
+      it "does not emit owner_approved when auto_merge is disabled" do
+        project.update!(auto_merge_enabled: false)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
+    context "when escalated PR has the paid-dismiss-escalation label" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation", "paid-dismiss-escalation" ],
+          pr_review_phase: "escalated",
+          paid_state: "completed")
+        stub_github_for_pr
+      end
+
+      it "returns dismiss_escalation trigger" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("dismiss_escalation")
+        expect(trigger[:phase]).to eq("escalated")
+      end
+    end
+
     context "when a restarted PR has signals" do
       before do
         create(:issue, :pull_request,

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -313,6 +313,18 @@ RSpec.describe Workflows::GitHubPollWorkflow do
           { issue_id: 10 }, timeout: anything)
     end
 
+    it "routes dismiss_escalation to DismissEscalationActivity" do
+      pr_data = {
+        issue_id: 10, pr_number: 42,
+        triggers: [ { type: "dismiss_escalation" } ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::DismissEscalationActivity, hash_including(issue_id: 10), timeout: anything)
+    end
+
     it "routes owner_approved to MergePullRequestActivity" do
       pr_data = {
         issue_id: 10, pr_number: 42,


### PR DESCRIPTION
## Summary

Define clear post-escalation behavior when a PR hits `max_review_rounds`, giving owners three resolution paths instead of leaving the PR stuck in the `escalated` phase indefinitely.

## Changes

### Escalation resolution paths
- **Owner approval → auto-merge**: `scan_escalated_pr` in the scanner activity now checks for owner approval combined with green CI and all existing merge conditions, emitting an `owner_approved` trigger to proceed with merge
- **Label-based dismissal**: Adding a `paid-dismiss-escalation` label triggers a new `dismiss_escalation` event, which transitions the PR back to the `ready` phase and cleans up both `paid-escalated` and `paid-dismiss-escalation` labels
- **Convert to draft**: Existing `maybe_restart_draft` logic already handles resetting escalated PRs back into the draft review cycle

### Escalation comment improvements
- `MarkEscalatedActivity` now @mentions the repo owner directly for visibility
- Comment body explains all three resolution options so the owner knows how to proceed

### New activity
- `DismissEscalationActivity` handles the escalated → ready phase transition and label cleanup

### Workflow routing
- `GitHubPollWorkflow` routes the new `dismiss_escalation` trigger to the appropriate activity

## Design Decisions

- **Three paths, not one**: Rather than picking a single post-escalation strategy, all three options are available simultaneously — owner approval, label dismissal, and convert-to-draft. This avoids needing project-level configuration while covering the common cases.
- **Label-based dismissal over UI**: Since the notification center (#912) isn't built yet, the `paid-dismiss-escalation` label provides a lightweight GitHub-native mechanism that works with existing external notification tooling.
- **Reuses existing merge checks**: The owner-approval path runs through the same merge condition checks as the `ready` phase rather than introducing a separate fast path, ensuring CI and merge requirements are still enforced.

---

Closes #1006