### PR TITLE
Fix #1005: investigate(scanner): does paid_state failed suppress re-scanning after review-goal failure

### DIFF
--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -181,7 +181,10 @@ class StaleRunDetectorJob < ApplicationJob
       agent_run.log!("system", "Run marked as timed out by stale run detector")
 
       if (issue = agent_run.issue)
-        issue.update!(paid_state: "failed") unless issue.paid_state == "failed"
+        # Review-goal failures restore "completed" instead of "failed" so
+        # auto-pick is not blocked by a transient review follow-up failure.
+        target_state = agent_run.review_goal? ? "completed" : "failed"
+        issue.update!(paid_state: target_state) unless issue.paid_state == target_state
       end
 
       Rails.logger.warn(

--- a/app/temporal/activities/mark_agent_run_failed_activity.rb
+++ b/app/temporal/activities/mark_agent_run_failed_activity.rb
@@ -25,8 +25,15 @@ module Activities
       ProcessRunQueueJob.perform_later
 
       # Always update issue state so it doesn't stay stuck in "in_progress".
-      if agent_run.issue && agent_run.issue.paid_state != "failed"
-        agent_run.issue.update!(paid_state: "failed")
+      # Review-goal failures restore the issue to "completed" rather than
+      # marking it "failed" — the underlying PR work succeeded; only the
+      # follow-up review run failed. Using "completed" keeps auto-pick
+      # unblocked and lets the scanner re-evaluate the PR on the next cycle.
+      if agent_run.issue
+        target_state = agent_run.review_goal? ? "completed" : "failed"
+        if agent_run.issue.paid_state != target_state
+          agent_run.issue.update!(paid_state: target_state)
+        end
       end
 
       logger.info(

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe StaleRunDetectorJob do
       expect(stale_run.issue.reload.paid_state).to eq("failed")
     end
 
+    it "sets issue paid_state to completed for stale review-goal runs" do
+      issue = create(:issue, :in_progress, :pull_request, project: create(:project))
+      stale_run = create(:agent_run, :running, :review_goal, project: issue.project, issue: issue, started_at: (running_threshold + 60).seconds.ago)
+
+      described_class.perform_now
+
+      expect(stale_run.issue.reload.paid_state).to eq("completed")
+    end
+
     it "creates a log entry on the resolved run" do
       stale_run = create(:agent_run, :running, started_at: (running_threshold + 60).seconds.ago)
 

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
       expect(issue.reload.paid_state).to eq("failed")
     end
 
+    it "sets issue paid_state to completed for review-goal runs" do
+      issue = create(:issue, :in_progress, :pull_request, project: project)
+      agent_run = create(:agent_run, :running, :review_goal, project: project, issue: issue)
+
+      activity.execute(agent_run_id: agent_run.id, error: "Review failed")
+
+      expect(issue.reload.paid_state).to eq("completed")
+    end
+
     it "does not overwrite timeout status but still updates issue" do
       issue = create(:issue, :in_progress, project: project)
       agent_run = create(:agent_run, :running, project: project, issue: issue)


### PR DESCRIPTION
## Summary

investigate(scanner): does paid_state failed suppress re-scanning after review-goal failure

See #1005 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1005