### PR TITLE
Fix #1004: fix(scanner): BODY_ONLY_REVIEW_BOT_LOGINS missing paid_agent bot, auto-merge bypasses actionable body-only feedback

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -619,8 +619,8 @@ module Activities
     # rather than as inline review threads. These bots need the body-only
     # anti-loop guard in check_review_bot_status because thread resolution
     # cannot be used to detect "already addressed" state.
-    BODY_ONLY_REVIEW_BOT_LOGINS = ProviderSupport::PROVIDER_BOT_USERNAMES
-      .fetch("codex", [])
+    BODY_ONLY_REVIEW_BOT_LOGINS = %w[codex paid_agent]
+      .flat_map { |key| ProviderSupport::PROVIDER_BOT_USERNAMES.fetch(key, []) }
       .map(&:downcase)
       .to_set
       .freeze
@@ -629,7 +629,7 @@ module Activities
       allowed = project&.review_enabled? ? (project.enabled_review_bot_logins.presence || Set.new) : nil
       latest = latest_allowed_bot_review(reviews, allowed)
 
-      # Body-only bots (Codex) can post their CLEAN signal as an issue
+      # Body-only bots (Codex, paid_agent) can post their CLEAN signal as an issue
       # comment — e.g. "Codex Review: Didn't find any major issues. Bravo." —
       # which is invisible to pull_request_reviews. When such a comment is
       # the most recent body-only-bot signal on the PR, treat the bot as

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1220,6 +1220,87 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when paid_agent posted a body-only review with no last agent run" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 0)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                       body: "Here are some review suggestions.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: []
+        )
+      end
+
+      it "emits a review_bot_comments trigger because the feedback is unaddressed" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("review_bot_comments", "review_bot_review_pending")
+      end
+    end
+
+    context "when paid_agent posted a body-only review before the last agent run completed" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                       body: "Here are some review suggestions.",
+                       submitted_at: 2.hours.ago } ],
+          review_threads: []
+        )
+      end
+
+      it "treats the review as already addressed and does not trigger" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+    end
+
+    context "when paid_agent posted a body-only review after the last agent run completed" do
+      before do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 2.hours.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                       body: "Here are some review suggestions.",
+                       submitted_at: 30.minutes.ago } ],
+          review_threads: []
+        )
+      end
+
+      it "emits a review_bot_comments trigger because the feedback is unaddressed" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("review_bot_comments")
+      end
+    end
+
     context "when PR is in draft phase with Claude review threads" do
       before do
         create(:issue, :pull_request,

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1607,14 +1607,15 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         )
       end
 
-      it "proceeds through normal flow instead of bypassing via clean signal" do
+      it "emits body-only review triggers instead of bypassing via clean signal" do
         result = activity.execute(project_id: project.id)
 
         trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
-        # With CI green, no bot issues, and owner_reviewer_login set, the
-        # draft scanner emits ready_for_owner — proving the non-clean review
-        # did not trigger the paid_agent clean signal bypass.
-        expect(trigger_types).to include("ready_for_owner")
+        # The non-clean body-only review is detected as unaddressed feedback,
+        # emitting review_bot_comments — proving the clean signal bypass was
+        # not triggered and the body-only anti-loop guard correctly flags the
+        # review for followup.
+        expect(trigger_types).to include("review_bot_comments")
       end
     end
 
@@ -1644,10 +1645,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         result = activity.execute(project_id: project.id)
 
         trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
-        # With CI green, no bot issues, and owner_reviewer_login set, the
-        # draft scanner reaches the normal flow and emits ready_for_owner —
-        # proving the clean signal bypass was skipped.
-        expect(trigger_types).to include("ready_for_owner")
+        # The latest non-clean body-only review is detected as unaddressed
+        # feedback, emitting review_bot_comments — proving the older clean
+        # signal did not bypass and the body-only anti-loop guard correctly
+        # flags the review for followup.
+        expect(trigger_types).to include("review_bot_comments")
       end
     end
 


### PR DESCRIPTION
## Summary

fix(scanner): BODY_ONLY_REVIEW_BOT_LOGINS missing paid_agent bot, auto-merge bypasses actionable body-only feedback

See #1004 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1004