### PR TITLE
Fix #974: Auto-pick should skip issues with existing PRs or active agent runs

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -231,8 +231,7 @@ class Issue < ApplicationRecord
       .pluck(:issue_id)
       .to_set
 
-    has_open_pr_ids = Issue
-      .where(parent_issue_id: issue_ids, is_pull_request: true, github_state: "open")
+    has_open_pr_ids = open_pull_request_parent_issue_ids(issue_ids: issue_ids)
       .distinct
       .pluck(:parent_issue_id)
       .to_set
@@ -248,6 +247,13 @@ class Issue < ApplicationRecord
         :eligible
       end
     end
+  end
+
+  def self.open_pull_request_parent_issue_ids(project: nil, issue_ids: nil)
+    scope = where(is_pull_request: true, github_state: "open").where.not(parent_issue_id: nil)
+    scope = scope.where(project: project) if project
+    scope = scope.where(parent_issue_id: issue_ids) if issue_ids
+    scope.select(:parent_issue_id)
   end
 
   private

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -59,7 +59,7 @@ module Issues
         .where(paid_state: %w[new planning failed])
         .where.not(id: AgentRun.where(project: project, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES).where.not(issue_id: nil).select(:issue_id))
         .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
-        .where.not(id: Issue.where(project: project).where.not(parent_issue_id: nil).distinct.select(:parent_issue_id))
+        .where.not(id: Issue.where(project: project, is_pull_request: false).where.not(parent_issue_id: nil).distinct.select(:parent_issue_id))
         .where.not(id: Issue.where(project: project, is_pull_request: true, github_state: "open").where.not(parent_issue_id: nil).select(:parent_issue_id))
 
       trusted_usernames = Array(project.allowed_github_usernames).presence

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -12,6 +12,7 @@ module Issues
   # Selection criteria:
   # - Open, non-PR issues with all dependencies satisfied
   # - No existing unfinished (queued/pending/running/paused) agent run
+  # - No existing open PR linked to the issue (via parent_issue_id)
   # - Not labeled with excluded labels (planning, research, waiting,
   #   tracking, epic, needs-manual-setup)
   # - Not a parent/tracking issue (has sub-issues)
@@ -59,6 +60,7 @@ module Issues
         .where.not(id: AgentRun.where(project: project, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES).where.not(issue_id: nil).select(:issue_id))
         .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
         .where.not(id: Issue.where(project: project).where.not(parent_issue_id: nil).distinct.select(:parent_issue_id))
+        .where.not(id: Issue.where(project: project, is_pull_request: true, github_state: "open").where.not(parent_issue_id: nil).select(:parent_issue_id))
 
       trusted_usernames = Array(project.allowed_github_usernames).presence
       scope = scope.where(github_creator_login: trusted_usernames) if trusted_usernames

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -60,7 +60,7 @@ module Issues
         .where.not(id: AgentRun.where(project: project, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES).where.not(issue_id: nil).select(:issue_id))
         .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
         .where.not(id: Issue.where(project: project, is_pull_request: false).where.not(parent_issue_id: nil).distinct.select(:parent_issue_id))
-        .where.not(id: Issue.where(project: project, is_pull_request: true, github_state: "open").where.not(parent_issue_id: nil).select(:parent_issue_id))
+        .where.not(id: Issue.open_pull_request_parent_issue_ids(project: project).distinct)
 
       trusted_usernames = Array(project.allowed_github_usernames).presence
       scope = scope.where(github_creator_login: trusted_usernames) if trusted_usernames

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -471,6 +471,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_11_163526) do
     t.string "pr_review_phase", default: "draft", null: false
     t.bigint "project_id", null: false
     t.datetime "relationships_parsed_at"
+    t.integer "review_goal_retry_count", default: 0, null: false
     t.string "source", default: "github", null: false
     t.string "title", limit: 1000, null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -471,7 +471,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_11_163526) do
     t.string "pr_review_phase", default: "draft", null: false
     t.bigint "project_id", null: false
     t.datetime "relationships_parsed_at"
-    t.integer "review_goal_retry_count", default: 0, null: false
     t.string "source", default: "github", null: false
     t.string "title", limit: 1000, null: false
     t.datetime "updated_at", null: false

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -884,6 +884,16 @@ RSpec.describe Issue do
       expect(result).to contain_exactly(with_open_pr.id)
     end
 
+    it "ignores open PRs that are not linked to a parent issue" do
+      linked_issue = create(:issue, project: project, github_state: "open")
+      create(:issue, :pull_request, project: project, parent_issue: linked_issue, github_state: "open")
+      create(:issue, :pull_request, project: project, parent_issue: nil, github_state: "open")
+
+      result = described_class.open_pull_request_parent_issue_ids(project: project).pluck(:parent_issue_id)
+
+      expect(result).to contain_exactly(linked_issue.id)
+    end
+
     it "scopes parent issue ids to the provided issue ids" do
       included = create(:issue, project: project, github_state: "open")
       excluded = create(:issue, project: project, github_state: "open")

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -870,6 +870,32 @@ RSpec.describe Issue do
     end
   end
 
+  describe ".open_pull_request_parent_issue_ids" do
+    let(:project) { create(:project) }
+
+    it "returns parent issue ids for open linked PRs only" do
+      with_open_pr = create(:issue, project: project, github_state: "open")
+      with_closed_pr = create(:issue, project: project, github_state: "open")
+      create(:issue, :pull_request, project: project, parent_issue: with_open_pr, github_state: "open")
+      create(:issue, :pull_request, project: project, parent_issue: with_closed_pr, github_state: "closed")
+
+      result = described_class.open_pull_request_parent_issue_ids(project: project).pluck(:parent_issue_id)
+
+      expect(result).to contain_exactly(with_open_pr.id)
+    end
+
+    it "scopes parent issue ids to the provided issue ids" do
+      included = create(:issue, project: project, github_state: "open")
+      excluded = create(:issue, project: project, github_state: "open")
+      create(:issue, :pull_request, project: project, parent_issue: included, github_state: "open")
+      create(:issue, :pull_request, project: project, parent_issue: excluded, github_state: "open")
+
+      result = described_class.open_pull_request_parent_issue_ids(issue_ids: [ included.id ]).pluck(:parent_issue_id)
+
+      expect(result).to contain_exactly(included.id)
+    end
+  end
+
   describe ".lifecycle_statuses" do
     let(:project) { create(:project) }
 

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -153,6 +153,15 @@ RSpec.describe Issues::AutoPick do
       expect(result.issue).to eq(issue)
     end
 
+    it "does not let unrelated open PRs without a parent issue suppress picking" do
+      create(:issue, :pull_request, project: project, parent_issue: nil, github_state: "open")
+      issue = create(:issue, project: project, github_number: 1)
+
+      result = described_class.new(project).call
+
+      expect(result.issue).to eq(issue)
+    end
+
     it "picks another eligible issue when the project already has an active run" do
       issue_with_run = create(:issue, project: project)
       create(:agent_run, :queued, project: project, issue: issue_with_run)
@@ -827,6 +836,15 @@ RSpec.describe Issues::AutoPick do
       result = described_class.eligible_issue_ids([ with_closed_pr ])
 
       expect(result).to include(with_closed_pr.id)
+    end
+
+    it "does not exclude issues because of open PRs without a parent issue" do
+      create(:issue, :pull_request, project: project, parent_issue: nil, github_state: "open")
+      issue = create(:issue, project: project, github_number: 1)
+
+      result = described_class.eligible_issue_ids([ issue ])
+
+      expect(result).to include(issue.id)
     end
 
     it "excludes tracker issues with open body-referenced issues" do

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -125,6 +125,25 @@ RSpec.describe Issues::AutoPick do
       expect(result).to be_nil
     end
 
+    it "skips issues that already have an open PR linked via parent_issue_id" do
+      issue_with_pr = create(:issue, project: project, github_number: 1)
+      create(:issue, :pull_request, project: project, parent_issue: issue_with_pr, github_state: "open")
+      eligible = create(:issue, project: project, github_number: 2)
+
+      result = described_class.new(project).call
+
+      expect(result.issue).to eq(eligible)
+    end
+
+    it "returns nil when all issues have open PRs" do
+      issue = create(:issue, project: project, github_number: 1)
+      create(:issue, :pull_request, project: project, parent_issue: issue, github_state: "open")
+
+      result = described_class.new(project).call
+
+      expect(result).to be_nil
+    end
+
     it "picks another eligible issue when the project already has an active run" do
       issue_with_run = create(:issue, project: project)
       create(:agent_run, :queued, project: project, issue: issue_with_run)
@@ -523,6 +542,26 @@ RSpec.describe Issues::AutoPick do
         expect(result).to be_a(AgentRun)
         expect(result.issue).to eq(issue)
       end
+
+      it "returns the existing run when a concurrent picker races on the same issue" do
+        # Simulates a TOCTOU race: two pickers both SELECT the same issue as
+        # eligible, then both INSERT. The DB unique partial index
+        # (idx_agent_runs_unique_active_issue) rejects the second INSERT.
+        # AutoPick rescues RecordNotUnique and returns the first run.
+        issue = create(:issue, project: project)
+
+        existing_run = nil
+        original_create = AgentRun.method(:create!)
+        allow(AgentRun).to receive(:create!) do |**attrs|
+          existing_run = original_create.call(**attrs)
+          raise ActiveRecord::RecordNotUnique, "idx_agent_runs_unique_active_issue"
+        end
+
+        result = described_class.new(project).call
+
+        expect(result).to eq(existing_run)
+        expect(AgentRun.where(issue: issue, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES).count).to eq(1)
+      end
     end
 
     context "when project has PRs needing attention" do
@@ -759,6 +798,17 @@ RSpec.describe Issues::AutoPick do
       result = described_class.eligible_issue_ids([])
 
       expect(result).to eq(Set.new)
+    end
+
+    it "excludes issues with open PRs linked via parent_issue_id" do
+      with_pr = create(:issue, project: project, github_number: 1)
+      create(:issue, :pull_request, project: project, parent_issue: with_pr, github_state: "open")
+      without_pr = create(:issue, project: project, github_number: 2)
+
+      result = described_class.eligible_issue_ids([ with_pr, without_pr ])
+
+      expect(result).not_to include(with_pr.id)
+      expect(result).to include(without_pr.id)
     end
 
     it "excludes tracker issues with open body-referenced issues" do

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -144,6 +144,15 @@ RSpec.describe Issues::AutoPick do
       expect(result).to be_nil
     end
 
+    it "does not skip issues whose linked PRs are closed" do
+      issue = create(:issue, project: project, github_number: 1)
+      create(:issue, :pull_request, project: project, parent_issue: issue, github_state: "closed")
+
+      result = described_class.new(project).call
+
+      expect(result.issue).to eq(issue)
+    end
+
     it "picks another eligible issue when the project already has an active run" do
       issue_with_run = create(:issue, project: project)
       create(:agent_run, :queued, project: project, issue: issue_with_run)

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -820,6 +820,15 @@ RSpec.describe Issues::AutoPick do
       expect(result).to include(without_pr.id)
     end
 
+    it "includes issues whose linked PRs are closed" do
+      with_closed_pr = create(:issue, project: project, github_number: 1)
+      create(:issue, :pull_request, project: project, parent_issue: with_closed_pr, github_state: "closed")
+
+      result = described_class.eligible_issue_ids([ with_closed_pr ])
+
+      expect(result).to include(with_closed_pr.id)
+    end
+
     it "excludes tracker issues with open body-referenced issues" do
       tracker = create(:issue, project: project, github_number: 413,
         title: "Remaining work tracker",


### PR DESCRIPTION
## Summary

Auto-pick should skip issues with existing PRs or active agent runs

See #974 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #974