### PR TITLE
Fix #1015: fix(scanner): body-only reviews with no inline comments assumed addressed after auto-continue push

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -884,8 +884,8 @@ module Activities
 
     # Returns true when the diff between the review's commit and the PR
     # HEAD touches at least one file mentioned in the review's inline
-    # comments. Falls back to true (assumes addressed) when inline
-    # comments have no file paths or the comparison cannot be fetched.
+    # comments. Returns false (assumes NOT addressed) when the review
+    # has no inline comments, since we cannot verify file overlap.
     def review_diff_touches_reviewed_files?(client, project, issue, review)
       return true if client.nil? || project.nil? || issue.nil?
 
@@ -904,7 +904,7 @@ module Activities
         .select { |c| c[:pull_request_review_id] == review_id }
         .filter_map { |c| c[:path] }
         .to_set
-      return true if reviewed_paths.empty?
+      return false if reviewed_paths.empty?
 
       # NOTE: pr_data is already fetched in scan_pr, but check_review_bot_status
       # does not receive it. This extra API call is behind multiple guard

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1253,10 +1253,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           .and_return([])
       end
 
-      it "falls back to treating the review as addressed" do
+      it "treats the body-only review as NOT addressed" do
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger]).to eq([])
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("review_bot_comments", "review_bot_review_pending")
       end
     end
 


### PR DESCRIPTION
## Summary

fix(scanner): body-only reviews with no inline comments assumed addressed after auto-continue push

See #1015 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1015