### PR TITLE
Fix #975: Allow setting different default providers per agent run type

### DIFF
--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -36,7 +36,8 @@ module Projects
 
     def new
       authorize @project, :run_agent?
-      @default_provider_identifier = settings_owner&.settings&.provider_priority(identifiers: true)&.first
+      selected_goal = params[:goal].presence || "create_pr"
+      @default_provider_identifier = settings_owner&.settings&.default_provider_identifier_for_goal(selected_goal)
       @available_run_provider_options = available_run_provider_options
       @issues = @project.issues
         .issues_only
@@ -120,7 +121,7 @@ module Projects
       create_run_and_redirect(
         on_error_path: project_path(@project),
         issue: issue,
-        provider_identifier: settings_owner&.settings&.default_provider_identifier,
+        provider_identifier: settings_owner&.settings&.default_provider_identifier_for_goal("create_pr"),
         goal: "create_pr",
         source_pull_request_number: source_pr_number
       )
@@ -529,7 +530,8 @@ module Projects
       requested_provider_identifier = provider_identifier || params[:provider].presence
       resolved_provider = resolve_provider_selection(
         requested_agent_type: requested_agent_type,
-        requested_provider_identifier: requested_provider_identifier
+        requested_provider_identifier: requested_provider_identifier,
+        goal: goal
       )
       raise NoRunnableProviderError, "No runnable provider could be resolved for this project." unless resolved_provider
 
@@ -555,7 +557,7 @@ module Projects
     def enqueue_resume_run(pr)
       create_agent_run(
         source_pull_request_number: pr.github_number,
-        provider_identifier: settings_owner&.settings&.default_provider_identifier,
+        provider_identifier: settings_owner&.settings&.default_provider_identifier_for_goal("create_pr"),
         goal: "create_pr",
         trigger_type: "automatic"
       )
@@ -694,12 +696,12 @@ module Projects
       enabled_retry_providers.any? { |provider| provider.provider_key == provider_key }
     end
 
-    def resolve_provider_selection(requested_agent_type:, requested_provider_identifier:)
+    def resolve_provider_selection(requested_agent_type:, requested_provider_identifier:, goal:)
       owner = settings_owner
       return unless owner
 
       configured_identifiers = UserSetting.enabled_agent_providers(owner, identifiers: true)
-      priority_identifiers = owner.settings.provider_priority(identifiers: true)
+      priority_identifiers = owner.settings.provider_priority_for_goal(goal, identifiers: true)
       default_identifier = priority_identifiers.first
 
       if requested_provider_identifier.present?

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -37,7 +37,10 @@ module Projects
     def new
       authorize @project, :run_agent?
       selected_goal = params[:goal].presence || "create_pr"
-      @default_provider_identifier = settings_owner&.settings&.default_provider_identifier_for_goal(selected_goal)
+      @default_provider_identifiers_by_goal = AgentRun::GOALS.index_with do |goal|
+        settings_owner&.settings&.default_provider_identifier_for_goal(goal)
+      end.compact
+      @default_provider_identifier = @default_provider_identifiers_by_goal[selected_goal]
       @available_run_provider_options = available_run_provider_options
       @issues = @project.issues
         .issues_only

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -529,6 +529,9 @@ module Projects
     end
 
     def create_agent_run(issue: nil, custom_prompt: nil, source_pull_request_number: nil, agent_type: nil, provider_identifier: nil, goal: nil, trigger_type: "manual", priority_tier: nil)
+      goal ||= params[:goal].presence || "create_pr"
+      goal = "create_pr" unless AgentRun::GOALS.include?(goal)
+
       requested_agent_type = agent_type || params[:agent_type].presence
       requested_provider_identifier = provider_identifier || params[:provider].presence
       resolved_provider = resolve_provider_selection(
@@ -539,9 +542,6 @@ module Projects
       raise NoRunnableProviderError, "No runnable provider could be resolved for this project." unless resolved_provider
 
       resolved_agent_type = provider_key_to_agent_type(resolved_provider.provider_key)
-
-      goal ||= params[:goal].presence || "create_pr"
-      goal = "create_pr" unless AgentRun::GOALS.include?(goal)
 
       AgentRun.create!(
         project: @project,

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -123,10 +123,7 @@ class ProvidersController < ApplicationController
     update_fallback_provider_flags!
 
     attrs = provider_settings_params
-    attrs[:default_agent_providers_by_goal] ||= sanitize_goal_default_provider_identifiers(
-      @user_setting,
-      enabled_agent_provider_identifiers
-    )
+    attrs[:default_agent_providers_by_goal] = goal_default_provider_attrs(attrs)
 
     if @user_setting.update(attrs)
       redirect_to providers_path, notice: "Provider settings saved successfully."
@@ -403,5 +400,21 @@ class ProvidersController < ApplicationController
 
       normalized[goal] = resolved.first
     end
+  end
+
+  def goal_default_provider_attrs(attrs)
+    submitted = attrs[:default_agent_providers_by_goal]
+    return sanitize_goal_default_provider_identifiers(@user_setting, enabled_agent_provider_identifiers) unless submitted
+
+    raw_submitted = params.dig(:user_setting, :default_agent_providers_by_goal)
+    return sanitize_goal_default_provider_identifiers(@user_setting, enabled_agent_provider_identifiers) if submitted.empty? && raw_goal_defaults_filtered_out?(raw_submitted)
+
+    submitted
+  end
+
+  def raw_goal_defaults_filtered_out?(raw_submitted)
+    return true unless raw_submitted.respond_to?(:keys)
+
+    raw_submitted.keys.map(&:to_s).intersection(AgentRun::GOALS).empty?
   end
 end

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -122,7 +122,13 @@ class ProvidersController < ApplicationController
 
     update_fallback_provider_flags!
 
-    if @user_setting.update(provider_settings_params)
+    attrs = provider_settings_params
+    attrs[:default_agent_providers_by_goal] ||= sanitize_goal_default_provider_identifiers(
+      @user_setting,
+      enabled_agent_provider_identifiers
+    )
+
+    if @user_setting.update(attrs)
       redirect_to providers_path, notice: "Provider settings saved successfully."
     else
       load_index_context
@@ -260,7 +266,8 @@ class ProvidersController < ApplicationController
     fallback_identifiers = fallback_candidate_provider_identifiers
 
     attrs = {
-      fallback_providers: settings.sanitize_provider_tokens(settings.fallback_providers, candidates: fallback_identifiers)
+      fallback_providers: settings.sanitize_provider_tokens(settings.fallback_providers, candidates: fallback_identifiers),
+      default_agent_providers_by_goal: sanitize_goal_default_provider_identifiers(settings, run_identifiers)
     }
 
     default_identifier = settings.default_provider_identifier
@@ -304,6 +311,12 @@ class ProvidersController < ApplicationController
     @enabled_agent_providers = enabled_agent_provider_identifiers
     @fallback_candidate_providers = fallback_candidate_provider_identifiers
     @default_provider_identifier = @user_setting.default_provider_identifier
+    @goal_provider_labels = {
+      "create_pr" => "PR Agent",
+      "review" => "Code Review Agent",
+      "create_issue" => "Issue Agent"
+    }
+    @explicit_goal_default_providers = @user_setting.default_agent_providers_by_goal.slice(*AgentRun::GOALS)
     @saved_fallback_provider_tokens = @user_setting.sanitize_provider_tokens(
       @user_setting.fallback_providers,
       candidates: (@enabled_agent_providers + @fallback_candidate_providers).uniq
@@ -343,7 +356,8 @@ class ProvidersController < ApplicationController
     permitted = params.require(:user_setting).permit(
       :default_agent_provider,
       :fallback_enabled,
-      :fallback_providers
+      :fallback_providers,
+      default_agent_providers_by_goal: AgentRun::GOALS
     )
 
     if permitted.key?(:fallback_providers)
@@ -377,5 +391,17 @@ class ProvidersController < ApplicationController
       .where(provider_key: executable_keys)
       .ordered
     UserSetting.provider_identifiers_for(providers, identifiers: true)
+  end
+
+  def sanitize_goal_default_provider_identifiers(settings, candidates)
+    AgentRun::GOALS.each_with_object({}) do |goal, normalized|
+      token = settings.default_agent_providers_by_goal[goal]
+      next if token.blank?
+
+      resolved = settings.sanitize_provider_tokens([ token ], candidates: candidates)
+      next if resolved.blank?
+
+      normalized[goal] = resolved.first
+    end
   end
 end

--- a/app/javascript/controllers/goal_toggle_controller.js
+++ b/app/javascript/controllers/goal_toggle_controller.js
@@ -9,13 +9,24 @@ export default class extends Controller {
     "prDropdown",
     "prTable",
     "prioritySection",
+    "providerSelect",
   ]
+  static values = {
+    currentGoal: String,
+    providerDefaults: Object,
+    providerManuallySelected: { type: Boolean, default: false },
+  }
 
   connect() {
     this.toggle()
   }
 
+  providerChanged() {
+    this.providerManuallySelectedValue = true
+  }
+
   toggle() {
+    const previousGoal = this.currentGoalValue || "create_pr"
     const selected = this.element.querySelector("input[name='goal']:checked")
     const goal = selected ? selected.value : "create_pr"
 
@@ -90,5 +101,31 @@ export default class extends Controller {
           "Push changes to an existing pull request's branch instead of creating a new one."
       })
     }
+
+    this.syncProviderDefault(previousGoal, goal)
+    this.currentGoalValue = goal
+  }
+
+  syncProviderDefault(previousGoal, goal) {
+    if (!this.hasProviderSelectTarget) return
+
+    const previousDefault = this.defaultProviderForGoal(previousGoal)
+    const nextDefault = this.defaultProviderForGoal(goal)
+    if (!nextDefault) return
+
+    const shouldSync =
+      !this.providerManuallySelectedValue ||
+      this.providerSelectTarget.value === previousDefault
+
+    if (!shouldSync) return
+
+    this.providerSelectTarget.value = nextDefault
+    this.providerManuallySelectedValue = false
+  }
+
+  defaultProviderForGoal(goal) {
+    if (!this.hasProviderDefaultsValue) return null
+
+    return this.providerDefaultsValue[goal] || null
   }
 }

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -23,6 +23,7 @@ class UserSetting < ApplicationRecord
   validates :agent_timeout_seconds,
     numericality: { only_integer: true, greater_than_or_equal_to: 60, less_than_or_equal_to: PG_INT_MAX }
   validate :validate_default_agent_provider
+  validate :validate_default_agent_providers_by_goal
 
   # Container Resources
   validates :container_memory_bytes,
@@ -202,6 +203,28 @@ class UserSetting < ApplicationRecord
     normalized_default_agent_provider || allowed_provider_identifiers_for_agent_runs.first
   end
 
+  def default_provider_identifier_for_goal(goal)
+    goal = goal.to_s
+    goal_provider = default_agent_providers_by_goal[goal] if goal.present?
+    return default_provider_identifier if goal_provider.blank?
+
+    resolved = identifiers_for_provider_token(goal_provider, candidates: allowed_provider_identifiers_for_agent_runs).first
+    resolved || default_provider_identifier
+  end
+
+  def provider_priority_for_goal(goal, identifiers: false)
+    goal_identifier = default_provider_identifier_for_goal(goal)
+    default = goal_identifier.present? ? [ goal_identifier ] : []
+    priorities = default + fallback_priority_for(
+      primary_provider: goal_identifier || default_agent_provider,
+      identifiers: true
+    )
+
+    return priorities if identifiers
+
+    map_identifiers_to_provider_keys(priorities)
+  end
+
   def sanitize_provider_tokens(tokens, candidates:)
     Array(tokens).flat_map do |token|
       token = token.to_s
@@ -282,6 +305,40 @@ class UserSetting < ApplicationRecord
     end
 
     self.fallback_providers = sanitize_provider_tokens(fallback_providers, candidates: allowed_provider_identifiers_for_fallback)
+  end
+
+  def validate_default_agent_providers_by_goal
+    return if default_agent_providers_by_goal.blank?
+
+    unless default_agent_providers_by_goal.is_a?(Hash)
+      errors.add(:default_agent_providers_by_goal, "must be a hash")
+      return
+    end
+
+    allowed_goals = AgentRun::GOALS
+    allowed_providers = allowed_provider_identifiers_for_agent_runs
+    normalized = {}
+
+    default_agent_providers_by_goal.each do |goal, provider|
+      goal = goal.to_s
+
+      unless allowed_goals.include?(goal)
+        errors.add(:default_agent_providers_by_goal, "contains invalid goal: #{goal}")
+        next
+      end
+
+      next if provider.blank?
+
+      resolved = identifiers_for_provider_token(provider.to_s, candidates: allowed_providers)
+      if resolved.empty? && !allowed_providers.include?(provider.to_s)
+        errors.add(:default_agent_providers_by_goal, "contains invalid provider for #{goal}")
+        next
+      end
+
+      normalized[goal] = resolved.first || provider.to_s
+    end
+
+    self.default_agent_providers_by_goal = normalized
   end
 
   def validate_default_agent_provider

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -950,7 +950,7 @@ module Containers
     end
 
     def fallback_providers_require_direct_outbound?(settings)
-      primary_identifier = agent_run.provider&.routing_key || settings.default_provider_identifier
+      primary_identifier = agent_run.provider&.routing_key || settings.default_provider_identifier_for_goal(agent_run.goal)
       fallback_identifiers = settings.fallback_priority_for(primary_provider: primary_identifier, identifiers: true)
       fallback_providers_by_id = settings.user.providers.where(
         id: fallback_identifiers.filter_map { |identifier| Provider.id_from_routing_key(identifier) }

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -329,7 +329,7 @@ module Issues
       settings = AgentRuns::UserSettingsResolver.call(project: @project, strict: false)
       return Provider.ensure_default_for(owner) unless settings
 
-      Provider.for_identifier(settings.user, settings.default_provider_identifier) || Provider.ensure_default_for(settings.user)
+      Provider.for_identifier(settings.user, settings.default_provider_identifier_for_goal("create_pr")) || Provider.ensure_default_for(settings.user)
     end
   end
 end

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -130,20 +130,20 @@ module Activities
       requested_agent_type || "claude_code"
     end
 
-    def default_provider_for(project)
+    def default_provider_for(project, goal:)
       owner = project.effective_owner
       return unless owner
 
       settings = AgentRuns::UserSettingsResolver.call(project: project, strict: false)
       return Provider.ensure_default_for(owner) unless settings
 
-      Provider.for_identifier(settings.user, settings.default_provider_identifier) || Provider.ensure_default_for(settings.user)
+      Provider.for_identifier(settings.user, settings.default_provider_identifier_for_goal(goal)) || Provider.ensure_default_for(settings.user)
     end
 
     def refresh_automatic_run_provider!(agent_run)
       return unless agent_run.automatic?
 
-      provider = default_provider_for(agent_run.project)
+      provider = default_provider_for(agent_run.project, goal: agent_run.goal)
       return unless provider
 
       agent_run.update!(

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -24,6 +24,12 @@ module Activities
       project = Project.find(project_id)
       issue = issue_id ? Issue.find(issue_id) : nil
       user_settings = resolve_user_settings(project)
+      provider_id, agent_type = resolve_provider_selection(
+        project: project,
+        requested_agent_type: input[:agent_type],
+        requested_provider_id: provider_id,
+        goal: goal
+      )
 
       # Resolve and render prompt version if no custom prompt is provided.
       # Skip for untrusted issues to match the safety behavior in AgentRun#prompt_for_issue.
@@ -128,6 +134,16 @@ module Activities
       return Provider.agent_type_for(provider.provider_key) if provider
 
       requested_agent_type || "claude_code"
+    end
+
+    def resolve_provider_selection(project:, requested_agent_type:, requested_provider_id:, goal:)
+      resolved_agent_type = resolve_agent_type(requested_agent_type, requested_provider_id)
+      return [ requested_provider_id, resolved_agent_type ] if requested_provider_id.present? || requested_agent_type.present?
+
+      provider = default_provider_for(project, goal: goal)
+      return [ nil, resolved_agent_type ] unless provider
+
+      [ provider.id, Provider.agent_type_for(provider.provider_key) ]
     end
 
     def default_provider_for(project, goal:)

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -21,6 +21,7 @@ module Activities
         project: project,
         requested_agent_type: requested_agent_type,
         requested_provider_id: provider_id,
+        goal: goal,
         agent_type_provided: input.key?(:agent_type),
         provider_id_provided: input.key?(:provider_id)
       )
@@ -91,7 +92,7 @@ module Activities
 
     private
 
-    def resolve_provider_selection(project:, requested_agent_type:, requested_provider_id:, agent_type_provided:, provider_id_provided:)
+    def resolve_provider_selection(project:, requested_agent_type:, requested_provider_id:, goal:, agent_type_provided:, provider_id_provided:)
       if provider_id_provided || agent_type_provided
         provider = provider_for_id(requested_provider_id)
         resolved_agent_type =
@@ -104,20 +105,20 @@ module Activities
         return [ requested_provider_id, resolved_agent_type ]
       end
 
-      provider = default_provider_for(project)
+      provider = default_provider_for(project, goal: goal)
       return [ provider&.id, Provider.agent_type_for(provider.provider_key) ] if provider
 
       [ nil, "claude_code" ]
     end
 
-    def default_provider_for(project)
+    def default_provider_for(project, goal:)
       owner = project.effective_owner
       return unless owner
 
       settings = AgentRuns::UserSettingsResolver.call(project: project, strict: false)
       return Provider.ensure_default_for(owner) unless settings
 
-      Provider.for_identifier(settings.user, settings.default_provider_identifier) || Provider.ensure_default_for(settings.user)
+      Provider.for_identifier(settings.user, settings.default_provider_identifier_for_goal(goal)) || Provider.ensure_default_for(settings.user)
     end
 
     def provider_for_id(provider_id)

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -17,13 +17,17 @@
     </div>
 
     <div class="border-t border-gray-200 px-4 py-5 sm:px-6">
-      <%= form_with url: project_agent_runs_path(@project), method: :post, class: "space-y-6", data: { controller: "goal-toggle" } do |f| %>
+      <% selected_goal = params[:goal].presence || "create_pr" %>
+      <%= form_with url: project_agent_runs_path(@project), method: :post, class: "space-y-6", data: {
+        controller: "goal-toggle",
+        goal_toggle_current_goal_value: selected_goal,
+        goal_toggle_provider_defaults_value: @default_provider_identifiers_by_goal.to_json
+      } do |f| %>
 
         <fieldset>
           <legend class="text-base font-semibold text-gray-900">Goal</legend>
           <p class="mt-1 text-sm text-gray-500" id="goal-description">What should the agent produce?</p>
           <div class="mt-4 flex items-center space-x-6" role="radiogroup" aria-describedby="goal-description">
-            <% selected_goal = params[:goal].presence || "create_pr" %>
             <label class="inline-flex items-center">
               <input type="radio" name="goal" value="create_pr" <%= "checked" if selected_goal == "create_pr" %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
               <span class="ml-2 text-sm text-gray-700">Create/Edit Pull Request</span>
@@ -115,7 +119,7 @@
         <div>
           <h2 class="text-base font-semibold text-gray-900">Provider</h2>
           <div class="mt-4">
-            <select name="provider" id="provider" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+            <select name="provider" id="provider" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" data-action="change->goal-toggle#providerChanged" data-goal-toggle-target="providerSelect">
               <% @available_run_provider_options.each do |label, identifier| %>
                 <option value="<%= identifier %>" <%= "selected" if identifier == @default_provider_identifier %>>
                   <%= label %>

--- a/app/views/providers/_settings.html.erb
+++ b/app/views/providers/_settings.html.erb
@@ -42,6 +42,31 @@
           <p class="mt-1 text-xs text-gray-500">This provider is always tried first for new agent runs.</p>
         </div>
 
+        <div>
+          <h3 class="block text-sm font-medium leading-6 text-gray-900">Per-Run-Type Defaults</h3>
+          <p class="mt-1 text-xs text-gray-500">Override the global primary for specific run types, or leave them on the shared default.</p>
+          <div class="mt-4 grid gap-4 sm:grid-cols-2">
+            <% AgentRun::GOALS.each do |goal| %>
+              <div>
+                <label for="user_setting_default_agent_providers_by_goal_<%= goal %>" class="block text-sm font-medium leading-6 text-gray-900">
+                  <%= @goal_provider_labels.fetch(goal, goal.humanize) %>
+                </label>
+                <div class="mt-2">
+                  <% global_provider_label = @provider_labels[@default_provider_identifier] || @default_provider_identifier.to_s.titleize.presence || "Not set" %>
+                  <%= select_tag "user_setting[default_agent_providers_by_goal][#{goal}]",
+                      options_for_select(
+                        [[ "Use global primary (#{global_provider_label})", "" ]] +
+                        @enabled_agent_providers.map { |provider| [ @provider_labels[provider] || provider.titleize, provider ] },
+                        @explicit_goal_default_providers[goal]
+                      ),
+                      id: "user_setting_default_agent_providers_by_goal_#{goal}",
+                      class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
         <div class="flex items-center">
           <%= form.check_box :fallback_enabled, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
           <%= form.label :fallback_enabled, "Enable automatic provider fallback", class: "ml-3 block text-sm font-medium leading-6 text-gray-900" %>

--- a/db/migrate/20260411163526_add_default_agent_providers_by_goal_to_user_settings.rb
+++ b/db/migrate/20260411163526_add_default_agent_providers_by_goal_to_user_settings.rb
@@ -1,0 +1,5 @@
+class AddDefaultAgentProvidersByGoalToUserSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_settings, :default_agent_providers_by_goal, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_11_022311) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_11_163526) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -204,8 +204,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_11_022311) do
     t.index ["issue_id"], name: "index_agent_runs_on_issue_id"
     t.index ["parent_workflow_id"], name: "index_agent_runs_on_parent_workflow_id"
     t.index ["project_id", "goal"], name: "index_agent_runs_on_project_id_and_goal"
-    t.index ["project_id", "issue_id", "goal"], name: "idx_agent_runs_unique_active_issue", unique: true, where: "((issue_id IS NOT NULL) AND ((status)::text = ANY ((ARRAY['queued'::character varying, 'pending'::character varying, 'running'::character varying, 'paused'::character varying])::text[])))"
-    t.index ["project_id", "source_pull_request_number", "goal"], name: "idx_agent_runs_unique_active_pr", unique: true, where: "((source_pull_request_number IS NOT NULL) AND ((status)::text = ANY ((ARRAY['queued'::character varying, 'pending'::character varying, 'running'::character varying, 'paused'::character varying])::text[])))"
+    t.index ["project_id", "issue_id", "goal"], name: "idx_agent_runs_unique_active_issue", unique: true, where: "((issue_id IS NOT NULL) AND ((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('pending'::character varying)::text, ('running'::character varying)::text, ('paused'::character varying)::text])))"
+    t.index ["project_id", "source_pull_request_number", "goal"], name: "idx_agent_runs_unique_active_pr", unique: true, where: "((source_pull_request_number IS NOT NULL) AND ((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('pending'::character varying)::text, ('running'::character varying)::text, ('paused'::character varying)::text])))"
     t.index ["project_id", "status", "completed_at"], name: "index_agent_runs_on_project_status_completed_at"
     t.index ["project_id", "status"], name: "index_agent_runs_on_project_id_and_status"
     t.index ["project_id"], name: "index_agent_runs_on_project_id"
@@ -997,6 +997,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_11_022311) do
     t.integer "container_timeout_seconds", default: 3600, null: false
     t.datetime "created_at", null: false
     t.string "default_agent_provider", default: "claude", null: false
+    t.jsonb "default_agent_providers_by_goal", default: {}, null: false
     t.jsonb "default_allowed_github_usernames", default: [], null: false
     t.string "default_branch", default: "main", null: false
     t.integer "default_poll_interval_seconds", default: 60, null: false

--- a/spec/models/user_setting_spec.rb
+++ b/spec/models/user_setting_spec.rb
@@ -142,6 +142,62 @@ RSpec.describe UserSetting do
     end
   end
 
+  describe "goal-specific default providers" do
+    let(:user) { create(:user) }
+
+    before do
+      allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[claude cursor codex])
+    end
+
+    it "normalizes configured goal defaults to provider identifiers" do
+      cursor = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true)
+      setting = build(
+        :user_setting,
+        user: user,
+        default_agent_providers_by_goal: {
+          "create_pr" => "cursor",
+          "review" => "claude",
+          "create_issue" => ""
+        }
+      )
+
+      expect(setting).to be_valid
+      expect(setting.default_agent_providers_by_goal).to eq(
+        "create_pr" => cursor.routing_key,
+        "review" => user.providers.find_by!(provider_key: "claude").routing_key
+      )
+    end
+
+    it "falls back to the global default when no goal-specific provider is set" do
+      codex = user.providers.create!(provider_key: "codex", enabled_for_agent_runs: true)
+      setting = create(:user_setting, user: user, default_agent_provider: codex.routing_key)
+
+      expect(setting.default_provider_identifier_for_goal("review")).to eq(codex.routing_key)
+    end
+
+    it "uses the goal-specific provider ahead of the global default" do
+      cursor = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
+      codex = user.providers.create!(provider_key: "codex", enabled_for_agent_runs: true, enabled_for_fallback: true)
+      setting = create(
+        :user_setting,
+        user: user,
+        default_agent_provider: cursor.routing_key,
+        default_agent_providers_by_goal: { "review" => codex.routing_key },
+        fallback_enabled: true
+      )
+
+      expect(setting.default_provider_identifier_for_goal("review")).to eq(codex.routing_key)
+      expect(setting.provider_priority_for_goal("review", identifiers: true).first).to eq(codex.routing_key)
+    end
+
+    it "rejects invalid goals" do
+      setting = build(:user_setting, user: user, default_agent_providers_by_goal: { "ship_it" => "claude" })
+
+      expect(setting).not_to be_valid
+      expect(setting.errors[:default_agent_providers_by_goal]).to include("contains invalid goal: ship_it")
+    end
+  end
+
   describe "#container_memory_gb" do
     it "converts bytes to gigabytes" do
       setting = build(:user_setting, container_memory_bytes: 4 * 1024 * 1024 * 1024)

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -444,6 +444,48 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("selected")
         expect(response.body).to include("Preselected PR")
       end
+
+      it "exposes goal-specific provider defaults to the goal toggle controller" do
+        owner = project.created_by
+        codex = owner.providers.create!(
+          provider_key: "codex",
+          auth_type: "subscription",
+          enabled_for_agent_runs: true,
+          enabled_for_fallback: true
+        )
+        owner.settings.update!(default_agent_providers_by_goal: { "review" => codex.routing_key })
+
+        get new_project_agent_run_path(project)
+
+        doc = Nokogiri::HTML(response.body)
+        form = doc.at_css("form[data-controller='goal-toggle']")
+        defaults = JSON.parse(form["data-goal-toggle-provider-defaults-value"])
+        provider = form.at_css("#provider")
+
+        expect(defaults["create_pr"]).to eq(owner.settings.default_provider_identifier_for_goal("create_pr"))
+        expect(defaults["review"]).to eq(codex.routing_key)
+        expect(provider["data-goal-toggle-target"]).to eq("providerSelect")
+        expect(provider["data-action"]).to include("change->goal-toggle#providerChanged")
+      end
+
+      it "pre-selects the goal-specific provider when goal=review" do
+        owner = project.created_by
+        codex = owner.providers.create!(
+          provider_key: "codex",
+          auth_type: "subscription",
+          enabled_for_agent_runs: true,
+          enabled_for_fallback: true
+        )
+        owner.settings.update!(default_agent_providers_by_goal: { "review" => codex.routing_key })
+
+        get new_project_agent_run_path(project, goal: "review")
+
+        doc = Nokogiri::HTML(response.body)
+        provider_select = doc.at_css("#provider")
+        selected_option = provider_select.at_css("option[selected]")
+
+        expect(selected_option["value"]).to eq(codex.routing_key)
+      end
     end
   end
 

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -660,6 +660,22 @@ RSpec.describe "AgentRuns" do
       context "with goal=review" do
         let(:pr) { create(:issue, :pull_request, project: project, github_number: 55, title: "Review target PR") }
 
+        it "uses the goal-specific default provider when no provider is selected" do
+          owner = project.created_by
+          codex = owner.providers.create!(
+            provider_key: "codex",
+            auth_type: "subscription",
+            enabled_for_agent_runs: true,
+            enabled_for_fallback: true
+          )
+          owner.settings.update!(default_agent_providers_by_goal: { "review" => codex.routing_key })
+
+          post project_agent_runs_path(project), params: { goal: "review", pull_request_ids: [ pr.id ] }
+
+          expect(AgentRun.last.provider).to eq(codex)
+          expect(AgentRun.last.agent_type).to eq("codex")
+        end
+
         it "creates a review agent run with source_pull_request_number" do
           expect {
             post project_agent_runs_path(project), params: { goal: "review", pull_request_ids: [ pr.id ] }

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -699,6 +699,23 @@ RSpec.describe "AgentRuns" do
         end
       end
 
+      it "normalizes an invalid goal to create_pr and uses the create_pr default provider" do
+        owner = project.created_by
+        codex = owner.providers.create!(
+          provider_key: "codex",
+          auth_type: "subscription",
+          enabled_for_agent_runs: true,
+          enabled_for_fallback: true
+        )
+        owner.settings.update!(default_agent_providers_by_goal: { "create_pr" => codex.routing_key })
+
+        post project_agent_runs_path(project), params: { goal: "invalid", issue_id: issue.id }
+
+        agent_run = AgentRun.last
+        expect(agent_run.goal).to eq("create_pr")
+        expect(agent_run.provider).to eq(codex)
+      end
+
       context "with goal=review" do
         let(:pr) { create(:issue, :pull_request, project: project, github_number: 55, title: "Review target PR") }
 

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -144,6 +144,28 @@ RSpec.describe "Providers" do
       )
     end
 
+    it "preserves saved goal defaults when submitted nested keys are all unpermitted" do
+      claude = user.providers.find_by!(provider_key: "claude")
+      user.settings.update!(
+        default_agent_provider: claude.routing_key,
+        default_agent_providers_by_goal: { "review" => claude.routing_key }
+      )
+
+      patch settings_providers_path, params: {
+        user_setting: {
+          default_agent_provider: "claude",
+          default_agent_providers_by_goal: { ship_it: "claude" },
+          fallback_enabled: false,
+          fallback_providers: [].to_json
+        }
+      }
+
+      expect(response).to redirect_to(providers_path)
+      expect(user.reload.settings.default_agent_providers_by_goal).to eq(
+        "review" => claude.routing_key
+      )
+    end
+
     it "disables fallback for providers not in enabled_fallback_provider_keys" do
       user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
       user.providers.create!(provider_key: "aider", enabled_for_agent_runs: true, enabled_for_fallback: true)

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe "Providers" do
         expect(response.body).to include("Providers")
         expect(response.body).to include("Provider Priority")
         expect(response.body).to include("Primary Provider")
+        expect(response.body).to include("Per-Run-Type Defaults")
+        expect(response.body).to include("PR Agent")
+        expect(response.body).to include("Code Review Agent")
       end
 
       it "shows empty state when no addable providers remain" do
@@ -96,10 +99,12 @@ RSpec.describe "Providers" do
     it "updates provider priority settings from the providers page" do
       cursor = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
       aider = user.providers.create!(provider_key: "aider", enabled_for_agent_runs: false, enabled_for_fallback: true)
+      claude = user.providers.find_by!(provider_key: "claude")
 
       patch settings_providers_path, params: {
         user_setting: {
           default_agent_provider: "cursor",
+          default_agent_providers_by_goal: { create_pr: "cursor", review: "claude" },
           fallback_enabled: true,
           fallback_providers: %w[claude aider].to_json
         }
@@ -108,8 +113,35 @@ RSpec.describe "Providers" do
       expect(response).to redirect_to(providers_path)
       settings = user.reload.settings
       expect(settings.default_agent_provider).to eq(cursor.routing_key)
+      expect(settings.default_agent_providers_by_goal).to eq("create_pr" => cursor.routing_key, "review" => claude.routing_key)
       expect(settings.fallback_enabled).to be(true)
-      expect(settings.fallback_providers).to eq([ user.providers.find_by!(provider_key: "claude").routing_key, aider.routing_key ])
+      expect(settings.fallback_providers).to eq([ claude.routing_key, aider.routing_key ])
+    end
+
+    it "drops goal-specific defaults whose providers are no longer enabled during reconciliation" do
+      cursor = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
+      user.settings.update!(
+        default_agent_provider: "claude",
+        default_agent_providers_by_goal: {
+          "create_pr" => cursor.routing_key,
+          "review" => user.providers.find_by!(provider_key: "claude").routing_key
+        }
+      )
+
+      cursor.update!(enabled_for_agent_runs: false)
+
+      patch settings_providers_path, params: {
+        user_setting: {
+          default_agent_provider: "claude",
+          fallback_enabled: false,
+          fallback_providers: [].to_json
+        }
+      }
+
+      expect(response).to redirect_to(providers_path)
+      expect(user.reload.settings.default_agent_providers_by_goal).to eq(
+        "review" => user.providers.find_by!(provider_key: "claude").routing_key
+      )
     end
 
     it "disables fallback for providers not in enabled_fallback_provider_keys" do

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -71,6 +71,27 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(agent_run.goal).to eq("review")
     end
 
+    it "refreshes automatic runs to the goal-specific default provider on resume" do
+      codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
+      queued_run = create(
+        :agent_run,
+        :queued,
+        project: project,
+        issue: issue,
+        source_pull_request_number: 42,
+        trigger_type: "automatic",
+        goal: "review"
+      )
+      project.created_by.settings.update!(default_agent_providers_by_goal: { "review" => codex_provider.routing_key })
+
+      result = activity.execute(agent_run_id: queued_run.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(codex_provider)
+      expect(agent_run.agent_type).to eq("codex")
+      expect(agent_run.status).to eq("pending")
+    end
+
     it "persists draft review round tracking metadata when provided" do
       result = activity.execute(
         project_id: project.id,

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -71,6 +71,33 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(agent_run.goal).to eq("review")
     end
 
+    it "uses the configured primary provider when agent type is omitted" do
+      codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
+      project.created_by.settings.update!(default_agent_provider: codex_provider.routing_key)
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(codex_provider)
+      expect(agent_run.agent_type).to eq("codex")
+    end
+
+    it "uses the goal-specific provider for fresh review runs" do
+      codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
+      project.created_by.settings.update!(default_agent_providers_by_goal: { "review" => codex_provider.routing_key })
+
+      result = activity.execute(
+        project_id: project.id,
+        issue_id: issue.id,
+        goal: "review",
+        source_pull_request_number: 42
+      )
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(codex_provider)
+      expect(agent_run.agent_type).to eq("codex")
+    end
+
     it "refreshes automatic runs to the goal-specific default provider on resume" do
       codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
       queued_run = create(

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -67,6 +67,17 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.agent_type).to eq("codex")
     end
 
+    it "uses the goal-specific provider when goal is review" do
+      codex_provider = user.providers.find_or_create_by!(provider_key: "codex", auth_type: "subscription")
+      user.settings.update!(default_agent_providers_by_goal: { "review" => codex_provider.routing_key })
+
+      result = activity.execute(project_id: project.id, source_pull_request_number: 42, goal: "review")
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(codex_provider)
+      expect(agent_run.agent_type).to eq("codex")
+    end
+
     it "stores custom_prompt and source_pull_request_number" do
       result = activity.execute(
         project_id: project.id,


### PR DESCRIPTION
## Summary

Allow setting different default providers per agent run type

See #975 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #975