### PR TITLE
Fix #1024: fix(scanner): merge conflicts invisible to skip_unchanged_pr? early-return guard

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -48,6 +48,15 @@ module Activities
       prs_to_trigger = []
       paid_prs.each do |issue|
         if skip_unchanged_pr?(project, issue)
+          if merge_conflict_rescan_needed?(project, issue)
+            result = scan_merge_conflict_only(project, client, issue)
+            if result && result != :skipped
+              scanned_count += 1
+              issue.update_column(:last_pr_scan_at, Time.current)
+              prs_to_trigger << result
+              next
+            end
+          end
           unchanged_count += 1
           next
         end
@@ -455,7 +464,6 @@ module Activities
       return false unless issue.last_pr_scan_at
       return false if issue.github_updated_at >= issue.last_pr_scan_at
       return false if recently_completed_run?(project, issue)
-      return false if merge_conflict_rescan_needed?(project, issue)
 
       logger.debug(
         message: "pr_scanner.skipped_unchanged",
@@ -472,6 +480,28 @@ module Activities
       project.auto_fix_merge_conflicts &&
         issue.pr_review_phase.in?(%w[ready escalated]) &&
         !followup_limit_reached?(project, issue)
+    end
+
+    def scan_merge_conflict_only(project, client, issue)
+      return :skipped if active_run_exists?(project, issue)
+
+      check_rate_budget!(client)
+      pr_data = fetch_pr_data(client, project, issue)
+      return :skipped if pr_data.nil?
+
+      triggers = check_merge_conflicts(project, pr_data)
+      return nil if triggers.empty?
+
+      log_triggers(project, issue, triggers)
+
+      {
+        issue_id: issue.id,
+        pr_number: issue.github_number,
+        triggers: triggers,
+        phase: issue.pr_review_phase,
+        labels_to_remove: [],
+        current_followup_count: issue.pr_followup_count
+      }
     end
 
     def recently_completed_run?(project, issue)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -455,6 +455,7 @@ module Activities
       return false unless issue.last_pr_scan_at
       return false if issue.github_updated_at >= issue.last_pr_scan_at
       return false if recently_completed_run?(project, issue)
+      return false if merge_conflict_rescan_needed?(project, issue)
 
       logger.debug(
         message: "pr_scanner.skipped_unchanged",
@@ -465,6 +466,10 @@ module Activities
       )
 
       true
+    end
+
+    def merge_conflict_rescan_needed?(project, issue)
+      project.auto_fix_merge_conflicts && issue.pr_review_phase.in?(%w[ready escalated])
     end
 
     def recently_completed_run?(project, issue)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -469,7 +469,9 @@ module Activities
     end
 
     def merge_conflict_rescan_needed?(project, issue)
-      project.auto_fix_merge_conflicts && issue.pr_review_phase.in?(%w[ready escalated])
+      project.auto_fix_merge_conflicts &&
+        issue.pr_review_phase.in?(%w[ready escalated]) &&
+        !followup_limit_reached?(project, issue)
     end
 
     def recently_completed_run?(project, issue)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -3466,6 +3466,36 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(result[:prs_to_trigger]).to eq([])
       end
 
+      it "does not re-emit non-conflict triggers during merge-conflict rescan" do
+        project.update!(auto_fix_merge_conflicts: true)
+        unchanged_pr.update!(pr_review_phase: "ready")
+        stub_github_for_pr(
+          mergeable: false,
+          checks: [ { name: "ci", conclusion: "failure" } ],
+          reviews: [ { id: 200, user_login: "reviewer", state: "CHANGES_REQUESTED",
+                       body: nil, submitted_at: 1.hour.ago } ]
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to contain_exactly(
+          hash_including(
+            pr_number: 42,
+            triggers: contain_exactly(hash_including(type: "merge_conflicts"))
+          )
+        )
+      end
+
+      it "skips unchanged ready PRs with no merge conflict when auto-fix is enabled" do
+        project.update!(auto_fix_merge_conflicts: true)
+        unchanged_pr.update!(pr_review_phase: "ready")
+        stub_github_for_pr(mergeable: true)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+
       it "updates last_pr_scan_at after scanning" do
         unchanged_pr.update_columns(last_pr_scan_at: nil, github_updated_at: Time.current)
         stub_github_for_pr

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -3457,6 +3457,15 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(result[:prs_to_trigger]).to eq([])
       end
 
+      it "still skips ready PRs at the follow-up limit when auto-fix is enabled" do
+        project.update!(auto_fix_merge_conflicts: true, max_pr_followup_runs: 1)
+        unchanged_pr.update!(pr_review_phase: "ready", pr_followup_count: 1)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+
       it "updates last_pr_scan_at after scanning" do
         unchanged_pr.update_columns(last_pr_scan_at: nil, github_updated_at: Time.current)
         stub_github_for_pr

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -3408,6 +3408,55 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(unchanged_pr.reload.last_pr_scan_at).to be_present
       end
 
+      it "scans ready PRs for merge conflicts when auto-fix is enabled" do
+        project.update!(auto_fix_merge_conflicts: true)
+        unchanged_pr.update!(pr_review_phase: "ready")
+        stub_github_for_pr(mergeable: false)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to contain_exactly(
+          hash_including(
+            pr_number: 42,
+            phase: "ready",
+            triggers: include(hash_including(type: "merge_conflicts"))
+          )
+        )
+      end
+
+      it "scans escalated PRs for merge conflicts when auto-fix is enabled" do
+        project.update!(auto_fix_merge_conflicts: true)
+        unchanged_pr.update!(pr_review_phase: "escalated")
+        stub_github_for_pr(mergeable: false)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to contain_exactly(
+          hash_including(
+            pr_number: 42,
+            phase: "escalated",
+            triggers: include(hash_including(type: "merge_conflicts"))
+          )
+        )
+      end
+
+      it "still skips draft PRs when auto-fix is enabled" do
+        project.update!(auto_fix_merge_conflicts: true)
+        unchanged_pr.update!(pr_review_phase: "draft")
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+
+      it "still skips ready PRs when auto-fix is disabled" do
+        unchanged_pr.update!(pr_review_phase: "ready")
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+
       it "updates last_pr_scan_at after scanning" do
         unchanged_pr.update_columns(last_pr_scan_at: nil, github_updated_at: Time.current)
         stub_github_for_pr


### PR DESCRIPTION
## Summary

fix(scanner): merge conflicts invisible to skip_unchanged_pr? early-return guard

See #1024 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1024