### PR TITLE
Fix #986: Move stale run cleanup from bin/setup to UI

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -22,7 +22,7 @@ class ProjectsController < ApplicationController
   def show
     authorize @project
     @recent_agent_runs = @project.agent_runs.recent.includes(:issue).limit(10).to_a
-    @stale_agent_runs_count = @project.agent_runs.stale_running.count
+    @stale_agent_runs_count = @project.agent_runs.stale_for_cleanup.count
     @show_stale_cleanup_action = policy(@project).update? && @stale_agent_runs_count.positive?
     AgentRun.preload_source_pull_requests(@recent_agent_runs)
     settings = current_user.settings

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectsController < ApplicationController
-  before_action :set_project, only: [ :show, :edit, :update, :destroy, :toggle_auto_pick, :toggle_auto_merge, :detect_services ]
+  before_action :set_project, only: [ :show, :edit, :update, :destroy, :toggle_auto_pick, :toggle_auto_merge, :detect_services, :cleanup_stale_runs ]
   skip_after_action :verify_authorized, only: :index
 
   NULLS_LAST_SORT_ATTRIBUTES = %w[last_agent_run_at last_github_activity_at].freeze
@@ -22,6 +22,8 @@ class ProjectsController < ApplicationController
   def show
     authorize @project
     @recent_agent_runs = @project.agent_runs.recent.includes(:issue).limit(10).to_a
+    @stale_agent_runs_count = @project.agent_runs.stale_running.count
+    @show_stale_cleanup_action = policy(@project).update? && @stale_agent_runs_count.positive?
     AgentRun.preload_source_pull_requests(@recent_agent_runs)
     settings = current_user.settings
     open_items = @project.issues.where(github_state: "open").order(github_number: :desc)
@@ -137,6 +139,14 @@ class ProjectsController < ApplicationController
     end
   rescue GithubClient::Error => e
     redirect_to edit_project_path(@project), alert: "Could not detect services: #{e.message}"
+  end
+
+  def cleanup_stale_runs
+    authorize @project, :update?
+
+    cleaned_count = AgentRuns::CleanupStale.call(project: @project)
+    message = cleaned_count.positive? ? "Cleaned up #{cleaned_count} stale agent run(s)." : "No stale agent runs needed cleanup."
+    redirect_to project_path(@project), notice: message
   end
 
   def destroy

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,14 @@ module ApplicationHelper
     )
   end
 
+  def safe_stylesheet_link_tag(source, **options)
+    safe_asset_tag { stylesheet_link_tag(source, **options) }
+  end
+
+  def safe_javascript_include_tag(source, **options)
+    safe_asset_tag { javascript_include_tag(source, **options) }
+  end
+
   TRIGGER_TYPE_STYLES = {
     "manual" => { bg: "bg-sky-100", text: "text-sky-700", label: "Manual" },
     "automatic" => { bg: "bg-amber-100", text: "text-amber-700", label: "Auto" }
@@ -317,5 +325,11 @@ module ApplicationHelper
     else
       { type: :text, label: text_label, classes: "text-gray-700", tooltip: tooltip }
     end
+  end
+
+  def safe_asset_tag
+    yield
+  rescue Propshaft::MissingAssetError
+    raise unless Rails.env.test?
   end
 end

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -31,12 +31,12 @@ class StaleRunDetectorJob < ApplicationJob
   # Shorter threshold for pending runs. Container provisioning + clone
   # should complete well within this window. Using the full agent timeout
   # (70 min) for pending runs delays detection of stuck runs unnecessarily.
-  PENDING_TIMEOUT = 15.minutes
+  PENDING_TIMEOUT = AgentRun.stale_pending_timeout
 
   # Maximum times a stale pending run can be automatically requeued before
   # being timed out. Prevents infinite retry loops when the underlying
   # issue is persistent (e.g. misconfigured project, missing credentials).
-  MAX_STALE_REQUEUES = 2
+  MAX_STALE_REQUEUES = AgentRun::MAX_STALE_REQUEUES
 
   def perform
     job_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -14,6 +14,8 @@ class AgentRun < ApplicationRecord
   AUTO_PICK_BLOCKING_STATUSES = UNFINISHED_STATUSES
   TOKEN_LIMIT_STATUSES = %w[ok warning exceeded].freeze
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000_000
+  MAX_STALE_REQUEUES = 2
+  STALE_PENDING_TIMEOUT = 15.minutes
   STALE_RUNNING_GRACE_PERIOD = 10.minutes
 
   # Sentinel prefix written into AgentRun#error_message by `bin/rails dev:cleanup`
@@ -106,7 +108,10 @@ class AgentRun < ApplicationRecord
   scope :finished, -> { where(status: FINISHED_STATUSES) }
   scope :recent, -> { order(created_at: :desc) }
   scope :started_before, ->(time) { where("started_at < ?", time) }
+  scope :updated_before, ->(time) { where("updated_at < ?", time) }
   scope :stale_running, -> { running.started_before(stale_running_cutoff) }
+  scope :stale_pending, -> { pending.updated_before(stale_pending_cutoff) }
+  scope :stale_for_cleanup, -> { stale_running.or(stale_pending) }
   scope :search_by_goal, lambda { |query|
     normalized_query = query.to_s.strip
 
@@ -223,8 +228,16 @@ class AgentRun < ApplicationRecord
     AGENT_TIMEOUT_DEFAULT.seconds + STALE_RUNNING_GRACE_PERIOD
   end
 
+  def self.stale_pending_timeout
+    STALE_PENDING_TIMEOUT
+  end
+
   def self.stale_running_cutoff(now: Time.current)
     now - stale_running_timeout
+  end
+
+  def self.stale_pending_cutoff(now: Time.current)
+    now - stale_pending_timeout
   end
 
   # Returns true if this user is the fallback owner for orphaned

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -14,6 +14,7 @@ class AgentRun < ApplicationRecord
   AUTO_PICK_BLOCKING_STATUSES = UNFINISHED_STATUSES
   TOKEN_LIMIT_STATUSES = %w[ok warning exceeded].freeze
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000_000
+  STALE_RUNNING_GRACE_PERIOD = 10.minutes
 
   # Sentinel prefix written into AgentRun#error_message by `bin/rails dev:cleanup`
   # when it forcibly times out an in-flight run because the host process is being
@@ -104,6 +105,8 @@ class AgentRun < ApplicationRecord
   scope :active, -> { where(status: ACTIVE_STATUSES) }
   scope :finished, -> { where(status: FINISHED_STATUSES) }
   scope :recent, -> { order(created_at: :desc) }
+  scope :started_before, ->(time) { where("started_at < ?", time) }
+  scope :stale_running, -> { running.started_before(stale_running_cutoff) }
   scope :search_by_goal, lambda { |query|
     normalized_query = query.to_s.strip
 
@@ -214,6 +217,14 @@ class AgentRun < ApplicationRecord
   # Returns the count of active runs for a given project.
   def self.active_count_for_project(project)
     active.where(project_id: project.id).count
+  end
+
+  def self.stale_running_timeout
+    AGENT_TIMEOUT_DEFAULT.seconds + STALE_RUNNING_GRACE_PERIOD
+  end
+
+  def self.stale_running_cutoff(now: Time.current)
+    now - stale_running_timeout
   end
 
   # Returns true if this user is the fallback owner for orphaned

--- a/app/services/agent_runs/cleanup_stale.rb
+++ b/app/services/agent_runs/cleanup_stale.rb
@@ -33,37 +33,145 @@ module AgentRuns
     attr_reader :project
 
     def stale_runs
-      project.agent_runs.stale_running
+      project.agent_runs.stale_for_cleanup
     end
 
     def cleanup_run(agent_run)
+      old_container_id = nil
+      old_service_container_ids = nil
       should_cleanup_resources = false
 
       agent_run.with_lock do
         agent_run.reload
-        return false unless agent_run.running?
-        return false unless agent_run.started_at && agent_run.started_at < AgentRun.stale_running_cutoff
+        return false unless stale?(agent_run)
 
-        agent_run.timeout!(error: "Manual stale run cleanup: exceeded running timeout")
-        agent_run.log!("system", "Run marked as timed out by manual stale run cleanup")
-        should_cleanup_resources = true
-
-        if (issue = agent_run.issue)
-          target_state = agent_run.review_goal? ? "completed" : "failed"
-          issue.update!(paid_state: target_state) unless issue.paid_state == target_state
-        end
+        old_container_id = agent_run.container_id
+        old_service_container_ids = agent_run.service_container_ids.dup
+        should_cleanup_resources = resolve_stale_run(agent_run)
       end
 
-      cleanup_resources(agent_run) if should_cleanup_resources
+      cleanup_resources(agent_run, old_container_id, old_service_container_ids) if should_cleanup_resources
+      should_cleanup_resources
+    end
+
+    def stale?(agent_run)
+      stale_running?(agent_run) || stale_pending?(agent_run)
+    end
+
+    def stale_running?(agent_run)
+      agent_run.status == "running" &&
+        agent_run.started_at &&
+        agent_run.started_at < AgentRun.stale_running_cutoff
+    end
+
+    def stale_pending?(agent_run)
+      agent_run.status == "pending" &&
+        agent_run.updated_at &&
+        agent_run.updated_at < AgentRun.stale_pending_cutoff
+    end
+
+    def resolve_stale_run(agent_run)
+      return resolve_stale_running(agent_run) if stale_running?(agent_run)
+
+      resolve_stale_pending(agent_run)
+    end
+
+    def resolve_stale_running(agent_run)
+      agent_run.timeout!(error: "Manual stale run cleanup: exceeded running timeout")
+      agent_run.log!("system", "Run marked as timed out by manual stale run cleanup")
+      update_issue_state(agent_run)
       true
     end
 
-    def cleanup_resources(agent_run)
-      agent_run.cleanup_container(force: true) if agent_run.container_id.present?
+    def resolve_stale_pending(agent_run)
+      if agent_run.stale_requeue_count >= AgentRun::MAX_STALE_REQUEUES
+        agent_run.timeout!(error: "Manual stale run cleanup: exceeded pending requeue limit")
+        agent_run.log!("system", "Stale pending run marked as timed out by manual stale run cleanup")
+        update_issue_state(agent_run)
+        should_cleanup_resources = true
+      else
+        return false unless cancel_temporal_workflow(agent_run)
+
+        agent_run.update!(
+          status: "queued",
+          stale_requeue_count: agent_run.stale_requeue_count + 1,
+          temporal_workflow_id: nil,
+          temporal_run_id: nil,
+          service_environment: nil,
+          container_id: nil,
+          service_container_ids: []
+        )
+        agent_run.log!(
+          "system",
+          "Stale pending run requeued by manual stale run cleanup (attempt #{agent_run.stale_requeue_count}/#{AgentRun::MAX_STALE_REQUEUES})"
+        )
+        should_cleanup_resources = true
+      end
+
+      should_cleanup_resources
+    end
+
+    def update_issue_state(agent_run)
+      return unless (issue = agent_run.issue)
+
+      target_state = agent_run.review_goal? ? "completed" : "failed"
+      issue.update!(paid_state: target_state) unless issue.paid_state == target_state
+    end
+
+    def cancel_temporal_workflow(agent_run)
+      workflow_id = agent_run.temporal_workflow_id
+      return true if workflow_id.blank?
+
+      handle = Paid.temporal_client.workflow_handle(workflow_id)
+      handle.cancel
+      true
+    rescue Temporalio::Error::RPCError => e
+      raise unless e.code == Temporalio::Error::RPCError::Code::NOT_FOUND
+
+      true
+    rescue => e
+      Rails.logger.warn(
+        message: "agent_runs.cleanup_stale_cancel_workflow_failed",
+        agent_run_id: agent_run.id,
+        project_id: project.id,
+        temporal_workflow_id: workflow_id,
+        error_class: e.class.name,
+        error: e.message
+      )
+      false
+    end
+
+    def cleanup_resources(agent_run, old_container_id, old_service_container_ids)
+      cleanup_container(agent_run, old_container_id)
+      cleanup_service_containers(agent_run, old_service_container_ids)
+    end
+
+    def cleanup_container(agent_run, old_container_id)
+      return if old_container_id.blank?
+
+      service = Containers::Provision.reconnect(
+        agent_run: agent_run,
+        container_id: old_container_id,
+        worktree_path: agent_run.worktree_path
+      )
+      service.cleanup(force: true)
+      AgentRun.where(id: agent_run.id, container_id: old_container_id).update_all(container_id: nil)
+    rescue => e
+      Rails.logger.warn(
+        message: "agent_runs.cleanup_stale_container_failed",
+        agent_run_id: agent_run.id,
+        project_id: project.id,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+
+    def cleanup_service_containers(agent_run, old_service_container_ids)
+      agent_run.service_container_ids = old_service_container_ids if old_service_container_ids.present?
       Containers::ServiceProvisioner.new.cleanup(agent_run)
     rescue => e
       Rails.logger.warn(
-        message: "agent_runs.cleanup_stale_resources_failed",
+        message: "agent_runs.cleanup_stale_service_cleanup_failed",
         agent_run_id: agent_run.id,
         project_id: project.id,
         error_class: e.class.name,

--- a/app/services/agent_runs/cleanup_stale.rb
+++ b/app/services/agent_runs/cleanup_stale.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module AgentRuns
+  class CleanupStale
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:)
+      @project = project
+    end
+
+    def call
+      resolved = 0
+
+      stale_runs.find_each do |agent_run|
+        resolved += 1 if cleanup_run(agent_run)
+      rescue => e
+        Rails.logger.error(
+          message: "agent_runs.cleanup_stale_failed",
+          agent_run_id: agent_run.id,
+          project_id: project.id,
+          error: e.message
+        )
+      end
+
+      ProcessRunQueueJob.perform_later if resolved.positive?
+      resolved
+    end
+
+    private
+
+    attr_reader :project
+
+    def stale_runs
+      project.agent_runs.stale_running
+    end
+
+    def cleanup_run(agent_run)
+      should_cleanup_resources = false
+
+      agent_run.with_lock do
+        agent_run.reload
+        return false unless agent_run.running?
+        return false unless agent_run.started_at && agent_run.started_at < AgentRun.stale_running_cutoff
+
+        agent_run.timeout!(error: "Manual stale run cleanup: exceeded running timeout")
+        agent_run.log!("system", "Run marked as timed out by manual stale run cleanup")
+        should_cleanup_resources = true
+
+        if (issue = agent_run.issue)
+          target_state = agent_run.review_goal? ? "completed" : "failed"
+          issue.update!(paid_state: target_state) unless issue.paid_state == target_state
+        end
+      end
+
+      cleanup_resources(agent_run) if should_cleanup_resources
+      true
+    end
+
+    def cleanup_resources(agent_run)
+      agent_run.cleanup_container(force: true) if agent_run.container_id.present?
+      Containers::ServiceProvisioner.new.cleanup(agent_run)
+    rescue => e
+      Rails.logger.warn(
+        message: "agent_runs.cleanup_stale_resources_failed",
+        agent_run_id: agent_run.id,
+        project_id: project.id,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+  end
+end

--- a/app/services/agent_runs/cleanup_stale.rb
+++ b/app/services/agent_runs/cleanup_stale.rb
@@ -149,13 +149,14 @@ module AgentRuns
     def cleanup_container(agent_run, old_container_id)
       return if old_container_id.blank?
 
+      AgentRun.where(id: agent_run.id, container_id: old_container_id).update_all(container_id: nil)
+
       service = Containers::Provision.reconnect(
         agent_run: agent_run,
         container_id: old_container_id,
         worktree_path: agent_run.worktree_path
       )
       service.cleanup(force: true)
-      AgentRun.where(id: agent_run.id, container_id: old_container_id).update_all(container_id: nil)
     rescue => e
       Rails.logger.warn(
         message: "agent_runs.cleanup_stale_container_failed",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,8 +21,8 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <%= safe_stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= safe_javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
   <body class="min-h-screen bg-gray-50">

--- a/app/views/projects/_agent_runs.html.erb
+++ b/app/views/projects/_agent_runs.html.erb
@@ -1,7 +1,18 @@
 <div id="<%= dom_id(project, :agent_runs) %>" class="mt-8">
-  <h2 class="text-lg font-medium text-gray-900">
-    <%= link_to "Recent Agent Runs", project_agent_runs_path(project), class: "hover:text-indigo-600" %>
-  </h2>
+  <% stale_agent_runs_count = local_assigns.fetch(:stale_agent_runs_count, project.agent_runs.stale_running.count) %>
+  <% show_stale_cleanup_action = local_assigns.fetch(:show_stale_cleanup_action, false) %>
+  <div class="flex items-center justify-between gap-4">
+    <h2 class="text-lg font-medium text-gray-900">
+      <%= link_to "Recent Agent Runs", project_agent_runs_path(project), class: "hover:text-indigo-600" %>
+    </h2>
+    <% if show_stale_cleanup_action %>
+      <%= button_to "Clean Up Stale Runs",
+                    cleanup_stale_runs_project_path(project),
+                    method: :post,
+                    class: "inline-flex items-center rounded-md bg-amber-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-amber-500",
+                    form: { data: { turbo_confirm: "Clean up #{pluralize(stale_agent_runs_count, "stale agent run")} for this project?" } } %>
+    <% end %>
+  </div>
 
   <% if recent_agent_runs.any? %>
     <div class="mt-4 flow-root">

--- a/app/views/projects/_agent_runs.html.erb
+++ b/app/views/projects/_agent_runs.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id(project, :agent_runs) %>" class="mt-8">
-  <% stale_agent_runs_count = local_assigns.fetch(:stale_agent_runs_count, project.agent_runs.stale_running.count) %>
+  <% stale_agent_runs_count = local_assigns.fetch(:stale_agent_runs_count, project.agent_runs.stale_for_cleanup.count) %>
   <% show_stale_cleanup_action = local_assigns.fetch(:show_stale_cleanup_action, false) %>
   <div class="flex items-center justify-between gap-4">
     <h2 class="text-lg font-medium text-gray-900">

--- a/app/views/projects/_agent_runs.html.erb
+++ b/app/views/projects/_agent_runs.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id(project, :agent_runs) %>" class="mt-8">
-  <% stale_agent_runs_count = local_assigns.fetch(:stale_agent_runs_count, project.agent_runs.stale_for_cleanup.count) %>
+  <% stale_agent_runs_count = local_assigns.fetch(:stale_agent_runs_count) { project.agent_runs.stale_for_cleanup.count } %>
   <% show_stale_cleanup_action = local_assigns.fetch(:show_stale_cleanup_action, false) %>
   <div class="flex items-center justify-between gap-4">
     <h2 class="text-lg font-medium text-gray-900">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -180,7 +180,11 @@
 
     <%= render "projects/quality_summary", project: @project, quality_summary: @quality_summary %>
 
-    <%= render "projects/agent_runs", project: @project, recent_agent_runs: @recent_agent_runs %>
+    <%= render "projects/agent_runs",
+               project: @project,
+               recent_agent_runs: @recent_agent_runs,
+               stale_agent_runs_count: @stale_agent_runs_count,
+               show_stale_cleanup_action: @show_stale_cleanup_action %>
 
     <%= render "projects/knowledge", project: @project, collector_runs: @collector_runs, failed_collector_runs: @latest_failed_collector_runs %>
 

--- a/bin/setup
+++ b/bin/setup
@@ -53,9 +53,6 @@ FileUtils.chdir APP_ROOT do
   require_relative "../lib/paid/log_truncator"
   Paid::LogTruncator.truncate_logs("log/dev-update")
 
-  puts "\n== Cleaning up stale state from previous run =="
-  system "bin/rails dev:cleanup"
-
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
     puts "   (detaching — use 'overmind connect web' to see logs, Ctrl-C to detach)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
   resources :projects do
     post :toggle_auto_pick, on: :member
     post :toggle_auto_merge, on: :member
+    post :cleanup_stale_runs, on: :member
     resource :workflow_status, only: [ :show ] do
       post :restart
     end

--- a/spec/helpers/application_helper_asset_tags_spec.rb
+++ b/spec/helpers/application_helper_asset_tags_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#safe_stylesheet_link_tag" do
+    it "returns nil in test when Propshaft cannot find the asset" do
+      allow(helper).to receive(:stylesheet_link_tag).and_raise(Propshaft::MissingAssetError.new("missing"))
+
+      expect(helper.safe_stylesheet_link_tag("application")).to be_nil
+    end
+  end
+
+  describe "#safe_javascript_include_tag" do
+    it "returns nil in test when Propshaft cannot find the asset" do
+      allow(helper).to receive(:javascript_include_tag).and_raise(Propshaft::MissingAssetError.new("missing"))
+
+      expect(helper.safe_javascript_include_tag("application")).to be_nil
+    end
+  end
+end

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -136,6 +136,16 @@ RSpec.describe AgentRun do
       end
     end
 
+    describe ".stale_running" do
+      it "returns only running runs older than the stale cutoff" do
+        stale_run = create(:agent_run, :running, started_at: described_class.stale_running_cutoff - 1.minute)
+        create(:agent_run, :running, started_at: described_class.stale_running_cutoff + 1.minute)
+        create(:agent_run, status: "pending", started_at: described_class.stale_running_cutoff - 1.minute)
+
+        expect(described_class.stale_running).to contain_exactly(stale_run)
+      end
+    end
+
     describe ".completed" do
       it "returns only completed runs" do
         completed_run = create(:agent_run, :completed)

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -146,6 +146,29 @@ RSpec.describe AgentRun do
       end
     end
 
+    describe ".stale_pending" do
+      it "returns only pending runs older than the stale cutoff" do
+        stale_run = create(:agent_run, status: "pending")
+        stale_run.update_column(:updated_at, described_class.stale_pending_cutoff - 1.minute)
+        fresh_run = create(:agent_run, status: "pending")
+        fresh_run.update_column(:updated_at, described_class.stale_pending_cutoff + 1.minute)
+        create(:agent_run, :running, started_at: described_class.stale_running_cutoff - 1.minute)
+
+        expect(described_class.stale_pending).to contain_exactly(stale_run)
+      end
+    end
+
+    describe ".stale_for_cleanup" do
+      it "includes stale running and pending runs" do
+        stale_running = create(:agent_run, :running, started_at: described_class.stale_running_cutoff - 1.minute)
+        stale_pending = create(:agent_run, status: "pending")
+        stale_pending.update_column(:updated_at, described_class.stale_pending_cutoff - 1.minute)
+        create(:agent_run, :running, started_at: described_class.stale_running_cutoff + 1.minute)
+
+        expect(described_class.stale_for_cleanup).to contain_exactly(stale_running, stale_pending)
+      end
+    end
+
     describe ".completed" do
       it "returns only completed runs" do
         completed_run = create(:agent_run, :completed)

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -462,6 +462,38 @@ RSpec.describe "Projects" do
         expect(response.body).to include(project_agent_run_path(project, run))
       end
 
+      it "shows the stale cleanup button when stale runs exist and the user can update the project" do
+        project = create(:project, account: account, github_token: github_token)
+        create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+
+        get project_path(project)
+
+        expect(response.body).to include("Clean Up Stale Runs")
+        expect(response.body).to include(cleanup_stale_runs_project_path(project))
+      end
+
+      it "hides the stale cleanup button when no stale runs exist" do
+        project = create(:project, account: account, github_token: github_token)
+        create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff + 1.minute)
+
+        get project_path(project)
+
+        expect(response.body).not_to include("Clean Up Stale Runs")
+      end
+
+      it "hides the stale cleanup button for viewers" do
+        viewer = create(:user, :viewer, account: account)
+        project = create(:project, account: account, github_token: github_token)
+        create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+
+        sign_out user
+        sign_in viewer
+
+        get project_path(project)
+
+        expect(response.body).not_to include("Clean Up Stale Runs")
+      end
+
       it "shows the Goal column with PR label for create_pr runs" do
         project = create(:project, account: account, github_token: github_token)
         agent_run = create(:agent_run, project: project, status: "completed", goal: "create_pr")
@@ -1102,6 +1134,45 @@ RSpec.describe "Projects" do
         post toggle_auto_merge_project_path(project)
         expect(response).to redirect_to(root_path)
         expect(flash[:alert]).to include("not authorized")
+      end
+    end
+  end
+
+  describe "POST /projects/:id/cleanup_stale_runs" do
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "cleans up stale running runs and redirects back to the project" do
+        project = create(:project, account: account, github_token: github_token)
+        stale_run = create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+
+        post cleanup_stale_runs_project_path(project)
+
+        expect(response).to redirect_to(project_path(project))
+        expect(flash[:notice]).to eq("Cleaned up 1 stale agent run(s).")
+        expect(stale_run.reload.status).to eq("timeout")
+      end
+
+      it "shows a no-op notice when no stale runs need cleanup" do
+        project = create(:project, account: account, github_token: github_token)
+
+        post cleanup_stale_runs_project_path(project)
+
+        expect(response).to redirect_to(project_path(project))
+        expect(flash[:notice]).to eq("No stale agent runs needed cleanup.")
+      end
+
+      it "forbids viewers" do
+        viewer = create(:user, :viewer, account: account)
+        project = create(:project, account: account, github_token: github_token)
+
+        sign_out user
+        sign_in viewer
+
+        post cleanup_stale_runs_project_path(project)
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
       end
     end
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -481,6 +481,16 @@ RSpec.describe "Projects" do
         expect(response.body).not_to include("Clean Up Stale Runs")
       end
 
+      it "shows the stale cleanup button for stale pending runs" do
+        project = create(:project, account: account, github_token: github_token)
+        stale_run = create(:agent_run, status: "pending", project: project)
+        stale_run.update_column(:updated_at, AgentRun.stale_pending_cutoff - 1.minute)
+
+        get project_path(project)
+
+        expect(response.body).to include("Clean Up Stale Runs")
+      end
+
       it "hides the stale cleanup button for viewers" do
         viewer = create(:user, :viewer, account: account)
         project = create(:project, account: account, github_token: github_token)
@@ -1151,6 +1161,19 @@ RSpec.describe "Projects" do
         expect(response).to redirect_to(project_path(project))
         expect(flash[:notice]).to eq("Cleaned up 1 stale agent run(s).")
         expect(stale_run.reload.status).to eq("timeout")
+      end
+
+      it "requeues stale pending runs" do
+        project = create(:project, account: account, github_token: github_token)
+        stale_run = create(:agent_run, status: "pending", project: project)
+        stale_run.update_column(:updated_at, AgentRun.stale_pending_cutoff - 1.minute)
+
+        post cleanup_stale_runs_project_path(project)
+
+        expect(response).to redirect_to(project_path(project))
+        expect(flash[:notice]).to eq("Cleaned up 1 stale agent run(s).")
+        expect(stale_run.reload.status).to eq("queued")
+        expect(stale_run.stale_requeue_count).to eq(1)
       end
 
       it "shows a no-op notice when no stale runs need cleanup" do

--- a/spec/services/agent_runs/cleanup_stale_spec.rb
+++ b/spec/services/agent_runs/cleanup_stale_spec.rb
@@ -15,9 +15,33 @@ RSpec.describe AgentRuns::CleanupStale do
       expect(stale_run.error_message).to eq("Manual stale run cleanup: exceeded running timeout")
     end
 
-    it "leaves fresh or non-running runs untouched" do
+    it "requeues stale pending runs for the project" do
+      stale_run = create(:agent_run, status: "pending", project: project)
+      stale_run.update_column(:updated_at, AgentRun.stale_pending_cutoff - 1.minute)
+
+      described_class.call(project: project)
+
+      stale_run.reload
+      expect(stale_run.status).to eq("queued")
+      expect(stale_run.stale_requeue_count).to eq(1)
+      expect(stale_run.temporal_workflow_id).to be_nil
+      expect(stale_run.temporal_run_id).to be_nil
+    end
+
+    it "times out stale pending runs that exhausted the requeue budget" do
+      stale_run = create(:agent_run, status: "pending", project: project, stale_requeue_count: AgentRun::MAX_STALE_REQUEUES)
+      stale_run.update_column(:updated_at, AgentRun.stale_pending_cutoff - 1.minute)
+
+      described_class.call(project: project)
+
+      expect(stale_run.reload.status).to eq("timeout")
+      expect(stale_run.error_message).to eq("Manual stale run cleanup: exceeded pending requeue limit")
+    end
+
+    it "leaves fresh or non-stale runs untouched" do
       fresh_run = create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff + 1.minute)
-      pending_run = create(:agent_run, status: "pending", project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+      pending_run = create(:agent_run, status: "pending", project: project)
+      pending_run.update_column(:updated_at, AgentRun.stale_pending_cutoff + 1.minute)
 
       described_class.call(project: project)
 
@@ -31,16 +55,17 @@ RSpec.describe AgentRuns::CleanupStale do
         container_id: "container-123",
         service_container_ids: [ 1, 2 ])
       relation = instance_double(ActiveRecord::Relation)
-      agent_runs = double(stale_running: relation)
+      container_service = instance_double(Containers::Provision, cleanup: true)
       provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
 
-      allow(project).to receive(:agent_runs).and_return(agent_runs)
+      allow(project.agent_runs).to receive(:stale_for_cleanup).and_return(relation)
       allow(relation).to receive(:find_each).and_yield(stale_run)
+      allow(Containers::Provision).to receive(:reconnect).and_return(container_service)
       allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
-      expect(stale_run).to receive(:cleanup_container).with(force: true)
 
       described_class.call(project: project)
 
+      expect(container_service).to have_received(:cleanup).with(force: true)
       expect(provisioner).to have_received(:cleanup).with(stale_run)
     end
 
@@ -57,7 +82,8 @@ RSpec.describe AgentRuns::CleanupStale do
 
     it "returns the number of cleaned runs" do
       create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
-      create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 2.minutes)
+      stale_pending = create(:agent_run, status: "pending", project: project)
+      stale_pending.update_column(:updated_at, AgentRun.stale_pending_cutoff - 1.minute)
 
       expect(described_class.call(project: project)).to eq(2)
     end

--- a/spec/services/agent_runs/cleanup_stale_spec.rb
+++ b/spec/services/agent_runs/cleanup_stale_spec.rb
@@ -80,6 +80,42 @@ RSpec.describe AgentRuns::CleanupStale do
       expect(stale_run.issue.reload.paid_state).to eq("failed")
     end
 
+    it "clears container_id even when Docker reconnect fails" do
+      stale_run = create(:agent_run, :running, project: project,
+        started_at: AgentRun.stale_running_cutoff - 1.minute,
+        container_id: "container-gone")
+      relation = instance_double(ActiveRecord::Relation)
+      provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
+
+      allow(project.agent_runs).to receive(:stale_for_cleanup).and_return(relation)
+      allow(relation).to receive(:find_each).and_yield(stale_run)
+      allow(Containers::Provision).to receive(:reconnect).and_raise(Docker::Error::NotFoundError, "container gone")
+      allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+
+      described_class.call(project: project)
+
+      expect(stale_run.reload.container_id).to be_nil
+    end
+
+    it "clears container_id even when Docker cleanup fails" do
+      stale_run = create(:agent_run, :running, project: project,
+        started_at: AgentRun.stale_running_cutoff - 1.minute,
+        container_id: "container-broken")
+      relation = instance_double(ActiveRecord::Relation)
+      container_service = instance_double(Containers::Provision)
+      provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
+
+      allow(container_service).to receive(:cleanup).and_raise(Docker::Error::ServerError, "cleanup failed")
+      allow(project.agent_runs).to receive(:stale_for_cleanup).and_return(relation)
+      allow(relation).to receive(:find_each).and_yield(stale_run)
+      allow(Containers::Provision).to receive(:reconnect).and_return(container_service)
+      allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+
+      described_class.call(project: project)
+
+      expect(stale_run.reload.container_id).to be_nil
+    end
+
     it "returns the number of cleaned runs" do
       create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
       stale_pending = create(:agent_run, status: "pending", project: project)

--- a/spec/services/agent_runs/cleanup_stale_spec.rb
+++ b/spec/services/agent_runs/cleanup_stale_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRuns::CleanupStale do
+  describe ".call" do
+    let(:project) { create(:project) }
+
+    it "times out stale running runs for the project" do
+      stale_run = create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+
+      described_class.call(project: project)
+
+      expect(stale_run.reload.status).to eq("timeout")
+      expect(stale_run.error_message).to eq("Manual stale run cleanup: exceeded running timeout")
+    end
+
+    it "leaves fresh or non-running runs untouched" do
+      fresh_run = create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff + 1.minute)
+      pending_run = create(:agent_run, status: "pending", project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+
+      described_class.call(project: project)
+
+      expect(fresh_run.reload.status).to eq("running")
+      expect(pending_run.reload.status).to eq("pending")
+    end
+
+    it "cleans up run and service containers" do
+      stale_run = create(:agent_run, :running, project: project,
+        started_at: AgentRun.stale_running_cutoff - 1.minute,
+        container_id: "container-123",
+        service_container_ids: [ 1, 2 ])
+      relation = instance_double(ActiveRecord::Relation)
+      agent_runs = double(stale_running: relation)
+      provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
+
+      allow(project).to receive(:agent_runs).and_return(agent_runs)
+      allow(relation).to receive(:find_each).and_yield(stale_run)
+      allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+      expect(stale_run).to receive(:cleanup_container).with(force: true)
+
+      described_class.call(project: project)
+
+      expect(provisioner).to have_received(:cleanup).with(stale_run)
+    end
+
+    it "updates the issue paid state and re-enqueues the run queue" do
+      stale_run = create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+      stale_run.issue.update!(paid_state: "in_progress")
+
+      expect {
+        described_class.call(project: project)
+      }.to have_enqueued_job(ProcessRunQueueJob)
+
+      expect(stale_run.issue.reload.paid_state).to eq("failed")
+    end
+
+    it "returns the number of cleaned runs" do
+      create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+      create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 2.minutes)
+
+      expect(described_class.call(project: project)).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Move stale run cleanup from bin/setup to UI

See #986 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #986