### PR TITLE
fix: add missing reviewer_login field to manual review settings form

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -215,7 +215,7 @@ class ProjectsController < ApplicationController
           copilot: [ :enabled, termination_permit ],
           paid_agent: [ :enabled, termination_permit ],
           ci_action: [ :enabled, :action_name, termination_permit ],
-          manual: [ :enabled, termination_permit ],
+          manual: [ :enabled, :reviewer_login, termination_permit ],
           codex: [ :enabled, termination_permit ]
         } }
       ]
@@ -237,6 +237,7 @@ class ProjectsController < ApplicationController
 
         config["enabled"] = ActiveModel::Type::Boolean.new.cast(config["enabled"]) if config.key?("enabled")
         config["action_name"] = config["action_name"].presence if config.key?("action_name")
+        config["reviewer_login"] = config["reviewer_login"].presence if config.key?("reviewer_login")
         next unless config["termination"].is_a?(Hash)
 
         term = config["termination"]

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -347,7 +347,14 @@
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
                   <label for="review_manual_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Manual Review</label>
                 </div>
-                <div class="ml-7 grid grid-cols-2 gap-3">
+                <div class="ml-7 space-y-3">
+                  <div>
+                    <label for="review_manual_reviewer_login" class="block text-xs font-medium text-gray-600">Reviewer Login</label>
+                    <input type="text" name="project[review_settings][methods][manual][reviewer_login]" id="review_manual_reviewer_login"
+                      value="<%= manual["reviewer_login"] %>" placeholder="e.g. octocat"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                  </div>
+                  <div class="grid grid-cols-2 gap-3">
                   <div>
                     <label for="review_manual_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                     <input type="number" name="project[review_settings][methods][manual][termination][max_review_rounds]" id="review_manual_max_rounds"
@@ -372,6 +379,7 @@
                       <%= "checked" if manual.dig("termination", "stop_when_no_comments") %>
                       class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
                     <label for="review_manual_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
+                  </div>
                   </div>
                 </div>
               </div>

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -955,6 +955,26 @@ RSpec.describe "Projects" do
           expect(response).to have_http_status(:unprocessable_content)
           expect(project.reload.review_settings).to eq({})
         end
+
+        it "persists manual reviewer_login and casts blank to nil" do
+          params_with_reviewer = { enabled: "1", wait_for_reviews: "0",
+                                   methods: { manual: { enabled: "1", reviewer_login: "alice",
+                                                        termination: { max_review_rounds: "3", stop_when_no_comments: "1",
+                                                                       quality_threshold: "", timeout_minutes: "" } } } }
+          patch project_path(project), params: { project: { review_settings: params_with_reviewer } }
+
+          expect(response).to redirect_to(project_path(project))
+          manual = project.reload.review_settings.dig("methods", "manual")
+          expect(manual).to include("enabled" => true, "reviewer_login" => "alice")
+
+          params_blank_reviewer = { enabled: "0", wait_for_reviews: "0",
+                                    methods: { manual: { enabled: "0", reviewer_login: "" } } }
+          patch project_path(project), params: { project: { review_settings: params_blank_reviewer } }
+
+          expect(response).to redirect_to(project_path(project))
+          manual = project.reload.review_settings.dig("methods", "manual")
+          expect(manual["reviewer_login"]).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- Add `reviewer_login` text input to the Manual Review section of the project edit form
- The model validation requires `reviewer_login` when manual review is enabled, but the form had no input for it, making it impossible to enable manual review
- Follows the same pattern as the CI Action's `action_name` field