### PR TITLE
Fix #999: bug(agent-runs): link PRs and review comments in project and index agent runs tables

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -277,7 +277,9 @@ module ApplicationHelper
       label = "#{prefix} ##{run.issue.github_number}"
       github_link_or_text(label, label, run.issue.github_url, tooltip: run.issue.title)
     elsif run.source_pull_request_number.present?
-      { type: :text, label: "PR ##{run.source_pull_request_number}", classes: "text-gray-700" }
+      url = source_pull_request_url(run)
+      label = "PR ##{run.source_pull_request_number}"
+      github_link_or_text(label, label, url)
     elsif run.pull_request_number.present?
       github_link_or_text("PR ##{run.pull_request_number}", "PR ##{run.pull_request_number}", run.pull_request_url)
     else
@@ -296,11 +298,11 @@ module ApplicationHelper
     end
   end
 
-  # Tooltip not available here: source_pull_request_number has no associated title
-  # column, and fetching titles from GitHub would introduce N+1 queries.
   def review_context(run)
     if run.source_pull_request_number.present?
-      { type: :text, label: "PR ##{run.source_pull_request_number}", classes: "text-gray-700" }
+      url = source_pull_request_url(run)
+      label = "PR ##{run.source_pull_request_number}"
+      github_link_or_text(label, label, url)
     else
       { type: :placeholder }
     end
@@ -325,6 +327,12 @@ module ApplicationHelper
     else
       { type: :text, label: text_label, classes: "text-gray-700", tooltip: tooltip }
     end
+  end
+
+  def source_pull_request_url(run)
+    return nil unless run.source_pull_request_number.present? && run.project.present?
+
+    "#{run.project.github_url}/pull/#{run.source_pull_request_number}"
   end
 
   def safe_asset_tag

--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -67,6 +67,10 @@
                       &middot;
                       <%= link_to "PR", run.pull_request_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
                     <% end %>
+                    <% if safe_github_url?(run.review_url) %>
+                      &middot;
+                      <%= link_to "Review", run.review_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
+                    <% end %>
                     <% if safe_github_url?(run.created_issue_url) %>
                       &middot;
                       <% issue_link_text = run.created_issue_number.present? ? "Issue ##{run.created_issue_number}" : "Issue" %>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -50,15 +50,15 @@
   </td>
   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
     <%= link_to "View", project_agent_run_path(project, agent_run), class: "text-indigo-600 hover:text-indigo-900" %>
-    <% if agent_run.pull_request_url.present? %>
+    <% if safe_github_url?(agent_run.pull_request_url) %>
       &middot;
       <%= link_to "PR", agent_run.pull_request_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
     <% end %>
-    <% if agent_run.review_url.present? %>
+    <% if safe_github_url?(agent_run.review_url) %>
       &middot;
       <%= link_to "Review", agent_run.review_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
     <% end %>
-    <% if agent_run.created_issue_url.present? %>
+    <% if safe_github_url?(agent_run.created_issue_url) %>
       &middot;
       <% issue_link_text = agent_run.created_issue_number.present? ? "Issue ##{agent_run.created_issue_number}" : "Issue" %>
       <%= link_to issue_link_text, agent_run.created_issue_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -54,6 +54,10 @@
       &middot;
       <%= link_to "PR", agent_run.pull_request_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
     <% end %>
+    <% if agent_run.review_url.present? %>
+      &middot;
+      <%= link_to "Review", agent_run.review_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
+    <% end %>
     <% if agent_run.created_issue_url.present? %>
       &middot;
       <% issue_link_text = agent_run.created_issue_number.present? ? "Issue ##{agent_run.created_issue_number}" : "Issue" %>

--- a/app/views/projects/agent_runs/_table.html.erb
+++ b/app/views/projects/agent_runs/_table.html.erb
@@ -48,6 +48,10 @@
                         &middot;
                         <%= link_to "PR", run.pull_request_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
                       <% end %>
+                      <% if run.review_url.present? %>
+                        &middot;
+                        <%= link_to "Review", run.review_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
+                      <% end %>
                       <% if run.created_issue_url.present? %>
                         &middot;
                         <% issue_link_text = run.created_issue_number.present? ? "Issue ##{run.created_issue_number}" : "Issue" %>

--- a/app/views/projects/agent_runs/_table.html.erb
+++ b/app/views/projects/agent_runs/_table.html.erb
@@ -44,15 +44,15 @@
                     </td>
                     <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                       <%= link_to "View", project_agent_run_path(project, run), class: "text-indigo-600 hover:text-indigo-900" %>
-                      <% if run.pull_request_url.present? %>
+                      <% if safe_github_url?(run.pull_request_url) %>
                         &middot;
                         <%= link_to "PR", run.pull_request_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
                       <% end %>
-                      <% if run.review_url.present? %>
+                      <% if safe_github_url?(run.review_url) %>
                         &middot;
                         <%= link_to "Review", run.review_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
                       <% end %>
-                      <% if run.created_issue_url.present? %>
+                      <% if safe_github_url?(run.created_issue_url) %>
                         &middot;
                         <% issue_link_text = run.created_issue_number.present? ? "Issue ##{run.created_issue_number}" : "Issue" %>
                         <%= link_to issue_link_text, run.created_issue_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe ApplicationHelper do
         pull_request_url: nil,
         created_issue_url: nil,
         created_issue_number: nil,
-        "finished?": false
+        "finished?": false,
+        project: nil
       }
       attrs = defaults.merge(overrides)
       Struct.new(*attrs.keys, keyword_init: true).new(**attrs)
@@ -28,6 +29,10 @@ RSpec.describe ApplicationHelper do
       attrs = { github_number: github_number, github_url: github_url,
                 "is_pull_request?": is_pull_request, title: title }
       Struct.new(*attrs.keys, keyword_init: true).new(**attrs)
+    end
+
+    def stub_project(github_url:)
+      Struct.new(:github_url, keyword_init: true).new(github_url: github_url)
     end
 
     context "when create_pr goal with issue" do
@@ -94,11 +99,22 @@ RSpec.describe ApplicationHelper do
     end
 
     context "when create_pr goal without issue" do
-      it "shows source PR number as text" do
-        run = stub_run("create_pr_goal?": true, source_pull_request_number: 7)
+      it "shows source PR number as link when project has a github_url" do
+        project = stub_project(github_url: "https://github.com/o/r")
+        run = stub_run("create_pr_goal?": true, source_pull_request_number: 7, project: project)
         result = helper.agent_run_context_display(run)
 
         expect(result).to include("PR #7")
+        expect(result).to include("https://github.com/o/r/pull/7")
+        expect(result).to include("<a")
+      end
+
+      it "shows source PR number as text when project is nil" do
+        run = stub_run("create_pr_goal?": true, source_pull_request_number: 7, project: nil)
+        result = helper.agent_run_context_display(run)
+
+        expect(result).to include("PR #7")
+        expect(result).not_to include("<a")
       end
 
       it "shows pull request number as link" do
@@ -145,11 +161,22 @@ RSpec.describe ApplicationHelper do
     end
 
     context "when review goal" do
-      it "shows PR number" do
-        run = stub_run("review_goal?": true, source_pull_request_number: 15)
+      it "shows PR number as link when project has a github_url" do
+        project = stub_project(github_url: "https://github.com/o/r")
+        run = stub_run("review_goal?": true, source_pull_request_number: 15, project: project)
         result = helper.agent_run_context_display(run)
 
         expect(result).to include("PR #15")
+        expect(result).to include("https://github.com/o/r/pull/15")
+        expect(result).to include("<a")
+      end
+
+      it "shows PR number as text when project is nil" do
+        run = stub_run("review_goal?": true, source_pull_request_number: 15, project: nil)
+        result = helper.agent_run_context_display(run)
+
+        expect(result).to include("PR #15")
+        expect(result).not_to include("<a")
       end
 
       it "shows placeholder without PR number" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -100,6 +100,28 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("#7")
       end
 
+      it "links to PR in context column for review goal runs" do
+        run = create(:agent_run, :review_goal, :completed, project: project)
+        get agent_runs_path
+        expected_url = "#{project.github_url}/pull/#{run.source_pull_request_number}"
+        expect(response.body).to include("PR #10")
+        expect(response.body).to include(expected_url)
+      end
+
+      it "shows review link in actions column when review_url is present" do
+        create(:agent_run, :with_review, project: project)
+        get agent_runs_path
+        expect(response.body).to include("Review")
+        expect(response.body).to include("https://github.com/example/repo/pull/10#pullrequestreview-123456")
+      end
+
+      it "shows PR link in actions column for completed create_pr runs" do
+        create(:agent_run, :completed, project: project)
+        get agent_runs_path
+        expect(response.body).to include(">PR</a>")
+        expect(response.body).to include("https://github.com/example/repo/pull/1")
+      end
+
       it "does not show runs from other accounts" do
         other_account = create(:account)
         other_token = create(:github_token, account: other_account)
@@ -184,6 +206,28 @@ RSpec.describe "AgentRuns" do
         create(:agent_run, project: project, issue: issue, goal: "create_pr")
         get project_agent_runs_path(project)
         expect(response.body).to include("#7")
+      end
+
+      it "links to PR in context column for review goal runs" do
+        run = create(:agent_run, :review_goal, :completed, project: project)
+        get project_agent_runs_path(project)
+        expected_url = "#{project.github_url}/pull/#{run.source_pull_request_number}"
+        expect(response.body).to include("PR #10")
+        expect(response.body).to include(expected_url)
+      end
+
+      it "shows review link in actions column when review_url is present" do
+        create(:agent_run, :with_review, project: project)
+        get project_agent_runs_path(project)
+        expect(response.body).to include("Review")
+        expect(response.body).to include("https://github.com/example/repo/pull/10#pullrequestreview-123456")
+      end
+
+      it "shows PR link in actions column for completed create_pr runs" do
+        create(:agent_run, :completed, project: project)
+        get project_agent_runs_path(project)
+        expect(response.body).to include(">PR</a>")
+        expect(response.body).to include("https://github.com/example/repo/pull/1")
       end
 
       it "does not show runs from other accounts" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "AgentRuns" do
         run = create(:agent_run, :review_goal, :completed, project: project)
         get agent_runs_path
         expected_url = "#{project.github_url}/pull/#{run.source_pull_request_number}"
-        expect(response.body).to include("PR #10")
+        expect(response.body).to include("PR ##{run.source_pull_request_number}")
         expect(response.body).to include(expected_url)
       end
 
@@ -212,7 +212,7 @@ RSpec.describe "AgentRuns" do
         run = create(:agent_run, :review_goal, :completed, project: project)
         get project_agent_runs_path(project)
         expected_url = "#{project.github_url}/pull/#{run.source_pull_request_number}"
-        expect(response.body).to include("PR #10")
+        expect(response.body).to include("PR ##{run.source_pull_request_number}")
         expect(response.body).to include(expected_url)
       end
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -462,6 +462,30 @@ RSpec.describe "Projects" do
         expect(response.body).to include(project_agent_run_path(project, run))
       end
 
+      it "links to PR in context column for review goal runs on project page" do
+        project = create(:project, account: account, github_token: github_token)
+        create(:agent_run, :review_goal, :completed, project: project)
+        get project_path(project)
+        expect(response.body).to include("PR #10")
+        expect(response.body).to include("#{project.github_url}/pull/10")
+      end
+
+      it "shows review link in actions column when review_url is present on project page" do
+        project = create(:project, account: account, github_token: github_token)
+        create(:agent_run, :with_review, project: project)
+        get project_path(project)
+        expect(response.body).to include("Review")
+        expect(response.body).to include("https://github.com/example/repo/pull/10#pullrequestreview-123456")
+      end
+
+      it "shows PR link in actions column for completed create_pr runs on project page" do
+        project = create(:project, account: account, github_token: github_token)
+        create(:agent_run, :completed, project: project)
+        get project_path(project)
+        expect(response.body).to include(">PR</a>")
+        expect(response.body).to include("https://github.com/example/repo/pull/1")
+      end
+
       it "shows the stale cleanup button when stale runs exist and the user can update the project" do
         project = create(:project, account: account, github_token: github_token)
         create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -464,10 +464,10 @@ RSpec.describe "Projects" do
 
       it "links to PR in context column for review goal runs on project page" do
         project = create(:project, account: account, github_token: github_token)
-        create(:agent_run, :review_goal, :completed, project: project)
+        run = create(:agent_run, :review_goal, :completed, project: project)
         get project_path(project)
-        expect(response.body).to include("PR #10")
-        expect(response.body).to include("#{project.github_url}/pull/10")
+        expect(response.body).to include("PR ##{run.source_pull_request_number}")
+        expect(response.body).to include("#{project.github_url}/pull/#{run.source_pull_request_number}")
       end
 
       it "shows review link in actions column when review_url is present on project page" do


### PR DESCRIPTION
## Summary

bug(agent-runs): link PRs and review comments in project and index agent runs tables

See #999 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #999