### PR TITLE
fix(pr-scanner): honor codex clean comments despite info posts

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,15 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Check for too many staged files (catches accidental cache/binary commits)
+# Pre-commit hook: rejects commits that look like accidental artifact uploads.
+#
+# Defense layers (see AGENTS.md "Artifact Prevention"):
+#   1. .gitignore (host)
+#   2. .git/info/exclude (container - CONTAINER_ARTIFACT_EXCLUDES)
+#   3. THIS HOOK (host pre-commit)
+#   4. validate_staged_files! in git_operations.rb (container auto-commit)
+#   5. CI pr-artifact-check workflow (PR-level)
+
 if [ "${SKIP_FILE_COUNT_CHECK:-0}" != "1" ]; then
   MAX_FILES="${PRE_COMMIT_MAX_FILES:-100}"
   file_count=$(git diff --cached --name-only | wc -l)
   if [ "$file_count" -gt "$MAX_FILES" ]; then
-    echo "ERROR: This commit stages $file_count files (limit: $MAX_FILES)."
-    echo "This usually indicates unintended files (caches, binaries, data dirs)."
-    echo "Please review your staged files with 'git diff --cached --name-only'."
-    echo "To override, run: SKIP_FILE_COUNT_CHECK=1 git commit ..."
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║  COMMIT REJECTED: Too many staged files                     ║"
+    echo "╠══════════════════════════════════════════════════════════════╣"
+    echo "║  This commit stages ${file_count} files (limit: ${MAX_FILES})."
+    echo "║"
+    echo "║  This almost always means unintended files were staged:"
+    echo "║  build artifacts, caches, binaries, or data directories."
+    echo "║"
+    echo "║  Review your staged files:"
+    echo "║    git diff --cached --name-only"
+    echo "║"
+    echo "║  To commit only specific files:"
+    echo "║    git reset HEAD"
+    echo "║    git add <specific-file-paths>"
+    echo "║"
+    echo "║  To override (only if you are certain):"
+    echo "║    SKIP_FILE_COUNT_CHECK=1 git commit ..."
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo ""
+    echo "First 20 staged files:"
+    git diff --cached --name-only | head -20 | sed 's/^/  /'
     exit 1
   fi
 fi

--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -1,0 +1,123 @@
+name: PR Artifact Check
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+permissions:
+  contents: read
+
+jobs:
+  check-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Check for artifact files in PR diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MAX_DIFF_FILES: 500
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          echo "=== PR #${PR_NUMBER} artifact check ==="
+          echo "Base: ${BASE_SHA}"
+          echo "Head: ${HEAD_SHA}"
+          echo ""
+
+          # Get the list of changed files
+          diff_files=$(git diff --name-only "${BASE_SHA}"..."${HEAD_SHA}" 2>/dev/null || true)
+          if [ -z "${diff_files}" ]; then
+            echo "No diff files found (empty PR or merge commit). Skipping check."
+            exit 0
+          fi
+
+          file_count=$(echo "${diff_files}" | wc -l)
+          echo "PR changes ${file_count} files"
+
+          # --- Check 1: Too many files ---
+          if [ "${file_count}" -gt "${MAX_DIFF_FILES}" ]; then
+            echo "::error::PR changes ${file_count} files (limit: ${MAX_DIFF_FILES}). This likely includes unintended build artifacts."
+            echo ""
+            echo "First 30 files:"
+            echo "${diff_files}" | head -30 | sed 's/^/  /'
+            echo ""
+            echo "Run 'git diff --name-only ${BASE_SHA}...${HEAD_SHA}' locally to review."
+            exit 1
+          fi
+
+          # --- Check 2: Forbidden directory prefixes ---
+          forbidden_prefixes=(
+            ".bundle-pr-"
+            ".cache-yarn/"
+            ".pg-local/"
+            ".pg-data/"
+            ".pg-install/"
+            ".pgbuild/"
+            ".pgdata/"
+            ".apt-cache/"
+            ".cache-pkg/"
+            ".xdg-cache/"
+            ".mise-cache/"
+            ".mise-data/"
+            ".npm-cache/"
+            ".rubocop-cache/"
+            "vendor/bundle/"
+            "vendor/gems/"
+            "node_modules/"
+          )
+
+          violations=""
+          while IFS= read -r file; do
+            for prefix in "${forbidden_prefixes[@]}"; do
+              if [[ "${file}" == "${prefix}"* ]]; then
+                violations="${violations}${file}"$'\n'
+                break
+              fi
+            done
+          done <<< "${diff_files}"
+
+          if [ -n "${violations}" ]; then
+            violation_count=$(echo "${violations}" | wc -l)
+            echo "::error::Found ${violation_count} files in forbidden artifact directories:"
+            echo "${violations}" | sed 's/^/  /'
+            echo ""
+            echo "These are build artifacts that should not be committed."
+            echo "Check .gitignore and .git/info/exclude to ensure these patterns are excluded."
+            exit 1
+          fi
+
+          # --- Check 3: Binary files that should not be committed ---
+          binary_extensions=(
+            ".so" ".dll" ".dylib" ".o" ".a" ".exe"
+            ".gem" ".deb" ".rpm" ".whl"
+            ".pyc" ".pyo" ".class" ".jar"
+            ".sqlite3" ".db"
+          )
+
+          binary_violations=""
+          while IFS= read -r file; do
+            for ext in "${binary_extensions[@]}"; do
+              if [[ "${file}" == *"${ext}" ]]; then
+                binary_violations="${binary_violations}${file}"$'\n'
+                break
+              fi
+            done
+          done <<< "${diff_files}"
+
+          if [ -n "${binary_violations}" ]; then
+            bv_count=$(echo "${binary_violations}" | wc -l)
+            echo "::error::Found ${bv_count} binary artifact files:"
+            echo "${binary_violations}" | sed 's/^/  /'
+            echo ""
+            echo "Binary files (compiled objects, packages, databases) should not be committed."
+            exit 1
+          fi
+
+          echo "No artifact violations detected. PR is clean."

--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -31,8 +31,9 @@ jobs:
           echo "Head: ${HEAD_SHA}"
           echo ""
 
-          # Get the list of changed files
-          diff_files=$(git diff --name-only "${BASE_SHA}"..."${HEAD_SHA}" 2>/dev/null || true)
+          # Get the list of changed files (exclude deletions — removing
+          # previously committed artifacts is a valid remediation).
+          diff_files=$(git diff --name-only --diff-filter=d "${BASE_SHA}"..."${HEAD_SHA}" 2>/dev/null || true)
           if [ -z "${diff_files}" ]; then
             echo "No diff files found (empty PR or merge commit). Skipping check."
             exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Paid (Platform for AI Development) is a Rails 8 application that orchestrates AI
 ## Git Workflow
 
 - **The `main` branch is protected** - Never commit directly to `main`. Always create a feature branch and open a pull request.
-- **Never commit build artifacts or tool caches** - Do not `git add` directories created by setup/install commands (e.g., `.corepack/`, `.pg-install/`, `.apt-cache/`, `.cache-pkg/`, `vendor/bundle/`, `.tmp-build/`, `.venv/`, `__pycache__/`). If `bin/setup`, `bundle install`, `yarn install`, or similar commands create new dotfile directories in the workspace root, those are build artifacts — not source code. Check `.gitignore` and `.git/info/exclude` before staging. When in doubt, use `git add <specific files>` rather than `git add -A`.
+- **Never commit build artifacts or tool caches** - Do not `git add` directories created by setup/install commands (e.g., `.corepack/`, `.pg-install/`, `.apt-cache/`, `.cache-pkg/`, `vendor/bundle/`, `.tmp-build/`, `.venv/`, `__pycache__/`, `.bundle-pr-*/`, `.cache-yarn/`). If `bin/setup`, `bundle install`, `yarn install`, or similar commands create new dotfile directories in the workspace root, those are build artifacts — not source code. Check `.gitignore` and `.git/info/exclude` before staging. **Always use `git add <specific files>`** — never use `git add -A` or `git add .` as these can stage artifact files that bypass exclude rules. The pre-commit hook rejects commits with more than 100 staged files.
 - **Conventional Commits are required** - Commits must use Conventional Commit format so release automation can generate semantic release notes correctly.
 - **Use git worktrees for concurrent branch work** - When working on multiple branches (e.g., making a PR while another branch has uncommitted changes), use `git worktree add` instead of stashing and switching branches. This avoids lost edits, stash conflicts, and accidental branch mix-ups. Remove worktrees when done with `git worktree remove`.
 
@@ -150,6 +150,18 @@ Orchestration code should be mechanically simple - delegate all semantic reasoni
 ### Always Fix Forward
 
 Never skip pre-commit hooks (`--no-verify`), never disable linters, never ignore failing tests. If a check fails, fix the underlying issue. This applies to both human developers, AI agents, and system-level code. The only acceptable use of `--no-verify` is when a hook fails due to an unpatched CVE with no released fix.
+
+### Artifact Prevention (Defense in Depth)
+
+The system has multiple layers to prevent build artifacts from reaching `main`:
+
+1. **`.gitignore`** (host) — excludes known artifact patterns for developers
+2. **`.git/info/exclude`** (container) — `CONTAINER_ARTIFACT_EXCLUDES` is injected by `Containers::GitOperations` to cover patterns the repo's `.gitignore` may miss
+3. **Pre-commit hook** (host) — rejects commits with >100 staged files (`.githooks/pre-commit`)
+4. **`validate_staged_files!`** (container auto-commit) — runs BEFORE the `--no-verify` commit in `commit_uncommitted_changes`, checking both file count and forbidden binary/directory patterns. This cannot be bypassed because it runs in Ruby, not as a git hook
+5. **CI `pr-artifact-check`** — catches artifacts that slip through all other layers by scanning PR diffs for forbidden directories and binary extensions
+
+When adding a new artifact pattern, update ALL of: `.gitignore`, `CONTAINER_ARTIFACT_EXCLUDES` in `git_operations.rb`, and the CI workflow `pr-artifact-check.yml`.
 
 ### Ruby Conventions
 

--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -767,8 +767,12 @@ module Containers
     # This is the last line of defense since hooks are bypassed.
     # Rejects commits that stage too many files or contain binary
     # artifacts / forbidden directories that slipped past exclude rules.
+    #
+    # Uses --diff-filter=d to exclude deletions — a commit that removes
+    # previously tracked artifacts is a valid remediation and must not
+    # be blocked by this guard.
     def validate_staged_files!
-      staged = execute_git("diff", "--cached", "--name-only")
+      staged = execute_git("diff", "--cached", "--name-only", "--diff-filter=d")
       return unless staged.success? && staged[:stdout].present?
 
       files = staged[:stdout].lines.map(&:strip).reject(&:blank?)

--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -38,24 +38,59 @@ module Containers
     # Patterns appended to .git/info/exclude inside agent containers.
     # Prevents build/tool artifacts from being staged by `git add -A`
     # even when the repo's .gitignore doesn't cover them.
+    #
+    # IMPORTANT: Keep in sync with .gitignore. When a pattern is added here
+    # that has no corresponding .gitignore entry, add one there too so
+    # developers on the host are also protected.
     CONTAINER_ARTIFACT_EXCLUDES = <<~PATTERNS.freeze
       #{CONTAINER_ARTIFACT_EXCLUDES_MARKER}
       # Node corepack cache
       .corepack/
-      # Yarn cache/offline mirror
+      # Yarn cache/offline mirror (created by yarn install)
       .yarn-cache/
+      .yarn-cache-v2/
+      .yarn-local-cache/
+      .yarn-tmp/
+      .cache-yarn/
       # NOTE: .yarn/cache/, .yarn/unplugged/, and .pnp.* are intentionally
       # omitted — Yarn zero-installs repos commit these by design.
-      # Ruby
+      # Ruby bundler (all variants including per-PR worktree bundles)
       vendor/bundle/
+      vendor/gems/
       .bundle/
-      # PostgreSQL build artifacts
+      .bundle-*/
+      .bundle-install/
+      .bundle-gems/
+      .bundle_path/
+      .gem/
+      .gems/
+      .gem-home/
+      .gem-spec-cache/
+      .gem_cache/
+      .gem-cache/
+      .gem_home/
+      # PostgreSQL (all known directory variants)
       .pg-install/
       .pg/
+      .pg-bin/
+      .pg-data/
+      .pg-lib/
+      .pg-share/
+      .pg-src/
+      .pgbuild/
       .pgdata/
       .pg_build/
       .pg_data/
       .pg_src/
+      .pg_bin/
+      .pg-data/
+      .pg-local/
+      .pg_log.txt
+      pgdata/
+      .postgres/
+      .local/
+      .local-include/
+      .local-deps/
       # Python
       .venv/
       __pycache__/
@@ -73,10 +108,67 @@ module Containers
       .*-build/
       .*_build/
       .npm-cache/
+      .npm/
       # mise/asdf
       .mise-cache/
       .mise-data/
+      .mise-home/
+      # Ruby build
+      .rubies/
+      .ruby_env.sh
+      # libyaml builds
+      .libyaml-build/
+      .libyaml-src/
+      .libyaml_build/
+      .libyaml_src/
+      # Tool caches
+      .rubocop-cache/
+      .rubocop_cache/
+      .aider*
     PATTERNS
+
+    # Maximum number of files allowed in the auto-commit safety net.
+    # commit_uncommitted_changes runs with --no-verify, so this guard
+    # is the last line of defense against artifact commits.
+    MAX_AUTO_COMMIT_FILES = 100
+
+    # Binary file extensions that should never appear in agent commits.
+    # Limited to clearly-artifact types (compiled objects, packages, caches)
+    # to avoid false positives on legitimate image/font/doc assets.
+    FORBIDDEN_BINARY_EXTENSIONS = %w[
+      .dll .dylib .o .a .lib .exe
+      .gem .deb .rpm .whl
+      .pyc .pyo .class .jar .war
+      .sqlite3 .db
+    ].freeze
+
+    # Shared-object extensions are versioned (.so.1, .so.1.2.3) which
+    # String#end_with? cannot match with a single pattern.  Handled as
+    # a separate check on the basename.
+    VERSIONED_SO_PATTERN = /\.so\.\d/
+
+    # Directory prefixes that indicate build artifacts rather than source.
+    # Any staged file whose path starts with one of these is rejected.
+    FORBIDDEN_DIRECTORY_PREFIXES = %w[
+      .bundle-pr-
+      .cache-yarn/
+      .pg-local/
+      .pg-data/
+      .pg-install/
+      .pgbuild/
+      .pgdata/
+      .apt-cache/
+      .cache-pkg/
+      .xdg-cache/
+      .mise-cache/
+      .mise-data/
+      .mise-home/
+      .npm-cache/
+      .rubocop-cache/
+      vendor/bundle/
+      vendor/gems/
+      node_modules/
+    ].freeze
 
     attr_reader :container_service, :agent_run
 
@@ -270,6 +362,8 @@ module Containers
 
       add_result = execute_git("add", "-A")
       raise Error, "Failed to stage changes: #{error_with_stderr(add_result)}" if add_result.failure?
+
+      validate_staged_files!
 
       commit_result = execute_git("commit", "--no-verify", "-m", commit_message)
       raise Error, "Failed to commit changes: #{error_with_stderr(commit_result)}" if commit_result.failure?
@@ -667,6 +761,40 @@ module Containers
 
     def validate_branch_name!
       raise PushError, "branch_name is blank" if agent_run.branch_name.blank?
+    end
+
+    # Validates staged files before the --no-verify auto-commit.
+    # This is the last line of defense since hooks are bypassed.
+    # Rejects commits that stage too many files or contain binary
+    # artifacts / forbidden directories that slipped past exclude rules.
+    def validate_staged_files!
+      staged = execute_git("diff", "--cached", "--name-only")
+      return unless staged.success? && staged[:stdout].present?
+
+      files = staged[:stdout].lines.map(&:strip).reject(&:blank?)
+
+      if files.size > MAX_AUTO_COMMIT_FILES
+        sample = files.first(20).join("\n  ")
+        raise Error,
+          "Auto-commit rejected: #{files.size} files staged (limit: #{MAX_AUTO_COMMIT_FILES}). " \
+          "This almost certainly includes unintended build artifacts. " \
+          "First 20 files:\n  #{sample}"
+      end
+
+      forbidden_files = files.select { |f| forbidden_artifact?(f) }
+      if forbidden_files.any?
+        sample = forbidden_files.first(10).join("\n  ")
+        raise Error,
+          "Auto-commit rejected: #{forbidden_files.size} forbidden artifact files detected. " \
+          "These are build artifacts that must not be committed:\n  #{sample}"
+      end
+    end
+
+    def forbidden_artifact?(path)
+      FORBIDDEN_DIRECTORY_PREFIXES.any? { |prefix| path.start_with?(prefix) } ||
+        FORBIDDEN_BINARY_EXTENSIONS.any? { |ext| path.end_with?(ext) } ||
+        path.end_with?(".so") ||
+        (File.basename(path) =~ VERSIONED_SO_PATTERN)
     end
 
     def install_hook(hook_name, script)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -23,7 +23,7 @@ module Activities
     REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i
     # Body-only review bots (currently Codex) signal "no findings" by posting
     # an *issue comment* — not a review — with text like
-    # "Codex Review: Didn't find any major issues. Bravo." Match the
+    # "Codex Review: Didn't find any major issues. Hooray!" Match the
     # distinctive phrase rather than the prefix so we are robust to minor
     # wording changes.
     BODY_ONLY_BOT_CLEAN_COMMENT_PATTERN = /didn'?t find any (?:major )?issues/i
@@ -750,6 +750,8 @@ module Activities
       .to_set
       .freeze
 
+    BODY_ONLY_REVIEW_PROVIDER_KEYS = %w[codex paid_agent].freeze
+
     def check_review_bot_status(reviews, unresolved_threads, project: nil, last_run: nil, client: nil, issue: nil)
       allowed = project&.review_enabled? ? (project.enabled_review_bot_logins.presence || Set.new) : nil
       latest = latest_allowed_bot_review(reviews, allowed)
@@ -933,10 +935,18 @@ module Activities
       BODY_ONLY_REVIEW_BOT_LOGINS.include?(login.downcase)
     end
 
-    # Returns true when the most recent issue comment authored by a body-only
-    # review bot (e.g. Codex) matches the clean signal pattern AND can speak
-    # authoritatively for the project's review configuration AND is at least
-    # as recent as that bot's latest review on this PR.
+    def body_only_review_provider_key_for(login)
+      return nil if login.blank?
+
+      BODY_ONLY_REVIEW_PROVIDER_KEYS.find do |provider_key|
+        ProviderSupport.provider_bot_username_for?(provider_key, login)
+      end
+    end
+
+    # Returns true when a clean issue comment authored by a body-only review
+    # bot (e.g. Codex) can speak authoritatively for the project's review
+    # configuration AND is at least as recent as that bot's latest review on
+    # this PR.
     #
     # The override is restricted to projects whose enabled review bots are
     # ALL body-only — i.e. no thread-based bot like Copilot is also enabled.
@@ -946,6 +956,13 @@ module Activities
     #
     # The comment-vs-review timestamp comparison prevents an older "Bravo"
     # comment from masking a newer non-clean review on a subsequent commit.
+    # We intentionally do not require the bot's absolute latest issue comment
+    # to be clean, because body-only bots can emit later informational
+    # comments (for example setup guidance) that do not request PR changes and
+    # should not suppress an earlier clean completion signal. The bypass is
+    # also restricted to projects whose enabled body-only bot methods all map
+    # to the same provider family as the clean comment; a Codex clean comment
+    # cannot speak for an outstanding paid_agent review.
     def body_only_bot_clean_comment_present?(client, project, issue, latest_review, allowed_bot_logins)
       return false if allowed_bot_logins.nil? || allowed_bot_logins.empty?
       return false unless allowed_bot_logins.subset?(BODY_ONLY_REVIEW_BOT_LOGINS)
@@ -957,11 +974,22 @@ module Activities
       end
       return false if bot_comments.empty?
 
-      latest_bot_comment = bot_comments.max_by { |c| c.created_at || Time.at(0) }
-      return false unless BODY_ONLY_BOT_CLEAN_COMMENT_PATTERN.match?(latest_bot_comment.body.to_s)
+      latest_clean_comment = bot_comments
+        .select { |c| BODY_ONLY_BOT_CLEAN_COMMENT_PATTERN.match?(c.body.to_s) }
+        .max_by { |c| c.created_at || Time.at(0) }
+      return false unless latest_clean_comment
+
+      provider_key = body_only_review_provider_key_for(latest_clean_comment.user&.login)
+      return false if provider_key.nil?
+
+      provider_logins = ProviderSupport::PROVIDER_BOT_USERNAMES
+        .fetch(provider_key, [])
+        .map(&:downcase)
+        .to_set
+      return false unless allowed_bot_logins.subset?(provider_logins)
 
       review_time = latest_review&.dig(:submitted_at)
-      comment_time = latest_bot_comment.created_at
+      comment_time = latest_clean_comment.created_at
       return true if review_time.nil? || comment_time.nil?
 
       comment_time >= review_time

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -590,7 +590,7 @@ RSpec.describe Containers::GitOperations do
 
       staged_result = Containers::Provision::Result.success(stdout: "file.rb\n", stderr: "", exit_code: 0)
       allow(container_service).to receive(:execute)
-        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
         .and_return(staged_result)
 
       expect(container_service).to receive(:execute)
@@ -612,7 +612,7 @@ RSpec.describe Containers::GitOperations do
 
       staged_result = Containers::Provision::Result.success(stdout: "file.rb\n", stderr: "", exit_code: 0)
       allow(container_service).to receive(:execute)
-        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
         .and_return(staged_result)
 
       project.update!(agent_co_author_trailer: "Co-Authored-By: Claude <noreply@anthropic.com>")
@@ -653,7 +653,7 @@ RSpec.describe Containers::GitOperations do
 
       staged_result = Containers::Provision::Result.success(stdout: "file.rb\n", stderr: "", exit_code: 0)
       allow(container_service).to receive(:execute)
-        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
         .and_return(staged_result)
 
       allow(container_service).to receive(:execute)
@@ -676,7 +676,7 @@ RSpec.describe Containers::GitOperations do
       files = (1..101).map { |i| ".bundle-pr-908/ruby/3.4.0/gems/gem-#{i}/lib.rb" }
       staged_result = Containers::Provision::Result.success(stdout: "#{files.join("\n")}\n", stderr: "", exit_code: 0)
       allow(container_service).to receive(:execute)
-        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
         .and_return(staged_result)
 
       expect { git_ops.commit_uncommitted_changes }.to raise_error(
@@ -700,7 +700,7 @@ RSpec.describe Containers::GitOperations do
         stderr: "", exit_code: 0
       )
       allow(container_service).to receive(:execute)
-        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
         .and_return(staged_result)
 
       expect { git_ops.commit_uncommitted_changes }.to raise_error(
@@ -724,7 +724,7 @@ RSpec.describe Containers::GitOperations do
         stderr: "", exit_code: 0
       )
       allow(container_service).to receive(:execute)
-        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
         .and_return(staged_result)
 
       expect { git_ops.commit_uncommitted_changes }.to raise_error(
@@ -748,13 +748,38 @@ RSpec.describe Containers::GitOperations do
         stderr: "", exit_code: 0
       )
       allow(container_service).to receive(:execute)
-        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
         .and_return(staged_result)
 
       expect { git_ops.commit_uncommitted_changes }.to raise_error(
         described_class::Error,
         /forbidden artifact files detected/
       )
+    end
+
+    it "allows commits that only delete forbidden artifact files" do
+      status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
+        .and_return(status_result)
+
+      allow(container_service).to receive(:execute)
+        .with([ "git", "add", "-A" ], timeout: nil, stream: false)
+        .and_return(success_result)
+
+      staged_result = Containers::Provision::Result.success(
+        stdout: "app/models/user.rb\n",
+        stderr: "", exit_code: 0
+      )
+      allow(container_service).to receive(:execute)
+        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
+        .and_return(staged_result)
+
+      expect(container_service).to receive(:execute)
+        .with([ "git", "commit", "--no-verify", "-m", "Apply agent changes" ], timeout: nil, stream: false)
+        .and_return(success_result)
+
+      expect(git_ops.commit_uncommitted_changes).to be true
     end
   end
 

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -588,6 +588,11 @@ RSpec.describe Containers::GitOperations do
         .with([ "git", "add", "-A" ], timeout: nil, stream: false)
         .and_return(success_result)
 
+      staged_result = Containers::Provision::Result.success(stdout: "file.rb\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .and_return(staged_result)
+
       expect(container_service).to receive(:execute)
         .with([ "git", "commit", "--no-verify", "-m", "Apply agent changes" ], timeout: nil, stream: false)
         .and_return(success_result)
@@ -604,6 +609,11 @@ RSpec.describe Containers::GitOperations do
       allow(container_service).to receive(:execute)
         .with([ "git", "add", "-A" ], timeout: nil, stream: false)
         .and_return(success_result)
+
+      staged_result = Containers::Provision::Result.success(stdout: "file.rb\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .and_return(staged_result)
 
       project.update!(agent_co_author_trailer: "Co-Authored-By: Claude <noreply@anthropic.com>")
 
@@ -641,11 +651,110 @@ RSpec.describe Containers::GitOperations do
         .with([ "git", "add", "-A" ], timeout: nil, stream: false)
         .and_return(success_result)
 
+      staged_result = Containers::Provision::Result.success(stdout: "file.rb\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .and_return(staged_result)
+
       allow(container_service).to receive(:execute)
         .with([ "git", "commit", "--no-verify", "-m", "Apply agent changes" ], timeout: nil, stream: false)
         .and_return(failure_result)
 
       expect { git_ops.commit_uncommitted_changes }.to raise_error(described_class::Error, /Failed to commit/)
+    end
+
+    it "rejects commits with too many staged files" do
+      status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
+        .and_return(status_result)
+
+      allow(container_service).to receive(:execute)
+        .with([ "git", "add", "-A" ], timeout: nil, stream: false)
+        .and_return(success_result)
+
+      files = (1..101).map { |i| ".bundle-pr-908/ruby/3.4.0/gems/gem-#{i}/lib.rb" }
+      staged_result = Containers::Provision::Result.success(stdout: "#{files.join("\n")}\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .and_return(staged_result)
+
+      expect { git_ops.commit_uncommitted_changes }.to raise_error(
+        described_class::Error,
+        /Auto-commit rejected: 101 files staged/
+      )
+    end
+
+    it "rejects commits with forbidden artifact directories" do
+      status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
+        .and_return(status_result)
+
+      allow(container_service).to receive(:execute)
+        .with([ "git", "add", "-A" ], timeout: nil, stream: false)
+        .and_return(success_result)
+
+      staged_result = Containers::Provision::Result.success(
+        stdout: "app/models/user.rb\nvendor/bundle/gem/lib.rb\n",
+        stderr: "", exit_code: 0
+      )
+      allow(container_service).to receive(:execute)
+        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .and_return(staged_result)
+
+      expect { git_ops.commit_uncommitted_changes }.to raise_error(
+        described_class::Error,
+        /forbidden artifact files detected/
+      )
+    end
+
+    it "rejects commits with binary files" do
+      status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
+        .and_return(status_result)
+
+      allow(container_service).to receive(:execute)
+        .with([ "git", "add", "-A" ], timeout: nil, stream: false)
+        .and_return(success_result)
+
+      staged_result = Containers::Provision::Result.success(
+        stdout: "app/models/user.rb\nlib/native_extension.so\n",
+        stderr: "", exit_code: 0
+      )
+      allow(container_service).to receive(:execute)
+        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .and_return(staged_result)
+
+      expect { git_ops.commit_uncommitted_changes }.to raise_error(
+        described_class::Error,
+        /forbidden artifact files detected/
+      )
+    end
+
+    it "rejects commits with versioned shared objects" do
+      status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
+        .and_return(status_result)
+
+      allow(container_service).to receive(:execute)
+        .with([ "git", "add", "-A" ], timeout: nil, stream: false)
+        .and_return(success_result)
+
+      staged_result = Containers::Provision::Result.success(
+        stdout: "app/models/user.rb\nlib/temporalio_bridge.so.3.3\n",
+        stderr: "", exit_code: 0
+      )
+      allow(container_service).to receive(:execute)
+        .with([ "git", "diff", "--cached", "--name-only" ], timeout: nil, stream: false)
+        .and_return(staged_result)
+
+      expect { git_ops.commit_uncommitted_changes }.to raise_error(
+        described_class::Error,
+        /forbidden artifact files detected/
+      )
     end
   end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -942,6 +942,84 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when a clean codex comment is followed by a newer informational codex comment" do
+      before do
+        enable_codex_review!
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        clean_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector"),
+          body: "Codex Review: Didn't find any major issues. Hooray!",
+          created_at: 10.minutes.ago
+        )
+        info_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector"),
+          body: "To use Codex here, create an environment for this repo.",
+          created_at: 5.minutes.ago
+        )
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: [],
+          recent_issue_comments: [ clean_comment, info_comment ]
+        )
+      end
+
+      it "still treats the bot as clean because later informational comments do not invalidate the clean signal" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
+      end
+    end
+
+    context "when codex and paid_agent are both enabled and only codex posted a clean comment" do
+      before do
+        project.update!(
+          review_settings: {
+            "enabled" => true,
+            "methods" => {
+              "codex" => { "enabled" => true },
+              "paid_agent" => {
+                "enabled" => true,
+                "termination" => { "max_review_rounds" => 2 }
+              }
+            }
+          }
+        )
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        clean_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector"),
+          body: "Codex Review: Didn't find any major issues. Hooray!",
+          created_at: 10.minutes.ago
+        )
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                       body: "Found issues that still need fixes.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: [],
+          recent_issue_comments: [ clean_comment ]
+        )
+      end
+
+      it "does not let codex's clean comment suppress paid_agent feedback" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).to include("review_bot_comments")
+      end
+    end
+
     context "when a project enables both Copilot and Codex and Copilot has unresolved threads" do
       before do
         enable_copilot_and_codex_review!


### PR DESCRIPTION
## Summary
- treat a matching clean Codex issue comment as authoritative even if a later Codex informational comment exists
- keep the clean-comment bypass scoped to the same body-only bot provider family so Codex cannot suppress paid_agent feedback
- add regression coverage for the PR #1022 comment pattern and the mixed codex + paid_agent safety case

## Testing
- COVERAGE=false bundle exec rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb:906 spec/temporal/activities/scan_paid_prs_activity_spec.rb:972 spec/temporal/activities/scan_paid_prs_activity_spec.rb:1007 spec/temporal/activities/scan_paid_prs_activity_spec.rb:1049 spec/temporal/activities/scan_paid_prs_activity_spec.rb:1084 spec/temporal/activities/scan_paid_prs_activity_spec.rb:2260 spec/temporal/activities/scan_paid_prs_activity_spec.rb:4481