### PR TITLE
fix(pr-scanner): honor codex clean comments despite info posts

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -982,11 +982,8 @@ module Activities
       provider_key = body_only_review_provider_key_for(latest_clean_comment.user&.login)
       return false if provider_key.nil?
 
-      provider_logins = ProviderSupport::PROVIDER_BOT_USERNAMES
-        .fetch(provider_key, [])
-        .map(&:downcase)
-        .to_set
-      return false unless allowed_bot_logins.subset?(provider_logins)
+      latest_review_provider_key = body_only_review_provider_key_for(latest_review&.dig(:user_login))
+      return false if latest_review_provider_key && latest_review_provider_key != provider_key
 
       review_time = latest_review&.dig(:submitted_at)
       comment_time = latest_clean_comment.created_at

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -23,7 +23,7 @@ module Activities
     REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i
     # Body-only review bots (currently Codex) signal "no findings" by posting
     # an *issue comment* — not a review — with text like
-    # "Codex Review: Didn't find any major issues. Bravo." Match the
+    # "Codex Review: Didn't find any major issues. Hooray!" Match the
     # distinctive phrase rather than the prefix so we are robust to minor
     # wording changes.
     BODY_ONLY_BOT_CLEAN_COMMENT_PATTERN = /didn'?t find any (?:major )?issues/i
@@ -750,6 +750,8 @@ module Activities
       .to_set
       .freeze
 
+    BODY_ONLY_REVIEW_PROVIDER_KEYS = %w[codex paid_agent].freeze
+
     def check_review_bot_status(reviews, unresolved_threads, project: nil, last_run: nil, client: nil, issue: nil)
       allowed = project&.review_enabled? ? (project.enabled_review_bot_logins.presence || Set.new) : nil
       latest = latest_allowed_bot_review(reviews, allowed)
@@ -933,10 +935,18 @@ module Activities
       BODY_ONLY_REVIEW_BOT_LOGINS.include?(login.downcase)
     end
 
-    # Returns true when the most recent issue comment authored by a body-only
-    # review bot (e.g. Codex) matches the clean signal pattern AND can speak
-    # authoritatively for the project's review configuration AND is at least
-    # as recent as that bot's latest review on this PR.
+    def body_only_review_provider_key_for(login)
+      return nil if login.blank?
+
+      BODY_ONLY_REVIEW_PROVIDER_KEYS.find do |provider_key|
+        ProviderSupport.provider_bot_username_for?(provider_key, login)
+      end
+    end
+
+    # Returns true when a clean issue comment authored by a body-only review
+    # bot (e.g. Codex) can speak authoritatively for the project's review
+    # configuration AND is at least as recent as that bot's latest review on
+    # this PR.
     #
     # The override is restricted to projects whose enabled review bots are
     # ALL body-only — i.e. no thread-based bot like Copilot is also enabled.
@@ -946,6 +956,13 @@ module Activities
     #
     # The comment-vs-review timestamp comparison prevents an older "Bravo"
     # comment from masking a newer non-clean review on a subsequent commit.
+    # We intentionally do not require the bot's absolute latest issue comment
+    # to be clean, because body-only bots can emit later informational
+    # comments (for example setup guidance) that do not request PR changes and
+    # should not suppress an earlier clean completion signal. The bypass is
+    # also restricted to projects whose enabled body-only bot methods all map
+    # to the same provider family as the clean comment; a Codex clean comment
+    # cannot speak for an outstanding paid_agent review.
     def body_only_bot_clean_comment_present?(client, project, issue, latest_review, allowed_bot_logins)
       return false if allowed_bot_logins.nil? || allowed_bot_logins.empty?
       return false unless allowed_bot_logins.subset?(BODY_ONLY_REVIEW_BOT_LOGINS)
@@ -957,11 +974,22 @@ module Activities
       end
       return false if bot_comments.empty?
 
-      latest_bot_comment = bot_comments.max_by { |c| c.created_at || Time.at(0) }
-      return false unless BODY_ONLY_BOT_CLEAN_COMMENT_PATTERN.match?(latest_bot_comment.body.to_s)
+      latest_clean_comment = bot_comments
+        .select { |c| BODY_ONLY_BOT_CLEAN_COMMENT_PATTERN.match?(c.body.to_s) }
+        .max_by { |c| c.created_at || Time.at(0) }
+      return false unless latest_clean_comment
+
+      provider_key = body_only_review_provider_key_for(latest_clean_comment.user&.login)
+      return false if provider_key.nil?
+
+      provider_logins = ProviderSupport::PROVIDER_BOT_USERNAMES
+        .fetch(provider_key, [])
+        .map(&:downcase)
+        .to_set
+      return false unless allowed_bot_logins.subset?(provider_logins)
 
       review_time = latest_review&.dig(:submitted_at)
-      comment_time = latest_bot_comment.created_at
+      comment_time = latest_clean_comment.created_at
       return true if review_time.nil? || comment_time.nil?
 
       comment_time >= review_time

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1020,6 +1020,53 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when codex and paid_agent are both enabled and codex clears codex-owned feedback" do
+      before do
+        project.update!(
+          review_settings: {
+            "enabled" => true,
+            "methods" => {
+              "codex" => { "enabled" => true },
+              "paid_agent" => {
+                "enabled" => true,
+                "termination" => { "max_review_rounds" => 2 }
+              }
+            }
+          }
+        )
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        clean_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector"),
+          body: "Codex Review: Didn't find any major issues. Hooray!",
+          created_at: 10.minutes.ago
+        )
+        info_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector"),
+          body: "To use Codex here, create an environment for this repo.",
+          created_at: 5.minutes.ago
+        )
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: [],
+          recent_issue_comments: [ clean_comment, info_comment ]
+        )
+      end
+
+      it "treats codex's clean comment as authoritative for codex-owned feedback" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
+      end
+    end
+
     context "when a project enables both Copilot and Codex and Copilot has unresolved threads" do
       before do
         enable_copilot_and_codex_review!

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -942,6 +942,84 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when a clean codex comment is followed by a newer informational codex comment" do
+      before do
+        enable_codex_review!
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        clean_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector"),
+          body: "Codex Review: Didn't find any major issues. Hooray!",
+          created_at: 10.minutes.ago
+        )
+        info_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector"),
+          body: "To use Codex here, create an environment for this repo.",
+          created_at: 5.minutes.ago
+        )
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
+                       body: "Here are some automated review suggestions.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: [],
+          recent_issue_comments: [ clean_comment, info_comment ]
+        )
+      end
+
+      it "still treats the bot as clean because later informational comments do not invalidate the clean signal" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("review_bot_review_pending", "review_bot_comments")
+      end
+    end
+
+    context "when codex and paid_agent are both enabled and only codex posted a clean comment" do
+      before do
+        project.update!(
+          review_settings: {
+            "enabled" => true,
+            "methods" => {
+              "codex" => { "enabled" => true },
+              "paid_agent" => {
+                "enabled" => true,
+                "termination" => { "max_review_rounds" => 2 }
+              }
+            }
+          }
+        )
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        clean_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "chatgpt-codex-connector"),
+          body: "Codex Review: Didn't find any major issues. Hooray!",
+          created_at: 10.minutes.ago
+        )
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                       body: "Found issues that still need fixes.",
+                       submitted_at: 1.hour.ago } ],
+          review_threads: [],
+          recent_issue_comments: [ clean_comment ]
+        )
+      end
+
+      it "does not let codex's clean comment suppress paid_agent feedback" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).to include("review_bot_comments")
+      end
+    end
+
     context "when a project enables both Copilot and Codex and Copilot has unresolved threads" do
       before do
         enable_copilot_and_codex_review!


### PR DESCRIPTION
## Summary
- treat a matching clean Codex issue comment as authoritative even if a later Codex informational comment exists
- keep the clean-comment bypass scoped to the same body-only bot provider family so Codex cannot suppress paid_agent feedback
- add regression coverage for the PR #1022 comment pattern and the mixed codex + paid_agent safety case

## Testing
- COVERAGE=false bundle exec rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb:906 spec/temporal/activities/scan_paid_prs_activity_spec.rb:972 spec/temporal/activities/scan_paid_prs_activity_spec.rb:1007 spec/temporal/activities/scan_paid_prs_activity_spec.rb:1049 spec/temporal/activities/scan_paid_prs_activity_spec.rb:1084