### PR TITLE
fix(auto-merge): handle zero-check repos correctly

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -345,7 +345,7 @@ module Activities
       if project.auto_merge_enabled? &&
           pr_data.present? &&
           owner_approved_or_self_authored?(project, reviews, pr_data) &&
-          !checks.nil? &&
+          checks.present? &&
           all_checks_green?(checks) &&
           mergeable == true &&
           no_outstanding_review_feedback?(project, client, issue, reviews, checks: checks) &&
@@ -398,7 +398,7 @@ module Activities
         mergeable = pr_data[:mergeable]
 
         if owner_approved_or_self_authored?(project, reviews, pr_data) &&
-            !checks.nil? &&
+            checks.present? &&
             all_checks_green?(checks) &&
             mergeable == true &&
             no_outstanding_review_feedback?(project, client, issue, reviews, checks: checks) &&

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -507,7 +507,7 @@ module Activities
       reviews ||= fetch_reviews(client, project, issue)
       unresolved_threads ||= fetch_unresolved_threads(client, project, issue)
 
-      partial_failure = pr_data.nil? || reviews.nil? || unresolved_threads.nil?
+      partial_failure = pr_data.nil? || checks.nil? || reviews.nil? || unresolved_threads.nil?
 
       triggers = []
 
@@ -735,7 +735,7 @@ module Activities
         end
       end
 
-      if project.review_method_enabled?("ci_action")
+      if project.review_method_enabled?("ci_action") && !checks.nil?
         action_name = project.review_method_config("ci_action")["action_name"]
         if action_name.present? && !ci_action_succeeded?(checks, action_name)
           triggers << { type: "ci_action_pending", action_name: action_name,

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -345,7 +345,7 @@ module Activities
       if project.auto_merge_enabled? &&
           pr_data.present? &&
           owner_approved_or_self_authored?(project, reviews, pr_data) &&
-          checks.present? &&
+          !checks.nil? &&
           all_checks_green?(checks) &&
           mergeable == true &&
           no_outstanding_review_feedback?(project, client, issue, reviews, checks: checks) &&
@@ -398,7 +398,7 @@ module Activities
         mergeable = pr_data[:mergeable]
 
         if owner_approved_or_self_authored?(project, reviews, pr_data) &&
-            checks.present? &&
+            !checks.nil? &&
             all_checks_green?(checks) &&
             mergeable == true &&
             no_outstanding_review_feedback?(project, client, issue, reviews, checks: checks) &&

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -304,10 +304,11 @@ module Activities
           return draft_trigger_payload(issue, triggers)
         end
 
-        # Only auto-advance when we have at least one check and all conclusions are green.
-        # all_checks_green? implicitly rejects nil conclusions (pending checks),
-        # and only after a clean review-bot review is present.
-        if checks.present? && all_checks_green?(checks)
+        # Auto-advance when checks were fetched successfully and all known
+        # conclusions are green. Repositories with no CI checks should still
+        # leave draft after a clean review; nil means the check fetch failed
+        # and we must fail closed instead of guessing.
+        if !checks.nil? && all_checks_green?(checks)
           # Check non-bot review gates (manual reviewer, ci_action) before advancing.
           reviews ||= fetch_reviews(client, project, issue) # safety: reviews already fetched above
           gate_triggers = non_bot_review_gate_triggers(project, reviews, checks)
@@ -344,7 +345,7 @@ module Activities
       if project.auto_merge_enabled? &&
           pr_data.present? &&
           owner_approved_or_self_authored?(project, reviews, pr_data) &&
-          checks.present? &&
+          !checks.nil? &&
           all_checks_green?(checks) &&
           mergeable == true &&
           no_outstanding_review_feedback?(project, client, issue, reviews, checks: checks) &&
@@ -397,7 +398,7 @@ module Activities
         mergeable = pr_data[:mergeable]
 
         if owner_approved_or_self_authored?(project, reviews, pr_data) &&
-            checks.present? &&
+            !checks.nil? &&
             all_checks_green?(checks) &&
             mergeable == true &&
             no_outstanding_review_feedback?(project, client, issue, reviews, checks: checks) &&
@@ -696,10 +697,12 @@ module Activities
         project_id: project.id,
         error: e.message
       )
-      []
+      nil
     end
 
     def ci_failure_triggers(checks)
+      return [] if checks.nil?
+
       completed = checks.select { |c| c[:conclusion].present? }
       return [] if completed.empty?
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -3597,7 +3597,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(trigger[:triggers].first[:type]).to eq("owner_approved")
       end
 
-      it "does not return owner_approved when the repo has no checks" do
+      it "returns owner_approved when the repo has no checks" do
         stub_github_for_pr(
           checks: [],
           reviews: default_clean_copilot_review + [
@@ -3607,7 +3607,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger]).to eq([])
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("owner_approved")
       end
 
       it "does not emit owner_approved when auto_merge is disabled" do
@@ -4651,7 +4653,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(trigger[:triggers].first[:type]).to eq("owner_approved")
       end
 
-      it "does not return owner_approved when the repo has no checks" do
+      it "returns owner_approved when the repo has no checks" do
         stub_github_for_pr(
           checks: [],
           reviews: default_clean_copilot_review + [
@@ -4661,7 +4663,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger]).to eq([])
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("owner_approved")
       end
 
       it "does not emit owner_approved when auto_merge is disabled" do

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -4983,6 +4983,44 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(unchanged_pr.reload.last_pr_scan_at).to be_nil
       end
 
+      it "returns :skipped when check-run fetch fails in ready phase" do
+        unchanged_pr.update_columns(
+          last_pr_scan_at: nil,
+          github_updated_at: Time.current,
+          pr_review_phase: "ready"
+        )
+        stub_github_for_pr(checks: [ { name: "ci", conclusion: "success" } ])
+        allow(github_client).to receive(:check_runs_for_ref)
+          .and_raise(GithubClient::Error.new("API error"))
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to be_empty
+        expect(unchanged_pr.reload.last_pr_scan_at).to be_nil
+      end
+
+      it "returns :skipped when check-run fetch fails for a ci_action gate in ready phase" do
+        unchanged_pr.update_columns(
+          last_pr_scan_at: nil,
+          github_updated_at: Time.current,
+          pr_review_phase: "ready"
+        )
+        project.update!(
+          review_settings: {
+            "enabled" => true,
+            "methods" => { "ci_action" => { "enabled" => true, "action_name" => "e2e-suite" } }
+          }
+        )
+        stub_github_for_pr(checks: [ { name: "e2e-suite", conclusion: "success" } ])
+        allow(github_client).to receive(:check_runs_for_ref)
+          .and_raise(GithubClient::Error.new("API error"))
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to be_empty
+        expect(unchanged_pr.reload.last_pr_scan_at).to be_nil
+      end
+
       it "reports skipped count in log output" do
         allow(Rails.logger).to receive(:info)
         allow(Rails.logger).to receive(:debug)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -3597,7 +3597,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(trigger[:triggers].first[:type]).to eq("owner_approved")
       end
 
-      it "returns owner_approved when the repo has no checks" do
+      it "does not return owner_approved when the repo has no checks" do
         stub_github_for_pr(
           checks: [],
           reviews: default_clean_copilot_review + [
@@ -3607,9 +3607,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger].size).to eq(1)
-        trigger = result[:prs_to_trigger].first
-        expect(trigger[:triggers].first[:type]).to eq("owner_approved")
+        expect(result[:prs_to_trigger]).to eq([])
       end
 
       it "does not emit owner_approved when auto_merge is disabled" do
@@ -4653,7 +4651,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(trigger[:triggers].first[:type]).to eq("owner_approved")
       end
 
-      it "returns owner_approved when the repo has no checks" do
+      it "does not return owner_approved when the repo has no checks" do
         stub_github_for_pr(
           checks: [],
           reviews: default_clean_copilot_review + [
@@ -4663,9 +4661,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger].size).to eq(1)
-        trigger = result[:prs_to_trigger].first
-        expect(trigger[:triggers].first[:type]).to eq("owner_approved")
+        expect(result[:prs_to_trigger]).to eq([])
       end
 
       it "does not emit owner_approved when auto_merge is disabled" do

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -856,10 +856,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         )
       end
 
-      it "treats the review as effectively clean and does not request another review" do
+      it "treats the review as effectively clean and advances to ready_for_owner" do
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger]).to eq([])
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].map { |t| t[:type] }).to eq([ "ready_for_owner" ])
       end
     end
 
@@ -3414,10 +3416,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         )
       end
 
-      it "treats the review as effectively clean when all threads are resolved" do
+      it "treats the review as effectively clean and advances to ready_for_owner" do
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger]).to eq([])
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].map { |t| t[:type] }).to eq([ "ready_for_owner" ])
       end
     end
 
@@ -3521,6 +3525,19 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(trigger[:triggers].first[:type]).to eq("ready_for_owner")
       end
 
+      it "returns ready_for_owner when the latest bot review is clean and the repo has no checks" do
+        stub_github_for_pr(
+          checks: [],
+          review_threads: []
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("ready_for_owner")
+      end
+
       it "does not return ready_for_owner when CI is pending" do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: nil } ],
@@ -3573,6 +3590,21 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
 
       it "returns owner_approved trigger" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("owner_approved")
+      end
+
+      it "returns owner_approved when the repo has no checks" do
+        stub_github_for_pr(
+          checks: [],
+          reviews: default_clean_copilot_review + [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
+          ]
+        )
+
         result = activity.execute(project_id: project.id)
 
         expect(result[:prs_to_trigger].size).to eq(1)
@@ -4614,6 +4646,21 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
 
       it "returns owner_approved trigger" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("owner_approved")
+      end
+
+      it "returns owner_approved when the repo has no checks" do
+        stub_github_for_pr(
+          checks: [],
+          reviews: default_clean_copilot_review + [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
+          ]
+        )
+
         result = activity.execute(project_id: project.id)
 
         expect(result[:prs_to_trigger].size).to eq(1)


### PR DESCRIPTION
## Summary
- allow clean draft PRs to advance to `ready_for_owner` when GitHub check runs were fetched successfully but the repo has no checks
- allow ready and escalated PRs in zero-check repos to emit `owner_approved` for auto-merge once the other review gates pass
- keep failing closed when the check-run fetch itself errors by distinguishing `nil` from `[]`

## Verification
- `bundle exec rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb`

## Notes
- The targeted RSpec run passes; the command still exits nonzero afterward in this repo because SimpleCov enforces a whole-repo coverage threshold on partial runs.