### PR TITLE
fix(agent-runs): resolve addressed review threads on no-change PR runs

### DIFF
--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -41,6 +41,10 @@ module Prompts
       unresolved_threads.any?
     end
 
+    def unresolved_review_thread_ids
+      unresolved_threads.filter_map { |thread| thread[:id] }
+    end
+
     PROMPT_SLUG = "coding.pr_review_rebase"
 
     # Fallback used only if the seeded prompt is missing or deactivated.

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -37,6 +37,10 @@ module Prompts
       new(...).build
     end
 
+    def includes_review_threads?
+      unresolved_threads.any?
+    end
+
     PROMPT_SLUG = "coding.pr_review_rebase"
 
     # Fallback used only if the seeded prompt is missing or deactivated.
@@ -85,7 +89,7 @@ module Prompts
       sections << issue_requirements_section if linked_issue?
       sections << merge_conflicts_section unless rebase_succeeded
       sections << ci_failures_section if failing_checks.any?
-      sections << code_review_section if unresolved_threads.any?
+      sections << code_review_section if includes_review_threads?
       sections << conversation_section if trusted_comments.any?
       sections << instructions_and_rules_shell
       sections << service_environment_section
@@ -119,7 +123,7 @@ module Prompts
       priorities << "Resolve merge conflicts" unless rebase_succeeded
       priorities << "Fix CI failures" if failing_checks.any?
       priorities << "Close implementation gaps against the linked issue" if linked_issue?
-      priorities << "Address code review comments" if unresolved_threads.any?
+      priorities << "Address code review comments" if includes_review_threads?
       priorities << "Address conversation comments" if trusted_comments.any?
       priorities.each_with_index.map { |p, i| "#{i + 1}. #{p}" }.join("\n")
     end
@@ -234,7 +238,7 @@ module Prompts
     # When reviewers have flagged specific issues, tell the agent to scan for
     # the same class of problem across the whole diff — not just the flagged lines.
     def review_scan_instruction
-      return "" unless unresolved_threads.any?
+      return "" unless includes_review_threads?
 
       ". Pay special attention to the same classes of issues the reviewers " \
         "raised — if they flagged one instance, scan for similar problems " \
@@ -242,7 +246,7 @@ module Prompts
     end
 
     def already_addressed_instruction
-      return "" unless unresolved_threads.any?
+      return "" unless includes_review_threads?
 
       "\n\nIf you verify that every unresolved review thread listed above is already " \
         "addressed on the current branch and no code changes are needed, do not " \

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -20,10 +20,10 @@ module Prompts
     ALREADY_ADDRESSED_MARKER = "PAID_REVIEW_THREADS_ALREADY_ADDRESSED"
 
     attr_reader :project, :pr_number, :github_client, :rebase_succeeded,
-                :lint_command, :test_command, :issue
+                :lint_command, :test_command, :issue, :prompt_version
 
     def initialize(project:, pr_number:, github_client:, rebase_succeeded:,
-                   lint_command: nil, test_command: nil, issue: nil)
+                   lint_command: nil, test_command: nil, issue: nil, prompt_version: nil)
       @project = project
       @pr_number = pr_number
       @github_client = github_client
@@ -31,6 +31,7 @@ module Prompts
       @lint_command = lint_command || detected_lint_command
       @test_command = test_command || detected_test_command
       @issue = issue
+      @prompt_version = prompt_version
     end
 
     def self.call(...)
@@ -113,6 +114,8 @@ module Prompts
         lint_command: lint_command,
         test_command: test_command
       }
+
+      return prompt_version.render(vars) if prompt_version.present?
 
       Prompts::Render.call(
         slug: PROMPT_SLUG,

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -17,6 +17,8 @@ module Prompts
   class BuildForPr
     include ServiceContainerSections
 
+    ALREADY_ADDRESSED_MARKER = "PAID_REVIEW_THREADS_ALREADY_ADDRESSED"
+
     attr_reader :project, :pr_number, :github_client, :rebase_succeeded,
                 :lint_command, :test_command, :issue
 
@@ -62,6 +64,8 @@ module Prompts
       If the commit is rejected, read the error output carefully, fix the issues, and commit again.
       Keep iterating until the commit succeeds. Do not leave uncommitted changes.
 
+      {{already_addressed_instruction}}
+
       When you're done, commit all your changes. Do not push.
 
       # Rules — you MUST follow these
@@ -97,6 +101,7 @@ module Prompts
         priority_list: priority_list,
         setup_database_instruction: setup_database_instruction,
         review_scan_instruction: review_scan_instruction,
+        already_addressed_instruction: already_addressed_instruction,
         lint_command: lint_command,
         test_command: test_command
       }
@@ -234,6 +239,15 @@ module Prompts
       ". Pay special attention to the same classes of issues the reviewers " \
         "raised — if they flagged one instance, scan for similar problems " \
         "elsewhere in your changes"
+    end
+
+    def already_addressed_instruction
+      return "" unless unresolved_threads.any?
+
+      "\n\nIf you verify that every unresolved review thread listed above is already " \
+        "addressed on the current branch and no code changes are needed, do not " \
+        "make a no-op commit. End your final response with a standalone line " \
+        "containing exactly `#{ALREADY_ADDRESSED_MARKER}`."
     end
 
     # Memoized data fetchers

--- a/app/temporal/activities/prepare_pr_prompt_activity.rb
+++ b/app/temporal/activities/prepare_pr_prompt_activity.rb
@@ -16,6 +16,10 @@ module Activities
       track_phase(agent_run_id: agent_run_id, phase_key: "prepare_pr_prompt", phase_group: "prompt", agent_run: agent_run) do
         project = agent_run.project
         client = project.github_token.client
+        prompt_version = Prompts::Resolve.call(
+          slug: Prompts::BuildForPr::PROMPT_SLUG,
+          project: project
+        )
 
         prompt = Prompts::BuildForPr.call(
           project: project,
@@ -24,16 +28,24 @@ module Activities
           rebase_succeeded: rebase_succeeded,
           issue: agent_run.issue
         )
+        includes_review_threads = prompt.include?("# Code Review Comments")
 
-        agent_run.update!(custom_prompt: prompt)
+        agent_run.update!(custom_prompt: prompt, prompt_version: prompt_version)
 
         logger.info(
           message: "agent_execution.prepare_pr_prompt",
           agent_run_id: agent_run_id,
-          prompt_length: prompt.length
+          prompt_length: prompt.length,
+          includes_review_threads: includes_review_threads,
+          prompt_version_id: prompt_version&.id
         )
 
-        { agent_run_id: agent_run_id, prompt_length: prompt.length }
+        {
+          agent_run_id: agent_run_id,
+          prompt_length: prompt.length,
+          includes_review_threads: includes_review_threads,
+          prompt_version_id: prompt_version&.id
+        }
       end
     end
   end

--- a/app/temporal/activities/prepare_pr_prompt_activity.rb
+++ b/app/temporal/activities/prepare_pr_prompt_activity.rb
@@ -30,6 +30,7 @@ module Activities
         )
         prompt = prompt_builder.build
         includes_review_threads = prompt_builder.includes_review_threads?
+        review_thread_ids = prompt_builder.unresolved_review_thread_ids
 
         agent_run.update!(custom_prompt: prompt, prompt_version: prompt_version)
 
@@ -38,6 +39,7 @@ module Activities
           agent_run_id: agent_run_id,
           prompt_length: prompt.length,
           includes_review_threads: includes_review_threads,
+          review_thread_count: review_thread_ids.size,
           prompt_version_id: prompt_version&.id
         )
 
@@ -45,6 +47,7 @@ module Activities
           agent_run_id: agent_run_id,
           prompt_length: prompt.length,
           includes_review_threads: includes_review_threads,
+          review_thread_ids: review_thread_ids,
           prompt_version_id: prompt_version&.id
         }
       end

--- a/app/temporal/activities/prepare_pr_prompt_activity.rb
+++ b/app/temporal/activities/prepare_pr_prompt_activity.rb
@@ -26,7 +26,8 @@ module Activities
           pr_number: agent_run.source_pull_request_number,
           github_client: client,
           rebase_succeeded: rebase_succeeded,
-          issue: agent_run.issue
+          issue: agent_run.issue,
+          prompt_version: prompt_version
         )
         prompt = prompt_builder.build
         includes_review_threads = prompt_builder.includes_review_threads?

--- a/app/temporal/activities/prepare_pr_prompt_activity.rb
+++ b/app/temporal/activities/prepare_pr_prompt_activity.rb
@@ -21,14 +21,15 @@ module Activities
           project: project
         )
 
-        prompt = Prompts::BuildForPr.call(
+        prompt_builder = Prompts::BuildForPr.new(
           project: project,
           pr_number: agent_run.source_pull_request_number,
           github_client: client,
           rebase_succeeded: rebase_succeeded,
           issue: agent_run.issue
         )
-        includes_review_threads = prompt.include?("# Code Review Comments")
+        prompt = prompt_builder.build
+        includes_review_threads = prompt_builder.includes_review_threads?
 
         agent_run.update!(custom_prompt: prompt, prompt_version: prompt_version)
 

--- a/app/temporal/activities/resolve_review_threads_activity.rb
+++ b/app/temporal/activities/resolve_review_threads_activity.rb
@@ -2,7 +2,8 @@
 
 module Activities
   # Resolves unresolved review threads on a pull request after the agent
-  # has pushed its changes.
+  # has pushed its changes. When thread_ids are provided, only those
+  # prompt-captured unresolved threads are eligible for auto-resolution.
   #
   # Individual thread resolution failures are logged but do not fail the
   # activity — this is a best-effort cleanup step.
@@ -11,12 +12,14 @@ module Activities
 
     def execute(input)
       agent_run_id = input[:agent_run_id]
+      thread_ids = Array(input[:thread_ids]).compact
       agent_run = AgentRun.find(agent_run_id)
       project = agent_run.project
       client = project.github_token.client
 
       threads = client.review_threads(project.full_name, agent_run.source_pull_request_number)
       unresolved = threads.reject { |t| t[:is_resolved] }
+      unresolved.select! { |thread| thread_ids.include?(thread[:id]) } if thread_ids.any?
 
       resolved_count = 0
       failed_count = 0
@@ -37,11 +40,17 @@ module Activities
       logger.info(
         message: "agent_execution.resolve_review_threads",
         agent_run_id: agent_run_id,
+        requested_thread_ids: thread_ids,
         resolved_count: resolved_count,
         failed_count: failed_count
       )
 
-      { agent_run_id: agent_run_id, resolved_count: resolved_count, failed_count: failed_count }
+      {
+        agent_run_id: agent_run_id,
+        requested_thread_ids: thread_ids,
+        resolved_count: resolved_count,
+        failed_count: failed_count
+      }
     end
   end
 end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -841,6 +841,7 @@ module Activities
           db_scoped.call
         end
       end
+      worker.report_on_exception = false
       canceled = false
       interrupted = false
       begin

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -841,8 +841,6 @@ module Activities
           db_scoped.call
         end
       end
-      worker.report_on_exception = false
-
       canceled = false
       interrupted = false
       begin

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -841,6 +841,7 @@ module Activities
           db_scoped.call
         end
       end
+      worker.report_on_exception = false
 
       canceled = false
       interrupted = false

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -238,6 +238,7 @@ module Activities
               success: true,
               has_changes: has_changes,
               output_present: provider_result.fetch(:output_present),
+              review_threads_already_addressed: provider_result.fetch(:review_threads_already_addressed, false),
               final_provider: attempt_label
             }
           rescue ProviderRateLimitError => e
@@ -583,7 +584,11 @@ module Activities
       if result.success?
         output_present = stdout.present? || stderr.present?
         agent_run.log!("system", "Agent execution succeeded with #{provider}")
-        return { pre_agent_sha: pre_agent_sha, output_present: output_present }
+        return {
+          pre_agent_sha: pre_agent_sha,
+          output_present: output_present,
+          review_threads_already_addressed: review_threads_already_addressed?(stdout: stdout, stderr: stderr, prompt: prompt)
+        }
       end
 
       output = (stderr.presence || stdout).to_s.strip
@@ -786,6 +791,16 @@ module Activities
       end
     rescue StandardError
       1.hour.from_now
+    end
+
+    def review_threads_already_addressed?(stdout:, stderr:, prompt:)
+      signal_present?(strip_prompt_echo(stdout, prompt)) ||
+        signal_present?(strip_prompt_echo(stderr, prompt))
+    end
+
+    def signal_present?(output)
+      marker = Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER
+      output.to_s.each_line.any? { |line| line.strip == marker }
     end
 
     # Runs a block while sending periodic heartbeats from the activity's

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -223,10 +223,11 @@ module Workflows
 
           if source_pull_request_number
             # Resolve review threads (best-effort, non-fatal)
-            if pr_run_without_prompt
+            if pr_run_without_prompt && pr_prompt_result[:review_thread_ids].present?
               begin
                 run_activity(Activities::ResolveReviewThreadsActivity,
-                  { agent_run_id: agent_run_id }, timeout: 60)
+                  { agent_run_id: agent_run_id,
+                    thread_ids: pr_prompt_result[:review_thread_ids] }, timeout: 60)
               rescue => e
                 Temporalio::Workflow.logger.warn(
                   message: "agent_execution.resolve_threads_failed",
@@ -271,7 +272,8 @@ module Workflows
               agent_result[:review_threads_already_addressed]
             begin
               run_activity(Activities::ResolveReviewThreadsActivity,
-                { agent_run_id: agent_run_id }, timeout: 60)
+                { agent_run_id: agent_run_id,
+                  thread_ids: pr_prompt_result[:review_thread_ids] }, timeout: 60)
             rescue => e
               Temporalio::Workflow.logger.warn(
                 message: "agent_execution.resolve_threads_failed",

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -223,20 +223,7 @@ module Workflows
 
           if source_pull_request_number
             # Resolve review threads (best-effort, non-fatal)
-            if pr_run_without_prompt && pr_prompt_result[:review_thread_ids].present?
-              begin
-                run_activity(Activities::ResolveReviewThreadsActivity,
-                  { agent_run_id: agent_run_id,
-                    thread_ids: pr_prompt_result[:review_thread_ids] }, timeout: 60)
-              rescue => e
-                Temporalio::Workflow.logger.warn(
-                  message: "agent_execution.resolve_threads_failed",
-                  agent_run_id: agent_run_id,
-                  error_class: e.class.name,
-                  error: e.message
-                )
-              end
-            end
+            resolve_followup_review_threads_after_push(agent_run_id, pr_run_without_prompt, pr_prompt_result)
 
             # Existing PR: mark complete with existing PR details
             complete_result = run_activity(Activities::CompleteExistingPrRunActivity,
@@ -267,23 +254,11 @@ module Workflows
           end
         else
           # No changes produced by agent
-          if source_pull_request_number && pr_run_without_prompt &&
-              pr_prompt_result[:includes_review_threads] &&
-              pr_prompt_result[:review_thread_ids].present? &&
-              agent_result[:review_threads_already_addressed]
-            begin
-              run_activity(Activities::ResolveReviewThreadsActivity,
-                { agent_run_id: agent_run_id,
-                  thread_ids: pr_prompt_result[:review_thread_ids] }, timeout: 60)
-            rescue => e
-              Temporalio::Workflow.logger.warn(
-                message: "agent_execution.resolve_threads_failed",
-                agent_run_id: agent_run_id,
-                error_class: e.class.name,
-                error: e.message
-              )
-            end
-          end
+          resolve_no_change_followup_review_threads(agent_run_id,
+            source_pull_request_number,
+            pr_run_without_prompt,
+            pr_prompt_result,
+            agent_result)
 
           if issue_id.present? && !source_pull_request_number
             # Issue-based run with no code changes / no PR: classify as
@@ -475,6 +450,51 @@ module Workflows
         message: "agent_execution.review_bot_request_failed",
         project_id: project_id,
         pr_number: pr_number,
+        error: e.message
+      )
+    end
+
+    def resolve_followup_review_threads_after_push(agent_run_id, pr_run_without_prompt, pr_prompt_result)
+      if Temporalio::Workflow.patched("resolve_review_threads_with_prompt_thread_ids")
+        return unless pr_run_without_prompt && pr_prompt_result[:review_thread_ids].present?
+
+        resolve_review_threads(agent_run_id, thread_ids: pr_prompt_result[:review_thread_ids])
+      else
+        return unless pr_run_without_prompt
+
+        resolve_review_threads(agent_run_id)
+      end
+    end
+
+    def resolve_no_change_followup_review_threads(agent_run_id, source_pull_request_number, pr_run_without_prompt, pr_prompt_result, agent_result)
+      if Temporalio::Workflow.patched("resolve_review_threads_with_prompt_thread_ids")
+        return unless source_pull_request_number && pr_run_without_prompt &&
+          pr_prompt_result[:includes_review_threads] &&
+          pr_prompt_result[:review_thread_ids].present? &&
+          agent_result[:review_threads_already_addressed]
+
+        resolve_review_threads(agent_run_id, thread_ids: pr_prompt_result[:review_thread_ids])
+      else
+        return unless source_pull_request_number && pr_run_without_prompt &&
+          pr_prompt_result[:includes_review_threads] &&
+          agent_result[:review_threads_already_addressed]
+
+        resolve_review_threads(agent_run_id)
+      end
+    end
+
+    def resolve_review_threads(agent_run_id, thread_ids: nil)
+      input = { agent_run_id: agent_run_id }
+      input[:thread_ids] = thread_ids if thread_ids.present?
+
+      run_activity(Activities::ResolveReviewThreadsActivity, input, timeout: 60)
+    rescue Temporalio::Error::CanceledError
+      raise
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "agent_execution.resolve_threads_failed",
+        agent_run_id: agent_run_id,
+        error_class: e.class.name,
         error: e.message
       )
     end

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -269,6 +269,7 @@ module Workflows
           # No changes produced by agent
           if source_pull_request_number && pr_run_without_prompt &&
               pr_prompt_result[:includes_review_threads] &&
+              pr_prompt_result[:review_thread_ids].present? &&
               agent_result[:review_threads_already_addressed]
             begin
               run_activity(Activities::ResolveReviewThreadsActivity,

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -144,11 +144,12 @@ module Workflows
         # Skip for review goals — they use their own review-specific prompt and
         # don't need the PR-editing prompt that instructs the agent to commit fixes.
         pr_run_without_prompt = source_pull_request_number.present? && custom_prompt.blank? && goal != "review"
+        pr_prompt_result = {}
         if pr_run_without_prompt
           rebase_result = run_activity(Activities::RebaseBranchActivity,
             { agent_run_id: agent_run_id }, timeout: 120)
 
-          run_activity(Activities::PreparePrPromptActivity,
+          pr_prompt_result = run_activity(Activities::PreparePrPromptActivity,
             { agent_run_id: agent_run_id,
               rebase_succeeded: rebase_result[:rebase_succeeded] }, timeout: 60)
         end
@@ -265,6 +266,22 @@ module Workflows
           end
         else
           # No changes produced by agent
+          if source_pull_request_number && pr_run_without_prompt &&
+              pr_prompt_result[:includes_review_threads] &&
+              agent_result[:review_threads_already_addressed]
+            begin
+              run_activity(Activities::ResolveReviewThreadsActivity,
+                { agent_run_id: agent_run_id }, timeout: 60)
+            rescue => e
+              Temporalio::Workflow.logger.warn(
+                message: "agent_execution.resolve_threads_failed",
+                agent_run_id: agent_run_id,
+                error_class: e.class.name,
+                error: e.message
+              )
+            end
+          end
+
           if issue_id.present? && !source_pull_request_number
             # Issue-based run with no code changes / no PR: classify as
             # needs_input or recommend_close and post an actionable GitHub comment.

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -138,6 +138,8 @@ upsert_global_prompt.call(
     If the commit is rejected, read the error output carefully, fix the issues, and commit again.
     Keep iterating until the commit succeeds. Do not leave uncommitted changes.
 
+    {{already_addressed_instruction}}
+
     When you're done, commit all your changes. Do not push.
 
     # Rules — you MUST follow these
@@ -154,6 +156,7 @@ upsert_global_prompt.call(
     var.call("priority_list", "Numbered priority list assembled from PR state"),
     var.call("setup_database_instruction", "Optional database setup line", required: false),
     var.call("review_scan_instruction", "Extra clause emphasizing same-class issues when reviewers flagged something", required: false),
+    var.call("already_addressed_instruction", "Instruction to emit the already-addressed marker when all listed review threads are already fixed", required: false),
     var.call("lint_command", "Project lint command"),
     var.call("test_command", "Project test command")
   ]

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -110,4 +110,21 @@ RSpec.describe Prompt, type: :model do
         .to include('Case B: body starts with EXACTLY "Generated no new comments." and "comments" is []')
     end
   end
+
+  describe "coding.pr_review_rebase already-addressed marker" do
+    it "seeded template includes the no-change review resolution variable slot" do
+      template = described_class.global.find_by(slug: "coding.pr_review_rebase").current_version.template
+      expect(template).to include("{{already_addressed_instruction}}")
+    end
+
+    it "fallback prompt includes the no-change review resolution variable slot" do
+      expect(Prompts::BuildForPr::FALLBACK_PROMPT).to include("{{already_addressed_instruction}}")
+    end
+
+    it "seeded template declares the no-change review resolution variable" do
+      variables = described_class.global.find_by(slug: "coding.pr_review_rebase").current_version.variables
+      names = variables.map { |variable| variable["name"] || variable[:name] }
+      expect(names).to include("already_addressed_instruction")
+    end
+  end
 end

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -134,6 +134,27 @@ RSpec.describe Prompts::BuildForPr do
     end
   end
 
+  describe "#unresolved_review_thread_ids" do
+    it "returns only unresolved review thread ids" do
+      allow(github_client).to receive(:review_threads)
+        .with(project.full_name, 42)
+        .and_return([
+          { id: "thread_1", is_resolved: false, comments: [ { body: "Needs a fix", author: "reviewer" } ] },
+          { id: "thread_2", is_resolved: true, comments: [ { body: "Already fixed", author: "reviewer" } ] },
+          { id: nil, is_resolved: false, comments: [ { body: "Missing id", author: "reviewer" } ] }
+        ])
+
+      builder = described_class.new(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(builder.unresolved_review_thread_ids).to eq([ "thread_1" ])
+    end
+  end
+
   describe "merge conflicts section" do
     it "includes merge conflicts instructions when rebase failed" do
       prompt = described_class.call(

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("Do not push")
     end
 
+    it "omits the already-addressed marker instruction when no unresolved review threads are present" do
+      expect(prompt).not_to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
+      expect(prompt).not_to include("do not make a no-op commit")
+    end
+
     it "includes proactive scan step" do
       expect(prompt).to include("Proactive scan")
       expect(prompt).to include("review the **entire diff**")
@@ -185,6 +190,18 @@ RSpec.describe Prompts::BuildForPr do
 
       expect(prompt).to include("same classes of issues the reviewers")
       expect(prompt).to include("Proactive scan")
+    end
+
+    it "includes the already-addressed marker instruction when unresolved review threads are present" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
+      expect(prompt).to include("do not make a no-op commit")
     end
 
     it "excludes resolved threads" do

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -104,6 +104,36 @@ RSpec.describe Prompts::BuildForPr do
     end
   end
 
+  describe "#includes_review_threads?" do
+    it "returns false when there are no unresolved review threads" do
+      builder = described_class.new(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(builder.includes_review_threads?).to be(false)
+    end
+
+    it "returns true when unresolved review threads are present" do
+      allow(github_client).to receive(:review_threads)
+        .with(project.full_name, 42)
+        .and_return([
+          { id: "thread_1", is_resolved: false, comments: [ { body: "Needs a fix", author: "reviewer" } ] }
+        ])
+
+      builder = described_class.new(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(builder.includes_review_threads?).to be(true)
+    end
+  end
+
   describe "merge conflicts section" do
     it "includes merge conflicts instructions when rebase failed" do
       prompt = described_class.call(

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -2,6 +2,7 @@
 
 require "rails_helper"
 require "ostruct"
+require "securerandom"
 
 RSpec.describe Prompts::BuildForPr do
   let(:project) { create(:project, allowed_github_usernames: [ "trusteduser" ]) }
@@ -34,6 +35,31 @@ RSpec.describe Prompts::BuildForPr do
         github_client: github_client,
         rebase_succeeded: true
       )
+    end
+
+    it "renders the instructions shell from an explicit prompt version when provided" do
+      prompt = create(:prompt, :global, slug: "test.#{SecureRandom.hex(8)}")
+      stale_version = prompt.create_version!(
+        template: "Pinned instructions {{lint_command}}",
+        variables: [
+          { "name" => "lint_command", "required" => true, "description" => "Lint command" }
+        ]
+      )
+      prompt.create_version!(
+        template: "Current instructions should not render",
+        variables: []
+      )
+
+      rendered = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true,
+        prompt_version: stale_version
+      )
+
+      expect(rendered).to include("Pinned instructions bundle exec rubocop")
+      expect(rendered).not_to include("Current instructions should not render")
     end
 
     it "includes the PR title and number" do

--- a/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
+++ b/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Activities::PreparePrPromptActivity do
     Prompt.find_by(slug: Prompts::BuildForPr::PROMPT_SLUG)&.destroy!
     create(:prompt, :global, slug: Prompts::BuildForPr::PROMPT_SLUG).tap do |record|
       record.create_version!(
-        template: "Priority order:\n{{priority_list}}\nMarker: #{Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER}",
+        template: "Priority order:\n{{priority_list}}\n# Code Review Comments",
         variables: [
           { "name" => "priority_list", "required" => true, "description" => "Priority list" }
         ]

--- a/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
+++ b/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Activities::PreparePrPromptActivity do
       expect(result[:prompt_length]).to be > 0
       expect(result[:agent_run_id]).to eq(agent_run.id)
       expect(result[:includes_review_threads]).to be(false)
+      expect(result[:review_thread_ids]).to eq([])
       expect(result[:prompt_version_id]).to eq(prompt.current_version.id)
     end
 
@@ -122,6 +123,7 @@ RSpec.describe Activities::PreparePrPromptActivity do
         result = activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
 
         expect(result[:includes_review_threads]).to be(true)
+        expect(result[:review_thread_ids]).to eq([ "thread_1" ])
         expect(agent_run.reload.custom_prompt).to include("Code Review Comments")
       end
     end

--- a/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
+++ b/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
@@ -59,6 +59,30 @@ RSpec.describe Activities::PreparePrPromptActivity do
       expect(agent_run.reload.prompt_version).to eq(prompt.current_version)
     end
 
+    it "renders the stored prompt from the same resolved prompt version" do
+      pinned_version = prompt.create_version!(
+        template: "Pinned shell {{priority_list}}",
+        variables: [
+          { "name" => "priority_list", "required" => true, "description" => "Priority list" }
+        ]
+      )
+      prompt.create_version!(
+        template: "New current shell",
+        variables: []
+      )
+
+      allow(Prompts::Resolve).to receive(:call)
+        .with(slug: Prompts::BuildForPr::PROMPT_SLUG, project: project)
+        .and_return(pinned_version)
+
+      activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+      agent_run.reload
+      expect(agent_run.prompt_version).to eq(pinned_version)
+      expect(agent_run.custom_prompt).to include("Pinned shell")
+      expect(agent_run.custom_prompt).not_to include("New current shell")
+    end
+
     it "returns prompt_length" do
       result = activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
 

--- a/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
+++ b/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe Activities::PreparePrPromptActivity do
   end
   let(:github_client) { instance_double(GithubClient) }
   let(:activity) { described_class.new }
+  let!(:prompt) do
+    Prompt.find_by(slug: Prompts::BuildForPr::PROMPT_SLUG)&.destroy!
+    create(:prompt, :global, slug: Prompts::BuildForPr::PROMPT_SLUG).tap do |record|
+      record.create_version!(
+        template: "Priority order:\n{{priority_list}}\nMarker: #{Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER}",
+        variables: [
+          { "name" => "priority_list", "required" => true, "description" => "Priority list" }
+        ]
+      )
+    end
+  end
 
   let(:pr_data) do
     OpenStruct.new(
@@ -42,11 +53,19 @@ RSpec.describe Activities::PreparePrPromptActivity do
       expect(agent_run.custom_prompt).to include("#42")
     end
 
+    it "stores the resolved prompt version on the agent run" do
+      activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+      expect(agent_run.reload.prompt_version).to eq(prompt.current_version)
+    end
+
     it "returns prompt_length" do
       result = activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
 
       expect(result[:prompt_length]).to be > 0
       expect(result[:agent_run_id]).to eq(agent_run.id)
+      expect(result[:includes_review_threads]).to be(false)
+      expect(result[:prompt_version_id]).to eq(prompt.current_version.id)
     end
 
     it "passes rebase_succeeded through to the prompt builder" do
@@ -87,6 +106,23 @@ RSpec.describe Activities::PreparePrPromptActivity do
         expect(agent_run.custom_prompt).to include("Issue Requirements")
         expect(agent_run.custom_prompt).to include("Add feature X")
         expect(agent_run.custom_prompt).to include("#99")
+      end
+    end
+
+    context "when unresolved review threads are present" do
+      before do
+        allow(github_client).to receive(:review_threads)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: "thread_1", is_resolved: false, comments: [ { body: "Needs a fix", path: "app/models/user.rb", line: 42, author: "reviewer" } ] }
+          ])
+      end
+
+      it "reports that the generated prompt included review threads" do
+        result = activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+        expect(result[:includes_review_threads]).to be(true)
+        expect(agent_run.reload.custom_prompt).to include("Code Review Comments")
       end
     end
 

--- a/spec/temporal/activities/resolve_review_threads_activity_spec.rb
+++ b/spec/temporal/activities/resolve_review_threads_activity_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe Activities::ResolveReviewThreadsActivity do
         expect(result[:failed_count]).to eq(0)
         expect(result[:agent_run_id]).to eq(agent_run.id)
       end
+
+      it "resolves only requested thread ids when provided" do
+        expect(github_client).to receive(:resolve_review_thread).with("thread_3")
+        expect(github_client).not_to receive(:resolve_review_thread).with("thread_1")
+        expect(github_client).not_to receive(:resolve_review_thread).with("thread_2")
+
+        result = activity.execute(agent_run_id: agent_run.id, thread_ids: [ "thread_3", "missing" ])
+
+        expect(result[:requested_thread_ids]).to eq([ "thread_3", "missing" ])
+        expect(result[:resolved_count]).to eq(1)
+      end
     end
 
     context "when individual thread resolution fails" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -452,6 +452,21 @@ RSpec.describe Activities::RunAgentActivity do
         expect(result[:success]).to be true
       end
 
+      it "returns review_threads_already_addressed when the agent emits the marker" do
+        marker_success = Containers::Provision::Result.success(
+          stdout: "Reviewed the branch.\n#{Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER}\n",
+          stderr: "",
+          exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(marker_success)
+        allow(git_ops).to receive(:has_changes_since?).with("pre_agent_sha_abc123").and_return(false)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:review_threads_already_addressed]).to be(true)
+        expect(result[:has_changes]).to be(false)
+      end
+
       it "succeeds and logs an informational message when provider has no output and no changes" do
         no_output_success = Containers::Provision::Result.success(stdout: "", stderr: "", exit_code: 0)
         allow(container_service).to receive(:execute).and_return(no_output_success)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -71,18 +71,6 @@ RSpec.describe Activities::RunAgentActivity do
       }
     end
 
-    it "does not report expected worker exceptions to stderr" do
-      allow(Temporalio::Activity::Context).to receive(:current_or_nil).and_return(mock_context)
-
-      expect {
-        expect {
-          activity.send(:with_periodic_heartbeat, "test", interval: 0.01) do
-            raise ArgumentError, "boom"
-          end
-        }.to raise_error(ArgumentError, "boom")
-      }.not_to output(/terminated with exception/).to_stderr
-    end
-
     it "yields without heartbeating when outside activity context" do
       allow(Temporalio::Activity::Context).to receive(:current_or_nil).and_return(nil)
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe Activities::RunAgentActivity do
       }
     end
 
+    it "does not report expected worker exceptions to stderr" do
+      allow(Temporalio::Activity::Context).to receive(:current_or_nil).and_return(mock_context)
+
+      expect {
+        expect {
+          activity.send(:with_periodic_heartbeat, "test", interval: 0.01) do
+            raise ArgumentError, "boom"
+          end
+        }.to raise_error(ArgumentError, "boom")
+      }.not_to output(/terminated with exception/).to_stderr
+    end
+
     it "yields without heartbeating when outside activity context" do
       allow(Temporalio::Activity::Context).to receive(:current_or_nil).and_return(nil)
 

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -501,6 +501,26 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       end
     end
 
+    def stub_no_changes_followup_with_marker_without_review_thread_ids
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
+        when "Activities::ProvisionServicesActivity" then {}
+        when "Activities::ProvisionContainerActivity" then {}
+        when "Activities::CloneRepoActivity" then {}
+        when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
+        when "Activities::PreparePrPromptActivity" then { includes_review_threads: true, review_thread_ids: [] }
+        when "Activities::RunAgentActivity" then { success: true, has_changes: false, review_threads_already_addressed: true }
+        when "Activities::MarkAgentRunCompleteActivity" then {}
+        when "Activities::RequestReviewActivity" then {}
+        when "Activities::CleanupContainerActivity" then {}
+        when "Activities::CleanupServicesActivity" then {}
+        when "Activities::CleanupWorktreeActivity" then {}
+        else {}
+        end
+      end
+    end
+
     it "requests a review-bot review even when the agent makes no changes on an existing PR" do
       stub_no_changes_followup
 
@@ -525,6 +545,15 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
     it "does not resolve review threads on a no-change PR follow-up unless the prompt included review threads" do
       stub_no_changes_followup
+
+      workflow.execute(input)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::ResolveReviewThreadsActivity, anything, timeout: anything)
+    end
+
+    it "does not resolve review threads on a no-change PR follow-up when the prompt captured no thread ids" do
+      stub_no_changes_followup_with_marker_without_review_thread_ids
 
       workflow.execute(input)
 

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -357,11 +357,32 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::ProvisionContainerActivity" then {}
         when "Activities::CloneRepoActivity" then {}
         when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
-        when "Activities::PreparePrPromptActivity" then {}
+        when "Activities::PreparePrPromptActivity" then { review_thread_ids: [ "thread_1" ] }
         when "Activities::RunAgentActivity" then { success: true, has_changes: true }
         when "Activities::PushBranchActivity" then {}
         when "Activities::ResolveReviewThreadsActivity" then {}
         when "Activities::CompleteExistingPrRunActivity" then { pr_review_phase: pr_review_phase }
+        when "Activities::RequestReviewActivity" then {}
+        when "Activities::CleanupContainerActivity" then {}
+        when "Activities::CleanupServicesActivity" then {}
+        when "Activities::CleanupWorktreeActivity" then {}
+        else {}
+        end
+      end
+    end
+
+    def stub_existing_pr_followup_without_review_threads
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
+        when "Activities::ProvisionServicesActivity" then {}
+        when "Activities::ProvisionContainerActivity" then {}
+        when "Activities::CloneRepoActivity" then {}
+        when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
+        when "Activities::PreparePrPromptActivity" then { review_thread_ids: [] }
+        when "Activities::RunAgentActivity" then { success: true, has_changes: true }
+        when "Activities::PushBranchActivity" then {}
+        when "Activities::CompleteExistingPrRunActivity" then { pr_review_phase: "ready" }
         when "Activities::RequestReviewActivity" then {}
         when "Activities::CleanupContainerActivity" then {}
         when "Activities::CleanupServicesActivity" then {}
@@ -409,6 +430,26 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
             reviewers: [ Activities::RequestReviewActivity::COPILOT_LOGIN ] },
           timeout: 60)
     end
+
+    it "passes prompt-captured review thread ids when resolving after pushing commits" do
+      stub_existing_pr_followup(pr_review_phase: "ready")
+
+      workflow.execute(input)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::ResolveReviewThreadsActivity,
+          { agent_run_id: 42, thread_ids: [ "thread_1" ] },
+          timeout: 60)
+    end
+
+    it "does not resolve review threads after pushing commits when the prompt captured none" do
+      stub_existing_pr_followup_without_review_threads
+
+      workflow.execute(input)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::ResolveReviewThreadsActivity, anything, timeout: anything)
+    end
   end
 
   describe "existing PR follow-up with no changes" do
@@ -427,7 +468,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::ProvisionContainerActivity" then {}
         when "Activities::CloneRepoActivity" then {}
         when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
-        when "Activities::PreparePrPromptActivity" then { includes_review_threads: false }
+        when "Activities::PreparePrPromptActivity" then { includes_review_threads: false, review_thread_ids: [] }
         when "Activities::RunAgentActivity" then { success: true, has_changes: false }
         when "Activities::MarkAgentRunCompleteActivity" then {}
         when "Activities::RequestReviewActivity" then {}
@@ -447,7 +488,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::ProvisionContainerActivity" then {}
         when "Activities::CloneRepoActivity" then {}
         when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
-        when "Activities::PreparePrPromptActivity" then { includes_review_threads: true }
+        when "Activities::PreparePrPromptActivity" then { includes_review_threads: true, review_thread_ids: [ "thread_1" ] }
         when "Activities::RunAgentActivity" then { success: true, has_changes: false, review_threads_already_addressed: true }
         when "Activities::ResolveReviewThreadsActivity" then {}
         when "Activities::MarkAgentRunCompleteActivity" then {}
@@ -478,7 +519,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
       expect(workflow).to have_received(:run_activity)
         .with(Activities::ResolveReviewThreadsActivity,
-          { agent_run_id: 42 },
+          { agent_run_id: 42, thread_ids: [ "thread_1" ] },
           timeout: 60)
     end
 

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -392,6 +392,28 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       end
     end
 
+    def stub_existing_pr_followup_legacy_prompt_result
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
+        when "Activities::ProvisionServicesActivity" then {}
+        when "Activities::ProvisionContainerActivity" then {}
+        when "Activities::CloneRepoActivity" then {}
+        when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
+        when "Activities::PreparePrPromptActivity" then {}
+        when "Activities::RunAgentActivity" then { success: true, has_changes: true }
+        when "Activities::PushBranchActivity" then {}
+        when "Activities::ResolveReviewThreadsActivity" then {}
+        when "Activities::CompleteExistingPrRunActivity" then { pr_review_phase: "ready" }
+        when "Activities::RequestReviewActivity" then {}
+        when "Activities::CleanupContainerActivity" then {}
+        when "Activities::CleanupServicesActivity" then {}
+        when "Activities::CleanupWorktreeActivity" then {}
+        else {}
+        end
+      end
+    end
+
     it "re-requests a review-bot review after pushing commits to a ready PR" do
       stub_existing_pr_followup(pr_review_phase: "ready")
 
@@ -449,6 +471,20 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::ResolveReviewThreadsActivity, anything, timeout: anything)
+    end
+
+    it "replays the legacy resolve activity after pushing commits when the workflow patch is not set" do
+      allow(Temporalio::Workflow).to receive(:patched).and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("resolve_review_threads_with_prompt_thread_ids").and_return(false)
+      stub_existing_pr_followup_legacy_prompt_result
+
+      workflow.execute(input)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::ResolveReviewThreadsActivity,
+          { agent_run_id: 42 },
+          timeout: 60)
     end
   end
 
@@ -521,6 +557,27 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       end
     end
 
+    def stub_no_changes_followup_legacy_prompt_result
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
+        when "Activities::ProvisionServicesActivity" then {}
+        when "Activities::ProvisionContainerActivity" then {}
+        when "Activities::CloneRepoActivity" then {}
+        when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
+        when "Activities::PreparePrPromptActivity" then { includes_review_threads: true }
+        when "Activities::RunAgentActivity" then { success: true, has_changes: false, review_threads_already_addressed: true }
+        when "Activities::ResolveReviewThreadsActivity" then {}
+        when "Activities::MarkAgentRunCompleteActivity" then {}
+        when "Activities::RequestReviewActivity" then {}
+        when "Activities::CleanupContainerActivity" then {}
+        when "Activities::CleanupServicesActivity" then {}
+        when "Activities::CleanupWorktreeActivity" then {}
+        else {}
+        end
+      end
+    end
+
     it "requests a review-bot review even when the agent makes no changes on an existing PR" do
       stub_no_changes_followup
 
@@ -559,6 +616,20 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::ResolveReviewThreadsActivity, anything, timeout: anything)
+    end
+
+    it "replays the legacy resolve activity on a no-change PR follow-up when the workflow patch is not set" do
+      allow(Temporalio::Workflow).to receive(:patched).and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("resolve_review_threads_with_prompt_thread_ids").and_return(false)
+      stub_no_changes_followup_legacy_prompt_result
+
+      workflow.execute(input)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::ResolveReviewThreadsActivity,
+          { agent_run_id: 42 },
+          timeout: 60)
     end
   end
 

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -427,8 +427,29 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::ProvisionContainerActivity" then {}
         when "Activities::CloneRepoActivity" then {}
         when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
-        when "Activities::PreparePrPromptActivity" then {}
+        when "Activities::PreparePrPromptActivity" then { includes_review_threads: false }
         when "Activities::RunAgentActivity" then { success: true, has_changes: false }
+        when "Activities::MarkAgentRunCompleteActivity" then {}
+        when "Activities::RequestReviewActivity" then {}
+        when "Activities::CleanupContainerActivity" then {}
+        when "Activities::CleanupServicesActivity" then {}
+        when "Activities::CleanupWorktreeActivity" then {}
+        else {}
+        end
+      end
+    end
+
+    def stub_no_changes_followup_with_marker
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
+        when "Activities::ProvisionServicesActivity" then {}
+        when "Activities::ProvisionContainerActivity" then {}
+        when "Activities::CloneRepoActivity" then {}
+        when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
+        when "Activities::PreparePrPromptActivity" then { includes_review_threads: true }
+        when "Activities::RunAgentActivity" then { success: true, has_changes: false, review_threads_already_addressed: true }
+        when "Activities::ResolveReviewThreadsActivity" then {}
         when "Activities::MarkAgentRunCompleteActivity" then {}
         when "Activities::RequestReviewActivity" then {}
         when "Activities::CleanupContainerActivity" then {}
@@ -448,6 +469,26 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         .with(Activities::RequestReviewActivity,
           { project_id: 1, pr_number: 42 },
           timeout: 60)
+    end
+
+    it "resolves review threads when a no-change PR follow-up reports they were already addressed" do
+      stub_no_changes_followup_with_marker
+
+      workflow.execute(input)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::ResolveReviewThreadsActivity,
+          { agent_run_id: 42 },
+          timeout: 60)
+    end
+
+    it "does not resolve review threads on a no-change PR follow-up unless the prompt included review threads" do
+      stub_no_changes_followup
+
+      workflow.execute(input)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::ResolveReviewThreadsActivity, anything, timeout: anything)
     end
   end
 


### PR DESCRIPTION
## Summary
- add an explicit marker for PR follow-up runs when unresolved review threads are already addressed and no code changes are needed
- persist the PR follow-up prompt version and only allow auto-resolution when the generated prompt actually included unresolved review threads
- teach the no-change PR workflow path to resolve review threads when that verified marker is present, with regression coverage for prompts, workflow behavior, and seeds

## Verification
- `COVERAGE=false bundle exec rspec spec/services/prompts/build_for_pr_spec.rb spec/temporal/activities/prepare_pr_prompt_activity_spec.rb spec/temporal/activities/run_agent_activity_spec.rb spec/temporal/workflows/agent_execution_workflow_spec.rb spec/db/seeds_prompts_spec.rb`
- `bundle exec rubocop app/services/prompts/build_for_pr.rb db/seeds/prompts.rb app/temporal/activities/prepare_pr_prompt_activity.rb app/temporal/activities/run_agent_activity.rb app/temporal/workflows/agent_execution_workflow.rb spec/services/prompts/build_for_pr_spec.rb spec/temporal/activities/prepare_pr_prompt_activity_spec.rb spec/temporal/activities/run_agent_activity_spec.rb spec/temporal/workflows/agent_execution_workflow_spec.rb spec/db/seeds_prompts_spec.rb`