### PR TITLE
Fix #1080: fix(automation): initial sync can start create_pr runs for existing PRs with only review-pending signals

### DIFF
--- a/app/temporal/activities/detect_labels_activity.rb
+++ b/app/temporal/activities/detect_labels_activity.rb
@@ -77,7 +77,9 @@ module Activities
       plan_label = project.label_for_stage(:plan)
       return { action: "start_planning", label: plan_label } if plan_label && issue.has_label?(plan_label)
 
-      if project.automation_on_label_enabled? && issue.has_label?(project.automation_label_name)
+      if project.automation_on_label_enabled? &&
+          !issue.is_pull_request? &&
+          issue.has_label?(project.automation_label_name)
         return { action: "execute_agent", label: project.automation_label_name }
       end
 

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -172,6 +172,7 @@ module Workflows
     def start_agent_workflow(project_id, issue_id, source_pull_request_number: nil)
       queue_input = { project_id: project_id, issue_id: issue_id }
       queue_input[:source_pull_request_number] = source_pull_request_number if source_pull_request_number
+      queue_input[:goal] = "create_pr" if source_pull_request_number
       run_activity(Activities::QueueAgentRunActivity, queue_input, timeout: 30)
     end
 
@@ -460,7 +461,8 @@ module Workflows
       unless Temporalio::Workflow.patched("draft-followup-direct-start-v1")
         run_activity(Activities::QueueAgentRunActivity,
           { project_id: project_id, issue_id: issue_id,
-            source_pull_request_number: pr_number }, timeout: 30)
+            source_pull_request_number: pr_number,
+            goal: "create_pr" }, timeout: 30)
         run_activity(Activities::RecordDraftReviewActivity,
           {
             issue_id: issue_id,
@@ -473,6 +475,7 @@ module Workflows
         project_id: project_id,
         issue_id: issue_id,
         source_pull_request_number: pr_number,
+        goal: "create_pr",
         count_toward_draft_review_round: true,
         expected_draft_review_count: pr_data[:current_draft_review_count]
       }, timeout: 30)
@@ -491,7 +494,8 @@ module Workflows
 
       run_activity(Activities::QueueAgentRunActivity,
         { project_id: project_id, issue_id: issue_id,
-          source_pull_request_number: pr_number }, timeout: 30)
+          source_pull_request_number: pr_number,
+          goal: "create_pr" }, timeout: 30)
       run_activity(Activities::RecordPrFollowupActivity, followup_input, timeout: 30)
     end
   end

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -169,10 +169,11 @@ module Workflows
       )
     end
 
+    # TODO(#1080): Remove patch guard after all pre-v1080 workflows have continued-as-new
     def start_agent_workflow(project_id, issue_id, source_pull_request_number: nil)
       queue_input = { project_id: project_id, issue_id: issue_id }
       queue_input[:source_pull_request_number] = source_pull_request_number if source_pull_request_number
-      queue_input[:goal] = "create_pr" if source_pull_request_number
+      queue_input[:goal] = "create_pr" if source_pull_request_number && Temporalio::Workflow.patched("queue-agent-run-goal-v1")
       run_activity(Activities::QueueAgentRunActivity, queue_input, timeout: 30)
     end
 
@@ -459,10 +460,10 @@ module Workflows
       # have continued-as-new past this point (i.e. no workflow history contains
       # the legacy queue-then-record command sequence).
       unless Temporalio::Workflow.patched("draft-followup-direct-start-v1")
-        run_activity(Activities::QueueAgentRunActivity,
-          { project_id: project_id, issue_id: issue_id,
-            source_pull_request_number: pr_number,
-            goal: "create_pr" }, timeout: 30)
+        legacy_input = { project_id: project_id, issue_id: issue_id,
+          source_pull_request_number: pr_number }
+        legacy_input[:goal] = "create_pr" if Temporalio::Workflow.patched("queue-agent-run-goal-v1")
+        run_activity(Activities::QueueAgentRunActivity, legacy_input, timeout: 30)
         run_activity(Activities::RecordDraftReviewActivity,
           {
             issue_id: issue_id,
@@ -471,14 +472,15 @@ module Workflows
         return
       end
 
-      run_activity(Activities::QueueAgentRunActivity, {
+      draft_input = {
         project_id: project_id,
         issue_id: issue_id,
         source_pull_request_number: pr_number,
-        goal: "create_pr",
         count_toward_draft_review_round: true,
         expected_draft_review_count: pr_data[:current_draft_review_count]
-      }, timeout: 30)
+      }
+      draft_input[:goal] = "create_pr" if Temporalio::Workflow.patched("queue-agent-run-goal-v1")
+      run_activity(Activities::QueueAgentRunActivity, draft_input, timeout: 30)
     end
 
     def start_pr_followup_workflow(project_id, pr_data)
@@ -492,10 +494,10 @@ module Workflows
         expected_followup_count: pr_data[:current_followup_count]
       }
 
-      run_activity(Activities::QueueAgentRunActivity,
-        { project_id: project_id, issue_id: issue_id,
-          source_pull_request_number: pr_number,
-          goal: "create_pr" }, timeout: 30)
+      followup_queue_input = { project_id: project_id, issue_id: issue_id,
+        source_pull_request_number: pr_number }
+      followup_queue_input[:goal] = "create_pr" if Temporalio::Workflow.patched("queue-agent-run-goal-v1")
+      run_activity(Activities::QueueAgentRunActivity, followup_queue_input, timeout: 30)
       run_activity(Activities::RecordPrFollowupActivity, followup_input, timeout: 30)
     end
   end

--- a/spec/temporal/activities/detect_labels_activity_spec.rb
+++ b/spec/temporal/activities/detect_labels_activity_spec.rb
@@ -249,17 +249,16 @@ RSpec.describe Activities::DetectLabelsActivity do
                is_pull_request: true, github_number: 42)
       end
 
-      it "returns execute_agent action with source_pull_request_number" do
+      it "returns none action" do
         result = activity.execute(project_id: project.id, issue_id: pull_request.id)
 
-        expect(result[:action]).to eq("execute_agent")
-        expect(result[:source_pull_request_number]).to eq(42)
+        expect(result[:action]).to eq("none")
       end
 
-      it "updates paid_state to in_progress" do
+      it "does not update paid_state" do
         activity.execute(project_id: project.id, issue_id: pull_request.id)
 
-        expect(pull_request.reload.paid_state).to eq("in_progress")
+        expect(pull_request.reload.paid_state).to eq("new")
       end
     end
 

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -168,6 +168,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
         .and_return({ queued: true })
       allow(Temporalio::Workflow).to receive(:start_child_workflow)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-agent-run-goal-v1")
+        .and_return(true)
     end
 
     it "queues execute_agent runs instead of starting them directly" do
@@ -188,6 +191,21 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(workflow).to have_received(:run_activity)
         .with(Activities::QueueAgentRunActivity,
           { project_id: project_id, issue_id: 10, source_pull_request_number: 42, goal: "create_pr" },
+          timeout: 30)
+    end
+
+    it "omits goal from queue input before the goal patch" do
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-agent-run-goal-v1")
+        .and_return(false)
+
+      detection = { action: "execute_agent", issue_id: 10, source_pull_request_number: 42 }
+
+      workflow.send(:handle_detection, detection, project_id)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 },
           timeout: 30)
     end
 
@@ -264,6 +282,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .and_return(true)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("escalation-reason-payload-v1")
+        .and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-agent-run-goal-v1")
         .and_return(true)
     end
 
@@ -473,6 +494,39 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
+    it "omits goal from legacy draft followup queue input before the goal patch" do
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("draft-followup-direct-start-v1")
+        .and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-agent-run-goal-v1")
+        .and_return(false)
+
+      workflow.send(:handle_pr_trigger, project_id,
+        draft_pr_data(current_draft_review_count: 1, triggers: [ { type: "ci_failure" } ]))
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 },
+          timeout: 30)
+    end
+
+    it "omits goal from patched draft followup queue input before the goal patch" do
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-agent-run-goal-v1")
+        .and_return(false)
+
+      workflow.send(:handle_pr_trigger, project_id,
+        draft_pr_data(current_draft_review_count: 1, triggers: [ { type: "ci_failure" } ]))
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          { project_id: project_id, issue_id: 10,
+            source_pull_request_number: 42,
+            count_toward_draft_review_round: true,
+            expected_draft_review_count: 1 }, timeout: 30)
+    end
+
     it "queues draft followup runs without incrementing draft review count yet" do
       workflow.send(:handle_pr_trigger, project_id,
         draft_pr_data(current_draft_review_count: 4, triggers: [ { type: "ci_failure" } ]))
@@ -517,6 +571,27 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::QueueAgentRunActivity,
           { project_id: project_id, issue_id: 10, source_pull_request_number: 42, goal: "create_pr" }, timeout: 30)
       expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
+    end
+
+    it "omits goal from ready-phase followup queue input before the goal patch" do
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-agent-run-goal-v1")
+        .and_return(false)
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
+
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "ready",
+        current_followup_count: 0,
+        triggers: [ { type: "ci_failure" } ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 }, timeout: 30)
     end
 
     it "routes review_bot_review_pending to RequestReviewActivity using the trigger's request_login" do
@@ -1030,6 +1105,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with("add-scan-security-alerts-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("add-check-knowledge-staleness-v1").and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-agent-run-goal-v1").and_return(true)
       allow(workflow).to receive(:interruptible_sleep)
       allow(workflow).to receive(:run_activity)
         .with(Activities::GetPollIntervalActivity, anything, timeout: anything)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -180,6 +180,17 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
+    it "queues create_pr explicitly for PR detections" do
+      detection = { action: "execute_agent", issue_id: 10, source_pull_request_number: 42 }
+
+      workflow.send(:handle_detection, detection, project_id)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42, goal: "create_pr" },
+          timeout: 30)
+    end
+
     it "starts PlanningWorkflow for start_planning action" do
       detection = { action: "start_planning", issue_id: 20 }
 
@@ -239,6 +250,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         project_id: project_id,
         issue_id: 10,
         source_pull_request_number: 42,
+        goal: "create_pr",
         count_toward_draft_review_round: true,
         expected_draft_review_count: count
       }
@@ -451,7 +463,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
       expect(workflow).to have_received(:run_activity)
         .with(Activities::QueueAgentRunActivity,
-          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 },
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42, goal: "create_pr" },
           timeout: 30)
       expect(workflow).to have_received(:run_activity)
         .with(Activities::RecordDraftReviewActivity,
@@ -503,7 +515,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
       expect(workflow).to have_received(:run_activity)
         .with(Activities::QueueAgentRunActivity,
-          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 }, timeout: 30)
+          { project_id: project_id, issue_id: 10, source_pull_request_number: 42, goal: "create_pr" }, timeout: 30)
       expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
@@ -977,6 +989,85 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::QueueAgentRunActivity,
           hash_including(count_toward_draft_review_round: true, expected_draft_review_count: 0),
           timeout: anything)
+    end
+  end
+
+  describe "initial sync for existing PRs" do
+    let(:workflow) { described_class.new }
+    let(:project_id) { 1 }
+
+    def stub_initial_sync(trigger_result:)
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::FetchIssuesActivity, { project_id: project_id }, timeout: 60)
+        .and_return(
+          { issues: [ { id: 10 } ], project_id: project_id },
+          { issues: [], project_id: project_id, project_missing: true }
+        )
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::DetectLabelsActivity, { project_id: project_id, issue_id: 10 }, timeout: 30)
+        .and_return({ action: "none", issue_id: 10, project_id: project_id })
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::ScanPaidPrsActivity, { project_id: project_id }, timeout: 120)
+        .and_return(trigger_result)
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
+    end
+
+    def execute_initial_sync(trigger_result:)
+      stub_initial_sync(trigger_result: trigger_result)
+      workflow.execute(project_id: project_id)
+    end
+
+    before do
+      allow(Temporalio::Workflow).to receive(:continue_as_new_suggested).and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched).and_call_original
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-rate-limit-budget-v1").and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-scan-paid-prs-v1").and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-scan-security-alerts-v1").and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-check-knowledge-staleness-v1").and_return(false)
+      allow(workflow).to receive(:interruptible_sleep)
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::GetPollIntervalActivity, anything, timeout: anything)
+        .and_return({ poll_interval_seconds: 60 })
+    end
+
+    it "queues a review run when paid_agent_review_pending is the only initial-sync PR signal" do
+      execute_initial_sync(trigger_result: {
+        prs_to_trigger: [
+          {
+            issue_id: 10,
+            pr_number: 42,
+            phase: "ready",
+            triggers: [ { type: "paid_agent_review_pending" } ]
+          }
+        ]
+      })
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(project_id: project_id, issue_id: 10,
+            source_pull_request_number: 42, goal: "review"),
+          timeout: 30)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(project_id: project_id, issue_id: 10,
+            source_pull_request_number: 42, goal: "create_pr"),
+          timeout: 30)
+    end
+
+    it "does not queue a create_pr run when an existing PR has no actionable initial-sync followup" do
+      execute_initial_sync(trigger_result: { prs_to_trigger: [] })
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(project_id: project_id, issue_id: 10,
+            source_pull_request_number: 42, goal: "create_pr"),
+          timeout: 30)
     end
   end
 end


### PR DESCRIPTION
## Summary

fix(automation): initial sync can start create_pr runs for existing PRs with only review-pending signals

See #1080 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1080