### PR TITLE
Fix #1040: feat(knowledge): extend secrets proxy to authenticate knowledge-run operations

### DIFF
--- a/app/controllers/api/secrets_proxy_controller.rb
+++ b/app/controllers/api/secrets_proxy_controller.rb
@@ -3,6 +3,7 @@
 module Api
   class SecretsProxyController < ActionController::API
     include Api::ContainerAuthentication
+    allow_knowledge_run_authentication!
 
     before_action :check_rate_limit
 
@@ -51,19 +52,19 @@ module Api
 
     def check_rate_limit
       limit = resolve_max_tokens_per_run
-      current_tokens = @agent_run.total_tokens
+      current_tokens = authenticated_run.total_tokens
 
       if current_tokens >= limit
         mark_token_limit_exceeded!(current_tokens:, limit:)
         render json: {
-          error: "Token limit exceeded for this agent run",
+          error: "Token limit exceeded for this #{authenticated_run_name}",
           token_usage: current_tokens,
           token_limit: limit
         }, status: :too_many_requests
         return
       end
 
-      warning_threshold = @agent_run.project.token_limit_warning_threshold
+      warning_threshold = authenticated_run.project.token_limit_warning_threshold
       warning_at = (limit * warning_threshold / 100.0).floor
       if current_tokens >= warning_at
         response.set_header("X-Token-Usage", current_tokens.to_s)
@@ -119,11 +120,13 @@ module Api
 
       TokenUsageTracker.track(
         agent_run: @agent_run,
+        knowledge_run: @knowledge_run,
         usage: {
           tokens_input: input_tokens,
           tokens_output: output_tokens,
           llm_model: model,
-          request_type: "agent"
+          request_type: token_usage_request_type,
+          metadata: token_usage_metadata
         }
       )
     rescue => e
@@ -161,7 +164,8 @@ module Api
     end
 
     def fetch_api_key(provider)
-      key = Rails.application.credentials.dig(:llm, :"#{provider}_api_key")
+      key = knowledge_run_api_key(provider)
+      key ||= Rails.application.credentials.dig(:llm, :"#{provider}_api_key")
       key ||= ENV["#{provider.to_s.upcase}_API_KEY"]
 
       unless key
@@ -174,18 +178,23 @@ module Api
     end
 
     def resolve_max_tokens_per_run
-      @max_tokens_per_run ||= @agent_run.effective_max_tokens_per_run
+      @max_tokens_per_run ||= authenticated_run.effective_max_tokens_per_run
     end
 
     def mark_token_limit_exceeded!(current_tokens:, limit:)
       status_changed = false
 
-      @agent_run.with_lock do
-        next if @agent_run.token_limit_status == "exceeded"
+      authenticated_run.with_lock do
+        next if authenticated_run.token_limit_status == "exceeded"
 
-        @agent_run.token_limit_status = "exceeded"
-        @agent_run.save!
+        authenticated_run.token_limit_status = "exceeded"
+        authenticated_run.save!
         status_changed = true
+      end
+
+      return unless status_changed
+
+      if @agent_run
         @agent_run.log!(
           "system",
           "Token limit exceeded: #{current_tokens} of #{limit} tokens used. " \
@@ -194,11 +203,10 @@ module Api
         )
       end
 
-      return unless status_changed
-
       Rails.logger.warn(
-        message: "agent_execution.token_limit_exceeded",
-        agent_run_id: @agent_run.id,
+        message: "#{logging_component}.token_limit_exceeded",
+        agent_run_id: @agent_run&.id,
+        knowledge_run_id: @knowledge_run&.id,
         current_tokens: current_tokens,
         hard_limit: limit
       )
@@ -208,8 +216,43 @@ module Api
       Rails.logger.error(
         message: message,
         agent_run_id: @agent_run&.id,
+        knowledge_run_id: @knowledge_run&.id,
         error: error
       )
+    end
+
+    def authenticated_run
+      @authenticated_run ||= @knowledge_run || @agent_run
+    end
+
+    def authenticated_run_name
+      @knowledge_run ? "knowledge run" : "agent run"
+    end
+
+    def logging_component
+      @knowledge_run ? "knowledge_execution" : "agent_execution"
+    end
+
+    def knowledge_run_api_key(provider)
+      return unless @knowledge_run
+
+      @knowledge_run.project
+        .effective_owner
+        &.provider_api_keys
+        &.for_api_service_type(provider.to_s)
+        &.order(created_at: :desc, id: :desc)
+        &.first
+        &.api_key
+    end
+
+    def token_usage_request_type
+      @knowledge_run ? "knowledge" : "agent"
+    end
+
+    def token_usage_metadata
+      return {} unless @knowledge_run
+
+      { operation_type: @knowledge_run.operation_type }
     end
   end
 end

--- a/app/controllers/concerns/api/container_authentication.rb
+++ b/app/controllers/concerns/api/container_authentication.rb
@@ -12,29 +12,52 @@ module Api
   #   end
   module ContainerAuthentication
     extend ActiveSupport::Concern
-    PROXY_CREDENTIAL_PREFIX = "paid-run".freeze
+    AGENT_RUN_PROXY_CREDENTIAL_PREFIX = "paid-run".freeze
+    KNOWLEDGE_RUN_PROXY_CREDENTIAL_PREFIX = "paid-knowledge-run".freeze
 
     included do
+      class_attribute :knowledge_run_authentication_enabled, instance_accessor: false, default: false
+
       before_action :validate_container_request
-      before_action :set_agent_run
+      before_action :set_authenticated_run
       before_action :verify_proxy_token
+    end
+
+    class_methods do
+      def allow_knowledge_run_authentication!
+        self.knowledge_run_authentication_enabled = true
+      end
     end
 
     private
 
     def validate_container_request
-      @agent_run_id, @embedded_proxy_token = extract_embedded_proxy_credentials
-      @agent_run_id ||= request.headers["X-Agent-Run-Id"]
+      embedded_run_type, embedded_run_id, @embedded_proxy_token = extract_embedded_proxy_credentials
+      header_run_type, header_run_id = extract_header_run_identity
 
-      render json: { error: "Missing agent run ID" }, status: :unauthorized unless @agent_run_id.present?
+      @authenticated_run_type = embedded_run_type || header_run_type
+      @authenticated_run_id = embedded_run_id || header_run_id
+
+      return if @authenticated_run_id.present?
+
+      render json: { error: missing_run_id_error }, status: :unauthorized
     end
 
-    def set_agent_run
+    def set_authenticated_run
       return if performed?
 
-      @agent_run = AgentRun.find_by(id: @agent_run_id)
+      case @authenticated_run_type
+      when :knowledge_run
+        @knowledge_run = KnowledgeRun.find_by(id: @authenticated_run_id)
+        @authenticated_run = @knowledge_run
+        error_message = "Invalid or inactive knowledge run"
+      else
+        @agent_run = AgentRun.find_by(id: @authenticated_run_id)
+        @authenticated_run = @agent_run
+        error_message = "Invalid or inactive agent run"
+      end
 
-      render json: { error: "Invalid or inactive agent run" }, status: :forbidden unless @agent_run&.active?
+      render json: { error: error_message }, status: :forbidden unless @authenticated_run&.active?
     end
 
     def verify_proxy_token
@@ -46,7 +69,7 @@ module Api
         render(json: { error: "Invalid proxy token" }, status: :forbidden) and return
       end
 
-      stored_token = @agent_run.ensure_proxy_token!
+      stored_token = @authenticated_run.ensure_proxy_token!
 
       unless ActiveSupport::SecurityUtils.secure_compare(provided_token, stored_token)
         render json: { error: "Invalid proxy token" }, status: :forbidden
@@ -58,11 +81,36 @@ module Api
         parse_proxy_credential(request.headers["X-Goog-Api-Key"])
     end
 
-    def parse_proxy_credential(value)
-      match = value.to_s.match(/\A#{PROXY_CREDENTIAL_PREFIX}:(\d+):([0-9a-f]+)\z/i)
-      return unless match
+    def extract_header_run_identity
+      agent_run_id = request.headers["X-Agent-Run-Id"] || params[:agent_run_id]
+      return [ :agent_run, agent_run_id ] if agent_run_id.present?
 
-      [ match[1], match[2] ]
+      knowledge_run_id = request.headers["X-Knowledge-Run-Id"] || params[:knowledge_run_id]
+      return [ :knowledge_run, knowledge_run_id ] if knowledge_run_authentication_enabled? && knowledge_run_id.present?
+
+      [ nil, nil ]
+    end
+
+    def parse_proxy_credential(value)
+      agent_run_match = value.to_s.match(/\A#{AGENT_RUN_PROXY_CREDENTIAL_PREFIX}:(\d+):([0-9a-f]+)\z/i)
+      return [ :agent_run, agent_run_match[1], agent_run_match[2] ] if agent_run_match
+
+      knowledge_run_match = value.to_s.match(/\A#{KNOWLEDGE_RUN_PROXY_CREDENTIAL_PREFIX}:(\d+):([0-9a-f]+)\z/i)
+      return [ :knowledge_run, knowledge_run_match[1], knowledge_run_match[2] ] if knowledge_run_authentication_enabled? && knowledge_run_match
+
+      nil
+    end
+
+    def knowledge_run_authentication_enabled?
+      self.class.knowledge_run_authentication_enabled
+    end
+
+    def missing_run_id_error
+      if knowledge_run_authentication_enabled?
+        "Missing agent run ID or knowledge run ID"
+      else
+        "Missing agent run ID"
+      end
     end
   end
 end

--- a/app/models/knowledge_run.rb
+++ b/app/models/knowledge_run.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class KnowledgeRun < ApplicationRecord
+  STATUSES = %w[pending running completed failed].freeze
+  ACTIVE_STATUSES = %w[pending running].freeze
+  OPERATION_TYPES = %w[embedding decision_drafting].freeze
+  TOKEN_LIMIT_STATUSES = AgentRun::TOKEN_LIMIT_STATUSES
+  DEFAULT_MAX_TOKENS_PER_RUN = 10_000
+
+  belongs_to :project
+  has_many :token_usages, dependent: :destroy
+
+  before_create :generate_proxy_token
+
+  validates :operation_type, presence: true, inclusion: { in: OPERATION_TYPES }
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :token_limit_status, inclusion: { in: TOKEN_LIMIT_STATUSES }, allow_nil: true
+  validates :final_provider, length: { maximum: 50 }
+  validates :max_tokens, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :total_tokens, numericality: { greater_than_or_equal_to: 0 }
+
+  scope :active, -> { where(status: ACTIVE_STATUSES) }
+
+  def active?
+    ACTIVE_STATUSES.include?(status)
+  end
+
+  def effective_max_tokens_per_run
+    max_tokens || DEFAULT_MAX_TOKENS_PER_RUN
+  end
+
+  def ensure_proxy_token!
+    return proxy_token if proxy_token.present?
+
+    token = SecureRandom.hex(32)
+    updated_rows = self.class.where(id: id, proxy_token: nil).update_all(proxy_token: token)
+
+    if updated_rows == 1
+      self.proxy_token = token
+    else
+      reload
+    end
+
+    proxy_token
+  end
+
+  private
+
+  def generate_proxy_token
+    self.proxy_token ||= SecureRandom.hex(32)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -104,6 +104,7 @@ class Project < ApplicationRecord
   has_many :project_service_containers, dependent: :destroy
   has_many :service_containers, through: :project_service_containers
   has_many :decision_records, dependent: :destroy
+  has_many :knowledge_runs, dependent: :destroy
   has_many :project_mcp_servers, dependent: :destroy
   has_many :mcp_server_definitions, through: :project_mcp_servers
   has_many :pre_commit_requirements, dependent: :destroy

--- a/app/models/token_usage.rb
+++ b/app/models/token_usage.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
 class TokenUsage < ApplicationRecord
-  REQUEST_TYPES = %w[agent planning evaluation run_summary run_delta].freeze
+  REQUEST_TYPES = %w[agent planning evaluation run_summary run_delta knowledge].freeze
 
-  belongs_to :agent_run
+  belongs_to :agent_run, optional: true
+  belongs_to :knowledge_run, optional: true
 
   validates :request_type, presence: true, inclusion: { in: REQUEST_TYPES }
   validates :input_tokens, numericality: { greater_than_or_equal_to: 0 }
   validates :output_tokens, numericality: { greater_than_or_equal_to: 0 }
   validates :cost_cents, numericality: { greater_than_or_equal_to: 0 }
   validates :llm_model, length: { maximum: 100 }
+  validate :exactly_one_run_present
 
-  scope :by_project, ->(project_id) { joins(:agent_run).where(agent_runs: { project_id: project_id }) }
+  scope :by_project, lambda { |project_id|
+    left_outer_joins(:agent_run, :knowledge_run)
+      .where("agent_runs.project_id = :project_id OR knowledge_runs.project_id = :project_id", project_id: project_id)
+  }
   scope :by_model, ->(llm_model) { where(llm_model: llm_model) }
   scope :by_request_type, ->(type) { where(request_type: type) }
   scope :by_time_period, ->(start_time, end_time) { where(created_at: start_time..end_time) }
@@ -26,7 +31,7 @@ class TokenUsage < ApplicationRecord
   # (e.g., by_time_period(...).billable) doesn't affect which runs are
   # considered to have proxy records.
   scope :billable, -> {
-    runs_with_proxy = unscoped.where.not(request_type: "run_summary").select(:agent_run_id).distinct
+    runs_with_proxy = unscoped.where.not(request_type: "run_summary").where.not(agent_run_id: nil).select(:agent_run_id).distinct
     where.not(request_type: "run_summary")
       .or(where(request_type: "run_summary").where.not(agent_run_id: runs_with_proxy))
   }
@@ -59,5 +64,13 @@ class TokenUsage < ApplicationRecord
     where(created_at: days.days.ago..)
       .group(Arel.sql("DATE(token_usages.created_at)"))
       .sum(:cost_cents)
+  end
+
+  private
+
+  def exactly_one_run_present
+    return if agent_run.present? ^ knowledge_run.present?
+
+    errors.add(:base, "must belong to exactly one run")
   end
 end

--- a/app/services/token_usage_tracker.rb
+++ b/app/services/token_usage_tracker.rb
@@ -18,7 +18,7 @@ class TokenUsageTracker
     tokens_input  = usage.fetch(:tokens_input, 0).to_i
     tokens_output = usage.fetch(:tokens_output, 0).to_i
     llm_model     = usage[:llm_model]
-    request_type  = usage.fetch(:request_type, nil).presence || "agent"
+    request_type  = usage.fetch(:request_type, nil).presence || default_request_type_for(tracked_run)
     metadata      = usage.fetch(:metadata, nil).presence || {}
     cost_cents    = calculate_cost(tokens_input, tokens_output, llm_model: llm_model)
     resolved_hard_limit = tracked_run.effective_max_tokens_per_run if update_aggregates
@@ -185,6 +185,11 @@ class TokenUsageTracker
     end
   end
   private_class_method :update_run_aggregates
+
+  def self.default_request_type_for(tracked_run)
+    tracked_run.is_a?(KnowledgeRun) ? "knowledge" : "agent"
+  end
+  private_class_method :default_request_type_for
 
   def self.record_usage_log(tracked_run, tokens_input:, tokens_output:, cost_cents:, llm_model:, request_type:)
     return unless tracked_run.is_a?(AgentRun)

--- a/app/services/token_usage_tracker.rb
+++ b/app/services/token_usage_tracker.rb
@@ -5,25 +5,28 @@ class TokenUsageTracker
   DEFAULT_INPUT_COST_PER_MILLION = BigDecimal("3.00")
   DEFAULT_OUTPUT_COST_PER_MILLION = BigDecimal("15.00")
 
-  # Tracks token usage for an agent run request.
+  # Tracks token usage for an agent run or knowledge run request.
   #
-  # @param agent_run [AgentRun] the run to attribute usage to
+  # @param agent_run [AgentRun, nil] the agent run to attribute usage to
+  # @param knowledge_run [KnowledgeRun, nil] the knowledge run to attribute usage to
   # @param usage [Hash] token data (:tokens_input, :tokens_output, :llm_model, :request_type, :metadata)
   # @param update_aggregates [Boolean] when false, only creates a TokenUsage record without
   #   updating agent_run/project counters or cost budgets (use for run_summary records
   #   that would otherwise double-count per-request tracking from the secrets proxy)
-  def self.track(agent_run:, usage:, update_aggregates: true)
+  def self.track(agent_run: nil, knowledge_run: nil, usage:, update_aggregates: true)
+    tracked_run = resolve_tracked_run!(agent_run:, knowledge_run:)
     tokens_input  = usage.fetch(:tokens_input, 0).to_i
     tokens_output = usage.fetch(:tokens_output, 0).to_i
     llm_model     = usage[:llm_model]
     request_type  = usage.fetch(:request_type, nil).presence || "agent"
     metadata      = usage.fetch(:metadata, nil).presence || {}
     cost_cents    = calculate_cost(tokens_input, tokens_output, llm_model: llm_model)
-    resolved_hard_limit = agent_run.effective_max_tokens_per_run if update_aggregates
+    resolved_hard_limit = tracked_run.effective_max_tokens_per_run if update_aggregates
 
     ActiveRecord::Base.transaction do
       record_per_request_usage(
         agent_run: agent_run,
+        knowledge_run: knowledge_run,
         input_tokens: tokens_input,
         output_tokens: tokens_output,
         cost_cents: cost_cents,
@@ -33,45 +36,37 @@ class TokenUsageTracker
       )
 
       if update_aggregates
-        agent_run.with_lock do
-          agent_run.increment(:tokens_input, tokens_input)
-          agent_run.increment(:tokens_output, tokens_output)
-          agent_run.increment(:cost_cents, cost_cents)
-          apply_token_limit_status(agent_run, hard_limit: resolved_hard_limit)
-          agent_run.save!
+        tracked_run.with_lock do
+          update_run_aggregates(tracked_run, tokens_input:, tokens_output:, cost_cents:)
+          apply_token_limit_status(tracked_run, hard_limit: resolved_hard_limit)
+          tracked_run.save!
         end
 
-        agent_run.project.increment_metrics!(
+        tracked_run.project.increment_metrics!(
           cost_cents: cost_cents,
           tokens_used: tokens_input + tokens_output
         )
 
-        update_cost_budgets(agent_run.project, cost_cents)
+        update_cost_budgets(tracked_run.project, cost_cents)
       end
 
-      agent_run.log!("metric", {
-        tokens_input: tokens_input,
-        tokens_output: tokens_output,
-        cost_cents: cost_cents,
-        llm_model: llm_model,
-        request_type: request_type
-      }.to_json, metadata: { type: "token_usage" })
+      record_usage_log(tracked_run, tokens_input:, tokens_output:, cost_cents:, llm_model:, request_type:)
     end
 
     # Enforce hard-stop budgets *after* the transaction commits so that:
     # 1. Row locks from the usage write are already released
     # 2. External side-effects (Temporal cancel, container cleanup) don't
     #    run inside a transaction — a failure won't roll back recorded usage
-    enforce_hard_stop_budgets(agent_run) if update_aggregates && cost_cents.positive?
+    enforce_hard_stop_budgets(tracked_run) if update_aggregates && cost_cents.positive? && agent_run.present?
   end
 
   # Evaluates the agent run's cumulative token usage against project limits
   # and updates the token_limit_status field. Logs warnings at the soft
   # threshold and records "exceeded" at the hard limit.
-  def self.apply_token_limit_status(agent_run, hard_limit:)
-    warning_threshold = agent_run.project.token_limit_warning_threshold
+  def self.apply_token_limit_status(tracked_run, hard_limit:)
+    warning_threshold = tracked_run.project.token_limit_warning_threshold
     warning_at = (hard_limit * warning_threshold / 100.0).floor
-    current_tokens = agent_run.total_tokens
+    current_tokens = tracked_run.total_tokens
 
     new_status = if current_tokens >= hard_limit
       "exceeded"
@@ -81,43 +76,45 @@ class TokenUsageTracker
       "ok"
     end
 
-    previous_status = agent_run.token_limit_status
+    previous_status = tracked_run.token_limit_status
 
     return if new_status == previous_status
 
-    agent_run.token_limit_status = new_status
+    tracked_run.token_limit_status = new_status
 
     if new_status == "warning" && previous_status != "warning"
-      agent_run.log!(
-        "system",
-        "Token usage warning: #{current_tokens} of #{hard_limit} tokens used " \
-        "(#{(current_tokens * 100.0 / hard_limit).round(1)}%). " \
-        "Run will be stopped at #{hard_limit} tokens.",
-        metadata: { type: "token_limit_warning" }
-      )
+      record_limit_log(tracked_run, "warning", current_tokens:, hard_limit:)
       Rails.logger.warn(
-        message: "agent_execution.token_limit_warning",
-        agent_run_id: agent_run.id,
-        current_tokens: current_tokens,
-        hard_limit: hard_limit,
-        usage_percent: (current_tokens * 100.0 / hard_limit).round(1)
+        log_payload_for(
+          tracked_run,
+          message: "#{logging_component_for(tracked_run)}.token_limit_warning",
+          current_tokens: current_tokens,
+          hard_limit: hard_limit,
+          usage_percent: (current_tokens * 100.0 / hard_limit).round(1)
+        )
       )
     elsif new_status == "exceeded"
-      agent_run.log!(
-        "system",
-        "Token limit exceeded: #{current_tokens} of #{hard_limit} tokens used. " \
-        "Agent will be stopped after the current operation completes.",
-        metadata: { type: "token_limit_exceeded" }
-      )
+      record_limit_log(tracked_run, "exceeded", current_tokens:, hard_limit:)
       Rails.logger.warn(
-        message: "agent_execution.token_limit_exceeded",
-        agent_run_id: agent_run.id,
-        current_tokens: current_tokens,
-        hard_limit: hard_limit
+        log_payload_for(
+          tracked_run,
+          message: "#{logging_component_for(tracked_run)}.token_limit_exceeded",
+          current_tokens: current_tokens,
+          hard_limit: hard_limit
+        )
       )
     end
   end
   private_class_method :apply_token_limit_status
+
+  def self.log_payload_for(tracked_run, message:, **extra)
+    {
+      message: message,
+      agent_run_id: tracked_run.is_a?(AgentRun) ? tracked_run.id : nil,
+      knowledge_run_id: tracked_run.is_a?(KnowledgeRun) ? tracked_run.id : nil
+    }.merge(extra)
+  end
+  private_class_method :log_payload_for
 
   # Thread-safe in-memory cache of LlmModel records keyed by model_id string.
   # Avoids a DB query per tracked request in the high-volume proxy path.
@@ -156,9 +153,10 @@ class TokenUsageTracker
   end
   private_class_method :lookup_model
 
-  def self.record_per_request_usage(agent_run:, input_tokens:, output_tokens:, cost_cents:, llm_model:, request_type:, metadata:)
+  def self.record_per_request_usage(agent_run:, knowledge_run:, input_tokens:, output_tokens:, cost_cents:, llm_model:, request_type:, metadata:)
     TokenUsage.create!(
       agent_run: agent_run,
+      knowledge_run: knowledge_run,
       input_tokens: input_tokens,
       output_tokens: output_tokens,
       cost_cents: cost_cents,
@@ -168,6 +166,64 @@ class TokenUsageTracker
     )
   end
   private_class_method :record_per_request_usage
+
+  def self.resolve_tracked_run!(agent_run:, knowledge_run:)
+    return agent_run if agent_run.present? && knowledge_run.blank?
+    return knowledge_run if knowledge_run.present? && agent_run.blank?
+
+    raise ArgumentError, "expected exactly one of agent_run or knowledge_run"
+  end
+  private_class_method :resolve_tracked_run!
+
+  def self.update_run_aggregates(tracked_run, tokens_input:, tokens_output:, cost_cents:)
+    if tracked_run.is_a?(AgentRun)
+      tracked_run.increment(:tokens_input, tokens_input)
+      tracked_run.increment(:tokens_output, tokens_output)
+      tracked_run.increment(:cost_cents, cost_cents)
+    else
+      tracked_run.increment(:total_tokens, tokens_input + tokens_output)
+    end
+  end
+  private_class_method :update_run_aggregates
+
+  def self.record_usage_log(tracked_run, tokens_input:, tokens_output:, cost_cents:, llm_model:, request_type:)
+    return unless tracked_run.is_a?(AgentRun)
+
+    tracked_run.log!("metric", {
+      tokens_input: tokens_input,
+      tokens_output: tokens_output,
+      cost_cents: cost_cents,
+      llm_model: llm_model,
+      request_type: request_type
+    }.to_json, metadata: { type: "token_usage" })
+  end
+  private_class_method :record_usage_log
+
+  def self.record_limit_log(tracked_run, state, current_tokens:, hard_limit:)
+    return unless tracked_run.is_a?(AgentRun)
+
+    message =
+      if state == "warning"
+        "Token usage warning: #{current_tokens} of #{hard_limit} tokens used " \
+          "(#{(current_tokens * 100.0 / hard_limit).round(1)}%). " \
+          "Run will be stopped at #{hard_limit} tokens."
+      else
+        "Token limit exceeded: #{current_tokens} of #{hard_limit} tokens used. " \
+          "Agent will be stopped after the current operation completes."
+      end
+
+    tracked_run.log!(
+      "system",
+      message,
+      metadata: { type: "token_limit_#{state}" }
+    )
+  end
+  private_class_method :record_limit_log
+
+  def self.logging_component_for(tracked_run)
+    tracked_run.is_a?(KnowledgeRun) ? "knowledge_execution" : "agent_execution"
+  end
+  private_class_method :logging_component_for
 
   def self.update_cost_budgets(project, cost_cents)
     # Only update daily/monthly budgets. Per-run budgets are enforced by

--- a/app/views/projects/_stats.html.erb
+++ b/app/views/projects/_stats.html.erb
@@ -21,14 +21,15 @@
       </div>
     <% end %>
     <% now = local_assigns.fetch(:now, Time.current) %>
-    <% monthly_cost_cents = local_assigns.fetch(:monthly_cost_cents, project.token_usages.billable.by_time_period(now.beginning_of_month, now).total_cost_cents) %>
+    <% project_token_usages = local_assigns.fetch(:project_token_usages, TokenUsage.billable.by_project(project.id)) %>
+    <% monthly_cost_cents = local_assigns.fetch(:monthly_cost_cents, project_token_usages.by_time_period(now.beginning_of_month, now).total_cost_cents) %>
     <% if monthly_cost_cents > 0 %>
       <div class="flex items-center gap-1.5 px-4 py-3">
         <span class="font-medium text-gray-500">This Month:</span>
         <span class="font-semibold text-gray-900">$<%= format("%.2f", monthly_cost_cents / 100.0) %></span>
       </div>
     <% end %>
-    <% today_cost_cents = local_assigns.fetch(:today_cost_cents, project.token_usages.billable.by_time_period(now.beginning_of_day, now).total_cost_cents) %>
+    <% today_cost_cents = local_assigns.fetch(:today_cost_cents, project_token_usages.by_time_period(now.beginning_of_day, now).total_cost_cents) %>
     <% if today_cost_cents > 0 %>
       <div class="flex items-center gap-1.5 px-4 py-3">
         <span class="font-medium text-gray-500">Today:</span>

--- a/db/migrate/20260413191015_create_knowledge_runs.rb
+++ b/db/migrate/20260413191015_create_knowledge_runs.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateKnowledgeRuns < ActiveRecord::Migration[8.1]
+  def change
+    create_table :knowledge_runs do |t|
+      t.references :project, null: false, foreign_key: { on_delete: :cascade }
+      t.string :operation_type, limit: 50, null: false
+      t.string :status, limit: 50, null: false, default: "pending"
+      t.string :final_provider, limit: 50
+      t.jsonb :provider_attempts, null: false, default: []
+      t.integer :total_tokens, null: false, default: 0
+      t.string :proxy_token, limit: 64
+      t.string :token_limit_status, limit: 50
+      t.integer :max_tokens
+
+      t.timestamps
+    end
+
+    add_index :knowledge_runs, :proxy_token, unique: true
+    add_index :knowledge_runs, [ :project_id, :status ]
+  end
+end

--- a/db/migrate/20260413191016_add_knowledge_run_to_token_usages.rb
+++ b/db/migrate/20260413191016_add_knowledge_run_to_token_usages.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddKnowledgeRunToTokenUsages < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :token_usages, :knowledge_run, null: true, foreign_key: { on_delete: :cascade }
+    change_column_null :token_usages, :agent_run_id, true
+
+    add_check_constraint :token_usages,
+      "(agent_run_id IS NOT NULL) <> (knowledge_run_id IS NOT NULL)",
+      name: "token_usages_exactly_one_run"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1031,10 +1031,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_191016) do
     t.integer "github_token_cache_ttl_minutes", default: 60, null: false
     t.integer "issue_goal_idle_timeout_seconds", default: 120, null: false
     t.integer "issue_goal_timeout_seconds", default: 600, null: false
-    t.jsonb "kb_chat_fallback_providers", default: [], null: false
-    t.string "kb_chat_provider", default: "claude", null: false
-    t.jsonb "kb_embedding_fallback_providers", default: [], null: false
-    t.string "kb_embedding_provider", default: "openai", null: false
     t.integer "max_comment_length", default: 2000, null: false
     t.integer "max_concurrent_runs", default: 2, null: false
     t.integer "max_issues_per_page", default: 50, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_191016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -561,6 +561,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
     t.index ["target_chunk_id"], name: "index_knowledge_links_on_target_chunk_id"
   end
 
+  create_table "knowledge_runs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "final_provider", limit: 50
+    t.integer "max_tokens"
+    t.string "operation_type", limit: 50, null: false
+    t.bigint "project_id", null: false
+    t.jsonb "provider_attempts", default: [], null: false
+    t.string "proxy_token", limit: 64
+    t.string "status", limit: 50, default: "pending", null: false
+    t.string "token_limit_status", limit: 50
+    t.integer "total_tokens", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "status"], name: "index_knowledge_runs_on_project_id_and_status"
+    t.index ["project_id"], name: "index_knowledge_runs_on_project_id"
+    t.index ["proxy_token"], name: "index_knowledge_runs_on_proxy_token", unique: true
+  end
+
   create_table "linear_tokens", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "created_at", null: false
@@ -975,10 +992,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
   end
 
   create_table "token_usages", force: :cascade do |t|
-    t.bigint "agent_run_id", null: false
+    t.bigint "agent_run_id"
     t.integer "cost_cents", default: 0, null: false
     t.datetime "created_at", null: false
     t.integer "input_tokens", default: 0, null: false
+    t.bigint "knowledge_run_id"
     t.string "llm_model", limit: 100
     t.jsonb "metadata", default: {}, null: false
     t.integer "output_tokens", default: 0, null: false
@@ -986,8 +1004,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
     t.datetime "updated_at", null: false
     t.index ["agent_run_id", "request_type"], name: "index_token_usages_on_agent_run_id_and_request_type"
     t.index ["created_at"], name: "index_token_usages_on_created_at"
+    t.index ["knowledge_run_id"], name: "index_token_usages_on_knowledge_run_id"
     t.index ["llm_model"], name: "index_token_usages_on_llm_model"
     t.index ["request_type"], name: "index_token_usages_on_request_type"
+    t.check_constraint "(agent_run_id IS NOT NULL) <> (knowledge_run_id IS NOT NULL)", name: "token_usages_exactly_one_run"
   end
 
   create_table "user_settings", force: :cascade do |t|
@@ -1011,6 +1031,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
     t.integer "github_token_cache_ttl_minutes", default: 60, null: false
     t.integer "issue_goal_idle_timeout_seconds", default: 120, null: false
     t.integer "issue_goal_timeout_seconds", default: 600, null: false
+    t.jsonb "kb_chat_fallback_providers", default: [], null: false
+    t.string "kb_chat_provider", default: "claude", null: false
+    t.jsonb "kb_embedding_fallback_providers", default: [], null: false
+    t.string "kb_embedding_provider", default: "openai", null: false
     t.integer "max_comment_length", default: 2000, null: false
     t.integer "max_concurrent_runs", default: 2, null: false
     t.integer "max_issues_per_page", default: 50, null: false
@@ -1125,6 +1149,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
   add_foreign_key "knowledge_chunks", "projects"
   add_foreign_key "knowledge_links", "knowledge_chunks", column: "source_chunk_id", on_delete: :cascade
   add_foreign_key "knowledge_links", "knowledge_chunks", column: "target_chunk_id", on_delete: :cascade
+  add_foreign_key "knowledge_runs", "projects", on_delete: :cascade
   add_foreign_key "linear_tokens", "accounts"
   add_foreign_key "linear_tokens", "users", column: "created_by_id"
   add_foreign_key "mcp_server_definitions", "accounts"
@@ -1162,6 +1187,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
   add_foreign_key "style_guides", "accounts", on_delete: :cascade
   add_foreign_key "style_guides", "projects", on_delete: :cascade
   add_foreign_key "token_usages", "agent_runs", on_delete: :cascade
+  add_foreign_key "token_usages", "knowledge_runs", on_delete: :cascade
   add_foreign_key "user_settings", "users"
   add_foreign_key "users", "accounts"
   add_foreign_key "workflow_states", "projects"

--- a/spec/factories/knowledge_runs.rb
+++ b/spec/factories/knowledge_runs.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :knowledge_run do
+    project
+    operation_type { "embedding" }
+    status { "pending" }
+    final_provider { nil }
+    provider_attempts { [] }
+    total_tokens { 0 }
+    proxy_token { SecureRandom.hex(32) }
+    token_limit_status { nil }
+    max_tokens { nil }
+
+    trait :running do
+      status { "running" }
+    end
+
+    trait :completed do
+      status { "completed" }
+    end
+
+    trait :failed do
+      status { "failed" }
+    end
+
+    trait :decision_drafting do
+      operation_type { "decision_drafting" }
+    end
+  end
+end

--- a/spec/factories/token_usages.rb
+++ b/spec/factories/token_usages.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :token_usage do
     agent_run
+    knowledge_run { nil }
     request_type { "agent" }
     input_tokens { 1000 }
     output_tokens { 500 }
@@ -16,6 +17,12 @@ FactoryBot.define do
 
     trait :evaluation do
       request_type { "evaluation" }
+    end
+
+    trait :knowledge do
+      agent_run { nil }
+      knowledge_run
+      request_type { "knowledge" }
     end
 
     trait :large do

--- a/spec/models/knowledge_run_spec.rb
+++ b/spec/models/knowledge_run_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe KnowledgeRun do
+  describe "associations" do
+    it { is_expected.to belong_to(:project) }
+    it { is_expected.to have_many(:token_usages).dependent(:destroy) }
+  end
+
+  describe "validations" do
+    subject(:knowledge_run) { build(:knowledge_run) }
+
+    it { is_expected.to validate_inclusion_of(:operation_type).in_array(described_class::OPERATION_TYPES) }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+    it { is_expected.to validate_inclusion_of(:token_limit_status).in_array(described_class::TOKEN_LIMIT_STATUSES).allow_nil }
+    it { is_expected.to validate_numericality_of(:total_tokens).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_numericality_of(:max_tokens).only_integer.is_greater_than(0).allow_nil }
+  end
+
+  describe "#active?" do
+    it "returns true for pending runs" do
+      expect(build(:knowledge_run, status: "pending")).to be_active
+    end
+
+    it "returns false for completed runs" do
+      expect(build(:knowledge_run, status: "completed")).not_to be_active
+    end
+  end
+
+  describe "#effective_max_tokens_per_run" do
+    it "uses the explicit max_tokens when present" do
+      expect(build(:knowledge_run, max_tokens: 1234).effective_max_tokens_per_run).to eq(1234)
+    end
+
+    it "falls back to the knowledge default" do
+      expect(build(:knowledge_run, max_tokens: nil).effective_max_tokens_per_run).to eq(described_class::DEFAULT_MAX_TOKENS_PER_RUN)
+    end
+  end
+
+  describe "#ensure_proxy_token!" do
+    it "returns the existing token when present" do
+      knowledge_run = create(:knowledge_run)
+
+      expect(knowledge_run.ensure_proxy_token!).to eq(knowledge_run.proxy_token)
+    end
+
+    it "generates and persists a token when proxy_token is nil" do
+      knowledge_run = create(:knowledge_run)
+      knowledge_run.update_column(:proxy_token, nil)
+
+      token = knowledge_run.ensure_proxy_token!
+
+      expect(token).to be_present
+      expect(knowledge_run.reload.proxy_token).to eq(token)
+    end
+  end
+end

--- a/spec/models/token_usage_spec.rb
+++ b/spec/models/token_usage_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe TokenUsage do
   describe "associations" do
-    it { is_expected.to belong_to(:agent_run) }
+    it { is_expected.to belong_to(:agent_run).optional }
+    it { is_expected.to belong_to(:knowledge_run).optional }
   end
 
   describe "validations" do
@@ -16,6 +17,17 @@ RSpec.describe TokenUsage do
     it { is_expected.to validate_numericality_of(:output_tokens).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_numericality_of(:cost_cents).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_length_of(:llm_model).is_at_most(100) }
+
+    it "requires exactly one run association" do
+      usage = build(:token_usage, agent_run: nil, knowledge_run: nil)
+      expect(usage).not_to be_valid
+
+      usage = build(:token_usage, agent_run: nil, knowledge_run: create(:knowledge_run, :running))
+      expect(usage).to be_valid
+
+      usage.agent_run = create(:agent_run, :running)
+      expect(usage).not_to be_valid
+    end
   end
 
   describe "#total_tokens" do
@@ -31,12 +43,14 @@ RSpec.describe TokenUsage do
         project = create(:project)
         agent_run = create(:agent_run, :running, project: project)
         usage = create(:token_usage, agent_run: agent_run)
+        knowledge_run = create(:knowledge_run, :running, project: project)
+        knowledge_usage = create(:token_usage, :knowledge, knowledge_run: knowledge_run)
 
         other_project = create(:project)
         other_run = create(:agent_run, :running, project: other_project)
         create(:token_usage, agent_run: other_run)
 
-        expect(described_class.by_project(project.id)).to contain_exactly(usage)
+        expect(described_class.by_project(project.id)).to contain_exactly(usage, knowledge_usage)
       end
     end
 

--- a/spec/requests/api/secrets_proxy_spec.rb
+++ b/spec/requests/api/secrets_proxy_spec.rb
@@ -210,6 +210,26 @@ RSpec.describe "Api::SecretsProxy" do
         expect(body["error"]).to include("not configured")
       end
     end
+
+    context "with a knowledge run and a project owner API key" do
+      let(:owner) { project.effective_owner }
+
+      before do
+        create(:provider_api_key, user: owner, api_service_type: "anthropic", api_key: "sk-owner-key")
+        allow(Rails.application.credentials).to receive(:dig)
+          .with(:llm, :anthropic_api_key).and_return("sk-ant-test-key")
+      end
+
+      it "uses the owner's API key for the proxied request" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: knowledge_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(WebMock).to have_requested(:post, target_url)
+          .with(headers: { "x-api-key" => "sk-owner-key" })
+      end
+    end
   end
 
   describe "POST /api/proxy/openai/*path" do

--- a/spec/requests/api/secrets_proxy_spec.rb
+++ b/spec/requests/api/secrets_proxy_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Api::SecretsProxy" do
   let(:project) { create(:project) }
   let(:agent_run) { create(:agent_run, :running, project: project) }
+  let(:knowledge_run) { create(:knowledge_run, :running, project: project) }
 
   let(:anthropic_response_body) do
     {
@@ -39,6 +40,14 @@ RSpec.describe "Api::SecretsProxy" do
       usageMetadata: { promptTokenCount: 80, candidatesTokenCount: 40, totalTokenCount: 120 },
       modelVersion: "gemini-2.0-flash"
     }.to_json
+  end
+
+  let(:knowledge_headers) do
+    {
+      "Content-Type" => "application/json",
+      "X-Knowledge-Run-Id" => knowledge_run.id.to_s,
+      "X-Proxy-Token" => knowledge_run.proxy_token
+    }
   end
 
   before do
@@ -238,6 +247,16 @@ RSpec.describe "Api::SecretsProxy" do
       }.to change { agent_run.reload.tokens_input }.by(100)
         .and change { agent_run.reload.tokens_output }.by(50)
     end
+
+    it "accepts knowledge-run authentication" do
+      post "/api/proxy/openai/v1/chat/completions",
+        params: {}.to_json,
+        headers: knowledge_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(knowledge_run.reload.total_tokens).to eq(150)
+      expect(TokenUsage.last.knowledge_run).to eq(knowledge_run)
+    end
   end
 
   describe "POST /api/proxy/google/*path" do
@@ -275,6 +294,17 @@ RSpec.describe "Api::SecretsProxy" do
       }.to change { agent_run.reload.tokens_input }.by(80)
         .and change { agent_run.reload.tokens_output }.by(40)
     end
+
+    it "accepts embedded knowledge-run credentials in x-goog-api-key" do
+      post "/api/proxy/google/v1beta/models/gemini-2.0-flash:generateContent",
+        params: {}.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "x-goog-api-key" => "paid-knowledge-run:#{knowledge_run.id}:#{knowledge_run.proxy_token}"
+        }
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "query string forwarding" do
@@ -309,7 +339,7 @@ RSpec.describe "Api::SecretsProxy" do
 
         expect(response).to have_http_status(:unauthorized)
         body = JSON.parse(response.body)
-        expect(body["error"]).to eq("Missing agent run ID")
+        expect(body["error"]).to eq("Missing agent run ID or knowledge run ID")
       end
     end
 
@@ -325,6 +355,17 @@ RSpec.describe "Api::SecretsProxy" do
           headers: {
             "Content-Type" => "application/json",
             "Authorization" => "Bearer paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+          }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "authenticates knowledge-run requests" do
+        post "/api/proxy/openai/v1/chat/completions",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "Authorization" => "Bearer paid-knowledge-run:#{knowledge_run.id}:#{knowledge_run.proxy_token}"
           }
 
         expect(response).to have_http_status(:ok)
@@ -455,6 +496,19 @@ RSpec.describe "Api::SecretsProxy" do
         new_token = agent_run.reload.proxy_token
         expect(new_token).to be_present
         expect(new_token).not_to eq(token)
+      end
+    end
+
+    context "with completed knowledge run" do
+      let(:knowledge_run) { create(:knowledge_run, :completed, project: project) }
+
+      it "returns forbidden" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: knowledge_headers
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to eq("Invalid or inactive knowledge run")
       end
     end
   end
@@ -608,6 +662,20 @@ RSpec.describe "Api::SecretsProxy" do
         expect(response.headers["X-Token-Limit-Warning"]).to eq("true")
         expect(response.headers["X-Token-Usage"]).to eq("85000")
         expect(response.headers["X-Token-Limit"]).to eq("100000")
+      end
+    end
+
+    context "when a knowledge run exceeds its own limit" do
+      let(:knowledge_run) { create(:knowledge_run, :running, project: project, total_tokens: 10_000, max_tokens: 10_000) }
+
+      it "returns 429 and marks the knowledge run exceeded" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: knowledge_headers
+
+        expect(response).to have_http_status(:too_many_requests)
+        expect(JSON.parse(response.body)["error"]).to eq("Token limit exceeded for this knowledge run")
+        expect(knowledge_run.reload.token_limit_status).to eq("exceeded")
       end
     end
   end

--- a/spec/services/token_usage_tracker_spec.rb
+++ b/spec/services/token_usage_tracker_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe TokenUsageTracker do
   let(:project) { create(:project) }
   let(:agent_run) { create(:agent_run, :running, project: project) }
+  let(:knowledge_run) { create(:knowledge_run, :running, project: project) }
 
   describe ".track" do
     it "increments tokens_input on the agent run" do
@@ -143,6 +144,53 @@ RSpec.describe TokenUsageTracker do
         expect(budget.reload.current_usage_cents).to eq(0)
       end
     end
+
+    context "with a knowledge run" do
+      it "increments total_tokens on the knowledge run" do
+        expect {
+          described_class.track(
+            knowledge_run: knowledge_run,
+            usage: { tokens_input: 80, tokens_output: 20, request_type: "knowledge" }
+          )
+        }.to change { knowledge_run.reload.total_tokens }.by(100)
+      end
+
+      it "creates a TokenUsage record for the knowledge run" do
+        described_class.track(
+          knowledge_run: knowledge_run,
+          usage: {
+            tokens_input: 1000,
+            tokens_output: 500,
+            llm_model: "text-embedding-3-large",
+            request_type: "knowledge",
+            metadata: { operation_type: "embedding" }
+          }
+        )
+
+        usage = TokenUsage.last
+        expect(usage.knowledge_run).to eq(knowledge_run)
+        expect(usage.agent_run).to be_nil
+        expect(usage.metadata).to include("operation_type" => "embedding")
+      end
+
+      it "updates project totals for knowledge runs" do
+        expect {
+          described_class.track(
+            knowledge_run: knowledge_run,
+            usage: { tokens_input: 100, tokens_output: 50, request_type: "knowledge" }
+          )
+        }.to change { project.reload.total_tokens_used }.by(150)
+      end
+
+      it "does not create an agent run log entry" do
+        expect {
+          described_class.track(
+            knowledge_run: knowledge_run,
+            usage: { tokens_input: 100, tokens_output: 50, request_type: "knowledge" }
+          )
+        }.not_to change(AgentRunLog, :count)
+      end
+    end
   end
 
   describe "token limit checking" do
@@ -261,6 +309,31 @@ RSpec.describe TokenUsageTracker do
       # 10M input = $30 = 3000 cents
       # 5M output = $75 = 7500 cents
       expect(described_class.calculate_cost(10_000_000, 5_000_000)).to eq(10_500)
+    end
+  end
+
+  describe "knowledge run token limit checking" do
+    before do
+      project.update!(token_limit_warning_threshold: 80)
+      knowledge_run.update!(max_tokens: 100)
+    end
+
+    it "sets warning when usage crosses the threshold" do
+      described_class.track(
+        knowledge_run: knowledge_run,
+        usage: { tokens_input: 60, tokens_output: 20, request_type: "knowledge" }
+      )
+
+      expect(knowledge_run.reload.token_limit_status).to eq("warning")
+    end
+
+    it "sets exceeded when usage reaches the hard limit" do
+      described_class.track(
+        knowledge_run: knowledge_run,
+        usage: { tokens_input: 60, tokens_output: 40, request_type: "knowledge" }
+      )
+
+      expect(knowledge_run.reload.token_limit_status).to eq("exceeded")
     end
   end
 end

--- a/spec/services/token_usage_tracker_spec.rb
+++ b/spec/services/token_usage_tracker_spec.rb
@@ -173,6 +173,15 @@ RSpec.describe TokenUsageTracker do
         expect(usage.metadata).to include("operation_type" => "embedding")
       end
 
+      it "defaults the request type to knowledge" do
+        described_class.track(
+          knowledge_run: knowledge_run,
+          usage: { tokens_input: 100, tokens_output: 50 }
+        )
+
+        expect(TokenUsage.last.request_type).to eq("knowledge")
+      end
+
       it "updates project totals for knowledge runs" do
         expect {
           described_class.track(

--- a/spec/services/token_usages/aggregate_spec.rb
+++ b/spec/services/token_usages/aggregate_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe TokenUsages::Aggregate do
       result = described_class.for_project(project.id)
       expect(result[:total_cost_cents]).to eq(30)
     end
+
+    it "includes knowledge-run token usage" do
+      knowledge_run = create(:knowledge_run, :running, project: project)
+      create(:token_usage, :knowledge, knowledge_run: knowledge_run, cost_cents: 40, input_tokens: 400, output_tokens: 0)
+
+      result = described_class.for_project(project.id)
+      expect(result[:total_cost_cents]).to eq(70)
+      expect(result[:total_input_tokens]).to eq(3400)
+    end
   end
 
   describe "#project_cost_projection" do


### PR DESCRIPTION
## Summary

feat(knowledge): extend secrets proxy to authenticate knowledge-run operations

See #1040 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1040