### PR TITLE
Fix #1036: codex: classify refresh_token_reused as auth_expired instead of generic provider error

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -82,6 +82,15 @@ module Activities
       /out of (?:extra )?usage/i
     ].freeze
 
+    AUTH_EXPIRED_PATTERNS = {
+      "codex" => [
+        /refresh_token_reused/i,
+        /Failed to refresh token/i,
+        /Please log out and sign in again/i,
+        /Your access token could not be refreshed/i
+      ].freeze
+    }.freeze
+
     # Maximum number of log rows to inspect when reclassifying a timeout.
     # Caps memory and DB load on long-running, verbose agent attempts.
     TIMEOUT_RATE_LIMIT_LOG_LIMIT = 200
@@ -288,6 +297,13 @@ module Activities
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "timeout")
             logger.warn(message: "agent_execution.provider_timeout", provider: provider, agent_run_id: agent_run.id, error: e.message)
             break
+          rescue ProviderAuthExpiredError => e
+            last_error = "auth_expired"
+            auth_provider = ProviderSupport.harness_provider_key_for(e.provider)
+            agent_run.auth_expire!(error: e.message, provider: auth_provider)
+            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "auth_expired")
+            logger.warn(message: "agent_execution.auth_expired", provider: provider, agent_run_id: agent_run.id, error: e.message)
+            break
           rescue ProviderExecutionError => e
             last_error = "error"
             if cancelled_by_cleanup?(agent_run)
@@ -351,6 +367,15 @@ module Activities
       def initialize(message, reset_at: nil)
         super(message)
         @reset_at = reset_at
+      end
+    end
+
+    class ProviderAuthExpiredError < StandardError
+      attr_reader :provider
+
+      def initialize(message, provider:)
+        super(message)
+        @provider = provider
       end
     end
 
@@ -563,6 +588,10 @@ module Activities
       output = (stderr.presence || stdout).to_s.strip
       rate_limit_output = strip_prompt_echo(output, prompt)
 
+      if auth_expired_error?(provider, rate_limit_output)
+        raise ProviderAuthExpiredError.new(output.truncate(500), provider: provider)
+      end
+
       # Check if this is a rate limit error
       if rate_limit_error?(rate_limit_output)
         reset_at = parse_rate_limit_reset(rate_limit_output)
@@ -621,6 +650,12 @@ module Activities
       return false if output.blank?
 
       TIMEOUT_RATE_LIMIT_PATTERNS.any? { |pattern| output.match?(pattern) }
+    end
+
+    def auth_expired_error?(provider, output)
+      return false if output.blank?
+
+      AUTH_EXPIRED_PATTERNS.fetch(provider.to_s, []).any? { |pattern| output.match?(pattern) }
     end
 
     def strip_prompt_echo(output, prompt)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -85,7 +85,8 @@ module Activities
     AUTH_EXPIRED_PATTERNS = {
       "codex" => [
         /refresh_token_reused/i,
-        /Failed to refresh token/i,
+        /refresh token has already been used to generate a new access token/i,
+        /refresh token was already used/i,
         /Please log out and sign in again/i,
         /Your access token could not be refreshed/i
       ].freeze

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -770,6 +770,28 @@ RSpec.describe Activities::RunAgentActivity do
         expect(agent_run.provider_switches).to eq(0)
         expect(container_service).to have_received(:execute).once
       end
+
+      it "treats generic refresh failures as ordinary provider errors" do
+        generic_refresh_failure = Containers::Provision::Result.failure(
+          error: "exit 1",
+          stdout: "",
+          stderr: "ERROR codex_core::auth: Failed to refresh token: 500 Internal Server Error",
+          exit_code: 1
+        )
+        allow(container_service).to receive(:execute).and_return(generic_refresh_failure, exec_success)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        agent_run.reload
+        expect(result).to include(success: true, final_provider: "cursor")
+        expect(agent_run.status).to eq("running")
+        expect(agent_run.providers_attempted).to contain_exactly(
+          hash_including("provider" => "codex", "success" => false, "error_type" => "error"),
+          hash_including("provider" => "cursor", "success" => true)
+        )
+        expect(agent_run.provider_switches).to eq(1)
+        expect(container_service).to have_received(:execute).twice
+      end
     end
 
     context "when agent times out (wall clock)" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -727,6 +727,51 @@ RSpec.describe Activities::RunAgentActivity do
       end
     end
 
+    context "when codex auth has expired" do
+      let(:agent_run) do
+        create(:agent_run, :with_git_context,
+          project: project,
+          issue: issue,
+          agent_type: "codex",
+          container_id: "abc123")
+      end
+      let(:auth_expired_output) do
+        Containers::Provision::Result.failure(
+          error: "exit 1",
+          stdout: "",
+          stderr: <<~STDERR,
+            ERROR codex_core::auth: Failed to refresh token: 401 Unauthorized
+            "message": "Your refresh token has already been used to generate a new access token. Please try signing in again."
+            "code": "refresh_token_reused"
+            ERROR codex_core::auth: Failed to refresh token: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.
+          STDERR
+          exit_code: 1
+        )
+      end
+
+      before do
+        user.settings.update!(fallback_enabled: true, fallback_providers: [ "cursor" ])
+        allow(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")
+        allow(container_service).to receive(:execute).and_return(auth_expired_output)
+      end
+
+      it "marks the run as auth_expired and does not fall back" do
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("auth_expired")
+        expect(agent_run.auth_provider).to eq("codex")
+        expect(agent_run.error_message).to include("refresh_token_reused")
+        expect(agent_run.providers_attempted).to contain_exactly(
+          hash_including("provider" => "codex", "success" => false, "error_type" => "auth_expired")
+        )
+        expect(agent_run.provider_switches).to eq(0)
+        expect(container_service).to have_received(:execute).once
+      end
+    end
+
     context "when agent times out (wall clock)" do
       before do
         allow(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -750,6 +750,7 @@ RSpec.describe Activities::RunAgentActivity do
       end
 
       before do
+        user.providers.find_or_create_by!(provider_key: "cursor")
         user.settings.update!(fallback_enabled: true, fallback_providers: [ "cursor" ])
         allow(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")
         allow(container_service).to receive(:execute).and_return(auth_expired_output)
@@ -779,6 +780,8 @@ RSpec.describe Activities::RunAgentActivity do
           exit_code: 1
         )
         allow(container_service).to receive(:execute).and_return(generic_refresh_failure, exec_success)
+        allow(git_ops).to receive(:commit_uncommitted_changes).and_return(false)
+        allow(git_ops).to receive(:has_changes_since?).with("pre_agent_sha_abc123").and_return(false)
 
         result = activity.execute(agent_run_id: agent_run.id)
 


### PR DESCRIPTION
## Summary

codex: classify refresh_token_reused as auth_expired instead of generic provider error

See #1036 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1036