### PR TITLE
Fix #1085: feat(infrastructure): add Flipper-based feature flags for staged automation rollouts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,10 @@ gem "agent-harness"
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 gem "ruby-maat"
 
+# Runtime feature flags for staged rollouts
+gem "flipper"
+gem "flipper-active_record"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[windows jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,11 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
+    flipper (1.4.1)
+      concurrent-ruby (< 2)
+    flipper-active_record (1.4.1)
+      activerecord (>= 4.2, < 9)
+      flipper (~> 1.4.1)
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -526,6 +531,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday-retry
+  flipper
+  flipper-active_record
   good_job (~> 4.14)
   jsbundling-rails
   kamal
@@ -608,6 +615,8 @@ CHECKSUMS
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   ferrum (0.17.2) sha256=2c2540a850b211a46f4d81de21bfd62048f507e4c327d1807225c3823c17e6ee
+  flipper (1.4.1) sha256=05843240fb3093c7037549e34b046b636c765120f22e0a6268212daf44166e4d
+  flipper-active_record (1.4.1) sha256=5197481ad0976a12c481b1778927d873738640f4023300bdb0d71b6e21245a37
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   good_job (4.14.2) sha256=f38f164346aee724bbfbdaed73e1a0bd382cc6354146029e0adcc619245ab6d1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_account
 
+  def feature_enabled?(flag_name, project: nil)
+    FeatureFlags.enabled?(flag_name, project:)
+  end
+  helper_method :feature_enabled?
+
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
     redirect_back(fallback_location: root_path)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -164,6 +164,10 @@ class Project < ApplicationRecord
     "#{owner}/#{repo}"
   end
 
+  def flipper_id
+    "Project;#{id}"
+  end
+
   def github_url
     "https://github.com/#{full_name}"
   end

--- a/app/services/feature_flags.rb
+++ b/app/services/feature_flags.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class FeatureFlags
+  Definition = Data.define(:name, :owner, :intent, :rollout_plan, :cleanup_criteria)
+
+  UnknownFlagError = Class.new(ArgumentError)
+  InvalidActorError = Class.new(ArgumentError)
+
+  DEFINITIONS = {
+    explicit_pr_automation_decisions: Definition.new(
+      name: :explicit_pr_automation_decisions,
+      owner: "infrastructure",
+      intent: "Stage the PR automation decision refactor for the #1077 bug class behind an explicit gate.",
+      rollout_plan: "Enable per project/repo during validation, monitor the new decision path, then promote to the default rollout.",
+      cleanup_criteria: "Remove after the explicit-decision path is the only implementation and the legacy branch is deleted."
+    )
+  }.freeze
+
+  class << self
+    def definitions
+      DEFINITIONS.values
+    end
+
+    def definition(flag_name)
+      DEFINITIONS.fetch(flag_name.to_sym)
+    rescue KeyError
+      raise UnknownFlagError, "Unknown feature flag: #{flag_name}"
+    end
+
+    def enabled?(flag_name, project: nil, actor: nil)
+      resolved_actor = resolve_actor(project:, actor:)
+      return feature(flag_name).enabled? unless resolved_actor
+
+      feature(flag_name).enabled?(resolved_actor)
+    end
+
+    def enable!(flag_name, project: nil, actor: nil)
+      resolved_actor = resolve_actor(project:, actor:)
+      return feature(flag_name).enable unless resolved_actor
+
+      feature(flag_name).enable(resolved_actor)
+    end
+
+    def disable!(flag_name, project: nil, actor: nil)
+      resolved_actor = resolve_actor(project:, actor:)
+      return feature(flag_name).disable unless resolved_actor
+
+      feature(flag_name).disable(resolved_actor)
+    end
+
+    def snapshot(project: nil, actor: nil)
+      DEFINITIONS.keys.index_with do |flag_name|
+        enabled?(flag_name, project:, actor:)
+      end
+    end
+
+    def explicit_pr_automation_decisions?(project: nil)
+      enabled?(:explicit_pr_automation_decisions, project:)
+    end
+
+    def flipper
+      Rails.configuration.x.feature_flags.flipper
+    end
+
+    private
+
+    def feature(flag_name)
+      flipper[definition(flag_name).name]
+    end
+
+    def resolve_actor(project:, actor:)
+      raise InvalidActorError, "Pass either project: or actor:, not both" if project && actor
+
+      return project if project
+      return actor if actor
+
+      nil
+    end
+  end
+end

--- a/app/services/feature_flags.rb
+++ b/app/services/feature_flags.rb
@@ -43,7 +43,13 @@ class FeatureFlags
 
     def disable!(flag_name, project: nil, actor: nil)
       resolved_actor = resolve_actor(project:, actor:)
-      return feature(flag_name).disable unless resolved_actor
+
+      unless resolved_actor
+        # Flipper's boolean-gate disable already calls clear(feature), which
+        # removes all gates (actor, group, percentage, etc.), so a global
+        # disable is a complete rollback — no stale actor gates survive.
+        return feature(flag_name).disable
+      end
 
       feature(flag_name).disable(resolved_actor)
     end

--- a/app/temporal/activities/base_activity.rb
+++ b/app/temporal/activities/base_activity.rb
@@ -60,6 +60,10 @@ module Activities
       Rails.logger
     end
 
+    def feature_enabled?(flag_name, project: nil)
+      FeatureFlags.enabled?(flag_name, project:)
+    end
+
     # Raises a retryable Temporal error when the GitHub API rate limit is
     # near exhaustion. Call this before making API requests so polling
     # activities stop early and let the next cycle handle remaining work.

--- a/app/temporal/activities/load_feature_flags_activity.rb
+++ b/app/temporal/activities/load_feature_flags_activity.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Activities
+  class LoadFeatureFlagsActivity < BaseActivity
+    activity_name "LoadFeatureFlags"
+
+    def execute(input)
+      project = Project.find_by(id: input[:project_id])
+      return { flags: {}, project_missing: true } unless project
+
+      { flags: FeatureFlags.snapshot(project: project), project_missing: false }
+    end
+  end
+end

--- a/app/temporal/workflows/base_workflow.rb
+++ b/app/temporal/workflows/base_workflow.rb
@@ -49,6 +49,18 @@ module Workflows
 
     private
 
+    def feature_flag_enabled?(flag_name, project_id:)
+      feature_flags_for(project_id).fetch(flag_name.to_sym)
+    end
+
+    def feature_flags_for(project_id)
+      @feature_flags_by_project ||= {}
+      @feature_flags_by_project[project_id] ||= begin
+        result = run_activity(Activities::LoadFeatureFlagsActivity, { project_id: project_id }, timeout: 10)
+        result.fetch(:flags, {})
+      end
+    end
+
     def deep_symbolize(obj)
       case obj
       when Hash then obj.deep_symbolize_keys

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "flipper"
+require "flipper/adapters/active_record"
+
+adapter = Flipper::Adapters::ActiveRecord.new
+flipper = Flipper.new(adapter)
+
+Rails.configuration.x.feature_flags ||= ActiveSupport::OrderedOptions.new
+Rails.configuration.x.feature_flags.flipper = flipper

--- a/db/migrate/20260413193745_create_flipper_tables.rb
+++ b/db/migrate/20260413193745_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[8.1]
+  def up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.text :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/migrate/20260413193745_create_flipper_tables.rb
+++ b/db/migrate/20260413193745_create_flipper_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateFlipperTables < ActiveRecord::Migration[8.1]
   def up
     create_table :flipper_features do |t|
@@ -12,7 +14,7 @@ class CreateFlipperTables < ActiveRecord::Migration[8.1]
       t.text :value
       t.timestamps null: false
     end
-    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+    add_index :flipper_gates, [ :feature_key, :key, :value ], unique: true, length: { value: 255 }
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_193745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -298,6 +298,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
     t.index ["project_id"], name: "index_decision_records_on_project_id"
     t.index ["superseded_by_id"], name: "index_decision_records_on_superseded_by_id"
     t.index ["tags"], name: "index_decision_records_on_tags", using: :gin
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.datetime "updated_at", null: false
+    t.text "value"
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "github_tokens", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1047,10 +1047,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_193745) do
     t.integer "github_token_cache_ttl_minutes", default: 60, null: false
     t.integer "issue_goal_idle_timeout_seconds", default: 120, null: false
     t.integer "issue_goal_timeout_seconds", default: 600, null: false
-    t.jsonb "kb_chat_fallback_providers", default: [], null: false
-    t.string "kb_chat_provider", default: "claude", null: false
-    t.jsonb "kb_embedding_fallback_providers", default: [], null: false
-    t.string "kb_embedding_provider", default: "openai", null: false
     t.integer "max_comment_length", default: 2000, null: false
     t.integer "max_concurrent_runs", default: 2, null: false
     t.integer "max_issues_per_page", default: 50, null: false

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -1,0 +1,56 @@
+# Feature Flags
+
+Paid uses Flipper-backed runtime flags only for staged behavior rollouts where replacing the old path in one deploy would be risky. Flags are temporary rollout controls, not a compatibility layer.
+
+## Definition checklist
+
+Every flag must be registered in `app/services/feature_flags.rb` with:
+
+- `owner`
+- `intent`
+- `rollout_plan`
+- `cleanup_criteria`
+
+The first shipped flag is `explicit_pr_automation_decisions`, which exists to stage the PR automation decision refactor for issue `#1077`.
+
+## House pattern
+
+Rails code and Temporal activities should query flags through `FeatureFlags`, never through raw Flipper string lookups:
+
+```ruby
+FeatureFlags.explicit_pr_automation_decisions?(project: project)
+FeatureFlags.enabled?(:explicit_pr_automation_decisions, project: project)
+```
+
+Temporal workflows must stay deterministic, so they should not read Flipper directly. Use the workflow helper, which snapshots flags through `Activities::LoadFeatureFlagsActivity`:
+
+```ruby
+feature_flag_enabled?(:explicit_pr_automation_decisions, project_id: project_id)
+```
+
+## Enablement
+
+List current state:
+
+```bash
+bundle exec rake feature_flags:list
+bundle exec rake feature_flags:list PROJECT=owner/repo
+```
+
+Enable or disable intentionally:
+
+```bash
+bundle exec rake "feature_flags:enable[explicit_pr_automation_decisions]" PROJECT=owner/repo
+bundle exec rake "feature_flags:disable[explicit_pr_automation_decisions]" PROJECT=owner/repo
+```
+
+Omit `PROJECT=owner/repo` to change the global flag state.
+
+## Issue convention
+
+When a rollout uses a flag:
+
+1. The umbrella issue defines the flag and rollout intent.
+2. The implementation issue/PR ships the new behavior behind that flag.
+3. Separate enablement work tracks which projects or repos should be opted in.
+4. Cleanup work removes the flag definition and the old path as soon as the rollout is complete.

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -34,17 +34,17 @@ List current state:
 
 ```bash
 bundle exec rake feature_flags:list
-bundle exec rake feature_flags:list PROJECT=owner/repo
+bundle exec rake feature_flags:list PROJECT_ID=123
 ```
 
 Enable or disable intentionally:
 
 ```bash
-bundle exec rake "feature_flags:enable[explicit_pr_automation_decisions]" PROJECT=owner/repo
-bundle exec rake "feature_flags:disable[explicit_pr_automation_decisions]" PROJECT=owner/repo
+bundle exec rake "feature_flags:enable[explicit_pr_automation_decisions]" PROJECT_ID=123
+bundle exec rake "feature_flags:disable[explicit_pr_automation_decisions]" PROJECT_ID=123
 ```
 
-Omit `PROJECT=owner/repo` to change the global flag state.
+Omit `PROJECT_ID=123` to change the global flag state. Use the Paid project id, not `owner/repo`, because the same GitHub repository can exist in multiple accounts.
 
 ## Issue convention
 

--- a/lib/tasks/feature_flags.rake
+++ b/lib/tasks/feature_flags.rake
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module FeatureFlagTasks
+  module_function
+
+  def project_scope
+    reference = ENV["PROJECT"].to_s.strip
+    return nil if reference.empty?
+
+    owner, repo = reference.split("/", 2)
+    raise ArgumentError, "PROJECT must be in owner/repo format" if owner.blank? || repo.blank?
+
+    Project.find_by!(owner:, repo:)
+  end
+
+  def scope_label(project)
+    project ? "project #{project.full_name}" : "global"
+  end
+end
+
+namespace :feature_flags do
+  desc "List supported feature flags and their current state"
+  task list: :environment do
+    project = FeatureFlagTasks.project_scope
+
+    FeatureFlags.definitions.each do |definition|
+      enabled = FeatureFlags.enabled?(definition.name, project:)
+
+      puts "#{definition.name}: #{enabled ? 'enabled' : 'disabled'} (#{FeatureFlagTasks.scope_label(project)})"
+      puts "  owner: #{definition.owner}"
+      puts "  intent: #{definition.intent}"
+      puts "  rollout_plan: #{definition.rollout_plan}"
+      puts "  cleanup_criteria: #{definition.cleanup_criteria}"
+    end
+  end
+
+  desc "Enable a feature flag globally or for PROJECT=owner/repo"
+  task :enable, [ :flag ] => :environment do |_task, args|
+    project = FeatureFlagTasks.project_scope
+    FeatureFlags.enable!(args.fetch(:flag), project:)
+
+    puts "Enabled #{args.fetch(:flag)} for #{FeatureFlagTasks.scope_label(project)}"
+  end
+
+  desc "Disable a feature flag globally or for PROJECT=owner/repo"
+  task :disable, [ :flag ] => :environment do |_task, args|
+    project = FeatureFlagTasks.project_scope
+    FeatureFlags.disable!(args.fetch(:flag), project:)
+
+    puts "Disabled #{args.fetch(:flag)} for #{FeatureFlagTasks.scope_label(project)}"
+  end
+end

--- a/lib/tasks/feature_flags.rake
+++ b/lib/tasks/feature_flags.rake
@@ -4,13 +4,17 @@ module FeatureFlagTasks
   module_function
 
   def project_scope
-    reference = ENV["PROJECT"].to_s.strip
-    return nil if reference.empty?
+    project_reference = ENV["PROJECT"].to_s.strip
+    project_id = ENV["PROJECT_ID"].to_s.strip
 
-    owner, repo = reference.split("/", 2)
-    raise ArgumentError, "PROJECT must be in owner/repo format" if owner.blank? || repo.blank?
+    raise ArgumentError, "Use PROJECT_ID=<id> for project-scoped feature flag changes" if project_reference.present?
+    return nil if project_id.empty?
 
-    Project.find_by!(owner:, repo:)
+    Project.find(Integer(project_id, 10))
+  rescue ArgumentError => e
+    raise e if e.message == "Use PROJECT_ID=<id> for project-scoped feature flag changes"
+
+    raise ArgumentError, "PROJECT_ID must be an integer"
   end
 
   def scope_label(project)
@@ -34,7 +38,7 @@ namespace :feature_flags do
     end
   end
 
-  desc "Enable a feature flag globally or for PROJECT=owner/repo"
+  desc "Enable a feature flag globally or for PROJECT_ID=<id>"
   task :enable, [ :flag ] => :environment do |_task, args|
     project = FeatureFlagTasks.project_scope
     FeatureFlags.enable!(args.fetch(:flag), project:)
@@ -42,7 +46,7 @@ namespace :feature_flags do
     puts "Enabled #{args.fetch(:flag)} for #{FeatureFlagTasks.scope_label(project)}"
   end
 
-  desc "Disable a feature flag globally or for PROJECT=owner/repo"
+  desc "Disable a feature flag globally or for PROJECT_ID=<id>"
   task :disable, [ :flag ] => :environment do |_task, args|
     project = FeatureFlagTasks.project_scope
     FeatureFlags.disable!(args.fetch(:flag), project:)

--- a/lib/tasks/feature_flags.rake
+++ b/lib/tasks/feature_flags.rake
@@ -10,11 +10,14 @@ module FeatureFlagTasks
     raise ArgumentError, "Use PROJECT_ID=<id> for project-scoped feature flag changes" if project_reference.present?
     return nil if project_id.empty?
 
-    Project.find(Integer(project_id, 10))
+    project_id = Integer(project_id, 10)
+    Project.find(project_id)
   rescue ArgumentError => e
     raise e if e.message == "Use PROJECT_ID=<id> for project-scoped feature flag changes"
 
     raise ArgumentError, "PROJECT_ID must be an integer"
+  rescue ActiveRecord::RecordNotFound
+    raise ArgumentError, "PROJECT_ID=#{project_id} does not match an existing project"
   end
 
   def scope_label(project)

--- a/spec/services/feature_flags_spec.rb
+++ b/spec/services/feature_flags_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe FeatureFlags do
     end
   end
 
+  describe ".disable!" do
+    it "clears actor gates when disabling globally" do
+      described_class.enable!(:explicit_pr_automation_decisions, project:)
+      expect(described_class.enabled?(:explicit_pr_automation_decisions, project:)).to be(true)
+
+      described_class.disable!(:explicit_pr_automation_decisions)
+
+      expect(described_class.enabled?(:explicit_pr_automation_decisions, project:)).to be(false)
+    end
+  end
+
   describe ".snapshot" do
     it "returns the current boolean state for every registered flag" do
       described_class.enable!(:explicit_pr_automation_decisions, project:)

--- a/spec/services/feature_flags_spec.rb
+++ b/spec/services/feature_flags_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FeatureFlags do
+  let(:project) { create(:project) }
+
+  before do
+    described_class.flipper.features.each(&:remove)
+  end
+
+  describe ".definition" do
+    it "returns metadata for registered flags" do
+      definition = described_class.definition(:explicit_pr_automation_decisions)
+
+      expect(definition.owner).to eq("infrastructure")
+      expect(definition.intent).to include("#1077")
+    end
+
+    it "raises for unknown flags" do
+      expect {
+        described_class.definition(:missing_flag)
+      }.to raise_error(described_class::UnknownFlagError, /missing_flag/)
+    end
+  end
+
+  describe ".enabled?" do
+    it "returns global flag state" do
+      expect(described_class.enabled?(:explicit_pr_automation_decisions)).to be(false)
+
+      described_class.enable!(:explicit_pr_automation_decisions)
+
+      expect(described_class.enabled?(:explicit_pr_automation_decisions)).to be(true)
+    end
+
+    it "supports project-scoped rollout checks" do
+      described_class.enable!(:explicit_pr_automation_decisions, project:)
+
+      expect(described_class.enabled?(:explicit_pr_automation_decisions, project:)).to be(true)
+      expect(described_class.enabled?(:explicit_pr_automation_decisions)).to be(false)
+    end
+  end
+
+  describe ".snapshot" do
+    it "returns the current boolean state for every registered flag" do
+      described_class.enable!(:explicit_pr_automation_decisions, project:)
+
+      expect(described_class.snapshot(project:)).to eq(
+        explicit_pr_automation_decisions: true
+      )
+    end
+  end
+end

--- a/spec/tasks/rake/task_feature_flags_tasks_spec.rb
+++ b/spec/tasks/rake/task_feature_flags_tasks_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe Rake::Task do
+  let(:enable_task) { described_class["feature_flags:enable"] }
+  let(:disable_task) { described_class["feature_flags:disable"] }
+  let(:list_task) { described_class["feature_flags:list"] }
+
+  around do |example|
+    original_project = ENV["PROJECT"]
+    original_project_id = ENV["PROJECT_ID"]
+
+    example.run
+  ensure
+    ENV["PROJECT"] = original_project
+    ENV["PROJECT_ID"] = original_project_id
+  end
+
+  before do
+    Rails.application.load_tasks unless described_class.task_defined?("feature_flags:list")
+    enable_task.reenable
+    disable_task.reenable
+    list_task.reenable
+    FeatureFlags.flipper.features.each(&:remove)
+  end
+
+  context "with feature_flags tasks loaded" do
+    it "scopes project-specific changes by PROJECT_ID" do
+      project = create(:project)
+      duplicate_repo_project = create(:project, owner: project.owner, repo: project.repo)
+      ENV["PROJECT_ID"] = project.id.to_s
+
+      enable_task.invoke("explicit_pr_automation_decisions")
+
+      expect(FeatureFlags.enabled?(:explicit_pr_automation_decisions, project: project)).to be(true)
+      expect(FeatureFlags.enabled?(:explicit_pr_automation_decisions, project: duplicate_repo_project)).to be(false)
+    end
+
+    it "rejects ambiguous owner/repo selectors" do
+      ENV["PROJECT"] = "owner/repo"
+
+      expect {
+        list_task.invoke
+      }.to raise_error(ArgumentError, "Use PROJECT_ID=<id> for project-scoped feature flag changes")
+    end
+
+    it "rejects non-integer project ids" do
+      ENV["PROJECT_ID"] = "owner/repo"
+
+      expect {
+        enable_task.invoke("explicit_pr_automation_decisions")
+      }.to raise_error(ArgumentError, "PROJECT_ID must be an integer")
+    end
+  end
+end

--- a/spec/tasks/rake/task_feature_flags_tasks_spec.rb
+++ b/spec/tasks/rake/task_feature_flags_tasks_spec.rb
@@ -53,5 +53,13 @@ RSpec.describe Rake::Task do
         enable_task.invoke("explicit_pr_automation_decisions")
       }.to raise_error(ArgumentError, "PROJECT_ID must be an integer")
     end
+
+    it "rejects project ids that do not exist" do
+      ENV["PROJECT_ID"] = "-1"
+
+      expect {
+        list_task.invoke
+      }.to raise_error(ArgumentError, "PROJECT_ID=-1 does not match an existing project")
+    end
   end
 end

--- a/spec/temporal/activities/load_feature_flags_activity_spec.rb
+++ b/spec/temporal/activities/load_feature_flags_activity_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::LoadFeatureFlagsActivity do
+  let(:activity) { described_class.new }
+  let(:project) { create(:project) }
+
+  before do
+    FeatureFlags.flipper.features.each(&:remove)
+  end
+
+  describe "#execute" do
+    it "returns project_missing when the project cannot be found" do
+      expect(activity.execute(project_id: -1)).to eq(
+        flags: {},
+        project_missing: true
+      )
+    end
+
+    it "returns a workflow-safe snapshot of project-scoped flags" do
+      FeatureFlags.enable!(:explicit_pr_automation_decisions, project:)
+
+      expect(activity.execute(project_id: project.id)).to eq(
+        flags: { explicit_pr_automation_decisions: true },
+        project_missing: false
+      )
+    end
+  end
+end

--- a/spec/temporal/workflows/base_workflow_spec.rb
+++ b/spec/temporal/workflows/base_workflow_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Workflows::BaseWorkflow do
+  let(:workflow_class) do
+    Class.new(described_class) do
+      def execute(input)
+        [
+          feature_flag_enabled?(:explicit_pr_automation_decisions, project_id: input[:project_id]),
+          feature_flag_enabled?(:explicit_pr_automation_decisions, project_id: input[:project_id])
+        ]
+      end
+    end
+  end
+
+  let(:workflow) { workflow_class.new }
+
+  describe "#feature_flag_enabled?" do
+    it "loads the workflow flag snapshot through an activity and memoizes it per project" do
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::LoadFeatureFlagsActivity, { project_id: 123 }, timeout: 10)
+        .and_return(flags: { explicit_pr_automation_decisions: true })
+
+      expect(workflow.execute(project_id: 123)).to eq([ true, true ])
+      expect(workflow).to have_received(:run_activity).once
+    end
+  end
+end


### PR DESCRIPTION
## Summary

feat(infrastructure): add Flipper-based feature flags for staged automation rollouts

See #1085 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1085