### PR TITLE
Fix #1072: fix(scanner): backfill review_goal_retry_reset_at for existing issues

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -106,6 +106,8 @@ module Activities
     def scan_pr(project, client, issue)
       return :skipped if active_run_exists?(project, issue)
 
+      backfill_review_goal_retry_reset_at!(issue)
+
       retry_needed = review_goal_retry_needed?(project, issue)
       retry_limit_reached = retry_needed && review_goal_retry_limit_reached?(project, issue)
       retry_limit_reason = "Review-goal retry limit reached " \
@@ -179,6 +181,13 @@ module Activities
           current_review_goal_retry_count: issue.review_goal_retry_count
         }
       end
+    end
+
+    def backfill_review_goal_retry_reset_at!(issue)
+      return unless issue.pr_review_phase == "restarted"
+      return if issue.review_goal_retry_reset_at.present?
+
+      issue.update_column(:review_goal_retry_reset_at, Time.current)
     end
 
     MAX_CONSECUTIVE_DRAFT_FAILURES = 3

--- a/db/migrate/20260413193654_backfill_null_review_goal_retry_reset_at_on_issues.rb
+++ b/db/migrate/20260413193654_backfill_null_review_goal_retry_reset_at_on_issues.rb
@@ -8,6 +8,7 @@ class BackfillNullReviewGoalRetryResetAtOnIssues < ActiveRecord::Migration[8.1]
   def up
     reset_at = Time.current
     MigrationIssue.unscoped
+      .where(is_pull_request: true, pr_review_phase: "restarted")
       .where(review_goal_retry_reset_at: nil)
       .in_batches
       .update_all(review_goal_retry_reset_at: reset_at)

--- a/db/migrate/20260413193654_backfill_null_review_goal_retry_reset_at_on_issues.rb
+++ b/db/migrate/20260413193654_backfill_null_review_goal_retry_reset_at_on_issues.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BackfillNullReviewGoalRetryResetAtOnIssues < ActiveRecord::Migration[8.1]
+  class MigrationIssue < ApplicationRecord
+    self.table_name = "issues"
+  end
+
+  def up
+    reset_at = Time.current
+    MigrationIssue.unscoped
+      .where(review_goal_retry_reset_at: nil)
+      .in_batches
+      .update_all(review_goal_retry_reset_at: reset_at)
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_165456) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_193654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"

--- a/spec/migrations/backfill_null_review_goal_retry_reset_at_on_issues_spec.rb
+++ b/spec/migrations/backfill_null_review_goal_retry_reset_at_on_issues_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260413193654_backfill_null_review_goal_retry_reset_at_on_issues")
+
+RSpec.describe BackfillNullReviewGoalRetryResetAtOnIssues, :aggregate_failures do
+  let(:migration) { described_class.new }
+
+  it "backfills existing NULL retry reset timestamps" do
+    issue = create(:issue)
+    issue.update_column(:review_goal_retry_reset_at, nil)
+
+    freeze_time do
+      migration.up
+
+      expect(issue.reload.review_goal_retry_reset_at).to be_within(1.second).of(Time.current)
+    end
+  end
+end

--- a/spec/migrations/backfill_null_review_goal_retry_reset_at_on_issues_spec.rb
+++ b/spec/migrations/backfill_null_review_goal_retry_reset_at_on_issues_spec.rb
@@ -6,14 +6,18 @@ require Rails.root.join("db/migrate/20260413193654_backfill_null_review_goal_ret
 RSpec.describe BackfillNullReviewGoalRetryResetAtOnIssues, :aggregate_failures do
   let(:migration) { described_class.new }
 
-  it "backfills existing NULL retry reset timestamps" do
-    issue = create(:issue)
-    issue.update_column(:review_goal_retry_reset_at, nil)
+  it "backfills existing NULL retry reset timestamps for restarted PRs only" do
+    restarted_pr = create(:issue, :pull_request, pr_review_phase: "restarted")
+    unaffected_issue = create(:issue)
+
+    restarted_pr.update_column(:review_goal_retry_reset_at, nil)
+    unaffected_issue.update_column(:review_goal_retry_reset_at, nil)
 
     freeze_time do
       migration.up
 
-      expect(issue.reload.review_goal_retry_reset_at).to be_within(1.second).of(Time.current)
+      expect(restarted_pr.reload.review_goal_retry_reset_at).to be_within(1.second).of(Time.current)
+      expect(unaffected_issue.reload.review_goal_retry_reset_at).to be_nil
     end
   end
 end

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -4453,6 +4453,49 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when a preexisting restarted PR still has a NULL retry reset timestamp" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "restarted",
+          review_goal_retry_reset_at: nil)
+      end
+
+      before do
+        enable_paid_agent_review!(project, max_review_rounds: 5)
+
+        3.times do |index|
+          create(:agent_run, :automatic,
+            project: project, issue: pr_issue,
+            source_pull_request_number: 42,
+            goal: "review", status: "failed",
+            created_at: (2.hours.ago + index.minutes),
+            started_at: (2.hours.ago + index.minutes),
+            completed_at: (2.hours.ago + index.minutes))
+        end
+
+        stub_github_for_pr(draft: true, reviews: [])
+      end
+
+      it "backfills the reset boundary before counting old failures" do
+        freeze_time do
+          result = activity.execute(project_id: project.id)
+
+          expect(pr_issue.reload.review_goal_retry_reset_at).to be_within(1.second).of(Time.current)
+          trigger = result[:prs_to_trigger].first
+          trigger_types = trigger[:triggers].map { |entry| entry[:type] }
+          pending_trigger = trigger[:triggers].find { |entry| entry[:type] == "paid_agent_review_pending" }
+
+          expect(trigger[:phase]).to eq("restarted")
+          expect(trigger_types).to include("paid_agent_review_pending")
+          expect(trigger_types).not_to include("review_goal_retry")
+          expect(trigger_types).not_to include("escalate_to_owner")
+          expect(pending_trigger[:details]).to eq("No paid_agent review found for PR")
+        end
+      end
+    end
+
     context "when a restarted PR has a stale successful review from before the reset" do
       let!(:pr_issue) do
         create(:issue, :pull_request,


### PR DESCRIPTION
## Summary

fix(scanner): backfill review_goal_retry_reset_at for existing issues

See #1072 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1072