### PR TITLE
Fix #1053: fix(workflow): show restart button for stale workflows, not just unhealthy

### DIFF
--- a/app/controllers/workflow_statuses_controller.rb
+++ b/app/controllers/workflow_statuses_controller.rb
@@ -18,7 +18,7 @@ class WorkflowStatusesController < ApplicationController
     end
 
     temporal_status = ProjectWorkflowManager.workflow_status(@project)
-    if temporal_status[:running]
+    if temporal_status[:running] && !@project.poll_stale_with_recheck?
       redirect_to project_path(@project), alert: "Issue monitor is already running."
       return
     end

--- a/app/views/workflow_statuses/_status.html.erb
+++ b/app/views/workflow_statuses/_status.html.erb
@@ -27,7 +27,7 @@
             <p class="mt-1 text-xs text-gray-500">Last restart: <%= health[:restart_reason] %></p>
           <% end %>
 
-          <% if local_assigns[:show_restart] && health[:status] == :unhealthy && project.active? %>
+          <% if local_assigns[:show_restart] && health[:status].in?([:unhealthy, :stale]) && project.active? %>
             <div class="mt-3">
               <%= button_to "Restart monitor",
                     restart_project_workflow_status_path(project),

--- a/spec/requests/workflow_statuses_spec.rb
+++ b/spec/requests/workflow_statuses_spec.rb
@@ -143,6 +143,15 @@ RSpec.describe "WorkflowStatuses" do
         expect(response.body).not_to include("Restart monitor")
       end
 
+      it "shows restart button when workflow is stale" do
+        allow(ProjectWorkflowManager).to receive(:workflow_status)
+          .with(project).and_return(status: :running, running: true)
+        project.update_column(:last_polled_at, 10.minutes.ago)
+
+        get project_workflow_status_path(project)
+        expect(response.body).to include("Restart monitor")
+      end
+
       it "does not show restart button when project is inactive" do
         project.update_column(:active, false)
 
@@ -212,10 +221,24 @@ RSpec.describe "WorkflowStatuses" do
       it "redirects with alert when workflow is already running" do
         allow(ProjectWorkflowManager).to receive(:workflow_status)
           .with(project).and_return(status: :running, running: true)
+        project.update_column(:last_polled_at, 30.seconds.ago)
 
         post restart_project_workflow_status_path(project)
         expect(response).to redirect_to(project_path(project))
         expect(flash[:alert]).to eq("Issue monitor is already running.")
+      end
+
+      it "restarts the poll workflow when it is stale" do
+        allow(ProjectWorkflowManager).to receive(:workflow_status)
+          .with(project).and_return(status: :running, running: true)
+        allow(ProjectWorkflowManager).to receive(:restart_polling)
+        project.update_column(:last_polled_at, 10.minutes.ago)
+
+        post restart_project_workflow_status_path(project)
+        expect(ProjectWorkflowManager).to have_received(:restart_polling)
+          .with(project, reason: "manual restart from UI")
+        expect(response).to redirect_to(project_path(project))
+        expect(flash[:notice]).to eq("Issue monitor restarted.")
       end
 
       it "redirects with alert when Temporal is unavailable" do


### PR DESCRIPTION
## Summary

fix(workflow): show restart button for stale workflows, not just unhealthy

See #1053 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1053