### PR TITLE
Fix #1056: fix(workflow): silent restart failure when WorkflowAlreadyStartedError is raised

### DIFF
--- a/app/controllers/workflow_statuses_controller.rb
+++ b/app/controllers/workflow_statuses_controller.rb
@@ -25,10 +25,11 @@ class WorkflowStatusesController < ApplicationController
 
     ProjectWorkflowManager.restart_polling(@project, reason: "manual restart from UI")
     redirect_to project_path(@project), notice: "Issue monitor restarted."
-  rescue Temporalio::Error::RPCError => e
+  rescue Temporalio::Error::RPCError, Temporalio::Error::WorkflowAlreadyStartedError => e
     Rails.logger.error(
       message: "workflow_status.restart_failed",
       project_id: @project.id,
+      error_class: e.class.name,
       error: e.message
     )
     redirect_to project_path(@project), alert: "Could not restart issue monitor. Please try again later."

--- a/app/jobs/poll_workflow_health_check_job.rb
+++ b/app/jobs/poll_workflow_health_check_job.rb
@@ -101,13 +101,14 @@ class PollWorkflowHealthCheckJob < ApplicationJob
       reason: reason
     )
 
-    ProjectWorkflowManager.restart_polling(project, reason: reason)
+    restarted = ProjectWorkflowManager.restart_polling(project, reason: reason)
 
     Rails.logger.info(
       message: "temporal_worker.poll_workflow_restarted",
       project_id: project.id
-    )
-    true
+    ) if restarted
+
+    restarted
   end
 
   # Maps Temporal workflow execution statuses to WorkflowState status strings.

--- a/app/services/project_workflow_manager.rb
+++ b/app/services/project_workflow_manager.rb
@@ -6,7 +6,7 @@
 # for labeled issues.
 class ProjectWorkflowManager
   class << self
-    def start_polling(project, restart_reason: nil)
+    def start_polling(project, restart_reason: nil, raise_on_conflict: false)
       Paid.temporal_client.start_workflow(
         Workflows::GitHubPollWorkflow,
         { project_id: project.id },
@@ -25,11 +25,15 @@ class ProjectWorkflowManager
         project_id: project.id,
         workflow_id: workflow_id_for(project)
       )
+      true
     rescue Temporalio::Error::WorkflowAlreadyStartedError
+      raise if raise_on_conflict
+
       Rails.logger.warn(
         message: "github_sync.polling_already_running",
         project_id: project.id
       )
+      false
     end
 
     def stop_polling(project)
@@ -71,7 +75,11 @@ class ProjectWorkflowManager
         raise unless e.code == Temporalio::Error::RPCError::Code::NOT_FOUND
       end
 
-      start_polling(project, restart_reason: reason || "self-healing restart")
+      start_polling(
+        project,
+        restart_reason: reason || "self-healing restart",
+        raise_on_conflict: true
+      )
     end
 
     def signal_sync(project)

--- a/spec/jobs/poll_workflow_health_check_job_spec.rb
+++ b/spec/jobs/poll_workflow_health_check_job_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe PollWorkflowHealthCheckJob do
   end
 
   describe "#perform" do
+    let(:job) { described_class.new }
+
     it "restarts workflows that are not running" do
       project = create(:project)
       workflow_handle = double("workflow_handle") # rubocop:disable RSpec/VerifiedDoubles
@@ -215,6 +217,18 @@ RSpec.describe PollWorkflowHealthCheckJob do
         id: "github-poll-#{project2.id}",
         task_queue: "paid-tasks"
       ).at_least(:once)
+    end
+
+    it "does not count a failed restart as restarted" do
+      project = create(:project)
+      allow(ProjectWorkflowManager).to receive_messages(
+        workflow_status: { status: Temporalio::Client::WorkflowExecutionStatus::FAILED, running: false },
+        restart_polling: false
+      )
+
+      expect(job.send(:check_and_heal, project)).to be(false)
+      expect(ProjectWorkflowManager).to have_received(:restart_polling)
+        .with(project, reason: "health check: was #{Temporalio::Client::WorkflowExecutionStatus::FAILED}")
     end
   end
 

--- a/spec/requests/workflow_statuses_spec.rb
+++ b/spec/requests/workflow_statuses_spec.rb
@@ -252,6 +252,24 @@ RSpec.describe "WorkflowStatuses" do
         expect(flash[:alert]).to eq("Could not restart issue monitor. Please try again later.")
       end
 
+      it "redirects with alert when restart conflicts with an existing workflow" do
+        allow(ProjectWorkflowManager).to receive(:workflow_status)
+          .with(project).and_return(status: :not_found, running: false)
+        allow(ProjectWorkflowManager).to receive(:restart_polling)
+          .and_raise(
+            Temporalio::Error::WorkflowAlreadyStartedError.new(
+              workflow_id: "github-poll-#{project.id}",
+              workflow_type: "GitHubPollWorkflow",
+              run_id: "test-run-id"
+            )
+          )
+
+        post restart_project_workflow_status_path(project)
+
+        expect(response).to redirect_to(project_path(project))
+        expect(flash[:alert]).to eq("Could not restart issue monitor. Please try again later.")
+      end
+
       it "does not allow restarting for other accounts' projects" do
         other_account = create(:account)
         other_token = create(:github_token, account: other_account)

--- a/spec/services/project_workflow_manager_spec.rb
+++ b/spec/services/project_workflow_manager_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProjectWorkflowManager do
 
   describe ".start_polling" do
     it "starts a GitHubPollWorkflow" do
-      described_class.start_polling(project)
+      result = described_class.start_polling(project)
 
       expect(temporal_client).to have_received(:start_workflow).with(
         Workflows::GitHubPollWorkflow,
@@ -22,6 +22,7 @@ RSpec.describe ProjectWorkflowManager do
         id: "github-poll-#{project.id}",
         task_queue: "paid-tasks"
       ).at_least(:once)
+      expect(result).to be(true)
     end
 
     it "handles already-started workflow gracefully" do
@@ -33,7 +34,21 @@ RSpec.describe ProjectWorkflowManager do
         )
       )
 
-      expect { described_class.start_polling(project) }.not_to raise_error
+      expect(described_class.start_polling(project)).to be(false)
+    end
+
+    it "re-raises already-started workflow conflicts when requested" do
+      allow(temporal_client).to receive(:start_workflow).and_raise(
+        Temporalio::Error::WorkflowAlreadyStartedError.new(
+          workflow_id: "github-poll-#{project.id}",
+          workflow_type: "GitHubPollWorkflow",
+          run_id: "test-run-id"
+        )
+      )
+
+      expect do
+        described_class.start_polling(project, raise_on_conflict: true)
+      end.to raise_error(Temporalio::Error::WorkflowAlreadyStartedError)
     end
   end
 
@@ -151,10 +166,11 @@ RSpec.describe ProjectWorkflowManager do
       allow(temporal_client).to receive(:workflow_handle).and_return(workflow_handle)
       allow(workflow_handle).to receive(:terminate)
 
-      described_class.restart_polling(project, reason: "test restart")
+      result = described_class.restart_polling(project, reason: "test restart")
 
       expect(workflow_handle).to have_received(:terminate).with("test restart")
       expect(temporal_client).to have_received(:start_workflow).at_least(:once)
+      expect(result).to be(true)
     end
 
     it "starts a new workflow even if terminate fails with not found" do
@@ -166,9 +182,25 @@ RSpec.describe ProjectWorkflowManager do
         )
       )
 
-      described_class.restart_polling(project)
+      result = described_class.restart_polling(project)
 
       expect(temporal_client).to have_received(:start_workflow).at_least(:once)
+      expect(result).to be(true)
+    end
+
+    it "re-raises workflow conflicts after terminate during restart" do
+      allow(temporal_client).to receive(:workflow_handle).and_return(workflow_handle)
+      allow(workflow_handle).to receive(:terminate)
+      allow(temporal_client).to receive(:start_workflow).and_raise(
+        Temporalio::Error::WorkflowAlreadyStartedError.new(
+          workflow_id: "github-poll-#{project.id}",
+          workflow_type: "GitHubPollWorkflow",
+          run_id: "test-run-id"
+        )
+      )
+
+      expect { described_class.restart_polling(project) }
+        .to raise_error(Temporalio::Error::WorkflowAlreadyStartedError)
     end
 
     it "re-raises non-NOT_FOUND RPC errors" do


### PR DESCRIPTION
## Summary

fix(workflow): silent restart failure when WorkflowAlreadyStartedError is raised

See #1056 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1056