### PR TITLE
fix(prompts): limit PR conversation context

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -394,10 +394,11 @@ class GithubClient
   #
   # @param repo [String] Repository in "owner/name" format
   # @param number [Integer] Issue or PR number
-  # @return [Array<Sawyer::Resource>] Up to 100 most-recent comments, each
-  #   with .user.login, .body, .created_at. Order within the returned page
-  #   is ascending by ID — callers that need a specific order must sort.
-  def recent_issue_comments(repo, number)
+  # @param pages [Integer] Number of most-recent pages to fetch (default: 1)
+  # @return [Array<Sawyer::Resource>] Up to +pages * 100+ most-recent comments,
+  #   each with .user.login, .body, .created_at. Order is ascending by ID
+  #   across the returned slice so callers can safely take the tail.
+  def recent_issue_comments(repo, number, pages: 1)
     handle_errors do
       first_page = client.issue_comments(repo, number, per_page: 100, page: 1)
       last_rel = client.last_response&.rels&.dig(:last)
@@ -406,8 +407,22 @@ class GithubClient
         return tag_multi_page(first_page, false)
       end
 
-      last_page = client.get(last_rel.href)
-      tag_multi_page(last_page, true)
+      page_count = [ pages.to_i, 1 ].max
+      recent_pages = []
+      page_response = client.get(last_rel.href)
+      recent_pages << Array(page_response)
+      remaining_pages = page_count - 1
+
+      while remaining_pages.positive?
+        prev_rel = client.last_response&.rels&.dig(:prev)
+        break unless prev_rel
+
+        page_response = client.get(prev_rel.href)
+        recent_pages << Array(page_response)
+        remaining_pages -= 1
+      end
+
+      tag_multi_page(recent_pages.reverse.flatten, true)
     end
   end
 

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -404,7 +404,7 @@ class GithubClient
       last_rel = client.last_response&.rels&.dig(:last)
 
       unless last_rel
-        return tag_multi_page(first_page, false)
+        return tag_recent_issue_comments_metadata(first_page, multi_page: false, older_pages_available: false)
       end
 
       page_count = [ pages.to_i, 1 ].max
@@ -422,7 +422,11 @@ class GithubClient
         remaining_pages -= 1
       end
 
-      tag_multi_page(recent_pages.reverse.flatten, true)
+      tag_recent_issue_comments_metadata(
+        recent_pages.reverse.flatten,
+        multi_page: true,
+        older_pages_available: client.last_response&.rels&.dig(:prev).present?
+      )
     end
   end
 
@@ -960,9 +964,11 @@ class GithubClient
 
   private
 
-  def tag_multi_page(page, multi)
-    page.instance_variable_set(:@multi_page, multi)
+  def tag_recent_issue_comments_metadata(page, multi_page:, older_pages_available:)
+    page.instance_variable_set(:@multi_page, multi_page)
+    page.instance_variable_set(:@older_pages_available, older_pages_available)
     page.define_singleton_method(:multi_page?) { @multi_page }
+    page.define_singleton_method(:older_pages_available?) { @older_pages_available }
     page
   end
 

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -422,10 +422,29 @@ class GithubClient
         remaining_pages -= 1
       end
 
+      prev_rel = client.last_response&.rels&.dig(:prev)
       tag_recent_issue_comments_metadata(
         recent_pages.reverse.flatten,
         multi_page: true,
-        older_pages_available: client.last_response&.rels&.dig(:prev).present?
+        older_pages_available: prev_rel.present?,
+        next_older_page_url: prev_rel&.href
+      )
+    end
+  end
+
+  # Fetches a single older page of issue comments by URL.
+  #
+  # @param page_url [String] Full GitHub API URL for the page
+  # @return [Array<Sawyer::Resource>] Comments with older_pages_available? and next_older_page_url metadata
+  def fetch_issue_comment_page(page_url)
+    handle_errors do
+      page_response = client.get(page_url)
+      prev_rel = client.last_response&.rels&.dig(:prev)
+      tag_recent_issue_comments_metadata(
+        Array(page_response),
+        multi_page: true,
+        older_pages_available: prev_rel.present?,
+        next_older_page_url: prev_rel&.href
       )
     end
   end
@@ -964,11 +983,13 @@ class GithubClient
 
   private
 
-  def tag_recent_issue_comments_metadata(page, multi_page:, older_pages_available:)
+  def tag_recent_issue_comments_metadata(page, multi_page:, older_pages_available:, next_older_page_url: nil)
     page.instance_variable_set(:@multi_page, multi_page)
     page.instance_variable_set(:@older_pages_available, older_pages_available)
+    page.instance_variable_set(:@next_older_page_url, next_older_page_url)
     page.define_singleton_method(:multi_page?) { @multi_page }
     page.define_singleton_method(:older_pages_available?) { @older_pages_available }
+    page.define_singleton_method(:next_older_page_url) { @next_older_page_url }
     page
   end
 

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -19,7 +19,7 @@ module Prompts
 
     DEFAULT_MAX_COMMENTS = BuildForIssue::DEFAULT_MAX_COMMENTS
     DEFAULT_MAX_COMMENT_LENGTH = BuildForIssue::DEFAULT_MAX_COMMENT_LENGTH
-    RECENT_COMMENT_PAGE_WINDOW = 2
+    GITHUB_COMMENTS_PER_PAGE = 100
 
     attr_reader :project, :pr_number, :github_client, :rebase_succeeded,
                 :lint_command, :test_command, :issue
@@ -265,7 +265,7 @@ module Prompts
         comments = github_client.recent_issue_comments(
           project.full_name,
           pr_number,
-          pages: RECENT_COMMENT_PAGE_WINDOW
+          pages: recent_comment_page_window
         )
         comments.select { |c| project.trusted_github_user?(c.user&.login) }
           .last(max_prompt_comments)
@@ -290,6 +290,10 @@ module Prompts
 
     def max_comment_length
       prompt_comment_settings[:max_comment_length]
+    end
+
+    def recent_comment_page_window
+      [ (max_prompt_comments.to_f / GITHUB_COMMENTS_PER_PAGE).ceil, 1 ].max
     end
 
     def truncate_comment_body(body)

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -288,7 +288,10 @@ module Prompts
     end
 
     def recent_comment_page_window
-      [ (max_prompt_comments.to_f / GITHUB_COMMENTS_PER_PAGE).ceil, 1 ].max
+      [
+        [ (max_prompt_comments.to_f / GITHUB_COMMENTS_PER_PAGE).ceil, 1 ].max,
+        MAX_RECENT_COMMENT_PAGES
+      ].min
     end
 
     def recent_trusted_comments

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -299,7 +299,7 @@ module Prompts
         trusted = select_trusted_comments(comments)
 
         return trusted.last(max_prompt_comments) if trusted.size >= max_prompt_comments
-        return trusted unless comments.respond_to?(:multi_page?) && comments.multi_page?
+        return trusted unless comments.respond_to?(:older_pages_available?) && comments.older_pages_available?
         return trusted if pages >= MAX_RECENT_COMMENT_PAGES
 
         pages += 1

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -295,18 +295,20 @@ module Prompts
     end
 
     def recent_trusted_comments
-      pages = recent_comment_page_window
+      comments = github_client.recent_issue_comments(project.full_name, pr_number, pages: recent_comment_page_window)
+      trusted = select_trusted_comments(comments)
+      pages_fetched = recent_comment_page_window
 
-      loop do
-        comments = github_client.recent_issue_comments(project.full_name, pr_number, pages: pages)
-        trusted = select_trusted_comments(comments)
+      while trusted.size < max_prompt_comments && pages_fetched < MAX_RECENT_COMMENT_PAGES
+        break unless comments.respond_to?(:next_older_page_url) && comments.next_older_page_url
 
-        return trusted.last(max_prompt_comments) if trusted.size >= max_prompt_comments
-        return trusted unless comments.respond_to?(:older_pages_available?) && comments.older_pages_available?
-        return trusted if pages >= MAX_RECENT_COMMENT_PAGES
-
-        pages += 1
+        older_page = github_client.fetch_issue_comment_page(comments.next_older_page_url)
+        trusted = select_trusted_comments(older_page) + trusted
+        pages_fetched += 1
+        comments = older_page
       end
+
+      trusted.last(max_prompt_comments)
     end
 
     def select_trusted_comments(comments)

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -17,6 +17,10 @@ module Prompts
   class BuildForPr
     include ServiceContainerSections
 
+    DEFAULT_MAX_COMMENTS = BuildForIssue::DEFAULT_MAX_COMMENTS
+    DEFAULT_MAX_COMMENT_LENGTH = BuildForIssue::DEFAULT_MAX_COMMENT_LENGTH
+    RECENT_COMMENT_PAGE_WINDOW = 2
+
     attr_reader :project, :pr_number, :github_client, :rebase_succeeded,
                 :lint_command, :test_command, :issue
 
@@ -212,7 +216,7 @@ module Prompts
 
     def conversation_section
       comment_text = trusted_comments.map do |c|
-        "- **#{c.user.login}**: #{c.body}"
+        "- **#{c.user.login}**: #{truncate_comment_body(c.body.to_s)}"
       end.join("\n")
 
       <<~SECTION
@@ -258,11 +262,40 @@ module Prompts
 
     def trusted_comments
       @trusted_comments ||= begin
-        comments = github_client.issue_comments(project.full_name, pr_number)
+        comments = github_client.recent_issue_comments(
+          project.full_name,
+          pr_number,
+          pages: RECENT_COMMENT_PAGE_WINDOW
+        )
         comments.select { |c| project.trusted_github_user?(c.user&.login) }
+          .last(max_prompt_comments)
       rescue GithubClient::Error
         []
       end
+    end
+
+    def prompt_comment_settings
+      @prompt_comment_settings ||= begin
+        settings = AgentRuns::UserSettingsResolver.call(project: project, strict: false)
+        {
+          max_comments: settings&.max_prompt_comments || DEFAULT_MAX_COMMENTS,
+          max_comment_length: settings&.max_comment_length || DEFAULT_MAX_COMMENT_LENGTH
+        }
+      end
+    end
+
+    def max_prompt_comments
+      prompt_comment_settings[:max_comments]
+    end
+
+    def max_comment_length
+      prompt_comment_settings[:max_comment_length]
+    end
+
+    def truncate_comment_body(body)
+      return body if body.length <= max_comment_length
+
+      "#{body[0, max_comment_length]}… [truncated]"
     end
 
     def detected_language

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -20,6 +20,7 @@ module Prompts
     DEFAULT_MAX_COMMENTS = BuildForIssue::DEFAULT_MAX_COMMENTS
     DEFAULT_MAX_COMMENT_LENGTH = BuildForIssue::DEFAULT_MAX_COMMENT_LENGTH
     GITHUB_COMMENTS_PER_PAGE = 100
+    MAX_RECENT_COMMENT_PAGES = 10
 
     attr_reader :project, :pr_number, :github_client, :rebase_succeeded,
                 :lint_command, :test_command, :issue
@@ -262,13 +263,7 @@ module Prompts
 
     def trusted_comments
       @trusted_comments ||= begin
-        comments = github_client.recent_issue_comments(
-          project.full_name,
-          pr_number,
-          pages: recent_comment_page_window
-        )
-        comments.select { |c| project.trusted_github_user?(c.user&.login) }
-          .last(max_prompt_comments)
+        recent_trusted_comments
       rescue GithubClient::Error
         []
       end
@@ -294,6 +289,25 @@ module Prompts
 
     def recent_comment_page_window
       [ (max_prompt_comments.to_f / GITHUB_COMMENTS_PER_PAGE).ceil, 1 ].max
+    end
+
+    def recent_trusted_comments
+      pages = recent_comment_page_window
+
+      loop do
+        comments = github_client.recent_issue_comments(project.full_name, pr_number, pages: pages)
+        trusted = select_trusted_comments(comments)
+
+        return trusted.last(max_prompt_comments) if trusted.size >= max_prompt_comments
+        return trusted unless comments.respond_to?(:multi_page?) && comments.multi_page?
+        return trusted if pages >= MAX_RECENT_COMMENT_PAGES
+
+        pages += 1
+      end
+    end
+
+    def select_trusted_comments(comments)
+      comments.select { |comment| project.trusted_github_user?(comment.user&.login) }
     end
 
     def truncate_comment_body(body)

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -872,7 +872,10 @@ RSpec.describe GithubClient do
               { id: 401, body: "Newer comment", user: { login: "maintainer" } },
               { id: 402, body: "Newest comment", user: { login: "maintainer" } }
             ].to_json,
-            headers: { "Content-Type" => "application/json" }
+            headers: {
+              "Content-Type" => "application/json",
+              "Link" => %(<#{api_base}/repos/#{repo}/issues/42/comments?page=4&per_page=100>; rel="prev")
+            }
           )
       end
 
@@ -887,6 +890,26 @@ RSpec.describe GithubClient do
       it "marks the result as multi-page" do
         result = client.recent_issue_comments(repo, 42)
 
+        expect(result.multi_page?).to be true
+      end
+
+      it "can include a bounded trailing window of recent pages" do
+        stub_request(:get, "#{api_base}/repos/#{repo}/issues/42/comments?page=4&per_page=100")
+          .to_return(
+            status: 200,
+            body: [
+              { id: 301, body: "Older recent comment", user: { login: "maintainer" } }
+            ].to_json,
+            headers: {
+              "Content-Type" => "application/json",
+              "Link" => %(<#{api_base}/repos/#{repo}/issues/42/comments?page=3&per_page=100>; rel="prev", ) +
+                %(<#{api_base}/repos/#{repo}/issues/42/comments?page=5&per_page=100>; rel="next")
+            }
+          )
+
+        result = client.recent_issue_comments(repo, 42, pages: 2)
+
+        expect(result.map(&:body)).to eq([ "Older recent comment", "Newer comment", "Newest comment" ])
         expect(result.multi_page?).to be true
       end
     end

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -844,6 +844,7 @@ RSpec.describe GithubClient do
         result = client.recent_issue_comments(repo, 42)
 
         expect(result.multi_page?).to be false
+        expect(result.older_pages_available?).to be false
       end
     end
 
@@ -891,6 +892,7 @@ RSpec.describe GithubClient do
         result = client.recent_issue_comments(repo, 42)
 
         expect(result.multi_page?).to be true
+        expect(result.older_pages_available?).to be true
       end
 
       it "can include a bounded trailing window of recent pages" do
@@ -911,6 +913,27 @@ RSpec.describe GithubClient do
 
         expect(result.map(&:body)).to eq([ "Older recent comment", "Newer comment", "Newest comment" ])
         expect(result.multi_page?).to be true
+        expect(result.older_pages_available?).to be true
+      end
+
+      it "marks the result when the fetched window already includes the oldest page" do
+        stub_request(:get, "#{api_base}/repos/#{repo}/issues/42/comments?page=4&per_page=100")
+          .to_return(
+            status: 200,
+            body: [
+              { id: 301, body: "Older recent comment", user: { login: "maintainer" } }
+            ].to_json,
+            headers: {
+              "Content-Type" => "application/json",
+              "Link" => %(<#{api_base}/repos/#{repo}/issues/42/comments?page=5&per_page=100>; rel="next")
+            }
+          )
+
+        result = client.recent_issue_comments(repo, 42, pages: 5)
+
+        expect(result.map(&:body)).to eq([ "Older recent comment", "Newer comment", "Newest comment" ])
+        expect(result.multi_page?).to be true
+        expect(result.older_pages_available?).to be false
       end
     end
   end

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -888,11 +888,12 @@ RSpec.describe GithubClient do
         expect(result.map(&:body)).not_to include("Very old comment")
       end
 
-      it "marks the result as multi-page" do
+      it "marks the result as multi-page with next_older_page_url" do
         result = client.recent_issue_comments(repo, 42)
 
         expect(result.multi_page?).to be true
         expect(result.older_pages_available?).to be true
+        expect(result.next_older_page_url).to eq("#{api_base}/repos/#{repo}/issues/42/comments?page=4&per_page=100")
       end
 
       it "can include a bounded trailing window of recent pages" do
@@ -934,7 +935,54 @@ RSpec.describe GithubClient do
         expect(result.map(&:body)).to eq([ "Older recent comment", "Newer comment", "Newest comment" ])
         expect(result.multi_page?).to be true
         expect(result.older_pages_available?).to be false
+        expect(result.next_older_page_url).to be_nil
       end
+    end
+  end
+
+  describe "#fetch_issue_comment_page" do
+    let(:repo) { "owner/repo" }
+
+    it "fetches a single page by URL and exposes pagination metadata" do
+      page_url = "#{api_base}/repos/#{repo}/issues/42/comments?page=3&per_page=100"
+      prev_url = "#{api_base}/repos/#{repo}/issues/42/comments?page=2&per_page=100"
+
+      stub_request(:get, page_url)
+        .to_return(
+          status: 200,
+          body: [
+            { id: 301, body: "Page 3 comment", user: { login: "dev" } }
+          ].to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "Link" => %(<#{prev_url}>; rel="prev")
+          }
+        )
+
+      result = client.fetch_issue_comment_page(page_url)
+
+      expect(result.size).to eq(1)
+      expect(result.first.body).to eq("Page 3 comment")
+      expect(result.older_pages_available?).to be true
+      expect(result.next_older_page_url).to eq(prev_url)
+    end
+
+    it "returns nil next_older_page_url when no prev link exists" do
+      page_url = "#{api_base}/repos/#{repo}/issues/42/comments?page=1&per_page=100"
+
+      stub_request(:get, page_url)
+        .to_return(
+          status: 200,
+          body: [
+            { id: 1, body: "First page comment", user: { login: "dev" } }
+          ].to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      result = client.fetch_issue_comment_page(page_url)
+
+      expect(result.older_pages_available?).to be false
+      expect(result.next_older_page_url).to be_nil
     end
   end
 

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -4,6 +4,25 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe Prompts::BuildForPr do
+  def recent_comments_with_page_state(comments, multi_page:)
+    comments.define_singleton_method(:multi_page?) { multi_page }
+    comments
+  end
+
+  def trusted_recent_comments(count)
+    Array.new(count) { |index| OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Trusted #{index + 1}") }
+  end
+
+  def untrusted_recent_comments(count)
+    Array.new(count) { |index| OpenStruct.new(user: OpenStruct.new(login: "bot#{index}"), body: "Noise #{index}") }
+  end
+
+  def stub_prompt_comment_settings(project, settings)
+    allow(AgentRuns::UserSettingsResolver).to receive(:call)
+      .with(project: project, strict: false)
+      .and_return(settings)
+  end
+
   let(:project) { create(:project, allowed_github_usernames: [ "trusteduser" ]) }
   let(:github_client) { instance_double(GithubClient) }
   let(:user_settings) { instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000) }
@@ -285,6 +304,32 @@ RSpec.describe Prompts::BuildForPr do
 
       expect(prompt).to include("Trusted comment 1")
       expect(prompt).to include("Trusted comment 205")
+    end
+
+    it "backfills older recent pages until it collects enough trusted comments" do
+      limited_settings = instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000)
+      newest_comments = recent_comments_with_page_state(
+        untrusted_recent_comments(100),
+        multi_page: true
+      )
+      older_recent_comments = recent_comments_with_page_state(
+        trusted_recent_comments(20) + newest_comments,
+        multi_page: true
+      )
+
+      stub_prompt_comment_settings(project, limited_settings)
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: 1)
+        .and_return(newest_comments)
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: 2)
+        .and_return(older_recent_comments)
+
+      prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
+
+      expect(prompt).to include("Trusted 1")
+      expect(prompt).to include("Trusted 20")
+      expect(prompt).not_to include("Noise 0")
     end
   end
 

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -4,9 +4,11 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe Prompts::BuildForPr do
-  def recent_comments_with_page_state(comments, multi_page:, older_pages_available: multi_page)
+  def recent_comments_with_page_state(comments, multi_page:, older_pages_available: multi_page, next_older_page_url: nil)
+    next_url = older_pages_available ? (next_older_page_url || "https://api.github.com/repos/o/r/issues/42/comments?page=1") : nil
     comments.define_singleton_method(:multi_page?) { multi_page }
     comments.define_singleton_method(:older_pages_available?) { older_pages_available }
+    comments.define_singleton_method(:next_older_page_url) { next_url }
     comments
   end
 
@@ -22,14 +24,6 @@ RSpec.describe Prompts::BuildForPr do
     allow(AgentRuns::UserSettingsResolver).to receive(:call)
       .with(project: project, strict: false)
       .and_return(settings)
-  end
-
-  def stub_recent_issue_comments(github_client, project, *responses)
-    responses.each_with_index do |comments, index|
-      allow(github_client).to receive(:recent_issue_comments)
-        .with(project.full_name, 42, pages: index + 1)
-        .and_return(comments)
-    end
   end
 
   let(:project) { create(:project, allowed_github_usernames: [ "trusteduser" ]) }
@@ -337,27 +331,31 @@ RSpec.describe Prompts::BuildForPr do
         .once
     end
 
-    it "backfills older recent pages until it collects enough trusted comments" do
-      limited_settings = instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000)
-      newest_comments = recent_comments_with_page_state(
-        untrusted_recent_comments(100),
-        multi_page: true,
-        older_pages_available: true
-      )
-      older_recent_comments = recent_comments_with_page_state(
-        trusted_recent_comments(20) + newest_comments,
-        multi_page: true,
-        older_pages_available: true
-      )
+    context "when trusted comments are sparse and backfill is needed" do
+      let(:older_page_url) { "https://api.github.com/repos/o/r/issues/42/comments?page=5" }
 
-      stub_prompt_comment_settings(project, limited_settings)
-      stub_recent_issue_comments(github_client, project, newest_comments, older_recent_comments)
+      before do
+        limited_settings = instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000)
+        newest = recent_comments_with_page_state(
+          untrusted_recent_comments(100), multi_page: true, older_pages_available: true,
+          next_older_page_url: older_page_url
+        )
+        older = recent_comments_with_page_state(trusted_recent_comments(20), multi_page: true, older_pages_available: true)
 
-      prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
+        stub_prompt_comment_settings(project, limited_settings)
+        allow(github_client).to receive(:recent_issue_comments).with(project.full_name, 42, pages: 1).and_return(newest)
+        allow(github_client).to receive(:fetch_issue_comment_page).with(older_page_url).and_return(older)
+      end
 
-      expect(prompt).to include("Trusted 1")
-      expect(prompt).to include("Trusted 20")
-      expect(prompt).not_to include("Noise 0")
+      it "fetches older pages incrementally until it collects enough trusted comments" do
+        prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
+
+        expect(prompt).to include("Trusted 1")
+        expect(prompt).to include("Trusted 20")
+        expect(prompt).not_to include("Noise 0")
+        expect(github_client).to have_received(:recent_issue_comments).once
+        expect(github_client).to have_received(:fetch_issue_comment_page).once
+      end
     end
 
     it "stops backfilling once the fetched window already includes the oldest page" do

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -315,6 +315,28 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("Trusted comment 205")
     end
 
+    it "clamps the initial trailing page window to the safety cap" do
+      expanded_settings = instance_double(UserSetting, max_prompt_comments: 5_000, max_comment_length: 2000)
+      expanded_comments = recent_comments_with_page_state(
+        trusted_recent_comments(25),
+        multi_page: true,
+        older_pages_available: false
+      )
+
+      allow(AgentRuns::UserSettingsResolver).to receive(:call)
+        .with(project: project, strict: false)
+        .and_return(expanded_settings)
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: 10)
+        .and_return(expanded_comments)
+
+      described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
+
+      expect(github_client).to have_received(:recent_issue_comments)
+        .with(project.full_name, 42, pages: 10)
+        .once
+    end
+
     it "backfills older recent pages until it collects enough trusted comments" do
       limited_settings = instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000)
       newest_comments = recent_comments_with_page_state(

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -6,6 +6,7 @@ require "ostruct"
 RSpec.describe Prompts::BuildForPr do
   let(:project) { create(:project, allowed_github_usernames: [ "trusteduser" ]) }
   let(:github_client) { instance_double(GithubClient) }
+  let(:user_settings) { instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000) }
 
   let(:pr_data) do
     OpenStruct.new(
@@ -23,7 +24,10 @@ RSpec.describe Prompts::BuildForPr do
 
 
 
-    allow(github_client).to receive_messages(check_runs_for_ref: [], review_threads: [], issue_comments: [])
+    allow(github_client).to receive_messages(check_runs_for_ref: [], review_threads: [], recent_issue_comments: [])
+    allow(AgentRuns::UserSettingsResolver).to receive(:call)
+      .with(project: project, strict: false)
+      .and_return(user_settings)
   end
 
   describe ".call" do
@@ -200,13 +204,17 @@ RSpec.describe Prompts::BuildForPr do
   end
 
   describe "conversation comments section" do
+    let(:recent_comments) do
+      [
+        OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Please also fix the tests"),
+        OpenStruct.new(user: OpenStruct.new(login: "randomuser"), body: "Ignore this")
+      ]
+    end
+
     before do
-      allow(github_client).to receive(:issue_comments)
-        .with(project.full_name, 42)
-        .and_return([
-          OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Please also fix the tests"),
-          OpenStruct.new(user: OpenStruct.new(login: "randomuser"), body: "Ignore this")
-        ])
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: described_class::RECENT_COMMENT_PAGE_WINDOW)
+        .and_return(recent_comments)
     end
 
     it "includes comments from trusted users only" do
@@ -220,6 +228,46 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("Conversation Comments")
       expect(prompt).to include("Please also fix the tests")
       expect(prompt).not_to include("Ignore this")
+    end
+
+    it "keeps only the most recent trusted comments within the limit" do
+      limited_settings = instance_double(UserSetting, max_prompt_comments: 2, max_comment_length: 2000)
+      limited_comments = [
+        OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Oldest trusted"),
+        OpenStruct.new(user: OpenStruct.new(login: "randomuser"), body: "Untrusted"),
+        OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Newer trusted"),
+        OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Newest trusted")
+      ]
+      allow(AgentRuns::UserSettingsResolver).to receive(:call)
+        .with(project: project, strict: false)
+        .and_return(limited_settings)
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: described_class::RECENT_COMMENT_PAGE_WINDOW)
+        .and_return(limited_comments)
+
+      prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
+
+      expect(prompt).to include("Newer trusted")
+      expect(prompt).to include("Newest trusted")
+      expect(prompt).not_to include("Oldest trusted")
+      expect(prompt).not_to include("Untrusted")
+    end
+
+    it "truncates long recent comment bodies" do
+      truncating_settings = instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 20)
+      long_comment = [
+        OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "This comment is definitely longer than twenty characters")
+      ]
+      allow(AgentRuns::UserSettingsResolver).to receive(:call)
+        .with(project: project, strict: false)
+        .and_return(truncating_settings)
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: described_class::RECENT_COMMENT_PAGE_WINDOW)
+        .and_return(long_comment)
+
+      prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
+
+      expect(prompt).to include("This comment is defi… [truncated]")
     end
   end
 
@@ -363,17 +411,16 @@ RSpec.describe Prompts::BuildForPr do
 
   describe "priority ordering" do
     it "orders priorities correctly with all sections present" do
-      allow(github_client).to receive_messages(check_runs_for_ref: [ { name: "ci", conclusion: "failure" } ], review_threads: [ { id: "t1", is_resolved: false, comments: [ { body: "fix", path: "a.rb", line: 1, author: "r" } ] } ], issue_comments: [ OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "comment") ])
+      allow(github_client).to receive_messages(
+        check_runs_for_ref: [ { name: "ci", conclusion: "failure" } ],
+        review_threads: [ { id: "t1", is_resolved: false, comments: [ { body: "fix", path: "a.rb", line: 1, author: "r" } ] } ]
+      )
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: described_class::RECENT_COMMENT_PAGE_WINDOW)
+        .and_return([ OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "comment") ])
 
       issue = create(:issue, project: project, title: "Issue", github_number: 1, body: "body")
-
-      prompt = described_class.call(
-        project: project,
-        pr_number: 42,
-        github_client: github_client,
-        rebase_succeeded: false,
-        issue: issue
-      )
+      prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: false, issue: issue)
 
       conflicts_pos = prompt.index("Resolve merge conflicts")
       ci_pos = prompt.index("Fix CI failures")

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe Prompts::BuildForPr do
-  def recent_comments_with_page_state(comments, multi_page:)
+  def recent_comments_with_page_state(comments, multi_page:, older_pages_available: multi_page)
     comments.define_singleton_method(:multi_page?) { multi_page }
+    comments.define_singleton_method(:older_pages_available?) { older_pages_available }
     comments
   end
 
@@ -21,6 +22,14 @@ RSpec.describe Prompts::BuildForPr do
     allow(AgentRuns::UserSettingsResolver).to receive(:call)
       .with(project: project, strict: false)
       .and_return(settings)
+  end
+
+  def stub_recent_issue_comments(github_client, project, *responses)
+    responses.each_with_index do |comments, index|
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: index + 1)
+        .and_return(comments)
+    end
   end
 
   let(:project) { create(:project, allowed_github_usernames: [ "trusteduser" ]) }
@@ -310,26 +319,43 @@ RSpec.describe Prompts::BuildForPr do
       limited_settings = instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000)
       newest_comments = recent_comments_with_page_state(
         untrusted_recent_comments(100),
-        multi_page: true
+        multi_page: true,
+        older_pages_available: true
       )
       older_recent_comments = recent_comments_with_page_state(
         trusted_recent_comments(20) + newest_comments,
-        multi_page: true
+        multi_page: true,
+        older_pages_available: true
       )
 
       stub_prompt_comment_settings(project, limited_settings)
-      allow(github_client).to receive(:recent_issue_comments)
-        .with(project.full_name, 42, pages: 1)
-        .and_return(newest_comments)
-      allow(github_client).to receive(:recent_issue_comments)
-        .with(project.full_name, 42, pages: 2)
-        .and_return(older_recent_comments)
+      stub_recent_issue_comments(github_client, project, newest_comments, older_recent_comments)
 
       prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
 
       expect(prompt).to include("Trusted 1")
       expect(prompt).to include("Trusted 20")
       expect(prompt).not_to include("Noise 0")
+    end
+
+    it "stops backfilling once the fetched window already includes the oldest page" do
+      limited_settings = instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000)
+      all_recent_comments = recent_comments_with_page_state(
+        trusted_recent_comments(5) + untrusted_recent_comments(10),
+        multi_page: true,
+        older_pages_available: false
+      )
+
+      stub_prompt_comment_settings(project, limited_settings)
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: 1)
+        .and_return(all_recent_comments)
+
+      prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
+
+      expect(prompt).to include("Trusted 1")
+      expect(prompt).to include("Trusted 5")
+      expect(github_client).to have_received(:recent_issue_comments).once
     end
   end
 

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe Prompts::BuildForPr do
 
 
     allow(github_client).to receive_messages(check_runs_for_ref: [], review_threads: [], recent_issue_comments: [])
-    allow(AgentRuns::UserSettingsResolver).to receive(:call)
-      .with(project: project, strict: false)
-      .and_return(user_settings)
+    allow(AgentRuns::UserSettingsResolver).to receive(:call).and_return(user_settings)
   end
 
   describe ".call" do
@@ -213,7 +211,7 @@ RSpec.describe Prompts::BuildForPr do
 
     before do
       allow(github_client).to receive(:recent_issue_comments)
-        .with(project.full_name, 42, pages: described_class::RECENT_COMMENT_PAGE_WINDOW)
+        .with(project.full_name, 42, pages: 1)
         .and_return(recent_comments)
     end
 
@@ -242,7 +240,7 @@ RSpec.describe Prompts::BuildForPr do
         .with(project: project, strict: false)
         .and_return(limited_settings)
       allow(github_client).to receive(:recent_issue_comments)
-        .with(project.full_name, 42, pages: described_class::RECENT_COMMENT_PAGE_WINDOW)
+        .with(project.full_name, 42, pages: 1)
         .and_return(limited_comments)
 
       prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
@@ -262,12 +260,31 @@ RSpec.describe Prompts::BuildForPr do
         .with(project: project, strict: false)
         .and_return(truncating_settings)
       allow(github_client).to receive(:recent_issue_comments)
-        .with(project.full_name, 42, pages: described_class::RECENT_COMMENT_PAGE_WINDOW)
+        .with(project.full_name, 42, pages: 1)
         .and_return(long_comment)
 
       prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
 
       expect(prompt).to include("This comment is defi… [truncated]")
+    end
+
+    it "fetches enough trailing pages to honor limits above 200 comments" do
+      expanded_settings = instance_double(UserSetting, max_prompt_comments: 205, max_comment_length: 2000)
+      expanded_comments = Array.new(205) do |index|
+        OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Trusted comment #{index + 1}")
+      end
+
+      allow(AgentRuns::UserSettingsResolver).to receive(:call)
+        .with(project: project, strict: false)
+        .and_return(expanded_settings)
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: 3)
+        .and_return(expanded_comments)
+
+      prompt = described_class.call(project: project, pr_number: 42, github_client: github_client, rebase_succeeded: true)
+
+      expect(prompt).to include("Trusted comment 1")
+      expect(prompt).to include("Trusted comment 205")
     end
   end
 
@@ -416,7 +433,7 @@ RSpec.describe Prompts::BuildForPr do
         review_threads: [ { id: "t1", is_resolved: false, comments: [ { body: "fix", path: "a.rb", line: 1, author: "r" } ] } ]
       )
       allow(github_client).to receive(:recent_issue_comments)
-        .with(project.full_name, 42, pages: described_class::RECENT_COMMENT_PAGE_WINDOW)
+        .with(project.full_name, 42, pages: 1)
         .and_return([ OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "comment") ])
 
       issue = create(:issue, project: project, title: "Issue", github_number: 1, body: "body")

--- a/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
+++ b/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Activities::PreparePrPromptActivity do
       .with(project.full_name, 42)
       .and_return(pr_data)
 
-    allow(github_client).to receive_messages(check_runs_for_ref: [], review_threads: [], issue_comments: [])
+    allow(github_client).to receive_messages(check_runs_for_ref: [], review_threads: [], recent_issue_comments: [])
   end
 
   describe "#execute" do


### PR DESCRIPTION
## Summary
- limit PR conversation context to recent trusted comments with per-comment truncation
- fetch a bounded trailing window of recent GitHub comment pages so busy PRs still surface relevant collaborator context
- add focused prompt and GitHub client coverage for recent-comment behavior

## Verification
- `bundle exec rspec spec/services/prompts/build_for_pr_spec.rb`
- `bundle exec rspec spec/services/github_client_spec.rb:893 spec/services/prompts/build_for_pr_spec.rb`

## Notes
- Focused RSpec runs pass, but SimpleCov still exits non-zero on partial-suite runs because repo-wide coverage thresholds are enforced.