### PR TITLE
Fix #1057: fix(workflow): health check doesn't record stale state before restart

### DIFF
--- a/app/jobs/poll_workflow_health_check_job.rb
+++ b/app/jobs/poll_workflow_health_check_job.rb
@@ -87,9 +87,17 @@ class PollWorkflowHealthCheckJob < ApplicationJob
   def check_stale_running(project)
     return unless project.poll_stale_with_recheck?
 
+    reason = "health check: stale RUNNING (last polled #{project.last_polled_at})"
+
+    WorkflowState.record_polling_status(
+      project,
+      status: "running",
+      restart_reason: reason
+    )
+
     restart_workflow(
       project,
-      reason: "health check: stale RUNNING (last polled #{project.last_polled_at})",
+      reason: reason,
       log_message: "temporal_worker.poll_workflow_stale_running"
     )
   end

--- a/app/models/workflow_state.rb
+++ b/app/models/workflow_state.rb
@@ -44,13 +44,14 @@ class WorkflowState < ApplicationRecord
       ws.error_message = nil
     end
 
-    should_broadcast = ws.new_record? || ws.status_changed?
+    should_broadcast =
+      ws.new_record? || ws.status_changed? || ws.restart_reason_changed? || ws.error_message_changed?
     ws.save!
 
     # Broadcast after the transaction commits so listeners never see data that
-    # could be rolled back. Skip when status is unchanged (e.g., healthy →
-    # healthy on every poll cycle) to avoid unnecessary DB queries and
-    # ActionCable traffic.
+    # could be rolled back. Skip when neither status nor user-visible restart
+    # metadata changed (e.g., healthy -> healthy on every poll cycle) to avoid
+    # unnecessary DB queries and ActionCable traffic.
     if should_broadcast
       ActiveRecord.after_all_transactions_commit { project.broadcast_workflow_status_update }
     end

--- a/spec/jobs/poll_workflow_health_check_job_spec.rb
+++ b/spec/jobs/poll_workflow_health_check_job_spec.rb
@@ -83,6 +83,24 @@ RSpec.describe PollWorkflowHealthCheckJob do
       ).at_least(:once)
     end
 
+    it "records stale restart context before attempting the restart" do
+      project = create(:project, poll_interval_seconds: 60, last_polled_at: 10.minutes.ago)
+      WorkflowState.record_polling_status(project, status: "running")
+      workflow_handle = double("workflow_handle") # rubocop:disable RSpec/VerifiedDoubles
+      desc = double("description", status: Temporalio::Client::WorkflowExecutionStatus::RUNNING) # rubocop:disable RSpec/VerifiedDoubles
+
+      allow(temporal_client).to receive(:workflow_handle).and_return(workflow_handle)
+      allow(workflow_handle).to receive(:describe).and_return(desc)
+      allow(workflow_handle).to receive(:terminate)
+      allow(temporal_client).to receive(:start_workflow).and_raise(StandardError, "restart failed")
+
+      expect { described_class.perform_now }.not_to raise_error
+
+      workflow_state = WorkflowState.find_by!(temporal_workflow_id: "github-poll-#{project.id}")
+      expect(workflow_state.status).to eq("running")
+      expect(workflow_state.restart_reason).to match(/health check: stale RUNNING/)
+    end
+
     it "uses per-project poll interval for staleness threshold" do
       # Project with a long poll interval (600s) — last_polled_at 10 min ago is NOT stale
       create(:project, poll_interval_seconds: 600, last_polled_at: 10.minutes.ago)

--- a/spec/jobs/poll_workflow_health_check_job_spec.rb
+++ b/spec/jobs/poll_workflow_health_check_job_spec.rb
@@ -67,9 +67,13 @@ RSpec.describe PollWorkflowHealthCheckJob do
       allow(temporal_client).to receive(:workflow_handle).and_return(workflow_handle)
       allow(workflow_handle).to receive(:describe).and_return(desc)
       allow(workflow_handle).to receive(:terminate)
+      allow(WorkflowState).to receive(:record_polling_status)
 
       described_class.perform_now
 
+      expect(WorkflowState).to have_received(:record_polling_status).with(
+        project, hash_including(status: "running", restart_reason: /health check: stale RUNNING/)
+      ).at_least(:once)
       expect(workflow_handle).to have_received(:terminate)
       expect(temporal_client).to have_received(:start_workflow).with(
         Workflows::GitHubPollWorkflow,

--- a/spec/models/workflow_state_spec.rb
+++ b/spec/models/workflow_state_spec.rb
@@ -129,4 +129,27 @@ RSpec.describe WorkflowState do
       expect(reloaded.result_data).to eq(result.stringify_keys)
     end
   end
+
+  describe ".record_polling_status" do
+    it "broadcasts when restart_reason changes on a running workflow" do
+      project = create(:project)
+      create(
+        :workflow_state,
+        project: project,
+        temporal_workflow_id: "github-poll-#{project.id}",
+        workflow_type: "GitHubPollWorkflow",
+        status: "running"
+      )
+
+      allow(project).to receive(:broadcast_workflow_status_update)
+
+      described_class.record_polling_status(
+        project,
+        status: "running",
+        restart_reason: "health check: stale RUNNING"
+      )
+
+      expect(project).to have_received(:broadcast_workflow_status_update)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

fix(workflow): health check doesn't record stale state before restart

See #1057 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1057