### PR TITLE
Fix #1031: feat(token-tracking): ingest Kilo (kilocode) token usage data from agent-harness

### DIFF
--- a/spec/services/agent_runs/execute_spec.rb
+++ b/spec/services/agent_runs/execute_spec.rb
@@ -397,6 +397,67 @@ RSpec.describe AgentRuns::Execute do
         described_class.call(agent_run: agent_run, prompt: prompt)
       end
     end
+
+    context "when kilocode returns token totals" do
+      let(:agent_run) { create(:agent_run, :kilocode, project: project) }
+      let(:kilocode_model) { "anthropic/claude-sonnet-4.5" }
+      let(:delta) { agent_run.token_usages.find_by!(request_type: "run_delta") }
+      let(:aggregate) { TokenUsages::Aggregate.call }
+      let(:response) do
+        AgentHarness::Response.new(
+          output: "Applied the requested change",
+          exit_code: 0,
+          duration: 12.5,
+          provider: :kilocode,
+          model: kilocode_model,
+          tokens: { input: 3200, output: 1200, total: 4400 }
+        )
+      end
+
+      before do
+        allow(AgentHarness).to receive(:send_message).and_return(response)
+      end
+
+      it "persists run_summary and run_delta records for the kilocode model" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        summary = agent_run.token_usages.find_by!(request_type: "run_summary")
+        delta = agent_run.token_usages.find_by!(request_type: "run_delta")
+
+        aggregate_failures do
+          expect(summary.input_tokens).to eq(3200)
+          expect(summary.output_tokens).to eq(1200)
+          expect(summary.llm_model).to eq(kilocode_model)
+          expect(delta.input_tokens).to eq(3200)
+          expect(delta.output_tokens).to eq(1200)
+          expect(delta.llm_model).to eq(kilocode_model)
+        end
+      end
+
+      it "tracks only the missing billable delta when proxy coverage is partial" do
+        TokenUsageTracker.track(
+          agent_run: agent_run,
+          usage: {
+            tokens_input: 1000,
+            tokens_output: 200,
+            llm_model: kilocode_model,
+            request_type: "agent"
+          }
+        )
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        aggregate_failures do
+          expect(delta.input_tokens).to eq(2200)
+          expect(delta.output_tokens).to eq(1000)
+          expect(agent_run.reload.tokens_input).to eq(3200)
+          expect(agent_run.tokens_output).to eq(1200)
+          expect(aggregate[:total_input_tokens]).to eq(3200)
+          expect(aggregate[:total_output_tokens]).to eq(1200)
+          expect(aggregate[:cost_by_request_type]).to include("agent", "run_delta")
+          expect(aggregate[:cost_by_request_type]).not_to include("run_summary")
+        end
+      end
+    end
   end
 
   describe "provider mapping" do

--- a/spec/services/agent_runs/execute_spec.rb
+++ b/spec/services/agent_runs/execute_spec.rb
@@ -418,6 +418,13 @@ RSpec.describe AgentRuns::Execute do
         allow(AgentHarness).to receive(:send_message).and_return(response)
       end
 
+      it "depends on agent-harness versions that parse kilocode token totals" do
+        # Kilocode runtime token extraction lives upstream in agent-harness.
+        # This ingestion spec guards Paid's contract against regressing to a
+        # gem version older than the 0.7.0 release that added that support.
+        expect(Gem.loaded_specs.fetch("agent-harness").version).to be >= Gem::Version.new("0.7.0")
+      end
+
       it "persists run_summary and run_delta records for the kilocode model" do
         described_class.call(agent_run: agent_run, prompt: prompt)
 

--- a/spec/services/token_usages/aggregate_spec.rb
+++ b/spec/services/token_usages/aggregate_spec.rb
@@ -23,6 +23,30 @@ RSpec.describe TokenUsages::Aggregate do
       expect(result[:cost_by_model]).to include("claude-3-5-sonnet-20241022" => 10, "gpt-4o" => 20)
       expect(result[:cost_by_request_type]).to include("agent" => 10, "planning" => 20)
     end
+
+    it "includes run_delta records without double-counting run_summary audit totals" do
+      kilocode_run = create(:agent_run, :kilocode, :running, project: project)
+      create(:token_usage, agent_run: kilocode_run, request_type: "run_summary",
+             input_tokens: 4000, output_tokens: 1500, cost_cents: 26,
+             llm_model: "anthropic/claude-sonnet-4.5")
+      create(:token_usage, agent_run: kilocode_run, request_type: "agent",
+             input_tokens: 1000, output_tokens: 500, cost_cents: 7,
+             llm_model: "anthropic/claude-sonnet-4.5")
+      create(:token_usage, agent_run: kilocode_run, request_type: "run_delta",
+             input_tokens: 3000, output_tokens: 1000, cost_cents: 19,
+             llm_model: "anthropic/claude-sonnet-4.5")
+
+      result = described_class.call
+
+      aggregate_failures do
+        expect(result[:total_cost_cents]).to eq(56)
+        expect(result[:total_input_tokens]).to eq(7000)
+        expect(result[:total_output_tokens]).to eq(3000)
+        expect(result[:cost_by_model]).to include("anthropic/claude-sonnet-4.5" => 26)
+        expect(result[:cost_by_request_type]).to include("agent" => 17, "planning" => 20, "run_delta" => 19)
+        expect(result[:cost_by_request_type]).not_to include("run_summary")
+      end
+    end
   end
 
   describe ".for_project" do


### PR DESCRIPTION
## Summary

feat(token-tracking): ingest Kilo (kilocode) token usage data from agent-harness

See #1031 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1031