### PR TITLE
Fix #1065: Project page synced issues table should color-code priority labels like GitHub

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -96,6 +96,21 @@ module ApplicationHelper
     )
   end
 
+  GITHUB_PRIORITY_LABEL_STYLES = {
+    "P0" => "bg-red-700 text-red-50",
+    "P1" => "bg-red-100 text-red-800",
+    "P2" => "bg-orange-100 text-orange-800",
+    "P3" => "bg-blue-100 text-blue-800"
+  }.freeze
+
+  DEFAULT_ISSUE_LABEL_STYLE = "bg-gray-100 text-gray-600"
+
+  def issue_label_badge_classes(project, label)
+    priority_tier = priority_tier_for_label(project, label)
+    styles = GITHUB_PRIORITY_LABEL_STYLES.fetch(priority_tier, DEFAULT_ISSUE_LABEL_STYLE)
+    "inline-flex items-center rounded-full px-2 py-0.5 text-xs #{styles}"
+  end
+
   SERVICE_CONTAINER_STATUS_STYLES = {
     "stopped" => { bg: "bg-gray-100", text: "text-gray-700", label: "Stopped" },
     "starting" => { bg: "bg-yellow-100", text: "text-yellow-800", label: "Starting" },
@@ -339,5 +354,16 @@ module ApplicationHelper
     yield
   rescue Propshaft::MissingAssetError
     raise unless Rails.env.test?
+  end
+
+  private
+
+  def priority_tier_for_label(project, label)
+    return "P0" if label == "P0"
+    return if project.blank?
+
+    Project::PRIORITY_TIERS.find do |tier|
+      label == project.priority_label_for(tier)
+    end
   end
 end

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -11,7 +11,7 @@
     <% if issue.labels.any? %>
       <div class="mt-1 flex flex-wrap gap-1">
         <% issue.labels.each do |label| %>
-          <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600"><%= label %></span>
+          <span class="<%= issue_label_badge_classes(project, label) %>"><%= label %></span>
         <% end %>
       </div>
     <% end %>

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -3,6 +3,26 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper do
+  describe "#issue_label_badge_classes" do
+    it "uses GitHub-like styling for default priority labels" do
+      project = build(:project)
+
+      expect(helper.issue_label_badge_classes(project, "P0")).to include("bg-red-700 text-red-50")
+      expect(helper.issue_label_badge_classes(project, "P1")).to include("bg-red-100 text-red-800")
+      expect(helper.issue_label_badge_classes(project, "P2")).to include("bg-orange-100 text-orange-800")
+      expect(helper.issue_label_badge_classes(project, "P3")).to include("bg-blue-100 text-blue-800")
+    end
+
+    it "uses GitHub-like styling for configured priority labels only" do
+      project = build(:project, priority_labels: { "P1" => "urgent", "P2" => "high-touch", "P3" => "later" })
+
+      expect(helper.issue_label_badge_classes(project, "urgent")).to include("bg-red-100 text-red-800")
+      expect(helper.issue_label_badge_classes(project, "high-touch")).to include("bg-orange-100 text-orange-800")
+      expect(helper.issue_label_badge_classes(project, "later")).to include("bg-blue-100 text-blue-800")
+      expect(helper.issue_label_badge_classes(project, "bug")).to include("bg-gray-100 text-gray-600")
+    end
+  end
+
   describe "#agent_run_context_display" do
     # Use plain Structs instead of instance_double to avoid ActiveRecord column
     # lookups that require a database connection (these are pure view-layer tests).

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -572,6 +572,20 @@ RSpec.describe "Projects" do
         expect(response.body).to include("Quick Run")
       end
 
+      it "color-codes only priority labels in synced issues" do
+        project = create(:project, account: account, github_token: github_token,
+          priority_labels: { "P1" => "urgent", "P2" => "high-touch", "P3" => "later" })
+        create(:issue, project: project, github_number: 5, title: "Styled labels",
+          github_state: "open", labels: [ "urgent", "bug", "later", "P0" ])
+
+        get project_path(project)
+
+        expect(response.body).to match(/<span class="[^"]*bg-red-100 text-red-800[^"]*">urgent<\/span>/)
+        expect(response.body).to match(/<span class="[^"]*bg-blue-100 text-blue-800[^"]*">later<\/span>/)
+        expect(response.body).to match(/<span class="[^"]*bg-red-700 text-red-50[^"]*">P0<\/span>/)
+        expect(response.body).to match(/<span class="[^"]*bg-gray-100 text-gray-600[^"]*">bug<\/span>/)
+      end
+
       it "shows Quick Run buttons next to pull requests" do
         project = create(:project, account: account, github_token: github_token)
         pr = create(:issue, :pull_request, project: project, github_number: 8, title: "Test PR", github_state: "open")


### PR DESCRIPTION
## Summary

Color-code priority labels in the project page's synced issues table to match GitHub's label color conventions, so urgency levels (P0–P3) are visually distinguishable at a glance rather than blending in with generic label styling.

## Changes

- **Helper (`app/helpers/application_helper.rb`)**: Added a helper method that maps priority labels (`P0`, `P1`, `P2`, `P3`) to GitHub-like colors — red for P0/P1, orange for P2, blue for P3. Supports project-specific mapped priority label names so custom priority naming schemes also get colorized.
- **View (`app/views/projects/_issue.html.erb`)**: Updated the synced issues partial to route labels through the new helper, applying priority-specific colored pill styling while preserving the existing gray pill for non-priority labels.
- **Tests**: Added helper specs (`spec/helpers/application_helper_context_display_spec.rb`) verifying color mapping logic and request specs (`spec/requests/projects_spec.rb`) confirming rendered output on the project page.

## Design Decisions

- **Priority colors are hardcoded to match GitHub conventions** rather than reading actual label hex values from the GitHub API. This keeps the implementation simple and avoids an extra API dependency, at the trade-off of not automatically reflecting custom color overrides a user might set on their GitHub labels.
- **Project-specific priority label mappings are respected**, so repos that use non-standard priority label names (configured in project settings) still get the colored treatment.
- **Non-priority labels are intentionally unchanged** — only labels identified as priority labels receive the color treatment, per the acceptance criteria.

## Screenshots

> **TODO**: Attach before/after screenshots of the synced issues table showing priority labels with the new color-coded styling.

---

Closes #1065