### PR TITLE
Fix #1078: Automate enqueuing of paid‑code‑review agent runs for PRs without active runs

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -992,7 +992,8 @@ module Activities
 
       if unfinished_run
         return [ { type: "paid_agent_review_pending",
-                   details: "paid_agent review run is still in progress" } ]
+                   details: "paid_agent review run is still in progress",
+                   active_run: true } ]
       end
 
       return [] if review_goal_retry_limit_reached?(project, issue)

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -278,6 +278,8 @@ module Workflows
     end
 
     def queue_paid_agent_review_run(project_id, pr_data)
+      return unless Temporalio::Workflow.patched("queue-paid-agent-review-run-v1")
+
       pending_trigger = (pr_data[:triggers] || []).find { |t| t[:type] == "paid_agent_review_pending" }
       return if pending_trigger&.dig(:active_run)
 

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -219,12 +219,7 @@ module Workflows
       trigger_types = (pr_data[:triggers] || []).map { |t| t[:type] }
 
       # Queue paid_agent review sidecar if bundled with ready_for_owner
-      if trigger_types.include?("paid_agent_review_pending")
-        run_activity(Activities::QueueAgentRunActivity,
-          { project_id: project_id, issue_id: pr_data[:issue_id],
-            source_pull_request_number: pr_data[:pr_number],
-            goal: "review" }, timeout: 30)
-      end
+      queue_paid_agent_review_run(project_id, pr_data) if trigger_types.include?("paid_agent_review_pending")
 
       result = run_activity(Activities::MarkPrReadyActivity,
         { project_id: project_id, pr_number: pr_data[:pr_number],
@@ -268,17 +263,28 @@ module Workflows
     def handle_paid_agent_review_pending(project_id, pr_data, trigger_types)
       other_triggers = trigger_types - [ "paid_agent_review_pending" ]
 
+      queue_paid_agent_review_run(project_id, pr_data)
+
       if other_triggers.empty?
-        # No other work to do — queue a review-goal agent run directly.
-        run_activity(Activities::QueueAgentRunActivity,
-          { project_id: project_id, issue_id: pr_data[:issue_id],
-            source_pull_request_number: pr_data[:pr_number],
-            goal: "review" }, timeout: 30)
+        # No other work to do — the paid-agent review queue above is the only
+        # action needed unless the trigger merely reflects an already-active
+        # review-goal run.
+        nil
       elsif pr_data[:phase].in?(%w[draft restarted])
         start_draft_followup_workflow(project_id, pr_data)
       else
         start_pr_followup_workflow(project_id, pr_data)
       end
+    end
+
+    def queue_paid_agent_review_run(project_id, pr_data)
+      pending_trigger = (pr_data[:triggers] || []).find { |t| t[:type] == "paid_agent_review_pending" }
+      return if pending_trigger&.dig(:active_run)
+
+      run_activity(Activities::QueueAgentRunActivity,
+        { project_id: project_id, issue_id: pr_data[:issue_id],
+          source_pull_request_number: pr_data[:pr_number],
+          goal: "review" }, timeout: 30)
     end
 
     def handle_review_bot_review_pending(project_id, pr_data, trigger_types)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -5651,6 +5651,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       pending_trigger = trigger[:triggers].find { |t| t[:type] == "paid_agent_review_pending" }
 
       expect(pending_trigger).to be_present
+      expect(pending_trigger[:active_run]).to be(true)
       expect(pending_trigger[:details]).to eq("paid_agent review run is still in progress")
       expect(trigger[:triggers].map { |t| t[:type] }).not_to include("ready_for_owner")
     end

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -295,6 +295,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive(:patched)
         .with("queue-agent-run-goal-v1")
         .and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-paid-agent-review-run-v1")
+        .and_return(true)
     end
 
     it "routes ready_for_owner to MarkPrReadyActivity and RequestReviewActivity" do
@@ -1094,6 +1097,23 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::QueueAgentRunActivity, hash_including(goal: "review"), timeout: anything)
     end
+
+    it "skips paid_agent review queueing before the Temporal patch" do
+      allow(Temporalio::Workflow).to receive(:patched).and_call_original
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-paid-agent-review-run-v1")
+        .and_return(false)
+
+      pr_data = {
+        issue_id: 10, pr_number: 42,
+        triggers: [ { type: "paid_agent_review_pending" } ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, hash_including(goal: "review"), timeout: anything)
+    end
   end
 
   describe "initial sync for existing PRs" do
@@ -1136,6 +1156,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with("add-check-knowledge-staleness-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("queue-agent-run-goal-v1").and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-paid-agent-review-run-v1").and_return(true)
       allow(workflow).to receive(:interruptible_sleep)
       allow(workflow).to receive(:run_activity)
         .with(Activities::GetPollIntervalActivity, anything, timeout: anything)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -274,6 +274,15 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       }
     end
 
+    def expected_review_queue_input
+      {
+        project_id: project_id,
+        issue_id: 10,
+        source_pull_request_number: 42,
+        goal: "review"
+      }
+    end
+
     before do
       allow(workflow).to receive(:run_activity).and_return({})
       allow(Temporalio::Workflow).to receive(:start_child_workflow)
@@ -1045,25 +1054,45 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     end
 
     it "routes paid_agent_review_pending with other triggers to followup workflow" do
-      allow(workflow).to receive(:run_activity)
-        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+      allow(workflow).to receive(:run_activity).with(Activities::QueueAgentRunActivity, anything, timeout: anything)
         .and_return({ queued: true })
 
-      pr_data = {
-        issue_id: 10, pr_number: 42, phase: "draft",
+      pr_data = draft_pr_data(
         current_draft_review_count: 0,
         triggers: [
           { type: "paid_agent_review_pending" },
           { type: "ci_failure", details: "CI failed" }
         ]
+      )
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity).with(
+        Activities::QueueAgentRunActivity,
+        expected_review_queue_input,
+        timeout: anything
+      )
+      expect(workflow).to have_received(:run_activity).with(
+        Activities::QueueAgentRunActivity,
+        hash_including(count_toward_draft_review_round: true, expected_draft_review_count: 0),
+        timeout: anything
+      )
+    end
+
+    it "does not queue a duplicate paid_agent review when the trigger reflects an active run" do
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
+
+      pr_data = {
+        issue_id: 10, pr_number: 42,
+        triggers: [ { type: "paid_agent_review_pending", active_run: true } ]
       }
 
       workflow.send(:handle_pr_trigger, project_id, pr_data)
 
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::QueueAgentRunActivity,
-          hash_including(count_toward_draft_review_round: true, expected_draft_review_count: 0),
-          timeout: anything)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, hash_including(goal: "review"), timeout: anything)
     end
   end
 


### PR DESCRIPTION
## Summary

Automate enqueuing of paid‑code‑review agent runs for PRs without active runs

See #1078 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1078