### PR TITLE
Fix #1079: Automate enqueuing of paid‑code‑review agent runs for PRs without active runs

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -159,7 +159,11 @@ module Activities
         end
       end
 
-      merge_retry_trigger(result, retry_trigger, issue)
+      annotate_paid_agent_review_enqueue(
+        merge_retry_trigger(result, retry_trigger, issue),
+        project,
+        issue
+      )
     end
 
     def merge_retry_trigger(result, retry_trigger, issue)
@@ -179,6 +183,13 @@ module Activities
           current_review_goal_retry_count: issue.review_goal_retry_count
         }
       end
+    end
+
+    def annotate_paid_agent_review_enqueue(result, project, issue)
+      return result unless result.is_a?(Hash)
+      return result unless queue_paid_agent_review?(project, issue, result[:triggers] || [])
+
+      result.merge(queue_paid_agent_review: true)
     end
 
     MAX_CONSECUTIVE_DRAFT_FAILURES = 3
@@ -962,6 +973,20 @@ module Activities
 
       bot_methods = project.enabled_review_methods & %w[copilot codex paid_agent]
       bot_methods == %w[paid_agent]
+    end
+
+    def queue_paid_agent_review?(project, issue, triggers)
+      settings = project.effective_review_settings
+      return false unless settings["enabled"] == true
+      return false unless settings.dig("methods", "paid_agent", "enabled") == true
+      return false if current_cycle_review_run_in_progress(project, issue)
+
+      trigger_types = triggers.map { |trigger| trigger[:type] }
+      return false unless trigger_types.include?("paid_agent_review_pending")
+      return false if trigger_types.include?("review_goal_retry")
+      return false if trigger_types.include?("ready_for_owner")
+
+      (trigger_types - [ "paid_agent_review_pending" ]).any?
     end
 
     # Returns a paid_agent_review_pending trigger when no up-to-date completed

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -241,7 +241,7 @@ module Activities
       # review method there is no other bot that can gate draft exit, so
       # paid_agent_review_pending must block advancement just like
       # review_bot_review_pending does for copilot/codex.
-      paid_agent_sole_reviewer = paid_agent_sole_review_method?(project)
+      paid_agent_sole_reviewer = paid_agent_blocking_draft_gate?(project)
       pending_triggers = (review_bot_triggers || []).select { |t| t[:type] == "review_bot_review_pending" }
       sidecar_triggers = (review_bot_triggers || []).select { |t| t[:type] == "paid_agent_review_pending" }
 
@@ -951,11 +951,13 @@ module Activities
     MAX_REVIEW_GOAL_RETRIES = 3
     REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES = (AgentRun::FAILURE_STATUSES + %w[no_output]).freeze
 
-    # Returns true when paid_agent is the only enabled bot review method,
-    # meaning its pending trigger must block draft exit since no other bot
-    # can gate the PR.
-    def paid_agent_sole_review_method?(project)
+    # Returns true when paid_agent is the only enabled bot review method AND
+    # the project is configured to wait for reviews. In that configuration a
+    # pending paid_agent review must block draft exit because no other review
+    # method can gate the PR.
+    def paid_agent_blocking_draft_gate?(project)
       return false unless project&.review_enabled?
+      return false unless project.wait_for_reviews?
       return false unless project.review_method_enabled?("paid_agent")
 
       bot_methods = project.enabled_review_methods & %w[copilot codex paid_agent]
@@ -993,7 +995,7 @@ module Activities
       # for mixed-bot projects so the remaining bot can keep gating the PR.
       # Paid-agent-only projects still need paid_agent_review_pending to block
       # draft exit until the retried review is posted.
-      return [] if review_goal_retry_needed?(project, issue) && !paid_agent_sole_review_method?(project)
+      return [] if review_goal_retry_needed?(project, issue) && !paid_agent_blocking_draft_gate?(project)
 
       # Count all finished review attempts (including failed/timed-out) toward
       # the max_review_rounds limit, but exclude retried runs because retry

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -179,8 +179,18 @@ module Workflows
       return if scan_result[:prs_to_trigger].blank?
 
       scan_result[:prs_to_trigger].each do |pr_data|
+        maybe_queue_paid_agent_review(project_id, pr_data)
         handle_pr_trigger(project_id, pr_data)
       end
+    end
+
+    def maybe_queue_paid_agent_review(project_id, pr_data)
+      return unless pr_data[:queue_paid_agent_review]
+
+      run_activity(Activities::QueueAgentRunActivity,
+        { project_id: project_id, issue_id: pr_data[:issue_id],
+          source_pull_request_number: pr_data[:pr_number],
+          goal: "review" }, timeout: 30)
     end
 
     def handle_pr_trigger(project_id, pr_data)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -5548,6 +5548,31 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     end
   end
 
+  context "when paid_agent is the only review method and wait_for_reviews is disabled" do
+    before do
+      enable_paid_agent_review!
+      project.update!(review_settings: project.effective_review_settings.deep_merge(
+        "wait_for_reviews" => false
+      ))
+      create(:issue, :pull_request,
+        project: project, github_number: 42,
+        labels: [ "paid-generated", "paid-automation" ],
+        pr_review_phase: "draft",
+        draft_review_count: 0)
+      stub_github_for_pr(draft: true, reviews: [])
+    end
+
+    it "advances to ready_for_owner while keeping paid_agent as a queued sidecar" do
+      result = activity.execute(project_id: project.id)
+
+      expect(result[:prs_to_trigger].size).to eq(1)
+      trigger = result[:prs_to_trigger].first
+      trigger_types = trigger[:triggers].map { |t| t[:type] }
+      expect(trigger_types).to include("ready_for_owner")
+      expect(trigger_types).to include("paid_agent_review_pending")
+    end
+  end
+
   context "when reviews are globally disabled but paid_agent sub-flag is true" do
     let!(:disabled_reviews_issue) do
       create(:issue, :pull_request,

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -5573,6 +5573,33 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     end
   end
 
+  context "when paid_agent needs a sidecar review during mixed-trigger draft followup" do
+    before do
+      enable_paid_agent_review!
+      create(:issue, :pull_request,
+        project: project, github_number: 42,
+        labels: [ "paid-generated", "paid-automation" ],
+        pr_review_phase: "draft",
+        draft_review_count: 0)
+      stub_github_for_pr(
+        draft: true,
+        checks: [ { name: "ci", conclusion: "failure" } ],
+        reviews: []
+      )
+    end
+
+    it "marks the PR for paid_agent review enqueue on the same poll cycle" do
+      result = activity.execute(project_id: project.id)
+
+      expect(result[:prs_to_trigger].size).to eq(1)
+      trigger = result[:prs_to_trigger].first
+
+      expect(trigger[:queue_paid_agent_review]).to be(true)
+      expect(trigger[:triggers].map { |entry| entry[:type] })
+        .to include("paid_agent_review_pending", "ci_failure")
+    end
+  end
+
   context "when reviews are globally disabled but paid_agent sub-flag is true" do
     let!(:disabled_reviews_issue) do
       create(:issue, :pull_request,

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -979,4 +979,50 @@ RSpec.describe Workflows::GitHubPollWorkflow do
           timeout: anything)
     end
   end
+
+  describe "#handle_pr_scan_results" do
+    let(:workflow) { described_class.new }
+    let(:project_id) { 1 }
+    let(:scan_result) do
+      {
+        prs_to_trigger: [
+          {
+            issue_id: 10,
+            pr_number: 42,
+            phase: "draft",
+            current_draft_review_count: 0,
+            queue_paid_agent_review: true,
+            triggers: [
+              { type: "paid_agent_review_pending" },
+              { type: "ci_failure", details: "CI failed" }
+            ]
+          }
+        ]
+      }
+    end
+
+    before do
+      allow(workflow).to receive(:run_activity).and_return({})
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("draft-followup-direct-start-v1")
+        .and_return(true)
+
+      workflow.send(:handle_pr_scan_results, scan_result, project_id)
+    end
+
+    it "queues paid_agent review sidecar before starting mixed-trigger draft followup" do
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(project_id: 1, issue_id: 10,
+            source_pull_request_number: 42, goal: "review"),
+          timeout: anything)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(project_id: 1, issue_id: 10,
+            source_pull_request_number: 42,
+            count_toward_draft_review_round: true,
+            expected_draft_review_count: 0),
+          timeout: anything)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Automate enqueuing of paid‑code‑review agent runs for PRs without active runs

See #1079 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1079