### PR TITLE
fix(agent-runs): sync created pull requests into local cache

### DIFF
--- a/spec/migrations/backfill_legacy_review_max_rounds_defaults_spec.rb
+++ b/spec/migrations/backfill_legacy_review_max_rounds_defaults_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe BackfillLegacyReviewMaxRoundsDefaults, :aggregate_failures do
     })
   end
 
+  before do
+    allow(Github::ReviewBotInstallationToken).to receive(:configured?).and_return(true)
+  end
+
   it "backfills persisted legacy default max review rounds without touching custom values" do
     legacy_defaults_project
     custom_project

--- a/spec/temporal/activities/create_github_issue_activity_spec.rb
+++ b/spec/temporal/activities/create_github_issue_activity_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Activities::CreateGithubIssueActivity do
   end
   let(:github_client) { instance_double(GithubClient) }
   let(:issue_response) do
-    Struct.new(:html_url, :number, :id, :title, :body, :state, :user, :labels, :created_at, :updated_at).new(
+    Struct.new(:html_url, :number, :id, :title, :body, :state, :user, :labels, :pull_request, :created_at, :updated_at).new(
       "https://github.com/owner/repo/issues/10",
       10,
       12345,
@@ -20,6 +20,7 @@ RSpec.describe Activities::CreateGithubIssueActivity do
       "open",
       Struct.new(:login).new("paid-bot"),
       [],
+      nil,
       Time.current,
       Time.current
     )

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -171,15 +171,15 @@ RSpec.describe Activities::CreatePullRequestActivity do
       end
 
       it "adds both custom labels to the PR" do
-      activity.execute(agent_run_id: agent_run.id)
+        activity.execute(agent_run_id: agent_run.id)
 
-      expect(github_client).to have_received(:add_labels_to_issue).with(
-        project.full_name, 42, [ "custom-generated", "custom-automation" ]
-      )
-      expect(project.issues.pull_requests_only.find_by!(github_number: 42).labels)
-        .to include("custom-generated", "custom-automation")
+        expect(github_client).to have_received(:add_labels_to_issue).with(
+          project.full_name, 42, [ "custom-generated", "custom-automation" ]
+        )
+        expect(project.issues.pull_requests_only.find_by!(github_number: 42).labels)
+          .to include("custom-generated", "custom-automation")
+      end
     end
-  end
 
     context "with priority label inheritance" do
       let(:project) do


### PR DESCRIPTION
## Summary

Sync newly created pull requests into Paid's local issue cache immediately so they appear in PR tables without waiting for a later poll cycle.

## Changes

- add a shared  path for GitHub issue-shaped payloads
- sync local PR rows immediately after PR creation and keep local labels in step with successful label application
- backfill missing local PR rows in the PR label recovery job for already-created runs
- cover the new sync and recovery behavior with focused specs

## Verification

- 
Randomized with seed 18611
............................................................................

Top 5 slowest examples (1.59 seconds, 13.8% of total time):
  Activities::CreateAggregatedPullRequestActivity#execute includes sub-task references in PR body
    0.66148 seconds ./spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb:89
  Activities::CreatePullRequestActivity#execute when auto_add_labels_enabled is true with custom labels adds both custom labels to the PR
    0.26726 seconds ./spec/temporal/activities/create_pull_request_activity_spec.rb:173
  Activities::CreatePullRequestActivity#execute when agent summary contains no issue references at all when summary has no overlap with changed files adds a system log about no overlap
    0.22757 seconds ./spec/temporal/activities/create_pull_request_activity_spec.rb:510
  Activities::CreatePullRequestActivity#execute uses templated fallback body when LLM description is nil
    0.22042 seconds ./spec/temporal/activities/create_pull_request_activity_spec.rb:102
  Activities::CreatePullRequestActivity#execute when agent summary uses differently-cased qualified ref for own repo does not log a scope mismatch warning (case-insensitive match)
    0.21471 seconds ./spec/temporal/activities/create_pull_request_activity_spec.rb:441

Top 4 slowest example groups:
  Activities::CreatePullRequestActivity
    0.16751 seconds average (7.71 seconds / 46 examples) ./spec/temporal/activities/create_pull_request_activity_spec.rb:6
  RecoverMissingPullRequestLabelsJob
    0.15167 seconds average (1.67 seconds / 11 examples) ./spec/jobs/recover_missing_pull_request_labels_job_spec.rb:6
  Activities::CreateAggregatedPullRequestActivity
    0.11836 seconds average (1.89 seconds / 16 examples) ./spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb:6
  Issues::UpsertFromGithub
    0.07939 seconds average (0.23816 seconds / 3 examples) ./spec/services/issues/upsert_from_github_spec.rb:5

Finished in 11.51 seconds (files took 2.07 seconds to load)
76 examples, 0 failures

Randomized with seed 18611

Coverage report generated for RSpec to /workspaces/paid/coverage.
Line Coverage: 7.73% (2280 / 29513)
- Inspecting 11 files
...........

11 files inspected, no offenses detected
