### PR TITLE
fix(pr-review): requeue paid-agent reviews and raise default review rounds

### DIFF
--- a/app/jobs/recover_missing_pull_request_labels_job.rb
+++ b/app/jobs/recover_missing_pull_request_labels_job.rb
@@ -35,8 +35,13 @@ class RecoverMissingPullRequestLabelsJob < ApplicationJob
       synced_pr = synced_prs[[ agent_run.project_id, agent_run.pull_request_number ]]
 
       unless synced_pr
-        not_synced += 1
-        next
+        synced_pr = backfill_synced_pr(agent_run)
+        if synced_pr
+          synced_prs[[ agent_run.project_id, agent_run.pull_request_number ]] = synced_pr
+        else
+          not_synced += 1
+          next
+        end
       end
 
       labels_to_recover = missing_labels(agent_run.project, synced_pr, agent_run)
@@ -135,6 +140,21 @@ class RecoverMissingPullRequestLabelsJob < ApplicationJob
     labels << automation unless synced_pr.has_label?(automation)
     labels.concat(inherited_missing)
     labels.uniq
+  end
+
+  def backfill_synced_pr(agent_run)
+    project = agent_run.project
+    github_issue = project.github_token.client.issue(project.full_name, agent_run.pull_request_number)
+    Issues::UpsertFromGithub.call(project: project, github_issue: github_issue)
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "agent_execution.pr_sync_recovery_failed",
+      agent_run_id: agent_run.id,
+      project_id: project.id,
+      pr_number: agent_run.pull_request_number,
+      error: e.message
+    )
+    nil
   end
 
   def inheritable_priority_labels(project, agent_run)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,7 +17,7 @@ class Project < ApplicationRecord
       "copilot" => {
         "enabled" => false,
         "termination" => {
-          "max_review_rounds" => 2,
+          "max_review_rounds" => 15,
           "stop_when_no_comments" => true,
           "quality_threshold" => nil,
           "timeout_minutes" => nil
@@ -26,7 +26,7 @@ class Project < ApplicationRecord
       "paid_agent" => {
         "enabled" => false,
         "termination" => {
-          "max_review_rounds" => 3,
+          "max_review_rounds" => 15,
           "max_review_goal_retries" => 3,
           "stop_when_no_comments" => true,
           "quality_threshold" => nil,
@@ -36,7 +36,7 @@ class Project < ApplicationRecord
       "codex" => {
         "enabled" => false,
         "termination" => {
-          "max_review_rounds" => 2,
+          "max_review_rounds" => 15,
           "stop_when_no_comments" => true,
           "quality_threshold" => nil,
           "timeout_minutes" => 60

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -233,6 +233,14 @@ class GithubClient
     handle_errors { client.create_pull_request(repo, base, head, title, body, **options) }
   end
 
+  # Fetches an issue-shaped resource by number.
+  #
+  # Pull requests are also exposed through GitHub's issues API; this is the
+  # representation our local issues table stores.
+  def issue(repo, number)
+    handle_errors { client.issue(repo, number) }
+  end
+
   # Lists labels for a repository.
   #
   # @param repo [String] Repository in "owner/name" format

--- a/app/services/issues/upsert_from_github.rb
+++ b/app/services/issues/upsert_from_github.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Issues
+  class UpsertFromGithub
+    def self.call(project:, github_issue:, body: github_issue.body)
+      issue = project.issues.find_or_initialize_by(github_issue_id: github_issue.id)
+      issue.update!(
+        github_number: github_issue.number,
+        title: github_issue.title,
+        body: body,
+        github_creator_login: github_issue.user&.login || "unknown",
+        github_state: github_issue.state,
+        labels: extract_labels(github_issue),
+        is_pull_request: github_issue.pull_request.present?,
+        github_created_at: github_issue.created_at,
+        github_updated_at: github_issue.updated_at
+      )
+      issue
+    end
+
+    def self.extract_labels(github_issue)
+      Array(github_issue.labels).map { |label| label.respond_to?(:name) ? label.name : label.to_s }
+    end
+    private_class_method :extract_labels
+  end
+end

--- a/app/temporal/activities/create_aggregated_pull_request_activity.rb
+++ b/app/temporal/activities/create_aggregated_pull_request_activity.rb
@@ -36,6 +36,7 @@ module Activities
         client, project, feature_branch, parent_issue, results, merged_branches, failed_merges
       )
 
+      sync_pull_request_record(client, project, pr.number)
       add_pr_labels(client, project, pr.number, parent_issue: parent_issue)
 
       logger.info(
@@ -163,12 +164,34 @@ module Activities
       return if labels.empty?
 
       client.add_labels_to_issue(project.full_name, pr_number, labels)
+      merge_local_pr_labels(project, pr_number, labels)
     rescue GithubClient::Error => e
       logger.warn(
         message: "aggregated_pr.add_labels_failed",
         pr_number: pr_number,
         error: e.message
       )
+    end
+
+    def sync_pull_request_record(client, project, pr_number)
+      github_issue = client.issue(project.full_name, pr_number)
+      Issues::UpsertFromGithub.call(project: project, github_issue: github_issue)
+    rescue => e
+      logger.warn(
+        message: "aggregated_pr.sync_failed",
+        project_id: project.id,
+        pr_number: pr_number,
+        error: e.message
+      )
+    end
+
+    def merge_local_pr_labels(project, pr_number, labels)
+      pull_request = project.issues.find_by(github_number: pr_number, is_pull_request: true)
+      return unless pull_request
+
+      pull_request.with_lock do
+        pull_request.update!(labels: (pull_request.labels + labels).uniq)
+      end
     end
   end
 end

--- a/app/temporal/activities/create_github_issue_activity.rb
+++ b/app/temporal/activities/create_github_issue_activity.rb
@@ -287,18 +287,7 @@ module Activities
     end
 
     def sync_issue_record(project, gh_issue)
-      issue = project.issues.find_or_initialize_by(github_issue_id: gh_issue.id)
-      issue.update!(
-        github_number: gh_issue.number,
-        title: gh_issue.title,
-        body: gh_issue.body,
-        github_creator_login: gh_issue.user&.login || "unknown",
-        github_state: gh_issue.state,
-        labels: (gh_issue.labels || []).map { |l| l.respond_to?(:name) ? l.name : l.to_s },
-        is_pull_request: false,
-        github_created_at: gh_issue.created_at,
-        github_updated_at: gh_issue.updated_at
-      )
+      Issues::UpsertFromGithub.call(project: project, github_issue: gh_issue)
     rescue => e
       logger.warn(
         message: "agent_execution.sync_created_issue_failed",

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -38,6 +38,7 @@ module Activities
 
         # Best-effort post-processing — failures here must not cause the
         # activity to be retried now that the run is already completed.
+        best_effort(agent_run_id, context: "sync_created_pull_request") { sync_pull_request_record(client, project, pr.number) }
         best_effort(agent_run_id, context: "add_pr_labels") { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
         best_effort(agent_run_id, context: "log_pr_action") { agent_run.log!("system", "PR #{pr_action}: #{pr.html_url}") }
 
@@ -319,6 +320,28 @@ module Activities
       return if labels.empty?
 
       client.add_labels_to_issue(project.full_name, pr_number, labels)
+      merge_local_pr_labels(project, pr_number, labels)
+    end
+
+    def sync_pull_request_record(client, project, pr_number)
+      github_issue = client.issue(project.full_name, pr_number)
+      Issues::UpsertFromGithub.call(project: project, github_issue: github_issue)
+    rescue => e
+      logger.warn(
+        message: "agent_execution.sync_created_pull_request_failed",
+        project_id: project.id,
+        pr_number: pr_number,
+        error: e.message
+      )
+    end
+
+    def merge_local_pr_labels(project, pr_number, labels)
+      pull_request = project.issues.find_by(github_number: pr_number, is_pull_request: true)
+      return unless pull_request
+
+      pull_request.with_lock do
+        pull_request.update!(labels: (pull_request.labels + labels).uniq)
+      end
     end
   end
 end

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -203,17 +203,10 @@ module Activities
         )
       end
 
-      issue = project.issues.find_or_initialize_by(github_issue_id: github_issue.id)
-      issue.update!(
-        github_number: github_issue.number,
-        title: github_issue.title,
-        body: trusted ? github_issue.body : nil,
-        github_creator_login: creator_login,
-        github_state: github_issue.state,
-        labels: extract_labels(github_issue),
-        is_pull_request: github_issue.pull_request.present?,
-        github_created_at: github_issue.created_at,
-        github_updated_at: github_issue.updated_at
+      issue = Issues::UpsertFromGithub.call(
+        project: project,
+        github_issue: github_issue,
+        body: trusted ? github_issue.body : nil
       )
 
       { id: issue.id, github_number: issue.github_number, labels: issue.labels,
@@ -439,12 +432,6 @@ module Activities
         scope.where(relationships_parsed_at: parsed_before)
       end
       scope.update_all(relationships_parsed_at: issue.github_updated_at)
-    end
-
-    def extract_labels(github_issue)
-      return [] unless github_issue.labels
-
-      github_issue.labels.map { |l| l.respond_to?(:name) ? l.name : l.to_s }
     end
   end
 end

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -262,7 +262,7 @@ module Activities
       blocking_triggers = (review_bot_triggers || []).reject { |t|
         t[:type] == "review_bot_review_pending" || t[:type] == "paid_agent_review_pending"
       }
-      paid_agent_rounds_exhausted = reviews && paid_agent_review_rounds_exhausted?(project, reviews)
+      paid_agent_rounds_exhausted = reviews && paid_agent_review_rounds_exhausted?(project, reviews, issue)
 
       # A clean final paid_agent review should still allow the PR to advance.
       # Only escalate when the latest blocking review is from paid_agent and the
@@ -852,7 +852,7 @@ module Activities
       allowed = project&.review_enabled? ? (project.enabled_review_bot_logins.presence || Set.new) : nil
       latest = latest_allowed_bot_review(reviews, allowed)
       paid_agent_limit_reached_for_latest_review =
-        paid_agent_review_limit_reached_for_review?(project, reviews, latest)
+        paid_agent_review_limit_reached_for_review?(project, reviews, latest, issue)
 
       # Body-only bots (Codex, paid_agent) can post their CLEAN signal as an issue
       # comment — e.g. "Codex Review: Didn't find any major issues. Bravo." —
@@ -949,7 +949,12 @@ module Activities
             # touches at least one reviewed file. Treat as effectively clean
             # to avoid re-requesting reviews that would produce no new
             # comments.
-            []
+            if ProviderSupport.provider_bot_username_for?("paid_agent", latest&.dig(:user_login))
+              pending_review = check_paid_agent_review_status(project, issue)
+              pending_review.presence || []
+            else
+              []
+            end
           end
         end
       when :unknown
@@ -1749,11 +1754,11 @@ module Activities
       body.include?(PAID_REVIEW_CLEAN_MARKER)
     end
 
-    def paid_agent_review_limit_reached_for_review?(project, reviews, review)
+    def paid_agent_review_limit_reached_for_review?(project, reviews, review, issue = nil)
       return false unless review.is_a?(Hash)
       return false unless ProviderSupport.provider_bot_username_for?("paid_agent", review[:user_login])
 
-      paid_agent_review_rounds_exhausted?(project, reviews)
+      paid_agent_review_rounds_exhausted?(project, reviews, issue)
     end
 
     # --- Paid-agent review round limit enforcement ---
@@ -1772,9 +1777,10 @@ module Activities
     # Counts the number of reviews submitted by the paid_agent bot account
     # on this PR. Each review submission counts as one round regardless of
     # state (APPROVED, COMMENTED, CHANGES_REQUESTED).
-    def paid_agent_review_count(reviews)
+    def paid_agent_review_count(reviews, issue = nil)
       return 0 if reviews.nil?
 
+      reviews = paid_agent_reviews_for_current_cycle(reviews, issue)
       paid_agent_logins = ProviderSupport::PROVIDER_BOT_USERNAMES.fetch("paid_agent", []).map(&:downcase).to_set
       reviews.count { |r| paid_agent_logins.include?(r[:user_login]&.downcase) }
     end
@@ -1782,11 +1788,23 @@ module Activities
     # Returns true when the paid_agent review method is enabled and the
     # number of reviews from the bot account on this PR has reached or
     # exceeded the configured max_review_rounds limit.
-    def paid_agent_review_rounds_exhausted?(project, reviews)
+    def paid_agent_review_rounds_exhausted?(project, reviews, issue = nil)
       max_rounds = paid_agent_max_review_rounds(project)
       return false if max_rounds.nil? || max_rounds <= 0
 
-      paid_agent_review_count(reviews) >= max_rounds
+      paid_agent_review_count(reviews, issue) >= max_rounds
+    end
+
+    def paid_agent_reviews_for_current_cycle(reviews, issue)
+      return reviews if reviews.nil?
+
+      reset_at = issue&.review_goal_retry_reset_at
+      return reviews unless issue&.pr_review_phase == "restarted" && reset_at.present?
+
+      reviews.select do |review|
+        submitted_at = review[:submitted_at]
+        submitted_at.nil? || submitted_at > reset_at
+      end
     end
 
     def paid_agent_limit_reason(project)

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -196,7 +196,7 @@
                   <div>
                     <label for="review_copilot_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                     <input type="number" name="project[review_settings][methods][copilot][termination][max_review_rounds]" id="review_copilot_max_rounds"
-                      value="<%= copilot.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 2"
+                      value="<%= copilot.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15"
                       class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
                   </div>
                   <div>
@@ -235,7 +235,7 @@
                   <div>
                     <label for="review_paid_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                     <input type="number" name="project[review_settings][methods][paid_agent][termination][max_review_rounds]" id="review_paid_max_rounds"
-                      value="<%= paid.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 3"
+                      value="<%= paid.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15"
                       class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
                   </div>
                   <div>
@@ -276,7 +276,7 @@
                   <div>
                     <label for="review_codex_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                     <input type="number" name="project[review_settings][methods][codex][termination][max_review_rounds]" id="review_codex_max_rounds"
-                      value="<%= codex.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 2"
+                      value="<%= codex.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15"
                       class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
                   </div>
                   <div>

--- a/db/migrate/20260414154102_backfill_legacy_review_max_rounds_defaults.rb
+++ b/db/migrate/20260414154102_backfill_legacy_review_max_rounds_defaults.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class BackfillLegacyReviewMaxRoundsDefaults < ActiveRecord::Migration[8.1]
+  class MigrationProject < ApplicationRecord
+    self.table_name = "projects"
+  end
+
+  LEGACY_DEFAULT_MAX_REVIEW_ROUNDS = {
+    "copilot" => 2,
+    "paid_agent" => 3,
+    "codex" => 2
+  }.freeze
+  NEW_DEFAULT_MAX_REVIEW_ROUNDS = 15
+
+  def up
+    MigrationProject.unscoped.find_each do |project|
+      review_settings = normalized_review_settings(project.review_settings)
+      next if review_settings.nil?
+
+      methods = review_settings["methods"]
+      next unless methods.is_a?(Hash)
+
+      changed = false
+      LEGACY_DEFAULT_MAX_REVIEW_ROUNDS.each do |method_name, legacy_rounds|
+        termination = methods.dig(method_name, "termination")
+        next unless termination.is_a?(Hash)
+        next unless termination["max_review_rounds"] == legacy_rounds
+
+        termination["max_review_rounds"] = NEW_DEFAULT_MAX_REVIEW_ROUNDS
+        changed = true
+      end
+
+      next unless changed
+
+      project.update_columns(review_settings: review_settings, updated_at: Time.current)
+    end
+  end
+
+  def down; end
+
+  private
+
+  def normalized_review_settings(value)
+    return unless value.is_a?(Hash)
+
+    value.deep_stringify_keys
+  end
+end

--- a/spec/jobs/recover_missing_pull_request_labels_job_spec.rb
+++ b/spec/jobs/recover_missing_pull_request_labels_job_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "ostruct"
 
 RSpec.describe RecoverMissingPullRequestLabelsJob do
   describe "#perform" do
@@ -10,6 +11,20 @@ RSpec.describe RecoverMissingPullRequestLabelsJob do
     before do
       allow(GithubClient).to receive(:new).and_return(github_client)
       allow(github_client).to receive(:add_labels_to_issue)
+      allow(github_client).to receive(:issue).and_return(
+        OpenStruct.new(
+          id: 9001,
+          number: 416,
+          title: "Recovered PR",
+          body: "Recovered body",
+          state: "open",
+          labels: [],
+          pull_request: OpenStruct.new(html_url: "https://github.com/viamin/paid/pull/416"),
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 1.day.ago,
+          updated_at: Time.current
+        )
+      )
     end
 
     it "reapplies the generated and automation labels when both are missing" do
@@ -190,7 +205,7 @@ RSpec.describe RecoverMissingPullRequestLabelsJob do
       expect(pull_request.reload.labels).to eq([])
     end
 
-    it "skips runs with no locally-synced PR record" do
+    it "backfills a missing local PR row before recovering labels" do
       create(:agent_run, :completed,
         project: project,
         issue: nil,
@@ -201,7 +216,9 @@ RSpec.describe RecoverMissingPullRequestLabelsJob do
 
       described_class.perform_now
 
-      expect(github_client).not_to have_received(:add_labels_to_issue)
+      expect(github_client).to have_received(:issue).with("viamin/paid", 416)
+      expect(project.issues.pull_requests_only.find_by!(github_number: 416).github_issue_id).to eq(9001)
+      expect(github_client).to have_received(:add_labels_to_issue)
     end
 
     it "deduplicates multiple completed runs for the same PR" do

--- a/spec/migrations/backfill_legacy_review_max_rounds_defaults_spec.rb
+++ b/spec/migrations/backfill_legacy_review_max_rounds_defaults_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260414154102_backfill_legacy_review_max_rounds_defaults")
+
+RSpec.describe BackfillLegacyReviewMaxRoundsDefaults, :aggregate_failures do
+  let(:migration) { described_class.new }
+  let(:legacy_defaults_project) do
+    create(:project, review_settings: {
+      "enabled" => true,
+      "methods" => {
+        "copilot" => { "enabled" => true, "termination" => { "max_review_rounds" => 2 } },
+        "paid_agent" => { "enabled" => true, "termination" => { "max_review_rounds" => 3 } },
+        "codex" => { "enabled" => true, "termination" => { "max_review_rounds" => 2 } }
+      }
+    })
+  end
+  let(:custom_project) do
+    create(:project, review_settings: {
+      "enabled" => true,
+      "methods" => {
+        "copilot" => { "enabled" => true, "termination" => { "max_review_rounds" => 9 } },
+        "paid_agent" => { "enabled" => true, "termination" => { "max_review_rounds" => 1 } },
+        "codex" => { "enabled" => true, "termination" => { "max_review_rounds" => 20 } }
+      }
+    })
+  end
+
+  it "backfills persisted legacy default max review rounds without touching custom values" do
+    legacy_defaults_project
+    custom_project
+    migration.up
+
+    legacy_defaults_project.reload
+    custom_project.reload
+
+    expect(legacy_defaults_project.review_settings.dig("methods", "copilot", "termination", "max_review_rounds")).to eq(15)
+    expect(legacy_defaults_project.review_settings.dig("methods", "paid_agent", "termination", "max_review_rounds")).to eq(15)
+    expect(legacy_defaults_project.review_settings.dig("methods", "codex", "termination", "max_review_rounds")).to eq(15)
+
+    expect(custom_project.review_settings.dig("methods", "copilot", "termination", "max_review_rounds")).to eq(9)
+    expect(custom_project.review_settings.dig("methods", "paid_agent", "termination", "max_review_rounds")).to eq(1)
+    expect(custom_project.review_settings.dig("methods", "codex", "termination", "max_review_rounds")).to eq(20)
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -676,7 +676,7 @@ RSpec.describe Project do
         expect(settings["enabled"]).to be false
         expect(settings["wait_for_reviews"]).to be true
         expect(settings.dig("methods", "copilot", "enabled")).to be false
-        expect(settings.dig("methods", "paid_agent", "termination", "max_review_rounds")).to eq(3)
+        expect(settings.dig("methods", "paid_agent", "termination", "max_review_rounds")).to eq(15)
       end
 
       it "merges custom settings over defaults" do
@@ -688,7 +688,7 @@ RSpec.describe Project do
 
         expect(settings["enabled"]).to be true
         expect(settings.dig("methods", "copilot", "enabled")).to be true
-        expect(settings.dig("methods", "copilot", "termination", "max_review_rounds")).to eq(2)
+        expect(settings.dig("methods", "copilot", "termination", "max_review_rounds")).to eq(15)
       end
 
       it "handles non-Hash review_settings gracefully" do
@@ -884,7 +884,7 @@ RSpec.describe Project do
 
         expect(config["enabled"]).to be true
         expect(config.dig("termination", "timeout_minutes")).to eq(60)
-        expect(config.dig("termination", "max_review_rounds")).to eq(3)
+        expect(config.dig("termination", "max_review_rounds")).to eq(15)
       end
     end
 

--- a/spec/services/issues/upsert_from_github_spec.rb
+++ b/spec/services/issues/upsert_from_github_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Issues::UpsertFromGithub do
+  describe ".call" do
+    let(:project) { create(:project) }
+    let(:github_issue) do
+      OpenStruct.new(
+        id: 1234,
+        number: 42,
+        title: "Sync me",
+        body: "GitHub body",
+        state: "open",
+        labels: [ OpenStruct.new(name: "paid-generated"), "P1" ],
+        pull_request: OpenStruct.new(html_url: "https://github.com/test/repo/pull/42"),
+        user: OpenStruct.new(login: "viamin"),
+        created_at: Time.zone.parse("2026-04-14 00:00:00 UTC"),
+        updated_at: Time.zone.parse("2026-04-14 00:01:00 UTC")
+      )
+    end
+
+    it "creates a local issue row using the GitHub issue-shaped payload" do
+      issue = described_class.call(project: project, github_issue: github_issue)
+
+      expect(issue).to have_attributes(
+        project_id: project.id,
+        github_issue_id: 1234,
+        github_number: 42,
+        title: "Sync me",
+        body: "GitHub body",
+        github_state: "open",
+        github_creator_login: "viamin",
+        is_pull_request: true,
+        labels: [ "paid-generated", "P1" ]
+      )
+    end
+
+    it "allows callers to override the stored body" do
+      issue = described_class.call(project: project, github_issue: github_issue, body: nil)
+
+      expect(issue.body).to be_nil
+    end
+
+    it "updates an existing row instead of creating a duplicate" do
+      existing = create(:issue, :pull_request, project: project, github_issue_id: 1234,
+        github_number: 40, title: "Old", labels: [])
+
+      issue = described_class.call(project: project, github_issue: github_issue)
+
+      expect(issue.id).to eq(existing.id)
+      expect(project.issues.where(github_issue_id: 1234).count).to eq(1)
+      expect(issue.github_number).to eq(42)
+    end
+  end
+end

--- a/spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb
@@ -9,11 +9,25 @@ RSpec.describe Activities::CreateAggregatedPullRequestActivity do
   let(:client) { instance_double(GithubClient) }
   let(:github_token) { instance_double(GithubToken, client: client) }
   let(:pr_response) { OpenStruct.new(html_url: "https://github.com/test/repo/pull/42", number: 42) }
+  let(:issue_response) do
+    OpenStruct.new(
+      id: 4242,
+      number: 42,
+      title: "Aggregated PR",
+      body: "Body",
+      state: "open",
+      labels: [],
+      pull_request: OpenStruct.new(html_url: "https://github.com/test/repo/pull/42"),
+      user: OpenStruct.new(login: "viamin"),
+      created_at: Time.zone.parse("2026-04-14 00:00:00 UTC"),
+      updated_at: Time.zone.parse("2026-04-14 00:01:00 UTC")
+    )
+  end
 
   before do
     allow(Project).to receive(:find).with(project.id).and_return(project)
     allow(project).to receive(:github_token).and_return(github_token)
-    allow(client).to receive(:create_pull_request).and_return(pr_response)
+    allow(client).to receive_messages(create_pull_request: pr_response, issue: issue_response)
     allow(client).to receive(:add_labels_to_issue)
   end
 
@@ -44,6 +58,12 @@ RSpec.describe Activities::CreateAggregatedPullRequestActivity do
       )
       expect(result[:pull_request_url]).to eq("https://github.com/test/repo/pull/42")
       expect(result[:pull_request_number]).to eq(42)
+    end
+
+    it "syncs a local pull request row for the aggregated PR" do
+      expect {
+        activity.execute(base_input)
+      }.to change { project.issues.pull_requests_only.where(github_number: 42).count }.by(1)
     end
 
     it "includes parent issue in PR title when provided" do
@@ -127,6 +147,8 @@ RSpec.describe Activities::CreateAggregatedPullRequestActivity do
         42,
         [ project.generated_label_name, project.automation_label_name ]
       )
+      expect(project.issues.pull_requests_only.find_by!(github_number: 42).labels)
+        .to include(project.generated_label_name, project.automation_label_name)
     end
 
     it "inherits matching priority labels from the parent issue" do

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "ostruct"
 
 RSpec.describe Activities::CreatePullRequestActivity do
   let(:activity) { described_class.new }
@@ -9,10 +10,24 @@ RSpec.describe Activities::CreatePullRequestActivity do
   let(:agent_run) { create(:agent_run, :with_git_context, :with_metrics, project: project, issue: issue) }
   let(:github_client) { instance_double(GithubClient) }
   let(:pr_response) { Struct.new(:html_url, :number).new("https://github.com/owner/repo/pull/42", 42) }
+  let(:issue_response) do
+    OpenStruct.new(
+      id: 4242,
+      number: 42,
+      title: "PR title",
+      body: "PR body",
+      state: "open",
+      labels: [],
+      pull_request: OpenStruct.new(html_url: "https://github.com/owner/repo/pull/42"),
+      user: OpenStruct.new(login: "viamin"),
+      created_at: Time.zone.parse("2026-04-14 00:00:00 UTC"),
+      updated_at: Time.zone.parse("2026-04-14 00:01:00 UTC")
+    )
+  end
 
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
-    allow(github_client).to receive_messages(pull_requests: [], create_pull_request: pr_response)
+    allow(github_client).to receive_messages(pull_requests: [], create_pull_request: pr_response, issue: issue_response)
     allow(github_client).to receive(:add_labels_to_issue)
     allow(github_client).to receive(:compare_changed_files).and_return([])
     # Stub external agent harness so Llm::GeneratePrDescription runs without real external calls.
@@ -55,6 +70,16 @@ RSpec.describe Activities::CreatePullRequestActivity do
       expect(agent_run.status).to eq("completed")
       expect(agent_run.pull_request_url).to eq("https://github.com/owner/repo/pull/42")
       expect(agent_run.pull_request_number).to eq(42)
+    end
+
+    it "syncs a local pull request row immediately after PR creation" do
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to change { project.issues.pull_requests_only.where(github_number: 42).count }.by(1)
+
+      pull_request = project.issues.pull_requests_only.find_by!(github_number: 42)
+      expect(pull_request.github_issue_id).to eq(4242)
+      expect(pull_request.labels).to include("paid-generated", "paid-automation")
     end
 
     it "adds the generated and automation labels to the PR" do
@@ -146,13 +171,15 @@ RSpec.describe Activities::CreatePullRequestActivity do
       end
 
       it "adds both custom labels to the PR" do
-        activity.execute(agent_run_id: agent_run.id)
+      activity.execute(agent_run_id: agent_run.id)
 
-        expect(github_client).to have_received(:add_labels_to_issue).with(
-          project.full_name, 42, [ "custom-generated", "custom-automation" ]
-        )
-      end
+      expect(github_client).to have_received(:add_labels_to_issue).with(
+        project.full_name, 42, [ "custom-generated", "custom-automation" ]
+      )
+      expect(project.issues.pull_requests_only.find_by!(github_number: 42).labels)
+        .to include("custom-generated", "custom-automation")
     end
+  end
 
     context "with priority label inheritance" do
       let(:project) do

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1456,6 +1456,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
     context "when paid_agent posted a body-only review before the last agent run completed" do
       before do
+        enable_paid_agent_review!
         create(:issue, :pull_request,
           project: project, github_number: 42,
           labels: [ "paid-generated", "paid-automation" ],
@@ -1486,8 +1487,58 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when paid_agent review pre-dates the last run and the diff touches reviewed files" do
+      before do
+        enable_paid_agent_review!
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          goal: "create_pr",
+          trigger_type: "automatic",
+          completed_at: 30.minutes.ago)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          goal: "review",
+          trigger_type: "automatic",
+          completed_at: 2.hours.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                       body: "Here are some review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
+              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+              pull_request_review_id: 1 }
+          ])
+        allow(github_client).to receive(:compare_changed_files)
+          .with(project.full_name, "rev_sha", "abc123")
+          .and_return([ "app/services/fetch_issues_activity.rb", "db/schema.rb" ])
+      end
+
+      it "requests a fresh paid_agent review instead of treating the old review as clean" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("paid_agent_review_pending")
+        expect(trigger_types).not_to include("ready_for_owner")
+      end
+    end
+
     context "when paid_agent posted a body-only review after the last agent run completed" do
       before do
+        enable_paid_agent_review!
         create(:issue, :pull_request,
           project: project, github_number: 42,
           labels: [ "paid-generated", "paid-automation" ],
@@ -4409,6 +4460,63 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         expect(trigger[:phase]).to eq("restarted")
         expect(pending_trigger[:details]).to eq("No paid_agent review found for PR")
+      end
+    end
+
+    context "when a restarted PR only has stale pre-restart paid_agent reviews" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "restarted",
+          review_goal_retry_reset_at: 1.hour.ago)
+      end
+
+      before do
+        enable_paid_agent_review!(project, max_review_rounds: 3)
+        create(:agent_run, :automatic,
+          project: project, issue: pr_issue,
+          source_pull_request_number: 42,
+          goal: "create_pr",
+          status: "completed",
+          created_at: 40.minutes.ago,
+          started_at: 40.minutes.ago,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          draft: true,
+          reviews: [
+            { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+              body: "Found issues.", submitted_at: 3.hours.ago },
+            { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+              body: "Still has issues.", submitted_at: 2.hours.ago },
+            { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+              body: "More issues.", submitted_at: 90.minutes.ago, commit_id: "rev_sha" }
+          ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
+              created_at: 90.minutes.ago, path: "app/services/fetch_issues_activity.rb",
+              pull_request_review_id: 3 }
+          ])
+        allow(github_client).to receive(:compare_changed_files)
+          .with(project.full_name, "rev_sha", "abc123")
+          .and_return([ "app/services/fetch_issues_activity.rb" ])
+      end
+
+      it "restarts the review cycle instead of counting the stale reviews against the new draft" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        trigger_types = trigger[:triggers].map { |entry| entry[:type] }
+
+        expect(trigger[:phase]).to eq("restarted")
+        expect(trigger_types).to include("paid_agent_review_pending")
+        expect(trigger_types).not_to include("escalate_to_owner")
+        expect(trigger_types).not_to include("ready_for_owner")
       end
     end
 


### PR DESCRIPTION
## Summary
- requeue `paid_agent` reviews after addressed body-only feedback instead of treating the old review as implicitly clean
- count `paid_agent` GitHub reviews only within the current restarted cycle when enforcing round limits
- raise default review-round settings to `15` for review methods with built-in defaults and backfill persisted legacy defaults

## Testing
- `SIMPLECOV_DISABLE=1 bin/rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb -e "paid_agent review pre-dates the last run and the diff touches reviewed files" -e "ready PR exhausted paid_agent review rounds before draft restart" -e "restarted PR only has stale pre-restart paid_agent reviews" -e "paid_agent posted a body-only review before the last agent run completed" spec/models/project_spec.rb -e "returns defaults when review_settings is empty" -e "merges custom settings over defaults" -e "returns merged config for a method" spec/migrations/backfill_legacy_review_max_rounds_defaults_spec.rb`

## Notes
- targeted specs passed; the repo's SimpleCov minimum-coverage gate still makes narrow `rspec` runs exit non-zero after reporting green examples