### PR TITLE
Fix #1082: refactor(automation): unify issue and PR automation behind an explicit decision layer

### DIFF
--- a/app/services/automation/decision.rb
+++ b/app/services/automation/decision.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Automation
+  class Decision < Data.define(:type, :payload)
+    class << self
+      def noop
+        new(type: "noop", payload: {})
+      end
+
+      def queue_create_pr_run(issue_id:, source_pull_request_number: nil,
+        count_toward_draft_review_round: false, expected_draft_review_count: nil)
+        new(type: "queue_create_pr_run", payload: {
+          issue_id: issue_id,
+          source_pull_request_number: source_pull_request_number,
+          count_toward_draft_review_round: count_toward_draft_review_round,
+          expected_draft_review_count: expected_draft_review_count
+        }.compact)
+      end
+
+      def queue_review_run(issue_id:, source_pull_request_number:)
+        new(type: "queue_review_run", payload: {
+          issue_id: issue_id,
+          source_pull_request_number: source_pull_request_number
+        })
+      end
+
+      def start_planning(issue_id:)
+        new(type: "start_planning", payload: { issue_id: issue_id })
+      end
+
+      def request_review(pr_number:, reviewers:)
+        new(type: "request_review", payload: {
+          pr_number: pr_number,
+          reviewers: reviewers
+        })
+      end
+
+      def mark_ready(issue_id:, pr_number:, owner_reviewer_login: nil)
+        new(type: "mark_ready", payload: {
+          issue_id: issue_id,
+          pr_number: pr_number,
+          owner_reviewer_login: owner_reviewer_login
+        }.compact)
+      end
+
+      def escalate(issue_id:, pr_number:, owner_reviewer_login: nil, reason: nil)
+        new(type: "escalate", payload: {
+          issue_id: issue_id,
+          pr_number: pr_number,
+          owner_reviewer_login: owner_reviewer_login,
+          reason: reason
+        }.compact)
+      end
+
+      def dismiss_escalation(issue_id:)
+        new(type: "dismiss_escalation", payload: { issue_id: issue_id })
+      end
+
+      def merge(issue_id:, pr_number:)
+        new(type: "merge", payload: {
+          issue_id: issue_id,
+          pr_number: pr_number
+        })
+      end
+
+      def record_pr_followup(issue_id:, labels_to_remove:, expected_followup_count:)
+        new(type: "record_pr_followup", payload: {
+          issue_id: issue_id,
+          labels_to_remove: labels_to_remove,
+          expected_followup_count: expected_followup_count
+        })
+      end
+
+      def record_review_goal_retry(issue_id:, expected_review_goal_retry_count:)
+        new(type: "record_review_goal_retry", payload: {
+          issue_id: issue_id,
+          expected_review_goal_retry_count: expected_review_goal_retry_count
+        })
+      end
+    end
+
+    def to_h
+      serialized_payload = payload.reject do |key, value|
+        key == :count_toward_draft_review_round && value == false
+      end
+
+      { type: type }.merge(serialized_payload)
+    end
+  end
+end

--- a/app/services/automation/evaluator.rb
+++ b/app/services/automation/evaluator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Automation
+  class Evaluator
+    def self.for(record, explicit_pr_decisions: false)
+      evaluator_class =
+        if record.is_pull_request?
+          PullRequestEvaluator
+        else
+          IssueEvaluator
+        end
+
+      evaluator_class.new(record:, explicit_pr_decisions:)
+    end
+  end
+end

--- a/app/services/automation/issue_evaluator.rb
+++ b/app/services/automation/issue_evaluator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Automation
+  class IssueEvaluator
+    include LabelPolicy
+
+    def initialize(record:, explicit_pr_decisions: false)
+      @record = record
+      @project = record.project
+      @explicit_pr_decisions = explicit_pr_decisions
+    end
+
+    def call
+      label_decision_for(project, record)
+    end
+
+    private
+
+    attr_reader :record, :project, :explicit_pr_decisions
+  end
+end

--- a/app/services/automation/label_policy.rb
+++ b/app/services/automation/label_policy.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Automation
+  module LabelPolicy
+    private
+
+    def actionable_state?(record)
+      record.paid_state.in?(%w[new needs_input recommend_close])
+    end
+
+    def triggering_label(project, record)
+      build_label = project.label_for_stage(:build)
+      return { action: "queue_create_pr_run", label: build_label } if build_label && record.has_label?(build_label)
+
+      plan_label = project.label_for_stage(:plan)
+      return { action: "start_planning", label: plan_label } if plan_label && record.has_label?(plan_label)
+
+      if project.automation_on_label_enabled? &&
+          !record.is_pull_request? &&
+          record.has_label?(project.automation_label_name)
+        return { action: "queue_create_pr_run", label: project.automation_label_name }
+      end
+
+      nil
+    end
+
+    def authorized_for_trigger?(project, record, label)
+      return true if record.trusted?
+      return true if trusted_user_added_label?(project, record, label)
+
+      Rails.logger.warn(
+        message: "github_sync.untrusted_issue_blocked",
+        project_id: project.id,
+        issue_id: record.id,
+        creator: record.github_creator_login,
+        label: label
+      )
+      false
+    end
+
+    def blocked_by_dependencies?(project, record)
+      max_logged = 10
+      blocking_relation = record.blocking_issues
+      blocking_numbers = blocking_relation.limit(max_logged + 1).pluck(:github_number)
+      return false if blocking_numbers.empty?
+
+      blocking_issues_truncated = blocking_numbers.length > max_logged
+      blocking_issues_to_log = blocking_numbers.first(max_logged)
+      blocking_issues_count = blocking_issues_truncated ? blocking_relation.count : blocking_numbers.length
+
+      Rails.logger.info(
+        message: "github_sync.blocked_by_dependencies",
+        project_id: project.id,
+        issue_id: record.id,
+        blocking_issues: blocking_issues_to_log,
+        blocking_issues_count: blocking_issues_count,
+        blocking_issues_truncated: blocking_issues_truncated
+      )
+
+      true
+    end
+
+    def trusted_user_added_label?(project, record, label)
+      events = project.github_token.client.issue_events(project.full_name, record.github_number)
+      relevant = events.select do |event|
+        (event.event == "labeled" || event.event == "unlabeled") &&
+          event_label_name(event) == label
+      end
+      return false if relevant.empty?
+
+      sorted = relevant.sort_by do |event|
+        event.respond_to?(:created_at) && event.created_at ? event.created_at : Time.at(0)
+      end
+
+      label_present = false
+      last_labeled_actor = nil
+
+      sorted.each do |event|
+        case event.event
+        when "labeled"
+          label_present = true
+          last_labeled_actor = event.actor&.login
+        when "unlabeled"
+          label_present = false
+          last_labeled_actor = nil
+        end
+      end
+
+      label_present && project.trusted_github_user?(last_labeled_actor)
+    rescue GithubClient::RateLimitError
+      raise
+    rescue => e
+      Rails.logger.warn(
+        message: "github_sync.issue_events_fetch_failed",
+        project_id: project.id,
+        issue_id: record.id,
+        github_number: record.github_number,
+        error_class: e.class.name,
+        error: e.message
+      )
+      false
+    end
+
+    def event_label_name(event)
+      label = event.label
+      return label.name if label.respond_to?(:name)
+
+      label&.[]("name") || label&.[](:name)
+    end
+
+    def label_decision_for(project, record)
+      return Result.noop unless actionable_state?(record)
+
+      trigger = triggering_label(project, record)
+      return Result.noop unless trigger
+      return Result.noop unless authorized_for_trigger?(project, record, trigger[:label])
+      return Result.noop if blocked_by_dependencies?(project, record)
+
+      decision = case trigger[:action]
+      when "queue_create_pr_run"
+        Decision.queue_create_pr_run(
+          issue_id: record.id,
+          source_pull_request_number: record.is_pull_request? ? record.github_number : nil
+        )
+      when "start_planning"
+        Decision.start_planning(issue_id: record.id)
+      else
+        Decision.noop
+      end
+
+      Result.new(decisions: [ decision ])
+    end
+  end
+end

--- a/app/services/automation/pull_request_evaluator.rb
+++ b/app/services/automation/pull_request_evaluator.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+module Automation
+  class PullRequestEvaluator
+    include LabelPolicy
+
+    FOLLOWUP_TRIGGER_TYPES = %w[
+      ci_failure review_threads conversation_comments changes_requested
+      actionable_labels merge_conflicts review_bot_comments review_bot_threads
+    ].freeze
+
+    def initialize(record:, explicit_pr_decisions: false)
+      @record = record
+      @project = record.project
+      @explicit_pr_decisions = explicit_pr_decisions
+    end
+
+    def call(scan: nil)
+      return explicit_scan_decisions(scan) if explicit_pr_decisions
+
+      label_decision_for(project, record)
+    end
+
+    private
+
+    attr_reader :record, :project, :explicit_pr_decisions
+
+    def explicit_scan_decisions(scan)
+      return Result.noop unless scan
+
+      scan = scan.deep_symbolize_keys
+      trigger_types = scan.fetch(:triggers, []).map { |trigger| trigger[:type] }
+
+      decisions =
+        if trigger_types.include?("escalate_to_owner")
+          [ escalate_decision(scan) ]
+        elsif trigger_types.include?("dismiss_escalation")
+          [ Decision.dismiss_escalation(issue_id: record.id) ]
+        elsif trigger_types.include?("owner_approved")
+          [ Decision.merge(issue_id: record.id, pr_number: scan[:pr_number]) ]
+        elsif trigger_types.include?("review_goal_retry")
+          review_goal_retry_decisions(scan, trigger_types)
+        elsif trigger_types.include?("ready_for_owner")
+          ready_for_owner_decisions(scan)
+        elsif trigger_types.include?("paid_agent_review_pending")
+          paid_agent_review_pending_decisions(scan, trigger_types)
+        elsif trigger_types.include?("review_bot_review_pending")
+          review_bot_review_pending_decisions(scan, trigger_types)
+        elsif trigger_types.include?("manual_review_pending") || trigger_types.include?("ci_action_pending")
+          non_bot_review_pending_decisions(scan, trigger_types)
+        else
+          standard_followup_decisions(scan)
+        end
+
+      Result.new(decisions: decisions.presence || [ Decision.noop ])
+    end
+
+    def ready_for_owner_decisions(scan)
+      decisions = []
+      decisions << queue_review_run_decision(scan) if trigger_present?(scan, "paid_agent_review_pending") && !paid_agent_active?(scan)
+      decisions << Decision.mark_ready(
+        issue_id: record.id,
+        pr_number: scan[:pr_number],
+        owner_reviewer_login: scan[:owner_reviewer_login]
+      )
+      decisions
+    end
+
+    def paid_agent_review_pending_decisions(scan, trigger_types)
+      decisions = []
+      decisions << queue_review_run_decision(scan) unless paid_agent_active?(scan)
+
+      other_triggers = trigger_types - [ "paid_agent_review_pending" ]
+      decisions.concat(followup_decisions(scan)) if other_triggers.any?
+      decisions
+    end
+
+    def review_bot_review_pending_decisions(scan, trigger_types)
+      decisions = []
+      decisions << review_bot_request_decision(scan)
+
+      other_triggers = trigger_types - [ "review_bot_review_pending" ]
+      decisions.concat(followup_decisions(scan)) if other_triggers.any?
+      decisions.compact
+    end
+
+    def non_bot_review_pending_decisions(scan, trigger_types)
+      decisions = []
+
+      manual_trigger = trigger(scan, "manual_review_pending")
+      if manual_trigger&.dig(:reviewer_login).present?
+        decisions << Decision.request_review(
+          pr_number: scan[:pr_number],
+          reviewers: [ manual_trigger[:reviewer_login] ]
+        )
+      end
+
+      other_triggers = trigger_types - %w[manual_review_pending ci_action_pending]
+      decisions.concat(followup_decisions(scan)) if other_triggers.any?
+      decisions
+    end
+
+    def review_goal_retry_decisions(scan, trigger_types)
+      decisions = [
+        Decision.record_review_goal_retry(
+          issue_id: record.id,
+          expected_review_goal_retry_count: scan[:current_review_goal_retry_count]
+        ),
+        queue_review_run_decision(scan)
+      ]
+
+      if trigger_types.include?("ready_for_owner")
+        decisions.concat(ready_for_owner_decisions(without_trigger(scan, "paid_agent_review_pending")))
+        return decisions
+      end
+
+      manual_trigger = trigger(scan, "manual_review_pending")
+      if manual_trigger&.dig(:reviewer_login).present?
+        decisions << Decision.request_review(
+          pr_number: scan[:pr_number],
+          reviewers: [ manual_trigger[:reviewer_login] ]
+        )
+      end
+
+      if followup_triggers?(scan)
+        decisions.concat(followup_decisions(scan))
+      else
+        review_bot_decision = review_bot_request_decision(scan)
+        decisions << review_bot_decision if review_bot_decision
+      end
+
+      decisions
+    end
+
+    def standard_followup_decisions(scan)
+      followup_decisions(scan)
+    end
+
+    def followup_decisions(scan)
+      if scan[:phase].in?(%w[draft restarted])
+        [
+          Decision.queue_create_pr_run(
+            issue_id: record.id,
+            source_pull_request_number: scan[:pr_number],
+            count_toward_draft_review_round: true,
+            expected_draft_review_count: scan[:current_draft_review_count]
+          )
+        ]
+      else
+        [
+          Decision.queue_create_pr_run(
+            issue_id: record.id,
+            source_pull_request_number: scan[:pr_number]
+          ),
+          Decision.record_pr_followup(
+            issue_id: record.id,
+            labels_to_remove: scan[:labels_to_remove] || [],
+            expected_followup_count: scan[:current_followup_count]
+          )
+        ]
+      end
+    end
+
+    def escalate_decision(scan)
+      Decision.escalate(
+        issue_id: record.id,
+        pr_number: scan[:pr_number],
+        owner_reviewer_login: scan[:owner_reviewer_login],
+        reason: trigger(scan, "escalate_to_owner")&.dig(:details)
+      )
+    end
+
+    def queue_review_run_decision(scan)
+      Decision.queue_review_run(issue_id: record.id, source_pull_request_number: scan[:pr_number])
+    end
+
+    def review_bot_request_decision(scan)
+      login = trigger(scan, "review_bot_review_pending")&.dig(:request_login)
+      return if login.blank?
+
+      Decision.request_review(pr_number: scan[:pr_number], reviewers: [ login ])
+    end
+
+    def followup_triggers?(scan)
+      scan.fetch(:triggers, []).any? { |item| FOLLOWUP_TRIGGER_TYPES.include?(item[:type]) }
+    end
+
+    def paid_agent_active?(scan)
+      trigger(scan, "paid_agent_review_pending")&.dig(:active_run)
+    end
+
+    def trigger_present?(scan, type)
+      trigger(scan, type).present?
+    end
+
+    def trigger(scan, type)
+      scan.fetch(:triggers, []).find { |item| item[:type] == type }
+    end
+
+    def without_trigger(scan, type)
+      scan.merge(triggers: scan.fetch(:triggers, []).reject { |item| item[:type] == type })
+    end
+  end
+end

--- a/app/services/automation/result.rb
+++ b/app/services/automation/result.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Automation
+  class Result < Data.define(:decisions)
+    class << self
+      def noop
+        new(decisions: [ Decision.noop ])
+      end
+    end
+
+    def to_h
+      { decisions: decisions.map(&:to_h) }
+    end
+  end
+end

--- a/app/temporal/activities/detect_labels_activity.rb
+++ b/app/temporal/activities/detect_labels_activity.rb
@@ -1,34 +1,27 @@
 # frozen_string_literal: true
 
 module Activities
-  # Checks an issue's labels against a project's label mappings to determine
-  # what action should be taken (execute agent, start planning, or none).
-  #
-  # Updates the issue's paid_state when an action is triggered.
+  # Evaluates a synced GitHub record through the shared automation decision
+  # layer and returns explicit decisions for the poll workflow to execute.
   class DetectLabelsActivity < BaseActivity
     def execute(input)
       project_id = input[:project_id]
       issue_id = input[:issue_id]
       project = Project.find(project_id)
       issue = project.issues.find(issue_id)
+      explicit_pr_decisions = FeatureFlags.explicit_pr_automation_decisions?(project:)
+      result = Automation::Evaluator.for(issue, explicit_pr_decisions:).call
 
-      action = determine_action(project, issue)
-
-      if action != "none"
-        new_state = (action == "execute_agent") ? "in_progress" : "planning"
-        issue.update!(paid_state: new_state)
-      end
+      update_paid_state!(issue, result)
 
       logger.info(
         message: "github_sync.detect_labels",
         project_id: project_id,
         issue_id: issue_id,
-        action: action
+        decision_types: result.decisions.map(&:type)
       )
 
-      result = { action: action, issue_id: issue_id, project_id: project_id }
-      result[:source_pull_request_number] = issue.github_number if issue.is_pull_request? && action != "none"
-      result
+      serialize_result(result, issue, project_id:, issue_id:)
     rescue GithubClient::RateLimitError => e
       raise Temporalio::Error::ApplicationError.new(
         e.message,
@@ -38,121 +31,45 @@ module Activities
 
     private
 
-    def determine_action(project, issue)
-      return "none" unless issue.paid_state.in?(%w[new needs_input recommend_close])
+    def update_paid_state!(issue, result)
+      first_decision = result.decisions.reject { |decision| decision.type == "noop" }.first
+      return unless first_decision
 
-      trigger = triggering_label(project, issue)
-      return "none" unless trigger
-      return "none" unless authorized_for_trigger?(project, issue, trigger[:label])
-
-      # Check dependencies after labels to avoid unnecessary DB queries for unlabeled issues.
-      # Pluck first (capped) to combine the existence check with data retrieval in one query.
-      max_logged = 10
-      blocking_relation = issue.blocking_issues
-      blocking_numbers = blocking_relation.limit(max_logged + 1).pluck(:github_number)
-
-      unless blocking_numbers.empty?
-        blocking_issues_truncated = blocking_numbers.length > max_logged
-        blocking_issues_to_log = blocking_numbers.first(max_logged)
-        blocking_issues_count = blocking_issues_truncated ? blocking_relation.count : blocking_numbers.length
-
-        logger.info(
-          message: "github_sync.blocked_by_dependencies",
-          project_id: project.id,
-          issue_id: issue.id,
-          blocking_issues: blocking_issues_to_log,
-          blocking_issues_count: blocking_issues_count,
-          blocking_issues_truncated: blocking_issues_truncated
-        )
-        return "none"
+      new_state = case first_decision.type
+      when "queue_create_pr_run"
+        "in_progress"
+      when "start_planning"
+        "planning"
       end
 
-      trigger[:action]
+      issue.update!(paid_state: new_state) if new_state
     end
 
-    def triggering_label(project, issue)
-      build_label = project.label_for_stage(:build)
-      return { action: "execute_agent", label: build_label } if build_label && issue.has_label?(build_label)
-
-      plan_label = project.label_for_stage(:plan)
-      return { action: "start_planning", label: plan_label } if plan_label && issue.has_label?(plan_label)
-
-      if project.automation_on_label_enabled? &&
-          !issue.is_pull_request? &&
-          issue.has_label?(project.automation_label_name)
-        return { action: "execute_agent", label: project.automation_label_name }
-      end
-
-      nil
-    end
-
-    def authorized_for_trigger?(project, issue, label)
-      return true if issue.trusted?
-      return true if trusted_user_added_label?(project, issue, label)
-
-      logger.warn(
-        message: "github_sync.untrusted_issue_blocked",
-        project_id: project.id,
-        issue_id: issue.id,
-        creator: issue.github_creator_login,
-        label: label
+    def serialize_result(result, issue, project_id:, issue_id:)
+      serialized = result.to_h.merge(
+        issue_id: issue_id,
+        project_id: project_id,
+        action: action_for(result)
       )
-      false
+
+      if issue.is_pull_request? && serialized[:action] == "execute_agent"
+        serialized[:source_pull_request_number] = issue.github_number
+      end
+
+      serialized
     end
 
-    def trusted_user_added_label?(project, issue, label)
-      client = project.github_token.client
-      events = client.issue_events(project.full_name, issue.github_number)
+    def action_for(result)
+      first_decision = result.decisions.reject { |decision| decision.type == "noop" }.first
 
-      # Walk label/unlabel events in chronological order to determine who
-      # last caused the label to become present. This prevents a bypass where
-      # a trusted user once added the label but later removed it and an
-      # untrusted user re-added it.
-      relevant = events.select do |event|
-        (event.event == "labeled" || event.event == "unlabeled") &&
-          event_label_name(event) == label
+      case first_decision&.type
+      when "queue_create_pr_run"
+        "execute_agent"
+      when "start_planning"
+        "start_planning"
+      else
+        "none"
       end
-
-      return false if relevant.empty?
-
-      sorted = relevant.sort_by do |event|
-        event.respond_to?(:created_at) && event.created_at ? event.created_at : Time.at(0)
-      end
-
-      label_present = false
-      last_labeled_actor = nil
-
-      sorted.each do |event|
-        case event.event
-        when "labeled"
-          label_present = true
-          last_labeled_actor = event.actor&.login
-        when "unlabeled"
-          label_present = false
-          last_labeled_actor = nil
-        end
-      end
-
-      label_present && project.trusted_github_user?(last_labeled_actor)
-    rescue GithubClient::RateLimitError
-      raise
-    rescue => e
-      logger.warn(
-        message: "github_sync.issue_events_fetch_failed",
-        project_id: project.id,
-        issue_id: issue.id,
-        github_number: issue.github_number,
-        error_class: e.class.name,
-        error: e.message
-      )
-      false
-    end
-
-    def event_label_name(event)
-      label = event.label
-      return label.name if label.respond_to?(:name)
-
-      label&.[]("name") || label&.[](:name)
     end
   end
 end

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -37,15 +37,17 @@ module Activities
     def execute(input)
       project_id = input[:project_id]
       project = Project.find_by(id: project_id)
-      return { prs_to_trigger: [], project_missing: true } unless project
-      return { prs_to_trigger: [] } unless project.auto_scan_prs
+      return { prs_to_trigger: [], automation_results: [], project_missing: true } unless project
+      return { prs_to_trigger: [], automation_results: [] } unless project.auto_scan_prs
 
       client = project.github_token.client
       paid_prs = find_paid_prs(project)
+      explicit_pr_decisions = FeatureFlags.explicit_pr_automation_decisions?(project:)
 
       scanned_count = 0
       unchanged_count = 0
       prs_to_trigger = []
+      automation_results = []
       paid_prs.each do |issue|
         if skip_unchanged_pr?(project, issue)
           if merge_conflict_rescan_needed?(project, issue)
@@ -53,7 +55,8 @@ module Activities
             if result && result != :skipped
               scanned_count += 1
               issue.update_column(:last_pr_scan_at, Time.current)
-              prs_to_trigger << result
+              collect_scan_result(issue, result, prs_to_trigger, automation_results,
+                explicit_pr_decisions:)
               next
             end
           end
@@ -68,14 +71,15 @@ module Activities
         next if result == :skipped
         scanned_count += 1
         issue.update_column(:last_pr_scan_at, Time.current)
-        prs_to_trigger << result if result
+        collect_scan_result(issue, result, prs_to_trigger, automation_results,
+          explicit_pr_decisions:) if result
       rescue Temporalio::Error::ApplicationError => e
         raise unless e.type == "RateLimit"
 
         logger.warn(
           message: "pr_scanner.rate_budget_exhausted_mid_scan",
           project_id: project_id,
-          prs_collected: prs_to_trigger.size,
+          prs_collected: explicit_pr_decisions ? automation_results.size : prs_to_trigger.size,
           prs_remaining: paid_prs.size - paid_prs.index(issue) - 1
         )
         break
@@ -87,13 +91,21 @@ module Activities
         prs_found: paid_prs.size,
         prs_scanned: scanned_count,
         prs_skipped_unchanged: unchanged_count,
-        prs_triggered: prs_to_trigger.size
+        prs_triggered: explicit_pr_decisions ? automation_results.size : prs_to_trigger.size
       )
 
-      { prs_to_trigger: prs_to_trigger }
+      { prs_to_trigger: prs_to_trigger, automation_results: automation_results }
     end
 
     private
+
+    def collect_scan_result(issue, result, prs_to_trigger, automation_results, explicit_pr_decisions:)
+      if explicit_pr_decisions
+        automation_results << Automation::Evaluator.for(issue, explicit_pr_decisions: true).call(scan: result).to_h
+      else
+        prs_to_trigger << result
+      end
+    end
 
     def find_paid_prs(project)
       project.issues

--- a/app/temporal/workflows/base_workflow.rb
+++ b/app/temporal/workflows/base_workflow.rb
@@ -53,7 +53,7 @@ module Workflows
       snapshot = feature_flag_snapshot_for(project_id)
       return false if snapshot[:project_missing]
 
-      snapshot.fetch(:flags).fetch(flag_name.to_sym)
+      snapshot.fetch(:flags, {}).fetch(flag_name.to_sym, false)
     end
 
     def feature_flag_snapshot_for(project_id)

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -32,10 +32,10 @@ module Workflows
         break if result[:project_missing]
 
         result[:issues].each do |issue_data|
-          detection = run_activity(Activities::DetectLabelsActivity,
+          evaluation = run_activity(Activities::DetectLabelsActivity,
             { project_id: project_id, issue_id: issue_data[:id] }, timeout: 30)
 
-          handle_detection(detection, project_id)
+          handle_automation_result(evaluation, project_id)
         end
 
         maybe_run_non_critical_activities(project_id)
@@ -133,14 +133,69 @@ module Workflows
       )
     end
 
-    def handle_detection(detection, project_id)
-      case detection[:action]
-      when "execute_agent"
-        start_agent_workflow(project_id, detection[:issue_id],
-          source_pull_request_number: detection[:source_pull_request_number])
-      when "start_planning"
-        start_planning_workflow(project_id, detection[:issue_id])
+    def handle_automation_result(result, project_id)
+      (result[:decisions] || []).each do |decision|
+        execute_automation_decision(project_id, decision)
       end
+    end
+
+    def execute_automation_decision(project_id, decision)
+      case decision[:type]
+      when "noop"
+        nil
+      when "queue_create_pr_run"
+        queue_create_pr_run(project_id, decision)
+      when "queue_review_run"
+        queue_review_run(project_id, decision)
+      when "start_planning"
+        start_planning_workflow(project_id, decision[:issue_id])
+      when "request_review"
+        request_review(project_id, decision[:pr_number], decision[:reviewers],
+          log_key: "pr_review.request_review_failed")
+      when "mark_ready"
+        handle_mark_ready(project_id, decision)
+      when "escalate"
+        handle_escalate_decision(project_id, decision)
+      when "dismiss_escalation"
+        handle_dismiss_escalation(project_id, decision)
+      when "merge"
+        handle_owner_approved(project_id, issue_id: decision[:issue_id], pr_number: decision[:pr_number])
+      when "record_pr_followup"
+        run_activity(Activities::RecordPrFollowupActivity, {
+          project_id: project_id,
+          issue_id: decision[:issue_id],
+          labels_to_remove: decision[:labels_to_remove] || [],
+          expected_followup_count: decision[:expected_followup_count]
+        }, timeout: 30)
+      when "record_review_goal_retry"
+        run_activity(Activities::RecordReviewGoalRetryActivity, {
+          issue_id: decision[:issue_id],
+          expected_review_goal_retry_count: decision[:expected_review_goal_retry_count]
+        }, timeout: 30)
+      end
+    end
+
+    def queue_create_pr_run(project_id, decision)
+      queue_input = {
+        project_id: project_id,
+        issue_id: decision[:issue_id],
+        source_pull_request_number: decision[:source_pull_request_number],
+        goal: "create_pr",
+        count_toward_draft_review_round: decision.fetch(:count_toward_draft_review_round, false),
+        expected_draft_review_count: decision[:expected_draft_review_count]
+      }.compact
+      queue_input.delete(:count_toward_draft_review_round) unless queue_input[:count_toward_draft_review_round]
+
+      run_activity(Activities::QueueAgentRunActivity, queue_input, timeout: 30)
+    end
+
+    def queue_review_run(project_id, decision)
+      run_activity(Activities::QueueAgentRunActivity, {
+        project_id: project_id,
+        issue_id: decision[:issue_id],
+        source_pull_request_number: decision[:source_pull_request_number],
+        goal: "review"
+      }, timeout: 30)
     end
 
     # Unlike agent workflows, planning workflows cannot be queued via QueueAgentRunActivity
@@ -169,15 +224,14 @@ module Workflows
       )
     end
 
-    # TODO(#1080): Remove patch guard after all pre-v1080 workflows have continued-as-new
-    def start_agent_workflow(project_id, issue_id, source_pull_request_number: nil)
-      queue_input = { project_id: project_id, issue_id: issue_id }
-      queue_input[:source_pull_request_number] = source_pull_request_number if source_pull_request_number
-      queue_input[:goal] = "create_pr" if source_pull_request_number && Temporalio::Workflow.patched("queue-agent-run-goal-v1")
-      run_activity(Activities::QueueAgentRunActivity, queue_input, timeout: 30)
-    end
-
     def handle_pr_scan_results(scan_result, project_id)
+      if feature_flag_enabled?(:explicit_pr_automation_decisions, project_id:)
+        (scan_result[:automation_results] || []).each do |result|
+          handle_automation_result(result, project_id)
+        end
+        return
+      end
+
       return if scan_result[:prs_to_trigger].blank?
 
       scan_result[:prs_to_trigger].each do |pr_data|
@@ -215,6 +269,36 @@ module Workflows
       end
     end
 
+    def handle_mark_ready(project_id, decision)
+      result = run_activity(Activities::MarkPrReadyActivity,
+        { project_id: project_id, pr_number: decision[:pr_number],
+          issue_id: decision[:issue_id] }, timeout: 60)
+
+      return unless result[:marked_ready]
+
+      reviewer = decision[:owner_reviewer_login]
+      return if reviewer.blank?
+
+      request_review(project_id, decision[:pr_number], [ reviewer ],
+        log_key: "pr_review.request_owner_review_failed")
+    end
+
+    def handle_escalate_decision(project_id, decision)
+      activity_input = if Temporalio::Workflow.patched("escalation-reason-payload-v1")
+        { issue_id: decision[:issue_id], reason: decision[:reason] }.compact
+      else
+        { issue_id: decision[:issue_id] }
+      end
+
+      run_activity(Activities::MarkEscalatedActivity, activity_input, timeout: 30)
+
+      reviewer = decision[:owner_reviewer_login]
+      return if reviewer.blank?
+
+      request_review(project_id, decision[:pr_number], [ reviewer ],
+        log_key: "pr_review.request_owner_review_failed")
+    end
+
     def handle_ready_for_owner(project_id, pr_data)
       trigger_types = (pr_data[:triggers] || []).map { |t| t[:type] }
 
@@ -231,19 +315,11 @@ module Workflows
     end
 
     def handle_escalate_to_owner(project_id, pr_data)
-      escalate_trigger = (pr_data[:triggers] || []).find { |t| t[:type] == "escalate_to_owner" }
-      reason = escalate_trigger&.dig(:details)
-
-      # TODO(#944): Remove patch guard after all pre-v944 workflows have continued-as-new
-      if Temporalio::Workflow.patched("escalation-reason-payload-v1")
-        activity_input = { issue_id: pr_data[:issue_id], reason: reason }.compact
-      else
-        activity_input = { issue_id: pr_data[:issue_id] }
-      end
-
-      run_activity(Activities::MarkEscalatedActivity, activity_input, timeout: 30)
-
-      request_owner_review(project_id, pr_data)
+      handle_escalate_decision(project_id,
+        issue_id: pr_data[:issue_id],
+        pr_number: pr_data[:pr_number],
+        owner_reviewer_login: pr_data[:owner_reviewer_login],
+        reason: (pr_data[:triggers] || []).find { |t| t[:type] == "escalate_to_owner" }&.dig(:details))
     end
 
     def handle_dismiss_escalation(project_id, pr_data)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_13_193745) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_14_154102) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"

--- a/spec/services/automation/issue_evaluator_spec.rb
+++ b/spec/services/automation/issue_evaluator_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::IssueEvaluator do
+  describe "#call" do
+    let(:project) { create(:project, label_mappings: { "build" => "paid-build", "plan" => "paid-plan" }) }
+
+    it "queues an explicit create_pr decision for build-labeled issues" do
+      issue = create(:issue, project: project, labels: [ "paid-build" ], paid_state: "new")
+
+      result = described_class.new(record: issue).call
+
+      expect(result.to_h).to eq(
+        decisions: [
+          {
+            type: "queue_create_pr_run",
+            issue_id: issue.id
+          }
+        ]
+      )
+    end
+
+    it "returns noop when dependencies block automation" do
+      issue = create(:issue, project: project, labels: [ "paid-build" ], paid_state: "new")
+      blocking_issue = create(:issue, project: project, github_state: "open")
+      create(:issue_dependency, issue: issue, depends_on_issue: blocking_issue)
+
+      result = described_class.new(record: issue).call
+
+      expect(result.to_h).to eq(decisions: [ { type: "noop" } ])
+    end
+  end
+end

--- a/spec/services/automation/pull_request_evaluator_spec.rb
+++ b/spec/services/automation/pull_request_evaluator_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::PullRequestEvaluator do
+  describe "#call" do
+    let(:project) { create(:project, label_mappings: { "build" => "paid-build", "plan" => "paid-plan" }) }
+    let(:pull_request) do
+      create(:issue, :pull_request,
+        project: project,
+        labels: [ "paid-build" ],
+        paid_state: "new",
+        github_number: 42)
+    end
+
+    it "keeps legacy initial-sync create_pr behavior when the flag is disabled" do
+      result = described_class.new(record: pull_request, explicit_pr_decisions: false).call
+
+      expect(result.to_h).to eq(
+        decisions: [
+          {
+            type: "queue_create_pr_run",
+            issue_id: pull_request.id,
+            source_pull_request_number: 42
+          }
+        ]
+      )
+    end
+
+    it "returns noop for initial-sync PR evaluation when the flag is enabled" do
+      result = described_class.new(record: pull_request, explicit_pr_decisions: true).call
+
+      expect(result.to_h).to eq(decisions: [ { type: "noop" } ])
+    end
+
+    it "maps paid_agent review signals to an explicit review decision" do
+      result = described_class.new(record: pull_request, explicit_pr_decisions: true).call(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: [ { type: "paid_agent_review_pending" } ]
+      })
+
+      expect(result.to_h).to eq(
+        decisions: [
+          {
+            type: "queue_review_run",
+            issue_id: pull_request.id,
+            source_pull_request_number: 42
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/temporal/activities/detect_labels_activity_spec.rb
+++ b/spec/temporal/activities/detect_labels_activity_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Activities::DetectLabelsActivity do
         result = activity.execute(project_id: project.id, issue_id: issue.id)
 
         expect(result[:action]).to eq("execute_agent")
+        expect(result[:decisions]).to eq([ { type: "queue_create_pr_run", issue_id: issue.id } ])
         expect(result[:issue_id]).to eq(issue.id)
         expect(result[:project_id]).to eq(project.id)
       end
@@ -38,6 +39,7 @@ RSpec.describe Activities::DetectLabelsActivity do
         result = activity.execute(project_id: project.id, issue_id: issue.id)
 
         expect(result[:action]).to eq("start_planning")
+        expect(result[:decisions]).to eq([ { type: "start_planning", issue_id: issue.id } ])
       end
 
       it "updates paid_state to planning" do
@@ -299,6 +301,30 @@ RSpec.describe Activities::DetectLabelsActivity do
 
         expect(result[:action]).to eq("execute_agent")
         expect(result[:source_pull_request_number]).to eq(99)
+      end
+    end
+
+    context "when explicit PR decisions are enabled for a build-labeled pull request" do
+      let(:pull_request) do
+        create(:issue, project: project, labels: [ "paid-build" ], paid_state: "new",
+               is_pull_request: true, github_number: 99)
+      end
+
+      before do
+        FeatureFlags.enable!(:explicit_pr_automation_decisions, project:)
+      end
+
+      it "returns noop instead of generic execute_agent" do
+        result = activity.execute(project_id: project.id, issue_id: pull_request.id)
+
+        expect(result[:action]).to eq("none")
+        expect(result[:decisions]).to eq([ { type: "noop" } ])
+      end
+
+      it "does not update paid_state" do
+        activity.execute(project_id: project.id, issue_id: pull_request.id)
+
+        expect(pull_request.reload.paid_state).to eq("new")
       end
     end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         result = activity.execute(project_id: -1)
 
         expect(result[:prs_to_trigger]).to eq([])
+        expect(result[:automation_results]).to eq([])
         expect(result[:project_missing]).to be true
       end
     end
@@ -80,6 +81,38 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         result = activity.execute(project_id: project.id)
 
         expect(result[:prs_to_trigger]).to eq([])
+        expect(result[:automation_results]).to eq([])
+      end
+    end
+
+    context "when explicit PR decisions are enabled" do
+      let(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project,
+          github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          paid_state: "completed")
+      end
+
+      before do
+        FeatureFlags.enable!(:explicit_pr_automation_decisions, project:)
+        pr_issue
+      end
+
+      it "returns automation results instead of legacy trigger payloads" do
+        stub_github_for_pr(checks: [ { name: "rspec", conclusion: "failure" } ])
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+        expect(result[:automation_results]).to contain_exactly(
+          {
+            decisions: [
+              { type: "queue_create_pr_run", issue_id: pr_issue.id, source_pull_request_number: 42 },
+              { type: "record_pr_followup", issue_id: pr_issue.id, labels_to_remove: [], expected_followup_count: 0 }
+            ]
+          }
+        )
       end
     end
 

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     end
   end
 
-  describe "#handle_detection" do
+  describe "#handle_automation_result" do
     let(:workflow) { described_class.new }
     let(:project_id) { 1 }
 
@@ -173,20 +173,20 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .and_return(true)
     end
 
-    it "queues execute_agent runs instead of starting them directly" do
-      detection = { action: "execute_agent", issue_id: 10 }
+    it "queues explicit create_pr decisions instead of starting runs directly" do
+      evaluation = { decisions: [ { type: "queue_create_pr_run", issue_id: 10 } ] }
 
-      workflow.send(:handle_detection, detection, project_id)
+      workflow.send(:handle_automation_result, evaluation, project_id)
 
       expect(workflow).to have_received(:run_activity)
-        .with(Activities::QueueAgentRunActivity, { project_id: project_id, issue_id: 10 }, timeout: 30)
+        .with(Activities::QueueAgentRunActivity, { project_id: project_id, issue_id: 10, goal: "create_pr" }, timeout: 30)
       expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
-    it "queues create_pr explicitly for PR detections" do
-      detection = { action: "execute_agent", issue_id: 10, source_pull_request_number: 42 }
+    it "queues create_pr explicitly for PR decisions" do
+      evaluation = { decisions: [ { type: "queue_create_pr_run", issue_id: 10, source_pull_request_number: 42 } ] }
 
-      workflow.send(:handle_detection, detection, project_id)
+      workflow.send(:handle_automation_result, evaluation, project_id)
 
       expect(workflow).to have_received(:run_activity)
         .with(Activities::QueueAgentRunActivity,
@@ -194,30 +194,15 @@ RSpec.describe Workflows::GitHubPollWorkflow do
           timeout: 30)
     end
 
-    it "omits goal from queue input before the goal patch" do
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("queue-agent-run-goal-v1")
-        .and_return(false)
-
-      detection = { action: "execute_agent", issue_id: 10, source_pull_request_number: 42 }
-
-      workflow.send(:handle_detection, detection, project_id)
-
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::QueueAgentRunActivity,
-          { project_id: project_id, issue_id: 10, source_pull_request_number: 42 },
-          timeout: 30)
-    end
-
-    it "starts PlanningWorkflow for start_planning action" do
-      detection = { action: "start_planning", issue_id: 20 }
+    it "starts PlanningWorkflow for start_planning decisions" do
+      evaluation = { decisions: [ { type: "start_planning", issue_id: 20 } ] }
 
       allow(workflow).to receive(:run_activity)
         .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
         .and_return({ has_capacity: true })
       allow(Temporalio::Workflow).to receive(:now).and_return(Time.now)
 
-      workflow.send(:handle_detection, detection, project_id)
+      workflow.send(:handle_automation_result, evaluation, project_id)
 
       expect(Temporalio::Workflow).to have_received(:start_child_workflow).with(
         Workflows::PlanningWorkflow,
@@ -237,8 +222,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::CheckRunCapacityActivity, anything, timeout: anything)
         .and_return({ has_capacity: false })
 
-      detection = { action: "start_planning", issue_id: 20 }
-      workflow.send(:handle_detection, detection, project_id)
+      evaluation = { decisions: [ { type: "start_planning", issue_id: 20 } ] }
+      workflow.send(:handle_automation_result, evaluation, project_id)
 
       expect(logger).to have_received(:info).with(hash_including(
         message: "planning.deferred_due_to_capacity",
@@ -1129,7 +1114,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         )
       allow(workflow).to receive(:run_activity)
         .with(Activities::DetectLabelsActivity, { project_id: project_id, issue_id: 10 }, timeout: 30)
-        .and_return({ action: "none", issue_id: 10, project_id: project_id })
+        .and_return({ decisions: [ { type: "noop" } ], action: "none", issue_id: 10, project_id: project_id })
       allow(workflow).to receive(:run_activity)
         .with(Activities::ScanPaidPrsActivity, { project_id: project_id }, timeout: 120)
         .and_return(trigger_result)
@@ -1162,6 +1147,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(workflow).to receive(:run_activity)
         .with(Activities::GetPollIntervalActivity, anything, timeout: anything)
         .and_return({ poll_interval_seconds: 60 })
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::LoadFeatureFlagsActivity, { project_id: project_id }, timeout: 10)
+        .and_return(flags: { explicit_pr_automation_decisions: false }, project_missing: false)
     end
 
     it "queues a review run when paid_agent_review_pending is the only initial-sync PR signal" do
@@ -1195,6 +1183,29 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::QueueAgentRunActivity,
           hash_including(project_id: project_id, issue_id: 10,
             source_pull_request_number: 42, goal: "create_pr"),
+          timeout: 30)
+    end
+
+    it "executes flagged explicit PR automation decisions instead of legacy trigger translation" do
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::LoadFeatureFlagsActivity, { project_id: project_id }, timeout: 10)
+        .and_return(flags: { explicit_pr_automation_decisions: true }, project_missing: false)
+
+      execute_initial_sync(trigger_result: {
+        prs_to_trigger: [],
+        automation_results: [
+          {
+            decisions: [
+              { type: "queue_review_run", issue_id: 10, source_pull_request_number: 42 }
+            ]
+          }
+        ]
+      })
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(project_id: project_id, issue_id: 10,
+            source_pull_request_number: 42, goal: "review"),
           timeout: 30)
     end
   end


### PR DESCRIPTION
## Summary

Unifies Paid's issue and PR automation behind an explicit decision layer so that PR evaluation cannot accidentally fall through to generic issue handling — the class of bug that caused PR #1077's spurious `create_pr` run. The new PR automation path is gated behind the `explicit_pr_automation_decisions` Flipper flag for incremental rollout.

## Changes

**Decision layer (`app/services/automation/`)**
- Added `Automation::Evaluator.for(record).call` as the single top-level entrypoint for all GitHub automation decisions
- Introduced `Automation::Decision` and `Automation::Result` value objects with an explicit set of outcomes (`noop`, `queue_create_pr_run`, `queue_review_run`, `start_planning`, `request_review`, `mark_ready`, `escalate`)
- Implemented `Automation::IssueEvaluator` and `Automation::PullRequestEvaluator` as separate evaluation strategies that share the result contract but keep domain logic distinct

**Temporal activities**
- `DetectLabelsActivity` now routes records through the shared decision layer instead of ad hoc issue-action logic
- `ScanPaidPrsActivity` emits explicit automation results when the Flipper flag is enabled; preserves the legacy trigger-payload path when the flag is off

**Temporal workflow**
- `GitHubPollWorkflow` executes explicit decisions for both initial sync evaluation and PR auto-continue, ensuring queueing always receives an explicit goal on the new path

**Feature flag**
- `explicit_pr_automation_decisions` gates the new PR automation path, allowing the legacy behavior to remain active until the rollout is validated

## Design Decisions

- **Separate evaluators, shared contract**: Issue and PR evaluation live in distinct classes to prevent logic leakage, but both return the same `Result` type so downstream consumers (workflow, queueing) don't branch on record type.
- **Flag guards the PR path only**: Issue evaluation through the new layer is unconditional since it replaces equivalent inline logic. The PR path has more behavioral risk, so it's flag-gated for controlled rollout.
- **Explicit goal on every queued run**: On the new path, `QueueAgentRunActivity` always receives a goal from the decision result rather than inferring one from missing params — directly addressing the root cause of #1077.

---

Closes #1082