### PR TITLE
feat(dev): add --restart-if-running flag to restart healthy Overmind …

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -25,12 +25,16 @@ fi
 # terminal being hung up — important in devcontainers where the host laptop
 # sleeping or the editor reconnecting sends SIGHUP to the foreground process
 # group and kills overmind+tmux. See log/dev-update/diagnostics for the
-# previous crash pattern that motivated this.
+# previous crash pattern that motivated this. --restart-if-running (or -R, or
+# DEV_RESTART_IF_RUNNING=1) tells bin/dev to restart a healthy existing
+# Overmind session instead of exiting early.
 DEV_DETACH_FLAG="${DEV_DETACH:-0}"
+DEV_RESTART_IF_RUNNING_FLAG="${DEV_RESTART_IF_RUNNING:-0}"
 DEV_PASSTHRU_ARGS=()
 for arg in "$@"; do
   case "$arg" in
     --detach|-D) DEV_DETACH_FLAG=1 ;;
+    --restart-if-running|-R) DEV_RESTART_IF_RUNNING_FLAG=1 ;;
     *) DEV_PASSTHRU_ARGS+=("$arg") ;;
   esac
 done
@@ -110,6 +114,19 @@ if [ -S "$OVERMIND_SOCKET" ]; then
       rm -f "$OVERMIND_SOCKET"
     fi
   else
+    if [ "$DEV_RESTART_IF_RUNNING_FLAG" = "1" ]; then
+      echo "Overmind is already running and healthy. Restarting processes..."
+      if restart_output="$(dev_supervisor_run_overmind overmind restart 2>&1)"; then
+        printf '%s\n' "$restart_output"
+        exit 0
+      else
+        echo "Failed to restart healthy Overmind session. Capturing diagnostics..." >&2
+        dev_supervisor_snapshot_state "bin-dev-healthy-overmind-restart-failed"
+        printf '%s\n' "$restart_output" >&2
+        exit 1
+      fi
+    fi
+
     echo "Overmind is already running and healthy."
     echo "Use 'overmind connect web' to attach, or 'overmind restart' to restart processes."
     printf '%s\n' "$status_output"

--- a/bin/setup
+++ b/bin/setup
@@ -59,8 +59,10 @@ FileUtils.chdir APP_ROOT do
     STDOUT.flush # flush the output before exec(2) so that it displays
     # --detach forks bin/dev into a new session and returns immediately, so
     # bin/setup exits back to the prompt instead of staying attached to the
-    # dev server output. Use `overmind connect` to re-attach.
-    exec "bin/dev", "--detach"
+    # dev server output. --restart-if-running lets bin/dev refresh an already
+    # healthy Overmind session after setup instead of exiting early. Use
+    # `overmind connect` to re-attach.
+    exec "bin/dev", "--detach", "--restart-if-running"
   end
 
   puts "\n== Setup complete! =="

--- a/spec/lib/dev_script_spec.rb
+++ b/spec/lib/dev_script_spec.rb
@@ -90,6 +90,51 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "restarts a healthy overmind session when requested" do
+    Dir.mktmpdir("dev", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, overmind: { running: true }, tmux: { pane_dead: false })
+
+      env = {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "SKIP_DEV_CLEANUP" => "1",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_SUPERVISOR_TMUX_SOCKET_DIR" => File.join(dir, "tmux")
+      }
+      stdout, stderr, status = Open3.capture3(env, script_path, "--restart-if-running", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Overmind is already running and healthy. Restarting processes...")
+      expect(stdout).to include("restarted web")
+      expect(File.exist?(File.join(dir, "overmind-restart-ran"))).to be(true)
+      expect(File.exist?(File.join(dir, "overmind-start-ran"))).to be(false)
+      expect(File.exist?(File.join(dir, "overmind-quit-ran"))).to be(false)
+    end
+  end
+
+  it "captures diagnostics when restarting a healthy overmind session fails" do
+    Dir.mktmpdir("dev", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(
+        dir,
+        overmind: { running: true, restart_exit_status: 1 },
+        tmux: { pane_dead: false }
+      )
+
+      env = {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "SKIP_DEV_CLEANUP" => "1",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_SUPERVISOR_TMUX_SOCKET_DIR" => File.join(dir, "tmux")
+      }
+      stdout, stderr, status = Open3.capture3(env, script_path, "--restart-if-running", chdir: dir)
+
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Overmind is already running and healthy. Restarting processes...")
+      expect(stderr).to include("Failed to restart healthy Overmind session. Capturing diagnostics...")
+      expect(stderr).to include("restart failed")
+      expect(Dir.glob(File.join(dir, "log", "dev-update", "diagnostics", "*bin-dev-healthy-overmind-restart-failed.log"))).not_to be_empty
+    end
+  end
+
   it "restarts an unhealthy overmind session with dead processes from overmind status" do
     Dir.mktmpdir("dev", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, overmind: { running: true, process_dead: true }, tmux: { pane_dead: false })
@@ -135,6 +180,7 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
   def prepare_script_fixture(dir, overmind: {}, tmux: {})
     overmind_running = overmind.fetch(:running, false)
     overmind_process_dead = overmind.fetch(:process_dead, false)
+    overmind_restart_exit_status = overmind.fetch(:restart_exit_status, 0)
     tmux_pane_dead = tmux.fetch(:pane_dead, false)
     start_exit_status = overmind.fetch(:start_exit_status, 0)
     FileUtils.mkdir_p(File.join(dir, "stubbin"))
@@ -183,6 +229,15 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
             touch "#{dir}/overmind-quit-ran"
             rm -f "#{dir}/overmind-running" "#{dir}/.overmind.sock"
             exit 0
+            ;;
+          restart)
+            touch "#{dir}/overmind-restart-ran"
+            if [ "#{overmind_restart_exit_status}" = "0" ]; then
+              echo "restarted web"
+            else
+              echo "restart failed" >&2
+            fi
+            exit #{overmind_restart_exit_status}
             ;;
           *)
             echo "unexpected overmind command: $*" >&2

--- a/spec/lib/setup_script_spec.rb
+++ b/spec/lib/setup_script_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "open3"
+require "tmpdir"
+require_relative "../support/exec_tmpdir"
+
+RSpec.describe "bin/setup" do # rubocop:disable RSpec/DescribeClass
+  include ExecTmpdir
+
+  let(:script_source) { File.expand_path("../../bin/setup", __dir__) }
+  let(:log_truncator_source) { File.expand_path("../../lib/paid/log_truncator.rb", __dir__) }
+
+  it "starts bin/dev detached with restart-if-running when server startup is enabled" do
+    Dir.mktmpdir("setup-script-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+      env = {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "WORKSPACE_ROOT" => File.join(dir, "workspace-root")
+      }
+
+      stdout, stderr, status = Open3.capture3(env, script_path, chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("== Starting development server ==")
+      expect(File.read(File.join(dir, "dev-args.log")).split).to eq(%w[--detach --restart-if-running])
+    end
+  end
+
+  it "skips bin/dev when --skip-server is provided" do
+    Dir.mktmpdir("setup-script-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+      env = {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "WORKSPACE_ROOT" => File.join(dir, "workspace-root")
+      }
+
+      stdout, stderr, status = Open3.capture3(env, script_path, "--skip-server", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("== Setup complete! ==")
+      expect(File.exist?(File.join(dir, "dev-args.log"))).to be(false)
+    end
+  end
+
+  def prepare_script_fixture(dir)
+    FileUtils.mkdir_p(File.join(dir, "bin"))
+    FileUtils.mkdir_p(File.join(dir, "lib", "paid"))
+    FileUtils.mkdir_p(File.join(dir, "stubbin"))
+    FileUtils.mkdir_p(File.join(dir, "log", "dev-update"))
+    FileUtils.mkdir_p(File.join(dir, "workspace-root"))
+
+    script_path = File.join(dir, "bin", "setup")
+    FileUtils.cp(script_source, script_path)
+    FileUtils.chmod("+x", script_path)
+    FileUtils.cp(log_truncator_source, File.join(dir, "lib", "paid", "log_truncator.rb"))
+
+    write_executable(
+      File.join(dir, "bin", "dev"),
+      <<~BASH
+        #!/usr/bin/env bash
+        printf '%s\n' "$@" > "#{dir}/dev-args.log"
+        exit 0
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "bin", "yarn-postinstall"),
+      <<~BASH
+        #!/usr/bin/env bash
+        exit 0
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "bin", "rails"),
+      <<~BASH
+        #!/usr/bin/env bash
+        exit 0
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "stubbin", "git"),
+      <<~BASH
+        #!/usr/bin/env bash
+        exit 0
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "stubbin", "bundle"),
+      <<~BASH
+        #!/usr/bin/env bash
+        case "$1" in
+          check)
+            exit 0
+            ;;
+          install)
+            exit 0
+            ;;
+          *)
+            echo "unexpected bundle command: $*" >&2
+            exit 1
+            ;;
+        esac
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "stubbin", "yarn"),
+      <<~BASH
+        #!/usr/bin/env bash
+        exit 0
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "stubbin", "docker"),
+      <<~BASH
+        #!/usr/bin/env bash
+        exit 0
+      BASH
+    )
+
+    script_path
+  end
+
+  def write_executable(path, contents)
+    File.write(path, contents)
+    FileUtils.chmod("+x", path)
+  end
+end


### PR DESCRIPTION
…sessions

    feat(setup): update bin/setup to use --restart-if-running when starting dev server

    test(dev): add specs for restarting healthy Overmind sessions and diagnostics capture

    test(setup): create setup_script_spec to validate server startup behavior