### PR TITLE
Fix #1135: fix(scanner): pause PR follow-up runs while paid_agent review is still outstanding

### DIFF
--- a/app/services/automation/pull_request_evaluator.rb
+++ b/app/services/automation/pull_request_evaluator.rb
@@ -69,9 +69,9 @@ module Automation
     def paid_agent_review_pending_decisions(scan, trigger_types)
       decisions = []
       decisions << queue_review_run_decision(scan) unless paid_agent_active?(scan)
-
-      other_triggers = trigger_types - [ "paid_agent_review_pending" ]
-      decisions.concat(followup_decisions(scan)) if other_triggers.any?
+      # paid_agent_review_pending is a hard gate: suppress create_pr follow-up
+      # runs while the review is outstanding. Other triggers will be re-detected
+      # after the review completes and feedback is addressed. (#1135)
       decisions
     end
 

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -337,14 +337,20 @@ module Workflows
     end
 
     def handle_paid_agent_review_pending(project_id, pr_data, trigger_types)
-      other_triggers = trigger_types - [ "paid_agent_review_pending" ]
-
       queue_paid_agent_review_run(project_id, pr_data)
 
+      if Temporalio::Workflow.patched("pause-followup-during-review-v1")
+        # paid_agent_review_pending is a hard gate: suppress all create_pr
+        # follow-up runs while the review for the current head is outstanding.
+        # Other triggers (CI failures, merge conflicts, conversation comments)
+        # will be re-detected on the next scan cycle after the review completes
+        # and any resulting code changes are made. (#1135)
+        return nil
+      end
+
+      other_triggers = trigger_types - [ "paid_agent_review_pending" ]
+
       if other_triggers.empty?
-        # No other work to do — the paid-agent review queue above is the only
-        # action needed unless the trigger merely reflects an already-active
-        # review-goal run.
         nil
       elsif pr_data[:phase].in?(%w[draft restarted])
         start_draft_followup_workflow(project_id, pr_data)

--- a/spec/services/automation/pull_request_evaluator_spec.rb
+++ b/spec/services/automation/pull_request_evaluator_spec.rb
@@ -51,5 +51,40 @@ RSpec.describe Automation::PullRequestEvaluator do
         ]
       )
     end
+
+    it "suppresses create_pr followup when paid_agent_review_pending coexists with other triggers (#1135)" do
+      result = described_class.new(record: pull_request, explicit_pr_decisions: true).call(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        current_draft_review_count: 0,
+        triggers: [
+          { type: "paid_agent_review_pending" },
+          { type: "ci_failure", details: [ "test-suite" ] }
+        ]
+      })
+
+      decision_types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(decision_types).to include("queue_review_run")
+      expect(decision_types).not_to include("queue_create_pr_run")
+    end
+
+    it "suppresses create_pr followup even with active_run and multiple triggers (#1135)" do
+      result = described_class.new(record: pull_request, explicit_pr_decisions: true).call(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        triggers: [
+          { type: "paid_agent_review_pending", active_run: true },
+          { type: "merge_conflicts", details: "PR has merge conflicts" },
+          { type: "conversation_comments", details: "3 new comment(s)" }
+        ]
+      })
+
+      decision_types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(decision_types).not_to include("queue_create_pr_run")
+      expect(decision_types).not_to include("record_pr_followup")
+    end
   end
 end

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -283,6 +283,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive(:patched)
         .with("queue-paid-agent-review-run-v1")
         .and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-followup-during-review-v1")
+        .and_return(true)
     end
 
     it "routes ready_for_owner to MarkPrReadyActivity and RequestReviewActivity" do
@@ -1076,7 +1079,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
           timeout: anything)
     end
 
-    it "routes paid_agent_review_pending with other triggers to followup workflow" do
+    it "suppresses create_pr followup when paid_agent_review_pending coexists with other triggers (#1135)" do
       allow(workflow).to receive(:run_activity).with(Activities::QueueAgentRunActivity, anything, timeout: anything)
         .and_return({ queued: true })
 
@@ -1095,6 +1098,74 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         expected_review_queue_input,
         timeout: anything
       )
+      expect(workflow).not_to have_received(:run_activity).with(
+        Activities::QueueAgentRunActivity,
+        hash_including(goal: "create_pr"),
+        timeout: anything
+      )
+    end
+
+    it "suppresses create_pr followup for ready-phase PRs when paid_agent review is pending (#1135)" do
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything).and_return({ queued: true })
+
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "ready", current_followup_count: 0,
+        triggers: [
+          { type: "paid_agent_review_pending" },
+          { type: "merge_conflicts", details: "PR has merge conflicts" }
+        ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, expected_review_queue_input, timeout: anything)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, hash_including(goal: "create_pr"), timeout: anything)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::RecordPrFollowupActivity, anything, timeout: anything)
+    end
+
+    it "suppresses create_pr followup when paid_agent review has active_run and other triggers present (#1135)" do
+      allow(workflow).to receive(:run_activity).with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
+
+      pr_data = draft_pr_data(
+        current_draft_review_count: 1,
+        triggers: [
+          { type: "paid_agent_review_pending", active_run: true },
+          { type: "conversation_comments", details: "2 new comment(s)" }
+        ]
+      )
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).not_to have_received(:run_activity).with(
+        Activities::QueueAgentRunActivity, hash_including(goal: "review"), timeout: anything
+      )
+      expect(workflow).not_to have_received(:run_activity).with(
+        Activities::QueueAgentRunActivity, hash_including(goal: "create_pr"), timeout: anything
+      )
+    end
+
+    it "falls back to old behavior before pause-followup-during-review-v1 patch" do
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-followup-during-review-v1")
+        .and_return(false)
+      allow(workflow).to receive(:run_activity).with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
+
+      pr_data = draft_pr_data(
+        current_draft_review_count: 0,
+        triggers: [
+          { type: "paid_agent_review_pending" },
+          { type: "ci_failure", details: "CI failed" }
+        ]
+      )
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
       expect(workflow).to have_received(:run_activity).with(
         Activities::QueueAgentRunActivity,
         hash_including(count_toward_draft_review_round: true, expected_draft_review_count: 0),
@@ -1123,6 +1194,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive(:patched)
         .with("queue-paid-agent-review-run-v1")
         .and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-followup-during-review-v1")
+        .and_return(true)
 
       pr_data = {
         issue_id: 10, pr_number: 42,
@@ -1178,6 +1252,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with("queue-agent-run-goal-v1").and_return(true)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("queue-paid-agent-review-run-v1").and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-followup-during-review-v1").and_return(true)
       allow(workflow).to receive(:interruptible_sleep)
       allow(workflow).to receive(:run_activity)
         .with(Activities::GetPollIntervalActivity, anything, timeout: anything)


### PR DESCRIPTION
## Summary

Allow `bin/dev` to restart an already-healthy Overmind session in-place, so that `bin/setup` can refresh running processes after dependency or configuration changes instead of exiting early with a "already running" message.

## Changes

### `bin/dev`
- Add `--restart-if-running` flag (short: `-R`, env: `DEV_RESTART_IF_RUNNING=1`) that runs `overmind restart` on a healthy existing session instead of printing the "already running" message and exiting
- On restart failure, capture diagnostics snapshot and exit non-zero with stderr output

### `bin/setup`
- Pass `--restart-if-running` alongside `--detach` when exec-ing `bin/dev`, so setup refreshes processes after installing deps/running migrations even when Overmind is already up

### Tests
- **`spec/lib/dev_script_spec.rb`** — Two new cases: successful restart of a healthy session, and diagnostics capture on restart failure. Overmind stub extended with `restart` subcommand support and configurable exit status.
- **`spec/lib/setup_script_spec.rb`** (new) — Verifies `bin/setup` passes `--detach --restart-if-running` to `bin/dev` by default, and skips `bin/dev` entirely with `--skip-server`. Uses stubbed binaries to isolate the script under test.

## Design Decisions

- **Temporal patch not needed** — This is a local dev tooling change with no workflow compatibility concerns. The flag is purely additive; existing `bin/dev` invocations without `-R` behave identically.
- **Restart vs. quit-and-start** — `overmind restart` preserves the existing tmux session and socket, avoiding the race conditions and cleanup issues that come with tearing down and re-launching. If restart fails, diagnostics are captured the same way as other Overmind failure paths.

---

Closes #1135