### PR TITLE
Fix #1030: feat(token-tracking): ingest Codex token usage data from agent-harness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "docker-api"
 gem "qdrant-ruby"
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-gem "agent-harness", "~> 0.7.0"
+gem "agent-harness", "~> 0.7.1"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 gem "ruby-maat"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    agent-harness (0.7.0)
+    agent-harness (0.7.1)
       logger (>= 1.6, < 2.0)
     ast (2.4.3)
     base64 (0.3.0)
@@ -518,7 +518,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness (~> 0.7.0)
+  agent-harness (~> 0.7.1)
   bootsnap
   brakeman
   bundler-audit
@@ -576,7 +576,7 @@ CHECKSUMS
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  agent-harness (0.7.0) sha256=049314ec6e719a0e019bd1b690ef555bb6b166b341cfe7a061f2e3a950999711
+  agent-harness (0.7.1) sha256=332ec536f8a72d52c89a084b16c531114a4143deb777e4ae9b7c5b7fb939d718
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032

--- a/spec/services/agent_runs/execute_spec.rb
+++ b/spec/services/agent_runs/execute_spec.rb
@@ -466,6 +466,96 @@ RSpec.describe AgentRuns::Execute do
       end
     end
 
+    context "when a codex run returns token usage" do
+      let(:agent_run) { create(:agent_run, :codex, project: project) }
+      let(:codex_model) { "o3" }
+      let(:delta) { agent_run.token_usages.find_by!(request_type: "run_delta") }
+      let(:aggregate) { TokenUsages::Aggregate.call }
+      let(:response) do
+        AgentHarness::Response.new(
+          output: "Applied the fix",
+          exit_code: 0,
+          duration: 18.3,
+          provider: :codex,
+          model: codex_model,
+          tokens: { input: 4500, output: 1800, total: 6300 }
+        )
+      end
+
+      before do
+        allow(AgentHarness).to receive(:send_message).and_return(response)
+      end
+
+      it "depends on agent-harness versions that parse codex token totals" do
+        expect(Gem.loaded_specs.fetch("agent-harness").version).to be >= Gem::Version.new("0.7.1")
+      end
+
+      it "persists run_summary and run_delta records for the codex model" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        summary = agent_run.token_usages.find_by!(request_type: "run_summary")
+        delta = agent_run.token_usages.find_by!(request_type: "run_delta")
+
+        aggregate_failures do
+          expect(summary.input_tokens).to eq(4500)
+          expect(summary.output_tokens).to eq(1800)
+          expect(summary.llm_model).to eq(codex_model)
+          expect(delta.input_tokens).to eq(4500)
+          expect(delta.output_tokens).to eq(1800)
+          expect(delta.llm_model).to eq(codex_model)
+        end
+      end
+
+      it "tracks only the missing billable delta when proxy coverage is partial" do
+        TokenUsageTracker.track(
+          agent_run: agent_run,
+          usage: {
+            tokens_input: 2000,
+            tokens_output: 500,
+            llm_model: codex_model,
+            request_type: "agent"
+          }
+        )
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        aggregate_failures do
+          expect(delta.input_tokens).to eq(2500)
+          expect(delta.output_tokens).to eq(1300)
+          expect(agent_run.reload.tokens_input).to eq(4500)
+          expect(agent_run.tokens_output).to eq(1800)
+          expect(aggregate[:total_input_tokens]).to eq(4500)
+          expect(aggregate[:total_output_tokens]).to eq(1800)
+          expect(aggregate[:cost_by_request_type]).to include("agent", "run_delta")
+          expect(aggregate[:cost_by_request_type]).not_to include("run_summary")
+        end
+      end
+
+      it "skips delta when proxy records fully cover the run" do
+        create(:token_usage, agent_run: agent_run, request_type: "agent",
+               input_tokens: 4500, output_tokens: 1800)
+
+        expect(TokenUsageTracker).to receive(:track).with(
+          agent_run: agent_run,
+          usage: hash_including(request_type: "run_summary"),
+          update_aggregates: false
+        )
+        expect(TokenUsageTracker).not_to receive(:track).with(
+          agent_run: anything,
+          usage: hash_including(request_type: "run_delta")
+        )
+
+        described_class.call(agent_run: agent_run, prompt: prompt)
+      end
+
+      it "uses the actual backend model name, not the provider name" do
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        models = agent_run.token_usages.pluck(:llm_model).uniq
+        expect(models).to eq([ codex_model ])
+        expect(models).not_to include("codex")
+      end
+    end
+
     context "when a copilot run returns token usage" do
       let(:agent_run) { create(:agent_run, :copilot, project: project) }
       let(:response) do


### PR DESCRIPTION
## Summary

Enable token usage tracking for Codex agent runs by upgrading agent-harness to v0.7.1, which extracts token data from Codex CLI's `--json` output. The existing `track_tokens` pipeline requires no changes — it automatically ingests the new data through the standard `Response#tokens` contract.

## Changes

**Dependencies**
- Updated `agent-harness` from `~> 0.7.0` to `~> 0.7.1` in Gemfile/Gemfile.lock
- v0.7.1 parses `input_tokens`, `cached_input_tokens`, and `output_tokens` from Codex CLI's JSONL stream

**Tests (`spec/services/agent_runs/execute_spec.rb`)**
- Added version guard test ensuring `>= 0.7.1`
- Added `run_summary` and `run_delta` record creation tests with correct model name
- Added partial proxy coverage delta computation test
- Added full proxy coverage skip test (no `run_delta` when fully covered)
- Added backend model name verification (uses actual model like `"o3"`, not `"codex"`)

## Design Decisions

- **No application code changes needed**: The `track_tokens` pipeline in `AgentRuns::Execute` is provider-agnostic — it reads `response.tokens` and `response.model` without provider-specific branching. This validates the original generic design.
- **`cached_input_tokens` folded into `input` upstream**: Agent-harness combines cached and uncached input tokens before returning the `Response#tokens` hash, avoiding the need for a new database column or migration in Paid. This trades granularity for simplicity — if cached token tracking becomes important later, it can be added as a separate field.
- **Model name reflects the actual backend model**: `TokenUsage#llm_model` records the model Codex delegates to (e.g., `o3`, `gpt-4.1`), not the CLI tool name, keeping cost aggregation accurate.

---

Closes #1030