### PR TITLE
Fix #1069: Agent runs index page should allow filtering by provider

### DIFF
--- a/app/controllers/agent_runs_controller.rb
+++ b/app/controllers/agent_runs_controller.rb
@@ -10,5 +10,6 @@ class AgentRunsController < ApplicationController
     @q.sorts = "created_at desc" if @q.sorts.empty?
     @pagy, @agent_runs = pagy(@q.result)
     AgentRun.preload_source_pull_requests(@agent_runs)
+    @provider_options = base_scope.distinct_effective_providers
   end
 end

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -16,6 +16,7 @@ module Projects
       @q.sorts = "created_at desc" if @q.sorts.empty?
       @pagy, @agent_runs = pagy(@q.result)
       AgentRun.preload_source_pull_requests(@agent_runs)
+      @provider_options = base_scope.distinct_effective_providers
     end
 
     def show

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -174,12 +174,22 @@ class AgentRun < ApplicationRecord
     Arel.sql("COALESCE(tokens_input, 0) + COALESCE(tokens_output, 0)")
   end
 
+  ransacker :effective_provider do
+    Arel.sql(effective_provider_sql)
+  end
+
   def self.ransackable_attributes(auth_object = nil)
-    %w[status agent_type branch_name trigger_type goal duration_seconds tokens_input tokens_output tokens_total cost_cents created_at started_at]
+    %w[status agent_type branch_name trigger_type goal duration_seconds tokens_input tokens_output tokens_total cost_cents created_at started_at effective_provider]
   end
 
   def self.ransackable_associations(auth_object = nil)
     %w[project]
+  end
+
+  def self.distinct_effective_providers
+    pluck(Arel.sql("DISTINCT #{effective_provider_sql}"))
+      .compact
+      .sort
   end
 
   def duration

--- a/app/views/agent_runs/_filters.html.erb
+++ b/app/views/agent_runs/_filters.html.erb
@@ -29,6 +29,16 @@
         class: "mt-1 block rounded-md border-gray-300 py-2 pl-3 pr-10 text-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500" %>
     </div>
 
+    <% if local_assigns[:provider_options]&.any? %>
+      <div>
+        <%= f.label :effective_provider_eq, "Provider", class: "block text-sm font-medium text-gray-700" %>
+        <%= f.select :effective_provider_eq,
+          options_for_select(provider_options.map { |p| [Provider.display_name_for(p), p] }, params.dig(:q, :effective_provider_eq)),
+          { include_blank: "All Providers" },
+          class: "mt-1 block rounded-md border-gray-300 py-2 pl-3 pr-10 text-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500" %>
+      </div>
+    <% end %>
+
     <div class="flex items-end gap-2">
       <%= f.submit "Filter",
         class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>

--- a/app/views/agent_runs/index.html.erb
+++ b/app/views/agent_runs/index.html.erb
@@ -5,7 +5,7 @@
     <h1 class="text-xl font-semibold text-gray-900">Agent Runs</h1>
   </div>
 
-  <%= render "agent_runs/filters", q: @q, show_project: true %>
+  <%= render "agent_runs/filters", q: @q, show_project: true, provider_options: @provider_options %>
 
   <%= render "agent_runs/index_table", agent_runs: @agent_runs, q: @q, pagy: @pagy, show_project: true %>
 </div>

--- a/app/views/projects/agent_runs/index.html.erb
+++ b/app/views/projects/agent_runs/index.html.erb
@@ -22,7 +22,7 @@
     <% end %>
   </div>
 
-  <%= render "agent_runs/filters", q: @q, show_project: false %>
+  <%= render "agent_runs/filters", q: @q, show_project: false, provider_options: @provider_options %>
 
   <%= render "agent_runs/index_table", agent_runs: @agent_runs, q: @q, pagy: @pagy, show_project: false, project: @project %>
 </div>


### PR DESCRIPTION
## Summary

Add a provider filter to the agent runs index page so users can quickly narrow the list to runs from a specific provider (Codex, OpenAI, Anthropic, etc.), making it easier to investigate provider-specific failure rates and workflow attribution as run volume grows.

## Changes

**Model (`app/models/agent_run.rb`)**
- Added `effective_provider` Ransack ransacker using the existing `effective_provider_sql` expression, which normalizes `final_provider` with a fallback to `agent_type`
- Exposed `effective_provider` via `ransackable_attributes` for search/filter support
- Added `distinct_effective_providers` class method to query unique provider values for populating the filter dropdown

**Controllers**
- `AgentRunsController#index` and `Projects::AgentRunsController#index` now set `@provider_options` from the base scope so the view can render the dropdown

**Views**
- Added a "Provider" dropdown to `_filters.html.erb` using the `effective_provider_eq` Ransack predicate
- Labels use `Provider.display_name_for` for human-friendly names, with "All Providers" as the blank/reset option
- Both index views pass `provider_options` to the filters partial
- The dropdown gracefully hides when no provider options exist (e.g., no runs yet)

## Design Decisions

- **Reuses `effective_provider_sql`** rather than introducing a new column or query — this keeps the filter consistent with how provider is already displayed in each row, ensuring predictable filtering behavior
- **Ransacker approach** integrates naturally with existing Ransack-based search, status filters, pagination, and sorting without requiring custom query logic in the controller
- **Scoped provider list** — the dropdown is populated from the current query scope's distinct values rather than a hardcoded list, so it always reflects actual data and stays in sync as new providers are added

---

Closes #1069