### PR TITLE
Fix #1148: feat(release): auto-merge release-please PRs based on per-project semver policy

### DIFF
--- a/app/controllers/api/github_webhooks_controller.rb
+++ b/app/controllers/api/github_webhooks_controller.rb
@@ -22,6 +22,10 @@ module Api
         handle_pull_request
       when "issue_comment"
         handle_issue_comment
+      when "check_suite"
+        handle_check_suite
+      when "check_run"
+        handle_check_run
       else
         head :ok
       end
@@ -52,6 +56,12 @@ module Api
     def handle_pull_request
       action = payload["action"]
       pr = payload["pull_request"] || {}
+
+      # Trigger auto-release evaluation when a release-please PR is opened,
+      # updated, or labeled — these events may make it eligible for auto-merge.
+      if %w[opened synchronize labeled].include?(action) && @project&.auto_release_enabled?
+        enqueue_auto_release_evaluation(pr["number"])
+      end
 
       # Only act on merge events — other PR actions (opened, synchronize, etc.)
       # are not relevant to human feedback quality signals.
@@ -109,6 +119,36 @@ module Api
       )
 
       head :ok
+    end
+
+    def handle_check_suite
+      return head(:ok) unless payload["action"] == "completed"
+      return head(:ok) unless @project&.auto_release_enabled?
+
+      enqueue_auto_release_evaluation
+      head :ok
+    end
+
+    def handle_check_run
+      return head(:ok) unless payload["action"] == "completed"
+      return head(:ok) unless @project&.auto_release_enabled?
+
+      enqueue_auto_release_evaluation
+      head :ok
+    end
+
+    def enqueue_auto_release_evaluation(pr_number = nil)
+      if pr_number
+        AutoReleaseEvaluationJob.perform_later(@project.id, pr_number: pr_number)
+      else
+        AutoReleaseEvaluationJob.perform_later(@project.id)
+      end
+    rescue => e
+      Rails.logger.warn(
+        message: "auto_release.enqueue_failed",
+        project_id: @project.id,
+        error: e.message
+      )
     end
 
     # Shared lookup used by all three event handlers (pull_request_review,

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -209,6 +209,7 @@ class ProjectsController < ApplicationController
       :generated_label_name, :automation_label_name,
       :auto_add_labels_enabled, :automation_on_label_enabled, :pr_aggregation_enabled,
       :inherit_priority_labels,
+      :auto_release_granularity,
       :agent_co_author_trailer,
       allowed_github_usernames: [],
       priority_labels: Project::PRIORITY_TIERS)

--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# Evaluates whether a release-please PR should be auto-merged based on
+# the project's auto_release_granularity setting. Checks CI status and
+# bump classification before merging.
+#
+# Triggered by:
+# - GitHub webhooks (check_suite.completed, pull_request.opened/synchronize/labeled)
+# - Safety-net enqueue from the project poll loop
+#
+# Concurrency: at most one evaluation per project at a time.
+class AutoReleaseEvaluationJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :default
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: -> { "auto-release-#{arguments.first}" }
+  )
+
+  EXPECTED_MERGE_STATUSES = [ 405, 409, 422 ].freeze
+  PAID_AUTO_RELEASED_LABEL = "paid-auto-released"
+
+  def perform(project_id, pr_number: nil)
+    project = Project.find_by(id: project_id)
+    return unless project&.auto_release_enabled?
+
+    client = project.github_token.client
+
+    release_pr = find_release_pr(client, project, pr_number)
+    return unless release_pr
+
+    previous_version = fetch_previous_version(client, project)
+    return unless previous_version
+
+    result = ReleasePlease::ParseReleasePr.call(
+      pr_data: release_pr,
+      previous_version: previous_version
+    )
+
+    unless result
+      Rails.logger.info(
+        message: "auto_release.parse_failed",
+        project_id: project.id,
+        pr_number: release_pr.number
+      )
+      return
+    end
+
+    unless project.auto_release_allows_bump?(result.bump)
+      Rails.logger.info(
+        message: "auto_release.merge_skipped",
+        project_id: project.id,
+        pr_number: result.pr_number,
+        reason: "granularity_mismatch",
+        bump: result.bump,
+        granularity: project.auto_release_granularity
+      )
+      return
+    end
+
+    unless all_checks_green?(client, project, release_pr)
+      Rails.logger.info(
+        message: "auto_release.merge_skipped",
+        project_id: project.id,
+        pr_number: result.pr_number,
+        reason: "checks_not_green",
+        bump: result.bump
+      )
+      return
+    end
+
+    merge_release_pr(client, project, result)
+  end
+
+  private
+
+  def find_release_pr(client, project, pr_number)
+    if pr_number
+      pr_data = client.pull_request(project.full_name, pr_number)
+      return pr_data if pr_data && !pr_data.merged_at && ReleasePlease::ParseReleasePr.release_please_pr?(pr_data)
+      return nil
+    end
+
+    prs = client.pull_requests(project.full_name, state: "open")
+    prs.find { |pr| ReleasePlease::ParseReleasePr.release_please_pr?(pr) }
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "auto_release.find_pr_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    nil
+  end
+
+  def fetch_previous_version(client, project)
+    content = client.contents(project.full_name, path: ".release-please-manifest.json")
+    manifest = JSON.parse(Base64.decode64(content.content))
+    manifest["."]
+  rescue GithubClient::Error, JSON::ParserError, NoMethodError => e
+    Rails.logger.warn(
+      message: "auto_release.fetch_version_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    nil
+  end
+
+  def all_checks_green?(client, project, pr_data)
+    checks = client.check_runs_for_ref(project.full_name, pr_data.head.sha)
+    return false if checks.nil? || checks.empty?
+
+    checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "auto_release.check_runs_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
+  end
+
+  def merge_release_pr(client, project, result)
+    client.merge_pull_request(
+      project.full_name, result.pr_number,
+      merge_method: project.merge_method
+    )
+
+    add_label(client, project, result.pr_number)
+    add_comment(client, project, result)
+
+    Rails.logger.info(
+      message: "auto_release.merged",
+      project_id: project.id,
+      pr_number: result.pr_number,
+      new_version: result.new_version,
+      bump: result.bump,
+      granularity: project.auto_release_granularity
+    )
+  rescue GithubClient::ApiError => e
+    raise unless EXPECTED_MERGE_STATUSES.include?(e.status)
+
+    Rails.logger.warn(
+      message: "auto_release.merge_failed_expected",
+      project_id: project.id,
+      pr_number: result.pr_number,
+      status: e.status,
+      error: e.message
+    )
+  end
+
+  def add_label(client, project, pr_number)
+    client.add_labels_to_issue(project.full_name, pr_number, [ PAID_AUTO_RELEASED_LABEL ])
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "auto_release.add_label_failed",
+      project_id: project.id,
+      pr_number: pr_number,
+      error: e.message
+    )
+  end
+
+  def add_comment(client, project, result)
+    comment = "This release PR was automatically merged by Paid's auto-release feature " \
+              "(#{result.bump} bump, policy: #{project.auto_release_granularity})."
+    client.add_comment(project.full_name, result.pr_number, comment)
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "auto_release.add_comment_failed",
+      project_id: project.id,
+      pr_number: result.pr_number,
+      error: e.message
+    )
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,6 +2,7 @@
 
 class Project < ApplicationRecord
   MERGE_METHODS = %w[squash merge rebase].freeze
+  AUTO_RELEASE_GRANULARITIES = %w[off patch_only minor_only major_only all].freeze
   KNOWLEDGE_STATUSES = %w[pending collecting ready failed stale].freeze
   # "none" is not a method — it is represented by enabled: false at the top level
   REVIEW_METHODS = %w[copilot paid_agent codex ci_action manual].freeze
@@ -82,6 +83,14 @@ class Project < ApplicationRecord
      description: "When Paid creates a PR for an issue, copy any user-defined priority labels (P1/P2/P3) from the issue onto the new PR." }.freeze
   ].freeze
 
+  AUTO_RELEASE_GRANULARITY_OPTIONS = [
+    [ "Off", "off" ],
+    [ "Patch only", "patch_only" ],
+    [ "Minor and below", "minor_only" ],
+    [ "Major and below", "major_only" ],
+    [ "All", "all" ]
+  ].freeze
+
   belongs_to :account
   belongs_to :github_token, counter_cache: true
   belongs_to :created_by, class_name: "User", optional: true
@@ -122,6 +131,7 @@ class Project < ApplicationRecord
   validates :poll_interval_seconds, numericality: { greater_than_or_equal_to: 60 }
   validates :max_pr_followup_runs, numericality: { greater_than_or_equal_to: 0 }
   validates :merge_method, inclusion: { in: MERGE_METHODS }
+  validates :auto_release_granularity, inclusion: { in: AUTO_RELEASE_GRANULARITIES }
   validates :max_draft_review_rounds, numericality: { greater_than_or_equal_to: 0 }
   validates :generated_label_name, presence: true
   validates :automation_label_name, presence: true
@@ -444,6 +454,21 @@ class Project < ApplicationRecord
         pr_numbers_with_active_runs: pr_numbers_with_active_runs
       }
     )
+  end
+
+  def auto_release_enabled?
+    auto_release_granularity != "off"
+  end
+
+  def auto_release_allows_bump?(bump_type)
+    case auto_release_granularity
+    when "off" then false
+    when "all" then true
+    when "major_only" then %w[major minor patch].include?(bump_type.to_s)
+    when "minor_only" then %w[minor patch].include?(bump_type.to_s)
+    when "patch_only" then bump_type.to_s == "patch"
+    else false
+    end
   end
 
   def review_settings=(value)

--- a/app/services/release_please/parse_release_pr.rb
+++ b/app/services/release_please/parse_release_pr.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module ReleasePlease
+  # Identifies and classifies release-please PRs by parsing the PR title
+  # and comparing the target version against the current released version.
+  #
+  # A release-please PR is identified by:
+  # - Author: github-actions[bot] (or a configured release-please app)
+  # - Title: matches `chore(<branch>): release <version>`
+  # - Label: `autorelease: pending`
+  #
+  # Returns a result struct with the parsed PR details and bump classification,
+  # or nil if the PR is not a valid release-please PR.
+  class ParseReleasePr
+    TITLE_PATTERN = /\Achore\(.+\): release (\d+\.\d+\.\d+)\z/
+    RELEASE_PLEASE_AUTHORS = %w[github-actions[bot] release-please[bot]].freeze
+    AUTORELEASE_LABEL = "autorelease: pending"
+
+    Result = Struct.new(:pr_number, :new_version, :previous_version, :bump, keyword_init: true)
+
+    class << self
+      def call(pr_data:, previous_version:)
+        return nil unless release_please_pr?(pr_data)
+
+        new_version = parse_version(pr_data)
+        return nil unless new_version
+
+        bump = classify_bump(previous_version, new_version)
+        return nil unless bump
+
+        Result.new(
+          pr_number: pr_data.number,
+          new_version: new_version,
+          previous_version: previous_version,
+          bump: bump
+        )
+      end
+
+      def release_please_pr?(pr_data)
+        author = pr_data.user&.login || pr_data.dig(:user, :login)
+        return false unless RELEASE_PLEASE_AUTHORS.include?(author)
+
+        title = pr_data.title || pr_data[:title]
+        return false unless title&.match?(TITLE_PATTERN)
+
+        labels = extract_labels(pr_data)
+        labels.include?(AUTORELEASE_LABEL)
+      end
+
+      private
+
+      def extract_labels(pr_data)
+        raw_labels = pr_data.labels || pr_data[:labels] || []
+        raw_labels.map { |l| l.respond_to?(:name) ? l.name : (l[:name] || l["name"]) }.compact
+      end
+
+      def parse_version(pr_data)
+        title = pr_data.title || pr_data[:title]
+        match = title&.match(TITLE_PATTERN)
+        match[1] if match
+      end
+
+      def classify_bump(previous_version_str, new_version_str)
+        prev = parse_semver(previous_version_str)
+        new_ver = parse_semver(new_version_str)
+        return nil unless prev && new_ver
+
+        if new_ver[0] > prev[0]
+          "major"
+        elsif new_ver[1] > prev[1]
+          "minor"
+        elsif new_ver[2] > prev[2]
+          "patch"
+        end
+      end
+
+      def parse_semver(version_str)
+        return nil if version_str.blank?
+
+        parts = version_str.to_s.split(".")
+        return nil unless parts.length == 3
+
+        parts.map(&:to_i)
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -480,6 +480,30 @@
             </div>
           </fieldset>
 
+          <fieldset id="auto-release" class="space-y-4">
+            <legend class="text-sm font-semibold leading-6 text-gray-900">Auto-Release</legend>
+
+            <div>
+              <%= form.label :auto_release_granularity, "Release PR Auto-Merge", class: "block text-sm font-medium leading-6 text-gray-900" %>
+              <div class="mt-2 max-w-xs">
+                <%= form.select :auto_release_granularity,
+                  Project::AUTO_RELEASE_GRANULARITY_OPTIONS,
+                  {},
+                  class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">
+                Automatically merge release-please PRs when CI passes. Controls which semver bump levels are auto-merged.
+                "Minor and below" includes both minor and patch bumps. "Major and below" includes all bump types.
+                Note: 0.x versioning uses literal semver positions (0.22.0 → 0.23.0 is a minor bump).
+              </p>
+              <% if @project.errors[:auto_release_granularity].any? %>
+                <% @project.errors[:auto_release_granularity].each do |msg| %>
+                  <p class="mt-1 text-xs text-red-600"><%= msg %></p>
+                <% end %>
+              <% end %>
+            </div>
+          </fieldset>
+
           <fieldset id="git-settings" class="space-y-4 rounded-md border border-gray-200 p-4">
             <legend class="text-sm font-semibold leading-6 text-gray-900">Git Settings</legend>
 

--- a/db/migrate/20260415181029_add_auto_release_granularity_to_projects.rb
+++ b/db/migrate/20260415181029_add_auto_release_granularity_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAutoReleaseGranularityToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :auto_release_granularity, :string, default: "off", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_154102) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_181029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -794,6 +794,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_154102) do
     t.boolean "auto_fix_merge_conflicts", default: true, null: false
     t.boolean "auto_merge_enabled", default: false, null: false
     t.boolean "auto_pick_enabled", default: false, null: false
+    t.string "auto_release_granularity", default: "off", null: false
     t.boolean "auto_scan_prs", default: true, null: false
     t.boolean "auto_scan_security", default: false, null: false
     t.string "automation_label_name", default: "paid-automation", null: false

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ApplicationJob do
     {
       default: %w[
         AnomalyDetectionJob
+        AutoReleaseEvaluationJob
         DiagnoseErrorJob
         EnqueueKnowledgeCollectionJob
         GithubTokenValidationJob

--- a/spec/jobs/auto_release_evaluation_job_spec.rb
+++ b/spec/jobs/auto_release_evaluation_job_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe AutoReleaseEvaluationJob do
+  let(:project) { create(:project, auto_release_granularity: "all") }
+  let(:client) { instance_double(GithubClient) }
+
+  let(:pr_data) do
+    OpenStruct.new(
+      number: 100,
+      title: "chore(main): release 1.1.0",
+      user: OpenStruct.new(login: "github-actions[bot]"),
+      labels: [ OpenStruct.new(name: "autorelease: pending") ],
+      head: OpenStruct.new(sha: "abc123"),
+      merged_at: nil
+    )
+  end
+
+  let(:manifest_content) do
+    OpenStruct.new(content: Base64.encode64('{ ".": "1.0.0" }'))
+  end
+
+  let(:green_checks) do
+    [ { conclusion: "success", name: "ci" } ]
+  end
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(client)
+    allow(client).to receive_messages(
+      pull_requests: [ pr_data ],
+      pull_request: pr_data,
+      contents: manifest_content,
+      check_runs_for_ref: green_checks
+    )
+    allow(client).to receive(:merge_pull_request)
+    allow(client).to receive(:add_labels_to_issue)
+    allow(client).to receive(:add_comment)
+  end
+
+  describe "#perform" do
+    it "merges a release PR when all conditions are met" do
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:merge_pull_request).with(
+        project.full_name, 100, merge_method: project.merge_method
+      )
+      expect(client).to have_received(:add_labels_to_issue).with(
+        project.full_name, 100, [ "paid-auto-released" ]
+      )
+      expect(client).to have_received(:add_comment)
+    end
+
+    it "skips when project has auto_release_granularity off" do
+      project.update!(auto_release_granularity: "off")
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when bump type exceeds granularity (minor bump with patch_only)" do
+      project.update!(auto_release_granularity: "patch_only")
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "merges patch bumps with patch_only granularity" do
+      project.update!(auto_release_granularity: "patch_only")
+      pr_data_patch = OpenStruct.new(
+        number: 100,
+        title: "chore(main): release 1.0.1",
+        user: OpenStruct.new(login: "github-actions[bot]"),
+        labels: [ OpenStruct.new(name: "autorelease: pending") ],
+        head: OpenStruct.new(sha: "abc123"),
+        merged_at: nil
+      )
+      allow(client).to receive_messages(pull_requests: [ pr_data_patch ], pull_request: pr_data_patch)
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when CI checks are not green" do
+      allow(client).to receive(:check_runs_for_ref).and_return(
+        [ { conclusion: "failure", name: "ci" } ]
+      )
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when CI checks are pending (no conclusion)" do
+      allow(client).to receive(:check_runs_for_ref).and_return(
+        [ { conclusion: nil, name: "ci" } ]
+      )
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when no release PR is found" do
+      allow(client).to receive(:pull_requests).and_return([])
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "accepts a specific pr_number parameter" do
+      described_class.perform_now(project.id, pr_number: 100)
+
+      expect(client).to have_received(:pull_request).with(project.full_name, 100)
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "handles expected merge failures gracefully" do
+      allow(client).to receive(:merge_pull_request).and_raise(
+        GithubClient::ApiError.new("Merge conflict", status: 409)
+      )
+
+      expect { described_class.perform_now(project.id) }.not_to raise_error
+    end
+
+    context "with granularity matrix" do
+      {
+        "all" => { major: true, minor: true, patch: true },
+        "major_only" => { major: true, minor: true, patch: true },
+        "minor_only" => { major: false, minor: true, patch: true },
+        "patch_only" => { major: false, minor: false, patch: true },
+        "off" => { major: false, minor: false, patch: false }
+      }.each do |granularity, bumps|
+        bumps.each do |bump_type, should_merge|
+          it "#{should_merge ? 'merges' : 'skips'} #{bump_type} bump with #{granularity} granularity" do
+            project.update!(auto_release_granularity: granularity)
+
+            version_map = { major: "2.0.0", minor: "1.1.0", patch: "1.0.1" }
+            new_version = version_map[bump_type]
+
+            pr = OpenStruct.new(
+              number: 100,
+              title: "chore(main): release #{new_version}",
+              user: OpenStruct.new(login: "github-actions[bot]"),
+              labels: [ OpenStruct.new(name: "autorelease: pending") ],
+              head: OpenStruct.new(sha: "abc123"),
+              merged_at: nil
+            )
+            allow(client).to receive_messages(pull_requests: [ pr ], pull_request: pr)
+
+            described_class.perform_now(project.id)
+
+            if should_merge
+              expect(client).to have_received(:merge_pull_request)
+            else
+              expect(client).not_to have_received(:merge_pull_request)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1459,4 +1459,75 @@ RSpec.describe Project do
       expect(project.semantic_search_available?).to be false
     end
   end
+
+  describe "auto_release_granularity" do
+    it "defaults to off" do
+      project = build(:project)
+      expect(project.auto_release_granularity).to eq("off")
+    end
+
+    it "validates inclusion in AUTO_RELEASE_GRANULARITIES" do
+      project = build(:project, auto_release_granularity: "invalid")
+      expect(project).not_to be_valid
+      expect(project.errors[:auto_release_granularity]).to be_present
+    end
+
+    it "accepts all valid granularities" do
+      Project::AUTO_RELEASE_GRANULARITIES.each do |granularity|
+        project = build(:project, auto_release_granularity: granularity)
+        expect(project).to be_valid
+      end
+    end
+  end
+
+  describe "#auto_release_enabled?" do
+    it "returns false when granularity is off" do
+      project = build(:project, auto_release_granularity: "off")
+      expect(project.auto_release_enabled?).to be false
+    end
+
+    it "returns true when granularity is not off" do
+      %w[patch_only minor_only major_only all].each do |granularity|
+        project = build(:project, auto_release_granularity: granularity)
+        expect(project.auto_release_enabled?).to be true
+      end
+    end
+  end
+
+  describe "#auto_release_allows_bump?" do
+    it "returns false for all bumps when off" do
+      project = build(:project, auto_release_granularity: "off")
+      %w[major minor patch].each do |bump|
+        expect(project.auto_release_allows_bump?(bump)).to be false
+      end
+    end
+
+    it "allows only patch when patch_only" do
+      project = build(:project, auto_release_granularity: "patch_only")
+      expect(project.auto_release_allows_bump?("patch")).to be true
+      expect(project.auto_release_allows_bump?("minor")).to be false
+      expect(project.auto_release_allows_bump?("major")).to be false
+    end
+
+    it "allows minor and patch when minor_only" do
+      project = build(:project, auto_release_granularity: "minor_only")
+      expect(project.auto_release_allows_bump?("patch")).to be true
+      expect(project.auto_release_allows_bump?("minor")).to be true
+      expect(project.auto_release_allows_bump?("major")).to be false
+    end
+
+    it "allows all bumps when major_only" do
+      project = build(:project, auto_release_granularity: "major_only")
+      expect(project.auto_release_allows_bump?("patch")).to be true
+      expect(project.auto_release_allows_bump?("minor")).to be true
+      expect(project.auto_release_allows_bump?("major")).to be true
+    end
+
+    it "allows all bumps when all" do
+      project = build(:project, auto_release_granularity: "all")
+      %w[major minor patch].each do |bump|
+        expect(project.auto_release_allows_bump?(bump)).to be true
+      end
+    end
+  end
 end

--- a/spec/requests/api/github_webhooks_spec.rb
+++ b/spec/requests/api/github_webhooks_spec.rb
@@ -421,5 +421,106 @@ RSpec.describe "Api::GithubWebhooks" do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context "with check_suite.completed event" do
+      let(:project) { create(:project, webhook_secret: "test-secret-123", auto_release_granularity: "all") }
+
+      let(:payload) do
+        {
+          action: "completed",
+          check_suite: { head_sha: "abc123", conclusion: "success" },
+          repository: { id: project.github_id, full_name: project.full_name }
+        }
+      end
+
+      it "enqueues AutoReleaseEvaluationJob" do
+        body, signature = sign_payload(payload, project.webhook_secret)
+
+        expect {
+          post webhook_url,
+            params: body,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-GitHub-Event" => "check_suite",
+              "X-Hub-Signature-256" => signature
+            }
+        }.to have_enqueued_job(AutoReleaseEvaluationJob).with(project.id)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not enqueue when auto_release is off" do
+        project.update!(auto_release_granularity: "off")
+        body, signature = sign_payload(payload, project.webhook_secret)
+
+        expect {
+          post webhook_url,
+            params: body,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-GitHub-Event" => "check_suite",
+              "X-Hub-Signature-256" => signature
+            }
+        }.not_to have_enqueued_job(AutoReleaseEvaluationJob)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with check_run.completed event" do
+      let(:project) { create(:project, webhook_secret: "test-secret-123", auto_release_granularity: "patch_only") }
+
+      let(:payload) do
+        {
+          action: "completed",
+          check_run: { head_sha: "abc123", conclusion: "success" },
+          repository: { id: project.github_id, full_name: project.full_name }
+        }
+      end
+
+      it "enqueues AutoReleaseEvaluationJob" do
+        body, signature = sign_payload(payload, project.webhook_secret)
+
+        expect {
+          post webhook_url,
+            params: body,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-GitHub-Event" => "check_run",
+              "X-Hub-Signature-256" => signature
+            }
+        }.to have_enqueued_job(AutoReleaseEvaluationJob).with(project.id)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with pull_request.synchronize event and auto_release enabled" do
+      let(:project) { create(:project, webhook_secret: "test-secret-123", auto_release_granularity: "all") }
+
+      let(:payload) do
+        {
+          action: "synchronize",
+          pull_request: { number: 42 },
+          repository: { id: project.github_id, full_name: project.full_name }
+        }
+      end
+
+      it "enqueues AutoReleaseEvaluationJob with pr_number" do
+        body, signature = sign_payload(payload, project.webhook_secret)
+
+        expect {
+          post webhook_url,
+            params: body,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-GitHub-Event" => "pull_request",
+              "X-Hub-Signature-256" => signature
+            }
+        }.to have_enqueued_job(AutoReleaseEvaluationJob).with(project.id, pr_number: 42)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end

--- a/spec/services/release_please/parse_release_pr_spec.rb
+++ b/spec/services/release_please/parse_release_pr_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe ReleasePlease::ParseReleasePr do
+  def build_pr_data(title:, author: "github-actions[bot]", labels: [ "autorelease: pending" ], number: 42)
+    OpenStruct.new(
+      number: number,
+      title: title,
+      user: OpenStruct.new(login: author),
+      labels: labels.map { |name| OpenStruct.new(name: name) }
+    )
+  end
+
+  describe ".call" do
+    it "parses a valid release-please PR and classifies a minor bump" do
+      pr = build_pr_data(title: "chore(main): release 1.2.0")
+      result = described_class.call(pr_data: pr, previous_version: "1.1.0")
+
+      expect(result).to be_present
+      expect(result.pr_number).to eq(42)
+      expect(result.new_version).to eq("1.2.0")
+      expect(result.previous_version).to eq("1.1.0")
+      expect(result.bump).to eq("minor")
+    end
+
+    it "classifies a major bump" do
+      pr = build_pr_data(title: "chore(main): release 2.0.0")
+      result = described_class.call(pr_data: pr, previous_version: "1.5.3")
+
+      expect(result.bump).to eq("major")
+    end
+
+    it "classifies a patch bump" do
+      pr = build_pr_data(title: "chore(main): release 1.2.3")
+      result = described_class.call(pr_data: pr, previous_version: "1.2.2")
+
+      expect(result.bump).to eq("patch")
+    end
+
+    it "handles 0.x versioning with literal semver positions" do
+      pr = build_pr_data(title: "chore(main): release 0.23.0")
+      result = described_class.call(pr_data: pr, previous_version: "0.22.0")
+
+      expect(result.bump).to eq("minor")
+    end
+
+    it "returns nil for non-release-please authors" do
+      pr = build_pr_data(title: "chore(main): release 1.0.0", author: "some-user")
+      result = described_class.call(pr_data: pr, previous_version: "0.9.0")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil when title does not match release-please format" do
+      pr = build_pr_data(title: "fix: some bug")
+      result = described_class.call(pr_data: pr, previous_version: "1.0.0")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil when autorelease: pending label is missing" do
+      pr = build_pr_data(title: "chore(main): release 1.1.0", labels: [ "some-label" ])
+      result = described_class.call(pr_data: pr, previous_version: "1.0.0")
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil when previous_version is blank" do
+      pr = build_pr_data(title: "chore(main): release 1.0.0")
+      result = described_class.call(pr_data: pr, previous_version: nil)
+
+      expect(result).to be_nil
+    end
+
+    it "accepts release-please[bot] as author" do
+      pr = build_pr_data(title: "chore(main): release 1.1.0", author: "release-please[bot]")
+      result = described_class.call(pr_data: pr, previous_version: "1.0.0")
+
+      expect(result).to be_present
+      expect(result.bump).to eq("minor")
+    end
+
+    it "returns nil when versions are equal" do
+      pr = build_pr_data(title: "chore(main): release 1.0.0")
+      result = described_class.call(pr_data: pr, previous_version: "1.0.0")
+
+      expect(result).to be_nil
+    end
+  end
+
+  describe ".release_please_pr?" do
+    it "returns true for valid release-please PRs" do
+      pr = build_pr_data(title: "chore(main): release 1.0.0")
+      expect(described_class.release_please_pr?(pr)).to be true
+    end
+
+    it "returns false for non-release-please PRs" do
+      pr = build_pr_data(title: "feat: add feature", author: "developer")
+      expect(described_class.release_please_pr?(pr)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Automatically merge release-please PRs based on a per-project semver policy, eliminating manual merge toil for routine releases while preserving human review gates for higher-risk version bumps. Projects can configure which bump levels (patch, minor, major, or all) flow through automatically, with `off` as the default for existing projects.

## Changes

### Data Model
- New `auto_release_granularity` string column on `projects` (default: `"off"`, not-null) — collapses the enabled/granularity pair into a single enum column (`off` / `patch_only` / `minor_only` / `major_only` / `all`) per the issue's recommended single-dropdown UX

### Model Layer
- `AUTO_RELEASE_GRANULARITIES` constant and inclusion validation, following the existing `MERGE_METHODS` / `REVIEW_METHODS` pattern
- `auto_release_enabled?` convenience predicate (true when not `"off"`)
- `auto_release_allows_bump?(bump_type)` with hierarchical semantics — `minor_only` allows both minor and patch, `major_only` allows all three, matching user expectations for "up to X" granularity

### Service (`ReleasePlease::ParseReleasePr`)
- Identifies release-please PRs by author (`github-actions[bot]` / `release-please[bot]`), title regex (`chore(<branch>): release <version>`), and `autorelease: pending` label
- Parses semver from title and classifies bump type against the previous version from `.release-please-manifest.json`

### Job (`AutoReleaseEvaluationJob`)
- GoodJob-based with `total_limit: 1` per-project concurrency to prevent racing merges
- Pipeline: find open release PR → fetch previous version → classify bump → check granularity policy → verify all CI checks green → merge via project's configured `merge_method`
- Adds `paid-auto-released` label and explanatory comment on merge
- Graceful handling of expected merge failures (405/409/422 from GitHub)

### Webhook Integration
- `check_suite.completed` and `check_run.completed` events trigger auto-release evaluation (reactive, not polling)
- `pull_request` events (`opened` / `synchronize` / `labeled`) also trigger evaluation for immediate response to new release PRs

### UI
- New "Auto-Release" fieldset in project edit view with a granularity dropdown and help text, positioned alongside existing automation toggles (Auto-Merge, Auto-Pick)

### Tests
- 239 examples covering model validation and predicate methods, service parsing edge cases (0.x versions, wrong author, missing labels), job granularity × bump matrix (15 combinations), CI gating logic, and webhook trigger routing

## Design Decisions

- **Single column over boolean + enum**: The issue flagged this as "probably cleaner" — a single `auto_release_granularity` column with `off` eliminates coupled-state bugs and simplifies the UI to one dropdown
- **Hierarchical granularity**: `minor_only` auto-merges both minor *and* patch bumps, not exclusively minor. This matches the mental model of "I trust automation up to this level of change" rather than requiring users to select multiple levels
- **Reactive via webhooks, not polling**: Auto-release evaluation is triggered by GitHub webhook events (`check_suite`, `check_run`, `pull_request`) to minimize latency and API calls, consistent with the issue's preference for event-driven behavior
- **Per-project concurrency limit**: `total_limit: 1` on the job prevents duplicate merge attempts when multiple check events fire in quick succession for the same release PR
- **0.x literal positions**: For pre-1.0 versions, bump classification uses literal semver positions rather than treating 0.x minor bumps as breaking — this matches release-please's own behavior

## Deployment Notes

- Run `bin/rails db:migrate` to add the `auto_release_granularity` column — existing projects default to `"off"` (no behavior change)

---

Closes #1148