### PR TITLE
Fix #389: Add Issue Enhancement agent run mode

### DIFF
--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -84,6 +84,20 @@ module Projects
           custom_prompt: custom_prompt,
           goal: goal
         )
+      elsif goal == "enhance_issue"
+        unless issue
+          redirect_to new_project_agent_run_path(@project, goal: goal),
+            alert: "Please select an issue to enhance."
+          return
+        end
+
+        create_run_and_redirect(
+          on_error_path: new_project_agent_run_path(@project, goal: goal),
+          issue: issue,
+          custom_prompt: custom_prompt,
+          goal: goal,
+          priority_tier: priority_tier
+        )
       else
         source_pr_number = resolve_pull_request
         unless issue || custom_prompt || source_pr_number

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -152,6 +152,8 @@ module ApplicationHelper
       create_issue_context(run)
     elsif run.review_goal?
       review_context(run)
+    elsif run.enhance_issue_goal?
+      enhance_issue_context(run)
     else
       { type: :placeholder }
     end
@@ -318,6 +320,15 @@ module ApplicationHelper
       url = source_pull_request_url(run)
       label = "PR ##{run.source_pull_request_number}"
       github_link_or_text(label, label, url)
+    else
+      { type: :placeholder }
+    end
+  end
+
+  def enhance_issue_context(run)
+    if run.issue.present?
+      label = "Issue ##{run.issue.github_number}"
+      github_link_or_text(label, label, run.issue.github_url, tooltip: run.issue.title)
     else
       { type: :placeholder }
     end

--- a/app/javascript/controllers/goal_toggle_controller.js
+++ b/app/javascript/controllers/goal_toggle_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
     const selected = this.element.querySelector("input[name='goal']:checked")
     const goal = selected ? selected.value : "create_pr"
 
-    const showIssue = goal === "create_pr"
+    const showIssue = goal === "create_pr" || goal === "enhance_issue"
     const showPr = goal === "create_pr" || goal === "review"
     const isReview = goal === "review"
     const showPriority = !isReview

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -3,7 +3,7 @@
 class AgentRun < ApplicationRecord
   STATUSES = %w[queued pending running paused completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
   AGENT_TYPES = %w[claude_code cursor codex copilot aider gemini opencode kilocode api].freeze
-  GOALS = %w[create_pr create_issue review].freeze
+  GOALS = %w[create_pr create_issue review enhance_issue].freeze
   TRIGGER_TYPES = %w[manual automatic].freeze
   ACTIVE_STATUSES = %w[pending running].freeze
   FINISHED_STATUSES = %w[completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
@@ -58,6 +58,7 @@ class AgentRun < ApplicationRecord
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :goal, presence: true, inclusion: { in: GOALS }
   validate :review_goal_requires_pull_request
+  validate :enhance_issue_goal_requires_issue
   validates :trigger_type, presence: true, inclusion: { in: TRIGGER_TYPES }
   validates :created_issue_url, length: { maximum: 500 }
   validates :worktree_path, length: { maximum: 500 }
@@ -416,7 +417,7 @@ class AgentRun < ApplicationRecord
   SQL
   GOAL_PRIORITY_SQL = Arel.sql(<<~SQL.squish).freeze
     CASE
-      WHEN goal = 'create_issue' THEN 0
+      WHEN goal IN ('create_issue', 'enhance_issue') THEN 0
       ELSE 1
     END
   SQL
@@ -484,6 +485,10 @@ class AgentRun < ApplicationRecord
 
   def review_goal?
     goal == "review"
+  end
+
+  def enhance_issue_goal?
+    goal == "enhance_issue"
   end
 
   def manual?
@@ -1014,12 +1019,29 @@ class AgentRun < ApplicationRecord
     end
   end
 
+  def enhance_issue_goal_requires_issue
+    if goal == "enhance_issue" && issue_id.blank?
+      errors.add(:issue, "is required for enhance_issue goals")
+    end
+  end
+
   def prompt_for_goal
     if review_goal?
       prompt_for_review
+    elsif enhance_issue_goal?
+      prompt_for_enhance_issue
     else
       prompt_for_issue
     end
+  end
+
+  def prompt_for_enhance_issue
+    return nil unless issue
+
+    "Enhance issue ##{issue.github_number} in #{project.full_name}. " \
+      "Read the issue description and all comments, then add a comment that either " \
+      "provides implementation context (relevant files, architecture notes, suggested approach) " \
+      "or asks specific clarifying questions the user needs to answer."
   end
 
   def empty_phase_summary

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -554,7 +554,7 @@ module Activities
       log_container_context(agent_run, provider)
       execution_started_at = Time.current
 
-      effective_timeout = if agent_run.create_issue_goal?
+      effective_timeout = if agent_run.create_issue_goal? || agent_run.enhance_issue_goal?
         user_settings&.issue_goal_timeout_seconds || DEFAULT_ISSUE_GOAL_TIMEOUT
       else
         user_settings&.agent_timeout_seconds || agent_timeout
@@ -569,7 +569,7 @@ module Activities
         effective_timeout = [ effective_timeout, remaining ].min
       end
 
-      effective_idle_timeout = if agent_run.create_issue_goal?
+      effective_idle_timeout = if agent_run.create_issue_goal? || agent_run.enhance_issue_goal?
         user_settings&.issue_goal_idle_timeout_seconds || DEFAULT_ISSUE_GOAL_IDLE_TIMEOUT
       elsif agent_run.review_goal?
         user_settings&.review_goal_idle_timeout_seconds || DEFAULT_REVIEW_GOAL_IDLE_TIMEOUT
@@ -1359,6 +1359,8 @@ module Activities
     def augment_prompt_for_goal(agent_run, prompt)
       if agent_run.create_issue_goal?
         augment_prompt_for_issue_goal(agent_run, prompt)
+      elsif agent_run.enhance_issue_goal?
+        augment_prompt_for_enhance_issue_goal(agent_run, prompt)
       elsif agent_run.review_goal?
         augment_prompt_for_review_goal(agent_run, prompt)
       else
@@ -1549,6 +1551,48 @@ module Activities
       Do NOT push code, create issues, or create new pull requests. Only post the review on PR #{{pr_number}}.
     AUGMENTED
 
+    ENHANCE_ISSUE_GOAL_PROMPT_SLUG = "goal.enhance_issue"
+
+    FALLBACK_ENHANCE_ISSUE_GOAL_PROMPT = <<~'AUGMENTED'
+      {{base_prompt}}
+
+      ---
+      IMPORTANT: Your goal is to ENHANCE AN EXISTING ISSUE by adding context or asking clarifying questions.
+      Do NOT write code, create PRs, or create new issues.
+
+      Read issue #{{issue_number}} in {{repo}} — its description and all comments — then add a SINGLE comment that either:
+
+      1. **Provides implementation context** — relevant files, architecture notes, suggested approach,
+         related patterns — if the issue has enough information to be implemented.
+      2. **Asks specific clarifying questions** — if the issue is ambiguous, missing acceptance criteria,
+         or has unstated constraints that need answers before implementation can begin.
+
+      Use curl to interact with the GitHub API via the proxy. Write JSON payloads to a temp file to avoid
+      shell quoting issues:
+
+      ```bash
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'COMMENT_JSON'
+      {
+        "body": "Your comment in markdown"
+      }
+      COMMENT_JSON
+      curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/issues/{{issue_number}}/comments" \
+        -H "Content-Type: application/json" \
+        -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
+        -H "X-Proxy-Token: $PROXY_TOKEN" \
+        --data-binary @"$tmpfile"
+      rm -f "$tmpfile"
+      ```
+
+      Available endpoints:
+      - GET  $GITHUB_API_URL/repos/{{repo}}/issues/{{issue_number}} — get issue details
+      - GET  $GITHUB_API_URL/repos/{{repo}}/issues/{{issue_number}}/comments — list comments
+      - POST $GITHUB_API_URL/repos/{{repo}}/issues/{{issue_number}}/comments — add comment
+
+      Do NOT push code, create issues, or create pull requests. Only add a comment to issue #{{issue_number}}.
+    AUGMENTED
+
     def augment_prompt_for_issue_goal(agent_run, prompt)
       vars = { base_prompt: prompt, repo: validated_repo_name(agent_run) }
       Prompts::Render.call(
@@ -1577,6 +1621,27 @@ module Activities
         project: agent_run.project,
         variables: vars,
         fallback: -> { Prompts::Render.interpolate(FALLBACK_REVIEW_GOAL_PROMPT, vars) }
+      )
+    end
+
+    def augment_prompt_for_enhance_issue_goal(agent_run, prompt)
+      issue = agent_run.issue
+      raise Temporalio::Error::ApplicationError.new(
+        "Enhance-issue goal requires an associated issue",
+        type: "MissingIssue",
+        non_retryable: true
+      ) unless issue
+
+      vars = {
+        base_prompt: prompt,
+        repo: validated_repo_name(agent_run),
+        issue_number: issue.github_number.to_s
+      }
+      Prompts::Render.call(
+        slug: ENHANCE_ISSUE_GOAL_PROMPT_SLUG,
+        project: agent_run.project,
+        variables: vars,
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_ENHANCE_ISSUE_GOAL_PROMPT, vars) }
       )
     end
 

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -124,7 +124,7 @@ module Workflows
         # Rails app is down (e.g. PendingMigration), the proxy is unreachable
         # and git operations fail. This check polls until the proxy recovers,
         # effectively pausing the workflow until credentials are available.
-        skip_clone = goal == "create_issue" && source_pull_request_number.blank?
+        skip_clone = (goal == "create_issue" || goal == "enhance_issue") && source_pull_request_number.blank?
         unless skip_clone
           if Temporalio::Workflow.patched("check_proxy_health_before_clone")
             ensure_proxy_healthy(agent_run_id)
@@ -159,7 +159,7 @@ module Workflows
         # (from CreateAgentRunActivity), plus a small Temporal buffer.
         # Issue goals use a shorter timeout since they only need to create
         # a GitHub issue via curl, not write code.
-        per_provider_timeout = if goal == "create_issue"
+        per_provider_timeout = if goal.in?(%w[create_issue enhance_issue])
           issue_goal_timeout_seconds
         else
           agent_timeout_seconds
@@ -205,6 +205,10 @@ module Workflows
             run_activity(Activities::CreateGithubIssueActivity,
               { agent_run_id: agent_run_id }, timeout: 120, retry_policy: NO_RETRY)
           end
+        elsif goal == "enhance_issue"
+          # Enhance-issue goal: the agent reads the issue and posts a comment
+          # via the GitHub API proxy during execution. No post-processing needed;
+          # label management and re-evaluation will be added in a follow-up.
         elsif goal == "review"
           # Review goal: complete the run — all output is PR comments posted
           # by the agent via the GitHub API proxy during execution.

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -40,6 +40,10 @@
               <input type="radio" name="goal" value="review" <%= "checked" if selected_goal == "review" %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
               <span class="ml-2 text-sm text-gray-700">PR Code Review</span>
             </label>
+            <label class="inline-flex items-center">
+              <input type="radio" name="goal" value="enhance_issue" <%= "checked" if selected_goal == "enhance_issue" %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
+              <span class="ml-2 text-sm text-gray-700">Enhance Issue</span>
+            </label>
           </div>
         </fieldset>
 

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ApplicationHelper do
         "create_pr_goal?": false,
         "create_issue_goal?": false,
         "review_goal?": false,
+        "enhance_issue_goal?": false,
         issue: nil,
         source_pull_request_number: nil,
         pull_request_number: nil,

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -1661,7 +1661,7 @@ RSpec.describe AgentRun do
     end
 
     it "defines valid GOALS" do
-      expect(described_class::GOALS).to eq(%w[create_pr create_issue review])
+      expect(described_class::GOALS).to eq(%w[create_pr create_issue review enhance_issue])
     end
 
     it "defines valid TRIGGER_TYPES" do


### PR DESCRIPTION
## Summary

Add an `enhance_issue` agent run goal that reads an existing issue's description and comments, combines it with project knowledge, and posts a structured comment providing implementation context or asking clarifying questions — bridging the gap between "issue filed" and "issue ready for implementation."

## Changes

### Model & Validations (`app/models/agent_run.rb`)
- Added `enhance_issue` to the `GOALS` enum with a predicate method, validation requiring an associated issue, and a dedicated prompt generator
- Routed `enhance_issue` through `prompt_for_goal` and prioritized it alongside `create_issue` in `GOAL_PRIORITY_SQL`

### UI & Stimulus (`app/views/projects/agent_runs/new.html.erb`, `app/javascript/controllers/goal_toggle_controller.js`)
- Added "Enhance Issue" radio button to the trigger agent run form
- Updated the goal toggle controller so selecting `enhance_issue` shows the issue dropdown and hides the PR/branch fields

### Controller (`app/controllers/projects/agent_runs_controller.rb`)
- Added `enhance_issue` branch in the `create` action, requiring issue selection

### Display (`app/helpers/application_helper.rb`)
- Added `enhance_issue_context` helper to render the linked issue in the agent runs table

### Workflow & Activity (`app/temporal/workflows/agent_execution_workflow.rb`, `app/temporal/activities/run_agent_activity.rb`)
- Skips repository clone for `enhance_issue` since it's API-only (no repo needed)
- Uses shorter issue-goal timeouts
- Added `ENHANCE_ISSUE_GOAL_PROMPT_SLUG` with a fallback prompt containing GitHub API instructions for commenting on issues
- Added `augment_prompt_for_enhance_issue_goal` for prompt construction

### Tests
- Updated GOALS constant expectation and stub defaults to include the new goal

## Design Decisions

- **No repo clone**: `enhance_issue` is an API-only operation (read issue, query knowledge, post comment), so the workflow skips the clone step entirely, saving time and resources.
- **Reuses issue-goal timeouts**: Shares timeout configuration with `create_issue` since both are lightweight, non-coding operations.
- **Comment posting via secrets proxy**: The agent posts its comment through the existing secrets proxy during execution rather than in a post-execution step, so the workflow uses a no-op post-execution branch.
- **This is sub-issue #989 only**: Covers the enum, form UI, and workflow scaffolding. The full `EnhanceIssueActivity` with knowledge base integration and the re-evaluation loop (label removal triggering re-runs) will follow in #990.

---

Closes #389