### PR TITLE
Fix #1152: Review agent run loop: scanner misclassifies unaddressed paid_agent reviews as addressed when HEAD == reviewed_commit

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1085,9 +1085,18 @@ module Activities
         issue
       ).order(completed_at: :desc).first
 
-      if last_review_run && last_create_pr_run
+      if last_review_run
         review_timestamp = last_review_run.completed_at || last_review_run.updated_at
-        return [] if review_timestamp >= last_create_pr_run.completed_at
+        if last_create_pr_run
+          return [] if review_timestamp >= last_create_pr_run.completed_at
+        else
+          # No create_pr has run in the current cycle. A completed review
+          # with no subsequent code changes means findings are unaddressed —
+          # suppress re-triggering to avoid back-to-back review runs on
+          # identical code (#1152). The workflow routes this state to a
+          # create_pr follow-up instead.
+          return []
+        end
       end
 
       [ { type: "paid_agent_review_pending", details: "No paid_agent review found for PR" } ]
@@ -1371,7 +1380,8 @@ module Activities
       # keeps this safe in either case.
       pr_data = client.pull_request(project.full_name, issue.github_number)
       head_sha = pr_data&.head&.sha
-      return true if head_sha.nil? || head_sha == reviewed_commit
+      return true if head_sha.nil?
+      return false if head_sha == reviewed_commit
 
       changed_files = client.compare_changed_files(
         project.full_name, reviewed_commit, head_sha

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -342,9 +342,11 @@ module Workflows
       queue_paid_agent_review_run(project_id, pr_data)
 
       if other_triggers.empty?
-        # No other work to do — the paid-agent review queue above is the only
-        # action needed unless the trigger merely reflects an already-active
-        # review-goal run.
+        # paid_agent_review_pending as sole trigger means no code changes are
+        # needed — the review queue above is the only action. When the scanner
+        # detects unaddressed review findings it emits review_bot_comments
+        # alongside, which routes through handle_review_bot_review_pending
+        # with a create_pr follow-up instead (#1152).
         nil
       elsif pr_data[:phase].in?(%w[draft restarted])
         start_draft_followup_workflow(project_id, pr_data)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1495,6 +1495,81 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when paid_agent review has inline comments and HEAD equals reviewed commit" do
+      before do
+        enable_paid_agent_review!
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                       body: "Here are some review suggestions.",
+                       submitted_at: 2.hours.ago, commit_id: "abc123" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
+              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+              pull_request_review_id: 1 }
+          ])
+      end
+
+      it "treats the review as unaddressed because HEAD has not advanced (#1152)" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("review_bot_comments", "review_bot_review_pending")
+      end
+    end
+
+    context "when restarted phase with review completed on current HEAD and no create_pr in cycle" do
+      before do
+        enable_paid_agent_review!
+        issue = create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "restarted",
+          review_goal_retry_reset_at: 1.hour.ago)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          goal: "review",
+          trigger_type: "automatic",
+          completed_at: 30.minutes.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                       body: "Here are some review suggestions.",
+                       submitted_at: 30.minutes.ago, commit_id: "abc123" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
+              created_at: 30.minutes.ago, path: "lib/agent_harness/providers/github_copilot.rb",
+              pull_request_review_id: 1 }
+          ])
+      end
+
+      it "does not emit paid_agent_review_pending to avoid review loop (#1152)" do
+        result = activity.execute(project_id: project.id)
+
+        trigger_types = result[:prs_to_trigger].flat_map { |t| t[:triggers].map { |x| x[:type] } }
+        expect(trigger_types).not_to include("paid_agent_review_pending")
+      end
+    end
+
     context "when paid_agent posted a body-only review with no last agent run" do
       before do
         create(:issue, :pull_request,


### PR DESCRIPTION
## Summary

Review agent run loop: scanner misclassifies unaddressed paid_agent reviews as addressed when HEAD == reviewed_commit

See #1152 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1152