### PR TITLE
fix(knowledge): mount /tmp tmpfs with exec for collector container

### DIFF
--- a/app/services/knowledge/containerized_runner.rb
+++ b/app/services/knowledge/containerized_runner.rb
@@ -308,8 +308,15 @@ module Knowledge
         "CpuPeriod" => 100_000,
         "CpuQuota" => options[:cpu_quota],
         "PidsLimit" => options[:pids_limit],
+        # /tmp must be `exec` because `bundle install` builds native gem
+        # extensions there. mkmf's try_link verifies the produced binary
+        # with File.executable?, which returns false on a noexec mount —
+        # producing a misleading "compiler failed to generate an executable
+        # file" error (see e.g. bigdecimal-4.1.1 extconf.rb). Docker's
+        # default tmpfs flags include noexec, so it must be overridden.
+        # /home/agent/.cache only stores cache data and stays noexec.
         "Tmpfs" => {
-          "/tmp" => "size=#{256 * 1024 * 1024},mode=1777",
+          "/tmp" => "exec,size=#{256 * 1024 * 1024},mode=1777",
           "/home/agent/.cache" => "size=#{128 * 1024 * 1024},mode=0755"
         },
         "Binds" => [

--- a/spec/services/knowledge/containerized_runner_spec.rb
+++ b/spec/services/knowledge/containerized_runner_spec.rb
@@ -312,6 +312,19 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
       binds = config.dig("HostConfig", "Binds")
       expect(binds.first).to match(%r{\Apaid-collector-42-[a-f0-9]{8}:/workspace:rw\z})
     end
+
+    # Regression: Docker's default tmpfs flags include noexec, which makes
+    # mkmf's File.executable? check fail when bundle install builds native
+    # gem extensions in /tmp — surfacing as a misleading "compiler failed
+    # to generate an executable file" error during routes collection.
+    it "mounts /tmp tmpfs with exec so bundle install can build native gems" do
+      config = nil
+      allow(Docker::Container).to receive(:create) { |cfg| config = cfg; mock_container }
+      described_class.new(project: project, commit_sha: commit_sha).run
+
+      tmp_options = config.dig("HostConfig", "Tmpfs", "/tmp")
+      expect(tmp_options.split(",")).to include("exec")
+    end
   end
 
   describe "network_mode validation" do


### PR DESCRIPTION
## Summary

Fixes routes-collector failure surfacing on the project page as:

> Knowledge collection failed
> routes: Command failed (exit 5): Gem::Ext::BuildError: ERROR: Failed to build gem native extension. current directory: /tmp/bundle/ruby/3.4.0/gems/bigdecimal-4.1.1/ext/bigdecimal /usr/local/bin/ruby extco...

The failure is **not** missing build tools or a Ruby/bigdecimal incompatibility — it's a mount-flag issue. Docker's default `--tmpfs` flags include `noexec`. `bundle install` builds native gem extensions under `/tmp/bundle`; mkmf's `try_link0` then validates the conftest binary with `File.executable?`, which returns `false` on a noexec mount, and mkmf raises the misleading *"compiler failed to generate an executable file"*.

bigdecimal 4.1.1 (released 2026-04-04) is the first gem in many Rails Gemfiles whose extconf calls `try_compile` immediately, lazily firing mkmf's `have_devel?` check on line 1 — which is why this only started biting now.

Reproduced in `paid-agent:latest`:
- Without `exec`: `gem install bigdecimal -v 4.1.1` produces the exact stack trace above.
- With `exec`: install succeeds.

`/home/agent/.cache` stays `noexec` since it only stores cache data.

## Test plan

- [x] Existing 43 specs in `containerized_runner_spec.rb` pass
- [x] New regression test asserts `/tmp` tmpfs options include `exec`
- [ ] Re-run knowledge collection on a Rails project page after merge and confirm routes collector completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)