### PR TITLE
Fix #1156: fix(pr-scanner): draft PRs get wedged when CI races post-review scan

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -343,7 +343,11 @@ module Activities
           return ready_for_owner_trigger(issue, sidecar_triggers: sidecar_triggers)
         end
 
-        return nil # CI still pending or checks unavailable
+        # CI still pending or checks unavailable — treat as incomplete so
+        # last_pr_scan_at is not advanced. GitHub does not bump PR
+        # updated_at on check-run state changes, so advancing here would
+        # permanently wedge the PR if CI finishes after this scan tick.
+        return :skipped
       end
 
       # Re-add pending triggers so the workflow can request the review.

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -3587,6 +3587,82 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         expect(result[:prs_to_trigger]).to eq([])
       end
+
+      it "does not advance last_pr_scan_at when checks are pending" do
+        issue = Issue.find_by(github_number: 42)
+        issue.update_columns(last_pr_scan_at: nil, github_updated_at: Time.current)
+
+        expect {
+          activity.execute(project_id: project.id)
+        }.not_to change { issue.reload.last_pr_scan_at }
+      end
+    end
+
+    context "when draft PR CI races post-review scan" do
+      let!(:draft_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 0,
+          github_updated_at: 1.hour.ago,
+          last_pr_scan_at: nil)
+      end
+
+      before do
+        project.update!(owner_reviewer_login: "viamin")
+      end
+
+      it "does not advance last_pr_scan_at when CI is still in-progress" do
+        stub_github_for_pr(
+          checks: [
+            { name: "lint", conclusion: "success" },
+            { name: "rspec", conclusion: nil }
+          ],
+          review_threads: []
+        )
+
+        result = activity.execute(project_id: project.id)
+        expect(result[:prs_to_trigger]).to eq([])
+        expect(draft_issue.reload.last_pr_scan_at).to be_nil
+      end
+
+      it "emits ready_for_owner on second scan after CI finishes green" do
+        stub_github_for_pr(
+          checks: [
+            { name: "lint", conclusion: "success" },
+            { name: "rspec", conclusion: nil }
+          ],
+          review_threads: []
+        )
+        activity.execute(project_id: project.id)
+
+        stub_github_for_pr(
+          checks: [
+            { name: "lint", conclusion: "success" },
+            { name: "rspec", conclusion: "success" }
+          ],
+          review_threads: []
+        )
+
+        result = activity.execute(project_id: project.id)
+        expect(result[:prs_to_trigger].size).to eq(1)
+        expect(result[:prs_to_trigger].first[:triggers].first[:type]).to eq("ready_for_owner")
+        expect(draft_issue.reload.last_pr_scan_at).to be_present
+      end
+
+      it "returns :skipped when check fetch fails (checks nil)" do
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:check_runs_for_ref)
+          .and_raise(GithubClient::Error.new("API error"))
+
+        expect {
+          activity.execute(project_id: project.id)
+        }.not_to change { draft_issue.reload.last_pr_scan_at }
+      end
     end
 
     context "when draft review limit is reached" do


### PR DESCRIPTION
## Summary

Prevent draft PRs from getting permanently wedged when CI check-runs complete after the first post-review scanner tick. The scanner was advancing `last_pr_scan_at` even when CI evaluation was incomplete, and since GitHub doesn't bump `pull_request.updated_at` on check-run state changes, the PR was never re-scanned — stalling both the individual PR and the project's auto-pick loop.

## Changes

- **Scanner activity** (`app/temporal/activities/scan_paid_prs_activity.rb`):
  - Changed the `return nil` at the bottom of `scan_draft_pr` (line 346) to `return :skipped` for the "CI still pending or checks unavailable" branch. The existing `:skipped` handling in `execute` already prevents `last_pr_scan_at` from being advanced, so no caller changes are needed.

- **Tests** (`spec/temporal/activities/scan_paid_prs_activity_spec.rb`):
  - Added spec verifying `last_pr_scan_at` is not advanced when CI is still in-progress
  - Added spec exercising the full race sequence: pending CI on first scan, green CI on second scan triggers `ready_for_owner`
  - Added spec covering the API failure path when check fetch returns `nil`

## Design Decisions

- **Minimal change over broader refactor**: The fix reuses the existing `:skipped` return convention rather than introducing a new return type or restructuring the three-outcome contract of `scan_draft_pr`. This is the smallest correct change — `execute` already treats `:skipped` as "don't advance the bookmark," which is exactly the semantics needed for incomplete CI evaluation.
- **Both pending-CI and nil-checks paths return `:skipped`**: These are semantically identical — the scanner cannot make a decision with missing inputs. Treating them the same avoids a class of future wedge bugs if check-fetch failures are transient.

---

Closes #1156