### PR TITLE
fix(dev): wait for overmind socket before exiting from --detach

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -51,6 +51,31 @@ if [ "$DEV_DETACH_FLAG" = "1" ] && [ -z "${DEV_DETACHED:-}" ]; then
   # the overmind PID you'd see in `ps` or `overmind status`.
   detached_pid=$!
   disown "$detached_pid" 2>/dev/null || true
+
+  # Wait for the detached child to open its Overmind socket before returning,
+  # so a follow-up `overmind status` / `overmind connect` from the caller
+  # (e.g. bin/setup) doesn't race the startup. Fall through with a warning
+  # after DEV_DETACH_READY_TIMEOUT seconds so we never hang setup scripts.
+  ready_timeout="${DEV_DETACH_READY_TIMEOUT:-60}"
+  deadline=$(( $(date +%s) + ready_timeout ))
+  socket_ready=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if [ -S "$OVERMIND_SOCKET" ]; then
+      socket_ready=1
+      break
+    fi
+    if ! kill -0 "$detached_pid" 2>/dev/null; then
+      echo "bin/dev detached process exited before the overmind socket appeared. See ${log_path}." >&2
+      exit 1
+    fi
+    sleep 0.2
+  done
+
+  if [ "$socket_ready" -ne 1 ]; then
+    echo "bin/dev detached (setsid pid=${detached_pid}), but overmind socket did not appear within ${ready_timeout}s. Tail ${log_path} to investigate." >&2
+    exit 0
+  fi
+
   echo "bin/dev detached (setsid pid=${detached_pid}). Use 'overmind connect' to attach."
   exit 0
 fi

--- a/bin/dev
+++ b/bin/dev
@@ -44,7 +44,7 @@ dev_supervisor_prepare_logging
 
 if [ "$DEV_DETACH_FLAG" = "1" ] && [ -z "${DEV_DETACHED:-}" ]; then
   log_path="$(dev_supervisor_overmind_log)"
-  echo "Detaching bin/dev — output streams to ${log_path}"
+  echo "Detaching bin/dev -- output streams to ${log_path}"
   DEV_DETACHED=1 setsid nohup "${APP_ROOT}/bin/dev" ${1+"$@"} </dev/null >>"$log_path" 2>&1 &
   # $! is the setsid wrapper PID, not overmind itself. Killing this PID still
   # propagates to the session, so it's useful for teardown; it just won't match

--- a/spec/lib/dev_script_spec.rb
+++ b/spec/lib/dev_script_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
 
   it "warns and exits when the overmind socket never appears after --detach" do
     Dir.mktmpdir("dev", exec_tmpdir) do |dir|
-      script_path = prepare_script_fixture(dir, overmind: { create_socket_on_start: false })
+      script_path = prepare_script_fixture(dir, overmind: { create_socket_on_start: false, start_sleep: 10 })
 
       env = {
         "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
@@ -224,6 +224,7 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
     tmux_pane_dead = tmux.fetch(:pane_dead, false)
     start_exit_status = overmind.fetch(:start_exit_status, 0)
     create_socket_on_start = overmind.fetch(:create_socket_on_start, false)
+    start_sleep = overmind.fetch(:start_sleep, 0)
     FileUtils.mkdir_p(File.join(dir, "stubbin"))
     FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
     FileUtils.mkdir_p(File.join(dir, "config"))
@@ -266,6 +267,9 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
             touch "#{dir}/overmind-running"
             if [ "#{create_socket_on_start ? 1 : 0}" = "1" ] && [ -n "${OVERMIND_SOCKET:-}" ]; then
               ruby -rsocket -e 'path = ENV.fetch("OVERMIND_SOCKET"); File.unlink(path) if File.exist?(path); UNIXServer.open(path) { |s| s.close }'
+            fi
+            if [ "#{start_sleep}" -gt 0 ]; then
+              sleep #{start_sleep}
             fi
             exit #{start_exit_status}
             ;;

--- a/spec/lib/dev_script_spec.rb
+++ b/spec/lib/dev_script_spec.rb
@@ -155,6 +155,46 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "waits for the overmind socket to appear before returning from --detach" do
+    Dir.mktmpdir("dev", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, overmind: { create_socket_on_start: true })
+
+      env = {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "SKIP_DEV_CLEANUP" => "1",
+        "OVERMIND_SOCKET" => File.join(dir, ".overmind.sock"),
+        "DEV_DETACH_READY_TIMEOUT" => "10"
+      }
+      stdout, stderr, status = Open3.capture3(env, script_path, "--detach", chdir: dir)
+      wait_for_detached_child(dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Detaching bin/dev")
+      expect(stdout).to match(/bin\/dev detached \(setsid pid=\d+\)\. Use 'overmind connect' to attach\./)
+      expect(stderr).not_to include("overmind socket did not appear")
+      expect(File.socket?(File.join(dir, ".overmind.sock"))).to be(true)
+    end
+  end
+
+  it "warns and exits when the overmind socket never appears after --detach" do
+    Dir.mktmpdir("dev", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, overmind: { create_socket_on_start: false })
+
+      env = {
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "SKIP_DEV_CLEANUP" => "1",
+        "OVERMIND_SOCKET" => File.join(dir, ".overmind.sock"),
+        "DEV_DETACH_READY_TIMEOUT" => "2"
+      }
+      stdout, stderr, status = Open3.capture3(env, script_path, "--detach", chdir: dir)
+      wait_for_detached_child(dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Detaching bin/dev")
+      expect(stderr).to include("overmind socket did not appear within 2s")
+    end
+  end
+
   it "captures an exit snapshot when overmind start fails" do
     Dir.mktmpdir("dev", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, overmind: { start_exit_status: 1 })
@@ -183,6 +223,7 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
     overmind_restart_exit_status = overmind.fetch(:restart_exit_status, 0)
     tmux_pane_dead = tmux.fetch(:pane_dead, false)
     start_exit_status = overmind.fetch(:start_exit_status, 0)
+    create_socket_on_start = overmind.fetch(:create_socket_on_start, false)
     FileUtils.mkdir_p(File.join(dir, "stubbin"))
     FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
     FileUtils.mkdir_p(File.join(dir, "config"))
@@ -223,6 +264,9 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
           start)
             touch "#{dir}/overmind-start-ran"
             touch "#{dir}/overmind-running"
+            if [ "#{create_socket_on_start ? 1 : 0}" = "1" ] && [ -n "${OVERMIND_SOCKET:-}" ]; then
+              ruby -rsocket -e 'path = ENV.fetch("OVERMIND_SOCKET"); File.unlink(path) if File.exist?(path); UNIXServer.open(path) { |s| s.close }'
+            fi
             exit #{start_exit_status}
             ;;
           quit)
@@ -283,6 +327,17 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
     UNIXServer.open(path) { |server| server.close }
     expect(File.socket?(path)).to be(true)
     path
+  end
+
+  # Polls the overmind log for the "bin/dev exiting" marker written by the
+  # EXIT trap in the detached child, so the tmpdir can be cleaned up safely.
+  def wait_for_detached_child(dir, timeout: 15)
+    log_path = File.join(dir, "log", "dev-update", "overmind.log")
+    deadline = Time.now + timeout
+    until Time.now > deadline
+      return if File.exist?(log_path) && File.read(log_path).include?("bin/dev exiting")
+      sleep 0.1
+    end
   end
 
   def assert_before_start_snapshot(dir)


### PR DESCRIPTION
## Summary

- `bin/dev --detach` used to print "bin/dev detached (setsid pid=…)" and exit before the forked child had opened `.overmind.sock`, so a follow-up `overmind status` / `overmind connect` from the caller (e.g. `bin/setup`) would race and fail with `dial unix .overmind.sock: connect: no such file or directory`.
- Parent now polls `$OVERMIND_SOCKET` for up to `DEV_DETACH_READY_TIMEOUT` seconds (default 60) before returning. Bails out early with an error if the detached child dies first; times out with a warning pointing at `log/dev-update/overmind.log` rather than hanging setup scripts.
- Two new specs in `spec/lib/dev_script_spec.rb` cover the readiness-wait success path and the timeout-with-warning path. Stub `overmind` gained an opt-in `create_socket_on_start` knob so the stubbed `start` can materialize a real Unix socket.

## Test plan

- [x] `bin/rspec spec/lib/dev_script_spec.rb` — 10 examples, 0 failures (8 existing + 2 new)
- [x] `shellcheck bin/dev` — clean (only pre-existing SC1091 info on the `source` line)
- [x] `bin/rubocop spec/lib/dev_script_spec.rb` — clean
- [ ] Manually confirm `bin/setup` → `overmind status` no longer races on a fresh devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)