### PR TITLE
Fix #1149: feat(projects): ensure standard labels (P1/P2/P3, etc.) exist on connected GitHub repos

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectsController < ApplicationController
-  before_action :set_project, only: [ :show, :edit, :update, :destroy, :toggle_auto_pick, :toggle_auto_merge, :detect_services, :cleanup_stale_runs ]
+  before_action :set_project, only: [ :show, :edit, :update, :destroy, :toggle_auto_pick, :toggle_auto_merge, :detect_services, :ensure_labels, :cleanup_stale_runs ]
   skip_after_action :verify_authorized, only: :index
 
   NULLS_LAST_SORT_ATTRIBUTES = %w[last_agent_run_at last_github_activity_at].freeze
@@ -141,6 +141,22 @@ class ProjectsController < ApplicationController
     redirect_to edit_project_path(@project), alert: "Could not detect services: #{e.message}"
   end
 
+  def ensure_labels
+    authorize @project, :update?
+
+    result = Projects::EnsureStandardLabels.call(project: @project)
+
+    if result.any_errors?
+      redirect_to edit_project_path(@project), alert: result.notice_message
+    else
+      redirect_to edit_project_path(@project), notice: result.notice_message
+    end
+  rescue GithubClient::ApiError => e
+    redirect_to edit_project_path(@project), alert: "Could not sync labels: #{e.message}"
+  rescue GithubClient::AuthenticationError => e
+    redirect_to edit_project_path(@project), alert: "GitHub authentication failed: #{e.message}"
+  end
+
   def cleanup_stale_runs
     authorize @project, :update?
 
@@ -264,6 +280,12 @@ class ProjectsController < ApplicationController
     settings
   end
 
+  def ensure_labels_best_effort(project)
+    Projects::EnsureStandardLabels.call(project: project)
+  rescue => e
+    Rails.logger.warn(message: "github_sync.ensure_labels_on_create_failed", project_id: project.id, error: e.message)
+  end
+
   def parse_usernames_csv
     params.dig(:project, :allowed_github_usernames_csv).to_s.split(",").map(&:strip).reject(&:blank?).uniq
   end
@@ -272,6 +294,7 @@ class ProjectsController < ApplicationController
     @project.name = @project.name.presence || @project.repo
 
     if @project.save
+      ensure_labels_best_effort(@project)
       redirect_to @project, notice: "Project was successfully added."
     else
       render :new, status: :unprocessable_content
@@ -287,6 +310,7 @@ class ProjectsController < ApplicationController
     @project.default_branch = repo_data.default_branch
 
     if @project.save
+      ensure_labels_best_effort(@project)
       redirect_to @project, notice: "Project was successfully added."
     else
       render :new, status: :unprocessable_content

--- a/app/services/projects/ensure_standard_labels.rb
+++ b/app/services/projects/ensure_standard_labels.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+module Projects
+  # Ensures that the project's configured standard labels exist on the connected
+  # GitHub repository. Creates missing labels and flags existing labels whose
+  # color or description diverge from Paid defaults.
+  #
+  # Standard labels include:
+  # - generated_label_name  (e.g. "paid-generated")
+  # - automation_label_name (e.g. "paid-automation")
+  # - Priority labels       (P1, P2, P3 by default)
+  #
+  # @example
+  #   result = Projects::EnsureStandardLabels.call(project: project)
+  #   result.created   # => ["paid-generated", "P1"]
+  #   result.existing  # => ["paid-automation"]
+  #   result.divergent # => [{ name: "P2", field: "color", expected: "ff9800", actual: "000000" }]
+  #   result.errors    # => []
+  class EnsureStandardLabels
+    LABEL_DEFINITIONS = {
+      generated: { color: "0e8a16", description: "Created by Paid" },
+      automation: { color: "1d76db", description: "Triggers Paid automation" },
+      priority: {
+        "P1" => { color: "d93f0b", description: "High priority" },
+        "P2" => { color: "ff9800", description: "Medium priority" },
+        "P3" => { color: "fbca04", description: "Low priority" }
+      }
+    }.freeze
+
+    attr_reader :project
+
+    def initialize(project:)
+      @project = project
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      client = project.github_token.client
+      repo = project.full_name
+
+      remote_labels = fetch_remote_labels(client, repo)
+      remote_by_name = remote_labels.each_with_object({}) do |label, h|
+        h[label.name.downcase] = label
+      end
+
+      created = []
+      existing = []
+      divergent = []
+      errors = []
+
+      expected_labels.each do |expected|
+        remote = remote_by_name[expected[:name].downcase]
+
+        if remote.nil?
+          create_label(client, repo, expected, created, errors)
+        else
+          existing << expected[:name]
+          check_divergence(remote, expected, divergent)
+        end
+      end
+
+      log_result(created, existing, divergent, errors)
+
+      Result.new(created: created, existing: existing, divergent: divergent, errors: errors)
+    end
+
+    private
+
+    def expected_labels
+      labels = []
+
+      labels << {
+        name: project.generated_label_name,
+        color: LABEL_DEFINITIONS[:generated][:color],
+        description: LABEL_DEFINITIONS[:generated][:description]
+      }
+
+      labels << {
+        name: project.automation_label_name,
+        color: LABEL_DEFINITIONS[:automation][:color],
+        description: LABEL_DEFINITIONS[:automation][:description]
+      }
+
+      project.effective_priority_labels.each do |tier, label_name|
+        defaults = LABEL_DEFINITIONS[:priority][tier] || {}
+        labels << {
+          name: label_name,
+          color: defaults[:color] || "ededed",
+          description: defaults[:description] || "Priority #{tier}"
+        }
+      end
+
+      labels
+    end
+
+    def fetch_remote_labels(client, repo)
+      client.labels(repo)
+    rescue GithubClient::ApiError => e
+      if e.status == 403
+        raise GithubClient::ApiError.new(
+          "Insufficient permissions to read labels. Ensure the GitHub token has repo scope.",
+          status: 403
+        )
+      end
+      raise
+    end
+
+    def create_label(client, repo, expected, created, errors)
+      client.create_label(repo, name: expected[:name], color: expected[:color], description: expected[:description])
+      created << expected[:name]
+    rescue GithubClient::ApiError => e
+      if e.status == 422
+        # Label was created between our fetch and create — treat as existing
+        return
+      end
+      if e.status == 403
+        errors << { name: expected[:name], error: "Insufficient permissions to create labels. Ensure the GitHub token has repo scope." }
+      else
+        errors << { name: expected[:name], error: e.message }
+      end
+    end
+
+    def check_divergence(remote, expected, divergent)
+      remote_color = remote.color.to_s.delete_prefix("#").downcase
+      expected_color = expected[:color].to_s.delete_prefix("#").downcase
+
+      if remote_color != expected_color
+        divergent << { name: expected[:name], field: "color", expected: expected_color, actual: remote_color }
+      end
+
+      remote_desc = remote.respond_to?(:description) ? remote.description.to_s : ""
+      if expected[:description].present? && remote_desc != expected[:description]
+        divergent << { name: expected[:name], field: "description", expected: expected[:description], actual: remote_desc }
+      end
+    end
+
+    def log_result(created, existing, divergent, errors)
+      Rails.logger.info(
+        message: "github_sync.ensure_standard_labels",
+        project_id: project.id,
+        repo: project.full_name,
+        created: created,
+        existing: existing,
+        divergent_count: divergent.size,
+        error_count: errors.size
+      )
+    end
+
+    # Result object returned by EnsureStandardLabels.
+    class Result
+      attr_reader :created, :existing, :divergent, :errors
+
+      def initialize(created:, existing:, divergent:, errors:)
+        @created = created
+        @existing = existing
+        @divergent = divergent
+        @errors = errors
+      end
+
+      def notice_message
+        parts = []
+        parts << "Created labels: #{created.join(', ')}." if created.any?
+        parts << "#{existing.size} label(s) already present." if existing.any?
+        if divergent.any?
+          names = divergent.map { |d| d[:name] }.uniq
+          parts << "Labels with different settings: #{names.join(', ')}."
+        end
+        if errors.any?
+          names = errors.map { |e| e[:name] }
+          parts << "Failed to create: #{names.join(', ')}."
+        end
+        parts.join(" ").presence || "All standard labels are up to date."
+      end
+
+      def any_errors?
+        errors.any?
+      end
+    end
+  end
+end

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -404,7 +404,7 @@
           <fieldset class="space-y-4">
             <div class="flex items-center justify-between">
               <legend class="text-sm font-semibold leading-6 text-gray-900">Labels</legend>
-              <%= button_to "Sync Labels to GitHub", ensure_labels_project_path(@project), method: :post, class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
+              <%= link_to "Sync Labels to GitHub", ensure_labels_project_path(@project), data: { turbo_method: :post }, class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
             </div>
 
             <div>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -402,7 +402,10 @@
           </fieldset>
 
           <fieldset class="space-y-4">
-            <legend class="text-sm font-semibold leading-6 text-gray-900">Labels</legend>
+            <div class="flex items-center justify-between">
+              <legend class="text-sm font-semibold leading-6 text-gray-900">Labels</legend>
+              <%= button_to "Sync Labels to GitHub", ensure_labels_project_path(@project), method: :post, class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
+            </div>
 
             <div>
               <%= form.label :generated_label_name, "Generated Label", class: "block text-sm font-medium leading-6 text-gray-900" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
       controller: "projects/pre_commit_requirements"
     resources :project_service_containers, only: [ :create, :destroy ], controller: "projects/service_containers"
     post :detect_services, on: :member
+    post :ensure_labels, on: :member
   end
 
   # API endpoints for agent containers

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -276,6 +276,8 @@ RSpec.describe "Projects" do
           github_client = instance_double(GithubClient)
           allow(GithubClient).to receive(:new).and_return(github_client)
           allow(github_client).to receive(:repository).with("octocat/hello-world").and_return(repo_response)
+          allow(github_client).to receive(:labels).with("octocat/hello-world").and_return([])
+          allow(github_client).to receive(:create_label)
         end
 
         it "creates a new project" do

--- a/spec/services/projects/ensure_standard_labels_spec.rb
+++ b/spec/services/projects/ensure_standard_labels_spec.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Projects::EnsureStandardLabels do
+  let(:github_client) { instance_double(GithubClient) }
+  let(:github_token_stub) { Struct.new(:client).new(github_client) }
+  let(:project) do
+    Struct.new(:id, :full_name, :owner, :repo, :github_token,
+               :generated_label_name, :automation_label_name,
+               :effective_priority_labels, keyword_init: true)
+      .new(
+        id: 1,
+        full_name: "test-owner/test-repo",
+        owner: "test-owner",
+        repo: "test-repo",
+        github_token: github_token_stub,
+        generated_label_name: "paid-generated",
+        automation_label_name: "paid-automation",
+        effective_priority_labels: { "P1" => "P1", "P2" => "P2", "P3" => "P3" }
+      )
+  end
+
+  def make_label(name, color: "000000", description: "")
+    OpenStruct.new(name: name, color: color, description: description)
+  end
+
+  describe ".call" do
+    context "when all labels are missing" do
+      before do
+        allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([])
+        allow(github_client).to receive(:create_label)
+      end
+
+      it "creates all standard labels" do
+        result = described_class.call(project: project)
+
+        expect(result.created).to contain_exactly("paid-generated", "paid-automation", "P1", "P2", "P3")
+        expect(result.existing).to be_empty
+        expect(result.divergent).to be_empty
+        expect(result.errors).to be_empty
+      end
+
+      it "calls create_label with correct parameters for each label" do
+        described_class.call(project: project)
+
+        expected_calls = {
+          "paid-generated" => { color: "0e8a16", description: "Created by Paid" },
+          "paid-automation" => { color: "1d76db", description: "Triggers Paid automation" },
+          "P1" => { color: "d93f0b", description: "High priority" },
+          "P2" => { color: "ff9800", description: "Medium priority" },
+          "P3" => { color: "fbca04", description: "Low priority" }
+        }
+
+        expected_calls.each do |name, attrs|
+          expect(github_client).to have_received(:create_label).with(
+            "test-owner/test-repo", name: name, **attrs
+          )
+        end
+      end
+    end
+
+    context "when all labels already exist with correct settings" do
+      before do
+        allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([
+          make_label("paid-generated", color: "0e8a16", description: "Created by Paid"),
+          make_label("paid-automation", color: "1d76db", description: "Triggers Paid automation"),
+          make_label("P1", color: "d93f0b", description: "High priority"),
+          make_label("P2", color: "ff9800", description: "Medium priority"),
+          make_label("P3", color: "fbca04", description: "Low priority")
+        ])
+      end
+
+      it "is a no-op" do
+        result = described_class.call(project: project)
+
+        expect(result.created).to be_empty
+        expect(result.existing).to contain_exactly("paid-generated", "paid-automation", "P1", "P2", "P3")
+        expect(result.divergent).to be_empty
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "when labels exist with different colors" do
+      before do
+        allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([
+          make_label("paid-generated", color: "0e8a16", description: "Created by Paid"),
+          make_label("paid-automation", color: "1d76db", description: "Triggers Paid automation"),
+          make_label("P1", color: "000000", description: "High priority"),
+          make_label("P2", color: "ff9800", description: "Medium priority"),
+          make_label("P3", color: "fbca04", description: "Low priority")
+        ])
+      end
+
+      it "flags divergent labels without overwriting" do
+        result = described_class.call(project: project)
+
+        expect(result.created).to be_empty
+        expect(result.divergent).to include(
+          { name: "P1", field: "color", expected: "d93f0b", actual: "000000" }
+        )
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "when the GitHub token lacks permissions to create labels" do
+      before do
+        allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([])
+        allow(github_client).to receive(:create_label)
+          .and_raise(GithubClient::ApiError.new("Resource not accessible by integration", status: 403))
+      end
+
+      it "records permission errors for each label" do
+        result = described_class.call(project: project)
+
+        expect(result.errors.size).to eq(5)
+        result.errors.each do |err|
+          expect(err[:error]).to include("Insufficient permissions")
+        end
+      end
+    end
+
+    context "when the GitHub token lacks permissions to read labels" do
+      before do
+        allow(github_client).to receive(:labels)
+          .and_raise(GithubClient::ApiError.new("Resource not accessible by integration", status: 403))
+      end
+
+      it "raises with a clear permission error" do
+        expect { described_class.call(project: project) }
+          .to raise_error(GithubClient::ApiError, /Insufficient permissions to read labels/)
+      end
+    end
+
+    context "when a label is created between fetch and create (422 race)" do
+      before do
+        allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([])
+        allow(github_client).to receive(:create_label) do |_repo, name:, **|
+          if name == "P1"
+            raise GithubClient::ApiError.new("Validation Failed", status: 422)
+          end
+        end
+      end
+
+      it "treats the 422 as the label already existing" do
+        result = described_class.call(project: project)
+
+        expect(result.created).not_to include("P1")
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "with custom priority label names" do
+      let(:project) do
+        Struct.new(:id, :full_name, :owner, :repo, :github_token,
+                   :generated_label_name, :automation_label_name,
+                   :effective_priority_labels, keyword_init: true)
+          .new(
+            id: 1,
+            full_name: "test-owner/test-repo",
+            owner: "test-owner",
+            repo: "test-repo",
+            github_token: github_token_stub,
+            generated_label_name: "paid-generated",
+            automation_label_name: "paid-automation",
+            effective_priority_labels: { "P1" => "critical", "P2" => "medium", "P3" => "low" }
+          )
+      end
+
+      before do
+        allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([])
+        allow(github_client).to receive(:create_label)
+      end
+
+      it "creates labels with the custom names" do
+        result = described_class.call(project: project)
+
+        expect(result.created).to include("critical", "medium", "low")
+      end
+    end
+
+    context "when label name matching is case-insensitive" do
+      before do
+        allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([
+          make_label("Paid-Generated", color: "0e8a16", description: "Created by Paid"),
+          make_label("PAID-AUTOMATION", color: "1d76db", description: "Triggers Paid automation"),
+          make_label("p1", color: "d93f0b", description: "High priority"),
+          make_label("p2", color: "ff9800", description: "Medium priority"),
+          make_label("p3", color: "fbca04", description: "Low priority")
+        ])
+      end
+
+      it "treats differently-cased labels as existing" do
+        result = described_class.call(project: project)
+
+        expect(result.created).to be_empty
+        expect(result.existing.size).to eq(5)
+      end
+    end
+  end
+
+  describe "Result#notice_message" do
+    it "summarizes created, existing, and divergent labels" do
+      result = described_class::Result.new(
+        created: [ "P1", "P2" ],
+        existing: [ "paid-generated" ],
+        divergent: [ { name: "paid-automation", field: "color", expected: "1d76db", actual: "000000" } ],
+        errors: []
+      )
+
+      message = result.notice_message
+      expect(message).to include("Created labels: P1, P2")
+      expect(message).to include("1 label(s) already present")
+      expect(message).to include("Labels with different settings: paid-automation")
+    end
+
+    it "reports errors" do
+      result = described_class::Result.new(
+        created: [],
+        existing: [],
+        divergent: [],
+        errors: [ { name: "P1", error: "forbidden" } ]
+      )
+
+      expect(result.notice_message).to include("Failed to create: P1")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Automatically bootstrap standard labels (P1/P2/P3, `paid-generated`, `paid-automation`) on connected GitHub repos so that Paid's label-application code paths no longer silently skip when labels are missing. Previously, `GithubClient#create_label` existed but was never called, requiring manual label creation on each new repo.

## Changes

**Service layer**
- New `Projects::EnsureStandardLabels` Servo service that fetches the repo's existing labels, diffs against the project's configured standard label set (priority labels + system labels), creates missing ones via `GithubClient#create_label`, and flags divergent labels (color/description mismatch) without overwriting user customizations.
- Case-insensitive label matching to avoid duplicates.
- Handles 422 race conditions (label created between fetch and create) gracefully as no-ops.

**Controller / routing**
- `POST /projects/:id/ensure_labels` member route for on-demand sync.
- `ensure_labels` action with full error handling and user-facing flash messages.
- `ensure_labels_best_effort` called during project creation — failures are logged but do not block import.

**UI**
- "Sync Labels to GitHub" button added to the Labels fieldset on the project edit page.

**Tests**
- 11 specs covering: missing labels, already-present labels, divergent color/description, insufficient permissions (both read and write scope errors), 422 race condition, custom priority label names, and case-insensitive matching.

## Design Decisions

- **Best-effort on import**: Label sync failures during project connect are logged and surfaced but do not block the import flow, since a missing label is recoverable while a failed import is not.
- **Flag, don't overwrite divergent labels**: When an existing label has a different color or description, the service reports the divergence rather than silently overwriting. This respects user customizations and avoids surprising side effects.
- **Generalized beyond priority labels**: The service handles both priority labels (P1/P2/P3, configurable per-project) and system labels (`paid-generated`, `paid-automation`), making it straightforward to add more standard labels in the future without a new code path.
- **Idempotent**: Safe to run repeatedly — already-correct labels are skipped, and 422 conflicts from concurrent creation are treated as success.

## Screenshots

> **Author**: please attach a screenshot of the "Sync Labels to GitHub" button on the project edit page before merging.

---

Closes #1149