### PR TITLE
Fix #1165: Replace enhance issue dropdown with multi-select table (matching PR code review table)

### DIFF
--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -47,6 +47,18 @@ module Projects
         .issues_only
         .where(github_state: "open")
         .order(github_number: :desc)
+        .to_a
+      issue_ids = @issues.map(&:id)
+      @issues_with_active_runs = @project.agent_runs
+        .where(issue_id: issue_ids, goal: "enhance_issue", status: AgentRun::UNFINISHED_STATUSES)
+        .distinct
+        .pluck(:issue_id)
+        .to_set
+      @issue_enhancement_rounds = @project.agent_runs
+        .where(issue_id: issue_ids, goal: "enhance_issue")
+        .where.not(status: AgentRun::UNFINISHED_STATUSES)
+        .group(:issue_id)
+        .count
       @pull_requests = @project.issues
         .pull_requests_only
         .where(github_state: "open")
@@ -86,15 +98,16 @@ module Projects
           goal: goal
         )
       elsif goal == "enhance_issue"
-        unless issue
+        issue_ids = Array(params[:issue_ids]).filter_map { |id| Integer(id, exception: false) }.select(&:positive?)
+        if issue_ids.empty?
           redirect_to new_project_agent_run_path(@project, goal: goal),
-            alert: "Please select an issue to enhance."
+            alert: "Please select at least one issue to enhance."
           return
         end
 
-        create_run_and_redirect(
+        create_enhance_issue_runs_and_redirect(
+          issue_ids: issue_ids,
           on_error_path: new_project_agent_run_path(@project, goal: goal),
-          issue: issue,
           custom_prompt: custom_prompt,
           goal: goal,
           priority_tier: priority_tier
@@ -864,6 +877,61 @@ module Projects
     rescue ActiveRecord::RecordNotUnique
       # Only proxy_token has a unique index; duplicate PR runs are caught
       # server-side above (active_pr_numbers filter) rather than by a DB constraint.
+      redirect_to on_error_path, alert: "An unexpected error occurred. Please try again."
+    end
+
+    def create_enhance_issue_runs_and_redirect(issue_ids:, on_error_path:, custom_prompt:, goal:, priority_tier:)
+      budget_result = CostBudgets::Check.call(@project)
+      unless budget_result[:allowed]
+        redirect_to on_error_path, alert: "Your project's AI budget has been reached. Please adjust your budget settings or try again later."
+        return
+      end
+
+      issues = @project.issues.issues_only.where(id: issue_ids)
+      if issues.empty?
+        redirect_to on_error_path, alert: "None of the selected issues could be found."
+        return
+      end
+
+      # Filter out issues that already have active (unfinished) enhance_issue runs
+      active_issue_ids = @project.agent_runs
+        .where(issue_id: issues.map(&:id), goal: "enhance_issue", status: AgentRun::UNFINISHED_STATUSES)
+        .pluck(:issue_id)
+      issues = issues.where.not(id: active_issue_ids) if active_issue_ids.any?
+      if issues.empty?
+        redirect_to on_error_path, alert: "All selected issues already have active enhancement runs."
+        return
+      end
+
+      github_sync_args_list = []
+      ActiveRecord::Base.transaction do
+        issues.each do |issue|
+          create_agent_run(
+            issue: issue,
+            custom_prompt: custom_prompt,
+            goal: goal,
+            priority_tier: priority_tier
+          )
+          sync_args = apply_priority_label(issue, priority_tier) if priority_tier
+          github_sync_args_list << [ issue, sync_args ] if sync_args
+        end
+      end
+
+      github_sync_args_list.each do |issue, (label_name, stale_labels)|
+        sync_priority_label_to_github(issue, label_name, stale_labels)
+      end
+
+      ProcessRunQueueJob.perform_later
+
+      notice = if issues.size == 1
+        "Agent run queued for issue enhancement."
+      else
+        "#{issues.size} agent runs queued for issue enhancement."
+      end
+      redirect_to project_path(@project), notice: notice
+    rescue NoRunnableProviderError => e
+      redirect_to on_error_path, alert: e.message
+    rescue ActiveRecord::RecordNotUnique
       redirect_to on_error_path, alert: "An unexpected error occurred. Please try again."
     end
 

--- a/app/javascript/controllers/goal_toggle_controller.js
+++ b/app/javascript/controllers/goal_toggle_controller.js
@@ -3,6 +3,9 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = [
     "issueSection",
+    "issueHeading",
+    "issueDropdown",
+    "issueTable",
     "prSection",
     "prHeading",
     "prDescription",
@@ -33,13 +36,16 @@ export default class extends Controller {
     const showIssue = goal === "create_pr" || goal === "enhance_issue"
     const showPr = goal === "create_pr" || goal === "review"
     const isReview = goal === "review"
+    const isEnhanceIssue = goal === "enhance_issue"
     const showPriority = !isReview
 
     this.issueSectionTargets.forEach((el) => {
       el.hidden = !showIssue
       el.querySelectorAll("input, select, textarea, button").forEach(
         (control) => {
-          control.disabled = !showIssue
+          if (!control.hasAttribute("data-permanently-disabled")) {
+            control.disabled = !showIssue
+          }
         }
       )
     })
@@ -82,6 +88,29 @@ export default class extends Controller {
           control.disabled = !isReview
         }
       })
+    })
+
+    // Toggle between dropdown (create_pr) and table (enhance_issue) for issues.
+    this.issueDropdownTargets.forEach((el) => {
+      el.hidden = isEnhanceIssue
+      el.querySelectorAll("select").forEach((control) => {
+        control.disabled = isEnhanceIssue || !showIssue
+      })
+    })
+
+    this.issueTableTargets.forEach((el) => {
+      el.hidden = !isEnhanceIssue
+      el.querySelectorAll("input[type='checkbox']").forEach((control) => {
+        if (!control.hasAttribute("data-permanently-disabled")) {
+          control.disabled = !isEnhanceIssue
+        }
+      })
+    })
+
+    this.issueHeadingTargets.forEach((el) => {
+      el.textContent = isEnhanceIssue
+        ? "Select Issues to Enhance"
+        : "Select Issue"
     })
 
     if (isReview) {

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -151,10 +151,6 @@ class Issue < ApplicationRecord
     draft_review_count + pr_followup_count
   end
 
-  def enhancement_rounds_count
-    agent_runs.where(goal: "enhance_issue").where.not(status: AgentRun::UNFINISHED_STATUSES).count
-  end
-
   def associated_pull_request
     if sub_issues.loaded?
       open_prs = sub_issues.select { |si| si.is_pull_request? && si.github_state == "open" }

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -151,6 +151,10 @@ class Issue < ApplicationRecord
     draft_review_count + pr_followup_count
   end
 
+  def enhancement_rounds_count
+    agent_runs.where(goal: "enhance_issue").where.not(status: AgentRun::UNFINISHED_STATUSES).count
+  end
+
   def associated_pull_request
     if sub_issues.loaded?
       open_prs = sub_issues.select { |si| si.is_pull_request? && si.github_state == "open" }

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -48,19 +48,24 @@
         </fieldset>
 
         <div data-goal-toggle-target="issueSection">
-          <h2 class="text-base font-semibold text-gray-900">Select Issue</h2>
+          <h2 class="text-base font-semibold text-gray-900" data-goal-toggle-target="issueHeading">Select Issue</h2>
 
           <div class="mt-4 rounded-lg border border-gray-200 p-4">
-            <label for="issue_id" class="block text-sm font-medium text-gray-700">Choose from synced issues:</label>
             <% if @issues.any? %>
-              <select name="issue_id" id="issue_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
-                <option value="">-- Select an issue --</option>
-                <% @issues.each do |issue| %>
-                  <option value="<%= issue.id %>" <%= "selected" if params[:issue_id].to_s == issue.id.to_s %>>
-                    #<%= issue.github_number %> - <%= truncate(issue.title, length: 60) %>
-                  </option>
-                <% end %>
-              </select>
+              <%# Single-select dropdown for create_pr goal %>
+              <div data-goal-toggle-target="issueDropdown">
+                <label for="issue_id" class="block text-sm font-medium text-gray-700">Choose from synced issues:</label>
+                <select name="issue_id" id="issue_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                  <option value="">-- Select an issue --</option>
+                  <% @issues.each do |issue| %>
+                    <option value="<%= issue.id %>" <%= "selected" if params[:issue_id].to_s == issue.id.to_s %>>
+                      #<%= issue.github_number %> - <%= truncate(issue.title, length: 60) %>
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+
+              <%= render "shared/issue_enhance_table", issues: @issues, issues_with_active_runs: @issues_with_active_runs, issue_enhancement_rounds: @issue_enhancement_rounds %>
             <% else %>
               <p class="mt-1 text-sm text-gray-500">No actionable open issues found. Sync issues first.</p>
             <% end %>

--- a/app/views/shared/_issue_enhance_table.html.erb
+++ b/app/views/shared/_issue_enhance_table.html.erb
@@ -1,0 +1,43 @@
+<%# Multi-select table for enhance_issue goal %>
+<div data-goal-toggle-target="issueTable" hidden>
+  <p class="block text-sm font-medium text-gray-700 mb-2">Select issues to enhance:</p>
+  <div class="overflow-x-auto rounded-md border border-gray-200">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="w-10 px-3 py-2"></th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Issue</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Status</th>
+          <th scope="col" class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500">Enhancement Rounds</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200 bg-white">
+        <% issues.each do |issue| %>
+          <% has_active_run = issues_with_active_runs.include?(issue.id) %>
+          <tr class="<%= 'opacity-50' if has_active_run %>">
+            <td class="px-3 py-2 text-center">
+              <%= tag.input type: "checkbox",
+                           name: "issue_ids[]",
+                           value: issue.id,
+                           disabled: has_active_run || nil,
+                           data: has_active_run ? { permanently_disabled: "true" } : {},
+                           class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 disabled:cursor-not-allowed" %>
+            </td>
+            <td class="px-3 py-2 text-sm text-gray-900">
+              #<%= issue.github_number %> - <%= truncate(issue.title, length: 50) %>
+              <% if has_active_run %>
+                <span class="ml-1 inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">In Progress</span>
+              <% end %>
+            </td>
+            <td class="px-3 py-2 text-sm text-gray-500">
+              <%= issue.paid_state.humanize %>
+            </td>
+            <td class="px-3 py-2 text-right text-sm text-gray-500">
+              <%= issue_enhancement_rounds[issue.id].to_i > 0 ? issue_enhancement_rounds[issue.id] : "—" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Replace the single-select issue dropdown on the trigger run form with a multi-select table for the `enhance_issue` goal type, giving users visibility into issue status and enhancement history before queuing runs — consistent with the existing PR code review table pattern (#957).

## Changes

### Model
- **`Issue#enhancement_rounds_count`** — new method counting completed `enhance_issue` agent runs per issue, mirroring `review_rounds_count` for PRs

### Views
- **`shared/_issue_enhance_table.html.erb`** (new) — multi-select table partial with columns for checkbox, issue number/title, `paid_state` status, and enhancement rounds; issues with active runs are grayed out with disabled checkboxes and an "In Progress" badge using `data-permanently-disabled`
- **`projects/agent_runs/new.html.erb`** — issue section now conditionally renders the dropdown (for `create_pr`) or the multi-select table (for `enhance_issue`), with dynamic heading toggling via `data-goal-toggle-target` attributes

### JavaScript
- **`goal_toggle_controller.js`** — added `issueHeading`, `issueDropdown`, and `issueTable` targets; toggles between dropdown and table based on goal type; checkbox enable/disable logic respects `data-permanently-disabled` to keep in-progress issues unselectable

### Controller
- **`agent_runs_controller#new`** — computes `@issues_with_active_runs` and `@issue_enhancement_rounds` for the table partial
- **`agent_runs_controller#create`** — accepts `issue_ids[]` array for `enhance_issue` goal; new `create_enhance_issue_runs_and_redirect` method (mirrors `create_review_runs_and_redirect`) creates one agent run per selected issue with server-side filtering of active runs, priority label support, and budget checks

## Design Decisions

- **Parallel structure with PR review table**: the issue table partial, controller logic, and Stimulus targets follow the same patterns established by the PR code review multi-select table, keeping both goal types consistent and reducing cognitive overhead for reviewers and maintainers
- **`data-permanently-disabled` attribute**: prevents the Stimulus controller from re-enabling checkboxes for issues with active runs during goal toggling, ensuring the grayed-out state is authoritative regardless of client-side interactions
- **Server-side active-run filtering**: even though the UI disables in-progress issues, the controller also filters them out during creation as a defense-in-depth measure against crafted form submissions

## Screenshots

> **Author**: please attach before/after screenshots of the trigger run form showing the issue dropdown (before) and the multi-select table (after), including at least one grayed-out in-progress issue.

---

Closes #1165