### PR TITLE
fix(knowledge): increase collector container memory and tmpfs to fix routes OOM

### DIFF
--- a/app/services/knowledge/containerized_runner.rb
+++ b/app/services/knowledge/containerized_runner.rb
@@ -32,13 +32,18 @@ module Knowledge
     class CloneError < Error; end
     class TimeoutError < ContainerError; end
 
-    # Lightweight resource limits — collectors don't need 4GB of memory.
+    # Matches the agent container memory budget (Containers::Provision
+    # defaults to 4GB). The routes collector runs `bundle install` and
+    # boots the target Rails app via `bin/rails routes`, which deterministically
+    # exceeded the previous 512MB cap and was killed by the cgroup OOM
+    # killer (exit 137). Other collectors use far less memory but share
+    # this container, so we size for the heaviest workload.
     CONTAINER_DEFAULTS = {
       image: "paid-agent:latest",
-      memory_bytes: 512 * 1024 * 1024,  # 512MB
-      cpu_quota: 100_000,                # 1 CPU
+      memory_bytes: 4 * 1024 * 1024 * 1024,  # 4GB
+      cpu_quota: 100_000,                     # 1 CPU
       pids_limit: 200,
-      timeout_seconds: 300,              # 5 minutes
+      timeout_seconds: 300,                   # 5 minutes
       workspace_mount: "/workspace",
       network_mode: "bridge"
     }.freeze
@@ -315,8 +320,15 @@ module Knowledge
         # file" error (see e.g. bigdecimal-4.1.1 extconf.rb). Docker's
         # default tmpfs flags include noexec, so it must be overridden.
         # /home/agent/.cache only stores cache data and stays noexec.
+        #
+        # /tmp size must fit the target repo's full gem set because the
+        # routes collector sets BUNDLE_PATH=/tmp/bundle and unpacks every
+        # gem there. Rails 8 apps commonly ship 300–600MB of gems, so the
+        # previous 256MB limit produced ENOSPC during `bundle install`.
+        # 2GB gives headroom for large gem sets and transient build files;
+        # tmpfs is charged against the container memory cgroup (now 4GB).
         "Tmpfs" => {
-          "/tmp" => "exec,size=#{256 * 1024 * 1024},mode=1777",
+          "/tmp" => "exec,size=#{2 * 1024 * 1024 * 1024},mode=1777",
           "/home/agent/.cache" => "size=#{128 * 1024 * 1024},mode=0755"
         },
         "Binds" => [

--- a/spec/services/knowledge/containerized_runner_spec.rb
+++ b/spec/services/knowledge/containerized_runner_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
   end
 
   describe "CONTAINER_DEFAULTS" do
-    it "uses 512MB memory limit" do
-      expect(described_class::CONTAINER_DEFAULTS[:memory_bytes]).to eq(512 * 1024 * 1024)
+    it "uses 4GB memory limit" do
+      expect(described_class::CONTAINER_DEFAULTS[:memory_bytes]).to eq(4 * 1024 * 1024 * 1024)
     end
 
     it "uses 1 CPU" do
@@ -126,7 +126,7 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
           "Image" => "paid-agent:latest",
           "HostConfig" => hash_including(
             "NetworkMode" => "bridge",
-            "Memory" => 512 * 1024 * 1024,
+            "Memory" => 4 * 1024 * 1024 * 1024,
             "Binds" => [ a_string_matching(%r{\Apaid-collector-42-[a-f0-9]{8}:/workspace:rw\z}) ]
           )
         )
@@ -324,6 +324,21 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
 
       tmp_options = config.dig("HostConfig", "Tmpfs", "/tmp")
       expect(tmp_options.split(",")).to include("exec")
+    end
+
+    # Regression: BUNDLE_PATH=/tmp/bundle means the routes collector unpacks
+    # the target repo's full gem set into /tmp. Rails 8 apps commonly ship
+    # 300–600MB of gems; an undersized /tmp surfaces as ENOSPC during
+    # bundle install and leaves routes collection broken even after the
+    # OOM fix. 2GB fits large gem sets with room for transient build files.
+    it "sizes /tmp tmpfs large enough for a target Rails app's gem set" do
+      config = nil
+      allow(Docker::Container).to receive(:create) { |cfg| config = cfg; mock_container }
+      described_class.new(project: project, commit_sha: commit_sha).run
+
+      tmp_options = config.dig("HostConfig", "Tmpfs", "/tmp").split(",")
+      size_option = tmp_options.find { |opt| opt.start_with?("size=") }
+      expect(size_option).to eq("size=#{2 * 1024 * 1024 * 1024}")
     end
   end
 


### PR DESCRIPTION
## Summary
- Bumps collector container memory from 512MB to 4GB (matching agent containers) to fix deterministic OOM kills (exit 137) when the routes collector boots a Rails application via `bin/rails routes`
- Bumps `/tmp` tmpfs from 256MB to 2GB so `bundle install` can unpack the target repo's full gem set into `BUNDLE_PATH=/tmp/bundle` without ENOSPC
- Adds regression spec pinning `/tmp` size to prevent silent shrinkage

## Test plan
- [x] `bin/rspec spec/services/knowledge/containerized_runner_spec.rb` — 44 examples, 0 failures
- [ ] Deploy to staging and trigger knowledge collection on a Rails 8 project that previously failed with exit 137
- [ ] Verify routes appear in the knowledge base after collection completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)