### PR TITLE
feat(auto-pick): configurable PR WIP limit

### DIFF
--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -35,6 +35,7 @@ class UserSettingsController < ApplicationController
       :default_agent_provider,
       :container_memory_gb,
       :max_concurrent_runs,
+      :max_auto_pick_open_prs,
       :container_timeout_seconds,
       :default_branch,
       :default_project_active,

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -41,6 +41,8 @@ class UserSetting < ApplicationRecord
     numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 }
   validates :max_parallel_agents_per_project,
     numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 20 }
+  validates :max_auto_pick_open_prs,
+    numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
 
   # Token & rate limits
   validates :max_tokens_per_run,

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -232,7 +232,7 @@ module Issues
     end
 
     # Returns true if the number of PRs needing attention meets or
-    # exceeds the user's configured limit. When the limit is 0 (default),
+    # exceeds the user's configured limit. When the limit is 0,
     # there is no cap and auto-pick is never blocked by open PRs.
     def prs_needing_attention_exceed_limit?
       limit = max_auto_pick_open_prs

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -153,7 +153,7 @@ module Issues
 
     def call
       return nil unless @project.auto_pick_enabled?
-      return nil if project_has_prs_needing_attention?
+      return nil if prs_needing_attention_exceed_limit?
 
       issue = find_next_eligible_issue
       return nil unless issue
@@ -208,15 +208,14 @@ module Issues
 
     private
 
-    # Returns true if the project has open pull requests that still need
-    # Paid's attention. Performs up to two lightweight EXISTS-style queries
-    # (leveraging the GIN labels index) instead of loading PR records into Ruby:
+    # Returns the count of open PRs that still need Paid's attention.
+    # A PR "needs attention" if it is failed, or in_progress but not
+    # yet handed off (missing paid-generated/paid-ready labels, or
+    # still in draft/restarted phase).
     #
-    # Blocking rules:
-    # - failed PRs always block (need investigation)
-    # - in_progress PRs block unless fully handed off (paid-generated +
-    #   paid-ready labels and out of draft/restarted phase)
-    def project_has_prs_needing_attention?
+    # Uses a single COUNT query. The handed_off subquery only matches
+    # in_progress rows, so failed PRs are never excluded by it.
+    def prs_needing_attention_count
       base = Issue.where(
         project: @project,
         is_pull_request: true,
@@ -224,19 +223,29 @@ module Issues
         paid_state: %w[in_progress failed]
       )
 
-      # Failed PRs always block — check first for a fast short-circuit.
-      return true if base.where(paid_state: "failed").exists?
-
-      # In-progress PRs block unless handed off: both labels present and
-      # not in a draft/restarted review phase.
       handed_off = base
         .where(paid_state: "in_progress")
         .where("labels @> ?::jsonb", [ @project.generated_label_name, PAID_READY_LABEL ].to_json)
         .where.not(pr_review_phase: %w[draft restarted])
 
-      base.where(paid_state: "in_progress")
-        .where.not(id: handed_off)
-        .exists?
+      base.where.not(id: handed_off).count
+    end
+
+    # Returns true if the number of PRs needing attention meets or
+    # exceeds the user's configured limit. When the limit is 0 (default),
+    # there is no cap and auto-pick is never blocked by open PRs.
+    def prs_needing_attention_exceed_limit?
+      limit = max_auto_pick_open_prs
+      return false if limit.zero?
+
+      prs_needing_attention_count >= limit
+    end
+
+    def max_auto_pick_open_prs
+      owner = @project.effective_owner
+      return 0 unless owner
+
+      owner.settings.max_auto_pick_open_prs
     end
 
     def eligible_issue_scope

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -243,7 +243,7 @@ module Issues
 
     def max_auto_pick_open_prs
       owner = @project.effective_owner
-      return 0 unless owner
+      return 1 unless owner
 
       owner.settings.max_auto_pick_open_prs
     end

--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -167,6 +167,14 @@
           </div>
 
           <div>
+            <%= form.label :max_auto_pick_open_prs, "Max Auto-Pick Open PRs", class: "block text-sm font-medium leading-6 text-gray-900" %>
+            <div class="mt-2">
+              <%= form.number_field :max_auto_pick_open_prs, min: 0, max: 100, step: 1, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+            </div>
+            <p class="mt-1 text-xs text-gray-500">Auto-pick pauses when this many open PRs still need work (failed or not yet handed off). Increase to allow more parallel PRs. Set to 0 for no limit. Default is 1 (original behavior).</p>
+          </div>
+
+          <div>
             <%= form.label :container_timeout_seconds, "Container Timeout (seconds)", class: "block text-sm font-medium leading-6 text-gray-900" %>
             <div class="mt-2">
               <%= form.number_field :container_timeout_seconds, min: 60, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>

--- a/db/migrate/20260416020545_add_max_auto_pick_open_prs_to_user_settings.rb
+++ b/db/migrate/20260416020545_add_max_auto_pick_open_prs_to_user_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMaxAutoPickOpenPrsToUserSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_settings, :max_auto_pick_open_prs, :integer, default: 1, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_181029) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_020545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -204,8 +204,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_181029) do
     t.index ["issue_id"], name: "index_agent_runs_on_issue_id"
     t.index ["parent_workflow_id"], name: "index_agent_runs_on_parent_workflow_id"
     t.index ["project_id", "goal"], name: "index_agent_runs_on_project_id_and_goal"
-    t.index ["project_id", "issue_id", "goal"], name: "idx_agent_runs_unique_active_issue", unique: true, where: "((issue_id IS NOT NULL) AND ((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('pending'::character varying)::text, ('running'::character varying)::text, ('paused'::character varying)::text])))"
-    t.index ["project_id", "source_pull_request_number", "goal"], name: "idx_agent_runs_unique_active_pr", unique: true, where: "((source_pull_request_number IS NOT NULL) AND ((status)::text = ANY (ARRAY[('queued'::character varying)::text, ('pending'::character varying)::text, ('running'::character varying)::text, ('paused'::character varying)::text])))"
+    t.index ["project_id", "issue_id", "goal"], name: "idx_agent_runs_unique_active_issue", unique: true, where: "((issue_id IS NOT NULL) AND ((status)::text = ANY ((ARRAY['queued'::character varying, 'pending'::character varying, 'running'::character varying, 'paused'::character varying])::text[])))"
+    t.index ["project_id", "source_pull_request_number", "goal"], name: "idx_agent_runs_unique_active_pr", unique: true, where: "((source_pull_request_number IS NOT NULL) AND ((status)::text = ANY ((ARRAY['queued'::character varying, 'pending'::character varying, 'running'::character varying, 'paused'::character varying])::text[])))"
     t.index ["project_id", "status", "completed_at"], name: "index_agent_runs_on_project_status_completed_at"
     t.index ["project_id", "status"], name: "index_agent_runs_on_project_id_and_status"
     t.index ["project_id"], name: "index_agent_runs_on_project_id"
@@ -638,7 +638,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_181029) do
     t.index ["provider", "active"], name: "index_llm_models_on_provider_and_active"
     t.index ["provider"], name: "index_llm_models_on_provider"
     t.index ["tier"], name: "index_llm_models_on_tier"
-    t.check_constraint "tier IS NULL OR (tier::text = ANY (ARRAY['low'::character varying::text, 'mid'::character varying::text, 'high'::character varying::text]))", name: "llm_models_tier_check"
+    t.check_constraint "tier IS NULL OR (tier::text = ANY (ARRAY['low'::character varying, 'mid'::character varying, 'high'::character varying]::text[]))", name: "llm_models_tier_check"
   end
 
   create_table "mcp_server_definitions", force: :cascade do |t|
@@ -695,6 +695,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_181029) do
     t.bigint "user_id"
     t.index ["account_id", "nav_section", "read_at"], name: "index_notifications_on_badge"
     t.index ["account_id", "read_at", "dismissed_at"], name: "index_notifications_on_unread"
+    t.index ["account_id", "source", "subject_type", "subject_id"], name: "index_notifications_on_dedup_account_wide", unique: true, where: "(user_id IS NULL)"
     t.index ["account_id", "user_id", "source", "subject_type", "subject_id"], name: "index_notifications_on_dedup", unique: true
     t.index ["subject_type", "subject_id"], name: "index_notifications_on_subject"
     t.index ["user_id"], name: "index_notifications_on_user_id"
@@ -1053,6 +1054,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_181029) do
     t.string "kb_chat_provider", default: "claude", null: false
     t.jsonb "kb_embedding_fallback_providers", default: [], null: false
     t.string "kb_embedding_provider", default: "openai", null: false
+    t.integer "max_auto_pick_open_prs", default: 1, null: false
     t.integer "max_comment_length", default: 2000, null: false
     t.integer "max_concurrent_runs", default: 2, null: false
     t.integer "max_issues_per_page", default: 50, null: false
@@ -1174,7 +1176,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_181029) do
   add_foreign_key "model_selections", "agent_runs", on_delete: :cascade
   add_foreign_key "model_selections", "llm_models"
   add_foreign_key "notifications", "accounts"
-  add_foreign_key "notifications", "users"
+  add_foreign_key "notifications", "users", on_delete: :nullify
   add_foreign_key "pre_commit_requirements", "accounts", on_delete: :cascade
   add_foreign_key "pre_commit_requirements", "projects", on_delete: :cascade
   add_foreign_key "pre_commit_requirements", "users", on_delete: :cascade

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -752,6 +752,16 @@ RSpec.describe Issues::AutoPick do
         expect(result).to be_nil
       end
 
+      it "defaults to limit of 1 when project has no effective owner" do
+        allow(project).to receive(:effective_owner).and_return(nil)
+        create(:issue, :pull_request, :in_progress, project: project)
+        create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_nil
+      end
+
       it "does not count handed-off PRs toward the limit" do
         project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
         create(:issue, :pull_request, :in_progress,

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -583,6 +583,10 @@ RSpec.describe Issues::AutoPick do
     end
 
     context "when project has PRs needing attention" do
+      before do
+        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
+      end
+
       it "returns nil when project has an open PR in in_progress state" do
         create(:issue, :pull_request, :in_progress, project: project)
         create(:issue, project: project)
@@ -694,6 +698,66 @@ RSpec.describe Issues::AutoPick do
 
       it "picks an issue when PRs are in new state" do
         create(:issue, :pull_request, project: project, paid_state: "new")
+        issue = create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_a(AgentRun)
+        expect(result.issue).to eq(issue)
+      end
+    end
+
+    context "with PR WIP limit" do
+      it "does not block auto-pick when limit is 0 (no limit)" do
+        project.effective_owner.settings.update!(max_auto_pick_open_prs: 0)
+        create(:issue, :pull_request, :in_progress, project: project)
+        create(:issue, :pull_request, :failed, project: project)
+        issue = create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_a(AgentRun)
+        expect(result.issue).to eq(issue)
+      end
+
+      it "blocks auto-pick with default limit of 1 when any PR needs attention" do
+        create(:issue, :pull_request, :in_progress, project: project)
+        create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_nil
+      end
+
+      it "allows auto-pick when PRs needing attention are below the limit" do
+        project.effective_owner.settings.update!(max_auto_pick_open_prs: 3)
+        create(:issue, :pull_request, :in_progress, project: project)
+        create(:issue, :pull_request, :failed, project: project)
+        issue = create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_a(AgentRun)
+        expect(result.issue).to eq(issue)
+      end
+
+      it "blocks auto-pick when PRs needing attention reach the limit" do
+        project.effective_owner.settings.update!(max_auto_pick_open_prs: 2)
+        create(:issue, :pull_request, :in_progress, project: project)
+        create(:issue, :pull_request, :failed, project: project)
+        create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_nil
+      end
+
+      it "does not count handed-off PRs toward the limit" do
+        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
+        create(:issue, :pull_request, :in_progress,
+          project: project,
+          labels: [ "paid-generated", "paid-ready" ],
+          pr_review_phase: "ready")
         issue = create(:issue, project: project)
 
         result = described_class.new(project).call


### PR DESCRIPTION
## Summary

- Replaces the binary "any PR needing attention blocks all auto-pick" gate with a configurable count-based WIP limit (`max_auto_pick_open_prs` user setting)
- Default of 1 preserves existing behavior; higher values allow more parallel PRs before pausing; 0 disables the gate entirely
- Handed-off PRs (paid-generated + paid-ready, out of draft/restarted) are not counted toward the limit

## Motivation

With max concurrency of 5 and only 1 active agent run, the old binary PR gate left most capacity idle. A single in-progress PR blocked all further auto-picking regardless of available slots.

## Changes

| File | Change |
|------|--------|
| `db/migrate/..._add_max_auto_pick_open_prs_to_user_settings.rb` | Adds `max_auto_pick_open_prs` integer column (default: 1) |
| `app/models/user_setting.rb` | Validation: integer 0–100 |
| `app/controllers/user_settings_controller.rb` | Permits new param |
| `app/views/user_settings/edit.html.erb` | Number field in Container Resources section |
| `app/services/issues/auto_pick.rb` | Replaces binary `project_has_prs_needing_attention?` with count-based `prs_needing_attention_exceed_limit?` using a single COUNT query |
| `spec/services/issues/auto_pick_spec.rb` | Updates existing PR gate specs to use explicit limit; adds 5 new WIP limit specs |

## Test plan

- [ ] Verify default=1 preserves old behavior: one in-progress PR blocks auto-pick
- [ ] Set limit to 3, create 2 PRs needing attention → auto-pick proceeds
- [ ] Set limit to 0 → auto-pick never blocked by PRs
- [ ] Handed-off PRs (paid-generated + paid-ready, phase=ready) are not counted
- [ ] Settings UI renders field with correct bounds and help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)