### PR TITLE
fix(agent-runs): skip git post-processing for no-repo goals

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -501,6 +501,15 @@ class AgentRun < ApplicationRecord
     goal == "enhance_issue"
   end
 
+  # Whether this run has a cloned git repository in its container.
+  # create_issue and enhance_issue goals skip cloning unless they target
+  # an existing PR branch (source_pull_request_number present).
+  def repo_cloned?
+    return true unless create_issue_goal? || enhance_issue_goal?
+
+    source_pull_request_number.present?
+  end
+
   def manual?
     trigger_type == "manual"
   end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -217,24 +217,30 @@ module Activities
             # different models) remain distinguishable in UI and retry logic.
             agent_run.update!(final_provider: attempt_label)
 
+            # Skip git post-processing for goals that don't clone a repo.
+            # These runs only interact via the GitHub API proxy — no git repo exists.
+
             # Evaluate pre-commit requirements against the working directory
             # before committing, so blocking failures prevent commits.
-            pre_commit_result = evaluate_pre_commit_requirements(agent_run)
-            if pre_commit_result[:blocking]
-              agent_run.log!("system", "Blocked by failing pre-commit requirements",
-                metadata: { pre_commit_results: pre_commit_result[:results] })
-              return {
-                agent_run_id: agent_run_id,
-                success: false,
-                has_changes: check_for_changes(agent_run, pre_agent_sha),
-                output_present: provider_result.fetch(:output_present),
-                final_provider: attempt_label,
-                error: "pre_commit_requirements_failed"
-              }
+            if agent_run.repo_cloned?
+              pre_commit_result = evaluate_pre_commit_requirements(agent_run)
+              if pre_commit_result[:blocking]
+                agent_run.log!("system", "Blocked by failing pre-commit requirements",
+                  metadata: { pre_commit_results: pre_commit_result[:results] })
+                return {
+                  agent_run_id: agent_run_id,
+                  success: false,
+                  has_changes: check_for_changes(agent_run, pre_agent_sha),
+                  output_present: provider_result.fetch(:output_present),
+                  final_provider: attempt_label,
+                  error: "pre_commit_requirements_failed"
+                }
+              end
+
+              commit_uncommitted_changes(agent_run)
             end
 
-            commit_uncommitted_changes(agent_run)
-            has_changes = check_for_changes(agent_run, pre_agent_sha)
+            has_changes = agent_run.repo_cloned? ? check_for_changes(agent_run, pre_agent_sha) : false
 
             if !has_changes && !provider_result.fetch(:output_present)
               agent_run.log!("system", "Provider completed with no output and no changes")


### PR DESCRIPTION
## Summary
- `enhance_issue` and `create_issue` goals (without a source PR) skip cloning a repo into the container, but `RunAgentActivity` unconditionally ran `commit_uncommitted_changes`, `evaluate_pre_commit_requirements`, and `check_for_changes` after agent success — all of which call `git status` and fail with `fatal: not a git repository`
- Extracted `AgentRun#repo_cloned?` to encapsulate the skip-clone business rule and guard the git post-processing block behind it
- Confirmed 2 existing `create_issue` runs and 1 `enhance_issue` run in the DB hit this same error

## Test plan
- [x] `bin/rspec spec/temporal/activities/run_agent_activity_spec.rb` — 112 examples, 0 failures
- [x] `bin/rspec spec/models/agent_run_spec.rb` — 260 examples, 0 failures
- [x] `bin/rubocop` — no offenses
- [ ] Manually trigger an `enhance_issue` agent run and verify it completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)