### PR TITLE
Fix #1146: fix(pr-description): disable tool access for Llm::GeneratePrDescription calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "docker-api"
 gem "qdrant-ruby"
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-gem "agent-harness", "~> 0.7.1"
+gem "agent-harness", "~> 0.7.2"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 gem "ruby-maat"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness (~> 0.7.1)
+  agent-harness (~> 0.7.2)
   bootsnap
   brakeman
   bundler-audit

--- a/app/services/agent_runs/diagnose_error.rb
+++ b/app/services/agent_runs/diagnose_error.rb
@@ -71,7 +71,8 @@ module AgentRuns
         diagnosis_prompt,
         provider: :claude,
         model: DEFAULT_MODEL,
-        timeout: TIMEOUT
+        timeout: TIMEOUT,
+        tools: :none
       )
       return nil unless response.success?
 

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -190,7 +190,8 @@ module Knowledge
         options = {
           provider: ProviderSupport.harness_provider_key_for(provider).to_sym,
           timeout: TIMEOUT,
-          dangerous_mode: false
+          dangerous_mode: false,
+          tools: :none
         }
         options[:model] = DEFAULT_MODEL if provider == DEFAULT_PROVIDER
         options

--- a/app/services/llm/generate_issue_title.rb
+++ b/app/services/llm/generate_issue_title.rb
@@ -43,7 +43,13 @@ module Llm
     private
 
     def request_title
-      response = AgentHarness.send_message(prompt, provider: :claude, model: DEFAULT_MODEL, timeout: TIMEOUT)
+      response = AgentHarness.send_message(
+        prompt,
+        provider: :claude,
+        model: DEFAULT_MODEL,
+        timeout: TIMEOUT,
+        tools: :none
+      )
       return nil unless response.success?
 
       clean_title(response.output)

--- a/app/services/llm/generate_pr_description.rb
+++ b/app/services/llm/generate_pr_description.rb
@@ -81,7 +81,8 @@ module Llm
         prompt,
         provider: :claude,
         model: DEFAULT_MODEL,
-        timeout: TIMEOUT
+        timeout: TIMEOUT,
+        tools: :none
       )
       return nil unless response.success?
 

--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -59,7 +59,8 @@ module Models
         build_prompt(candidates),
         provider: :claude,
         model: MODEL,
-        timeout: TIMEOUT
+        timeout: TIMEOUT,
+        tools: :none
       )
       return nil unless response.success?
 

--- a/app/services/prompt_evolution/mutate.rb
+++ b/app/services/prompt_evolution/mutate.rb
@@ -71,7 +71,8 @@ module PromptEvolution
         build_prompt,
         provider: :claude,
         model: DEFAULT_MODEL,
-        timeout: TIMEOUT
+        timeout: TIMEOUT,
+        tools: :none
       )
       unless response.success?
         Rails.logger.warn(

--- a/app/services/style_guides/compress.rb
+++ b/app/services/style_guides/compress.rb
@@ -78,7 +78,8 @@ module StyleGuides
         provider: :claude,
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       )
 
       validate_response!(response)

--- a/app/services/style_guides/extract.rb
+++ b/app/services/style_guides/extract.rb
@@ -108,7 +108,8 @@ module StyleGuides
         provider: :claude,
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       )
     end
 

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -37,7 +37,13 @@ module Activities
 
     def decompose(issue, context)
       prompt = build_prompt(issue, context)
-      response = AgentHarness.send_message(prompt, provider: :claude, model: DEFAULT_MODEL, timeout: TIMEOUT)
+      response = AgentHarness.send_message(
+        prompt,
+        provider: :claude,
+        model: DEFAULT_MODEL,
+        timeout: TIMEOUT,
+        tools: :none
+      )
 
       unless response.success?
         raise Temporalio::Error::ApplicationError.new(

--- a/spec/services/agent_runs/diagnose_error_spec.rb
+++ b/spec/services/agent_runs/diagnose_error_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe AgentRuns::DiagnoseError do
         a_string_including("diagnosing a failed agent run"),
         provider: :claude,
         model: "claude-sonnet-4-6",
-        timeout: 60
+        timeout: 60,
+        tools: :none
       )
     end
 
@@ -127,7 +128,8 @@ RSpec.describe AgentRuns::DiagnoseError do
           a_string_including("API_KEY=[REDACTED]").and(satisfy { |s| !s.include?("sk_live_abcdef1234567890") }),
           provider: :claude,
           model: "claude-sonnet-4-6",
-          timeout: 60
+          timeout: 60,
+          tools: :none
         )
       end
 
@@ -153,7 +155,8 @@ RSpec.describe AgentRuns::DiagnoseError do
           a_string_including("API_KEY=[REDACTED]").and(satisfy { |s| !s.include?("sk_live_secret123") }),
           provider: :claude,
           model: "claude-sonnet-4-6",
-          timeout: 60
+          timeout: 60,
+          tools: :none
         )
       end
 
@@ -181,7 +184,8 @@ RSpec.describe AgentRuns::DiagnoseError do
           a_string_including("TOKEN=[REDACTED]").and(satisfy { |s| !s.include?("ghp_abc123secret") }),
           provider: :claude,
           model: "claude-sonnet-4-6",
-          timeout: 60
+          timeout: 60,
+          tools: :none
         )
       end
     end
@@ -222,7 +226,8 @@ RSpec.describe AgentRuns::DiagnoseError do
           satisfy { |s| !s.include?("ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789") },
           provider: :claude,
           model: "claude-sonnet-4-6",
-          timeout: 60
+          timeout: 60,
+          tools: :none
         )
       end
 

--- a/spec/services/knowledge/decisions/draft_spec.rb
+++ b/spec/services/knowledge/decisions/draft_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe Knowledge::Decisions::Draft do
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
         timeout: described_class::TIMEOUT,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       )
     end
 
@@ -117,7 +118,8 @@ RSpec.describe Knowledge::Decisions::Draft do
         a_string_matching(/Decision Record/),
         provider: :cursor,
         timeout: described_class::TIMEOUT,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       )
     end
 
@@ -133,14 +135,16 @@ RSpec.describe Knowledge::Decisions::Draft do
         a_string_matching(/Decision Record/),
         provider: :cursor,
         timeout: described_class::TIMEOUT,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       ).ordered
       expect(AgentHarness).to have_received(:send_message).with(
         a_string_matching(/Decision Record/),
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
         timeout: described_class::TIMEOUT,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       ).ordered
     end
 
@@ -157,7 +161,8 @@ RSpec.describe Knowledge::Decisions::Draft do
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
         timeout: described_class::TIMEOUT,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       )
       expect(AgentHarness).not_to have_received(:send_message).with(
         anything,

--- a/spec/services/llm/generate_issue_title_spec.rb
+++ b/spec/services/llm/generate_issue_title_spec.rb
@@ -17,8 +17,19 @@ RSpec.describe Llm::GenerateIssueTitle do
         a_string_matching(/Generate a concise GitHub issue title/),
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
-        timeout: described_class::TIMEOUT
+        timeout: described_class::TIMEOUT,
+        tools: :none
       )
+    end
+
+    it "passes tools: :none to disable CLI tool access during text-only generation" do
+      response = instance_double(AgentHarness::Response, success?: true, output: "JWT authentication system review")
+      allow(AgentHarness).to receive(:send_message).and_return(response)
+
+      described_class.call(summary: summary)
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(tools: :none))
     end
 
     it "strips double quotes from the generated title" do

--- a/spec/services/llm/generate_pr_description_spec.rb
+++ b/spec/services/llm/generate_pr_description_spec.rb
@@ -35,8 +35,23 @@ RSpec.describe Llm::GeneratePrDescription do
         a_string_including("Lead with", "Agent Output", agent_summary),
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
-        timeout: described_class::TIMEOUT
+        timeout: described_class::TIMEOUT,
+        tools: :none
       )
+    end
+
+    it "passes tools: :none to disable CLI tool access during text-only generation" do
+      response = instance_double(AgentHarness::Response, success?: true, output: generated_description)
+      allow(AgentHarness).to receive(:send_message).and_return(response)
+
+      described_class.call(
+        agent_summary: agent_summary,
+        issue_title: issue_title,
+        issue_body: issue_body
+      )
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(tools: :none))
     end
 
     it "includes issue context in the prompt" do

--- a/spec/services/models/meta_agent_selector_spec.rb
+++ b/spec/services/models/meta_agent_selector_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Models::MetaAgentSelector do
         a_string_matching(/Select the best LLM model/),
         provider: :claude,
         model: "claude-haiku-4-5-20251001",
-        timeout: 15
+        timeout: 15,
+        tools: :none
       )
     end
 

--- a/spec/services/prompt_evolution/mutate_spec.rb
+++ b/spec/services/prompt_evolution/mutate_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe PromptEvolution::Mutate do
         a_string_including(current_version.template),
         provider: :claude,
         model: "claude-sonnet-4-6",
-        timeout: 60
+        timeout: 60,
+        tools: :none
       )
     end
 

--- a/spec/services/style_guides/compress_spec.rb
+++ b/spec/services/style_guides/compress_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe StyleGuides::Compress do
         provider: :claude,
         model: "claude-sonnet-4-6",
         timeout: 120,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       )
     end
 

--- a/spec/services/style_guides/extract_spec.rb
+++ b/spec/services/style_guides/extract_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe StyleGuides::Extract do
         provider: :claude,
         model: "claude-sonnet-4-6",
         timeout: 120,
-        dangerous_mode: false
+        dangerous_mode: false,
+        tools: :none
       )
     end
 

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -256,7 +256,8 @@ RSpec.describe Activities::CreatePullRequestActivity do
           a_string_including(issue.title).and(including(issue.body)),
           provider: :claude,
           model: Llm::GeneratePrDescription::DEFAULT_MODEL,
-          timeout: Llm::GeneratePrDescription::TIMEOUT
+          timeout: Llm::GeneratePrDescription::TIMEOUT,
+          tools: :none
         )
       end
 

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         a_string_including("Add OAuth"),
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
-        timeout: described_class::TIMEOUT
+        timeout: described_class::TIMEOUT,
+        tools: :none
       )
     end
 
@@ -81,7 +82,8 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         a_string_including("Auth docs"),
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
-        timeout: described_class::TIMEOUT
+        timeout: described_class::TIMEOUT,
+        tools: :none
       )
     end
 


### PR DESCRIPTION
## Summary

Prevents `Llm::GeneratePrDescription` and other text-only LLM services from contaminating their output with host-repo state by disabling tool access on the underlying `claude` CLI. This fixes #1140, where a PR body described an unrelated branch's diff because Claude Code ran `git` tools against the Rails host's working directory instead of answering the prompt.

## Changes

### Dependencies
- Bump `agent-harness` from `~> 0.7.1` to `~> 0.7.2` to pick up the upstream `tools:` option (viamin/agent-harness#113); 0.7.3 is installed.

### Services (text-only LLM calls)
Pass `tools: :none` to every `AgentHarness.send_message` call that only needs text generation:
- `app/services/llm/generate_pr_description.rb` — the #1140 root cause
- `app/services/llm/generate_issue_title.rb`
- `app/services/agent_runs/diagnose_error.rb`
- `app/services/knowledge/decisions/draft.rb`
- `app/services/models/meta_agent_selector.rb`
- `app/services/prompt_evolution/mutate.rb`
- `app/services/style_guides/compress.rb`
- `app/services/style_guides/extract.rb`
- `app/temporal/activities/decompose_feature_activity.rb`

### Intentionally unchanged
- `app/services/agent_runs/execute.rb` — this is the real agent run and must retain tool access (`dangerous_mode: true`).

### Tests
- New regression specs in `generate_pr_description_spec.rb` and `generate_issue_title_spec.rb` assert `tools: :none` is forwarded to the harness.
- Updated 9 existing specs to include the new kwarg in their matcher expectations.

## Design Decisions

- **Defense in depth, not a root-cause fix.** Disabling tools is a safeguard layered on top of the CLI invocation. The long-term fix is to stop shelling out to a CLI for text-only calls; that remains tracked as a separate follow-up.
- **Audited every `Llm::*`-adjacent service rather than patching only `GeneratePrDescription`.** Any service that summarizes, classifies, or drafts text has the same class of failure mode, so all text-only `send_message` sites were updated consistently.
- **Upstream-first.** The `tools:` option was added in `agent-harness` (viamin/agent-harness#113) rather than worked around in Paid, keeping provider-specific behavior out of the Rails app per `CLAUDE.md`.

## Operational Notes

- Requires `agent-harness >= 0.7.2` at install time. `bundle install` will pick up `0.7.3` on deploy; no migration or config changes.

---

Closes #1146