### PR TITLE
Fix #1115: Introduce shared automation abstractions

### DIFF
--- a/app/services/automation/action.rb
+++ b/app/services/automation/action.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Automation
+  # Automation commands/actions — the executable side of an automation
+  # decision.
+  #
+  # At this stage the action vocabulary is intentionally the same as the
+  # decision vocabulary: strategies emit Automation::Decision values and
+  # executors (jobs, Temporal activities) consume them as actions. This
+  # alias exists so callers that think in terms of "what to execute" have
+  # a name for that role, and so later phases can evolve action semantics
+  # independently without renaming every call site.
+  Action = Decision
+end

--- a/app/services/automation/context.rb
+++ b/app/services/automation/context.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Automation
+  # Shared input for automation strategies.
+  #
+  # A Context carries the project being automated, the subject record
+  # (issue or pull request), and a free-form metadata hash where upstream
+  # layers can attach signals or scan data collected from providers.
+  #
+  # Strategies (auto-pick, auto-continue, auto-review, auto-merge) all
+  # share this input shape so that future coordinators can evaluate them
+  # uniformly without knowing their internals.
+  class Context < Data.define(:project, :record, :metadata)
+    EMPTY_METADATA = {}.freeze
+
+    def self.build(record:, project: nil, metadata: nil)
+      project ||= record.respond_to?(:project) ? record.project : nil
+      raise ArgumentError, "Automation::Context requires a project" if project.nil?
+
+      new(
+        project: project,
+        record: record,
+        metadata: (metadata || EMPTY_METADATA).freeze
+      )
+    end
+
+    def metadata_fetch(key, default = nil)
+      metadata.fetch(key, default)
+    end
+
+    def with_metadata(extra)
+      self.class.build(
+        project: project,
+        record: record,
+        metadata: metadata.merge(extra || {})
+      )
+    end
+  end
+end

--- a/app/services/automation/strategy.rb
+++ b/app/services/automation/strategy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Automation
+  # Shared contract implemented by every automation strategy.
+  #
+  # A strategy is a pure policy object: it receives an Automation::Context
+  # and returns an Automation::Result describing the actions to take. It
+  # performs no I/O of its own — signal collection and side effects live
+  # in the layers above and below.
+  #
+  # Concrete strategies (auto-pick, auto-continue, auto-review, auto-merge)
+  # will be introduced in follow-on issues and plug into this interface
+  # without changing how orchestration invokes them.
+  module Strategy
+    # @param context [Automation::Context]
+    # @return [Automation::Result]
+    def evaluate(context)
+      raise NotImplementedError, "#{self.class} must implement #evaluate(context)"
+    end
+
+    # Convenience helper so strategies can return a noop result without
+    # reaching into the Result class directly.
+    def noop_result
+      Result.noop
+    end
+  end
+end

--- a/spec/services/automation/action_spec.rb
+++ b/spec/services/automation/action_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Action do
+  it "is the same vocabulary as Automation::Decision" do
+    expect(described_class).to be(Automation::Decision)
+  end
+
+  it "constructs via the shared factory methods" do
+    action = described_class.noop
+
+    expect(action).to be_a(Automation::Decision)
+    expect(action.to_h).to eq(type: "noop")
+  end
+end

--- a/spec/services/automation/context_spec.rb
+++ b/spec/services/automation/context_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Context do
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project) }
+
+  describe ".build" do
+    it "constructs a context with project, record, and empty metadata by default" do
+      context = described_class.build(record: issue)
+
+      expect(context.project).to eq(project)
+      expect(context.record).to eq(issue)
+      expect(context.metadata).to eq({})
+    end
+
+    it "accepts explicit metadata and freezes it" do
+      context = described_class.build(record: issue, metadata: { phase: "draft" })
+
+      expect(context.metadata).to eq(phase: "draft")
+      expect(context.metadata).to be_frozen
+    end
+
+    it "allows overriding the project explicitly" do
+      other_project = create(:project)
+      context = described_class.build(record: issue, project: other_project)
+
+      expect(context.project).to eq(other_project)
+    end
+
+    it "raises when no project can be resolved" do
+      record = Object.new
+
+      expect { described_class.build(record: record) }
+        .to raise_error(ArgumentError, /requires a project/)
+    end
+  end
+
+  describe "#metadata_fetch" do
+    it "returns the stored value when present" do
+      context = described_class.build(record: issue, metadata: { phase: "ready" })
+
+      expect(context.metadata_fetch(:phase)).to eq("ready")
+    end
+
+    it "returns the default when the key is missing" do
+      context = described_class.build(record: issue)
+
+      expect(context.metadata_fetch(:phase, "draft")).to eq("draft")
+    end
+  end
+
+  describe "#with_metadata" do
+    it "returns a new context with merged metadata without mutating the original" do
+      original = described_class.build(record: issue, metadata: { phase: "draft" })
+      extended = original.with_metadata(scan: { pr_number: 42 })
+
+      expect(extended.metadata).to eq(phase: "draft", scan: { pr_number: 42 })
+      expect(original.metadata).to eq(phase: "draft")
+    end
+  end
+end

--- a/spec/services/automation/strategy_spec.rb
+++ b/spec/services/automation/strategy_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Strategy do
+  let(:base_strategy) do
+    Class.new do
+      include Automation::Strategy
+    end
+  end
+
+  let(:concrete_strategy) do
+    Class.new do
+      include Automation::Strategy
+
+      def evaluate(_context)
+        Automation::Result.new(decisions: [ Automation::Decision.noop ])
+      end
+    end
+  end
+
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project) }
+  let(:context) { Automation::Context.build(record: issue) }
+
+  it "raises NotImplementedError when a strategy does not implement #evaluate" do
+    expect { base_strategy.new.evaluate(context) }
+      .to raise_error(NotImplementedError, /must implement #evaluate/)
+  end
+
+  it "lets strategies return a pre-built noop result" do
+    klass = Class.new do
+      include Automation::Strategy
+
+      def evaluate(_context)
+        noop_result
+      end
+    end
+
+    expect(klass.new.evaluate(context).to_h)
+      .to eq(decisions: [ { type: "noop" } ])
+  end
+
+  it "exposes the shared contract: Context in, Result out" do
+    result = concrete_strategy.new.evaluate(context)
+
+    expect(result).to be_a(Automation::Result)
+    expect(result.to_h).to eq(decisions: [ { type: "noop" } ])
+  end
+end


### PR DESCRIPTION
## Summary

Lay down a shared automation domain layer so upcoming auto-pick, auto-continue, auto-review, and auto-merge extractions have a common vocabulary to plug into without a big-bang rewrite. The abstractions are intentionally minimal and provider-neutral — just enough shape to enable follow-on work.

## Changes

### Services
- Add `Automation::Context` (`app/services/automation/context.rb`) — a `Data` class wrapping project, record, and metadata with `.build`, `#metadata_fetch`, and `#with_metadata` helpers for passing shared evaluation inputs.
- Add `Automation::Strategy` (`app/services/automation/strategy.rb`) — module defining the `evaluate(context) → Result` contract that concrete strategies will implement.
- Add `Automation::Action` (`app/services/automation/action.rb`) — alias over the existing `Automation::Decision` vocabulary so action/decision terminology stays consistent as new strategies land.

### Tests
- Add 12 examples across the three new files covering construction, metadata access, and contract behavior.

## Design Decisions

- **Minimal surface area.** Only the types strictly needed by the four upcoming extractions are introduced. Anything provider-specific is deliberately deferred to follow-on issues.
- **Reuse over rename.** `Automation::Action` aliases the existing `Automation::Decision` rather than replacing it, preserving current call sites while letting new code use the clearer name.
- **Untouched existing code.** `Decision`, `Result`, `IssueEvaluator`, and `PullRequestEvaluator` are left alone — this PR is additive only, so there is no behavioral risk to existing automations.
- **Depends on #1114.** This builds on that foundation; merge order matters.

---

Closes #1115