### PR TITLE
Fix #1116: Define provider capability interfaces for automation

### DIFF
--- a/app/services/automation/providers/data/check_run.rb
+++ b/app/services/automation/providers/data/check_run.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Normalized CI check result. Providers MAY surface richer detail
+      # (annotations, logs URL, duration) via additional data classes, but
+      # this shape is the minimum automation policy depends on.
+      #
+      # - +name+ [String] Check/job name.
+      # - +status+ [Symbol] One of {STATUSES}. Represents execution
+      #   progress — whether the check has finished at all.
+      # - +conclusion+ [Symbol, nil] One of {CONCLUSIONS}. Nil while the
+      #   check is still running.
+      # - +url+ [String, nil] Optional browser-viewable URL.
+      class CheckRun < ::Data.define(:name, :status, :conclusion, :url)
+        STATUSES = %i[queued in_progress completed].freeze
+        CONCLUSIONS = %i[
+          success failure neutral cancelled skipped timed_out
+          action_required stale
+        ].freeze
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/data/comment.rb
+++ b/app/services/automation/providers/data/comment.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Provider-neutral conversation comment. Returned by comment-fetch
+      # methods on both {Automation::Providers::RepositoryProvider} and
+      # {Automation::Providers::WorkItemProvider}.
+      #
+      # - +id+ [Integer, String] Provider-local comment identifier.
+      # - +author_login+ [String, nil] Author login, downcased.
+      # - +body+ [String] Markdown body.
+      # - +created_at+ [Time]
+      # - +updated_at+ [Time, nil]
+      # - +url+ [String, nil] Browser-viewable URL.
+      Comment = ::Data.define(
+        :id,
+        :author_login,
+        :body,
+        :created_at,
+        :updated_at,
+        :url
+      )
+    end
+  end
+end

--- a/app/services/automation/providers/data/dependency.rb
+++ b/app/services/automation/providers/data/dependency.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Structured dependency edge exposed by a work-item provider.
+      # +relation+ describes the semantic link ("blocks", "blocked_by",
+      # "related_to", "duplicates", ...). Policy code uses +relation+ to
+      # decide whether the edge blocks auto-pick.
+      #
+      # - +relation+ [Symbol]
+      # - +target_repo+ [String] Provider-local container identifier of
+      #   the target work item.
+      # - +target_number+ [Integer, String] Target work-item identifier.
+      Dependency = ::Data.define(:relation, :target_repo, :target_number)
+    end
+  end
+end

--- a/app/services/automation/providers/data/issue.rb
+++ b/app/services/automation/providers/data/issue.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Provider-neutral work-item snapshot. Returned by
+      # {Automation::Providers::WorkItemProvider#fetch_issue} and
+      # {Automation::Providers::WorkItemProvider#list_issues}.
+      #
+      # Fields:
+      # - +number+ [Integer, String] Provider-local identifier. Integer for
+      #   GitHub/GitLab; String for Jira/Linear-style keys.
+      # - +title+ [String]
+      # - +body+ [String, nil]
+      # - +state+ [Symbol] One of {STATES}.
+      # - +raw_state+ [String, nil] Provider-native state name for audit.
+      # - +author_login+ [String, nil]
+      # - +assignee_logins+ [Array<String>]
+      # - +labels+ [Array<String>]
+      # - +dependencies+ [Array<Dependency>] Structured blocker/relates-to
+      #   edges exposed by the provider. Policy code also consults
+      #   text-parsed dependencies; this field covers only what the
+      #   provider models natively.
+      # - +created_at+ [Time]
+      # - +updated_at+ [Time]
+      # - +closed_at+ [Time, nil]
+      # - +url+ [String, nil]
+      # - +pull_request_number+ [Integer, String, nil] Set when the provider
+      #   exposes issues and PRs as a single entity (GitHub) and the item
+      #   is actually a PR. Nil for providers where issues and PRs are
+      #   distinct resources.
+      class Issue < ::Data.define(
+        :number,
+        :title,
+        :body,
+        :state,
+        :raw_state,
+        :author_login,
+        :assignee_logins,
+        :labels,
+        :dependencies,
+        :created_at,
+        :updated_at,
+        :closed_at,
+        :url,
+        :pull_request_number
+      )
+        STATES = %i[open closed].freeze
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/data/merge_result.rb
+++ b/app/services/automation/providers/data/merge_result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Outcome of a {Automation::Providers::RepositoryProvider#merge_pull_request}
+      # call.
+      #
+      # - +merged+ [Boolean] +true+ when the PR is merged (including
+      #   already-merged outcomes).
+      # - +sha+ [String, nil] Resulting merge commit SHA. Nil when the
+      #   provider did not return one (e.g. squash merge into a
+      #   fast-forward branch where the provider reports success without a
+      #   distinct merge commit).
+      # - +message+ [String, nil] Human-readable summary the provider
+      #   returned. May be the merge commit message or a status line.
+      MergeResult = ::Data.define(:merged, :sha, :message)
+    end
+  end
+end

--- a/app/services/automation/providers/data/pull_request.rb
+++ b/app/services/automation/providers/data/pull_request.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Provider-neutral pull-request snapshot. Returned by
+      # {Automation::Providers::RepositoryProvider#fetch_pull_request} and
+      # {Automation::Providers::RepositoryProvider#list_pull_requests}.
+      #
+      # Fields:
+      # - +number+ [Integer] Provider-local PR number.
+      # - +title+ [String]
+      # - +body+ [String, nil] Markdown body.
+      # - +state+ [Symbol] One of {STATES}. Providers MUST normalize to
+      #   these values.
+      # - +draft+ [Boolean] +true+ for draft/WIP PRs.
+      # - +merged+ [Boolean] +true+ when the PR has been merged.
+      # - +mergeable+ [Boolean, nil] +nil+ when the provider has not yet
+      #   computed mergeability; +true+/+false+ otherwise.
+      # - +head_sha+ [String] Commit SHA at the tip of the source branch.
+      # - +head_ref+ [String] Source branch ref.
+      # - +base_ref+ [String] Target branch ref.
+      # - +author_login+ [String, nil] Login of the PR author, downcased.
+      # - +labels+ [Array<String>] Label names currently applied.
+      # - +created_at+ [Time]
+      # - +updated_at+ [Time]
+      # - +merged_at+ [Time, nil] Nil when not merged.
+      # - +url+ [String, nil] Browser-viewable URL.
+      # - +raw_state+ [String, nil] The provider's native state label,
+      #   preserved for audit when +state+ normalization loses detail.
+      class PullRequest < ::Data.define(
+        :number,
+        :title,
+        :body,
+        :state,
+        :draft,
+        :merged,
+        :mergeable,
+        :head_sha,
+        :head_ref,
+        :base_ref,
+        :author_login,
+        :labels,
+        :created_at,
+        :updated_at,
+        :merged_at,
+        :url,
+        :raw_state
+      )
+        STATES = %i[open closed].freeze
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/data/review.rb
+++ b/app/services/automation/providers/data/review.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Provider-neutral pull-request review. Returned by
+      # {Automation::Providers::ReviewProvider#fetch_reviews} and
+      # {Automation::Providers::ReviewProvider#submit_review}.
+      #
+      # - +id+ [Integer, String] Provider-local review identifier.
+      # - +author_login+ [String, nil] Reviewer login, downcased.
+      # - +state+ [Symbol] One of {STATES}. Providers MUST normalize to
+      #   this set.
+      # - +raw_state+ [String, nil] Native provider state for audit.
+      # - +body+ [String] Markdown body (empty string when no body).
+      # - +submitted_at+ [Time, nil] Nil for reviews still in +:pending+
+      #   state.
+      # - +commit_sha+ [String, nil] SHA that the review was submitted
+      #   against.
+      class Review < ::Data.define(
+        :id,
+        :author_login,
+        :state,
+        :raw_state,
+        :body,
+        :submitted_at,
+        :commit_sha
+      )
+        STATES = %i[approved changes_requested commented dismissed pending].freeze
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/data/review_request.rb
+++ b/app/services/automation/providers/data/review_request.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Snapshot of the reviewers whose review has been requested but not
+      # yet satisfied. Returned by
+      # {Automation::Providers::ReviewProvider#fetch_review_requests}.
+      #
+      # - +users+ [Array<String>] Pending user reviewer logins, downcased.
+      # - +teams+ [Array<String>] Pending team/group identifiers. Providers
+      #   without a team concept MUST return an empty array.
+      ReviewRequest = ::Data.define(:users, :teams)
+    end
+  end
+end

--- a/app/services/automation/providers/data/review_thread.rb
+++ b/app/services/automation/providers/data/review_thread.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Provider-neutral review thread (line-level discussion). Returned by
+      # {Automation::Providers::ReviewProvider#fetch_review_threads}.
+      #
+      # - +id+ [String] Provider-local thread identifier. The value is
+      #   opaque to the policy layer but MUST round-trip to
+      #   {Automation::Providers::ReviewProvider#resolve_review_thread}.
+      # - +resolved+ [Boolean]
+      # - +comments+ [Array<ReviewThreadComment>] Ordered from oldest to
+      #   newest.
+      ReviewThread = ::Data.define(:id, :resolved, :comments)
+    end
+  end
+end

--- a/app/services/automation/providers/data/review_thread_comment.rb
+++ b/app/services/automation/providers/data/review_thread_comment.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # A single comment inside a review thread.
+      #
+      # - +author_login+ [String, nil] Downcased.
+      # - +body+ [String]
+      # - +path+ [String, nil] File path the comment targets.
+      # - +line+ [Integer, nil] Line number the comment targets.
+      ReviewThreadComment = ::Data.define(:author_login, :body, :path, :line)
+    end
+  end
+end

--- a/app/services/automation/providers/data/timeline_event.rb
+++ b/app/services/automation/providers/data/timeline_event.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Data
+      # Normalized activity record for a work item or pull request.
+      # Returned by
+      # {Automation::Providers::WorkItemProvider#fetch_issue_timeline}.
+      #
+      # - +event+ [Symbol] One of {EVENTS}. Providers SHOULD map
+      #   provider-specific activities onto this set; unmappable events
+      #   SHOULD use +:other+ and preserve details in +raw+.
+      # - +actor_login+ [String, nil] Login of the acting user, downcased.
+      # - +label_name+ [String, nil] Set only for +:labeled+/+:unlabeled+
+      #   events.
+      # - +created_at+ [Time]
+      # - +raw+ [Hash] Provider-native payload preserved verbatim for
+      #   audit/debugging. Policy code MUST NOT depend on its shape.
+      class TimelineEvent < ::Data.define(
+        :event,
+        :actor_login,
+        :label_name,
+        :created_at,
+        :raw
+      )
+        EVENTS = %i[
+          labeled unlabeled commented assigned unassigned
+          reopened closed merged referenced other
+        ].freeze
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/repository_provider.rb
+++ b/app/services/automation/providers/repository_provider.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    # RepositoryProvider defines the capabilities the automation system needs
+    # from a source-control provider (GitHub, GitLab, Bitbucket, ...) for pull
+    # request orchestration: reading PR state, observing CI checks, and
+    # executing the side effects that automation decisions produce (merging,
+    # labeling, commenting, marking ready).
+    #
+    # == Contract
+    #
+    # Implementations of this module MUST:
+    #
+    # - Accept the exact keyword arguments declared by each method.
+    # - Return values of the documented {Automation::Providers::Data} type, or
+    #   +nil+ where explicitly allowed. Providers MUST NOT return raw SDK
+    #   objects — the data classes are the stable boundary between automation
+    #   policy and provider internals.
+    # - Raise a subclass of {ProviderError} for expected transient or
+    #   permanent provider failures (authentication, rate limiting, not
+    #   found). Unexpected errors may propagate, but callers should be able
+    #   to distinguish "provider said no" from "code blew up" via the
+    #   provider error hierarchy supplied by the implementation.
+    # - Be idempotent for write operations when the underlying API is
+    #   idempotent (e.g. merging an already-merged PR succeeds with a
+    #   representative {Data::MergeResult}, not an exception).
+    #
+    # Implementations MAY cache transient state (client handles, pagination
+    # cursors) but MUST NOT cache mutable entity state between calls —
+    # freshness is the caller's concern.
+    #
+    # == Usage
+    #
+    #   provider = Automation::Providers::Resolver.repository_for(project)
+    #   pr = provider.fetch_pull_request(repo: "acme/widgets", number: 42)
+    #   provider.merge_pull_request(
+    #     repo: "acme/widgets", number: 42, method: :squash
+    #   ) if pr.mergeable
+    #
+    # == Method groups
+    #
+    # * Read: {#fetch_pull_request}, {#list_pull_requests},
+    #   {#fetch_pull_request_files}, {#fetch_check_runs}
+    # * Write (labels/comments): {#add_labels}, {#remove_label},
+    #   {#add_comment}
+    # * Write (lifecycle): {#mark_ready_for_review}, {#merge_pull_request}
+    module RepositoryProvider
+      # Base class for errors raised by provider implementations. Concrete
+      # providers may define narrower subclasses (e.g.
+      # +GithubRepositoryProvider::NotFoundError+) but SHOULD ensure they
+      # inherit from this class so policy code can rescue a single type.
+      class ProviderError < StandardError; end
+
+      # Fetches a pull request by its numeric identifier.
+      #
+      # @param repo [String] Provider-specific repo identifier. For GitHub:
+      #   "owner/name". Providers may accept alternate forms (e.g. a numeric
+      #   project id) but MUST document the accepted shapes.
+      # @param number [Integer] Pull request number (provider-local).
+      # @return [Automation::Providers::Data::PullRequest]
+      # @raise [ProviderError] When the PR cannot be located or access is
+      #   denied.
+      def fetch_pull_request(repo:, number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Lists pull requests for a repository, optionally narrowed by
+      # provider-common filters.
+      #
+      # @param repo [String]
+      # @param state [Symbol] One of +:open+, +:closed+, or +:all+. Providers
+      #   that do not distinguish these states MAY ignore the parameter but
+      #   MUST document the behavior.
+      # @param head [String, nil] Optional branch filter ("owner:branch" for
+      #   GitHub; provider-specific otherwise).
+      # @param base [String, nil] Optional base-branch filter.
+      # @return [Array<Automation::Providers::Data::PullRequest>]
+      def list_pull_requests(repo:, state: :open, head: nil, base: nil)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Returns the file paths modified by a pull request.
+      #
+      # @param repo [String]
+      # @param number [Integer]
+      # @return [Array<String>] Changed file paths relative to the repo root.
+      def fetch_pull_request_files(repo:, number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Fetches check runs (CI status) for a git ref. Providers that model CI
+      # status separately from "checks" are responsible for normalizing to a
+      # unified {Data::CheckRun} representation.
+      #
+      # @param repo [String]
+      # @param ref [String] Branch name, tag, or commit SHA.
+      # @return [Array<Automation::Providers::Data::CheckRun>]
+      def fetch_check_runs(repo:, ref:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Adds labels to a pull request. Providers that do not support labels
+      # natively (e.g. Linear workflow states) SHOULD translate the call into
+      # an equivalent status transition and document the mapping.
+      #
+      # @param repo [String]
+      # @param number [Integer]
+      # @param labels [Array<String>] Label names to add. Existing labels
+      #   MUST NOT be removed.
+      # @return [void]
+      def add_labels(repo:, number:, labels:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Removes a single label from a pull request. No-op if the label is
+      # not currently applied.
+      #
+      # @param repo [String]
+      # @param number [Integer]
+      # @param label [String]
+      # @return [void]
+      def remove_label(repo:, number:, label:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Posts a comment on a pull request's conversation thread.
+      #
+      # @param repo [String]
+      # @param number [Integer]
+      # @param body [String] Markdown body.
+      # @return [Automation::Providers::Data::Comment] The created comment.
+      def add_comment(repo:, number:, body:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Transitions a draft pull request to "ready for review". No-op if the
+      # PR is already non-draft.
+      #
+      # @param repo [String]
+      # @param number [Integer]
+      # @return [void]
+      def mark_ready_for_review(repo:, number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Merges a pull request.
+      #
+      # @param repo [String]
+      # @param number [Integer]
+      # @param method [Symbol] One of +:squash+, +:merge+, +:rebase+.
+      #   Providers that do not support a method SHOULD raise
+      #   {ProviderError} rather than silently downgrading.
+      # @param commit_title [String, nil] Optional merge commit title.
+      # @param commit_message [String, nil] Optional merge commit body.
+      # @return [Automation::Providers::Data::MergeResult]
+      # @raise [ProviderError] When the merge is rejected by the provider
+      #   (e.g. merge conflict, protected branch violation).
+      def merge_pull_request(repo:, number:, method:, commit_title: nil, commit_message: nil)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      private
+
+      def not_implemented_message(method_name)
+        "#{self.class} must implement ##{method_name}"
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/resolver.rb
+++ b/app/services/automation/providers/resolver.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    # Resolver maps a {Project} to the concrete provider implementations
+    # for each capability area (repository, work item, review).
+    #
+    # Implementations register themselves via {.register}. Automation
+    # policy code looks up the provider for a project via
+    # {.repository_for}, {.work_item_for}, and {.review_for}. When a
+    # project has not opted into a specific provider type it defaults to
+    # +:github+, matching the system's only concrete provider today.
+    #
+    # == Example registration
+    #
+    #   Automation::Providers::Resolver.register(
+    #     :github,
+    #     repository: ->(project) { Github::RepositoryProvider.new(project) },
+    #     work_item:  ->(project) { Github::WorkItemProvider.new(project) },
+    #     review:     ->(project) { Github::ReviewProvider.new(project) }
+    #   )
+    #
+    # Factories are invoked with the {Project} on every resolution call.
+    # They MAY cache the returned instance per project (e.g. memoize on
+    # the project), but the resolver itself is intentionally stateless so
+    # that tests can register and clear implementations independently.
+    class Resolver
+      CAPABILITIES = %i[repository work_item review].freeze
+
+      UnknownProviderTypeError = Class.new(StandardError)
+      UnknownCapabilityError = Class.new(StandardError)
+      UnregisteredProviderError = Class.new(StandardError)
+
+      class << self
+        # Registers factories for a provider type. Factories are callables
+        # (procs/lambdas/objects responding to +#call+) that accept a
+        # {Project} and return an object that includes the corresponding
+        # capability module ({RepositoryProvider}, {WorkItemProvider},
+        # {ReviewProvider}).
+        #
+        # Passing +nil+ for a capability unregisters it.
+        #
+        # @param provider_type [Symbol] e.g. +:github+, +:gitlab+.
+        # @param repository [#call, nil]
+        # @param work_item [#call, nil]
+        # @param review [#call, nil]
+        # @return [void]
+        def register(provider_type, repository: nil, work_item: nil, review: nil)
+          entry = registry[provider_type.to_sym] ||= {}
+          { repository:, work_item:, review: }.each do |capability, factory|
+            next if factory.nil?
+
+            validate_factory!(factory, capability)
+            entry[capability] = factory
+          end
+        end
+
+        # Removes all registered factories for +provider_type+. Primarily
+        # useful in tests to isolate registration between examples.
+        #
+        # @param provider_type [Symbol, nil] When nil, clears every
+        #   registration.
+        # @return [void]
+        def reset!(provider_type = nil)
+          if provider_type.nil?
+            registry.clear
+          else
+            registry.delete(provider_type.to_sym)
+          end
+        end
+
+        # @return [Array<Symbol>] Registered provider type identifiers.
+        def registered_provider_types
+          registry.keys
+        end
+
+        # @param provider_type [Symbol]
+        # @return [Boolean]
+        def registered?(provider_type)
+          registry.key?(provider_type.to_sym)
+        end
+
+        # Resolves the repository provider for +project+.
+        # @return [Object] An instance including {RepositoryProvider}.
+        def repository_for(project)
+          resolve(:repository, project)
+        end
+
+        # Resolves the work-item provider for +project+.
+        # @return [Object] An instance including {WorkItemProvider}.
+        def work_item_for(project)
+          resolve(:work_item, project)
+        end
+
+        # Resolves the review provider for +project+.
+        # @return [Object] An instance including {ReviewProvider}.
+        def review_for(project)
+          resolve(:review, project)
+        end
+
+        # The provider type a project is configured to use. Falls back to
+        # +:github+ for projects that have not opted in to an alternate
+        # provider (the system's only concrete provider today).
+        #
+        # Projects signal their provider type by defining a +#provider_type+
+        # method returning a Symbol or String. Deferring to a duck-typed
+        # method keeps this resolver usable in tests and future codepaths
+        # before a database column is introduced.
+        #
+        # @param project [Object]
+        # @return [Symbol]
+        def provider_type_for(project)
+          raw = project.respond_to?(:provider_type) ? project.provider_type : nil
+          raw.present? ? raw.to_sym : :github
+        end
+
+        private
+
+        def registry
+          @registry ||= {}
+        end
+
+        def resolve(capability, project)
+          raise UnknownCapabilityError, capability.inspect unless CAPABILITIES.include?(capability)
+
+          provider_type = provider_type_for(project)
+          entry = registry[provider_type] or
+            raise UnknownProviderTypeError,
+              "No providers registered for provider_type #{provider_type.inspect}"
+
+          factory = entry[capability] or
+            raise UnregisteredProviderError,
+              "No #{capability} provider registered for provider_type #{provider_type.inspect}"
+
+          factory.call(project)
+        end
+
+        def validate_factory!(factory, capability)
+          return if factory.respond_to?(:call)
+
+          raise ArgumentError,
+            "#{capability} factory must respond to #call (got #{factory.class})"
+        end
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/review_provider.rb
+++ b/app/services/automation/providers/review_provider.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    # ReviewProvider defines the capabilities the automation system needs
+    # to observe and drive pull-request review flows: inspecting pending
+    # and satisfied reviewer state, requesting reviewers, submitting and
+    # resolving review threads.
+    #
+    # A review provider is logically separate from a {RepositoryProvider}
+    # because review workflows are often delegated to specialized systems
+    # (Reviewable, LGTM apps, in-house bots) that front the source-control
+    # host. For providers where reviews live inline with the repository
+    # (e.g. GitHub), a single implementation class MAY include both
+    # modules.
+    #
+    # == Contract
+    #
+    # Implementations MUST:
+    #
+    # - Report review state as one of the enumerated symbols declared on
+    #   {Automation::Providers::Data::Review::STATES}. The raw provider
+    #   label MAY be preserved on +raw_state+.
+    # - Treat {#fetch_pending_reviewers} and {#fetch_review_requests} as the
+    #   authoritative source for "what review is still outstanding". Policy
+    #   code uses these methods to distinguish "no review yet" from
+    #   "review satisfied".
+    # - Ensure write operations are idempotent: re-requesting an already
+    #   pending reviewer MUST NOT raise; re-resolving a resolved thread
+    #   MUST NOT raise.
+    #
+    # == Method groups
+    #
+    # * Read: {#fetch_reviews}, {#fetch_review_threads},
+    #   {#fetch_review_requests}, {#fetch_pending_reviewers}
+    # * Write: {#request_reviewers}, {#submit_review},
+    #   {#resolve_review_thread}
+    module ReviewProvider
+      class ProviderError < StandardError; end
+
+      # Fetches all completed and in-progress reviews on a pull request.
+      #
+      # @param repo [String]
+      # @param pr_number [Integer]
+      # @return [Array<Automation::Providers::Data::Review>]
+      def fetch_reviews(repo:, pr_number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Fetches review threads (line-level discussions) and their
+      # resolution state on a pull request.
+      #
+      # @param repo [String]
+      # @param pr_number [Integer]
+      # @return [Array<Automation::Providers::Data::ReviewThread>]
+      def fetch_review_threads(repo:, pr_number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Fetches the pending review requests on a pull request.
+      #
+      # @param repo [String]
+      # @param pr_number [Integer]
+      # @return [Automation::Providers::Data::ReviewRequest] The pending
+      #   users and teams whose review has been requested but not yet
+      #   satisfied.
+      def fetch_review_requests(repo:, pr_number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Returns the set of reviewer logins whose review is still pending.
+      # A convenience method; providers MAY implement it as a projection
+      # over {#fetch_review_requests}.
+      #
+      # @param repo [String]
+      # @param pr_number [Integer]
+      # @return [Array<String>] Downcased reviewer logins.
+      def fetch_pending_reviewers(repo:, pr_number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Requests review from users. Idempotent: already-pending reviewers
+      # MUST NOT cause the call to fail.
+      #
+      # @param repo [String]
+      # @param pr_number [Integer]
+      # @param reviewers [Array<String>] Reviewer logins. Providers MUST
+      #   accept downcased logins.
+      # @return [Array<String>] The subset of +reviewers+ that the provider
+      #   considers newly-requested (i.e. excluding ones that were already
+      #   pending).
+      def request_reviewers(repo:, pr_number:, reviewers:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Submits a review. Providers that do not distinguish review state
+      # (e.g. "approve" vs "request changes") MAY accept only +:comment+
+      # but MUST reject the other states loudly.
+      #
+      # @param repo [String]
+      # @param pr_number [Integer]
+      # @param body [String] Markdown body.
+      # @param event [Symbol] One of +:approve+, +:request_changes+,
+      #   +:comment+.
+      # @return [Automation::Providers::Data::Review]
+      def submit_review(repo:, pr_number:, body:, event:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Marks a review thread as resolved. No-op if already resolved.
+      #
+      # @param repo [String]
+      # @param pr_number [Integer]
+      # @param thread_id [String] Provider-local thread identifier, as
+      #   returned by {#fetch_review_threads}.
+      # @return [void]
+      def resolve_review_thread(repo:, pr_number:, thread_id:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      private
+
+      def not_implemented_message(method_name)
+        "#{self.class} must implement ##{method_name}"
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/work_item_provider.rb
+++ b/app/services/automation/providers/work_item_provider.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    # WorkItemProvider defines the capabilities the automation system needs
+    # from a work-item tracker (GitHub Issues, Linear, Jira, ...) for
+    # issue-driven orchestration: selecting issues, inspecting dependencies,
+    # and transitioning state.
+    #
+    # "Work item" is intentionally generic. Implementations are expected to
+    # map the provider's native concepts (issue, ticket, story, task) onto
+    # the {Automation::Providers::Data::Issue} shape, but the policy layer
+    # only knows about work items.
+    #
+    # == Contract
+    #
+    # Implementations MUST:
+    #
+    # - Return {Data::Issue} records whose +state+ is one of the enumerated
+    #   symbols declared on that class, even if the provider's native state
+    #   names differ. Provider-specific state names MAY also be exposed on
+    #   the +raw_state+ field for audit purposes.
+    # - Populate {Data::Issue#dependencies} with structured dependency
+    #   records whenever the provider natively models blockers/dependencies.
+    #   Providers without a native dependency model MAY return an empty
+    #   array; text-parsed dependencies remain the responsibility of
+    #   Paid's {Issues::ParseDependencies} service.
+    # - Treat {#transition_state} as the single write-path for lifecycle
+    #   changes. Label-based transitions SHOULD route through label
+    #   add/remove rather than {#transition_state}.
+    #
+    # == Method groups
+    #
+    # * Read: {#fetch_issue}, {#list_issues}, {#fetch_issue_comments},
+    #   {#fetch_issue_timeline}
+    # * Write: {#create_issue}, {#add_labels}, {#remove_label},
+    #   {#add_comment}, {#transition_state}
+    module WorkItemProvider
+      class ProviderError < StandardError; end
+
+      # Fetches a single work item by its provider-local identifier.
+      #
+      # @param repo [String] Provider-specific container identifier
+      #   (repo slug for GitHub; project key for Jira; team key for
+      #   Linear). Providers MUST document the accepted shape.
+      # @param number [Integer, String] Work-item identifier. Providers
+      #   whose identifiers are not integers (e.g. Linear "ENG-123") MUST
+      #   accept String and document the format.
+      # @return [Automation::Providers::Data::Issue]
+      def fetch_issue(repo:, number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Lists work items matching the given filters.
+      #
+      # @param repo [String]
+      # @param state [Symbol] One of +:open+, +:closed+, or +:all+.
+      # @param labels [Array<String>, nil] Optional label/tag filter.
+      # @param assignees [Array<String>, nil] Optional assignee-login
+      #   filter. Providers that do not expose assignee identity MAY raise
+      #   {ProviderError} rather than silently ignoring the filter.
+      # @return [Array<Automation::Providers::Data::Issue>]
+      def list_issues(repo:, state: :open, labels: nil, assignees: nil)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Fetches conversation comments on a work item.
+      #
+      # @param repo [String]
+      # @param number [Integer, String]
+      # @return [Array<Automation::Providers::Data::Comment>]
+      def fetch_issue_comments(repo:, number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Fetches the activity timeline for a work item. Providers with no
+      # native timeline SHOULD return synthetic events derived from the
+      # state transitions they can observe.
+      #
+      # @param repo [String]
+      # @param number [Integer, String]
+      # @return [Array<Automation::Providers::Data::TimelineEvent>]
+      def fetch_issue_timeline(repo:, number:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Creates a new work item.
+      #
+      # @param repo [String]
+      # @param title [String]
+      # @param body [String]
+      # @param labels [Array<String>]
+      # @return [Automation::Providers::Data::Issue]
+      def create_issue(repo:, title:, body: "", labels: [])
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Adds labels to a work item.
+      #
+      # @param repo [String]
+      # @param number [Integer, String]
+      # @param labels [Array<String>]
+      # @return [void]
+      def add_labels(repo:, number:, labels:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Removes a label from a work item. No-op when the label is absent.
+      #
+      # @param repo [String]
+      # @param number [Integer, String]
+      # @param label [String]
+      # @return [void]
+      def remove_label(repo:, number:, label:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Posts a comment on a work item.
+      #
+      # @param repo [String]
+      # @param number [Integer, String]
+      # @param body [String] Markdown body.
+      # @return [Automation::Providers::Data::Comment]
+      def add_comment(repo:, number:, body:)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      # Transitions a work item to a new lifecycle state.
+      #
+      # @param repo [String]
+      # @param number [Integer, String]
+      # @param state [Symbol] Target state. Must be one of the states
+      #   declared on {Automation::Providers::Data::Issue::STATES}.
+      #   Providers MAY accept a provider-specific String instead, but MUST
+      #   raise {ProviderError} if the requested transition is not legal.
+      # @param reason [String, nil] Optional human-readable reason that the
+      #   provider SHOULD surface in its audit log.
+      # @return [Automation::Providers::Data::Issue] The updated issue.
+      def transition_state(repo:, number:, state:, reason: nil)
+        raise NotImplementedError, not_implemented_message(__method__)
+      end
+
+      private
+
+      def not_implemented_message(method_name)
+        "#{self.class} must implement ##{method_name}"
+      end
+    end
+  end
+end

--- a/docs/rdrs/RDR-023-automation-modularization-architecture.md
+++ b/docs/rdrs/RDR-023-automation-modularization-architecture.md
@@ -8,7 +8,7 @@
 - **Status**: Draft
 - **Type**: Architecture
 - **Priority**: High
-- **Related Issues**: #1114
+- **Related Issues**: #1114, #1116
 - **Related Tests**: N/A
 - **Related RDRs**: [RDR-012](RDR-012-github-integration.md) (GitHub Integration), [RDR-022](RDR-022-auto-merge-pr-strategy.md) (Auto-Merge Strategy), [RDR-002](RDR-002-workflow-orchestration.md) (Workflow Orchestration)
 
@@ -597,19 +597,22 @@ end
 
 **Goal**: Extract GitHub API calls from activities into adapter classes behind interfaces.
 
-1. Define adapter interfaces (`RepositoryAdapter`, `WorkItemAdapter`, `ReviewAdapter`).
-2. Define adapter data objects (`PullRequestData`, `ReviewData`, etc.).
-3. Implement `Adapters::GitHub` backed by existing Octokit client usage.
-4. Replace direct Octokit calls in `ScanPaidPrsActivity` and `MergePullRequestActivity` with adapter calls.
+1. Define adapter interfaces (`RepositoryProvider`, `WorkItemProvider`, `ReviewProvider`). — *Shipped as `Automation::Providers::*` in #1116.*
+2. Define adapter data objects (`PullRequest`, `Review`, etc.). — *Shipped under `Automation::Providers::Data` in #1116.*
+3. Implement a GitHub provider set backed by existing Octokit client usage.
+4. Replace direct Octokit calls in `ScanPaidPrsActivity` and `MergePullRequestActivity` with provider calls.
 5. Verify behavior parity via existing integration tests.
+
+The interface code is placed under `app/services/automation/providers/` (rather than `app/adapters/` as originally sketched) so that the capability modules live alongside other automation namespaces (`Automation::Decision`, `Automation::Result`, `Automation::Strategies::*`). The term "provider" tracks the wording used in #1116 and avoids collision with the existing `::Provider` model, which models LLM providers.
 
 **Files to create**:
 
-- `app/adapters/repository_adapter.rb`
-- `app/adapters/work_item_adapter.rb`
-- `app/adapters/review_adapter.rb`
-- `app/adapters/github.rb`
-- `app/adapters/data/*.rb` (data objects)
+- `app/services/automation/providers/repository_provider.rb`
+- `app/services/automation/providers/work_item_provider.rb`
+- `app/services/automation/providers/review_provider.rb`
+- `app/services/automation/providers/resolver.rb`
+- `app/services/automation/providers/data/*.rb` (data objects)
+- `app/services/automation/providers/github/*.rb` (concrete provider implementations — not yet created)
 
 **Files to modify**:
 

--- a/spec/services/automation/providers/data/check_run_spec.rb
+++ b/spec/services/automation/providers/data/check_run_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::CheckRun do
+  it "is an immutable Data class with the documented fields" do
+    cr = described_class.new(name: "rspec", status: :completed, conclusion: :success, url: nil)
+    expect(cr.status).to eq(:completed)
+    expect(cr.conclusion).to eq(:success)
+  end
+
+  it "declares the provider-neutral status and conclusion enums" do
+    expect(described_class::STATUSES).to include(:queued, :in_progress, :completed)
+    expect(described_class::CONCLUSIONS).to include(:success, :failure, :cancelled, :timed_out)
+  end
+end

--- a/spec/services/automation/providers/data/comment_spec.rb
+++ b/spec/services/automation/providers/data/comment_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::Comment do
+  it "captures author, body, and timestamps" do
+    c = described_class.new(
+      id: 9, author_login: "bot", body: "hi",
+      created_at: Time.at(0), updated_at: nil, url: nil
+    )
+    expect(c.body).to eq("hi")
+  end
+end

--- a/spec/services/automation/providers/data/issue_spec.rb
+++ b/spec/services/automation/providers/data/issue_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::Issue do
+  it "is an immutable Data class with the documented fields" do
+    dep = Automation::Providers::Data::Dependency.new(
+      relation: :blocked_by, target_repo: "x/y", target_number: 42
+    )
+    issue = described_class.new(
+      number: 7, title: "t", body: "b", state: :open, raw_state: "open",
+      author_login: "alice", assignee_logins: [ "bob" ], labels: [ "bug" ],
+      dependencies: [ dep ], created_at: Time.at(0), updated_at: Time.at(1),
+      closed_at: nil, url: nil, pull_request_number: nil
+    )
+
+    expect(issue.dependencies).to eq([ dep ])
+    expect(issue.state).to eq(:open)
+  end
+
+  it "declares the provider-neutral state enum" do
+    expect(described_class::STATES).to contain_exactly(:open, :closed)
+  end
+
+  describe Automation::Providers::Data::Dependency do
+    it "is an immutable Data class capturing the relation and target" do
+      dep = described_class.new(relation: :blocks, target_repo: "x/y", target_number: 3)
+      expect(dep.relation).to eq(:blocks)
+      expect(dep.target_number).to eq(3)
+    end
+  end
+end

--- a/spec/services/automation/providers/data/merge_result_spec.rb
+++ b/spec/services/automation/providers/data/merge_result_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::MergeResult do
+  it "captures whether the merge happened, with an optional sha" do
+    result = described_class.new(merged: true, sha: "abc", message: "ok")
+    expect(result.merged).to be(true)
+    expect(result.sha).to eq("abc")
+  end
+end

--- a/spec/services/automation/providers/data/pull_request_spec.rb
+++ b/spec/services/automation/providers/data/pull_request_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::PullRequest do
+  it "is an immutable Data class with the documented fields" do
+    pr = described_class.new(
+      number: 1, title: "t", body: "b", state: :open,
+      draft: false, merged: false, mergeable: true,
+      head_sha: "abc", head_ref: "f", base_ref: "main",
+      author_login: "alice", labels: [ "a" ],
+      created_at: Time.at(0), updated_at: Time.at(1),
+      merged_at: nil, url: "http://example.com", raw_state: "open"
+    )
+
+    expect(pr).to have_attributes(
+      number: 1, title: "t", state: :open, draft: false,
+      head_sha: "abc", labels: [ "a" ]
+    )
+    expect { pr.number = 2 }.to raise_error(NoMethodError)
+  end
+
+  it "declares the provider-neutral state enum" do
+    expect(described_class::STATES).to contain_exactly(:open, :closed)
+  end
+end

--- a/spec/services/automation/providers/data/review_request_spec.rb
+++ b/spec/services/automation/providers/data/review_request_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::ReviewRequest do
+  it "captures pending users and teams separately" do
+    req = described_class.new(users: [ "alice" ], teams: [ "reviewers" ])
+    expect(req.users).to contain_exactly("alice")
+    expect(req.teams).to contain_exactly("reviewers")
+  end
+end

--- a/spec/services/automation/providers/data/review_spec.rb
+++ b/spec/services/automation/providers/data/review_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::Review do
+  it "is an immutable Data class with the documented fields" do
+    review = described_class.new(
+      id: 1, author_login: "alice", state: :approved, raw_state: "APPROVED",
+      body: "lgtm", submitted_at: Time.at(0), commit_sha: "abc"
+    )
+
+    expect(review.state).to eq(:approved)
+    expect(review.body).to eq("lgtm")
+  end
+
+  it "declares the provider-neutral state enum" do
+    expect(described_class::STATES).to include(
+      :approved, :changes_requested, :commented, :dismissed, :pending
+    )
+  end
+end

--- a/spec/services/automation/providers/data/review_thread_spec.rb
+++ b/spec/services/automation/providers/data/review_thread_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::ReviewThread do
+  it "captures the thread id, resolution status, and comments" do
+    comment = Automation::Providers::Data::ReviewThreadComment.new(
+      author_login: "alice", body: "here", path: "a.rb", line: 10
+    )
+    thread = described_class.new(id: "T_1", resolved: false, comments: [ comment ])
+
+    expect(thread.comments.first.path).to eq("a.rb")
+  end
+end

--- a/spec/services/automation/providers/data/timeline_event_spec.rb
+++ b/spec/services/automation/providers/data/timeline_event_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Data::TimelineEvent do
+  it "captures the event type, actor, and optional label" do
+    event = described_class.new(
+      event: :labeled, actor_login: "alice",
+      label_name: "paid-build", created_at: Time.at(0),
+      raw: { event: "labeled" }
+    )
+
+    expect(event.event).to eq(:labeled)
+    expect(event.label_name).to eq("paid-build")
+  end
+
+  it "declares the provider-neutral event enum" do
+    expect(described_class::EVENTS).to include(:labeled, :unlabeled, :closed, :merged)
+  end
+end

--- a/spec/services/automation/providers/repository_provider_spec.rb
+++ b/spec/services/automation/providers/repository_provider_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::RepositoryProvider do
+  # A minimal class that includes the interface without implementing any
+  # method. Used to verify that every contract method raises
+  # NotImplementedError by default — implementations MUST override them.
+  let(:unimplemented_class) do
+    Class.new do
+      include Automation::Providers::RepositoryProvider
+    end
+  end
+
+  let(:unimplemented) { unimplemented_class.new }
+
+  describe "the interface contract" do
+    it "declares the capability methods automation policy depends on" do
+      expected_methods = %i[
+        fetch_pull_request
+        list_pull_requests
+        fetch_pull_request_files
+        fetch_check_runs
+        add_labels
+        remove_label
+        add_comment
+        mark_ready_for_review
+        merge_pull_request
+      ]
+
+      expect(described_class.instance_methods(false)).to include(*expected_methods)
+    end
+
+    it "raises NotImplementedError for each method when not overridden" do
+      expect { unimplemented.fetch_pull_request(repo: "x/y", number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_pull_request/)
+      expect { unimplemented.list_pull_requests(repo: "x/y") }
+        .to raise_error(NotImplementedError, /#list_pull_requests/)
+      expect { unimplemented.fetch_pull_request_files(repo: "x/y", number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_pull_request_files/)
+      expect { unimplemented.fetch_check_runs(repo: "x/y", ref: "main") }
+        .to raise_error(NotImplementedError, /#fetch_check_runs/)
+      expect { unimplemented.add_labels(repo: "x/y", number: 1, labels: []) }
+        .to raise_error(NotImplementedError, /#add_labels/)
+      expect { unimplemented.remove_label(repo: "x/y", number: 1, label: "a") }
+        .to raise_error(NotImplementedError, /#remove_label/)
+      expect { unimplemented.add_comment(repo: "x/y", number: 1, body: "") }
+        .to raise_error(NotImplementedError, /#add_comment/)
+      expect { unimplemented.mark_ready_for_review(repo: "x/y", number: 1) }
+        .to raise_error(NotImplementedError, /#mark_ready_for_review/)
+      expect { unimplemented.merge_pull_request(repo: "x/y", number: 1, method: :squash) }
+        .to raise_error(NotImplementedError, /#merge_pull_request/)
+    end
+
+    it "provides a ProviderError base class for implementations to extend" do
+      expect(described_class::ProviderError).to be < StandardError
+    end
+  end
+
+  describe "a conforming implementation" do
+    let(:implementation_class) do
+      Class.new do
+        include Automation::Providers::RepositoryProvider
+
+        def fetch_pull_request(repo:, number:)
+          Automation::Providers::Data::PullRequest.new(
+            number: number, title: "t", body: "", state: :open,
+            draft: false, merged: false, mergeable: true,
+            head_sha: "abc", head_ref: "feature", base_ref: "main",
+            author_login: "alice", labels: [], created_at: Time.now,
+            updated_at: Time.now, merged_at: nil, url: nil, raw_state: nil
+          )
+        end
+
+        def list_pull_requests(repo:, state: :open, head: nil, base: nil)
+          []
+        end
+
+        def fetch_pull_request_files(repo:, number:)
+          []
+        end
+
+        def fetch_check_runs(repo:, ref:)
+          []
+        end
+
+        def add_labels(repo:, number:, labels:); end
+        def remove_label(repo:, number:, label:); end
+
+        def add_comment(repo:, number:, body:)
+          Automation::Providers::Data::Comment.new(
+            id: 1, author_login: "bot", body: body,
+            created_at: Time.now, updated_at: nil, url: nil
+          )
+        end
+
+        def mark_ready_for_review(repo:, number:); end
+
+        def merge_pull_request(repo:, number:, method:, commit_title: nil, commit_message: nil)
+          Automation::Providers::Data::MergeResult.new(merged: true, sha: "abc", message: "merged")
+        end
+      end
+    end
+
+    it "can fulfill every interface method without raising" do
+      impl = implementation_class.new
+
+      expect(impl.fetch_pull_request(repo: "x/y", number: 1))
+        .to be_a(Automation::Providers::Data::PullRequest)
+      expect(impl.list_pull_requests(repo: "x/y")).to eq([])
+      expect(impl.fetch_pull_request_files(repo: "x/y", number: 1)).to eq([])
+      expect(impl.fetch_check_runs(repo: "x/y", ref: "main")).to eq([])
+      expect { impl.add_labels(repo: "x/y", number: 1, labels: [ "a" ]) }.not_to raise_error
+      expect { impl.remove_label(repo: "x/y", number: 1, label: "a") }.not_to raise_error
+      expect(impl.add_comment(repo: "x/y", number: 1, body: "hi"))
+        .to be_a(Automation::Providers::Data::Comment)
+      expect { impl.mark_ready_for_review(repo: "x/y", number: 1) }.not_to raise_error
+      expect(impl.merge_pull_request(repo: "x/y", number: 1, method: :squash))
+        .to be_a(Automation::Providers::Data::MergeResult)
+    end
+  end
+end

--- a/spec/services/automation/providers/resolver_spec.rb
+++ b/spec/services/automation/providers/resolver_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::Resolver do
+  around do |example|
+    # Specs mutate the module-level registry; snapshot it so the rest of
+    # the suite is unaffected regardless of example order.
+    previous = described_class.instance_variable_get(:@registry)
+    described_class.instance_variable_set(:@registry, previous&.deep_dup || {})
+    example.run
+  ensure
+    described_class.instance_variable_set(:@registry, previous)
+  end
+
+  # A real class stands in for Project. Subclasses override #provider_type
+  # to exercise the resolver's configuration paths. Using a real class
+  # keeps verifying-double lint satisfied without coupling the spec to
+  # the full Project schema.
+  let(:project_without_provider_type_class) { Class.new }
+  let(:project_without_provider_type) { project_without_provider_type_class.new }
+
+  let(:project_with_provider_type_class) do
+    Class.new do
+      attr_accessor :provider_type
+
+      def initialize(provider_type)
+        @provider_type = provider_type
+      end
+    end
+  end
+
+  let(:repo_factory) { ->(_project) { Object.new } }
+  let(:work_item_factory) { ->(_project) { Object.new } }
+  let(:review_factory) { ->(_project) { Object.new } }
+
+  describe ".provider_type_for" do
+    it "defaults to :github when the project does not declare a provider_type" do
+      expect(described_class.provider_type_for(project_without_provider_type))
+        .to eq(:github)
+    end
+
+    it "reads provider_type from the project when declared" do
+      project = project_with_provider_type_class.new("gitlab")
+
+      expect(described_class.provider_type_for(project)).to eq(:gitlab)
+    end
+
+    it "returns :github when provider_type is blank" do
+      project = project_with_provider_type_class.new(nil)
+
+      expect(described_class.provider_type_for(project)).to eq(:github)
+    end
+  end
+
+  describe ".register" do
+    it "registers factories that a resolve call invokes with the project" do
+      described_class.reset!
+      described_class.register(
+        :github,
+        repository: repo_factory,
+        work_item: work_item_factory,
+        review: review_factory
+      )
+
+      expect(repo_factory).to receive(:call).with(project_without_provider_type).and_return(:repo)
+      expect(described_class.repository_for(project_without_provider_type)).to eq(:repo)
+    end
+
+    it "rejects factories that do not respond to #call" do
+      expect {
+        described_class.register(:github, repository: "not-a-callable")
+      }.to raise_error(ArgumentError, /must respond to #call/)
+    end
+
+    it "allows partial registration and accumulates capabilities over calls" do
+      described_class.reset!
+      described_class.register(:github, repository: repo_factory)
+      described_class.register(:github, work_item: work_item_factory)
+
+      expect(described_class.registered?(:github)).to be true
+      expect { described_class.repository_for(project_without_provider_type) }.not_to raise_error
+      expect { described_class.work_item_for(project_without_provider_type) }.not_to raise_error
+    end
+  end
+
+  describe ".repository_for / .work_item_for / .review_for" do
+    before do
+      described_class.reset!
+      described_class.register(
+        :github,
+        repository: repo_factory,
+        work_item: work_item_factory,
+        review: review_factory
+      )
+    end
+
+    it "raises when no providers are registered for the project's provider type" do
+      project = project_with_provider_type_class.new(:gitlab)
+
+      expect { described_class.repository_for(project) }
+        .to raise_error(described_class::UnknownProviderTypeError, /gitlab/)
+    end
+
+    it "raises when the registered provider type lacks the requested capability" do
+      described_class.reset!
+      described_class.register(:github, repository: repo_factory)
+
+      expect { described_class.work_item_for(project_without_provider_type) }
+        .to raise_error(described_class::UnregisteredProviderError, /work_item/)
+    end
+  end
+
+  describe ".reset!" do
+    it "clears a single provider type when given one" do
+      described_class.register(:github, repository: repo_factory)
+      described_class.register(:gitlab, repository: repo_factory)
+
+      described_class.reset!(:github)
+
+      expect(described_class.registered_provider_types).to contain_exactly(:gitlab)
+    end
+
+    it "clears every registration when called without arguments" do
+      described_class.register(:github, repository: repo_factory)
+      described_class.register(:gitlab, repository: repo_factory)
+
+      described_class.reset!
+
+      expect(described_class.registered_provider_types).to be_empty
+    end
+  end
+
+  describe "capability validation" do
+    it "surfaces an error when policy code asks for an unknown capability" do
+      described_class.reset!
+      described_class.register(:github, repository: repo_factory)
+
+      expect {
+        described_class.send(:resolve, :not_a_capability, project_without_provider_type)
+      }.to raise_error(described_class::UnknownCapabilityError)
+    end
+  end
+end

--- a/spec/services/automation/providers/review_provider_spec.rb
+++ b/spec/services/automation/providers/review_provider_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::ReviewProvider do
+  let(:unimplemented_class) do
+    Class.new do
+      include Automation::Providers::ReviewProvider
+    end
+  end
+
+  let(:unimplemented) { unimplemented_class.new }
+
+  describe "the interface contract" do
+    it "declares the capability methods automation policy depends on" do
+      expected_methods = %i[
+        fetch_reviews
+        fetch_review_threads
+        fetch_review_requests
+        fetch_pending_reviewers
+        request_reviewers
+        submit_review
+        resolve_review_thread
+      ]
+
+      expect(described_class.instance_methods(false)).to include(*expected_methods)
+    end
+
+    it "raises NotImplementedError for each method when not overridden" do
+      expect { unimplemented.fetch_reviews(repo: "x/y", pr_number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_reviews/)
+      expect { unimplemented.fetch_review_threads(repo: "x/y", pr_number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_review_threads/)
+      expect { unimplemented.fetch_review_requests(repo: "x/y", pr_number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_review_requests/)
+      expect { unimplemented.fetch_pending_reviewers(repo: "x/y", pr_number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_pending_reviewers/)
+      expect { unimplemented.request_reviewers(repo: "x/y", pr_number: 1, reviewers: []) }
+        .to raise_error(NotImplementedError, /#request_reviewers/)
+      expect { unimplemented.submit_review(repo: "x/y", pr_number: 1, body: "", event: :comment) }
+        .to raise_error(NotImplementedError, /#submit_review/)
+      expect { unimplemented.resolve_review_thread(repo: "x/y", pr_number: 1, thread_id: "t") }
+        .to raise_error(NotImplementedError, /#resolve_review_thread/)
+    end
+
+    it "provides a ProviderError base class for implementations to extend" do
+      expect(described_class::ProviderError).to be < StandardError
+    end
+  end
+
+  describe "a conforming implementation" do
+    let(:implementation_class) do
+      Class.new do
+        include Automation::Providers::ReviewProvider
+
+        def fetch_reviews(repo:, pr_number:); []; end
+        def fetch_review_threads(repo:, pr_number:); []; end
+
+        def fetch_review_requests(repo:, pr_number:)
+          Automation::Providers::Data::ReviewRequest.new(users: [], teams: [])
+        end
+
+        def fetch_pending_reviewers(repo:, pr_number:); []; end
+
+        def request_reviewers(repo:, pr_number:, reviewers:)
+          reviewers
+        end
+
+        def submit_review(repo:, pr_number:, body:, event:)
+          Automation::Providers::Data::Review.new(
+            id: 1, author_login: "bot", state: :commented, raw_state: "COMMENTED",
+            body: body, submitted_at: Time.now, commit_sha: "abc"
+          )
+        end
+
+        def resolve_review_thread(repo:, pr_number:, thread_id:); end
+      end
+    end
+
+    it "can fulfill every interface method without raising" do
+      impl = implementation_class.new
+
+      expect(impl.fetch_reviews(repo: "x/y", pr_number: 1)).to eq([])
+      expect(impl.fetch_review_threads(repo: "x/y", pr_number: 1)).to eq([])
+      expect(impl.fetch_review_requests(repo: "x/y", pr_number: 1))
+        .to be_a(Automation::Providers::Data::ReviewRequest)
+      expect(impl.fetch_pending_reviewers(repo: "x/y", pr_number: 1)).to eq([])
+      expect(impl.request_reviewers(repo: "x/y", pr_number: 1, reviewers: [ "a" ])).to eq([ "a" ])
+      expect(impl.submit_review(repo: "x/y", pr_number: 1, body: "lgtm", event: :approve))
+        .to be_a(Automation::Providers::Data::Review)
+      expect { impl.resolve_review_thread(repo: "x/y", pr_number: 1, thread_id: "t") }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/automation/providers/work_item_provider_spec.rb
+++ b/spec/services/automation/providers/work_item_provider_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Providers::WorkItemProvider do
+  let(:unimplemented_class) do
+    Class.new do
+      include Automation::Providers::WorkItemProvider
+    end
+  end
+
+  let(:unimplemented) { unimplemented_class.new }
+
+  describe "the interface contract" do
+    it "declares the capability methods automation policy depends on" do
+      expected_methods = %i[
+        fetch_issue
+        list_issues
+        fetch_issue_comments
+        fetch_issue_timeline
+        create_issue
+        add_labels
+        remove_label
+        add_comment
+        transition_state
+      ]
+
+      expect(described_class.instance_methods(false)).to include(*expected_methods)
+    end
+
+    it "raises NotImplementedError for each method when not overridden" do
+      expect { unimplemented.fetch_issue(repo: "x/y", number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_issue/)
+      expect { unimplemented.list_issues(repo: "x/y") }
+        .to raise_error(NotImplementedError, /#list_issues/)
+      expect { unimplemented.fetch_issue_comments(repo: "x/y", number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_issue_comments/)
+      expect { unimplemented.fetch_issue_timeline(repo: "x/y", number: 1) }
+        .to raise_error(NotImplementedError, /#fetch_issue_timeline/)
+      expect { unimplemented.create_issue(repo: "x/y", title: "t") }
+        .to raise_error(NotImplementedError, /#create_issue/)
+      expect { unimplemented.add_labels(repo: "x/y", number: 1, labels: []) }
+        .to raise_error(NotImplementedError, /#add_labels/)
+      expect { unimplemented.remove_label(repo: "x/y", number: 1, label: "a") }
+        .to raise_error(NotImplementedError, /#remove_label/)
+      expect { unimplemented.add_comment(repo: "x/y", number: 1, body: "") }
+        .to raise_error(NotImplementedError, /#add_comment/)
+      expect { unimplemented.transition_state(repo: "x/y", number: 1, state: :closed) }
+        .to raise_error(NotImplementedError, /#transition_state/)
+    end
+
+    it "provides a ProviderError base class for implementations to extend" do
+      expect(described_class::ProviderError).to be < StandardError
+    end
+  end
+
+  describe "a conforming implementation" do
+    let(:implementation_class) do
+      Class.new do
+        include Automation::Providers::WorkItemProvider
+
+        def fetch_issue(repo:, number:)
+          Automation::Providers::Data::Issue.new(
+            number: number, title: "t", body: "",
+            state: :open, raw_state: "open",
+            author_login: "alice", assignee_logins: [], labels: [],
+            dependencies: [], created_at: Time.now, updated_at: Time.now,
+            closed_at: nil, url: nil, pull_request_number: nil
+          )
+        end
+
+        def list_issues(repo:, state: :open, labels: nil, assignees: nil); []; end
+        def fetch_issue_comments(repo:, number:); []; end
+        def fetch_issue_timeline(repo:, number:); []; end
+
+        def create_issue(repo:, title:, body: "", labels: [])
+          fetch_issue(repo: repo, number: 1)
+        end
+
+        def add_labels(repo:, number:, labels:); end
+        def remove_label(repo:, number:, label:); end
+
+        def add_comment(repo:, number:, body:)
+          Automation::Providers::Data::Comment.new(
+            id: 1, author_login: nil, body: body,
+            created_at: Time.now, updated_at: nil, url: nil
+          )
+        end
+
+        def transition_state(repo:, number:, state:, reason: nil)
+          fetch_issue(repo: repo, number: number)
+        end
+      end
+    end
+
+    it "can fulfill every interface method without raising" do
+      impl = implementation_class.new
+
+      expect(impl.fetch_issue(repo: "x/y", number: 1))
+        .to be_a(Automation::Providers::Data::Issue)
+      expect(impl.list_issues(repo: "x/y")).to eq([])
+      expect(impl.fetch_issue_comments(repo: "x/y", number: 1)).to eq([])
+      expect(impl.fetch_issue_timeline(repo: "x/y", number: 1)).to eq([])
+      expect(impl.create_issue(repo: "x/y", title: "t"))
+        .to be_a(Automation::Providers::Data::Issue)
+      expect { impl.add_labels(repo: "x/y", number: 1, labels: [ "a" ]) }.not_to raise_error
+      expect { impl.remove_label(repo: "x/y", number: 1, label: "a") }.not_to raise_error
+      expect(impl.add_comment(repo: "x/y", number: 1, body: "hi"))
+        .to be_a(Automation::Providers::Data::Comment)
+      expect(impl.transition_state(repo: "x/y", number: 1, state: :closed))
+        .to be_a(Automation::Providers::Data::Issue)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Establishes stable provider capability interfaces so automation policy can target repository, work-item, and review providers without coupling to a specific vendor. This unblocks future implementations for GitLab, Bitbucket, Linear, Jira, and similar systems by giving them a clear contract to satisfy.

## Changes

- **Provider interfaces**: Defined repository-provider capabilities covering pull request state, comments, checks, and merge operations.
- **Work-item interfaces**: Defined issue selection, dependency/blocker inspection, and status-transition capabilities.
- **Review interfaces**: Defined review-provider capabilities for pending/satisfied status and review-request execution.
- **Resolution rules**: Documented how strategies and providers are resolved from project configuration.
- **Contract documentation**: Added a high-level contract describing how implementations should satisfy each capability.

## Design Decisions

- **Capability-shaped, not vendor-shaped**: Interfaces are sliced by automation concern (repository, work-item, review) rather than by external system, so a single vendor can implement multiple capabilities and a single capability can have multiple backings.
- **Policy/provider boundary**: Automation policy depends only on these interfaces, never on concrete clients. This keeps GitHub-specific behavior out of policy code and makes alternative providers a pure additive change.
- **Configuration-driven resolution**: Strategy and provider selection is sourced from project configuration so swapping providers does not require code changes in automation policy.

## Operational Notes

This change introduces interface definitions only — no behavioral or schema changes. Provider implementations land in follow-up work tracking against #1114.

---

Closes #1116