### PR TITLE
fix(knowledge): create writable log/ and tmp/ in collector workspace

### DIFF
--- a/app/services/knowledge/containerized_runner.rb
+++ b/app/services/knowledge/containerized_runner.rb
@@ -246,28 +246,56 @@ module Knowledge
     # the entire archive in memory.
     def seed_workspace!
       stream_repo_tar_to_container!
+
+      workspace = options[:workspace_mount]
+      writable_paths = [ "#{workspace}/log", "#{workspace}/tmp" ]
+
       # Force root ownership so the agent user cannot restore write
       # permissions (they don't own the files). Tar preserves uid/gid
       # from the host clone, which may be a non-root user, so an
-      # explicit chown is required. Then set read + execute (for
-      # directories) for all users so the agent can read the codebase
-      # for analysis. Collectors should write only to the size-limited
-      # tmpfs locations (/tmp, /home/agent/.cache).
-      _stdout, _stderr, chown_status = @container.exec(
-        [ "chown", "-R", "root:root", options[:workspace_mount] ],
-        user: "root"
-      )
-      raise ContainerError, "Failed to set workspace ownership (exit #{chown_status})" unless chown_status.to_i.zero?
+      # explicit chown is required.
+      exec_setup!([ "chown", "-R", "root:root", workspace ], "set workspace ownership")
 
-      _stdout, _stderr, status = @container.exec(
-        [ "chmod", "-R", "a=rX", options[:workspace_mount] ],
-        user: "root"
-      )
-      raise ContainerError, "Failed to set workspace permissions (exit #{status})" unless status.to_i.zero?
+      # Pre-create Rails writable directories BEFORE locking the workspace
+      # down. The routes collector boots the target Rails app via
+      # `bin/rails routes`, and Rails initializes its logger by writing to
+      # log/<env>.log during boot. Without writable log/, Rails aborts with
+      # "Unable to access log file. Please ensure that
+      # /workspace/log/development.log exists and is writable". tmp/ is
+      # similarly expected by bootsnap and other boot-time writers. The
+      # mkdir MUST precede the chmod below: after `chmod -R a=rX`,
+      # /workspace has no write bit, and CapDrop: ALL strips
+      # CAP_DAC_OVERRIDE so even root cannot create new entries there.
+      exec_setup!([ "mkdir", "-p", *writable_paths ], "create Rails writable directories")
+
+      # Set read + execute (for directories) for all users so the agent can
+      # read the codebase for analysis. Collectors should write only to
+      # the size-limited tmpfs locations (/tmp, /home/agent/.cache) and
+      # the Rails writable dirs granted below.
+      exec_setup!([ "chmod", "-R", "a=rX", workspace ], "set workspace permissions")
+
+      # Grant the agent user ownership + write access to log/ and tmp/ only.
+      # The rest of /workspace remains read-only so the agent cannot mutate
+      # source code it analyzes. These two dirs are the minimal set required
+      # for Rails to boot cleanly during collection; any pre-existing
+      # contents (unusual for log/tmp, which are typically gitignored) are
+      # also re-owned to agent so Rails can rotate/truncate them.
+      exec_setup!([ "chown", "-R", "agent:agent", *writable_paths ], "set Rails writable directory ownership")
+      exec_setup!([ "chmod", "-R", "u+rwX", *writable_paths ], "grant Rails writable directory permissions")
     rescue ContainerError
       raise
     rescue Docker::Error::DockerError, Errno::ENOENT => e
       raise ContainerError, "Failed to seed workspace: #{e.message}"
+    end
+
+    # Runs a workspace setup command as root and raises ContainerError on
+    # non-zero exit. Centralizes the exec+check pattern so the order and
+    # error shape of seed_workspace! is easy to read at a glance.
+    def exec_setup!(command, failing_action)
+      _stdout, _stderr, status = @container.exec(command, user: "root")
+      return if status.to_i.zero?
+
+      raise ContainerError, "Failed to #{failing_action} (exit #{status})"
     end
 
     def stream_repo_tar_to_container!

--- a/spec/services/knowledge/containerized_runner_spec.rb
+++ b/spec/services/knowledge/containerized_runner_spec.rb
@@ -158,6 +158,95 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
       )
     end
 
+    # Regression: without writable log/ and tmp/, `bin/rails routes` fails
+    # during logger initialization with "Unable to access log file. Please
+    # ensure that /workspace/log/development.log exists and is writable".
+    # This surfaced after #1167 raised the memory limit past the point where
+    # Rails could finish booting and hit the logger.
+    it "pre-creates log/ and tmp/ before locking the workspace read-only" do
+      described_class.new(project: project, commit_sha: commit_sha).run
+
+      expect(mock_container).to have_received(:exec).with(
+        [ "mkdir", "-p", "/workspace/log", "/workspace/tmp" ],
+        user: "root"
+      )
+    end
+
+    # Ordering invariant: mkdir MUST precede chmod -R a=rX. After that
+    # chmod, /workspace is read-only even for root (CapDrop: ALL strips
+    # CAP_DAC_OVERRIDE), so a reorder would break directory creation in
+    # production while leaving mock-based tests green.
+    it "creates Rails writable dirs before applying the read-only chmod" do
+      call_order = []
+      allow(mock_container).to receive(:exec) do |cmd, **|
+        call_order << cmd
+        [ [ "" ], [ "" ], 0 ]
+      end
+
+      described_class.new(project: project, commit_sha: commit_sha).run
+
+      mkdir_index = call_order.index do |cmd|
+        cmd.is_a?(Array) && cmd.first == "mkdir" && cmd.include?("/workspace/log")
+      end
+      lockdown_index = call_order.index { |cmd| cmd == [ "chmod", "-R", "a=rX", "/workspace" ] }
+
+      expect(mkdir_index).not_to be_nil
+      expect(lockdown_index).not_to be_nil
+      expect(mkdir_index).to be < lockdown_index
+    end
+
+    it "grants the agent user write access to log/ and tmp/ only" do
+      described_class.new(project: project, commit_sha: commit_sha).run
+
+      expect(mock_container).to have_received(:exec).with(
+        [ "chown", "-R", "agent:agent", "/workspace/log", "/workspace/tmp" ],
+        user: "root"
+      )
+      expect(mock_container).to have_received(:exec).with(
+        [ "chmod", "-R", "u+rwX", "/workspace/log", "/workspace/tmp" ],
+        user: "root"
+      )
+    end
+
+    it "raises ContainerError when mkdir of Rails writable dirs fails" do
+      allow(mock_container).to receive(:exec)
+        .with([ "mkdir", "-p", "/workspace/log", "/workspace/tmp" ], user: "root")
+        .and_return([ [ "" ], [ "Permission denied" ], 1 ])
+
+      expect {
+        described_class.new(project: project, commit_sha: commit_sha).run
+      }.to raise_error(
+        Knowledge::ContainerizedRunner::ContainerError,
+        /Failed to create Rails writable directories/
+      )
+    end
+
+    it "raises ContainerError when chown of Rails writable dirs fails" do
+      allow(mock_container).to receive(:exec)
+        .with([ "chown", "-R", "agent:agent", "/workspace/log", "/workspace/tmp" ], user: "root")
+        .and_return([ [ "" ], [ "Operation not permitted" ], 1 ])
+
+      expect {
+        described_class.new(project: project, commit_sha: commit_sha).run
+      }.to raise_error(
+        Knowledge::ContainerizedRunner::ContainerError,
+        /Failed to set Rails writable directory ownership/
+      )
+    end
+
+    it "raises ContainerError when chmod of Rails writable dirs fails" do
+      allow(mock_container).to receive(:exec)
+        .with([ "chmod", "-R", "u+rwX", "/workspace/log", "/workspace/tmp" ], user: "root")
+        .and_return([ [ "" ], [ "Operation not permitted" ], 1 ])
+
+      expect {
+        described_class.new(project: project, commit_sha: commit_sha).run
+      }.to raise_error(
+        Knowledge::ContainerizedRunner::ContainerError,
+        /Failed to grant Rails writable directory permissions/
+      )
+    end
+
     it "raises ContainerError when chown fails during seeding" do
       allow(mock_container).to receive(:exec)
         .with([ "chown", "-R", "root:root", "/workspace" ], user: "root")


### PR DESCRIPTION
## Summary

- The routes collector boots the target Rails app via \`bin/rails routes\`, which initializes its logger by writing to \`log/<env>.log\` during boot. Before #1167 raised the container memory cap to 4GB, Rails was OOM-killed before reaching logger init; the memory bump exposed this latent bug, surfacing as `Rails Error: Unable to access log file. Please ensure that /workspace/log/development.log exists and is writable`.
- Pre-creates writable \`log/\` and \`tmp/\` dirs for the \`agent\` user inside the otherwise read-only workspace. The rest of \`/workspace\` stays read-only so collectors still can't mutate source.
- The \`mkdir\` must precede the \`chmod -R a=rX\` lockdown: after that chmod, \`/workspace\` has no write bit, and \`CapDrop: ALL\` strips CAP_DAC_OVERRIDE so even root cannot create entries there.
- Extracts an \`exec_setup!\` helper to keep \`seed_workspace!\` readable as setup steps grow.

## Test plan

- [x] \`bin/rspec spec/services/knowledge/containerized_runner_spec.rb spec/services/knowledge/collectors/routes_collector_spec.rb\` — 84 examples pass
- [x] \`bin/rubocop app/services/knowledge/containerized_runner.rb spec/services/knowledge/containerized_runner_spec.rb\` — clean
- [x] New regression tests cover: pre-creation of log/tmp, agent write grant on log/tmp only, mkdir/chown/chmod failure paths, and the critical ordering invariant (mkdir before chmod-lockdown)
- [ ] Verify routes collection succeeds end-to-end on a real Rails target repo after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)