### PR TITLE
Fix #1147: refactor(pr-description): route text-only Llm::* services through agent-harness text mode

### DIFF
--- a/app/services/agent_runs/diagnose_error.rb
+++ b/app/services/agent_runs/diagnose_error.rb
@@ -72,7 +72,8 @@ module AgentRuns
         provider: :claude,
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
-        tools: :none
+        tools: :none,
+        **Llm::TextMode.options
       )
       return nil unless response.success?
 

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -13,6 +13,13 @@ module Knowledge
     # (no API keys in container). Falls back to in-process AgentHarness when
     # Docker is unavailable.
     #
+    # Text-mode routing (#1147): the in-process Claude path opts into
+    # +Llm::TextMode.options+ so host-side drafting uses the HTTP text
+    # transport when +ANTHROPIC_API_KEY+ is configured. Non-Claude providers
+    # and the containerized path continue to use their existing CLI transport
+    # unchanged, because +TextTransport+ is Anthropic-only and the container
+    # already isolates +cwd+/memory concerns.
+    #
     # @example
     #   Knowledge::Decisions::Draft.call(agent_run: agent_run)
     class Draft
@@ -194,6 +201,9 @@ module Knowledge
           tools: :none
         }
         options[:model] = DEFAULT_MODEL if provider == DEFAULT_PROVIDER
+        # Only route through text mode for Claude; other providers are not
+        # required to expose HTTP text transport and fall back to CLI.
+        options.merge!(Llm::TextMode.options) if provider == DEFAULT_PROVIDER
         options
       end
 

--- a/app/services/llm/generate_issue_title.rb
+++ b/app/services/llm/generate_issue_title.rb
@@ -48,7 +48,8 @@ module Llm
         provider: :claude,
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
-        tools: :none
+        tools: :none,
+        **TextMode.options
       )
       return nil unless response.success?
 

--- a/app/services/llm/generate_pr_description.rb
+++ b/app/services/llm/generate_pr_description.rb
@@ -82,7 +82,8 @@ module Llm
         provider: :claude,
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
-        tools: :none
+        tools: :none,
+        **TextMode.options
       )
       return nil unless response.success?
 

--- a/app/services/llm/text_mode.rb
+++ b/app/services/llm/text_mode.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Llm
+  # Decides whether a pure-text LLM call should use agent-harness's
+  # HTTP-based text mode (+mode: :text+) or the default CLI transport.
+  #
+  # Text mode bypasses the +claude+ CLI entirely, eliminating host-process
+  # +cwd+ / git-state sensitivity and avoiding CLAUDE.md memory loading.
+  # That closes the class of bug where a PR body silently inherits context
+  # from whatever directory the Rails host happens to be in.
+  #
+  # Billing/auth constraint: agent-harness's text transport requires a
+  # direct Anthropic API key. Using it with OAuth/subscription credentials
+  # would silently shift billing from subscription-backed CLI usage to
+  # API-metered HTTP usage, so this router only opts in when
+  # +ANTHROPIC_API_KEY+ is explicitly configured in the host environment.
+  # Without an API key, callers fall back to the CLI transport and billing
+  # routing is preserved unchanged.
+  #
+  # Kill switch: set +PAID_LLM_TEXT_MODE_DISABLED=1+ to force all
+  # +Llm::*+ services back onto the CLI path without a code change. Useful
+  # during a staged rollout if regressions appear on the HTTP path.
+  module TextMode
+    KILL_SWITCH_ENV = "PAID_LLM_TEXT_MODE_DISABLED"
+    API_KEY_ENV = "ANTHROPIC_API_KEY"
+    TRUTHY_VALUES = %w[1 true yes on].freeze
+
+    module_function
+
+    # Options to merge into +AgentHarness.send_message+. Returns
+    # +{mode: :text}+ when HTTP transport is eligible, otherwise +{}+ so
+    # the call falls back to the default CLI transport.
+    #
+    # @return [Hash]
+    def options
+      enabled? ? { mode: :text } : {}
+    end
+
+    # @return [Boolean] whether text mode should be used for this process.
+    def enabled?
+      return false if kill_switch_enabled?
+
+      api_key_present?
+    end
+
+    def kill_switch_enabled?
+      TRUTHY_VALUES.include?(ENV[KILL_SWITCH_ENV].to_s.strip.downcase)
+    end
+
+    def api_key_present?
+      key = ENV[API_KEY_ENV]
+      !key.nil? && !key.strip.empty?
+    end
+  end
+end

--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -60,7 +60,8 @@ module Models
         provider: :claude,
         model: MODEL,
         timeout: TIMEOUT,
-        tools: :none
+        tools: :none,
+        **Llm::TextMode.options
       )
       return nil unless response.success?
 

--- a/app/services/prompt_evolution/mutate.rb
+++ b/app/services/prompt_evolution/mutate.rb
@@ -72,7 +72,8 @@ module PromptEvolution
         provider: :claude,
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
-        tools: :none
+        tools: :none,
+        **Llm::TextMode.options
       )
       unless response.success?
         Rails.logger.warn(

--- a/app/services/style_guides/compress.rb
+++ b/app/services/style_guides/compress.rb
@@ -79,7 +79,8 @@ module StyleGuides
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
         dangerous_mode: false,
-        tools: :none
+        tools: :none,
+        **Llm::TextMode.options
       )
 
       validate_response!(response)

--- a/app/services/style_guides/extract.rb
+++ b/app/services/style_guides/extract.rb
@@ -109,7 +109,8 @@ module StyleGuides
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
         dangerous_mode: false,
-        tools: :none
+        tools: :none,
+        **Llm::TextMode.options
       )
     end
 

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -42,7 +42,8 @@ module Activities
         provider: :claude,
         model: DEFAULT_MODEL,
         timeout: TIMEOUT,
-        tools: :none
+        tools: :none,
+        **Llm::TextMode.options
       )
 
       unless response.success?

--- a/spec/services/agent_runs/diagnose_error_spec.rb
+++ b/spec/services/agent_runs/diagnose_error_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe AgentRuns::DiagnoseError do
     allow(github_token).to receive(:client).and_return(github_client)
     allow(AgentHarness).to receive(:send_message).and_return(llm_response)
     allow(github_client).to receive(:create_issue).and_return(gh_issue)
+    # Default: preserve CLI transport so existing exact-match expectations
+    # pass. Individual specs flip this on to prove text-mode routing.
+    allow(Llm::TextMode).to receive(:options).and_return({})
   end
 
   describe ".call" do
@@ -46,6 +49,15 @@ RSpec.describe AgentRuns::DiagnoseError do
         timeout: 60,
         tools: :none
       )
+    end
+
+    it "routes through agent-harness text mode when an API key is configured" do
+      allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+
+      described_class.call(agent_run: agent_run)
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(mode: :text))
     end
 
     it "creates a GitHub issue with the diagnosis" do

--- a/spec/services/knowledge/decisions/draft_spec.rb
+++ b/spec/services/knowledge/decisions/draft_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe Knowledge::Decisions::Draft do
   before do
     allow(Knowledge::AnalysisRunner).to receive(:available?).and_return(false)
     allow(AgentHarness).to receive(:send_message).and_return(llm_response)
+    # Default: preserve CLI transport so existing exact-match expectations
+    # pass. Individual specs flip this on to prove text-mode routing.
+    allow(Llm::TextMode).to receive(:options).and_return({})
     agent_run.log!("stdout", "Implemented JWT authentication for API endpoints")
   end
 
@@ -107,6 +110,27 @@ RSpec.describe Knowledge::Decisions::Draft do
         dangerous_mode: false,
         tools: :none
       )
+    end
+
+    it "routes the Claude provider through agent-harness text mode when an API key is configured" do
+      allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+
+      described_class.call(agent_run: agent_run)
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(provider: :claude, mode: :text))
+    end
+
+    it "does not route non-claude providers through text mode (text transport is Anthropic-only)" do
+      allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+      project.created_by.settings.update!(kb_chat_provider: "cursor", kb_chat_fallback_providers: [])
+
+      described_class.call(agent_run: agent_run)
+
+      expect(AgentHarness).to have_received(:send_message) do |_prompt, **opts|
+        expect(opts[:provider]).to eq(:cursor)
+        expect(opts).not_to have_key(:mode)
+      end
     end
 
     it "uses the configured knowledge chat provider" do

--- a/spec/services/llm/generate_issue_title_spec.rb
+++ b/spec/services/llm/generate_issue_title_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Llm::GenerateIssueTitle do
+  before { allow(Llm::TextMode).to receive(:options).and_return(mode: :text) }
+
   let(:summary) { "The authentication system uses JWT tokens with a 24-hour expiry." }
 
   describe ".call" do
@@ -18,8 +20,31 @@ RSpec.describe Llm::GenerateIssueTitle do
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
         timeout: described_class::TIMEOUT,
-        tools: :none
+        tools: :none,
+        mode: :text
       )
+    end
+
+    it "routes through agent-harness text mode when an API key is configured" do
+      response = instance_double(AgentHarness::Response, success?: true, output: "JWT authentication system review")
+      allow(AgentHarness).to receive(:send_message).and_return(response)
+
+      described_class.call(summary: summary)
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(mode: :text))
+    end
+
+    it "falls back to the CLI transport when text mode is ineligible (preserves subscription billing)" do
+      allow(Llm::TextMode).to receive(:options).and_return({})
+      response = instance_double(AgentHarness::Response, success?: true, output: "JWT authentication system review")
+      allow(AgentHarness).to receive(:send_message).and_return(response)
+
+      described_class.call(summary: summary)
+
+      expect(AgentHarness).to have_received(:send_message) do |_prompt, **opts|
+        expect(opts).not_to have_key(:mode)
+      end
     end
 
     it "passes tools: :none to disable CLI tool access during text-only generation" do

--- a/spec/services/llm/generate_pr_description_spec.rb
+++ b/spec/services/llm/generate_pr_description_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Llm::GeneratePrDescription do
+  before { allow(Llm::TextMode).to receive(:options).and_return(mode: :text) }
+
   let(:agent_summary) { "Added OAuth middleware and user session management." }
   let(:issue_title) { "Add OAuth support" }
   let(:issue_body) { "We need OAuth2 support for third-party integrations." }
@@ -36,8 +38,49 @@ RSpec.describe Llm::GeneratePrDescription do
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
         timeout: described_class::TIMEOUT,
-        tools: :none
+        tools: :none,
+        mode: :text
       )
+    end
+
+    it "routes through agent-harness text mode when an API key is configured" do
+      response = instance_double(AgentHarness::Response, success?: true, output: generated_description)
+      allow(AgentHarness).to receive(:send_message).and_return(response)
+
+      described_class.call(agent_summary: agent_summary)
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(mode: :text))
+    end
+
+    it "falls back to the CLI transport when text mode is ineligible (preserves subscription billing)" do
+      allow(Llm::TextMode).to receive(:options).and_return({})
+      response = instance_double(AgentHarness::Response, success?: true, output: generated_description)
+      allow(AgentHarness).to receive(:send_message).and_return(response)
+
+      described_class.call(agent_summary: agent_summary)
+
+      expect(AgentHarness).to have_received(:send_message) do |_prompt, **opts|
+        expect(opts).not_to have_key(:mode)
+      end
+    end
+
+    it "produces an identical request regardless of host-process cwd (#1140 regression)" do
+      response = instance_double(AgentHarness::Response, success?: true, output: generated_description)
+      captured = []
+      allow(AgentHarness).to receive(:send_message) do |prompt, **opts|
+        captured << [ prompt, opts ]
+        response
+      end
+
+      [ "/tmp", Rails.root.to_s ].each do |dir|
+        Dir.chdir(dir) do
+          described_class.call(agent_summary: agent_summary, issue_title: issue_title, issue_body: issue_body)
+        end
+      end
+
+      expect(captured.map(&:first).uniq.size).to eq(1)
+      expect(captured.map(&:last).uniq.size).to eq(1)
     end
 
     it "passes tools: :none to disable CLI tool access during text-only generation" do

--- a/spec/services/llm/text_mode_spec.rb
+++ b/spec/services/llm/text_mode_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Llm::TextMode do
+  describe ".options" do
+    context "when ANTHROPIC_API_KEY is set" do
+      before { stub_const("ENV", ENV.to_hash.merge("ANTHROPIC_API_KEY" => "sk-ant-abc", "PAID_LLM_TEXT_MODE_DISABLED" => nil)) }
+
+      it "returns the text-mode option" do
+        expect(described_class.options).to eq(mode: :text)
+      end
+    end
+
+    context "when ANTHROPIC_API_KEY is blank" do
+      before { stub_const("ENV", ENV.to_hash.merge("ANTHROPIC_API_KEY" => "", "PAID_LLM_TEXT_MODE_DISABLED" => nil)) }
+
+      it "returns an empty hash so the call falls back to CLI transport" do
+        expect(described_class.options).to eq({})
+      end
+    end
+
+    context "when ANTHROPIC_API_KEY is missing" do
+      before { stub_const("ENV", ENV.to_hash.except("ANTHROPIC_API_KEY").merge("PAID_LLM_TEXT_MODE_DISABLED" => nil)) }
+
+      it "returns an empty hash so subscription/OAuth billing is preserved" do
+        expect(described_class.options).to eq({})
+      end
+    end
+
+    context "when the kill switch is set" do
+      before do
+        stub_const("ENV", ENV.to_hash.merge(
+          "ANTHROPIC_API_KEY" => "sk-ant-abc",
+          "PAID_LLM_TEXT_MODE_DISABLED" => "1"
+        ))
+      end
+
+      it "returns an empty hash even when the API key is present" do
+        expect(described_class.options).to eq({})
+      end
+    end
+
+    context "when the kill switch has a non-truthy value" do
+      before do
+        stub_const("ENV", ENV.to_hash.merge(
+          "ANTHROPIC_API_KEY" => "sk-ant-abc",
+          "PAID_LLM_TEXT_MODE_DISABLED" => "0"
+        ))
+      end
+
+      it "still routes to text mode" do
+        expect(described_class.options).to eq(mode: :text)
+      end
+    end
+  end
+
+  describe ".enabled?" do
+    it "is a boolean" do
+      expect(described_class.enabled?).to be_in([ true, false ])
+    end
+  end
+end

--- a/spec/services/models/meta_agent_selector_spec.rb
+++ b/spec/services/models/meta_agent_selector_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe Models::MetaAgentSelector do
 
     before do
       allow(AgentHarness).to receive(:send_message).and_return(successful_response)
+      # Default: preserve CLI transport so existing exact-match expectations
+      # pass. Individual specs flip this on to prove text-mode routing.
+      allow(Llm::TextMode).to receive(:options).and_return({})
     end
 
     it "selects a model via LLM meta-agent" do
@@ -49,6 +52,15 @@ RSpec.describe Models::MetaAgentSelector do
         timeout: 15,
         tools: :none
       )
+    end
+
+    it "routes through agent-harness text mode when an API key is configured" do
+      allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+
+      described_class.call(agent_run: agent_run)
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(mode: :text))
     end
 
     context "when meta-agent selects a cheap model for simple task" do

--- a/spec/services/prompt_evolution/mutate_spec.rb
+++ b/spec/services/prompt_evolution/mutate_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe PromptEvolution::Mutate do
 
   before do
     allow(AgentHarness).to receive(:send_message).and_return(harness_response)
+    # Default: preserve CLI transport so existing exact-match expectations
+    # pass. Individual specs flip this on to prove text-mode routing.
+    allow(Llm::TextMode).to receive(:options).and_return({})
   end
 
   describe ".call" do
@@ -90,6 +93,15 @@ RSpec.describe PromptEvolution::Mutate do
         a_string_including("Refinement", "Simplification"),
         hash_including(provider: :claude)
       )
+    end
+
+    it "routes through agent-harness text mode when an API key is configured" do
+      allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+
+      described_class.call(prompt: prompt)
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(mode: :text))
     end
   end
 

--- a/spec/services/style_guides/compress_spec.rb
+++ b/spec/services/style_guides/compress_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe StyleGuides::Compress do
 
     before do
       allow(AgentHarness).to receive(:send_message).and_return(response)
+      # Default: preserve CLI transport so existing exact-match expectations
+      # pass. Individual specs flip this on to prove text-mode routing.
+      allow(Llm::TextMode).to receive(:options).and_return({})
     end
 
     it "compresses the style guide content" do
@@ -51,6 +54,15 @@ RSpec.describe StyleGuides::Compress do
         dangerous_mode: false,
         tools: :none
       )
+    end
+
+    it "routes through agent-harness text mode when an API key is configured" do
+      allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+
+      described_class.call(style_guide: style_guide)
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(mode: :text))
     end
 
     it "returns the updated style guide" do

--- a/spec/services/style_guides/extract_spec.rb
+++ b/spec/services/style_guides/extract_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe StyleGuides::Extract do
   before do
     allow(StyleGuides::CollectCodeSamples).to receive(:call).and_return(collected_samples)
     allow(AgentHarness).to receive(:send_message).and_return(llm_response)
+    # Default: preserve CLI transport so existing exact-match expectations
+    # pass. Individual specs flip this on to prove text-mode routing.
+    allow(Llm::TextMode).to receive(:options).and_return({})
   end
 
   describe ".call" do
@@ -86,6 +89,17 @@ RSpec.describe StyleGuides::Extract do
         dangerous_mode: false,
         tools: :none
       )
+    end
+
+    it "routes through agent-harness text mode when an API key is configured" do
+      allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+
+      described_class.call(project: project)
+
+      # Extract issues one LLM call per language, so the route assertion
+      # holds for every invocation.
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(mode: :text)).at_least(:once)
     end
 
     it "returns empty result when no samples are collected" do

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
     before do
       allow(AgentHarness).to receive(:send_message).and_return(llm_response)
+      # Default: preserve CLI transport so existing exact-match expectations
+      # pass. Individual specs flip this on to prove text-mode routing.
+      allow(Llm::TextMode).to receive(:options).and_return({})
     end
 
     it "returns parsed tasks from LLM output" do
@@ -65,6 +68,19 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         timeout: described_class::TIMEOUT,
         tools: :none
       )
+    end
+
+    it "routes through agent-harness text mode when an API key is configured" do
+      allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+
+      activity.execute(
+        project_id: project.id,
+        issue_id: issue.id,
+        knowledge_context: knowledge_context
+      )
+
+      expect(AgentHarness).to have_received(:send_message)
+        .with(anything, hash_including(mode: :text))
     end
 
     it "includes knowledge context in the prompt when available" do


### PR DESCRIPTION
## Summary

refactor(pr-description): route text-only Llm::* services through agent-harness text mode

See #1147 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1147