### PR TITLE
Fix #1176: Auto-pick should prioritize issues by label (P1 > P2 > P3 > unlabeled)

### DIFF
--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -16,9 +16,11 @@ module Issues
   # - Not labeled with excluded labels (planning, research, waiting,
   #   tracking, epic, needs-manual-setup)
   # - Not a parent/tracking issue (has sub-issues)
-  # - Ordered by priority: issues in partially-complete dependency trees
-  #   first, then by unblock count (how many open issues depend on this
-  #   one), then by github_number ascending as tiebreaker
+  # - Ordered by priority: highest priority label first (P1 > P2 > P3 >
+  #   unlabeled, using each project's configured label names), then
+  #   issues in partially-complete dependency trees, then by unblock
+  #   count (how many open issues depend on this one), then by
+  #   github_number ascending (FIFO — older issues first)
   #
   # Returns the created AgentRun or nil if no eligible issue is found.
   class AutoPick
@@ -256,11 +258,33 @@ module Issues
       eligible_issue_scope
         .joins(priority_joins)
         .order(
+          Arel.sql("#{priority_label_order_sql} ASC"),
           Arel.sql("COALESCE(started_trees.in_started_tree, 0) DESC"),
           Arel.sql("COALESCE(unblock_counts.unblock_count, 0) DESC"),
           Arel.sql("issues.github_number ASC")
         )
         .first
+    end
+
+    # Returns a CASE expression that maps each issue to a numeric priority
+    # rank based on the project's configured priority labels
+    # (Project#effective_priority_labels). Lower rank sorts first, so
+    # P1-labeled issues beat P2/P3/unlabeled, P2 beats P3/unlabeled, and
+    # P3 beats unlabeled. Label names are interpolated via connection.quote
+    # to keep the CASE safe for use with Arel.sql.
+    def priority_label_order_sql
+      effective = @project.effective_priority_labels
+      conn = Issue.connection
+      cases = Project::PRIORITY_TIERS.each_with_index.filter_map do |tier, index|
+        label_name = effective[tier]
+        next if label_name.blank?
+
+        quoted = conn.quote([ label_name ].to_json)
+        "WHEN issues.labels @> #{quoted}::jsonb THEN #{index + 1}"
+      end
+      return (Project::PRIORITY_TIERS.size + 1).to_s if cases.empty?
+
+      "CASE #{cases.join(' ')} ELSE #{Project::PRIORITY_TIERS.size + 1} END"
     end
 
     # Precomputed LEFT JOINs for priority ordering. Uses subqueries

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -399,6 +399,99 @@ RSpec.describe Issues::AutoPick do
       expect(result.issue).to eq(issue_c)
     end
 
+    context "with priority labels" do
+      it "picks a P1 issue before a P2 issue" do
+        p2_issue = create(:issue, project: project, github_number: 1, labels: [ "P2" ])
+        p1_issue = create(:issue, project: project, github_number: 2, labels: [ "P1" ])
+
+        result = described_class.new(project).call
+
+        expect(result.issue).to eq(p1_issue)
+        expect(result.issue).not_to eq(p2_issue)
+      end
+
+      it "picks a P1 issue before P2, P3, and unlabeled issues" do
+        create(:issue, project: project, github_number: 1, labels: [])
+        create(:issue, project: project, github_number: 2, labels: [ "P3" ])
+        create(:issue, project: project, github_number: 3, labels: [ "P2" ])
+        p1_issue = create(:issue, project: project, github_number: 4, labels: [ "P1" ])
+
+        result = described_class.new(project).call
+
+        expect(result.issue).to eq(p1_issue)
+      end
+
+      it "picks a P2 issue before P3 and unlabeled issues" do
+        create(:issue, project: project, github_number: 1, labels: [])
+        create(:issue, project: project, github_number: 2, labels: [ "P3" ])
+        p2_issue = create(:issue, project: project, github_number: 3, labels: [ "P2" ])
+
+        result = described_class.new(project).call
+
+        expect(result.issue).to eq(p2_issue)
+      end
+
+      it "picks a P3 issue before an unlabeled issue" do
+        create(:issue, project: project, github_number: 1, labels: [])
+        p3_issue = create(:issue, project: project, github_number: 2, labels: [ "P3" ])
+
+        result = described_class.new(project).call
+
+        expect(result.issue).to eq(p3_issue)
+      end
+
+      it "picks a P1 issue even when an unlabeled issue has a lower github_number (FIFO)" do
+        create(:issue, project: project, github_number: 1)
+        p1_issue = create(:issue, project: project, github_number: 100, labels: [ "P1" ])
+
+        result = described_class.new(project).call
+
+        expect(result.issue).to eq(p1_issue)
+      end
+
+      it "falls back to github_number (FIFO) within the same priority tier" do
+        earlier = create(:issue, project: project, github_number: 5, labels: [ "P1" ])
+        _later = create(:issue, project: project, github_number: 10, labels: [ "P1" ])
+
+        result = described_class.new(project).call
+
+        expect(result.issue).to eq(earlier)
+      end
+
+      it "still skips blocked P1 issues in favor of unblocked lower-priority issues" do
+        blocking = create(:issue, project: project, github_number: 1, labels: [ "P3" ])
+        blocked_p1 = create(:issue, project: project, github_number: 2, labels: [ "P1" ])
+        create(:issue_dependency, issue: blocked_p1, depends_on_issue: blocking)
+        unblocked_p2 = create(:issue, project: project, github_number: 3, labels: [ "P2" ])
+
+        result = described_class.new(project).call
+
+        # Blocked P1 is ineligible, and P2 beats P3 among remaining issues.
+        expect(result.issue).to eq(unblocked_p2)
+      end
+
+      it "respects custom priority label names configured on the project" do
+        project.update!(priority_labels: { "P1" => "critical", "P2" => "high", "P3" => "medium" })
+        create(:issue, project: project, github_number: 1, labels: [ "medium" ])
+        critical_issue = create(:issue, project: project, github_number: 2, labels: [ "critical" ])
+
+        result = described_class.new(project).call
+
+        expect(result.issue).to eq(critical_issue)
+      end
+
+      it "treats the highest priority label as winning when multiple are present" do
+        lower = create(:issue, project: project, github_number: 1, labels: [ "P2" ])
+        mixed = create(:issue, project: project, github_number: 2, labels: [ "P2", "P1" ])
+
+        result = described_class.new(project).call
+
+        # `mixed` carries P1 — it should beat the pure P2 issue despite a higher number.
+        expect(result.issue).to eq(mixed)
+        expect(result.issue).not_to eq(lower)
+      end
+    end
+
     it "returns nil when no eligible issues exist" do
       result = described_class.new(project).call
 


### PR DESCRIPTION
## Summary

Auto-pick should prioritize issues by label (P1 > P2 > P3 > unlabeled)

See #1176 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1176