### PR TITLE
chore(infra): pin Postgres to 16.13 across devcontainer, compose, and CI

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -30,7 +30,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:16.1
+    image: postgres:16.13
     restart: unless-stopped
     networks:
     - default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,26 @@ jobs:
       - name: Run lint checks
         run: bin/lint
 
+      - name: Verify Postgres image pins are in sync
+        # All three files must pin the same postgres:<tag> so that schema.rb
+        # dumps are byte-identical across dev, devcontainer, and CI. Drift
+        # across minor versions causes cosmetic pg_get_expr() churn in schema.rb.
+        run: |
+          dev=$(grep -oE 'postgres:[0-9][^[:space:]]*' .devcontainer/compose.yaml | head -1)
+          compose=$(grep -oE 'postgres:[0-9][^[:space:]]*' docker-compose.yml | head -1)
+          ci=$(grep -oE 'postgres:[0-9][^[:space:]]*' .github/workflows/ci.yml | head -1)
+          echo "devcontainer/compose.yaml: ${dev:-<none>}"
+          echo "docker-compose.yml:        ${compose:-<none>}"
+          echo ".github/workflows/ci.yml:  ${ci:-<none>}"
+          if [ -z "$dev" ] || [ -z "$compose" ] || [ -z "$ci" ]; then
+            echo "::error::Postgres image pin missing in one or more files"
+            exit 1
+          fi
+          if [ "$dev" != "$compose" ] || [ "$compose" != "$ci" ]; then
+            echo "::error::Postgres image pins are out of sync. Update all three together."
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
         # dumps are byte-identical across dev, devcontainer, and CI. Drift
         # across minor versions causes cosmetic pg_get_expr() churn in schema.rb.
         run: |
-          dev=$(grep -oE 'postgres:[0-9][^[:space:]]*' .devcontainer/compose.yaml | head -1)
-          compose=$(grep -oE 'postgres:[0-9][^[:space:]]*' docker-compose.yml | head -1)
-          ci=$(grep -oE 'postgres:[0-9][^[:space:]]*' .github/workflows/ci.yml | head -1)
+          dev=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .devcontainer/compose.yaml | head -1 | awk '{print $NF}')
+          compose=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' docker-compose.yml | head -1 | awk '{print $NF}')
+          ci=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/ci.yml | head -1 | awk '{print $NF}')
           echo "devcontainer/compose.yaml: ${dev:-<none>}"
           echo "docker-compose.yml:        ${compose:-<none>}"
           echo ".github/workflows/ci.yml:  ${ci:-<none>}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16.13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@
 
 services:
   postgres:
-    image: postgres:16.1
+    image: postgres:16.13
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
## Summary

- Pin the three Postgres infra locations to the same exact patch version (`16.13`), eliminating a drift source that was producing cosmetic `db/schema.rb` flip-flops across contributors.
- Add a CI guard (lint-job step) that fails the build if the three pins ever drift apart again, so this fix doesn't rot.
- Before: [.devcontainer/compose.yaml](.devcontainer/compose.yaml) and [docker-compose.yml](docker-compose.yml) pinned stale `16.1` (Nov 2023); [.github/workflows/ci.yml](.github/workflows/ci.yml) used the floating `postgres:16` tag.
- `pg_get_expr()` serializes index/check-constraint predicates slightly differently across 16.x patch releases (e.g. `ARRAY[('x'::varchar)::text, ...]` vs `ARRAY['x'::varchar, ...]::text[]`) — semantically identical but textually divergent. With CI running whichever 16.x Docker Hub currently tags as latest and local devs on 16.1, whoever last re-dumped schema set the "winning" format, and the next person to dump from the other version produced a diff.

## Verification

Loaded main's `db/schema.rb` into a fresh `postgres:16.13` container and re-dumped — produced byte-identical output to what's committed. So merging this does NOT introduce a one-time schema churn; existing `main` was already written by a 16.13-equivalent.

## Test plan

- [ ] CI green on this branch (Postgres service now pins to 16.13 explicitly)
- [ ] New "Verify Postgres image pins are in sync" step passes on aligned pins and fails the build when drift is introduced (dry-run confirmed locally)
- [ ] Rebuild devcontainer locally, run `bin/setup`, confirm `db/schema.rb` stays clean after `db:prepare` / `db:migrate`
- [ ] `docker compose up postgres` pulls `postgres:16.13` (no unexpected restart, data dir remains compatible — 16.1 → 16.13 is in-major, no dump/restore needed)

## Notes

- This does NOT touch the `service_containers` allowlist defaults (`postgres:16` as a user-facing example) since those are data-layer defaults for user projects, not infra for running Paid itself.
- Next bump should be all three locations together — the CI guard now enforces that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)