### PR TITLE
Fix #1118: Add GitHub automation adapters

### DIFF
--- a/app/services/automation/providers/github/base_adapter.rb
+++ b/app/services/automation/providers/github/base_adapter.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Github
+      # Shared behavior for the GitHub-backed automation adapters.
+      #
+      # All three capability adapters (repository, review, work item) front
+      # the same underlying {::GithubClient}. BaseAdapter resolves the client
+      # from the project, centralizes error translation into the provider
+      # error hierarchy expected by automation policy, and provides the small
+      # helpers the adapters share (login normalization, timestamp parsing,
+      # etc.).
+      #
+      # Adapters MUST wrap outbound GitHub calls in {#with_errors} so that
+      # policy code rescues a single +ProviderError+ family regardless of
+      # which adapter raised.
+      class BaseAdapter
+        # Error class the concrete adapter raises on provider failure.
+        # Subclasses override to point at the capability-specific hierarchy
+        # (RepositoryProvider::ProviderError, etc.) so policy code can
+        # rescue narrowly without losing access to the unified family.
+        PROVIDER_ERROR = Class.new(StandardError)
+
+        attr_reader :project
+
+        # @param project [Project, #github_token] The Paid project whose
+        #   GitHub credentials back this adapter. Tests may pass any object
+        #   responding to +#github_token+ (or +#client+ directly via the
+        #   +client:+ keyword) to avoid loading a real project.
+        # @param client [::GithubClient, nil] Optional pre-built client for
+        #   tests. When omitted, the client is lazily derived from
+        #   +project.github_token.client+.
+        def initialize(project, client: nil)
+          @project = project
+          @client = client
+        end
+
+        # Exposes the underlying GitHub client to subclasses and specs.
+        #
+        # @return [::GithubClient]
+        def client
+          @client ||= resolve_client
+        end
+
+        private
+
+        def resolve_client
+          token = project.respond_to?(:github_token) ? project.github_token : nil
+          raise provider_error_class, "Project #{project_identifier} has no GitHub token" if token.nil?
+
+          token.client
+        end
+
+        def project_identifier
+          project.respond_to?(:full_name) ? project.full_name : project.inspect
+        end
+
+        # Wraps a GitHub API call, translating {::GithubClient} error classes
+        # into this adapter's ProviderError. Unknown errors propagate so
+        # that genuine bugs do not masquerade as provider failures.
+        def with_errors
+          yield
+        rescue ::GithubClient::Error => e
+          raise provider_error_class, e.message
+        end
+
+        # Concrete adapters override to return the capability-specific
+        # ProviderError class declared by the interface module.
+        def provider_error_class
+          self.class::PROVIDER_ERROR
+        end
+
+        def normalize_login(value)
+          value&.to_s&.downcase.presence
+        end
+
+        def parse_time(value)
+          case value
+          when Time, ActiveSupport::TimeWithZone then value
+          when String then Time.parse(value)
+          end
+        rescue ArgumentError
+          nil
+        end
+
+        def extract_labels(source)
+          Array(source).map { |label| label.respond_to?(:name) ? label.name : label.to_s }
+        end
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/github/base_adapter.rb
+++ b/app/services/automation/providers/github/base_adapter.rb
@@ -87,6 +87,23 @@ module Automation
         def extract_labels(source)
           Array(source).map { |label| label.respond_to?(:name) ? label.name : label.to_s }
         end
+
+        # Accept either a Sawyer::Resource (Octokit's default) or a plain Hash
+        # with symbol/string keys so adapters stay usable in unit tests that
+        # stub the client with hashes.
+        def read_field(source, key)
+          return nil if source.nil?
+
+          if source.respond_to?(key)
+            source.public_send(key)
+          elsif source.respond_to?(:[])
+            source[key] || source[key.to_s]
+          end
+        end
+
+        def read_sub_field(source, *keys)
+          keys.reduce(source) { |acc, key| acc && read_field(acc, key) }
+        end
       end
     end
   end

--- a/app/services/automation/providers/github/base_adapter.rb
+++ b/app/services/automation/providers/github/base_adapter.rb
@@ -91,13 +91,21 @@ module Automation
         # Accept either a Sawyer::Resource (Octokit's default) or a plain Hash
         # with symbol/string keys so adapters stay usable in unit tests that
         # stub the client with hashes.
+        #
+        # For Hash sources, we branch on +key?+ rather than relying on
+        # +source[key] || source[key.to_s]+: the +||+ form would convert
+        # legitimate +false+ values to +nil+ (e.g. +{mergeable: false}+
+        # silently becoming +mergeable: nil+ in the normalized data), losing
+        # the distinction between "not mergeable" and "unknown".
         def read_field(source, key)
           return nil if source.nil?
 
           if source.respond_to?(key)
             source.public_send(key)
+          elsif source.respond_to?(:key?) && source.key?(key)
+            source[key]
           elsif source.respond_to?(:[])
-            source[key] || source[key.to_s]
+            source[key.to_s]
           end
         end
 

--- a/app/services/automation/providers/github/repository_provider.rb
+++ b/app/services/automation/providers/github/repository_provider.rb
@@ -144,7 +144,12 @@ module Automation
 
           Data::CheckRun.new(
             name: run_field(run, :name).to_s,
-            status: CHECK_STATUS_MAP[raw_status] || :completed,
+            # Default to :queued for unknown statuses so consumers gating on
+            # "all checks finished?" keep waiting instead of advancing while
+            # the check is still running. GitHub has added new status values
+            # over time (e.g. "waiting", "pending"); a :completed fallback
+            # would let auto-merge / auto-review races slip through.
+            status: CHECK_STATUS_MAP[raw_status] || :queued,
             conclusion: raw_conclusion ? CHECK_CONCLUSION_MAP[raw_conclusion.to_s] : nil,
             url: run_field(run, :html_url) || run_field(run, :details_url)
           )

--- a/app/services/automation/providers/github/repository_provider.rb
+++ b/app/services/automation/providers/github/repository_provider.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Github
+      # GitHub-backed implementation of
+      # {Automation::Providers::RepositoryProvider}. Wraps {::GithubClient}
+      # calls and normalizes the Octokit/Sawyer objects returned by the
+      # underlying REST/GraphQL endpoints into the provider-neutral
+      # {Automation::Providers::Data} types.
+      #
+      # This adapter is the reference implementation the other capability
+      # adapters (work-item, review) mirror; future providers (GitLab,
+      # Bitbucket) should preserve the same public surface.
+      class RepositoryProvider < BaseAdapter
+        include Automation::Providers::RepositoryProvider
+
+        PROVIDER_ERROR = Automation::Providers::RepositoryProvider::ProviderError
+
+        PR_STATE_MAP = {
+          "open" => :open,
+          "closed" => :closed
+        }.freeze
+
+        CHECK_STATUS_MAP = {
+          "queued" => :queued,
+          "in_progress" => :in_progress,
+          "completed" => :completed
+        }.freeze
+
+        CHECK_CONCLUSION_MAP = {
+          "success" => :success,
+          "failure" => :failure,
+          "neutral" => :neutral,
+          "cancelled" => :cancelled,
+          "skipped" => :skipped,
+          "timed_out" => :timed_out,
+          "action_required" => :action_required,
+          "stale" => :stale
+        }.freeze
+
+        MERGE_METHODS = %i[squash merge rebase].freeze
+
+        def fetch_pull_request(repo:, number:)
+          pr = with_errors { client.pull_request(repo, number) }
+          build_pull_request(pr)
+        end
+
+        def list_pull_requests(repo:, state: :open, head: nil, base: nil)
+          options = { state: state.to_s }
+          options[:head] = head if head
+          options[:base] = base if base
+
+          prs = with_errors { client.pull_requests(repo, **options) }
+          Array(prs).map { |pr| build_pull_request(pr) }
+        end
+
+        def fetch_pull_request_files(repo:, number:)
+          with_errors { client.pull_request_files(repo, number) }
+        end
+
+        def fetch_check_runs(repo:, ref:)
+          runs = with_errors { client.check_runs_for_ref(repo, ref) }
+          Array(runs).map { |run| build_check_run(run) }
+        end
+
+        def add_labels(repo:, number:, labels:)
+          names = Array(labels).map(&:to_s).reject(&:empty?)
+          return if names.empty?
+
+          with_errors { client.add_labels_to_issue(repo, number, names) }
+          nil
+        end
+
+        def remove_label(repo:, number:, label:)
+          with_errors { client.remove_label_from_issue(repo, number, label) }
+          nil
+        rescue PROVIDER_ERROR => e
+          # Removing an absent label returns 404 from GitHub; treat as
+          # idempotent rather than propagating a ProviderError.
+          raise unless e.message.to_s.match?(/not\s*found/i)
+
+          nil
+        end
+
+        def add_comment(repo:, number:, body:)
+          comment = with_errors { client.add_comment(repo, number, body.to_s) }
+          build_comment(comment)
+        end
+
+        def mark_ready_for_review(repo:, number:)
+          with_errors { client.mark_pull_request_ready(repo, number) }
+          nil
+        end
+
+        def merge_pull_request(repo:, number:, method:, commit_title: nil, commit_message: nil)
+          unless MERGE_METHODS.include?(method.to_sym)
+            raise PROVIDER_ERROR, "Unsupported merge method: #{method.inspect}"
+          end
+
+          response = with_errors do
+            client.merge_pull_request(
+              repo,
+              number,
+              merge_method: method.to_s,
+              commit_title: commit_title,
+              commit_message: commit_message
+            )
+          end
+
+          build_merge_result(response)
+        end
+
+        private
+
+        def build_pull_request(pr)
+          raw_state = pr_field(pr, :state)
+          merged_at = parse_time(pr_field(pr, :merged_at))
+
+          Data::PullRequest.new(
+            number: pr_field(pr, :number),
+            title: pr_field(pr, :title).to_s,
+            body: pr_field(pr, :body),
+            state: PR_STATE_MAP.fetch(raw_state.to_s, :closed),
+            draft: pr_field(pr, :draft) == true,
+            merged: pr_field(pr, :merged) == true || merged_at.present?,
+            mergeable: pr_field(pr, :mergeable),
+            head_sha: pr_sub_field(pr, :head, :sha).to_s,
+            head_ref: pr_sub_field(pr, :head, :ref).to_s,
+            base_ref: pr_sub_field(pr, :base, :ref).to_s,
+            author_login: normalize_login(pr_sub_field(pr, :user, :login)),
+            labels: extract_labels(pr_field(pr, :labels)),
+            created_at: parse_time(pr_field(pr, :created_at)),
+            updated_at: parse_time(pr_field(pr, :updated_at)),
+            merged_at: merged_at,
+            url: pr_field(pr, :html_url),
+            raw_state: raw_state&.to_s
+          )
+        end
+
+        def build_check_run(run)
+          raw_status = run_field(run, :status).to_s
+          raw_conclusion = run_field(run, :conclusion)
+
+          Data::CheckRun.new(
+            name: run_field(run, :name).to_s,
+            status: CHECK_STATUS_MAP[raw_status] || :completed,
+            conclusion: raw_conclusion ? CHECK_CONCLUSION_MAP[raw_conclusion.to_s] : nil,
+            url: run_field(run, :html_url) || run_field(run, :details_url)
+          )
+        end
+
+        def build_comment(comment)
+          Data::Comment.new(
+            id: comment_field(comment, :id),
+            author_login: normalize_login(comment_sub_field(comment, :user, :login)),
+            body: comment_field(comment, :body).to_s,
+            created_at: parse_time(comment_field(comment, :created_at)),
+            updated_at: parse_time(comment_field(comment, :updated_at)),
+            url: comment_field(comment, :html_url)
+          )
+        end
+
+        def build_merge_result(response)
+          merged = bool_field(response, :merged)
+          Data::MergeResult.new(
+            merged: merged.nil? ? true : merged,
+            sha: response_field(response, :sha),
+            message: response_field(response, :message)
+          )
+        end
+
+        # --- field accessors --------------------------------------------------
+        # Accept either a Sawyer::Resource (Octokit's default) or a plain Hash
+        # with symbol/string keys so adapters stay usable in unit tests that
+        # stub the client with hashes.
+
+        def pr_field(pr, key)
+          read_field(pr, key)
+        end
+
+        def pr_sub_field(pr, *keys)
+          keys.reduce(pr) { |acc, key| acc && read_field(acc, key) }
+        end
+
+        def run_field(run, key)
+          read_field(run, key)
+        end
+
+        def comment_field(comment, key)
+          read_field(comment, key)
+        end
+
+        def comment_sub_field(comment, *keys)
+          keys.reduce(comment) { |acc, key| acc && read_field(acc, key) }
+        end
+
+        def response_field(response, key)
+          read_field(response, key)
+        end
+
+        def bool_field(source, key)
+          value = read_field(source, key)
+          return value if value == true || value == false
+
+          nil
+        end
+
+        def read_field(source, key)
+          return nil if source.nil?
+
+          if source.respond_to?(key)
+            source.public_send(key)
+          elsif source.respond_to?(:[])
+            source[key] || source[key.to_s]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/github/repository_provider.rb
+++ b/app/services/automation/providers/github/repository_provider.rb
@@ -73,14 +73,14 @@ module Automation
         end
 
         def remove_label(repo:, number:, label:)
-          with_errors { client.remove_label_from_issue(repo, number, label) }
+          client.remove_label_from_issue(repo, number, label)
           nil
-        rescue PROVIDER_ERROR => e
+        rescue ::GithubClient::NotFoundError
           # Removing an absent label returns 404 from GitHub; treat as
           # idempotent rather than propagating a ProviderError.
-          raise unless e.message.to_s.match?(/not\s*found/i)
-
           nil
+        rescue ::GithubClient::Error => e
+          raise PROVIDER_ERROR, e.message
         end
 
         def add_comment(repo:, number:, body:)

--- a/app/services/automation/providers/github/repository_provider.rb
+++ b/app/services/automation/providers/github/repository_provider.rb
@@ -114,36 +114,36 @@ module Automation
         private
 
         def build_pull_request(pr)
-          raw_state = pr_field(pr, :state)
-          merged_at = parse_time(pr_field(pr, :merged_at))
+          raw_state = read_field(pr, :state)
+          merged_at = parse_time(read_field(pr, :merged_at))
 
           Data::PullRequest.new(
-            number: pr_field(pr, :number),
-            title: pr_field(pr, :title).to_s,
-            body: pr_field(pr, :body),
+            number: read_field(pr, :number),
+            title: read_field(pr, :title).to_s,
+            body: read_field(pr, :body),
             state: PR_STATE_MAP.fetch(raw_state.to_s, :closed),
-            draft: pr_field(pr, :draft) == true,
-            merged: pr_field(pr, :merged) == true || merged_at.present?,
-            mergeable: pr_field(pr, :mergeable),
-            head_sha: pr_sub_field(pr, :head, :sha).to_s,
-            head_ref: pr_sub_field(pr, :head, :ref).to_s,
-            base_ref: pr_sub_field(pr, :base, :ref).to_s,
-            author_login: normalize_login(pr_sub_field(pr, :user, :login)),
-            labels: extract_labels(pr_field(pr, :labels)),
-            created_at: parse_time(pr_field(pr, :created_at)),
-            updated_at: parse_time(pr_field(pr, :updated_at)),
+            draft: read_field(pr, :draft) == true,
+            merged: read_field(pr, :merged) == true || merged_at.present?,
+            mergeable: read_field(pr, :mergeable),
+            head_sha: read_sub_field(pr, :head, :sha).to_s,
+            head_ref: read_sub_field(pr, :head, :ref).to_s,
+            base_ref: read_sub_field(pr, :base, :ref).to_s,
+            author_login: normalize_login(read_sub_field(pr, :user, :login)),
+            labels: extract_labels(read_field(pr, :labels)),
+            created_at: parse_time(read_field(pr, :created_at)),
+            updated_at: parse_time(read_field(pr, :updated_at)),
             merged_at: merged_at,
-            url: pr_field(pr, :html_url),
+            url: read_field(pr, :html_url),
             raw_state: raw_state&.to_s
           )
         end
 
         def build_check_run(run)
-          raw_status = run_field(run, :status).to_s
-          raw_conclusion = run_field(run, :conclusion)
+          raw_status = read_field(run, :status).to_s
+          raw_conclusion = read_field(run, :conclusion)
 
           Data::CheckRun.new(
-            name: run_field(run, :name).to_s,
+            name: read_field(run, :name).to_s,
             # Default to :queued for unknown statuses so consumers gating on
             # "all checks finished?" keep waiting instead of advancing while
             # the check is still running. GitHub has added new status values
@@ -151,18 +151,18 @@ module Automation
             # would let auto-merge / auto-review races slip through.
             status: CHECK_STATUS_MAP[raw_status] || :queued,
             conclusion: raw_conclusion ? CHECK_CONCLUSION_MAP[raw_conclusion.to_s] : nil,
-            url: run_field(run, :html_url) || run_field(run, :details_url)
+            url: read_field(run, :html_url) || read_field(run, :details_url)
           )
         end
 
         def build_comment(comment)
           Data::Comment.new(
-            id: comment_field(comment, :id),
-            author_login: normalize_login(comment_sub_field(comment, :user, :login)),
-            body: comment_field(comment, :body).to_s,
-            created_at: parse_time(comment_field(comment, :created_at)),
-            updated_at: parse_time(comment_field(comment, :updated_at)),
-            url: comment_field(comment, :html_url)
+            id: read_field(comment, :id),
+            author_login: normalize_login(read_sub_field(comment, :user, :login)),
+            body: read_field(comment, :body).to_s,
+            created_at: parse_time(read_field(comment, :created_at)),
+            updated_at: parse_time(read_field(comment, :updated_at)),
+            url: read_field(comment, :html_url)
           )
         end
 
@@ -172,49 +172,10 @@ module Automation
           # prevents a malformed response (or a test mock that forgets the
           # field) from being reported as a successful merge.
           Data::MergeResult.new(
-            merged: response_field(response, :merged) == true,
-            sha: response_field(response, :sha),
-            message: response_field(response, :message)
+            merged: read_field(response, :merged) == true,
+            sha: read_field(response, :sha),
+            message: read_field(response, :message)
           )
-        end
-
-        # --- field accessors --------------------------------------------------
-        # Accept either a Sawyer::Resource (Octokit's default) or a plain Hash
-        # with symbol/string keys so adapters stay usable in unit tests that
-        # stub the client with hashes.
-
-        def pr_field(pr, key)
-          read_field(pr, key)
-        end
-
-        def pr_sub_field(pr, *keys)
-          keys.reduce(pr) { |acc, key| acc && read_field(acc, key) }
-        end
-
-        def run_field(run, key)
-          read_field(run, key)
-        end
-
-        def comment_field(comment, key)
-          read_field(comment, key)
-        end
-
-        def comment_sub_field(comment, *keys)
-          keys.reduce(comment) { |acc, key| acc && read_field(acc, key) }
-        end
-
-        def response_field(response, key)
-          read_field(response, key)
-        end
-
-        def read_field(source, key)
-          return nil if source.nil?
-
-          if source.respond_to?(key)
-            source.public_send(key)
-          elsif source.respond_to?(:[])
-            source[key] || source[key.to_s]
-          end
         end
       end
     end

--- a/app/services/automation/providers/github/repository_provider.rb
+++ b/app/services/automation/providers/github/repository_provider.rb
@@ -162,9 +162,12 @@ module Automation
         end
 
         def build_merge_result(response)
-          merged = bool_field(response, :merged)
+          # GitHub's merge API returns +merged: true+ on 2xx and raises on
+          # non-2xx, so defaulting to +false+ when the field is missing
+          # prevents a malformed response (or a test mock that forgets the
+          # field) from being reported as a successful merge.
           Data::MergeResult.new(
-            merged: merged.nil? ? true : merged,
+            merged: response_field(response, :merged) == true,
             sha: response_field(response, :sha),
             message: response_field(response, :message)
           )
@@ -197,13 +200,6 @@ module Automation
 
         def response_field(response, key)
           read_field(response, key)
-        end
-
-        def bool_field(source, key)
-          value = read_field(source, key)
-          return value if value == true || value == false
-
-          nil
         end
 
         def read_field(source, key)

--- a/app/services/automation/providers/github/repository_provider.rb
+++ b/app/services/automation/providers/github/repository_provider.rb
@@ -150,9 +150,32 @@ module Automation
             # over time (e.g. "waiting", "pending"); a :completed fallback
             # would let auto-merge / auto-review races slip through.
             status: CHECK_STATUS_MAP[raw_status] || :queued,
-            conclusion: raw_conclusion ? CHECK_CONCLUSION_MAP[raw_conclusion.to_s] : nil,
+            conclusion: normalize_conclusion(raw_conclusion),
             url: read_field(run, :html_url) || read_field(run, :details_url)
           )
+        end
+
+        # Map GitHub's +conclusion+ string to the normalized symbol.
+        #
+        # +nil+ is preserved because {Data::CheckRun#conclusion} documents it
+        # as "Nil while the check is still running". An unknown non-nil
+        # conclusion (e.g. a forward-compat value GitHub adds later) must NOT
+        # collapse to +nil+, since that would be indistinguishable from
+        # "still running" — instead we conservatively report
+        # +:action_required+ and log the gap so the mapping can be updated.
+        def normalize_conclusion(raw_conclusion)
+          return nil if raw_conclusion.nil?
+
+          key = raw_conclusion.to_s
+          mapped = CHECK_CONCLUSION_MAP[key]
+          return mapped if mapped
+
+          Rails.logger.warn(
+            message: "automation.github.unknown_check_conclusion",
+            component: "automation_provider",
+            raw_conclusion: key
+          )
+          :action_required
         end
 
         def build_comment(comment)

--- a/app/services/automation/providers/github/review_provider.rb
+++ b/app/services/automation/providers/github/review_provider.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Github
+      # GitHub-backed implementation of
+      # {Automation::Providers::ReviewProvider}.
+      #
+      # GitHub exposes review state through REST for individual reviews and
+      # through GraphQL for review threads (line-level conversations). This
+      # adapter hides that split behind the normalized {Data} types. Bot
+      # reviewers and team reviewers are preserved where the interface
+      # accepts them.
+      class ReviewProvider < BaseAdapter
+        include Automation::Providers::ReviewProvider
+
+        PROVIDER_ERROR = Automation::Providers::ReviewProvider::ProviderError
+
+        REVIEW_STATE_MAP = {
+          "APPROVED" => :approved,
+          "CHANGES_REQUESTED" => :changes_requested,
+          "COMMENTED" => :commented,
+          "DISMISSED" => :dismissed,
+          "PENDING" => :pending
+        }.freeze
+
+        REVIEW_EVENTS = {
+          approve: "APPROVE",
+          request_changes: "REQUEST_CHANGES",
+          comment: "COMMENT"
+        }.freeze
+
+        def fetch_reviews(repo:, pr_number:)
+          reviews = with_errors { client.pull_request_reviews(repo, pr_number) }
+          Array(reviews).map { |review| build_review(review) }
+        end
+
+        def fetch_review_threads(repo:, pr_number:)
+          threads = with_errors { client.review_threads(repo, pr_number) }
+          Array(threads).map { |thread| build_review_thread(thread) }
+        end
+
+        def fetch_review_requests(repo:, pr_number:)
+          payload = with_errors { client.pull_request_review_requests(repo, pr_number) }
+          Data::ReviewRequest.new(
+            users: Array(payload[:users]).filter_map { |u| normalize_login(u) },
+            teams: Array(payload[:teams]).map(&:to_s)
+          )
+        end
+
+        def fetch_pending_reviewers(repo:, pr_number:)
+          fetch_review_requests(repo: repo, pr_number: pr_number).users
+        end
+
+        def request_reviewers(repo:, pr_number:, reviewers:)
+          desired = Array(reviewers).filter_map { |r| normalize_login(r) }.uniq
+          return [] if desired.empty?
+
+          already_pending = fetch_pending_reviewers(repo: repo, pr_number: pr_number).to_set
+          newly_requested = desired.reject { |login| already_pending.include?(login) }
+          return [] if newly_requested.empty?
+
+          with_errors do
+            client.request_pull_request_review(repo, pr_number, reviewers: newly_requested)
+          end
+
+          newly_requested
+        end
+
+        def submit_review(repo:, pr_number:, body:, event:)
+          api_event = REVIEW_EVENTS[event.to_sym] or
+            raise PROVIDER_ERROR, "Unsupported review event: #{event.inspect}"
+
+          response = with_errors do
+            client.create_pull_request_review(repo, pr_number, event: api_event, body: body.to_s)
+          end
+
+          build_review(response)
+        end
+
+        def resolve_review_thread(repo:, pr_number:, thread_id:)
+          # thread_id is the GraphQL node id returned by #fetch_review_threads.
+          # repo and pr_number are accepted per the interface but unused here
+          # because the mutation operates on the opaque node id.
+          _ = repo
+          _ = pr_number
+          with_errors { client.resolve_review_thread(thread_id) }
+          nil
+        end
+
+        private
+
+        def build_review(review)
+          raw_state = read_field(review, :state).to_s
+          submitted = parse_time(read_field(review, :submitted_at))
+          login = read_field(review, :user_login) || read_sub_field(review, :user, :login)
+
+          Data::Review.new(
+            id: read_field(review, :id),
+            author_login: normalize_login(login),
+            state: REVIEW_STATE_MAP[raw_state] || :commented,
+            raw_state: raw_state,
+            body: read_field(review, :body).to_s,
+            submitted_at: submitted,
+            commit_sha: read_field(review, :commit_id) || read_field(review, :commit_sha)
+          )
+        end
+
+        def build_review_thread(thread)
+          raw_comments = Array(read_field(thread, :comments))
+          comments = raw_comments.map { |c| build_thread_comment(c) }
+
+          Data::ReviewThread.new(
+            id: read_field(thread, :id).to_s,
+            resolved: bool_field(thread, :is_resolved) || bool_field(thread, :resolved) || false,
+            comments: comments
+          )
+        end
+
+        def build_thread_comment(comment)
+          Data::ReviewThreadComment.new(
+            author_login: normalize_login(
+              read_field(comment, :author) || read_sub_field(comment, :user, :login)
+            ),
+            body: read_field(comment, :body).to_s,
+            path: read_field(comment, :path),
+            line: read_field(comment, :line)
+          )
+        end
+
+        def bool_field(source, key)
+          value = read_field(source, key)
+          return value if value == true || value == false
+
+          nil
+        end
+
+        def read_sub_field(source, *keys)
+          keys.reduce(source) { |acc, key| acc && read_field(acc, key) }
+        end
+
+        def read_field(source, key)
+          return nil if source.nil?
+
+          if source.respond_to?(key)
+            source.public_send(key)
+          elsif source.respond_to?(:[])
+            source[key] || source[key.to_s]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/automation/providers/github/review_provider.rb
+++ b/app/services/automation/providers/github/review_provider.rb
@@ -134,20 +134,6 @@ module Automation
 
           nil
         end
-
-        def read_sub_field(source, *keys)
-          keys.reduce(source) { |acc, key| acc && read_field(acc, key) }
-        end
-
-        def read_field(source, key)
-          return nil if source.nil?
-
-          if source.respond_to?(key)
-            source.public_send(key)
-          elsif source.respond_to?(:[])
-            source[key] || source[key.to_s]
-          end
-        end
       end
     end
   end

--- a/app/services/automation/providers/github/work_item_provider.rb
+++ b/app/services/automation/providers/github/work_item_provider.rb
@@ -69,12 +69,14 @@ module Automation
         end
 
         def remove_label(repo:, number:, label:)
-          with_errors { client.remove_label_from_issue(repo, number, label) }
+          client.remove_label_from_issue(repo, number, label)
           nil
-        rescue PROVIDER_ERROR => e
-          raise unless e.message.to_s.match?(/not\s*found/i)
-
+        rescue ::GithubClient::NotFoundError
+          # Removing an absent label returns 404 from GitHub; treat as
+          # idempotent rather than propagating a ProviderError.
           nil
+        rescue ::GithubClient::Error => e
+          raise PROVIDER_ERROR, e.message
         end
 
         def add_comment(repo:, number:, body:)

--- a/app/services/automation/providers/github/work_item_provider.rb
+++ b/app/services/automation/providers/github/work_item_provider.rb
@@ -33,10 +33,22 @@ module Automation
           build_issue(issue)
         end
 
+        # GitHub's REST `/issues` endpoint only accepts a single +assignee+
+        # query parameter, so this adapter cannot silently combine multiple
+        # assignee logins into an intersection filter. Per the
+        # {Automation::Providers::WorkItemProvider} contract, callers
+        # passing more than one assignee get a {ProviderError} rather than a
+        # narrowed result set that would look like an intersection.
         def list_issues(repo:, state: :open, labels: nil, assignees: nil)
+          filter_logins = Array(assignees).compact.reject { |a| a.to_s.strip.empty? }
+          if filter_logins.length > 1
+            raise PROVIDER_ERROR,
+                  "GitHub Issues API supports a single assignee filter; got #{filter_logins.length}"
+          end
+
           options = {}
           options[:state] = state.to_s if state
-          options[:assignee] = Array(assignees).first if assignees.present?
+          options[:assignee] = filter_logins.first if filter_logins.any?
 
           issues = with_errors { client.issues(repo, labels: labels, **options) }
           Array(issues).map { |issue| build_issue(issue) }

--- a/app/services/automation/providers/github/work_item_provider.rb
+++ b/app/services/automation/providers/github/work_item_provider.rb
@@ -172,20 +172,6 @@ module Automation
             login ? [ login ] : []
           end
         end
-
-        def read_sub_field(source, *keys)
-          keys.reduce(source) { |acc, key| acc && read_field(acc, key) }
-        end
-
-        def read_field(source, key)
-          return nil if source.nil?
-
-          if source.respond_to?(key)
-            source.public_send(key)
-          elsif source.respond_to?(:[])
-            source[key] || source[key.to_s]
-          end
-        end
       end
     end
   end

--- a/app/services/automation/providers/github/work_item_provider.rb
+++ b/app/services/automation/providers/github/work_item_provider.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+module Automation
+  module Providers
+    module Github
+      # GitHub-backed implementation of
+      # {Automation::Providers::WorkItemProvider}.
+      #
+      # GitHub models issues and pull requests through a shared API; this
+      # adapter surfaces both through {Data::Issue}. The +pull_request_number+
+      # field is populated when the fetched item is also a pull request,
+      # letting policy code distinguish issue-only items from PR-backed ones
+      # without re-fetching.
+      #
+      # Structured dependency edges are intentionally left empty: GitHub's
+      # native dependency graph is not exposed through the REST API used by
+      # this adapter. Paid's {Issues::ParseDependencies} text parser
+      # continues to be the source of truth for cross-issue blockers.
+      class WorkItemProvider < BaseAdapter
+        include Automation::Providers::WorkItemProvider
+
+        PROVIDER_ERROR = Automation::Providers::WorkItemProvider::ProviderError
+
+        ISSUE_STATE_MAP = {
+          "open" => :open,
+          "closed" => :closed
+        }.freeze
+
+        CLOSED_STATES = %i[closed].freeze
+
+        def fetch_issue(repo:, number:)
+          issue = with_errors { client.issue(repo, number) }
+          build_issue(issue)
+        end
+
+        def list_issues(repo:, state: :open, labels: nil, assignees: nil)
+          options = {}
+          options[:state] = state.to_s if state
+          options[:assignee] = Array(assignees).first if assignees.present?
+
+          issues = with_errors { client.issues(repo, labels: labels, **options) }
+          Array(issues).map { |issue| build_issue(issue) }
+        end
+
+        def fetch_issue_comments(repo:, number:)
+          comments = with_errors { client.issue_comments(repo, number) }
+          Array(comments).map { |comment| build_comment(comment) }
+        end
+
+        def fetch_issue_timeline(repo:, number:)
+          events = with_errors { client.issue_events(repo, number) }
+          Array(events).map { |event| build_timeline_event(event) }
+        end
+
+        def create_issue(repo:, title:, body: "", labels: [])
+          names = Array(labels).map(&:to_s).reject(&:empty?)
+          created = with_errors do
+            client.create_issue(repo, title: title.to_s, body: body.to_s, labels: names)
+          end
+          build_issue(created)
+        end
+
+        def add_labels(repo:, number:, labels:)
+          names = Array(labels).map(&:to_s).reject(&:empty?)
+          return if names.empty?
+
+          with_errors { client.add_labels_to_issue(repo, number, names) }
+          nil
+        end
+
+        def remove_label(repo:, number:, label:)
+          with_errors { client.remove_label_from_issue(repo, number, label) }
+          nil
+        rescue PROVIDER_ERROR => e
+          raise unless e.message.to_s.match?(/not\s*found/i)
+
+          nil
+        end
+
+        def add_comment(repo:, number:, body:)
+          comment = with_errors { client.add_comment(repo, number, body.to_s) }
+          build_comment(comment)
+        end
+
+        def transition_state(repo:, number:, state:, reason: nil)
+          symbolic = state.to_sym
+          unless Data::Issue::STATES.include?(symbolic)
+            raise PROVIDER_ERROR, "Unsupported issue state: #{state.inspect}"
+          end
+
+          options = { state: symbolic.to_s }
+          options[:state_reason] = reason if reason && CLOSED_STATES.include?(symbolic)
+
+          updated = with_errors { client.update_issue(repo, number, **options) }
+          build_issue(updated)
+        end
+
+        private
+
+        def build_issue(issue)
+          raw_state = read_field(issue, :state)
+          pr_payload = read_field(issue, :pull_request)
+
+          Data::Issue.new(
+            number: read_field(issue, :number),
+            title: read_field(issue, :title).to_s,
+            body: read_field(issue, :body),
+            state: ISSUE_STATE_MAP.fetch(raw_state.to_s, :closed),
+            raw_state: raw_state&.to_s,
+            author_login: normalize_login(read_sub_field(issue, :user, :login)),
+            assignee_logins: extract_assignee_logins(issue),
+            labels: extract_labels(read_field(issue, :labels)),
+            dependencies: [],
+            created_at: parse_time(read_field(issue, :created_at)),
+            updated_at: parse_time(read_field(issue, :updated_at)),
+            closed_at: parse_time(read_field(issue, :closed_at)),
+            url: read_field(issue, :html_url),
+            pull_request_number: pr_payload.present? ? read_field(issue, :number) : nil
+          )
+        end
+
+        def build_comment(comment)
+          Data::Comment.new(
+            id: read_field(comment, :id),
+            author_login: normalize_login(read_sub_field(comment, :user, :login)),
+            body: read_field(comment, :body).to_s,
+            created_at: parse_time(read_field(comment, :created_at)),
+            updated_at: parse_time(read_field(comment, :updated_at)),
+            url: read_field(comment, :html_url)
+          )
+        end
+
+        def build_timeline_event(event)
+          raw = event.respond_to?(:to_hash) ? event.to_hash : (event.is_a?(Hash) ? event : {})
+
+          Data::TimelineEvent.new(
+            event: map_timeline_event(read_field(event, :event)),
+            actor_login: normalize_login(read_sub_field(event, :actor, :login)),
+            label_name: read_sub_field(event, :label, :name),
+            created_at: parse_time(read_field(event, :created_at)),
+            raw: raw
+          )
+        end
+
+        def map_timeline_event(name)
+          symbolic = name.to_s.to_sym
+          return symbolic if Data::TimelineEvent::EVENTS.include?(symbolic)
+
+          :other
+        end
+
+        def extract_assignee_logins(issue)
+          assignees = read_field(issue, :assignees)
+          if assignees.present?
+            Array(assignees).filter_map { |a| normalize_login(read_field(a, :login)) }
+          else
+            login = normalize_login(read_sub_field(issue, :assignee, :login))
+            login ? [ login ] : []
+          end
+        end
+
+        def read_sub_field(source, *keys)
+          keys.reduce(source) { |acc, key| acc && read_field(acc, key) }
+        end
+
+        def read_field(source, key)
+          return nil if source.nil?
+
+          if source.respond_to?(key)
+            source.public_send(key)
+          elsif source.respond_to?(:[])
+            source[key] || source[key.to_s]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -241,6 +241,18 @@ class GithubClient
     handle_errors { client.issue(repo, number) }
   end
 
+  # Updates an issue. Accepts the same keys the GitHub REST API does
+  # (+state+, +state_reason+, +title+, +body+, ...); policy code only
+  # uses it for lifecycle transitions today.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param number [Integer] Issue number
+  # @param options [Hash] Attributes to update on the issue
+  # @return [Sawyer::Resource] The updated issue
+  def update_issue(repo, number, **options)
+    handle_errors { client.update_issue(repo, number, options) }
+  end
+
   # Lists labels for a repository.
   #
   # @param repo [String] Repository in "owner/name" format
@@ -560,6 +572,19 @@ class GithubClient
   # @return [Sawyer::Resource] The review request response
   def request_pull_request_review(repo, number, reviewers:)
     handle_errors { client.request_pull_request_review(repo, number, reviewers: reviewers) }
+  end
+
+  # Creates a pull request review.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param number [Integer] Pull request number
+  # @param event [String] One of "APPROVE", "REQUEST_CHANGES", "COMMENT"
+  # @param body [String] Review body (Markdown supported)
+  # @return [Sawyer::Resource] The created review
+  def create_pull_request_review(repo, number, event:, body: "")
+    handle_errors do
+      client.create_pull_request_review(repo, number, event: event, body: body.to_s)
+    end
   end
 
   # Dispatches a repository event for workflows triggered by repository_dispatch.

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -330,7 +330,10 @@ class GithubClient
   #
   # @param repo [String] Repository in "owner/name" format
   # @param ref [String] Git ref (branch name, tag, or SHA)
-  # @return [Array<Hash>] Check runs with :name and :conclusion keys
+  # @return [Array<Hash>] Check runs with :name, :status, :conclusion,
+  #   :html_url, and :details_url keys. +:status+ reflects execution
+  #   progress ("queued", "in_progress", "completed") and is required
+  #   by callers that gate on whether a check has finished.
   def check_runs_for_ref(repo, ref)
     handle_errors do
       all_check_runs = []
@@ -358,7 +361,15 @@ class GithubClient
         )
       end
 
-      all_check_runs.map { |cr| { name: cr.name, conclusion: cr.conclusion } }
+      all_check_runs.map do |cr|
+        {
+          name: cr.name,
+          status: cr.status,
+          conclusion: cr.conclusion,
+          html_url: cr.html_url,
+          details_url: cr.details_url
+        }
+      end
     end
   end
 

--- a/config/initializers/automation_providers.rb
+++ b/config/initializers/automation_providers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Automation::Providers::Resolver.reset!(:github)
+  Automation::Providers::Resolver.register(
+    :github,
+    repository: ->(project) { Automation::Providers::Github::RepositoryProvider.new(project) },
+    work_item: ->(project) { Automation::Providers::Github::WorkItemProvider.new(project) },
+    review: ->(project) { Automation::Providers::Github::ReviewProvider.new(project) }
+  )
+end

--- a/spec/services/automation/providers/github/repository_provider_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_spec.rb
@@ -120,20 +120,63 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
   end
 
   describe "#fetch_check_runs" do
-    it "normalizes check runs and conclusions" do
-      expect(client).to receive(:check_runs_for_ref)
+    let(:completed_run) do
+      {
+        name: "test",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://github.com/acme/widgets/runs/1",
+        details_url: "https://ci.example.com/jobs/1"
+      }
+    end
+    let(:in_progress_run) do
+      {
+        name: "integration",
+        status: "in_progress",
+        conclusion: nil,
+        html_url: nil,
+        details_url: "https://ci.example.com/jobs/2"
+      }
+    end
+    let(:queued_run) do
+      { name: "lint", status: "queued", conclusion: nil, html_url: nil, details_url: nil }
+    end
+
+    before do
+      allow(client).to receive(:check_runs_for_ref)
         .with("acme/widgets", "abc123")
-        .and_return([
-          { name: "test", conclusion: "success" },
-          { name: "lint", conclusion: nil }
-        ])
+        .and_return([ completed_run, in_progress_run, queued_run ])
+    end
 
-      result = adapter.fetch_check_runs(repo: "acme/widgets", ref: "abc123")
+    it "normalizes completed runs with their conclusion and URL" do
+      run = adapter.fetch_check_runs(repo: "acme/widgets", ref: "abc123").first
 
-      expect(result.first).to be_a(Automation::Providers::Data::CheckRun)
-      expect(result.first.name).to eq("test")
-      expect(result.first.conclusion).to eq(:success)
-      expect(result.last.conclusion).to be_nil
+      expect(run).to be_a(Automation::Providers::Data::CheckRun)
+      expect(run).to have_attributes(
+        name: "test",
+        status: :completed,
+        conclusion: :success,
+        url: "https://github.com/acme/widgets/runs/1"
+      )
+    end
+
+    # Critical regression guard: an in-progress check must not be reported
+    # as :completed. That would let consumers gating on execution progress
+    # (e.g. "all checks finished?") advance while work is still running.
+    it "reports in-progress runs as :in_progress, not :completed" do
+      run = adapter.fetch_check_runs(repo: "acme/widgets", ref: "abc123")[1]
+
+      expect(run).to have_attributes(
+        status: :in_progress,
+        conclusion: nil,
+        url: "https://ci.example.com/jobs/2"
+      )
+    end
+
+    it "reports queued runs as :queued with no URL when neither html_url nor details_url is present" do
+      run = adapter.fetch_check_runs(repo: "acme/widgets", ref: "abc123").last
+
+      expect(run).to have_attributes(status: :queued, conclusion: nil, url: nil)
     end
   end
 

--- a/spec/services/automation/providers/github/repository_provider_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_spec.rb
@@ -178,6 +178,22 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
 
       expect(run).to have_attributes(status: :queued, conclusion: nil, url: nil)
     end
+
+    # Defense against future GitHub status values (e.g. "waiting", "pending"):
+    # an unknown status must NOT be classified as :completed, otherwise
+    # consumers gating on execution progress could advance while the check
+    # is still running.
+    it "defaults unknown statuses to :queued, never :completed" do
+      unknown_run = { name: "future-state", status: "waiting", conclusion: nil,
+                      html_url: nil, details_url: nil }
+      allow(client).to receive(:check_runs_for_ref)
+        .with("acme/widgets", "abc123")
+        .and_return([ unknown_run ])
+
+      run = adapter.fetch_check_runs(repo: "acme/widgets", ref: "abc123").first
+
+      expect(run.status).to eq(:queued)
+    end
   end
 
   describe "#add_labels" do

--- a/spec/services/automation/providers/github/repository_provider_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_spec.rb
@@ -83,6 +83,29 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
       expect(result.merged).to be true
       expect(result.merged_at).to eq(Time.utc(2026, 2, 1))
     end
+
+    # Regression guard: Hash-backed mocks with +mergeable: false+ must not
+    # silently become +mergeable: nil+. A naive +source[key] || source[key.to_s]+
+    # in +read_field+ would collapse the +false+ to +nil+ and lose the
+    # distinction between "not mergeable" and "mergeability unknown".
+    it "preserves literal false on hash-keyed fields" do
+      hash_pr = {
+        number: 42, title: "t", body: "b", state: "open",
+        draft: false, merged: false, mergeable: false,
+        created_at: nil, updated_at: nil, merged_at: nil,
+        html_url: nil,
+        head: { ref: "feature", sha: "abc" },
+        base: { ref: "main" },
+        user: { login: "alice" },
+        labels: []
+      }
+      allow(client).to receive(:pull_request).and_return(hash_pr)
+
+      result = adapter.fetch_pull_request(repo: "acme/widgets", number: 42)
+
+      expect(result.mergeable).to be false
+      expect(result.draft).to be false
+    end
   end
 
   describe "#list_pull_requests" do
@@ -193,6 +216,28 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
       run = adapter.fetch_check_runs(repo: "acme/widgets", ref: "abc123").first
 
       expect(run.status).to eq(:queued)
+    end
+
+    # Defense against future GitHub conclusion values: an unknown conclusion
+    # must NOT collapse to nil, since Data::CheckRun documents nil as "check
+    # is still running". Mapping to :action_required keeps auto-merge
+    # conservative until the CHECK_CONCLUSION_MAP is updated.
+    it "maps unknown conclusions to :action_required and logs the gap" do
+      future_run = { name: "future-verdict", status: "completed",
+                     conclusion: "new_verdict", html_url: nil, details_url: nil }
+      allow(client).to receive(:check_runs_for_ref)
+        .with("acme/widgets", "abc123")
+        .and_return([ future_run ])
+      expect(Rails.logger).to receive(:warn).with(
+        hash_including(
+          message: "automation.github.unknown_check_conclusion",
+          raw_conclusion: "new_verdict"
+        )
+      )
+
+      run = adapter.fetch_check_runs(repo: "acme/widgets", ref: "abc123").first
+
+      expect(run).to have_attributes(status: :completed, conclusion: :action_required)
     end
   end
 

--- a/spec/services/automation/providers/github/repository_provider_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_spec.rb
@@ -246,6 +246,17 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
         adapter.merge_pull_request(repo: "acme/widgets", number: 42, method: :fast_forward)
       }.to raise_error(Automation::Providers::RepositoryProvider::ProviderError, /Unsupported/)
     end
+
+    it "defaults merged to false when the response omits the field" do
+      # Guard against a malformed response (or an incomplete test mock)
+      # reporting a successful merge by accident. Only a literal
+      # +merged: true+ should produce +merged: true+ in the result.
+      expect(client).to receive(:merge_pull_request).and_return(OpenStruct.new(sha: "abc"))
+
+      result = adapter.merge_pull_request(repo: "acme/widgets", number: 42, method: :squash)
+
+      expect(result.merged).to be false
+    end
   end
 
   describe "client resolution" do

--- a/spec/services/automation/providers/github/repository_provider_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_spec.rb
@@ -168,6 +168,18 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
       }.not_to raise_error
     end
 
+    it "swallows 404 regardless of the underlying message text" do
+      # Octokit does not guarantee "not found" appears in every 404 body
+      # (e.g. "Label does not exist"). Classification must be by error
+      # class, not message regex.
+      expect(client).to receive(:remove_label_from_issue)
+        .and_raise(GithubClient::NotFoundError, "Label does not exist")
+
+      expect {
+        adapter.remove_label(repo: "acme/widgets", number: 42, label: "stale")
+      }.not_to raise_error
+    end
+
     it "propagates unexpected provider errors" do
       expect(client).to receive(:remove_label_from_issue)
         .and_raise(GithubClient::ApiError.new("boom", status: 500))

--- a/spec/services/automation/providers/github/repository_provider_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_spec.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Automation::Providers::Github::RepositoryProvider do
+  # Real stand-ins for Project/GithubToken avoid coupling to the DB schema
+  # while still satisfying rubocop's RSpec/VerifiedDoubles rule.
+  let(:project_class) do
+    Class.new do
+      attr_accessor :github_token
+      def full_name = "acme/widgets"
+    end
+  end
+  let(:token_class) do
+    Class.new do
+      attr_accessor :client
+      def initialize(client) = (@client = client)
+    end
+  end
+
+  let(:client) { instance_double(GithubClient) }
+  let(:project) { project_class.new }
+  let(:adapter) { described_class.new(project, client: client) }
+
+  let(:pr_resource) do
+    OpenStruct.new(
+      number: 42,
+      title: "Add widgets",
+      body: "desc",
+      state: "open",
+      draft: false,
+      merged: false,
+      mergeable: true,
+      merged_at: nil,
+      created_at: Time.utc(2026, 1, 1),
+      updated_at: Time.utc(2026, 1, 2),
+      html_url: "https://github.com/acme/widgets/pull/42",
+      head: OpenStruct.new(ref: "feature", sha: "abc123"),
+      base: OpenStruct.new(ref: "main"),
+      user: OpenStruct.new(login: "Alice"),
+      labels: [ OpenStruct.new(name: "automation") ]
+    )
+  end
+
+  it "conforms to the RepositoryProvider interface" do
+    expect(described_class.ancestors).to include(Automation::Providers::RepositoryProvider)
+  end
+
+  describe "#fetch_pull_request" do
+    it "normalizes Octokit responses to Data::PullRequest" do
+      expect(client).to receive(:pull_request).with("acme/widgets", 42).and_return(pr_resource)
+
+      result = adapter.fetch_pull_request(repo: "acme/widgets", number: 42)
+
+      expect(result).to be_a(Automation::Providers::Data::PullRequest)
+      expect(result.number).to eq(42)
+      expect(result.state).to eq(:open)
+      expect(result.head_sha).to eq("abc123")
+      expect(result.head_ref).to eq("feature")
+      expect(result.base_ref).to eq("main")
+      expect(result.author_login).to eq("alice")
+      expect(result.labels).to eq([ "automation" ])
+      expect(result.raw_state).to eq("open")
+    end
+
+    it "translates GithubClient errors into ProviderError" do
+      expect(client).to receive(:pull_request).and_raise(GithubClient::NotFoundError)
+
+      expect {
+        adapter.fetch_pull_request(repo: "acme/widgets", number: 99)
+      }.to raise_error(Automation::Providers::RepositoryProvider::ProviderError)
+    end
+
+    it "derives merged from merged_at when #merged is false" do
+      pr_resource.state = "closed"
+      pr_resource.merged_at = Time.utc(2026, 2, 1)
+      allow(client).to receive(:pull_request).and_return(pr_resource)
+
+      result = adapter.fetch_pull_request(repo: "acme/widgets", number: 42)
+
+      expect(result.state).to eq(:closed)
+      expect(result.merged).to be true
+      expect(result.merged_at).to eq(Time.utc(2026, 2, 1))
+    end
+  end
+
+  describe "#list_pull_requests" do
+    it "forwards filter options to the client" do
+      expect(client).to receive(:pull_requests)
+        .with("acme/widgets", state: "open", head: "acme:feature", base: "main")
+        .and_return([ pr_resource ])
+
+      result = adapter.list_pull_requests(
+        repo: "acme/widgets", state: :open, head: "acme:feature", base: "main"
+      )
+
+      expect(result.size).to eq(1)
+      expect(result.first).to be_a(Automation::Providers::Data::PullRequest)
+    end
+
+    it "omits nil head/base options" do
+      expect(client).to receive(:pull_requests)
+        .with("acme/widgets", state: "all")
+        .and_return([])
+
+      adapter.list_pull_requests(repo: "acme/widgets", state: :all)
+    end
+  end
+
+  describe "#fetch_pull_request_files" do
+    it "returns the string list the client provides" do
+      expect(client).to receive(:pull_request_files)
+        .with("acme/widgets", 42)
+        .and_return([ "a.rb", "b.rb" ])
+
+      expect(adapter.fetch_pull_request_files(repo: "acme/widgets", number: 42))
+        .to eq([ "a.rb", "b.rb" ])
+    end
+  end
+
+  describe "#fetch_check_runs" do
+    it "normalizes check runs and conclusions" do
+      expect(client).to receive(:check_runs_for_ref)
+        .with("acme/widgets", "abc123")
+        .and_return([
+          { name: "test", conclusion: "success" },
+          { name: "lint", conclusion: nil }
+        ])
+
+      result = adapter.fetch_check_runs(repo: "acme/widgets", ref: "abc123")
+
+      expect(result.first).to be_a(Automation::Providers::Data::CheckRun)
+      expect(result.first.name).to eq("test")
+      expect(result.first.conclusion).to eq(:success)
+      expect(result.last.conclusion).to be_nil
+    end
+  end
+
+  describe "#add_labels" do
+    it "adds non-empty labels to the issue" do
+      expect(client).to receive(:add_labels_to_issue)
+        .with("acme/widgets", 42, [ "automation", "ready" ])
+
+      adapter.add_labels(repo: "acme/widgets", number: 42, labels: [ "automation", "ready", "" ])
+    end
+
+    it "no-ops when labels is empty" do
+      expect(client).not_to receive(:add_labels_to_issue)
+      adapter.add_labels(repo: "acme/widgets", number: 42, labels: [])
+    end
+  end
+
+  describe "#remove_label" do
+    it "calls the client and returns nil on success" do
+      expect(client).to receive(:remove_label_from_issue)
+        .with("acme/widgets", 42, "stale")
+
+      expect(adapter.remove_label(repo: "acme/widgets", number: 42, label: "stale")).to be_nil
+    end
+
+    it "swallows 404 as idempotent" do
+      expect(client).to receive(:remove_label_from_issue)
+        .and_raise(GithubClient::NotFoundError, "not found")
+
+      expect {
+        adapter.remove_label(repo: "acme/widgets", number: 42, label: "stale")
+      }.not_to raise_error
+    end
+
+    it "propagates unexpected provider errors" do
+      expect(client).to receive(:remove_label_from_issue)
+        .and_raise(GithubClient::ApiError.new("boom", status: 500))
+
+      expect {
+        adapter.remove_label(repo: "acme/widgets", number: 42, label: "stale")
+      }.to raise_error(Automation::Providers::RepositoryProvider::ProviderError)
+    end
+  end
+
+  describe "#add_comment" do
+    it "returns the created comment as Data::Comment" do
+      created = OpenStruct.new(
+        id: 99,
+        body: "hi",
+        created_at: Time.utc(2026, 3, 1),
+        updated_at: Time.utc(2026, 3, 1),
+        html_url: "https://github.com/acme/widgets/pull/42#c99",
+        user: OpenStruct.new(login: "Bot")
+      )
+      expect(client).to receive(:add_comment)
+        .with("acme/widgets", 42, "hi")
+        .and_return(created)
+
+      result = adapter.add_comment(repo: "acme/widgets", number: 42, body: "hi")
+
+      expect(result).to be_a(Automation::Providers::Data::Comment)
+      expect(result.id).to eq(99)
+      expect(result.author_login).to eq("bot")
+      expect(result.body).to eq("hi")
+    end
+  end
+
+  describe "#mark_ready_for_review" do
+    it "delegates to the GraphQL helper" do
+      expect(client).to receive(:mark_pull_request_ready).with("acme/widgets", 42)
+
+      expect(adapter.mark_ready_for_review(repo: "acme/widgets", number: 42)).to be_nil
+    end
+  end
+
+  describe "#merge_pull_request" do
+    it "forwards the merge method and returns a normalized MergeResult" do
+      expect(client).to receive(:merge_pull_request).with(
+        "acme/widgets",
+        42,
+        merge_method: "squash",
+        commit_title: "Title",
+        commit_message: "Body"
+      ).and_return(OpenStruct.new(merged: true, sha: "def456", message: "Squashed"))
+
+      result = adapter.merge_pull_request(
+        repo: "acme/widgets", number: 42, method: :squash,
+        commit_title: "Title", commit_message: "Body"
+      )
+
+      expect(result).to be_a(Automation::Providers::Data::MergeResult)
+      expect(result.merged).to be true
+      expect(result.sha).to eq("def456")
+    end
+
+    it "rejects unsupported merge methods" do
+      expect {
+        adapter.merge_pull_request(repo: "acme/widgets", number: 42, method: :fast_forward)
+      }.to raise_error(Automation::Providers::RepositoryProvider::ProviderError, /Unsupported/)
+    end
+  end
+
+  describe "client resolution" do
+    it "derives the client from the project's github_token when not injected" do
+      project.github_token = token_class.new(client)
+      resolved = described_class.new(project)
+
+      expect(resolved.client).to eq(client)
+    end
+
+    it "raises when no GitHub token is configured" do
+      project.github_token = nil
+      resolved = described_class.new(project)
+
+      expect { resolved.client }.to raise_error(
+        Automation::Providers::RepositoryProvider::ProviderError, /no GitHub token/
+      )
+    end
+  end
+end

--- a/spec/services/automation/providers/github/review_provider_spec.rb
+++ b/spec/services/automation/providers/github/review_provider_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Automation::Providers::Github::ReviewProvider do
+  let(:project_class) do
+    Class.new do
+      def full_name = "acme/widgets"
+    end
+  end
+
+  let(:client) { instance_double(GithubClient) }
+  let(:project) { project_class.new }
+  let(:adapter) { described_class.new(project, client: client) }
+
+  it "conforms to the ReviewProvider interface" do
+    expect(described_class.ancestors).to include(Automation::Providers::ReviewProvider)
+  end
+
+  describe "#fetch_reviews" do
+    it "normalizes reviews into Data::Review" do
+      expect(client).to receive(:pull_request_reviews)
+        .with("acme/widgets", 42)
+        .and_return([
+          {
+            id: 1, user_login: "Alice", state: "APPROVED",
+            body: "lgtm", submitted_at: Time.utc(2026, 1, 1), commit_id: "abc123"
+          }
+        ])
+
+      result = adapter.fetch_reviews(repo: "acme/widgets", pr_number: 42)
+
+      expect(result.first).to be_a(Automation::Providers::Data::Review)
+      expect(result.first.state).to eq(:approved)
+      expect(result.first.raw_state).to eq("APPROVED")
+      expect(result.first.author_login).to eq("alice")
+      expect(result.first.commit_sha).to eq("abc123")
+    end
+
+    it "maps unknown states to :commented" do
+      expect(client).to receive(:pull_request_reviews)
+        .and_return([ { id: 1, user_login: "a", state: "SOMETHING", body: "", submitted_at: nil, commit_id: nil } ])
+
+      result = adapter.fetch_reviews(repo: "acme/widgets", pr_number: 42)
+
+      expect(result.first.state).to eq(:commented)
+    end
+  end
+
+  describe "#fetch_review_threads" do
+    it "normalizes threads and thread comments" do
+      expect(client).to receive(:review_threads).with("acme/widgets", 42).and_return([
+        {
+          id: "thread1",
+          is_resolved: false,
+          comments: [
+            { body: "nit", path: "app/x.rb", line: 3, author: "Alice" }
+          ]
+        }
+      ])
+
+      result = adapter.fetch_review_threads(repo: "acme/widgets", pr_number: 42)
+
+      expect(result.first).to be_a(Automation::Providers::Data::ReviewThread)
+      expect(result.first.id).to eq("thread1")
+      expect(result.first.resolved).to be false
+      expect(result.first.comments.first).to be_a(Automation::Providers::Data::ReviewThreadComment)
+      expect(result.first.comments.first.author_login).to eq("alice")
+    end
+  end
+
+  describe "#fetch_review_requests / #fetch_pending_reviewers" do
+    it "returns a Data::ReviewRequest" do
+      expect(client).to receive(:pull_request_review_requests)
+        .with("acme/widgets", 42)
+        .and_return({ users: [ "Alice", "Bob" ], teams: [ "backend" ] })
+
+      result = adapter.fetch_review_requests(repo: "acme/widgets", pr_number: 42)
+
+      expect(result).to be_a(Automation::Providers::Data::ReviewRequest)
+      expect(result.users).to eq([ "alice", "bob" ])
+      expect(result.teams).to eq([ "backend" ])
+    end
+
+    it "exposes pending users as downcased logins" do
+      expect(client).to receive(:pull_request_review_requests)
+        .and_return({ users: [ "Alice" ], teams: [] })
+
+      expect(adapter.fetch_pending_reviewers(repo: "acme/widgets", pr_number: 42))
+        .to eq([ "alice" ])
+    end
+  end
+
+  describe "#request_reviewers" do
+    it "filters out already-pending reviewers and returns the new set" do
+      allow(client).to receive(:pull_request_review_requests)
+        .and_return({ users: [ "alice" ], teams: [] })
+      expect(client).to receive(:request_pull_request_review)
+        .with("acme/widgets", 42, reviewers: [ "bob" ])
+
+      result = adapter.request_reviewers(
+        repo: "acme/widgets", pr_number: 42, reviewers: [ "Alice", "Bob" ]
+      )
+
+      expect(result).to eq([ "bob" ])
+    end
+
+    it "is idempotent when everyone requested is already pending" do
+      allow(client).to receive(:pull_request_review_requests)
+        .and_return({ users: [ "alice" ], teams: [] })
+      expect(client).not_to receive(:request_pull_request_review)
+
+      expect(
+        adapter.request_reviewers(repo: "acme/widgets", pr_number: 42, reviewers: [ "alice" ])
+      ).to eq([])
+    end
+
+    it "returns [] for empty inputs without calling the client" do
+      expect(client).not_to receive(:pull_request_review_requests)
+
+      expect(adapter.request_reviewers(repo: "acme/widgets", pr_number: 42, reviewers: []))
+        .to eq([])
+    end
+  end
+
+  describe "#submit_review" do
+    it "maps the event symbol to GitHub's enum and returns Data::Review" do
+      expect(client).to receive(:create_pull_request_review)
+        .with("acme/widgets", 42, event: "APPROVE", body: "nice")
+        .and_return(OpenStruct.new(
+          id: 7, body: "nice", state: "APPROVED",
+          submitted_at: Time.utc(2026, 1, 1), commit_id: "def",
+          user: OpenStruct.new(login: "Bot")
+        ))
+
+      result = adapter.submit_review(
+        repo: "acme/widgets", pr_number: 42, body: "nice", event: :approve
+      )
+
+      expect(result).to be_a(Automation::Providers::Data::Review)
+      expect(result.state).to eq(:approved)
+      expect(result.commit_sha).to eq("def")
+    end
+
+    it "rejects unknown events" do
+      expect {
+        adapter.submit_review(repo: "acme/widgets", pr_number: 42, body: "", event: :bogus)
+      }.to raise_error(Automation::Providers::ReviewProvider::ProviderError, /Unsupported/)
+    end
+  end
+
+  describe "#resolve_review_thread" do
+    it "forwards the opaque thread id to the GraphQL mutation" do
+      expect(client).to receive(:resolve_review_thread).with("thread-node-id")
+
+      expect(
+        adapter.resolve_review_thread(repo: "acme/widgets", pr_number: 42, thread_id: "thread-node-id")
+      ).to be_nil
+    end
+
+    it "translates GithubClient errors into ReviewProvider::ProviderError" do
+      expect(client).to receive(:resolve_review_thread)
+        .and_raise(GithubClient::ApiError.new("boom", status: 500))
+
+      expect {
+        adapter.resolve_review_thread(repo: "acme/widgets", pr_number: 42, thread_id: "t")
+      }.to raise_error(Automation::Providers::ReviewProvider::ProviderError)
+    end
+  end
+end

--- a/spec/services/automation/providers/github/work_item_provider_spec.rb
+++ b/spec/services/automation/providers/github/work_item_provider_spec.rb
@@ -82,12 +82,30 @@ RSpec.describe Automation::Providers::Github::WorkItemProvider do
       expect(result.first.number).to eq(42)
     end
 
-    it "passes the first assignee to the client when provided" do
+    it "passes the single assignee to the client when provided" do
       expect(client).to receive(:issues)
         .with("acme/widgets", labels: nil, state: "open", assignee: "bob")
         .and_return([])
 
       adapter.list_issues(repo: "acme/widgets", assignees: [ "bob" ])
+    end
+
+    it "raises ProviderError when more than one assignee is supplied" do
+      expect(client).not_to receive(:issues)
+
+      expect {
+        adapter.list_issues(repo: "acme/widgets", assignees: [ "alice", "bob" ])
+      }.to raise_error(
+        Automation::Providers::WorkItemProvider::ProviderError, /single assignee/
+      )
+    end
+
+    it "ignores blank assignee entries before counting" do
+      expect(client).to receive(:issues)
+        .with("acme/widgets", labels: nil, state: "open", assignee: "bob")
+        .and_return([])
+
+      adapter.list_issues(repo: "acme/widgets", assignees: [ "", nil, "bob" ])
     end
   end
 

--- a/spec/services/automation/providers/github/work_item_provider_spec.rb
+++ b/spec/services/automation/providers/github/work_item_provider_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Automation::Providers::Github::WorkItemProvider do
+  let(:project_class) do
+    Class.new do
+      def full_name = "acme/widgets"
+    end
+  end
+
+  let(:client) { instance_double(GithubClient) }
+  let(:project) { project_class.new }
+  let(:adapter) { described_class.new(project, client: client) }
+
+  let(:issue_resource) do
+    OpenStruct.new(
+      number: 42,
+      title: "Bug",
+      body: "details",
+      state: "open",
+      created_at: Time.utc(2026, 1, 1),
+      updated_at: Time.utc(2026, 1, 2),
+      closed_at: nil,
+      html_url: "https://github.com/acme/widgets/issues/42",
+      user: OpenStruct.new(login: "Alice"),
+      assignees: [ OpenStruct.new(login: "Bob") ],
+      labels: [ OpenStruct.new(name: "bug"), OpenStruct.new(name: "priority:high") ],
+      pull_request: nil
+    )
+  end
+
+  it "conforms to the WorkItemProvider interface" do
+    expect(described_class.ancestors).to include(Automation::Providers::WorkItemProvider)
+  end
+
+  describe "#fetch_issue" do
+    it "normalizes the issue response" do
+      expect(client).to receive(:issue).with("acme/widgets", 42).and_return(issue_resource)
+
+      result = adapter.fetch_issue(repo: "acme/widgets", number: 42)
+
+      expect(result).to be_a(Automation::Providers::Data::Issue)
+      expect(result.number).to eq(42)
+      expect(result.state).to eq(:open)
+      expect(result.labels).to eq([ "bug", "priority:high" ])
+      expect(result.assignee_logins).to eq([ "bob" ])
+      expect(result.author_login).to eq("alice")
+      expect(result.dependencies).to eq([])
+      expect(result.pull_request_number).to be_nil
+    end
+
+    it "exposes pull_request_number when the item is also a PR" do
+      issue_resource.pull_request = OpenStruct.new(url: "...")
+
+      expect(client).to receive(:issue).and_return(issue_resource)
+
+      result = adapter.fetch_issue(repo: "acme/widgets", number: 42)
+
+      expect(result.pull_request_number).to eq(42)
+    end
+
+    it "translates GithubClient errors to WorkItemProvider::ProviderError" do
+      expect(client).to receive(:issue).and_raise(GithubClient::AuthenticationError)
+
+      expect {
+        adapter.fetch_issue(repo: "acme/widgets", number: 1)
+      }.to raise_error(Automation::Providers::WorkItemProvider::ProviderError)
+    end
+  end
+
+  describe "#list_issues" do
+    it "forwards state and label filters" do
+      expect(client).to receive(:issues)
+        .with("acme/widgets", labels: [ "bug" ], state: "open")
+        .and_return([ issue_resource ])
+
+      result = adapter.list_issues(repo: "acme/widgets", state: :open, labels: [ "bug" ])
+
+      expect(result.size).to eq(1)
+      expect(result.first.number).to eq(42)
+    end
+
+    it "passes the first assignee to the client when provided" do
+      expect(client).to receive(:issues)
+        .with("acme/widgets", labels: nil, state: "open", assignee: "bob")
+        .and_return([])
+
+      adapter.list_issues(repo: "acme/widgets", assignees: [ "bob" ])
+    end
+  end
+
+  describe "#fetch_issue_comments" do
+    it "normalizes comments" do
+      raw = OpenStruct.new(
+        id: 7,
+        body: "hi",
+        created_at: Time.utc(2026, 1, 1),
+        updated_at: Time.utc(2026, 1, 1),
+        html_url: "http://example.com/7",
+        user: OpenStruct.new(login: "Carol")
+      )
+      expect(client).to receive(:issue_comments).with("acme/widgets", 42).and_return([ raw ])
+
+      result = adapter.fetch_issue_comments(repo: "acme/widgets", number: 42)
+
+      expect(result.first).to be_a(Automation::Providers::Data::Comment)
+      expect(result.first.author_login).to eq("carol")
+    end
+  end
+
+  describe "#fetch_issue_timeline" do
+    it "maps known events to the canonical set" do
+      event = {
+        event: "labeled",
+        created_at: Time.utc(2026, 1, 1),
+        actor: { login: "Dave" },
+        label: { name: "bug" }
+      }
+      expect(client).to receive(:issue_events).with("acme/widgets", 42).and_return([ event ])
+
+      result = adapter.fetch_issue_timeline(repo: "acme/widgets", number: 42)
+
+      expect(result.first).to be_a(Automation::Providers::Data::TimelineEvent)
+      expect(result.first.event).to eq(:labeled)
+      expect(result.first.label_name).to eq("bug")
+      expect(result.first.actor_login).to eq("dave")
+    end
+
+    it "falls back to :other for unknown events" do
+      event = { event: "transferred", created_at: Time.utc(2026, 1, 1), actor: { login: "Dave" } }
+      expect(client).to receive(:issue_events).and_return([ event ])
+
+      result = adapter.fetch_issue_timeline(repo: "acme/widgets", number: 42)
+
+      expect(result.first.event).to eq(:other)
+    end
+  end
+
+  describe "#create_issue" do
+    it "delegates to the client with normalized labels" do
+      expect(client).to receive(:create_issue)
+        .with("acme/widgets", title: "New", body: "body", labels: [ "a" ])
+        .and_return(issue_resource)
+
+      result = adapter.create_issue(repo: "acme/widgets", title: "New", body: "body", labels: [ "a", "" ])
+
+      expect(result).to be_a(Automation::Providers::Data::Issue)
+    end
+  end
+
+  describe "#add_labels / #remove_label / #add_comment" do
+    it "#add_labels forwards labels" do
+      expect(client).to receive(:add_labels_to_issue).with("acme/widgets", 42, [ "bug" ])
+      adapter.add_labels(repo: "acme/widgets", number: 42, labels: [ "bug" ])
+    end
+
+    it "#remove_label is idempotent for 404" do
+      expect(client).to receive(:remove_label_from_issue).and_raise(GithubClient::NotFoundError)
+
+      expect {
+        adapter.remove_label(repo: "acme/widgets", number: 42, label: "stale")
+      }.not_to raise_error
+    end
+
+    it "#add_comment returns a Data::Comment" do
+      created = OpenStruct.new(
+        id: 3, body: "hey",
+        created_at: Time.utc(2026, 1, 1), updated_at: nil, html_url: nil,
+        user: OpenStruct.new(login: "Bot")
+      )
+      expect(client).to receive(:add_comment).with("acme/widgets", 42, "hey").and_return(created)
+
+      result = adapter.add_comment(repo: "acme/widgets", number: 42, body: "hey")
+
+      expect(result.author_login).to eq("bot")
+    end
+  end
+
+  describe "#transition_state" do
+    it "updates the issue state through the client" do
+      expect(client).to receive(:update_issue)
+        .with("acme/widgets", 42, state: "closed", state_reason: "completed")
+        .and_return(issue_resource)
+
+      result = adapter.transition_state(
+        repo: "acme/widgets", number: 42, state: :closed, reason: "completed"
+      )
+
+      expect(result).to be_a(Automation::Providers::Data::Issue)
+    end
+
+    it "rejects states that are not part of the canonical set" do
+      expect {
+        adapter.transition_state(repo: "acme/widgets", number: 42, state: :in_progress)
+      }.to raise_error(Automation::Providers::WorkItemProvider::ProviderError, /Unsupported/)
+    end
+  end
+end

--- a/spec/services/automation/providers/github/work_item_provider_spec.rb
+++ b/spec/services/automation/providers/github/work_item_provider_spec.rb
@@ -164,6 +164,18 @@ RSpec.describe Automation::Providers::Github::WorkItemProvider do
       }.not_to raise_error
     end
 
+    it "#remove_label swallows 404 regardless of the underlying message text" do
+      # Octokit does not guarantee "not found" appears in every 404 body
+      # (e.g. "Label does not exist"). Classification must be by error
+      # class, not message regex.
+      expect(client).to receive(:remove_label_from_issue)
+        .and_raise(GithubClient::NotFoundError, "Label does not exist")
+
+      expect {
+        adapter.remove_label(repo: "acme/widgets", number: 42, label: "stale")
+      }.not_to raise_error
+    end
+
     it "#add_comment returns a Data::Comment" do
       created = OpenStruct.new(
         id: 3, body: "hey",

--- a/spec/services/automation/providers/resolver_registration_spec.rb
+++ b/spec/services/automation/providers/resolver_registration_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Verifies the config/initializers/automation_providers.rb initializer wires
+# the GitHub-backed adapters into the provider resolver registry so policy
+# code can resolve them from a Project without knowing provider details.
+RSpec.describe Automation::Providers::Resolver do
+  let(:project_class) do
+    Class.new do
+      def provider_type = nil
+      def full_name = "acme/widgets"
+    end
+  end
+  let(:project) { project_class.new }
+
+  describe ".registered?" do
+    it "reports :github as registered after boot" do
+      expect(described_class.registered?(:github)).to be true
+    end
+  end
+
+  describe ".repository_for" do
+    it "returns a GitHub::RepositoryProvider instance" do
+      expect(described_class.repository_for(project))
+        .to be_a(Automation::Providers::Github::RepositoryProvider)
+    end
+  end
+
+  describe ".work_item_for" do
+    it "returns a GitHub::WorkItemProvider instance" do
+      expect(described_class.work_item_for(project))
+        .to be_a(Automation::Providers::Github::WorkItemProvider)
+    end
+  end
+
+  describe ".review_for" do
+    it "returns a GitHub::ReviewProvider instance" do
+      expect(described_class.review_for(project))
+        .to be_a(Automation::Providers::Github::ReviewProvider)
+    end
+  end
+end

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -720,29 +720,40 @@ RSpec.describe GithubClient do
     let(:ref) { "abc123" }
 
     context "when check runs exist" do
+      let(:check_runs_payload) do
+        [
+          {
+            id: 1, name: "rspec", status: "completed", conclusion: "failure",
+            html_url: "https://github.com/owner/repo/runs/1",
+            details_url: "https://ci.example.com/jobs/1"
+          },
+          {
+            id: 2, name: "rubocop", status: "completed", conclusion: "success",
+            html_url: "https://github.com/owner/repo/runs/2",
+            details_url: "https://ci.example.com/jobs/2"
+          },
+          {
+            id: 3, name: "integration", status: "in_progress", conclusion: nil,
+            html_url: "https://github.com/owner/repo/runs/3",
+            details_url: "https://ci.example.com/jobs/3"
+          }
+        ]
+      end
+
       before do
         stub_request(:get, "#{api_base}/repos/#{repo}/commits/#{ref}/check-runs")
           .with(query: hash_including("per_page" => "100", "page" => "1"))
           .to_return(
             status: 200,
-            body: {
-              total_count: 2,
-              check_runs: [
-                { id: 1, name: "rspec", conclusion: "failure" },
-                { id: 2, name: "rubocop", conclusion: "success" }
-              ]
-            }.to_json,
+            body: { total_count: check_runs_payload.length, check_runs: check_runs_payload }.to_json,
             headers: { "Content-Type" => "application/json" }
           )
       end
 
-      it "returns check run names and conclusions" do
+      it "returns check run names, statuses, conclusions, and URLs" do
         result = client.check_runs_for_ref(repo, ref)
 
-        expect(result).to eq([
-          { name: "rspec", conclusion: "failure" },
-          { name: "rubocop", conclusion: "success" }
-        ])
+        expect(result).to eq(check_runs_payload.map { |cr| cr.except(:id) })
       end
     end
 


### PR DESCRIPTION
## Summary

Add GitHub automation adapters

See #1118 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1118