### PR TITLE
Fix #1181: Disable issues with open paid-generated PRs from quick run in project issues table and Trigger Agent Run form

### DIFF
--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -54,6 +54,9 @@ module Projects
         .distinct
         .pluck(:issue_id)
         .to_set
+      @issues_with_open_paid_pr = Issue.ids_with_open_paid_generated_pr(
+        project: @project, issue_ids: issue_ids
+      )
       @issue_enhancement_rounds = @project.agent_runs
         .where(issue_id: issue_ids, goal: "enhance_issue")
         .where.not(status: AgentRun::UNFINISHED_STATUSES)
@@ -120,6 +123,14 @@ module Projects
           return
         end
 
+        if goal == "create_pr" && issue && source_pr_number.blank?
+          if (paid_pr = issue.associated_paid_pull_request)
+            redirect_to new_project_agent_run_path(@project, goal: goal),
+              alert: "Paid already opened PR ##{paid_pr.github_number} for this issue. Start a run on the PR instead."
+            return
+          end
+        end
+
         create_run_and_redirect(
           on_error_path: new_project_agent_run_path(@project, goal: goal),
           issue: issue,
@@ -143,9 +154,9 @@ module Projects
         return
       end
 
-      if issue&.associated_pull_request
+      if (paid_pr = issue&.associated_paid_pull_request)
         redirect_to project_path(@project),
-          alert: "This issue already has an associated pull request."
+          alert: "Paid already opened PR ##{paid_pr.github_number} for this issue. Quick run on the PR instead."
         return
       end
 

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -54,7 +54,7 @@ module Projects
         .distinct
         .pluck(:issue_id)
         .to_set
-      @issues_with_open_paid_pr = Issue.ids_with_open_paid_generated_pr(
+      @paid_prs_by_issue_id = Issue.open_paid_generated_prs_by_issue_id(
         project: @project, issue_ids: issue_ids
       )
       @issue_enhancement_rounds = @project.agent_runs

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -29,6 +29,9 @@ class ProjectsController < ApplicationController
     open_items = @project.issues.where(github_state: "open").order(github_number: :desc)
     @issues = open_items.issues_only.includes(:sub_issues).limit(settings.max_issues_per_page)
     @issue_lifecycle_statuses = Issue.lifecycle_statuses(@issues)
+    @issue_ids_with_open_paid_pr = Issue.ids_with_open_paid_generated_pr(
+      project: @project, issue_ids: @issues.map(&:id)
+    )
     @pull_requests = open_items.pull_requests_only.limit(settings.max_prs_per_page)
     @pr_numbers_with_queued_auto_continue = @project.pr_numbers_with_queued_auto_continue
     @pr_numbers_with_active_runs = @project.pr_numbers_with_active_runs

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -29,7 +29,7 @@ class ProjectsController < ApplicationController
     open_items = @project.issues.where(github_state: "open").order(github_number: :desc)
     @issues = open_items.issues_only.includes(:sub_issues).limit(settings.max_issues_per_page)
     @issue_lifecycle_statuses = Issue.lifecycle_statuses(@issues)
-    @issue_ids_with_open_paid_pr = Issue.ids_with_open_paid_generated_pr(
+    @paid_prs_by_issue_id = Issue.open_paid_generated_prs_by_issue_id(
       project: @project, issue_ids: @issues.map(&:id)
     )
     @pull_requests = open_items.pull_requests_only.limit(settings.max_prs_per_page)

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -264,6 +264,50 @@ class Issue < ApplicationRecord
     scope.select(:parent_issue_id)
   end
 
+  # Returns the set of issue IDs that have at least one open paid-generated
+  # pull request. A PR is "paid-generated" when an AgentRun in the same
+  # project produced it (AgentRun#pull_request_number matches the PR issue's
+  # github_number). Used to disable quick-run actions on issues that already
+  # have an open paid PR so the user is steered to iterate on the PR instead.
+  def self.ids_with_open_paid_generated_pr(project:, issue_ids:)
+    issue_ids = Array(issue_ids).compact
+    return Set.new if issue_ids.empty?
+
+    open_pr_numbers = project.issues
+      .pull_requests_only
+      .where(github_state: "open")
+      .pluck(:github_number)
+    return Set.new if open_pr_numbers.empty?
+
+    project.agent_runs
+      .where(issue_id: issue_ids, pull_request_number: open_pr_numbers)
+      .distinct
+      .pluck(:issue_id)
+      .to_set
+  end
+
+  # Returns the open paid-generated pull request (an Issue with
+  # is_pull_request: true) associated with this issue, if any. Prefers the
+  # most recently updated one when multiple exist. Used by views to both
+  # hint users toward the PR and disable the quick-run action on the issue.
+  def associated_paid_pull_request
+    return nil if is_pull_request?
+    return nil unless project_id && id
+
+    paid_pr_numbers = project.agent_runs
+      .where(issue_id: id)
+      .where.not(pull_request_number: nil)
+      .distinct
+      .pluck(:pull_request_number)
+    return nil if paid_pr_numbers.empty?
+
+    project.issues
+      .pull_requests_only
+      .where(github_state: "open", github_number: paid_pr_numbers)
+      .order(github_updated_at: :desc, updated_at: :desc)
+      .first
+  end
+
   private
 
   CLOSING_KEYWORD_RE = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b/i

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -264,48 +264,52 @@ class Issue < ApplicationRecord
     scope.select(:parent_issue_id)
   end
 
-  # Returns the set of issue IDs that have at least one open paid-generated
-  # pull request. A PR is "paid-generated" when an AgentRun in the same
-  # project produced it (AgentRun#pull_request_number matches the PR issue's
-  # github_number). Used to disable quick-run actions on issues that already
-  # have an open paid PR so the user is steered to iterate on the PR instead.
-  def self.ids_with_open_paid_generated_pr(project:, issue_ids:)
+  # Returns a Hash mapping issue_id => the most recently updated open
+  # paid-generated pull request (an Issue row with is_pull_request: true).
+  # A PR is "paid-generated" when an AgentRun in the same project produced
+  # it (AgentRun#pull_request_number matches the PR issue's github_number).
+  # Views and controllers precompute this hash once per request so per-issue
+  # renders can look up the PR without re-querying (fixes the partial N+1
+  # that would otherwise fire for each rendered issue with an open paid PR).
+  def self.open_paid_generated_prs_by_issue_id(project:, issue_ids:)
     issue_ids = Array(issue_ids).compact
-    return Set.new if issue_ids.empty?
+    return {} if issue_ids.empty?
 
-    open_pr_numbers = project.issues
-      .pull_requests_only
-      .where(github_state: "open")
-      .pluck(:github_number)
-    return Set.new if open_pr_numbers.empty?
-
-    project.agent_runs
-      .where(issue_id: issue_ids, pull_request_number: open_pr_numbers)
+    issue_pr_pairs = project.agent_runs
+      .where(issue_id: issue_ids)
+      .where.not(pull_request_number: nil)
       .distinct
-      .pluck(:issue_id)
-      .to_set
+      .pluck(:issue_id, :pull_request_number)
+    return {} if issue_pr_pairs.empty?
+
+    pr_numbers = issue_pr_pairs.map(&:last).uniq
+    open_prs_by_number = project.issues
+      .pull_requests_only
+      .where(github_state: "open", github_number: pr_numbers)
+      .index_by(&:github_number)
+    return {} if open_prs_by_number.empty?
+
+    recency = ->(pr) { [ pr.github_updated_at || Time.at(0), pr.updated_at || Time.at(0) ] }
+
+    issue_pr_pairs.each_with_object({}) do |(issue_id, pr_number), result|
+      pr = open_prs_by_number[pr_number]
+      next unless pr
+
+      existing = result[issue_id]
+      result[issue_id] = pr if existing.nil? || (recency.call(pr) <=> recency.call(existing)) == 1
+    end
   end
 
   # Returns the open paid-generated pull request (an Issue with
   # is_pull_request: true) associated with this issue, if any. Prefers the
-  # most recently updated one when multiple exist. Used by views to both
-  # hint users toward the PR and disable the quick-run action on the issue.
+  # most recently updated one when multiple exist. Intended for single-issue
+  # controller checks; for rendering collections, use
+  # .open_paid_generated_prs_by_issue_id to avoid per-row queries.
   def associated_paid_pull_request
     return nil if is_pull_request?
     return nil unless project_id && id
 
-    paid_pr_numbers = project.agent_runs
-      .where(issue_id: id)
-      .where.not(pull_request_number: nil)
-      .distinct
-      .pluck(:pull_request_number)
-    return nil if paid_pr_numbers.empty?
-
-    project.issues
-      .pull_requests_only
-      .where(github_state: "open", github_number: paid_pr_numbers)
-      .order(github_updated_at: :desc, updated_at: :desc)
-      .first
+    self.class.open_paid_generated_prs_by_issue_id(project: project, issue_ids: [ id ])[id]
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -421,7 +421,7 @@ class Project < ApplicationRecord
     open_items = issues.where(github_state: "open").order(github_number: :desc)
     displayed = open_items.issues_only.includes(:sub_issues).limit(25)
     lifecycle_statuses = Issue.lifecycle_statuses(displayed)
-    issue_ids_with_open_paid_pr = Issue.ids_with_open_paid_generated_pr(
+    paid_prs_by_issue_id = Issue.open_paid_generated_prs_by_issue_id(
       project: self, issue_ids: displayed.map(&:id)
     )
     broadcast_replace_to(
@@ -430,7 +430,7 @@ class Project < ApplicationRecord
       partial: "projects/issues",
       locals: { project: self, issues: displayed,
                 issue_lifecycle_statuses: lifecycle_statuses,
-                issue_ids_with_open_paid_pr: issue_ids_with_open_paid_pr }
+                paid_prs_by_issue_id: paid_prs_by_issue_id }
     )
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -421,12 +421,16 @@ class Project < ApplicationRecord
     open_items = issues.where(github_state: "open").order(github_number: :desc)
     displayed = open_items.issues_only.includes(:sub_issues).limit(25)
     lifecycle_statuses = Issue.lifecycle_statuses(displayed)
+    issue_ids_with_open_paid_pr = Issue.ids_with_open_paid_generated_pr(
+      project: self, issue_ids: displayed.map(&:id)
+    )
     broadcast_replace_to(
       self, :project_updates,
       target: ActionView::RecordIdentifier.dom_id(self, :issues),
       partial: "projects/issues",
       locals: { project: self, issues: displayed,
-                issue_lifecycle_statuses: lifecycle_statuses }
+                issue_lifecycle_statuses: lifecycle_statuses,
+                issue_ids_with_open_paid_pr: issue_ids_with_open_paid_pr }
     )
   end
 

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -19,19 +19,26 @@
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= issue_lifecycle_badge(local_assigns.fetch(:lifecycle_status, :eligible)) %>
     <% paid_pr = local_assigns.fetch(:paid_pr, nil) %>
-    <% if paid_pr %>
-      <%# Paid already produced an open PR for this issue — steer the user to
-          iterate on that PR rather than starting a duplicate run. %>
-      <%= link_to "#{project.github_url}/pull/#{paid_pr.github_number}",
+    <%# Prefer the paid-generated PR when one exists; otherwise fall back to
+        any open associated PR so manually-opened PRs still get a visible
+        link (matches pre-#1181 behavior). Build URL from the parent issue's
+        project to avoid N+1 on sub_issues: :project. %>
+    <% linked_pr = paid_pr || issue.associated_pull_request %>
+    <% if linked_pr %>
+      <%= link_to "#{project.github_url}/pull/#{linked_pr.github_number}",
                   target: "_blank",
                   rel: "noopener noreferrer",
-                  title: "Paid already opened PR ##{paid_pr.github_number} for this issue. Quick run on the PR to iterate on it.",
+                  title: paid_pr ? "Paid already opened PR ##{paid_pr.github_number} for this issue. Quick run on the PR to iterate on it." : nil,
                   class: "inline-flex items-center space-x-1 text-xs font-medium text-indigo-600 hover:text-indigo-900" do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3.5 w-3.5" aria-hidden="true">
           <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/>
         </svg>
-        <span>PR #<%= paid_pr.github_number %></span>
+        <span>PR #<%= linked_pr.github_number %></span>
       <% end %>
+    <% end %>
+    <% if paid_pr %>
+      <%# Paid already produced an open PR — steer the user to iterate on
+          that PR rather than starting a duplicate run. %>
       <span class="inline-flex cursor-not-allowed items-center rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-400"
             title="<%= "Quick run on PR ##{paid_pr.github_number} instead of this issue." %>"
             aria-disabled="true"

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -18,17 +18,27 @@
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= issue_lifecycle_badge(local_assigns.fetch(:lifecycle_status, :eligible)) %>
-    <% if (pr = issue.associated_pull_request) %>
-      <%# Build URL from the parent issue's project to avoid N+1 on sub_issues: :project %>
-      <%= link_to "#{project.github_url}/pull/#{pr.github_number}",
+    <% has_open_paid_pr = local_assigns.fetch(:has_open_paid_pr, false) %>
+    <% paid_pr = has_open_paid_pr ? issue.associated_paid_pull_request : nil %>
+    <% if paid_pr %>
+      <%# Paid already produced an open PR for this issue — steer the user to
+          iterate on that PR rather than starting a duplicate run. %>
+      <%= link_to "#{project.github_url}/pull/#{paid_pr.github_number}",
                   target: "_blank",
                   rel: "noopener noreferrer",
+                  title: "Paid already opened PR ##{paid_pr.github_number} for this issue. Quick run on the PR to iterate on it.",
                   class: "inline-flex items-center space-x-1 text-xs font-medium text-indigo-600 hover:text-indigo-900" do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3.5 w-3.5" aria-hidden="true">
           <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/>
         </svg>
-        <span>PR #<%= pr.github_number %></span>
+        <span>PR #<%= paid_pr.github_number %></span>
       <% end %>
+      <span class="inline-flex cursor-not-allowed items-center rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-400"
+            title="<%= "Quick run on PR ##{paid_pr.github_number} instead of this issue." %>"
+            aria-disabled="true"
+            data-issue-quick-run-disabled="true">
+        Quick Run
+      </span>
     <% else %>
       <%= button_to "Quick Run",
                     quick_create_project_agent_runs_path(project, issue_id: issue.id),

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -18,8 +18,7 @@
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= issue_lifecycle_badge(local_assigns.fetch(:lifecycle_status, :eligible)) %>
-    <% has_open_paid_pr = local_assigns.fetch(:has_open_paid_pr, false) %>
-    <% paid_pr = has_open_paid_pr ? issue.associated_paid_pull_request : nil %>
+    <% paid_pr = local_assigns.fetch(:paid_pr, nil) %>
     <% if paid_pr %>
       <%# Paid already produced an open PR for this issue — steer the user to
           iterate on that PR rather than starting a duplicate run. %>

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -7,8 +7,13 @@
       <div class="max-h-96 overflow-y-auto">
         <ul role="list" class="divide-y divide-gray-200">
           <% statuses = local_assigns.fetch(:issue_lifecycle_statuses, {}) %>
+          <% paid_pr_issue_ids = local_assigns.fetch(:issue_ids_with_open_paid_pr, Set.new) %>
           <% issues.each do |issue| %>
-            <%= render "projects/issue", issue: issue, project: project, lifecycle_status: statuses[issue.id] %>
+            <%= render "projects/issue",
+                      issue: issue,
+                      project: project,
+                      lifecycle_status: statuses[issue.id],
+                      has_open_paid_pr: paid_pr_issue_ids.include?(issue.id) %>
           <% end %>
         </ul>
       </div>

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -7,13 +7,13 @@
       <div class="max-h-96 overflow-y-auto">
         <ul role="list" class="divide-y divide-gray-200">
           <% statuses = local_assigns.fetch(:issue_lifecycle_statuses, {}) %>
-          <% paid_pr_issue_ids = local_assigns.fetch(:issue_ids_with_open_paid_pr, Set.new) %>
+          <% paid_prs_by_issue_id = local_assigns.fetch(:paid_prs_by_issue_id, {}) %>
           <% issues.each do |issue| %>
             <%= render "projects/issue",
                       issue: issue,
                       project: project,
                       lifecycle_status: statuses[issue.id],
-                      has_open_paid_pr: paid_pr_issue_ids.include?(issue.id) %>
+                      paid_pr: paid_prs_by_issue_id[issue.id] %>
           <% end %>
         </ul>
       </div>

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -58,8 +58,12 @@
                 <select name="issue_id" id="issue_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                   <option value="">-- Select an issue --</option>
                   <% @issues.each do |issue| %>
-                    <option value="<%= issue.id %>" <%= "selected" if params[:issue_id].to_s == issue.id.to_s %>>
-                      #<%= issue.github_number %> - <%= truncate(issue.title, length: 60) %>
+                    <% has_open_paid_pr = @issues_with_open_paid_pr.include?(issue.id) %>
+                    <option value="<%= issue.id %>"
+                            <%= "selected" if params[:issue_id].to_s == issue.id.to_s && !has_open_paid_pr %>
+                            <%= "disabled" if has_open_paid_pr %>
+                            title="<%= has_open_paid_pr ? "Paid already opened a PR for this issue. Quick run on the PR instead." : "" %>">
+                      #<%= issue.github_number %> - <%= truncate(issue.title, length: 60) %><%= " (open paid PR — quick run on the PR instead)" if has_open_paid_pr %>
                     </option>
                   <% end %>
                 </select>

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -58,12 +58,12 @@
                 <select name="issue_id" id="issue_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                   <option value="">-- Select an issue --</option>
                   <% @issues.each do |issue| %>
-                    <% has_open_paid_pr = @issues_with_open_paid_pr.include?(issue.id) %>
+                    <% paid_pr = @paid_prs_by_issue_id[issue.id] %>
                     <option value="<%= issue.id %>"
-                            <%= "selected" if params[:issue_id].to_s == issue.id.to_s && !has_open_paid_pr %>
-                            <%= "disabled" if has_open_paid_pr %>
-                            title="<%= has_open_paid_pr ? "Paid already opened a PR for this issue. Quick run on the PR instead." : "" %>">
-                      #<%= issue.github_number %> - <%= truncate(issue.title, length: 60) %><%= " (open paid PR — quick run on the PR instead)" if has_open_paid_pr %>
+                            <%= "selected" if params[:issue_id].to_s == issue.id.to_s && paid_pr.nil? %>
+                            <%= "disabled" if paid_pr %>
+                            title="<%= paid_pr ? "Paid already opened PR ##{paid_pr.github_number} for this issue. Quick run on the PR instead." : "" %>">
+                      #<%= issue.github_number %> - <%= truncate(issue.title, length: 60) %><%= " (open paid PR ##{paid_pr.github_number} — quick run on the PR instead)" if paid_pr %>
                     </option>
                   <% end %>
                 </select>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -165,7 +165,7 @@
 
     <%= render "projects/issues", project: @project, issues: @issues,
                issue_lifecycle_statuses: @issue_lifecycle_statuses,
-               issue_ids_with_open_paid_pr: @issue_ids_with_open_paid_pr %>
+               paid_prs_by_issue_id: @paid_prs_by_issue_id %>
 
     <%= render "projects/pull_requests", project: @project, pull_requests: @pull_requests,
                pr_numbers_with_queued_auto_continue: @pr_numbers_with_queued_auto_continue,

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -163,7 +163,9 @@
   <div data-show-actions="<%= policy(@project).run_agent? %>">
     <%= render "projects/stats", project: @project, budgets: @cost_budgets %>
 
-    <%= render "projects/issues", project: @project, issues: @issues, issue_lifecycle_statuses: @issue_lifecycle_statuses %>
+    <%= render "projects/issues", project: @project, issues: @issues,
+               issue_lifecycle_statuses: @issue_lifecycle_statuses,
+               issue_ids_with_open_paid_pr: @issue_ids_with_open_paid_pr %>
 
     <%= render "projects/pull_requests", project: @project, pull_requests: @pull_requests,
                pr_numbers_with_queued_auto_continue: @pr_numbers_with_queued_auto_continue,

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -479,10 +479,10 @@ RSpec.describe Issue do
       end
     end
 
-    describe ".ids_with_open_paid_generated_pr" do
+    describe ".open_paid_generated_prs_by_issue_id" do
       let(:project) { create(:project) }
 
-      it "returns IDs of issues whose open PRs were created by an agent run" do
+      it "maps issue_id to the open paid-generated PR" do
         issue_with_paid_pr = create(:issue, project: project)
         paid_pr = create(:issue, :pull_request, project: project, github_number: 99, github_state: "open")
         create(:agent_run, :completed, project: project, issue: issue_with_paid_pr,
@@ -493,13 +493,12 @@ RSpec.describe Issue do
         create(:issue, :pull_request, project: project, parent_issue: issue_without_paid_pr,
           github_state: "open")
 
-        result = described_class.ids_with_open_paid_generated_pr(
+        result = described_class.open_paid_generated_prs_by_issue_id(
           project: project,
           issue_ids: [ issue_with_paid_pr.id, issue_without_paid_pr.id ]
         )
 
-        expect(result).to include(issue_with_paid_pr.id)
-        expect(result).not_to include(issue_without_paid_pr.id)
+        expect(result).to eq(issue_with_paid_pr.id => paid_pr)
       end
 
       it "excludes issues whose paid PR has been closed" do
@@ -509,16 +508,72 @@ RSpec.describe Issue do
           pull_request_number: paid_pr.github_number,
           pull_request_url: "https://github.com/example/repo/pull/#{paid_pr.github_number}")
 
-        result = described_class.ids_with_open_paid_generated_pr(
+        result = described_class.open_paid_generated_prs_by_issue_id(
           project: project, issue_ids: [ issue.id ]
         )
 
         expect(result).to be_empty
       end
 
-      it "returns an empty set when no issue IDs are supplied" do
-        expect(described_class.ids_with_open_paid_generated_pr(project: project, issue_ids: []))
-          .to eq(Set.new)
+      it "returns an empty hash when no issue IDs are supplied" do
+        expect(described_class.open_paid_generated_prs_by_issue_id(project: project, issue_ids: []))
+          .to eq({})
+      end
+
+      it "prefers the most recently updated PR when multiple are linked to one issue" do
+        issue = create(:issue, project: project)
+        older_pr = create(:issue, :pull_request, project: project, github_number: 98,
+          github_state: "open", github_updated_at: 2.hours.ago)
+        newer_pr = create(:issue, :pull_request, project: project, github_number: 99,
+          github_state: "open", github_updated_at: 1.minute.ago)
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: older_pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{older_pr.github_number}")
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: newer_pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{newer_pr.github_number}")
+
+        result = described_class.open_paid_generated_prs_by_issue_id(
+          project: project, issue_ids: [ issue.id ]
+        )
+
+        expect(result).to eq(issue.id => newer_pr)
+      end
+
+      it "ignores PRs from other projects with matching numbers" do
+        other_project = create(:project)
+        issue = create(:issue, project: project)
+        create(:issue, :pull_request, project: other_project, github_number: 99, github_state: "open")
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: 99,
+          pull_request_url: "https://github.com/example/repo/pull/99")
+
+        result = described_class.open_paid_generated_prs_by_issue_id(
+          project: project, issue_ids: [ issue.id ]
+        )
+
+        expect(result).to be_empty
+      end
+
+      it "issues a bounded number of queries regardless of issue count" do
+        issues = Array.new(5) { create(:issue, project: project) }
+        issues.each_with_index do |issue, idx|
+          pr = create(:issue, :pull_request, project: project, github_number: 100 + idx, github_state: "open")
+          create(:agent_run, :completed, project: project, issue: issue,
+            pull_request_number: pr.github_number,
+            pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+        end
+
+        # Two queries: agent_runs pairs, then open PRs by number.
+        query_count = 0
+        counter = ->(*, payload) { query_count += 1 unless payload[:name] == "SCHEMA" }
+        ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+          described_class.open_paid_generated_prs_by_issue_id(
+            project: project, issue_ids: issues.map(&:id)
+          )
+        end
+
+        expect(query_count).to eq(2)
       end
     end
   end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -426,6 +426,101 @@ RSpec.describe Issue do
         end
       end
     end
+
+    describe "#associated_paid_pull_request" do
+      let(:project) { create(:project) }
+
+      it "returns the open PR when a completed agent run produced it" do
+        issue = create(:issue, project: project)
+        pr = create(:issue, :pull_request, project: project, github_number: 99, github_state: "open")
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+
+        expect(issue.associated_paid_pull_request).to eq(pr)
+      end
+
+      it "returns nil when the only linked PR was not paid-generated" do
+        issue = create(:issue, project: project)
+        create(:issue, :pull_request, project: project, parent_issue: issue, github_state: "open")
+
+        expect(issue.associated_paid_pull_request).to be_nil
+      end
+
+      it "returns nil when the paid-generated PR has been closed" do
+        issue = create(:issue, project: project)
+        pr = create(:issue, :pull_request, :closed, project: project, github_number: 99)
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+
+        expect(issue.associated_paid_pull_request).to be_nil
+      end
+
+      it "returns nil when called on a pull request record" do
+        issue = create(:issue, project: project)
+        pr = create(:issue, :pull_request, project: project, github_number: 99, github_state: "open")
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+
+        expect(pr.associated_paid_pull_request).to be_nil
+      end
+
+      it "ignores PRs from other projects with matching numbers" do
+        other_project = create(:project)
+        issue = create(:issue, project: project)
+        create(:issue, :pull_request, project: other_project, github_number: 99, github_state: "open")
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: 99,
+          pull_request_url: "https://github.com/example/repo/pull/99")
+
+        expect(issue.associated_paid_pull_request).to be_nil
+      end
+    end
+
+    describe ".ids_with_open_paid_generated_pr" do
+      let(:project) { create(:project) }
+
+      it "returns IDs of issues whose open PRs were created by an agent run" do
+        issue_with_paid_pr = create(:issue, project: project)
+        paid_pr = create(:issue, :pull_request, project: project, github_number: 99, github_state: "open")
+        create(:agent_run, :completed, project: project, issue: issue_with_paid_pr,
+          pull_request_number: paid_pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{paid_pr.github_number}")
+
+        issue_without_paid_pr = create(:issue, project: project)
+        create(:issue, :pull_request, project: project, parent_issue: issue_without_paid_pr,
+          github_state: "open")
+
+        result = described_class.ids_with_open_paid_generated_pr(
+          project: project,
+          issue_ids: [ issue_with_paid_pr.id, issue_without_paid_pr.id ]
+        )
+
+        expect(result).to include(issue_with_paid_pr.id)
+        expect(result).not_to include(issue_without_paid_pr.id)
+      end
+
+      it "excludes issues whose paid PR has been closed" do
+        issue = create(:issue, project: project)
+        paid_pr = create(:issue, :pull_request, :closed, project: project, github_number: 99)
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: paid_pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{paid_pr.github_number}")
+
+        result = described_class.ids_with_open_paid_generated_pr(
+          project: project, issue_ids: [ issue.id ]
+        )
+
+        expect(result).to be_empty
+      end
+
+      it "returns an empty set when no issue IDs are supplied" do
+        expect(described_class.ids_with_open_paid_generated_pr(project: project, issue_ids: []))
+          .to eq(Set.new)
+      end
+    end
   end
 
   describe "#ready_to_work?" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -482,6 +482,23 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("Preselected issue")
       end
 
+      it "disables issues with an open paid-generated PR in the dropdown" do
+        issue = create(:issue, project: project, github_number: 10, title: "Has paid PR", github_state: "open", paid_state: "new")
+        pr = create(:issue, :pull_request, project: project, github_number: 77,
+          github_state: "open", parent_issue: issue)
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+
+        get new_project_agent_run_path(project)
+
+        doc = Nokogiri::HTML(response.body)
+        option = doc.at_css("select#issue_id option[value='#{issue.id}']")
+        expect(option).to be_present
+        expect(option["disabled"]).to eq("disabled")
+        expect(option.text).to include("open paid PR")
+      end
+
       it "pre-selects PR when pull_request_id param is present" do
         pr = create(:issue, :pull_request, project: project, github_number: 30, title: "Preselected PR")
         get new_project_agent_run_path(project, pull_request_id: pr.id)
@@ -605,6 +622,24 @@ RSpec.describe "AgentRuns" do
         expect(response).to redirect_to(new_project_agent_run_path(project, goal: "create_pr"))
         follow_redirect!
         expect(response.body).to include("Please select an issue")
+      end
+
+      it "rejects a create_pr run when the issue already has an open paid-generated PR" do
+        pr_issue = create(:issue, project: project, github_number: 42, title: "Has paid PR")
+        pr = create(:issue, :pull_request, project: project, github_number: 99,
+          github_state: "open", parent_issue: pr_issue)
+        create(:agent_run, :completed, project: project, issue: pr_issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+
+        expect {
+          post project_agent_runs_path(project),
+            params: { goal: "create_pr", issue_id: pr_issue.id }
+        }.not_to change(AgentRun, :count)
+
+        expect(response).to redirect_to(new_project_agent_run_path(project, goal: "create_pr"))
+        follow_redirect!
+        expect(response.body).to include("Paid already opened PR ##{pr.github_number}")
       end
 
       context "with pull_request_id parameter" do
@@ -932,9 +967,13 @@ RSpec.describe "AgentRuns" do
         end
       end
 
-      it "rejects quick run for an issue with an associated pull request" do
+      it "rejects quick run for an issue with an open paid-generated pull request" do
         pr_issue = create(:issue, project: project, github_number: 42, title: "Fix the bug")
-        create(:issue, :pull_request, project: project, parent_issue: pr_issue)
+        pr = create(:issue, :pull_request, project: project, github_number: 99,
+          github_state: "open", parent_issue: pr_issue)
+        create(:agent_run, :completed, project: project, issue: pr_issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
 
         expect {
           post quick_create_project_agent_runs_path(project), params: { issue_id: pr_issue.id }
@@ -942,7 +981,30 @@ RSpec.describe "AgentRuns" do
 
         expect(response).to redirect_to(project_path(project))
         follow_redirect!
-        expect(response.body).to include("already has an associated pull request")
+        expect(response.body).to include("Paid already opened PR ##{pr.github_number}")
+      end
+
+      it "allows quick run when the associated pull request was not paid-generated" do
+        pr_issue = create(:issue, project: project, github_number: 42, title: "Fix the bug")
+        create(:issue, :pull_request, project: project, github_number: 100,
+          github_state: "open", parent_issue: pr_issue)
+
+        expect {
+          post quick_create_project_agent_runs_path(project), params: { issue_id: pr_issue.id }
+        }.to change(AgentRun, :count).by(1)
+      end
+
+      it "re-enables quick run once the paid-generated pull request is closed" do
+        pr_issue = create(:issue, project: project, github_number: 42, title: "Fix the bug")
+        pr = create(:issue, :pull_request, :closed, project: project, github_number: 99,
+          parent_issue: pr_issue)
+        create(:agent_run, :completed, project: project, issue: pr_issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+
+        expect {
+          post quick_create_project_agent_runs_path(project), params: { issue_id: pr_issue.id }
+        }.to change(AgentRun, :count).by(1)
       end
 
       it "ignores goal params and still uses quick-run defaults" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -590,8 +590,8 @@ RSpec.describe "Projects" do
         expect(response.body).to include("Quick run on PR ##{pr.github_number}")
       end
 
-      it "keeps Quick Run enabled when the PR was not paid-generated" do
-        project = create(:project, account: account, github_token: github_token)
+      it "keeps Quick Run enabled and still shows a PR-link icon when the PR was not paid-generated" do
+        project = create(:project, account: account, github_token: github_token, owner: "octocat", repo: "hello")
         issue = create(:issue, project: project, github_number: 5, title: "Test issue", github_state: "open")
         create(:issue, :pull_request, project: project, github_number: 78,
           github_state: "open", parent_issue: issue)
@@ -599,6 +599,8 @@ RSpec.describe "Projects" do
         get project_path(project)
 
         expect(response.body).to include(quick_create_project_agent_runs_path(project, issue_id: issue.id))
+        expect(response.body).to include("https://github.com/octocat/hello/pull/78")
+        expect(response.body).to include("PR #78")
       end
 
       it "re-enables Quick Run after the paid-generated PR is closed" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -574,6 +574,47 @@ RSpec.describe "Projects" do
         expect(response.body).to include("Quick Run")
       end
 
+      it "disables Quick Run when the issue has an open paid-generated PR" do
+        project = create(:project, account: account, github_token: github_token)
+        issue = create(:issue, project: project, github_number: 5, title: "Test issue", github_state: "open")
+        pr = create(:issue, :pull_request, project: project, github_number: 77,
+          github_state: "open", parent_issue: issue)
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+
+        get project_path(project)
+
+        expect(response.body).not_to include(quick_create_project_agent_runs_path(project, issue_id: issue.id))
+        expect(response.body).to include(%(data-issue-quick-run-disabled="true"))
+        expect(response.body).to include("Quick run on PR ##{pr.github_number}")
+      end
+
+      it "keeps Quick Run enabled when the PR was not paid-generated" do
+        project = create(:project, account: account, github_token: github_token)
+        issue = create(:issue, project: project, github_number: 5, title: "Test issue", github_state: "open")
+        create(:issue, :pull_request, project: project, github_number: 78,
+          github_state: "open", parent_issue: issue)
+
+        get project_path(project)
+
+        expect(response.body).to include(quick_create_project_agent_runs_path(project, issue_id: issue.id))
+      end
+
+      it "re-enables Quick Run after the paid-generated PR is closed" do
+        project = create(:project, account: account, github_token: github_token)
+        issue = create(:issue, project: project, github_number: 5, title: "Test issue", github_state: "open")
+        pr = create(:issue, :pull_request, :closed, project: project, github_number: 77,
+          parent_issue: issue)
+        create(:agent_run, :completed, project: project, issue: issue,
+          pull_request_number: pr.github_number,
+          pull_request_url: "https://github.com/example/repo/pull/#{pr.github_number}")
+
+        get project_path(project)
+
+        expect(response.body).to include(quick_create_project_agent_runs_path(project, issue_id: issue.id))
+      end
+
       it "color-codes only priority labels in synced issues" do
         project = create(:project, account: account, github_token: github_token,
           priority_labels: { "P1" => "urgent", "P2" => "high-touch", "P3" => "later" })


### PR DESCRIPTION
## Summary

Disable issues with open paid-generated PRs from quick run in project issues table and Trigger Agent Run form

See #1181 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1181