### PR TITLE
Fix #1117: Normalize automation configuration objects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -474,6 +474,7 @@ class Project < ApplicationRecord
 
   def review_settings=(value)
     @effective_review_settings = nil
+    @automation_configuration = nil
     super
   end
 
@@ -487,24 +488,50 @@ class Project < ApplicationRecord
     @effective_review_settings = DEFAULT_REVIEW_SETTINGS.deep_merge(rs)
   end
 
+  # Returns the {Automation::Configuration::Project} value object describing
+  # this project's normalized automation/review configuration. Strategy
+  # code and activities should read through this rather than calling the
+  # individual +review_*+ / +auto_*+ helpers so new providers and toggles
+  # can be added in one place. Memoized per-instance; invalidated by
+  # {#review_settings=} and by {#reload_automation_configuration}.
+  def automation_configuration
+    @automation_configuration ||= Automation::Configuration::Project.from(self)
+  end
+
+  # Forces a rebuild of the memoized {#automation_configuration}. Used by
+  # callers that mutate +auto_*+ columns (e.g. toggle actions) without
+  # going through {#review_settings=}.
+  def reload_automation_configuration
+    @automation_configuration = nil
+    automation_configuration
+  end
+
   def review_enabled?
-    effective_review_settings["enabled"] == true
+    automation_configuration.auto_review.enabled?
   end
 
   def wait_for_reviews?
-    effective_review_settings["wait_for_reviews"] != false
+    automation_configuration.auto_review.wait_for_reviews?
   end
 
   def address_all_bot_reviews?
-    effective_review_settings["address_all_bot_reviews"] == true
+    automation_configuration.auto_review.address_all_bot_reviews?
   end
 
   def review_method_enabled?(method)
-    effective_review_settings.dig("methods", method.to_s, "enabled") == true
+    automation_configuration.auto_review.method_enabled?(method)
   end
 
   def enabled_review_methods
-    REVIEW_METHODS.select { |m| review_method_enabled?(m) }
+    automation_configuration.auto_review.ordered_enabled_methods.map { |m| m.name.to_s }
+  end
+
+  # Returns the {Automation::Configuration::ReviewMethod} value object for
+  # +method+, or nil when the name is not a known review method. Prefer
+  # this over {#review_method_config} when you need typed accessors
+  # (termination limits, action_name, reviewer_login).
+  def review_method(method)
+    automation_configuration.auto_review.method_for(method)
   end
 
   # Returns the set of bot GitHub logins (downcased) for all enabled review
@@ -531,11 +558,7 @@ class Project < ApplicationRecord
   # fallback (driven by AgentExecutionWorkflow after every agent run)
   # would request bot reviews on projects that have opted out of review.
   def review_bot_request_login
-    return nil unless review_enabled?
-    return Activities::RequestReviewActivity::COPILOT_LOGIN if review_method_enabled?("copilot")
-    return Activities::RequestReviewActivity::CODEX_LOGIN if review_method_enabled?("codex")
-
-    nil
+    automation_configuration.auto_review.bot_request_login
   end
 
   private

--- a/app/services/automation/configuration/auto_continue.rb
+++ b/app/services/automation/configuration/auto_continue.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Automation
+  module Configuration
+    # Auto-continue automation configuration for a project. Auto-continue
+    # runs today have no dedicated project-level toggle — scanning only
+    # triggers for active (non-paused) issues — so this value object
+    # captures the behaviour enabled by the project-scope automation flags.
+    #
+    # +auto_scan_prs+ gates PR scanning; when scanning is off, auto-continue
+    # cannot observe PRs. Strategy code should consult
+    # {AutoContinue#enabled?} instead of reading +project.auto_scan_prs+
+    # directly so future gates (rate limits, provider toggles, etc.) can be
+    # added without touching callers.
+    class AutoContinue < ::Data.define(:enabled)
+      def self.from_project(project)
+        new(enabled: project.auto_scan_prs == true)
+      end
+
+      def enabled? = enabled == true
+    end
+  end
+end

--- a/app/services/automation/configuration/auto_merge.rb
+++ b/app/services/automation/configuration/auto_merge.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Automation
+  module Configuration
+    # Auto-merge automation configuration for a project. Wraps the
+    # +auto_merge_enabled+ toggle, the selected merge method (squash /
+    # merge / rebase), and the +auto_fix_merge_conflicts+ follow-up flag.
+    class AutoMerge < ::Data.define(:enabled, :merge_method, :fix_merge_conflicts)
+      def self.from_project(project)
+        new(
+          enabled: project.auto_merge_enabled == true,
+          merge_method: project.merge_method,
+          fix_merge_conflicts: project.auto_fix_merge_conflicts == true
+        )
+      end
+
+      def enabled? = enabled == true
+      def fix_merge_conflicts? = fix_merge_conflicts == true
+    end
+  end
+end

--- a/app/services/automation/configuration/auto_pick.rb
+++ b/app/services/automation/configuration/auto_pick.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Automation
+  module Configuration
+    # Auto-pick automation configuration for a project. Currently wraps the
+    # +auto_pick_enabled+ toggle; future extensions (provider selection
+    # override, per-tier caps) should live here so strategy code stops
+    # reaching into Project columns directly.
+    class AutoPick < ::Data.define(:enabled)
+      def self.from_project(project)
+        new(enabled: project.auto_pick_enabled == true)
+      end
+
+      def enabled? = enabled == true
+    end
+  end
+end

--- a/app/services/automation/configuration/auto_review.rb
+++ b/app/services/automation/configuration/auto_review.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Automation
+  module Configuration
+    # Auto-review automation configuration for a project. Wraps
+    # {ReviewSettings} and encodes the provider-selection and ordering
+    # rules that previously lived as conditionals in
+    # +Project#review_bot_request_login+ and various activities.
+    #
+    # Callers should ask the config object for the strategy-level answers
+    # they need (e.g. "which bot should we request?", "what's the ordered
+    # list of enabled methods?") rather than branching on raw method flags.
+    class AutoReview < ::Data.define(:review_settings)
+      # Canonical ordering for enabled review methods. Matches the legacy
+      # +Project::REVIEW_METHODS+ order so views and intersection callers
+      # observe the same sequence after the normalization refactor.
+      METHOD_ORDER = ReviewMethod::NAMES
+
+      # Priority order used by {#bot_request_login}: the first bot-backed
+      # method that is enabled wins. Copilot takes precedence over codex
+      # because codex does not auto-review draft PRs and requires an
+      # explicit @-mention (see +Activities::RequestReviewActivity+).
+      BOT_REQUEST_PRIORITY = %i[copilot codex].freeze
+
+      # Maps each bot-backed review method to its canonical GitHub login.
+      # Defined here (rather than reached out of
+      # +Activities::RequestReviewActivity+) so that the config object is
+      # the single source of truth for provider-selection rules.
+      BOT_REVIEWER_LOGINS = {
+        copilot: "copilot",
+        codex: "chatgpt-codex-connector"
+      }.freeze
+
+      def self.from_project(project)
+        new(review_settings: ReviewSettings.from_project(project))
+      end
+
+      def enabled? = review_settings.enabled?
+      def wait_for_reviews? = review_settings.wait_for_reviews?
+      def address_all_bot_reviews? = review_settings.address_all_bot_reviews?
+
+      def method_for(name)
+        review_settings.method_for(name)
+      end
+
+      def method_enabled?(name)
+        review_settings.method_enabled?(name)
+      end
+
+      # Returns the enabled review methods as {ReviewMethod} objects in
+      # {METHOD_ORDER}. Unlike {#bot_request_login}, this helper does NOT
+      # gate on +review_settings.enabled?+ — callers that need the global
+      # review toggle honoured (e.g. scan decision logic) should consult
+      # {#enabled?} separately. This mirrors the legacy semantics of
+      # +Project#enabled_review_methods+, which returns per-method flags
+      # regardless of the top-level toggle.
+      def ordered_enabled_methods
+        METHOD_ORDER.filter_map { |name| method_for(name) if method_enabled?(name) }
+      end
+
+      # Returns the GitHub login Paid should request as the automated
+      # reviewer, or nil when no bot-backed method is enabled. Preserves
+      # the legacy precedence rule (copilot before codex) and the safety
+      # rule that a globally-disabled review toggle short-circuits the
+      # lookup regardless of per-method flags.
+      def bot_request_login
+        return nil unless enabled?
+
+        BOT_REQUEST_PRIORITY.each do |name|
+          return BOT_REVIEWER_LOGINS.fetch(name) if method_enabled?(name)
+        end
+        nil
+      end
+
+      # True when +paid_agent+ is the only enabled review method. Used by
+      # scan code that has to distinguish "paid_agent review only" from
+      # "paid_agent plus other methods" when deciding how to gate PR
+      # phases. Gated on {#enabled?} because a globally-disabled review
+      # toggle means no review method is effectively active.
+      def paid_agent_sole_method?
+        return false unless enabled?
+
+        review_settings.enabled_method_names == [ :paid_agent ]
+      end
+    end
+  end
+end

--- a/app/services/automation/configuration/project.rb
+++ b/app/services/automation/configuration/project.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Automation
+  module Configuration
+    # Aggregates every automation-configuration value object for a single
+    # {::Project}. Build once per scan/evaluation and pass around instead
+    # of the raw {::Project} record, so strategy code can consume the
+    # normalized config without reaching into nested settings hashes or
+    # checking individual boolean columns.
+    #
+    # Each sub-config is a frozen {::Data} value object; this top-level
+    # wrapper is itself a +Data.define+ so equality, deconstruction, and
+    # freezing work out of the box.
+    class Project < ::Data.define(
+      :auto_pick,
+      :auto_continue,
+      :auto_review,
+      :auto_merge
+    )
+      def self.from(project)
+        new(
+          auto_pick: AutoPick.from_project(project),
+          auto_continue: AutoContinue.from_project(project),
+          auto_review: AutoReview.from_project(project),
+          auto_merge: AutoMerge.from_project(project)
+        )
+      end
+
+      # Convenience accessor for the ReviewSettings nested inside the
+      # auto-review config. Callers that only need review-method lookups
+      # can reach it without drilling through +auto_review+.
+      def review_settings
+        auto_review.review_settings
+      end
+    end
+  end
+end

--- a/app/services/automation/configuration/review_method.rb
+++ b/app/services/automation/configuration/review_method.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Automation
+  module Configuration
+    # A single review method configuration (copilot / paid_agent / codex /
+    # ci_action / manual). Wraps the nested +review_settings.methods.<name>+
+    # hash with a normalized interface so call sites do not have to reach
+    # into raw +dig(...)+ chains.
+    class ReviewMethod < ::Data.define(
+      :name,
+      :enabled,
+      :action_name,
+      :reviewer_login,
+      :termination
+    )
+      NAMES = %i[copilot paid_agent codex ci_action manual].freeze
+
+      class << self
+        def from_hash(name, hash)
+          hash ||= {}
+          new(
+            name: name.to_sym,
+            enabled: hash["enabled"] == true,
+            action_name: presence_or_nil(hash["action_name"]),
+            reviewer_login: presence_or_nil(hash["reviewer_login"]),
+            termination: Termination.from_hash(hash["termination"])
+          )
+        end
+
+        private
+
+        def presence_or_nil(value)
+          return nil if value.nil?
+
+          str = value.to_s
+          str.strip.empty? ? nil : str
+        end
+      end
+
+      def enabled? = enabled == true
+
+      def max_review_rounds
+        termination.max_review_rounds
+      end
+
+      def max_review_goal_retries
+        termination.max_review_goal_retries
+      end
+
+      def timeout_minutes
+        termination.timeout_minutes
+      end
+
+      def stop_when_no_comments?
+        termination.stop_when_no_comments == true
+      end
+    end
+  end
+end

--- a/app/services/automation/configuration/review_settings.rb
+++ b/app/services/automation/configuration/review_settings.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Automation
+  module Configuration
+    # Normalized view of a project's +review_settings+ JSONB field.
+    # Construct via {.from_project}, which delegates to
+    # +Project#effective_review_settings+ so defaults are already merged in.
+    #
+    # The object exposes per-method configs via {#method_for} (keyed by
+    # symbol) and enabled-method helpers used by auto-review strategy
+    # resolution.
+    class ReviewSettings < ::Data.define(
+      :enabled,
+      :wait_for_reviews,
+      :address_all_bot_reviews,
+      :methods
+    )
+      class << self
+        def from_project(project)
+          from_hash(project.effective_review_settings)
+        end
+
+        def from_hash(hash)
+          hash ||= {}
+          methods_hash = hash["methods"] || {}
+          methods = ReviewMethod::NAMES.each_with_object({}) do |name, memo|
+            memo[name] = ReviewMethod.from_hash(name, methods_hash[name.to_s])
+          end.freeze
+
+          new(
+            enabled: hash["enabled"] == true,
+            wait_for_reviews: hash["wait_for_reviews"] != false,
+            address_all_bot_reviews: hash["address_all_bot_reviews"] == true,
+            methods: methods
+          )
+        end
+      end
+
+      def enabled? = enabled == true
+      def wait_for_reviews? = wait_for_reviews == true
+      def address_all_bot_reviews? = address_all_bot_reviews == true
+
+      # Returns the {ReviewMethod} for +name+, or nil when the name is not
+      # a known review method.
+      def method_for(name)
+        methods[name.to_sym]
+      end
+
+      def method_enabled?(name)
+        method_for(name)&.enabled? == true
+      end
+
+      # Returns the symbol names of all enabled review methods, preserving
+      # the canonical +ReviewMethod::NAMES+ ordering.
+      def enabled_method_names
+        ReviewMethod::NAMES.select { |n| methods[n].enabled? }
+      end
+
+      # Returns an Array of {ReviewMethod} objects for every enabled method.
+      def enabled_methods
+        enabled_method_names.map { |n| methods[n] }
+      end
+    end
+  end
+end

--- a/app/services/automation/configuration/termination.rb
+++ b/app/services/automation/configuration/termination.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Automation
+  module Configuration
+    # Termination conditions for a review method: how many rounds to allow,
+    # whether to stop when reviewers post no comments, an optional quality
+    # threshold, and a wall-clock timeout.
+    #
+    # Only +paid_agent+ uses +max_review_goal_retries+; it is nil for every
+    # other method.
+    #
+    # Construct from the nested Hash returned by
+    # +Project#review_method_config+:
+    #
+    #   Termination.from_hash(config.dig("termination"))
+    class Termination < ::Data.define(
+      :max_review_rounds,
+      :max_review_goal_retries,
+      :stop_when_no_comments,
+      :quality_threshold,
+      :timeout_minutes
+    )
+      EMPTY = new(
+        max_review_rounds: nil,
+        max_review_goal_retries: nil,
+        stop_when_no_comments: false,
+        quality_threshold: nil,
+        timeout_minutes: nil
+      ).freeze
+
+      def self.from_hash(hash)
+        return EMPTY if hash.nil? || hash.empty?
+
+        new(
+          max_review_rounds: integer_or_nil(hash["max_review_rounds"]),
+          max_review_goal_retries: integer_or_nil(hash["max_review_goal_retries"]),
+          stop_when_no_comments: hash["stop_when_no_comments"] == true,
+          quality_threshold: presence_or_nil(hash["quality_threshold"]),
+          timeout_minutes: integer_or_nil(hash["timeout_minutes"])
+        )
+      end
+
+      def self.integer_or_nil(value)
+        return nil if value.nil?
+        return value if value.is_a?(Integer)
+
+        Integer(value)
+      rescue ArgumentError, TypeError
+        nil
+      end
+      private_class_method :integer_or_nil
+
+      def self.presence_or_nil(value)
+        return nil if value.nil?
+
+        str = value.to_s
+        str.strip.empty? ? nil : str
+      end
+      private_class_method :presence_or_nil
+    end
+  end
+end

--- a/app/temporal/activities/dispatch_claude_review_activity.rb
+++ b/app/temporal/activities/dispatch_claude_review_activity.rb
@@ -38,7 +38,7 @@ module Activities
     private
 
     def claude_review_action?(project)
-      project.review_method_config("ci_action").to_h["action_name"].to_s.strip == ACTION_NAME
+      project.review_method(:ci_action).action_name.to_s.strip == ACTION_NAME
     end
   end
 end

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -754,7 +754,7 @@ module Activities
       triggers = []
 
       if project.review_method_enabled?("manual")
-        reviewer = project.review_method_config("manual")["reviewer_login"]
+        reviewer = project.review_method(:manual).reviewer_login
         if reviewer.present? && !manual_reviewer_approved?(reviews, reviewer)
           triggers << { type: "manual_review_pending", reviewer_login: reviewer,
                         details: "Awaiting approval from #{reviewer}" }
@@ -762,7 +762,7 @@ module Activities
       end
 
       if project.review_method_enabled?("ci_action") && !checks.nil?
-        action_name = project.review_method_config("ci_action")["action_name"]
+        action_name = project.review_method(:ci_action).action_name
         if action_name.present? && !ci_action_review_complete?(project, checks, pr_data)
           dispatch_needed = ci_action_dispatch_required?(issue, checks, action_name)
           triggers << { type: "ci_action_pending", action_name: action_name,
@@ -1054,8 +1054,7 @@ module Activities
       # bookkeeping marks the superseded run as retried before enqueuing its
       # replacement. Counting both would burn two rounds for one logical retry.
       finished_count = current_cycle_review_runs.finished.count
-      max_rounds = project.review_method_config("paid_agent")
-        .dig("termination", "max_review_rounds")
+      max_rounds = project.review_method(:paid_agent).max_review_rounds
 
       if max_rounds.present? && finished_count >= max_rounds.to_i
         return []
@@ -1228,16 +1227,11 @@ module Activities
     end
 
     def review_goal_max_retries(project)
-      termination = project.review_method_config("paid_agent")
-        .dig("termination") || {}
-      retries = termination["max_review_goal_retries"]
-      max_rounds = termination["max_review_rounds"]
+      method_config = project.review_method(:paid_agent)
+      retries = method_config.max_review_goal_retries
+      max_rounds = method_config.max_review_rounds
 
-      effective = if retries.present?
-        retries.to_i
-      else
-        MAX_REVIEW_GOAL_RETRIES
-      end
+      effective = retries.present? ? retries.to_i : MAX_REVIEW_GOAL_RETRIES
 
       if max_rounds.present?
         [ effective, max_rounds.to_i ].min
@@ -1591,7 +1585,7 @@ module Activities
     # ci_action is complete when the configured action_name appears in
     # the check-run list with a "success" conclusion.
     def ci_action_review_complete?(project, checks, pr_data)
-      action_name = project.review_method_config("ci_action").to_h["action_name"]
+      action_name = project.review_method(:ci_action).action_name
       if action_name.blank?
         Rails.logger.warn(message: "reviews.ci_action_missing_action_name", project_id: project.id)
         return false
@@ -1608,7 +1602,7 @@ module Activities
     def manual_review_complete?(project, reviews)
       return false if reviews.nil?
 
-      reviewer = project.review_method_config("manual").to_h["reviewer_login"]
+      reviewer = project.review_method(:manual).reviewer_login
       return false if reviewer.blank?
 
       reviews.any? do |r|
@@ -1663,7 +1657,7 @@ module Activities
       timestamps << owner_ts if owner_ts
 
       if project.review_method_enabled?("manual")
-        reviewer = project.review_method_config("manual").to_h["reviewer_login"]
+        reviewer = project.review_method(:manual).reviewer_login
         if reviewer.present?
           manual_ts = latest_approval_timestamp_for(project, reviews) do |r|
             r[:user_login]&.downcase == reviewer.strip.downcase
@@ -1828,7 +1822,7 @@ module Activities
       return nil unless project.review_enabled?
       return nil unless project.review_method_enabled?("paid_agent")
 
-      raw = project.review_method_config("paid_agent").dig("termination", "max_review_rounds")
+      raw = project.review_method(:paid_agent).max_review_rounds
       raw.present? ? raw.to_i : nil
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -888,6 +888,58 @@ RSpec.describe Project do
       end
     end
 
+    describe "#review_method" do
+      it "returns the ReviewMethod value object with merged termination defaults" do
+        project = build(:project, review_settings: {
+          "methods" => {
+            "paid_agent" => {
+              "enabled" => true,
+              "termination" => { "timeout_minutes" => 60 }
+            }
+          }
+        })
+        method = project.review_method(:paid_agent)
+
+        expect(method).to be_a(Automation::Configuration::ReviewMethod)
+        expect(method.enabled?).to be true
+        expect(method.timeout_minutes).to eq(60)
+        expect(method.max_review_rounds).to eq(15)
+      end
+
+      it "returns a disabled method when the review settings are empty" do
+        project = build(:project, review_settings: {})
+        expect(project.review_method(:paid_agent).enabled?).to be false
+      end
+    end
+
+    describe "#automation_configuration" do
+      it "exposes the aggregate Automation::Configuration::Project value object" do
+        project = build(:project, auto_pick_enabled: true, auto_merge_enabled: true)
+
+        config = project.automation_configuration
+
+        expect(config).to be_a(Automation::Configuration::Project)
+        expect(config.auto_pick.enabled?).to be true
+        expect(config.auto_merge.enabled?).to be true
+      end
+
+      it "memoizes the configuration across calls" do
+        project = build(:project)
+        expect(project.automation_configuration).to equal(project.automation_configuration)
+      end
+
+      it "invalidates the memoized configuration when review_settings= is assigned" do
+        project = build(:project, review_settings: { "enabled" => false })
+        original = project.automation_configuration
+
+        project.review_settings = { "enabled" => true,
+                                    "methods" => { "paid_agent" => { "enabled" => true } } }
+
+        expect(project.automation_configuration).not_to equal(original)
+        expect(project.automation_configuration.auto_review.enabled?).to be true
+      end
+    end
+
     describe "validation" do
       it "accepts empty review_settings" do
         project = build(:project, review_settings: {})

--- a/spec/services/automation/configuration/auto_review_spec.rb
+++ b/spec/services/automation/configuration/auto_review_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Configuration::AutoReview do
+  def build_config(enabled: true, **methods)
+    method_hashes = Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) do |name, h|
+      h[name.to_s] = methods[name] || { "enabled" => false }
+    end
+    described_class.new(
+      review_settings: Automation::Configuration::ReviewSettings.from_hash(
+        "enabled" => enabled,
+        "methods" => method_hashes
+      )
+    )
+  end
+
+  describe "#bot_request_login" do
+    it "returns nil when the review toggle is off" do
+      config = build_config(enabled: false, copilot: { "enabled" => true })
+
+      expect(config.bot_request_login).to be_nil
+    end
+
+    it "prefers copilot when both copilot and codex are enabled" do
+      config = build_config(
+        copilot: { "enabled" => true },
+        codex: { "enabled" => true }
+      )
+
+      expect(config.bot_request_login).to eq("copilot")
+    end
+
+    it "falls back to codex when copilot is disabled" do
+      config = build_config(codex: { "enabled" => true })
+
+      expect(config.bot_request_login).to eq("chatgpt-codex-connector")
+    end
+
+    it "returns nil when no bot-backed method is enabled" do
+      config = build_config(manual: { "enabled" => true, "reviewer_login" => "alice" })
+
+      expect(config.bot_request_login).to be_nil
+    end
+  end
+
+  describe "#ordered_enabled_methods" do
+    it "returns enabled methods in canonical order regardless of input order" do
+      config = build_config(
+        manual: { "enabled" => true, "reviewer_login" => "alice" },
+        copilot: { "enabled" => true }
+      )
+
+      expect(config.ordered_enabled_methods.map(&:name)).to eq(%i[copilot manual])
+    end
+
+    it "is NOT gated by the review toggle (mirrors legacy Project#enabled_review_methods)" do
+      config = build_config(enabled: false, copilot: { "enabled" => true })
+
+      expect(config.ordered_enabled_methods.map(&:name)).to eq(%i[copilot])
+    end
+  end
+
+  describe "#paid_agent_sole_method?" do
+    it "returns true only when paid_agent is the sole enabled method and reviews are enabled" do
+      config = build_config(paid_agent: { "enabled" => true })
+      expect(config.paid_agent_sole_method?).to be true
+    end
+
+    it "returns false when another method is also enabled" do
+      config = build_config(
+        paid_agent: { "enabled" => true },
+        copilot: { "enabled" => true }
+      )
+      expect(config.paid_agent_sole_method?).to be false
+    end
+
+    it "returns false when reviews are globally disabled" do
+      config = build_config(enabled: false, paid_agent: { "enabled" => true })
+      expect(config.paid_agent_sole_method?).to be false
+    end
+  end
+end

--- a/spec/services/automation/configuration/project_spec.rb
+++ b/spec/services/automation/configuration/project_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Configuration::Project do
+  describe ".from" do
+    it "aggregates every sub-config from a project record" do
+      project = build(:project,
+        auto_pick_enabled: true,
+        auto_merge_enabled: true,
+        auto_fix_merge_conflicts: true,
+        merge_method: "squash",
+        review_settings: {
+          "enabled" => true,
+          "methods" => { "paid_agent" => { "enabled" => true } }
+        })
+
+      config = described_class.from(project)
+
+      expect(config.auto_pick.enabled?).to be true
+      expect(config.auto_merge.enabled?).to be true
+      expect(config.auto_merge.fix_merge_conflicts?).to be true
+      expect(config.auto_merge.merge_method).to eq("squash")
+      expect(config.auto_review.enabled?).to be true
+      expect(config.review_settings.method_enabled?(:paid_agent)).to be true
+    end
+
+    it "defaults auto_continue to enabled when auto_scan_prs is on" do
+      project = build(:project)
+      expect(described_class.from(project).auto_continue.enabled?).to be true
+    end
+  end
+
+  describe "value-object semantics" do
+    it "is equal to another Project built from the same project record" do
+      project = build(:project)
+      first = described_class.from(project)
+      second = described_class.from(project)
+
+      expect(first).to eq(second)
+    end
+  end
+end

--- a/spec/services/automation/configuration/review_method_spec.rb
+++ b/spec/services/automation/configuration/review_method_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Configuration::ReviewMethod do
+  describe ".from_hash" do
+    it "defaults to disabled with empty termination when given nil" do
+      method = described_class.from_hash(:paid_agent, nil)
+
+      expect(method.name).to eq(:paid_agent)
+      expect(method.enabled?).to be false
+      expect(method.action_name).to be_nil
+      expect(method.reviewer_login).to be_nil
+      expect(method.termination).to eq(Automation::Configuration::Termination::EMPTY)
+    end
+
+    it "normalizes action_name and reviewer_login, stripping blanks to nil" do
+      method = described_class.from_hash(
+        :ci_action,
+        "enabled" => true,
+        "action_name" => "Claude Code Review",
+        "reviewer_login" => " ",
+        "termination" => { "timeout_minutes" => 45 }
+      )
+
+      expect(method.enabled?).to be true
+      expect(method.action_name).to eq("Claude Code Review")
+      expect(method.reviewer_login).to be_nil
+      expect(method.timeout_minutes).to eq(45)
+    end
+
+    it "exposes termination accessors directly on the method" do
+      method = described_class.from_hash(
+        :paid_agent,
+        "enabled" => true,
+        "termination" => {
+          "max_review_rounds" => 10,
+          "max_review_goal_retries" => 2,
+          "stop_when_no_comments" => true
+        }
+      )
+
+      expect(method.max_review_rounds).to eq(10)
+      expect(method.max_review_goal_retries).to eq(2)
+      expect(method.stop_when_no_comments?).to be true
+    end
+  end
+
+  it "lists the canonical NAMES" do
+    expect(described_class::NAMES).to eq(%i[copilot paid_agent codex ci_action manual])
+  end
+end

--- a/spec/services/automation/configuration/review_settings_spec.rb
+++ b/spec/services/automation/configuration/review_settings_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Configuration::ReviewSettings do
+  describe ".from_hash" do
+    it "returns a fully-populated object even when the input is empty" do
+      settings = described_class.from_hash({})
+
+      expect(settings.enabled?).to be false
+      expect(settings.wait_for_reviews?).to be true
+      expect(settings.address_all_bot_reviews?).to be false
+      expect(settings.enabled_method_names).to eq([])
+      expect(settings.methods.keys).to match_array(Automation::Configuration::ReviewMethod::NAMES)
+    end
+
+    it "builds a ReviewMethod for every known method even when absent" do
+      settings = described_class.from_hash(
+        "enabled" => true,
+        "methods" => {
+          "paid_agent" => { "enabled" => true }
+        }
+      )
+
+      expect(settings.method_for(:paid_agent).enabled?).to be true
+      expect(settings.method_for(:copilot).enabled?).to be false
+    end
+
+    it "treats wait_for_reviews as true by default and respects explicit false" do
+      explicit_false = described_class.from_hash("wait_for_reviews" => false)
+      explicit_true  = described_class.from_hash("wait_for_reviews" => true)
+
+      expect(explicit_false.wait_for_reviews?).to be false
+      expect(explicit_true.wait_for_reviews?).to be true
+    end
+  end
+
+  describe "#enabled_method_names" do
+    it "returns enabled methods in canonical ReviewMethod::NAMES order" do
+      settings = described_class.from_hash(
+        "methods" => {
+          "manual" => { "enabled" => true },
+          "copilot" => { "enabled" => true },
+          "paid_agent" => { "enabled" => true }
+        }
+      )
+
+      expect(settings.enabled_method_names).to eq(%i[copilot paid_agent manual])
+    end
+  end
+
+  describe ".from_project" do
+    it "delegates to Project#effective_review_settings" do
+      project = build(:project, review_settings: { "enabled" => true })
+      settings = described_class.from_project(project)
+
+      expect(settings.enabled?).to be true
+    end
+  end
+end

--- a/spec/services/automation/configuration/termination_spec.rb
+++ b/spec/services/automation/configuration/termination_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Configuration::Termination do
+  describe ".from_hash" do
+    it "returns the frozen EMPTY value when given nil" do
+      expect(described_class.from_hash(nil)).to equal(described_class::EMPTY)
+    end
+
+    it "returns the frozen EMPTY value when given an empty hash" do
+      expect(described_class.from_hash({})).to equal(described_class::EMPTY)
+    end
+
+    it "normalizes a full termination hash" do
+      termination = described_class.from_hash(
+        "max_review_rounds" => 15,
+        "max_review_goal_retries" => 3,
+        "stop_when_no_comments" => true,
+        "quality_threshold" => "high",
+        "timeout_minutes" => 60
+      )
+
+      expect(termination).to have_attributes(
+        max_review_rounds: 15,
+        max_review_goal_retries: 3,
+        stop_when_no_comments: true,
+        quality_threshold: "high",
+        timeout_minutes: 60
+      )
+    end
+
+    it "coerces numeric strings to integers" do
+      termination = described_class.from_hash(
+        "max_review_rounds" => "5",
+        "timeout_minutes" => "120"
+      )
+
+      expect(termination.max_review_rounds).to eq(5)
+      expect(termination.timeout_minutes).to eq(120)
+    end
+
+    it "treats non-integer values as nil" do
+      termination = described_class.from_hash("max_review_rounds" => "not-a-number")
+      expect(termination.max_review_rounds).to be_nil
+    end
+
+    it "treats blank quality_threshold as nil" do
+      termination = described_class.from_hash("quality_threshold" => "  ")
+      expect(termination.quality_threshold).to be_nil
+    end
+
+    it "defaults stop_when_no_comments to false when missing or non-true" do
+      expect(described_class.from_hash("stop_when_no_comments" => false).stop_when_no_comments).to be false
+      expect(described_class.from_hash("stop_when_no_comments" => "true").stop_when_no_comments).to be false
+    end
+  end
+
+  it "EMPTY exposes nil/default values" do
+    expect(described_class::EMPTY).to have_attributes(
+      max_review_rounds: nil,
+      max_review_goal_retries: nil,
+      stop_when_no_comments: false,
+      quality_threshold: nil,
+      timeout_minutes: nil
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Normalize automation configuration objects

See #1117 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1117