### PR TITLE
Fix #1119: Extract auto-review into strategy modules

### DIFF
--- a/app/services/automation/pull_request_evaluator.rb
+++ b/app/services/automation/pull_request_evaluator.rb
@@ -4,11 +4,6 @@ module Automation
   class PullRequestEvaluator
     include LabelPolicy
 
-    FOLLOWUP_TRIGGER_TYPES = %w[
-      ci_failure review_threads conversation_comments changes_requested
-      actionable_labels merge_conflicts review_bot_comments review_bot_threads
-    ].freeze
-
     def initialize(record:, explicit_pr_decisions: false)
       @record = record
       @project = record.project
@@ -25,180 +20,16 @@ module Automation
 
     attr_reader :record, :project, :explicit_pr_decisions
 
+    # Delegates to {Strategies::AutoReview}. The strategy owns the
+    # per-trigger routing (paid_agent, copilot/codex, manual, ci_action) as
+    # well as escalate / dismiss_escalation / owner_approved / ready /
+    # follow-up composition. Returning early for +nil+ scans preserves the
+    # legacy "no scan, no opinion" behavior callers already depend on.
     def explicit_scan_decisions(scan)
-      return Result.noop unless scan
+      return Result.noop if scan.nil?
 
-      scan = scan.deep_symbolize_keys
-      trigger_types = scan.fetch(:triggers, []).map { |trigger| trigger[:type] }
-
-      decisions =
-        if trigger_types.include?("escalate_to_owner")
-          [ escalate_decision(scan) ]
-        elsif trigger_types.include?("dismiss_escalation")
-          [ Decision.dismiss_escalation(issue_id: record.id) ]
-        elsif trigger_types.include?("owner_approved")
-          [ Decision.merge(issue_id: record.id, pr_number: scan[:pr_number]) ]
-        elsif trigger_types.include?("review_goal_retry")
-          review_goal_retry_decisions(scan, trigger_types)
-        elsif trigger_types.include?("ready_for_owner")
-          ready_for_owner_decisions(scan)
-        elsif trigger_types.include?("paid_agent_review_pending")
-          paid_agent_review_pending_decisions(scan, trigger_types)
-        elsif trigger_types.include?("review_bot_review_pending")
-          review_bot_review_pending_decisions(scan, trigger_types)
-        elsif trigger_types.include?("manual_review_pending") || trigger_types.include?("ci_action_pending")
-          non_bot_review_pending_decisions(scan, trigger_types)
-        else
-          standard_followup_decisions(scan)
-        end
-
-      Result.new(decisions: decisions.presence || [ Decision.noop ])
-    end
-
-    def ready_for_owner_decisions(scan)
-      decisions = []
-      decisions << queue_review_run_decision(scan) if trigger_present?(scan, "paid_agent_review_pending") && !paid_agent_active?(scan)
-      decisions << Decision.mark_ready(
-        issue_id: record.id,
-        pr_number: scan[:pr_number],
-        owner_reviewer_login: scan[:owner_reviewer_login]
-      )
-      decisions
-    end
-
-    def paid_agent_review_pending_decisions(scan, trigger_types)
-      decisions = []
-      decisions << queue_review_run_decision(scan) unless paid_agent_active?(scan)
-      # paid_agent_review_pending is a hard gate: suppress create_pr follow-up
-      # runs while the review is outstanding. Other triggers will be re-detected
-      # after the review completes and feedback is addressed. (#1135)
-      decisions
-    end
-
-    def review_bot_review_pending_decisions(scan, trigger_types)
-      decisions = []
-      decisions << review_bot_request_decision(scan)
-
-      other_triggers = trigger_types - [ "review_bot_review_pending" ]
-      decisions.concat(followup_decisions(scan)) if other_triggers.any?
-      decisions.compact
-    end
-
-    def non_bot_review_pending_decisions(scan, trigger_types)
-      decisions = []
-
-      manual_trigger = trigger(scan, "manual_review_pending")
-      if manual_trigger&.dig(:reviewer_login).present?
-        decisions << Decision.request_review(
-          pr_number: scan[:pr_number],
-          reviewers: [ manual_trigger[:reviewer_login] ]
-        )
-      end
-
-      other_triggers = trigger_types - %w[manual_review_pending ci_action_pending]
-      decisions.concat(followup_decisions(scan)) if other_triggers.any?
-      decisions
-    end
-
-    def review_goal_retry_decisions(scan, trigger_types)
-      decisions = [
-        Decision.record_review_goal_retry(
-          issue_id: record.id,
-          expected_review_goal_retry_count: scan[:current_review_goal_retry_count]
-        ),
-        queue_review_run_decision(scan)
-      ]
-
-      if trigger_types.include?("ready_for_owner")
-        decisions.concat(ready_for_owner_decisions(without_trigger(scan, "paid_agent_review_pending")))
-        return decisions
-      end
-
-      manual_trigger = trigger(scan, "manual_review_pending")
-      if manual_trigger&.dig(:reviewer_login).present?
-        decisions << Decision.request_review(
-          pr_number: scan[:pr_number],
-          reviewers: [ manual_trigger[:reviewer_login] ]
-        )
-      end
-
-      if followup_triggers?(scan)
-        decisions.concat(followup_decisions(scan))
-      else
-        review_bot_decision = review_bot_request_decision(scan)
-        decisions << review_bot_decision if review_bot_decision
-      end
-
-      decisions
-    end
-
-    def standard_followup_decisions(scan)
-      followup_decisions(scan)
-    end
-
-    def followup_decisions(scan)
-      if scan[:phase].in?(%w[draft restarted])
-        [
-          Decision.queue_create_pr_run(
-            issue_id: record.id,
-            source_pull_request_number: scan[:pr_number],
-            count_toward_draft_review_round: true,
-            expected_draft_review_count: scan[:current_draft_review_count]
-          )
-        ]
-      else
-        [
-          Decision.queue_create_pr_run(
-            issue_id: record.id,
-            source_pull_request_number: scan[:pr_number]
-          ),
-          Decision.record_pr_followup(
-            issue_id: record.id,
-            labels_to_remove: scan[:labels_to_remove] || [],
-            expected_followup_count: scan[:current_followup_count]
-          )
-        ]
-      end
-    end
-
-    def escalate_decision(scan)
-      Decision.escalate(
-        issue_id: record.id,
-        pr_number: scan[:pr_number],
-        owner_reviewer_login: scan[:owner_reviewer_login],
-        reason: trigger(scan, "escalate_to_owner")&.dig(:details)
-      )
-    end
-
-    def queue_review_run_decision(scan)
-      Decision.queue_review_run(issue_id: record.id, source_pull_request_number: scan[:pr_number])
-    end
-
-    def review_bot_request_decision(scan)
-      login = trigger(scan, "review_bot_review_pending")&.dig(:request_login)
-      return if login.blank?
-
-      Decision.request_review(pr_number: scan[:pr_number], reviewers: [ login ])
-    end
-
-    def followup_triggers?(scan)
-      scan.fetch(:triggers, []).any? { |item| FOLLOWUP_TRIGGER_TYPES.include?(item[:type]) }
-    end
-
-    def paid_agent_active?(scan)
-      trigger(scan, "paid_agent_review_pending")&.dig(:active_run)
-    end
-
-    def trigger_present?(scan, type)
-      trigger(scan, type).present?
-    end
-
-    def trigger(scan, type)
-      scan.fetch(:triggers, []).find { |item| item[:type] == type }
-    end
-
-    def without_trigger(scan, type)
-      scan.merge(triggers: scan.fetch(:triggers, []).reject { |item| item[:type] == type })
+      context = Context.build(record: record, project: project, metadata: { scan: scan })
+      Strategies::AutoReview.new.evaluate(context)
     end
   end
 end

--- a/app/services/automation/review_methods/base.rb
+++ b/app/services/automation/review_methods/base.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Automation
+  module ReviewMethods
+    # Contract implemented by every review method plugin.
+    #
+    # Each plugin encapsulates the per-method auto-review policy: given the
+    # method's configuration and the current scan signals, it reports an
+    # {Automation::Strategies::AutoReview::Outcome} and (optionally) the
+    # concrete {Automation::Decision} that should be emitted to advance
+    # that method's state.
+    #
+    # Plugins are intentionally stateless — a fresh instance is constructed
+    # per evaluation with the current config and signals. Subclasses
+    # override {#evaluate}, {#decision}, and {#kind}.
+    #
+    # == Plugin taxonomy ({#kind})
+    #
+    # * +:bot+    — automated reviewer backed by a GitHub bot account
+    #   (copilot). Requests review via GraphQL; produces inline threads.
+    # * +:agent+  — Paid's own review agent (paid_agent). Runs in a
+    #   Temporal workflow; produces a review body.
+    # * +:comment_bot+ — a bot triggered by @-mention comment (codex). Posts
+    #   a body-only review.
+    # * +:human+  — explicit human reviewer (manual). Gated on approval.
+    # * +:ci+     — GitHub Action (ci_action). Gated on check-run success.
+    class Base
+      # @param method [Automation::Configuration::ReviewMethod]
+      # @param config [Automation::Configuration::AutoReview]
+      # @param signals [Automation::Strategies::AutoReview::Signals]
+      def initialize(method:, config:, signals:)
+        @method = method
+        @config = config
+        @signals = signals
+      end
+
+      # @return [Symbol] the canonical method name (:paid_agent, :copilot, ...)
+      def name
+        method.name
+      end
+
+      # @return [Symbol] kind of provider (see class-level docs).
+      def kind
+        raise NotImplementedError, "#{self.class} must implement #kind"
+      end
+
+      # Whether an unsatisfied outcome from this method should block PR
+      # progress by default. Individual {#evaluate} implementations may
+      # override on a case-by-case basis via the +blocking:+ kwarg on
+      # Outcome factories.
+      def blocking_by_default?
+        false
+      end
+
+      # @return [Automation::Strategies::AutoReview::Outcome]
+      def evaluate
+        raise NotImplementedError, "#{self.class} must implement #evaluate"
+      end
+
+      # Concrete Decision this method wants emitted alongside its Outcome,
+      # or +nil+ when no provider-side action is needed.
+      #
+      # @return [Automation::Decision, nil]
+      def decision
+        nil
+      end
+
+      protected
+
+      attr_reader :method, :config, :signals
+
+      def outcome_pending(blocking: blocking_by_default?, message: nil, metadata: Automation::Strategies::AutoReview::Outcome::EMPTY_METADATA)
+        Automation::Strategies::AutoReview::Outcome.pending(method: name, blocking:, message:, metadata:)
+      end
+
+      def outcome_satisfied(message: nil, metadata: Automation::Strategies::AutoReview::Outcome::EMPTY_METADATA)
+        Automation::Strategies::AutoReview::Outcome.satisfied(method: name, message:, metadata:)
+      end
+
+      def outcome_retryable_failure(blocking: true, message: nil, metadata: Automation::Strategies::AutoReview::Outcome::EMPTY_METADATA)
+        Automation::Strategies::AutoReview::Outcome.retryable_failure(method: name, blocking:, message:, metadata:)
+      end
+
+      def outcome_exhausted_retries(blocking: true, message: nil, metadata: Automation::Strategies::AutoReview::Outcome::EMPTY_METADATA)
+        Automation::Strategies::AutoReview::Outcome.exhausted_retries(method: name, blocking:, message:, metadata:)
+      end
+
+      def outcome_not_applicable(message: nil)
+        Automation::Strategies::AutoReview::Outcome.not_applicable(method: name, message:)
+      end
+    end
+  end
+end

--- a/app/services/automation/review_methods/ci_action.rb
+++ b/app/services/automation/review_methods/ci_action.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Automation
+  module ReviewMethods
+    # CI-action-based review — delegates review responsibilities to a
+    # GitHub Action (e.g. +Claude Code Review+). Paid dispatches the
+    # action via +repository_dispatch+ and waits for the configured
+    # +action_name+ check run to conclude +success+.
+    #
+    # Like {Manual}, a ci_action pending outcome blocks PR progress when
+    # +wait_for_reviews+ is enabled. The decision emitted in that case is
+    # handled at the workflow layer (dispatching the action) rather than
+    # via {Automation::Decision} — ci_action has no corresponding decision
+    # type today, so this plugin reports +:pending+ without producing a
+    # decision, leaving the existing dispatch path in place.
+    class CiAction < Base
+      TRIGGER_TYPE = "ci_action_pending"
+
+      def kind = :ci
+
+      def blocking_by_default?
+        config.wait_for_reviews?
+      end
+
+      def evaluate
+        pending = signals.trigger(TRIGGER_TYPE)
+        if pending
+          return outcome_pending(
+            blocking: blocking_by_default?,
+            message: "ci_action review pending",
+            metadata: {
+              action_name: method.action_name,
+              dispatch_required: pending[:dispatch_required] == true
+            }.compact
+          )
+        end
+
+        return outcome_not_applicable unless config.method_enabled?(:ci_action)
+
+        outcome_satisfied
+      end
+
+      # ci_action dispatch is currently owned by +DispatchClaudeReviewActivity+
+      # in the workflow layer; there is no matching {Automation::Decision}
+      # type today. Returning +nil+ preserves that ownership while still
+      # letting the strategy report the method's pending/satisfied state.
+      def decision
+        nil
+      end
+    end
+  end
+end

--- a/app/services/automation/review_methods/codex.rb
+++ b/app/services/automation/review_methods/codex.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Automation
+  module ReviewMethods
+    # ChatGPT Codex Connector review — body-only bot triggered by
+    # @-mention comment (codex does NOT auto-review drafts like copilot
+    # does). Paid mentions the bot via RequestReviewActivity; codex then
+    # posts a review body rather than inline threads.
+    #
+    # Like copilot, codex's pending outcome is a non-blocking sidecar.
+    class Codex < Base
+      BOT_LOGIN = "chatgpt-codex-connector"
+      TRIGGER_TYPE = "review_bot_review_pending"
+
+      def kind = :comment_bot
+
+      def evaluate
+        pending = matching_trigger
+        if pending
+          return outcome_pending(
+            blocking: false,
+            message: "codex review requested",
+            metadata: { reviewer_login: BOT_LOGIN }
+          )
+        end
+
+        return outcome_not_applicable unless config.method_enabled?(:codex)
+
+        outcome_satisfied
+      end
+
+      def decision
+        trigger = matching_trigger
+        return nil if trigger.nil?
+        return nil unless trigger[:request_login].to_s.casecmp(BOT_LOGIN).zero?
+
+        Automation::Decision.request_review(
+          pr_number: signals.pr_number,
+          reviewers: [ BOT_LOGIN ]
+        )
+      end
+
+      private
+
+      def matching_trigger
+        signals.trigger(TRIGGER_TYPE)
+      end
+    end
+  end
+end

--- a/app/services/automation/review_methods/codex.rb
+++ b/app/services/automation/review_methods/codex.rb
@@ -30,9 +30,7 @@ module Automation
       end
 
       def decision
-        trigger = matching_trigger
-        return nil if trigger.nil?
-        return nil unless trigger[:request_login].to_s.casecmp(BOT_LOGIN).zero?
+        return nil unless matching_trigger
 
         Automation::Decision.request_review(
           pr_number: signals.pr_number,
@@ -43,7 +41,11 @@ module Automation
       private
 
       def matching_trigger
-        signals.trigger(TRIGGER_TYPE)
+        trigger = signals.trigger(TRIGGER_TYPE)
+        return nil if trigger.nil?
+        return nil unless trigger[:request_login].to_s.casecmp(BOT_LOGIN).zero?
+
+        trigger
       end
     end
   end

--- a/app/services/automation/review_methods/copilot.rb
+++ b/app/services/automation/review_methods/copilot.rb
@@ -35,9 +35,7 @@ module Automation
       # Mirrors the existing +PullRequestEvaluator+ behavior, which routes
       # whichever login the scan supplies without re-consulting the config.
       def decision
-        trigger = matching_trigger
-        return nil if trigger.nil?
-        return nil unless trigger[:request_login].to_s.casecmp(BOT_LOGIN).zero?
+        return nil unless matching_trigger
 
         Automation::Decision.request_review(
           pr_number: signals.pr_number,
@@ -48,7 +46,11 @@ module Automation
       private
 
       def matching_trigger
-        signals.trigger(TRIGGER_TYPE)
+        trigger = signals.trigger(TRIGGER_TYPE)
+        return nil if trigger.nil?
+        return nil unless trigger[:request_login].to_s.casecmp(BOT_LOGIN).zero?
+
+        trigger
       end
     end
   end

--- a/app/services/automation/review_methods/copilot.rb
+++ b/app/services/automation/review_methods/copilot.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Automation
+  module ReviewMethods
+    # GitHub Copilot review — requested via GraphQL review-request on the PR.
+    # Copilot auto-reviews draft PRs once assigned and posts inline review
+    # threads.
+    #
+    # Copilot's pending outcome is a non-blocking sidecar: the PR continues
+    # along the normal follow-up path, and the strategy simply emits a
+    # +request_review+ decision so the bot gets assigned.
+    class Copilot < Base
+      BOT_LOGIN = "copilot"
+      TRIGGER_TYPE = "review_bot_review_pending"
+
+      def kind = :bot
+
+      def evaluate
+        pending = matching_trigger
+        if pending
+          return outcome_pending(
+            blocking: false,
+            message: "copilot review requested",
+            metadata: { reviewer_login: BOT_LOGIN }
+          )
+        end
+
+        return outcome_not_applicable unless config.method_enabled?(:copilot)
+
+        outcome_satisfied
+      end
+
+      # Emits a request_review decision whenever the scan surfaces a
+      # review_bot_review_pending trigger addressed to the copilot login.
+      # Mirrors the existing +PullRequestEvaluator+ behavior, which routes
+      # whichever login the scan supplies without re-consulting the config.
+      def decision
+        trigger = matching_trigger
+        return nil if trigger.nil?
+        return nil unless trigger[:request_login].to_s.casecmp(BOT_LOGIN).zero?
+
+        Automation::Decision.request_review(
+          pr_number: signals.pr_number,
+          reviewers: [ BOT_LOGIN ]
+        )
+      end
+
+      private
+
+      def matching_trigger
+        signals.trigger(TRIGGER_TYPE)
+      end
+    end
+  end
+end

--- a/app/services/automation/review_methods/manual.rb
+++ b/app/services/automation/review_methods/manual.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Automation
+  module ReviewMethods
+    # Manual reviewer — a human GitHub user configured per-project via
+    # +review_settings.methods.manual.reviewer_login+. Paid requests the
+    # reviewer and then waits for an APPROVED review before the PR is
+    # considered ready.
+    #
+    # Manual is blocking when +wait_for_reviews+ is on (the default); an
+    # unsatisfied manual outcome holds the PR in its current phase until
+    # the reviewer signs off.
+    class Manual < Base
+      TRIGGER_TYPE = "manual_review_pending"
+
+      def kind = :human
+
+      def blocking_by_default?
+        config.wait_for_reviews?
+      end
+
+      def evaluate
+        pending = signals.trigger(TRIGGER_TYPE)
+        if pending
+          return outcome_pending(
+            blocking: blocking_by_default?,
+            message: "manual review pending",
+            metadata: { reviewer_login: pending[:reviewer_login] }.compact
+          )
+        end
+
+        return outcome_not_applicable unless config.method_enabled?(:manual)
+
+        outcome_satisfied
+      end
+
+      def decision
+        reviewer_login = pending_reviewer_login
+        return nil if reviewer_login.blank?
+
+        Automation::Decision.request_review(
+          pr_number: signals.pr_number,
+          reviewers: [ reviewer_login ]
+        )
+      end
+
+      private
+
+      def pending_reviewer_login
+        signals.trigger(TRIGGER_TYPE)&.dig(:reviewer_login)
+      end
+    end
+  end
+end

--- a/app/services/automation/review_methods/paid_agent.rb
+++ b/app/services/automation/review_methods/paid_agent.rb
@@ -93,7 +93,7 @@ module Automation
 
       def exhausted?
         escalate = signals.trigger(ESCALATE_TRIGGER_TYPE)
-        escalate && escalate[:reason].to_s.include?("paid_agent")
+        escalate && escalate[:details].to_s.include?("paid_agent")
       end
     end
   end

--- a/app/services/automation/review_methods/paid_agent.rb
+++ b/app/services/automation/review_methods/paid_agent.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Automation
+  module ReviewMethods
+    # Paid Agent review — Paid's first-party review agent, run via the
+    # Temporal +agent_execution+ workflow with +goal=review+.
+    #
+    # Distinctive properties:
+    #
+    # * Body-only review (no inline threads); clean runs mark themselves with
+    #   the paid-review clean marker.
+    # * Has a retry budget (+max_review_goal_retries+) on top of the per-PR
+    #   review round cap (+max_review_rounds+). A failed review run is a
+    #   retryable failure until the budget is spent.
+    # * When +paid_agent+ is the sole enabled review method, a pending
+    #   outcome is a hard block on draft→ready progression. With other
+    #   methods enabled, the outcome is a non-blocking sidecar so the PR
+    #   can continue to accumulate feedback from other reviewers in
+    #   parallel.
+    class PaidAgent < Base
+      TRIGGER_TYPE = "paid_agent_review_pending"
+      RETRY_TRIGGER_TYPE = "review_goal_retry"
+      ESCALATE_TRIGGER_TYPE = "escalate_to_owner"
+
+      def kind = :agent
+
+      def blocking_by_default?
+        config.paid_agent_sole_method?
+      end
+
+      def evaluate
+        if signals.trigger?(RETRY_TRIGGER_TYPE)
+          return outcome_retryable_failure(
+            blocking: blocking_by_default?,
+            message: "paid_agent review failed; retrying within budget",
+            metadata: { retry_count: signals.review_goal_retry_count }
+          )
+        end
+
+        pending = signals.trigger(TRIGGER_TYPE)
+        if pending
+          return outcome_pending(
+            blocking: blocking_by_default?,
+            message: pending_message(pending),
+            metadata: {
+              active_run: pending[:active_run] == true,
+              sole_method: config.paid_agent_sole_method?
+            }
+          )
+        end
+
+        return outcome_not_applicable unless config.method_enabled?(:paid_agent)
+
+        if exhausted?
+          return outcome_exhausted_retries(message: "paid_agent retry budget exhausted")
+        end
+
+        outcome_satisfied
+      end
+
+      # Paid agent methods queue a review run whenever the scan indicates a
+      # pending paid_agent review (and no run is already active) or a
+      # review-goal retry is due. This mirrors the behavior previously
+      # encoded in +Automation::PullRequestEvaluator+ and trusts the scan
+      # to only emit the triggers when the method is actually enabled.
+      def decision
+        return nil unless should_queue_review_run?
+
+        Automation::Decision.queue_review_run(
+          issue_id: signals.issue_id,
+          source_pull_request_number: signals.pr_number
+        )
+      end
+
+      private
+
+      def should_queue_review_run?
+        return true if signals.trigger?(RETRY_TRIGGER_TYPE)
+
+        pending = signals.trigger(TRIGGER_TYPE)
+        return false unless pending
+
+        pending[:active_run] != true
+      end
+
+      def pending_message(trigger)
+        if trigger[:active_run]
+          "paid_agent review already running"
+        else
+          "paid_agent review requested"
+        end
+      end
+
+      def exhausted?
+        escalate = signals.trigger(ESCALATE_TRIGGER_TYPE)
+        escalate && escalate[:reason].to_s.include?("paid_agent")
+      end
+    end
+  end
+end

--- a/app/services/automation/review_methods/registry.rb
+++ b/app/services/automation/review_methods/registry.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Automation
+  module ReviewMethods
+    # Registry of known review method plugins.
+    #
+    # {Strategies::AutoReview} looks up the plugin class for a given
+    # {Configuration::ReviewMethod} by name; tests MAY register a fake
+    # plugin class via {.register} to exercise the strategy without
+    # touching provider-specific behavior.
+    class Registry
+      UnknownMethodError = Class.new(StandardError)
+
+      DEFAULTS = {
+        paid_agent: PaidAgent,
+        copilot: Copilot,
+        codex: Codex,
+        manual: Manual,
+        ci_action: CiAction
+      }.freeze
+
+      class << self
+        def resolve(name)
+          klass = registry.fetch(name.to_sym) do
+            raise UnknownMethodError, "No review method plugin registered for #{name.inspect}"
+          end
+          klass
+        end
+
+        def register(name, plugin_class)
+          registry[name.to_sym] = plugin_class
+        end
+
+        def reset!
+          @registry = nil
+        end
+
+        def known
+          registry.keys
+        end
+
+        private
+
+        def registry
+          @registry ||= DEFAULTS.dup
+        end
+      end
+    end
+  end
+end

--- a/app/services/automation/strategies/auto_review.rb
+++ b/app/services/automation/strategies/auto_review.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+module Automation
+  module Strategies
+    # Auto-review strategy — owns the policy that translates a PR scan's
+    # review-related triggers and counters into {Automation::Decision}
+    # objects. Each configured review method
+    # (+copilot+ / +paid_agent+ / +codex+ / +ci_action+ / +manual+) is
+    # represented by a plugin under {Automation::ReviewMethods}; the
+    # strategy calls each enabled plugin, aggregates their
+    # {Outcome} reports, and composes a prioritized decision list that
+    # preserves current mixed-provider behavior.
+    #
+    # == High-level outcomes
+    #
+    # Per-method plugins report one of:
+    #
+    # * +:pending+            — review work still outstanding.
+    # * +:satisfied+          — review complete for this PR head.
+    # * +:retryable_failure+  — failure, but retry budget remains.
+    # * +:exhausted_retries+  — failure with no retries left.
+    # * +:not_applicable+     — method disabled or out of scope.
+    #
+    # A pending outcome may be either +blocking+ (the PR cannot advance
+    # until satisfied — e.g. paid_agent as sole method, or manual/ci_action
+    # when +wait_for_reviews+ is on) or a non-blocking +sidecar+ (the PR
+    # continues through follow-up work while the review is requested).
+    #
+    # == Mixed-provider handling
+    #
+    # When multiple review methods are enabled, the strategy:
+    #
+    # 1. Evaluates every enabled method, producing one outcome per method.
+    # 2. Emits each plugin's proposed decision (e.g. +queue_review_run+ for
+    #    paid_agent, +request_review+ for copilot/codex/manual) — so every
+    #    provider gets the chance to advance its own review concurrently.
+    # 3. Adds follow-up / ready / escalate / merge decisions based on the
+    #    non-review triggers present in the scan, unless a blocking
+    #    outcome forbids advancing (e.g. paid_agent_review_pending as the
+    #    sole method suppresses +queue_create_pr_run+ per #1135).
+    #
+    # This matches the behavior previously encoded in
+    # {Automation::PullRequestEvaluator} while making the per-method policy
+    # pluggable and the outcome vocabulary explicit.
+    class AutoReview
+      include Automation::Strategy
+
+      FOLLOWUP_TRIGGER_TYPES = %w[
+        ci_failure review_threads conversation_comments changes_requested
+        actionable_labels merge_conflicts review_bot_comments review_bot_threads
+      ].freeze
+
+      # Scan may be provided via +context.metadata[:scan]+; when absent,
+      # the strategy emits a noop result (this mirrors the behavior of
+      # {Automation::PullRequestEvaluator} when called without explicit
+      # scan data).
+      #
+      # @param context [Automation::Context]
+      # @return [Automation::Result]
+      def evaluate(context)
+        scan = context.metadata_fetch(:scan)
+        return noop_result if scan.nil?
+
+        config = Automation::Configuration::AutoReview.from_project(context.project)
+        signals = AutoReview::Signals.from_scan(scan)
+        plugins = build_plugins(config, signals)
+        outcomes = plugins.map(&:evaluate)
+
+        decisions = compose_decisions(signals, plugins, outcomes, scan)
+        Automation::Result.new(decisions: decisions.presence || [ Automation::Decision.noop ])
+      end
+
+      # Evaluates just the per-method outcomes for a given project and
+      # scan, without composing the decision list. Useful for callers that
+      # want to inspect review state (e.g. the explicit scan tree in
+      # {Automation::PullRequestEvaluator}) without committing to a
+      # decision composition.
+      #
+      # @return [Array<Outcome>]
+      def outcomes_for(project:, scan:)
+        config = Automation::Configuration::AutoReview.from_project(project)
+        signals = AutoReview::Signals.from_scan(scan)
+        build_plugins(config, signals).map(&:evaluate)
+      end
+
+      private
+
+      # Instantiates a plugin for every known review method, whether or
+      # not the project has it enabled. The plugins themselves decide
+      # what state to report based on both signals and config, so the
+      # scan-trigger-driven routing from {PullRequestEvaluator} continues
+      # to work even when a trigger is present for a method the config
+      # reports as disabled (e.g. in focused specs that exercise trigger
+      # routing without fully configuring review_settings).
+      def build_plugins(config, signals)
+        Automation::Configuration::ReviewMethod::NAMES.map do |name|
+          method = config.method_for(name)
+          plugin_class = Automation::ReviewMethods::Registry.resolve(name)
+          plugin_class.new(method: method, config: config, signals: signals)
+        end
+      end
+
+      def compose_decisions(signals, plugins, outcomes, scan)
+        decisions = []
+        trigger_types = signals.trigger_types
+
+        if trigger_types.include?("escalate_to_owner")
+          decisions << escalate_decision(signals)
+          return decisions
+        end
+
+        if trigger_types.include?("dismiss_escalation")
+          decisions << Automation::Decision.dismiss_escalation(issue_id: signals.issue_id)
+          return decisions
+        end
+
+        if trigger_types.include?("owner_approved")
+          decisions << Automation::Decision.merge(issue_id: signals.issue_id, pr_number: signals.pr_number)
+          return decisions
+        end
+
+        if trigger_types.include?("review_goal_retry")
+          return review_goal_retry_decisions(signals, plugins, outcomes, trigger_types)
+        end
+
+        if trigger_types.include?("ready_for_owner")
+          return ready_for_owner_decisions(signals, plugins, outcomes, trigger_types)
+        end
+
+        if trigger_types.include?(Automation::ReviewMethods::PaidAgent::TRIGGER_TYPE)
+          return paid_agent_pending_decisions(plugins)
+        end
+
+        if trigger_types.include?(Automation::ReviewMethods::Copilot::TRIGGER_TYPE)
+          return review_bot_pending_decisions(plugins, signals, trigger_types)
+        end
+
+        if trigger_types.include?(Automation::ReviewMethods::Manual::TRIGGER_TYPE) ||
+           trigger_types.include?(Automation::ReviewMethods::CiAction::TRIGGER_TYPE)
+          return non_bot_pending_decisions(plugins, signals, trigger_types)
+        end
+
+        followup_decisions(signals)
+      end
+
+      def paid_agent_pending_decisions(plugins)
+        # paid_agent_review_pending is a hard gate: emit only the
+        # queue_review_run decision and suppress create_pr follow-up runs
+        # while the review is outstanding (#1135).
+        paid_plugin = plugins.find { |p| p.name == :paid_agent }
+        decision = paid_plugin&.decision
+        decision ? [ decision ] : []
+      end
+
+      def review_bot_pending_decisions(plugins, signals, trigger_types)
+        decisions = review_bot_request_decisions(plugins)
+
+        other_triggers = trigger_types - [ Automation::ReviewMethods::Copilot::TRIGGER_TYPE ]
+        decisions.concat(followup_decisions(signals)) if other_triggers.any?
+        decisions.compact
+      end
+
+      def non_bot_pending_decisions(plugins, signals, trigger_types)
+        decisions = manual_request_decisions(plugins)
+
+        other_triggers = trigger_types - %w[manual_review_pending ci_action_pending]
+        decisions.concat(followup_decisions(signals)) if other_triggers.any?
+        decisions
+      end
+
+      def ready_for_owner_decisions(signals, plugins, outcomes, trigger_types)
+        decisions = []
+
+        paid_pending = trigger_types.include?(Automation::ReviewMethods::PaidAgent::TRIGGER_TYPE)
+        paid_active = outcomes.any? { |o| o.method == :paid_agent && o.pending? && o.metadata[:active_run] }
+
+        if paid_pending && !paid_active
+          paid_decision = plugins.find { |p| p.name == :paid_agent }&.decision
+          decisions << paid_decision if paid_decision
+        end
+
+        decisions << Automation::Decision.mark_ready(
+          issue_id: signals.issue_id,
+          pr_number: signals.pr_number,
+          owner_reviewer_login: signals.owner_reviewer_login
+        )
+
+        decisions
+      end
+
+      def review_goal_retry_decisions(signals, plugins, outcomes, trigger_types)
+        decisions = [
+          Automation::Decision.record_review_goal_retry(
+            issue_id: signals.issue_id,
+            expected_review_goal_retry_count: signals.review_goal_retry_count
+          )
+        ]
+
+        paid_decision = plugins.find { |p| p.name == :paid_agent }&.decision
+        decisions << paid_decision if paid_decision
+
+        if trigger_types.include?("ready_for_owner")
+          sans_paid = without_trigger(signals, Automation::ReviewMethods::PaidAgent::TRIGGER_TYPE)
+          decisions.concat(
+            ready_for_owner_decisions(sans_paid, plugins, outcomes, sans_paid.trigger_types)
+          )
+          return decisions
+        end
+
+        decisions.concat(manual_request_decisions(plugins))
+
+        if signals.triggers.any? { |t| FOLLOWUP_TRIGGER_TYPES.include?(t[:type].to_s) }
+          decisions.concat(followup_decisions(signals))
+        else
+          decisions.concat(review_bot_request_decisions(plugins))
+        end
+
+        decisions
+      end
+
+      def review_bot_request_decisions(plugins)
+        bot_plugins = plugins.select { |p| p.kind == :bot || p.kind == :comment_bot }
+        bot_plugins.filter_map(&:decision)
+      end
+
+      def manual_request_decisions(plugins)
+        plugins.select { |p| p.kind == :human }.filter_map(&:decision)
+      end
+
+      def followup_decisions(signals)
+        if signals.draft_phase?
+          [
+            Automation::Decision.queue_create_pr_run(
+              issue_id: signals.issue_id,
+              source_pull_request_number: signals.pr_number,
+              count_toward_draft_review_round: true,
+              expected_draft_review_count: signals.draft_review_count
+            )
+          ]
+        else
+          [
+            Automation::Decision.queue_create_pr_run(
+              issue_id: signals.issue_id,
+              source_pull_request_number: signals.pr_number
+            ),
+            Automation::Decision.record_pr_followup(
+              issue_id: signals.issue_id,
+              labels_to_remove: signals.labels_to_remove,
+              expected_followup_count: signals.followup_count
+            )
+          ]
+        end
+      end
+
+      def escalate_decision(signals)
+        trigger = signals.trigger("escalate_to_owner") || {}
+        Automation::Decision.escalate(
+          issue_id: signals.issue_id,
+          pr_number: signals.pr_number,
+          owner_reviewer_login: signals.owner_reviewer_login,
+          reason: trigger[:details]
+        )
+      end
+
+      def without_trigger(signals, type)
+        filtered = signals.triggers.reject { |t| t[:type].to_s == type.to_s }
+        Signals.new(
+          issue_id: signals.issue_id,
+          pr_number: signals.pr_number,
+          phase: signals.phase,
+          triggers: filtered.freeze,
+          counters: signals.counters,
+          owner_reviewer_login: signals.owner_reviewer_login,
+          labels_to_remove: signals.labels_to_remove
+        )
+      end
+    end
+  end
+end

--- a/app/services/automation/strategies/auto_review.rb
+++ b/app/services/automation/strategies/auto_review.rb
@@ -66,7 +66,7 @@ module Automation
         plugins = build_plugins(config, signals)
         outcomes = plugins.map(&:evaluate)
 
-        decisions = compose_decisions(signals, plugins, outcomes, scan)
+        decisions = compose_decisions(signals, plugins, outcomes)
         Automation::Result.new(decisions: decisions.presence || [ Automation::Decision.noop ])
       end
 
@@ -100,7 +100,7 @@ module Automation
         end
       end
 
-      def compose_decisions(signals, plugins, outcomes, scan)
+      def compose_decisions(signals, plugins, outcomes)
         decisions = []
         trigger_types = signals.trigger_types
 
@@ -163,7 +163,10 @@ module Automation
       def non_bot_pending_decisions(plugins, signals, trigger_types)
         decisions = manual_request_decisions(plugins)
 
-        other_triggers = trigger_types - %w[manual_review_pending ci_action_pending]
+        other_triggers = trigger_types - [
+          Automation::ReviewMethods::Manual::TRIGGER_TYPE,
+          Automation::ReviewMethods::CiAction::TRIGGER_TYPE
+        ]
         decisions.concat(followup_decisions(signals)) if other_triggers.any?
         decisions
       end

--- a/app/services/automation/strategies/auto_review/outcome.rb
+++ b/app/services/automation/strategies/auto_review/outcome.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Automation
+  module Strategies
+    class AutoReview
+      # Outcome reports where a single review method stands in the auto-review
+      # lifecycle. {Strategies::AutoReview} aggregates per-method outcomes
+      # from {Automation::ReviewMethods} plugins into the final
+      # {Automation::Result}.
+      #
+      # == Outcome states
+      #
+      # * +:pending+            — the method expects further activity before
+      #   the PR is ready (e.g. review not yet submitted, reviewer not yet
+      #   approved, CI action not yet run).
+      # * +:satisfied+          — the method has completed successfully for
+      #   the current PR head (e.g. clean review, approval on file,
+      #   action_name check succeeded).
+      # * +:retryable_failure+  — the method failed but the configured retry
+      #   budget permits another attempt (paid_agent only, today).
+      # * +:exhausted_retries+  — the method failed and the retry budget has
+      #   been spent. Callers SHOULD escalate to a human.
+      # * +:not_applicable+     — the method is disabled or does not apply
+      #   to the current phase (e.g. draft copilot review when the review
+      #   toggle is off).
+      #
+      # == Blocking semantics
+      #
+      # A +pending+ outcome may be either +blocking+ (acts as a hard gate on
+      # PR progress — e.g. +paid_agent+ when it is the sole enabled method,
+      # or +manual+/+ci_action+ when +wait_for_reviews+ is on) or
+      # +non-blocking sidecar+ (surfaces a review action alongside other
+      # follow-up work without stopping the PR — e.g. a copilot review
+      # requested while auto-continue proceeds). Every factory accepts a
+      # +blocking:+ kwarg so callers can declare the policy explicitly.
+      class Outcome < ::Data.define(:method, :state, :blocking, :message, :metadata)
+        STATES = %i[pending satisfied retryable_failure exhausted_retries not_applicable].freeze
+
+        EMPTY_METADATA = {}.freeze
+
+        class << self
+          def pending(method:, blocking: false, message: nil, metadata: EMPTY_METADATA)
+            build(method:, state: :pending, blocking:, message:, metadata:)
+          end
+
+          def satisfied(method:, message: nil, metadata: EMPTY_METADATA)
+            build(method:, state: :satisfied, blocking: false, message:, metadata:)
+          end
+
+          def retryable_failure(method:, blocking: true, message: nil, metadata: EMPTY_METADATA)
+            build(method:, state: :retryable_failure, blocking:, message:, metadata:)
+          end
+
+          def exhausted_retries(method:, blocking: true, message: nil, metadata: EMPTY_METADATA)
+            build(method:, state: :exhausted_retries, blocking:, message:, metadata:)
+          end
+
+          def not_applicable(method:, message: nil)
+            build(method:, state: :not_applicable, blocking: false, message:, metadata: EMPTY_METADATA)
+          end
+
+          private
+
+          def build(method:, state:, blocking:, message:, metadata:)
+            unless STATES.include?(state)
+              raise ArgumentError, "Unknown outcome state: #{state.inspect}"
+            end
+
+            new(
+              method: method.to_sym,
+              state: state,
+              blocking: blocking == true,
+              message: message,
+              metadata: (metadata || EMPTY_METADATA).freeze
+            )
+          end
+        end
+
+        STATES.each do |s|
+          define_method(:"#{s}?") { state == s }
+        end
+
+        def blocking? = blocking == true
+        def sidecar? = !blocking?
+
+        def to_h
+          {
+            method: method,
+            state: state,
+            blocking: blocking,
+            message: message,
+            metadata: metadata
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/automation/strategies/auto_review/signals.rb
+++ b/app/services/automation/strategies/auto_review/signals.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Automation
+  module Strategies
+    class AutoReview
+      # Immutable input for {Strategies::AutoReview}. Wraps the scan payload
+      # emitted by +ScanPaidPrsActivity+ with helpers that plugin classes
+      # can use without drilling into nested Hashes.
+      #
+      # Signals are intentionally provider-neutral: they describe "what the
+      # scan observed" (phase, per-trigger hashes, counters) rather than
+      # raw GitHub state. A future signal collector
+      # (RDR-023 Layer 2) will populate this structure without changing
+      # the downstream plugin contract.
+      class Signals < ::Data.define(
+        :issue_id,
+        :pr_number,
+        :phase,
+        :triggers,
+        :counters,
+        :owner_reviewer_login,
+        :labels_to_remove
+      )
+        EMPTY_TRIGGERS = [].freeze
+        EMPTY_COUNTERS = {}.freeze
+        EMPTY_LABELS = [].freeze
+
+        PHASES = %w[draft ready escalated restarted].freeze
+
+        class << self
+          def from_scan(scan)
+            scan = (scan || {}).deep_symbolize_keys
+            triggers = Array(scan[:triggers]).map { |t| t.is_a?(Hash) ? t.deep_symbolize_keys.freeze : {}.freeze }.freeze
+
+            new(
+              issue_id: scan[:issue_id],
+              pr_number: scan[:pr_number],
+              phase: scan[:phase]&.to_s,
+              triggers: triggers,
+              counters: build_counters(scan).freeze,
+              owner_reviewer_login: scan[:owner_reviewer_login],
+              labels_to_remove: Array(scan[:labels_to_remove]).freeze
+            )
+          end
+
+          private
+
+          def build_counters(scan)
+            {
+              draft_review: scan[:current_draft_review_count],
+              followup: scan[:current_followup_count],
+              review_goal_retry: scan[:current_review_goal_retry_count]
+            }
+          end
+        end
+
+        def draft_phase? = phase == "draft" || phase == "restarted"
+        def ready_phase? = phase == "ready"
+        def escalated_phase? = phase == "escalated"
+
+        def trigger(type)
+          triggers.find { |t| t[:type].to_s == type.to_s }
+        end
+
+        def trigger?(type)
+          !trigger(type).nil?
+        end
+
+        def trigger_types
+          triggers.map { |t| t[:type].to_s }
+        end
+
+        def trigger_types_excluding(*types)
+          excluded = types.map(&:to_s)
+          trigger_types - excluded
+        end
+
+        def draft_review_count = counters[:draft_review]
+        def followup_count = counters[:followup]
+        def review_goal_retry_count = counters[:review_goal_retry]
+      end
+    end
+  end
+end

--- a/spec/services/automation/review_methods/base_spec.rb
+++ b/spec/services/automation/review_methods/base_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::ReviewMethods::Base do
+  let(:config) do
+    Automation::Configuration::AutoReview.new(
+      review_settings: Automation::Configuration::ReviewSettings.from_hash(
+        "enabled" => true,
+        "methods" => Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) do |n, h|
+          h[n.to_s] = { "enabled" => false }
+        end
+      )
+    )
+  end
+  let(:signals) { Automation::Strategies::AutoReview::Signals.from_scan(pr_number: 1) }
+  let(:method_value) { config.method_for(:copilot) }
+
+  it "requires subclasses to implement #kind and #evaluate" do
+    base = described_class.new(method: method_value, config: config, signals: signals)
+
+    expect { base.kind }.to raise_error(NotImplementedError)
+    expect { base.evaluate }.to raise_error(NotImplementedError)
+  end
+
+  it "returns nil from #decision by default" do
+    base = described_class.new(method: method_value, config: config, signals: signals)
+
+    expect(base.decision).to be_nil
+  end
+
+  it "reports its method name via Base#name" do
+    base = described_class.new(method: method_value, config: config, signals: signals)
+    expect(base.name).to eq(:copilot)
+  end
+
+  it "is non-blocking by default" do
+    base = described_class.new(method: method_value, config: config, signals: signals)
+    expect(base.blocking_by_default?).to be false
+  end
+end

--- a/spec/services/automation/review_methods/ci_action_spec.rb
+++ b/spec/services/automation/review_methods/ci_action_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::ReviewMethods::CiAction do
+  def build_config(wait_for_reviews: true, **methods)
+    method_hashes = Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) do |name, h|
+      h[name.to_s] = methods[name] || { "enabled" => false }
+    end
+    Automation::Configuration::AutoReview.new(
+      review_settings: Automation::Configuration::ReviewSettings.from_hash(
+        "enabled" => true,
+        "wait_for_reviews" => wait_for_reviews,
+        "methods" => method_hashes
+      )
+    )
+  end
+
+  def build_plugin(config:, triggers: [])
+    signals = Automation::Strategies::AutoReview::Signals.from_scan(
+      issue_id: 1, pr_number: 50, phase: "ready", triggers: triggers
+    )
+    described_class.new(method: config.method_for(:ci_action), config: config, signals: signals)
+  end
+
+  it "identifies as :ci" do
+    expect(build_plugin(config: build_config).kind).to eq(:ci)
+  end
+
+  it "blocks by default when wait_for_reviews is on" do
+    expect(build_plugin(config: build_config(wait_for_reviews: true)).blocking_by_default?).to be true
+    expect(build_plugin(config: build_config(wait_for_reviews: false)).blocking_by_default?).to be false
+  end
+
+  describe "#evaluate" do
+    it "reports not_applicable when ci_action is disabled and no trigger is present" do
+      expect(build_plugin(config: build_config).evaluate).to be_not_applicable
+    end
+
+    it "reports pending (blocking) when a ci_action_pending trigger fires" do
+      plugin = build_plugin(
+        config: build_config(ci_action: { "enabled" => true, "action_name" => "Claude Code Review" }),
+        triggers: [ { type: "ci_action_pending", dispatch_required: true } ]
+      )
+
+      outcome = plugin.evaluate
+      expect(outcome).to be_pending
+      expect(outcome).to be_blocking
+      expect(outcome.metadata[:action_name]).to eq("Claude Code Review")
+      expect(outcome.metadata[:dispatch_required]).to be true
+    end
+
+    it "reports satisfied when ci_action is enabled and no trigger is present" do
+      plugin = build_plugin(
+        config: build_config(ci_action: { "enabled" => true, "action_name" => "Claude Code Review" })
+      )
+
+      expect(plugin.evaluate).to be_satisfied
+    end
+  end
+
+  it "produces no decision (dispatch is owned by the workflow layer)" do
+    plugin = build_plugin(
+      config: build_config(ci_action: { "enabled" => true, "action_name" => "Claude Code Review" }),
+      triggers: [ { type: "ci_action_pending", dispatch_required: true } ]
+    )
+
+    expect(plugin.decision).to be_nil
+  end
+end

--- a/spec/services/automation/review_methods/codex_spec.rb
+++ b/spec/services/automation/review_methods/codex_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe Automation::ReviewMethods::Codex do
     expect(outcome.metadata[:reviewer_login]).to eq("chatgpt-codex-connector")
   end
 
+  it "ignores a trigger addressed to a different bot (e.g. copilot)" do
+    plugin = build_plugin(
+      config: build_config(codex: { "enabled" => true }),
+      triggers: [ { type: "review_bot_review_pending", request_login: "copilot" } ]
+    )
+
+    expect(plugin.evaluate).to be_satisfied
+  end
+
   describe "#decision" do
     it "requests review from the codex login when the trigger targets codex" do
       plugin = build_plugin(

--- a/spec/services/automation/review_methods/codex_spec.rb
+++ b/spec/services/automation/review_methods/codex_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::ReviewMethods::Codex do
+  def build_config(**methods)
+    method_hashes = Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) do |name, h|
+      h[name.to_s] = methods[name] || { "enabled" => false }
+    end
+    Automation::Configuration::AutoReview.new(
+      review_settings: Automation::Configuration::ReviewSettings.from_hash(
+        "enabled" => true,
+        "methods" => method_hashes
+      )
+    )
+  end
+
+  def build_plugin(config:, triggers: [])
+    signals = Automation::Strategies::AutoReview::Signals.from_scan(
+      issue_id: 1, pr_number: 50, phase: "ready", triggers: triggers
+    )
+    described_class.new(method: config.method_for(:codex), config: config, signals: signals)
+  end
+
+  it "identifies as :comment_bot" do
+    expect(build_plugin(config: build_config).kind).to eq(:comment_bot)
+  end
+
+  it "reports satisfied when enabled with no trigger, not_applicable when disabled with no trigger" do
+    expect(build_plugin(config: build_config(codex: { "enabled" => true })).evaluate).to be_satisfied
+    expect(build_plugin(config: build_config).evaluate).to be_not_applicable
+  end
+
+  it "reports pending (sidecar) with the codex login when its trigger fires" do
+    plugin = build_plugin(
+      config: build_config(codex: { "enabled" => true }),
+      triggers: [ { type: "review_bot_review_pending", request_login: "chatgpt-codex-connector" } ]
+    )
+
+    outcome = plugin.evaluate
+    expect(outcome).to be_pending
+    expect(outcome).to be_sidecar
+    expect(outcome.metadata[:reviewer_login]).to eq("chatgpt-codex-connector")
+  end
+
+  describe "#decision" do
+    it "requests review from the codex login when the trigger targets codex" do
+      plugin = build_plugin(
+        config: build_config(codex: { "enabled" => true }),
+        triggers: [ { type: "review_bot_review_pending", request_login: "chatgpt-codex-connector" } ]
+      )
+
+      expect(plugin.decision.payload[:reviewers]).to eq([ "chatgpt-codex-connector" ])
+    end
+
+    it "is nil when the trigger targets a different bot (e.g. copilot)" do
+      plugin = build_plugin(
+        config: build_config(codex: { "enabled" => true }),
+        triggers: [ { type: "review_bot_review_pending", request_login: "copilot" } ]
+      )
+
+      expect(plugin.decision).to be_nil
+    end
+  end
+end

--- a/spec/services/automation/review_methods/copilot_spec.rb
+++ b/spec/services/automation/review_methods/copilot_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::ReviewMethods::Copilot do
+  def build_config(**methods)
+    method_hashes = Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) do |name, h|
+      h[name.to_s] = methods[name] || { "enabled" => false }
+    end
+    review_settings = Automation::Configuration::ReviewSettings.from_hash(
+      "enabled" => true,
+      "methods" => method_hashes
+    )
+    Automation::Configuration::AutoReview.new(review_settings: review_settings)
+  end
+
+  def build_plugin(config:, triggers: [])
+    signals = Automation::Strategies::AutoReview::Signals.from_scan(
+      issue_id: 1,
+      pr_number: 50,
+      phase: "draft",
+      triggers: triggers
+    )
+    described_class.new(method: config.method_for(:copilot), config: config, signals: signals)
+  end
+
+  it "identifies as :bot" do
+    expect(build_plugin(config: build_config).kind).to eq(:bot)
+  end
+
+  describe "#evaluate" do
+    it "reports not_applicable when copilot is disabled and no trigger is present" do
+      plugin = build_plugin(config: build_config)
+
+      expect(plugin.evaluate).to be_not_applicable
+    end
+
+    it "reports satisfied when copilot is enabled and no trigger is present" do
+      plugin = build_plugin(config: build_config(copilot: { "enabled" => true }))
+
+      expect(plugin.evaluate).to be_satisfied
+    end
+
+    it "reports pending (sidecar) when a review_bot_review_pending trigger is present" do
+      plugin = build_plugin(
+        config: build_config(copilot: { "enabled" => true }),
+        triggers: [ { type: "review_bot_review_pending", request_login: "copilot" } ]
+      )
+
+      outcome = plugin.evaluate
+      expect(outcome).to be_pending
+      expect(outcome).to be_sidecar
+      expect(outcome.metadata[:reviewer_login]).to eq("copilot")
+    end
+  end
+
+  describe "#decision" do
+    it "requests review from the copilot login when the trigger targets copilot" do
+      plugin = build_plugin(
+        config: build_config(copilot: { "enabled" => true }),
+        triggers: [ { type: "review_bot_review_pending", request_login: "copilot" } ]
+      )
+
+      decision = plugin.decision
+      expect(decision.type).to eq("request_review")
+      expect(decision.payload).to include(pr_number: 50, reviewers: [ "copilot" ])
+    end
+
+    it "is nil when the trigger targets a different bot (e.g. codex)" do
+      plugin = build_plugin(
+        config: build_config(copilot: { "enabled" => true }),
+        triggers: [ { type: "review_bot_review_pending", request_login: "chatgpt-codex-connector" } ]
+      )
+
+      expect(plugin.decision).to be_nil
+    end
+
+    it "is nil when no trigger is present" do
+      plugin = build_plugin(config: build_config(copilot: { "enabled" => true }))
+
+      expect(plugin.decision).to be_nil
+    end
+  end
+end

--- a/spec/services/automation/review_methods/copilot_spec.rb
+++ b/spec/services/automation/review_methods/copilot_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Automation::ReviewMethods::Copilot do
       expect(outcome).to be_sidecar
       expect(outcome.metadata[:reviewer_login]).to eq("copilot")
     end
+
+    it "ignores a trigger addressed to a different bot (e.g. codex)" do
+      plugin = build_plugin(
+        config: build_config(copilot: { "enabled" => true }),
+        triggers: [ { type: "review_bot_review_pending", request_login: "chatgpt-codex-connector" } ]
+      )
+
+      expect(plugin.evaluate).to be_satisfied
+    end
   end
 
   describe "#decision" do

--- a/spec/services/automation/review_methods/manual_spec.rb
+++ b/spec/services/automation/review_methods/manual_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::ReviewMethods::Manual do
+  def build_config(wait_for_reviews: true, **methods)
+    method_hashes = Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) do |name, h|
+      h[name.to_s] = methods[name] || { "enabled" => false }
+    end
+    Automation::Configuration::AutoReview.new(
+      review_settings: Automation::Configuration::ReviewSettings.from_hash(
+        "enabled" => true,
+        "wait_for_reviews" => wait_for_reviews,
+        "methods" => method_hashes
+      )
+    )
+  end
+
+  def build_plugin(config:, triggers: [])
+    signals = Automation::Strategies::AutoReview::Signals.from_scan(
+      issue_id: 1, pr_number: 50, phase: "ready", triggers: triggers
+    )
+    described_class.new(method: config.method_for(:manual), config: config, signals: signals)
+  end
+
+  it "identifies as :human" do
+    expect(build_plugin(config: build_config).kind).to eq(:human)
+  end
+
+  it "blocks by default when wait_for_reviews is on" do
+    expect(build_plugin(config: build_config(wait_for_reviews: true)).blocking_by_default?).to be true
+    expect(build_plugin(config: build_config(wait_for_reviews: false)).blocking_by_default?).to be false
+  end
+
+  describe "#evaluate" do
+    it "reports not_applicable when manual is disabled and no trigger is present" do
+      expect(build_plugin(config: build_config).evaluate).to be_not_applicable
+    end
+
+    it "reports pending (blocking) when a manual_review_pending trigger is present and wait_for_reviews is on" do
+      plugin = build_plugin(
+        config: build_config(manual: { "enabled" => true, "reviewer_login" => "alice" }),
+        triggers: [ { type: "manual_review_pending", reviewer_login: "alice" } ]
+      )
+
+      outcome = plugin.evaluate
+      expect(outcome).to be_pending
+      expect(outcome).to be_blocking
+      expect(outcome.metadata[:reviewer_login]).to eq("alice")
+    end
+
+    it "reports pending (sidecar) when wait_for_reviews is off" do
+      plugin = build_plugin(
+        config: build_config(wait_for_reviews: false, manual: { "enabled" => true, "reviewer_login" => "alice" }),
+        triggers: [ { type: "manual_review_pending", reviewer_login: "alice" } ]
+      )
+
+      expect(plugin.evaluate).to be_sidecar
+    end
+  end
+
+  describe "#decision" do
+    it "requests review from the trigger's reviewer_login" do
+      plugin = build_plugin(
+        config: build_config(manual: { "enabled" => true, "reviewer_login" => "alice" }),
+        triggers: [ { type: "manual_review_pending", reviewer_login: "alice" } ]
+      )
+
+      expect(plugin.decision.payload).to eq(pr_number: 50, reviewers: [ "alice" ])
+    end
+
+    it "returns nil when the pending trigger has no reviewer_login" do
+      plugin = build_plugin(
+        config: build_config(manual: { "enabled" => true }),
+        triggers: [ { type: "manual_review_pending" } ]
+      )
+
+      expect(plugin.decision).to be_nil
+    end
+  end
+end

--- a/spec/services/automation/review_methods/paid_agent_spec.rb
+++ b/spec/services/automation/review_methods/paid_agent_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::ReviewMethods::PaidAgent do
+  def build_config(**methods)
+    method_hashes = Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) do |name, h|
+      h[name.to_s] = methods[name] || { "enabled" => false }
+    end
+    review_settings = Automation::Configuration::ReviewSettings.from_hash(
+      "enabled" => true,
+      "methods" => method_hashes
+    )
+    Automation::Configuration::AutoReview.new(review_settings: review_settings)
+  end
+
+  def build_plugin(config:, triggers: [], **scan_overrides)
+    signals = Automation::Strategies::AutoReview::Signals.from_scan({
+      issue_id: 7,
+      pr_number: 42,
+      phase: "ready",
+      triggers: triggers
+    }.merge(scan_overrides))
+    method = config.method_for(:paid_agent)
+    described_class.new(method: method, config: config, signals: signals)
+  end
+
+  describe "#kind" do
+    it "identifies as :agent" do
+      expect(build_plugin(config: build_config).kind).to eq(:agent)
+    end
+  end
+
+  describe "#evaluate" do
+    it "reports satisfied when the method is enabled and no review trigger is present" do
+      plugin = build_plugin(config: build_config(paid_agent: { "enabled" => true }))
+
+      expect(plugin.evaluate).to be_satisfied
+    end
+
+    it "reports not_applicable when the method is disabled and no triggers are present" do
+      plugin = build_plugin(config: build_config)
+
+      expect(plugin.evaluate).to be_not_applicable
+    end
+
+    it "reports pending (sidecar) when paid_agent_review_pending fires and other methods are enabled" do
+      config = build_config(paid_agent: { "enabled" => true }, copilot: { "enabled" => true })
+      plugin = build_plugin(config: config, triggers: [ { type: "paid_agent_review_pending" } ])
+
+      outcome = plugin.evaluate
+      expect(outcome).to be_pending
+      expect(outcome).to be_sidecar
+      expect(outcome.metadata[:active_run]).to be false
+      expect(outcome.metadata[:sole_method]).to be false
+    end
+
+    it "reports pending (blocking) when paid_agent is the sole enabled method" do
+      config = build_config(paid_agent: { "enabled" => true })
+      plugin = build_plugin(config: config, triggers: [ { type: "paid_agent_review_pending" } ])
+
+      outcome = plugin.evaluate
+      expect(outcome).to be_blocking
+      expect(outcome.metadata[:sole_method]).to be true
+    end
+
+    it "reports retryable_failure when a review_goal_retry trigger is present" do
+      plugin = build_plugin(
+        config: build_config(paid_agent: { "enabled" => true }),
+        triggers: [ { type: "review_goal_retry" } ],
+        current_review_goal_retry_count: 2
+      )
+
+      outcome = plugin.evaluate
+      expect(outcome).to be_retryable_failure
+      expect(outcome.metadata[:retry_count]).to eq(2)
+    end
+
+    it "reports exhausted_retries on escalate_to_owner triggers naming paid_agent" do
+      plugin = build_plugin(
+        config: build_config(paid_agent: { "enabled" => true }),
+        triggers: [ { type: "escalate_to_owner", reason: "paid_agent retry budget exhausted" } ]
+      )
+
+      expect(plugin.evaluate).to be_exhausted_retries
+    end
+  end
+
+  describe "#decision" do
+    it "queues a review run when the pending trigger has no active_run" do
+      plugin = build_plugin(
+        config: build_config(paid_agent: { "enabled" => true }),
+        triggers: [ { type: "paid_agent_review_pending" } ]
+      )
+
+      expect(plugin.decision.to_h).to eq(
+        type: "queue_review_run",
+        issue_id: 7,
+        source_pull_request_number: 42
+      )
+    end
+
+    it "returns nil when the pending trigger reports active_run: true" do
+      plugin = build_plugin(
+        config: build_config(paid_agent: { "enabled" => true }),
+        triggers: [ { type: "paid_agent_review_pending", active_run: true } ]
+      )
+
+      expect(plugin.decision).to be_nil
+    end
+
+    it "queues a review run for review_goal_retry triggers" do
+      plugin = build_plugin(
+        config: build_config(paid_agent: { "enabled" => true }),
+        triggers: [ { type: "review_goal_retry" } ]
+      )
+
+      expect(plugin.decision.type).to eq("queue_review_run")
+    end
+
+    it "returns nil when no paid_agent trigger is present" do
+      plugin = build_plugin(config: build_config(paid_agent: { "enabled" => true }))
+
+      expect(plugin.decision).to be_nil
+    end
+  end
+
+  describe "#blocking_by_default?" do
+    it "is true when paid_agent is the sole enabled review method" do
+      config = build_config(paid_agent: { "enabled" => true })
+      expect(build_plugin(config: config).blocking_by_default?).to be true
+    end
+
+    it "is false when other methods are enabled alongside paid_agent" do
+      config = build_config(paid_agent: { "enabled" => true }, manual: { "enabled" => true, "reviewer_login" => "alice" })
+      expect(build_plugin(config: config).blocking_by_default?).to be false
+    end
+  end
+end

--- a/spec/services/automation/review_methods/paid_agent_spec.rb
+++ b/spec/services/automation/review_methods/paid_agent_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Automation::ReviewMethods::PaidAgent do
     it "reports exhausted_retries on escalate_to_owner triggers naming paid_agent" do
       plugin = build_plugin(
         config: build_config(paid_agent: { "enabled" => true }),
-        triggers: [ { type: "escalate_to_owner", reason: "paid_agent retry budget exhausted" } ]
+        triggers: [ { type: "escalate_to_owner", details: "paid_agent retry budget exhausted" } ]
       )
 
       expect(plugin.evaluate).to be_exhausted_retries

--- a/spec/services/automation/review_methods/registry_spec.rb
+++ b/spec/services/automation/review_methods/registry_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::ReviewMethods::Registry do
+  after { described_class.reset! }
+
+  it "resolves each of the five known review methods" do
+    expect(described_class.resolve(:paid_agent)).to eq(Automation::ReviewMethods::PaidAgent)
+    expect(described_class.resolve(:copilot)).to eq(Automation::ReviewMethods::Copilot)
+    expect(described_class.resolve(:codex)).to eq(Automation::ReviewMethods::Codex)
+    expect(described_class.resolve(:manual)).to eq(Automation::ReviewMethods::Manual)
+    expect(described_class.resolve(:ci_action)).to eq(Automation::ReviewMethods::CiAction)
+  end
+
+  it "accepts string names" do
+    expect(described_class.resolve("copilot")).to eq(Automation::ReviewMethods::Copilot)
+  end
+
+  it "raises an UnknownMethodError for unknown names" do
+    expect { described_class.resolve(:mystery) }
+      .to raise_error(described_class::UnknownMethodError, /mystery/)
+  end
+
+  it "lets tests swap in a fake plugin and then reset" do
+    fake = Class.new(Automation::ReviewMethods::Base)
+    described_class.register(:copilot, fake)
+    expect(described_class.resolve(:copilot)).to eq(fake)
+
+    described_class.reset!
+    expect(described_class.resolve(:copilot)).to eq(Automation::ReviewMethods::Copilot)
+  end
+
+  it "lists the canonical names" do
+    expect(described_class.known).to match_array(%i[paid_agent copilot codex manual ci_action])
+  end
+end

--- a/spec/services/automation/strategies/auto_review/outcome_spec.rb
+++ b/spec/services/automation/strategies/auto_review/outcome_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Strategies::AutoReview::Outcome do
+  describe "factories" do
+    it "builds a pending outcome with sidecar defaults" do
+      outcome = described_class.pending(method: :copilot)
+
+      expect(outcome.state).to eq(:pending)
+      expect(outcome).to be_pending
+      expect(outcome).not_to be_blocking
+      expect(outcome).to be_sidecar
+      expect(outcome.method).to eq(:copilot)
+      expect(outcome.metadata).to eq({})
+    end
+
+    it "builds a blocking pending outcome when requested" do
+      outcome = described_class.pending(method: :paid_agent, blocking: true)
+
+      expect(outcome).to be_blocking
+      expect(outcome).not_to be_sidecar
+    end
+
+    it "builds a satisfied outcome that is never blocking" do
+      outcome = described_class.satisfied(method: :copilot)
+
+      expect(outcome).to be_satisfied
+      expect(outcome).not_to be_blocking
+    end
+
+    it "builds a retryable_failure outcome that blocks by default" do
+      outcome = described_class.retryable_failure(method: :paid_agent)
+
+      expect(outcome).to be_retryable_failure
+      expect(outcome).to be_blocking
+    end
+
+    it "builds an exhausted_retries outcome that blocks by default" do
+      outcome = described_class.exhausted_retries(method: :paid_agent)
+
+      expect(outcome).to be_exhausted_retries
+      expect(outcome).to be_blocking
+    end
+
+    it "builds a not_applicable outcome that is never blocking" do
+      outcome = described_class.not_applicable(method: :codex)
+
+      expect(outcome).to be_not_applicable
+      expect(outcome).not_to be_blocking
+    end
+  end
+
+  it "freezes metadata so callers cannot mutate shared state" do
+    outcome = described_class.pending(method: :manual, metadata: { reviewer_login: "alice" })
+
+    expect(outcome.metadata).to be_frozen
+    expect(outcome.metadata[:reviewer_login]).to eq("alice")
+  end
+
+  it "symbolizes method names" do
+    outcome = described_class.satisfied(method: "copilot")
+    expect(outcome.method).to eq(:copilot)
+  end
+
+  it "emits a hash view for logging" do
+    outcome = described_class.pending(
+      method: :paid_agent,
+      blocking: true,
+      message: "paid_agent pending",
+      metadata: { active_run: true }
+    )
+
+    expect(outcome.to_h).to eq(
+      method: :paid_agent,
+      state: :pending,
+      blocking: true,
+      message: "paid_agent pending",
+      metadata: { active_run: true }
+    )
+  end
+
+  it "raises on unknown state" do
+    expect {
+      described_class.send(:build, method: :copilot, state: :weird, blocking: false, message: nil, metadata: {})
+    }.to raise_error(ArgumentError, /Unknown outcome state/)
+  end
+end

--- a/spec/services/automation/strategies/auto_review/signals_spec.rb
+++ b/spec/services/automation/strategies/auto_review/signals_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Strategies::AutoReview::Signals do
+  describe ".from_scan" do
+    it "normalizes an empty scan into an object with empty collections" do
+      signals = described_class.from_scan(nil)
+
+      expect(signals.triggers).to eq([])
+      expect(signals.labels_to_remove).to eq([])
+      expect(signals.counters).to include(draft_review: nil, followup: nil, review_goal_retry: nil)
+    end
+
+    it "symbolizes trigger keys and freezes each trigger" do
+      signals = described_class.from_scan(
+        "pr_number" => 42,
+        "phase" => "draft",
+        "triggers" => [
+          { "type" => "paid_agent_review_pending", "active_run" => true }
+        ]
+      )
+
+      expect(signals.pr_number).to eq(42)
+      expect(signals.phase).to eq("draft")
+      expect(signals.triggers.first[:type]).to eq("paid_agent_review_pending")
+      expect(signals.triggers.first[:active_run]).to be true
+      expect(signals.triggers.first).to be_frozen
+    end
+
+    it "captures counters for drafts, followups, and review-goal retries" do
+      signals = described_class.from_scan(
+        current_draft_review_count: 2,
+        current_followup_count: 3,
+        current_review_goal_retry_count: 1
+      )
+
+      expect(signals.draft_review_count).to eq(2)
+      expect(signals.followup_count).to eq(3)
+      expect(signals.review_goal_retry_count).to eq(1)
+    end
+  end
+
+  describe "phase predicates" do
+    it "treats draft and restarted as draft_phase?" do
+      expect(described_class.from_scan(phase: "draft")).to be_draft_phase
+      expect(described_class.from_scan(phase: "restarted")).to be_draft_phase
+    end
+
+    it "identifies ready and escalated phases" do
+      expect(described_class.from_scan(phase: "ready")).to be_ready_phase
+      expect(described_class.from_scan(phase: "escalated")).to be_escalated_phase
+    end
+  end
+
+  describe "trigger lookup helpers" do
+    subject(:signals) do
+      described_class.from_scan(
+        triggers: [
+          { type: "paid_agent_review_pending" },
+          { type: "ci_failure", details: [ "lint" ] }
+        ]
+      )
+    end
+
+    it "looks up a trigger by type regardless of string/symbol keys" do
+      expect(signals.trigger(:paid_agent_review_pending)).to be_a(Hash)
+      expect(signals.trigger?("paid_agent_review_pending")).to be true
+      expect(signals.trigger?(:missing_trigger)).to be false
+    end
+
+    it "exposes the ordered list of trigger type strings" do
+      expect(signals.trigger_types).to eq(%w[paid_agent_review_pending ci_failure])
+    end
+
+    it "computes trigger_types_excluding for gate-style filtering" do
+      expect(signals.trigger_types_excluding("paid_agent_review_pending")).to eq([ "ci_failure" ])
+    end
+  end
+end

--- a/spec/services/automation/strategies/auto_review_spec.rb
+++ b/spec/services/automation/strategies/auto_review_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Strategies::AutoReview do
+  let(:strategy) { described_class.new }
+  let(:project) { create(:project) }
+  let(:pull_request) do
+    create(:issue, :pull_request, project: project, github_number: 42, paid_state: "new")
+  end
+
+  def evaluate(scan: nil)
+    context = Automation::Context.build(
+      record: pull_request,
+      project: project,
+      metadata: scan.nil? ? {} : { scan: scan }
+    )
+    strategy.evaluate(context)
+  end
+
+  it "is an Automation::Strategy" do
+    expect(described_class.ancestors).to include(Automation::Strategy)
+  end
+
+  it "returns noop when no scan is provided" do
+    expect(evaluate.to_h).to eq(decisions: [ { type: "noop" } ])
+  end
+
+  describe "trigger routing" do
+    it "routes paid_agent_review_pending to a queue_review_run decision" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: [ { type: "paid_agent_review_pending" } ]
+      })
+
+      expect(result.to_h).to eq(
+        decisions: [
+          {
+            type: "queue_review_run",
+            issue_id: pull_request.id,
+            source_pull_request_number: 42
+          }
+        ]
+      )
+    end
+
+    it "suppresses follow-up decisions while paid_agent_review_pending is outstanding (#1135)" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        current_draft_review_count: 0,
+        triggers: [
+          { type: "paid_agent_review_pending" },
+          { type: "ci_failure", details: [ "test-suite" ] }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to include("queue_review_run")
+      expect(types).not_to include("queue_create_pr_run")
+    end
+
+    it "emits neither create_pr nor followup when paid_agent is already running with other triggers" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        triggers: [
+          { type: "paid_agent_review_pending", active_run: true },
+          { type: "merge_conflicts", details: "PR has merge conflicts" }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).not_to include("queue_create_pr_run")
+      expect(types).not_to include("record_pr_followup")
+    end
+
+    it "routes review_bot_review_pending to a request_review decision for the trigger login" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        triggers: [
+          { type: "review_bot_review_pending", request_login: "copilot" }
+        ]
+      })
+
+      expect(result.to_h).to eq(
+        decisions: [
+          { type: "request_review", pr_number: 42, reviewers: [ "copilot" ] }
+        ]
+      )
+    end
+
+    it "emits the trigger's reviewer for manual_review_pending" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: [
+          { type: "manual_review_pending", reviewer_login: "alice" }
+        ]
+      })
+
+      expect(result.to_h[:decisions].first).to include(
+        type: "request_review",
+        reviewers: [ "alice" ]
+      )
+    end
+
+    it "falls through to follow-up decisions when no review-specific trigger is present but a ci_failure is" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        labels_to_remove: [ "paid-needs-input" ],
+        triggers: [ { type: "ci_failure", details: "test-suite" } ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to eq(%w[queue_create_pr_run record_pr_followup])
+    end
+
+    it "emits an escalate decision on escalate_to_owner triggers" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "escalated",
+        owner_reviewer_login: "bob",
+        triggers: [ { type: "escalate_to_owner", details: "paid_agent retry budget exhausted" } ]
+      })
+
+      expect(result.to_h[:decisions].first).to include(
+        type: "escalate",
+        pr_number: 42,
+        owner_reviewer_login: "bob",
+        reason: "paid_agent retry budget exhausted"
+      )
+    end
+
+    it "emits a merge decision on owner_approved triggers" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: [ { type: "owner_approved" } ]
+      })
+
+      expect(result.to_h[:decisions].first).to include(
+        type: "merge",
+        issue_id: pull_request.id,
+        pr_number: 42
+      )
+    end
+
+    it "routes review_goal_retry to both a record_review_goal_retry and a queue_review_run decision" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        current_review_goal_retry_count: 1,
+        triggers: [ { type: "review_goal_retry" } ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to include("record_review_goal_retry", "queue_review_run")
+    end
+
+    it "marks ready on ready_for_owner triggers" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        owner_reviewer_login: "bob",
+        triggers: [ { type: "ready_for_owner" } ]
+      })
+
+      expect(result.to_h[:decisions].first).to include(
+        type: "mark_ready",
+        issue_id: pull_request.id,
+        pr_number: 42,
+        owner_reviewer_login: "bob"
+      )
+    end
+
+    it "queues a paid_agent review run alongside mark_ready when ready_for_owner overlaps with paid_agent_review_pending" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        owner_reviewer_login: "bob",
+        triggers: [
+          { type: "ready_for_owner" },
+          { type: "paid_agent_review_pending" }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to include("queue_review_run", "mark_ready")
+    end
+
+    it "does NOT queue a paid_agent review run when ready_for_owner overlaps with an already-running paid_agent" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        owner_reviewer_login: "bob",
+        triggers: [
+          { type: "ready_for_owner" },
+          { type: "paid_agent_review_pending", active_run: true }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to eq([ "mark_ready" ])
+    end
+
+    it "falls through to standard follow-up decisions for a scan with no triggers" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: []
+      })
+
+      expect(result.to_h[:decisions]).to eq([
+        { type: "queue_create_pr_run", issue_id: pull_request.id, source_pull_request_number: 42 },
+        { type: "record_pr_followup", issue_id: pull_request.id, labels_to_remove: [], expected_followup_count: nil }
+      ])
+    end
+  end
+
+  describe "#outcomes_for" do
+    it "returns one outcome per known review method" do
+      outcomes = strategy.outcomes_for(project: project, scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        triggers: [ { type: "paid_agent_review_pending" } ]
+      })
+
+      expect(outcomes.map(&:method)).to match_array(%i[copilot paid_agent codex ci_action manual])
+      paid_agent = outcomes.find { |o| o.method == :paid_agent }
+      expect(paid_agent).to be_pending
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extract auto-review into strategy modules

See #1119 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1119