### PR TITLE
fix(auto-pick): detect trackers by body heading, not prose

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -14,6 +14,13 @@ class Issue < ApplicationRecord
   VALID_SOURCES = [ GITHUB_SOURCE, SYNTHETIC_CODE_SCANNING_SOURCE, DEPENDABOT_ALERT_SOURCE ].freeze
   SEVERITY_ORDER = %w[critical high medium low].freeze
   TRACKER_PATTERN = /\b(?:tracker|remaining\s+work|completion\s+criteria|phase\s+tracker|meta\s+issue)\b/i
+  # Body match requires the tracker vocabulary to appear inside a markdown
+  # heading (e.g. "## Tracker", "## Remaining Work"). Matching anywhere in
+  # the body produced false positives for feature issues that incidentally
+  # mention "tracker" in prose (e.g. "support custom issue trackers",
+  # "deploy tracker"), which then got permanently excluded from auto-pick
+  # by the "tracker with no body refs" safety net in Issues::AutoPick.
+  TRACKER_BODY_HEADING_PATTERN = /^[#]{1,6}\s+.*\b(?:tracker|remaining\s+work|completion\s+criteria|phase\s+tracker|meta\s+issue)\b/i
   # Large offset so synthetic github_issue_id values never collide with real
   # GitHub issue IDs (which currently range in the low billions).
   SYNTHETIC_CODE_SCANNING_ID_OFFSET = 800_000_000_000
@@ -119,7 +126,7 @@ class Issue < ApplicationRecord
   end
 
   def tracker_issue?
-    TRACKER_PATTERN.match?(title.to_s) || TRACKER_PATTERN.match?(body.to_s)
+    TRACKER_PATTERN.match?(title.to_s) || TRACKER_BODY_HEADING_PATTERN.match?(body.to_s)
   end
 
   def body_referenced_issue_numbers

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -31,10 +31,13 @@ module Issues
     PAID_READY_LABEL = "paid-ready"
 
     # SQL ILIKE patterns used to pre-filter potential tracker issues before
-    # applying the full Ruby-level Issue::TRACKER_PATTERN check. Each pattern
-    # must be a *superset* of its TRACKER_PATTERN counterpart so that no
-    # tracker escapes the prefilter (e.g. "remaining%work" covers any
-    # whitespace variant that `remaining\s+work` would match).
+    # applying the full Ruby-level Issue#tracker_issue? check. The Ruby check
+    # matches tracker vocabulary in the title OR inside a markdown heading in
+    # the body; each SQL pattern here must be a *superset* of both branches
+    # so that no tracker escapes the prefilter (e.g. "%remaining%work%"
+    # covers any whitespace variant that `remaining\s+work` would match, and
+    # "%tracker%" covers both "## Tracker" headings and bare-word title
+    # matches).
     TRACKER_SQL_PATTERNS = [ "%tracker%", "%remaining%work%", "%completion%criteria%", "%phase%tracker%", "%meta%issue%" ].freeze
 
     # Returns the Set of issue IDs from +displayed_issues+ that are
@@ -83,7 +86,8 @@ module Issues
 
     # Identifies tracker issues whose body references other issues that are
     # still open. Uses a SQL pre-filter (ILIKE) to narrow candidates, then
-    # applies the full Ruby-side TRACKER_PATTERN and reference parsing.
+    # applies the full Ruby-side Issue#tracker_issue? check and reference
+    # parsing.
     # Only queries open/closed state for issue numbers actually referenced
     # by tracker candidates (not all project issues).
     #

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -915,8 +915,8 @@ RSpec.describe Issue do
       expect(issue.tracker_issue?).to be true
     end
 
-    it "returns true for 'meta issue' in body" do
-      issue = build(:issue, body: "This is a meta issue tracking all items")
+    it "returns true for 'meta issue' in a body heading" do
+      issue = build(:issue, title: "Phase 2 umbrella", body: "## Meta issue\nTracks all items")
       expect(issue.tracker_issue?).to be true
     end
 
@@ -928,6 +928,29 @@ RSpec.describe Issue do
     it "is case-insensitive" do
       issue = build(:issue, title: "PHASE TRACKER for Q2")
       expect(issue.tracker_issue?).to be true
+    end
+
+    # Regression: feature issues that incidentally mention tracker vocabulary in
+    # prose were being permanently excluded from auto-pick by the "tracker with
+    # no body refs" safety net. Body matches now require a markdown heading.
+    context "when tracker vocabulary appears only in prose body" do
+      it "returns false for 'issue tracker' mentioned in a feature description" do
+        issue = build(:issue, title: "Support custom issue trackers",
+          body: "In enterprise codebases, the issue tracker is rarely GitHub Issues.")
+        expect(issue.tracker_issue?).to be false
+      end
+
+      it "returns false for 'deploy tracker' mentioned in prose" do
+        issue = build(:issue, title: "Support multi-step PRs",
+          body: "- An external service (deploy tracker, CI/CD system, etc.)")
+        expect(issue.tracker_issue?).to be false
+      end
+
+      it "returns false for 'custom tracker integration' in a bulleted list" do
+        issue = build(:issue, title: "Support PR templates",
+          body: "- Linked issues/tickets (with custom tracker integration)")
+        expect(issue.tracker_issue?).to be false
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- `Issue#tracker_issue?` now only matches tracker vocabulary in the body when it appears inside a markdown heading (e.g. `## Tracker`, `## Remaining Work`). Title matches are unchanged.
- Fixes three feature issues (paid#660, #665, #1180) that were stuck as auto-pick-ineligible because their bodies incidentally contained the word `tracker` (e.g. "support custom issue trackers", "deploy tracker, CI/CD system", "custom tracker integration"), which tripped `tracker_issue?` → `Issues::AutoPick`'s conservative "tracker with no body refs → block" path.
- The `TRACKER_SQL_PATTERNS` pre-filter in [auto_pick.rb:38](app/services/issues/auto_pick.rb#L38) remains a correct superset of the tightened Ruby check, so no schema/scope changes are needed.

## Why the previous behavior was wrong

The regex `/\b(?:tracker|…|meta\s+issue)\b/i` applied to a full body matches any prose mention. In production the eligibility scope for `paid` was returning 0 issues despite 4 passing every other filter — they were all being blocked as "trackers with no body refs":

| Issue | Why it was blocked |
|---|---|
| paid#660 "Support custom issue trackers" | body: "issue tracker is rarely GitHub Issues" |
| paid#665 "Support PR templates" | body: "custom tracker integration" |
| paid#1180 "Support multi-step PRs" | body: "deploy tracker, CI/CD system" |

After the fix, all three are correctly classified as non-trackers. Existing tracker specs (both in `spec/models/issue_spec.rb` and `spec/services/issues/auto_pick_spec.rb`) still pass because they put tracker vocabulary in the title or in `## Completion criteria`/`## Required`-style headings — exactly the pattern this tightening preserves.

## Test plan

- [x] `bin/rspec spec/models/issue_spec.rb spec/services/issues/auto_pick_spec.rb` → 235 examples, 0 failures
- [x] `bin/lint --changed` → clean
- [x] Manually verified against production DB: paid#660, #665, #1180 flip to `tracker_issue? == false`, `paid` project eligible-issue count goes 0 → 4
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)