### PR TITLE
fix(auto-pick): resolve self-repo PR refs as local deps, not external

### DIFF
--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -188,8 +188,12 @@ module Issues
       new_local_ids = Set.new
       return new_local_ids if referenced_numbers.empty?
 
+      # Include pull requests so "Depends on #N" resolves when #N is a PR
+      # in the same project. Blocking on an open PR is what the user
+      # declared; blocking on a closed/merged PR is a satisfied dep and
+      # ready_for_work will correctly not treat it as blocking.
       project_issues = issue.project.issues
-        .where(github_number: referenced_numbers, is_pull_request: false)
+        .where(github_number: referenced_numbers)
         .index_by(&:github_number)
 
       adj = adjacency || IssueDependency.account_adjacency(issue.project.account)
@@ -284,9 +288,14 @@ module Issues
         refs_by_project_id[project.id] << number if project
       end
 
+      # Include pull requests so a fully-qualified self-reference like
+      # "Depends on owner/repo#N" resolves to the local row when #N is a PR
+      # rather than falling through to the external-dep branch (which
+      # would block unconditionally). ready_for_work evaluates the target's
+      # github_state, so closed/merged PRs correctly do not block.
       result = {}
       refs_by_project_id.each do |project_id, numbers|
-        issues = Issue.where(project_id: project_id, github_number: numbers.to_a, is_pull_request: false)
+        issues = Issue.where(project_id: project_id, github_number: numbers.to_a)
         result[project_id] = issues.index_by(&:github_number)
       end
       result

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -297,8 +297,12 @@ module Activities
       # Only check external deps whose depends_on_number was synced in this run
       scope = scope.where(depends_on_number: synced_numbers) if synced_numbers.any?
 
+      # Include pull requests so stale external deps that point at a PR in
+      # this project (e.g. "Depends on owner/repo#<PR number>") get promoted
+      # to local deps on sync instead of staying blocked. ready_for_work
+      # then evaluates the PR's github_state correctly.
       issues_by_number = project.issues
-        .where(is_pull_request: false, github_number: scope.select(:depends_on_number))
+        .where(github_number: scope.select(:depends_on_number))
         .index_by(&:github_number)
 
       scope.find_each do |dep|

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -166,6 +166,22 @@ RSpec.describe Issue do
 
         expect(described_class.ready_for_work(project)).not_to include(issue)
       end
+
+      it "excludes issues whose dep points at an open PR" do
+        pr = create(:issue, :pull_request, project: project, github_state: "open")
+        issue = create(:issue, project: project)
+        create(:issue_dependency, issue: issue, depends_on_issue: pr)
+
+        expect(described_class.ready_for_work(project)).not_to include(issue)
+      end
+
+      it "includes issues whose dep points at a closed/merged PR" do
+        pr = create(:issue, :pull_request, project: project, github_state: "closed")
+        issue = create(:issue, project: project)
+        create(:issue_dependency, issue: issue, depends_on_issue: pr)
+
+        expect(described_class.ready_for_work(project)).to include(issue)
+      end
     end
   end
 

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -74,13 +74,15 @@ RSpec.describe Issues::ParseDependencies do
       expect(issue.dependencies).to be_empty
     end
 
-    it "ignores references to pull requests" do
-      create(:issue, :pull_request, project: project, github_number: 9007)
+    it "records a local dep when a bare #N refers to a PR in the same project" do
+      pr = create(:issue, :pull_request, project: project, github_number: 9007)
       issue = create(:issue, project: project, body: "Depends on #9007")
 
       described_class.call(issue: issue)
 
-      expect(issue.dependencies).to be_empty
+      # The dep points at the PR row. ready_for_work evaluates the PR's
+      # github_state, so an open PR blocks while a closed/merged PR does not.
+      expect(issue.dependencies).to contain_exactly(pr)
     end
 
     it "does nothing when body is blank and no existing dependencies" do
@@ -311,6 +313,40 @@ RSpec.describe Issues::ParseDependencies do
         described_class.call(issue: local_issue)
 
         expect(local_issue.dependencies.reload).to be_empty
+      end
+
+      it "resolves fully-qualified self-references to PRs as local deps" do
+        # Regression: "Depends on owner/repo#N" where owner/repo matches the
+        # project's own repo and #N is a PR was falling through to the
+        # external-dep branch, which blocks unconditionally regardless of
+        # the PR's state.
+        pr = create(:issue, :pull_request, project: project, github_number: 9099, github_state: "closed")
+        issue = create(:issue, project: project,
+                       body: "## Depends on\n#{project.owner}/#{project.repo}#9099")
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to contain_exactly(pr)
+        expect(issue.issue_dependencies.where.not(depends_on_owner: nil)).to be_empty
+      end
+
+      it "cleans up a stale external dep when re-parsed after the target PR is synced" do
+        # Simulates the fleet of existing rows created before this fix:
+        # the external dep record exists but the target is actually a local PR.
+        pr = create(:issue, :pull_request, project: project, github_number: 9099)
+        issue = create(:issue, project: project,
+                       body: "## Depends on\n#{project.owner}/#{project.repo}#9099")
+        issue.issue_dependencies.create!(
+          depends_on_owner: project.owner.downcase,
+          depends_on_repo: project.repo.downcase,
+          depends_on_number: 9099
+        )
+
+        described_class.call(issue: issue)
+
+        # External record gone, replaced by a local dep pointing at the PR row.
+        expect(issue.issue_dependencies.where.not(depends_on_owner: nil)).to be_empty
+        expect(issue.dependencies.reload).to contain_exactly(pr)
       end
     end
   end

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -1160,4 +1160,27 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
     end
   end
+
+  describe "external dependency resolution" do
+    # Private helper, but the execute-flow setup to exercise it end-to-end
+    # requires extensive GitHub API mocking. The behavior under test is a
+    # focused, pure DB promotion — test it directly.
+    it "promotes a stale external dep pointing at a local PR to a local dep" do
+      pr = create(:issue, :pull_request, project: project, github_number: 9099)
+      issue = create(:issue, project: project)
+      stale = issue.issue_dependencies.create!(
+        depends_on_owner: project.owner.downcase,
+        depends_on_repo: project.repo.downcase,
+        depends_on_number: 9099
+      )
+
+      activity.send(:resolve_external_dependencies, project, [ 9099 ])
+
+      stale.reload
+      expect(stale.depends_on_issue_id).to eq(pr.id)
+      expect(stale.depends_on_owner).to be_nil
+      expect(stale.depends_on_repo).to be_nil
+      expect(stale.depends_on_number).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `Depends on owner/repo#N` (and bare `Depends on #N`) where `#N` is a pull request in the same project was silently being stored as an **external** dep with `depends_on_issue_id=nil`.
- External deps are treated as unconditionally blocking by `Issue.ready_for_work`, regardless of whether the target is open or closed — so an issue declaring `Depends on viamin/paid#<merged PR>` stayed auto-pick-blocked **forever**.
- Root cause: the dep parser hard-filtered `is_pull_request: false` in both same-project lookups ([parse_dependencies.rb:192](app/services/issues/parse_dependencies.rb#L192), [:289](app/services/issues/parse_dependencies.rb#L289)). The post-sync promotion path had the same bug in [fetch_issues_activity.rb:301](app/temporal/activities/fetch_issues_activity.rb#L301).
- Fix: drop that filter in all three places. PR rows now resolve as local deps like any other target; `ready_for_work` correctly blocks only while the PR is open and unblocks the moment it closes/merges.

## Why this is safe

- Pull requests and issues live in the same `issues` table, distinguished by `is_pull_request`. `IssueDependency#depends_on_issue_id` already points at `issues(id)`, so the FK works for PR targets with no schema change.
- Dependency extraction only happens inside dependency-scoped text (`Depends on …`, `Blocked by …`, `## Dependencies` sections). Incidental `#N` mentions are still ignored — no new false blocks from prose.
- Dep membership predicates (`IssueDependency#local?`, `Issue#dependencies`, `account_adjacency`, `DetectCycle`) already work against any `issues(id)` row; PR targets need no special handling.

## Self-healing for existing broken rows

This is the subtle part. There are **two** promotion paths that can convert a stale external dep into a correct local dep:

1. **Body re-parse** ([FetchIssuesActivity#parse_issue_relationships](app/temporal/activities/fetch_issues_activity.rb#L223)) — only fires when `relationships_parsed_at < github_updated_at`. For rows whose body hasn't been edited since the bug existed (e.g. paid#860), this path **does not fire**. First version of this PR relied on it; that was wrong.
2. **Target-sync promotion** ([FetchIssuesActivity#resolve_external_dependencies](app/temporal/activities/fetch_issues_activity.rb#L290)) — fires on every sync against deps whose `depends_on_number` was just synced. This is the path that catches stuck rows without needing a body edit. It had the same PR filter, so without the second commit it would not self-heal PR-target deps either.

With both filters removed, existing broken rows self-heal on the next sync that touches the target PR.

## Impact in production

Verified against the live dev DB against paid#860 (`Depends on viamin/paid#859`, where #859 is a merged PR):

| State | Before fix | After fix |
|---|---|---|
| Dep record | external (`depends_on_issue_id=nil`) | local (`depends_on_issue_id=<PR row>`) |
| `ready_for_work` includes #860 | no | yes |
| Auto-pick eligible | no | yes — already running in an active agent run |

Combined with #1187, the paid project's auto-pick eligible scope goes 0 → 5 today (and 6 once #1081 completes via cascade through #1083).

## Test plan

- [x] `bin/rspec spec/services/issues/parse_dependencies_spec.rb spec/models/issue_spec.rb spec/services/issues/auto_pick_spec.rb spec/temporal/activities/fetch_issues_activity_spec.rb` → 338 examples, 0 failures
- [x] `bin/lint --changed` → clean
- [x] Live re-parse against paid#860 confirms the dep flips external → local and the issue becomes auto-pickable (currently running in active agent run)
- [x] Live `resolve_external_dependencies` run against a reset paid#860 confirms target-sync promotion works when no body edit has occurred
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)