### PR TITLE
Fix #1081: test(automation): add regression coverage for initial PR sync vs PR follow-up decision paths

### DIFF
--- a/spec/services/automation/issue_evaluator_spec.rb
+++ b/spec/services/automation/issue_evaluator_spec.rb
@@ -30,5 +30,32 @@ RSpec.describe Automation::IssueEvaluator do
 
       expect(result.to_h).to eq(decisions: [ { type: "noop" } ])
     end
+
+    # Regression coverage for PR #1077: issue automation must keep queueing
+    # create_pr while PR automation does not. The evaluator contract differs
+    # between records by type; this test pins the "issue side" of that split
+    # so a future refactor cannot quietly drop issue automation.
+    context "when the record is an issue (not a pull request)" do
+      let(:automation_project) do
+        create(:project,
+          label_mappings: {},
+          automation_on_label_enabled: true,
+          automation_label_name: "my-auto")
+      end
+
+      it "queues a create_pr run for an automation-labeled issue with no source_pull_request_number" do
+        issue = create(:issue,
+          project: automation_project,
+          labels: [ "my-auto" ],
+          paid_state: "new",
+          is_pull_request: false)
+
+        result = described_class.new(record: issue).call
+
+        expect(result.to_h).to eq(
+          decisions: [ { type: "queue_create_pr_run", issue_id: issue.id } ]
+        )
+      end
+    end
   end
 end

--- a/spec/services/automation/pull_request_evaluator_spec.rb
+++ b/spec/services/automation/pull_request_evaluator_spec.rb
@@ -87,4 +87,97 @@ RSpec.describe Automation::PullRequestEvaluator do
       expect(decision_types).not_to include("record_pr_followup")
     end
   end
+
+  # Regression coverage for PR #1077: the evaluator must distinguish between
+  # initial label-based sync of an existing PR (which should never implicitly
+  # queue a create_pr) and PR follow-up scanning (which produces explicit goal
+  # decisions based on scan triggers).
+  describe "#1077 regression: initial sync vs PR follow-up decision paths" do
+    let(:project) do
+      create(:project,
+        label_mappings: { "build" => "paid-build", "plan" => "paid-plan" },
+        automation_on_label_enabled: true,
+        automation_label_name: "paid-automation")
+    end
+
+    context "with an initial sync of an existing PR (no scan payload)" do
+      it "returns noop for an automation-labeled PR when the explicit flag is enabled" do
+        pr = create(:issue, :pull_request,
+          project: project, labels: [ "paid-automation" ], paid_state: "new", github_number: 7)
+
+        result = described_class.new(record: pr, explicit_pr_decisions: true).call
+
+        expect(result.to_h).to eq(decisions: [ { type: "noop" } ])
+      end
+
+      it "returns noop for a completed PR with generated+automation labels (PR #1077 scenario)" do
+        pr = create(:issue, :pull_request,
+          project: project,
+          labels: [ project.generated_label_name, project.automation_label_name ],
+          paid_state: "completed",
+          github_number: 42)
+
+        result = described_class.new(record: pr, explicit_pr_decisions: true).call
+
+        expect(result.to_h).to eq(decisions: [ { type: "noop" } ])
+      end
+    end
+
+    context "with a PR follow-up scan carrying actionable signals (explicit goal path)" do
+      let(:pr) { create(:issue, :pull_request, project: project, github_number: 42) }
+
+      it "emits queue_create_pr_run with source_pull_request_number for ready-phase CI failure" do
+        result = described_class.new(record: pr, explicit_pr_decisions: true).call(scan: {
+          issue_id: pr.id,
+          pr_number: 42,
+          phase: "ready",
+          current_followup_count: 0,
+          labels_to_remove: [],
+          triggers: [ { type: "ci_failure", details: [ "rspec" ] } ]
+        })
+
+        decisions = result.to_h[:decisions]
+        create_decision = decisions.find { |d| d[:type] == "queue_create_pr_run" }
+        expect(create_decision).to include(issue_id: pr.id, source_pull_request_number: 42)
+        expect(decisions.map { |d| d[:type] }).to include("record_pr_followup")
+      end
+
+      it "emits queue_create_pr_run tagged for draft round tracking on draft-phase follow-ups" do
+        result = described_class.new(record: pr, explicit_pr_decisions: true).call(scan: {
+          issue_id: pr.id,
+          pr_number: 42,
+          phase: "draft",
+          current_draft_review_count: 1,
+          triggers: [ { type: "merge_conflicts", details: "PR has merge conflicts" } ]
+        })
+
+        decisions = result.to_h[:decisions]
+        create_decision = decisions.find { |d| d[:type] == "queue_create_pr_run" }
+        expect(create_decision).to include(
+          issue_id: pr.id,
+          source_pull_request_number: 42,
+          count_toward_draft_review_round: true,
+          expected_draft_review_count: 1
+        )
+      end
+    end
+
+    context "with a PR follow-up scan carrying only review signals (review-only path)" do
+      let(:pr) { create(:issue, :pull_request, project: project, github_number: 42) }
+
+      it "queues a review run and does NOT queue a default create_pr" do
+        result = described_class.new(record: pr, explicit_pr_decisions: true).call(scan: {
+          issue_id: pr.id,
+          pr_number: 42,
+          phase: "draft",
+          current_draft_review_count: 0,
+          triggers: [ { type: "paid_agent_review_pending" } ]
+        })
+
+        decision_types = result.to_h[:decisions].map { |d| d[:type] }
+        expect(decision_types).to eq([ "queue_review_run" ])
+        expect(decision_types).not_to include("queue_create_pr_run")
+      end
+    end
+  end
 end

--- a/spec/temporal/activities/detect_labels_activity_spec.rb
+++ b/spec/temporal/activities/detect_labels_activity_spec.rb
@@ -432,6 +432,72 @@ RSpec.describe Activities::DetectLabelsActivity do
       end
     end
 
+    # Regression coverage for PR #1077: initial label-based sync of an open PR
+    # carrying the automation label must NOT queue a default create_pr run.
+    # The original bug queued create_pr on this exact payload; these tests pin
+    # the decision boundary so re-introducing that code path fails loudly.
+    describe "#1077 regression: initial sync of automation-labeled PRs" do
+      let(:automation_project) do
+        create(:project,
+          label_mappings: {},
+          automation_on_label_enabled: true,
+          automation_label_name: "paid-automation")
+      end
+
+      it "returns no action for a paid-generated+paid-automation PR on initial sync (legacy path)" do
+        pull_request = create(:issue, :pull_request,
+          project: automation_project,
+          labels: [ automation_project.generated_label_name, automation_project.automation_label_name ],
+          paid_state: "completed",
+          github_number: 77)
+
+        result = activity.execute(project_id: automation_project.id, issue_id: pull_request.id)
+
+        expect(result[:action]).to eq("none")
+        expect(result[:decisions]).to eq([ { type: "noop" } ])
+      end
+
+      it "does not change paid_state for an existing automation-labeled PR on initial sync" do
+        pull_request = create(:issue, :pull_request,
+          project: automation_project,
+          labels: [ automation_project.generated_label_name, automation_project.automation_label_name ],
+          paid_state: "completed",
+          github_number: 77)
+
+        activity.execute(project_id: automation_project.id, issue_id: pull_request.id)
+
+        expect(pull_request.reload.paid_state).to eq("completed")
+      end
+
+      it "returns noop when the explicit-decision flag is enabled for an automation-labeled PR" do
+        pull_request = create(:issue, :pull_request,
+          project: automation_project,
+          labels: [ automation_project.automation_label_name ],
+          paid_state: "new",
+          github_number: 78)
+        FeatureFlags.enable!(:explicit_pr_automation_decisions, project: automation_project)
+
+        result = activity.execute(project_id: automation_project.id, issue_id: pull_request.id)
+
+        expect(result[:action]).to eq("none")
+        expect(result[:decisions]).to eq([ { type: "noop" } ])
+      end
+
+      it "still queues create_pr for automation-labeled issues (distinguishes from PRs)" do
+        issue = create(:issue,
+          project: automation_project,
+          labels: [ automation_project.automation_label_name ],
+          paid_state: "new",
+          is_pull_request: false)
+
+        result = activity.execute(project_id: automation_project.id, issue_id: issue.id)
+
+        expect(result[:action]).to eq("execute_agent")
+        expect(result[:decisions]).to eq([ { type: "queue_create_pr_run", issue_id: issue.id } ])
+        expect(result).not_to have_key(:source_pull_request_number)
+      end
+    end
+
     context "when issue is from an untrusted user and an untrusted user added the label" do
       let(:issue) do
         create(:issue, project: project, labels: [ "paid-build" ], paid_state: "new",

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -265,5 +265,53 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.goal).to eq("review")
       expect(agent_run.source_pull_request_number).to eq(42)
     end
+
+    # Regression coverage for PR #1077. When a caller targets a PR the goal
+    # must be explicit in the call site so initial-sync paths cannot silently
+    # queue a default create_pr run for an existing PR. These tests pin the
+    # outputs of each explicit goal alongside a source_pull_request_number so
+    # that a future refactor relying on the activity-level default is caught.
+    describe "#1077 regression: PR-originated runs carry the caller's explicit goal" do
+      it "records goal=review on the created run when the caller passes goal: 'review'" do
+        result = activity.execute(
+          project_id: project.id,
+          source_pull_request_number: 42,
+          goal: "review"
+        )
+
+        agent_run = AgentRun.find(result[:agent_run_id])
+        expect(agent_run.goal).to eq("review")
+        expect(agent_run.source_pull_request_number).to eq(42)
+      end
+
+      it "records goal=create_pr on the created run when the caller passes goal: 'create_pr'" do
+        result = activity.execute(
+          project_id: project.id,
+          issue_id: issue.id,
+          source_pull_request_number: 42,
+          goal: "create_pr"
+        )
+
+        agent_run = AgentRun.find(result[:agent_run_id])
+        expect(agent_run.goal).to eq("create_pr")
+        expect(agent_run.source_pull_request_number).to eq(42)
+      end
+
+      it "deduplicates review-goal PR runs without colliding with create_pr runs for the same PR" do
+        create(:agent_run, :running, project: project,
+          source_pull_request_number: 42, goal: "create_pr")
+
+        result = activity.execute(
+          project_id: project.id,
+          source_pull_request_number: 42,
+          goal: "review"
+        )
+
+        agent_run = AgentRun.find(result[:agent_run_id])
+        expect(agent_run.goal).to eq("review")
+        expect(result[:queued]).to be true
+        expect(result[:duplicate]).to be_nil
+      end
+    end
   end
 end

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -1320,4 +1320,142 @@ RSpec.describe Workflows::GitHubPollWorkflow do
           timeout: 30)
     end
   end
+
+  # Regression coverage for PR #1077: the full poll cycle must never implicitly
+  # queue a default create_pr run for an existing automation-labeled PR. These
+  # end-to-end workflow tests lock the decision boundary between initial sync
+  # (DetectLabelsActivity) and PR follow-up (ScanPaidPrsActivity) and assert
+  # that every PR-targeting QueueAgentRunActivity call carries an explicit goal.
+  describe "#1077 regression: PR-originated queue paths require explicit goals" do
+    let(:workflow) { described_class.new }
+    let(:project_id) { 1 }
+
+    before do
+      allow(Temporalio::Workflow).to receive(:start_child_workflow)
+      allow(Temporalio::Workflow).to receive(:patched).and_call_original
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("draft-followup-direct-start-v1").and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-agent-run-goal-v1").and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("queue-paid-agent-review-run-v1").and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-followup-during-review-v1").and_return(true)
+      allow(workflow).to receive(:run_activity).and_return({})
+    end
+
+    it "routes draft-phase paid_agent_review_pending to a review run with no create_pr side effect" do
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "draft",
+        current_draft_review_count: 0,
+        triggers: [ { type: "paid_agent_review_pending" } ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(goal: "review", source_pull_request_number: 42), timeout: anything)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, hash_including(goal: "create_pr"), timeout: anything)
+    end
+
+    it "queues no runs when an initial PR scan returns no actionable triggers" do
+      allow(workflow).to receive(:run_activity).and_return({ prs_to_trigger: [] })
+
+      workflow.send(:handle_pr_scan_results, { prs_to_trigger: [] }, project_id)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+    end
+
+    it "queues draft create_pr with explicit goal when a follow-up scan reports CI failure" do
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
+
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "draft",
+        current_draft_review_count: 0,
+        triggers: [ { type: "ci_failure", details: [ "rspec" ] } ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(
+            project_id: project_id,
+            issue_id: 10,
+            source_pull_request_number: 42,
+            goal: "create_pr",
+            count_toward_draft_review_round: true,
+            expected_draft_review_count: 0
+          ), timeout: 30)
+    end
+
+    it "queues ready-phase create_pr with explicit goal on merge_conflicts + conversation_comments" do
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "ready", current_followup_count: 0,
+        triggers: [
+          { type: "merge_conflicts", details: "PR has merge conflicts" },
+          { type: "conversation_comments", details: "2 new comment(s)" }
+        ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity,
+          hash_including(project_id: project_id, issue_id: 10,
+            source_pull_request_number: 42, goal: "create_pr"), timeout: 30)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::RecordPrFollowupActivity, anything, timeout: anything)
+    end
+
+    def record_queue_invocations(workflow)
+      collected = []
+      allow(workflow).to receive(:run_activity) do |activity_class, input, **_opts|
+        collected << input if activity_class == Activities::QueueAgentRunActivity
+        case activity_class
+        when Activities::MarkPrReadyActivity then { marked_ready: true }
+        when Activities::QueueAgentRunActivity then { queued: true }
+        else {}
+        end
+      end
+      collected
+    end
+
+    def pr_scenarios_requiring_explicit_goal
+      # Each scenario must exercise a code path that ends up calling
+      # QueueAgentRunActivity with a source_pull_request_number, so the
+      # guardrail below can assert an explicit :goal is always set.
+      [
+        { phase: "draft", current_draft_review_count: 0, triggers: [ { type: "ci_failure" } ] },
+        { phase: "draft", current_draft_review_count: 0, triggers: [ { type: "paid_agent_review_pending" } ] },
+        { phase: "ready", current_followup_count: 0, triggers: [ { type: "merge_conflicts" } ] },
+        { phase: "ready", current_review_goal_retry_count: 0,
+          triggers: [ { type: "review_goal_retry", details: "retry" } ] }
+      ]
+    end
+
+    it "never calls QueueAgentRunActivity with a PR number and no goal across PR trigger types" do
+      queue_invocations = record_queue_invocations(workflow)
+
+      pr_scenarios_requiring_explicit_goal.each do |scenario|
+        workflow.send(:handle_pr_trigger, project_id, scenario.merge(issue_id: 10, pr_number: 42))
+      end
+
+      pr_targeting_calls = queue_invocations.select do |input|
+        input.is_a?(Hash) && input[:source_pull_request_number].present?
+      end
+      offending = pr_targeting_calls.select { |input| input[:goal].blank? }
+
+      expect(offending).to be_empty, "expected every PR-targeting QueueAgentRunActivity call to carry an explicit :goal"
+      expect(pr_targeting_calls).not_to be_empty, "scenarios must actually exercise PR queueing paths"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

test(automation): add regression coverage for initial PR sync vs PR follow-up decision paths

See #1081 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1081