### PR TITLE
Fix #1180: Support multi-step PRs for multi-deployment migrations

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -67,12 +67,26 @@ class Issue < ApplicationRecord
   scope :pull_requests_only, -> { where(is_pull_request: true) }
   scope :auto_continue_active, -> { where(auto_continue_paused: false) }
   scope :ready_for_work, ->(project) {
-    blocked_by_local = IssueDependency
+    blocked_by_local_open = IssueDependency
       .joins(:issue, :depends_on_issue)
       .where(
         depends_on_issue: { github_state: "open" },
         issues: { project_id: project.id }
       )
+      .select(:issue_id)
+
+    # Deployment-blocked deps: target PR has merged/closed, but has not
+    # yet been marked as deployed. These keep the dependent issue blocked
+    # so multi-step migrations (add column → backfill → drop) cannot be
+    # started out of order.
+    blocked_by_local_deployment_pending = IssueDependency
+      .joins(:issue, :depends_on_issue)
+      .where(
+        requires_deployment: true,
+        depends_on_issue: { is_pull_request: true, deployed_at: nil }
+      )
+      .where.not(depends_on_issue: { github_state: "open" })
+      .where(issues: { project_id: project.id })
       .select(:issue_id)
 
     blocked_by_external = IssueDependency
@@ -82,7 +96,8 @@ class Issue < ApplicationRecord
       .select(:issue_id)
 
     where(project: project, github_state: "open", is_pull_request: false)
-      .where.not(id: blocked_by_local)
+      .where.not(id: blocked_by_local_open)
+      .where.not(id: blocked_by_local_deployment_pending)
       .where.not(id: blocked_by_external)
   }
 
@@ -199,11 +214,24 @@ class Issue < ApplicationRecord
   end
 
   def ready_to_work?
-    blocking_issues.none? && blocking_external_dependencies.none?
+    blocking_issues.none? &&
+      blocking_deployment_dependencies.none? &&
+      blocking_external_dependencies.none?
   end
 
   def blocking_issues
     dependencies.where(github_state: "open").where.not(paid_state: "recommend_close")
+  end
+
+  # Deployment-blocked dependencies whose target PR has merged/closed but
+  # has not yet been marked as deployed. See .ready_for_work for the
+  # corresponding query-level filter used during batch eligibility checks.
+  def blocking_deployment_dependencies
+    issue_dependencies
+      .joins(:depends_on_issue)
+      .where(requires_deployment: true)
+      .where(depends_on_issue: { is_pull_request: true, deployed_at: nil })
+      .where.not(depends_on_issue: { github_state: "open" })
   end
 
   def blocking_external_dependencies
@@ -212,6 +240,23 @@ class Issue < ApplicationRecord
 
   def dependent_issues
     dependents
+  end
+
+  # True when this issue represents a PR that has been marked as deployed
+  # to production. Used by deployment-aware dependency resolution so a
+  # step-N PR can unblock only after step-(N-1) has actually shipped.
+  def deployed?
+    is_pull_request? && deployed_at.present?
+  end
+
+  # Stamps this PR as deployed, clearing deployment-blocked dependents.
+  # Callers (release-please integration, external webhooks, manual
+  # attestation) must ensure the PR has actually reached production
+  # before invoking.
+  def mark_deployed!(time: Time.current)
+    raise ArgumentError, "only pull requests can be marked as deployed" unless is_pull_request?
+
+    update!(deployed_at: time)
   end
 
   # Compute lifecycle statuses for a collection of issues.
@@ -230,6 +275,19 @@ class Issue < ApplicationRecord
       .pluck(:issue_id)
       .to_set
 
+    # Match blocking_deployment_dependencies semantics: target PR has
+    # merged/closed but has not yet been marked deployed.
+    blocked_by_deployment_pending = IssueDependency
+      .joins(:depends_on_issue)
+      .where(
+        issue_id: issue_ids,
+        requires_deployment: true,
+        depends_on_issue: { is_pull_request: true, deployed_at: nil }
+      )
+      .where.not(depends_on_issue: { github_state: "open" })
+      .pluck(:issue_id)
+      .to_set
+
     # Match IssueDependency#external? semantics: owner+repo+number present, no local issue link
     blocked_by_external = IssueDependency
       .where(issue_id: issue_ids, depends_on_issue_id: nil)
@@ -239,7 +297,7 @@ class Issue < ApplicationRecord
       .pluck(:issue_id)
       .to_set
 
-    blocked_ids = blocked_by_local | blocked_by_external
+    blocked_ids = blocked_by_local | blocked_by_deployment_pending | blocked_by_external
 
     active_run_ids = AgentRun
       .where(issue_id: issue_ids, status: AgentRun::UNFINISHED_STATUSES)

--- a/app/models/issue_dependency.rb
+++ b/app/models/issue_dependency.rb
@@ -65,6 +65,22 @@ class IssueDependency < ApplicationRecord
     "#{depends_on_owner}/#{depends_on_repo}##{depends_on_number}"
   end
 
+  # True when this dependency should remain blocking until the target PR
+  # has been marked deployed (not merely merged). Only meaningful for
+  # local deps that resolve to a PR; for external deps we cannot observe
+  # deployment state, so requires_deployment has no incremental effect
+  # beyond the existing always-blocking external behaviour.
+  def deployment_pending?
+    return false unless requires_deployment?
+    return false unless local?
+
+    target = depends_on_issue
+    return false unless target&.is_pull_request?
+    return false if target.github_state == "open" # already blocking via the regular path
+
+    target.deployed_at.nil?
+  end
+
   private
 
   def not_self_referential

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -135,6 +135,7 @@ module Issues
       new_local_deps = sync_local_deps(local_deps, current_local_by_id)
       new_cross_refs = sync_cross_project_deps(
         cross_deps,
+        local_deps,
         current_local_by_id,
         new_local_deps,
         current_external_by_key
@@ -325,7 +326,7 @@ module Issues
       new_local_deps
     end
 
-    def sync_cross_project_deps(cross_deps, current_local_by_id, new_local_deps, current_external_by_key)
+    def sync_cross_project_deps(cross_deps, local_deps, current_local_by_id, new_local_deps, current_external_by_key)
       resolved_ids = Set.new
       external_keys = Set.new
       return { resolved_ids: resolved_ids, external_keys: external_keys } if cross_deps.empty?
@@ -341,6 +342,13 @@ module Issues
         requires_deployment = cross_deps[[ owner, repo, number ]]
         project_key = [ owner.downcase, repo.downcase ]
         project = project_lookup[project_key]
+        # Preserve the deployment flag from a matching local ref so a plain
+        # self-repo cross-ref (e.g. "Depends on owner/repo#N") cannot silently
+        # downgrade a dep that a local "Awaits deployment of #N" already
+        # promoted. Mirrors the stickiness contract enforced by merge_refs.
+        if project&.id == issue.project_id && local_deps[number]
+          requires_deployment = true
+        end
 
         if project
           dep_issue = issues_by_project.dig(project.id, number)

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -132,15 +132,16 @@ module Issues
       return if local_deps.empty? && cross_deps.empty? &&
                current_local_by_id.empty? && current_external_by_key.empty?
 
-      new_local_ids = sync_local_deps(local_deps, current_local_by_id)
+      new_local_deps = sync_local_deps(local_deps, current_local_by_id)
       new_cross_refs = sync_cross_project_deps(
         cross_deps,
         current_local_by_id,
-        new_local_ids,
+        new_local_deps,
         current_external_by_key
       )
 
-      remove_stale_local_deps(current_local_by_id.keys.to_set, new_local_ids | new_cross_refs[:resolved_ids])
+      kept_local_ids = new_local_deps.keys.to_set | new_cross_refs[:resolved_ids]
+      remove_stale_local_deps(current_local_by_id.keys.to_set, kept_local_ids)
       remove_stale_external_deps(current_external_by_key.keys.to_set, new_cross_refs[:external_keys])
     end
 
@@ -278,9 +279,14 @@ module Issues
       end
     end
 
+    # Returns a Hash mapping dep_issue_id => IssueDependency record for every
+    # local dep persisted in this run (either reused from current_local_by_id
+    # or freshly created). The record handle is needed by sync_cross_project_deps
+    # so a later cross-repo ref for the same local issue can promote the dep's
+    # requires_deployment flag without losing it.
     def sync_local_deps(local_deps, current_local_by_id)
-      new_local_ids = Set.new
-      return new_local_ids if local_deps.empty?
+      new_local_deps = {}
+      return new_local_deps if local_deps.empty?
 
       referenced_numbers = local_deps.keys
 
@@ -301,25 +307,25 @@ module Issues
         next if dep_issue.id == issue.id
 
         requires_deployment = local_deps[number]
-        new_local_ids << dep_issue.id
 
         if (existing = current_local_by_id[dep_issue.id])
           update_deployment_flag(existing, requires_deployment)
+          new_local_deps[dep_issue.id] = existing
           next
         end
 
         next if would_create_cycle?(dep_issue, adj)
 
-        issue.issue_dependencies.create!(
+        new_local_deps[dep_issue.id] = issue.issue_dependencies.create!(
           depends_on_issue: dep_issue,
           requires_deployment: requires_deployment
         )
       end
 
-      new_local_ids
+      new_local_deps
     end
 
-    def sync_cross_project_deps(cross_deps, current_local_by_id, new_local_ids, current_external_by_key)
+    def sync_cross_project_deps(cross_deps, current_local_by_id, new_local_deps, current_external_by_key)
       resolved_ids = Set.new
       external_keys = Set.new
       return { resolved_ids: resolved_ids, external_keys: external_keys } if cross_deps.empty?
@@ -345,7 +351,14 @@ module Issues
               update_deployment_flag(existing, requires_deployment)
               next
             end
-            next if new_local_ids.include?(dep_issue.id)
+            # A local ref (e.g. "#123") earlier in the body may have already
+            # created this dep without the deployment flag. Promote it here
+            # instead of silently dropping the cross-repo ref's deployment
+            # wording.
+            if (just_created = new_local_deps[dep_issue.id])
+              update_deployment_flag(just_created, requires_deployment)
+              next
+            end
             next if would_create_cycle?(dep_issue, adj)
 
             issue.issue_dependencies.create!(

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -14,12 +14,23 @@ module Issues
   #   - "Blocked by viamin/other-project#42"
   #   - Checklist items: "- [ ] #101"
   #
+  # Deployment-blocking variants (require the target PR to have been marked
+  # deployed before the dependency unblocks; see IssueDependency#deployment_pending?):
+  #   - "Awaits deployment of #101"
+  #   - "Depends on deployment of #101"
+  #   - "Blocked by deployment of viamin/agent-harness#31"
+  #   - Within a ## Dependencies section: "- Deployment of #101"
+  #
   # Comments support the same addition patterns plus removal patterns.
-  # Removals work for both local (#N) and cross-repo (owner/repo#N) refs:
+  # Removals work for both local (#N) and cross-repo (owner/repo#N) refs and
+  # remove the dependency entirely (regardless of whether it was
+  # deployment-flagged or a plain dependency):
   #   - "No longer depends on #101"
-  #   - "No longer blocked by viamin/agent-harness#31"
+  #   - "No longer awaits deployment of #101"
+  #   - "No longer blocked by deployment of viamin/agent-harness#31"
   #   - "Unblocked by #101"
   #   - "Remove dependency #101"
+  #   - "Remove deployment dependency on #101"
   #
   # Comment-declared dependency additions are applied on top of the
   # body-declared dependencies, but comment-based removals can remove
@@ -29,6 +40,10 @@ module Issues
   #   - Across comments (relative to the body baseline), a later
   #     "Depends on #N" re-adds a previously removed dep, and a later
   #     "No longer depends on #N" removes it again.
+  #
+  # When a ref appears with deployment wording anywhere (body or any comment)
+  # the resulting dependency is marked as requires_deployment. Removing and
+  # re-adding the dep clears and re-derives the flag from later directives.
   #
   # The final dependency set is NOT simply (body + comments) - removals;
   # it is the result of replaying all directives in order.
@@ -53,13 +68,35 @@ module Issues
       ((?:(?:[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)?\#\d+[\s,]*)+)  # One or more refs
     /xi
 
+    # Matches deployment-blocking phrasing: "awaits deployment of #N",
+    # "depends on deployment of #N", "blocked by deployment of #N".
+    INLINE_DEPLOYMENT_PATTERN = /
+      \b(?:
+        awaits\s+deployment\s+of
+        |(?:depends?\s+on|blocked?\s+by)\s+deployment\s+of
+      )\b
+      :?\s*
+      ((?:(?:[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)?\#\d+[\s,]*)+)
+    /xi
+
+    # Inside a "## Dependencies" section, users commonly write list items as
+    # bare phrases like "- Deployment of #101" without a preceding verb.
+    SECTION_DEPLOYMENT_PATTERN = /
+      \bdeployment\s+of\b
+      :?\s*
+      ((?:(?:[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)?\#\d+[\s,]*)+)
+    /xi
+
     INLINE_REMOVAL_PATTERN = /
       \b(?:
-        no\s+longer\s+(?:depends?\s+on|blocked?\s+by)\b # "no longer depends on"
-        |unblocked\s+by\b                               # "unblocked by"
-        |remove\s+dependenc(?:y|ies)\b(?:\s+on\b)?      # "remove dependency [on]"
+        no\s+longer\s+(?:                              # "no longer ..."
+          awaits\s+deployment\s+of                     # "no longer awaits deployment of"
+          |(?:depends?\s+on|blocked?\s+by)(?:\s+deployment\s+of)?  # "no longer depends on [deployment of]"
+        )\b
+        |unblocked\s+by\b                              # "unblocked by"
+        |remove\s+(?:deployment\s+)?dependenc(?:y|ies)\b(?:\s+on\b)?  # "remove [deployment] dependency [on]"
       )
-      :?\s*                                             # Optional colon
+      :?\s*                                            # Optional colon
       ((?:(?:[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)?\#\d+[\s,]*)+) # local or cross-repo refs
     /xi
 
@@ -84,22 +121,27 @@ module Issues
     end
 
     def call
-      local_numbers, cross_refs = resolve_dependencies
+      local_deps, cross_deps = resolve_dependencies
 
       current_deps = issue.issue_dependencies.to_a
-      current_local_ids = current_deps.select(&:local?).map(&:depends_on_issue_id).to_set
-      current_external_keys = current_deps.select(&:external?).map { |d|
+      current_local_by_id = current_deps.select(&:local?).index_by(&:depends_on_issue_id)
+      current_external_by_key = current_deps.select(&:external?).index_by do |d|
         [ d.depends_on_owner.downcase, d.depends_on_repo.downcase, d.depends_on_number ]
-      }.to_set
+      end
 
-      return if local_numbers.empty? && cross_refs.empty? &&
-               current_local_ids.empty? && current_external_keys.empty?
+      return if local_deps.empty? && cross_deps.empty? &&
+               current_local_by_id.empty? && current_external_by_key.empty?
 
-      new_local_ids = sync_local_deps(local_numbers, current_local_ids)
-      new_cross_refs = sync_cross_project_deps(cross_refs, current_local_ids | new_local_ids, current_external_keys)
+      new_local_ids = sync_local_deps(local_deps, current_local_by_id)
+      new_cross_refs = sync_cross_project_deps(
+        cross_deps,
+        current_local_by_id,
+        new_local_ids,
+        current_external_by_key
+      )
 
-      remove_stale_local_deps(current_local_ids, new_local_ids | new_cross_refs[:resolved_ids])
-      remove_stale_external_deps(current_external_keys, new_cross_refs[:external_keys])
+      remove_stale_local_deps(current_local_by_id.keys.to_set, new_local_ids | new_cross_refs[:resolved_ids])
+      remove_stale_external_deps(current_external_by_key.keys.to_set, new_cross_refs[:external_keys])
     end
 
     private
@@ -108,19 +150,24 @@ module Issues
     # removals take precedence over additions. Across comments, a later
     # directive can override an earlier one (e.g., re-add after removal).
     # Callers must supply comments sorted oldest-first for correct semantics.
+    #
+    # Returns two hashes keyed by ref identifier with boolean values indicating
+    # whether the resulting dependency requires deployment:
+    #   local_deps:  { github_number => requires_deployment? }
+    #   cross_deps:  { [owner, repo, number] => requires_deployment? }
     def resolve_dependencies
-      local_numbers = Set.new
-      cross_refs = Set.new
+      local_deps = {}
+      cross_deps = {}
 
       if issue.body.present?
-        extract_body_refs(issue.body, local_numbers, cross_refs)
+        extract_body_refs(issue.body, local_deps, cross_deps)
       end
 
       comments.each do |comment_body|
         next if comment_body.blank?
 
-        added_local = Set.new
-        added_cross = Set.new
+        added_local = {}
+        added_cross = {}
         extract_body_refs(comment_body, added_local, added_cross)
 
         removed_local = Set.new
@@ -128,16 +175,28 @@ module Issues
         extract_removal_refs(comment_body, removed_local, removed_cross)
 
         # Within a single comment, removals win over additions.
-        added_local.subtract(removed_local)
-        added_cross.subtract(removed_cross)
+        removed_local.each { |num| added_local.delete(num) }
+        removed_cross.each { |key| added_cross.delete(key) }
 
-        local_numbers.merge(added_local)
-        cross_refs.merge(added_cross)
-        local_numbers.subtract(removed_local)
-        cross_refs.subtract(removed_cross)
+        merge_refs(local_deps, added_local)
+        merge_refs(cross_deps, added_cross)
+        removed_local.each { |num| local_deps.delete(num) }
+        removed_cross.each { |key| cross_deps.delete(key) }
       end
 
-      [ local_numbers.to_a, cross_refs.to_a ]
+      [ local_deps, cross_deps ]
+    end
+
+    # Merges new ref additions into the running map. A deployment flag, once
+    # set by any directive, sticks until the ref is removed — so upgrading a
+    # plain "Depends on #N" to "Awaits deployment of #N" later in the text
+    # promotes the dep, but a later "Depends on #N" cannot silently downgrade
+    # a deployment dep. Explicit removal + re-add resets the flag.
+    def merge_refs(dest, src)
+      src.each do |key, requires_deployment|
+        dest[key] = true if requires_deployment
+        dest[key] = false unless dest.key?(key)
+      end
     end
 
     # Extracts both local (#N) and cross-repo (owner/repo#N) removal refs.
@@ -157,41 +216,79 @@ module Issues
     # Extracts refs from body using both dependency sections and inline patterns.
     # Only dependency-scoped text is parsed — incidental #N mentions (e.g. in a
     # "Notes" section) are intentionally ignored.
-    def extract_body_refs(body, local_numbers, cross_refs)
+    def extract_body_refs(body, local_deps, cross_deps)
       body.scan(DEPENDENCY_SECTION_PATTERN) do |(section_body)|
-        extract_all_refs(section_body, local_numbers, cross_refs)
+        extract_section_refs(section_body, local_deps, cross_deps)
       end
 
-      extract_inline_refs(body, local_numbers, cross_refs)
+      extract_inline_refs(body, local_deps, cross_deps)
     end
 
-    # Extracts refs from inline "Depends on" / "Blocked by" patterns only.
-    def extract_inline_refs(text, local_numbers, cross_refs)
-      text.scan(INLINE_DEPENDS_PATTERN) do |(refs_str)|
-        extract_all_refs(refs_str, local_numbers, cross_refs)
+    # Within a "## Dependencies" section, recognise both explicit
+    # "awaits/depends on/blocked by deployment of #N" phrasing and the shorter
+    # list-item style "- Deployment of #N". Remaining refs are treated as
+    # plain dependencies.
+    def extract_section_refs(section_body, local_deps, cross_deps)
+      scratch = section_body.dup
+
+      [ INLINE_DEPLOYMENT_PATTERN, SECTION_DEPLOYMENT_PATTERN ].each do |pattern|
+        scratch.scan(pattern) do |(refs_str)|
+          extract_all_refs(refs_str, local_deps, cross_deps, requires_deployment: true)
+        end
+        scratch = scratch.gsub(pattern, "")
+      end
+
+      extract_all_refs(scratch, local_deps, cross_deps, requires_deployment: false)
+    end
+
+    # Extracts refs from inline "Depends on" / "Blocked by" / deployment patterns.
+    # Deployment-phrased matches are consumed first so the plain pattern does
+    # not double-count them as non-deployment deps.
+    def extract_inline_refs(text, local_deps, cross_deps)
+      scratch = text.dup
+
+      scratch.scan(INLINE_DEPLOYMENT_PATTERN) do |(refs_str)|
+        extract_all_refs(refs_str, local_deps, cross_deps, requires_deployment: true)
+      end
+      scratch = scratch.gsub(INLINE_DEPLOYMENT_PATTERN, "")
+
+      scratch.scan(INLINE_DEPENDS_PATTERN) do |(refs_str)|
+        extract_all_refs(refs_str, local_deps, cross_deps, requires_deployment: false)
       end
     end
 
     # Extracts both cross-repo and local issue refs from a string of refs.
-    # Cross-repo tuples are normalized to lowercase for consistent Set comparison
+    # Cross-repo tuples are normalized to lowercase for consistent comparison
     # (e.g., removal of "Owner/Repo#1" matches addition of "owner/repo#1").
-    def extract_all_refs(text, local_numbers, cross_refs)
+    # `requires_deployment: true` sets a sticky flag on the ref — once set,
+    # it cannot be silently cleared by a later non-deployment mention of the
+    # same ref (only explicit removal clears it).
+    def extract_all_refs(text, local_deps, cross_deps, requires_deployment:)
       text.scan(CROSS_REPO_REF_PATTERN) do |owner, repo, number|
-        cross_refs << [ owner.downcase, repo.downcase, number.to_i ]
+        key = [ owner.downcase, repo.downcase, number.to_i ]
+        cross_deps[key] = true if requires_deployment
+        cross_deps[key] = false unless cross_deps.key?(key)
       end
 
       stripped = text.gsub(CROSS_REPO_REF_PATTERN, "")
-      stripped.scan(ISSUE_REF_PATTERN) { |(num)| local_numbers << num.to_i }
+      stripped.scan(ISSUE_REF_PATTERN) do |(num)|
+        n = num.to_i
+        local_deps[n] = true if requires_deployment
+        local_deps[n] = false unless local_deps.key?(n)
+      end
     end
 
-    def sync_local_deps(referenced_numbers, current_local_ids)
+    def sync_local_deps(local_deps, current_local_by_id)
       new_local_ids = Set.new
-      return new_local_ids if referenced_numbers.empty?
+      return new_local_ids if local_deps.empty?
+
+      referenced_numbers = local_deps.keys
 
       # Include pull requests so "Depends on #N" resolves when #N is a PR
       # in the same project. Blocking on an open PR is what the user
       # declared; blocking on a closed/merged PR is a satisfied dep and
-      # ready_for_work will correctly not treat it as blocking.
+      # ready_for_work will correctly not treat it as blocking — unless the
+      # dep is deployment-flagged and the PR has not been marked deployed.
       project_issues = issue.project.issues
         .where(github_number: referenced_numbers)
         .index_by(&:github_number)
@@ -203,29 +300,39 @@ module Issues
         next unless dep_issue
         next if dep_issue.id == issue.id
 
+        requires_deployment = local_deps[number]
         new_local_ids << dep_issue.id
 
-        next if current_local_ids.include?(dep_issue.id)
+        if (existing = current_local_by_id[dep_issue.id])
+          update_deployment_flag(existing, requires_deployment)
+          next
+        end
+
         next if would_create_cycle?(dep_issue, adj)
 
-        issue.issue_dependencies.create!(depends_on_issue: dep_issue)
+        issue.issue_dependencies.create!(
+          depends_on_issue: dep_issue,
+          requires_deployment: requires_deployment
+        )
       end
 
       new_local_ids
     end
 
-    def sync_cross_project_deps(cross_refs, current_local_ids, current_external_keys)
+    def sync_cross_project_deps(cross_deps, current_local_by_id, new_local_ids, current_external_by_key)
       resolved_ids = Set.new
       external_keys = Set.new
-      return { resolved_ids: resolved_ids, external_keys: external_keys } if cross_refs.empty?
+      return { resolved_ids: resolved_ids, external_keys: external_keys } if cross_deps.empty?
 
       account = issue.project.account
       adj = adjacency || IssueDependency.account_adjacency(account)
 
+      cross_refs = cross_deps.keys
       project_lookup = build_project_lookup(account, cross_refs)
       issues_by_project = build_issue_lookup(project_lookup, cross_refs)
 
       cross_refs.each do |owner, repo, number|
+        requires_deployment = cross_deps[[ owner, repo, number ]]
         project_key = [ owner.downcase, repo.downcase ]
         project = project_lookup[project_key]
 
@@ -234,10 +341,17 @@ module Issues
 
           if dep_issue
             resolved_ids << dep_issue.id
-            next if current_local_ids.include?(dep_issue.id)
+            if (existing = current_local_by_id[dep_issue.id])
+              update_deployment_flag(existing, requires_deployment)
+              next
+            end
+            next if new_local_ids.include?(dep_issue.id)
             next if would_create_cycle?(dep_issue, adj)
 
-            issue.issue_dependencies.create!(depends_on_issue: dep_issue)
+            issue.issue_dependencies.create!(
+              depends_on_issue: dep_issue,
+              requires_deployment: requires_deployment
+            )
             next
           end
         end
@@ -245,16 +359,26 @@ module Issues
         # Store as external reference with normalized (downcased) owner/repo
         key = [ owner.downcase, repo.downcase, number ]
         external_keys << key
-        next if current_external_keys.include?(key)
+        if (existing = current_external_by_key[key])
+          update_deployment_flag(existing, requires_deployment)
+          next
+        end
 
         issue.issue_dependencies.create!(
           depends_on_owner: owner.downcase,
           depends_on_repo: repo.downcase,
-          depends_on_number: number
+          depends_on_number: number,
+          requires_deployment: requires_deployment
         )
       end
 
       { resolved_ids: resolved_ids, external_keys: external_keys }
+    end
+
+    def update_deployment_flag(dependency, requires_deployment)
+      return if dependency.requires_deployment == requires_deployment
+
+      dependency.update!(requires_deployment: requires_deployment)
     end
 
     # Batch-loads projects for all unique owner/repo pairs in cross_refs

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -133,13 +133,8 @@ module Issues
                current_local_by_id.empty? && current_external_by_key.empty?
 
       new_local_deps = sync_local_deps(local_deps, current_local_by_id)
-      new_cross_refs = sync_cross_project_deps(
-        cross_deps,
-        local_deps,
-        current_local_by_id,
-        new_local_deps,
-        current_external_by_key
-      )
+      current_state = { local_by_id: current_local_by_id, external_by_key: current_external_by_key }
+      new_cross_refs = sync_cross_project_deps(cross_deps, local_deps, current_state, new_local_deps)
 
       kept_local_ids = new_local_deps.keys.to_set | new_cross_refs[:resolved_ids]
       remove_stale_local_deps(current_local_by_id.keys.to_set, kept_local_ids)
@@ -326,7 +321,9 @@ module Issues
       new_local_deps
     end
 
-    def sync_cross_project_deps(cross_deps, local_deps, current_local_by_id, new_local_deps, current_external_by_key)
+    def sync_cross_project_deps(cross_deps, local_deps, current_state, new_local_deps)
+      current_local_by_id = current_state[:local_by_id]
+      current_external_by_key = current_state[:external_by_key]
       resolved_ids = Set.new
       external_keys = Set.new
       return { resolved_ids: resolved_ids, external_keys: external_keys } if cross_deps.empty?

--- a/db/migrate/20260416170200_add_deployed_at_to_issues.rb
+++ b/db/migrate/20260416170200_add_deployed_at_to_issues.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Tracks when a pull request was deployed to production. Used by the
+# multi-step PR dependency feature so a dependent PR can wait until its
+# predecessor has actually shipped, not just merged. Null means the PR
+# has not been marked as deployed. Indexed only on open PRs so that
+# deployment-blocked dependency checks stay cheap on the hot path.
+class AddDeployedAtToIssues < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issues, :deployed_at, :datetime
+
+    add_index :issues, :deployed_at,
+              where: "is_pull_request = true",
+              name: "idx_issues_deployed_at_on_prs"
+  end
+end

--- a/db/migrate/20260416170200_add_deployed_at_to_issues.rb
+++ b/db/migrate/20260416170200_add_deployed_at_to_issues.rb
@@ -3,7 +3,7 @@
 # Tracks when a pull request was deployed to production. Used by the
 # multi-step PR dependency feature so a dependent PR can wait until its
 # predecessor has actually shipped, not just merged. Null means the PR
-# has not been marked as deployed. Indexed only on open PRs so that
+# has not been marked as deployed. Partial index covers all PRs so
 # deployment-blocked dependency checks stay cheap on the hot path.
 class AddDeployedAtToIssues < ActiveRecord::Migration[8.1]
   def change

--- a/db/migrate/20260416170203_add_requires_deployment_to_issue_dependencies.rb
+++ b/db/migrate/20260416170203_add_requires_deployment_to_issue_dependencies.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Flags a dependency as blocking until the target has been deployed, not
+# merely merged/closed. Defaults to false so all existing dependency
+# semantics are preserved. Parsed from body/comment phrases like
+# "Awaits deployment of #N" or "Blocked by deployment of #N".
+class AddRequiresDeploymentToIssueDependencies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issue_dependencies, :requires_deployment, :boolean,
+               default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_050235) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_170203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -496,6 +496,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_050235) do
     t.string "depends_on_owner"
     t.string "depends_on_repo"
     t.bigint "issue_id", null: false
+    t.boolean "requires_deployment", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["depends_on_issue_id"], name: "index_issue_dependencies_on_depends_on_issue_id"
     t.index ["issue_id", "depends_on_issue_id"], name: "idx_issue_dependencies_unique", unique: true
@@ -509,6 +510,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_050235) do
     t.text "body"
     t.datetime "ci_action_dispatched_at"
     t.datetime "created_at", null: false
+    t.datetime "deployed_at"
     t.integer "draft_review_count", default: 0, null: false
     t.datetime "github_created_at", null: false
     t.string "github_creator_login"
@@ -530,6 +532,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_050235) do
     t.string "source", default: "github", null: false
     t.string "title", limit: 1000, null: false
     t.datetime "updated_at", null: false
+    t.index ["deployed_at"], name: "idx_issues_deployed_at_on_prs", where: "(is_pull_request = true)"
     t.index ["github_creator_login"], name: "index_issues_on_github_creator_login"
     t.index ["labels"], name: "index_issues_on_labels_gin_open_issues", where: "((is_pull_request = false) AND ((github_state)::text = 'open'::text))", using: :gin
     t.index ["labels"], name: "index_issues_on_labels_gin_open_prs", where: "((is_pull_request = true) AND ((github_state)::text = 'open'::text))", using: :gin

--- a/spec/models/issue_dependency_spec.rb
+++ b/spec/models/issue_dependency_spec.rb
@@ -227,6 +227,54 @@ RSpec.describe IssueDependency do
     end
   end
 
+  describe "#deployment_pending?" do
+    let(:project) { create(:project) }
+    let(:issue) { create(:issue, project: project) }
+
+    it "returns false when requires_deployment is false" do
+      pr = create(:issue, :pull_request, :closed, project: project, deployed_at: nil)
+      dep = create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: false)
+
+      expect(dep).not_to be_deployment_pending
+    end
+
+    it "returns false when target is still open (regular blocking path applies)" do
+      pr = create(:issue, :pull_request, project: project, github_state: "open", deployed_at: nil)
+      dep = create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
+
+      expect(dep).not_to be_deployment_pending
+    end
+
+    it "returns false when target is not a pull request" do
+      non_pr = create(:issue, :closed, project: project)
+      dep = create(:issue_dependency, issue: issue, depends_on_issue: non_pr, requires_deployment: true)
+
+      expect(dep).not_to be_deployment_pending
+    end
+
+    it "returns true when target PR has merged but has no deployed_at" do
+      pr = create(:issue, :pull_request, :closed, project: project, deployed_at: nil)
+      dep = create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
+
+      expect(dep).to be_deployment_pending
+    end
+
+    it "returns false when target PR has been marked deployed" do
+      pr = create(:issue, :pull_request, :closed, project: project, deployed_at: Time.current)
+      dep = create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
+
+      expect(dep).not_to be_deployment_pending
+    end
+
+    it "returns false for external deps (deployment cannot be observed)" do
+      dep = create(:issue_dependency, issue: issue, depends_on_issue: nil,
+                                       depends_on_owner: "viamin", depends_on_repo: "agent-harness",
+                                       depends_on_number: 31, requires_deployment: true)
+
+      expect(dep).not_to be_deployment_pending
+    end
+  end
+
   describe "cascade deletion" do
     it "is destroyed when the dependent issue is destroyed" do
       project = create(:project)

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -182,6 +182,22 @@ RSpec.describe Issue do
 
         expect(described_class.ready_for_work(project)).to include(issue)
       end
+
+      it "excludes issues whose deployment-blocked dep points at a merged but undeployed PR" do
+        pr = create(:issue, :pull_request, project: project, github_state: "closed", deployed_at: nil)
+        issue = create(:issue, project: project)
+        create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
+
+        expect(described_class.ready_for_work(project)).not_to include(issue)
+      end
+
+      it "includes issues whose deployment-blocked dep points at a deployed PR" do
+        pr = create(:issue, :pull_request, project: project, github_state: "closed", deployed_at: Time.current)
+        issue = create(:issue, project: project)
+        create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
+
+        expect(described_class.ready_for_work(project)).to include(issue)
+      end
     end
   end
 
@@ -637,6 +653,69 @@ RSpec.describe Issue do
                                 depends_on_number: 42)
 
       expect(issue.ready_to_work?).to be false
+    end
+
+    it "returns false when a deployment-blocked dep points at a merged but undeployed PR" do
+      pr = create(:issue, :pull_request, project: project, github_state: "closed", deployed_at: nil)
+      issue = create(:issue, project: project)
+      create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
+
+      expect(issue.ready_to_work?).to be false
+    end
+
+    it "returns true when a deployment-blocked dep's target PR has been marked deployed" do
+      pr = create(:issue, :pull_request, project: project, github_state: "closed", deployed_at: Time.current)
+      issue = create(:issue, project: project)
+      create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
+
+      expect(issue.ready_to_work?).to be true
+    end
+  end
+
+  describe "#deployed?" do
+    it "is false for non-PR issues" do
+      issue = build(:issue, is_pull_request: false, deployed_at: Time.current)
+
+      expect(issue).not_to be_deployed
+    end
+
+    it "is false for PRs without a deployed_at timestamp" do
+      pr = build(:issue, :pull_request, deployed_at: nil)
+
+      expect(pr).not_to be_deployed
+    end
+
+    it "is true for PRs with a deployed_at timestamp" do
+      pr = build(:issue, :pull_request, deployed_at: Time.current)
+
+      expect(pr).to be_deployed
+    end
+  end
+
+  describe "#mark_deployed!" do
+    let(:project) { create(:project) }
+
+    it "sets deployed_at on a PR" do
+      pr = create(:issue, :pull_request, project: project, deployed_at: nil)
+
+      freeze_time do
+        pr.mark_deployed!
+        expect(pr.deployed_at).to eq(Time.current)
+      end
+    end
+
+    it "accepts an explicit timestamp" do
+      pr = create(:issue, :pull_request, project: project, deployed_at: nil)
+      ts = 2.days.ago.change(usec: 0)
+
+      pr.mark_deployed!(time: ts)
+      expect(pr.deployed_at).to be_within(1.second).of(ts)
+    end
+
+    it "raises when called on a non-PR issue" do
+      issue = create(:issue, project: project, is_pull_request: false)
+
+      expect { issue.mark_deployed! }.to raise_error(ArgumentError, /pull requests/)
     end
   end
 
@@ -1142,6 +1221,26 @@ RSpec.describe Issue do
       issue = create(:issue, project: project, github_state: "open")
       dep = create(:issue, project: project, github_state: "closed")
       create(:issue_dependency, issue: issue, depends_on_issue: dep)
+
+      result = described_class.lifecycle_statuses([ issue ])
+
+      expect(result[issue.id]).to eq(:eligible)
+    end
+
+    it "returns :blocked when a deployment-blocked dep points at a merged but undeployed PR" do
+      issue = create(:issue, project: project, github_state: "open")
+      pr = create(:issue, :pull_request, project: project, github_state: "closed", deployed_at: nil)
+      create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
+
+      result = described_class.lifecycle_statuses([ issue ])
+
+      expect(result[issue.id]).to eq(:blocked)
+    end
+
+    it "returns :eligible when a deployment-blocked dep's target PR has been marked deployed" do
+      issue = create(:issue, project: project, github_state: "open")
+      pr = create(:issue, :pull_request, project: project, github_state: "closed", deployed_at: Time.current)
+      create(:issue_dependency, issue: issue, depends_on_issue: pr, requires_deployment: true)
 
       result = described_class.lifecycle_statuses([ issue ])
 

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -708,6 +708,43 @@ RSpec.describe Issues::ParseDependencies do
         expect(dep).to be_present
         expect(dep.requires_deployment).to be true
       end
+
+      it "preserves deployment flag when a local deployment ref is paired with a plain self-repo cross-ref" do
+        # Inverse of the preceding test: body has a local deployment ref AND a
+        # plain self-repo cross-ref to the same issue. The plain cross-ref must
+        # not silently downgrade the deployment flag set by the local ref.
+        pr = create(:issue, :pull_request, project: project, github_number: 9213)
+        body = <<~MD
+          Awaits deployment of #9213
+          Depends on #{project.owner}/#{project.repo}#9213
+        MD
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be true
+      end
+
+      it "preserves deployment flag on re-parse when plain self-repo cross-ref is present" do
+        # Same scenario on re-parse: the dep already exists with
+        # requires_deployment=true; a plain self-repo cross-ref in the body
+        # must not downgrade it via the current_local_by_id branch.
+        pr = create(:issue, :pull_request, project: project, github_number: 9214)
+        body = <<~MD
+          Awaits deployment of #9214
+          Depends on #{project.owner}/#{project.repo}#9214
+        MD
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be true
+      end
     end
   end
 end

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -555,5 +555,140 @@ RSpec.describe Issues::ParseDependencies do
       expect { described_class.call(issue: issue, comments: [ "Depends on #9010" ]) }
         .not_to change(IssueDependency, :count)
     end
+
+    describe "deployment-blocked dependencies" do
+      it "parses 'Awaits deployment of #N' as requires_deployment" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9201)
+        issue = create(:issue, project: project, body: "Awaits deployment of #9201")
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be true
+      end
+
+      it "parses 'Depends on deployment of #N' as requires_deployment" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9202)
+        issue = create(:issue, project: project, body: "This PR depends on deployment of #9202 before merging.")
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be true
+      end
+
+      it "parses 'Blocked by deployment of #N' as requires_deployment" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9203)
+        issue = create(:issue, project: project, body: "Blocked by deployment of #9203.")
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be true
+      end
+
+      it "parses cross-repo deployment refs as requires_deployment" do
+        account = create(:account)
+        project_a = create(:project, account: account, owner: "viamin", repo: "repo-a")
+        project_b = create(:project, account: account, owner: "viamin", repo: "repo-b")
+        pr = create(:issue, :pull_request, project: project_b, github_number: 31)
+        issue = create(:issue, project: project_a, body: "Awaits deployment of viamin/repo-b#31.")
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be true
+      end
+
+      it "persists requires_deployment on external (unresolvable) refs" do
+        issue = create(:issue, project: project, body: "Awaits deployment of someoneelse/elsewhere#88.")
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_owner: "someoneelse")
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be true
+      end
+
+      it "treats a plain 'Depends on #N' as a non-deployment dep" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9205)
+        issue = create(:issue, project: project, body: "Depends on #9205")
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be false
+      end
+
+      it "parses a ## Dependencies section list item with 'Deployment of #N' as deployment-flagged" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9206)
+        plain = create(:issue, project: project, github_number: 9207)
+        issue = create(:issue, project: project, body: <<~MD)
+          ## Dependencies
+          - Deployment of #9206
+          - #9207
+        MD
+
+        described_class.call(issue: issue)
+
+        deployment_dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        plain_dep = issue.issue_dependencies.find_by(depends_on_issue_id: plain.id)
+
+        expect(deployment_dep.requires_deployment).to be true
+        expect(plain_dep.requires_deployment).to be false
+      end
+
+      it "treats a ref mentioned both with and without deployment wording as deployment-flagged" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9208)
+        issue = create(:issue, project: project, body: "Depends on #9208. Also awaits deployment of #9208.")
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep.requires_deployment).to be true
+      end
+
+      it "promotes an existing non-deployment dep when a later comment uses deployment wording" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9209)
+        issue = create(:issue, project: project, body: "Depends on #9209")
+
+        described_class.call(issue: issue)
+        expect(issue.issue_dependencies.find_by(depends_on_issue_id: pr.id).requires_deployment).to be false
+
+        described_class.call(issue: issue, comments: [ "Actually, this awaits deployment of #9209." ])
+        expect(issue.issue_dependencies.find_by(depends_on_issue_id: pr.id).requires_deployment).to be true
+      end
+
+      it "resets the deployment flag when a ref is removed and re-added as a plain dep" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9210)
+        issue = create(:issue, project: project, body: "Awaits deployment of #9210")
+
+        described_class.call(issue: issue)
+        expect(issue.issue_dependencies.find_by(depends_on_issue_id: pr.id).requires_deployment).to be true
+
+        described_class.call(issue: issue, comments: [
+          "No longer awaits deployment of #9210",
+          "Depends on #9210"
+        ])
+
+        expect(issue.issue_dependencies.find_by(depends_on_issue_id: pr.id).requires_deployment).to be false
+      end
+
+      it "accepts 'No longer blocked by deployment of #N' as removal" do
+        pr = create(:issue, :pull_request, project: project, github_number: 9211)
+        issue = create(:issue, project: project, body: "Blocked by deployment of #9211")
+
+        described_class.call(issue: issue)
+        expect(issue.dependencies).to contain_exactly(pr)
+
+        described_class.call(issue: issue, comments: [ "No longer blocked by deployment of #9211" ])
+        expect(issue.reload.dependencies).to be_empty
+      end
+    end
   end
 end

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -689,6 +689,25 @@ RSpec.describe Issues::ParseDependencies do
         described_class.call(issue: issue, comments: [ "No longer blocked by deployment of #9211" ])
         expect(issue.reload.dependencies).to be_empty
       end
+
+      it "promotes a freshly-created local dep when a self-repo cross-ref flags deployment" do
+        # Body mixes a plain local ref with a self-repo cross-ref that carries
+        # deployment wording. Both resolve to the same local issue; the
+        # deployment flag from the cross-ref must stick.
+        pr = create(:issue, :pull_request, project: project, github_number: 9212)
+        body = <<~MD
+          ## Dependencies
+          - Depends on #9212
+          - Blocked by deployment of #{project.owner}/#{project.repo}#9212
+        MD
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        dep = issue.issue_dependencies.find_by(depends_on_issue_id: pr.id)
+        expect(dep).to be_present
+        expect(dep.requires_deployment).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Support multi-step PRs for multi-deployment migrations

See #1180 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1180