### PR TITLE
Fix #1083: rollout(automation): enable explicit_pr_automation_decisions for viamin/paid

### DIFF
--- a/db/migrate/20260416173627_enable_explicit_pr_automation_decisions_for_viamin_paid.rb
+++ b/db/migrate/20260416173627_enable_explicit_pr_automation_decisions_for_viamin_paid.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Rollout: enable :explicit_pr_automation_decisions for the viamin/paid project.
+# Idempotent; safe to run on environments that do not have a viamin/paid project
+# (dev/CI/fresh installs) — in that case the migration is a no-op.
+class EnableExplicitPrAutomationDecisionsForViaminPaid < ActiveRecord::Migration[8.1]
+  FLAG = :explicit_pr_automation_decisions
+  TARGET_OWNER = "viamin"
+  TARGET_REPO = "paid"
+
+  class MigrationProject < ApplicationRecord
+    self.table_name = "projects"
+
+    def flipper_id
+      "Project;#{id}"
+    end
+  end
+
+  def up
+    projects = MigrationProject.unscoped.where(owner: TARGET_OWNER, repo: TARGET_REPO)
+    if projects.none?
+      say "No #{TARGET_OWNER}/#{TARGET_REPO} project present; skipping #{FLAG} enablement"
+      return
+    end
+
+    projects.find_each do |project|
+      FeatureFlags.enable!(FLAG, project: project)
+      say "Enabled #{FLAG} for project #{project.id} (#{TARGET_OWNER}/#{TARGET_REPO})"
+    end
+  end
+
+  def down
+    projects = MigrationProject.unscoped.where(owner: TARGET_OWNER, repo: TARGET_REPO)
+    projects.find_each do |project|
+      FeatureFlags.disable!(FLAG, project: project)
+      say "Disabled #{FLAG} for project #{project.id} (#{TARGET_OWNER}/#{TARGET_REPO})"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_050235) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_173627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"

--- a/spec/migrations/enable_explicit_pr_automation_decisions_for_viamin_paid_spec.rb
+++ b/spec/migrations/enable_explicit_pr_automation_decisions_for_viamin_paid_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260416173627_enable_explicit_pr_automation_decisions_for_viamin_paid")
+
+RSpec.describe EnableExplicitPrAutomationDecisionsForViaminPaid do
+  let(:migration) { described_class.new }
+
+  before do
+    FeatureFlags.flipper.features.each(&:remove)
+  end
+
+  it "enables explicit_pr_automation_decisions for the viamin/paid project" do
+    viamin_paid = create(:project, owner: "viamin", repo: "paid")
+    other_project = create(:project, owner: "other", repo: "repo")
+
+    migration.up
+
+    expect(FeatureFlags.explicit_pr_automation_decisions?(project: viamin_paid)).to be(true)
+    expect(FeatureFlags.explicit_pr_automation_decisions?(project: other_project)).to be(false)
+  end
+
+  it "is a no-op when the viamin/paid project is absent" do
+    create(:project, owner: "other", repo: "repo")
+
+    expect { migration.up }.not_to raise_error
+    expect(FeatureFlags.enabled?(:explicit_pr_automation_decisions)).to be(false)
+  end
+
+  it "is idempotent on repeated up runs" do
+    viamin_paid = create(:project, owner: "viamin", repo: "paid")
+
+    migration.up
+    migration.up
+
+    expect(FeatureFlags.explicit_pr_automation_decisions?(project: viamin_paid)).to be(true)
+  end
+
+  it "reverses enablement on down" do
+    viamin_paid = create(:project, owner: "viamin", repo: "paid")
+
+    migration.up
+    expect(FeatureFlags.explicit_pr_automation_decisions?(project: viamin_paid)).to be(true)
+
+    migration.down
+    expect(FeatureFlags.explicit_pr_automation_decisions?(project: viamin_paid)).to be(false)
+  end
+end


### PR DESCRIPTION
## Summary

rollout(automation): enable explicit_pr_automation_decisions for viamin/paid

See #1083 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1083