### PR TITLE
Fix #805: Add pause all button to agent runs page with navigation indicator

### DIFF
--- a/app/controllers/agent_runs_controller.rb
+++ b/app/controllers/agent_runs_controller.rb
@@ -12,4 +12,19 @@ class AgentRunsController < ApplicationController
     AgentRun.preload_source_pull_requests(@agent_runs)
     @provider_options = base_scope.distinct_effective_providers
   end
+
+  def pause_scheduler
+    authorize current_account, :update?
+    current_account.update!(scheduler_paused_at: Time.current) unless current_account.scheduler_paused?
+    redirect_to agent_runs_path, notice: "Scheduler paused. Queued runs will not start until resumed."
+  end
+
+  def resume_scheduler
+    authorize current_account, :update?
+    if current_account.scheduler_paused?
+      current_account.update!(scheduler_paused_at: nil)
+      ProcessRunQueueJob.perform_later
+    end
+    redirect_to agent_runs_path, notice: "Scheduler resumed."
+  end
 end

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -159,7 +159,9 @@ class ProcessRunQueueJob < ApplicationJob
   # don't re-query the project list and aggregate stats each time.
   def ordered_auto_pick_projects
     @ordered_auto_pick_projects ||= begin
-      projects = Project.active.where(auto_pick_enabled: true).includes(:created_by, :account).order(:id).to_a
+      projects = Project.active.where(auto_pick_enabled: true).includes(:created_by, :account)
+        .joins(:account).where(accounts: { scheduler_paused_at: nil })
+        .order(:id).to_a
       return projects if projects.empty?
 
       project_ids = projects.map(&:id)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -41,6 +41,10 @@ class Account < ApplicationRecord
     regenerate_slug_and_retry!
   end
 
+  def scheduler_paused?
+    scheduler_paused_at.present?
+  end
+
   # Returns the fallback owner for this account — the first owner by ID,
   # or the first user by ID if no owner membership exists. Used for
   # orphaned-project ownership resolution.

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -447,9 +447,14 @@ class AgentRun < ApplicationRecord
 
   # Returns the next queued run without claiming it.
   # Used to check per-user capacity before acquiring the lock.
+  #
+  # Runs whose project belongs to an account with a paused scheduler are
+  # excluded so a "pause all" toggle can hold new starts while still
+  # accepting new queue entries from the project trigger button.
   def self.peek_next_queued_run(exclude_ids: [])
     scope = queued_with_priority.order(QUEUE_ORDER)
     scope = scope.where.not(id: exclude_ids) if exclude_ids.any?
+    scope = scope.joins(project: :account).where(accounts: { scheduler_paused_at: nil })
     scope.first
   end
 

--- a/app/views/agent_runs/index.html.erb
+++ b/app/views/agent_runs/index.html.erb
@@ -1,9 +1,46 @@
 <% content_for(:title) { "Agent Runs - Paid" } %>
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-  <div class="sm:flex sm:items-center sm:justify-between">
+  <div class="sm:flex sm:items-center sm:justify-between gap-4">
     <h1 class="text-xl font-semibold text-gray-900">Agent Runs</h1>
+    <% if current_account.scheduler_paused? %>
+      <%= button_to resume_scheduler_agent_runs_path,
+        method: :post,
+        class: "mt-3 sm:mt-0 inline-flex items-center gap-x-1.5 rounded-md bg-green-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600",
+        data: { testid: "resume-scheduler-button" } do %>
+        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z" />
+        </svg>
+        Resume Scheduler
+      <% end %>
+    <% else %>
+      <%= button_to pause_scheduler_agent_runs_path,
+        method: :post,
+        class: "mt-3 sm:mt-0 inline-flex items-center gap-x-1.5 rounded-md bg-yellow-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-500",
+        data: { testid: "pause-scheduler-button" } do %>
+        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
+        </svg>
+        Pause All
+      <% end %>
+    <% end %>
   </div>
+
+  <% if current_account.scheduler_paused? %>
+    <div class="mt-4 rounded-md bg-yellow-50 p-4 ring-1 ring-inset ring-yellow-200" data-testid="scheduler-paused-banner">
+      <div class="flex">
+        <svg class="h-5 w-5 flex-shrink-0 text-yellow-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5Zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />
+        </svg>
+        <div class="ml-3">
+          <h3 class="text-sm font-semibold text-yellow-800">Scheduler paused</h3>
+          <p class="mt-1 text-sm text-yellow-700">
+            New agent runs will not start automatically. You can still enqueue runs from project pages — they will remain queued until the scheduler is resumed. Runs already in progress will continue to completion.
+          </p>
+        </div>
+      </div>
+    </div>
+  <% end %>
 
   <%= render "agent_runs/filters", q: @q, show_project: true, provider_options: @provider_options %>
 

--- a/app/views/agent_runs/index.html.erb
+++ b/app/views/agent_runs/index.html.erb
@@ -3,25 +3,27 @@
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="sm:flex sm:items-center sm:justify-between gap-4">
     <h1 class="text-xl font-semibold text-gray-900">Agent Runs</h1>
-    <% if current_account.scheduler_paused? %>
-      <%= button_to resume_scheduler_agent_runs_path,
-        method: :post,
-        class: "mt-3 sm:mt-0 inline-flex items-center gap-x-1.5 rounded-md bg-green-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600",
-        data: { testid: "resume-scheduler-button" } do %>
-        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z" />
-        </svg>
-        Resume Scheduler
-      <% end %>
-    <% else %>
-      <%= button_to pause_scheduler_agent_runs_path,
-        method: :post,
-        class: "mt-3 sm:mt-0 inline-flex items-center gap-x-1.5 rounded-md bg-yellow-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-500",
-        data: { testid: "pause-scheduler-button" } do %>
-        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
-        </svg>
-        Pause All
+    <% if policy(current_account).update? %>
+      <% if current_account.scheduler_paused? %>
+        <%= button_to resume_scheduler_agent_runs_path,
+          method: :post,
+          class: "mt-3 sm:mt-0 inline-flex items-center gap-x-1.5 rounded-md bg-green-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600",
+          data: { testid: "resume-scheduler-button" } do %>
+          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z" />
+          </svg>
+          Resume Scheduler
+        <% end %>
+      <% else %>
+        <%= button_to pause_scheduler_agent_runs_path,
+          method: :post,
+          class: "mt-3 sm:mt-0 inline-flex items-center gap-x-1.5 rounded-md bg-yellow-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-500",
+          data: { testid: "pause-scheduler-button" } do %>
+          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
+          </svg>
+          Pause All
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,17 @@
               <%= link_to "Dashboard", dashboard_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700", data: { nav_section: "dashboard" } %>
               <%= link_to "Projects", projects_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700", data: { nav_section: "projects" } %>
               <%= link_to "Agent Runs", agent_runs_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700", data: { nav_section: "agent_runs" } %>
+              <% if current_account&.scheduler_paused? %>
+                <%= link_to agent_runs_path,
+                  class: "inline-flex items-center gap-x-1 rounded-full bg-yellow-100 px-2.5 py-1 text-xs font-semibold text-yellow-800 ring-1 ring-inset ring-yellow-400 hover:bg-yellow-200",
+                  title: "Scheduler is paused — click to manage",
+                  data: { testid: "navbar-scheduler-paused" } do %>
+                  <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
+                  </svg>
+                  <span>Paused</span>
+                <% end %>
+              <% end %>
               <%= link_to "Prompts", prompts_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700" %>
 
               <%= link_to "Quality", quality_dashboard_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700" %>
@@ -86,6 +97,16 @@
             <%= link_to "Dashboard", dashboard_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>
             <%= link_to "Projects", projects_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>
             <%= link_to "Agent Runs", agent_runs_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>
+            <% if current_account&.scheduler_paused? %>
+              <%= link_to agent_runs_path,
+                data: { action: "mobile-menu#close", testid: "navbar-scheduler-paused-mobile" },
+                class: "flex items-center gap-x-2 rounded-md bg-yellow-100 px-3 py-2 text-base font-semibold text-yellow-800 ring-1 ring-inset ring-yellow-400 hover:bg-yellow-200" do %>
+                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
+                </svg>
+                <span>Scheduler Paused</span>
+              <% end %>
+            <% end %>
             <%= link_to "Prompts", prompts_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>
 
             <%= link_to "Quality", quality_dashboard_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,12 @@ Rails.application.routes.draw do
   resources :service_containers
 
   # All agent runs across projects
-  resources :agent_runs, only: [ :index ]
+  resources :agent_runs, only: [ :index ] do
+    collection do
+      post :pause_scheduler
+      post :resume_scheduler
+    end
+  end
 
   # Prompt management
   resources :prompts do

--- a/db/migrate/20260416183113_add_scheduler_paused_at_to_accounts.rb
+++ b/db/migrate/20260416183113_add_scheduler_paused_at_to_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSchedulerPausedAtToAccounts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :accounts, :scheduler_paused_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_173627) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_183113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -83,6 +83,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_173627) do
     t.datetime "created_at", null: false
     t.integer "default_max_tokens_per_run", default: 10000000, null: false
     t.string "name", null: false
+    t.datetime "scheduler_paused_at"
     t.string "slug", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_accounts_on_slug", unique: true

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -195,6 +195,39 @@ RSpec.describe ProcessRunQueueJob do
       expect(queued_run.reload.status).to eq("queued")
     end
 
+    it "does not start queued runs when the account's scheduler is paused" do
+      paused_account = create(:account, scheduler_paused_at: Time.current)
+      paused_project = create(:project, account: paused_account, created_by: create(:user, account: paused_account))
+      paused_run = create(:agent_run, :queued, project: paused_project)
+
+      expect(temporal_client).not_to receive(:start_workflow)
+
+      described_class.new.perform
+
+      expect(paused_run.reload.status).to eq("queued")
+    end
+
+    it "still starts queued runs for accounts whose scheduler is not paused" do
+      paused_account = create(:account, scheduler_paused_at: Time.current)
+      paused_project = create(:project, account: paused_account, created_by: create(:user, account: paused_account))
+      paused_run = create(:agent_run, :queued, project: paused_project, created_at: 2.minutes.ago)
+
+      active_project = create(:project)
+      active_run = create(:agent_run, :queued, project: active_project, created_at: 1.minute.ago)
+
+      started_ids = []
+      allow(temporal_client).to receive(:start_workflow) do |_wf, input, **_opts|
+        started_ids << input[:agent_run_id]
+        workflow_handle
+      end
+
+      described_class.new.perform
+
+      expect(started_ids).to eq([ active_run.id ])
+      expect(active_run.reload.status).to eq("pending")
+      expect(paused_run.reload.status).to eq("queued")
+    end
+
     it "skips blocked user and starts runs for other users" do
       blocked_project = create(:project)
       blocked_user = blocked_project.created_by
@@ -263,6 +296,16 @@ RSpec.describe ProcessRunQueueJob do
 
       it "skips projects with auto_pick_enabled disabled" do
         create(:project, auto_pick_enabled: false)
+
+        expect(Issues::AutoPick).not_to receive(:new)
+
+        described_class.new.perform
+      end
+
+      it "skips auto-pick seeding for projects whose account is paused" do
+        paused_account = create(:account, scheduler_paused_at: Time.current)
+        paused_user = create(:user, account: paused_account)
+        create_auto_pick_project(account: paused_account, user: paused_user)
 
         expect(Issues::AutoPick).not_to receive(:new)
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -65,4 +65,14 @@ RSpec.describe Account do
       expect(account.slug).to eq("my-company-2")
     end
   end
+
+  describe "#scheduler_paused?" do
+    it "is false by default" do
+      expect(create(:account).scheduler_paused?).to be false
+    end
+
+    it "is true when scheduler_paused_at is set" do
+      expect(create(:account, scheduler_paused_at: Time.current).scheduler_paused?).to be true
+    end
+  end
 end

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -131,6 +131,137 @@ RSpec.describe "AgentRuns" do
         get agent_runs_path
         expect(response.body).not_to include(other_project.name)
       end
+
+      it "shows the pause all button when scheduler is running" do
+        get agent_runs_path
+        expect(response.body).to include("Pause All")
+        expect(response.body).to include(pause_scheduler_agent_runs_path)
+      end
+
+      it "shows the resume button and paused banner when scheduler is paused" do
+        account.update!(scheduler_paused_at: Time.current)
+        get agent_runs_path
+        expect(response.body).to include("Resume Scheduler")
+        expect(response.body).to include("Scheduler paused")
+        expect(response.body).to include(resume_scheduler_agent_runs_path)
+      end
+
+      it "does not render the navbar pause indicator when the scheduler is running" do
+        get agent_runs_path
+        expect(response.body).not_to include("navbar-scheduler-paused")
+      end
+
+      it "renders the navbar pause indicator (desktop and mobile) when the scheduler is paused" do
+        account.update!(scheduler_paused_at: Time.current)
+        get agent_runs_path
+        expect(response.body).to include("navbar-scheduler-paused")
+        expect(response.body).to include("navbar-scheduler-paused-mobile")
+      end
+    end
+  end
+
+  describe "POST /agent_runs/pause_scheduler" do
+    context "when not authenticated" do
+      it "redirects to the sign in page" do
+        post pause_scheduler_agent_runs_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as an admin" do
+      before do
+        user.add_role(:admin, account)
+        sign_in user
+      end
+
+      it "marks the current account's scheduler as paused" do
+        freeze_time do
+          post pause_scheduler_agent_runs_path
+
+          expect(account.reload.scheduler_paused_at).to eq(Time.current)
+          expect(response).to redirect_to(agent_runs_path)
+          expect(flash[:notice]).to include("paused")
+        end
+      end
+
+      it "is idempotent when the scheduler is already paused" do
+        original_time = 2.hours.ago
+        account.update!(scheduler_paused_at: original_time)
+
+        post pause_scheduler_agent_runs_path
+
+        expect(account.reload.scheduler_paused_at).to be_within(1.second).of(original_time)
+        expect(response).to redirect_to(agent_runs_path)
+      end
+    end
+
+    context "when authenticated as a member without admin role" do
+      before do
+        user.add_role(:member, account)
+        sign_in user
+      end
+
+      it "rejects the request" do
+        post pause_scheduler_agent_runs_path
+
+        expect(account.reload.scheduler_paused_at).to be_nil
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("not authorized")
+      end
+    end
+  end
+
+  describe "POST /agent_runs/resume_scheduler" do
+    context "when not authenticated" do
+      it "redirects to the sign in page" do
+        post resume_scheduler_agent_runs_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as an admin" do
+      before do
+        user.add_role(:admin, account)
+        sign_in user
+      end
+
+      it "clears the paused-at timestamp and enqueues the queue processor" do
+        account.update!(scheduler_paused_at: 1.hour.ago)
+
+        expect {
+          post resume_scheduler_agent_runs_path
+        }.to have_enqueued_job(ProcessRunQueueJob)
+
+        expect(account.reload.scheduler_paused_at).to be_nil
+        expect(response).to redirect_to(agent_runs_path)
+        expect(flash[:notice]).to include("resumed")
+      end
+
+      it "is a no-op when the scheduler is not paused" do
+        expect {
+          post resume_scheduler_agent_runs_path
+        }.not_to have_enqueued_job(ProcessRunQueueJob)
+
+        expect(account.reload.scheduler_paused_at).to be_nil
+        expect(response).to redirect_to(agent_runs_path)
+      end
+    end
+
+    context "when authenticated as a member without admin role" do
+      before do
+        user.add_role(:member, account)
+        account.update!(scheduler_paused_at: 1.hour.ago)
+        sign_in user
+      end
+
+      it "rejects the request" do
+        original_time = account.scheduler_paused_at
+
+        post resume_scheduler_agent_runs_path
+
+        expect(account.reload.scheduler_paused_at).to be_within(1.second).of(original_time)
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -132,20 +132,6 @@ RSpec.describe "AgentRuns" do
         expect(response.body).not_to include(other_project.name)
       end
 
-      it "shows the pause all button when scheduler is running" do
-        get agent_runs_path
-        expect(response.body).to include("Pause All")
-        expect(response.body).to include(pause_scheduler_agent_runs_path)
-      end
-
-      it "shows the resume button and paused banner when scheduler is paused" do
-        account.update!(scheduler_paused_at: Time.current)
-        get agent_runs_path
-        expect(response.body).to include("Resume Scheduler")
-        expect(response.body).to include("Scheduler paused")
-        expect(response.body).to include(resume_scheduler_agent_runs_path)
-      end
-
       it "does not render the navbar pause indicator when the scheduler is running" do
         get agent_runs_path
         expect(response.body).not_to include("navbar-scheduler-paused")
@@ -156,6 +142,42 @@ RSpec.describe "AgentRuns" do
         get agent_runs_path
         expect(response.body).to include("navbar-scheduler-paused")
         expect(response.body).to include("navbar-scheduler-paused-mobile")
+      end
+
+      context "when authorized to manage the account" do
+        before { user.add_role(:admin, account) }
+
+        it "shows the pause all button when scheduler is running" do
+          get agent_runs_path
+          expect(response.body).to include("Pause All")
+          expect(response.body).to include(pause_scheduler_agent_runs_path)
+        end
+
+        it "shows the resume button and paused banner when scheduler is paused" do
+          account.update!(scheduler_paused_at: Time.current)
+          get agent_runs_path
+          expect(response.body).to include("Resume Scheduler")
+          expect(response.body).to include("Scheduler paused")
+          expect(response.body).to include(resume_scheduler_agent_runs_path)
+        end
+      end
+
+      context "without permission to manage the account" do
+        before { user.add_role(:member, account) }
+
+        it "does not render the pause all button when scheduler is running" do
+          get agent_runs_path
+          expect(response.body).not_to include("Pause All")
+          expect(response.body).not_to include(pause_scheduler_agent_runs_path)
+        end
+
+        it "does not render the resume button when scheduler is paused but still shows the banner" do
+          account.update!(scheduler_paused_at: Time.current)
+          get agent_runs_path
+          expect(response.body).not_to include("Resume Scheduler")
+          expect(response.body).not_to include(resume_scheduler_agent_runs_path)
+          expect(response.body).to include("Scheduler paused")
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Add pause all button to agent runs page with navigation indicator

See #805 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #805