### PR TITLE
Fix #839: fix(review-runs): avoid malformed JSON in PR review proxy requests

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1491,7 +1491,14 @@ module Activities
       incomplete. If you cannot identify specific file paths and line numbers, do not
       include that issue in the review.
 
-      Post your review using the GitHub API proxy:
+      Post your review using the GitHub API proxy.
+
+      IMPORTANT: Do NOT pass the review JSON inline with a single-quoted `-d '...'`.
+      Review bodies and inline comments contain markdown, suggestion blocks, newlines,
+      and apostrophes — inlining that payload breaks shell quoting and produces
+      malformed JSON (invalid control characters inside strings) that Rails rejects
+      before the request ever reaches GitHub. Always write the review JSON to a
+      temporary file and submit it with `--data-binary @file`.
 
       ```bash
       # Get PR details (metadata and links)
@@ -1511,22 +1518,27 @@ module Activities
       # inline comments is incomplete. If you cannot identify a specific file
       # path and line number for an issue, do not include that issue in the review.
       # Note: "side" must be "RIGHT" (new code) or "LEFT" (deleted code).
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'REVIEW_JSON'
+      {
+        "body": "Overall summary of the actionable issues found",
+        "event": "COMMENT",
+        "comments": [
+          {
+            "path": "file.rb",
+            "line": 10,
+            "side": "RIGHT",
+            "body": "Actionable change request on this line"
+          }
+        ]
+      }
+      REVIEW_JSON
       curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews" \
         -H "Content-Type: application/json" \
         -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
         -H "X-Proxy-Token: $PROXY_TOKEN" \
-        -d '{
-          "body": "Overall summary of the actionable issues found",
-          "event": "COMMENT",
-          "comments": [
-            {
-              "path": "file.rb",
-              "line": 10,
-              "side": "RIGHT",
-              "body": "Actionable change request on this line"
-            }
-          ]
-        }'
+        --data-binary @"$tmpfile"
+      rm -f "$tmpfile"
 
       # Case B — clean PR, no actionable issues: post a single review with an EMPTY
       # comments array and a body that begins with the EXACT phrase
@@ -1534,16 +1546,25 @@ module Activities
       # "<!-- paid-review-clean -->" somewhere in the body. These are the
       # signals Paid uses to mark the review as clean and stop the review loop.
       # Do NOT paraphrase either signal.
+      tmpfile=$(mktemp)
+      cat > "$tmpfile" <<'REVIEW_JSON'
+      {
+        "body": "Generated no new comments. The PR looks ready as-is. <!-- paid-review-clean -->",
+        "event": "COMMENT",
+        "comments": []
+      }
+      REVIEW_JSON
       curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews" \
         -H "Content-Type: application/json" \
         -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
         -H "X-Proxy-Token: $PROXY_TOKEN" \
-        -d '{
-          "body": "Generated no new comments. The PR looks ready as-is. <!-- paid-review-clean -->",
-          "event": "COMMENT",
-          "comments": []
-        }'
+        --data-binary @"$tmpfile"
+      rm -f "$tmpfile"
       ```
+
+      If you ever need to send any other JSON payload to the proxy (for example a
+      follow-up issue comment), apply the same pattern: write the body to a temp
+      file and submit with `--data-binary @file`. Never inline JSON with `-d '...'`.
 
       # Pre-submission verification
 

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -616,7 +616,14 @@ upsert_global_prompt.call(
     incomplete. If you cannot identify specific file paths and line numbers, do not
     include that issue in the review.
 
-    Post your review using the GitHub API proxy:
+    Post your review using the GitHub API proxy.
+
+    IMPORTANT: Do NOT pass the review JSON inline with a single-quoted `-d '...'`.
+    Review bodies and inline comments contain markdown, suggestion blocks, newlines,
+    and apostrophes — inlining that payload breaks shell quoting and produces
+    malformed JSON (invalid control characters inside strings) that Rails rejects
+    before the request ever reaches GitHub. Always write the review JSON to a
+    temporary file and submit it with `--data-binary @file`.
 
     ```bash
     # Get PR details (metadata and links)
@@ -636,22 +643,27 @@ upsert_global_prompt.call(
     # inline comments is incomplete. If you cannot identify a specific file
     # path and line number for an issue, do not include that issue in the review.
     # Note: "side" must be "RIGHT" (new code) or "LEFT" (deleted code).
+    tmpfile=$(mktemp)
+    cat > "$tmpfile" <<'REVIEW_JSON'
+    {
+      "body": "Overall summary of the actionable issues found",
+      "event": "COMMENT",
+      "comments": [
+        {
+          "path": "file.rb",
+          "line": 10,
+          "side": "RIGHT",
+          "body": "Actionable change request on this line"
+        }
+      ]
+    }
+    REVIEW_JSON
     curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews" \
       -H "Content-Type: application/json" \
       -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
       -H "X-Proxy-Token: $PROXY_TOKEN" \
-      -d '{
-        "body": "Overall summary of the actionable issues found",
-        "event": "COMMENT",
-        "comments": [
-          {
-            "path": "file.rb",
-            "line": 10,
-            "side": "RIGHT",
-            "body": "Actionable change request on this line"
-          }
-        ]
-      }'
+      --data-binary @"$tmpfile"
+    rm -f "$tmpfile"
 
     # Case B — clean PR, no actionable issues: post a single review with an EMPTY
     # comments array and a body that begins with the EXACT phrase
@@ -659,16 +671,25 @@ upsert_global_prompt.call(
     # "<!-- paid-review-clean -->" somewhere in the body. These are the
     # signals Paid uses to mark the review as clean and stop the review loop.
     # Do NOT paraphrase either signal.
+    tmpfile=$(mktemp)
+    cat > "$tmpfile" <<'REVIEW_JSON'
+    {
+      "body": "Generated no new comments. The PR looks ready as-is. <!-- paid-review-clean -->",
+      "event": "COMMENT",
+      "comments": []
+    }
+    REVIEW_JSON
     curl -X POST --connect-timeout 10 --max-time 30 "$GITHUB_API_URL/repos/{{repo}}/pulls/{{pr_number}}/reviews" \
       -H "Content-Type: application/json" \
       -H "X-Agent-Run-Id: $AGENT_RUN_ID" \
       -H "X-Proxy-Token: $PROXY_TOKEN" \
-      -d '{
-        "body": "Generated no new comments. The PR looks ready as-is. <!-- paid-review-clean -->",
-        "event": "COMMENT",
-        "comments": []
-      }'
+      --data-binary @"$tmpfile"
+    rm -f "$tmpfile"
     ```
+
+    If you ever need to send any other JSON payload to the proxy (for example a
+    follow-up issue comment), apply the same pattern: write the body to a temp
+    file and submit with `--data-binary @file`. Never inline JSON with `-d '...'`.
 
     # Pre-submission verification
 

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -109,6 +109,51 @@ RSpec.describe Prompt, type: :model do
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
         .to include('Case B: body starts with EXACTLY "Generated no new comments." and "comments" is []')
     end
+
+    # Regression for #839: review JSON posted with inline `-d '...'` breaks
+    # when the body contains multiline markdown or apostrophes, producing an
+    # invalid JSON payload that Rails rejects before the request reaches
+    # GitHub. Reviews must be submitted via a temp file + `--data-binary @file`.
+    describe "review payload submission pattern (issue #839)" do
+      let(:seed_template) do
+        described_class.global.find_by(slug: "goal.review_pull_request").current_version.template
+      end
+      let(:fallback_template) { Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT }
+
+      # Match any curl invocation whose target URL is the /pulls/<n>/reviews
+      # endpoint, regardless of what flags come between `curl` and the URL.
+      # This catches new shapes (e.g. `curl -sS -X POST`) that a future edit
+      # might introduce.
+      let(:inline_review_curl_pattern) do
+        /curl[^\n]*\/pulls\/[^\n]*\/reviews[^\n]*(?:\\\n[^\n]*)*-d\s+'/m
+      end
+
+      it "seeded template posts the review via a temp file and --data-binary" do
+        expect(seed_template).to include('--data-binary @"$tmpfile"')
+        expect(seed_template).to include("tmpfile=$(mktemp)")
+      end
+
+      it "FALLBACK_REVIEW_GOAL_PROMPT posts the review via a temp file and --data-binary" do
+        expect(fallback_template).to include('--data-binary @"$tmpfile"')
+        expect(fallback_template).to include("tmpfile=$(mktemp)")
+      end
+
+      it "seeded template does not model inline `-d '{...}'` for the reviews endpoint" do
+        expect(seed_template).not_to match(inline_review_curl_pattern)
+      end
+
+      it "FALLBACK_REVIEW_GOAL_PROMPT does not model inline `-d '{...}'` for the reviews endpoint" do
+        expect(fallback_template).not_to match(inline_review_curl_pattern)
+      end
+
+      it "seeded template warns against inline JSON payloads" do
+        expect(seed_template).to match(/Do NOT pass .*inline/i)
+      end
+
+      it "FALLBACK_REVIEW_GOAL_PROMPT warns against inline JSON payloads" do
+        expect(fallback_template).to match(/Do NOT pass .*inline/i)
+      end
+    end
   end
 
   describe "coding.pr_review_rebase already-addressed marker" do


### PR DESCRIPTION
## Summary

fix(review-runs): avoid malformed JSON in PR review proxy requests

See #839 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #839