### PR TITLE
Fix #875: feat(models): map task complexity score to model tier

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -154,7 +154,8 @@ class ProvidersController < ApplicationController
     attrs = params.require(:provider).permit(
       *permitted,
       config: { opencode: [ :api_provider, :model ], kilocode: [ :api_provider, :model ] },
-      tier_model_ids: LlmModel::TIERS
+      tier_model_ids: LlmModel::TIERS,
+      complexity_thresholds: Provider::COMPLEXITY_THRESHOLD_KEYS
     )
 
     # Convert config to a plain Hash and slice to only the relevant provider_key,
@@ -170,7 +171,25 @@ class ProvidersController < ApplicationController
     if result.key?("tier_model_ids")
       result["tier_model_ids"] = result["tier_model_ids"].to_h.compact_blank
     end
+    if result.key?("complexity_thresholds")
+      result["complexity_thresholds"] = normalize_complexity_thresholds(result["complexity_thresholds"])
+    end
     result
+  end
+
+  # Coerces blank-string form inputs to nil and integer-like strings to Ints,
+  # dropping missing keys so they fall back to the model's default thresholds
+  # rather than persisting blank values that fail the model-level validation.
+  def normalize_complexity_thresholds(raw)
+    return {} unless raw.is_a?(Hash)
+
+    raw.each_with_object({}) do |(key, value), result|
+      next unless Provider::COMPLEXITY_THRESHOLD_KEYS.include?(key.to_s)
+      next if value.nil? || value.to_s.strip.empty?
+
+      coerced = Integer(value, exception: false)
+      result[key.to_s] = coerced || value
+    end
   end
 
   def load_provider_options

--- a/app/models/model_selection.rb
+++ b/app/models/model_selection.rb
@@ -9,4 +9,5 @@ class ModelSelection < ApplicationRecord
   validates :selector_type, presence: true, inclusion: { in: SELECTOR_TYPES }
   validates :agent_run_id, uniqueness: true
   validates :complexity_score, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }, allow_nil: true
+  validates :tier, inclusion: { in: LlmModel::TIERS }, allow_nil: true
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -543,10 +543,13 @@ class Provider < ApplicationRecord
       coerced[key] = value
     end
 
-    low_max = coerced["low_max"]
-    mid_max = coerced["mid_max"]
-    return if low_max.nil? || mid_max.nil?
-    return if low_max < mid_max
+    # Compare against effective values so partial submissions (e.g. only low_max)
+    # cannot persist a configuration that is inconsistent when merged with the
+    # defaults (e.g. low_max=8 with the default mid_max=7 would leave the "mid"
+    # tier unreachable).
+    effective_low_max = coerced["low_max"] || DEFAULT_COMPLEXITY_THRESHOLDS["low_max"]
+    effective_mid_max = coerced["mid_max"] || DEFAULT_COMPLEXITY_THRESHOLDS["mid_max"]
+    return if effective_low_max < effective_mid_max
 
     errors.add(:complexity_thresholds, "low_max must be less than mid_max")
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -8,6 +8,10 @@ class Provider < ApplicationRecord
   AUTH_TYPES = %w[subscription api_key].freeze
   FALLBACK_ROLES = %w[standard rate_limit_fallback].freeze
   ROUTING_KEY_PREFIX = "provider:".freeze
+  # Default cutoffs for mapping a complexity score (1-10) to an LlmModel tier.
+  # complexity <= low_max => "low", <= mid_max => "mid", else "high".
+  DEFAULT_COMPLEXITY_THRESHOLDS = { "low_max" => 3, "mid_max" => 7 }.freeze
+  COMPLEXITY_THRESHOLD_KEYS = %w[low_max mid_max].freeze
   # Upstream API providers supported by direct-outbound CLI tools (OpenCode,
   # KiloCode). Each entry maps a slug to its base URL and the ProviderApiKey
   # service type required for authentication.
@@ -72,6 +76,7 @@ class Provider < ApplicationRecord
   validate :opencode_api_key_config_must_be_valid
   validate :kilocode_api_key_config_must_be_valid
   validate :tier_model_ids_must_be_valid
+  validate :complexity_thresholds_must_be_valid
   validate :agent_co_author_trailer_is_single_line
 
   before_destroy :prevent_destroying_last_agent_run_provider
@@ -100,6 +105,17 @@ class Provider < ApplicationRecord
     label += " #{model_id}" if model_id.present?
     label += " (API Key)" if api_key?
     label
+  end
+
+  # Returns a merged hash of complexity thresholds (stored values overlaid on
+  # defaults) so callers can read a concrete mapping without re-checking for
+  # missing keys every time. Integers are coerced so JSONB round-trips (which
+  # may preserve Rails' Integer/Float or return strings) don't leak into the
+  # tier-mapping logic.
+  def effective_complexity_thresholds
+    stored = complexity_thresholds.is_a?(Hash) ? complexity_thresholds : {}
+    DEFAULT_COMPLEXITY_THRESHOLDS.merge(stored.slice(*COMPLEXITY_THRESHOLD_KEYS))
+      .transform_values { |v| Integer(v) rescue v }
   end
 
   def routing_key
@@ -498,6 +514,41 @@ class Provider < ApplicationRecord
         errors.add(:tier_model_ids, "model #{model_id} does not belong to provider #{provider_key}")
       end
     end
+  end
+
+  def complexity_thresholds_must_be_valid
+    return if complexity_thresholds.blank?
+
+    unless complexity_thresholds.is_a?(Hash)
+      errors.add(:complexity_thresholds, "must be a hash of threshold keys to integers")
+      return
+    end
+
+    invalid_keys = complexity_thresholds.keys.map(&:to_s) - COMPLEXITY_THRESHOLD_KEYS
+    if invalid_keys.any?
+      errors.add(:complexity_thresholds, "contains unknown key(s): #{invalid_keys.join(', ')}")
+      return
+    end
+
+    coerced = {}
+    COMPLEXITY_THRESHOLD_KEYS.each do |key|
+      raw = complexity_thresholds[key] || complexity_thresholds[key.to_sym]
+      next if raw.nil?
+
+      value = Integer(raw, exception: false)
+      if value.nil? || !value.between?(1, 10)
+        errors.add(:complexity_thresholds, "#{key} must be an integer between 1 and 10")
+        return
+      end
+      coerced[key] = value
+    end
+
+    low_max = coerced["low_max"]
+    mid_max = coerced["mid_max"]
+    return if low_max.nil? || mid_max.nil?
+    return if low_max < mid_max
+
+    errors.add(:complexity_thresholds, "low_max must be less than mid_max")
   end
 
   def kilocode_api_key_config_must_be_valid

--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -15,7 +15,10 @@ module Models
     end
 
     def call
-      candidates = available_candidates
+      initial_complexity = RulesBasedSelector.new(agent_run: agent_run).estimate_complexity
+      initial_tier = TierForComplexity.call(complexity: initial_complexity, agent_run: agent_run)
+
+      candidates = available_candidates(tier: initial_tier)
       return nil if candidates.empty?
 
       response = request_selection(candidates)
@@ -24,9 +27,13 @@ module Models
       selected = candidates.find { |m| m.model_id == response[:model_id] }
       return nil unless selected
 
+      final_complexity = response[:complexity_score] || initial_complexity
+      final_tier = TierForComplexity.call(complexity: final_complexity, agent_run: agent_run) || initial_tier
+
       {
         model: selected,
         selector_type: "meta_agent",
+        tier: final_tier,
         reasoning: response[:reasoning],
         candidates: candidates.map { |m| { model_id: m.model_id, score: m.capability_score.to_f } },
         complexity_score: response[:complexity_score]
@@ -45,11 +52,18 @@ module Models
 
     attr_reader :agent_run
 
-    def available_candidates
+    def available_candidates(tier: nil)
       scope = LlmModel.active
 
       excluded = agent_run.project.model_preferences["excluded_model_ids"]
       scope = scope.where.not(model_id: excluded) if excluded.present?
+
+      if tier
+        tier_scope = scope.by_tier(tier)
+        # Fall back to the full pool when the tier is empty so the meta-agent
+        # still has something to choose from (e.g. before tiers are seeded).
+        return tier_scope.order(Arel.sql("capability_score DESC NULLS LAST")).to_a if tier_scope.exists?
+      end
 
       scope.order(Arel.sql("capability_score DESC NULLS LAST")).to_a
     end

--- a/app/services/models/rules_based_selector.rb
+++ b/app/services/models/rules_based_selector.rb
@@ -12,7 +12,8 @@ module Models
 
     def call
       complexity = estimate_complexity
-      candidates = build_candidates(complexity)
+      tier = TierForComplexity.call(complexity: complexity, agent_run: agent_run)
+      candidates = build_candidates(complexity: complexity, tier: tier)
 
       return nil if candidates.empty?
 
@@ -21,17 +22,16 @@ module Models
       {
         model: selected,
         selector_type: "rules",
-        reasoning: "Rules-based selection: complexity=#{complexity.round(1)}, " \
+        tier: tier,
+        reasoning: "Rules-based selection: complexity=#{complexity.round(1)}, tier=#{tier || 'unknown'}, " \
                    "selected #{selected.display_name} (capability=#{selected.capability_score})",
         candidates: candidates.map { |m| { model_id: m.model_id, score: m.capability_score.to_f } },
         complexity_score: complexity
       }
     end
 
-    private
-
-    attr_reader :agent_run
-
+    # Public so collaborators (e.g. MetaAgentSelector) can reuse the same
+    # heuristic to establish an initial tier before the LLM meta-agent runs.
     def estimate_complexity
       score = 5.0
 
@@ -48,27 +48,44 @@ module Models
       score.clamp(1.0, 10.0)
     end
 
-    def build_candidates(complexity)
+    private
+
+    attr_reader :agent_run
+
+    def build_candidates(complexity:, tier:)
       scope = LlmModel.active
 
       # Exclude models the project has excluded
       excluded = agent_run.project.model_preferences["excluded_model_ids"]
       scope = scope.where.not(model_id: excluded) if excluded.present?
 
-      # Filter by minimum capability, then order by cost-effectiveness
+      tier_candidates = tier ? tier_scope(scope, tier).to_a : []
+      # Fall back to the broader pool when the tier has no active models, so a
+      # missing tier mapping never leaves the system with zero candidates.
+      return tier_candidates if tier_candidates.any?
+
+      fallback_candidates(scope, complexity)
+    end
+
+    def tier_scope(scope, tier)
+      ordering = tier == "low" ? cost_asc_ordering : capability_desc_ordering
+      scope.by_tier(tier).order(ordering).limit(5)
+    end
+
+    def fallback_candidates(scope, complexity)
       if complexity < 4.0
-        scope = scope.where("capability_score >= 5 OR capability_score IS NULL")
-        # For simple tasks, prefer cheaper models among those that meet the threshold
-        scope.order(Arel.sql("input_cost_per_million ASC NULLS LAST")).limit(5).to_a
-      elsif complexity >= 7.0
-        scope = scope.where("capability_score >= 8 OR capability_score IS NULL")
-        # For complex tasks, prefer the most capable models
-        scope.order(Arel.sql("capability_score DESC NULLS LAST")).limit(5).to_a
+        scope.order(cost_asc_ordering).limit(5).to_a
       else
-        # For medium complexity, prefer higher capability (same as complex tasks
-        # but with a wider pool since no minimum capability filter is applied)
-        scope.order(Arel.sql("capability_score DESC NULLS LAST")).limit(5).to_a
+        scope.order(capability_desc_ordering).limit(5).to_a
       end
+    end
+
+    def capability_desc_ordering
+      Arel.sql("capability_score DESC NULLS LAST")
+    end
+
+    def cost_asc_ordering
+      Arel.sql("input_cost_per_million ASC NULLS LAST")
     end
   end
 end

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -26,6 +26,7 @@ module Models
         ms.reasoning = selected[:reasoning]
         ms.candidates = selected[:candidates]
         ms.complexity_score = selected[:complexity_score]
+        ms.tier = selected[:tier] || tier_for(selected)
         ms.selection_duration_ms = duration_ms
       end
     rescue ActiveRecord::RecordNotUnique
@@ -70,8 +71,21 @@ module Models
         selector_type: "override",
         reasoning: reason,
         candidates: [ { model_id: model.model_id, score: model.capability_score.to_f } ],
-        complexity_score: nil
+        complexity_score: nil,
+        # For override paths the tier follows the chosen model directly, since
+        # no complexity-based routing was performed.
+        tier: model.tier
       }
+    end
+
+    # Recorded tier for a selection. Prefers the selector's own tier (derived
+    # from the complexity->tier mapping it used) and falls back to the model's
+    # own tier so ModelSelection.tier is populated for every run, even when the
+    # complexity score is absent (override paths).
+    def tier_for(selected)
+      return nil if selected.blank?
+
+      selected[:tier].presence || selected[:model]&.tier
     end
   end
 end

--- a/app/services/models/tier_for_complexity.rb
+++ b/app/services/models/tier_for_complexity.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Models
+  # Maps a complexity score (1-10) to an LlmModel tier ("low" | "mid" | "high")
+  # using tunable thresholds. Thresholds are resolved from the first source that
+  # defines them: project-level `model_preferences["complexity_thresholds"]`,
+  # the agent_run's provider, or Provider::DEFAULT_COMPLEXITY_THRESHOLDS.
+  #
+  # Returns nil when the complexity score is nil or non-numeric — callers fall
+  # back to their existing behavior when no tier can be derived.
+  class TierForComplexity
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(complexity:, agent_run: nil, project: nil, provider: nil)
+      @complexity = complexity
+      @agent_run = agent_run
+      @project = project || agent_run&.project
+      @provider = provider || agent_run&.provider
+    end
+
+    def call
+      return nil if complexity.nil?
+
+      score = Float(complexity)
+      thresholds = effective_thresholds
+
+      return "low" if score <= thresholds["low_max"]
+      return "mid" if score <= thresholds["mid_max"]
+
+      "high"
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    def effective_thresholds
+      project_override || provider_thresholds || Provider::DEFAULT_COMPLEXITY_THRESHOLDS.dup
+    end
+
+    private
+
+    attr_reader :complexity, :agent_run, :project, :provider
+
+    def project_override
+      return nil unless project
+
+      raw = project.model_preferences&.dig("complexity_thresholds")
+      return nil unless raw.is_a?(Hash)
+
+      normalized = Provider::DEFAULT_COMPLEXITY_THRESHOLDS.merge(
+        raw.slice(*Provider::COMPLEXITY_THRESHOLD_KEYS)
+      )
+      normalized.transform_values { |v| Integer(v, exception: false) || v }
+    end
+
+    def provider_thresholds
+      provider&.effective_complexity_thresholds
+    end
+  end
+end

--- a/app/views/providers/_form.html.erb
+++ b/app/views/providers/_form.html.erb
@@ -238,6 +238,28 @@
     <% end %>
   <% end %>
 
+  <% thresholds = provider.effective_complexity_thresholds %>
+  <div class="rounded-lg border border-gray-200 p-4">
+    <h3 class="text-sm font-semibold text-gray-900">Complexity → Tier Thresholds</h3>
+    <p class="mt-1 text-xs text-gray-500">Tasks with complexity score (1–10) at or below each threshold route to that tier. Scores above mid_max route to the high tier.</p>
+    <div class="mt-3 grid grid-cols-2 gap-4">
+      <div>
+        <%= form.label "complexity_thresholds[low_max]", "Low tier max", class: "block text-sm font-medium text-gray-900" %>
+        <%= form.number_field "complexity_thresholds[low_max]",
+            value: thresholds["low_max"],
+            in: 1..10, step: 1,
+            class: "mt-1 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+      </div>
+      <div>
+        <%= form.label "complexity_thresholds[mid_max]", "Mid tier max", class: "block text-sm font-medium text-gray-900" %>
+        <%= form.number_field "complexity_thresholds[mid_max]",
+            value: thresholds["mid_max"],
+            in: 1..10, step: 1,
+            class: "mt-1 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+      </div>
+    </div>
+  </div>
+
   <div class="space-y-3 rounded-lg border border-gray-200 p-4">
     <div class="flex items-center">
       <%= form.check_box :enabled_for_agent_runs, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>

--- a/db/migrate/20260416185455_add_complexity_thresholds_to_providers.rb
+++ b/db/migrate/20260416185455_add_complexity_thresholds_to_providers.rb
@@ -1,0 +1,13 @@
+class AddComplexityThresholdsToProviders < ActiveRecord::Migration[8.1]
+  # Maps a complexity score (1-10) to a model tier. A task with complexity
+  # <= low_max routes to the "low" tier, <= mid_max routes to "mid", and
+  # anything higher routes to "high". Stored as JSONB per-provider so
+  # thresholds are data-driven rather than hardcoded in Ruby, and so each
+  # provider can tune its own complexity->tier mapping.
+  DEFAULT_COMPLEXITY_THRESHOLDS = { "low_max" => 3, "mid_max" => 7 }.freeze
+
+  def change
+    add_column :providers, :complexity_thresholds, :jsonb,
+      default: DEFAULT_COMPLEXITY_THRESHOLDS, null: false
+  end
+end

--- a/db/migrate/20260416185458_add_tier_to_model_selections.rb
+++ b/db/migrate/20260416185458_add_tier_to_model_selections.rb
@@ -1,0 +1,9 @@
+class AddTierToModelSelections < ActiveRecord::Migration[8.1]
+  def change
+    add_column :model_selections, :tier, :string, limit: 10
+    add_index :model_selections, :tier
+    add_check_constraint :model_selections,
+      "tier IS NULL OR tier IN ('low', 'mid', 'high')",
+      name: "model_selections_tier_check"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_173627) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_185458) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -707,10 +707,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_173627) do
     t.text "reasoning"
     t.integer "selection_duration_ms"
     t.string "selector_type", limit: 50, null: false
+    t.string "tier", limit: 10
     t.datetime "updated_at", null: false
     t.index ["agent_run_id"], name: "index_model_selections_on_agent_run_id", unique: true
     t.index ["llm_model_id"], name: "index_model_selections_on_llm_model_id"
     t.index ["selector_type"], name: "index_model_selections_on_selector_type"
+    t.index ["tier"], name: "index_model_selections_on_tier"
+    t.check_constraint "tier IS NULL OR (tier::text = ANY (ARRAY['low'::character varying, 'mid'::character varying, 'high'::character varying]::text[]))", name: "model_selections_tier_check"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -952,6 +955,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_173627) do
   create_table "providers", force: :cascade do |t|
     t.text "agent_co_author_trailer"
     t.string "auth_type", limit: 20, default: "subscription", null: false
+    t.jsonb "complexity_thresholds", default: {"low_max" => 3, "mid_max" => 7}, null: false
     t.jsonb "config", default: {}, null: false
     t.datetime "created_at", null: false
     t.boolean "enabled_for_agent_runs", default: true, null: false

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -21,6 +21,48 @@ RSpec.describe Provider do
       expect(provider).not_to allow_value("unknown_provider").for(:provider_key)
     end
 
+    describe "complexity_thresholds" do
+      let(:provider) { build(:provider, provider_key: "cursor") }
+
+      it "is valid with the default thresholds" do
+        expect(provider).to be_valid
+      end
+
+      it "accepts custom integer thresholds" do
+        provider.complexity_thresholds = { "low_max" => 2, "mid_max" => 8 }
+        expect(provider).to be_valid
+      end
+
+      it "rejects unknown threshold keys" do
+        provider.complexity_thresholds = { "ultra_max" => 5 }
+        expect(provider).not_to be_valid
+        expect(provider.errors[:complexity_thresholds].join).to include("unknown key")
+      end
+
+      it "rejects non-integer values" do
+        provider.complexity_thresholds = { "low_max" => "nope", "mid_max" => 7 }
+        expect(provider).not_to be_valid
+        expect(provider.errors[:complexity_thresholds].join).to include("integer")
+      end
+
+      it "rejects out-of-range values" do
+        provider.complexity_thresholds = { "low_max" => 0, "mid_max" => 7 }
+        expect(provider).not_to be_valid
+        expect(provider.errors[:complexity_thresholds].join).to include("between 1 and 10")
+      end
+
+      it "rejects low_max >= mid_max" do
+        provider.complexity_thresholds = { "low_max" => 7, "mid_max" => 5 }
+        expect(provider).not_to be_valid
+        expect(provider.errors[:complexity_thresholds].join).to include("less than mid_max")
+      end
+
+      it "exposes a merged-with-defaults hash via effective_complexity_thresholds" do
+        provider.complexity_thresholds = { "low_max" => 4 }
+        expect(provider.effective_complexity_thresholds).to eq("low_max" => 4, "mid_max" => 7)
+      end
+    end
+
     describe "tier_model_ids" do
       let(:provider) { build(:provider, provider_key: "cursor") }
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe Provider do
         expect(provider.errors[:complexity_thresholds].join).to include("less than mid_max")
       end
 
+      it "rejects a partial low_max that is inconsistent with the default mid_max" do
+        provider.complexity_thresholds = { "low_max" => 8 }
+        expect(provider).not_to be_valid
+        expect(provider.errors[:complexity_thresholds].join).to include("less than mid_max")
+      end
+
+      it "rejects a partial mid_max that is inconsistent with the default low_max" do
+        provider.complexity_thresholds = { "mid_max" => 2 }
+        expect(provider).not_to be_valid
+        expect(provider.errors[:complexity_thresholds].join).to include("less than mid_max")
+      end
+
       it "exposes a merged-with-defaults hash via effective_complexity_thresholds" do
         provider.complexity_thresholds = { "low_max" => 4 }
         expect(provider.effective_complexity_thresholds).to eq("low_max" => 4, "mid_max" => 7)

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -481,6 +481,28 @@ RSpec.describe "Providers" do
       expect(provider.reload.tier_model_ids).to eq("low" => "haiku-x", "mid" => "sonnet-x", "high" => "opus-x")
     end
 
+    it "persists complexity_thresholds on update" do
+      provider = user.providers.create!(provider_key: "cursor")
+
+      patch provider_path(provider), params: {
+        provider: { complexity_thresholds: { low_max: "2", mid_max: "8" } }
+      }
+
+      expect(response).to redirect_to(providers_path)
+      expect(provider.reload.complexity_thresholds).to eq("low_max" => 2, "mid_max" => 8)
+    end
+
+    it "rejects invalid complexity_thresholds" do
+      provider = user.providers.create!(provider_key: "cursor")
+
+      patch provider_path(provider), params: {
+        provider: { complexity_thresholds: { low_max: "8", mid_max: "3" } }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("less than mid_max")
+    end
+
     it "rejects enabling agent runs on a provider that has become unsupported" do
       provider = user.providers.create!(provider_key: "cursor")
 

--- a/spec/services/models/meta_agent_selector_spec.rb
+++ b/spec/services/models/meta_agent_selector_spec.rb
@@ -33,6 +33,40 @@ RSpec.describe Models::MetaAgentSelector do
       expect(result[:complexity_score]).to eq(7.5)
     end
 
+    it "records a tier derived from the meta-agent's complexity score" do
+      result = described_class.call(agent_run: agent_run)
+
+      # complexity_score 7.5 with default thresholds (mid_max=7) => "high"
+      expect(result[:tier]).to eq("high")
+    end
+
+    context "when candidates are tier-filtered" do
+      let!(:low_model) { create(:llm_model, :cheap, model_id: "tier-low-agent", tier: "low", capability_score: 4.0) }
+      let!(:mid_model) { create(:llm_model, model_id: "tier-mid-agent", tier: "mid", capability_score: 7.0) }
+
+      let(:successful_response) do
+        instance_double(
+          AgentHarness::Response,
+          success?: true,
+          output: '{"model": "tier-low-agent", "reasoning": "Simple task", "complexity_score": 2.0}'
+        )
+      end
+
+      before do
+        LlmModel.where.not(id: [ low_model.id, mid_model.id ]).destroy_all
+        # Widen the low tier so the rules-based estimator puts this run there.
+        agent_run.project.update!(
+          model_preferences: { "complexity_thresholds" => { "low_max" => 6, "mid_max" => 8 } }
+        )
+      end
+
+      it "restricts candidates to the complexity-derived tier" do
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:candidates].map { |c| c[:model_id] }).to contain_exactly("tier-low-agent")
+      end
+    end
+
     it "includes all candidates in the result" do
       result = described_class.call(agent_run: agent_run)
 

--- a/spec/services/models/rules_based_selector_spec.rb
+++ b/spec/services/models/rules_based_selector_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Models::RulesBasedSelector do
     let(:agent_run) { create(:agent_run) }
 
     before do
-      create(:llm_model, capability_score: 9.0, model_id: "best-model")
-      create(:llm_model, capability_score: 5.0, model_id: "basic-model")
+      create(:llm_model, capability_score: 9.0, model_id: "best-model", tier: "high")
+      create(:llm_model, capability_score: 5.0, model_id: "basic-model", tier: "low")
     end
 
     it "returns a result with a selected model" do
@@ -33,6 +33,104 @@ RSpec.describe Models::RulesBasedSelector do
       result = described_class.call(agent_run: agent_run)
 
       expect(result).to be_nil
+    end
+
+    describe "tier-based routing" do
+      let!(:low_model)  { create(:llm_model, :cheap, model_id: "tier-low", tier: "low",  capability_score: 4.0) }
+      let!(:mid_model)  { create(:llm_model,        model_id: "tier-mid", tier: "mid",  capability_score: 7.0) }
+      let!(:high_model) { create(:llm_model, :expensive, model_id: "tier-high", tier: "high", capability_score: 9.5) }
+
+      before do
+        LlmModel.where.not(id: [ low_model.id, mid_model.id, high_model.id ]).destroy_all
+      end
+
+      it "routes simple tasks (low complexity) to the low tier" do
+        # create_issue with a short issue body drives the complexity estimator
+        # below the low_max threshold when the project overrides it to 3.
+        agent_run.project.update!(
+          model_preferences: { "complexity_thresholds" => { "low_max" => 4, "mid_max" => 7 } }
+        )
+        run = create(:agent_run, :create_issue_goal, project: agent_run.project)
+
+        result = described_class.call(agent_run: run)
+
+        expect(result[:tier]).to eq("low")
+        expect(result[:model]).to eq(low_model)
+      end
+
+      it "routes medium tasks to the mid tier" do
+        # Short issue body yields complexity 4.0 which lands in "mid" with the
+        # default thresholds (low_max=3, mid_max=7).
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:tier]).to eq("mid")
+        expect(result[:model]).to eq(mid_model)
+      end
+
+      it "routes complex tasks to the high tier" do
+        agent_run.issue.update!(body: "A" * 5000)
+        agent_run.update!(source_pull_request_number: 99)
+
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:tier]).to eq("high")
+        expect(result[:model]).to eq(high_model)
+      end
+
+      it "respects project excluded_model_ids even within a tier" do
+        agent_run.project.update!(
+          model_preferences: { "excluded_model_ids" => [ mid_model.model_id ] }
+        )
+        # Default complexity is 5.0 => mid tier. Excluding mid_model should
+        # yield zero tier candidates, so the fallback pool is used instead.
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:model]).not_to eq(mid_model)
+      end
+
+      it "honors project-level threshold overrides" do
+        agent_run.project.update!(
+          model_preferences: { "complexity_thresholds" => { "low_max" => 6, "mid_max" => 8 } }
+        )
+        # Complexity 4.0 (short body) now falls into the "low" tier with
+        # low_max=6.
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:tier]).to eq("low")
+        expect(result[:model]).to eq(low_model)
+      end
+
+      it "honors provider-level threshold overrides on the agent run" do
+        provider = create(:provider, user: agent_run.project.effective_owner)
+        provider.update!(complexity_thresholds: { "low_max" => 3, "mid_max" => 9 })
+        agent_run.update!(provider: provider)
+
+        # Complexity 4.0 (short body) → above low_max=3, below mid_max=9 →
+        # "mid". With default thresholds (mid_max=7) this would also be "mid",
+        # so the next update below proves thresholds are actually used.
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:tier]).to eq("mid")
+
+        # Reconfigure so mid_max=3 ⇒ complexity 4.0 routes to high.
+        provider.update!(complexity_thresholds: { "low_max" => 2, "mid_max" => 3 })
+        agent_run.reload
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:tier]).to eq("high")
+      end
+
+      it "falls back to the broader pool when the tier has no active models" do
+        high_model.update!(active: false)
+        agent_run.issue.update!(body: "A" * 5000)
+        agent_run.update!(source_pull_request_number: 99)
+
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result).to be_present
+        expect(result[:tier]).to eq("high")
+        expect(result[:model]).not_to eq(high_model)
+      end
     end
   end
 end

--- a/spec/services/models/select_spec.rb
+++ b/spec/services/models/select_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Models::Select do
     end
 
     context "with project model override (required_model_id)" do
-      let!(:llm_model) { create(:llm_model, model_id: "claude-sonnet-4-6") }
+      let!(:llm_model) { create(:llm_model, model_id: "claude-sonnet-4-6", tier: "high") }
 
       before do
         project.update!(model_preferences: { "required_model_id" => "claude-sonnet-4-6" })
@@ -25,6 +25,12 @@ RSpec.describe Models::Select do
         expect(selection).to be_a(ModelSelection)
         expect(selection.llm_model).to eq(llm_model)
         expect(selection.selector_type).to eq("override")
+      end
+
+      it "records the tier from the selected model" do
+        selection = described_class.call(agent_run: agent_run)
+
+        expect(selection.tier).to eq("high")
       end
 
       it "persists a ModelSelection record" do
@@ -102,6 +108,7 @@ RSpec.describe Models::Select do
         allow(Models::MetaAgentSelector).to receive(:call).and_return({
           model: llm_model,
           selector_type: "meta_agent",
+          tier: "high",
           reasoning: "Complex task needs high capability",
           candidates: [ { model_id: "claude-sonnet-4-6", score: 9.0 } ],
           complexity_score: 7.5
@@ -115,6 +122,12 @@ RSpec.describe Models::Select do
         expect(selection.selector_type).to eq("meta_agent")
         expect(selection.reasoning).to eq("Complex task needs high capability")
         expect(selection.complexity_score).to eq(7.5)
+      end
+
+      it "persists the meta-agent tier" do
+        selection = described_class.call(agent_run: agent_run)
+
+        expect(selection.tier).to eq("high")
       end
     end
 

--- a/spec/services/models/tier_for_complexity_spec.rb
+++ b/spec/services/models/tier_for_complexity_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Models::TierForComplexity do
+  describe ".call" do
+    it "returns nil when complexity is nil" do
+      expect(described_class.call(complexity: nil)).to be_nil
+    end
+
+    it "returns nil when complexity is non-numeric" do
+      expect(described_class.call(complexity: "not-a-number")).to be_nil
+    end
+
+    it "maps low complexity to the low tier using defaults" do
+      expect(described_class.call(complexity: 1)).to eq("low")
+      expect(described_class.call(complexity: 3)).to eq("low")
+    end
+
+    it "maps mid complexity to the mid tier using defaults" do
+      expect(described_class.call(complexity: 4)).to eq("mid")
+      expect(described_class.call(complexity: 7)).to eq("mid")
+    end
+
+    it "maps high complexity to the high tier using defaults" do
+      expect(described_class.call(complexity: 8)).to eq("high")
+      expect(described_class.call(complexity: 10)).to eq("high")
+    end
+
+    it "uses provider thresholds when provided" do
+      provider = build(:provider, complexity_thresholds: { "low_max" => 5, "mid_max" => 8 })
+      expect(described_class.call(complexity: 5, provider: provider)).to eq("low")
+      expect(described_class.call(complexity: 6, provider: provider)).to eq("mid")
+      expect(described_class.call(complexity: 9, provider: provider)).to eq("high")
+    end
+
+    it "prefers project overrides over provider thresholds" do
+      provider = build(:provider, complexity_thresholds: { "low_max" => 5, "mid_max" => 8 })
+      project = build(:project)
+      project.model_preferences = { "complexity_thresholds" => { "low_max" => 1, "mid_max" => 2 } }
+
+      expect(described_class.call(complexity: 3, provider: provider, project: project)).to eq("high")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

feat(models): map task complexity score to model tier

See #875 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #875