### PR TITLE
Fix #711: feat(evolution): human review gate for evolved prompts

### DIFF
--- a/app/controllers/prompt_reviews_controller.rb
+++ b/app/controllers/prompt_reviews_controller.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# Human review gate for evolved prompt variants.
+#
+# - `GET /prompt_reviews` (`#queue`) lists all pending versions across the
+#   signed-in user's accessible prompts (account-wide queue).
+# - Nested `GET /prompts/:prompt_id/reviews` (`#index`) and `:show` let
+#   reviewers inspect a pending version alongside its parent (diff + metrics).
+# - `POST :approve` / `POST :reject` delegate to the PromptReviews services.
+# - `PATCH :update` supersedes a pending version with a reviewer-edited one
+#   (content fields are immutable, so editing produces a new pending version
+#   with the old one rejected as "superseded").
+class PromptReviewsController < ApplicationController
+  before_action :set_prompt, only: [ :index, :show, :update, :approve, :reject ]
+  before_action :set_prompt_version, only: [ :show, :update, :approve, :reject ]
+  skip_after_action :verify_authorized, only: [ :index, :queue ]
+
+  def queue
+    account_prompt_ids = policy_scope(Prompt).pluck(:id)
+    @prompt_versions = PromptVersion.pending_review
+      .where(prompt_id: account_prompt_ids)
+      .includes(:prompt, :created_by_user, :parent_version)
+      .order(created_at: :desc)
+  end
+
+  def index
+    @prompt_versions = @prompt.prompt_versions.pending_review
+      .includes(:created_by_user, :parent_version)
+      .order(created_at: :desc)
+  end
+
+  def show
+    authorize @prompt, :show?
+  end
+
+  def update
+    authorize @prompt, :update?
+
+    new_version = PromptReviews::Edit.call(
+      prompt_version: @prompt_version,
+      reviewer: current_user,
+      attributes: edit_params
+    )
+    redirect_to prompt_review_path(@prompt, new_version),
+      notice: "Edited variant saved as v#{new_version.version} (pending review)."
+  rescue ArgumentError, ActiveRecord::RecordInvalid => e
+    redirect_to prompt_review_path(@prompt, @prompt_version), alert: error_message(e)
+  end
+
+  def approve
+    authorize @prompt, :update?
+
+    PromptReviews::Approve.call(
+      prompt_version: @prompt_version,
+      reviewer: current_user,
+      notes: review_notes_param
+    )
+    redirect_to prompt_path(@prompt),
+      notice: "v#{@prompt_version.version} approved and promoted to current."
+  rescue ArgumentError, ActiveRecord::RecordInvalid => e
+    redirect_to prompt_review_path(@prompt, @prompt_version), alert: error_message(e)
+  end
+
+  def reject
+    authorize @prompt, :update?
+
+    PromptReviews::Reject.call(
+      prompt_version: @prompt_version,
+      reviewer: current_user,
+      notes: review_notes_param
+    )
+    redirect_to prompt_reviews_path(@prompt),
+      notice: "v#{@prompt_version.version} rejected."
+  rescue ArgumentError, ActiveRecord::RecordInvalid => e
+    redirect_to prompt_review_path(@prompt, @prompt_version), alert: error_message(e)
+  end
+
+  private
+
+  def set_prompt
+    @prompt = policy_scope(Prompt).find(params[:prompt_id])
+  end
+
+  def set_prompt_version
+    @prompt_version = @prompt.prompt_versions.find(params[:id])
+  end
+
+  def edit_params
+    permitted = params.require(:prompt_version)
+      .permit(:template, :system_prompt, :change_notes, :review_notes)
+    # Preserve parent version variables — reviewers rarely change these and
+    # they're stored as structured metadata that doesn't round-trip cleanly
+    # through a plain text form input.
+    permitted.to_h.symbolize_keys.merge(variables: @prompt_version.variables)
+  end
+
+  def review_notes_param
+    params.dig(:prompt_version, :review_notes).to_s.strip.presence
+  end
+
+  def error_message(error)
+    case error
+    when ActiveRecord::RecordInvalid then error.record.errors.full_messages.join(", ")
+    else error.message
+    end
+  end
+end

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -119,7 +119,7 @@ class PromptsController < ApplicationController
   end
 
   def prompt_params
-    params.require(:prompt).permit(:name, :slug, :category, :description, :active, :project_id)
+    params.require(:prompt).permit(:name, :slug, :category, :description, :active, :project_id, :requires_review)
   end
 
   def prompt_version_params

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -32,7 +32,7 @@ class Prompt < ApplicationRecord
   scope :for_project, ->(project) { where(project: project) }
 
   def self.ransackable_attributes(auth_object = nil)
-    %w[name slug category active description created_at updated_at]
+    %w[name slug category active description created_at updated_at requires_review]
   end
 
   def self.ransackable_associations(auth_object = nil)
@@ -66,6 +66,29 @@ class Prompt < ApplicationRecord
       update!(current_version: version)
       version
     end
+  end
+
+  # Creates a new version without promoting it to current_version. Used by the
+  # prompt evolution pipeline when +requires_review+ is true so a human can
+  # review the proposed variant before it becomes active.
+  #
+  # @param attributes [Hash] Attributes for the new PromptVersion (review_status
+  #   defaults to "pending")
+  # @return [PromptVersion] The newly created (unpromoted) version
+  def create_pending_version!(attributes = {})
+    with_lock do
+      next_version = (prompt_versions.maximum(:version) || 0) + 1
+
+      # Strip caller-supplied version keys to prevent overriding auto-increment.
+      safe_attributes = attributes.except(:version, "version")
+      safe_attributes[:review_status] ||= "pending"
+
+      prompt_versions.create!(safe_attributes.merge(version: next_version))
+    end
+  end
+
+  def pending_reviews
+    prompt_versions.pending_review
   end
 
   # Resolves the effective prompt for a given project, using inheritance:

--- a/app/models/prompt_version.rb
+++ b/app/models/prompt_version.rb
@@ -3,9 +3,12 @@
 class PromptVersion < ApplicationRecord
   IMMUTABLE_ATTRIBUTES = %w[template version prompt_id created_by_user_id parent_version_id variables system_prompt created_by change_notes].freeze
 
+  REVIEW_STATUSES = %w[pending approved rejected].freeze
+
   belongs_to :prompt
   belongs_to :created_by_user, class_name: "User", optional: true
   belongs_to :parent_version, class_name: "PromptVersion", optional: true
+  belongs_to :reviewed_by_user, class_name: "User", optional: true
 
   has_many :agent_runs, dependent: :nullify
   has_many :ab_test_variants, dependent: :restrict_with_error
@@ -15,8 +18,14 @@ class PromptVersion < ApplicationRecord
     numericality: { only_integer: true, greater_than: 0 },
     uniqueness: { scope: :prompt_id }
   validates :template, presence: true
+  validates :review_status, inclusion: { in: REVIEW_STATUSES }, allow_nil: true
 
   validate :immutable_content_after_creation, on: :update
+
+  scope :pending_review, -> { where(review_status: "pending") }
+  scope :approved, -> { where(review_status: "approved") }
+  scope :rejected, -> { where(review_status: "rejected") }
+  scope :awaiting_review, -> { pending_review }
 
   # Renders the template by interpolating variables in a single pass.
   # Values that themselves contain `{{other_var}}` substrings are NOT
@@ -26,6 +35,24 @@ class PromptVersion < ApplicationRecord
   # @return [String] The rendered template
   def render(vars = {})
     Prompts::Render.interpolate(template, vars)
+  end
+
+  def pending_review?
+    review_status == "pending"
+  end
+
+  def approved?
+    review_status == "approved"
+  end
+
+  def rejected?
+    review_status == "rejected"
+  end
+
+  # True when this version participates in the review workflow (was created
+  # while the prompt's review gate was enabled), regardless of outcome.
+  def under_review?
+    review_status.present?
   end
 
   private

--- a/app/services/ab_tests/promote_winner.rb
+++ b/app/services/ab_tests/promote_winner.rb
@@ -4,6 +4,13 @@ module AbTests
   # Promotes the winning variant's prompt version as the new default
   # for the associated prompt.
   #
+  # When the prompt has +requires_review+ enabled, the winning variant is
+  # NOT auto-promoted. Instead, it is flagged as pending review so a human
+  # can approve/reject via the review queue before it becomes active.
+  # The winning variant can be pre-marked pending by the caller; this
+  # service will normalize non-reviewed variants into pending state so
+  # downstream review UI works consistently.
+  #
   # @example
   #   AbTests::PromoteWinner.call(ab_test: completed_test)
   class PromoteWinner
@@ -23,12 +30,21 @@ module AbTests
       prompt = ab_test.prompt
       winning_version = ab_test.winner_variant.prompt_version
 
-      # Use with_lock to prevent concurrent version updates (consistent with
-      # Prompt#create_version! which also locks before updating current_version).
-      prompt.with_lock do
-        prompt.update!(current_version: winning_version)
+      if prompt.requires_review?
+        gate_for_review(winning_version)
+      else
+        promote_immediately(prompt, winning_version)
       end
+
       winning_version
+    end
+
+    # True when the winning version was queued for human review rather than
+    # promoted immediately. Callers can use this to surface the right UI hint.
+    def gated?
+      return false unless ab_test&.prompt&.requires_review?
+
+      ab_test.winner_variant&.prompt_version&.pending_review?
     end
 
     private
@@ -36,6 +52,23 @@ module AbTests
     def validate!
       raise ArgumentError, "A/B test is not completed" unless ab_test.completed?
       raise ArgumentError, "A/B test has no winner" unless ab_test.winner_variant
+    end
+
+    def promote_immediately(prompt, winning_version)
+      # Use with_lock to prevent concurrent version updates (consistent with
+      # Prompt#create_version! which also locks before updating current_version).
+      prompt.with_lock do
+        prompt.update!(current_version: winning_version)
+      end
+    end
+
+    def gate_for_review(winning_version)
+      return if winning_version.pending_review?
+      # Don't overwrite an existing review outcome; approved/rejected versions
+      # stay as-is and the caller can decide what to do next (e.g., re-run).
+      return if winning_version.under_review?
+
+      winning_version.update!(review_status: "pending")
     end
   end
 end

--- a/app/services/prompt_evolution/create_variants.rb
+++ b/app/services/prompt_evolution/create_variants.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module PromptEvolution
+  # Persists mutation variants produced by +PromptEvolution::Mutate+ as
+  # PromptVersion records. Honors the prompt's review gate:
+  #
+  # - When +prompt.requires_review+ is true, variants are created as pending
+  #   reviews and NOT promoted to current_version. A human must approve via
+  #   PromptReviews::Approve before the variant becomes active.
+  # - When +prompt.requires_review+ is false (advanced-user opt-out), the
+  #   first variant is auto-promoted to current_version and marked approved.
+  #
+  # @example
+  #   mutations = PromptEvolution::Mutate.call(prompt: prompt, ...)
+  #   PromptEvolution::CreateVariants.call(
+  #     prompt: prompt,
+  #     mutations: mutations,
+  #     created_by_user: system_user
+  #   )
+  class CreateVariants
+    attr_reader :prompt, :mutations, :created_by_user
+
+    def initialize(prompt:, mutations:, created_by_user: nil)
+      @prompt = prompt
+      @mutations = Array(mutations)
+      @created_by_user = created_by_user
+    end
+
+    def self.call(...)
+      new(...).create
+    end
+
+    def create
+      return [] if mutations.empty?
+
+      parent = prompt.current_version
+      variants = mutations.map do |mutation|
+        persist_variant(mutation, parent)
+      end
+
+      auto_promote_first(variants) unless prompt.requires_review?
+      variants
+    end
+
+    private
+
+    def persist_variant(mutation, parent)
+      attributes = {
+        template: mutation.template,
+        system_prompt: parent&.system_prompt,
+        variables: parent&.variables || [],
+        change_notes: change_notes_for(mutation),
+        created_by: "evolution",
+        created_by_user: created_by_user,
+        parent_version: parent
+      }
+      # Always start evolved variants as pending so history records the
+      # review-workflow lineage; auto-promote flips the first one to approved
+      # when the review gate is off.
+      prompt.create_pending_version!(attributes)
+    end
+
+    def auto_promote_first(variants)
+      winner = variants.first
+      return unless winner
+
+      prompt.with_lock do
+        winner.update!(
+          review_status: "approved",
+          reviewed_by_user: created_by_user,
+          reviewed_at: Time.current,
+          review_notes: "Auto-promoted (requires_review disabled)"
+        )
+        prompt.update!(current_version: winner)
+      end
+    end
+
+    def change_notes_for(mutation)
+      parts = [ "Evolved variant (#{mutation.strategy})" ]
+      parts << mutation.reasoning if mutation.reasoning.present?
+      parts.join(": ")
+    end
+  end
+end

--- a/app/services/prompt_reviews/approve.rb
+++ b/app/services/prompt_reviews/approve.rb
@@ -29,6 +29,8 @@ module PromptReviews
 
       prompt = prompt_version.prompt
       prompt.with_lock do
+        raise ArgumentError, "prompt version is no longer pending review" unless prompt_version.reload.pending_review?
+
         prompt_version.update!(
           review_status: "approved",
           reviewed_by_user: reviewer,

--- a/app/services/prompt_reviews/approve.rb
+++ b/app/services/prompt_reviews/approve.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module PromptReviews
+  # Approves a pending evolved prompt version and promotes it to be the
+  # prompt's current version.
+  #
+  # @example
+  #   PromptReviews::Approve.call(
+  #     prompt_version: evolved_version,
+  #     reviewer: current_user,
+  #     notes: "LGTM"
+  #   )
+  class Approve
+    attr_reader :prompt_version, :reviewer, :notes, :promote
+
+    def initialize(prompt_version:, reviewer:, notes: nil, promote: true)
+      @prompt_version = prompt_version
+      @reviewer = reviewer
+      @notes = notes
+      @promote = promote
+    end
+
+    def self.call(...)
+      new(...).approve
+    end
+
+    def approve
+      validate!
+
+      prompt = prompt_version.prompt
+      prompt.with_lock do
+        prompt_version.update!(
+          review_status: "approved",
+          reviewed_by_user: reviewer,
+          reviewed_at: Time.current,
+          review_notes: notes
+        )
+        prompt.update!(current_version: prompt_version) if promote
+      end
+      prompt_version
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "reviewer is required" unless reviewer
+      raise ArgumentError, "prompt version is not pending review" unless prompt_version.pending_review?
+    end
+  end
+end

--- a/app/services/prompt_reviews/edit.rb
+++ b/app/services/prompt_reviews/edit.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module PromptReviews
+  # Supersedes a pending evolved prompt version with a reviewer-edited variant.
+  # Because PromptVersion content is immutable after creation, editing is
+  # modelled as: create a new pending version (parent = old) with the edited
+  # template, and reject the old version with a "superseded" note.
+  #
+  # @example
+  #   PromptReviews::Edit.call(
+  #     prompt_version: evolved_version,
+  #     reviewer: current_user,
+  #     attributes: { template: "Refined template", change_notes: "Tightened wording" }
+  #   )
+  class Edit
+    attr_reader :prompt_version, :reviewer, :attributes
+
+    def initialize(prompt_version:, reviewer:, attributes:)
+      @prompt_version = prompt_version
+      @reviewer = reviewer
+      @attributes = attributes || {}
+    end
+
+    def self.call(...)
+      new(...).edit
+    end
+
+    def edit
+      validate!
+
+      new_version = nil
+      prompt = prompt_version.prompt
+      ActiveRecord::Base.transaction do
+        new_version = prompt.create_pending_version!(
+          template: attributes.fetch(:template, prompt_version.template),
+          system_prompt: attributes.fetch(:system_prompt, prompt_version.system_prompt),
+          variables: attributes.fetch(:variables, prompt_version.variables),
+          change_notes: attributes[:change_notes].presence ||
+            "Reviewer-edited variant of v#{prompt_version.version}",
+          created_by: "reviewer",
+          created_by_user: reviewer,
+          parent_version: prompt_version
+        )
+        prompt_version.update!(
+          review_status: "rejected",
+          reviewed_by_user: reviewer,
+          reviewed_at: Time.current,
+          review_notes: superseded_note(new_version)
+        )
+      end
+      new_version
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "reviewer is required" unless reviewer
+      raise ArgumentError, "prompt version is not pending review" unless prompt_version.pending_review?
+      template = attributes[:template].to_s
+      raise ArgumentError, "template is required" if template.strip.empty?
+    end
+
+    def superseded_note(new_version)
+      base = "Superseded by v#{new_version.version} (reviewer edit)."
+      extra = attributes[:review_notes].to_s.strip
+      extra.empty? ? base : "#{base} #{extra}"
+    end
+  end
+end

--- a/app/services/prompt_reviews/reject.rb
+++ b/app/services/prompt_reviews/reject.rb
@@ -26,12 +26,16 @@ module PromptReviews
     def reject
       validate!
 
-      prompt_version.update!(
-        review_status: "rejected",
-        reviewed_by_user: reviewer,
-        reviewed_at: Time.current,
-        review_notes: notes
-      )
+      prompt_version.prompt.with_lock do
+        raise ArgumentError, "prompt version is no longer pending review" unless prompt_version.reload.pending_review?
+
+        prompt_version.update!(
+          review_status: "rejected",
+          reviewed_by_user: reviewer,
+          reviewed_at: Time.current,
+          review_notes: notes
+        )
+      end
       prompt_version
     end
 

--- a/app/services/prompt_reviews/reject.rb
+++ b/app/services/prompt_reviews/reject.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module PromptReviews
+  # Rejects a pending evolved prompt version. The version is retained for
+  # audit/history but is not promoted to current.
+  #
+  # @example
+  #   PromptReviews::Reject.call(
+  #     prompt_version: evolved_version,
+  #     reviewer: current_user,
+  #     notes: "Removes important safety guidance"
+  #   )
+  class Reject
+    attr_reader :prompt_version, :reviewer, :notes
+
+    def initialize(prompt_version:, reviewer:, notes:)
+      @prompt_version = prompt_version
+      @reviewer = reviewer
+      @notes = notes
+    end
+
+    def self.call(...)
+      new(...).reject
+    end
+
+    def reject
+      validate!
+
+      prompt_version.update!(
+        review_status: "rejected",
+        reviewed_by_user: reviewer,
+        reviewed_at: Time.current,
+        review_notes: notes
+      )
+      prompt_version
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "reviewer is required" unless reviewer
+      raise ArgumentError, "rejection notes are required" if notes.to_s.strip.empty?
+      raise ArgumentError, "prompt version is not pending review" unless prompt_version.pending_review?
+    end
+  end
+end

--- a/app/views/prompt_reviews/index.html.erb
+++ b/app/views/prompt_reviews/index.html.erb
@@ -1,0 +1,59 @@
+<% content_for :title do %>Pending Reviews - <%= @prompt.name %> - Paid<% end %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mb-6">
+    <%= link_to prompt_path(@prompt), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+      <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+      </svg>
+      Back to <%= @prompt.name %>
+    <% end %>
+  </div>
+
+  <div class="bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-5 sm:px-6">
+      <h1 class="text-xl font-semibold text-gray-900">Pending Reviews</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        Evolved variants for <strong><%= @prompt.name %></strong> waiting for human approval.
+      </p>
+    </div>
+
+    <div class="border-t border-gray-200">
+      <% if @prompt_versions.any? %>
+        <table class="min-w-full divide-y divide-gray-300">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Version</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Change Notes</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Source</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Created</th>
+              <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+                <span class="sr-only">Review</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% @prompt_versions.each do |version| %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                  v<%= version.version %>
+                  <span class="ml-2 inline-flex items-center rounded-md bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">pending</span>
+                </td>
+                <td class="px-3 py-4 text-sm text-gray-500"><%= version.change_notes.presence || "-" %></td>
+                <td class="px-3 py-4 text-sm text-gray-500"><%= version.created_by || "-" %></td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= local_time(version.created_at, format: :short) %></td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <%= link_to "Review", prompt_review_path(@prompt, version), class: "text-indigo-600 hover:text-indigo-900" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="px-4 py-8 text-center text-sm text-gray-500">
+          No pending reviews for this prompt.
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/prompt_reviews/queue.html.erb
+++ b/app/views/prompt_reviews/queue.html.erb
@@ -1,0 +1,51 @@
+<% content_for :title do %>Prompt Review Queue - Paid<% end %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-5 sm:px-6">
+      <h1 class="text-xl font-semibold text-gray-900">Prompt Review Queue</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        Evolved prompt variants across your prompts that are waiting for human approval.
+      </p>
+    </div>
+
+    <div class="border-t border-gray-200">
+      <% if @prompt_versions.any? %>
+        <table class="min-w-full divide-y divide-gray-300">
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Prompt</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Version</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Source</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Created</th>
+              <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+                <span class="sr-only">Review</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% @prompt_versions.each do |version| %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                  <%= link_to version.prompt.name, prompt_path(version.prompt), class: "text-indigo-600 hover:text-indigo-900" %>
+                </td>
+                <td class="px-3 py-4 text-sm text-gray-500">
+                  v<%= version.version %>
+                </td>
+                <td class="px-3 py-4 text-sm text-gray-500"><%= version.created_by || "-" %></td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= local_time(version.created_at, format: :short) %></td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                  <%= link_to "Review", prompt_review_path(version.prompt, version), class: "text-indigo-600 hover:text-indigo-900" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="px-4 py-8 text-center text-sm text-gray-500">
+          No pending reviews. Evolved variants will appear here when prompts with review gates enabled produce new proposals.
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/prompt_reviews/show.html.erb
+++ b/app/views/prompt_reviews/show.html.erb
@@ -1,0 +1,178 @@
+<% content_for :title do %>Review v<%= @prompt_version.version %> - <%= @prompt.name %> - Paid<% end %>
+
+<% parent = @prompt_version.parent_version || @prompt.current_version %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mb-6">
+    <%= link_to prompt_reviews_path(@prompt), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+      <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+      </svg>
+      Back to Pending Reviews
+    <% end %>
+  </div>
+
+  <div class="bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-5 sm:px-6 flex items-center justify-between">
+      <div>
+        <h1 class="text-xl font-semibold text-gray-900">
+          Review v<%= @prompt_version.version %> of <%= @prompt.name %>
+        </h1>
+        <p class="mt-1 text-sm text-gray-500">
+          <%= @prompt_version.change_notes.presence || "Evolved variant awaiting approval." %>
+        </p>
+      </div>
+      <span class="inline-flex items-center rounded-md bg-yellow-100 px-3 py-1 text-sm font-medium text-yellow-800">
+        Pending Review
+      </span>
+    </div>
+
+    <div class="border-t border-gray-200">
+      <dl class="divide-y divide-gray-200">
+        <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500">Source</dt>
+          <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+            <%= @prompt_version.created_by || "-" %>
+            <% if @prompt_version.created_by_user %>
+              (<%= @prompt_version.created_by_user.email %>)
+            <% end %>
+          </dd>
+        </div>
+        <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500">Created</dt>
+          <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= local_time(@prompt_version.created_at, format: :short) %></dd>
+        </div>
+        <% if parent %>
+          <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+            <dt class="text-sm font-medium text-gray-500">Parent version</dt>
+            <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">v<%= parent.version %></dd>
+          </div>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+
+  <%# Quality metrics comparison %>
+  <% parent_score = parent&.avg_quality_score %>
+  <% candidate_score = @prompt_version.avg_quality_score %>
+  <div class="mt-8 bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-5 sm:px-6">
+      <h2 class="text-lg font-medium text-gray-900">Quality Metrics</h2>
+      <p class="mt-1 text-sm text-gray-500">Observed performance so far (more samples may arrive before you review).</p>
+    </div>
+    <div class="border-t border-gray-200 px-4 py-5 sm:px-6">
+      <dl class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-gray-500">Parent (v<%= parent&.version || "-" %>)</dt>
+          <dd class="mt-1 text-sm text-gray-900">
+            <% if parent_score %>
+              Avg quality: <span class="font-semibold"><%= parent_score.to_f.round(3) %></span>
+            <% else %>
+              <span class="text-gray-400 italic">No metrics yet</span>
+            <% end %>
+          </dd>
+          <dd class="text-xs text-gray-500 mt-1">Samples: <%= parent&.usage_count || 0 %></dd>
+        </div>
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-gray-500">Candidate (v<%= @prompt_version.version %>)</dt>
+          <dd class="mt-1 text-sm text-gray-900">
+            <% if candidate_score %>
+              Avg quality: <span class="font-semibold"><%= candidate_score.to_f.round(3) %></span>
+            <% else %>
+              <span class="text-gray-400 italic">No metrics yet</span>
+            <% end %>
+          </dd>
+          <dd class="text-xs text-gray-500 mt-1">Samples: <%= @prompt_version.usage_count %></dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+
+  <%# Diff: parent vs candidate %>
+  <% if parent %>
+    <div class="mt-8 bg-white shadow sm:rounded-lg">
+      <div class="px-4 py-5 sm:px-6">
+        <h2 class="text-lg font-medium text-gray-900">Template Diff</h2>
+        <p class="mt-1 text-sm text-gray-500">
+          Current v<%= parent.version %> (left) vs. proposed v<%= @prompt_version.version %> (right).
+        </p>
+      </div>
+      <div class="grid grid-cols-2 divide-x divide-gray-200 border-t border-gray-200">
+        <div class="p-4">
+          <pre class="overflow-x-auto rounded-lg bg-red-50 p-4 text-sm text-gray-800 font-mono whitespace-pre-wrap"><%= parent.template %></pre>
+        </div>
+        <div class="p-4">
+          <pre class="overflow-x-auto rounded-lg bg-green-50 p-4 text-sm text-gray-800 font-mono whitespace-pre-wrap"><%= @prompt_version.template %></pre>
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <div class="mt-8 bg-white shadow sm:rounded-lg">
+      <div class="px-4 py-5 sm:px-6">
+        <h2 class="text-lg font-medium text-gray-900">Template</h2>
+      </div>
+      <div class="border-t border-gray-200 p-4">
+        <pre class="overflow-x-auto rounded-lg bg-gray-50 p-4 text-sm text-gray-800 font-mono whitespace-pre-wrap"><%= @prompt_version.template %></pre>
+      </div>
+    </div>
+  <% end %>
+
+  <% if policy(@prompt).update? %>
+    <%# Approve form %>
+    <div class="mt-8 bg-white shadow sm:rounded-lg">
+      <div class="px-4 py-5 sm:p-6">
+        <h3 class="text-base font-semibold leading-6 text-gray-900">Approve</h3>
+        <p class="mt-1 text-sm text-gray-500">Approving promotes this variant to the prompt's current version.</p>
+        <%= form_with url: approve_prompt_review_path(@prompt, @prompt_version), method: :post, local: true, class: "mt-4" do |form| %>
+          <%= form.label "prompt_version[review_notes]", "Notes (optional)", class: "block text-sm font-medium text-gray-700" %>
+          <%= form.text_area "prompt_version[review_notes]", rows: 2, class: "mt-1 block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm", placeholder: "LGTM, shipping." %>
+          <div class="mt-4">
+            <%= form.submit "Approve and Promote", class: "rounded-md bg-green-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600 cursor-pointer" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <%# Reject form %>
+    <div class="mt-8 bg-white shadow sm:rounded-lg">
+      <div class="px-4 py-5 sm:p-6">
+        <h3 class="text-base font-semibold leading-6 text-gray-900">Reject</h3>
+        <p class="mt-1 text-sm text-gray-500">Rejecting keeps the current version active. Notes are required.</p>
+        <%= form_with url: reject_prompt_review_path(@prompt, @prompt_version), method: :post, local: true, class: "mt-4" do |form| %>
+          <%= form.label "prompt_version[review_notes]", "Reason", class: "block text-sm font-medium text-gray-700" %>
+          <%= form.text_area "prompt_version[review_notes]", rows: 3, required: true, class: "mt-1 block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm", placeholder: "Why are you rejecting this variant?" %>
+          <div class="mt-4">
+            <%= form.submit "Reject", class: "rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 cursor-pointer" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <%# Edit form %>
+    <div class="mt-8 bg-white shadow sm:rounded-lg">
+      <div class="px-4 py-5 sm:p-6">
+        <h3 class="text-base font-semibold leading-6 text-gray-900">Edit &amp; Resubmit</h3>
+        <p class="mt-1 text-sm text-gray-500">
+          Tweak the template and save a new pending variant. The current pending version will be superseded.
+        </p>
+        <%= form_with url: prompt_review_path(@prompt, @prompt_version), method: :patch, local: true, class: "mt-4 space-y-4" do |form| %>
+          <div>
+            <%= form.label "prompt_version[template]", "Template", class: "block text-sm font-medium text-gray-700" %>
+            <%= form.text_area "prompt_version[template]", rows: 10, class: "mt-1 block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm font-mono", value: @prompt_version.template %>
+          </div>
+          <div>
+            <%= form.label "prompt_version[system_prompt]", "System prompt (optional)", class: "block text-sm font-medium text-gray-700" %>
+            <%= form.text_area "prompt_version[system_prompt]", rows: 3, class: "mt-1 block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm font-mono", value: @prompt_version.system_prompt %>
+          </div>
+          <div>
+            <%= form.label "prompt_version[change_notes]", "Change notes", class: "block text-sm font-medium text-gray-700" %>
+            <%= form.text_field "prompt_version[change_notes]", class: "mt-1 block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm" %>
+          </div>
+          <div>
+            <%= form.submit "Save edited variant", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 cursor-pointer" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/prompts/_form.html.erb
+++ b/app/views/prompts/_form.html.erb
@@ -72,6 +72,17 @@
       <%= form.label :active, class: "ml-3 block text-sm font-medium leading-6 text-gray-900" %>
     </div>
 
+    <div>
+      <div class="flex items-center">
+        <%= form.check_box :requires_review, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+        <%= form.label :requires_review, "Require human review for evolved variants", class: "ml-3 block text-sm font-medium leading-6 text-gray-900" %>
+      </div>
+      <p class="mt-1 ml-7 text-xs text-gray-500">
+        When enabled, prompt-evolution and A/B test winners are queued for manual approval
+        before replacing the current version. Turn off for advanced users to auto-promote.
+      </p>
+    </div>
+
     <hr class="border-gray-200">
 
     <div>

--- a/app/views/prompts/show.html.erb
+++ b/app/views/prompts/show.html.erb
@@ -32,6 +32,15 @@
               A/B Tests
             <% end %>
           <% end %>
+          <% pending_count = @prompt.pending_reviews.count %>
+          <% if pending_count > 0 %>
+            <%= link_to prompt_reviews_path(@prompt), class: "inline-flex items-center rounded-md bg-yellow-50 px-3 py-2 text-sm font-semibold text-yellow-800 shadow-sm ring-1 ring-inset ring-yellow-200 hover:bg-yellow-100" do %>
+              Pending Reviews
+              <span class="ml-2 inline-flex items-center rounded-full bg-yellow-200 px-2 py-0.5 text-xs font-semibold text-yellow-900">
+                <%= pending_count %>
+              </span>
+            <% end %>
+          <% end %>
           <% if policy(@prompt).update? %>
             <%= link_to edit_prompt_path(@prompt), class: "inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" do %>
               <svg class="-ml-0.5 mr-1.5 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -69,6 +78,19 @@
             </dd>
           </div>
         <% end %>
+
+        <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+          <dt class="text-sm font-medium text-gray-500">Review Gate</dt>
+          <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+            <% if @prompt.requires_review? %>
+              <span class="inline-flex items-center rounded-md bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">Required</span>
+              <span class="ml-2 text-xs text-gray-500">Evolved variants need human approval before promotion.</span>
+            <% else %>
+              <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">Off</span>
+              <span class="ml-2 text-xs text-gray-500">Evolved variants are auto-promoted.</span>
+            <% end %>
+          </dd>
+        </div>
 
         <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
           <dt class="text-sm font-medium text-gray-500">Current Version</dt>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,14 @@ Rails.application.routes.draw do
       post :cancel, on: :member
       post :promote, on: :member
     end
+    resources :reviews, only: [ :index, :show, :update ], controller: "prompt_reviews" do
+      post :approve, on: :member
+      post :reject, on: :member
+    end
   end
+
+  # Account-wide pending prompt review queue
+  get "prompt_reviews", to: "prompt_reviews#queue", as: :prompt_reviews_queue
 
   # Style guide management
   resources :style_guides do

--- a/db/migrate/20260416221824_add_review_gate_to_prompts.rb
+++ b/db/migrate/20260416221824_add_review_gate_to_prompts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddReviewGateToPrompts < ActiveRecord::Migration[8.1]
+  def change
+    # When true, evolved prompt variants must be approved by a human reviewer
+    # before they can be promoted to current_version. When false, evolved
+    # variants auto-promote (advanced-user opt-out).
+    add_column :prompts, :requires_review, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260416221827_add_review_state_to_prompt_versions.rb
+++ b/db/migrate/20260416221827_add_review_state_to_prompt_versions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddReviewStateToPromptVersions < ActiveRecord::Migration[8.1]
+  # Adds human review state to prompt versions. A null review_status means the
+  # version was created outside the review workflow (manual edits, seeds, etc.)
+  # and is not subject to the review gate. Evolved versions created while
+  # prompts.requires_review is true start in "pending" and transition to
+  # "approved" or "rejected" via the review UI.
+  def change
+    add_column :prompt_versions, :review_status, :string, limit: 20
+    add_reference :prompt_versions, :reviewed_by_user,
+      null: true, foreign_key: { to_table: :users, on_delete: :nullify }
+    add_column :prompt_versions, :reviewed_at, :datetime
+    add_column :prompt_versions, :review_notes, :text
+
+    # Partial index: only versions participating in the review workflow are
+    # indexed. Most historical versions have a null status and don't need to
+    # appear in review queue queries.
+    add_index :prompt_versions, [ :prompt_id, :review_status ],
+      where: "review_status IS NOT NULL",
+      name: "index_prompt_versions_on_prompt_and_review_status"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_185458) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_221827) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -714,7 +714,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_185458) do
     t.index ["llm_model_id"], name: "index_model_selections_on_llm_model_id"
     t.index ["selector_type"], name: "index_model_selections_on_selector_type"
     t.index ["tier"], name: "index_model_selections_on_tier"
-    t.check_constraint "tier IS NULL OR (tier::text = ANY (ARRAY['low'::character varying, 'mid'::character varying, 'high'::character varying]::text[]))", name: "model_selections_tier_check"
+    t.check_constraint "tier IS NULL OR (tier::text = ANY (ARRAY['low'::character varying::text, 'mid'::character varying::text, 'high'::character varying::text]))", name: "model_selections_tier_check"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -844,6 +844,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_185458) do
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
     t.string "default_branch", default: "main", null: false
+    t.jsonb "fitness_weights", default: {}, null: false
     t.string "generated_label_name", default: "paid-generated", null: false
     t.bigint "github_id", null: false
     t.bigint "github_token_id", null: false
@@ -896,6 +897,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_185458) do
     t.bigint "created_by_user_id"
     t.bigint "parent_version_id"
     t.bigint "prompt_id", null: false
+    t.text "review_notes"
+    t.string "review_status", limit: 20
+    t.datetime "reviewed_at"
+    t.bigint "reviewed_by_user_id"
     t.text "system_prompt"
     t.text "template", null: false
     t.integer "usage_count", default: 0, null: false
@@ -903,8 +908,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_185458) do
     t.integer "version", null: false
     t.index ["created_by_user_id"], name: "index_prompt_versions_on_created_by_user_id"
     t.index ["parent_version_id"], name: "index_prompt_versions_on_parent_version_id"
+    t.index ["prompt_id", "review_status"], name: "index_prompt_versions_on_prompt_and_review_status", where: "(review_status IS NOT NULL)"
     t.index ["prompt_id", "version"], name: "index_prompt_versions_on_prompt_id_and_version", unique: true
     t.index ["prompt_id"], name: "index_prompt_versions_on_prompt_id"
+    t.index ["reviewed_by_user_id"], name: "index_prompt_versions_on_reviewed_by_user_id"
   end
 
   create_table "prompts", force: :cascade do |t|
@@ -916,6 +923,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_185458) do
     t.text "description"
     t.string "name", limit: 255, null: false
     t.bigint "project_id"
+    t.boolean "requires_review", default: false, null: false
     t.string "slug", limit: 100, null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_prompts_on_account_id"
@@ -1240,6 +1248,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_185458) do
   add_foreign_key "prompt_versions", "prompt_versions", column: "parent_version_id", on_delete: :nullify
   add_foreign_key "prompt_versions", "prompts", on_delete: :cascade
   add_foreign_key "prompt_versions", "users", column: "created_by_user_id", on_delete: :nullify
+  add_foreign_key "prompt_versions", "users", column: "reviewed_by_user_id", on_delete: :nullify
   add_foreign_key "prompts", "accounts", on_delete: :cascade
   add_foreign_key "prompts", "projects", on_delete: :cascade
   add_foreign_key "prompts", "prompt_versions", column: "current_version_id", on_delete: :nullify

--- a/spec/factories/prompt_versions.rb
+++ b/spec/factories/prompt_versions.rb
@@ -17,5 +17,21 @@ FactoryBot.define do
         version.parent_version ||= build(:prompt_version, prompt: version.prompt)
       end
     end
+
+    trait :pending_review do
+      review_status { "pending" }
+      created_by { "evolution" }
+    end
+
+    trait :approved do
+      review_status { "approved" }
+      reviewed_at { Time.current }
+    end
+
+    trait :rejected do
+      review_status { "rejected" }
+      reviewed_at { Time.current }
+      review_notes { "Did not meet quality bar" }
+    end
   end
 end

--- a/spec/factories/prompts.rb
+++ b/spec/factories/prompts.rb
@@ -46,5 +46,9 @@ FactoryBot.define do
         prompt.create_version!(template: "Default template for {{title}}")
       end
     end
+
+    trait :requires_review do
+      requires_review { true }
+    end
   end
 end

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -183,6 +183,36 @@ RSpec.describe Prompt do
         expect(version.version).to eq(1)
       end
     end
+
+    describe "#create_pending_version!" do
+      it "creates a pending version without promoting it to current" do
+        prompt = create(:prompt, :global, :with_version)
+        original = prompt.current_version
+
+        pending = prompt.create_pending_version!(template: "Proposed variant")
+
+        expect(pending).to be_pending_review
+        expect(pending.version).to eq(original.version + 1)
+        expect(prompt.reload.current_version).to eq(original)
+      end
+
+      it "honours an explicit review_status" do
+        prompt = create(:prompt, :global)
+        version = prompt.create_pending_version!(template: "V", review_status: "approved")
+        expect(version).to be_approved
+      end
+    end
+
+    describe "#pending_reviews" do
+      it "returns only pending versions" do
+        prompt = create(:prompt, :global, :with_version)
+        pending_v = prompt.create_pending_version!(template: "Pending")
+        prompt.create_pending_version!(template: "Rejected")
+          .update!(review_status: "rejected", reviewed_at: Time.current, review_notes: "no")
+
+        expect(prompt.pending_reviews).to contain_exactly(pending_v)
+      end
+    end
   end
 
   describe ".resolve" do

--- a/spec/models/prompt_version_spec.rb
+++ b/spec/models/prompt_version_spec.rb
@@ -56,6 +56,57 @@ RSpec.describe PromptVersion do
     end
   end
 
+  describe "review state" do
+    let(:prompt) { create(:prompt, :global) }
+
+    it "defaults to nil review_status (not participating in review workflow)" do
+      version = create(:prompt_version, prompt: prompt, version: 1)
+      expect(version.review_status).to be_nil
+      expect(version).not_to be_under_review
+      expect(version).not_to be_pending_review
+    end
+
+    it "supports pending/approved/rejected transitions" do
+      version = create(:prompt_version, :pending_review, prompt: prompt, version: 1)
+
+      expect(version).to be_pending_review
+      expect(version).to be_under_review
+      expect(version).not_to be_approved
+
+      version.update!(review_status: "approved", reviewed_at: Time.current)
+      expect(version).to be_approved
+      expect(version).not_to be_pending_review
+    end
+
+    it "rejects invalid review_status values" do
+      version = build(:prompt_version, prompt: prompt, version: 1, review_status: "bogus")
+      expect(version).not_to be_valid
+      expect(version.errors[:review_status]).to be_present
+    end
+
+    it "scopes versions by review state" do
+      pending = create(:prompt_version, :pending_review, prompt: prompt, version: 1)
+      approved = create(:prompt_version, :approved, prompt: prompt, version: 2)
+      rejected = create(:prompt_version, :rejected, prompt: prompt, version: 3)
+      _unreviewed = create(:prompt_version, prompt: prompt, version: 4)
+
+      expect(described_class.pending_review).to contain_exactly(pending)
+      expect(described_class.approved).to contain_exactly(approved)
+      expect(described_class.rejected).to contain_exactly(rejected)
+    end
+
+    it "allows review fields to be updated after creation" do
+      version = create(:prompt_version, :pending_review, prompt: prompt, version: 1)
+      user = create(:user)
+
+      version.reviewed_by_user = user
+      version.reviewed_at = Time.current
+      version.review_notes = "Good enough"
+      version.review_status = "approved"
+      expect(version).to be_valid
+    end
+  end
+
   describe "#render" do
     it "interpolates variables into the template" do
       version = build(:prompt_version, template: "Fix **{{title}}** (\#{{number}})\n\n{{body}}")

--- a/spec/requests/prompt_reviews_spec.rb
+++ b/spec/requests/prompt_reviews_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "PromptReviews" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+  let(:prompt) { create(:prompt, :for_account, :requires_review, :with_version, account: account) }
+  let!(:pending_version) do
+    prompt.create_pending_version!(template: "Proposed variant {{title}}", change_notes: "Evolved")
+  end
+
+  describe "GET /prompt_reviews" do
+    context "when not authenticated" do
+      it "redirects to sign in" do
+        get prompt_reviews_queue_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "lists pending prompt versions in the user's account" do
+        get prompt_reviews_queue_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Prompt Review Queue")
+        expect(response.body).to include(prompt.name)
+      end
+
+      it "hides prompts from other accounts" do
+        other_account = create(:account)
+        other_prompt = create(:prompt, :for_account, :requires_review, :with_version, account: other_account)
+        other_prompt.create_pending_version!(template: "Secret", change_notes: "Other")
+
+        get prompt_reviews_queue_path
+        expect(response.body).not_to include(other_prompt.name)
+      end
+    end
+  end
+
+  describe "GET /prompts/:prompt_id/reviews" do
+    before { sign_in user }
+
+    it "lists pending versions for this prompt" do
+      get prompt_reviews_path(prompt)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Pending Reviews")
+      expect(response.body).to include("v#{pending_version.version}")
+    end
+  end
+
+  describe "GET /prompts/:prompt_id/reviews/:id" do
+    before { sign_in user }
+
+    it "shows the review detail with diff vs parent" do
+      get prompt_review_path(prompt, pending_version)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Proposed variant")
+      expect(response.body).to include("Template Diff")
+      expect(response.body).to include("Quality Metrics")
+    end
+  end
+
+  describe "POST /prompts/:prompt_id/reviews/:id/approve" do
+    before { sign_in user }
+
+    it "approves the version and sets it as current" do
+      post approve_prompt_review_path(prompt, pending_version),
+        params: { prompt_version: { review_notes: "LGTM" } }
+
+      expect(pending_version.reload).to be_approved
+      expect(prompt.reload.current_version).to eq(pending_version)
+      expect(response).to redirect_to(prompt_path(prompt))
+    end
+
+    context "when user lacks update permission" do
+      let(:secondary_user) { create(:user, :viewer, account: account) }
+
+      it "is denied" do
+        sign_out user
+        sign_in secondary_user
+
+        post approve_prompt_review_path(prompt, pending_version)
+        expect(pending_version.reload).not_to be_approved
+        expect(flash[:alert]).to include("not authorized")
+      end
+    end
+  end
+
+  describe "POST /prompts/:prompt_id/reviews/:id/reject" do
+    before { sign_in user }
+
+    it "rejects the version with notes" do
+      post reject_prompt_review_path(prompt, pending_version),
+        params: { prompt_version: { review_notes: "Safety regression" } }
+
+      expect(pending_version.reload).to be_rejected
+      expect(pending_version.review_notes).to eq("Safety regression")
+    end
+
+    it "redirects back with an alert when notes are missing" do
+      post reject_prompt_review_path(prompt, pending_version),
+        params: { prompt_version: { review_notes: "" } }
+
+      expect(pending_version.reload).to be_pending_review
+      expect(flash[:alert]).to be_present
+    end
+  end
+
+  describe "PATCH /prompts/:prompt_id/reviews/:id" do
+    before { sign_in user }
+
+    it "creates a new pending variant and supersedes the old one" do
+      expect {
+        patch prompt_review_path(prompt, pending_version),
+          params: { prompt_version: { template: "Refined {{title}}", change_notes: "Reviewer edit" } }
+      }.to change(PromptVersion, :count).by(1)
+
+      new_version = prompt.reload.prompt_versions.order(:version).last
+      expect(new_version).to be_pending_review
+      expect(new_version.template).to eq("Refined {{title}}")
+      expect(pending_version.reload).to be_rejected
+      expect(response).to redirect_to(prompt_review_path(prompt, new_version))
+    end
+  end
+end

--- a/spec/services/ab_tests/promote_winner_spec.rb
+++ b/spec/services/ab_tests/promote_winner_spec.rb
@@ -37,5 +37,32 @@ RSpec.describe AbTests::PromoteWinner do
 
       expect { described_class.call(ab_test: ab_test) }.to raise_error(ArgumentError, /no winner/)
     end
+
+    context "when the prompt requires human review" do
+      before { prompt.update!(requires_review: true) }
+
+      it "does NOT promote immediately; marks the winning version pending" do
+        original = prompt.current_version
+
+        described_class.call(ab_test: ab_test)
+
+        expect(prompt.reload.current_version).to eq(original)
+        expect(new_version.reload).to be_pending_review
+      end
+
+      it "leaves an already-approved winner alone" do
+        new_version.update!(review_status: "approved")
+
+        described_class.call(ab_test: ab_test)
+
+        # current_version still not auto-promoted (requires explicit approval
+        # through PromptReviews::Approve), and status preserved.
+        expect(new_version.reload).to be_approved
+      end
+
+      it "returns the winning version regardless of gate" do
+        expect(described_class.call(ab_test: ab_test)).to eq(new_version)
+      end
+    end
   end
 end

--- a/spec/services/prompt_evolution/create_variants_spec.rb
+++ b/spec/services/prompt_evolution/create_variants_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PromptEvolution::CreateVariants do
+  let(:user) { create(:user) }
+  let(:prompt) { create(:prompt, :global, :with_version) }
+  let(:mutation) do
+    PromptEvolution::Mutate::Mutation.new(
+      template: "Refined template {{title}}",
+      strategy: "refinement",
+      reasoning: "Clearer instructions",
+      expected_improvement: "Better results"
+    )
+  end
+
+  describe ".call" do
+    context "when the prompt requires review" do
+      before { prompt.update!(requires_review: true) }
+
+      it "creates pending versions and does NOT promote them" do
+        original_current = prompt.current_version
+
+        variants = described_class.call(prompt: prompt, mutations: [ mutation ], created_by_user: user)
+
+        expect(variants.size).to eq(1)
+        expect(variants.first).to be_pending_review
+        expect(prompt.reload.current_version).to eq(original_current)
+      end
+
+      it "stamps evolution provenance" do
+        variants = described_class.call(prompt: prompt, mutations: [ mutation ], created_by_user: user)
+        variant = variants.first
+
+        expect(variant.created_by).to eq("evolution")
+        expect(variant.created_by_user).to eq(user)
+        expect(variant.parent_version).to eq(prompt.current_version)
+        expect(variant.change_notes).to include("refinement")
+      end
+    end
+
+    context "when the prompt does NOT require review" do
+      it "auto-promotes the first variant and marks it approved" do
+        original_current = prompt.current_version
+
+        variants = described_class.call(prompt: prompt, mutations: [ mutation ], created_by_user: user)
+
+        winner = variants.first.reload
+        expect(winner).to be_approved
+        expect(prompt.reload.current_version).to eq(winner)
+        expect(prompt.current_version).not_to eq(original_current)
+      end
+
+      it "returns an empty array when no mutations are supplied" do
+        expect(described_class.call(prompt: prompt, mutations: [])).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/prompt_reviews/approve_spec.rb
+++ b/spec/services/prompt_reviews/approve_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PromptReviews::Approve do
+  let(:account) { create(:account) }
+  let(:reviewer) { create(:user, account: account) }
+  let(:prompt) { create(:prompt, :for_account, :requires_review, :with_version, account: account) }
+  let(:pending_version) do
+    prompt.create_pending_version!(template: "Proposed variant {{title}}", change_notes: "Evolved")
+  end
+
+  describe ".call" do
+    it "marks the version approved and promotes it to current" do
+      original = prompt.current_version
+
+      described_class.call(prompt_version: pending_version, reviewer: reviewer, notes: "LGTM")
+
+      pending_version.reload
+      expect(pending_version).to be_approved
+      expect(pending_version.reviewed_by_user).to eq(reviewer)
+      expect(pending_version.reviewed_at).to be_present
+      expect(pending_version.review_notes).to eq("LGTM")
+      expect(prompt.reload.current_version).to eq(pending_version)
+      expect(prompt.reload.current_version).not_to eq(original)
+    end
+
+    it "can approve without promoting when promote: false" do
+      original = prompt.current_version
+
+      described_class.call(prompt_version: pending_version, reviewer: reviewer, promote: false)
+
+      expect(pending_version.reload).to be_approved
+      expect(prompt.reload.current_version).to eq(original)
+    end
+
+    it "raises when version is not pending" do
+      pending_version.update!(review_status: "approved")
+
+      expect {
+        described_class.call(prompt_version: pending_version, reviewer: reviewer)
+      }.to raise_error(ArgumentError, /not pending/)
+    end
+
+    it "raises without a reviewer" do
+      expect {
+        described_class.call(prompt_version: pending_version, reviewer: nil)
+      }.to raise_error(ArgumentError, /reviewer/)
+    end
+  end
+end

--- a/spec/services/prompt_reviews/edit_spec.rb
+++ b/spec/services/prompt_reviews/edit_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PromptReviews::Edit do
+  let(:account) { create(:account) }
+  let(:reviewer) { create(:user, account: account) }
+  let(:prompt) { create(:prompt, :for_account, :requires_review, :with_version, account: account) }
+  let!(:pending_version) do
+    prompt.create_pending_version!(template: "Original proposed {{title}}", change_notes: "Evolved")
+  end
+
+  describe ".call" do
+    it "creates a new pending version with the edited template" do
+      expect {
+        described_class.call(
+          prompt_version: pending_version,
+          reviewer: reviewer,
+          attributes: { template: "Refined proposal {{title}}", change_notes: "Tightened wording" }
+        )
+      }.to change(PromptVersion, :count).by(1)
+
+      new_version = prompt.reload.prompt_versions.order(:version).last
+      expect(new_version.template).to eq("Refined proposal {{title}}")
+      expect(new_version).to be_pending_review
+      expect(new_version.parent_version).to eq(pending_version)
+      expect(new_version.created_by_user).to eq(reviewer)
+    end
+
+    it "supersedes the old version as rejected" do
+      described_class.call(
+        prompt_version: pending_version,
+        reviewer: reviewer,
+        attributes: { template: "Refined proposal {{title}}" }
+      )
+
+      expect(pending_version.reload).to be_rejected
+      expect(pending_version.review_notes).to include("Superseded")
+      expect(pending_version.reviewed_by_user).to eq(reviewer)
+    end
+
+    it "does not promote anything to current_version" do
+      original_current = prompt.current_version
+
+      described_class.call(
+        prompt_version: pending_version,
+        reviewer: reviewer,
+        attributes: { template: "Refined {{title}}" }
+      )
+
+      expect(prompt.reload.current_version).to eq(original_current)
+    end
+
+    it "requires a non-empty template" do
+      expect {
+        described_class.call(prompt_version: pending_version, reviewer: reviewer, attributes: { template: "" })
+      }.to raise_error(ArgumentError, /template/)
+    end
+
+    it "rejects editing non-pending versions" do
+      pending_version.update!(review_status: "approved")
+
+      expect {
+        described_class.call(prompt_version: pending_version, reviewer: reviewer, attributes: { template: "x" })
+      }.to raise_error(ArgumentError, /not pending/)
+    end
+  end
+end

--- a/spec/services/prompt_reviews/reject_spec.rb
+++ b/spec/services/prompt_reviews/reject_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PromptReviews::Reject do
+  let(:account) { create(:account) }
+  let(:reviewer) { create(:user, account: account) }
+  let(:prompt) { create(:prompt, :for_account, :requires_review, :with_version, account: account) }
+  let(:pending_version) do
+    prompt.create_pending_version!(template: "Proposed variant {{title}}")
+  end
+
+  describe ".call" do
+    it "marks the version rejected with reviewer + notes" do
+      described_class.call(prompt_version: pending_version, reviewer: reviewer, notes: "Changes safety wording")
+
+      pending_version.reload
+      expect(pending_version).to be_rejected
+      expect(pending_version.reviewed_by_user).to eq(reviewer)
+      expect(pending_version.review_notes).to eq("Changes safety wording")
+    end
+
+    it "does not change the prompt's current version" do
+      original = prompt.current_version
+      described_class.call(prompt_version: pending_version, reviewer: reviewer, notes: "nope")
+
+      expect(prompt.reload.current_version).to eq(original)
+    end
+
+    it "requires non-empty notes" do
+      expect {
+        described_class.call(prompt_version: pending_version, reviewer: reviewer, notes: "   ")
+      }.to raise_error(ArgumentError, /notes/)
+    end
+
+    it "raises when version is not pending" do
+      pending_version.update!(review_status: "rejected")
+      expect {
+        described_class.call(prompt_version: pending_version, reviewer: reviewer, notes: "x")
+      }.to raise_error(ArgumentError, /not pending/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

feat(evolution): human review gate for evolved prompts

See #711 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #711