### PR TITLE
Fix #1192: fix(agent-runs): provider credit/quota errors misclassified as recommend_close

### DIFF
--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -8,15 +8,38 @@ module Activities
   #   already satisfied, obsolete, or not actionable)
   # - `needs_input`: agent produced no output and no changes (issue is likely
   #   underspecified or ambiguous)
+  # - `provider_error`: provider returned an error (e.g. credit/quota exhaustion)
+  #   before the agent actually ran. The run is failed so retry / provider
+  #   fallback handles it instead of parking the issue.
   #
-  # For each outcome, posts a GitHub comment with actionable next steps and
-  # updates the Paid-side issue state so users are not left at a dead end.
+  # For each outcome (other than `provider_error`), posts a GitHub comment with
+  # actionable next steps and updates the Paid-side issue state so users are not
+  # left at a dead end.
   class HandleNoOutputIssueRunActivity < BaseActivity
     activity_name "HandleNoOutputIssueRun"
 
     PAID_NEEDS_INPUT_LABEL = "paid-needs-input"
     NEEDS_INPUT_COMMENT_MARKER = "<!-- paid:needs-input -->"
     RECOMMEND_CLOSE_COMMENT_MARKER = "<!-- paid:recommend-close -->"
+
+    # Patterns indicating the agent "output" is actually a provider-level
+    # credit/quota/billing error rather than legitimate agent output. When
+    # matched, the output is treated as evidence of a provider failure, not
+    # grounds to recommend closing the issue. Mirrors and extends the patterns
+    # in RunAgentActivity so a provider error that slipped past the primary
+    # detector is still caught here.
+    PROVIDER_ERROR_OUTPUT_PATTERNS = [
+      /requires? more credits/i,
+      /add more credits/i,
+      /insufficient credits/i,
+      /not enough credits/i,
+      /purchase (?:more )?credits/i,
+      /buy (?:more )?credits/i,
+      /quota exceeded/i,
+      /rate.?limit/i,
+      /too many requests/i,
+      /\b429\b/
+    ].freeze
 
     def execute(input)
       agent_run_id = input[:agent_run_id]
@@ -33,19 +56,22 @@ module Activities
 
       project = agent_run.project
       client = project.github_token.client
-      outcome = output_present ? "recommend_close" : "needs_input"
+      agent_summary = agent_run.agent_summary_with_stderr_fallback(limit: 100)
+      outcome = classify_outcome(agent_run, output_present, agent_summary)
 
       track_phase(agent_run_id: agent_run_id, phase_key: "handle_no_output_issue_run", phase_group: "post", agent_run: agent_run, metadata: { outcome: outcome }) do
-        agent_summary = agent_run.agent_summary_with_stderr_fallback(limit: 100)
-
-        if outcome == "needs_input"
+        case outcome
+        when "provider_error"
+          handle_provider_error(agent_run, agent_summary)
+        when "needs_input"
           handle_needs_input(client, agent_run, agent_summary)
+          agent_run.complete!
+          agent_run.log!("system", "Completed without PR: #{outcome}")
         else
           handle_recommend_close(client, agent_run, agent_summary)
+          agent_run.complete!
+          agent_run.log!("system", "Completed without PR: #{outcome}")
         end
-
-        agent_run.complete!
-        agent_run.log!("system", "Completed without PR: #{outcome}")
 
         logger.info(
           message: "agent_execution.no_output_issue_run",
@@ -61,6 +87,36 @@ module Activities
     end
 
     private
+
+    # Determines the correct outcome for this run based on output presence
+    # and evidence that the agent actually performed work. Defense in depth:
+    # even if RunAgentActivity failed to detect a provider error, this check
+    # prevents credit/quota errors from being misclassified as recommend_close.
+    def classify_outcome(agent_run, output_present, agent_summary)
+      return "needs_input" unless output_present
+
+      # Guard: if the agent produced output but shows no evidence of having
+      # actually run (zero iterations AND zero cost), the "output" is likely
+      # a provider-level error (e.g. credit exhaustion) rather than a real
+      # agent response. Confirm by checking the output for provider error
+      # patterns.
+      if agent_run.iterations.to_i.zero? && agent_run.cost_cents.to_i.zero?
+        return "provider_error" if provider_error_output?(agent_summary)
+      end
+
+      "recommend_close"
+    end
+
+    def provider_error_output?(text)
+      return false if text.blank?
+
+      PROVIDER_ERROR_OUTPUT_PATTERNS.any? { |pattern| text.match?(pattern) }
+    end
+
+    def handle_provider_error(agent_run, agent_summary)
+      agent_run.fail!(error: "Provider error detected in output: #{agent_summary.to_s.truncate(500)}")
+      agent_run.log!("system", "Failed: provider error detected in output (not a real agent response)")
+    end
 
     def handle_needs_input(client, agent_run, agent_summary)
       project = agent_run.project
@@ -139,11 +195,21 @@ module Activities
       end
     end
 
+    # Redacts lines that match known provider-error patterns so raw
+    # provider error text (e.g. OpenRouter billing URLs, credit balances)
+    # is never posted to public GitHub comments.
+    def sanitize_summary_for_github(text)
+      return text if text.blank?
+
+      text.each_line.reject { |line| provider_error_output?(line) }.join.strip
+    end
+
     def post_needs_input_comment(client, project, issue, agent_summary)
       return if comment_exists?(client, project, issue, NEEDS_INPUT_COMMENT_MARKER)
 
       automation_label = triggering_label_for(project)
       needs_input_label = project.label_for_stage("needs_input") || PAID_NEEDS_INPUT_LABEL
+      sanitized_summary = sanitize_summary_for_github(agent_summary)
 
       lines = [
         NEEDS_INPUT_COMMENT_MARKER,
@@ -153,11 +219,11 @@ module Activities
         ""
       ]
 
-      if agent_summary.present?
+      if sanitized_summary.present?
         lines.concat([
           "**Agent output:**",
           "",
-          agent_summary.truncate(2000),
+          sanitized_summary.truncate(2000),
           ""
         ])
       end
@@ -190,6 +256,7 @@ module Activities
       return if comment_exists?(client, project, issue, RECOMMEND_CLOSE_COMMENT_MARKER)
 
       automation_label = triggering_label_for(project)
+      sanitized_summary = sanitize_summary_for_github(agent_summary)
 
       lines = [
         RECOMMEND_CLOSE_COMMENT_MARKER,
@@ -200,11 +267,11 @@ module Activities
         ""
       ]
 
-      if agent_summary.present?
+      if sanitized_summary.present?
         lines.concat([
           "**Agent output:**",
           "",
-          agent_summary.truncate(2000),
+          sanitized_summary.truncate(2000),
           ""
         ])
       end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -92,6 +92,21 @@ module Activities
       ].freeze
     }.freeze
 
+    # Patterns for provider-level credit/quota exhaustion errors that may be
+    # emitted as agent "output" even when the CLI exits with a zero status
+    # (observed with OpenRouter-backed providers returning a billing error as
+    # the only stdout line). These must be specific enough to avoid matching
+    # ordinary agent prose that mentions credits/billing — they key on phrases
+    # that only appear in provider error responses.
+    INSUFFICIENT_CREDITS_PATTERNS = [
+      /requires? more credits/i,
+      /add more credits/i,
+      /insufficient credits/i,
+      /not enough credits/i,
+      /purchase (?:more )?credits/i,
+      /buy (?:more )?credits/i
+    ].freeze
+
     # Maximum number of log rows to inspect when reclassifying a timeout.
     # Caps memory and DB load on long-running, verbose agent attempts.
     TIMEOUT_RATE_LIMIT_LOG_LIMIT = 200
@@ -607,6 +622,17 @@ module Activities
       stderr = normalize_output_text(result[:stderr])
 
       if result.success?
+        # Detect provider credit/quota errors that slip through as successful
+        # exits. Some providers (e.g. OpenRouter) return a billing error as
+        # the only stdout line with exit code 0. The agent never actually ran,
+        # so treat this as a provider failure to trigger fallback/retry.
+        combined_output = [ stdout, stderr ].compact.join("\n")
+        sanitized_output = strip_prompt_echo(combined_output, prompt)
+        if insufficient_credits_error?(sanitized_output)
+          raise ProviderExecutionError,
+            "Provider credit/quota error from #{provider}: #{sanitized_output.truncate(500)}"
+        end
+
         output_present = stdout.present? || stderr.present?
         agent_run.log!("system", "Agent execution succeeded with #{provider}")
         return {
@@ -687,6 +713,16 @@ module Activities
       return false if output.blank?
 
       AUTH_EXPIRED_PATTERNS.fetch(provider.to_s, []).any? { |pattern| output.match?(pattern) }
+    end
+
+    # Detects provider-level credit/quota exhaustion errors surfaced as
+    # agent output. Used in the successful-exit-code path to catch cases
+    # where a provider (e.g. OpenRouter) returns a billing error as the
+    # only stdout content with exit code 0.
+    def insufficient_credits_error?(output)
+      return false if output.blank?
+
+      INSUFFICIENT_CREDITS_PATTERNS.any? { |pattern| output.match?(pattern) }
     end
 
     def strip_prompt_echo(output, prompt)

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -235,6 +235,142 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
       end
     end
 
+    context "when output is present but agent did not actually run (provider error)" do
+      let(:credit_error) do
+        "Error: This request requires more credits, or fewer max_tokens. " \
+          "You requested up to 32000 tokens, but can only afford 4744. " \
+          "To increase, visit https://openrouter.ai/settings/credits and add more credits"
+      end
+
+      it "classifies as provider_error when iterations and cost are zero" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", credit_error)
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("provider_error")
+      end
+
+      it "fails the run instead of completing it" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", credit_error)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(agent_run.reload.status).to eq("failed")
+      end
+
+      it "does not transition issue to recommend_close" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", credit_error)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(issue.reload.paid_state).not_to eq("recommend_close")
+      end
+
+      it "does not post a recommend-close comment on GitHub" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", credit_error)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(client).not_to have_received(:add_comment)
+          .with(project.full_name, issue.github_number, a_string_including("Recommend Close"))
+      end
+
+      it "enqueues ProcessRunQueueJob for retry" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", credit_error)
+
+        expect { activity.execute(agent_run_id: agent_run.id, output_present: true) }
+          .to have_enqueued_job(ProcessRunQueueJob)
+      end
+
+      it "allows recommend_close when agent has iterations > 0" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 5, cost_cents: 0)
+        agent_run.log!("stdout", "The issue is already fixed in the codebase")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("recommend_close")
+      end
+
+      it "allows recommend_close when agent has cost_cents > 0" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 50)
+        agent_run.log!("stdout", "This issue appears resolved already")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("recommend_close")
+      end
+
+      it "detects quota exceeded errors" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "Error: quota exceeded for this API key")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("provider_error")
+      end
+
+      it "detects rate limit errors" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "Error: rate limit exceeded, please retry later")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("provider_error")
+      end
+    end
+
+    context "when GitHub comment would contain provider error text" do
+      it "redacts provider error lines from recommend_close comments" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
+        agent_run.log!("stdout", "Some legitimate output\nError: quota exceeded\nMore output")
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(client).to have_received(:add_comment) do |_repo, _number, body|
+          expect(body).to include("Recommend Close")
+          expect(body).not_to include("quota exceeded")
+        end
+      end
+
+      it "redacts provider error lines from needs_input comments" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run.log!("stderr", "Some context\nrequires more credits\nMore context")
+
+        activity.execute(agent_run_id: agent_run.id, output_present: false)
+
+        expect(client).to have_received(:add_comment) do |_repo, _number, body|
+          expect(body).to include("Needs Input")
+          expect(body).not_to include("requires more credits")
+        end
+      end
+    end
+
     context "when GitHub API returns errors" do
       it "completes the run even when comment posting fails" do
         issue = create(:issue, :in_progress, project: project)


### PR DESCRIPTION
## Summary

fix(agent-runs): provider credit/quota errors misclassified as recommend_close

See #1192 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1192