### PR TITLE
Fix #826: fix(pr-review): reconcile internal pr_review_phase with manual GitHub draft/ready transitions

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -145,7 +145,26 @@ module Activities
         if review_goal_retry_limit_requires_escalation?(project, issue)
           return escalate_trigger(issue, reason: retry_limit_reason)
         end
-        scan_draft_pr(project, client, issue)
+
+        # Check draft-specific escalation conditions before spending rate
+        # budget on a PR data fetch. These mirror the guards at the top of
+        # scan_draft_pr; duplicating them here avoids a wasted API call when
+        # the PR will be immediately escalated anyway.
+        if draft_review_limit_reached?(project, issue)
+          return escalate_trigger(issue)
+        end
+        if consecutive_draft_failures_breaker?(project, issue)
+          return escalate_trigger(issue,
+            reason: "Consecutive draft follow-up failures (#{MAX_CONSECUTIVE_DRAFT_FAILURES} runs with no output)")
+        end
+
+        check_rate_budget!(client)
+        pr_data = fetch_pr_data(client, project, issue)
+        if maybe_advance_to_ready(project, issue, pr_data)
+          scan_ready_pr(project, client, issue, pr_data: pr_data)
+        else
+          scan_draft_pr(project, client, issue, pr_data: pr_data)
+        end
       when "ready"
         check_rate_budget!(client)
         pr_data = fetch_pr_data(client, project, issue)
@@ -207,9 +226,13 @@ module Activities
 
     # --- Draft phase scanning ---
 
+    def draft_review_limit_reached?(project, issue)
+      project.max_draft_review_rounds.positive? &&
+        issue.draft_review_count >= project.max_draft_review_rounds
+    end
+
     def scan_draft_pr(project, client, issue, pr_data: nil)
-      if project.max_draft_review_rounds.positive? &&
-          issue.draft_review_count >= project.max_draft_review_rounds
+      if draft_review_limit_reached?(project, issue)
         return escalate_trigger(issue)
       end
 
@@ -578,6 +601,30 @@ module Activities
         project_id: project.id,
         pr_number: issue.github_number,
         previous_phase: issue.pr_review_phase_before_last_save
+      )
+
+      true
+    end
+
+    # Detect when a user marks a draft PR as ready on GitHub without going
+    # through Paid's MarkPrReadyActivity. Advances the local phase to "ready"
+    # so that ready-phase automation (merge-conflict handling, auto-merge,
+    # review-goal evaluation) kicks in. Only applies to draft/restarted
+    # phases — escalated and merged are intentional local states that should
+    # not be overwritten by GitHub draft status alone.
+    def maybe_advance_to_ready(project, issue, pr_data)
+      return false if pr_data.nil?
+      return false if pr_data.draft
+      return false unless issue.draft_phase?
+
+      previous_phase = issue.pr_review_phase
+      issue.update!(pr_review_phase: "ready")
+
+      logger.info(
+        message: "pr_scanner.phase_advanced_to_ready",
+        project_id: project.id,
+        pr_number: issue.github_number,
+        previous_phase: previous_phase
       )
 
       true

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -157,6 +157,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       it "escalates draft PRs at max review rounds without checking rate budget" do
         project.update!(max_draft_review_rounds: 3)
         pr_issue.update!(pr_review_phase: "draft", draft_review_count: 3)
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, 99)
+          .and_return(OpenStruct.new(draft: true, number: 99, head: OpenStruct.new(sha: "abc123", repo: OpenStruct.new(fork: false)), mergeable: true, user: OpenStruct.new(login: "someone-else")))
         allow(github_client).to receive(:rate_limit_remaining!).and_return(5)
 
         result = activity.execute(project_id: project.id)
@@ -702,7 +705,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft_review_count: 0)
         create(:agent_run, :running,
           project: project, source_pull_request_number: 42, goal: "review")
-        stub_github_for_pr(reviews: [])
+        stub_github_for_pr(draft: true, reviews: [])
       end
 
       it "does not skip the PR" do
@@ -852,6 +855,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
                        body: "I found some issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
@@ -882,6 +886,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [],
           reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
                        body: "I found some issues.", submitted_at: 1.hour.ago } ],
@@ -963,6 +968,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           created_at: 10.minutes.ago
         )
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector[bot]", state: "COMMENTED",
                        body: "Here are some automated review suggestions.",
@@ -1122,6 +1128,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         # must NOT be silently dropped just because Codex separately commented
         # clean. The two bots' state is independent.
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
                        body: "Copilot reviewed 5 out of 5 changed files and generated 2 comments.",
@@ -1163,6 +1170,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         # Copilot has NOT reviewed at all. The pending trigger for Copilot
         # must still fire — Codex's clean comment cannot speak for Copilot.
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector[bot]", state: "COMMENTED",
                        body: "Found 2 issues.", submitted_at: 10.minutes.ago } ],
@@ -1224,6 +1232,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           created_at: 30.minutes.ago
         )
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [],
           review_threads: [],
@@ -1303,6 +1312,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           source_pull_request_number: 42,
           completed_at: 2.hours.ago)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
                        body: "Here are some automated review suggestions.",
@@ -1547,6 +1557,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           trigger_type: "automatic",
           completed_at: 30.minutes.ago)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
                        body: "Here are some review suggestions.",
@@ -1715,6 +1726,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "claude[bot]", state: "COMMENTED",
                        body: "I found some issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
@@ -1745,6 +1757,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "claude-code[bot]", state: "COMMENTED",
                        body: "I found some issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
@@ -1777,6 +1790,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
@@ -1806,6 +1820,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago }
@@ -1839,6 +1854,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [],
           review_threads: [
             {
@@ -1868,6 +1884,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
@@ -1979,6 +1996,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
@@ -2008,6 +2026,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Please tighten the error handling.", submitted_at: 1.hour.ago },
@@ -2042,6 +2061,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           created_at: 10.minutes.ago
         )
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
@@ -2077,6 +2097,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           created_at: 10.minutes.ago
         )
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
@@ -2107,6 +2128,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
@@ -2139,6 +2161,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
@@ -2170,6 +2193,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "<!-- PAID_AGENT_REVIEW_STATUS: clean -->", submitted_at: 1.hour.ago },
@@ -2198,6 +2222,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
                        body: "Copilot reviewed 5 out of 5 changed files and generated no comments.",
                        submitted_at: 1.hour.ago } ],
@@ -2228,6 +2253,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [],
           checks: [ { name: "ci", conclusion: "success" } ]
         )
@@ -2255,6 +2281,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 100, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
                        body: "Copilot found issues.", submitted_at: 1.day.ago } ],
           checks: [ { name: "ci", conclusion: "success" } ]
@@ -2278,7 +2305,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           labels: [ "paid-generated", "paid-automation" ],
           pr_review_phase: "draft",
           draft_review_count: 0)
-        stub_github_for_pr(reviews: [])
+        stub_github_for_pr(draft: true, reviews: [])
       end
 
       it "keeps the PR in draft and requests a bot review" do
@@ -2301,7 +2328,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           labels: [ "paid-generated", "paid-automation" ],
           pr_review_phase: "draft",
           draft_review_count: 0)
-        stub_github_for_pr(reviews: [])
+        stub_github_for_pr(draft: true, reviews: [])
       end
 
       it "still requests review from the configured bot only" do
@@ -2322,7 +2349,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           labels: [ "paid-generated", "paid-automation" ],
           pr_review_phase: "draft",
           draft_review_count: 0)
-        stub_github_for_pr
+        stub_github_for_pr(draft: true)
         allow(github_client).to receive(:pull_request_reviews)
           .with(project.full_name, 42)
           .and_raise(GithubClient::Error, "GitHub review API unavailable")
@@ -2345,6 +2372,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           review_threads: [
             {
               id: "thread_1",
@@ -2374,6 +2402,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
                        body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
                        submitted_at: 1.hour.ago } ]
@@ -2401,6 +2430,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [],
           checks: [ { name: "rspec", conclusion: "failure" } ]
         )
@@ -2425,6 +2455,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
                        body: "Copilot reviewed 3 out of 3 changed files and generated 2 comments.",
                        submitted_at: 1.hour.ago } ],
@@ -2458,6 +2489,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
                        body: "Looks good. <!-- paid-review-clean -->",
                        submitted_at: 1.hour.ago } ],
@@ -2483,6 +2515,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
                        body: "Found a few things to fix in the error handling.",
                        submitted_at: 1.hour.ago } ],
@@ -2512,6 +2545,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Looks good. <!-- paid-review-clean -->",
@@ -2552,6 +2586,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Looks good. <!-- paid-review-clean -->",
@@ -2588,6 +2623,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
                        body: "Looks good. <!-- paid-review-clean -->",
                        submitted_at: 1.hour.ago } ],
@@ -2623,6 +2659,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 1)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 3.hours.ago },
@@ -2666,6 +2703,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 1)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
@@ -2709,6 +2747,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 2.hours.ago },
@@ -2747,6 +2786,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 3.hours.ago },
@@ -2789,6 +2829,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 1)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 2.hours.ago },
@@ -2827,6 +2868,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 3)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 1.hour.ago }
@@ -2907,6 +2949,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 1)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 3.hours.ago },
@@ -2956,6 +2999,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           comments: [ { author: "copilot-pull-request-reviewer[bot]", body: "Please fix this" } ]
         }
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 3.hours.ago },
@@ -3003,6 +3047,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           comments: [ { author: "copilot-pull-request-reviewer[bot]", body: "Please fix this" } ]
         }
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
               body: "Copilot found issues.", submitted_at: 3.hours.ago },
@@ -3046,6 +3091,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 1)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 2.hours.ago },
@@ -3084,6 +3130,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 1)
         stub_github_for_pr(
+          draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
               body: "Found issues.", submitted_at: 2.hours.ago },
@@ -3114,6 +3161,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           review_threads: []
         )
@@ -3138,6 +3186,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
                        body: "Copilot reviewed 9 out of 9 changed files and generated 2 comments.",
@@ -3171,6 +3220,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [],
           review_threads: []
@@ -3205,6 +3255,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 1, user_login: "alice", state: "APPROVED", body: "LGTM",
@@ -3238,6 +3289,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 1, user_login: "alice", state: "APPROVED", body: "LGTM",
@@ -3275,6 +3327,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [],
           review_threads: []
@@ -3310,6 +3363,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [],
           review_threads: []
@@ -3347,6 +3401,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         )
         pr_issue
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [],
           review_threads: []
@@ -3376,6 +3431,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           head_repo_fork: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [],
@@ -3407,6 +3463,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [
             { name: "ci", conclusion: "success" },
             { name: "e2e-suite", conclusion: "success" }
@@ -3440,6 +3497,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [
             { name: "ci", conclusion: "success" },
             { name: "e2e-suite", conclusion: "success" }
@@ -3574,6 +3632,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [
             { name: "lint", conclusion: "success" },
             { name: "rspec", conclusion: nil }
@@ -3615,6 +3674,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "does not advance last_pr_scan_at when CI is still in-progress" do
         stub_github_for_pr(
+          draft: true,
           checks: [
             { name: "lint", conclusion: "success" },
             { name: "rspec", conclusion: nil }
@@ -3628,22 +3688,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
 
       it "emits ready_for_owner on second scan after CI finishes green" do
-        stub_github_for_pr(
-          checks: [
-            { name: "lint", conclusion: "success" },
-            { name: "rspec", conclusion: nil }
-          ],
-          review_threads: []
-        )
+        pending_checks = [ { name: "lint", conclusion: "success" }, { name: "rspec", conclusion: nil } ]
+        stub_github_for_pr(draft: true, checks: pending_checks, review_threads: [])
         activity.execute(project_id: project.id)
 
-        stub_github_for_pr(
-          checks: [
-            { name: "lint", conclusion: "success" },
-            { name: "rspec", conclusion: "success" }
-          ],
-          review_threads: []
-        )
+        green_checks = [ { name: "lint", conclusion: "success" }, { name: "rspec", conclusion: "success" } ]
+        stub_github_for_pr(draft: true, checks: green_checks, review_threads: [])
 
         result = activity.execute(project_id: project.id)
         expect(result[:prs_to_trigger].size).to eq(1)
@@ -3653,6 +3703,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "returns :skipped when check fetch fails (checks nil)" do
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           review_threads: []
         )
@@ -3673,6 +3724,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           labels: [ "paid-generated", "paid-automation" ],
           pr_review_phase: "draft",
           draft_review_count: 3)
+        stub_github_for_pr(draft: true)
       end
 
       it "returns escalate_to_owner trigger" do
@@ -3696,6 +3748,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       before do
         stub_github_for_pr(
+          draft: true,
           review_threads: [
             { id: "thread_1", is_resolved: false,
               comments: [ { body: "Fix this", path: "app/model.rb", line: 10, author: "viamin" } ] }
@@ -3779,6 +3832,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           review_threads: [
             {
               id: "thread_1",
@@ -3817,7 +3871,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         create(:agent_run, :completed,
           project: project, source_pull_request_number: 42,
           completed_at: 1.hour.ago)
-        stub_github_for_pr(issue_comments: [ comment ])
+        stub_github_for_pr(draft: true, issue_comments: [ comment ])
       end
 
       it "triggers a draft followup for new conversation comments" do
@@ -3849,6 +3903,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           project: project, source_pull_request_number: 42,
           completed_at: 1.hour.ago)
         stub_github_for_pr(
+          draft: true,
           issue_comments: [ comment ],
           checks: [ { name: "ci", conclusion: nil } ]
         )
@@ -3872,6 +3927,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           project: project, source_pull_request_number: 42,
           completed_at: 1.hour.ago)
         stub_github_for_pr(
+          draft: true,
           reviews: default_clean_copilot_review + [
             { id: 1, user_login: "viamin", state: "CHANGES_REQUESTED", body: "", submitted_at: 30.minutes.ago }
           ]
@@ -3896,6 +3952,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
                        body: "Copilot reviewed and generated 1 comment.",
                        submitted_at: 1.hour.ago } ],
@@ -3927,6 +3984,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "draft",
           draft_review_count: 0)
         stub_github_for_pr(
+          draft: true,
           checks: [],
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
                        body: "Copilot reviewed 20 out of 20 changed files in this pull request and generated 3 comments.",
@@ -3957,6 +4015,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "still requires a clean bot review before returning ready_for_owner" do
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [],
           review_threads: []
@@ -3972,6 +4031,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "does not return ready_for_owner when CI is failing" do
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "failure" } ],
           reviews: [],
           review_threads: []
@@ -3986,6 +4046,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "ignores review threads but still requires a clean bot review when CI is green" do
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [],
           review_threads: [
@@ -4006,22 +4067,15 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
 
       it "returns review_bot_review_pending when bot review is non-clean even without fetching threads" do
-        stub_github_for_pr(
-          checks: [ { name: "ci", conclusion: "success" } ],
-          reviews: [
-            { id: 200, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
-              submitted_at: 1.hour.ago }
-          ],
-          review_threads: [
-            {
-              id: "thread_bot",
-              is_resolved: false,
-              comments: [ { body: "Fix this", path: "app/model.rb", line: 5,
-                            author: "copilot-pull-request-reviewer[bot]" } ]
-            }
-          ]
-        )
+        non_clean_review = { id: 200, user_login: "copilot-pull-request-reviewer[bot]",
+                             state: "COMMENTED",
+                             body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
+                             submitted_at: 1.hour.ago }
+        bot_thread = { id: "thread_bot", is_resolved: false,
+                       comments: [ { body: "Fix this", path: "app/model.rb", line: 5,
+                                     author: "copilot-pull-request-reviewer[bot]" } ] }
+        stub_github_for_pr(draft: true, checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [ non_clean_review ], review_threads: [ bot_thread ])
 
         result = activity.execute(project_id: project.id)
 
@@ -4033,6 +4087,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "returns ready_for_owner when CI is green and the latest bot review is clean" do
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           review_threads: []
         )
@@ -4046,6 +4101,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "returns ready_for_owner when the latest bot review is clean and the repo has no checks" do
         stub_github_for_pr(
+          draft: true,
           checks: [],
           review_threads: []
         )
@@ -4059,6 +4115,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "does not return ready_for_owner when CI is pending" do
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: nil } ],
           review_threads: []
         )
@@ -4071,6 +4128,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       it "detects non-configured bot unresolved threads with address_all_bot_reviews enabled" do
         project.update!(review_settings: project.review_settings.merge("address_all_bot_reviews" => true))
         stub_github_for_pr(
+          draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 200, user_login: "chatgpt-codex-connector", state: "COMMENTED",
@@ -4931,6 +4989,100 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when a draft PR is manually marked ready on GitHub" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft",
+          draft_review_count: 2,
+          pr_followup_count: 1)
+      end
+
+      before do
+        stub_github_for_pr(draft: false,
+          checks: [ { name: "ci", conclusion: "failure" } ])
+      end
+
+      it "advances the local phase to ready" do
+        activity.execute(project_id: project.id)
+
+        expect(pr_issue.reload.pr_review_phase).to eq("ready")
+      end
+
+      it "scans the PR using ready-phase logic" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:phase]).to eq("ready")
+        expect(trigger[:triggers].first[:type]).to eq("ci_failure")
+      end
+
+      it "preserves existing draft_review_count" do
+        activity.execute(project_id: project.id)
+
+        expect(pr_issue.reload.draft_review_count).to eq(2)
+      end
+    end
+
+    context "when a restarted PR is manually marked ready on GitHub" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "restarted",
+          draft_review_count: 0,
+          pr_followup_count: 0)
+      end
+
+      before do
+        stub_github_for_pr(draft: false,
+          checks: [ { name: "ci", conclusion: "failure" } ])
+      end
+
+      it "advances the local phase to ready" do
+        activity.execute(project_id: project.id)
+
+        expect(pr_issue.reload.pr_review_phase).to eq("ready")
+      end
+
+      it "scans the PR using ready-phase logic" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:phase]).to eq("ready")
+        expect(trigger[:triggers].first[:type]).to eq("ci_failure")
+      end
+    end
+
+    context "when a draft PR fetch fails during phase reconciliation" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "draft")
+      end
+
+      before do
+        allow(github_client).to receive(:pull_request)
+          .and_raise(GithubClient::Error.new("API error"))
+        allow(github_client).to receive(:review_threads)
+          .and_raise(GithubClient::Error.new("API error"))
+        allow(github_client).to receive(:pull_request_reviews)
+          .and_raise(GithubClient::Error.new("API error"))
+        allow(github_client).to receive(:recent_issue_comments)
+          .and_raise(GithubClient::Error.new("API error"))
+      end
+
+      it "keeps the phase as draft" do
+        activity.execute(project_id: project.id)
+
+        expect(pr_issue.reload.pr_review_phase).to eq("draft")
+      end
+    end
+
     context "when a restarted PR only has stale pre-restart paid_agent reviews" do
       let!(:pr_issue) do
         create(:issue, :pull_request,
@@ -5324,6 +5476,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           pr_review_phase: "restarted",
           draft_review_count: 2)
         stub_github_for_pr(
+          draft: true,
           reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
                        body: "I found issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
@@ -5670,7 +5823,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       before do
         enable_paid_agent_review!
         pr_issue
-        stub_github_for_pr(reviews: [])
+        stub_github_for_pr(draft: true, reviews: [])
       end
 
       it "emits review_goal_retry when most recent review-goal run failed" do
@@ -5831,6 +5984,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
             goal: "review",
             source_pull_request_number: 42)
         end
+        stub_github_for_pr(draft: false, reviews: [])
 
         result = activity.execute(project_id: project.id)
 
@@ -5853,6 +6007,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           goal: "review",
           status: "running",
           source_pull_request_number: 42)
+        stub_github_for_pr(draft: false, reviews: [])
 
         result = activity.execute(project_id: project.id)
 
@@ -5865,18 +6020,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       it "does not escalate in ready phase while a manual review-goal run is still running" do
         pr_issue.update!(pr_review_phase: "ready", review_goal_retry_count: 3)
         3.times do
-          create(:agent_run, :failed,
-            project: project,
-            goal: "review",
-            source_pull_request_number: 42,
-            trigger_type: "automatic")
+          create(:agent_run, :failed, project: project, goal: "review",
+            source_pull_request_number: 42, trigger_type: "automatic")
         end
-        create(:agent_run,
-          project: project,
-          goal: "review",
-          status: "running",
-          trigger_type: "manual",
-          source_pull_request_number: 42)
+        create(:agent_run, project: project, goal: "review",
+          status: "running", trigger_type: "manual", source_pull_request_number: 42)
+        stub_github_for_pr(draft: false, reviews: [])
 
         result = activity.execute(project_id: project.id)
 
@@ -5946,6 +6095,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "continues scanning other signals alongside review_goal_retry" do
         stub_github_for_pr(
+          draft: true,
           reviews: [],
           checks: [ { name: "rspec", conclusion: "failure" } ]
         )
@@ -5988,7 +6138,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
 
       it "preserves paid_agent_review_pending draft gate when sole reviewer and retry is needed" do
-        stub_github_for_pr(reviews: [])
+        stub_github_for_pr(draft: true, reviews: [])
         create(:agent_run, :failed,
           project: project,
           goal: "review",
@@ -6011,7 +6161,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
             "copilot" => { "enabled" => true }
           }
         })
-        stub_github_for_pr(reviews: [])
+        stub_github_for_pr(draft: true, reviews: [])
         create(:agent_run, :failed,
           project: project,
           goal: "review",
@@ -6153,7 +6303,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         labels: [ "paid-generated", "paid-automation" ],
         pr_review_phase: "draft",
         draft_review_count: 0)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "blocks draft exit with a paid_agent_review_pending trigger (no ready_for_owner)" do
@@ -6181,7 +6331,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         "enabled" => false,
         "methods" => { "paid_agent" => { "enabled" => true } }
       })
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "does not emit a paid_agent_review_pending trigger" do
@@ -6216,7 +6366,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         project: project, issue: issue,
         source_pull_request_number: 42,
         goal: "review", status: "queued")
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "keeps the paid_agent_review_pending trigger active" do
@@ -6245,7 +6395,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         project: project, issue: issue,
         source_pull_request_number: 42,
         goal: "review", status: "running")
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "still blocks draft exit until the review is posted" do
@@ -6275,7 +6425,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           goal: "review", status: "completed",
           completed_at: 1.hour.ago)
       end
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "does not emit a paid_agent_review_pending trigger" do
@@ -6304,7 +6454,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "completed",
         completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "does not emit a paid_agent_review_pending trigger" do
@@ -6333,7 +6483,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "timeout")
       run.update_columns(updated_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "retries the timed-out review" do
@@ -6359,7 +6509,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           source_pull_request_number: 42,
           goal: "review", status: "timeout")
       end
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "does not emit a paid_agent_review_pending trigger" do
@@ -6398,7 +6548,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "create_pr", status: "completed",
         completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "emits a paid_agent_review_pending trigger because retried runs do not consume review rounds" do
@@ -6428,7 +6578,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "create_pr", status: "completed",
         completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "emits a paid_agent_review_pending trigger" do
@@ -6456,7 +6606,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "failed",
         started_at: 1.hour.ago, completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "emits a paid_agent_review_pending trigger to retry" do
@@ -6509,7 +6659,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         goal: "review", status: "cancelled",
         trigger_type: "automatic",
         started_at: 1.hour.ago, completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "does not emit review_goal_retry or paid_agent_review_pending" do
@@ -6539,7 +6689,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           goal: "review", status: "failed",
           started_at: 1.hour.ago, completed_at: 1.hour.ago)
       end
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "escalates to owner instead of retrying" do
@@ -6661,7 +6811,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "failed",
         started_at: 1.hour.ago, completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "caps default retry limit to max_review_rounds and escalates" do
@@ -6836,7 +6986,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         goal: "review",
         started_at: 1.hour.ago,
         completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "retries instead of escalating because the breaker resets for the new cycle" do
@@ -6880,7 +7030,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         goal: "review",
         started_at: 1.hour.ago,
         completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "retries instead of escalating because the breaker resets after a successful review" do
@@ -6919,7 +7069,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "completed",
         completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "does not retry when a completed review exists after the last create_pr run" do
@@ -6957,7 +7107,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "failed",
         started_at: 1.hour.ago, completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "escalates after custom retry limit" do
@@ -6985,7 +7135,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "timeout",
         started_at: 1.hour.ago, completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "counts timeout as a failure and retries" do
@@ -7013,7 +7163,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "no_output",
         started_at: 1.hour.ago, completed_at: 1.hour.ago)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "treats no_output as retryable and re-emits paid_agent_review_pending" do
@@ -7044,7 +7194,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           goal: "review", status: "no_output",
           started_at: 1.hour.ago, completed_at: 1.hour.ago)
       end
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "escalates instead of getting stuck behind the rounds cap" do
@@ -7138,7 +7288,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         labels: [ "paid-generated", "paid-automation" ],
         pr_review_phase: "draft",
         draft_review_count: 0)
-      stub_github_for_pr(reviews: [
+      stub_github_for_pr(draft: true, reviews: [
         { id: 200, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
           body: "Review complete.\n<!-- paid-review-clean -->", submitted_at: 1.hour.ago }
       ])
@@ -7169,7 +7319,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         labels: [ "paid-generated", "paid-automation" ],
         pr_review_phase: "draft",
         draft_review_count: 0)
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "gates draft exit via copilot (paid_agent does not independently block)" do
@@ -7210,7 +7360,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           goal: "review", status: "failed",
           started_at: 1.hour.ago, completed_at: 1.hour.ago)
       end
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "stops retrying paid_agent and lets copilot keep gating the PR" do
@@ -7246,6 +7396,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         pr_review_phase: "draft",
         draft_review_count: 1)
       stub_github_for_pr(
+        draft: true,
         reviews: [
           { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
             body: "Found issues.", submitted_at: 2.hours.ago },
@@ -7295,7 +7446,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           goal: "review", status: "failed",
           started_at: 1.hour.ago, completed_at: 1.hour.ago)
       end
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "escalates because paid_agent is the sole bot and manual cannot recover failed review-goal runs" do
@@ -7338,7 +7489,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           goal: "review", status: "failed",
           started_at: 1.hour.ago, completed_at: 1.hour.ago)
       end
-      stub_github_for_pr(reviews: [])
+      stub_github_for_pr(draft: true, reviews: [])
     end
 
     it "escalates because paid_agent is the sole bot and ci_action cannot recover failed review-goal runs" do


### PR DESCRIPTION
## Summary

fix(pr-review): reconcile internal pr_review_phase with manual GitHub draft/ready transitions

See #826 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #826