### PR TITLE
Fix #829: fix(agent-runs): provider exhaustion on PR follow-up runs can leave projects effectively stalled

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -8,6 +8,7 @@ class AgentRun < ApplicationRecord
   ACTIVE_STATUSES = %w[pending running].freeze
   FINISHED_STATUSES = %w[completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
   FAILURE_STATUSES = %w[failed timeout auth_expired rate_limited].freeze
+  OPERATIONAL_FAILURE_STATUSES = %w[failed timeout auth_expired rate_limited].freeze
   TERMINAL_FAILURE_STATUSES = (FAILURE_STATUSES + %w[cancelled]).freeze
   UNFINISHED_STATUSES = %w[queued pending running paused].freeze
   GUARDRAIL_VIOLATION_TYPES = %w[loop_detected token_limit cost_limit time_limit anomaly].freeze
@@ -541,6 +542,23 @@ class AgentRun < ApplicationRecord
 
   def successful?
     status == "completed"
+  end
+
+  # Returns true when this run failed due to an operational/infrastructure
+  # issue (provider exhaustion, timeout, auth expiry, rate limiting) rather
+  # than a code-level failure. Used by the PR scanner's operational failure
+  # breaker to detect when a PR is stalled due to infrastructure problems
+  # that the agent cannot fix by retrying.
+  #
+  # A "failed" run is only operational when the error message indicates
+  # provider exhaustion or rate limiting — other "failed" runs are assumed
+  # to be code-level failures where a retry might help.
+  def operational_failure?
+    return false unless OPERATIONAL_FAILURE_STATUSES.include?(status)
+    return true if status.in?(%w[timeout auth_expired rate_limited])
+
+    # "failed" status: only operational when caused by provider exhaustion
+    error_message.to_s.match?(/All providers exhausted/i)
   end
 
   def total_tokens

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -8,7 +8,6 @@ class AgentRun < ApplicationRecord
   ACTIVE_STATUSES = %w[pending running].freeze
   FINISHED_STATUSES = %w[completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
   FAILURE_STATUSES = %w[failed timeout auth_expired rate_limited].freeze
-  OPERATIONAL_FAILURE_STATUSES = %w[failed timeout auth_expired rate_limited].freeze
   TERMINAL_FAILURE_STATUSES = (FAILURE_STATUSES + %w[cancelled]).freeze
   UNFINISHED_STATUSES = %w[queued pending running paused].freeze
   GUARDRAIL_VIOLATION_TYPES = %w[loop_detected token_limit cost_limit time_limit anomaly].freeze
@@ -554,7 +553,7 @@ class AgentRun < ApplicationRecord
   # provider exhaustion or rate limiting — other "failed" runs are assumed
   # to be code-level failures where a retry might help.
   def operational_failure?
-    return false unless OPERATIONAL_FAILURE_STATUSES.include?(status)
+    return false unless FAILURE_STATUSES.include?(status)
     return true if status.in?(%w[timeout auth_expired rate_limited])
 
     # "failed" status: only operational when caused by provider exhaustion

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -219,6 +219,11 @@ module Issues
     # yet handed off (missing paid-generated/paid-ready labels, or
     # still in draft/restarted phase).
     #
+    # Escalated PRs are excluded because they have already been surfaced
+    # to the owner for attention — keeping them in the count would let
+    # operationally stalled PRs (e.g. provider exhaustion, repeated
+    # timeouts) block auto-pick indefinitely even after escalation.
+    #
     # Uses a single COUNT query. The handed_off subquery only matches
     # in_progress rows, so failed PRs are never excluded by it.
     def prs_needing_attention_count
@@ -234,7 +239,9 @@ module Issues
         .where("labels @> ?::jsonb", [ @project.generated_label_name, PAID_READY_LABEL ].to_json)
         .where.not(pr_review_phase: %w[draft restarted])
 
-      base.where.not(id: handed_off).count
+      escalated = base.where(pr_review_phase: "escalated")
+
+      base.where.not(id: handed_off).where.not(id: escalated).count
     end
 
     # Returns true if the number of PRs needing attention meets or

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -124,6 +124,15 @@ module Activities
     def scan_pr(project, client, issue)
       return :skipped if active_run_exists?(project, issue)
 
+      # Escalate PRs that are repeatedly failing due to operational issues
+      # (provider exhaustion, timeouts, rate limiting) so they stop blocking
+      # project progress and surface to the owner for attention.
+      if operational_failure_breaker?(project, issue)
+        return escalate_trigger(issue,
+          reason: "Consecutive operational failures " \
+                  "(#{MAX_CONSECUTIVE_OPERATIONAL_FAILURES} runs failed due to provider exhaustion/timeout)")
+      end
+
       backfill_review_goal_retry_reset_at!(issue)
 
       retry_needed = review_goal_retry_needed?(project, issue)
@@ -228,6 +237,7 @@ module Activities
     end
 
     MAX_CONSECUTIVE_DRAFT_FAILURES = 3
+    MAX_CONSECUTIVE_OPERATIONAL_FAILURES = 3
 
     # --- Draft phase scanning ---
 
@@ -755,6 +765,38 @@ module Activities
       recent_runs.all? do |run|
         unproductive_statuses.include?(run.status) && (run.status == "no_output" || run.iterations.to_i.zero?)
       end
+    end
+
+    # Circuit breaker: if the last N automatic follow-up runs on this PR
+    # all failed due to operational issues (provider exhaustion, wall-clock
+    # timeout, auth expiry, rate limiting), escalate to the owner. These
+    # are infrastructure failures the agent cannot fix by retrying — they
+    # indicate a systemic problem (all providers down, quota exceeded, etc.)
+    # that requires human intervention.
+    #
+    # Unlike consecutive_draft_failures_breaker? (draft-phase only, checks
+    # for unproductive output), this breaker applies across all phases and
+    # checks for infrastructure-class failures specifically. A run that
+    # failed due to a code error won't trip this breaker because a retry
+    # with different code changes might succeed.
+    #
+    # Skips PRs already in "escalated" phase to avoid re-escalating.
+    # Skips draft/restarted phases because those have their own failure
+    # breaker (consecutive_draft_failures_breaker?) with phase-aware
+    # guards (e.g. draft_review_count resets on restart).
+    def operational_failure_breaker?(project, issue)
+      return false if issue.pr_review_phase.in?(%w[draft restarted escalated])
+
+      recent_runs = project.agent_runs
+        .where(source_pull_request_number: issue.github_number)
+        .where(trigger_type: "automatic", goal: "create_pr")
+        .finished
+        .order(created_at: :desc)
+        .limit(MAX_CONSECUTIVE_OPERATIONAL_FAILURES)
+
+      return false if recent_runs.size < MAX_CONSECUTIVE_OPERATIONAL_FAILURES
+
+      recent_runs.all?(&:operational_failure?)
     end
 
     # Returns true when the latest finished automatic review-goal run in the

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -566,6 +566,58 @@ RSpec.describe AgentRun do
       end
     end
 
+    describe "#operational_failure?" do
+      it "returns true for timeout status" do
+        agent_run = build(:agent_run, :timeout, error_message: "wall_clock_timeout: exceeded 30 minutes")
+
+        expect(agent_run.operational_failure?).to be true
+      end
+
+      it "returns true for auth_expired status" do
+        agent_run = build(:agent_run, :auth_expired)
+
+        expect(agent_run.operational_failure?).to be true
+      end
+
+      it "returns true for rate_limited status" do
+        agent_run = build(:agent_run, :rate_limited)
+
+        expect(agent_run.operational_failure?).to be true
+      end
+
+      it "returns true for failed status with provider exhaustion error" do
+        agent_run = build(:agent_run, :failed,
+          error_message: "All providers exhausted: claude_code, codex")
+
+        expect(agent_run.operational_failure?).to be true
+      end
+
+      it "returns false for failed status with code-level error" do
+        agent_run = build(:agent_run, :failed,
+          error_message: "An error occurred during execution")
+
+        expect(agent_run.operational_failure?).to be false
+      end
+
+      it "returns false for completed status" do
+        agent_run = build(:agent_run, :completed)
+
+        expect(agent_run.operational_failure?).to be false
+      end
+
+      it "returns false for no_output status" do
+        agent_run = build(:agent_run, :no_output)
+
+        expect(agent_run.operational_failure?).to be false
+      end
+
+      it "returns false for failed status with nil error message" do
+        agent_run = build(:agent_run, :failed, error_message: nil)
+
+        expect(agent_run.operational_failure?).to be false
+      end
+    end
+
     describe "#total_tokens" do
       it "returns sum of input and output tokens" do
         agent_run = build(:agent_run, tokens_input: 1000, tokens_output: 500)

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -800,6 +800,47 @@ RSpec.describe Issues::AutoPick do
       end
     end
 
+    context "when PR is in escalated phase" do
+      before do
+        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
+      end
+
+      it "does not count escalated in_progress PRs as needing attention" do
+        create(:issue, :pull_request, :in_progress,
+          project: project,
+          pr_review_phase: "escalated")
+        issue = create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_a(AgentRun)
+        expect(result.issue).to eq(issue)
+      end
+
+      it "does not count escalated failed PRs as needing attention" do
+        create(:issue, :pull_request, :failed,
+          project: project,
+          pr_review_phase: "escalated")
+        issue = create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_a(AgentRun)
+        expect(result.issue).to eq(issue)
+      end
+
+      it "still blocks auto-pick for non-escalated failed PRs" do
+        create(:issue, :pull_request, :failed,
+          project: project,
+          pr_review_phase: "ready")
+        create(:issue, project: project)
+
+        result = described_class.new(project).call
+
+        expect(result).to be_nil
+      end
+    end
+
     context "with PR WIP limit" do
       it "does not block auto-pick when limit is 0 (no limit)" do
         project.effective_owner.settings.update!(max_auto_pick_open_prs: 0)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -3824,6 +3824,145 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when consecutive follow-up runs fail with operational errors" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          draft_review_count: 0)
+      end
+
+      before do
+        stub_github_for_pr(review_threads: [], reviews: [], checks: [])
+      end
+
+      def create_followup_run(status:, error_message: nil, created_at: Time.current)
+        create(:agent_run,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          trigger_type: "automatic",
+          goal: "create_pr",
+          status: status,
+          error_message: error_message,
+          started_at: created_at - 5.minutes,
+          completed_at: created_at,
+          created_at: created_at)
+      end
+
+      it "escalates after 3 consecutive provider exhaustion failures" do
+        3.times do |i|
+          create_followup_run(
+            status: "failed",
+            error_message: "All providers exhausted: claude_code, codex",
+            created_at: i.minutes.ago)
+        end
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("escalate_to_owner")
+        expect(trigger[:triggers].first[:details]).to include("Consecutive operational failures")
+      end
+
+      it "escalates after 3 consecutive timeout failures" do
+        3.times do |i|
+          create_followup_run(
+            status: "timeout",
+            error_message: "wall_clock_timeout: exceeded 30 minutes",
+            created_at: i.minutes.ago)
+        end
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("escalate_to_owner")
+        expect(trigger[:triggers].first[:details]).to include("Consecutive operational failures")
+      end
+
+      it "escalates after 3 consecutive mixed operational failures" do
+        create_followup_run(status: "timeout", error_message: "wall_clock_timeout", created_at: 1.minute.ago)
+        create_followup_run(status: "rate_limited", error_message: "All providers rate limited", created_at: 2.minutes.ago)
+        create_followup_run(status: "failed", error_message: "All providers exhausted: claude_code", created_at: 3.minutes.ago)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger = result[:prs_to_trigger].first
+        expect(trigger[:triggers].first[:type]).to eq("escalate_to_owner")
+      end
+
+      it "does not escalate when a code-level failure breaks the streak" do
+        create_followup_run(status: "timeout", error_message: "wall_clock_timeout", created_at: 1.minute.ago)
+        create_followup_run(status: "failed", error_message: "An error occurred during execution", created_at: 2.minutes.ago)
+        create_followup_run(status: "timeout", error_message: "wall_clock_timeout", created_at: 3.minutes.ago)
+
+        result = activity.execute(project_id: project.id)
+
+        triggers = result[:prs_to_trigger]
+        if triggers.any?
+          expect(triggers.first[:triggers].first[:type]).not_to eq("escalate_to_owner")
+        end
+      end
+
+      it "does not escalate with fewer than 3 consecutive operational failures" do
+        2.times do |i|
+          create_followup_run(
+            status: "failed",
+            error_message: "All providers exhausted: claude_code",
+            created_at: i.minutes.ago)
+        end
+
+        result = activity.execute(project_id: project.id)
+
+        triggers = result[:prs_to_trigger]
+        if triggers.any?
+          expect(triggers.first[:triggers].first[:type]).not_to eq("escalate_to_owner")
+        end
+      end
+
+      it "does not re-escalate PRs already in escalated phase" do
+        pr_issue.update!(pr_review_phase: "escalated")
+        3.times do |i|
+          create_followup_run(
+            status: "failed",
+            error_message: "All providers exhausted: claude_code",
+            created_at: i.minutes.ago)
+        end
+
+        result = activity.execute(project_id: project.id)
+
+        triggers = result[:prs_to_trigger]
+        escalation_triggers = triggers.select do |t|
+          t[:triggers].any? { |tr| tr[:details]&.include?("Consecutive operational failures") }
+        end
+        expect(escalation_triggers).to be_empty
+      end
+
+      it "does not count manual runs toward the breaker" do
+        create_followup_run(status: "timeout", error_message: "wall_clock_timeout", created_at: 1.minute.ago)
+        create_followup_run(status: "timeout", error_message: "wall_clock_timeout", created_at: 2.minutes.ago)
+        create(:agent_run, :timeout,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          trigger_type: "manual",
+          goal: "create_pr",
+          error_message: "wall_clock_timeout",
+          created_at: 3.minutes.ago)
+
+        result = activity.execute(project_id: project.id)
+
+        triggers = result[:prs_to_trigger]
+        if triggers.any?
+          expect(triggers.first[:triggers].first[:type]).not_to eq("escalate_to_owner")
+        end
+      end
+    end
+
     context "when draft PR has unresolved trusted review threads" do
       before do
         create(:issue, :pull_request,


### PR DESCRIPTION
## Summary

fix(agent-runs): provider exhaustion on PR follow-up runs can leave projects effectively stalled

See #829 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #829