### PR TITLE
Fix #842: Replace project quality summary range with score distribution histogram

### DIFF
--- a/app/services/quality_metrics/dashboard_stats.rb
+++ b/app/services/quality_metrics/dashboard_stats.rb
@@ -77,6 +77,14 @@ module QualityMetrics
       end
     end
 
+    DISTRIBUTION_BANDS = [
+      { label: "0–20", min: 0.0, max: 0.2 },
+      { label: "20–40", min: 0.2, max: 0.4 },
+      { label: "40–60", min: 0.4, max: 0.6 },
+      { label: "60–80", min: 0.6, max: 0.8 },
+      { label: "80–100", min: 0.8, max: 1.01 }
+    ].freeze
+
     def overview
       row = metrics
         .select(
@@ -95,7 +103,8 @@ module QualityMetrics
         min_score: row.min_score&.to_f,
         max_score: row.max_score&.to_f,
         automated_count: row.automated_count.to_i,
-        human_count: row.human_count.to_i
+        human_count: row.human_count.to_i,
+        score_distribution: score_distribution
       }
     end
 
@@ -103,6 +112,24 @@ module QualityMetrics
 
     def metrics
       @metrics ||= QualityMetric.by_project(project.id).with_composite_score
+    end
+
+    def score_distribution
+      counts = metrics
+        .group(Arel.sql(<<~SQL.squish))
+          CASE
+            WHEN composite_score < 0.2 THEN 0
+            WHEN composite_score < 0.4 THEN 1
+            WHEN composite_score < 0.6 THEN 2
+            WHEN composite_score < 0.8 THEN 3
+            ELSE 4
+          END
+        SQL
+        .count
+
+      DISTRIBUTION_BANDS.each_with_index.map do |band, i|
+        { label: band[:label], count: counts.fetch(i, 0) }
+      end
     end
 
     def trends

--- a/app/services/quality_metrics/dashboard_stats.rb
+++ b/app/services/quality_metrics/dashboard_stats.rb
@@ -128,7 +128,7 @@ module QualityMetrics
         .count
 
       DISTRIBUTION_BANDS.each_with_index.map do |band, i|
-        { label: band[:label], count: counts.fetch(i, 0) }
+        { label: band[:label], min: band[:min], count: counts.fetch(i, 0) }
       end
     end
 

--- a/app/views/projects/_quality_summary.html.erb
+++ b/app/views/projects/_quality_summary.html.erb
@@ -16,9 +16,16 @@
             </div>
           </div>
           <div class="text-right">
-            <span class="text-sm text-gray-500">Range</span>
-            <div class="mt-1 text-sm font-medium text-gray-700">
-              <%= format_quality_score(quality_summary[:min_score]) %> - <%= format_quality_score(quality_summary[:max_score]) %>
+            <span class="text-sm text-gray-500">Score Distribution</span>
+            <% distribution = quality_summary[:score_distribution] %>
+            <% max_count = distribution.map { |b| b[:count] }.max %>
+            <div class="mt-1 flex items-end gap-px" style="height: 32px;">
+              <% distribution.each do |band| %>
+                <% bar_height = max_count > 0 ? (band[:count].to_f / max_count * 100).round : 0 %>
+                <div class="w-5 rounded-t <%= band[:count] > 0 ? quality_score_bar_color(band[:label].split("–").first.to_f / 100.0) : 'bg-gray-200' %>"
+                     style="height: <%= [bar_height, 4].max %>%;"
+                     title="<%= band[:label] %>%: <%= pluralize(band[:count], 'score') %>"></div>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/projects/_quality_summary.html.erb
+++ b/app/views/projects/_quality_summary.html.erb
@@ -22,7 +22,7 @@
             <div class="mt-1 flex items-end gap-px" style="height: 32px;">
               <% distribution.each do |band| %>
                 <% bar_height = max_count > 0 ? (band[:count].to_f / max_count * 100).round : 0 %>
-                <div class="w-5 rounded-t <%= band[:count] > 0 ? quality_score_bar_color(band[:label].split("–").first.to_f / 100.0) : 'bg-gray-200' %>"
+                <div class="w-5 rounded-t <%= band[:count] > 0 ? quality_score_bar_color(band[:min]) : 'bg-gray-200' %>"
                      style="height: <%= [bar_height, 4].max %>%;"
                      title="<%= band[:label] %>%: <%= pluralize(band[:count], 'score') %>"></div>
               <% end %>

--- a/spec/services/quality_metrics/dashboard_stats_spec.rb
+++ b/spec/services/quality_metrics/dashboard_stats_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe QualityMetrics::DashboardStats do
 
         expect(dist.size).to eq(5)
         expect(dist.map { |b| b[:label] }).to eq(%w[0–20 20–40 40–60 60–80 80–100])
+        expect(dist.map { |b| b[:min] }).to eq([ 0.0, 0.2, 0.4, 0.6, 0.8 ])
         # 0.6 falls in 60–80 band, 0.8 falls in 80–100 band
         expect(dist[3][:count]).to eq(1)
         expect(dist[4][:count]).to eq(1)

--- a/spec/services/quality_metrics/dashboard_stats_spec.rb
+++ b/spec/services/quality_metrics/dashboard_stats_spec.rb
@@ -53,10 +53,20 @@ RSpec.describe QualityMetrics::DashboardStats do
 
         expect(result[:overview][:total_metrics]).to eq(2)
         expect(result[:overview][:average_score]).to eq(0.7)
-        expect(result[:overview][:min_score]).to eq(0.6)
-        expect(result[:overview][:max_score]).to eq(0.8)
         expect(result[:overview][:automated_count]).to eq(1)
         expect(result[:overview][:human_count]).to eq(1)
+      end
+
+      it "returns score distribution with five bands" do
+        result = described_class.call(project: project)
+        dist = result[:overview][:score_distribution]
+
+        expect(dist.size).to eq(5)
+        expect(dist.map { |b| b[:label] }).to eq(%w[0–20 20–40 40–60 60–80 80–100])
+        # 0.6 falls in 60–80 band, 0.8 falls in 80–100 band
+        expect(dist[3][:count]).to eq(1)
+        expect(dist[4][:count]).to eq(1)
+        expect(dist[0][:count]).to eq(0)
       end
 
       it "returns trend data points" do


### PR DESCRIPTION
## Summary

Replace project quality summary range with score distribution histogram

See #842 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #842