### PR TITLE
Fix #841: Use emoji-only status in project issues table with header tooltip legend

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,9 +90,20 @@ module ApplicationHelper
   def issue_lifecycle_badge(status)
     display = ISSUE_LIFECYCLE_DISPLAY[status] || ISSUE_LIFECYCLE_DISPLAY[:eligible]
     tag.span(
-      "#{display[:emoji]} #{display[:label]}",
+      display[:emoji],
       title: display[:title] || display[:label],
-      class: "inline-flex items-center text-sm"
+      class: "inline-flex items-center text-sm",
+      aria: { label: display[:label] }
+    )
+  end
+
+  def issue_lifecycle_legend_tooltip
+    legend = ISSUE_LIFECYCLE_DISPLAY.map { |_key, display| "#{display[:emoji]} = #{display[:label]}" }.join("  ·  ")
+    tag.span(
+      "ℹ️",
+      title: legend,
+      class: "ml-1 cursor-help text-sm text-gray-400",
+      aria: { label: "Status legend" }
     )
   end
 

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id(project, :issues) %>" class="mt-8">
-  <h2 class="text-lg font-medium text-gray-900">Synced Issues</h2>
+  <h2 class="text-lg font-medium text-gray-900">Synced Issues <%= issue_lifecycle_legend_tooltip %></h2>
   <p class="mt-1 text-sm text-gray-500">Shows all open GitHub issues cached locally. Automation eligibility is evaluated separately from trust and labels.</p>
 
   <% if issues.any? %>


### PR DESCRIPTION
## Summary

Use emoji-only status in project issues table with header tooltip legend

See #841 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #841