### PR TITLE
Fix #863: fix(devcontainer): configure OpenCode auto-approval inside container only

### DIFF
--- a/.devcontainer/configure-llm-tools.sh
+++ b/.devcontainer/configure-llm-tools.sh
@@ -179,11 +179,24 @@ cat << 'EOF' > "$HOME/.config/kilo/config.json"
 EOF
 
 # ============================================================================
-# OpenCode, GitHub Copilot CLI, Cursor
+# OpenCode
 # ============================================================================
 
-# These tools use environment variables or their own config mechanisms
-# OpenCode: Uses OPENCODE_PERMISSION environment variable (set in containerEnv if needed)
+# Only auth.json is bind-mounted from the host, so writing opencode.json here
+# stays container-local and won't affect the host's OpenCode installation.
+echo "Configuring OpenCode..."
+mkdir -p "$HOME/.config/opencode"
+cat << 'EOF' > "$HOME/.config/opencode/opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": "allow"
+}
+EOF
+
+# ============================================================================
+# GitHub Copilot CLI, Cursor
+# ============================================================================
+
 # GitHub Copilot CLI: Uses ~/.copilot config (bind-mounted from host)
 # Cursor: Uses ~/.cursor config (bind-mounted from host)
 
@@ -200,9 +213,9 @@ echo "  - Gemini CLI: Auto-accept mode (autoAccept=true)"
 echo "  - KiloCode: Auto-approve mode (permission=allow, container-specific config)"
 echo "  - Aider: Path shim (no global auto-approve mode available)"
 echo "  - Cursor: Config mounted from host (~/.cursor)"
-echo "  - OpenCode: Config mounted from host (~/.config)"
+echo "  - OpenCode: Auto-approve mode (permission=allow, container-specific config)"
 echo "  - GitHub Copilot CLI: Config mounted from host (~/.copilot)"
 echo ""
 echo "WARNING: These tools will auto-approve all operations inside this container."
-echo "  Some tool state and configuration may be written back to host-mounted directories (e.g., ~/.claude, ~/.config)."
+echo "  Some tool state and configuration may be written back to host-mounted directories (e.g., ~/.claude)."
 echo "  Use only in isolated/dev environments where this behavior is acceptable."

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,8 +47,8 @@
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
     // LLM CLI Authentication - GitHub CLI config
     "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached",
-    // LLM CLI Authentication - opencode config
-    "source=${localEnv:HOME}/.config/opencode,target=/home/vscode/.config/opencode,type=bind,consistency=cached",
+    // LLM CLI Authentication - opencode auth only (config stays container-local for auto-approval)
+    "source=${localEnv:HOME}/.config/opencode/auth.json,target=/home/vscode/.config/opencode/auth.json,type=bind,consistency=cached",
     // GitHub CLI Extensions - Share extensions between host and container
     "source=${localEnv:HOME}/.local/share/gh,target=/home/vscode/.local/share/gh,type=bind,consistency=cached",
     // opencode Extensions - Share extensions between host and container

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,6 +39,9 @@
     "OVERMIND_SOCKET": "${containerWorkspaceFolder}/.overmind.sock",
     "PATH": "${containerEnv:PATH}:/home/vscode/.local/bin"
   },
+  // Ensure host paths that are bind-mounted as files (not directories) exist before
+  // Docker creates them as directories. See: https://github.com/moby/moby/issues/26702
+  "initializeCommand": "mkdir -p ~/.config/opencode && touch ~/.config/opencode/auth.json",
   "mounts": [
     // Git configuration
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",


### PR DESCRIPTION
## Summary

fix(devcontainer): configure OpenCode auto-approval inside container only

See #863 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #863