### PR TITLE
Fix #878: chore(models): gap analysis for tier-based selection (rate limits, fallback, overrides)

### DIFF
--- a/app/services/models/tier_for_complexity.rb
+++ b/app/services/models/tier_for_complexity.rb
@@ -26,10 +26,15 @@ module Models
       score = Float(complexity)
       thresholds = effective_thresholds
 
-      return "low" if score <= thresholds["low_max"]
-      return "mid" if score <= thresholds["mid_max"]
+      tier = if score <= thresholds["low_max"]
+        "low"
+      elsif score <= thresholds["mid_max"]
+        "mid"
+      else
+        "high"
+      end
 
-      "high"
+      cap_tier(tier)
     rescue ArgumentError, TypeError
       nil
     end
@@ -41,6 +46,20 @@ module Models
     private
 
     attr_reader :complexity, :agent_run, :project, :provider
+
+    # Caps the derived tier at the project's max_tier preference when set.
+    # For example, max_tier "mid" downgrades "high" → "mid" but leaves
+    # "low" and "mid" unchanged.
+    def cap_tier(tier)
+      max = project&.model_preferences&.dig("max_tier")
+      return tier unless max.present? && LlmModel::TIERS.include?(max)
+
+      max_index = LlmModel::TIERS.index(max)
+      tier_index = LlmModel::TIERS.index(tier)
+      return tier unless tier_index
+
+      tier_index <= max_index ? tier : max
+    end
 
     def project_override
       return nil unless project

--- a/spec/services/models/select_spec.rb
+++ b/spec/services/models/select_spec.rb
@@ -167,5 +167,49 @@ RSpec.describe Models::Select do
         expect(selection.selector_type).to eq("rules")
       end
     end
+
+    context "when required_model_id bypasses tier logic (regression)" do
+      let!(:low_tier_model) { create(:llm_model, model_id: "cheap-model", tier: "low", capability_score: 3.0) }
+
+      before do
+        # Even with max_tier set, required_model_id must always win
+        project.update!(model_preferences: {
+          "required_model_id" => "cheap-model",
+          "max_tier" => "high"
+        })
+      end
+
+      it "selects the required model regardless of tier settings" do
+        selection = described_class.call(agent_run: agent_run)
+
+        expect(selection.llm_model).to eq(low_tier_model)
+        expect(selection.selector_type).to eq("override")
+        expect(selection.tier).to eq("low")
+      end
+
+      it "does not invoke tier-based selectors" do
+        allow(Models::RulesBasedSelector).to receive(:call)
+
+        described_class.call(agent_run: agent_run)
+
+        expect(Models::MetaAgentSelector).not_to have_received(:call)
+        expect(Models::RulesBasedSelector).not_to have_received(:call)
+      end
+    end
+
+    context "with max_tier project preference" do
+      before do
+        create(:llm_model, model_id: "powerful-model", tier: "high", capability_score: 9.5)
+        create(:llm_model, model_id: "mid-model", tier: "mid", capability_score: 7.0)
+        project.update!(model_preferences: { "max_tier" => "mid" })
+      end
+
+      it "caps tier selection to the max_tier" do
+        selection = described_class.call(agent_run: agent_run)
+
+        expect(selection).to be_a(ModelSelection)
+        expect(selection.tier).to be_in(%w[low mid])
+      end
+    end
   end
 end

--- a/spec/services/models/tier_for_complexity_spec.rb
+++ b/spec/services/models/tier_for_complexity_spec.rb
@@ -41,5 +41,44 @@ RSpec.describe Models::TierForComplexity do
 
       expect(described_class.call(complexity: 3, provider: provider, project: project)).to eq("high")
     end
+
+    context "with max_tier project preference" do
+      it "caps high tier to mid when max_tier is mid" do
+        project = build(:project)
+        project.model_preferences = { "max_tier" => "mid" }
+
+        expect(described_class.call(complexity: 9, project: project)).to eq("mid")
+      end
+
+      it "does not affect tiers at or below the cap" do
+        project = build(:project)
+        project.model_preferences = { "max_tier" => "mid" }
+
+        expect(described_class.call(complexity: 2, project: project)).to eq("low")
+        expect(described_class.call(complexity: 5, project: project)).to eq("mid")
+      end
+
+      it "caps to low when max_tier is low" do
+        project = build(:project)
+        project.model_preferences = { "max_tier" => "low" }
+
+        expect(described_class.call(complexity: 9, project: project)).to eq("low")
+        expect(described_class.call(complexity: 5, project: project)).to eq("low")
+      end
+
+      it "ignores invalid max_tier values" do
+        project = build(:project)
+        project.model_preferences = { "max_tier" => "invalid" }
+
+        expect(described_class.call(complexity: 9, project: project)).to eq("high")
+      end
+
+      it "ignores blank max_tier" do
+        project = build(:project)
+        project.model_preferences = { "max_tier" => "" }
+
+        expect(described_class.call(complexity: 9, project: project)).to eq("high")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

chore(models): gap analysis for tier-based selection (rate limits, fallback, overrides)

See #878 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #878