### PR TITLE
Fix #802: "Back to ..." links should return to the previous page, not a hardcoded destination

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -381,6 +381,8 @@ module ApplicationHelper
     raise unless Rails.env.test?
   end
 
+  private
+
   def safe_return_path?(path)
     path.start_with?("/") && !path.start_with?("//")
   end
@@ -391,8 +393,6 @@ module ApplicationHelper
   rescue URI::InvalidURIError
     false
   end
-
-  private
 
   def priority_tier_for_label(project, label)
     return "P0" if label == "P0"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -278,6 +278,20 @@ module ApplicationHelper
     end
   end
 
+  # Returns the best "back" URL: checks params[:return_to] first, then
+  # request.referer, then falls back to the provided default path.
+  # Only internal (same-host, path-only) URLs are accepted to prevent open redirects.
+  def back_link_path(default_path)
+    return_to = params[:return_to]
+    if return_to.present? && safe_return_path?(return_to)
+      return_to
+    elsif request.referer.present? && safe_referer?(request.referer)
+      request.referer
+    else
+      default_path
+    end
+  end
+
   # Redacts potential secrets from error messages before displaying them in the UI.
   # Uses the Knowledge::Redaction::Redactor for consistent secret detection.
   def redacted_error_message(message)
@@ -365,6 +379,17 @@ module ApplicationHelper
     yield
   rescue Propshaft::MissingAssetError
     raise unless Rails.env.test?
+  end
+
+  def safe_return_path?(path)
+    path.start_with?("/") && !path.start_with?("//")
+  end
+
+  def safe_referer?(url)
+    uri = URI.parse(url)
+    uri.host == request.host
+  rescue URI::InvalidURIError
+    false
   end
 
   private

--- a/app/views/ab_tests/show.html.erb
+++ b/app/views/ab_tests/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to prompt_ab_tests_path(@prompt), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(prompt_ab_tests_path(@prompt)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/integration_credentials/index.html.erb
+++ b/app/views/integration_credentials/index.html.erb
@@ -13,7 +13,7 @@
       <p class="mt-1 text-sm text-gray-500"><%= description %></p>
     </div>
     <div class="mt-4 flex gap-3 sm:mt-0">
-      <%= link_to "Back to Integrations", integrations_path, class: "inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+      <%= link_to "Back to Integrations", back_link_path(integrations_path), class: "inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
       <%= link_to "Add Credential", new_integration_credential_path(category: @category_filter, service_key: @service_key_filter), class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
     </div>
   </div>

--- a/app/views/integration_credentials/new.html.erb
+++ b/app/views/integration_credentials/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div>
-    <%= link_to integration_credentials_path(category: @category_filter, service_key: @service_key_filter), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(integration_credentials_path(category: @category_filter, service_key: @service_key_filter)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <span aria-hidden="true" class="mr-1">&larr;</span>
       Back to credentials
     <% end %>

--- a/app/views/integration_credentials/show.html.erb
+++ b/app/views/integration_credentials/show.html.erb
@@ -8,7 +8,7 @@
     <% back_link_params = { category: params[:category].presence || @integration_credential.category } %>
     <% service_key_val = params[:service_key].presence %>
     <% back_link_params[:service_key] = service_key_val if service_key_val.present? %>
-    <%= link_to integration_credentials_path(back_link_params), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(integration_credentials_path(back_link_params)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <span aria-hidden="true" class="mr-1">&larr;</span>
       Back to credentials
     <% end %>

--- a/app/views/knowledge/artifacts/show.html.erb
+++ b/app/views/knowledge/artifacts/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to knowledge_search_path(project_id: @project.id), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(knowledge_search_path(project_id: @project.id)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/knowledge/context_intake/show.html.erb
+++ b/app/views/knowledge/context_intake/show.html.erb
@@ -9,7 +9,7 @@
       </p>
     </div>
     <div class="mt-4 sm:mt-0 sm:ml-4">
-      <%= link_to project_path(@project), class: "text-sm text-indigo-600 hover:text-indigo-500" do %>
+      <%= link_to back_link_path(project_path(@project)), class: "text-sm text-indigo-600 hover:text-indigo-500" do %>
         &larr; Back to project
       <% end %>
     </div>

--- a/app/views/linear_tokens/new.html.erb
+++ b/app/views/linear_tokens/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to integrations_path, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(integrations_path), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/linear_tokens/show.html.erb
+++ b/app/views/linear_tokens/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to linear_tokens_path, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(linear_tokens_path), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/projects/agent_runs/index.html.erb
+++ b/app/views/projects/agent_runs/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to project_path(@project), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(project_path(@project)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to project_path(@project), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(project_path(@project)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/projects/agent_runs/show.html.erb
+++ b/app/views/projects/agent_runs/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to project_path(@project), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(project_path(@project)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to project_path(@project), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(project_path(@project)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/projects/quality_dashboards/show.html.erb
+++ b/app/views/projects/quality_dashboards/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to project_path(@project), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(project_path(@project)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to projects_path, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(projects_path), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/prompt_reviews/index.html.erb
+++ b/app/views/prompt_reviews/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to prompt_path(@prompt), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(prompt_path(@prompt)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/prompt_reviews/show.html.erb
+++ b/app/views/prompt_reviews/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to prompt_reviews_path(@prompt), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(prompt_reviews_path(@prompt)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/prompts/diff.html.erb
+++ b/app/views/prompts/diff.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to prompt_path(@prompt), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(prompt_path(@prompt)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/prompts/edit.html.erb
+++ b/app/views/prompts/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to prompt_path(@prompt), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(prompt_path(@prompt)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/prompts/new.html.erb
+++ b/app/views/prompts/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to prompts_path, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(prompts_path), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/prompts/show.html.erb
+++ b/app/views/prompts/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to prompts_path, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(prompts_path), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/provider_api_keys/edit.html.erb
+++ b/app/views/provider_api_keys/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to provider_api_key_path(@provider_api_key), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(provider_api_key_path(@provider_api_key)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/provider_api_keys/new.html.erb
+++ b/app/views/provider_api_keys/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to integrations_path, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(integrations_path), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/provider_api_keys/show.html.erb
+++ b/app/views/provider_api_keys/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to provider_api_keys_path, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(provider_api_keys_path), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/service_containers/show.html.erb
+++ b/app/views/service_containers/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to service_containers_path, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+    <%= link_to back_link_path(service_containers_path), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
       </svg>

--- a/app/views/style_guides/edit.html.erb
+++ b/app/views/style_guides/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to "← Back to Style Guide", style_guide_path(@style_guide), class: "text-sm text-indigo-600 hover:text-indigo-900" %>
+    <%= link_to "← Back to Style Guide", back_link_path(style_guide_path(@style_guide)), class: "text-sm text-indigo-600 hover:text-indigo-900" %>
   </div>
 
   <h1 class="text-2xl font-bold text-gray-900">Edit Style Guide</h1>

--- a/app/views/style_guides/new.html.erb
+++ b/app/views/style_guides/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to "← Back to Style Guides", style_guides_path, class: "text-sm text-indigo-600 hover:text-indigo-900" %>
+    <%= link_to "← Back to Style Guides", back_link_path(style_guides_path), class: "text-sm text-indigo-600 hover:text-indigo-900" %>
   </div>
 
   <h1 class="text-2xl font-bold text-gray-900">New Style Guide</h1>

--- a/app/views/style_guides/show.html.erb
+++ b/app/views/style_guides/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
-    <%= link_to "← Back to Style Guides", style_guides_path, class: "text-sm text-indigo-600 hover:text-indigo-900" %>
+    <%= link_to "← Back to Style Guides", back_link_path(style_guides_path), class: "text-sm text-indigo-600 hover:text-indigo-900" %>
   </div>
 
   <div class="sm:flex sm:items-center sm:justify-between">

--- a/spec/helpers/application_helper_back_link_spec.rb
+++ b/spec/helpers/application_helper_back_link_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#back_link_path" do
+    let(:default_path) { "/projects" }
+
+    context "when params[:return_to] is a valid internal path" do
+      it "returns the return_to path" do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new(return_to: "/agent_runs"))
+        allow(helper.request).to receive(:referer).and_return(nil)
+
+        expect(helper.back_link_path(default_path)).to eq("/agent_runs")
+      end
+
+      it "accepts paths with query strings" do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new(return_to: "/agent_runs?status=running"))
+        allow(helper.request).to receive(:referer).and_return(nil)
+
+        expect(helper.back_link_path(default_path)).to eq("/agent_runs?status=running")
+      end
+    end
+
+    context "when params[:return_to] is unsafe" do
+      it "rejects external URLs" do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new(return_to: "https://evil.com/steal"))
+        allow(helper.request).to receive(:referer).and_return(nil)
+
+        expect(helper.back_link_path(default_path)).to eq(default_path)
+      end
+
+      it "rejects protocol-relative URLs" do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new(return_to: "//evil.com/steal"))
+        allow(helper.request).to receive(:referer).and_return(nil)
+
+        expect(helper.back_link_path(default_path)).to eq(default_path)
+      end
+    end
+
+    context "when return_to is absent but referer is a same-host URL" do
+      it "returns the referer" do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new({}))
+        allow(helper.request).to receive_messages(referer: "http://test.host/agent_runs", host: "test.host")
+
+        expect(helper.back_link_path(default_path)).to eq("http://test.host/agent_runs")
+      end
+    end
+
+    context "when referer is from a different host" do
+      it "falls back to default" do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new({}))
+        allow(helper.request).to receive_messages(referer: "https://other.com/page", host: "test.host")
+
+        expect(helper.back_link_path(default_path)).to eq(default_path)
+      end
+    end
+
+    context "when neither return_to nor referer is available" do
+      it "returns the default path" do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new({}))
+        allow(helper.request).to receive(:referer).and_return(nil)
+
+        expect(helper.back_link_path(default_path)).to eq(default_path)
+      end
+    end
+
+    context "when both return_to and referer are present" do
+      it "uses return_to over referer" do
+        allow(helper).to receive(:params).and_return(ActionController::Parameters.new(return_to: "/specific_page"))
+        allow(helper.request).to receive_messages(referer: "http://test.host/other_page", host: "test.host")
+
+        expect(helper.back_link_path(default_path)).to eq("/specific_page")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

"Back to ..." links should return to the previous page, not a hardcoded destination

See #802 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #802