### PR TITLE
Fix #1236: perf(temporal-worker): isolate poll workflows from agent execution workloads

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
     "DB_HOST": "postgres",
     "TEMPORAL_ADDRESS": "temporal:7233",
     "TEMPORAL_NAMESPACE": "default",
-    "TEMPORAL_TASK_QUEUE": "paid-tasks",
+    "TEMPORAL_POLL_TASK_QUEUE": "paid-poll-tasks",
+    "TEMPORAL_AGENT_TASK_QUEUE": "paid-agent-tasks",
     "TEMPORAL_UI_URL": "http://localhost:8080",
     "QDRANT_URL": "http://qdrant:6333",
     // LLM CLI tools - dangerous/auto-approve mode (container only)

--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,9 @@ TEMPORAL_HOST=localhost:7233
 # Temporal namespace
 # TEMPORAL_NAMESPACE=default
 
-# Temporal task queue name
-# TEMPORAL_TASK_QUEUE=paid-tasks
+# Temporal task queue names (poll and agent workloads are isolated)
+# TEMPORAL_POLL_TASK_QUEUE=paid-poll-tasks
+# TEMPORAL_AGENT_TASK_QUEUE=paid-agent-tasks
 
 # Temporal UI base URL (used for workflow monitoring links in the UI)
 TEMPORAL_UI_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ bin/dev                 # Start Rails, JS/CSS watchers, and the Temporal worker
 | `TEMPORAL_HOST` | Temporal server address | `localhost:7233` |
 | `TEMPORAL_ADDRESS` | Temporal address (alternative to TEMPORAL_HOST) | _(falls back to TEMPORAL_HOST)_ |
 | `TEMPORAL_NAMESPACE` | Temporal namespace | `default` |
-| `TEMPORAL_TASK_QUEUE` | Temporal task queue name | `paid-tasks` |
+| `TEMPORAL_POLL_TASK_QUEUE` | Temporal poll workflow task queue | `paid-poll-tasks` |
+| `TEMPORAL_AGENT_TASK_QUEUE` | Temporal agent execution task queue | `paid-agent-tasks` |
 | `TEMPORAL_UI_URL` | Temporal UI base URL for monitoring links | `http://localhost:8080` |
 | `OPENAI_API_KEY` | OpenAI API key (for agents that use OpenAI) | _(none)_ |
 | `GOOGLE_API_KEY` | Google API key for Gemini proxy requests | _(none)_ |

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -250,7 +250,7 @@ class ProcessRunQueueJob < ApplicationJob
       Workflows::AgentExecutionWorkflow,
       workflow_input,
       id: workflow_id,
-      task_queue: Paid.task_queue
+      task_queue: Paid.agent_task_queue
     )
 
     Rails.logger.info(

--- a/app/services/project_workflow_manager.rb
+++ b/app/services/project_workflow_manager.rb
@@ -11,7 +11,7 @@ class ProjectWorkflowManager
         Workflows::GitHubPollWorkflow,
         { project_id: project.id },
         id: workflow_id_for(project),
-        task_queue: Paid.task_queue
+        task_queue: Paid.poll_task_queue
       )
 
       WorkflowState.record_polling_status(

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -247,6 +247,7 @@ module Workflows
         Workflows::PlanningWorkflow,
         { project_id: project_id, issue_id: issue_id },
         id: workflow_id,
+        task_queue: Paid::AGENT_TASK_QUEUE,
         parent_close_policy: Temporalio::Workflow::ParentClosePolicy::ABANDON
       )
     end

--- a/bin/temporal_worker
+++ b/bin/temporal_worker
@@ -18,28 +18,47 @@ activities = Activities.constants.map { |c| Activities.const_get(c) }
 workflows = Workflows.constants.map { |c| Workflows.const_get(c) }
                      .select { |c| c.is_a?(Class) && c < Workflows::BaseWorkflow }
 
+# Partition workflows into poll vs agent queues.
+# GitHubPollWorkflow runs on the poll queue; everything else on the agent queue.
+poll_workflows = workflows.select { |w| w == Workflows::GitHubPollWorkflow }
+agent_workflows = workflows.reject { |w| w == Workflows::GitHubPollWorkflow }
+
 puts "Starting Temporal worker..."
 puts "Activities: #{activities.map(&:name).join(", ")}"
-puts "Workflows: #{workflows.map(&:name).join(", ")}"
+puts "Poll workflows (#{Paid.poll_task_queue}): #{poll_workflows.map(&:name).join(", ")}"
+puts "Agent workflows (#{Paid.agent_task_queue}): #{agent_workflows.map(&:name).join(", ")}"
 
 graceful_shutdown = ENV.fetch("TEMPORAL_GRACEFUL_SHUTDOWN_PERIOD", "30").to_i
-workflow_slots = ENV.fetch("TEMPORAL_WORKFLOW_SLOTS", "20").to_i
-activity_slots = ENV.fetch("TEMPORAL_ACTIVITY_SLOTS", "4").to_i
-local_activity_slots = ENV.fetch("TEMPORAL_LOCAL_ACTIVITY_SLOTS", activity_slots.to_s).to_i
-activity_task_polls = ENV.fetch("TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS", activity_slots.to_s).to_i
-workflow_task_polls = ENV.fetch("TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS", workflow_slots.to_s).to_i
+
+# Agent worker concurrency (large pool for long-running agent activities)
+agent_workflow_slots = ENV.fetch("TEMPORAL_WORKFLOW_SLOTS", "20").to_i
+agent_activity_slots = ENV.fetch("TEMPORAL_ACTIVITY_SLOTS", "4").to_i
+agent_local_activity_slots = ENV.fetch("TEMPORAL_LOCAL_ACTIVITY_SLOTS", agent_activity_slots.to_s).to_i
+agent_activity_task_polls = ENV.fetch("TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS", agent_activity_slots.to_s).to_i
+agent_workflow_task_polls = ENV.fetch("TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS", agent_workflow_slots.to_s).to_i
+
+# Poll worker concurrency (small fixed pool — poll activities are short-lived)
+poll_workflow_slots = ENV.fetch("TEMPORAL_POLL_WORKFLOW_SLOTS", "20").to_i
+poll_activity_slots = ENV.fetch("TEMPORAL_POLL_ACTIVITY_SLOTS", "10").to_i
+poll_local_activity_slots = ENV.fetch("TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS", poll_activity_slots.to_s).to_i
+poll_activity_task_polls = ENV.fetch("TEMPORAL_POLL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS", poll_activity_slots.to_s).to_i
+poll_workflow_task_polls = ENV.fetch("TEMPORAL_POLL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS", poll_workflow_slots.to_s).to_i
 
 db_pool = ENV.fetch("DB_POOL") { ENV.fetch("RAILS_MAX_THREADS", "20") }.to_i
-min_required_pool = activity_slots + local_activity_slots + 2 # +2 for heartbeat/polling
+total_activity_slots = agent_activity_slots + agent_local_activity_slots +
+                       poll_activity_slots + poll_local_activity_slots
+min_required_pool = total_activity_slots + 4 # +4 for heartbeat/polling on both workers
 
-puts "Temporal concurrency: workflows=#{workflow_slots} activities=#{activity_slots} " \
-     "local_activities=#{local_activity_slots} activity_polls=#{activity_task_polls} " \
-     "workflow_polls=#{workflow_task_polls}"
+puts "Agent worker concurrency: workflows=#{agent_workflow_slots} activities=#{agent_activity_slots} " \
+     "local_activities=#{agent_local_activity_slots} activity_polls=#{agent_activity_task_polls} " \
+     "workflow_polls=#{agent_workflow_task_polls}"
+puts "Poll worker concurrency: workflows=#{poll_workflow_slots} activities=#{poll_activity_slots} " \
+     "local_activities=#{poll_local_activity_slots} activity_polls=#{poll_activity_task_polls} " \
+     "workflow_polls=#{poll_workflow_task_polls}"
 
 if db_pool < min_required_pool
   warn "WARNING: DB_POOL (#{db_pool}) is less than the recommended minimum " \
-       "(#{min_required_pool}) for activity_slots=#{activity_slots} + " \
-       "local_activity_slots=#{local_activity_slots}. " \
+       "(#{min_required_pool}) for total activity_slots=#{total_activity_slots}. " \
        "Increase DB_POOL or reduce activity concurrency to avoid connection exhaustion."
 end
 
@@ -50,18 +69,39 @@ forced_exit_buffer = ENV.fetch("TEMPORAL_FORCE_EXIT_BUFFER_SECONDS", "10").to_i
 forced_exit_timeout = graceful_shutdown + forced_exit_buffer
 force_exit_thread = nil
 
-worker = Temporalio::Worker.new(
+activity_instances = activities.map(&:new)
+
+# Poll worker: handles GitHubPollWorkflow and its activities on the poll queue.
+# Small activity pool ensures poll cycles are never blocked by agent workloads.
+poll_worker = Temporalio::Worker.new(
   client: Paid.temporal_client,
-  task_queue: Paid.task_queue,
-  activities: activities.map(&:new),
-  workflows: workflows,
+  task_queue: Paid.poll_task_queue,
+  activities: activity_instances,
+  workflows: poll_workflows,
   tuner: Temporalio::Worker::Tuner.create_fixed(
-    workflow_slots: workflow_slots,
-    activity_slots: activity_slots,
-    local_activity_slots: local_activity_slots
+    workflow_slots: poll_workflow_slots,
+    activity_slots: poll_activity_slots,
+    local_activity_slots: poll_local_activity_slots
   ),
-  max_concurrent_activity_task_polls: activity_task_polls,
-  max_concurrent_workflow_task_polls: workflow_task_polls,
+  max_concurrent_activity_task_polls: poll_activity_task_polls,
+  max_concurrent_workflow_task_polls: poll_workflow_task_polls,
+  graceful_shutdown_period: graceful_shutdown
+)
+
+# Agent worker: handles AgentExecutionWorkflow, PlanningWorkflow, etc. on the agent queue.
+# Larger activity pool for long-running agent activities.
+agent_worker = Temporalio::Worker.new(
+  client: Paid.temporal_client,
+  task_queue: Paid.agent_task_queue,
+  activities: activity_instances,
+  workflows: agent_workflows,
+  tuner: Temporalio::Worker::Tuner.create_fixed(
+    workflow_slots: agent_workflow_slots,
+    activity_slots: agent_activity_slots,
+    local_activity_slots: agent_local_activity_slots
+  ),
+  max_concurrent_activity_task_polls: agent_activity_task_polls,
+  max_concurrent_workflow_task_polls: agent_workflow_task_polls,
   graceful_shutdown_period: graceful_shutdown
 )
 
@@ -81,15 +121,16 @@ worker = Temporalio::Worker.new(
       exit! 1
     end
 
-    warn "Received #{signal}, shutting down Temporal worker gracefully"
+    warn "Received #{signal}, shutting down Temporal workers gracefully"
     request_shutdown.call(reason: "#{signal} received")
 
     force_exit_thread ||= Thread.new do
       sleep(forced_exit_timeout)
-      warn "Temporal worker did not exit within #{forced_exit_timeout}s, forcing exit"
+      warn "Temporal workers did not exit within #{forced_exit_timeout}s, forcing exit"
       exit! 1
     end
   end
 end
 
-worker.run(cancellation: shutdown_cancellation)
+# Run both workers in the same process, sharing the cancellation token.
+Temporalio::Worker.run_all(poll_worker, agent_worker, cancellation: shutdown_cancellation)

--- a/config/initializers/temporal.rb
+++ b/config/initializers/temporal.rb
@@ -55,5 +55,22 @@ module Paid
     def task_queue
       ENV.fetch("TEMPORAL_TASK_QUEUE", "paid-tasks")
     end
+
+    # Dedicated task queue for GitHubPollWorkflow instances.
+    # Isolates poll activities from agent-execution workloads so that
+    # long-running agent runs cannot starve time-sensitive poll cycles.
+    def poll_task_queue
+      ENV.fetch("TEMPORAL_POLL_TASK_QUEUE", "paid-poll-tasks")
+    end
+
+    # Dedicated task queue for AgentExecutionWorkflow and related workflows.
+    # Keeps agent workloads on their own activity pool, independent of polling.
+    def agent_task_queue
+      ENV.fetch("TEMPORAL_AGENT_TASK_QUEUE", "paid-agent-tasks")
+    end
   end
+
+  # Resolved at load time so workflow code can reference it as a constant
+  # without breaking Temporal's deterministic replay requirement.
+  AGENT_TASK_QUEUE = ENV.fetch("TEMPORAL_AGENT_TASK_QUEUE", "paid-agent-tasks")
 end

--- a/config/initializers/temporal.rb
+++ b/config/initializers/temporal.rb
@@ -52,10 +52,6 @@ module Paid
       ENV.fetch("TEMPORAL_UI_URL", "http://localhost:8080").sub(%r{/+\z}, "")
     end
 
-    def task_queue
-      ENV.fetch("TEMPORAL_TASK_QUEUE", "paid-tasks")
-    end
-
     # Dedicated task queue for GitHubPollWorkflow instances.
     # Isolates poll activities from agent-execution workloads so that
     # long-running agent runs cannot starve time-sensitive poll cycles.
@@ -72,5 +68,5 @@ module Paid
 
   # Resolved at load time so workflow code can reference it as a constant
   # without breaking Temporal's deterministic replay requirement.
-  AGENT_TASK_QUEUE = ENV.fetch("TEMPORAL_AGENT_TASK_QUEUE", "paid-agent-tasks")
+  AGENT_TASK_QUEUE = agent_task_queue
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,8 @@ services:
       - DATABASE_URL=postgres://paid:paid@postgres:5432/paid_development
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_NAMESPACE=default
-      - TEMPORAL_TASK_QUEUE=paid-tasks
+      - TEMPORAL_POLL_TASK_QUEUE=paid-poll-tasks
+      - TEMPORAL_AGENT_TASK_QUEUE=paid-agent-tasks
       - RAILS_ENV=development
       - PAID_PROXY_PORT=3000
       - CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR:-}

--- a/docs/AGENT_SYSTEM.md
+++ b/docs/AGENT_SYSTEM.md
@@ -822,44 +822,56 @@ end
 
 ## Worker Configuration
 
-### Fixed Pool (Phase 1)
+### Task Queue Isolation
 
-```yaml
-# config/temporal.yml
-development:
-  workers: 2
-  task_queue: "paid-development"
+`bin/temporal_worker` runs **two Temporal workers** in a single process, each polling
+a dedicated task queue. This isolates time-sensitive poll workflows from long-running
+agent-execution workloads, preventing the noisy-neighbor problem where saturated agent
+activity slots starve poll cycles.
 
-production:
-  workers: 5
-  task_queue: "paid-production"
-```
+| Task queue | Default name | Workflows | Purpose |
+|---|---|---|---|
+| **Poll queue** | `paid-poll-tasks` | `GitHubPollWorkflow` | Short-lived poll activities with a small, fixed activity pool. Ensures `last_polled_at` freshness is independent of agent load. |
+| **Agent queue** | `paid-agent-tasks` | `AgentExecutionWorkflow`, `PlanningWorkflow`, `ParallelAgentExecutionWorkflow` | Long-running agent activities with a larger pool. |
+
+Both workers register **all activities** — the queue assignment determines which worker
+picks up workflow tasks and their associated activity invocations.
+
+Child workflows started from the poll workflow (e.g., `PlanningWorkflow`) are explicitly
+routed to the agent task queue so they don't consume poll worker capacity.
+
+#### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `TEMPORAL_POLL_TASK_QUEUE` | `paid-poll-tasks` | Poll worker task queue name |
+| `TEMPORAL_AGENT_TASK_QUEUE` | `paid-agent-tasks` | Agent worker task queue name |
+| `TEMPORAL_POLL_ACTIVITY_SLOTS` | `10` | Max concurrent poll activities |
+| `TEMPORAL_POLL_WORKFLOW_SLOTS` | `20` | Max concurrent poll workflow tasks |
+| `TEMPORAL_ACTIVITY_SLOTS` | `4` | Max concurrent agent activities |
+| `TEMPORAL_WORKFLOW_SLOTS` | `20` | Max concurrent agent workflow tasks |
 
 ### Worker Process
 
 ```ruby
-# bin/temporal-worker
-require_relative "../config/environment"
-
-worker = Temporal::Worker.new(
-  client: Paid::TemporalClient.instance,
-  task_queue: Rails.configuration.temporal[:task_queue]
+# bin/temporal_worker (simplified)
+poll_worker = Temporalio::Worker.new(
+  client: Paid.temporal_client,
+  task_queue: Paid.poll_task_queue,   # "paid-poll-tasks"
+  activities: all_activities,
+  workflows: [Workflows::GitHubPollWorkflow],
+  tuner: Temporalio::Worker::Tuner.create_fixed(activity_slots: 10)
 )
 
-# Register workflows
-worker.register_workflow(GitHubPollWorkflow)
-worker.register_workflow(PlanningWorkflow)
-worker.register_workflow(AgentExecutionWorkflow)
-worker.register_workflow(PromptEvolutionWorkflow)
+agent_worker = Temporalio::Worker.new(
+  client: Paid.temporal_client,
+  task_queue: Paid.agent_task_queue,  # "paid-agent-tasks"
+  activities: all_activities,
+  workflows: [Workflows::AgentExecutionWorkflow, ...],
+  tuner: Temporalio::Worker::Tuner.create_fixed(activity_slots: 4)
+)
 
-# Register activities
-worker.register_activity(FetchIssuesActivity)
-worker.register_activity(RunAgentActivity)
-worker.register_activity(CreatePullRequestActivity)
-# ... etc
-
-puts "Starting Temporal worker..."
-worker.run
+Temporalio::Worker.run_all(poll_worker, agent_worker, cancellation: shutdown)
 ```
 
 ### Docker Compose Integration
@@ -871,7 +883,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: bin/temporal-worker
+    command: bin/temporal_worker
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - RAILS_ENV=production

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -110,7 +110,8 @@ Total web threads = `WEB_CONCURRENCY × RAILS_MAX_THREADS`.
 |----------|---------|-------------|
 | `TEMPORAL_ADDRESS` | `localhost:7233` | Temporal server address |
 | `TEMPORAL_NAMESPACE` | `default` | Temporal namespace |
-| `TEMPORAL_TASK_QUEUE` | `paid-tasks` | Task queue name |
+| `TEMPORAL_POLL_TASK_QUEUE` | `paid-poll-tasks` | Poll workflow task queue |
+| `TEMPORAL_AGENT_TASK_QUEUE` | `paid-agent-tasks` | Agent execution task queue |
 | `TEMPORAL_WORKFLOW_SLOTS` | `20` | Max concurrent workflow tasks |
 | `TEMPORAL_ACTIVITY_SLOTS` | `4` | Max concurrent activity executions |
 | `TEMPORAL_LOCAL_ACTIVITY_SLOTS` | `=ACTIVITY_SLOTS` | Max concurrent local activities |
@@ -381,7 +382,7 @@ Temporal workers register on a shared task queue and the Temporal server
 distributes work across all registered workers.
 
 1. Deploy additional Temporal worker processes (`bin/temporal_worker`)
-2. All workers use the same `TEMPORAL_TASK_QUEUE`
+2. All workers use the same `TEMPORAL_POLL_TASK_QUEUE` / `TEMPORAL_AGENT_TASK_QUEUE`
 3. Each worker needs its own `DB_POOL` and Docker Engine access
 4. Total activity slots = sum across all workers
 

--- a/spec/jobs/poll_workflow_health_check_job_spec.rb
+++ b/spec/jobs/poll_workflow_health_check_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PollWorkflowHealthCheckJob do
   let(:temporal_client) { instance_double(Temporalio::Client) }
 
   before do
-    allow(Paid).to receive_messages(temporal_client: temporal_client, task_queue: "paid-tasks")
+    allow(Paid).to receive_messages(temporal_client: temporal_client, poll_task_queue: "paid-poll-tasks")
     allow(temporal_client).to receive(:start_workflow)
   end
 
@@ -29,7 +29,7 @@ RSpec.describe PollWorkflowHealthCheckJob do
         Workflows::GitHubPollWorkflow,
         { project_id: project.id },
         id: "github-poll-#{project.id}",
-        task_queue: "paid-tasks"
+        task_queue: "paid-poll-tasks"
       ).at_least(:once)
     end
 
@@ -81,7 +81,7 @@ RSpec.describe PollWorkflowHealthCheckJob do
         Workflows::GitHubPollWorkflow,
         { project_id: project.id },
         id: "github-poll-#{project.id}",
-        task_queue: "paid-tasks"
+        task_queue: "paid-poll-tasks"
       ).at_least(:once)
     end
 
@@ -154,7 +154,7 @@ RSpec.describe PollWorkflowHealthCheckJob do
         Workflows::GitHubPollWorkflow,
         { project_id: project.id },
         id: "github-poll-#{project.id}",
-        task_queue: "paid-tasks"
+        task_queue: "paid-poll-tasks"
       ).at_least(:once)
     end
 
@@ -174,7 +174,7 @@ RSpec.describe PollWorkflowHealthCheckJob do
         Workflows::GitHubPollWorkflow,
         { project_id: project.id },
         id: "github-poll-#{project.id}",
-        task_queue: "paid-tasks"
+        task_queue: "paid-poll-tasks"
       ).at_least(:once)
     end
 
@@ -194,7 +194,7 @@ RSpec.describe PollWorkflowHealthCheckJob do
         Workflows::GitHubPollWorkflow,
         { project_id: project.id },
         id: "github-poll-#{project.id}",
-        task_queue: "paid-tasks"
+        task_queue: "paid-poll-tasks"
       ).at_least(:once)
     end
 
@@ -237,7 +237,7 @@ RSpec.describe PollWorkflowHealthCheckJob do
         Workflows::GitHubPollWorkflow,
         { project_id: project2.id },
         id: "github-poll-#{project2.id}",
-        task_queue: "paid-tasks"
+        task_queue: "paid-poll-tasks"
       ).at_least(:once)
     end
 

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ProcessRunQueueJob do
   let(:workflow_handle) { double("WorkflowHandle", id: "queued-workflow-id") } # rubocop:disable RSpec/VerifiedDoubles
 
   before do
-    allow(Paid).to receive_messages(temporal_client: temporal_client, task_queue: "paid-tasks")
+    allow(Paid).to receive_messages(temporal_client: temporal_client, agent_task_queue: "paid-agent-tasks")
     allow(temporal_client).to receive(:start_workflow).and_return(workflow_handle)
   end
 
@@ -27,7 +27,7 @@ RSpec.describe ProcessRunQueueJob do
       expect(temporal_client).to receive(:start_workflow).with(
         Workflows::AgentExecutionWorkflow,
         hash_including(agent_run_id: queued_run.id),
-        hash_including(task_queue: "paid-tasks")
+        hash_including(task_queue: "paid-agent-tasks")
       ).and_return(workflow_handle)
 
       described_class.new.perform
@@ -377,7 +377,7 @@ RSpec.describe ProcessRunQueueJob do
         expect(temporal_client).to receive(:start_workflow).with(
           Workflows::AgentExecutionWorkflow,
           hash_including(agent_run_id: manual_run.id),
-          hash_including(task_queue: "paid-tasks")
+          hash_including(task_queue: "paid-agent-tasks")
         ).and_return(workflow_handle)
 
         described_class.new.perform

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Project do
     let(:workflow_handle) { double("workflow_handle") } # rubocop:disable RSpec/VerifiedDoubles
 
     before do
-      allow(Paid).to receive_messages(temporal_client: temporal_client, task_queue: "paid-tasks")
+      allow(Paid).to receive_messages(temporal_client: temporal_client, poll_task_queue: "paid-poll-tasks")
       allow(temporal_client).to receive(:start_workflow)
       allow(temporal_client).to receive(:workflow_handle).and_return(workflow_handle)
       allow(workflow_handle).to receive(:cancel)
@@ -282,7 +282,7 @@ RSpec.describe Project do
           Workflows::GitHubPollWorkflow,
           { project_id: project.id },
           id: "github-poll-#{project.id}",
-          task_queue: "paid-tasks"
+          task_queue: "paid-poll-tasks"
         )
       end
 
@@ -344,7 +344,7 @@ RSpec.describe Project do
           Workflows::GitHubPollWorkflow,
           { project_id: project.id },
           id: "github-poll-#{project.id}",
-          task_queue: "paid-tasks"
+          task_queue: "paid-poll-tasks"
         )
       end
 
@@ -373,7 +373,7 @@ RSpec.describe Project do
     let(:temporal_client) { instance_double(Temporalio::Client) }
 
     before do
-      allow(Paid).to receive_messages(temporal_client: temporal_client, task_queue: "paid-tasks")
+      allow(Paid).to receive_messages(temporal_client: temporal_client, poll_task_queue: "paid-poll-tasks")
       allow(temporal_client).to receive(:start_workflow)
     end
 

--- a/spec/services/project_workflow_manager_spec.rb
+++ b/spec/services/project_workflow_manager_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ProjectWorkflowManager do
   let(:project) { create(:project) }
 
   before do
-    allow(Paid).to receive_messages(temporal_client: temporal_client, task_queue: "paid-tasks")
+    allow(Paid).to receive_messages(temporal_client: temporal_client, poll_task_queue: "paid-poll-tasks")
     allow(temporal_client).to receive(:start_workflow)
   end
 
@@ -20,7 +20,7 @@ RSpec.describe ProjectWorkflowManager do
         Workflows::GitHubPollWorkflow,
         { project_id: project.id },
         id: "github-poll-#{project.id}",
-        task_queue: "paid-tasks"
+        task_queue: "paid-poll-tasks"
       ).at_least(:once)
       expect(result).to be(true)
     end
@@ -232,7 +232,7 @@ RSpec.describe ProjectWorkflowManager do
         Workflows::GitHubPollWorkflow,
         { project_id: polling_project.id },
         id: "github-poll-#{polling_project.id}",
-        task_queue: "paid-tasks"
+        task_queue: "paid-poll-tasks"
       ).at_least(:once)
     end
 


### PR DESCRIPTION
## Summary

perf(temporal-worker): isolate poll workflows from agent execution workloads

See #1236 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1236