### PR TITLE
Fix #1237: fix(poll-workflow): heartbeat last_polled_at mid-cycle, not only at the end

### DIFF
--- a/app/jobs/poll_workflow_health_check_job.rb
+++ b/app/jobs/poll_workflow_health_check_job.rb
@@ -9,9 +9,12 @@
 # - Crashed workers or connection issues
 #
 # Staleness detection: even if a workflow reports RUNNING, it may be stuck
-# (e.g., nondeterminism errors during replay). Each successful poll cycle
-# updates `project.last_polled_at`; if that timestamp exceeds
-# `3 * poll_interval + 3 minutes`, the workflow is restarted.
+# (e.g., nondeterminism errors during replay). The poll workflow updates
+# `project.last_polled_at` after each major step (fetch issues, detect
+# labels, scans) via RecordPollHeartbeatActivity, so the timestamp
+# reflects last forward progress — not just cycle completion. If that
+# timestamp exceeds `3 * poll_interval + 3 minutes`, the workflow is
+# restarted.
 #
 # Scheduled via GoodJob cron every 5 minutes.
 class PollWorkflowHealthCheckJob < ApplicationJob

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -344,7 +344,7 @@ class Project < ApplicationRecord
 
   # Shared staleness window used by both the health-check job and the
   # automation health UI. A poll workflow is considered stale when it has not
-  # completed a poll cycle within 3× the configured interval plus a buffer.
+  # recorded forward progress within 3× the configured interval plus a buffer.
   STALENESS_BUFFER = 3.minutes
 
   def poll_staleness_window

--- a/app/temporal/activities/get_poll_interval_activity.rb
+++ b/app/temporal/activities/get_poll_interval_activity.rb
@@ -3,9 +3,10 @@
 module Activities
   # Retrieves the configured poll interval for a project and records a
   # heartbeat by updating `last_polled_at`. This runs at the end of each
-  # poll cycle, so the timestamp serves as a reliable indicator that the
-  # full cycle completed (used by PollWorkflowHealthCheckJob to detect
-  # stale RUNNING workflows).
+  # poll cycle. Mid-cycle heartbeats are recorded by
+  # RecordPollHeartbeatActivity after each major step so the
+  # PollWorkflowHealthCheckJob sees forward progress even when a single
+  # cycle takes longer than the staleness window.
   #
   # Extracted as an activity because workflows cannot perform I/O directly.
   class GetPollIntervalActivity < BaseActivity

--- a/app/temporal/activities/record_poll_heartbeat_activity.rb
+++ b/app/temporal/activities/record_poll_heartbeat_activity.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Activities
+  # Lightweight activity that records forward progress in a poll workflow
+  # by touching `project.last_polled_at`. Called after each major step
+  # (fetch issues, detect labels loop, non-critical scans) so the
+  # PollWorkflowHealthCheckJob sees the workflow as alive even when a
+  # single cycle takes longer than the staleness window.
+  #
+  # This is intentionally minimal — no return payload beyond confirmation —
+  # to keep Temporal history overhead low when called multiple times per cycle.
+  class RecordPollHeartbeatActivity < BaseActivity
+    def execute(input)
+      project = Project.find_by(id: input[:project_id])
+      return { recorded: false } unless project
+
+      project.touch_last_polled_at
+
+      { recorded: true }
+    end
+  end
+end

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -31,6 +31,8 @@ module Workflows
 
         break if result[:project_missing]
 
+        record_poll_heartbeat(project_id)
+
         result[:issues].each do |issue_data|
           evaluation = run_activity(Activities::DetectLabelsActivity,
             { project_id: project_id, issue_id: issue_data[:id] }, timeout: 30)
@@ -38,7 +40,11 @@ module Workflows
           handle_automation_result(evaluation, project_id)
         end
 
+        record_poll_heartbeat(project_id)
+
         maybe_run_non_critical_activities(project_id)
+
+        record_poll_heartbeat(project_id)
 
         poll_config = run_activity(Activities::GetPollIntervalActivity,
           { project_id: project_id }, timeout: 10)
@@ -55,6 +61,11 @@ module Workflows
     end
 
     private
+
+    def record_poll_heartbeat(project_id)
+      run_activity(Activities::RecordPollHeartbeatActivity,
+        { project_id: project_id }, timeout: 10)
+    end
 
     def interruptible_sleep(duration)
       cancellation, @sleep_cancel_proc = Temporalio::Cancellation.new

--- a/app/views/workflow_statuses/_status.html.erb
+++ b/app/views/workflow_statuses/_status.html.erb
@@ -39,7 +39,7 @@
           <% if project.active? %>
             <dl class="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-gray-500">
               <% if project.last_polled_at %>
-                <dt>Last checked</dt>
+                <dt>Last progress</dt>
                 <dd class="text-gray-900"><%= time_ago_in_words(project.last_polled_at) %> ago</dd>
               <% end %>
               <dt>Check interval</dt>

--- a/spec/requests/workflow_statuses_spec.rb
+++ b/spec/requests/workflow_statuses_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "WorkflowStatuses" do
           project.update_column(:last_polled_at, 2.minutes.ago)
 
           get project_workflow_status_path(project)
-          expect(response.body).to include("Last checked")
+          expect(response.body).to include("Last progress")
           expect(response.body).to include("2 minutes ago")
         end
       end

--- a/spec/temporal/activities/record_poll_heartbeat_activity_spec.rb
+++ b/spec/temporal/activities/record_poll_heartbeat_activity_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::RecordPollHeartbeatActivity do
+  let(:activity) { described_class.new }
+
+  describe "#execute" do
+    let(:project) { create(:project) }
+
+    it "updates last_polled_at on the project" do
+      freeze_time do
+        activity.execute(project_id: project.id)
+
+        expect(project.reload.last_polled_at).to eq(Time.current)
+      end
+    end
+
+    it "returns recorded: true for existing projects" do
+      result = activity.execute(project_id: project.id)
+
+      expect(result[:recorded]).to be true
+    end
+
+    it "returns recorded: false when project is missing" do
+      result = activity.execute(project_id: -1)
+
+      expect(result[:recorded]).to be false
+    end
+  end
+end

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -1259,6 +1259,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::GetPollIntervalActivity, anything, timeout: anything)
         .and_return({ poll_interval_seconds: 60 })
       allow(workflow).to receive(:run_activity)
+        .with(Activities::RecordPollHeartbeatActivity, anything, timeout: anything)
+        .and_return({ recorded: true })
+      allow(workflow).to receive(:run_activity)
         .with(Activities::LoadFeatureFlagsActivity, { project_id: project_id }, timeout: 10)
         .and_return(flags: { explicit_pr_automation_decisions: false }, project_missing: false)
     end


### PR DESCRIPTION
## Summary

fix(poll-workflow): heartbeat last_polled_at mid-cycle, not only at the end

See #1237 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1237