### PR TITLE
Fix #784: refactor(agent-runs): move RunAgentActivity provider execution behind agent-harness

### DIFF
--- a/app/services/providers/harness_execution_plan.rb
+++ b/app/services/providers/harness_execution_plan.rb
@@ -4,17 +4,50 @@ module Providers
   class HarnessExecutionPlan
     Result = Struct.new(:command, :env, :preparation, keyword_init: true)
 
-    def initialize(provider:, prompt:)
+    def initialize(provider:, prompt:, options: {})
       @provider = provider
       @prompt = prompt
+      @options = options
     end
 
     def self.call(...)
       new(...).call
     end
 
+    # Builds an execution plan for a provider identified by its app-level key
+    # (e.g. "claude", "codex") without requiring a Provider model record.
+    # Used for subscription-auth and standard providers that don't have a
+    # per-user Provider entry.
+    #
+    # Container-executed providers are always externally sandboxed (the
+    # agent Docker container is the sandbox), so this is passed through to
+    # the harness provider so provider-specific nested sandbox mechanisms
+    # (e.g. Codex bubblewrap) are bypassed automatically.
+    #
+    # @param provider_key [String] app-level provider key
+    # @param prompt [String] the prompt to execute
+    # @param options [Hash] options forwarded to the harness provider
+    # @return [Result] command, env, and preparation
+    def self.for_provider_key(provider_key:, prompt:, options: {})
+      harness_key = ProviderSupport.harness_provider_key_for(provider_key).to_sym
+      klass = AgentHarness::Providers::Registry.instance.get(harness_key)
+      capture = ExecutorCapture.new
+
+      config = AgentHarness::ProviderConfig.new(harness_key)
+      config.externally_sandboxed = true
+
+      provider_instance = klass.new(executor: capture, config: config)
+      provider_instance.send_message(prompt: prompt, **options)
+
+      Result.new(
+        command: capture.command,
+        env: capture.env,
+        preparation: capture.preparation
+      )
+    end
+
     def call
-      harness_provider.send_message(prompt: @prompt, provider_runtime: provider_runtime)
+      harness_provider.send_message(prompt: @prompt, provider_runtime: provider_runtime, **@options)
 
       Result.new(
         command: capture_executor.command,

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -484,11 +484,13 @@ module Providers
       # Get the base command from agent-harness (without prompt), then add
       # test-specific flags before the prompt argument.
       base_cmd = harness_test_plan.command[0..-2]
-      command = (base_cmd + [
+      separator_index = base_cmd.index("--") || base_cmd.length
+      cmd_with_flags = base_cmd[0...separator_index] + [
         "--skip-git-repo-check",
         "--output-last-message",
         "$tmp_output"
-      ]).join(" ")
+      ] + base_cmd[separator_index..]
+      command = cmd_with_flags.join(" ")
       unset_flags = subscription_auth_unset_flags("codex")
       <<~SH.squish
         tmp_output="$(mktemp)" &&

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -17,15 +17,6 @@ module Providers
     PROMPT = "Respond with exactly: PING OK"
     EXPECTED_OUTPUT = "PING OK"
     TIMEOUT = 60
-    CONTAINER_COMMANDS = Activities::RunAgentActivity::AGENT_COMMANDS.slice(
-      "claude",
-      "codex",
-      "cursor",
-      "gemini",
-      "kilocode",
-      "opencode",
-      "copilot"
-    ).freeze
     RATE_LIMIT_PATTERNS = Activities::RunAgentActivity::RATE_LIMIT_PATTERNS
     AUTHENTICATION_ERROR_PATTERNS = [
       /api[_ -]?key/i,
@@ -370,20 +361,22 @@ module Providers
     end
 
     def test_command
-      command = CONTAINER_COMMANDS[provider.provider_key]
-      raise UnsupportedProviderError, "Unsupported provider: #{provider.provider_key}" unless command
+      unless ProviderSupport.container_executable_provider_key?(provider.provider_key)
+        raise UnsupportedProviderError, "Unsupported provider: #{provider.provider_key}"
+      end
 
-      # This method only builds the container-exec command after that path has
-      # already been selected elsewhere. For Copilot on this path, preserve the
-      # installed CLI contract (`github-copilot-cli --message ...`) rather
-      # than applying any harness-specific invocation shape.
       return codex_test_command if provider.provider_key == "codex"
       return gemini_test_command if provider.provider_key == "gemini"
       return harness_runtime_command if provider.opencode_agent_harness_runtime?
-      return provider.direct_outbound_exec_command(command_prefix: command, prompt: PROMPT) if provider.requires_direct_outbound?
-      return kilocode_test_command if provider.provider_key == "kilocode"
 
-      command + [ PROMPT ]
+      plan = harness_test_plan
+      if provider.requires_direct_outbound?
+        provider.direct_outbound_exec_command(command_prefix: plan.command[0..-2], prompt: PROMPT)
+      elsif provider.provider_key == "kilocode"
+        kilocode_test_command
+      else
+        plan.command
+      end
     end
 
     def test_command_env
@@ -402,6 +395,14 @@ module Providers
       @direct_outbound_execution_plan ||= Providers::HarnessExecutionPlan.call(
         provider: provider,
         prompt: PROMPT
+      )
+    end
+
+    def harness_test_plan
+      @harness_test_plan ||= Providers::HarnessExecutionPlan.for_provider_key(
+        provider_key: provider.provider_key,
+        prompt: PROMPT,
+        options: { dangerous_mode: true }
       )
     end
 
@@ -480,12 +481,14 @@ module Providers
 
     def codex_test_command
       escaped_prompt = Shellwords.escape(PROMPT)
-      command = command_with_flags_before_separator(
-        CONTAINER_COMMANDS.fetch("codex"),
+      # Get the base command from agent-harness (without prompt), then add
+      # test-specific flags before the prompt argument.
+      base_cmd = harness_test_plan.command[0..-2]
+      command = (base_cmd + [
         "--skip-git-repo-check",
         "--output-last-message",
         "$tmp_output"
-      ).join(" ")
+      ]).join(" ")
       unset_flags = subscription_auth_unset_flags("codex")
       <<~SH.squish
         tmp_output="$(mktemp)" &&
@@ -505,14 +508,11 @@ module Providers
       SH
     end
 
-    def command_with_flags_before_separator(command, *flags)
-      separator_index = command.index("--") || command.length
-      command[0...separator_index] + flags + command[separator_index..]
-    end
-
     def gemini_test_command
       escaped_prompt = Shellwords.escape(PROMPT)
-      command = "gemini -y -p #{escaped_prompt}"
+      # Get the base command from agent-harness (without prompt)
+      base_cmd = harness_test_plan.command[0..-2]
+      command = (base_cmd + [ escaped_prompt ]).join(" ")
       unset_flags = subscription_auth_unset_flags("gemini")
       <<~SH.squish
         tmp_output="$(mktemp)" &&

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -976,12 +976,15 @@ module Activities
     # app-level key. Delegates command construction to agent-harness so
     # provider CLI flag semantics are owned upstream.
     #
-    # The plan is cached per (provider_key, prompt) pair so that
-    # multiple branches within build_command can share the same
-    # capture without re-running the harness provider.
+    # The plan is cached per (provider_key, prompt, harness_runtime?)
+    # tuple so that multiple branches within build_command can share
+    # the same capture without re-running the harness provider. The
+    # boolean discriminator ensures calls with and without a
+    # provider_entry that has an agent_harness_provider_runtime are
+    # never conflated.
     def harness_execution_plan_for(provider_key, prompt, provider_entry: nil)
       @harness_plan_cache ||= {}
-      cache_key = [ provider_key, prompt ]
+      cache_key = [ provider_key, prompt, provider_entry&.agent_harness_provider_runtime.present? ]
       return @harness_plan_cache[cache_key] if @harness_plan_cache.key?(cache_key)
 
       options = { dangerous_mode: true }

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -977,8 +977,8 @@ module Activities
     # provider CLI flag semantics are owned upstream.
     #
     # The plan is cached per (provider_key, prompt) pair so that
-    # build_command, command_env_for, and command_preparation_for can
-    # share the same capture without re-running the harness provider.
+    # multiple branches within build_command can share the same
+    # capture without re-running the harness provider.
     def harness_execution_plan_for(provider_key, prompt, provider_entry: nil)
       @harness_plan_cache ||= {}
       cache_key = [ provider_key, prompt ]

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -6,34 +6,15 @@ module Activities
   class RunAgentActivity < BaseActivity
     activity_name "RunAgent"
 
-    # Maps agent_type/provider to the CLI command used inside the container.
-    # Each entry is an array of command parts; the prompt is appended as the last argument.
-    #
-    # NOTE: This hash defines command templates for all providers the system
-    # knows how to run. Currently Claude CLI, Codex CLI, Cursor agent CLI,
-    # Gemini CLI, Kilocode CLI, OpenCode CLI, GitHub Copilot CLI, and Aider CLI
-    # are installed in the agent Docker container (docker/agent/Dockerfile).
-    #
-    # Copilot remains hardcoded here for now instead of delegating to
-    # agent-harness because the installed Copilot CLI and the harness's
-    # built-in GitHub Copilot provider are not yet aligned on binary name and
-    # invocation shape. Paid installs `github-copilot-cli`, while
-    # agent-harness 0.5.6 expects `copilot -p ...`.
-    # Actual container execution is
-    # gated by ProviderSupport::CONTAINER_EXECUTABLE_PROVIDER_KEYS — providers
-    # not in that set are filtered out upstream (UserSetting, ProvidersController)
-    # before reaching provider_order.
-    AGENT_COMMANDS = {
-      "claude_code" => %w[claude --print --output-format=text --dangerously-skip-permissions -p],
-      "claude" => %w[claude --print --output-format=text --dangerously-skip-permissions -p],
-      "codex" => %w[codex exec --dangerously-bypass-approvals-and-sandbox --],
-      "gemini" => %w[gemini -y -p],
-      "kilocode" => %w[kilo run --auto],
-      "opencode" => %w[opencode run],
-      "copilot" => %w[github-copilot-cli --message],
-      "cursor" => %w[cursor-agent --message],
-      "aider" => %w[aider --yes --no-auto-commits --message]
-    }.freeze
+    # Returns true if the given provider key can be executed inside the
+    # container. Replaces the former AGENT_COMMANDS.key? check. Container
+    # executability is gated by ProviderSupport::CONTAINER_EXECUTABLE_PROVIDER_KEYS
+    # — providers not in that set are filtered out upstream (UserSetting,
+    # ProvidersController) before reaching provider_order.
+    def self.container_executable?(provider_key)
+      key = AGENT_TYPE_TO_PROVIDER.fetch(provider_key, provider_key)
+      ProviderSupport.container_executable_provider_key?(key)
+    end
 
     # Maps agent_type values to their canonical settings provider name.
     # Some agent types (e.g., "claude_code") share the same underlying provider as
@@ -121,7 +102,7 @@ module Activities
     POST_RUN_BOOKKEEPING_ERROR_TYPE = "PostRunBookkeepingFailed"
 
     def self.provider_order(agent_type:, fallback_enabled:, fallback_providers:)
-      return [ agent_type ].select { |p| AGENT_COMMANDS.key?(p) } unless fallback_enabled
+      return [ agent_type ].select { |p| container_executable?(p) } unless fallback_enabled
 
       canonical = AGENT_TYPE_TO_PROVIDER.fetch(agent_type, agent_type)
       providers = [ agent_type ]
@@ -135,7 +116,7 @@ module Activities
         providers << fallback
       end
 
-      providers.select { |p| AGENT_COMMANDS.key?(p) }
+      providers.select { |p| container_executable?(p) }
     end
 
     def self.provider_attempt_count(agent_type:, fallback_enabled:, fallback_providers:)
@@ -405,7 +386,7 @@ module Activities
     class ProviderExecutionError < StandardError; end
     class ProviderTimeoutError < StandardError; end
     class InfiniteLoopError < StandardError; end
-    CommandContext = Struct.new(:provider_candidate, :provider, :command_prefix, :user, keyword_init: true)
+    CommandContext = Struct.new(:provider_candidate, :provider, :user, keyword_init: true)
 
     private
 
@@ -457,7 +438,7 @@ module Activities
               user: user_settings.user
             )
           else
-            [ agent_run.agent_type ].select { |provider| self.class::AGENT_COMMANDS.key?(provider) }
+            [ agent_run.agent_type ].select { |provider| self.class.container_executable?(provider) }
           end
       end
 
@@ -547,8 +528,7 @@ module Activities
       container_service = reconnect_container(agent_run)
       provider = provider_command_key(provider_candidate, agent_run, user_settings.user)
 
-      command_prefix = AGENT_COMMANDS[provider]
-      unless command_prefix
+      unless self.class.container_executable?(provider)
         raise ProviderExecutionError, "Unsupported provider: #{provider}"
       end
 
@@ -565,7 +545,6 @@ module Activities
       command_context = CommandContext.new(
         provider_candidate: provider_candidate,
         provider: provider,
-        command_prefix: command_prefix,
         user: user_settings.user
       )
       command = build_command(command_context, prompt)
@@ -979,13 +958,46 @@ module Activities
       if provider_entry&.opencode_agent_harness_runtime?
         harness_runtime_command(provider_entry, prompt)
       elsif provider_entry&.requires_direct_outbound?
-        provider_entry.direct_outbound_exec_command(command_prefix: command_context.command_prefix, prompt: prompt)
+        plan = harness_execution_plan_for(command_context.provider, prompt, provider_entry: provider_entry)
+        provider_entry.direct_outbound_exec_command(command_prefix: plan.command[0..-2], prompt: prompt)
       elsif provider_entry&.api_key?
-        api_key_auth_command(provider_entry, command_context.command_prefix, prompt)
+        plan = harness_execution_plan_for(command_context.provider, prompt)
+        api_key_auth_command(provider_entry, plan.command[0..-2], prompt)
       elsif ProviderSupport.subscription_auth_unset_vars_for(command_context.provider).any?
-        subscription_auth_command(command_context.provider, command_context.command_prefix, prompt)
+        plan = harness_execution_plan_for(command_context.provider, prompt)
+        subscription_auth_command(command_context.provider, plan.command[0..-2], prompt)
       else
-        command_context.command_prefix + [ prompt ]
+        plan = harness_execution_plan_for(command_context.provider, prompt)
+        plan.command
+      end
+    end
+
+    # Builds a harness execution plan for a provider identified by its
+    # app-level key. Delegates command construction to agent-harness so
+    # provider CLI flag semantics are owned upstream.
+    #
+    # The plan is cached per (provider_key, prompt) pair so that
+    # build_command, command_env_for, and command_preparation_for can
+    # share the same capture without re-running the harness provider.
+    def harness_execution_plan_for(provider_key, prompt, provider_entry: nil)
+      @harness_plan_cache ||= {}
+      cache_key = [ provider_key, prompt ]
+      return @harness_plan_cache[cache_key] if @harness_plan_cache.key?(cache_key)
+
+      options = { dangerous_mode: true }
+
+      @harness_plan_cache[cache_key] = if provider_entry&.agent_harness_provider_runtime
+        Providers::HarnessExecutionPlan.call(
+          provider: provider_entry,
+          prompt: prompt,
+          options: options
+        )
+      else
+        Providers::HarnessExecutionPlan.for_provider_key(
+          provider_key: ProviderSupport.provider_key_for_agent_type(provider_key),
+          prompt: prompt,
+          options: options
+        )
       end
     end
 
@@ -1057,7 +1069,7 @@ module Activities
       end
 
       providers.select do |provider_candidate|
-        self.class::AGENT_COMMANDS.key?(provider_command_key(provider_candidate, nil, user))
+        self.class.container_executable?(provider_command_key(provider_candidate, nil, user))
       end
     end
 

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -341,14 +341,12 @@ RSpec.describe Providers::TestAgent do
         allow(test_run).to receive(:with_container).and_yield(test_run)
       end
 
-      it "adds the skip git repo check flag" do
+      it "adds the skip git repo check flag before the prompt" do
         described_class.call(provider: provider)
 
         expect(test_run).to have_received(:execute_in_container).with(
-          a_string_including('if [ "$PAID_CODEX_SUBSCRIPTION_AUTH" = "1" ]')
+          a_string_matching(/--skip-git-repo-check\s+--output-last-message\s+\$tmp_output\s+Respond/)
             .and(include("-u OPENAI_API_KEY"))
-            .and(include("--skip-git-repo-check"))
-            .and(include("--output-last-message"))
             .and(include("codex"))
             .and(include("exec")),
           timeout: 60,

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -66,11 +66,11 @@ RSpec.describe Providers::TestAgent do
         expect(result.error_type).to be_nil
       end
 
-      it "executes the claude cli inside the container" do
+      it "executes the claude cli inside the container with harness-generated flags" do
         described_class.call(provider: provider)
 
         expect(test_run).to have_received(:execute_in_container).with(
-          array_including("claude", "--print", "--output-format=text", "--dangerously-skip-permissions", "-p", "Respond with exactly: PING OK"),
+          array_including("claude", "--print", "--dangerously-skip-permissions", "Respond with exactly: PING OK"),
           timeout: 60,
           stream: false,
           env: {}
@@ -342,22 +342,15 @@ RSpec.describe Providers::TestAgent do
       end
 
       it "adds the skip git repo check flag" do
-        service = described_class.new(provider: provider)
-        base_command = Providers::TestAgent::CONTAINER_COMMANDS.fetch("codex")
-        codex_command = service.send(
-          :command_with_flags_before_separator,
-          base_command,
-          "--skip-git-repo-check",
-          "--output-last-message",
-          "$tmp_output"
-        ).join(" ")
-
         described_class.call(provider: provider)
 
         expect(test_run).to have_received(:execute_in_container).with(
           a_string_including('if [ "$PAID_CODEX_SUBSCRIPTION_AUTH" = "1" ]')
             .and(include("-u OPENAI_API_KEY"))
-            .and(include(codex_command)),
+            .and(include("--skip-git-repo-check"))
+            .and(include("--output-last-message"))
+            .and(include("codex"))
+            .and(include("exec")),
           timeout: 60,
           stream: false,
           env: {}
@@ -414,7 +407,7 @@ RSpec.describe Providers::TestAgent do
           a_string_including('if [ "$PAID_GEMINI_SUBSCRIPTION_AUTH" = "1" ]')
             .and(include("-u GEMINI_API_KEY"))
             .and(include("-u GOOGLE_GEMINI_BASE_URL"))
-            .and(include("gemini -y -p"))
+            .and(include("gemini"))
             .and(include('grep -q "Error when talking to Gemini API"'))
             .and(include('ruby -rjson -e')),
           timeout: 60,

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -133,36 +133,50 @@ RSpec.describe Activities::RunAgentActivity do
     end
   end
 
-  describe "AGENT_COMMANDS" do
-    it "includes a command mapping for codex" do
-      expect(described_class::AGENT_COMMANDS).to have_key("codex")
-      expect(described_class::AGENT_COMMANDS["codex"]).to include("codex")
+  describe ".container_executable?" do
+    it "recognizes codex as container executable" do
+      expect(described_class.container_executable?("codex")).to be true
     end
 
-    it "includes upstream sandbox bypass flags for codex" do
-      cmd = described_class::AGENT_COMMANDS["codex"]
-      expect(cmd).to start_with("codex", "exec", "--dangerously-bypass-approvals-and-sandbox")
-      expect(cmd).to include("--")
+    it "recognizes gemini as container executable" do
+      expect(described_class.container_executable?("gemini")).to be true
     end
 
-    it "includes a command mapping for gemini" do
-      expect(described_class::AGENT_COMMANDS).to have_key("gemini")
-      expect(described_class::AGENT_COMMANDS["gemini"]).to include("gemini")
+    it "recognizes kilocode as container executable" do
+      expect(described_class.container_executable?("kilocode")).to be true
     end
 
-    it "includes a command mapping for kilocode" do
-      expect(described_class::AGENT_COMMANDS).to have_key("kilocode")
-      expect(described_class::AGENT_COMMANDS["kilocode"]).to include("kilo")
+    it "recognizes opencode as container executable" do
+      expect(described_class.container_executable?("opencode")).to be true
     end
 
-    it "includes a command mapping for opencode" do
-      expect(described_class::AGENT_COMMANDS).to have_key("opencode")
-      expect(described_class::AGENT_COMMANDS["opencode"]).to eq(%w[opencode run])
+    it "recognizes copilot as container executable" do
+      expect(described_class.container_executable?("copilot")).to be true
     end
 
-    it "includes a command mapping for copilot" do
-      expect(described_class::AGENT_COMMANDS).to have_key("copilot")
-      expect(described_class::AGENT_COMMANDS["copilot"]).to include("github-copilot-cli")
+    it "recognizes claude_code via agent type mapping" do
+      expect(described_class.container_executable?("claude_code")).to be true
+    end
+
+    it "rejects unknown providers" do
+      expect(described_class.container_executable?("unknown")).to be false
+    end
+  end
+
+  describe "harness-generated commands" do
+    it "generates codex command with sandbox bypass through agent-harness" do
+      plan = Providers::HarnessExecutionPlan.for_provider_key(
+        provider_key: "codex", prompt: "test", options: { dangerous_mode: true }
+      )
+      expect(plan.command).to include("codex", "exec")
+      expect(plan.command).to include("--dangerously-bypass-approvals-and-sandbox")
+    end
+
+    it "generates claude command with dangerous-mode flags through agent-harness" do
+      plan = Providers::HarnessExecutionPlan.for_provider_key(
+        provider_key: "claude", prompt: "test", options: { dangerous_mode: true }
+      )
+      expect(plan.command).to include("claude", "--print", "--dangerously-skip-permissions")
     end
   end
 
@@ -255,17 +269,15 @@ RSpec.describe Activities::RunAgentActivity do
       context = described_class::CommandContext.new(
         provider_candidate: "codex",
         provider: "codex",
-        command_prefix: described_class::AGENT_COMMANDS["codex"],
         user: nil
       )
       command = activity.send(:build_command, context, "say 'hi'")
       script = command[2]
-      codex_command = described_class::AGENT_COMMANDS.fetch("codex").join(" ")
 
       expect(command[0..1]).to eq(%w[sh -c])
       expect(script).to include('if [ "$PAID_CODEX_SUBSCRIPTION_AUTH" = "1" ]')
       expect(script).to include("-u OPENAI_API_KEY")
-      expect(script).to include(codex_command)
+      expect(script).to include("codex")
       expect(command[3]).to eq("--")
       expect(command[4]).to eq("say 'hi'")
     end
@@ -274,7 +286,6 @@ RSpec.describe Activities::RunAgentActivity do
       context = described_class::CommandContext.new(
         provider_candidate: "gemini",
         provider: "gemini",
-        command_prefix: described_class::AGENT_COMMANDS["gemini"],
         user: nil
       )
       command = activity.send(:build_command, context, "say 'hi'")
@@ -284,7 +295,7 @@ RSpec.describe Activities::RunAgentActivity do
       expect(script).to include('if [ "$PAID_GEMINI_SUBSCRIPTION_AUTH" = "1" ]')
       expect(script).to include("-u GEMINI_API_KEY")
       expect(script).to include("-u GOOGLE_GEMINI_BASE_URL")
-      expect(script).to include("gemini -y -p")
+      expect(script).to include("gemini")
       expect(command[3]).to eq("--")
       expect(command[4]).to eq("say 'hi'")
     end
@@ -294,7 +305,6 @@ RSpec.describe Activities::RunAgentActivity do
       context = described_class::CommandContext.new(
         provider_candidate: "codex",
         provider: "codex",
-        command_prefix: described_class::AGENT_COMMANDS["codex"],
         user: nil
       )
       command = activity.send(:build_command, context, multiline_prompt)
@@ -303,16 +313,16 @@ RSpec.describe Activities::RunAgentActivity do
       expect(command[2]).not_to include("\n")
     end
 
-    it "keeps non-subscription providers in array form" do
+    it "returns the harness-generated command for non-subscription providers" do
       context = described_class::CommandContext.new(
         provider_candidate: "claude",
         provider: "claude",
-        command_prefix: described_class::AGENT_COMMANDS["claude"],
         user: nil
       )
       command = activity.send(:build_command, context, "ping")
 
-      expect(command).to eq(described_class::AGENT_COMMANDS["claude"] + [ "ping" ])
+      expect(command).to include("claude", "--print", "--dangerously-skip-permissions")
+      expect(command.last).to eq("ping")
     end
 
     it "builds an API-key wrapper for anthropic-backed fallback entries" do
@@ -321,7 +331,6 @@ RSpec.describe Activities::RunAgentActivity do
       context = described_class::CommandContext.new(
         provider_candidate: provider.routing_key,
         provider: "claude",
-        command_prefix: described_class::AGENT_COMMANDS["claude"],
         user: user
       )
 
@@ -417,7 +426,6 @@ RSpec.describe Activities::RunAgentActivity do
     described_class::CommandContext.new(
       provider_candidate: provider.routing_key,
       provider: "opencode",
-      command_prefix: described_class::AGENT_COMMANDS["opencode"],
       user: user
     )
   end
@@ -550,7 +558,7 @@ RSpec.describe Activities::RunAgentActivity do
         allow(git_ops).to receive(:has_changes_since?).and_return(false)
 
         expect(container_service).to receive(:execute).with(
-          array_including("claude", "--print", "--output-format=text", "--dangerously-skip-permissions", "-p"),
+          array_including("claude", "--print", "--dangerously-skip-permissions"),
           hash_including(timeout: anything)
         ).and_return(exec_success)
 


### PR DESCRIPTION
## Summary

refactor(agent-runs): move RunAgentActivity provider execution behind agent-harness

See #784 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #784