### PR TITLE
Fix #827: Track KiloCode quota failures that hang until timeout

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -71,6 +71,17 @@ module Containers
       end
     end
 
+    # Raised when streaming output matches an abort pattern, indicating a
+    # fatal provider error where the CLI is known to hang instead of exiting.
+    class OutputAbortError < Error
+      attr_reader :matched_output
+
+      def initialize(msg = "Process aborted due to fatal output pattern", matched_output: nil)
+        @matched_output = matched_output
+        super(msg)
+      end
+    end
+
     # Bundles watchdog shared state (mutex, refs, timeouts) into a single
     # object to keep start_watchdog's parameter list under 4.
     WatchdogContext = Struct.new(
@@ -204,13 +215,13 @@ module Containers
     # @raise [StartupTimeoutError] when no output is received within +startup_timeout+ seconds
     # @raise [IdleTimeoutError] when output stops for more than +idle_timeout+ seconds
     # @raise [TimeoutError] when total wall-clock +timeout+ is exceeded
-    def execute(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil)
+    def execute(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil, abort_patterns: nil)
       raise ProvisionError, "Container not provisioned" unless container
 
-      with_codex_auth_lock(command) { execute_unlocked(command, timeout:, startup_timeout:, idle_timeout:, stream:, env:, preparation:, heartbeat_path:) }
+      with_codex_auth_lock(command) { execute_unlocked(command, timeout:, startup_timeout:, idle_timeout:, stream:, env:, preparation:, heartbeat_path:, abort_patterns:) }
     end
 
-    private def execute_unlocked(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil)
+    private def execute_unlocked(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil, abort_patterns: nil)
       timeout ||= options[:timeout_seconds]
       cmd_array = command.is_a?(Array) ? command : [ "sh", "-c", command ]
       exec_options = { wait: timeout }
@@ -237,6 +248,7 @@ module Containers
       exec_completed = false
       timeout_reason = nil # :startup, :idle, or :wall_clock, set by watchdog
       timeout_reason_ref = -> { timeout_reason }
+      abort_matched_output = nil # set when an abort_pattern matches stderr
       watchdog = nil
 
       timeout_check = TimeoutCheckState.new(
@@ -281,6 +293,23 @@ module Containers
           when :stderr
             stderr_buffer << normalized_chunk
             log_output(:stderr, normalized_chunk) if stream
+
+            # Check stderr against abort patterns — if the CLI emits a fatal
+            # error but hangs instead of exiting, stop the container immediately
+            # rather than waiting for the idle/wall-clock timeout.
+            if abort_patterns&.any? && abort_matched_output.nil?
+              matched = abort_patterns.any? { |pat| normalized_chunk.match?(pat) }
+              if matched
+                abort_matched_output = normalized_chunk
+                log_system("container.execute.abort_pattern_matched",
+                  output: normalized_chunk.truncate(200))
+                begin
+                  container.stop(timeout: 0)
+                rescue Docker::Error::DockerError => e
+                  log_system("container.execute.abort_stop_failed", error: e.message)
+                end
+              end
+            end
           end
         end
 
@@ -288,6 +317,16 @@ module Containers
         # to prevent late/false timeouts during post-processing.
         watchdog_mutex.synchronize { exec_completed = true }
         stop_watchdog(watchdog)
+
+        # Check if we stopped the container due to an abort pattern match.
+        # This takes precedence over timeout checks because the abort was
+        # the actual cause of termination.
+        if abort_matched_output
+          raise OutputAbortError.new(
+            "Process aborted: fatal output pattern detected",
+            matched_output: abort_matched_output
+          )
+        end
 
         # Check if the watchdog stopped the container (exec returns normally
         # with a non-zero exit code when the process is killed).
@@ -319,6 +358,9 @@ module Containers
             exit_code: exit_code
           )
         end
+      rescue OutputAbortError
+        log_partial_output(stdout_buffer, stderr_buffer)
+        raise
       rescue StartupTimeoutError, IdleTimeoutError => e
         log_partial_output(stdout_buffer, stderr_buffer)
         timeout_value = e.is_a?(StartupTimeoutError) ? startup_timeout : idle_timeout
@@ -330,6 +372,16 @@ module Containers
       rescue Docker::Error::DockerError => e
         # Log partial output first — raise_if_watchdog_timeout! may re-raise.
         log_partial_output(stdout_buffer, stderr_buffer)
+
+        # Check if the Docker error was caused by an abort pattern stopping the
+        # container. This takes precedence over timeout classification.
+        if abort_matched_output
+          raise OutputAbortError.new(
+            "Process aborted: fatal output pattern detected",
+            matched_output: abort_matched_output
+          )
+        end
+
         begin
           raise_if_watchdog_timeout!(timeout_check)
         rescue StartupTimeoutError, IdleTimeoutError => timeout_error

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -107,6 +107,20 @@ module Activities
       /buy (?:more )?credits/i
     ].freeze
 
+    # Patterns that indicate a fatal provider quota/billing error where the
+    # CLI is known to hang instead of exiting promptly. When any of these
+    # match streaming stderr, the container is stopped immediately rather
+    # than waiting for an idle or wall-clock timeout.
+    #
+    # These are intentionally a strict subset of RATE_LIMIT_PATTERNS —
+    # only patterns where the CLI is empirically known to hang after emitting
+    # the error. Generic rate-limit messages from CLIs that exit cleanly
+    # should NOT be added here.
+    PROVIDER_ABORT_PATTERNS = [
+      /free tier limit reached/i,
+      /please upgrade to a paid plan/i
+    ].freeze
+
     # Maximum number of log rows to inspect when reclassifying a timeout.
     # Caps memory and DB load on long-running, verbose agent attempts.
     TIMEOUT_RATE_LIMIT_LOG_LIMIT = 200
@@ -615,7 +629,8 @@ module Activities
           timeout: effective_timeout,
           idle_timeout: effective_idle_timeout,
           env: command_env,
-          preparation: command_preparation
+          preparation: command_preparation,
+          abort_patterns: PROVIDER_ABORT_PATTERNS
         )
       end
       stdout = normalize_output_text(result[:stdout])
@@ -673,6 +688,16 @@ module Activities
       else "wall_clock"
       end
       raise ProviderTimeoutError, "#{timeout_type}_timeout: #{e.message}"
+    rescue Containers::Provision::OutputAbortError => e
+      # The container was stopped early because stderr matched a fatal
+      # provider quota pattern (e.g. KiloCode "Free tier limit reached").
+      # Classify as rate-limited so dashboards and retry logic see the
+      # real root cause instead of a generic timeout.
+      reset_at = parse_rate_limit_reset(e.matched_output.to_s)
+      raise ProviderRateLimitError.new(
+        "Rate limited by #{provider}: #{e.matched_output.to_s.truncate(200)}",
+        reset_at: reset_at
+      )
     end
 
     # Checks if the agent run is stuck in an infinite loop by analyzing

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1246,6 +1246,68 @@ RSpec.describe Containers::Provision do
       end
     end
 
+    context "when stderr matches an abort pattern" do
+      let(:abort_patterns) { [ /free tier limit reached/i ] }
+      let(:quota_error) { "Error: Free tier limit reached. Please upgrade to a paid plan." }
+
+      before do
+        allow(mock_container).to receive(:stop)
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stderr, quota_error) if block
+          # Simulate exec returning after container.stop was called
+          [ [], [ quota_error ], 1 ]
+        end
+      end
+
+      it "raises OutputAbortError with the matched output" do
+        expect { service.execute("kilo run --auto", abort_patterns: abort_patterns) }
+          .to raise_error(described_class::OutputAbortError) { |e|
+            expect(e.matched_output).to eq(quota_error)
+          }
+      end
+
+      it "stops the container immediately" do
+        service.execute("kilo run --auto", abort_patterns: abort_patterns) rescue nil
+
+        expect(mock_container).to have_received(:stop).with(timeout: 0)
+      end
+
+      it "logs the abort pattern match" do
+        allow(agent_run).to receive(:log!)
+
+        service.execute("kilo run --auto", abort_patterns: abort_patterns) rescue nil
+
+        expect(agent_run).to have_received(:log!).with(
+          "system", "container.execute.abort_pattern_matched",
+          metadata: hash_including(output: a_string_matching(/Free tier limit reached/))
+        )
+      end
+    end
+
+    context "when stderr does not match abort patterns" do
+      let(:abort_patterns) { [ /free tier limit reached/i ] }
+
+      before do
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stderr, "some benign warning\n") if block
+          [ [ "output" ], [ "some benign warning\n" ], 0 ]
+        end
+      end
+
+      it "does not raise OutputAbortError" do
+        result = service.execute("kilo run --auto", abort_patterns: abort_patterns)
+
+        expect(result.success?).to be true
+      end
+
+      it "does not stop the container" do
+        allow(mock_container).to receive(:stop)
+        service.execute("kilo run --auto", abort_patterns: abort_patterns)
+
+        expect(mock_container).not_to have_received(:stop)
+      end
+    end
+
     context "when container is not provisioned" do
       let(:unprovisioned_service) { described_class.new(agent_run: agent_run, worktree_path: worktree_path) }
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1606,6 +1606,24 @@ RSpec.describe Activities::RunAgentActivity do
         expect(agent_run.providers_attempted.first["error_type"]).to eq("timeout")
       end
 
+      it "classifies OutputAbortError from quota patterns as rate_limited instead of timeout" do
+        allow(container_service).to receive(:execute).and_raise(
+          Containers::Provision::OutputAbortError.new(
+            "Process aborted: fatal output pattern detected",
+            matched_output: "Error: Free tier limit reached. Please upgrade to a paid plan."
+          )
+        )
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("rate_limited")
+        expect(agent_run.error_message).to include("rate limited")
+        expect(agent_run.providers_attempted.first["error_type"]).to eq("rate_limited")
+      end
+
       it "preserves timeout handling when the timeout happens before provider execution starts" do
         allow(activity).to receive(:augment_prompt_for_goal)
           .and_raise(Containers::Provision::TimeoutError, "took too long before exec")


### PR DESCRIPTION
## Summary

Track KiloCode quota failures that hang until timeout

See #827 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #827