### PR TITLE
fix(pr-scanner): rescan draft PRs beyond a staleness ceiling

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -20,6 +20,11 @@ module Activities
 
     MIN_COMMENT_LENGTH = 20
     CI_ACTION_DISPATCH_GRACE_PERIOD = 2.minutes
+    # Floor for re-scanning a PR even when GitHub's `updated_at` has not
+    # advanced. `updated_at` does not bump for check-run state changes,
+    # unanswered bot review requests, or review-goal retry timers — without
+    # a time ceiling, PRs waiting on those signals are skipped indefinitely.
+    SCAN_STALENESS_MULTIPLIER = 3
     KNOWN_BOT_PREFIXES = %w[dependabot renovate github-actions].freeze
     REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i
     # Body-only review bots (currently Codex) signal "no findings" by posting
@@ -587,6 +592,7 @@ module Activities
       return false unless issue.last_pr_scan_at
       return false if issue.github_updated_at >= issue.last_pr_scan_at
       return false if recently_completed_run?(project, issue)
+      return false if scan_age_exceeds_ceiling?(project, issue)
 
       logger.debug(
         message: "pr_scanner.skipped_unchanged",
@@ -597,6 +603,31 @@ module Activities
       )
 
       true
+    end
+
+    # Only draft/restarted PRs need a time-based rescan floor. They're the
+    # phases waiting on signals that do not bump GitHub's `updated_at` (bot
+    # review requests, CI state transitions, review-goal retry timers).
+    # `ready`/`escalated` PRs already have a targeted rescan path via
+    # `merge_conflict_rescan_needed?`; bypassing skip here would regress that
+    # optimization back into full per-PR scans.
+    def scan_age_exceeds_ceiling?(project, issue)
+      return false unless issue.pr_review_phase.in?(%w[draft restarted])
+
+      ceiling = SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+      stale = issue.last_pr_scan_at < ceiling.seconds.ago
+
+      if stale
+        logger.info(
+          message: "pr_scanner.scan_age_ceiling_exceeded",
+          project_id: project.id,
+          pr_number: issue.github_number,
+          last_pr_scan_at: issue.last_pr_scan_at,
+          ceiling_seconds: ceiling
+        )
+      end
+
+      stale
     end
 
     def merge_conflict_rescan_needed?(project, issue)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -5378,8 +5378,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           github_number: 42,
           labels: [ "paid-generated", "paid-automation" ],
           paid_state: "completed",
-          github_updated_at: 2.hours.ago,
-          last_pr_scan_at: 1.hour.ago)
+          github_updated_at: 5.minutes.ago,
+          last_pr_scan_at: 30.seconds.ago)
       end
 
       it "skips PRs where github_updated_at < last_pr_scan_at" do
@@ -5411,11 +5411,39 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         create(:agent_run, :completed,
           project: project,
           source_pull_request_number: 42,
-          completed_at: 30.minutes.ago)
+          completed_at: 30.seconds.ago)
         stub_github_for_pr
         activity.execute(project_id: project.id)
 
-        expect(unchanged_pr.reload.last_pr_scan_at).to be_present
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
+      end
+
+      it "rescans draft PRs whose last scan exceeds the staleness ceiling" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        unchanged_pr.update!(pr_review_phase: "draft")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+        stub_github_for_pr
+
+        activity.execute(project_id: project.id)
+
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
+      end
+
+      it "does not bypass skip for stale ready PRs (preserves merge-conflict rescan path)" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        unchanged_pr.update!(pr_review_phase: "ready")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+        expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
       end
 
       it "scans ready PRs for merge conflicts when auto-fix is enabled" do


### PR DESCRIPTION
## Summary

- Draft/restarted PRs waiting on signals that don't bump GitHub's `updated_at` (unanswered bot review requests, CI state transitions, review-goal retry timers) were skipped indefinitely by `skip_unchanged_pr?`, so scans stopped queuing follow-up agent runs even when triggers like `ci_failure`, `paid_agent_review_pending`, or `ready_for_owner` were obviously pending.
- Adds a time-based rescan floor: draft/restarted PRs whose `last_pr_scan_at` exceeds `3 × poll_interval_seconds` (15 min at the default 300s interval) are rescanned on the next cycle.
- Scoped to draft/restarted only — ready/escalated PRs keep their targeted merge-conflict rescan path (#1024).

## Context

During today's investigation into why there were 0 active agent runs despite 41 open paid-generated draft PRs on viamin/paid, simulating the scanner on 15 stuck PRs showed every one of them would have emitted an actionable trigger (`paid_agent_review_pending`, `ci_failure`, `review_bot_comments`, or `ready_for_owner`) — but the scanner wasn't running on them because `github_updated_at` hadn't advanced. Oldest stuck scan age was 584 min; one PR was already classified as `ready_for_owner` and had been sitting in draft for nearly 10 hours.

GitHub does not bump `pull_request.updated_at` for:
- Check-run state changes (a CI job going queued → failed)
- A review request that never gets answered
- Time-based transitions Paid owns internally

This is the same class of bug #1024 fixed for merge conflicts — just for a different set of signals.

## Test plan

- [x] `bin/rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb` — 281 examples, 0 failures
- [x] `bin/rubocop` clean on both files
- [x] New spec pins that stale ready PRs still take the merge-conflict rescan path (guards against a future edit widening the ceiling and regressing #1024)
- [ ] After merge: confirm stuck draft PRs on viamin/paid get re-evaluated on the next poll cycle and produce follow-up agent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)