### PR TITLE
fix(setup): pass Claude install contract build args to agent-image

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -43,7 +43,7 @@ FileUtils.chdir APP_ROOT do
   system "bin/rails qdrant:check"
 
   puts "\n== Building agent container image =="
-  system! "docker compose --profile setup up agent-image --build"
+  system! "scripts/build-agent-image.sh"
 
   puts "\n== Removing old logs and tempfiles =="
   FileUtils.rm_f(Dir["log/*.log"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,9 @@ services:
     build:
       context: ./docker/agent
       dockerfile: Dockerfile
+      args:
+        CLAUDE_INSTALL_COMMAND: ${CLAUDE_INSTALL_COMMAND:-}
+        CLAUDE_POST_INSTALL_BINARY_PATH: ${CLAUDE_POST_INSTALL_BINARY_PATH:-}
     image: paid-agent:latest
     command: ["true"]
     profiles:
@@ -191,6 +194,9 @@ services:
     build:
       context: ./docker/agent
       dockerfile: Dockerfile
+      args:
+        CLAUDE_INSTALL_COMMAND: ${CLAUDE_INSTALL_COMMAND:-}
+        CLAUDE_POST_INSTALL_BINARY_PATH: ${CLAUDE_POST_INSTALL_BINARY_PATH:-}
     image: paid-agent:latest
     volumes:
       - ./agent-workspace:/workspace

--- a/spec/lib/setup_script_spec.rb
+++ b/spec/lib/setup_script_spec.rb
@@ -124,6 +124,15 @@ RSpec.describe "bin/setup" do # rubocop:disable RSpec/DescribeClass
       BASH
     )
 
+    FileUtils.mkdir_p(File.join(dir, "scripts"))
+    write_executable(
+      File.join(dir, "scripts", "build-agent-image.sh"),
+      <<~BASH
+        #!/usr/bin/env bash
+        exit 0
+      BASH
+    )
+
     script_path
   end
 


### PR DESCRIPTION
## Summary
- `bin/setup` failed at the Docker build step because `docker compose --profile setup up agent-image --build` did not pass the `CLAUDE_INSTALL_COMMAND` / `CLAUDE_POST_INSTALL_BINARY_PATH` build-args introduced by #788. Only `scripts/build-agent-image.sh` and CI were updated.
- Switch `bin/setup` to invoke `scripts/build-agent-image.sh` so local setup uses the same agent-harness install contract extraction as CI.
- Wire the two build-args through `docker-compose.yml` (on both `agent-image` and `agent-test` services) so the compose path also works when the env vars are exported. Use `${VAR:-}` defaults to avoid compose emitting "variable not set" warnings on every unrelated `docker compose up`.

## Test plan
- [x] `bin/setup --skip-server` completes successfully and builds `paid-agent:latest`.
- [x] `docker compose config` emits no "variable is not set" warnings.
- [x] `docker compose --profile setup config agent-image` renders the build args without warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)