### PR TITLE
fix(service-containers): pin postgres default to 16.13

### DIFF
--- a/db/migrate/20260417204111_pin_postgres_in_allowed_service_images.rb
+++ b/db/migrate/20260417204111_pin_postgres_in_allowed_service_images.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class PinPostgresInAllowedServiceImages < ActiveRecord::Migration[8.1]
+  OLD_DEFAULT = [ "postgres:16", "redis:7-alpine", "selenium/standalone-chromium:latest" ].freeze
+  NEW_DEFAULT = [ "postgres:16.13", "redis:7-alpine", "selenium/standalone-chromium:latest" ].freeze
+
+  def up
+    change_column_default :user_settings, :allowed_service_images, from: OLD_DEFAULT, to: NEW_DEFAULT
+
+    execute(<<~SQL.squish)
+      UPDATE user_settings
+      SET allowed_service_images = (
+        SELECT jsonb_agg(
+          CASE WHEN elem = '"postgres:16"'::jsonb THEN '"postgres:16.13"'::jsonb ELSE elem END
+        )
+        FROM jsonb_array_elements(allowed_service_images) AS elem
+      )
+      WHERE allowed_service_images @> '["postgres:16"]'::jsonb
+    SQL
+  end
+
+  def down
+    change_column_default :user_settings, :allowed_service_images, from: NEW_DEFAULT, to: OLD_DEFAULT
+
+    execute(<<~SQL.squish)
+      UPDATE user_settings
+      SET allowed_service_images = (
+        SELECT jsonb_agg(
+          CASE WHEN elem = '"postgres:16.13"'::jsonb THEN '"postgres:16"'::jsonb ELSE elem END
+        )
+        FROM jsonb_array_elements(allowed_service_images) AS elem
+      )
+      WHERE allowed_service_images @> '["postgres:16.13"]'::jsonb
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_17_061353) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_17_204111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -1084,7 +1084,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_17_061353) do
 
   create_table "user_settings", force: :cascade do |t|
     t.integer "agent_timeout_seconds", default: 3600, null: false
-    t.jsonb "allowed_service_images", default: ["postgres:16", "redis:7-alpine", "selenium/standalone-chromium:latest"]
+    t.jsonb "allowed_service_images", default: ["postgres:16.13", "redis:7-alpine", "selenium/standalone-chromium:latest"]
     t.integer "circuit_breaker_failure_threshold", default: 5, null: false
     t.integer "circuit_breaker_timeout_seconds", default: 300, null: false
     t.bigint "container_memory_bytes", default: 4294967296, null: false


### PR DESCRIPTION
## Summary

- Change the `user_settings.allowed_service_images` column default from `postgres:16` (floating) to `postgres:16.13` (pinned).
- Backfill existing `user_settings` rows that still hold `postgres:16`.

## Why

Agent sidecar postgres containers are spun up via `Containers::ServiceProvisioner` using the image list in `user_settings.allowed_service_images`. The default was the floating `postgres:16` tag, so agents running on different hosts (or at different times) got different 16.x minor versions. Different 16.x patches render `pg_get_indexdef` / check-constraint expressions differently (e.g. `ANY(ARRAY[...]::text[])` vs `ANY(ARRAY[('x'::character varying)::text, ...])`), which caused recurring `schema.rb` drift in PRs even after the dev/CI containers were pinned to 16.13.

## Test plan

- [ ] `bin/rails db:migrate` succeeds and bumps `schema.rb` version.
- [ ] After migrating, `user_settings.allowed_service_images` shows `postgres:16.13` in all rows that previously had `postgres:16`; any custom entries are preserved.
- [ ] `schema.rb` default matches the migrated state.
- [ ] `bin/rails db:rollback` restores the previous default and values without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)