### PR TITLE
fix(devcontainer): avoid kilocode permission save-merge corruption

### DIFF
--- a/.devcontainer/configure-llm-tools.sh
+++ b/.devcontainer/configure-llm-tools.sh
@@ -172,9 +172,34 @@ fi
 # the host (only ~/.kilocode is mounted), so writing here is container-local.
 echo "Configuring KiloCode..."
 mkdir -p "$HOME/.config/kilo"
+# NOTE: the schema's string shortcut `"permission": "allow"` is semantically
+# correct ("dangerously skip permissions") but triggers an upstream kilo bug
+# where its save-merge (`{...config.permission, <key>: "allow"}`) spreads the
+# string character-by-character into `{0:"a",1:"l",...}` and corrupts the
+# file. We use the object form with every known key explicitly set to "allow"
+# so the spread-merge is a no-op. Revert to the string shortcut once the
+# upstream save bug is fixed. Keys from https://app.kilo.ai/config.json.
 cat << 'EOF' > "$HOME/.config/kilo/config.json"
 {
-  "permission": "allow"
+  "$schema": "https://app.kilo.ai/config.json",
+  "permission": {
+    "read": "allow",
+    "edit": "allow",
+    "glob": "allow",
+    "grep": "allow",
+    "list": "allow",
+    "bash": "allow",
+    "task": "allow",
+    "external_directory": "allow",
+    "todowrite": "allow",
+    "question": "allow",
+    "webfetch": "allow",
+    "websearch": "allow",
+    "codesearch": "allow",
+    "lsp": "allow",
+    "doom_loop": "allow",
+    "skill": "allow"
+  }
 }
 EOF
 


### PR DESCRIPTION
## Summary

- The devcontainer seeds `~/.config/kilo/config.json` with `"permission": "allow"` — the string shortcut documented in kilo's published schema (`https://app.kilo.ai/config.json`) meaning "allow everything."
- The string form **validates on load** but triggers an upstream kilo save bug: its save-merge path does `{...config.permission, <key>: "allow"}`. Spreading the string `"allow"` enumerates its characters into indexed keys, producing:
  ```json
  { "permission": { "0": "a", "1": "l", "2": "l", "3": "o", "4": "w", "<key>": "allow" } }
  ```
  The next `kilo` invocation then dies with `Error: Configuration is invalid ↳ Invalid input permission`, rendering kilo unusable in the devcontainer until the file is rewritten by hand.
- Fix: write the **object form** with every schema-defined permission key explicitly set to `"allow"`. This preserves the original "skip all permission prompts" intent; kilo's spread-merge becomes a no-op over an object, so subsequent permission-save events can no longer corrupt the file.
- Comment in the script explains the workaround and the revert trigger (once upstream fixes the save bug, we can collapse back to `"permission": "allow"`).

## Notes / Caveats

- Keys enumerated from the upstream schema: `read, edit, glob, grep, list, bash, task, external_directory, todowrite, question, webfetch, websearch, codesearch, lsp, doom_loop, skill`. If kilo adds a new permission category in a future release, it will default to `ask` until added here — a minor maintenance cost traded for avoiding the corruption bug.
- `doom_loop` is undocumented in the published schema and on kilo's docs site. Setting it to `"allow"` preserves the previous "allow everything" semantics; this PR does not change its effective behavior relative to `main`. Filing a separate upstream docs request is recommended.
- Scope is intentionally limited to the devcontainer seed. `app/models/provider.rb:234-235` separately writes a base64-decoded config into production agent containers; those containers re-seed on each run (ephemeral tmpfs), but a mid-run permission grant could still corrupt within a single agent session. Suggest a follow-up issue to audit that seed for the same shape.

## Test plan

- [ ] Rebuild the devcontainer and confirm `~/.config/kilo/config.json` matches the new object form.
- [ ] Run `kilo config check` — expect `No config warnings.` and exit 0.
- [ ] Run `kilo --help` — expect successful output (previously errored with `Invalid input permission`).
- [ ] Trigger an in-session permission event in `kilo` (any tool that would historically have prompted) and verify the config file remains valid afterwards.
- [ ] Confirm no regression in other LLM tool seeds in `.devcontainer/configure-llm-tools.sh` (OpenCode, Gemini, etc.).

## Upstream bug

The root cause is a bug in the kilocode CLI (observed on `7.2.10`). A separate upstream report describing the string-spread corruption on permission save should be filed at the kilocode-ai repo; this PR is the Paid-side workaround, not a full fix.