### PR TITLE
fix(scheduler): cap auto-pick seeding at owner concurrency budget

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -30,7 +30,6 @@ class ProcessRunQueueJob < ApplicationJob
   # Prevents unbounded scanning when a large queue has many runs that
   # can't start due to per-user capacity limits.
   MAX_ITERATIONS_PER_PERFORM = 100
-  MAX_SEEDS_PER_PERFORM = 20
   AUTO_PICK_RESERVED_SLOTS = 1
 
   def perform
@@ -45,6 +44,7 @@ class ProcessRunQueueJob < ApplicationJob
       iterations = 0
       skipped_ids = Set.new
       @user_capacity = {}  # { user_id => { active: count, max: limit } }
+      @auto_pick_seed_budget = {}  # { user_id => { active: unfinished auto-pick count, max: concurrency } }
 
       seed_auto_pick_queue
 
@@ -126,33 +126,50 @@ class ProcessRunQueueJob < ApplicationJob
     cap[:active] += 1 if cap
   end
 
-  # Seeds the queue with all currently auto-pickable issues before run
-  # selection. Priorities still determine what starts next, but keeping
-  # low-priority auto-pick work queued makes latent work visible and ready
-  # to consume spare capacity.
+  # Seeds the queue with auto-pickable issues up to each owner's
+  # max_concurrent_runs budget. Priorities still determine what starts next;
+  # capping seeding at user capacity keeps low-priority work out of the queue
+  # unless higher-priority work is exhausted, and avoids flooding the queue
+  # with runs that cannot start for a long time.
   def seed_auto_pick_queue
-    seeds_count = 0
-
     loop do
-      break if seeds_count >= MAX_SEEDS_PER_PERFORM
-
       created_in_pass = false
 
       ordered_auto_pick_projects.each do |project|
-        break if seeds_count >= MAX_SEEDS_PER_PERFORM
-
-        next unless project.effective_owner
+        owner = project.effective_owner
+        next unless owner
+        next unless owner_has_seed_budget?(owner)
 
         run = Issues::AutoPick.new(project).call
         next unless run
 
-        seeds_count += 1
+        record_seeded_auto_pick_run(owner)
         created_in_pass = true
         @ordered_auto_pick_projects = nil
       end
 
       break unless created_in_pass
     end
+  end
+
+  # Checks whether the owner has remaining auto-pick seed budget. Uses an
+  # in-memory cache (mirrors #user_has_capacity?) to avoid repeated COUNTs
+  # as the same owner is visited across projects and passes.
+  def owner_has_seed_budget?(owner)
+    budget = seed_budget_for(owner)
+    budget[:active] < budget[:max]
+  end
+
+  def seed_budget_for(owner)
+    @auto_pick_seed_budget[owner.id] ||= {
+      active: AgentRun.unfinished_auto_pick_count_for_user(owner),
+      max: owner.settings.max_concurrent_runs
+    }
+  end
+
+  def record_seeded_auto_pick_run(owner)
+    budget = @auto_pick_seed_budget[owner.id]
+    budget[:active] += 1 if budget
   end
 
   # Memoized within a single perform so repeated auto-pick passes

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -235,6 +235,31 @@ class AgentRun < ApplicationRecord
     active.where(project_id: project.id).count
   end
 
+  # Returns the count of unfinished (queued/pending/running/paused) auto-pick
+  # runs attributable to the given user. Used by queue seeding to cap queued
+  # auto-pick work at the user's max_concurrent_runs instead of seeding every
+  # eligible issue. Mirrors active_count_for_user's owner-resolution chain.
+  #
+  # Filters on the explicit `auto_pick: true` column set by
+  # Issues::AutoPick#create_agent_run, not the broader legacy inference used by
+  # ProcessRunQueueJob#auto_pick_run? (which also treats any automatic run
+  # without a source_pull_request_number as auto-pick). The column is set on
+  # every new auto-pick run, so the count is accurate for seeding decisions.
+  def self.unfinished_auto_pick_count_for_user(user)
+    base = where(status: UNFINISHED_STATUSES, auto_pick: true)
+    scope = base.joins(:project).where(projects: { created_by_id: user.id })
+
+    if orphaned_project_owner?(user)
+      scope = scope.or(
+        base.joins(:project).where(
+          projects: { created_by_id: nil, account_id: user.account_id }
+        )
+      )
+    end
+
+    scope.count
+  end
+
   def self.stale_running_timeout
     AGENT_TIMEOUT_DEFAULT.seconds + STALE_RUNNING_GRACE_PERIOD
   end

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -366,6 +366,48 @@ RSpec.describe ProcessRunQueueJob do
         expect(project.agent_runs.queued.count).to eq(1)
       end
 
+      it "caps seeded auto-pick runs at the owner's max_concurrent_runs" do
+        project = create(:project, auto_pick_enabled: true)
+        user = project.created_by
+        user.settings.update!(max_concurrent_runs: 2)
+
+        10.times { create(:issue, project: project) }
+
+        described_class.new.perform
+
+        expect(project.agent_runs.where(auto_pick: true).count).to eq(2)
+      end
+
+      it "counts already-running auto-pick runs against the seed budget" do
+        project = create(:project, auto_pick_enabled: true)
+        user = project.created_by
+        user.settings.update!(max_concurrent_runs: 2)
+
+        create(:agent_run, :running, project: project, trigger_type: "automatic", auto_pick: true)
+        5.times { create(:issue, project: project) }
+
+        described_class.new.perform
+
+        expect(project.agent_runs.where(auto_pick: true).count).to eq(2)
+      end
+
+      it "shares the seed budget across projects owned by the same user" do
+        account = create(:account)
+        user = create(:user, account: account)
+        user.settings.update!(max_concurrent_runs: 2)
+
+        first_project = create_auto_pick_project(account: account, user: user)
+        second_project = create_auto_pick_project(account: account, user: user)
+
+        3.times { create(:issue, project: first_project) }
+        3.times { create(:issue, project: second_project) }
+
+        described_class.new.perform
+
+        total_seeded = AgentRun.where(project: [ first_project, second_project ], auto_pick: true).count
+        expect(total_seeded).to eq(2)
+      end
+
       it "still starts a manual run with one slot reserved from auto-pick" do
         project = create(:project)
         user = project.created_by


### PR DESCRIPTION
## Summary

Cap auto-pick queue seeding at each owner's `max_concurrent_runs` budget so low-priority (or unlabeled) issues stop being pulled into the queue ahead of higher-priority work that hasn't yet arrived.

### Problem

`ProcessRunQueueJob#seed_auto_pick_queue` greedily called `Issues::AutoPick#call` up to `MAX_SEEDS_PER_PERFORM = 20` times per invocation, draining every eligible priority-labeled issue and then spilling into unlabeled issues. The AutoPick ordering (P1 → P2 → P3 → unlabeled) was correct, but the seeder didn't stop at the priority boundary — it simply kept going until it ran out of eligible work or hit 20.

Concrete example: #827 (unlabeled) was auto-picked on 2026-04-16 during a mass-seed of ~60 runs, because all P1/P2/P3 eligible issues had already been seeded into the queue during the same `perform` invocation.

### Fix

Replace the fixed 20-seed cap with a per-owner budget: seed while the owner's unfinished (queued/pending/running/paused) auto-pick count is below their `max_concurrent_runs` setting. Pipeline stays full via short, frequent top-ups from subsequent `ProcessRunQueueJob` invocations — but queue depth is proportional to configured concurrency.

### Changes

- `app/jobs/process_run_queue_job.rb` — remove `MAX_SEEDS_PER_PERFORM`; add `@auto_pick_seed_budget` per-perform cache with `owner_has_seed_budget?`, `seed_budget_for`, `record_seeded_auto_pick_run` helpers (mirrors existing `@user_capacity` pattern).
- `app/models/agent_run.rb` — add `AgentRun.unfinished_auto_pick_count_for_user(user)` filtering on the `auto_pick: true` column. Mirrors `active_count_for_user`'s owner-resolution chain (including orphaned-project fallback).
- `spec/jobs/process_run_queue_job_spec.rb` — 3 new specs: budget cap at concurrency limit, counts already-running auto-pick against budget, shares budget across a user's projects.

### Preserved behavior

- `max_auto_pick_open_prs` (0 = unlimited) still enforced inside `Issues::AutoPick#call` via `prs_needing_attention_exceed_limit?`.
- `AUTO_PICK_RESERVED_SLOTS = 1` still reserves one concurrent slot for non-auto-pick work.
- Priority ordering in AutoPick unchanged.
- Round-robin across a user's projects still works (existing spec passes).

## Test plan

- [x] `bin/rspec spec/jobs/process_run_queue_job_spec.rb` — 28 examples, 0 failures (25 existing + 3 new)
- [x] `bin/rspec spec/models/agent_run_spec.rb` — 272 examples, 0 failures
- [x] `bin/rspec spec/services/issues/auto_pick_spec.rb` — 93 examples, 0 failures
- [x] `bin/rubocop` — no offenses on changed files
- [ ] Verify in staging that unlabeled issues stay unqueued when priority-labeled work is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)