### PR TITLE
feat(dashboard): include merged pull requests in the recent activity stream

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -22,9 +22,7 @@ class DashboardController < ApplicationController
     @active_runs = live_agent_runs.active.includes(:project, :issue)
       .order("agent_runs.created_at DESC")
       .limit(20)
-    @recent_runs = live_agent_runs.finished.includes(:project, :issue)
-      .order(Arel.sql("COALESCE(agent_runs.completed_at, agent_runs.created_at) DESC"))
-      .limit(10)
+    @recent_activity = Dashboard::RecentActivity.call(account: current_account)
   end
 
   def metrics

--- a/app/services/dashboard/live_broadcaster.rb
+++ b/app/services/dashboard/live_broadcaster.rb
@@ -47,15 +47,11 @@ module Dashboard
     def broadcast_activity_stream
       return unless agent_run.finished?
 
-      recent_runs = account_agent_runs.finished.includes(:project, :issue)
-        .order(Arel.sql("COALESCE(agent_runs.completed_at, agent_runs.created_at) DESC"))
-        .limit(10)
-
       Turbo::StreamsChannel.broadcast_update_to(
         stream_name,
         target: "activity-stream",
         partial: "dashboard/activity_stream",
-        locals: { recent_runs: recent_runs }
+        locals: { activity_items: Dashboard::RecentActivity.call(account: account) }
       )
     end
 

--- a/app/services/dashboard/recent_activity.rb
+++ b/app/services/dashboard/recent_activity.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Dashboard
+  class RecentActivity
+    DEFAULT_LIMIT = 10
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, limit: DEFAULT_LIMIT)
+      @account = account
+      @limit = limit
+    end
+
+    def call
+      (recent_agent_runs + recent_merged_prs)
+        .sort_by { |item| -item_timestamp(item).to_i }
+        .first(limit)
+    end
+
+    private
+
+    attr_reader :account, :limit
+
+    def recent_agent_runs
+      AgentRun.joins(:project)
+        .where(projects: { account_id: account.id })
+        .finished
+        .includes(:project, :issue)
+        .order(Arel.sql("COALESCE(agent_runs.completed_at, agent_runs.created_at) DESC"))
+        .limit(limit)
+        .to_a
+    end
+
+    def recent_merged_prs
+      Issue.joins(:project)
+        .where(projects: { account_id: account.id })
+        .where(is_pull_request: true, pr_review_phase: "merged")
+        .includes(:project)
+        .order(github_updated_at: :desc)
+        .limit(limit)
+        .to_a
+    end
+
+    def item_timestamp(item)
+      case item
+      when AgentRun then item.completed_at || item.created_at
+      when Issue    then item.github_updated_at
+      end
+    end
+  end
+end

--- a/app/views/dashboard/_activity_stream.html.erb
+++ b/app/views/dashboard/_activity_stream.html.erb
@@ -1,28 +1,50 @@
-<% if recent_runs.any? %>
+<% if activity_items.any? %>
   <div class="overflow-hidden rounded-lg bg-white shadow">
     <ul class="divide-y divide-gray-200">
-      <% recent_runs.each do |run| %>
-        <li id="<%= dom_id(run, :activity) %>" class="px-4 py-3">
-          <div class="flex items-center justify-between gap-4">
-            <div class="flex items-center gap-3">
-              <%= agent_run_status_badge(run.status) %>
-              <span class="text-sm font-medium text-gray-900"><%= run.project.full_name %></span>
-              <% if run.issue.present? %>
-                <span class="text-sm text-gray-500">#<%= run.issue.github_number %></span>
-              <% end %>
+      <% activity_items.each do |item| %>
+        <% if item.is_a?(AgentRun) %>
+          <li id="<%= dom_id(item, :activity) %>" class="px-4 py-3">
+            <div class="flex items-center justify-between gap-4">
+              <div class="flex items-center gap-3">
+                <%= agent_run_status_badge(item.status) %>
+                <span class="text-sm font-medium text-gray-900"><%= item.project.full_name %></span>
+                <% if item.issue.present? %>
+                  <span class="text-sm text-gray-500">#<%= item.issue.github_number %></span>
+                <% end %>
+              </div>
+              <div class="flex items-center gap-4 text-sm text-gray-500">
+                <span><%= item.agent_type.titleize %></span>
+                <% if item.duration_seconds.present? %>
+                  <span><%= format_duration(item.duration_seconds) %></span>
+                <% end %>
+                <span><%= time_ago_in_words(item.completed_at || item.created_at) %> ago</span>
+              </div>
             </div>
-            <div class="flex items-center gap-4 text-sm text-gray-500">
-              <span><%= run.agent_type.titleize %></span>
-              <% if run.duration_seconds.present? %>
-                <span><%= format_duration(run.duration_seconds) %></span>
-              <% end %>
-              <span><%= time_ago_in_words(run.completed_at || run.created_at) %> ago</span>
+            <% if item.error_message.present? %>
+              <p class="mt-1 truncate text-sm text-red-600"><%= item.error_message %></p>
+            <% end %>
+          </li>
+        <% else %>
+          <li id="<%= dom_id(item, :activity) %>" class="px-4 py-3">
+            <div class="flex items-center justify-between gap-4">
+              <div class="flex min-w-0 items-center gap-3">
+                <span class="inline-flex items-center rounded-md bg-purple-100 px-2 py-1 text-xs font-medium text-purple-700">Merged</span>
+                <span class="text-sm font-medium text-gray-900"><%= item.project.full_name %></span>
+                <% if safe_github_url?(item.github_url) %>
+                  <%= link_to "PR ##{item.github_number}", item.github_url,
+                        target: "_blank", rel: "noopener noreferrer",
+                        class: "text-sm text-indigo-600 hover:text-indigo-900" %>
+                <% else %>
+                  <span class="text-sm text-gray-500">PR #<%= item.github_number %></span>
+                <% end %>
+                <span class="truncate text-sm text-gray-500"><%= item.title %></span>
+              </div>
+              <div class="flex items-center gap-4 text-sm text-gray-500">
+                <span><%= time_ago_in_words(item.github_updated_at) %> ago</span>
+              </div>
             </div>
-          </div>
-          <% if run.error_message.present? %>
-            <p class="mt-1 truncate text-sm text-red-600"><%= run.error_message %></p>
-          <% end %>
-        </li>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -78,7 +78,7 @@
     </summary>
     <div class="mt-4">
       <div id="activity-stream">
-        <%= render "dashboard/activity_stream", recent_runs: @recent_runs %>
+        <%= render "dashboard/activity_stream", activity_items: @recent_activity %>
       </div>
     </div>
   </details>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -73,6 +73,20 @@ RSpec.describe "Dashboard" do
         expect(response.body).to include("42s")
       end
 
+      it "includes merged pull requests in the recent activity stream" do
+        merged_pr = create(:issue, :pull_request, project: project,
+                                                  pr_review_phase: "merged",
+                                                  github_number: 1234,
+                                                  title: "Ship the thing",
+                                                  github_updated_at: 3.minutes.ago)
+
+        get dashboard_path
+
+        expect(response.body).to include("PR ##{merged_pr.github_number}")
+        expect(response.body).to include("Ship the thing")
+        expect(response.body).to include("Merged")
+      end
+
       it "has collapsible sections" do
         get dashboard_path
 

--- a/spec/services/dashboard/recent_activity_spec.rb
+++ b/spec/services/dashboard/recent_activity_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Dashboard::RecentActivity do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:project) { create(:project, account: account) }
+
+    it "returns finished agent runs and merged PRs for the account, sorted by recency" do
+      older_run = create(:agent_run, project: project, status: "completed",
+                                     completed_at: 2.hours.ago,
+                                     duration_seconds: 30)
+      newer_run = create(:agent_run, project: project, status: "completed",
+                                     completed_at: 5.minutes.ago,
+                                     duration_seconds: 10)
+      merged_pr = create(:issue, :pull_request, project: project,
+                                                pr_review_phase: "merged",
+                                                github_updated_at: 30.minutes.ago)
+
+      items = described_class.call(account: account)
+
+      expect(items).to eq([ newer_run, merged_pr, older_run ])
+    end
+
+    it "excludes agent runs that are not finished" do
+      create(:agent_run, project: project, status: "running", started_at: 1.minute.ago)
+
+      expect(described_class.call(account: account)).to be_empty
+    end
+
+    it "excludes PRs that have not been merged" do
+      create(:issue, :pull_request, project: project, pr_review_phase: "ready",
+                                    github_updated_at: 1.minute.ago)
+
+      expect(described_class.call(account: account)).to be_empty
+    end
+
+    it "excludes non-PR issues even if somehow marked as merged" do
+      create(:issue, project: project, is_pull_request: false,
+                     github_updated_at: 1.minute.ago)
+
+      expect(described_class.call(account: account)).to be_empty
+    end
+
+    it "scopes results to the given account" do
+      other_project = create(:project)
+      create(:agent_run, project: other_project, status: "completed", completed_at: 1.minute.ago)
+      create(:issue, :pull_request, project: other_project, pr_review_phase: "merged",
+                                    github_updated_at: 1.minute.ago)
+
+      expect(described_class.call(account: account)).to be_empty
+    end
+
+    it "caps the combined result at the configured limit" do
+      12.times do |i|
+        create(:agent_run, project: project, status: "completed",
+                           completed_at: (i + 1).minutes.ago)
+      end
+      12.times do |i|
+        create(:issue, :pull_request, project: project, pr_review_phase: "merged",
+                                      github_updated_at: (i + 1).minutes.ago)
+      end
+
+      expect(described_class.call(account: account, limit: 5).size).to eq(5)
+      expect(described_class.call(account: account).size).to eq(described_class::DEFAULT_LIMIT)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds merged pull requests to the Recent Activity section of the dashboard, interleaved with finished agent runs and sorted by most-recent activity.
- Extracts the activity query into a shared `Dashboard::RecentActivity` service so the controller and the Turbo live broadcaster stay in sync.
- Uses `github_updated_at` as a merge-time proxy — same approach already documented in `Dashboard::Stats#merged_pr_aggregate` pending a dedicated `merged_at` column.

## Known limitations

- Merges performed externally (e.g. by a human on GitHub, outside any Paid agent run) only appear after the next page load or next agent-run broadcast, since the Turbo broadcast is still driven by agent-run state transitions.
- `github_updated_at` can drift from true merge time if a merged PR receives later activity (comments, label changes) that gets resynced.

## Test plan

- [x] `bin/rspec spec/services/dashboard/recent_activity_spec.rb spec/services/dashboard/live_broadcaster_spec.rb spec/requests/dashboard_spec.rb` (33 examples, 0 failures)
- [ ] Manually verify a merged PR appears in the Recent Activity section with the purple "Merged" badge and the correct `github_updated_at` relative time.
- [ ] Confirm live Turbo update fires on the next finished agent run after a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)