### PR TITLE
fix(agent-runs): remove stale run detection from startup cleanup

### DIFF
--- a/bin/dev-update
+++ b/bin/dev-update
@@ -41,7 +41,7 @@ STOPPED_OVERMIND=0
 OVERMIND_STOP_POLL_COUNT="${DEV_UPDATE_OVERMIND_STOP_POLL_COUNT:-10}"
 OVERMIND_START_POLL_COUNT="${DEV_UPDATE_OVERMIND_START_POLL_COUNT:-15}"
 OVERMIND_POLL_INTERVAL="${DEV_UPDATE_OVERMIND_POLL_INTERVAL:-1}"
-STARTUP_CLEANUP_GRACE_PERIOD="${DEV_UPDATE_STARTUP_CLEANUP_GRACE_PERIOD:-300}"
+STARTUP_CLEANUP_KILL_ALL="${DEV_UPDATE_STARTUP_CLEANUP_KILL_ALL:-}"
 
 newline_list_to_csv() {
   printf '%s' "${1:-}" | tr '\n' ',' | sed 's/,$//'
@@ -244,7 +244,7 @@ stop_overmind() {
 
 run_setup() {
   log "Running bin/setup --skip-server..."
-  STARTUP_CLEANUP_GRACE_PERIOD="$STARTUP_CLEANUP_GRACE_PERIOD" bin/setup --skip-server
+  STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" bin/setup --skip-server
 }
 
 start_dev() {
@@ -267,7 +267,7 @@ start_dev() {
   # Start bin/dev detached so this script can exit cleanly.
   # Unset PORT so bin/dev applies its own default (3000) instead of
   # inheriting a per-process port assigned by the previous Overmind session.
-  env -u PORT STARTUP_CLEANUP_GRACE_PERIOD="$STARTUP_CLEANUP_GRACE_PERIOD" nohup bin/dev >>"$START_DEV_LOG" 2>&1 &
+  env -u PORT STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" nohup bin/dev >>"$START_DEV_LOG" 2>&1 &
   disown
   log "Dev environment start command launched (PID $!)."
 

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -18,22 +18,6 @@ module DevCleanup
     count = ServiceContainer.running.update_all(status: "stopped", docker_container_id: nil)
     puts "  Marked #{count} service container(s) as stopped" if count > 0
   end
-
-  # For selective cleanup, use the provisioner to clean up service containers that no
-  # longer have active agent runs referencing them.
-  def cleanup_stale_service_containers
-    provisioner = Containers::ServiceProvisioner.new
-    count = 0
-    ServiceContainer.running.find_each do |sc|
-      next if sc.active_agent_run_count > 0
-
-      provisioner.stop_orphaned_container!(sc)
-      count += 1
-    rescue => e
-      warn "  WARNING: Failed to stop service container #{sc.name}: #{e.message}"
-    end
-    puts "  Cleaned up #{count} orphaned service container(s)" if count > 0
-  end
 end
 
 namespace :dev do
@@ -41,7 +25,6 @@ namespace :dev do
   task cleanup: :environment do
     if ENV["STARTUP_CLEANUP_KILL_ALL"] == "1"
       stale_count = 0
-      stale_container_ids = []
 
       AgentRun.active.find_each do |run|
         run.with_lock do
@@ -51,7 +34,6 @@ namespace :dev do
           run.timeout!(error: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted")
           run.log!("system", "Run marked as timed out during startup cleanup")
           run.issue&.update!(paid_state: "failed") unless run.issue&.paid_state == "failed"
-          stale_container_ids << run.container_id if run.container_id.present?
           stale_count += 1
         end
       end
@@ -69,9 +51,6 @@ namespace :dev do
         DevCleanup.mark_service_containers_stopped
       end
 
-      if stale_count > 0
-        ProcessRunQueueJob.perform_later
-      end
     end
 
     # Always process the queue — queued runs may be stranded if the job was

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -13,13 +13,13 @@ module DevCleanup
     Kernel.system("docker", "stop", *ids, out: File::NULL, err: File::NULL)
   end
 
-  # After grace=0 cleanup stops all service containers, sync DB records.
+  # After kill_all cleanup stops all service containers, sync DB records.
   def mark_service_containers_stopped
     count = ServiceContainer.running.update_all(status: "stopped", docker_container_id: nil)
     puts "  Marked #{count} service container(s) as stopped" if count > 0
   end
 
-  # For grace>0, use the provisioner to clean up service containers that no
+  # For selective cleanup, use the provisioner to clean up service containers that no
   # longer have active agent runs referencing them.
   def cleanup_stale_service_containers
     provisioner = Containers::ServiceProvisioner.new
@@ -37,43 +37,27 @@ module DevCleanup
 end
 
 namespace :dev do
-  desc "Mark stale agent runs as timed out, stop their containers (+ orphans when grace=0), and process the run queue"
+  desc "Process stranded queued runs. Set STARTUP_CLEANUP_KILL_ALL=1 to also force-timeout all active runs and stop their containers."
   task cleanup: :environment do
-    raw = ENV.fetch("STARTUP_CLEANUP_GRACE_PERIOD", "300")
-    grace = begin
-      Integer(raw).clamp(0..).seconds
-    rescue ArgumentError
-      warn "  WARNING: Invalid STARTUP_CLEANUP_GRACE_PERIOD=#{raw.inspect}, defaulting to 0"
-      0.seconds
-    end
+    if ENV["STARTUP_CLEANUP_KILL_ALL"] == "1"
+      stale_count = 0
+      stale_container_ids = []
 
-    stale_count = 0
-    skipped_count = 0
-    stale_container_ids = []
+      AgentRun.active.find_each do |run|
+        run.with_lock do
+          run.reload
+          next if run.finished?
 
-    AgentRun.active.find_each do |run|
-      run.with_lock do
-        run.reload
-        next if run.finished?
-
-        if grace.zero? || run.updated_at < grace.ago
           run.timeout!(error: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted")
           run.log!("system", "Run marked as timed out during startup cleanup")
           run.issue&.update!(paid_state: "failed") unless run.issue&.paid_state == "failed"
           stale_container_ids << run.container_id if run.container_id.present?
           stale_count += 1
-        else
-          skipped_count += 1
         end
       end
-    end
 
-    puts "  Resolved #{stale_count} stale agent run(s)" if stale_count > 0
-    puts "  Skipped #{skipped_count} recent run(s) for Temporal recovery" if skipped_count > 0
+      puts "  Resolved #{stale_count} stale agent run(s)" if stale_count > 0
 
-    # grace=0: stop ALL labeled containers (agent + service + orphaned).
-    # grace>0: stop stale run containers + clean up service containers via provisioner.
-    if grace.zero?
       orphaned = DevCleanup.find_orphaned_containers
       orphaned.uniq!
       if orphaned.any?
@@ -84,22 +68,19 @@ namespace :dev do
         # returned empty (e.g. Docker unavailable), we must not blindly flip DB records.
         DevCleanup.mark_service_containers_stopped
       end
-    else
-      if stale_container_ids.any?
-        stale_container_ids.uniq!
-        puts "  Stopping #{stale_container_ids.size} container(s) for stale runs"
-        DevCleanup.stop_containers(stale_container_ids)
+
+      if stale_count > 0
+        ProcessRunQueueJob.perform_later
       end
-      # Clean up service containers for stale runs via provisioner reference counting.
-      DevCleanup.cleanup_stale_service_containers
     end
 
     # Always process the queue — queued runs may be stranded if the job was
     # never re-enqueued after a restart (no cron schedule for this job).
+    # Stale run detection is handled by StaleRunDetectorJob (cron every 5 min).
     queued = AgentRun.queued.count
-    if stale_count > 0 || queued > 0
+    if queued > 0
       ProcessRunQueueJob.perform_later
-      puts "  Processing run queue (#{queued} queued)" if queued > 0
+      puts "  Processing run queue (#{queued} queued)"
     end
   end
 end

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -220,37 +220,37 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
-  it "passes a startup cleanup grace period to bin/setup during full restart" do
+  it "does not forward STARTUP_CLEANUP_KILL_ALL when unset during full restart" do
     Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
-      script_path = prepare_script_fixture(dir, capture_startup_cleanup_grace_period_in_dev: true)
+      script_path = prepare_script_fixture(dir, capture_kill_all_in_dev: true)
 
       env = poll_env.merge(
         "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
         "OVERMIND_SOCKET" => ".overmind.sock",
-        "DEV_UPDATE_STARTUP_CLEANUP_GRACE_PERIOD" => nil
+        "DEV_UPDATE_STARTUP_CLEANUP_KILL_ALL" => nil
       )
       stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
 
       expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
-      expect(File.read(File.join(dir, "setup-env.log"))).to eq("300\n")
-      expect(File.read(File.join(dir, "dev-env.log"))).to eq("300\n")
+      expect(File.read(File.join(dir, "setup-env.log"))).to eq("\n")
+      expect(File.read(File.join(dir, "dev-env.log"))).to eq("\n")
     end
   end
 
-  it "forwards an overridden startup cleanup grace period to both setup and dev during full restart" do
+  it "forwards STARTUP_CLEANUP_KILL_ALL to both setup and dev during full restart" do
     Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
-      script_path = prepare_script_fixture(dir, capture_startup_cleanup_grace_period_in_dev: true)
+      script_path = prepare_script_fixture(dir, capture_kill_all_in_dev: true)
 
       env = poll_env.merge(
         "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
         "OVERMIND_SOCKET" => ".overmind.sock",
-        "DEV_UPDATE_STARTUP_CLEANUP_GRACE_PERIOD" => "600"
+        "DEV_UPDATE_STARTUP_CLEANUP_KILL_ALL" => "1"
       )
       stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
 
       expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
-      expect(File.read(File.join(dir, "setup-env.log"))).to eq("600\n")
-      expect(File.read(File.join(dir, "dev-env.log"))).to eq("600\n")
+      expect(File.read(File.join(dir, "setup-env.log"))).to eq("1\n")
+      expect(File.read(File.join(dir, "dev-env.log"))).to eq("1\n")
     end
   end
 
@@ -346,7 +346,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     start_overmind_running: false,
     dev_starts_overmind: true,
     capture_port_in_dev: false,
-    capture_startup_cleanup_grace_period_in_dev: false
+    capture_kill_all_in_dev: false
   )
     FileUtils.mkdir_p(File.join(dir, "bin"))
     FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
@@ -362,15 +362,15 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
 
     dev_start_line = dev_starts_overmind ? %(touch "#{dir}/overmind-running") : ""
     capture_port_line = capture_port_in_dev ? %(printf '%s\n' "${PORT:-}" > "#{dir}/dev-port.log") : ""
-    capture_startup_cleanup_grace_period_line =
-      capture_startup_cleanup_grace_period_in_dev ? %(printf '%s\n' "${STARTUP_CLEANUP_GRACE_PERIOD:-}" > "#{dir}/dev-env.log") : ""
+    capture_kill_all_line =
+      capture_kill_all_in_dev ? %(printf '%s\n' "${STARTUP_CLEANUP_KILL_ALL:-}" > "#{dir}/dev-env.log") : ""
 
     write_executable(
       File.join(dir, "bin", "setup"),
       <<~BASH
         #!/usr/bin/env bash
         touch "#{dir}/setup-ran"
-        printf '%s\n' "${STARTUP_CLEANUP_GRACE_PERIOD:-}" > "#{dir}/setup-env.log"
+        printf '%s\n' "${STARTUP_CLEANUP_KILL_ALL:-}" > "#{dir}/setup-env.log"
         exit #{setup_exit_status}
       BASH
     )
@@ -381,7 +381,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
         #!/usr/bin/env bash
         touch "#{dir}/dev-ran"
         #{capture_port_line}
-        #{capture_startup_cleanup_grace_period_line}
+        #{capture_kill_all_line}
         #{dev_start_line}
         echo "bin/dev booted"
       BASH

--- a/spec/tasks/dev_rake_spec.rb
+++ b/spec/tasks/dev_rake_spec.rb
@@ -7,70 +7,30 @@ require "rake"
 RSpec.describe "dev:cleanup" do
   let(:task) { Rake::Task["dev:cleanup"] }
 
-  # Default grace period is now 300s for Temporal recovery. Tests in the
-  # top-level context verify immediate-cleanup behavior, so force grace=0.
-  around do |example|
-    old_val = ENV["STARTUP_CLEANUP_GRACE_PERIOD"]
-    ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = "0"
-    example.run
-  ensure
-    ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = old_val
-  end
-
   before do
     Rails.application.load_tasks unless Rake::Task.task_defined?("dev:cleanup")
     task.reenable
 
-    # Stub docker commands by default so tests don't hit real docker
     allow(DevCleanup).to receive(:find_orphaned_containers).and_return([])
     allow(DevCleanup).to receive(:mark_service_containers_stopped)
     allow(DevCleanup).to receive(:cleanup_stale_service_containers)
   end
 
-  # The dev:cleanup rake task prints progress lines to stdout ("Resolved N
-  # stale agent run(s)", etc.) and warnings to stderr ("WARNING: Invalid
-  # STARTUP_CLEANUP_GRACE_PERIOD=..."). Swallow both so rspec output stays
-  # signal.
-  around { |example| SilenceStreams.call(:stdout, :stderr) { example.run } }
-
-  it "times out runs stuck in running" do
-    running_run = create(:agent_run, :running)
-
-    task.invoke
-
-    running_run.reload
-    expect(running_run.status).to eq("timeout")
-    expect(running_run.error_message).to include("process was restarted")
-    expect(running_run.completed_at).to be_present
+  around do |example|
+    old_kill_all = ENV.delete("STARTUP_CLEANUP_KILL_ALL")
+    SilenceStreams.call(:stdout, :stderr) { example.run }
+  ensure
+    ENV["STARTUP_CLEANUP_KILL_ALL"] = old_kill_all
   end
 
-  it "times out runs stuck in pending" do
+  it "does not touch active runs by default" do
+    running_run = create(:agent_run, :running)
     pending_run = create(:agent_run, status: "pending")
 
     task.invoke
 
-    pending_run.reload
-    expect(pending_run.status).to eq("timeout")
-    expect(pending_run.error_message).to include("process was restarted")
-  end
-
-  it "creates a system log entry on each resolved run" do
-    running_run = create(:agent_run, :running)
-
-    task.invoke
-
-    log = running_run.agent_run_logs.last
-    expect(log.log_type).to eq("system")
-    expect(log.content).to include("startup cleanup")
-  end
-
-  it "updates the associated issue paid_state to failed" do
-    running_run = create(:agent_run, :running)
-    running_run.issue.update!(paid_state: "in_progress")
-
-    task.invoke
-
-    expect(running_run.issue.reload.paid_state).to eq("failed")
+    expect(running_run.reload.status).to eq("running")
+    expect(pending_run.reload.status).to eq("pending")
   end
 
   it "does not touch finished runs" do
@@ -93,13 +53,7 @@ RSpec.describe "dev:cleanup" do
     expect(queued_run.reload.status).to eq("queued")
   end
 
-  it "triggers ProcessRunQueueJob when runs are resolved" do
-    create(:agent_run, :running)
-
-    expect { task.invoke }.to have_enqueued_job(ProcessRunQueueJob)
-  end
-
-  it "triggers ProcessRunQueueJob when queued runs exist but no stale runs" do
+  it "triggers ProcessRunQueueJob when queued runs exist" do
     create(:agent_run, :queued)
 
     expect { task.invoke }.to have_enqueued_job(ProcessRunQueueJob)
@@ -109,179 +63,108 @@ RSpec.describe "dev:cleanup" do
     expect { task.invoke }.not_to have_enqueued_job(ProcessRunQueueJob)
   end
 
-  it "resolves multiple stale runs in a single pass" do
-    running = create(:agent_run, :running)
-    pending_run = create(:agent_run, status: "pending")
+  it "does not trigger ProcessRunQueueJob when only active (non-queued) runs exist" do
+    create(:agent_run, :running)
 
-    task.invoke
-
-    expect(running.reload.status).to eq("timeout")
-    expect(pending_run.reload.status).to eq("timeout")
+    expect { task.invoke }.not_to have_enqueued_job(ProcessRunQueueJob)
   end
 
-  it "marks service containers as stopped when grace is zero and containers were found" do
-    allow(DevCleanup).to receive(:find_orphaned_containers).and_return([ "abc123" ])
-    allow(DevCleanup).to receive(:stop_containers)
-
-    task.invoke
-
-    expect(DevCleanup).to have_received(:stop_containers).with([ "abc123" ])
-    expect(DevCleanup).to have_received(:mark_service_containers_stopped)
-  end
-
-  it "does not mark service containers as stopped when no orphaned containers exist" do
-    task.invoke
-
-    expect(DevCleanup).not_to have_received(:mark_service_containers_stopped)
-  end
-
-  it "stops orphaned agent containers" do
-    allow(DevCleanup).to receive(:find_orphaned_containers).and_return([ "abc123" ])
-    allow(DevCleanup).to receive(:stop_containers)
-
-    task.invoke
-
-    expect(DevCleanup).to have_received(:stop_containers).with([ "abc123" ])
-  end
-
-  it "does not call docker stop when no orphaned containers exist" do
-    allow(DevCleanup).to receive(:stop_containers)
-
-    task.invoke
-
-    expect(DevCleanup).not_to have_received(:stop_containers)
-  end
-
-  context "with STARTUP_CLEANUP_GRACE_PERIOD set" do
+  context "with STARTUP_CLEANUP_KILL_ALL=1" do
     around do |example|
-      old_val = ENV["STARTUP_CLEANUP_GRACE_PERIOD"]
-      ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = "1800"
+      old_val = ENV["STARTUP_CLEANUP_KILL_ALL"]
+      ENV["STARTUP_CLEANUP_KILL_ALL"] = "1"
       example.run
     ensure
-      ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = old_val
+      ENV["STARTUP_CLEANUP_KILL_ALL"] = old_val
     end
 
-    it "skips runs updated within the grace period" do
-      recent_run = create(:agent_run, :running, updated_at: 10.minutes.ago)
+    it "times out runs stuck in running" do
+      running_run = create(:agent_run, :running)
 
       task.invoke
 
-      expect(recent_run.reload.status).to eq("running")
+      running_run.reload
+      expect(running_run.status).to eq("timeout")
+      expect(running_run.error_message).to include("process was restarted")
+      expect(running_run.completed_at).to be_present
     end
 
-    it "times out runs older than the grace period" do
-      old_run = create(:agent_run, :running, updated_at: 60.minutes.ago)
+    it "times out runs stuck in pending" do
+      pending_run = create(:agent_run, status: "pending")
 
       task.invoke
 
-      expect(old_run.reload.status).to eq("timeout")
+      pending_run.reload
+      expect(pending_run.status).to eq("timeout")
+      expect(pending_run.error_message).to include("process was restarted")
     end
 
-    it "only stops containers belonging to stale runs" do
-      old_run = create(:agent_run, :running, updated_at: 60.minutes.ago, container_id: "stale-container")
-      create(:agent_run, :running, updated_at: 10.minutes.ago, container_id: "recent-container")
+    it "creates a system log entry on each resolved run" do
+      running_run = create(:agent_run, :running)
+
+      task.invoke
+
+      log = running_run.agent_run_logs.last
+      expect(log.log_type).to eq("system")
+      expect(log.content).to include("startup cleanup")
+    end
+
+    it "updates the associated issue paid_state to failed" do
+      running_run = create(:agent_run, :running)
+      running_run.issue.update!(paid_state: "in_progress")
+
+      task.invoke
+
+      expect(running_run.issue.reload.paid_state).to eq("failed")
+    end
+
+    it "resolves multiple stale runs in a single pass" do
+      running = create(:agent_run, :running)
+      pending_run = create(:agent_run, status: "pending")
+
+      task.invoke
+
+      expect(running.reload.status).to eq("timeout")
+      expect(pending_run.reload.status).to eq("timeout")
+    end
+
+    it "triggers ProcessRunQueueJob when runs are resolved" do
+      create(:agent_run, :running)
+
+      expect { task.invoke }.to have_enqueued_job(ProcessRunQueueJob)
+    end
+
+    it "marks service containers as stopped when orphaned containers were found" do
+      allow(DevCleanup).to receive(:find_orphaned_containers).and_return([ "abc123" ])
       allow(DevCleanup).to receive(:stop_containers)
 
       task.invoke
 
-      expect(old_run.reload.status).to eq("timeout")
-      expect(DevCleanup).to have_received(:stop_containers).with([ "stale-container" ])
+      expect(DevCleanup).to have_received(:stop_containers).with([ "abc123" ])
+      expect(DevCleanup).to have_received(:mark_service_containers_stopped)
     end
 
-    it "does not stop containers when only recent runs exist" do
-      create(:agent_run, :running, updated_at: 10.minutes.ago, container_id: "recent-container")
+    it "does not mark service containers as stopped when no orphaned containers exist" do
+      task.invoke
+
+      expect(DevCleanup).not_to have_received(:mark_service_containers_stopped)
+    end
+
+    it "stops orphaned agent containers" do
+      allow(DevCleanup).to receive(:find_orphaned_containers).and_return([ "abc123" ])
+      allow(DevCleanup).to receive(:stop_containers)
+
+      task.invoke
+
+      expect(DevCleanup).to have_received(:stop_containers).with([ "abc123" ])
+    end
+
+    it "does not call docker stop when no orphaned containers exist" do
       allow(DevCleanup).to receive(:stop_containers)
 
       task.invoke
 
       expect(DevCleanup).not_to have_received(:stop_containers)
-    end
-
-    it "does not scan for all labeled containers" do
-      create(:agent_run, :running, updated_at: 60.minutes.ago)
-
-      task.invoke
-
-      expect(DevCleanup).not_to have_received(:find_orphaned_containers)
-    end
-
-    it "cleans up stale service containers via provisioner" do
-      create(:agent_run, :running, updated_at: 60.minutes.ago)
-
-      task.invoke
-
-      expect(DevCleanup).to have_received(:cleanup_stale_service_containers)
-    end
-
-    it "deduplicates container IDs before stopping" do
-      create(:agent_run, :running, updated_at: 60.minutes.ago, container_id: "same-container")
-      create(:agent_run, :running, updated_at: 60.minutes.ago, container_id: "same-container")
-      allow(DevCleanup).to receive(:stop_containers)
-
-      task.invoke
-
-      expect(DevCleanup).to have_received(:stop_containers).with([ "same-container" ])
-    end
-  end
-
-  context "with invalid STARTUP_CLEANUP_GRACE_PERIOD" do
-    around do |example|
-      old_val = ENV["STARTUP_CLEANUP_GRACE_PERIOD"]
-      ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = "not_a_number"
-      example.run
-    ensure
-      ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = old_val
-    end
-
-    it "falls back to zero and times out all active runs" do
-      running_run = create(:agent_run, :running)
-
-      task.invoke
-
-      expect(running_run.reload.status).to eq("timeout")
-    end
-  end
-
-  context "with negative STARTUP_CLEANUP_GRACE_PERIOD" do
-    around do |example|
-      old_val = ENV["STARTUP_CLEANUP_GRACE_PERIOD"]
-      ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = "-300"
-      example.run
-    ensure
-      ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = old_val
-    end
-
-    it "clamps to zero and times out all active runs" do
-      running_run = create(:agent_run, :running)
-
-      task.invoke
-
-      expect(running_run.reload.status).to eq("timeout")
-    end
-  end
-
-  context "with default STARTUP_CLEANUP_GRACE_PERIOD (unset)" do
-    around do |example|
-      old_val = ENV.delete("STARTUP_CLEANUP_GRACE_PERIOD")
-      example.run
-    ensure
-      ENV["STARTUP_CLEANUP_GRACE_PERIOD"] = old_val
-    end
-
-    it "preserves recent runs for Temporal recovery" do
-      recent_run = create(:agent_run, :running, updated_at: 1.minute.ago)
-
-      task.invoke
-
-      expect(recent_run.reload.status).to eq("running")
-    end
-
-    it "times out runs older than the default grace period" do
-      old_run = create(:agent_run, :running, updated_at: 10.minutes.ago)
-
-      task.invoke
-
-      expect(old_run.reload.status).to eq("timeout")
     end
   end
 end

--- a/spec/tasks/dev_rake_spec.rb
+++ b/spec/tasks/dev_rake_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "dev:cleanup" do
 
     allow(DevCleanup).to receive(:find_orphaned_containers).and_return([])
     allow(DevCleanup).to receive(:mark_service_containers_stopped)
-    allow(DevCleanup).to receive(:cleanup_stale_service_containers)
   end
 
   around do |example|
@@ -128,10 +127,17 @@ RSpec.describe "dev:cleanup" do
       expect(pending_run.reload.status).to eq("timeout")
     end
 
-    it "triggers ProcessRunQueueJob when runs are resolved" do
+    it "triggers ProcessRunQueueJob when queued runs exist alongside resolved runs" do
       create(:agent_run, :running)
+      create(:agent_run, :queued)
 
       expect { task.invoke }.to have_enqueued_job(ProcessRunQueueJob)
+    end
+
+    it "does not trigger ProcessRunQueueJob when only active runs are resolved" do
+      create(:agent_run, :running)
+
+      expect { task.invoke }.not_to have_enqueued_job(ProcessRunQueueJob)
     end
 
     it "marks service containers as stopped when orphaned containers were found" do


### PR DESCRIPTION
## Summary

- Removes stale run detection from the `dev:cleanup` rake task (called by `bin/dev` via `bin/setup`). The old code used `updated_at` with a 5-minute grace period, which falsely timed out healthy runs since `updated_at` is only written at run start/end, not mid-run.
- The startup cleanup now only processes stranded queued runs (which have no cron schedule). `STARTUP_CLEANUP_KILL_ALL=1` remains for explicit force-kill of all active runs + orphaned containers.
- Stale run detection is fully handled by `StaleRunDetectorJob` (cron every 5 min, uses `started_at` with 70-min threshold) and `DockerOrphanCleanupJob` (cron every 5 min).

## Data that motivated this change

From the test@example.com account (7,151 finished runs):
- **P75 completed run duration**: 14.6 min — well beyond the 5-min grace
- **P90 completed run duration**: 25.5 min
- **Zero mid-run `updated_at` writes** — `updated_at` stays frozen at `started_at` until completion
- All 5 currently active runs had `updated_at` = `started_at` (no mid-run updates)

## Test plan

- [x] `spec/tasks/dev_rake_spec.rb` — rewritten for new behavior (16 tests, all pass)
- [x] `spec/lib/dev_update_spec.rb` — updated `KILL_ALL` forwarding tests (13 tests, all pass)
- [x] `spec/temporal/activities/run_agent_activity_spec.rb` — stale cleanup error prefix tests still pass
- [x] Lint passes