### PR TITLE
chore(deps): change Dependabot schedule from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     assignees:
       - "viamin"
@@ -29,7 +29,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     assignees:
       - "viamin"
@@ -55,7 +55,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     assignees:
       - "viamin"
@@ -69,7 +69,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     assignees:
       - "viamin"
@@ -83,7 +83,7 @@ updates:
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     assignees:
       - "viamin"


### PR DESCRIPTION
## Summary
- Update all Dependabot ecosystems (bundler, npm, github-actions, docker, devcontainers) to check for dependency updates daily instead of weekly for faster security patches and version updates.