### PR TITLE
fix(release): preserve conventional PR titles

### DIFF
--- a/app/services/conventional_commit_title.rb
+++ b/app/services/conventional_commit_title.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ConventionalCommitTitle
+  CONVENTIONAL_PATTERN = /\A(?<type>feat|fix|perf|docs|refactor|ci|build|test|chore)(?<rest>(?:\([^)]+\))?!?: .+)\z/i
+
+  class << self
+    def normalize(title)
+      match = title.to_s.strip.match(CONVENTIONAL_PATTERN)
+      return nil unless match
+
+      "#{match[:type].downcase}#{match[:rest]}"
+    end
+  end
+end

--- a/app/temporal/activities/create_aggregated_pull_request_activity.rb
+++ b/app/temporal/activities/create_aggregated_pull_request_activity.rb
@@ -86,6 +86,9 @@ module Activities
 
     def pr_title(parent_issue)
       if parent_issue
+        conventional_title = ConventionalCommitTitle.normalize(parent_issue.title)
+        return conventional_title.truncate(255) if conventional_title
+
         "Feature ##{parent_issue.github_number}: #{parent_issue.title}".truncate(255)
       else
         "Aggregated feature changes"

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -127,6 +127,9 @@ module Activities
     def pr_title(issue)
       return "Agent changes" unless issue
 
+      conventional_title = ConventionalCommitTitle.normalize(issue.title)
+      return conventional_title.truncate(255) if conventional_title
+
       "Fix ##{issue.github_number}: #{issue.title}".truncate(255)
     end
 

--- a/spec/services/conventional_commit_title_spec.rb
+++ b/spec/services/conventional_commit_title_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConventionalCommitTitle do
+  describe ".normalize" do
+    it "returns a normalized conventional commit title" do
+      expect(described_class.normalize("Feat(quality): Pause low-quality automation"))
+        .to eq("feat(quality): Pause low-quality automation")
+    end
+
+    it "supports breaking-change markers" do
+      expect(described_class.normalize("feat!: Replace automation policy"))
+        .to eq("feat!: Replace automation policy")
+    end
+
+    it "strips surrounding whitespace" do
+      expect(described_class.normalize("  fix(agent-runs): Resume stalled runs  "))
+        .to eq("fix(agent-runs): Resume stalled runs")
+    end
+
+    it "rejects titles that only contain a conventional commit inside non-conventional text" do
+      expect(described_class.normalize("Fix #714: feat(quality): Pause low-quality automation")).to be_nil
+    end
+
+    it "rejects ordinary issue titles" do
+      expect(described_class.normalize("Add queue monitoring dashboard")).to be_nil
+    end
+  end
+end

--- a/spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb
@@ -77,6 +77,17 @@ RSpec.describe Activities::CreateAggregatedPullRequestActivity do
       )
     end
 
+    it "preserves conventional commit parent issue titles in the PR title" do
+      parent_issue = create(:issue, project: project, github_number: 99, title: "feat(scaling): worker pool tuning")
+
+      activity.execute(base_input.merge(parent_issue_id: parent_issue.id))
+
+      expect(client).to have_received(:create_pull_request).with(
+        anything,
+        hash_including(title: "feat(scaling): worker pool tuning")
+      )
+    end
+
     it "uses generic title when no parent issue" do
       activity.execute(base_input)
 

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe Activities::CreatePullRequestActivity do
       expect(result[:pull_request_number]).to eq(42)
     end
 
+    it "preserves conventional commit issue titles in the PR title" do
+      issue.update!(title: "feat(quality): automatic pause on quality threshold breach")
+
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(github_client).to have_received(:create_pull_request).with(
+        anything,
+        hash_including(title: "feat(quality): automatic pause on quality threshold breach")
+      )
+    end
+
+    it "normalizes the conventional commit type to lowercase in PR titles" do
+      issue.update!(title: "Feat(quality): automatic pause on quality threshold breach")
+
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(github_client).to have_received(:create_pull_request).with(
+        anything,
+        hash_including(title: "feat(quality): automatic pause on quality threshold breach")
+      )
+    end
+
     it "checks for an existing PR before creating a new one" do
       activity.execute(agent_run_id: agent_run.id)
 


### PR DESCRIPTION
## Summary

- Preserve issue titles that already start with a Conventional Commit type when creating Paid-generated PRs
- Apply the same title preservation to aggregated feature PRs
- Add regression coverage for conventional title normalization and PR title generation

## Verification

- `COVERAGE=false bin/rspec spec/services/conventional_commit_title_spec.rb spec/temporal/activities/create_pull_request_activity_spec.rb spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb`
- `bin/rubocop app/services/conventional_commit_title.rb app/temporal/activities/create_pull_request_activity.rb app/temporal/activities/create_aggregated_pull_request_activity.rb spec/services/conventional_commit_title_spec.rb spec/temporal/activities/create_pull_request_activity_spec.rb spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb`
- `git diff --check`