### PR TITLE
fix(agent-runs): strip Claude CLI JSON envelope from agent summary

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -879,11 +879,13 @@ class AgentRun < ApplicationRecord
   end
 
   # Returns the agent's stdout output joined as a single string.
+  # Strips the raw JSON envelope when stdout is a Claude CLI --output-format json
+  # response, extracting just the assistant's result text.
   #
   # @param limit [Integer] Max number of log entries to fetch (default 500)
   # @return [String] The agent summary text (may be empty)
   def agent_summary(limit: 500)
-    logs_text(log_type: "stdout", limit: limit)
+    extract_text_from_stdout(logs_text(log_type: "stdout", limit: limit))
   end
 
   # Returns the agent's output, preferring stdout but falling back to stderr.
@@ -892,7 +894,7 @@ class AgentRun < ApplicationRecord
   # @param limit [Integer] Max number of log entries to fetch (default 500)
   # @return [String] The best available agent output (may be empty)
   def agent_summary_with_stderr_fallback(limit: 500)
-    summary = logs_text(log_type: "stdout", limit: limit)
+    summary = extract_text_from_stdout(logs_text(log_type: "stdout", limit: limit))
     return summary if summary.present?
 
     logs_text(log_type: "stderr", limit: limit)
@@ -1094,6 +1096,19 @@ class AgentRun < ApplicationRecord
 
     if expected_draft_review_count.blank?
       errors.add(:expected_draft_review_count, "is required when counting toward draft review rounds")
+    end
+  end
+
+  def extract_text_from_stdout(raw_stdout)
+    return raw_stdout if raw_stdout.blank?
+
+    parsed = AgentHarness::Providers::Anthropic.parse_cli_json_envelope(raw_stdout)
+    return raw_stdout unless parsed
+
+    if parsed[:error].present?
+      "Agent encountered an error: #{parsed[:error]}"
+    else
+      parsed[:output].presence || raw_stdout
     end
   end
 

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2083,6 +2083,79 @@ RSpec.describe AgentRun do
     end
   end
 
+  describe "#agent_summary JSON envelope stripping" do
+    let(:agent_run) { create(:agent_run) }
+
+    it "extracts result text from a Claude CLI JSON envelope" do
+      envelope = {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "All done. Here's a summary:\n\n- Fixed the bug\n- Added tests",
+        duration_ms: 5000,
+        session_id: "abc-123",
+        total_cost_usd: 0.05,
+        usage: { input_tokens: 100, output_tokens: 50 }
+      }.to_json
+
+      agent_run.log!("stdout", envelope)
+
+      expect(agent_run.agent_summary).to eq("All done. Here's a summary:\n\n- Fixed the bug\n- Added tests")
+    end
+
+    it "returns raw stdout when it is not a JSON envelope" do
+      agent_run.log!("stdout", "Just some plain text output")
+
+      expect(agent_run.agent_summary).to eq("Just some plain text output")
+    end
+
+    it "returns raw stdout when JSON is not a CLI envelope" do
+      agent_run.log!("stdout", '{"some": "other", "json": true}')
+
+      expect(agent_run.agent_summary).to eq('{"some": "other", "json": true}')
+    end
+
+    it "returns raw stdout when envelope result is empty" do
+      agent_run.log!("stdout", '{"type":"result","result":"","is_error":false}')
+
+      expect(agent_run.agent_summary).to eq('{"type":"result","result":"","is_error":false}')
+    end
+
+    it "surfaces classified error message for is_error envelopes" do
+      envelope = {
+        type: "result",
+        result: "Rate limit exceeded: too many requests",
+        is_error: true
+      }.to_json
+
+      agent_run.log!("stdout", envelope)
+
+      expect(agent_run.agent_summary).to eq("Agent encountered an error: Rate limit exceeded")
+    end
+
+    it "handles multi-chunk stdout that forms a complete JSON envelope" do
+      part1 = '{"type":"result","result":"Done","is_error":false'
+      part2 = ',"session_id":"abc"}'
+
+      agent_run.log!("stdout", part1)
+      agent_run.log!("stdout", part2)
+
+      expect(agent_run.agent_summary).to eq("Done")
+    end
+
+    it "strips envelope in agent_summary_with_stderr_fallback too" do
+      envelope = { type: "result", result: "Task complete", is_error: false }.to_json
+      agent_run.log!("stdout", envelope)
+      agent_run.log!("stderr", "some error output")
+
+      expect(agent_run.agent_summary_with_stderr_fallback).to eq("Task complete")
+    end
+
+    it "returns empty string when no stdout logs exist" do
+      expect(agent_run.agent_summary).to eq("")
+    end
+  end
+
   describe "#phase_summary" do
     def set_run_timestamps(agent_run, base_time)
       agent_run.update_columns(


### PR DESCRIPTION
## Summary

- Container execution captures raw Claude CLI `--output-format json` stdout verbatim into `agent_run_logs`. When `agent_summary` reads those logs for PR comments, the raw JSON envelope (with `usage`, `cost_usd`, `session_id`, `modelUsage`, etc.) was posted as-is instead of the assistant's result text.
- Adds `extract_text_from_stdout` to `AgentRun` that calls `AgentHarness::Providers::Anthropic.parse_cli_json_envelope` to extract just the `result` text from JSON envelopes. Falls back to raw text for non-JSON/non-envelope output. Error envelopes surface the classified error message.

This is the Paid-side fix for the issue agent-harness [PR #120](https://github.com/viamin/agent-harness/pull/120) addressed in the provider — that PR added the parsing method, but Paid never called it from the container execution path.