### PR TITLE
fix(agent-runs): push rebase-only PR followups

### DIFF
--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -594,6 +594,11 @@ module Containers
       true
     end
 
+    def head_differs_from_remote_branch?(branch)
+      fetch_branch(branch)
+      head_sha != remote_branch_sha(branch)
+    end
+
     # Force-pushes the current branch using --force-with-lease.
     #
     # Used after a successful rebase when the remote branch already exists

--- a/app/temporal/activities/rebase_branch_activity.rb
+++ b/app/temporal/activities/rebase_branch_activity.rb
@@ -23,6 +23,7 @@ module Activities
         )
 
         rebase_succeeded = git_ops.rebase_onto(base_branch)
+        branch_changed = rebase_succeeded && git_ops.head_differs_from_remote_branch?(agent_run.branch_name)
 
         agent_run.log!("system",
           rebase_succeeded ? "Rebased onto #{base_branch}" : "Rebase onto #{base_branch} failed (conflicts)")
@@ -31,10 +32,16 @@ module Activities
           message: "agent_execution.rebase_branch",
           agent_run_id: agent_run_id,
           base_branch: base_branch,
-          rebase_succeeded: rebase_succeeded
+          rebase_succeeded: rebase_succeeded,
+          branch_changed: branch_changed
         )
 
-        { agent_run_id: agent_run_id, rebase_succeeded: rebase_succeeded, base_branch: base_branch }
+        {
+          agent_run_id: agent_run_id,
+          rebase_succeeded: rebase_succeeded,
+          base_branch: base_branch,
+          branch_changed: branch_changed
+        }
       end
     end
 

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -145,9 +145,11 @@ module Workflows
         # don't need the PR-editing prompt that instructs the agent to commit fixes.
         pr_run_without_prompt = source_pull_request_number.present? && custom_prompt.blank? && goal != "review"
         pr_prompt_result = {}
+        branch_changed_before_agent = false
         if pr_run_without_prompt
           rebase_result = run_activity(Activities::RebaseBranchActivity,
             { agent_run_id: agent_run_id }, timeout: 120)
+          branch_changed_before_agent = rebase_result[:branch_changed] == true
 
           pr_prompt_result = run_activity(Activities::PreparePrPromptActivity,
             { agent_run_id: agent_run_id,
@@ -224,7 +226,7 @@ module Workflows
           # by the agent via the GitHub API proxy during execution.
           run_activity(Activities::CompleteReviewGoalActivity,
             { agent_run_id: agent_run_id }, timeout: 30, retry_policy: NO_RETRY)
-        elsif agent_result[:has_changes]
+        elsif agent_result[:has_changes] || branch_changed_before_agent
           # Step 5: Push branch (inside container)
           # Re-check proxy health before push — the agent may have run for
           # a long time and the proxy could have gone down in the meantime.

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -1228,6 +1228,37 @@ RSpec.describe Containers::GitOperations do
     end
   end
 
+  describe "#head_differs_from_remote_branch?" do
+    it "returns true when HEAD differs from the remote branch" do
+      allow(container_service).to receive(:execute)
+        .with([ "git", "fetch", "origin", "refs/heads/feature:refs/remotes/origin/feature" ], timeout: nil, stream: false)
+        .and_return(success_result)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
+        .and_return(Containers::Provision::Result.success(stdout: "local-sha\n", stderr: "", exit_code: 0))
+      allow(container_service).to receive(:execute)
+        .with([ "git", "rev-parse", "refs/remotes/origin/feature" ], timeout: nil, stream: false)
+        .and_return(Containers::Provision::Result.success(stdout: "remote-sha\n", stderr: "", exit_code: 0))
+
+      expect(git_ops.head_differs_from_remote_branch?("feature")).to be true
+    end
+
+    it "returns false when HEAD matches the remote branch" do
+      sha = Containers::Provision::Result.success(stdout: "same-sha\n", stderr: "", exit_code: 0)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "fetch", "origin", "refs/heads/feature:refs/remotes/origin/feature" ], timeout: nil, stream: false)
+        .and_return(success_result)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
+        .and_return(sha)
+      allow(container_service).to receive(:execute)
+        .with([ "git", "rev-parse", "refs/remotes/origin/feature" ], timeout: nil, stream: false)
+        .and_return(sha)
+
+      expect(git_ops.head_differs_from_remote_branch?("feature")).to be false
+    end
+  end
+
   describe "#rebase_onto" do
     let(:fetch_result) { success_result }
     let(:shallow_true_result) { Containers::Provision::Result.success(stdout: "true\n", stderr: "", exit_code: 0) }

--- a/spec/temporal/activities/rebase_branch_activity_spec.rb
+++ b/spec/temporal/activities/rebase_branch_activity_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Activities::RebaseBranchActivity do
   end
 
   before do
-    agent_run.update!(container_id: "container-123")
+    agent_run.update!(container_id: "container-123", branch_name: "fix-branch")
 
     allow(Containers::Provision).to receive(:reconnect).and_return(container_service)
     allow(GithubClient).to receive(:new).and_return(github_client)
@@ -37,15 +37,38 @@ RSpec.describe Activities::RebaseBranchActivity do
     context "when rebase succeeds" do
       before do
         success_result = Containers::Provision::Result.success(stdout: "", stderr: "", exit_code: 0)
+        after_sha = Containers::Provision::Result.success(stdout: "after-sha\n", stderr: "", exit_code: 0)
+        remote_sha = Containers::Provision::Result.success(stdout: "remote-sha\n", stderr: "", exit_code: 0)
         allow(container_service).to receive(:execute).and_return(success_result)
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
+          .and_return(after_sha)
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rev-parse", "refs/remotes/origin/fix-branch" ], timeout: nil, stream: false)
+          .and_return(remote_sha)
       end
 
       it "returns rebase_succeeded: true" do
         result = activity.execute(agent_run_id: agent_run.id)
 
         expect(result[:rebase_succeeded]).to be true
+        expect(result[:branch_changed]).to be true
         expect(result[:base_branch]).to eq("main")
         expect(result[:agent_run_id]).to eq(agent_run.id)
+      end
+
+      it "returns branch_changed: false when HEAD is unchanged" do
+        same_sha = Containers::Provision::Result.success(stdout: "same-sha\n", stderr: "", exit_code: 0)
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
+          .and_return(same_sha)
+        allow(container_service).to receive(:execute)
+          .with([ "git", "rev-parse", "refs/remotes/origin/fix-branch" ], timeout: nil, stream: false)
+          .and_return(same_sha)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:branch_changed]).to be false
       end
 
       it "fetches the base branch from the PR" do
@@ -96,6 +119,7 @@ RSpec.describe Activities::RebaseBranchActivity do
         result = activity.execute(agent_run_id: agent_run.id)
 
         expect(result[:rebase_succeeded]).to be false
+        expect(result[:branch_changed]).to be false
         expect(result[:base_branch]).to eq("main")
       end
     end

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -594,6 +594,29 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       end
     end
 
+    def stub_rebase_only_followup
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
+        when "Activities::ProvisionServicesActivity" then {}
+        when "Activities::ProvisionContainerActivity" then {}
+        when "Activities::CheckProxyHealthActivity" then {}
+        when "Activities::CloneRepoActivity" then {}
+        when "Activities::RebaseBranchActivity" then { rebase_succeeded: true, branch_changed: true }
+        when "Activities::PreparePrPromptActivity" then { includes_review_threads: false, review_thread_ids: [] }
+        when "Activities::RunAgentActivity" then { success: true, has_changes: false }
+        when "Activities::PushBranchActivity" then {}
+        when "Activities::CompleteExistingPrRunActivity" then { pr_review_phase: "ready" }
+        when "Activities::RequestReviewActivity" then {}
+        when "Activities::DraftDecisionRecordActivity" then {}
+        when "Activities::CleanupContainerActivity" then {}
+        when "Activities::CleanupServicesActivity" then {}
+        when "Activities::CleanupWorktreeActivity" then {}
+        else {}
+        end
+      end
+    end
+
     it "requests a review-bot review even when the agent makes no changes on an existing PR" do
       stub_no_changes_followup
 
@@ -646,6 +669,25 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         .with(Activities::ResolveReviewThreadsActivity,
           { agent_run_id: 42 },
           timeout: 60)
+    end
+
+    it "pushes an automatic rebase even when the agent makes no additional changes" do
+      stub_rebase_only_followup
+
+      workflow.execute(input)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::PushBranchActivity,
+          { agent_run_id: 42 },
+          timeout: 60)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::CompleteExistingPrRunActivity,
+          { agent_run_id: 42 },
+          timeout: 60)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::MarkAgentRunCompleteActivity,
+          { agent_run_id: 42, reason: "no_changes" },
+          timeout: 30)
     end
   end
 


### PR DESCRIPTION
## Summary

- detect when an automatic existing-PR rebase leaves local HEAD ahead of the remote PR branch
- push and complete the existing-PR run when the pre-agent rebase changed the branch, even if the agent made no extra edits
- cover the rebase-only push path and remote HEAD comparison helper

## Verification

- `COVERAGE=false bin/rspec spec/temporal/activities/rebase_branch_activity_spec.rb spec/temporal/workflows/agent_execution_workflow_spec.rb spec/services/containers/git_operations_spec.rb`
- `bin/rubocop app/services/containers/git_operations.rb app/temporal/activities/rebase_branch_activity.rb app/temporal/workflows/agent_execution_workflow.rb spec/services/containers/git_operations_spec.rb spec/temporal/activities/rebase_branch_activity_spec.rb spec/temporal/workflows/agent_execution_workflow_spec.rb`