### PR TITLE
fix(github-sync): incremental watermark permanently skips issues updated at the sync boundary

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -53,7 +53,12 @@ module Activities
           project.touch_last_issue_sync_at(new_watermark)
         end
       elsif !truncated
-        project.touch_last_issue_sync_at(sync_started_at)
+        # Subtract 1 second to create an inclusive boundary: GitHub's
+        # `since` filter is strictly `updated_at > X`, so any issue whose
+        # `updated_at` equals the watermark exactly would be excluded on
+        # the next poll. The small overlap is harmless because sync_issue
+        # is idempotent (upsert by github_issue_id).
+        project.touch_last_issue_sync_at(sync_started_at - 1.second)
       end
 
       # Exclude closed issues from downstream processing (DetectLabelsActivity).

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -1009,12 +1009,12 @@ RSpec.describe Activities::FetchIssuesActivity do
         ).once
       end
 
-      it "updates last_issue_sync_at after sync" do
+      it "updates last_issue_sync_at to sync_started_at minus 1 second" do
         freeze_time do
           activity.execute(project_id: project.id)
 
           project.reload
-          expect(project.last_issue_sync_at).to be_within(1.second).of(Time.current)
+          expect(project.last_issue_sync_at).to be_within(0.1).of(Time.current - 1.second)
         end
       end
 
@@ -1130,6 +1130,39 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
     end
 
+    context "when an issue has updated_at equal to the previous watermark" do
+      let(:watermark) { 10.minutes.ago.change(usec: 0) }
+      let(:project) { create(:project, label_mappings: { "build" => "paid-build" }, last_issue_sync_at: watermark) }
+
+      let(:boundary_issue) do
+        OpenStruct.new(
+          id: 1001,
+          number: 1,
+          title: "Boundary issue",
+          body: "Body",
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-build") ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: 1.day.ago,
+          updated_at: watermark
+        )
+      end
+
+      before do
+        allow(github_client).to receive(:issues).and_return([ boundary_issue ])
+      end
+
+      it "sets the watermark to sync_started_at minus 1 second so boundary issues are re-fetched" do
+        freeze_time do
+          activity.execute(project_id: project.id)
+
+          project.reload
+          expect(project.last_issue_sync_at).to be_within(0.1).of(Time.current - 1.second)
+        end
+      end
+    end
+
     context "when project has no last_issue_sync_at (first sync)" do
       let(:project) { create(:project, label_mappings: { "build" => "paid-build" }, last_issue_sync_at: nil) }
 
@@ -1155,7 +1188,7 @@ RSpec.describe Activities::FetchIssuesActivity do
           activity.execute(project_id: project.id)
 
           project.reload
-          expect(project.last_issue_sync_at).to be_within(1.second).of(Time.current)
+          expect(project.last_issue_sync_at).to be_within(0.1).of(Time.current - 1.second)
         end
       end
     end


### PR DESCRIPTION
## Summary

fix(github-sync): incremental watermark permanently skips issues updated at the sync boundary

See #1257 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1257