### PR TITLE
fix(devcontainer): repair LLM tool setup and Codex config mounts

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -9,7 +9,6 @@ services:
 
     volumes:
     - ../../paid:/workspaces/paid:cached
-    - ${CLAUDE_AI_TOOLKIT_PATH:-../../claude-ai-toolkit}:/workspaces/claude-ai-toolkit:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/.devcontainer/configure-llm-tools.sh
+++ b/.devcontainer/configure-llm-tools.sh
@@ -6,22 +6,23 @@
 # the container may persist back to the host.
 
 set -euo pipefail
+set -x
+echo "[DEBUG] Starting configure-llm-tools.sh"
 
 echo "Configuring LLM CLI tools for devcontainer..."
 
-# Create wrapper directory for container-specific scripts
+
+echo "[DEBUG] Creating wrapper directory..."
 WRAPPER_DIR="/usr/local/bin/devcontainer-llm-wrappers"
 sudo mkdir -p "$WRAPPER_DIR"
 
-PLUGIN_DIR="/workspaces/claude-ai-toolkit"
 
 # ============================================================================
 # Claude Code
 # ============================================================================
 
-# Persist Claude state (~/.claude.json) across container rebuilds by
-# symlinking it into the bind-mounted ~/.claude/ directory.
-# This MUST happen before the VS Code extension launches Claude.
+
+echo "[DEBUG] Setting up Claude state symlink..."
 CLAUDE_STATE="$HOME/.claude.json"
 CLAUDE_STATE_PERSISTENT="$HOME/.claude/claude.json"
 
@@ -44,6 +45,8 @@ else
 fi
 
 # Resolve Claude binary location: prefer PATH, fall back to default install path
+
+echo "[DEBUG] Resolving Claude binary..."
 CLAUDE_BIN_DEFAULT="$HOME/.local/bin/claude"
 CLAUDE_BIN_RESOLVED="$(command -v claude 2>/dev/null || true)"
 
@@ -56,24 +59,15 @@ else
   CLAUDE_BIN=""
 fi
 
-# Create Claude wrapper that adds --dangerously-skip-permissions and --plugin-dir
+# Create Claude wrapper that adds --dangerously-skip-permissions
 if [ -n "$CLAUDE_BIN" ] && [ -f "$CLAUDE_BIN" ] && [ ! -f "$CLAUDE_BIN.real" ]; then
-  echo "Creating Claude wrapper..."
+  echo "[DEBUG] Creating Claude wrapper..."
   mv "$CLAUDE_BIN" "$CLAUDE_BIN.real"
-  if [ -d "$PLUGIN_DIR" ]; then
-    cat << CLAUDE_EOF > "$CLAUDE_BIN"
-#!/bin/bash
-# Claude wrapper for devcontainer - dangerous mode + plugin
-exec "$CLAUDE_BIN.real" --dangerously-skip-permissions --plugin-dir "$PLUGIN_DIR" "\$@"
-CLAUDE_EOF
-  else
-    echo "WARNING: Plugin directory $PLUGIN_DIR not found; skipping --plugin-dir flag." >&2
-    cat << CLAUDE_EOF > "$CLAUDE_BIN"
+  cat << CLAUDE_EOF > "$CLAUDE_BIN"
 #!/bin/bash
 # Claude wrapper for devcontainer - dangerous mode
 exec "$CLAUDE_BIN.real" --dangerously-skip-permissions "\$@"
 CLAUDE_EOF
-  fi
   chmod +x "$CLAUDE_BIN"
 fi
 
@@ -82,7 +76,7 @@ fi
 # ============================================================================
 
 # Create Codex wrapper that uses CLI flags for dangerous mode
-echo "Creating Codex wrapper..."
+echo "[DEBUG] Creating Codex wrapper..."
 cat << 'EOF' | sudo tee "$WRAPPER_DIR/codex" > /dev/null
 #!/bin/bash
 # Codex wrapper for devcontainer - auto-approve mode
@@ -102,7 +96,7 @@ fi
 
 # Create Aider path shim (resolves install location; does not add auto-approval flags
 # since Aider does not have a global auto-approve mode)
-echo "Creating Aider path shim..."
+echo "[DEBUG] Creating Aider path shim..."
 cat << 'EOF' | sudo tee "$WRAPPER_DIR/aider" > /dev/null
 #!/bin/bash
 # Aider path shim for devcontainer
@@ -137,7 +131,7 @@ fi
 
 # For Gemini CLI, create a container-specific settings file
 # We put it in /etc to avoid conflicts with bind-mounted ~/.config
-echo "Configuring Gemini CLI..."
+echo "[DEBUG] Configuring Gemini CLI..."
 sudo mkdir -p /etc/gemini-cli
 cat << 'EOF' | sudo tee /etc/gemini-cli/settings.json > /dev/null
 {
@@ -170,7 +164,7 @@ fi
 
 # KiloCode reads config from ~/.config/kilo/ which is NOT bind-mounted from
 # the host (only ~/.kilocode is mounted), so writing here is container-local.
-echo "Configuring KiloCode..."
+echo "[DEBUG] Configuring KiloCode..."
 mkdir -p "$HOME/.config/kilo"
 # NOTE: the schema's string shortcut `"permission": "allow"` is semantically
 # correct ("dangerously skip permissions") but triggers an upstream kilo bug
@@ -209,8 +203,11 @@ EOF
 
 # Only auth.json is bind-mounted from the host, so writing opencode.json here
 # stays container-local and won't affect the host's OpenCode installation.
-echo "Configuring OpenCode..."
+echo "[DEBUG] Configuring OpenCode..."
+# Ensure ~/.config/opencode is owned by the devcontainer user and writable
 mkdir -p "$HOME/.config/opencode"
+sudo chown -R "${DEVCONTAINER_USER:-$USER}:${DEVCONTAINER_GROUP:-$(id -gn "${DEVCONTAINER_USER:-$USER}")}" "$HOME/.config/opencode"
+sudo chmod -R u+rwX "$HOME/.config/opencode"
 cat << 'EOF' > "$HOME/.config/opencode/opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
@@ -226,13 +223,10 @@ EOF
 # Cursor: Uses ~/.cursor config (bind-mounted from host)
 
 echo ""
-echo "LLM CLI tools configured for devcontainer!"
+echo "[DEBUG] LLM CLI tools configured for devcontainer!"
 echo ""
 echo "Configured tools:"
 echo "  - Claude: Dangerous mode (--dangerously-skip-permissions)"
-if [ -d "$PLUGIN_DIR" ]; then
-  echo "            Plugin: claude-ai-toolkit loaded from $PLUGIN_DIR"
-fi
 echo "  - Codex: Auto-approve mode (approval_policy=never, sandbox=danger-full-access)"
 echo "  - Gemini CLI: Auto-accept mode (autoAccept=true)"
 echo "  - KiloCode: Auto-approve mode (permission=allow, container-specific config)"

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -748,17 +748,63 @@ module Containers
       host = codex_subscription_auth_host_mount_path
       if host.present?
         log_system("container.codex_credentials_shared", source_path: host)
+        seed_sanitized_codex_config!(source_path: host)
       else
         seed_local_credentials!(
           source_path: codex_local_config_path,
           target_path: "/home/agent/.codex",
-          files: %w[auth.json config.toml],
+          files: %w[auth.json],
           success_log_key: "container.codex_credentials_seeded",
           failure_log_key: "container.codex_credentials_seed_failed"
         )
+        seed_sanitized_codex_config!(source_path: codex_local_config_path)
       end
 
       seed_codex_notify_hook!
+    end
+
+    # Writes a minimal Codex config.toml derived from the host config but with
+    # incompatible sections stripped. The host config may contain [projects.*]
+    # map sections that newer Codex CLI versions reject ("invalid type: map,
+    # expected a sequence"). For container runs, project trust is managed by
+    # --skip-git-repo-check, so those sections are unnecessary.
+    def seed_sanitized_codex_config!(source_path:)
+      return unless source_path.present?
+
+      source_file = File.join(source_path, "config.toml")
+      return unless File.file?(source_file)
+
+      content = File.read(source_file)
+      sanitized = strip_codex_project_sections(content)
+      encoded = Base64.strict_encode64(sanitized)
+      container.exec(
+        [ "sh", "-lc", "echo #{Shellwords.escape(encoded)} | base64 -d > /home/agent/.codex/config.toml" ],
+        user: "agent"
+      )
+      log_system("container.codex_config_sanitized")
+    rescue Docker::Error::DockerError, SystemCallError => e
+      log_system("container.codex_config_sanitization_failed", error: e.message)
+    end
+
+    def strip_codex_project_sections(toml)
+      in_projects = false
+      toml.lines.reject do |line|
+        if line.match?(/\A\[projects/)
+          in_projects = true
+          next true
+        end
+
+        if in_projects
+          if line.match?(/\A\[/) && !line.match?(/\A\[projects/)
+            in_projects = false
+            next false
+          end
+
+          next true
+        end
+
+        false
+      end.join
     end
 
     # Appends the Codex notify hook to config.toml inside the container.
@@ -1431,10 +1477,7 @@ module Containers
       base = codex_subscription_auth_host_mount_path
       return [] unless base.present?
 
-      binds = [ "#{File.join(base, 'auth.json')}:/home/agent/.codex/auth.json:rw" ]
-      config_path = File.join(base, "config.toml")
-      binds << "#{config_path}:/home/agent/.codex/config.toml:ro" if File.file?(config_path)
-      binds
+      [ "#{File.join(base, 'auth.json')}:/home/agent/.codex/auth.json:rw" ]
     end
 
     def codex_auth_lock_required?(command)

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -15,6 +15,21 @@ IMAGE_NAME="${IMAGE_NAME:-paid-agent}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 FULL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
 
+DOCKER_BUILD_ENV=()
+TEMP_DOCKER_CONFIG=""
+docker_config_path="${DOCKER_CONFIG:-${HOME}/.docker}/config.json"
+
+# VS Code devcontainers inject a short-lived Docker credential helper into
+# ~/.docker/config.json. Nested docker builds can outlive that helper and then
+# fail while resolving public images with:
+#   error getting credentials - err: exit status 255
+# The agent image only pulls public images, so bypass that helper for this build.
+if [ -f "${docker_config_path}" ] && grep -q '"credsStore"[[:space:]]*:[[:space:]]*"dev-containers-' "${docker_config_path}"; then
+    TEMP_DOCKER_CONFIG="$(mktemp -d)"
+    DOCKER_BUILD_ENV=(env DOCKER_CONFIG="${TEMP_DOCKER_CONFIG}")
+    trap 'rm -rf "${TEMP_DOCKER_CONFIG}"' EXIT
+fi
+
 # Extract ruby-maat version from Gemfile.lock (single source of truth).
 # Restrict the match to the GEM section and take only the first hit to avoid
 # matching the CHECKSUMS section (which includes a sha256 suffix).
@@ -66,7 +81,7 @@ echo "  claude-cli: ${CLAUDE_INSTALL_COMMAND}"
 echo "  codex: ${CODEX_PACKAGE}"
 echo "  gemini-cli: ${GEMINI_CLI_INSTALL_COMMAND}"
 
-docker build \
+"${DOCKER_BUILD_ENV[@]}" docker build \
     -t "${FULL_IMAGE}" \
     -f "${PROJECT_ROOT}/docker/agent/Dockerfile" \
     --build-arg "RUBY_MAAT_VERSION=${RUBY_MAAT_VERSION}" \

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -883,11 +883,11 @@ RSpec.describe Containers::Provision do
         FileUtils.rm_rf(codex_config_dir)
       end
 
-      it "bind-mounts only Codex auth/config files and sets the subscription marker" do
+      it "bind-mounts only Codex auth.json and sets the subscription marker" do
         expect(Docker::Container).to receive(:create) do |config|
           binds = config["HostConfig"]["Binds"]
           expect(binds).to include("#{File.join(codex_config_dir, 'auth.json')}:/home/agent/.codex/auth.json:rw")
-          expect(binds).to include("#{File.join(codex_config_dir, 'config.toml')}:/home/agent/.codex/config.toml:ro")
+          expect(binds).not_to include("config.toml")
           env = config["Env"]
           expect(env).to include("PAID_CODEX_SUBSCRIPTION_AUTH=1")
           expect(env).to include("ANTHROPIC_BASE_URL=http://web:3000/api/proxy/anthropic")
@@ -898,15 +898,15 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "uses a shared writable Codex auth mount instead of copying credentials" do
+      it "writes a sanitized config.toml and uses a shared writable auth mount" do
         allow(agent_run).to receive(:log!).and_call_original
 
         service.provision
 
-        expect(mock_container).not_to have_received(:exec).with(
-          [ "sh", "-lc", include("/home/agent/.codex/config.toml").and(include('model_provider = "paid"')) ],
+        expect(mock_container).to have_received(:exec).with(
+          [ "sh", "-lc", include("/home/agent/.codex/config.toml") ],
           user: "agent"
-        )
+        ).at_least(:once)
         expect(agent_run).to have_received(:log!).with(
           "system",
           "container.codex_credentials_shared",
@@ -967,7 +967,7 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "copies local Codex auth files into the writable tmpfs in a single batch" do
+      it "copies local Codex auth files into the writable tmpfs" do
         service.provision
 
         expect(mock_container).to have_received(:exec).with(
@@ -976,11 +976,16 @@ RSpec.describe Containers::Provision do
         )
         expect(mock_container).to have_received(:exec).with(
           [ "sh", "-lc", satisfy { |cmd|
-            cmd.include?("/home/agent/.codex/auth.json") &&
-              cmd.include?("/home/agent/.codex/config.toml")
+            cmd.include?("/home/agent/.codex/auth.json")
           } ],
           user: "agent"
-        )
+        ).at_least(:once)
+        expect(mock_container).to have_received(:exec).with(
+          [ "sh", "-lc", satisfy { |cmd|
+            cmd.include?("/home/agent/.codex/config.toml")
+          } ],
+          user: "agent"
+        ).at_least(:once)
       end
     end
 
@@ -1961,6 +1966,50 @@ RSpec.describe Containers::Provision do
         )
         expect(result).to be_success
       end
+    end
+  end
+
+  describe "#strip_codex_project_sections" do
+    let(:service) { described_class.new(agent_run: agent_run, project: project) }
+
+    it "strips [projects.*] sections and their key-value pairs" do
+      toml = <<~TOML
+        model = "gpt-5"
+        [projects."/Users/bart/Projects/paid"]
+        trust_level = "trusted"
+        [projects."/workspaces/other"]
+        trust_level = "untrusted"
+        [notice]
+        key = "value"
+      TOML
+
+      result = service.send(:strip_codex_project_sections, toml)
+
+      expect(result).to eq("model = \"gpt-5\"\n[notice]\nkey = \"value\"\n")
+    end
+
+    it "returns content unchanged when no [projects] sections exist" do
+      toml = "model = \"gpt-5\"\n"
+
+      result = service.send(:strip_codex_project_sections, toml)
+
+      expect(result).to eq(toml)
+    end
+
+    it "handles consecutive [projects.*] sections" do
+      toml = <<~TOML
+        model = "gpt-5"
+        [projects."/a"]
+        trust_level = "trusted"
+        [projects."/b"]
+        trust_level = "trusted"
+        [features]
+        multi_agent = true
+      TOML
+
+      result = service.send(:strip_codex_project_sections, toml)
+
+      expect(result).to eq("model = \"gpt-5\"\n[features]\nmulti_agent = true\n")
     end
   end
 end


### PR DESCRIPTION
## Summary
- Remove the optional claude-ai-toolkit bind mount from the devcontainer compose setup so missing local paths do not break builds
- Make devcontainer LLM tool setup avoid the Claude plugin flag and ensure OpenCode config ownership is writable
- Avoid devcontainer Docker credential helper failures during nested agent image builds
- Seed sanitized Codex config inside agent containers while binding only writable `auth.json`

## Testing
- `COVERAGE=false bin/rspec spec/services/containers/provision_spec.rb`