### PR TITLE
fix(providers): make test agent checks handle provider output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "docker-api"
 gem "qdrant-ruby"
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-gem "agent-harness", "~> 0.7.4"
+gem "agent-harness"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 gem "ruby-maat"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    agent-harness (0.7.4)
+    agent-harness (0.9.0)
       logger (>= 1.6, < 2.0)
     ast (2.4.3)
     base64 (0.3.0)
@@ -518,7 +518,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness (~> 0.7.4)
+  agent-harness
   bootsnap
   brakeman
   bundler-audit
@@ -576,7 +576,7 @@ CHECKSUMS
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  agent-harness (0.7.4) sha256=fee1005567354ca8d8bf14d7f66067b09978edee0674ebfd66d0ebe0a2212660
+  agent-harness (0.9.0) sha256=d519927ffcba50c1abac1d16092611de8c06eceb449e047687afe86a711e29cf
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -218,9 +218,9 @@ module Providers
         )
       end
 
-      output = normalize_output_text(response[:stdout]).strip
+      output = extract_ping_output(response[:stdout])
 
-      if output == EXPECTED_OUTPUT
+      if output.include?(EXPECTED_OUTPUT)
         Result.new(success: true, error_type: nil, message: "Agent is healthy")
       else
         Result.new(
@@ -229,6 +229,77 @@ module Providers
           message: "Agent responded but output did not match expected ping"
         )
       end
+    end
+
+    # Extracts the agent text response from stdout, handling multiple output
+    # formats that providers produce:
+    #
+    # - Plain text ("PING OK") — direct match
+    # - JSON envelope (Claude --output-format=json) — extracts "result" field
+    # - JSONL (Kilocode --format json) — extracts "text" from structured events
+    # - Noisy output (OpenCode migration, tool banners) — strips known noise
+    def extract_ping_output(stdout)
+      raw = normalize_output_text(stdout).strip
+      return raw if raw == EXPECTED_OUTPUT
+
+      extract_from_json_envelope(raw) ||
+        extract_from_jsonl(raw) ||
+        strip_noise_from_output(raw)
+    end
+
+    def extract_from_json_envelope(raw)
+      parsed = JSON.parse(raw)
+      return nil unless parsed.is_a?(Hash)
+
+      result = parsed["result"]
+      result.is_a?(String) ? result.strip : nil
+    rescue JSON::ParserError
+      nil
+    end
+
+    def extract_from_jsonl(raw)
+      text_parts = []
+      raw.each_line do |line|
+        line = line.strip
+        next if line.empty?
+
+        begin
+          event = JSON.parse(line)
+          next unless event.is_a?(Hash)
+
+          text = extract_text_from_jsonl_event(event)
+          text_parts << text if text
+        rescue JSON::ParserError
+          text_parts << line
+        end
+      end
+
+      text_parts.any? ? text_parts.join.strip : nil
+    end
+
+    def extract_text_from_jsonl_event(event)
+      case event["type"]
+      when "text"
+        event.dig("part", "text") || event["text"]
+      when "result"
+        event["result"] || event.dig("part", "text") || event["text"] || event["message"]
+      end
+    end
+
+    OUTPUT_NOISE_PATTERNS = [
+      /Performing one time database migration/i,
+      /npm warn/i
+    ].freeze
+
+    def strip_noise_from_output(raw)
+      cleaned = raw.lines
+        .map(&:strip)
+        .reject(&:empty?)
+        .reject { |line| OUTPUT_NOISE_PATTERNS.any? { |p| p.match?(line) } }
+        .join(" ")
+        .strip
+
+      cleaned.presence || raw
     end
 
     def build_test_run

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -239,6 +239,16 @@ RUN useradd -m -s /bin/bash agent \
     && mkdir -p /workspace /home/agent/.config /home/agent/.local/share \
     && chown -R agent:agent /workspace /home/agent
 
+# Pre-seed the OpenCode SQLite database so the first container invocation does
+# not emit "Performing one time database migration, may take a few minutes..."
+# into stdout, which breaks the Test Agent ping response matching.
+# The opencode binary creates its DB on first run; this step discards the
+# network-dependent output and only keeps the migrated SQLite file.
+USER agent
+RUN mkdir -p /home/agent/.local/share/opencode \
+    && timeout 10s opencode run "OK" > /dev/null 2>&1 || true
+USER root
+
 # Set up working directory
 WORKDIR /workspace
 

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -78,6 +78,81 @@ RSpec.describe Providers::TestAgent do
       end
     end
 
+    context "when claude returns JSON envelope output from the container runtime path" do
+      let(:provider_record) { user.providers.find_or_create_by!(provider_key: "claude").tap { |p| p.update!(enabled_for_agent_runs: true, enabled_for_fallback: false) } }
+      let(:execution_result) do
+        Containers::Provision::Result.success(
+          stdout: JSON.generate("result" => "PING OK", "is_error" => false, "session_id" => "abc123"),
+          stderr: "",
+          exit_code: 0
+        )
+      end
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "claude")
+        stub_insert_all
+        allow(test_run).to receive(:with_container).and_yield(test_run)
+      end
+
+      it "extracts the result from the JSON envelope and returns success" do
+        result = described_class.call(provider: provider)
+
+        expect(result).to be_success
+        expect(result.message).to eq("Agent is healthy")
+      end
+    end
+
+    context "when kilocode returns JSONL output from the container runtime path" do
+      let(:provider_record) { create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+      let(:execution_result) do
+        jsonl = [
+          JSON.generate("type" => "text", "part" => { "text" => "PING OK" }),
+          JSON.generate("type" => "result", "result" => "PING OK")
+        ].join("\n")
+        Containers::Provision::Result.success(stdout: jsonl, stderr: "", exit_code: 0)
+      end
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_insert_all
+        allow(test_run).to receive(:with_container).and_yield(test_run)
+      end
+
+      it "extracts text from JSONL events and returns success" do
+        result = described_class.call(provider: provider)
+
+        expect(result).to be_success
+        expect(result.message).to eq("Agent is healthy")
+      end
+    end
+
+    context "when opencode returns migration noise with the ping response" do
+      let(:provider_record) { create(:provider, user: user, provider_key: "opencode", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+      let(:execution_result) do
+        Containers::Provision::Result.success(
+          stdout: "Performing one time database migration, may take a few minutes...\nPING OK",
+          stderr: "",
+          exit_code: 0
+        )
+      end
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "opencode")
+        stub_insert_all
+        allow(test_run).to receive(:with_container).and_yield(test_run)
+      end
+
+      it "strips the migration noise and returns success" do
+        result = described_class.call(provider: provider)
+
+        expect(result).to be_success
+        expect(result.message).to eq("Agent is healthy")
+      end
+    end
+
     context "when claude returns an auth error from the container runtime path" do
       let(:provider_record) { user.providers.find_or_create_by!(provider_key: "claude").tap { |p| p.update!(enabled_for_agent_runs: true, enabled_for_fallback: false) } }
       let(:execution_result) do


### PR DESCRIPTION
## Summary
- Update `agent-harness` to 0.9.0 for current provider behavior
- Extract `PING OK` from plain text, JSON envelopes, JSONL events, and noisy provider output
- Pre-seed OpenCode state in the agent image so first-run migration output does not mask health-check responses
- Add provider test coverage for Claude JSON, KiloCode JSONL, and OpenCode noise cases

## Testing
- `COVERAGE=false bin/rspec spec/services/providers/test_agent_spec.rb`
- `bin/rspec spec/services/providers/test_agent_spec.rb` passes examples (`42 examples, 0 failures`) but exits 2 under focused coverage threshold