### PR TITLE
fix(agent-runs): harden provider execution fallback

### DIFF
--- a/app/services/containers/heartbeat_setup.rb
+++ b/app/services/containers/heartbeat_setup.rb
@@ -23,9 +23,10 @@ module Containers
 
     # Providers that support heartbeat hooks.
     # Codex heartbeat is handled by Provision#seed_codex_notify_hook! which
-    # appends a [notify] section to the full config.toml written during
-    # container provisioning. Adding codex here would overwrite that config.
-    SUPPORTED_PROVIDERS = %w[claude].freeze
+    # appends a notify command to the full config.toml written during
+    # container provisioning. HeartbeatSetup still advertises availability so
+    # the container watchdog checks the host-visible heartbeat file.
+    SUPPORTED_PROVIDERS = %w[claude codex].freeze
 
     attr_reader :provider, :worktree_path
 
@@ -77,6 +78,7 @@ module Containers
     def preparation_file_writes
       case canonical_provider
       when "claude" then claude_file_writes
+      when "codex" then []
       else []
       end
     end

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -722,15 +722,13 @@ module Containers
     def seed_codex_config!
       content = <<~TOML
         model_provider = "paid"
+        notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]
 
         [model_providers.paid]
         name = "Paid"
         base_url = "#{proxy_base_url}/api/proxy/openai"
         env_key = "OPENAI_API_KEY"
         wire_api = "responses"
-
-        [notify]
-        command = "date +%s > /tmp/agent_heartbeat"
       TOML
 
       write_container_file("/home/agent/.codex/config.toml", content)
@@ -763,7 +761,7 @@ module Containers
       seed_codex_notify_hook!
     end
 
-    # Writes a minimal Codex config.toml derived from the host config but with
+    # Writes a Codex config.toml derived from the host config but with
     # incompatible sections stripped. The host config may contain [projects.*]
     # map sections that newer Codex CLI versions reject ("invalid type: map,
     # expected a sequence"). For container runs, project trust is managed by
@@ -776,11 +774,7 @@ module Containers
 
       content = File.read(source_file)
       sanitized = strip_codex_project_sections(content)
-      encoded = Base64.strict_encode64(sanitized)
-      container.exec(
-        [ "sh", "-lc", "echo #{Shellwords.escape(encoded)} | base64 -d > /home/agent/.codex/config.toml" ],
-        user: "agent"
-      )
+      write_container_file("/home/agent/.codex/config.toml", sanitized)
       log_system("container.codex_config_sanitized")
     rescue Docker::Error::DockerError, SystemCallError => e
       log_system("container.codex_config_sanitization_failed", error: e.message)
@@ -809,24 +803,43 @@ module Containers
 
     # Appends the Codex notify hook to config.toml inside the container.
     # For subscription auth, the base config may come from the host or local
-    # copy and won't include the heartbeat hook. This method appends the
-    # [notify] section so the watchdog receives heartbeats during Codex turns.
-    # Silently skips when config.toml is bind-mounted read-only (host mount
-    # with existing config.toml).
+    # copy and may include an older notify shape. This method rewrites the
+    # notify command idempotently so the watchdog receives heartbeats during
+    # Codex turns without leaving duplicate TOML keys.
+    # Creates config.toml when subscription auth only provided auth.json.
     def seed_codex_notify_hook!
-      notify_toml = <<~TOML
+      result = container.exec([ "sh", "-lc", codex_notify_rewrite_script ], user: "agent")
+      exit_code = result.is_a?(Array) ? result[2].to_i : 0
+      raise Docker::Error::DockerError, "config rewrite exited with #{exit_code}" unless exit_code == 0
 
-        [notify]
-        command = "date +%s > /tmp/agent_heartbeat"
-      TOML
-
-      container.exec(
-        [ "sh", "-lc", "printf '%s' #{Shellwords.escape(notify_toml)} >> /home/agent/.codex/config.toml" ],
-        user: "agent"
-      )
       log_system("container.codex_notify_hook_seeded")
     rescue Docker::Error::DockerError => e
       log_system("container.codex_notify_hook_seed_failed", error: e.message)
+    end
+
+    def codex_notify_rewrite_script
+      notify_line = 'notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]'
+      escaped_notify_line = Shellwords.escape(notify_line)
+
+      <<~SH.squish
+        config=/home/agent/.codex/config.toml;
+        touch "$config" 2>/dev/null || true;
+        tmp="$(mktemp)";
+        awk -v notify_line=#{escaped_notify_line} '
+          BEGIN { in_notify = 0 }
+          /^[[:space:]]*\\[notify\\][[:space:]]*$/ { in_notify = 1; next }
+          in_notify && /^[[:space:]]*\\[[^]]+\\][[:space:]]*$/ { in_notify = 0 }
+          in_notify { next }
+          /^[[:space:]]*notify[[:space:]]*=/ { next }
+          !inserted && /^[[:space:]]*\\[[^]]+\\][[:space:]]*$/ { print notify_line; print ""; inserted = 1 }
+          { print }
+          END { if (!inserted) { print ""; print notify_line } }
+        ' "$config" > "$tmp" &&
+        cat "$tmp" > "$config";
+        status=$?;
+        rm -f "$tmp";
+        exit "$status"
+      SH
     end
 
     # Serializes only Codex CLI executions that share a host-backed auth.json.

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -15,7 +15,6 @@ module Activities
       issue_id = input[:issue_id]
       custom_prompt = input[:custom_prompt]
       provider_id = input[:provider_id]
-      agent_type = resolve_agent_type(input[:agent_type], provider_id)
       goal = input.fetch(:goal, "create_pr")
       source_pull_request_number = input[:source_pull_request_number]
       count_toward_draft_review_round = input.fetch(:count_toward_draft_review_round, false)
@@ -131,19 +130,34 @@ module Activities
 
     def resolve_agent_type(requested_agent_type, provider_id)
       provider = Provider.find_by(id: provider_id) if provider_id.present?
-      return Provider.agent_type_for(provider.provider_key) if provider
+      return Provider.agent_type_for(provider.provider_key) if provider && provider_runnable?(provider)
 
-      requested_agent_type || "claude_code"
+      agent_type_runnable?(requested_agent_type) ? requested_agent_type : "claude_code"
     end
 
     def resolve_provider_selection(project:, requested_agent_type:, requested_provider_id:, goal:)
-      resolved_agent_type = resolve_agent_type(requested_agent_type, requested_provider_id)
-      return [ requested_provider_id, resolved_agent_type ] if requested_provider_id.present? || requested_agent_type.present?
+      requested_provider = Provider.find_by(id: requested_provider_id) if requested_provider_id.present?
+      if requested_provider && provider_runnable?(requested_provider)
+        return [ requested_provider.id, Provider.agent_type_for(requested_provider.provider_key) ]
+      end
+
+      return [ nil, requested_agent_type ] if agent_type_runnable?(requested_agent_type)
 
       provider = default_provider_for(project, goal: goal)
-      return [ nil, resolved_agent_type ] unless provider
+      return [ nil, "claude_code" ] unless provider
 
       [ provider.id, Provider.agent_type_for(provider.provider_key) ]
+    end
+
+    def provider_runnable?(provider)
+      ProviderSupport.container_executable_provider_key?(provider.provider_key)
+    end
+
+    def agent_type_runnable?(agent_type)
+      return false if agent_type.blank?
+
+      AgentRun::AGENT_TYPES.include?(agent_type) &&
+        ProviderSupport.container_executable_provider_key?(Provider.provider_key_for_agent_type(agent_type))
     end
 
     def default_provider_for(project, goal:)

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -95,20 +95,32 @@ module Activities
     def resolve_provider_selection(project:, requested_agent_type:, requested_provider_id:, goal:, agent_type_provided:, provider_id_provided:)
       if provider_id_provided || agent_type_provided
         provider = provider_for_id(requested_provider_id)
-        resolved_agent_type =
-          if provider
-            Provider.agent_type_for(provider.provider_key)
-          else
-            requested_agent_type || "claude_code"
-          end
+        return [ provider.id, Provider.agent_type_for(provider.provider_key) ] if provider && provider_runnable?(provider)
+        return [ nil, requested_agent_type ] if agent_type_runnable?(requested_agent_type)
 
-        return [ requested_provider_id, resolved_agent_type ]
+        logger.warn(
+          message: "agent_execution.requested_provider_not_runnable",
+          project_id: project.id,
+          requested_provider_id: requested_provider_id,
+          requested_agent_type: requested_agent_type
+        )
       end
 
       provider = default_provider_for(project, goal: goal)
       return [ provider&.id, Provider.agent_type_for(provider.provider_key) ] if provider
 
       [ nil, "claude_code" ]
+    end
+
+    def provider_runnable?(provider)
+      ProviderSupport.container_executable_provider_key?(provider.provider_key)
+    end
+
+    def agent_type_runnable?(agent_type)
+      return false if agent_type.blank?
+
+      AgentRun::AGENT_TYPES.include?(agent_type) &&
+        ProviderSupport.container_executable_provider_key?(Provider.provider_key_for_agent_type(agent_type))
     end
 
     def default_provider_for(project, goal:)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -457,6 +457,13 @@ module Activities
           end
       end
 
+      providers = providers.select do |provider_candidate|
+        self.class.container_executable?(provider_command_key(provider_candidate, agent_run, user_settings.user))
+      end
+      if providers.empty? && fallback_to_default_provider?(agent_run)
+        providers = default_provider_candidates(agent_run, user_settings)
+      end
+
       @rate_limit_fallbacks = load_rate_limit_fallbacks(user_settings.user)
       @inserted_rate_limit_fallbacks = Set.new
 
@@ -524,6 +531,33 @@ module Activities
     # Returns the canonical settings-level provider name for a given agent type.
     def canonical_provider(provider)
       AGENT_TYPE_TO_PROVIDER.fetch(provider, provider)
+    end
+
+    def default_provider_candidates(agent_run, user_settings)
+      candidates = [
+        user_settings.default_provider_identifier_for_goal(agent_run.goal),
+        "claude_code"
+      ].compact_blank
+
+      seen = Set.new
+      candidates.each_with_object([]) do |provider_candidate, runnable|
+        provider = provider_command_key(provider_candidate, agent_run, user_settings.user)
+        next unless self.class.container_executable?(provider)
+
+        canonical = canonical_provider(provider)
+        next if seen.include?(canonical)
+
+        seen << canonical
+        runnable << provider_candidate
+      end
+    end
+
+    def fallback_to_default_provider?(agent_run)
+      return true if agent_run.provider.present?
+
+      provider_key = Provider.provider_key_for_agent_type(agent_run.agent_type)
+      AgentRun::AGENT_TYPES.include?(agent_run.agent_type) &&
+        ProviderSupport.supported_provider_key?(provider_key)
     end
 
     def provider_state_for(user_settings, provider_state_name, provider_states)
@@ -618,7 +652,7 @@ module Activities
         container_service.execute(
           command,
           timeout: effective_timeout,
-          idle_timeout: effective_idle_timeout,
+          idle_timeout: heartbeat.available? ? effective_idle_timeout : nil,
           env: command_env,
           preparation: command_preparation,
           heartbeat_path: heartbeat.available? ? heartbeat.heartbeat_path : nil,

--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -21,11 +21,10 @@ module ProviderSupport
   }.freeze
 
   # Provider keys whose CLIs are actually installed in the agent Docker container
-  # (docker/agent/Dockerfile). Only these providers can execute in container-based
-  # runs. Currently Claude CLI, Codex CLI, Cursor agent CLI, Gemini CLI,
-  # Kilocode CLI, OpenCode CLI, GitHub Copilot CLI, and Aider CLI are installed
-  # in the container image. Update this list when new CLIs are added to the Dockerfile.
-  CONTAINER_EXECUTABLE_PROVIDER_KEYS = Set.new(%w[aider claude codex copilot cursor gemini kilocode opencode]).freeze
+  # and can execute repository-changing agent tasks. GitHub Copilot CLI is
+  # intentionally excluded: the installed github-copilot-cli only supports
+  # shell/git/gh assist subcommands, not a general agent run command.
+  CONTAINER_EXECUTABLE_PROVIDER_KEYS = Set.new(%w[aider claude codex cursor gemini kilocode opencode]).freeze
 
   module_function
 

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe ProviderSupport do
       expect(described_class::CONTAINER_EXECUTABLE_PROVIDER_KEYS).to include("opencode")
     end
 
-    it "includes copilot" do
-      expect(described_class::CONTAINER_EXECUTABLE_PROVIDER_KEYS).to include("copilot")
+    it "excludes copilot because the CLI is not an agent runner" do
+      expect(described_class::CONTAINER_EXECUTABLE_PROVIDER_KEYS).not_to include("copilot")
     end
 
     it "includes aider" do
@@ -56,9 +56,9 @@ RSpec.describe ProviderSupport do
       expect(keys).to include("opencode")
     end
 
-    it "includes copilot when backed by the agent harness registry" do
+    it "excludes copilot even when backed by the agent harness registry" do
       keys = described_class.container_executable_provider_keys
-      expect(keys).to include("copilot")
+      expect(keys).not_to include("copilot")
     end
 
     it "includes aider when backed by the agent harness registry" do
@@ -88,8 +88,8 @@ RSpec.describe ProviderSupport do
       expect(described_class.container_executable_provider_key?("opencode")).to be true
     end
 
-    it "returns true for copilot" do
-      expect(described_class.container_executable_provider_key?("copilot")).to be true
+    it "returns false for copilot" do
+      expect(described_class.container_executable_provider_key?("copilot")).to be false
     end
 
     it "returns true for aider" do

--- a/spec/services/containers/heartbeat_setup_spec.rb
+++ b/spec/services/containers/heartbeat_setup_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe Containers::HeartbeatSetup do
       expect(setup).to be_available
     end
 
-    it "returns false for codex (heartbeat handled by Provision)" do
+    it "returns true for codex with worktree" do
       setup = described_class.new(provider: "codex", worktree_path: worktree_path)
-      expect(setup).not_to be_available
+      expect(setup).to be_available
     end
 
     it "returns false for unsupported provider" do
@@ -136,7 +136,7 @@ RSpec.describe Containers::HeartbeatSetup do
     context "with codex provider" do
       let(:setup) { described_class.new(provider: "codex", worktree_path: worktree_path) }
 
-      it "returns nil (codex heartbeat handled by Provision)" do
+      it "returns nil because codex config is handled by Provision" do
         expect(setup.preparation).to be_nil
       end
     end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -271,6 +271,25 @@ RSpec.describe Containers::Provision do
         )
       end
 
+      it "seeds Codex config with the current notify command shape" do
+        service.provision
+
+        expect(mock_container).to have_received(:exec).with(
+          [
+            "sh",
+            "-lc",
+            satisfy { |cmd|
+              decoded = decoded_base64_content(cmd)
+              cmd.include?("/home/agent/.codex/config.toml") &&
+                decoded.include?('notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]') &&
+                decoded.index('notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]') < decoded.index("[model_providers.paid]") &&
+                !decoded.include?("[notify]")
+            }
+          ],
+          user: "agent"
+        )
+      end
+
       it "does not mount host subscription auth directories by default" do
         expect(Docker::Container).to receive(:create) do |config|
           binds = config["HostConfig"]["Binds"]
@@ -867,7 +886,15 @@ RSpec.describe Containers::Provision do
 
       before do
         File.write(File.join(codex_config_dir, "auth.json"), "{}")
-        File.write(File.join(codex_config_dir, "config.toml"), "model = \"gpt-5\"")
+        File.write(File.join(codex_config_dir, "config.toml"), <<~TOML)
+          model = "gpt-5"
+
+          [projects."/workspaces/paid"]
+          trust_level = "trusted"
+
+          [features]
+          multi_agent = true
+        TOML
 
         allow(ENV).to receive(:fetch).and_call_original
         allow(ENV).to receive(:[]).and_call_original
@@ -883,11 +910,11 @@ RSpec.describe Containers::Provision do
         FileUtils.rm_rf(codex_config_dir)
       end
 
-      it "bind-mounts only Codex auth.json and sets the subscription marker" do
+      it "bind-mounts only Codex auth and sets the subscription marker" do
         expect(Docker::Container).to receive(:create) do |config|
           binds = config["HostConfig"]["Binds"]
           expect(binds).to include("#{File.join(codex_config_dir, 'auth.json')}:/home/agent/.codex/auth.json:rw")
-          expect(binds).not_to include("config.toml")
+          expect(binds.none? { |bind| bind.include?("/home/agent/.codex/config.toml") }).to be true
           env = config["Env"]
           expect(env).to include("PAID_CODEX_SUBSCRIPTION_AUTH=1")
           expect(env).to include("ANTHROPIC_BASE_URL=http://web:3000/api/proxy/anthropic")
@@ -898,19 +925,60 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "writes a sanitized config.toml and uses a shared writable auth mount" do
+      it "uses a shared writable Codex auth mount instead of copying credentials" do
         allow(agent_run).to receive(:log!).and_call_original
 
         service.provision
 
-        expect(mock_container).to have_received(:exec).with(
-          [ "sh", "-lc", include("/home/agent/.codex/config.toml") ],
+        expect(mock_container).not_to have_received(:exec).with(
+          [ "sh", "-lc", include("/home/agent/.codex/config.toml").and(include('model_provider = "paid"')) ],
           user: "agent"
-        ).at_least(:once)
+        )
         expect(agent_run).to have_received(:log!).with(
           "system",
           "container.codex_credentials_shared",
           metadata: hash_including(source_path: codex_config_dir)
+        )
+      end
+
+      it "writes a sanitized host Codex config into writable tmpfs before rewriting notify" do
+        service.provision
+
+        expect(mock_container).to have_received(:exec).with(
+          [
+            "sh",
+            "-lc",
+            satisfy { |cmd|
+              decoded = decoded_base64_content(cmd)
+              cmd.include?("/home/agent/.codex/config.toml") &&
+                decoded.include?('model = "gpt-5"') &&
+                decoded.include?("[features]") &&
+                !decoded.include?("[projects")
+            }
+          ],
+          user: "agent"
+        )
+      end
+
+      it "rewrites Codex notify command using the current CLI config shape" do
+        service.provision
+
+        expect(mock_container).to have_received(:exec).with(
+          [
+            "sh",
+            "-lc",
+            satisfy { |cmd|
+              cmd.include?("/home/agent/.codex/config.toml") &&
+                cmd.include?('touch "$config"') &&
+                cmd.include?("awk") &&
+                cmd.include?("-v notify_line=") &&
+                cmd.include?("!inserted") &&
+                cmd.include?("notify[[:space:]]*=") &&
+                cmd.include?(".paid-heartbeat") &&
+                !cmd.include?("[notify]")
+            }
+          ],
+          user: "agent"
         )
       end
 
@@ -967,7 +1035,7 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "copies local Codex auth files into the writable tmpfs" do
+      it "copies local Codex auth and writes sanitized config into the writable tmpfs" do
         service.provision
 
         expect(mock_container).to have_received(:exec).with(
@@ -976,16 +1044,18 @@ RSpec.describe Containers::Provision do
         )
         expect(mock_container).to have_received(:exec).with(
           [ "sh", "-lc", satisfy { |cmd|
-            cmd.include?("/home/agent/.codex/auth.json")
+            cmd.include?("/home/agent/.codex/auth.json") &&
+              !cmd.include?("/home/agent/.codex/config.toml")
           } ],
           user: "agent"
-        ).at_least(:once)
+        )
         expect(mock_container).to have_received(:exec).with(
           [ "sh", "-lc", satisfy { |cmd|
-            cmd.include?("/home/agent/.codex/config.toml")
+            cmd.include?("/home/agent/.codex/config.toml") &&
+              decoded_base64_content(cmd).include?('model = "gpt-5"')
           } ],
           user: "agent"
-        ).at_least(:once)
+        )
       end
     end
 

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(result[:provider_attempt_count]).to eq(1)
     end
 
+    it "falls back to the runnable default when a requested agent_type is not container executable" do
+      result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "copilot")
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(project.created_by.providers.find_by!(provider_key: "claude"))
+      expect(agent_run.agent_type).to eq("claude_code")
+      expect(result[:provider_attempt_count]).to eq(1)
+    end
+
     it "derives agent_type from provider_id when only a provider is supplied" do
       provider = create(:provider, user: project.created_by, provider_key: "cursor")
 
@@ -57,6 +66,16 @@ RSpec.describe Activities::CreateAgentRunActivity do
       agent_run = AgentRun.find(result[:agent_run_id])
       expect(agent_run.provider).to eq(provider)
       expect(agent_run.agent_type).to eq("cursor")
+    end
+
+    it "falls back to the runnable default when a requested provider_id is not container executable" do
+      provider = create(:provider, user: project.created_by, provider_key: "copilot")
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id, provider_id: provider.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(project.created_by.providers.find_by!(provider_key: "claude"))
+      expect(agent_run.agent_type).to eq("claude_code")
     end
 
     it "persists the goal when provided" do

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.provider_id).to be_nil
     end
 
+    it "falls back to the runnable default when a requested agent_type is not container executable" do
+      result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "copilot")
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(user.providers.find_by!(provider_key: "claude"))
+      expect(agent_run.agent_type).to eq("claude_code")
+    end
+
     it "derives agent_type from provider_id when only a provider is supplied" do
       codex_provider = user.providers.find_or_create_by!(provider_key: "codex", auth_type: "subscription")
 
@@ -54,6 +62,16 @@ RSpec.describe Activities::QueueAgentRunActivity do
       agent_run = AgentRun.find(result[:agent_run_id])
       expect(agent_run.provider).to eq(codex_provider)
       expect(agent_run.agent_type).to eq("codex")
+    end
+
+    it "falls back to the runnable default when a requested provider_id is not container executable" do
+      copilot_provider = user.providers.find_or_create_by!(provider_key: "copilot", auth_type: "subscription")
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id, provider_id: copilot_provider.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.provider).to eq(user.providers.find_by!(provider_key: "claude"))
+      expect(agent_run.agent_type).to eq("claude_code")
     end
 
     it "uses the configured primary provider when agent type is omitted" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe Activities::RunAgentActivity do
       expect(described_class.container_executable?("opencode")).to be true
     end
 
-    it "recognizes copilot as container executable" do
-      expect(described_class.container_executable?("copilot")).to be true
+    it "does not treat copilot as container executable" do
+      expect(described_class.container_executable?("copilot")).to be false
     end
 
     it "recognizes claude_code via agent type mapping" do
@@ -241,14 +241,14 @@ RSpec.describe Activities::RunAgentActivity do
       expect(result).to eq(%w[claude_code opencode codex])
     end
 
-    it "includes copilot in fallback order when listed" do
+    it "skips copilot in fallback order because it is not an agent runner" do
       result = described_class.provider_order(
         agent_type: "claude_code",
         fallback_enabled: true,
         fallback_providers: %w[copilot codex]
       )
 
-      expect(result).to eq(%w[claude_code copilot codex])
+      expect(result).to eq(%w[claude_code codex])
     end
   end
 
@@ -416,6 +416,29 @@ RSpec.describe Activities::RunAgentActivity do
       providers = activity.send(:build_provider_order, provider_run, user.settings)
 
       expect(providers).to eq([ cursor.routing_key, aider.routing_key, claude.routing_key ])
+    end
+
+    it "filters an explicitly selected provider that is no longer container executable" do
+      copilot_provider = create(:provider, user: user, provider_key: "copilot")
+      codex_provider = create(:provider, user: user, provider_key: "codex")
+      agent_run.update!(provider: copilot_provider, agent_type: "copilot")
+      user.settings.update!(fallback_enabled: true, fallback_providers: [ codex_provider.routing_key ])
+
+      providers = activity.send(:build_provider_order, agent_run, user.settings)
+
+      expect(providers).to eq([ codex_provider.routing_key, user.providers.find_by!(provider_key: "claude").routing_key ])
+      expect(providers).not_to include(copilot_provider.routing_key)
+    end
+
+    it "falls back to a runnable default when a saved provider is no longer container executable" do
+      copilot_provider = create(:provider, user: user, provider_key: "copilot")
+      agent_run.update!(provider: copilot_provider, agent_type: "copilot")
+      user.settings.update!(fallback_enabled: false)
+
+      providers = activity.send(:build_provider_order, agent_run, user.settings)
+
+      expect(providers).to eq([ user.providers.find_by!(provider_key: "claude").routing_key ])
+      expect(providers).not_to include(copilot_provider.routing_key)
     end
   end
 
@@ -1337,6 +1360,42 @@ RSpec.describe Activities::RunAgentActivity do
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
             idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT
+          )
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "does not apply idle timeout to providers without heartbeat support" do
+        agent_run.update!(agent_type: "kilocode")
+        project.update!(max_execution_seconds: 86_400)
+        allow(container_service).to receive(:execute).and_return(exec_success)
+        allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+
+        expect(container_service).to receive(:execute).with(
+          anything,
+          hash_including(
+            timeout: AGENT_TIMEOUT_DEFAULT,
+            idle_timeout: nil,
+            heartbeat_path: nil
+          )
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "applies idle timeout and heartbeat path to codex" do
+        agent_run.update!(agent_type: "codex")
+        project.update!(max_execution_seconds: 86_400)
+        allow(container_service).to receive(:execute).and_return(exec_success)
+        allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+
+        expect(container_service).to receive(:execute).with(
+          anything,
+          hash_including(
+            timeout: AGENT_TIMEOUT_DEFAULT,
+            idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
+            heartbeat_path: File.join(agent_run.worktree_path, ".paid-heartbeat")
           )
         ).and_return(exec_success)
 


### PR DESCRIPTION
## Summary

- fix Codex config generation/rewrite so `notify` is top-level and compatible with the current CLI
- preserve sanitized Codex subscription config handling from #1316 while adding an idempotent notify rewrite
- disable idle timeouts for providers that do not have heartbeat support, keeping wall-clock timeouts intact
- exclude Copilot from container-executable providers and fall back from stale non-runnable provider selections

## Review Notes

Recent runs showed several provider failure modes:

- Codex rejected old `[notify]` table config.
- Codex subscription config could place `notify` under `[features]`, causing `invalid type: sequence, expected a boolean in features`.
- Copilot was selected for container execution even though the installed CLI is not a repo-changing agent runner.
- KiloCode-style providers could be killed by idle timeout while silently waiting on model output.

This patch keeps invalid provider config from creating doomed runs, and it gives stale saved provider selections a runtime path back to a runnable default without hiding truly unsupported agent types.

## Verification

- `git diff --check`
- `bin/rubocop app/services/containers/heartbeat_setup.rb app/services/containers/provision.rb app/temporal/activities/run_agent_activity.rb app/temporal/activities/create_agent_run_activity.rb app/temporal/activities/queue_agent_run_activity.rb lib/provider_support.rb spec/lib/provider_support_spec.rb spec/services/containers/heartbeat_setup_spec.rb spec/services/containers/provision_spec.rb spec/temporal/activities/run_agent_activity_spec.rb spec/temporal/activities/create_agent_run_activity_spec.rb spec/temporal/activities/queue_agent_run_activity_spec.rb`
- `bin/rspec spec/services/containers/heartbeat_setup_spec.rb spec/services/containers/provision_spec.rb spec/lib/provider_support_spec.rb spec/temporal/activities/run_agent_activity_spec.rb spec/temporal/activities/create_agent_run_activity_spec.rb spec/temporal/activities/queue_agent_run_activity_spec.rb` (`408 examples, 0 failures`; command exits 2 because partial-suite SimpleCov coverage is below the global 80% threshold)
