### PR TITLE
fix(auto-release): handle package names in release titles and empty check runs

### DIFF
--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -110,7 +110,7 @@ class AutoReleaseEvaluationJob < ApplicationJob
 
   def all_checks_green?(client, project, pr_data)
     checks = client.check_runs_for_ref(project.full_name, pr_data.head.sha)
-    return false if checks.nil? || checks.empty?
+    return true if checks.nil? || checks.empty?
 
     checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
   rescue GithubClient::Error => e

--- a/app/services/release_please/parse_release_pr.rb
+++ b/app/services/release_please/parse_release_pr.rb
@@ -12,7 +12,7 @@ module ReleasePlease
   # Returns a result struct with the parsed PR details and bump classification,
   # or nil if the PR is not a valid release-please PR.
   class ParseReleasePr
-    TITLE_PATTERN = /\Achore\(.+\): release (\d+\.\d+\.\d+)\z/
+    TITLE_PATTERN = /\Achore\(.+\): release (?:\S+ )?(\d+\.\d+\.\d+)\z/
     RELEASE_PLEASE_AUTHORS = %w[github-actions[bot] release-please[bot]].freeze
     AUTORELEASE_LABEL = "autorelease: pending"
 

--- a/spec/jobs/auto_release_evaluation_job_spec.rb
+++ b/spec/jobs/auto_release_evaluation_job_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe AutoReleaseEvaluationJob do
       expect(client).not_to have_received(:merge_pull_request)
     end
 
+    it "merges when no CI checks exist" do
+      allow(client).to receive(:check_runs_for_ref).and_return([])
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:merge_pull_request)
+    end
+
     it "skips when no release PR is found" do
       allow(client).to receive(:pull_requests).and_return([])
 

--- a/spec/services/release_please/parse_release_pr_spec.rb
+++ b/spec/services/release_please/parse_release_pr_spec.rb
@@ -82,6 +82,24 @@ RSpec.describe ReleasePlease::ParseReleasePr do
       expect(result.bump).to eq("minor")
     end
 
+    it "parses ruby gem release titles with package name" do
+      pr = build_pr_data(title: "chore(main): release agent-harness 0.9.1")
+      result = described_class.call(pr_data: pr, previous_version: "0.9.0")
+
+      expect(result).to be_present
+      expect(result.new_version).to eq("0.9.1")
+      expect(result.bump).to eq("patch")
+    end
+
+    it "parses scoped npm package release titles" do
+      pr = build_pr_data(title: "chore(main): release @scope/package 2.0.0")
+      result = described_class.call(pr_data: pr, previous_version: "1.5.0")
+
+      expect(result).to be_present
+      expect(result.new_version).to eq("2.0.0")
+      expect(result.bump).to eq("major")
+    end
+
     it "returns nil when versions are equal" do
       pr = build_pr_data(title: "chore(main): release 1.0.0")
       result = described_class.call(pr_data: pr, previous_version: "1.0.0")
@@ -93,6 +111,11 @@ RSpec.describe ReleasePlease::ParseReleasePr do
   describe ".release_please_pr?" do
     it "returns true for valid release-please PRs" do
       pr = build_pr_data(title: "chore(main): release 1.0.0")
+      expect(described_class.release_please_pr?(pr)).to be true
+    end
+
+    it "returns true for release-please PRs with package name" do
+      pr = build_pr_data(title: "chore(main): release agent-harness 1.0.0")
       expect(described_class.release_please_pr?(pr)).to be true
     end
 


### PR DESCRIPTION
## Summary
- Fix `TITLE_PATTERN` regex in `ReleasePlease::ParseReleasePr` to handle package names in release-please PR titles (e.g. `chore(main): release agent-harness 0.9.1`), which the `ruby` release type generates
- Fix `all_checks_green?` in `AutoReleaseEvaluationJob` to treat empty check runs as passing instead of blocking, so repos without CI configured can still auto-release

## Root Cause
Agent-harness has an open release-please PR (#142) titled `chore(main): release agent-harness 0.9.1` that Paid's auto-release never merged because:
1. The title regex `/\Achore\(.+\): release (\d+\.\d+\.\d+)\z/` didn't match titles with a package name before the version
2. The repo has no CI checks, and the code treated 0 check runs as "not green"

## Test plan
- [x] Added specs for ruby gem and scoped npm package title formats
- [x] Added spec for merging when no CI checks exist
- [x] All 40 relevant specs pass
- [x] Linting passes