### PR TITLE
fix(maintenance): StaleRunDetectorJob should handle paused runs

### DIFF
--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-# Detects agent runs stuck in "running" or "pending" status beyond
+# Detects agent runs stuck in "running", "pending", or "paused" status beyond
 # the configured timeout thresholds.
 #
 # Running runs use the full agent timeout plus a grace period.
 # Pending runs use a shorter threshold since the pending→running
 # transition (container provisioning + clone) should complete in minutes.
+# Paused runs use their own threshold so guardrail pauses do not block
+# auto-pick forever when nobody manually resumes or terminates them.
 #
-# Stale pending runs that have not exhausted their requeue budget are
+# Stale pending/paused runs that have not exhausted their requeue budget are
 # automatically requeued (reset to "queued") so transient failures
 # (e.g. worker restart, temporary resource exhaustion) self-heal.
 # Runs that exceed MAX_STALE_REQUEUES are timed out like stale running runs.
@@ -33,6 +35,10 @@ class StaleRunDetectorJob < ApplicationJob
   # (70 min) for pending runs delays detection of stuck runs unnecessarily.
   PENDING_TIMEOUT = AgentRun.stale_pending_timeout
 
+  # Paused runs need a manual decision in the happy path, but should not block
+  # PR scanning indefinitely if the pause is never acted on.
+  PAUSED_TIMEOUT = AgentRun.stale_paused_timeout
+
   # Maximum times a stale pending run can be automatically requeued before
   # being timed out. Prevents infinite retry loops when the underlying
   # issue is persistent (e.g. misconfigured project, missing credentials).
@@ -42,6 +48,7 @@ class StaleRunDetectorJob < ApplicationJob
     job_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     running_threshold = agent_timeout_with_grace.ago
     pending_threshold = PENDING_TIMEOUT.ago
+    paused_threshold = PAUSED_TIMEOUT.ago
     resolved = 0
     requeued = 0
 
@@ -57,6 +64,21 @@ class StaleRunDetectorJob < ApplicationJob
 
     stale_pending_runs(pending_threshold).find_each do |agent_run|
       case requeue_stale_pending_run(agent_run)
+      when :requeued
+        requeued += 1
+      when :exhausted
+        resolved += 1 if resolve_stale_run(agent_run)
+      end
+    rescue => e
+      Rails.logger.error(
+        message: "stale_run_detector.resolve_failed",
+        agent_run_id: agent_run.id,
+        error: e.message
+      )
+    end
+
+    stale_paused_runs(paused_threshold).find_each do |agent_run|
+      case requeue_stale_paused_run(agent_run)
       when :requeued
         requeued += 1
       when :exhausted
@@ -104,6 +126,11 @@ class StaleRunDetectorJob < ApplicationJob
     AgentRun.pending.where("updated_at < ?", threshold)
   end
 
+  # Runs stuck in "paused" whose pause timestamp is before the threshold.
+  def stale_paused_runs(threshold)
+    AgentRun.paused.where("paused_at < ?", threshold)
+  end
+
   # Attempts to requeue a stale pending run.
   # Returns :requeued if successfully requeued, :exhausted if requeue budget
   # is spent (caller should time out), or :skip if the run is no longer
@@ -115,46 +142,37 @@ class StaleRunDetectorJob < ApplicationJob
   # non-NOT_FOUND error, we skip the requeue to avoid duplicate workflows — the
   # next detector cycle will retry.
   def requeue_stale_pending_run(agent_run)
-    pending_threshold = PENDING_TIMEOUT.ago
+    requeue_stale_unfinished_run(agent_run, pending_requeue_policy)
+  end
+
+  def requeue_stale_paused_run(agent_run)
+    requeue_stale_unfinished_run(agent_run, paused_requeue_policy)
+  end
+
+  def requeue_stale_unfinished_run(agent_run, policy)
     old_container_id = nil
     old_service_container_ids = nil
-    old_workflow_id = nil
 
     agent_run.with_lock do
       agent_run.reload
       return :skip if agent_run.finished?
-      return :skip unless agent_run.status == "pending"
-      return :skip unless agent_run.updated_at < pending_threshold
+      return :skip unless agent_run.status == policy.fetch(:status)
+      return :skip unless stale_for_requeue?(agent_run, policy)
+      return :exhausted if timeout_before_requeue?(agent_run, policy)
       return :exhausted if agent_run.stale_requeue_count >= MAX_STALE_REQUEUES
 
       old_container_id = agent_run.container_id
       old_service_container_ids = agent_run.service_container_ids.dup
-      old_workflow_id = agent_run.temporal_workflow_id
 
-      # Cancel the old Temporal workflow before requeuing. If cancellation
-      # fails (non-NOT_FOUND), skip this requeue to prevent duplicate workflows.
-      #
-      # NOTE: This network call is intentionally inside with_lock. Releasing
-      # the lock first would create a window where the run is still "pending"
-      # and another detector cycle could double-requeue it. The Temporal cancel
-      # RPC is fast (sub-second) so the lock duration is bounded in practice.
-      unless cancel_temporal_workflow(agent_run, old_workflow_id)
+      unless cancel_temporal_workflow(agent_run, agent_run.temporal_workflow_id)
         return :skip
       end
 
-      agent_run.update!(
-        status: "queued",
-        stale_requeue_count: agent_run.stale_requeue_count + 1,
-        temporal_workflow_id: nil,
-        temporal_run_id: nil,
-        service_environment: nil,
-        container_id: nil,
-        service_container_ids: []
-      )
-      agent_run.log!("system", "Stale pending run requeued by stale run detector (attempt #{agent_run.stale_requeue_count}/#{MAX_STALE_REQUEUES})")
+      agent_run.update!(requeue_attributes(agent_run, policy))
+      agent_run.log!("system", stale_requeue_log(agent_run))
 
       Rails.logger.info(
-        message: "stale_run_detector.requeued_stale_pending_run",
+        message: "stale_run_detector.requeued_stale_#{agent_run.status_before_last_save}_run",
         agent_run_id: agent_run.id,
         project_id: agent_run.project_id,
         stale_requeue_count: agent_run.stale_requeue_count
@@ -164,6 +182,67 @@ class StaleRunDetectorJob < ApplicationJob
     cleanup_docker_resources_by_id(agent_run, old_container_id, old_service_container_ids)
 
     :requeued
+  end
+
+  def pending_requeue_policy
+    {
+      status: "pending",
+      stale_attribute: :updated_at,
+      threshold: PENDING_TIMEOUT.ago,
+      reset_attributes: {}
+    }
+  end
+
+  def paused_requeue_policy
+    {
+      status: "paused",
+      stale_attribute: :paused_at,
+      threshold: PAUSED_TIMEOUT.ago,
+      reset_attributes: {
+        started_at: nil,
+        completed_at: nil,
+        duration_seconds: nil,
+        paused_at: nil,
+        guardrail_violation_type: nil,
+        guardrail_context: nil
+      },
+      timeout_before_requeue: true
+    }
+  end
+
+  def stale_for_requeue?(agent_run, policy)
+    stale_at = agent_run.public_send(policy.fetch(:stale_attribute))
+    stale_at.present? && stale_at < policy.fetch(:threshold)
+  end
+
+  def timeout_before_requeue?(agent_run, policy)
+    policy[:timeout_before_requeue] && non_restartable_paused_run?(agent_run)
+  end
+
+  def non_restartable_paused_run?(agent_run)
+    guardrail_violation_type(agent_run) == "time_limit" && agent_run.iterations.to_i.zero?
+  end
+
+  def guardrail_violation_type(agent_run)
+    agent_run.guardrail_violation_type.presence ||
+      agent_run.guardrail_context&.dig("violation_type").presence
+  end
+
+  def requeue_attributes(agent_run, policy)
+    {
+      status: "queued",
+      stale_requeue_count: agent_run.stale_requeue_count + 1,
+      temporal_workflow_id: nil,
+      temporal_run_id: nil,
+      service_environment: nil,
+      container_id: nil,
+      service_container_ids: []
+    }.merge(policy.fetch(:reset_attributes))
+  end
+
+  def stale_requeue_log(agent_run)
+    previous_status = agent_run.status_before_last_save
+    "Stale #{previous_status} run requeued by stale run detector (attempt #{agent_run.stale_requeue_count}/#{MAX_STALE_REQUEUES})"
   end
 
   def resolve_stale_run(agent_run)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -16,6 +16,7 @@ class AgentRun < ApplicationRecord
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000_000
   MAX_STALE_REQUEUES = 2
   STALE_PENDING_TIMEOUT = 15.minutes
+  STALE_PAUSED_TIMEOUT = 2.hours
   STALE_RUNNING_GRACE_PERIOD = 10.minutes
 
   # Sentinel prefix written into AgentRun#error_message by `bin/rails dev:cleanup`
@@ -278,12 +279,20 @@ class AgentRun < ApplicationRecord
     STALE_PENDING_TIMEOUT
   end
 
+  def self.stale_paused_timeout
+    STALE_PAUSED_TIMEOUT
+  end
+
   def self.stale_running_cutoff(now: Time.current)
     now - stale_running_timeout
   end
 
   def self.stale_pending_cutoff(now: Time.current)
     now - stale_pending_timeout
+  end
+
+  def self.stale_paused_cutoff(now: Time.current)
+    now - stale_paused_timeout
   end
 
   # Returns true if this user is the fallback owner for orphaned

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe StaleRunDetectorJob do
   let(:running_threshold) { AGENT_TIMEOUT_DEFAULT + described_class::GRACE_PERIOD.to_i }
   # Pending runs: shorter dedicated threshold
   let(:pending_threshold) { described_class::PENDING_TIMEOUT.to_i }
+  # Paused runs: guardrail pauses should not block auto-pick indefinitely
+  let(:paused_threshold) { described_class::PAUSED_TIMEOUT.to_i }
 
   describe "#perform" do
     it "times out runs stuck in running beyond the threshold" do
@@ -320,6 +322,71 @@ RSpec.describe StaleRunDetectorJob do
         described_class.perform_now
 
         expect(stale_run.reload.status).to eq("queued")
+      end
+    end
+
+    context "with stale paused runs" do
+      it "requeues a stale paused run that has not exhausted requeue budget" do
+        stale_run = create(:agent_run, :paused, paused_at: (paused_threshold + 60).seconds.ago)
+
+        described_class.perform_now
+
+        stale_run.reload
+        expect(stale_run.status).to eq("queued")
+        expect(stale_run.stale_requeue_count).to eq(1)
+        expect(stale_run.started_at).to be_nil
+        expect(stale_run.paused_at).to be_nil
+        expect(stale_run.guardrail_violation_type).to be_nil
+        expect(stale_run.guardrail_context).to be_nil
+      end
+
+      it "does not touch paused runs within the threshold" do
+        recent_run = create(:agent_run, :paused, paused_at: (paused_threshold - 60).seconds.ago)
+
+        described_class.perform_now
+
+        expect(recent_run.reload.status).to eq("paused")
+      end
+
+      it "times out a stale paused run that has exhausted requeue budget" do
+        stale_run = create(:agent_run, :paused,
+          paused_at: (paused_threshold + 60).seconds.ago,
+          stale_requeue_count: described_class::MAX_STALE_REQUEUES)
+
+        described_class.perform_now
+
+        stale_run.reload
+        expect(stale_run.status).to eq("timeout")
+        expect(stale_run.error_message).to include("Stale run detected")
+      end
+
+      it "times out a stale time-limit paused run with zero iterations" do
+        stale_run = create(:agent_run, :paused,
+          paused_at: (paused_threshold + 60).seconds.ago,
+          guardrail_violation_type: "time_limit",
+          guardrail_context: { violation_type: "time_limit" },
+          iterations: 0)
+
+        described_class.perform_now
+
+        stale_run.reload
+        expect(stale_run.status).to eq("timeout")
+        expect(stale_run.stale_requeue_count).to eq(0)
+        expect(stale_run.error_message).to include("Stale run detected")
+      end
+
+      it "requeues a stale time-limit paused run that made progress" do
+        stale_run = create(:agent_run, :paused,
+          paused_at: (paused_threshold + 60).seconds.ago,
+          guardrail_violation_type: "time_limit",
+          guardrail_context: { violation_type: "time_limit" },
+          iterations: 1)
+
+        described_class.perform_now
+
+        stale_run.reload
+        expect(stale_run.status).to eq("queued")
+        expect(stale_run.stale_requeue_count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## Summary

fix(maintenance): StaleRunDetectorJob should handle paused runs

See #1309 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1309