### PR TITLE
fix(prompts): prepare bundled gems before review validation

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1593,6 +1593,14 @@ module Activities
         (replace `main` with the PR's actual base branch if different).
       You also have access to the GitHub API via a proxy for posting review comments.
 
+      You may run targeted validation when it is useful for review confidence.
+      Before running Ruby/Rails commands such as `bin/rspec`, run
+      `bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
+      so the fresh review checkout has the bundled gems it needs without
+      changing the lockfile. If dependency installation or test execution still
+      fails because of missing network access, services, or environment
+      constraints, mention that specific blocker in the review body.
+
       Review the code for:
       1. **Performance** — inefficient algorithms, N+1 queries, unnecessary allocations, missing caching
       2. **Security** — SQL injection, XSS, insecure deserialization, secrets in code

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1595,9 +1595,10 @@ module Activities
 
       You may run targeted validation when it is useful for review confidence.
       Before running Ruby/Rails commands such as `bin/rspec`, run
-      `bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
-      so the fresh review checkout has the bundled gems it needs without
-      changing the lockfile. If dependency installation or test execution still
+      `BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle check || BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
+      so the fresh review checkout has the bundled gems it needs in a writable
+      path outside the repository without changing the lockfile. If dependency
+      installation or test execution still
       fails because of missing network access, services, or environment
       constraints, mention that specific blocker in the review body.
 

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -586,9 +586,10 @@ upsert_global_prompt.call(
 
     You may run targeted validation when it is useful for review confidence.
     Before running Ruby/Rails commands such as `bin/rspec`, run
-    `bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
-    so the fresh review checkout has the bundled gems it needs without
-    changing the lockfile. If dependency installation or test execution still
+    `BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle check || BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
+    so the fresh review checkout has the bundled gems it needs in a writable
+    path outside the repository without changing the lockfile. If dependency
+    installation or test execution still
     fails because of missing network access, services, or environment
     constraints, mention that specific blocker in the review body.
 

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -584,6 +584,14 @@ upsert_global_prompt.call(
       (replace `main` with the PR's actual base branch if different).
     You also have access to the GitHub API via a proxy for posting review comments.
 
+    You may run targeted validation when it is useful for review confidence.
+    Before running Ruby/Rails commands such as `bin/rspec`, run
+    `bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
+    so the fresh review checkout has the bundled gems it needs without
+    changing the lockfile. If dependency installation or test execution still
+    fails because of missing network access, services, or environment
+    constraints, mention that specific blocker in the review body.
+
     Review the code for:
     1. **Performance** — inefficient algorithms, N+1 queries, unnecessary allocations, missing caching
     2. **Security** — SQL injection, XSS, insecure deserialization, secrets in code

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -112,19 +112,25 @@ RSpec.describe Prompt, type: :model do
 
     it "seeded template tells reviewers to install bundled gems before Ruby validation" do
       template = described_class.global.find_by(slug: "goal.review_pull_request").current_version.template
-      expect(template).to include("bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3")
+      expect(template).to include(
+        "BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle check || " \
+          "BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3"
+      )
       expect(template).to include("Before running Ruby/Rails commands")
-      expect(template).to match(/without\s+changing the lockfile/)
+      expect(template).to match(/writable\s+path outside the repository without changing the lockfile/)
       expect(template).to include("missing network access")
     end
 
     it "FALLBACK_REVIEW_GOAL_PROMPT tells reviewers to install bundled gems before Ruby validation" do
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
-        .to include("bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3")
+        .to include(
+          "BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle check || " \
+            "BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3"
+        )
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
         .to include("Before running Ruby/Rails commands")
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
-        .to match(/without\s+changing the lockfile/)
+        .to match(/writable\s+path outside the repository without changing the lockfile/)
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
         .to include("missing network access")
     end

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -110,6 +110,25 @@ RSpec.describe Prompt, type: :model do
         .to include('Case B: body starts with EXACTLY "Generated no new comments." and "comments" is []')
     end
 
+    it "seeded template tells reviewers to install bundled gems before Ruby validation" do
+      template = described_class.global.find_by(slug: "goal.review_pull_request").current_version.template
+      expect(template).to include("bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3")
+      expect(template).to include("Before running Ruby/Rails commands")
+      expect(template).to match(/without\s+changing the lockfile/)
+      expect(template).to include("missing network access")
+    end
+
+    it "FALLBACK_REVIEW_GOAL_PROMPT tells reviewers to install bundled gems before Ruby validation" do
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
+        .to include("bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3")
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
+        .to include("Before running Ruby/Rails commands")
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
+        .to match(/without\s+changing the lockfile/)
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
+        .to include("missing network access")
+    end
+
     # Regression for #839: review JSON posted with inline `-d '...'` breaks
     # when the body contains multiline markdown or apostrophes, producing an
     # invalid JSON payload that Rails rejects before the request reaches


### PR DESCRIPTION
## Summary
- Tell review-goal agents to run `bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3` before Ruby/Rails validation.
- Keep seeded and fallback review prompts in sync.
- Add regression coverage for the Bundler preparation and environment-blocker guidance.

## Tests
- `COVERAGE=false bin/rspec spec/db/seeds_prompts_spec.rb`
- `git diff --check`
- pre-commit hook: RuboCop, ESLint, markdownlint, ShellCheck

Related: #1324