### PR TITLE
fix(agent-runs): handle unsupported auth refresh flows

### DIFF
--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -407,10 +407,10 @@ module Projects
         return
       end
 
-      code = params[:auth_code]&.strip
-      if code.blank?
+      token = (params[:auth_token].presence || params[:auth_code])&.strip
+      if token.blank?
         redirect_to project_agent_run_path(@project, @agent_run),
-          alert: "Please provide an authentication code."
+          alert: "Please provide an authentication token."
         return
       end
 
@@ -436,7 +436,7 @@ module Projects
         return
       end
 
-      AgentHarness.refresh_auth(provider, code: code)
+      AgentHarness.refresh_auth(provider, token: token)
 
       new_run = AgentRun.create!(
         project: @project,
@@ -465,6 +465,16 @@ module Projects
       )
       redirect_to project_agent_run_path(@project, @agent_run),
         alert: "Re-authentication failed: #{e.message}"
+    rescue NotImplementedError => e
+      Rails.logger.error(
+        message: "agent_execution.refresh_auth_unavailable",
+        agent_run_id: @agent_run.id,
+        provider: @agent_run.auth_provider,
+        error_class: e.class.name,
+        error_message: e.message
+      )
+      redirect_to project_agent_run_path(@project, @agent_run),
+        alert: "Re-authentication is not supported for this provider."
     rescue ActiveRecord::RecordNotUnique => e
       alert = if (e.cause&.message || e.message).include?("proxy_token")
         "An unexpected error occurred. Please try again."

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,20 @@ module ApplicationHelper
     )
   end
 
+  def agent_harness_auth_url(provider)
+    return nil if provider.blank? || !AgentHarness.respond_to?(:auth_url)
+
+    AgentHarness.auth_url(provider.to_sym)
+  rescue NotImplementedError, AgentHarness::Error => e
+    Rails.logger.info(
+      message: "agent_execution.auth_url_unavailable",
+      provider: provider,
+      error_class: e.class.name,
+      error_message: e.message
+    )
+    nil
+  end
+
   def safe_stylesheet_link_tag(source, **options)
     safe_asset_tag { stylesheet_link_tag(source, **options) }
   end

--- a/app/views/agent_runs/_detail_actions.html.erb
+++ b/app/views/agent_runs/_detail_actions.html.erb
@@ -88,7 +88,7 @@
         </p>
         <p class="mt-2 text-sm text-amber-700">2. Paste the refreshed OAuth token below:</p>
         <%= form_with url: refresh_auth_project_agent_run_path(agent_run.project, agent_run), method: :post, class: "mt-2 flex items-center space-x-2" do |f| %>
-          <%= f.text_field :auth_token, placeholder: "Paste OAuth token here", class: "block w-full rounded-md border-amber-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500", aria: { label: "OAuth token" } %>
+          <%= f.password_field :auth_token, placeholder: "Paste OAuth token here", autocomplete: "off", spellcheck: false, class: "block w-full rounded-md border-amber-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500", aria: { label: "OAuth token" } %>
           <%= f.submit "Re-authenticate", class: "inline-flex items-center rounded-md bg-amber-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-amber-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-600 cursor-pointer" %>
         <% end %>
       </div>

--- a/app/views/agent_runs/_detail_actions.html.erb
+++ b/app/views/agent_runs/_detail_actions.html.erb
@@ -79,18 +79,24 @@
     message that the Stimulus controller reveals on status transition. %>
 <% if show_retry %>
   <% if agent_run.auth_expired? && agent_run.auth_provider.present? && AgentHarness.respond_to?(:refresh_auth) && AgentHarness.respond_to?(:auth_url) %>
-    <% auth_url = AgentHarness.auth_url(agent_run.auth_provider.to_sym) %>
+    <% auth_url = agent_harness_auth_url(agent_run.auth_provider) %>
     <% if auth_url.present? %>
       <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-4" data-when-auth-expired>
         <p class="text-sm text-amber-700">
           1. Visit the login URL to re-authenticate:
           <%= link_to auth_url, auth_url, target: "_blank", rel: "noopener noreferrer", class: "text-amber-800 underline hover:text-amber-900 break-all" %>
         </p>
-        <p class="mt-2 text-sm text-amber-700">2. Paste the auth code below:</p>
+        <p class="mt-2 text-sm text-amber-700">2. Paste the refreshed OAuth token below:</p>
         <%= form_with url: refresh_auth_project_agent_run_path(agent_run.project, agent_run), method: :post, class: "mt-2 flex items-center space-x-2" do |f| %>
-          <%= f.text_field :auth_code, placeholder: "Paste auth code here", class: "block w-full rounded-md border-amber-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500", aria: { label: "Authentication code" } %>
+          <%= f.text_field :auth_token, placeholder: "Paste OAuth token here", class: "block w-full rounded-md border-amber-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500", aria: { label: "OAuth token" } %>
           <%= f.submit "Re-authenticate", class: "inline-flex items-center rounded-md bg-amber-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-amber-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-600 cursor-pointer" %>
         <% end %>
+      </div>
+    <% else %>
+      <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-4" data-when-auth-expired>
+        <p class="text-sm text-amber-700">
+          Authentication has expired for <%= Provider.display_name(agent_run.auth_provider) %>, but Paid cannot generate a browser login URL for this provider. Refresh the configured provider credentials, then retry the run.
+        </p>
       </div>
     <% end %>
   <% else %>

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -413,6 +413,24 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("Claude Code")
       end
 
+      it "masks the auth refresh token input when a browser auth URL is available" do
+        agent_run = create(:agent_run, :auth_expired, project: project, auth_provider: "claude")
+        without_partial_double_verification do
+          allow(AgentHarness).to receive(:respond_to?).and_call_original
+          allow(AgentHarness).to receive(:respond_to?).with(:refresh_auth).and_return(true)
+          allow(AgentHarness).to receive(:respond_to?).with(:auth_url).and_return(true)
+          allow(AgentHarness).to receive(:auth_url).with(:claude).and_return("https://example.com/auth")
+        end
+
+        get project_agent_run_path(project, agent_run)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('type="password"')
+        expect(response.body).to include('name="auth_token"')
+        expect(response.body).to include('autocomplete="off"')
+        expect(response.body).to include('spellcheck="false"')
+      end
+
       it "shows auth-expired details when the provider cannot generate an auth URL" do
         agent_run = create(:agent_run, :auth_expired, project: project, agent_type: "codex", auth_provider: "codex")
         without_partial_double_verification do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -413,6 +413,24 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("Claude Code")
       end
 
+      it "shows auth-expired details when the provider cannot generate an auth URL" do
+        agent_run = create(:agent_run, :auth_expired, project: project, agent_type: "codex", auth_provider: "codex")
+        without_partial_double_verification do
+          allow(AgentHarness).to receive(:respond_to?).and_call_original
+          allow(AgentHarness).to receive(:respond_to?).with(:refresh_auth).and_return(true)
+          allow(AgentHarness).to receive(:respond_to?).with(:auth_url).and_return(true)
+          allow(AgentHarness).to receive(:auth_url)
+            .with(:codex)
+            .and_raise(NotImplementedError, "Provider codex uses api_key auth and does not support OAuth URL generation")
+        end
+
+        get project_agent_run_path(project, agent_run)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Paid cannot generate a browser login URL")
+        expect(response.body).to include("Codex")
+      end
+
       it "shows the run timeline when phase data exists" do
         agent_run = create(:agent_run, :completed, project: project)
         create(:agent_run_phase, agent_run: agent_run, phase_key: "prepare_pr_prompt", phase_group: "prompt")
@@ -1879,14 +1897,14 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("Only runs with expired authentication")
       end
 
-      it "redirects when auth code is blank" do
+      it "redirects when auth token is blank" do
         agent_run = create(:agent_run, :auth_expired, project: project)
 
         post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "  " }
 
         expect(response).to redirect_to(project_agent_run_path(project, agent_run))
         follow_redirect!
-        expect(response.body).to include("Please provide an authentication code")
+        expect(response.body).to include("Please provide an authentication token")
       end
 
       it "creates a new queued run and marks original as retried on success" do
@@ -1896,7 +1914,7 @@ RSpec.describe "AgentRuns" do
         end
 
         expect {
-          post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "valid-code" }
+          post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_token: "valid-token" }
         }.to change(AgentRun, :count).by(1)
 
         new_run = AgentRun.last
@@ -1908,7 +1926,20 @@ RSpec.describe "AgentRuns" do
         expect(agent_run.reload.status).to eq("retried")
         expect(response).to redirect_to(project_agent_run_path(project, new_run))
         without_partial_double_verification do
-          expect(AgentHarness).to have_received(:refresh_auth).with(:claude, code: "valid-code")
+          expect(AgentHarness).to have_received(:refresh_auth).with(:claude, token: "valid-token")
+        end
+      end
+
+      it "still accepts the legacy auth_code parameter as a token" do
+        agent_run = create(:agent_run, :auth_expired, project: project)
+        without_partial_double_verification do
+          allow(AgentHarness).to receive(:refresh_auth)
+        end
+
+        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "legacy-token" }
+
+        without_partial_double_verification do
+          expect(AgentHarness).to have_received(:refresh_auth).with(:claude, token: "legacy-token")
         end
       end
 
@@ -1919,14 +1950,14 @@ RSpec.describe "AgentRuns" do
         end
 
         expect {
-          post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "valid-code" }
+          post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_token: "valid-token" }
         }.to have_enqueued_job(ProcessRunQueueJob)
       end
 
       it "redirects with alert when auth_provider is missing" do
         agent_run = create(:agent_run, :auth_expired, project: project, auth_provider: nil)
 
-        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "valid-code" }
+        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_token: "valid-token" }
 
         expect(response).to redirect_to(project_agent_run_path(project, agent_run))
         follow_redirect!
@@ -1938,11 +1969,25 @@ RSpec.describe "AgentRuns" do
         allow(AgentHarness).to receive(:respond_to?).and_call_original
         allow(AgentHarness).to receive(:respond_to?).with(:refresh_auth).and_return(false)
 
-        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "valid-code" }
+        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_token: "valid-token" }
 
         expect(response).to redirect_to(project_agent_run_path(project, agent_run))
         follow_redirect!
         expect(response.body).to include("Re-authentication is not supported")
+      end
+
+      it "redirects with alert when the provider does not support refresh_auth" do
+        agent_run = create(:agent_run, :auth_expired, project: project, auth_provider: "codex")
+        without_partial_double_verification do
+          allow(AgentHarness).to receive(:refresh_auth)
+            .and_raise(NotImplementedError, "Provider codex uses api_key auth and does not support credential refresh")
+        end
+
+        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_token: "valid-token" }
+
+        expect(response).to redirect_to(project_agent_run_path(project, agent_run))
+        follow_redirect!
+        expect(response.body).to include("Re-authentication is not supported for this provider")
       end
 
       it "redirects with alert on AgentHarness::AuthenticationError" do
@@ -1952,7 +1997,7 @@ RSpec.describe "AgentRuns" do
             .and_raise(AgentHarness::AuthenticationError, "Invalid code")
         end
 
-        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "bad-code" }
+        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_token: "bad-token" }
 
         expect(response).to redirect_to(project_agent_run_path(project, agent_run))
         follow_redirect!
@@ -1967,7 +2012,7 @@ RSpec.describe "AgentRuns" do
             .and_raise(AgentHarness::Error, "Provider unavailable")
         end
 
-        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "some-code" }
+        post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_token: "some-token" }
 
         expect(response).to redirect_to(project_agent_run_path(project, agent_run))
         follow_redirect!
@@ -1983,7 +2028,7 @@ RSpec.describe "AgentRuns" do
         end
 
         expect {
-          post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_code: "valid-code" }
+          post refresh_auth_project_agent_run_path(project, agent_run), params: { auth_token: "valid-token" }
         }.to change(AgentRun, :count).by(1)
 
         new_run = AgentRun.last


### PR DESCRIPTION
## Summary

- Prevent auth-expired agent-run pages from crashing when a provider cannot generate an OAuth URL, such as Codex API-key auth.
- Show a clear auth-expired message for providers without browser login URL support.
- Align refresh-auth submissions with the agent-harness `token:` API while preserving legacy `auth_code` param compatibility.
- Handle unsupported provider refresh flows with a normal redirect alert instead of a server error.

## Testing

- `COVERAGE=false bin/rspec spec/requests/agent_runs_spec.rb:1878`
- `COVERAGE=false bin/rspec spec/requests/agent_runs_spec.rb`
- `bin/lint --changed`
- `git diff --check`

## Upstream follow-up

- viamin/agent-harness#143
- viamin/agent-harness#144