### PR TITLE
fix(css): limit Tailwind watch source scope

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import "tailwindcss" source("../..");
 
 @custom-variant dark (&:where(.dark, .dark *));
 


### PR DESCRIPTION
## Summary
- Limit Tailwind v4 automatic source detection to the Rails app tree instead of the repository root
- Prevent repo-local logs like log/development.log and log/dev-update/overmind.log from retriggering the CSS watcher

## Verification
- Observed Tailwind watcher CPU drop from about 23% to about 0.8% after applying source("../..") and restarting the CSS watcher
- Ran `yarn build:css` successfully in the PR worktree
- Pre-commit hook passed for the staged stylesheet change