### PR TITLE
test: speed up slow service specs

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -17,6 +17,10 @@ require "faraday/retry"
 class GithubClient
   DEFAULT_CHECK_RUNS_PER_PAGE = 100
   DEFAULT_CHECK_RUNS_MAX_PAGES = 10
+  RETRY_MAX = 3
+  RETRY_INTERVAL = 0.5
+  RETRY_INTERVAL_RANDOMNESS = 0.5
+  RETRY_BACKOFF_FACTOR = 2
 
   # Base error for all GitHub client errors
   class Error < StandardError; end
@@ -1124,10 +1128,10 @@ class GithubClient
   def configure_middleware
     client.middleware = Faraday::RackBuilder.new do |builder|
       builder.use Faraday::Retry::Middleware,
-        max: 3,
-        interval: 0.5,
-        interval_randomness: 0.5,
-        backoff_factor: 2,
+        max: RETRY_MAX,
+        interval: RETRY_INTERVAL,
+        interval_randomness: RETRY_INTERVAL_RANDOMNESS,
+        backoff_factor: RETRY_BACKOFF_FACTOR,
         retry_statuses: [ 429, 500, 502, 503, 504 ],
         exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS +
           [ Octokit::ServerError ],
@@ -1195,10 +1199,10 @@ class GithubClient
       f.request :json
       if with_retry
         f.request :retry,
-          max: 3,
-          interval: 0.5,
-          interval_randomness: 0.5,
-          backoff_factor: 2,
+          max: RETRY_MAX,
+          interval: RETRY_INTERVAL,
+          interval_randomness: RETRY_INTERVAL_RANDOMNESS,
+          backoff_factor: RETRY_BACKOFF_FACTOR,
           methods: %i[post],
           retry_statuses: [ 429, 500, 502, 503, 504 ],
           exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS +

--- a/app/services/prompt_evolution/sample_runs.rb
+++ b/app/services/prompt_evolution/sample_runs.rb
@@ -23,12 +23,13 @@ module PromptEvolution
     MIN_RUNS_FOR_EVALUATION = 5
     MAX_RUNS_TO_FETCH = 10_000
 
-    attr_reader :sample_size, :days, :project_id
+    attr_reader :sample_size, :days, :project_id, :random
 
-    def initialize(sample_size: DEFAULT_SAMPLE_SIZE, days: DEFAULT_DAYS, project_id: nil)
+    def initialize(sample_size: DEFAULT_SAMPLE_SIZE, days: DEFAULT_DAYS, project_id: nil, random: Random.new)
       @sample_size = sample_size
       @days = days
       @project_id = project_id
+      @random = random
     end
 
     def self.call(...)
@@ -69,21 +70,21 @@ module PromptEvolution
       end
       return AgentRun.none if grouped.empty?
 
-      strata = grouped.to_a.shuffle
+      strata = grouped.to_a.shuffle(random: random)
       base_allocation, remainder = sample_size.divmod(strata.size)
       sampled_ids = []
       leftover_ids = []
 
       strata.each_with_index do |(_key, stratum_runs), index|
         allocation = [ base_allocation + (index < remainder ? 1 : 0), 1 ].max
-        shuffled_runs = stratum_runs.shuffle
+        shuffled_runs = stratum_runs.shuffle(random: random)
 
         sampled_ids.concat(shuffled_runs.first(allocation).map(&:first))
         leftover_ids.concat(shuffled_runs.drop(allocation).map(&:first))
       end
 
       if sampled_ids.size < sample_size
-        sampled_ids.concat(leftover_ids.shuffle.first(sample_size - sampled_ids.size))
+        sampled_ids.concat(leftover_ids.shuffle(random: random).first(sample_size - sampled_ids.size))
       end
 
       AgentRun.where(id: sampled_ids.first(sample_size))

--- a/spec/lib/dev_script_spec.rb
+++ b/spec/lib/dev_script_spec.rb
@@ -22,12 +22,18 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
   # inherits the parent process env by default, so exporting here propagates
   # into each child bin/dev process.
   around do |example|
-    prior = ENV.to_h.slice("DEV_SUPERVISOR_FAST_DIAGNOSTICS", "DEV_SUPERVISOR_QUIT_GRACE_SECONDS")
+    prior = ENV.to_h.slice(
+      "DEV_SUPERVISOR_FAST_DIAGNOSTICS",
+      "DEV_SUPERVISOR_MONITOR_INTERVAL",
+      "DEV_SUPERVISOR_QUIT_GRACE_SECONDS"
+    )
     ENV["DEV_SUPERVISOR_FAST_DIAGNOSTICS"] = "1"
+    ENV["DEV_SUPERVISOR_MONITOR_INTERVAL"] = "0.01"
     ENV["DEV_SUPERVISOR_QUIT_GRACE_SECONDS"] = "0"
     example.run
   ensure
     ENV["DEV_SUPERVISOR_FAST_DIAGNOSTICS"] = prior["DEV_SUPERVISOR_FAST_DIAGNOSTICS"]
+    ENV["DEV_SUPERVISOR_MONITOR_INTERVAL"] = prior["DEV_SUPERVISOR_MONITOR_INTERVAL"]
     ENV["DEV_SUPERVISOR_QUIT_GRACE_SECONDS"] = prior["DEV_SUPERVISOR_QUIT_GRACE_SECONDS"]
   end
 
@@ -196,20 +202,20 @@ RSpec.describe "bin/dev" do # rubocop:disable RSpec/DescribeClass
 
   it "warns and exits when the overmind socket never appears after --detach" do
     Dir.mktmpdir("dev", exec_tmpdir) do |dir|
-      script_path = prepare_script_fixture(dir, overmind: { create_socket_on_start: false, start_sleep: 10 })
+      script_path = prepare_script_fixture(dir, overmind: { create_socket_on_start: false })
 
       env = {
         "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
         "SKIP_DEV_CLEANUP" => "1",
         "OVERMIND_SOCKET" => File.join(dir, ".overmind.sock"),
-        "DEV_DETACH_READY_TIMEOUT" => "2"
+        "DEV_DETACH_READY_TIMEOUT" => "0"
       }
       stdout, stderr, status = Open3.capture3(env, script_path, "--detach", chdir: dir)
       wait_for_detached_child(dir)
 
       expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
       expect(stdout).to include("Detaching bin/dev")
-      expect(stderr).to include("overmind socket did not appear within 2s")
+      expect(stderr).to include("overmind socket did not appear within 0s")
     end
   end
 

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe GithubClient do
   let(:client) { described_class.new(token: token) }
   let(:api_base) { "https://api.github.com" }
 
+  before do
+    stub_const("GithubClient::RETRY_INTERVAL", 0)
+    stub_const("GithubClient::RETRY_INTERVAL_RANDOMNESS", 0)
+    stub_const("GithubClient::RETRY_BACKOFF_FACTOR", 1)
+  end
+
   describe "#validate_token" do
     context "when token is valid" do
       before do

--- a/spec/services/prompt_evolution/sample_runs_spec.rb
+++ b/spec/services/prompt_evolution/sample_runs_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "set"
 
 RSpec.describe PromptEvolution::SampleRuns do
   let(:project) { create(:project) }
@@ -9,7 +8,20 @@ RSpec.describe PromptEvolution::SampleRuns do
   let(:prompt_version) { prompt.current_version }
 
   def create_completed_run(composite_score: 0.85, **attrs)
-    run_attrs = {
+    run = insert_completed_run(**attrs)
+    insert_quality_metric(run: run, composite_score: composite_score)
+    run
+  end
+
+  def insert_completed_run(**attrs)
+    run_attrs = default_run_attrs.merge(attrs)
+    run_attrs[:source_pull_request_number] = 1 if run_attrs[:goal] == "review"
+
+    AgentRun.find(AgentRun.insert_all!([ agent_run_row(run_attrs) ], returning: %w[id]).rows.first.first)
+  end
+
+  def default_run_attrs
+    {
       project: project,
       prompt_version: prompt_version,
       goal: "create_pr",
@@ -18,12 +30,48 @@ RSpec.describe PromptEvolution::SampleRuns do
       tokens_output: 500,
       duration_seconds: 120,
       completed_at: 1.day.ago
-    }.merge(attrs)
-    run_attrs[:source_pull_request_number] = 1 if run_attrs[:goal] == "review"
-    run = create(:agent_run, :completed, run_attrs)
-    create(:quality_metric, :automated, agent_run: run, prompt_version: prompt_version,
-      composite_score: composite_score)
-    run
+    }
+  end
+
+  def agent_run_row(attrs)
+    now = Time.current
+    {
+      agent_type: "claude_code",
+      custom_prompt: "Sample run",
+      project_id: attrs[:project].id,
+      prompt_version_id: attrs[:prompt_version]&.id,
+      source_pull_request_number: attrs[:source_pull_request_number],
+      status: "completed",
+      goal: attrs[:goal],
+      trigger_type: "automatic",
+      proxy_token: SecureRandom.hex(32),
+      cost_cents: attrs[:cost_cents],
+      tokens_input: attrs[:tokens_input],
+      tokens_output: attrs[:tokens_output],
+      duration_seconds: attrs[:duration_seconds],
+      started_at: attrs[:completed_at] - attrs[:duration_seconds].seconds,
+      completed_at: attrs[:completed_at],
+      result_commit_sha: "abc123def456789012345678901234567890abcd",
+      pull_request_url: "https://github.com/example/repo/pull/1",
+      pull_request_number: 1,
+      created_at: now,
+      updated_at: now
+    }
+  end
+
+  def insert_quality_metric(run:, composite_score:, metric_type: "automated", version: prompt_version)
+    now = Time.current
+    QualityMetric.insert_all!([
+      {
+        agent_run_id: run.id,
+        prompt_version_id: version&.id,
+        metric_type: metric_type,
+        feedback_source: metric_type == "human" ? "pr_merge" : "system",
+        composite_score: composite_score,
+        created_at: now,
+        updated_at: now
+      }
+    ])
   end
 
   describe ".call" do
@@ -47,7 +95,7 @@ RSpec.describe PromptEvolution::SampleRuns do
     end
 
     it "excludes runs without prompt versions" do
-      create(:agent_run, :completed, project: project, prompt_version: nil, completed_at: 1.day.ago)
+      insert_completed_run(prompt_version: nil, completed_at: 1.day.ago)
 
       result = described_class.call(sample_size: 10, days: 7)
 
@@ -55,9 +103,8 @@ RSpec.describe PromptEvolution::SampleRuns do
     end
 
     it "excludes runs with only human metrics" do
-      run = create(:agent_run, :completed, project: project, prompt_version: prompt_version,
-        completed_at: 1.day.ago)
-      create(:quality_metric, :human, agent_run: run, prompt_version: prompt_version)
+      run = insert_completed_run(project: project, prompt_version: prompt_version, completed_at: 1.day.ago)
+      insert_quality_metric(run: run, metric_type: "human", composite_score: 1.0)
 
       result = described_class.call(sample_size: 10, days: 7)
 
@@ -66,10 +113,8 @@ RSpec.describe PromptEvolution::SampleRuns do
     end
 
     it "excludes runs with nil automated composite scores" do
-      run = create(:agent_run, :completed, project: project, prompt_version: prompt_version,
-        completed_at: 1.day.ago)
-      create(:quality_metric, :automated, agent_run: run, prompt_version: prompt_version,
-        composite_score: nil)
+      run = insert_completed_run(project: project, prompt_version: prompt_version, completed_at: 1.day.ago)
+      insert_quality_metric(run: run, composite_score: nil)
 
       result = described_class.call(sample_size: 10, days: 7)
 
@@ -78,9 +123,8 @@ RSpec.describe PromptEvolution::SampleRuns do
     end
 
     it "excludes runs outside the time window" do
-      run = create(:agent_run, :completed, project: project, prompt_version: prompt_version,
-        completed_at: 30.days.ago)
-      create(:quality_metric, :automated, agent_run: run)
+      run = insert_completed_run(project: project, prompt_version: prompt_version, completed_at: 30.days.ago)
+      insert_quality_metric(run: run, composite_score: 0.85)
 
       result = described_class.call(sample_size: 10, days: 7)
 
@@ -90,9 +134,8 @@ RSpec.describe PromptEvolution::SampleRuns do
     it "filters by project_id when provided" do
       other_project = create(:project)
       create_completed_run
-      other_run = create(:agent_run, :completed, project: other_project,
-        prompt_version: prompt_version, completed_at: 1.day.ago)
-      create(:quality_metric, :automated, agent_run: other_run)
+      other_run = insert_completed_run(project: other_project, prompt_version: prompt_version, completed_at: 1.day.ago)
+      insert_quality_metric(run: other_run, composite_score: 0.85)
 
       result = described_class.call(sample_size: 10, days: 7, project_id: project.id)
 
@@ -106,10 +149,10 @@ RSpec.describe PromptEvolution::SampleRuns do
       project2 = create(:project)
       create_completed_run(goal: "create_pr")
       create_completed_run(goal: "create_issue")
-      run3 = create(:agent_run, :completed, project: project2,
+      run3 = insert_completed_run(project: project2,
         prompt_version: prompt_version, goal: "review", completed_at: 1.day.ago,
         source_pull_request_number: 1)
-      create(:quality_metric, :automated, agent_run: run3)
+      insert_quality_metric(run: run3, composite_score: 0.85)
 
       result = described_class.call(sample_size: 10, days: 7)
 
@@ -118,7 +161,7 @@ RSpec.describe PromptEvolution::SampleRuns do
     end
 
     it "does not bias selection toward the first strata when strata exceed sample size" do
-      strata_projects = Array.new(10) { create(:project) }
+      strata_projects = Array.new(5) { create(:project) }
 
       strata_projects.each_with_index do |strata_project, index|
         create_completed_run(
@@ -128,16 +171,12 @@ RSpec.describe PromptEvolution::SampleRuns do
         )
       end
 
-      # Run multiple times to verify later strata can be selected
-      all_selected_project_ids = Set.new
-      10.times do
-        result = described_class.call(sample_size: 3, days: 14)
-        result.samples.each { |s| all_selected_project_ids << s[:project].id }
-      end
+      result = described_class.call(sample_size: 3, days: 14, random: Random.new(1))
+      selected_project_ids = result.samples.map { |s| s[:project].id }
 
-      # With shuffling, projects beyond the first 3 must appear at least once.
-      # Without randomization, only the first 3 strata would ever be selected.
-      expect(all_selected_project_ids.size).to be > 3
+      # With shuffling, projects beyond the first 3 can be selected.
+      # Without randomization, only the first 3 strata would be selected.
+      expect(selected_project_ids & strata_projects.drop(3).map(&:id)).not_to be_empty
     end
 
     it "returns exactly sample_size when enough runs exist and strata don't divide evenly" do

--- a/spec/services/prompt_evolution/select_spec.rb
+++ b/spec/services/prompt_evolution/select_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe PromptEvolution::Select do
   let(:prompt) { create(:prompt, :global, :with_version) }
   let(:v1) { prompt.current_version }
+  let(:metric_project) { create(:project) }
 
   def add_version(parent: nil)
     next_version = (prompt.prompt_versions.maximum(:version) || 0) + 1
@@ -17,14 +18,56 @@ RSpec.describe PromptEvolution::Select do
   end
 
   def add_metrics(version, scores:)
-    Array(scores).each do |score|
-      run = create(:agent_run, project: create(:project))
-      create(:quality_metric, :automated,
-        agent_run: run,
-        prompt_version: version,
-        composite_score: score
-      )
+    now = Time.current
+    score_list = Array(scores)
+    run_ids = insert_metric_runs(version, score_list.size, now: now)
+    metric_rows = run_ids.zip(score_list).map do |run_id, score|
+      metric_row(run_id: run_id, version: version, score: score, metric_type: "automated", now: now)
     end
+    return if metric_rows.empty?
+
+    QualityMetric.insert_all!(metric_rows)
+  end
+
+  def add_metric(version, score:, metric_type:)
+    now = Time.current
+    run_id = insert_metric_runs(version, 1, now: now).first
+    QualityMetric.insert_all!([
+      metric_row(run_id: run_id, version: version, score: score, metric_type: metric_type, now: now)
+    ])
+  end
+
+  def insert_metric_runs(version, count, now:)
+    return [] if count.zero?
+
+    rows = Array.new(count) do
+      {
+        agent_type: "claude_code",
+        custom_prompt: "Metric run",
+        project_id: metric_project.id,
+        prompt_version_id: version.id,
+        status: "pending",
+        goal: "create_pr",
+        trigger_type: "automatic",
+        proxy_token: SecureRandom.hex(32),
+        created_at: now,
+        updated_at: now
+      }
+    end
+
+    AgentRun.insert_all!(rows, returning: %w[id]).rows.flatten
+  end
+
+  def metric_row(run_id:, version:, score:, metric_type:, now:)
+    {
+      agent_run_id: run_id,
+      prompt_version_id: version.id,
+      metric_type: metric_type,
+      feedback_source: metric_type == "human" ? "pr_merge" : "system",
+      composite_score: score,
+      created_at: now,
+      updated_at: now
+    }
   end
 
   describe ".call" do
@@ -85,8 +128,7 @@ RSpec.describe PromptEvolution::Select do
 
       add_metrics(v1, scores: [ 0.5, 0.5, 0.5 ])
       3.times do
-        run = create(:agent_run, project: create(:project))
-        create(:quality_metric, :human, agent_run: run, prompt_version: v2, composite_score: 1.0)
+        add_metric(v2, score: 1.0, metric_type: "human")
       end
       add_metrics(v2, scores: [ 0.8, 0.82, 0.81 ])
 


### PR DESCRIPTION
## Summary

- Extract GitHub retry timing into constants so specs can disable retry sleeps without changing production behavior
- Speed up `bin/dev` specs by shortening monitor and detach timeout waits in test env
- Speed up PromptEvolution specs with lean persisted fixture rows and deterministic sampling randomness

## Performance

Focused PromptEvolution pair went from roughly `18.45s` to about `3-4s` locally after fixture changes.

Broader focused run after review cleanup:

```text
134 examples, 0 failures
Finished in 8.26 seconds
```

## Verification

```bash
COVERAGE=false bin/rspec spec/lib/dev_script_spec.rb spec/services/github_client_spec.rb spec/services/prompt_evolution/select_spec.rb spec/services/prompt_evolution/sample_runs_spec.rb --format progress --profile 10
bin/rubocop app/services/github_client.rb app/services/prompt_evolution/sample_runs.rb spec/lib/dev_script_spec.rb spec/services/github_client_spec.rb spec/services/prompt_evolution/select_spec.rb spec/services/prompt_evolution/sample_runs_spec.rb
git diff --check -- app/services/github_client.rb app/services/prompt_evolution/sample_runs.rb spec/lib/dev_script_spec.rb spec/services/github_client_spec.rb spec/services/prompt_evolution/select_spec.rb spec/services/prompt_evolution/sample_runs_spec.rb
```