### PR TITLE
fix(scanner): apply hard gate to review_bot_review_pending matching paid_agent behavior (#1336)

### DIFF
--- a/app/services/automation/strategies/auto_review.rb
+++ b/app/services/automation/strategies/auto_review.rb
@@ -153,11 +153,11 @@ module Automation
       end
 
       def review_bot_pending_decisions(plugins, signals, trigger_types)
-        decisions = review_bot_request_decisions(plugins)
-
-        other_triggers = trigger_types - [ Automation::ReviewMethods::Copilot::TRIGGER_TYPE ]
-        decisions.concat(followup_decisions(signals)) if other_triggers.any?
-        decisions.compact
+        # review_bot_review_pending is a hard gate: emit only review
+        # request decisions and suppress create_pr follow-up runs while
+        # the bot review is outstanding, mirroring the
+        # paid_agent_review_pending hard gate from #1135. (#1336)
+        review_bot_request_decisions(plugins).compact
       end
 
       def non_bot_pending_decisions(plugins, signals, trigger_types)

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -406,9 +406,9 @@ module Workflows
     end
 
     def handle_review_bot_review_pending(project_id, pr_data, trigger_types)
-      dispatch_review_bot_review_request(project_id, pr_data)
-
       if Temporalio::Workflow.patched("pause-followup-during-review-v1")
+        dispatch_review_bot_review_request(project_id, pr_data)
+
         # review_bot_review_pending is a hard gate: suppress all create_pr
         # follow-up runs while a bot review is outstanding, mirroring the
         # paid_agent_review_pending hard gate from #1135. Other triggers
@@ -421,13 +421,14 @@ module Workflows
       other_triggers = trigger_types - [ "review_bot_review_pending" ]
 
       if pr_data[:phase].in?(%w[draft restarted])
+        dispatch_review_bot_review_request(project_id, pr_data)
         return if other_triggers.empty?
 
         start_draft_followup_workflow(project_id, pr_data)
         return
       end
 
-      return if other_triggers.empty?
+      return dispatch_review_bot_review_request(project_id, pr_data) if other_triggers.empty?
 
       start_pr_followup_workflow(project_id, pr_data)
     end

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -406,7 +406,7 @@ module Workflows
     end
 
     def handle_review_bot_review_pending(project_id, pr_data, trigger_types)
-      if Temporalio::Workflow.patched("pause-followup-during-review-v1")
+      if Temporalio::Workflow.patched("pause-review-bot-followup-during-review-v1")
         dispatch_review_bot_review_request(project_id, pr_data)
 
         # review_bot_review_pending is a hard gate: suppress all create_pr

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -406,21 +406,28 @@ module Workflows
     end
 
     def handle_review_bot_review_pending(project_id, pr_data, trigger_types)
+      dispatch_review_bot_review_request(project_id, pr_data)
+
+      if Temporalio::Workflow.patched("pause-followup-during-review-v1")
+        # review_bot_review_pending is a hard gate: suppress all create_pr
+        # follow-up runs while a bot review is outstanding, mirroring the
+        # paid_agent_review_pending hard gate from #1135. Other triggers
+        # (CI failures, merge conflicts, conversation comments) will be
+        # re-detected on the next scan cycle after the review completes
+        # and any resulting code changes are made. (#1336)
+        return nil
+      end
+
       other_triggers = trigger_types - [ "review_bot_review_pending" ]
 
-      # review_bot_review_pending is only a draft-phase gate when it is the
-      # sole trigger. Mixed trigger sets still need a follow-up run to address
-      # actionable feedback or CI failures, even if that same head is also
-      # waiting on a bot review.
       if pr_data[:phase].in?(%w[draft restarted])
-        dispatch_review_bot_review_request(project_id, pr_data)
         return if other_triggers.empty?
 
         start_draft_followup_workflow(project_id, pr_data)
         return
       end
 
-      return dispatch_review_bot_review_request(project_id, pr_data) if other_triggers.empty?
+      return if other_triggers.empty?
 
       start_pr_followup_workflow(project_id, pr_data)
     end

--- a/spec/services/automation/strategies/auto_review_spec.rb
+++ b/spec/services/automation/strategies/auto_review_spec.rb
@@ -97,6 +97,25 @@ RSpec.describe Automation::Strategies::AutoReview do
       )
     end
 
+    it "suppresses create_pr follow-up when review_bot_review_pending is bundled with other triggers (#1336)" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        labels_to_remove: [],
+        triggers: [
+          { type: "review_bot_review_pending", request_login: "copilot" },
+          { type: "ci_failure", details: "test-suite" }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to include("request_review")
+      expect(types).not_to include("queue_create_pr_run")
+      expect(types).not_to include("record_pr_followup")
+    end
+
     it "emits the trigger's reviewer for manual_review_pending" do
       result = evaluate(scan: {
         issue_id: pull_request.id,

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -637,7 +637,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::RequestReviewActivity, hash_including(reviewers: chain), timeout: anything)
     end
 
-    it "requests review and dispatches draft followup when other triggers are present in draft" do
+    it "requests review but suppresses draft followup when other triggers are present (hard gate #1336)" do
       pr_data = {
         issue_id: 10, pr_number: 42, phase: "draft",
         current_draft_review_count: 1,
@@ -652,8 +652,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(workflow).to have_received(:run_activity)
         .with(Activities::RequestReviewActivity,
           hash_including(reviewers: array_including(Activities::RequestReviewActivity::COPILOT_LOGIN)), timeout: anything)
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::QueueAgentRunActivity, expected_draft_queue_input(count: 1), timeout: 30)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
     end
 
     it "does not start followup workflow when review_bot_review_pending is the only trigger" do
@@ -670,7 +670,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
-    it "still dispatches ready-phase followup when review_bot_review_pending is bundled with actionable triggers" do
+    it "suppresses ready-phase followup when review_bot_review_pending is bundled with actionable triggers (hard gate #1336)" do
       pr_data = {
         issue_id: 10, pr_number: 42, phase: "ready",
         triggers: [
@@ -681,10 +681,10 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
       workflow.send(:handle_pr_trigger, project_id, pr_data)
 
-      expect(workflow).not_to have_received(:run_activity)
+      expect(workflow).to have_received(:run_activity)
         .with(Activities::RequestReviewActivity,
           hash_including(reviewers: array_including(Activities::RequestReviewActivity::COPILOT_LOGIN)), timeout: anything)
-      expect(workflow).to have_received(:run_activity)
+      expect(workflow).not_to have_received(:run_activity)
         .with(Activities::RecordPrFollowupActivity, anything, timeout: anything)
     end
 

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -286,6 +286,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive(:patched)
         .with("pause-followup-during-review-v1")
         .and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-review-bot-followup-during-review-v1")
+        .and_return(true)
     end
 
     it "routes ready_for_owner to MarkPrReadyActivity and RequestReviewActivity" do
@@ -690,7 +693,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
     it "preserves ready-phase replay order before the review pending hard gate patch" do
       allow(Temporalio::Workflow).to receive(:patched)
-        .with("pause-followup-during-review-v1")
+        .with("pause-review-bot-followup-during-review-v1")
         .and_return(false)
 
       pr_data = {
@@ -1380,6 +1383,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive(:patched)
         .with("pause-followup-during-review-v1").and_return(true)
       allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-review-bot-followup-during-review-v1").and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
         .with("batch-evaluate-issues-v1").and_return(true)
       allow(workflow).to receive(:interruptible_sleep)
       allow(workflow).to receive(:run_activity)
@@ -1474,6 +1479,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with("queue-paid-agent-review-run-v1").and_return(true)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("pause-followup-during-review-v1").and_return(true)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-review-bot-followup-during-review-v1").and_return(true)
       allow(workflow).to receive(:run_activity).and_return({})
     end
 

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -688,6 +688,28 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::RecordPrFollowupActivity, anything, timeout: anything)
     end
 
+    it "preserves ready-phase replay order before the review pending hard gate patch" do
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("pause-followup-during-review-v1")
+        .and_return(false)
+
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "ready",
+        current_followup_count: 0,
+        triggers: [
+          { type: "review_bot_review_pending", request_login: Activities::RequestReviewActivity::COPILOT_LOGIN },
+          { type: "ci_failure", details: [ "rspec" ] }
+        ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::RequestReviewActivity, anything, timeout: anything)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::RecordPrFollowupActivity, hash_including(issue_id: 10), timeout: anything)
+    end
+
     it "triggers dev environment update after successful merge" do
       allow(Temporalio::Workflow).to receive(:patched).with("add-dev-environment-update-v1").and_return(true)
 


### PR DESCRIPTION
## Summary

- **Root cause**: `review_bot_review_pending` allowed `create_pr` follow-ups when bundled with other triggers (CI failures, conversation comments), while `paid_agent_review_pending` suppressed them via the #1135 hard gate. For paid-agent-only projects, stale `paid-code-reviewer[bot]` reviews caused the scanner to emit `review_bot_review_pending` instead of `paid_agent_review_pending`, bypassing the hard gate and creating agent run loops.
- **Fix**: Both the old trigger-routing path (`git_hub_poll_workflow.rb`) and the new strategy-based path (`auto_review.rb`) now treat `review_bot_review_pending` as a hard gate equivalent to `paid_agent_review_pending`. Review requests are dispatched, but `create_pr` follow-ups are suppressed until the review completes.

## Evidence

HuntHelper/railscrawler#627 had 10 consecutive `create_pr` agent runs in ~100 minutes with no review runs. The project uses paid_agent reviews only. Two stale COMMENTED reviews from `paid-code-reviewer[bot]` (on older commits) caused the scanner to emit `review_bot_review_pending` → no hard gate → create_pr follow-ups looped.

## Test plan

- [x] Updated 2 existing workflow tests to verify hard gate behavior
- [x] Added 1 new strategy test for mixed-trigger hard gate
- [x] All 81 workflow tests pass
- [x] All 17 auto_review strategy tests pass
- [x] RuboCop clean

Fixes #1336