### PR TITLE
fix(scanner): unify review_bot_review_pending and paid_agent_review_pending into a single hard-gated code path

### DIFF
--- a/app/services/automation/strategies/auto_review.rb
+++ b/app/services/automation/strategies/auto_review.rb
@@ -211,6 +211,11 @@ module Automation
 
         decisions.concat(manual_request_decisions(plugins))
 
+        if trigger_types.include?(Automation::ReviewMethods::Copilot::TRIGGER_TYPE)
+          decisions.concat(review_bot_request_decisions(plugins))
+          return decisions
+        end
+
         if signals.triggers.any? { |t| FOLLOWUP_TRIGGER_TYPES.include?(t[:type].to_s) }
           decisions.concat(followup_decisions(signals))
         else

--- a/app/services/automation/strategies/auto_review.rb
+++ b/app/services/automation/strategies/auto_review.rb
@@ -152,12 +152,11 @@ module Automation
         decision ? [ decision ] : []
       end
 
-      def review_bot_pending_decisions(plugins, signals, trigger_types)
-        decisions = review_bot_request_decisions(plugins)
-
-        other_triggers = trigger_types - [ Automation::ReviewMethods::Copilot::TRIGGER_TYPE ]
-        decisions.concat(followup_decisions(signals)) if other_triggers.any?
-        decisions.compact
+      def review_bot_pending_decisions(plugins, _signals, _trigger_types)
+        # Bot review pending is a hard gate, matching paid_agent_review_pending:
+        # request/queue the review action only and wait for the next scan before
+        # starting any create_pr follow-up work. (#1336)
+        review_bot_request_decisions(plugins)
       end
 
       def non_bot_pending_decisions(plugins, signals, trigger_types)

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -480,6 +480,11 @@ module Workflows
 
       dispatch_manual_review_request(project_id, pr_data)
 
+      if trigger_types.include?("review_bot_review_pending")
+        dispatch_bot_review_request(project_id, pr_data)
+        return
+      end
+
       followup_trigger_types = %w[
         ci_failure review_threads conversation_comments changes_requested
         actionable_labels merge_conflicts review_bot_comments review_bot_threads

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -406,6 +406,15 @@ module Workflows
     end
 
     def handle_review_bot_review_pending(project_id, pr_data, trigger_types)
+      if Temporalio::Workflow.patched("pause-followup-during-review-v1")
+        # review_bot_review_pending is also a hard gate: suppress create_pr
+        # follow-up runs while any bot review for the current head is
+        # outstanding. This keeps stale bot-review signals from looping
+        # follow-up runs when bundled with other actionable triggers. (#1336)
+        dispatch_review_bot_review_request(project_id, pr_data)
+        return nil
+      end
+
       other_triggers = trigger_types - [ "review_bot_review_pending" ]
 
       # review_bot_review_pending is only a draft-phase gate when it is the

--- a/spec/services/automation/strategies/auto_review_spec.rb
+++ b/spec/services/automation/strategies/auto_review_spec.rb
@@ -97,6 +97,40 @@ RSpec.describe Automation::Strategies::AutoReview do
       )
     end
 
+    it "suppresses follow-up decisions while review_bot_review_pending is outstanding (#1336)" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        triggers: [
+          { type: "review_bot_review_pending", request_login: "copilot" },
+          { type: "ci_failure", details: [ "test-suite" ] }
+        ]
+      })
+
+      expect(result.to_h).to eq(
+        decisions: [
+          { type: "request_review", pr_number: 42, reviewers: [ "copilot" ] }
+        ]
+      )
+    end
+
+    it "suppresses follow-up decisions for auto-review bot pending triggers with no request login" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        triggers: [
+          { type: "review_bot_review_pending", request_login: nil },
+          { type: "merge_conflicts", details: "PR has merge conflicts" }
+        ]
+      })
+
+      expect(result.to_h).to eq(decisions: [ { type: "noop" } ])
+    end
+
     it "emits the trigger's reviewer for manual_review_pending" do
       result = evaluate(scan: {
         issue_id: pull_request.id,

--- a/spec/services/automation/strategies/auto_review_spec.rb
+++ b/spec/services/automation/strategies/auto_review_spec.rb
@@ -206,6 +206,25 @@ RSpec.describe Automation::Strategies::AutoReview do
       expect(types).to include("record_review_goal_retry", "queue_review_run")
     end
 
+    it "suppresses retry follow-up decisions while review_bot_review_pending is outstanding" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_review_goal_retry_count: 1,
+        current_followup_count: 0,
+        triggers: [
+          { type: "review_goal_retry" },
+          { type: "review_bot_review_pending", request_login: "copilot" },
+          { type: "ci_failure", details: [ "test-suite" ] }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to include("record_review_goal_retry", "queue_review_run", "request_review")
+      expect(types).not_to include("queue_create_pr_run", "record_pr_followup")
+    end
+
     it "marks ready on ready_for_owner triggers" do
       result = evaluate(scan: {
         issue_id: pull_request.id,

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -637,7 +637,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::RequestReviewActivity, hash_including(reviewers: chain), timeout: anything)
     end
 
-    it "requests review and dispatches draft followup when other triggers are present in draft" do
+    it "requests review and suppresses draft followup when other triggers are present in draft" do
       pr_data = {
         issue_id: 10, pr_number: 42, phase: "draft",
         current_draft_review_count: 1,
@@ -652,8 +652,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(workflow).to have_received(:run_activity)
         .with(Activities::RequestReviewActivity,
           hash_including(reviewers: array_including(Activities::RequestReviewActivity::COPILOT_LOGIN)), timeout: anything)
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::QueueAgentRunActivity, expected_draft_queue_input(count: 1), timeout: 30)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, hash_including(goal: "create_pr"), timeout: anything)
     end
 
     it "does not start followup workflow when review_bot_review_pending is the only trigger" do
@@ -670,7 +670,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(Temporalio::Workflow).not_to have_received(:start_child_workflow)
     end
 
-    it "still dispatches ready-phase followup when review_bot_review_pending is bundled with actionable triggers" do
+    it "requests review and suppresses ready-phase followup when review_bot_review_pending is bundled with actionable triggers" do
       pr_data = {
         issue_id: 10, pr_number: 42, phase: "ready",
         triggers: [
@@ -681,10 +681,30 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
       workflow.send(:handle_pr_trigger, project_id, pr_data)
 
-      expect(workflow).not_to have_received(:run_activity)
+      expect(workflow).to have_received(:run_activity)
         .with(Activities::RequestReviewActivity,
           hash_including(reviewers: array_including(Activities::RequestReviewActivity::COPILOT_LOGIN)), timeout: anything)
-      expect(workflow).to have_received(:run_activity)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::RecordPrFollowupActivity, anything, timeout: anything)
+    end
+
+    it "suppresses create_pr followup for stale auto-review bot signals with no request login" do
+      pr_data = {
+        issue_id: 10, pr_number: 42, phase: "ready",
+        current_followup_count: 0,
+        triggers: [
+          { type: "review_bot_review_pending", request_login: nil },
+          { type: "ci_failure", details: [ "rspec" ] }
+        ]
+      }
+
+      workflow.send(:handle_pr_trigger, project_id, pr_data)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::RequestReviewActivity, anything, timeout: anything)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::QueueAgentRunActivity, hash_including(goal: "create_pr"), timeout: anything)
+      expect(workflow).not_to have_received(:run_activity)
         .with(Activities::RecordPrFollowupActivity, anything, timeout: anything)
     end
 

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -986,7 +986,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
           hash_including(reviewers: [ "human-reviewer" ]), timeout: anything)
     end
 
-    it "defers bot review but dispatches manual review when followup triggers coexist" do
+    it "dispatches bot review and suppresses followup when bot pending coexists with retry followup triggers" do
       pr_data = {
         issue_id: 10, pr_number: 42, phase: "ready",
         triggers: [
@@ -1002,11 +1002,11 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
       expect(workflow).to have_received(:run_activity)
         .with(Activities::QueueAgentRunActivity, hash_including(goal: "review"), timeout: anything)
-      expect(workflow).not_to have_received(:run_activity)
+      expect(workflow).to have_received(:run_activity)
         .with(Activities::RequestReviewActivity, hash_including(reviewers: [ "copilot-bot" ]), timeout: anything)
       expect(workflow).to have_received(:run_activity)
         .with(Activities::RequestReviewActivity, hash_including(reviewers: [ "human-reviewer" ]), timeout: anything)
-      expect(workflow).to have_received(:run_activity)
+      expect(workflow).not_to have_received(:run_activity)
         .with(Activities::RecordPrFollowupActivity, anything, timeout: anything)
     end
 


### PR DESCRIPTION
## Summary

fix(scanner): unify review_bot_review_pending and paid_agent_review_pending into a single hard-gated code path

See #1336 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1336