### PR TITLE
fix(github-sync): reconcile open pull requests

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -22,6 +22,7 @@ module Activities
       synced_issues = github_issues.map { |gi| sync_issue(project, gi) }
       parse_issue_relationships(project, synced_issues) if synced_issues.any?
       closed_count = close_stale_issues(project, github_issues, truncated: truncated, incremental: incremental)
+      stale_pr_count = reconcile_open_pull_requests(project, client) if incremental && !truncated
 
       if truncated && incremental
         # Incremental fetches sort ascending (oldest-updated first), so a
@@ -93,6 +94,7 @@ module Activities
         project_id: project.id,
         issue_count: synced_issues.size,
         closed_count: closed_count,
+        stale_pr_count: stale_pr_count || 0,
         incremental: incremental,
         rescan_count: incremental ? open_issues.count { |si| si[:rescan] } : 0
       )
@@ -424,6 +426,79 @@ module Activities
           count: count
         )
       end
+
+      count
+    end
+
+    def reconcile_open_pull_requests(project, client)
+      open_pr_numbers, truncated = fetch_open_pull_request_numbers(client, project.full_name)
+      return 0 if truncated
+
+      backfill_open_pull_requests(project, client, open_pr_numbers)
+      close_stale_pull_requests(project, open_pr_numbers)
+    end
+
+    def fetch_open_pull_request_numbers(client, repo_full_name)
+      prs = []
+      page = 1
+      truncated = false
+
+      loop do
+        page_prs = client.pull_requests(repo_full_name, state: "open", per_page: DEFAULT_PER_PAGE, page: page)
+        break if page_prs.empty?
+
+        prs.concat(page_prs)
+        break if page_prs.size < DEFAULT_PER_PAGE
+
+        page += 1
+        next unless page > DEFAULT_MAX_PAGES
+
+        truncated = client.pull_requests(repo_full_name, state: "open", per_page: DEFAULT_PER_PAGE, page: page).any?
+        logger.warn(
+          message: "github_sync.fetch_pull_requests_page_limit",
+          repo: repo_full_name,
+          fetched_count: prs.size,
+          max_pages: DEFAULT_MAX_PAGES
+        ) if truncated
+        break
+      end
+
+      [ prs.map(&:number).uniq, truncated ]
+    end
+
+    def backfill_open_pull_requests(project, client, open_pr_numbers)
+      return if open_pr_numbers.empty?
+
+      existing_open_numbers = project.issues
+        .pull_requests_only
+        .where(github_state: "open", github_number: open_pr_numbers)
+        .pluck(:github_number)
+        .to_set
+
+      (open_pr_numbers - existing_open_numbers.to_a).each do |number|
+        github_issue = client.issue(project.full_name, number)
+        sync_issue(project, github_issue)
+      end
+    end
+
+    def close_stale_pull_requests(project, open_pr_numbers)
+      stale_prs = project.issues
+        .pull_requests_only
+        .where(github_state: "open", source: Issue::GITHUB_SOURCE)
+      stale_prs = stale_prs.where.not(github_number: open_pr_numbers) if open_pr_numbers.any?
+
+      count = stale_prs.count
+      return 0 if count.zero?
+
+      stale_prs.update_all(github_state: "closed", updated_at: Time.current)
+      project.broadcast_issues_update
+      project.broadcast_pull_requests_update
+
+      logger.info(
+        message: "github_sync.closed_stale_pull_requests",
+        project_id: project.id,
+        count: count
+      )
 
       count
     end

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -435,6 +435,7 @@ module Activities
       return 0 if truncated
 
       backfill_open_pull_requests(project, client, open_pr_numbers)
+      resolve_external_dependencies(project, open_pr_numbers) if open_pr_numbers.any?
       close_stale_pull_requests(project, open_pr_numbers)
     end
 

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -1072,6 +1072,29 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(pr.is_pull_request).to be true
       end
 
+      it "promotes external dependencies after backfilling open pull requests" do
+        issue = create(:issue, project: project, github_number: 53)
+        dependency = issue.issue_dependencies.create!(
+          depends_on_owner: project.owner.downcase,
+          depends_on_repo: project.repo.downcase,
+          depends_on_number: 52
+        )
+
+        allow(github_client).to receive(:pull_requests).and_return([
+          OpenStruct.new(number: 52)
+        ])
+        allow(github_client).to receive(:issue).with(project.full_name, 52).and_return(github_pr_issue(52))
+
+        activity.execute(project_id: project.id)
+
+        pr = project.issues.find_by!(github_issue_id: 5052)
+        dependency.reload
+        expect(dependency.depends_on_issue_id).to eq(pr.id)
+        expect(dependency.depends_on_owner).to be_nil
+        expect(dependency.depends_on_repo).to be_nil
+        expect(dependency.depends_on_number).to be_nil
+      end
+
       it "does not close local pull requests when the open PR reconciliation is truncated" do
         stub_const("#{described_class}::DEFAULT_PER_PAGE", 2)
         stub_const("#{described_class}::DEFAULT_MAX_PAGES", 1)

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Activities::FetchIssuesActivity do
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
     allow(github_client).to receive_messages(issue_comments: [], "rate_limit_remaining!": 100)
+    allow(github_client).to receive(:pull_requests).and_return([])
   end
 
   # Helper: route github_client.issues calls by label (or nil for unlabeled fetches)
@@ -20,6 +21,21 @@ RSpec.describe Activities::FetchIssuesActivity do
       label = Array(opts[:labels]).first
       mapping.fetch(label, [])
     end
+  end
+
+  def github_pr_issue(number)
+    OpenStruct.new(
+      id: 5000 + number,
+      number: number,
+      title: "Open PR",
+      body: "PR body",
+      state: "open",
+      labels: [ OpenStruct.new(name: "paid-generated") ],
+      pull_request: OpenStruct.new(html_url: "https://github.com/owner/repo/pull/#{number}"),
+      user: OpenStruct.new(login: "viamin"),
+      created_at: 2.days.ago,
+      updated_at: 5.minutes.ago
+    )
   end
 
   describe "#execute" do
@@ -1024,6 +1040,57 @@ RSpec.describe Activities::FetchIssuesActivity do
         activity.execute(project_id: project.id)
 
         expect(stale.reload.github_state).to eq("open")
+      end
+
+      it "marks locally-open pull requests closed when GitHub no longer reports them open" do
+        stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5000,
+                          github_number: 50, github_state: "open")
+        open_pr = create(:issue, :pull_request, project: project, github_issue_id: 5001,
+                         github_number: 51, github_state: "open")
+
+        allow(github_client).to receive(:pull_requests).and_return([
+          OpenStruct.new(number: open_pr.github_number)
+        ])
+
+        activity.execute(project_id: project.id)
+
+        expect(stale_pr.reload.github_state).to eq("closed")
+        expect(open_pr.reload.github_state).to eq("open")
+      end
+
+      it "backfills open pull requests missing from the local cache" do
+        allow(github_client).to receive(:pull_requests).and_return([
+          OpenStruct.new(number: 52)
+        ])
+        allow(github_client).to receive(:issue).with(project.full_name, 52).and_return(github_pr_issue(52))
+
+        activity.execute(project_id: project.id)
+
+        pr = project.issues.find_by!(github_issue_id: 5052)
+        expect(pr.github_number).to eq(52)
+        expect(pr.github_state).to eq("open")
+        expect(pr.is_pull_request).to be true
+      end
+
+      it "does not close local pull requests when the open PR reconciliation is truncated" do
+        stub_const("#{described_class}::DEFAULT_PER_PAGE", 2)
+        stub_const("#{described_class}::DEFAULT_MAX_PAGES", 1)
+        stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5000,
+                          github_number: 50, github_state: "open")
+
+        allow(github_client).to receive(:pull_requests) do |_repo, **opts|
+          page = opts[:page] || 1
+          if page == 1
+            [ OpenStruct.new(number: 1), OpenStruct.new(number: 2) ]
+          else
+            [ OpenStruct.new(number: 3) ]
+          end
+        end
+        allow(Rails.logger).to receive(:warn)
+
+        activity.execute(project_id: project.id)
+
+        expect(stale_pr.reload.github_state).to eq("open")
       end
 
       it "includes re-scannable open issues not in the incremental fetch results" do


### PR DESCRIPTION
## Summary
- reconcile locally cached open PR rows against GitHub's current open PR list during incremental issue sync
- backfill missing open PR rows through the issue-shaped GitHub API resource
- close stale local PR rows conservatively, skipping closure when the open PR list is truncated

## Verification
- `bin/rubocop app/temporal/activities/fetch_issues_activity.rb spec/temporal/activities/fetch_issues_activity_spec.rb`
- `bin/rspec spec/temporal/activities/fetch_issues_activity_spec.rb` (55 examples, 0 failures; command exits 2 because partial runs trip the repo-wide SimpleCov 80% threshold)