### PR TITLE
Fix #1263: Clicking notification shows "Content missing" due to Turbo Frame mismatch

### DIFF
--- a/app/views/notifications/_dropdown_item.html.erb
+++ b/app/views/notifications/_dropdown_item.html.erb
@@ -18,7 +18,7 @@
 
   <div class="flex-1 min-w-0">
     <% if notification.action_url.present? %>
-      <%= link_to notification.title, notification.action_url, class: "block text-sm font-medium text-gray-900 truncate hover:text-indigo-600" %>
+      <%= link_to notification.title, notification.action_url, class: "block text-sm font-medium text-gray-900 truncate hover:text-indigo-600", data: { turbo_frame: "_top" } %>
     <% else %>
       <p class="text-sm font-medium text-gray-900 truncate"><%= notification.title %></p>
     <% end %>

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe "Notifications" do
       expect(response.body).to include("Dropdown alert")
     end
 
+    it "targets action links at the top frame in dropdown content" do
+      notification = create(:notification, :with_action_url, account: account, title: "Linked alert")
+
+      get notifications_path(dropdown: "true")
+
+      link = Nokogiri::HTML(response.body)
+        .css("a")
+        .find { |anchor| anchor.text == notification.title }
+
+      expect(link["href"]).to eq(notification.action_url)
+      expect(link["data-turbo-frame"]).to eq("_top")
+    end
+
     it "excludes dismissed notifications" do
       create(:notification, account: account, title: "Active alert")
       create(:notification, :dismissed, account: account, title: "Dismissed alert")


### PR DESCRIPTION
## Summary

Clicking notification shows "Content missing" due to Turbo Frame mismatch

See #1263 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1263