### PR TITLE
fix(containers): align network isolation claims across provider auth modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
 
 - **GitHub Integration**: Add projects via PAT, watch for labeled issues
 - **Temporal Workflows**: Durable, observable orchestration of agent activities
-- **Container Isolation**: Agents run in sandboxed Docker containers; proxy-mode runs use the restricted `paid_agent` network with no default internet access
-  - Gap: subscription-auth and direct-outbound provider runs use the internal network for provider access; tracked by [#1284](https://github.com/viamin/paid/issues/1284).
+- **Container Isolation**: Agents run in sandboxed Docker containers. Proxy-mode runs use the restricted `paid_agent` network with no default internet access; subscription-auth and direct-outbound provider runs use `paid_internal` so provider CLIs can reach upstream APIs directly.
 - **Multiple Agents and Providers**: Support for Claude Code, Codex, Cursor, Gemini, Aider, OpenCode, Kilocode, and Copilot when the runtime is both supported by `agent-harness` and installed in `paid-agent`
   - Gap: broader runtime parity is tracked by provider metadata and smoke-test refactors ([#798](https://github.com/viamin/paid/issues/798), [#796](https://github.com/viamin/paid/issues/796)) plus agent-image install delegation work ([#789](https://github.com/viamin/paid/issues/789)-[#795](https://github.com/viamin/paid/issues/795)).
 - **Secrets Proxy**: Git credentials and default platform LLM keys are proxied through authenticated endpoints
@@ -27,8 +26,7 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
 - **Live Dashboards**: Track active runs, performance, quality, cost, and knowledge-collection health from the UI
 - **Provider and Integration Management**: Test provider auth from the UI and manage GitHub, Linear, and provider API keys
   - Gap: generic integration credentials exist in the data model but are hidden from the main integrations hub pending RBAC/admin-role work; tracked by [#1283](https://github.com/viamin/paid/issues/1283).
-- **Service Containers**: Attach approved supporting services like Postgres, Redis, or Selenium to project runs when agents need dependencies beyond the app code
-  - Gap: direct-outbound provider runs can select a different Docker network than service provisioning expects; tracked by [#1282](https://github.com/viamin/paid/issues/1282). Shared-database isolation fallout is tracked separately by [#1280](https://github.com/viamin/paid/issues/1280).
+- **Service Containers**: Attach approved supporting services like Postgres, Redis, or Selenium to project runs when agents need dependencies beyond the app code. Service containers are attached to the same Docker network selected for the agent run. Shared-database isolation fallout is tracked separately by [#1280](https://github.com/viamin/paid/issues/1280).
 
 ## How It Works
 
@@ -37,7 +35,7 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
 3. An `AgentExecutionWorkflow` starts in Temporal, orchestrating:
    - Prompt resolution, provider selection, and project policy checks
    - Knowledge-base retrieval and style-guide injection when available
-   - Docker container provisioning on a restricted network
+   - Docker container provisioning on the network selected for the provider auth mode
    - Repository clone and branch creation inside the container
    - Agent execution (e.g., Claude Code) with the issue as prompt
    - Branch push, PR creation, issue update, and optional review follow-up
@@ -252,8 +250,8 @@ By default, provider tests and real agent runs use the same containerized auth p
 
 ### Networks
 
-- **paid_internal**: Infrastructure services (Rails, Temporal, Postgres)
-- **paid_agent**: Restricted network for agent containers (`internal: true`, no default internet access). Allowed egress enforced via iptables.
+- **paid_internal**: Infrastructure services (Rails, Temporal, Postgres) and agent runs that require direct provider egress, including subscription-auth and direct-outbound provider modes.
+- **paid_agent**: Restricted network for proxy-mode agent containers (`internal: true`, no default internet access). Allowed egress is enforced via iptables.
 
 ### Temporal CLI Access
 
@@ -326,12 +324,13 @@ bin/ci                       # Runs setup, lint, and security audit
 └────────────────────────────┬────────────────────────────────────┘
                              │
 ┌────────────────────────────▼────────────────────────────────────┐
-│                  Docker Containers (paid_agent network)          │
+│        Docker Containers (paid_agent or paid_internal)           │
 │   Agent CLI (Claude, Codex, Cursor, Gemini, Aider, ...)         │
-│   ── Secrets Proxy ──► Anthropic/OpenAI APIs                    │
+│   ── Proxy mode: Secrets Proxy ──► Provider APIs                │
+│   ── Subscription/direct outbound: HTTPS to Provider APIs        │
 │   ── Git Credential Proxy ──► GitHub                            │
 │   ── Optional service containers (Postgres/Redis/Selenium)      │
-│   ── No default internet access                                 │
+│   ── No default internet access only on paid_agent              │
 └─────────────────────────────────────────────────────────────────┘
 ```
 

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -120,6 +120,10 @@ module Containers
 
     attr_reader :agent_run, :worktree_path, :container, :options, :workspace_volume
 
+    def self.network_for(agent_run:)
+      new(agent_run: agent_run).network_name
+    end
+
     # @param agent_run [AgentRun] The agent run to associate logs with
     # @param worktree_path [String, nil] Path to an existing worktree to bind-mount.
     #   When nil, a Docker named volume is created for in-container git clone.
@@ -134,7 +138,7 @@ module Containers
         Rails.logger.warn(
           message: "container_manager.container.network_option_ignored",
           agent_run_id: agent_run.id,
-          hint: "The :network option is ignored; containers always use #{NetworkPolicy::NETWORK_NAME}"
+          hint: "The :network option is ignored; containers use the network selected by provider auth mode"
         )
         options.delete(:network)
       end
@@ -146,8 +150,8 @@ module Containers
     end
 
     # Provisions a new container with security hardening.
-    # Ensures the agent network exists before creating the container,
-    # and applies firewall rules after start to restrict outbound traffic.
+    # Ensures the selected network exists before creating the container,
+    # and applies firewall rules for restricted proxy-mode runs after start.
     #
     # @return [Result] Result object with success/failure status
     def provision
@@ -208,6 +212,10 @@ module Containers
       raise ProvisionError, "Container not provisioned" unless container
 
       with_codex_auth_lock(command) { execute_unlocked(command, timeout:, startup_timeout:, idle_timeout:, stream:, env:, preparation:, heartbeat_path:, abort_patterns:) }
+    end
+
+    def network_name
+      network_contract.network
     end
 
     private def execute_unlocked(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil, abort_patterns: nil)
@@ -1311,12 +1319,18 @@ module Containers
       }
     end
 
-    # Subscription auth requires outbound HTTPS to reach Anthropic's servers.
-    # The paid_agent network is internal-only and blocks this, so subscription
-    # mode uses the infrastructure network which has outbound routing.
-    # API key mode continues to use the restricted paid_agent network.
+    # Proxy-mode API key auth uses the restricted paid_agent network.
+    # Subscription auth and direct-outbound providers use paid_internal so
+    # provider CLIs can reach their upstream APIs directly.
     def container_network
-      direct_outbound_provider? || subscription_auth? ? NetworkPolicy::INFRA_NETWORK_NAME : NetworkPolicy::NETWORK_NAME
+      network_name
+    end
+
+    def network_contract
+      @network_contract ||= NetworkPolicy.contract(
+        subscription_auth: subscription_auth?,
+        direct_outbound: direct_outbound_provider?
+      )
     end
 
     def direct_outbound_provider?
@@ -1430,7 +1444,7 @@ module Containers
 
     def proxy_base_url
       proxy_port = Rails.application.config.x.paid_proxy_port
-      proxy_host = subscription_auth? || direct_outbound_provider? ? "web" : "paid-proxy"
+      proxy_host = network_contract.restricted? ? "paid-proxy" : "web"
       "http://#{proxy_host}:#{proxy_port}"
     end
 
@@ -1569,20 +1583,14 @@ module Containers
     end
 
     def ensure_network!
-      # Subscription auth uses the infrastructure network (already managed by compose).
-      # Only the restricted agent network needs explicit creation.
-      return if subscription_auth? || direct_outbound_provider?
-
-      NetworkPolicy.ensure_network!
-      log_system("container.network.ready", network: NetworkPolicy::NETWORK_NAME)
+      NetworkPolicy.ensure_network!(network: network_name)
+      log_system("container.network.ready", network: network_name, mode: network_contract.mode)
     rescue NetworkPolicy::Error => e
       raise ProvisionError, "Network setup failed: #{e.message}"
     end
 
     def apply_network_restrictions!
-      # Subscription auth containers are on the infrastructure network and need
-      # outbound access to Anthropic. Firewall rules would block this.
-      return if subscription_auth? || direct_outbound_provider?
+      return unless network_contract.firewall?
 
       NetworkPolicy.apply_firewall_rules(
         container,

--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -104,7 +104,7 @@ module Containers
       return {} if service_containers.empty?
 
       @network = network
-      NetworkPolicy.ensure_network!
+      NetworkPolicy.ensure_network!(network: @network)
 
       # Record association early so concurrent cleanup counts this run.
       container_ids = service_containers.map(&:id)

--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -87,6 +87,7 @@ module Containers
     }.freeze
 
     DEFAULT_RESOURCE_LIMITS = { memory: 1 * 1024 * 1024 * 1024, cpu_quota: 100_000, pids_limit: 200 }.freeze
+    PAID_SERVICE_NETWORKS = [ NetworkPolicy::NETWORK_NAME, NetworkPolicy::INFRA_NETWORK_NAME ].freeze
 
     # Provisions all service containers needed by an agent run's project.
     #
@@ -473,8 +474,13 @@ module Containers
 
     def ensure_connected_to_network!(service_container)
       container = Docker::Container.get(service_container.docker_container_id)
-      endpoint = container_network_endpoint(container, @network)
-      return if network_alias?(endpoint, service_container.name)
+      networks = container.info.dig("NetworkSettings", "Networks") || {}
+      endpoint = networks.fetch(@network, nil)
+
+      if network_alias?(endpoint, service_container.name)
+        disconnect_unselected_paid_networks!(container.id, networks)
+        return
+      end
 
       network = Docker::Network.get(@network)
       network.disconnect(container.id) if endpoint
@@ -487,12 +493,20 @@ module Containers
         name: service_container.name,
         network: @network,
         container_id: container.id)
+      disconnect_unselected_paid_networks!(container.id, networks)
     rescue Docker::Error::DockerError, Excon::Error => e
       raise Error, "Failed to attach service container #{service_container.name} to network #{@network}: #{e.message}"
     end
 
-    def container_network_endpoint(container, network)
-      container.info.dig("NetworkSettings", "Networks")&.fetch(network, nil)
+    def disconnect_unselected_paid_networks!(container_id, networks)
+      (PAID_SERVICE_NETWORKS - [ @network ]).each do |network_name|
+        next unless networks.key?(network_name)
+
+        Docker::Network.get(network_name).disconnect(container_id)
+        log_info("service_provisioner.network_disconnected",
+          network: network_name,
+          container_id: container_id)
+      end
     end
 
     def network_alias?(endpoint, name)

--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -181,6 +181,7 @@ module Containers
     def ensure_running!(service_container)
       if service_container.running?
         if docker_container_alive?(service_container.docker_container_id)
+          ensure_connected_to_network!(service_container)
           schedule_metrics_collection(service_container)
           return
         else
@@ -203,6 +204,7 @@ module Containers
       # updating status to "running" before returning. Skip start if so.
       if service_container.reload.running?
         adopted = true
+        ensure_connected_to_network!(service_container)
       else
         docker_container.start
         service_container.update!(docker_container_id: docker_container.id, status: "running")
@@ -467,6 +469,34 @@ module Containers
       container.info.dig("State", "Running") == true
     rescue Docker::Error::DockerError, Excon::Error
       false
+    end
+
+    def ensure_connected_to_network!(service_container)
+      container = Docker::Container.get(service_container.docker_container_id)
+      endpoint = container_network_endpoint(container, @network)
+      return if network_alias?(endpoint, service_container.name)
+
+      network = Docker::Network.get(@network)
+      network.disconnect(container.id) if endpoint
+      network.connect(
+        container.id,
+        {},
+        "EndpointConfig" => { "Aliases" => [ service_container.name ] }
+      )
+      log_info("service_provisioner.network_connected",
+        name: service_container.name,
+        network: @network,
+        container_id: container.id)
+    rescue Docker::Error::DockerError, Excon::Error => e
+      raise Error, "Failed to attach service container #{service_container.name} to network #{@network}: #{e.message}"
+    end
+
+    def container_network_endpoint(container, network)
+      container.info.dig("NetworkSettings", "Networks")&.fetch(network, nil)
+    end
+
+    def network_alias?(endpoint, name)
+      Array(endpoint&.fetch("Aliases", nil)).include?(name)
     end
 
     def generate_env_vars(service_container, db_override: nil)

--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -87,7 +87,6 @@ module Containers
     }.freeze
 
     DEFAULT_RESOURCE_LIMITS = { memory: 1 * 1024 * 1024 * 1024, cpu_quota: 100_000, pids_limit: 200 }.freeze
-    PAID_SERVICE_NETWORKS = [ NetworkPolicy::NETWORK_NAME, NetworkPolicy::INFRA_NETWORK_NAME ].freeze
 
     # Provisions all service containers needed by an agent run's project.
     #
@@ -478,7 +477,6 @@ module Containers
       endpoint = networks.fetch(@network, nil)
 
       if network_alias?(endpoint, service_container.name)
-        disconnect_unselected_paid_networks!(container.id, networks)
         return
       end
 
@@ -493,20 +491,8 @@ module Containers
         name: service_container.name,
         network: @network,
         container_id: container.id)
-      disconnect_unselected_paid_networks!(container.id, networks)
     rescue Docker::Error::DockerError, Excon::Error => e
       raise Error, "Failed to attach service container #{service_container.name} to network #{@network}: #{e.message}"
-    end
-
-    def disconnect_unselected_paid_networks!(container_id, networks)
-      (PAID_SERVICE_NETWORKS - [ @network ]).each do |network_name|
-        next unless networks.key?(network_name)
-
-        Docker::Network.get(network_name).disconnect(container_id)
-        log_info("service_provisioner.network_disconnected",
-          network: network_name,
-          container_id: container_id)
-      end
     end
 
     def network_alias?(endpoint, name)

--- a/app/services/network_policy.rb
+++ b/app/services/network_policy.rb
@@ -5,10 +5,10 @@ require "ipaddr"
 require "net/http"
 require "json"
 
-# Manages Docker network isolation for agent containers.
+# Manages Docker network selection and isolation for agent containers.
 #
-# Ensures the restricted agent network exists and applies firewall rules
-# to limit outbound traffic to only allowed destinations (secrets proxy, GitHub).
+# Ensures the selected Docker network exists and applies firewall rules for
+# proxy-mode runs on the restricted agent network.
 #
 # @example Ensure network is ready before provisioning
 #   NetworkPolicy.ensure_network!
@@ -23,10 +23,21 @@ class NetworkPolicy
   # Raised when network operations fail
   class Error < StandardError; end
 
+  NetworkContract = Struct.new(:mode, :network, :restricted, :firewall, keyword_init: true) do
+    def restricted?
+      restricted
+    end
+
+    def firewall?
+      firewall
+    end
+  end
+
   NETWORK_NAME = "paid_agent"
 
   # Infrastructure network with outbound routing.
-  # Used by subscription-auth containers that need to reach Anthropic directly.
+  # Used by subscription-auth and direct-outbound containers that need to
+  # reach provider APIs directly.
   INFRA_NETWORK_NAME = "paid_internal"
 
   NETWORK_SUBNET = "172.28.0.0/16"
@@ -45,18 +56,36 @@ class NetworkPolicy
   SECRETS_PROXY_PORT = Rails.application.config.x.paid_proxy_port
 
   class << self
-    # Returns the network name that agent containers should use.
-    # Subscription-auth containers use the infrastructure network (paid_internal)
-    # for outbound HTTPS access; API-key containers use the restricted network.
+    # Returns the intended network contract for an agent container.
     #
+    # Proxy mode uses the restricted paid_agent network plus in-container
+    # firewall rules. Subscription-auth and direct-outbound runs use
+    # paid_internal because provider CLIs must reach upstream provider APIs.
+    #
+    # @param subscription_auth [Boolean] whether host-backed provider auth is present
+    # @param direct_outbound [Boolean] whether this run uses a provider that bypasses Paid's proxy
+    # @return [NetworkContract]
+    def contract(subscription_auth: subscription_auth?, direct_outbound: false)
+      if subscription_auth
+        unrestricted_contract("subscription_auth")
+      elsif direct_outbound
+        unrestricted_contract("direct_outbound")
+      else
+        restricted_contract
+      end
+    end
+
+    # Returns the network name that agent containers should use.
+    #
+    # @param direct_outbound [Boolean] whether this run uses a provider that bypasses Paid's proxy
     # @return [String] Docker network name
-    def agent_network
-      subscription_auth? ? INFRA_NETWORK_NAME : NETWORK_NAME
+    def agent_network(direct_outbound: false)
+      contract(direct_outbound: direct_outbound).network
     end
 
     # Returns true when any provider CLI config is available for
     # subscription-based authentication (e.g. from `claude login`,
-    # `gemini auth login`, or Codex `auth.json`).
+    # `gemini auth login`, Codex `auth.json`, or Copilot `hosts.json`).
     #
     # Mirrors the detection logic in Containers::Provision#subscription_auth?
     # so that service containers are always placed on the same network as the
@@ -64,16 +93,18 @@ class NetworkPolicy
     #
     # @return [Boolean]
     def subscription_auth?
-      claude_subscription_auth? || codex_subscription_auth? || gemini_subscription_auth?
+      claude_subscription_auth? || codex_subscription_auth? || gemini_subscription_auth? || copilot_subscription_auth?
     end
 
     # Ensures the agent Docker network exists. Creates it if missing.
     #
     # @return [Docker::Network] the agent network
     # @raise [Error] if network creation fails
-    def ensure_network!
-      Docker::Network.get(NETWORK_NAME)
+    def ensure_network!(network: NETWORK_NAME)
+      Docker::Network.get(network)
     rescue Docker::Error::NotFoundError
+      raise Error, "Docker network #{network} does not exist" unless network == NETWORK_NAME
+
       create_network
     end
 
@@ -148,6 +179,24 @@ class NetworkPolicy
 
     private
 
+    def restricted_contract
+      NetworkContract.new(
+        mode: "proxy",
+        network: NETWORK_NAME,
+        restricted: true,
+        firewall: true
+      )
+    end
+
+    def unrestricted_contract(mode)
+      NetworkContract.new(
+        mode: mode,
+        network: INFRA_NETWORK_NAME,
+        restricted: false,
+        firewall: false
+      )
+    end
+
     # Per-provider subscription auth checks mirror
     # Containers::Provision#claude_subscription_auth? etc.
     # Each looks for the specific credential file that proves a real login.
@@ -165,6 +214,11 @@ class NetworkPolicy
     def gemini_subscription_auth?
       dir = gemini_config_dir
       dir.present? && File.file?(File.join(dir, "oauth_creds.json"))
+    end
+
+    def copilot_subscription_auth?
+      dir = copilot_config_dir
+      dir.present? && File.file?(File.join(dir, "hosts.json"))
     end
 
     # Returns the Claude config directory path, checking the explicit
@@ -214,6 +268,21 @@ class NetworkPolicy
       end
 
       "/.gemini" if credential_present?("/.gemini", "oauth_creds.json")
+    end
+
+    # Returns the GitHub Copilot config directory path.
+    def copilot_config_dir
+      if ENV["COPILOT_CONFIG_DIR"].present?
+        return ENV["COPILOT_CONFIG_DIR"] if credential_present?(ENV["COPILOT_CONFIG_DIR"], "hosts.json")
+      end
+
+      home = home_dir
+      if home.present?
+        config_copilot = File.join(home, ".config", "github-copilot")
+        return config_copilot if credential_present?(config_copilot, "hosts.json")
+      end
+
+      "/.config/github-copilot" if credential_present?("/.config/github-copilot", "hosts.json")
     end
 
     # Returns true when the directory exists and contains the given credential file.

--- a/app/temporal/activities/provision_services_activity.rb
+++ b/app/temporal/activities/provision_services_activity.rb
@@ -13,7 +13,7 @@ module Activities
       agent_run = AgentRun.find(agent_run_id)
       track_phase(agent_run_id: agent_run_id, phase_key: "provision_services", phase_group: "setup", agent_run: agent_run) do
         provisioner = Containers::ServiceProvisioner.new
-        env_vars = provisioner.provision(agent_run, network: NetworkPolicy.agent_network)
+        env_vars = provisioner.provision(agent_run, network: Containers::Provision.network_for(agent_run: agent_run))
 
         logger.info(
           message: "agent_execution.services_provisioned",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,14 @@
 
 # Networks:
 #   paid_internal - For Paid infrastructure services (Rails, Temporal, Postgres)
-#   paid_agent    - Restricted network for agent containers (no default internet access)
+#                   and agent runs that require direct provider egress
+#   paid_agent    - Restricted network for proxy-mode agent containers
+#                   (no default internet access)
 #
-# Agent containers use paid_agent network with internal: true to prevent
-# default outbound access. Allowed egress (secrets proxy, GitHub) is
-# enforced via iptables rules applied by scripts/setup-agent-network.sh.
+# Proxy-mode agent containers use paid_agent with internal: true to prevent
+# default outbound access. Subscription-auth and direct-outbound provider
+# runs use paid_internal so provider CLIs can reach upstream APIs directly.
+# Allowed egress on paid_agent is enforced by NetworkPolicy iptables rules.
 
 services:
   postgres:
@@ -228,7 +231,7 @@ networks:
     name: paid_internal
     driver: bridge
 
-  # Restricted network for agent containers (API key mode).
+  # Restricted network for proxy-mode agent containers.
   # internal: true disables default internet access.
   # Explicit name: ensures NetworkPolicy::NETWORK_NAME matches.
   paid_agent:

--- a/docs/AGENT_SYSTEM.md
+++ b/docs/AGENT_SYSTEM.md
@@ -672,10 +672,10 @@ Service containers are provisioned as part of the agent execution workflow via `
 
 ### Network Setup
 
-Service containers are placed on the same Docker network as the agent container. The network is selected by `NetworkPolicy.agent_network`:
+Service containers are placed on the same Docker network as the agent container. The network is selected from the same per-run contract used by `Containers::Provision`:
 
-- **`paid_agent`** — Restricted network for API-key mode. Outbound traffic is limited to the secrets proxy, GitHub, DNS, and service containers via iptables rules.
-- **`paid_internal`** — Infrastructure network for subscription-auth mode (e.g., `claude login`). Allows outbound HTTPS for direct provider API access.
+- **`paid_agent`** — Restricted network for proxy-mode API-key auth. Outbound traffic is limited to the secrets proxy, GitHub, DNS, and service containers via iptables rules.
+- **`paid_internal`** — Infrastructure network for subscription-auth mode (e.g., `claude login`) and direct-outbound provider runs. Allows outbound HTTPS for direct provider API access.
 
 Service containers register a DNS alias matching their name, so agents can reach them by hostname (e.g., `proj-postgres`, `proj-redis`).
 

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -421,8 +421,11 @@ Paid uses two Docker networks to isolate agent traffic:
 
 | Network | Purpose | Internet Access |
 |---------|---------|-----------------|
-| `paid_internal` | Rails, Temporal, PostgreSQL, Qdrant | Yes |
-| `paid_agent` | Agent container execution | No (internal only) |
+| `paid_internal` | Rails, Temporal, PostgreSQL, Qdrant, subscription-auth agent runs, direct-outbound provider runs | Yes |
+| `paid_agent` | Proxy-mode agent container execution | No (internal only) |
 
-Agent containers communicate with external services only through the secrets proxy
-on the internal network. This prevents credential leakage and controls API access.
+Proxy-mode agent containers communicate with external services through the secrets
+proxy and the Git credential proxy. Subscription-auth and direct-outbound provider
+runs are explicit exceptions: they use `paid_internal` so their provider CLIs can
+reach upstream APIs directly. Service containers are placed on the same network
+as the agent run that needs them.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,7 +14,7 @@ Multiple layers of protection ensure that a breach in one layer doesn't compromi
 │                                                                              │
 │  ┌─────────────────────────────────────────────────────────────────────────┐│
 │  │ Layer 1: Network Isolation                                              ││
-│  │ Containers can only reach allowlisted domains                           ││
+│  │ Proxy-mode containers can only reach allowlisted destinations           ││
 │  └─────────────────────────────────────────────────────────────────────────┘│
 │                                    │                                         │
 │  ┌─────────────────────────────────────────────────────────────────────────┐│
@@ -42,9 +42,9 @@ Agents receive only the permissions they need:
 |----------|--------------|-----------|
 | Source code | Read/Write (worktree only) | Needed for implementation |
 | GitHub API | Via proxy only | Prevents token exfiltration |
-| LLM APIs | Via proxy only | Prevents key exfiltration |
+| LLM APIs | Via proxy in proxy mode; direct HTTPS in subscription-auth and direct-outbound modes | Proxy mode prevents key exfiltration; direct modes are explicit exceptions for provider CLIs that require native upstream access |
 | File system | Worktree + temp only | No access to host |
-| Network | Allowlisted domains | Prevents data exfiltration |
+| Network | Restricted in proxy mode; provider egress allowed in subscription-auth and direct-outbound modes | Keeps the no-default-internet boundary scoped to runs that can use the secrets proxy |
 | Other containers | None | No lateral movement |
 
 ### 3. No Implicit Trust
@@ -145,7 +145,17 @@ end
 
 ### Network Isolation
 
-Containers use a dedicated network with strict egress rules:
+Paid chooses the agent Docker network from the provider auth mode:
+
+| Mode | Docker network | Default internet access | Firewall policy |
+|------|----------------|-------------------------|-----------------|
+| Proxy mode API-key auth | `paid_agent` | No | Apply in-container iptables allowlist for DNS, secrets proxy, GitHub, and service containers |
+| Subscription auth | `paid_internal` | Yes | Do not apply the restrictive firewall because the provider CLI must reach upstream provider APIs directly |
+| Direct-outbound provider auth | `paid_internal` | Yes | Do not apply the restrictive firewall because the provider runtime intentionally bypasses Paid's secrets proxy |
+
+Service containers are attached to the same Docker network selected for the agent run so database, Redis, or browser endpoints remain reachable in every mode.
+
+Proxy-mode containers use a dedicated network with strict egress rules:
 
 ```ruby
 class FirewallService

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe Containers::Provision do
 
     context "with network integration" do
       it "ensures the agent network exists before provisioning" do
-        expect(NetworkPolicy).to receive(:ensure_network!).ordered
+        expect(NetworkPolicy).to receive(:ensure_network!).with(network: NetworkPolicy::NETWORK_NAME).ordered
         expect(Docker::Container).to receive(:create).ordered.and_return(mock_container)
 
         service.provision
@@ -692,8 +692,8 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "skips network creation" do
-        expect(NetworkPolicy).not_to receive(:ensure_network!)
+      it "ensures the infrastructure network exists" do
+        expect(NetworkPolicy).to receive(:ensure_network!).with(network: NetworkPolicy::INFRA_NETWORK_NAME)
 
         service.provision
       end

--- a/spec/services/containers/service_provisioner_spec.rb
+++ b/spec/services/containers/service_provisioner_spec.rb
@@ -64,7 +64,13 @@ RSpec.describe Containers::ServiceProvisioner do
       it "reuses running containers when Docker container is alive" do
         service_container.update!(status: "running", docker_container_id: "alive123")
         alive_container = instance_double(Docker::Container,
-          info: { "State" => { "Running" => true } })
+          id: "alive123",
+          info: {
+            "State" => { "Running" => true },
+            "NetworkSettings" => {
+              "Networks" => { NetworkPolicy::NETWORK_NAME => { "Aliases" => [ "test-postgres" ] } }
+            }
+          })
         allow(Docker::Container).to receive(:get).with("alive123").and_return(alive_container)
         allow(alive_container).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
         allow(Docker::Container).to receive(:create).and_call_original
@@ -73,6 +79,57 @@ RSpec.describe Containers::ServiceProvisioner do
 
         expect(result).to include("DATABASE_URL")
         expect(Docker::Container).not_to have_received(:create)
+      end
+
+      it "connects reused running containers to the requested network with the service alias" do
+        service_container.update!(status: "running", docker_container_id: "alive123")
+        alive_container = instance_double(Docker::Container,
+          id: "alive123",
+          info: {
+            "State" => { "Running" => true },
+            "NetworkSettings" => {
+              "Networks" => { NetworkPolicy::NETWORK_NAME => { "Aliases" => [ "test-postgres" ] } }
+            }
+          })
+        network = instance_double(Docker::Network)
+
+        allow(Docker::Container).to receive(:get).with("alive123").and_return(alive_container)
+        allow(Docker::Network).to receive(:get).with(NetworkPolicy::INFRA_NETWORK_NAME).and_return(network)
+        allow(network).to receive(:connect)
+        allow(alive_container).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
+
+        provisioner.provision(agent_run, network: NetworkPolicy::INFRA_NETWORK_NAME)
+
+        expect(network).to have_received(:connect).with(
+          "alive123",
+          {},
+          "EndpointConfig" => { "Aliases" => [ "test-postgres" ] }
+        )
+      end
+
+      it "reconnects reused containers when the requested network is missing the service alias" do
+        service_container.update!(status: "running", docker_container_id: "alive123")
+        alive_container = instance_double(Docker::Container,
+          id: "alive123",
+          info: {
+            "State" => { "Running" => true },
+            "NetworkSettings" => { "Networks" => { NetworkPolicy::NETWORK_NAME => { "Aliases" => [] } } }
+          })
+        network = instance_double(Docker::Network)
+
+        allow(Docker::Container).to receive(:get).with("alive123").and_return(alive_container)
+        allow(Docker::Network).to receive(:get).with(NetworkPolicy::NETWORK_NAME).and_return(network)
+        allow(network).to receive_messages(disconnect: nil, connect: nil)
+        allow(alive_container).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
+
+        provisioner.provision(agent_run)
+
+        expect(network).to have_received(:disconnect).with("alive123")
+        expect(network).to have_received(:connect).with(
+          "alive123",
+          {},
+          "EndpointConfig" => { "Aliases" => [ "test-postgres" ] }
+        )
       end
 
       it "re-provisions when Docker container is dead" do
@@ -173,7 +230,13 @@ RSpec.describe Containers::ServiceProvisioner do
 
       it "leaves the shared container record intact" do
         docker_container = instance_double(Docker::Container,
-          info: { "State" => { "Running" => true } })
+          id: "shared123",
+          info: {
+            "State" => { "Running" => true },
+            "NetworkSettings" => {
+              "Networks" => { NetworkPolicy::NETWORK_NAME => { "Aliases" => [ "db-fail-postgres" ] } }
+            }
+          })
         allow(Docker::Container).to receive(:get).with("shared123").and_return(docker_container)
         allow(docker_container).to receive(:exec)
           .and_return([ [], [ "psql: connection refused" ], 2 ])
@@ -200,11 +263,23 @@ RSpec.describe Containers::ServiceProvisioner do
       let(:stale_json) do
         { "Config" => { "Labels" => managed_labels }, "State" => { "Running" => false } }
       end
+      let(:running_json) do
+        { "Config" => { "Labels" => managed_labels }, "State" => { "Running" => true } }
+      end
+      let(:running_container) do
+        instance_double(Docker::Container,
+          id: "running789",
+          info: {
+            "State" => { "Running" => true },
+            "NetworkSettings" => {
+              "Networks" => { NetworkPolicy::NETWORK_NAME => { "Aliases" => [ "conflict-postgres" ] } }
+            }
+          })
+      end
 
       before do
         create(:project_service_container, project: project, service_container: service_container)
       end
-
 
       it "removes stale stopped container and retries" do
         stale = instance_double(Docker::Container, id: "stale789")
@@ -235,26 +310,46 @@ RSpec.describe Containers::ServiceProvisioner do
       end
 
       it "adopts a running container instead of deleting it" do
-        existing = instance_double(Docker::Container, id: "running789")
-        running_json = { "Config" => { "Labels" => managed_labels }, "State" => { "Running" => true } }
+        allow(Docker::Image).to receive(:create)
+        allow(Docker::Container).to receive(:create)
+          .and_raise(Docker::Error::ConflictError, "Conflict. The container name is already in use")
+        allow(Docker::Container).to receive(:get).with("conflict-postgres").and_return(running_container)
+        allow(running_container).to receive_messages(json: running_json, stop: nil, delete: nil)
+        allow(provisioner).to receive_messages(docker_healthcheck_status: nil, tcp_port_open?: true)
+
+        # Stub per-run database creation
+        allow(Docker::Container).to receive(:get).with("running789").and_return(running_container)
+        allow(running_container).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
+
+        result = provisioner.provision(agent_run)
+
+        expect(running_container).not_to have_received(:stop)
+        expect(running_container).not_to have_received(:delete)
+        expect(service_container.reload.docker_container_id).to eq("running789")
+        expect(result).to include("DATABASE_URL")
+      end
+
+      it "connects adopted running containers to the requested network with the service alias" do
+        network = instance_double(Docker::Network)
 
         allow(Docker::Image).to receive(:create)
         allow(Docker::Container).to receive(:create)
           .and_raise(Docker::Error::ConflictError, "Conflict. The container name is already in use")
-        allow(Docker::Container).to receive(:get).with("conflict-postgres").and_return(existing)
-        allow(existing).to receive_messages(json: running_json, stop: nil, delete: nil)
+        allow(Docker::Container).to receive(:get).with("conflict-postgres").and_return(running_container)
+        allow(Docker::Container).to receive(:get).with("running789").and_return(running_container)
+        allow(Docker::Network).to receive(:get).with(NetworkPolicy::INFRA_NETWORK_NAME).and_return(network)
+        allow(network).to receive(:connect)
+        allow(running_container).to receive_messages(json: running_json, stop: nil, delete: nil)
         allow(provisioner).to receive_messages(docker_healthcheck_status: nil, tcp_port_open?: true)
+        allow(running_container).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
 
-        # Stub per-run database creation
-        allow(Docker::Container).to receive(:get).with("running789").and_return(existing)
-        allow(existing).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
+        provisioner.provision(agent_run, network: NetworkPolicy::INFRA_NETWORK_NAME)
 
-        result = provisioner.provision(agent_run)
-
-        expect(existing).not_to have_received(:stop)
-        expect(existing).not_to have_received(:delete)
-        expect(service_container.reload.docker_container_id).to eq("running789")
-        expect(result).to include("DATABASE_URL")
+        expect(network).to have_received(:connect).with(
+          "running789",
+          {},
+          "EndpointConfig" => { "Aliases" => [ "conflict-postgres" ] }
+        )
       end
 
       it "raises when stale container is not managed by Paid" do

--- a/spec/services/containers/service_provisioner_spec.rb
+++ b/spec/services/containers/service_provisioner_spec.rb
@@ -91,11 +91,10 @@ RSpec.describe Containers::ServiceProvisioner do
               "Networks" => { NetworkPolicy::NETWORK_NAME => { "Aliases" => [ "test-postgres" ] } }
             }
           })
-        network = instance_double(Docker::Network)
+        network = instance_double(Docker::Network, connect: nil, disconnect: nil)
 
         allow(Docker::Container).to receive(:get).with("alive123").and_return(alive_container)
-        allow(Docker::Network).to receive(:get).with(NetworkPolicy::INFRA_NETWORK_NAME).and_return(network)
-        allow(network).to receive(:connect)
+        allow(Docker::Network).to receive(:get).and_return(network)
         allow(alive_container).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
 
         provisioner.provision(agent_run, network: NetworkPolicy::INFRA_NETWORK_NAME)
@@ -105,6 +104,31 @@ RSpec.describe Containers::ServiceProvisioner do
           {},
           "EndpointConfig" => { "Aliases" => [ "test-postgres" ] }
         )
+      end
+
+      it "disconnects reused running containers from the non-selected Paid network" do
+        service_container.update!(status: "running", docker_container_id: "alive123")
+        alive_container = instance_double(Docker::Container,
+          id: "alive123",
+          info: {
+            "State" => { "Running" => true },
+            "NetworkSettings" => {
+              "Networks" => {
+                NetworkPolicy::NETWORK_NAME => { "Aliases" => [ "test-postgres" ] },
+                NetworkPolicy::INFRA_NETWORK_NAME => { "Aliases" => [ "test-postgres" ] }
+              }
+            }
+          })
+        infra_network = instance_double(Docker::Network)
+
+        allow(Docker::Container).to receive(:get).with("alive123").and_return(alive_container)
+        allow(Docker::Network).to receive(:get).with(NetworkPolicy::INFRA_NETWORK_NAME).and_return(infra_network)
+        allow(infra_network).to receive(:disconnect)
+        allow(alive_container).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
+
+        provisioner.provision(agent_run)
+
+        expect(infra_network).to have_received(:disconnect).with("alive123")
       end
 
       it "reconnects reused containers when the requested network is missing the service alias" do
@@ -338,6 +362,8 @@ RSpec.describe Containers::ServiceProvisioner do
         allow(Docker::Container).to receive(:get).with("conflict-postgres").and_return(running_container)
         allow(Docker::Container).to receive(:get).with("running789").and_return(running_container)
         allow(Docker::Network).to receive(:get).with(NetworkPolicy::INFRA_NETWORK_NAME).and_return(network)
+        allow(Docker::Network).to receive(:get).with(NetworkPolicy::NETWORK_NAME)
+          .and_return(instance_double(Docker::Network, disconnect: nil))
         allow(network).to receive(:connect)
         allow(running_container).to receive_messages(json: running_json, stop: nil, delete: nil)
         allow(provisioner).to receive_messages(docker_healthcheck_status: nil, tcp_port_open?: true)

--- a/spec/services/containers/service_provisioner_spec.rb
+++ b/spec/services/containers/service_provisioner_spec.rb
@@ -5,6 +5,15 @@ require "rails_helper"
 RSpec.describe Containers::ServiceProvisioner do
   let(:provisioner) { described_class.new }
 
+  def running_docker_container(id:, networks:)
+    instance_double(Docker::Container,
+      id: id,
+      info: {
+        "State" => { "Running" => true },
+        "NetworkSettings" => { "Networks" => networks }
+      })
+  end
+
   describe "#provision" do
     let(:project) { create(:project) }
     let(:issue) { create(:issue, project: project) }
@@ -106,29 +115,30 @@ RSpec.describe Containers::ServiceProvisioner do
         )
       end
 
-      it "disconnects reused running containers from the non-selected Paid network" do
+      it "keeps shared containers attached to the other active run's Paid network" do
         service_container.update!(status: "running", docker_container_id: "alive123")
-        alive_container = instance_double(Docker::Container,
+        create(:agent_run, :running, project: project, issue: create(:issue, project: project),
+          service_container_ids: [ service_container.id ])
+        alive_container = running_docker_container(
           id: "alive123",
-          info: {
-            "State" => { "Running" => true },
-            "NetworkSettings" => {
-              "Networks" => {
-                NetworkPolicy::NETWORK_NAME => { "Aliases" => [ "test-postgres" ] },
-                NetworkPolicy::INFRA_NETWORK_NAME => { "Aliases" => [ "test-postgres" ] }
-              }
-            }
-          })
-        infra_network = instance_double(Docker::Network)
+          networks: { NetworkPolicy::NETWORK_NAME => { "Aliases" => [ "test-postgres" ] } }
+        )
+        agent_network = instance_double(Docker::Network, disconnect: nil)
+        infra_network = instance_double(Docker::Network, connect: nil, disconnect: nil)
 
         allow(Docker::Container).to receive(:get).with("alive123").and_return(alive_container)
+        allow(Docker::Network).to receive(:get).with(NetworkPolicy::NETWORK_NAME).and_return(agent_network)
         allow(Docker::Network).to receive(:get).with(NetworkPolicy::INFRA_NETWORK_NAME).and_return(infra_network)
-        allow(infra_network).to receive(:disconnect)
         allow(alive_container).to receive(:exec).and_return([ [ "(0 rows)" ], [], 0 ])
 
-        provisioner.provision(agent_run)
+        provisioner.provision(agent_run, network: NetworkPolicy::INFRA_NETWORK_NAME)
 
-        expect(infra_network).to have_received(:disconnect).with("alive123")
+        expect(infra_network).to have_received(:connect).with(
+          "alive123",
+          {},
+          "EndpointConfig" => { "Aliases" => [ "test-postgres" ] }
+        )
+        expect(agent_network).not_to have_received(:disconnect)
       end
 
       it "reconnects reused containers when the requested network is missing the service alias" do

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -108,6 +108,21 @@ RSpec.describe NetworkPolicy do
           .to raise_error(described_class::Error, /Failed to create agent network/)
       end
     end
+
+    context "when the infrastructure network is missing" do
+      before do
+        allow(Docker::Network).to receive(:get)
+          .with(described_class::INFRA_NETWORK_NAME)
+          .and_raise(Docker::Error::NotFoundError)
+      end
+
+      it "raises instead of creating the infrastructure network" do
+        expect(Docker::Network).not_to receive(:create)
+
+        expect { described_class.ensure_network!(network: described_class::INFRA_NETWORK_NAME) }
+          .to raise_error(described_class::Error, /paid_internal does not exist/)
+      end
+    end
   end
 
   describe ".network_exists?" do
@@ -294,12 +309,13 @@ RSpec.describe NetworkPolicy do
     around do |example|
       # Isolate env vars used by config dir detection
       original_env = ENV.to_h.slice(
-        "CLAUDE_CONFIG_DIR", "CODEX_CONFIG_DIR", "CODEX_HOME", "GEMINI_CONFIG_DIR"
+        "CLAUDE_CONFIG_DIR", "CODEX_CONFIG_DIR", "CODEX_HOME", "GEMINI_CONFIG_DIR", "COPILOT_CONFIG_DIR"
       )
       ENV.delete("CLAUDE_CONFIG_DIR")
       ENV.delete("CODEX_CONFIG_DIR")
       ENV.delete("CODEX_HOME")
       ENV.delete("GEMINI_CONFIG_DIR")
+      ENV.delete("COPILOT_CONFIG_DIR")
       example.run
     ensure
       original_env.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
@@ -375,6 +391,54 @@ RSpec.describe NetworkPolicy do
       it "selects the infrastructure network" do
         expect(described_class.agent_network).to eq(described_class::INFRA_NETWORK_NAME)
       end
+    end
+
+    context "when only Copilot credentials exist" do
+      before do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:exist?).with("/tmp/copilot-test").and_return(true)
+        ENV["COPILOT_CONFIG_DIR"] = "/tmp/copilot-test"
+        allow(File).to receive(:file?).and_return(false)
+        allow(File).to receive(:file?)
+          .with("/tmp/copilot-test/hosts.json").and_return(true)
+      end
+
+      it "returns true" do
+        expect(described_class.subscription_auth?).to be true
+      end
+
+      it "selects the infrastructure network" do
+        expect(described_class.agent_network).to eq(described_class::INFRA_NETWORK_NAME)
+      end
+    end
+  end
+
+  describe ".contract" do
+    it "returns the restricted proxy-mode contract by default" do
+      contract = described_class.contract(subscription_auth: false)
+
+      expect(contract.mode).to eq("proxy")
+      expect(contract.network).to eq(described_class::NETWORK_NAME)
+      expect(contract).to be_restricted
+      expect(contract).to be_firewall
+    end
+
+    it "returns the infrastructure contract for subscription auth" do
+      contract = described_class.contract(subscription_auth: true)
+
+      expect(contract.mode).to eq("subscription_auth")
+      expect(contract.network).to eq(described_class::INFRA_NETWORK_NAME)
+      expect(contract).not_to be_restricted
+      expect(contract).not_to be_firewall
+    end
+
+    it "returns the infrastructure contract for direct outbound providers" do
+      contract = described_class.contract(subscription_auth: false, direct_outbound: true)
+
+      expect(contract.mode).to eq("direct_outbound")
+      expect(contract.network).to eq(described_class::INFRA_NETWORK_NAME)
+      expect(contract).not_to be_restricted
+      expect(contract).not_to be_firewall
     end
   end
 

--- a/spec/temporal/activities/provision_services_activity_spec.rb
+++ b/spec/temporal/activities/provision_services_activity_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Activities::ProvisionServicesActivity do
         .and_return({ "DATABASE_URL" => "postgres://agent:agent@pg:5432/agent_test" })
       allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
       allow(agent_run).to receive(:service_container_ids).and_return([ 1 ])
-      allow(NetworkPolicy).to receive(:agent_network).and_return(NetworkPolicy::NETWORK_NAME)
+      allow(Containers::Provision).to receive(:network_for).with(agent_run: agent_run).and_return(NetworkPolicy::NETWORK_NAME)
 
       result = activity.execute(agent_run_id: agent_run.id)
 
@@ -29,7 +29,21 @@ RSpec.describe Activities::ProvisionServicesActivity do
       allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
       allow(provisioner).to receive(:provision)
         .with(agent_run, network: NetworkPolicy::NETWORK_NAME).and_return({})
-      allow(NetworkPolicy).to receive(:agent_network).and_return(NetworkPolicy::NETWORK_NAME)
+      allow(Containers::Provision).to receive(:network_for).with(agent_run: agent_run).and_return(NetworkPolicy::NETWORK_NAME)
+      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+      allow(agent_run).to receive(:service_container_ids).and_return([])
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:service_environment]).to eq({})
+    end
+
+    it "uses the same network selected for the agent container" do
+      provisioner = instance_double(Containers::ServiceProvisioner)
+      allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+      allow(Containers::Provision).to receive(:network_for).with(agent_run: agent_run).and_return(NetworkPolicy::INFRA_NETWORK_NAME)
+      allow(provisioner).to receive(:provision)
+        .with(agent_run, network: NetworkPolicy::INFRA_NETWORK_NAME).and_return({})
       allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
       allow(agent_run).to receive(:service_container_ids).and_return([])
 


### PR DESCRIPTION
## Summary

fix(containers): align network isolation claims across provider auth modes

See #1284 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1284