### PR TITLE
fix(secrets): remove direct provider credential injection from agent runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
   - Gap: subscription-auth and direct-outbound provider runs use the internal network for provider access; tracked by [#1284](https://github.com/viamin/paid/issues/1284).
 - **Multiple Agents and Providers**: Support for Claude Code, Codex, Cursor, Gemini, Aider, OpenCode, Kilocode, and Copilot when the runtime is both supported by `agent-harness` and installed in `paid-agent`
   - Gap: broader runtime parity is tracked by provider metadata and smoke-test refactors ([#798](https://github.com/viamin/paid/issues/798), [#796](https://github.com/viamin/paid/issues/796)) plus agent-image install delegation work ([#789](https://github.com/viamin/paid/issues/789)-[#795](https://github.com/viamin/paid/issues/795)).
-- **Secrets Proxy**: Git credentials and default platform LLM keys are proxied through authenticated endpoints
-  - Gap: stored provider API-key auth and subscription auth can still place provider credentials inside the agent runtime; agent-run cleanup is tracked by [#1281](https://github.com/viamin/paid/issues/1281), and knowledge-side direct key usage is tracked by [#1043](https://github.com/viamin/paid/issues/1043) and [#1044](https://github.com/viamin/paid/issues/1044).
+- **Secrets Proxy**: Git credentials, default platform LLM keys, and stored provider API-key auth for proxy-compatible agent CLIs are proxied through authenticated endpoints
+  - Caveat: subscription auth intentionally copies CLI login state into the agent runtime, and direct-outbound OpenCode/KiloCode API-key providers still place provider credentials in runtime config because they can target non-proxied upstream APIs. Knowledge-side direct key usage is tracked by [#1043](https://github.com/viamin/paid/issues/1043) and [#1044](https://github.com/viamin/paid/issues/1044).
 - **Human-in-the-Loop**: All changes go through PRs; humans approve merges (can be automated if desired)
 - **Full Automation or Manual Control**: Auto-pick next issue or trigger runs manually from the UI
 - **Prompt Management**: Version prompts as data, diff versions, and manage A/B tests before promoting prompt changes
@@ -205,7 +205,10 @@ bin/dev                 # Start Rails, JS/CSS watchers, and the Temporal worker
 By default, provider tests and real agent runs use the same containerized auth path. For Codex and Gemini, when a Paid-managed proxy key is configured on the `web` service, Test Agent can instead use the agent-harness auth path for faster validation. Each provider can usually be configured in one of two ways:
 
 1. Paid-managed proxy auth using an API key on the `web` service.
-2. Subscription auth using local CLI login state that Paid copies into the agent container.
+2. Stored provider API-key auth using an API key saved in Paid. For Claude, Codex, Gemini, Cursor, and Aider agent runs, Paid keeps the stored key server-side and routes provider calls through the secrets proxy.
+3. Subscription auth using local CLI login state that Paid copies into the agent container.
+
+OpenCode and KiloCode direct-outbound API-key entries are the exception: Paid writes their runtime provider config inside the agent container because those tools can target upstream APIs that the secrets proxy does not cover.
 
 ### Claude
 

--- a/app/controllers/api/secrets_proxy_controller.rb
+++ b/app/controllers/api/secrets_proxy_controller.rb
@@ -164,7 +164,10 @@ module Api
     end
 
     def fetch_api_key(provider)
-      key = knowledge_run_api_key(provider)
+      key = agent_run_api_key(provider)
+      return if performed?
+
+      key ||= knowledge_run_api_key(provider)
       key ||= Rails.application.credentials.dig(:llm, :"#{provider}_api_key")
       key ||= ENV["#{provider.to_s.upcase}_API_KEY"]
 
@@ -175,6 +178,32 @@ module Api
       end
 
       key
+    end
+
+    def agent_run_api_key(provider)
+      return unless @agent_run
+      return unless request.headers["X-Paid-Provider-Id"].present?
+
+      provider_entry = agent_run_provider_entry(provider)
+      unless provider_entry
+        log_error("secrets_proxy.invalid_provider_key", "Provider key is not available for #{provider}")
+        render json: { error: "Provider key is not available for this agent run" }, status: :forbidden
+        return nil
+      end
+
+      provider_entry.provider_api_key.api_key
+    end
+
+    def agent_run_provider_entry(provider)
+      provider_id = request.headers["X-Paid-Provider-Id"].presence
+      return unless provider_id
+
+      @agent_run.project.effective_owner
+        &.providers
+        &.api_key
+        &.for_agent_runs
+        &.joins(:provider_api_key)
+        &.find_by(id: provider_id, provider_api_keys: { api_service_type: provider.to_s })
     end
 
     def resolve_max_tokens_per_run

--- a/app/controllers/api/secrets_proxy_controller.rb
+++ b/app/controllers/api/secrets_proxy_controller.rb
@@ -198,12 +198,18 @@ module Api
       provider_id = request.headers["X-Paid-Provider-Id"].presence
       return unless provider_id
 
-      @agent_run.project.effective_owner
+      provider_entries = @agent_run.project.effective_owner
         &.providers
         &.api_key
-        &.for_agent_runs
         &.joins(:provider_api_key)
-        &.find_by(id: provider_id, provider_api_keys: { api_service_type: provider.to_s })
+      return unless provider_entries
+
+      available_provider_entries(provider_entries)
+        .find_by(id: provider_id, provider_api_keys: { api_service_type: provider.to_s })
+    end
+
+    def available_provider_entries(provider_entries)
+      provider_entries.for_agent_runs.or(provider_entries.for_fallback)
     end
 
     def resolve_max_tokens_per_run

--- a/app/controllers/concerns/api/container_authentication.rb
+++ b/app/controllers/concerns/api/container_authentication.rb
@@ -78,6 +78,7 @@ module Api
 
     def extract_embedded_proxy_credentials
       parse_proxy_credential(request.headers["Authorization"]&.delete_prefix("Bearer ")) ||
+        parse_proxy_credential(request.headers["X-Api-Key"]) ||
         parse_proxy_credential(request.headers["X-Goog-Api-Key"])
     end
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1287,19 +1287,18 @@ module Activities
 
     def api_key_auth_command(provider_entry, command_prefix, prompt)
       base = command_prefix.shelljoin
-      unset_flags = api_key_unset_vars_for(provider_entry)
-        .map { |var| "-u #{var}" }
-        .join(" ")
       env_assignments = api_key_env_var_names_for(provider_entry)
-        .map { |var| %(#{var}="$PAID_PROVIDER_API_KEY") }
+        .map { |var| %(#{var}="paid-run:$AGENT_RUN_ID:$PROXY_TOKEN") }
+        .join(" ")
+      header_assignments = api_key_proxy_header_assignments_for(provider_entry)
         .join(" ")
 
-      script = "env #{unset_flags} #{env_assignments} #{base} \"$1\""
+      script = "env #{header_assignments} #{env_assignments} #{base} \"$1\""
       [ "sh", "-c", script, "--", prompt ]
     end
 
     def api_key_command_env(provider_entry)
-      { "PAID_PROVIDER_API_KEY" => provider_entry.provider_api_key&.api_key.to_s }
+      { "PAID_PROVIDER_ID" => provider_entry.id.to_s }
     end
 
     def api_key_env_var_names_for(provider_entry)
@@ -1315,18 +1314,17 @@ module Activities
       end
     end
 
-    def api_key_unset_vars_for(provider_entry)
+    def api_key_proxy_header_assignments_for(provider_entry)
       case provider_entry.provider_key
       when "gemini"
-        ProviderSupport.subscription_auth_unset_vars_for("gemini")
-      when "codex"
-        ProviderSupport.subscription_auth_unset_vars_for("codex")
-      when "claude", "cursor", "aider"
-        %w[
-          ANTHROPIC_BASE_URL
-          ANTHROPIC_HEADER_X_AGENT_RUN_ID
-          ANTHROPIC_HEADER_X_PROXY_TOKEN
+        [
+          %(GOOGLE_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID"),
+          %(GEMINI_CLI_CUSTOM_HEADERS="X-Agent-Run-Id: $AGENT_RUN_ID, X-Proxy-Token: $PROXY_TOKEN, X-Paid-Provider-Id: $PAID_PROVIDER_ID")
         ]
+      when "codex"
+        [ %(OPENAI_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID") ]
+      when "claude", "cursor", "aider"
+        [ %(ANTHROPIC_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID") ]
       else
         []
       end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1324,7 +1324,12 @@ module Activities
       when "codex"
         [ %(OPENAI_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID") ]
       when "claude", "cursor", "aider"
-        [ %(ANTHROPIC_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID") ]
+        [
+          %(ANTHROPIC_BASE_URL="$PAID_PROXY_URL/api/proxy/anthropic"),
+          %(ANTHROPIC_HEADER_X_AGENT_RUN_ID="$AGENT_RUN_ID"),
+          %(ANTHROPIC_HEADER_X_PROXY_TOKEN="$PROXY_TOKEN"),
+          %(ANTHROPIC_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID")
+        ]
       else
         []
       end

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -24,7 +24,7 @@ Multiple layers of protection ensure that a breach in one layer doesn't compromi
 │                                    │                                         │
 │  ┌─────────────────────────────────────────────────────────────────────────┐│
 │  │ Layer 3: Secrets Proxy                                                  ││
-│  │ API keys never enter containers; Paid proxies all authenticated calls    ││
+│  │ Proxy-compatible API-key calls keep provider keys outside containers     ││
 │  └─────────────────────────────────────────────────────────────────────────┘│
 │                                    │                                         │
 │  ┌─────────────────────────────────────────────────────────────────────────┐│
@@ -440,9 +440,19 @@ Agents are configured to use the proxy instead of direct API calls:
 ENV["ANTHROPIC_BASE_URL"] = "http://paid-proxy:3001/proxy/api.anthropic.com"
 ENV["OPENAI_BASE_URL"] = "http://paid-proxy:3001/proxy/api.openai.com"
 
-# No API keys in environment - the proxy adds them
-# ENV["ANTHROPIC_API_KEY"] is NOT set
+# No provider API keys in environment - the proxy adds them.
+# Some CLIs require an API-key-shaped value; Paid uses a run-scoped
+# proxy credential such as "paid-run:<id>:<token>", not the provider key.
 ```
+
+Agent-run provider auth modes have the following runtime secret contract:
+
+| Auth mode | Providers | Runtime material | Notes |
+| --- | --- | --- | --- |
+| Paid-managed proxy key | Claude, Codex, Gemini, Cursor, Aider | Run id, proxy token, provider proxy base URL | Provider key stays on the Rails service and is added by the secrets proxy. |
+| Stored provider API key | Claude, Codex, Gemini, Cursor, Aider | Run-scoped proxy credential plus provider entry id | Provider key stays server-side; the proxy validates the provider belongs to the run owner before forwarding. |
+| Subscription auth | Claude, Codex, Gemini, Copilot | CLI login state mounted or copied into the runtime | Explicit exception: the CLI needs native account session files. |
+| Direct-outbound API key | OpenCode, KiloCode | Provider API key in runtime env or config | Explicit exception: these entries can target upstream APIs outside the proxy coverage. |
 
 ---
 

--- a/spec/requests/api/secrets_proxy_spec.rb
+++ b/spec/requests/api/secrets_proxy_spec.rb
@@ -108,6 +108,42 @@ RSpec.describe "Api::SecretsProxy" do
           .with(headers: { "x-api-key" => "sk-stored-anthropic-key" })
       end
 
+      it "uses a fallback-only provider API key when a provider id header is present" do
+        provider = create_anthropic_api_key_provider(
+          :rate_limit_fallback,
+          api_key: "sk-fallback-anthropic-key",
+          enabled_for_agent_runs: false,
+          enabled_for_fallback: true
+        )
+
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: valid_headers.merge(
+            "X-Paid-Provider-Id" => provider.id.to_s,
+            "x-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+          )
+
+        expect(WebMock).to have_requested(:post, target_url)
+          .with(headers: { "x-api-key" => "sk-fallback-anthropic-key" })
+      end
+
+      it "rejects provider ids that are disabled for agent runs and fallback" do
+        provider = create_anthropic_api_key_provider(
+          enabled_for_agent_runs: false,
+          enabled_for_fallback: false
+        )
+
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: valid_headers.merge(
+            "X-Paid-Provider-Id" => provider.id.to_s,
+            "x-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+          )
+
+        expect(response).to have_http_status(:forbidden)
+        expect(WebMock).not_to have_requested(:post, target_url)
+      end
+
       it "rejects provider ids that are not available to the agent run owner" do
         other_user = create(:user)
         api_key = create(:provider_api_key, user: other_user, api_service_type: "anthropic")
@@ -767,5 +803,24 @@ RSpec.describe "Api::SecretsProxy" do
         expect(knowledge_run.reload.token_limit_status).to eq("exceeded")
       end
     end
+  end
+
+  def create_anthropic_api_key_provider(*traits, api_key: "sk-stored-anthropic-key", **attributes)
+    provider_api_key = create(
+      :provider_api_key,
+      user: project.effective_owner,
+      api_service_type: "anthropic",
+      api_key: api_key
+    )
+
+    create(
+      :provider,
+      :api_key,
+      *traits,
+      user: project.effective_owner,
+      provider_key: "claude",
+      provider_api_key: provider_api_key,
+      **attributes
+    )
   end
 end

--- a/spec/requests/api/secrets_proxy_spec.rb
+++ b/spec/requests/api/secrets_proxy_spec.rb
@@ -88,6 +88,42 @@ RSpec.describe "Api::SecretsProxy" do
           .with(headers: { "x-api-key" => "sk-ant-test-key" })
       end
 
+      it "uses the run owner's stored provider API key when a provider id header is present" do
+        api_key = create(
+          :provider_api_key,
+          user: project.effective_owner,
+          api_service_type: "anthropic",
+          api_key: "sk-stored-anthropic-key"
+        )
+        provider = create(:provider, :api_key, user: project.effective_owner, provider_key: "claude", provider_api_key: api_key)
+
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: valid_headers.merge(
+            "X-Paid-Provider-Id" => provider.id.to_s,
+            "x-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+          )
+
+        expect(WebMock).to have_requested(:post, target_url)
+          .with(headers: { "x-api-key" => "sk-stored-anthropic-key" })
+      end
+
+      it "rejects provider ids that are not available to the agent run owner" do
+        other_user = create(:user)
+        api_key = create(:provider_api_key, user: other_user, api_service_type: "anthropic")
+        provider = create(:provider, :api_key, user: other_user, provider_key: "claude", provider_api_key: api_key)
+
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: valid_headers.merge(
+            "X-Paid-Provider-Id" => provider.id.to_s,
+            "x-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+          )
+
+        expect(response).to have_http_status(:forbidden)
+        expect(WebMock).not_to have_requested(:post, target_url)
+      end
+
       it "forwards anthropic-version header when present" do
         post "/api/proxy/anthropic/v1/messages",
           params: {}.to_json,
@@ -306,6 +342,26 @@ RSpec.describe "Api::SecretsProxy" do
         .with(headers: { "x-goog-api-key" => "google-test-key" })
     end
 
+    it "uses the run owner's stored provider API key when a provider id header is present" do
+      api_key = create(
+        :provider_api_key,
+        user: project.effective_owner,
+        api_service_type: "google",
+        api_key: "stored-google-key"
+      )
+      provider = create(:provider, :api_key, user: project.effective_owner, provider_key: "gemini", provider_api_key: api_key)
+
+      post "/api/proxy/google/v1beta/models/gemini-2.0-flash:generateContent",
+        params: {}.to_json,
+        headers: valid_headers.merge(
+          "X-Paid-Provider-Id" => provider.id.to_s,
+          "x-goog-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+        )
+
+      expect(WebMock).to have_requested(:post, target_url)
+        .with(headers: { "x-goog-api-key" => "stored-google-key" })
+    end
+
     it "tracks token usage with Google usageMetadata field names" do
       expect {
         post "/api/proxy/google/v1beta/models/gemini-2.0-flash:generateContent",
@@ -404,6 +460,19 @@ RSpec.describe "Api::SecretsProxy" do
           headers: {
             "Content-Type" => "application/json",
             "x-goog-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+          }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with embedded proxy credentials in x-api-key" do
+      it "authenticates the request" do
+        post "/api/proxy/anthropic/v1/messages",
+          params: {}.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+            "x-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
           }
 
         expect(response).to have_http_status(:ok)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -338,11 +338,50 @@ RSpec.describe Activities::RunAgentActivity do
       env = activity.send(:command_env_for, context, "ping")
 
       expect(command[0..1]).to eq(%w[sh -c])
-      expect(command[2]).to include('env -u ANTHROPIC_BASE_URL -u ANTHROPIC_HEADER_X_AGENT_RUN_ID -u ANTHROPIC_HEADER_X_PROXY_TOKEN')
-      expect(command[2]).to include('ANTHROPIC_API_KEY="$PAID_PROVIDER_API_KEY"')
+      expect(command[2]).to include('ANTHROPIC_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID"')
+      expect(command[2]).to include('ANTHROPIC_API_KEY="paid-run:$AGENT_RUN_ID:$PROXY_TOKEN"')
+      expect(command[2]).not_to include("sk-anthropic-secret")
       expect(command[3]).to eq("--")
       expect(command[4]).to eq("ping")
-      expect(env).to eq("PAID_PROVIDER_API_KEY" => "sk-anthropic-secret")
+      expect(env).to eq("PAID_PROVIDER_ID" => provider.id.to_s)
+    end
+
+    it "builds an API-key wrapper for OpenAI-backed fallback entries without injecting the provider key" do
+      api_key = create(:provider_api_key, user: user, api_service_type: "openai", api_key: "sk-openai-secret")
+      provider = create(:provider, :api_key, user: user, provider_key: "codex", provider_api_key: api_key)
+      context = described_class::CommandContext.new(
+        provider_candidate: provider.routing_key,
+        provider: "codex",
+        user: user
+      )
+
+      command = activity.send(:build_command, context, "ping")
+      env = activity.send(:command_env_for, context, "ping")
+
+      expect(command[2]).to include('OPENAI_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID"')
+      expect(command[2]).to include('OPENAI_API_KEY="paid-run:$AGENT_RUN_ID:$PROXY_TOKEN"')
+      expect(command[2]).not_to include("sk-openai-secret")
+      expect(env).to eq("PAID_PROVIDER_ID" => provider.id.to_s)
+    end
+
+    it "builds an API-key wrapper for Google-backed fallback entries without injecting the provider key" do
+      api_key = create(:provider_api_key, user: user, api_service_type: "google", api_key: "google-secret")
+      provider = create(:provider, :api_key, user: user, provider_key: "gemini", provider_api_key: api_key)
+      context = described_class::CommandContext.new(
+        provider_candidate: provider.routing_key,
+        provider: "gemini",
+        user: user
+      )
+
+      command = activity.send(:build_command, context, "ping")
+      env = activity.send(:command_env_for, context, "ping")
+
+      expect(command[2]).to include('GOOGLE_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID"')
+      expect(command[2]).to include("X-Paid-Provider-Id: $PAID_PROVIDER_ID")
+      expect(command[2]).to include('GEMINI_API_KEY="paid-run:$AGENT_RUN_ID:$PROXY_TOKEN"')
+      expect(command[2]).to include('GOOGLE_API_KEY="paid-run:$AGENT_RUN_ID:$PROXY_TOKEN"')
+      expect(command[2]).not_to include("google-secret")
+      expect(env).to eq("PAID_PROVIDER_ID" => provider.id.to_s)
     end
 
     it "uses canonical provider state keys for subscription entries" do
@@ -517,8 +556,9 @@ RSpec.describe Activities::RunAgentActivity do
         rate_limit_failure
       else
         expect(command[0..1]).to eq(%w[sh -c])
-        expect(command[2]).to include('ANTHROPIC_API_KEY="$PAID_PROVIDER_API_KEY"')
-        expect(opts[:env]).to include("PAID_PROVIDER_API_KEY" => "sk-fallback-secret")
+        expect(command[2]).to include('ANTHROPIC_API_KEY="paid-run:$AGENT_RUN_ID:$PROXY_TOKEN"')
+        expect(command[2]).not_to include("sk-fallback-secret")
+        expect(opts[:env]).to include("PAID_PROVIDER_ID" => fallback_provider.id.to_s)
         exec_success
       end
     end
@@ -1806,7 +1846,7 @@ RSpec.describe Activities::RunAgentActivity do
           include("provider" => "claude_code", "error_type" => "rate_limited"),
           include("provider" => fallback_provider.routing_key, "error_type" => "rate_limited")
         )
-        expect(execute_calls.any? { |command, opts| command.first == "sh" && opts[:env] == { "PAID_PROVIDER_API_KEY" => "sk-fallback-secret" } }).to be(false)
+        expect(execute_calls.any? { |_command, opts| opts[:env].value?("sk-fallback-secret") }).to be(false)
       end
 
       it "uses provider display names in exhausted-provider labels" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -338,6 +338,9 @@ RSpec.describe Activities::RunAgentActivity do
       env = activity.send(:command_env_for, context, "ping")
 
       expect(command[0..1]).to eq(%w[sh -c])
+      expect(command[2]).to include('ANTHROPIC_BASE_URL="$PAID_PROXY_URL/api/proxy/anthropic"')
+      expect(command[2]).to include('ANTHROPIC_HEADER_X_AGENT_RUN_ID="$AGENT_RUN_ID"')
+      expect(command[2]).to include('ANTHROPIC_HEADER_X_PROXY_TOKEN="$PROXY_TOKEN"')
       expect(command[2]).to include('ANTHROPIC_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID"')
       expect(command[2]).to include('ANTHROPIC_API_KEY="paid-run:$AGENT_RUN_ID:$PROXY_TOKEN"')
       expect(command[2]).not_to include("sk-anthropic-secret")
@@ -556,6 +559,9 @@ RSpec.describe Activities::RunAgentActivity do
         rate_limit_failure
       else
         expect(command[0..1]).to eq(%w[sh -c])
+        expect(command[2]).to include('ANTHROPIC_BASE_URL="$PAID_PROXY_URL/api/proxy/anthropic"')
+        expect(command[2]).to include('ANTHROPIC_HEADER_X_AGENT_RUN_ID="$AGENT_RUN_ID"')
+        expect(command[2]).to include('ANTHROPIC_HEADER_X_PROXY_TOKEN="$PROXY_TOKEN"')
         expect(command[2]).to include('ANTHROPIC_API_KEY="paid-run:$AGENT_RUN_ID:$PROXY_TOKEN"')
         expect(command[2]).not_to include("sk-fallback-secret")
         expect(opts[:env]).to include("PAID_PROVIDER_ID" => fallback_provider.id.to_s)


### PR DESCRIPTION
## Summary

fix(secrets): remove direct provider credential injection from agent runs

See #1281 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1281