### PR TITLE
feat(agent-runs): move cancel cleanup to background job for faster UI response

### DIFF
--- a/app/controllers/concerns/agent_run_cancellable.rb
+++ b/app/controllers/concerns/agent_run_cancellable.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 # Shared cancellation logic for controllers that cancel agent runs.
-# Handles external cleanup, row-level pessimistic locking to prevent race conditions,
-# and redirect with appropriate flash messaging.
+# Sets the cancelled status immediately and enqueues a background job
+# for the slow cleanup (Temporal workflow cancellation + container teardown),
+# so the web UI responds without blocking.
 #
 # Used by Projects::AgentRunsController and DashboardController.
 module AgentRunCancellable
@@ -16,24 +17,8 @@ module AgentRunCancellable
       return
     end
 
-    begin
-      AgentRuns::Cancel.call(agent_run: agent_run, skip_status_update: true)
-    rescue StandardError => e
-      Rails.logger.error(
-        message: "agent_execution.cancel_failed",
-        agent_run_id: agent_run.id,
-        error_class: e.class.name,
-        error_message: e.message
-      )
-      redirect_to redirect_path, status: :see_other, alert: "Unable to cancel agent run. Please try again."
-      return
-    end
-
     cancelled = false
 
-    # with_lock calls reload(lock: true), so agent_run is freshly
-    # loaded inside the block — safe against races where the run
-    # finishes between the external cancellation and this status update.
     agent_run.with_lock do
       if agent_run.active?
         agent_run.cancel!
@@ -42,6 +27,7 @@ module AgentRunCancellable
     end
 
     if cancelled
+      AgentRunCancellationJob.perform_later(agent_run.id)
       redirect_to redirect_path, status: :see_other, notice: "Agent run cancelled."
     else
       redirect_to redirect_path, status: :see_other, notice: "Agent run finished before it could be cancelled."

--- a/app/jobs/agent_run_cancellation_job.rb
+++ b/app/jobs/agent_run_cancellation_job.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class AgentRunCancellationJob < ApplicationJob
+  queue_as :default
+
+  retry_on Temporalio::Error::RPCError, wait: :polynomially_longer, attempts: 5
   discard_on ActiveRecord::RecordNotFound
 
   def perform(agent_run_id)

--- a/app/jobs/agent_run_cancellation_job.rb
+++ b/app/jobs/agent_run_cancellation_job.rb
@@ -4,6 +4,7 @@ class AgentRunCancellationJob < ApplicationJob
   queue_as :default
 
   retry_on Temporalio::Error::RPCError, wait: :polynomially_longer, attempts: 5
+  retry_on Docker::Error::DockerError, wait: :polynomially_longer, attempts: 3
   discard_on ActiveRecord::RecordNotFound
 
   def perform(agent_run_id)

--- a/app/jobs/agent_run_cancellation_job.rb
+++ b/app/jobs/agent_run_cancellation_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AgentRunCancellationJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(agent_run_id)
+    agent_run = AgentRun.find(agent_run_id)
+
+    cancel_temporal_workflow(agent_run)
+    cleanup_container(agent_run)
+  end
+
+  private
+
+  def cancel_temporal_workflow(agent_run)
+    return if agent_run.temporal_workflow_id.blank?
+
+    handle = Paid.temporal_client.workflow_handle(agent_run.temporal_workflow_id)
+    handle.cancel
+  rescue Temporalio::Error::RPCError => e
+    raise unless e.code == Temporalio::Error::RPCError::Code::NOT_FOUND
+
+    Rails.logger.info(
+      message: "agent_execution.cancel_workflow_not_found",
+      agent_run_id: agent_run.id,
+      temporal_workflow_id: agent_run.temporal_workflow_id
+    )
+  end
+
+  def cleanup_container(agent_run)
+    return if agent_run.container_id.blank?
+
+    agent_run.cleanup_container(force: true)
+  end
+end

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -777,25 +777,39 @@ class AgentRun < ApplicationRecord
   end
 
   def complete!(result_commit: nil, pr_url: nil, pr_number: nil, issue_url: nil, issue_number: nil)
-    update!(
-      status: "completed",
-      completed_at: Time.current,
-      result_commit_sha: result_commit,
-      pull_request_url: pr_url,
-      pull_request_number: pr_number,
-      created_issue_url: issue_url,
-      created_issue_number: issue_number,
-      duration_seconds: duration
-    )
+    with_lock do
+      reload
+      if finished?
+        false
+      else
+        update!(
+          status: "completed",
+          completed_at: Time.current,
+          result_commit_sha: result_commit,
+          pull_request_url: pr_url,
+          pull_request_number: pr_number,
+          created_issue_url: issue_url,
+          created_issue_number: issue_number,
+          duration_seconds: duration
+        )
+      end
+    end
   end
 
   def complete_no_output!(reason: "no_changes")
-    update!(
-      status: "no_output",
-      completed_at: Time.current,
-      error_message: reason,
-      duration_seconds: duration
-    )
+    with_lock do
+      reload
+      if finished?
+        false
+      else
+        update!(
+          status: "no_output",
+          completed_at: Time.current,
+          error_message: reason,
+          duration_seconds: duration
+        )
+      end
+    end
   end
 
   def result_url

--- a/app/temporal/activities/complete_existing_pr_run_activity.rb
+++ b/app/temporal/activities/complete_existing_pr_run_activity.rb
@@ -31,19 +31,22 @@ module Activities
     def execute(input)
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
+      return result(agent_run) if agent_run.finished?
+
       track_phase(agent_run_id: agent_run_id, phase_key: "complete_existing_pr_run", phase_group: "post", agent_run: agent_run) do
         project = agent_run.project
         client = project.github_token.client
 
         pr = client.pull_request(project.full_name, agent_run.source_pull_request_number)
 
-        agent_run.complete!(
+        completed = agent_run.complete!(
           result_commit: agent_run.result_commit_sha,
           pr_url: pr.html_url,
           pr_number: pr.number
         )
-        record_draft_review_round_if_needed(agent_run)
+        return result(agent_run.reload) unless completed
 
+        record_draft_review_round_if_needed(agent_run)
         post_update_comment(client, project, pr.number, agent_run)
 
         agent_run.log!("system", "Pushed updates to existing PR: #{pr.html_url}")
@@ -61,12 +64,20 @@ module Activities
 
         ProcessRunQueueJob.perform_later
 
-        { agent_run_id: agent_run_id, pull_request_url: pr.html_url, pull_request_number: pr.number,
-          pr_review_phase: agent_run.issue&.pr_review_phase }
+        result(agent_run)
       end
     end
 
     private
+
+    def result(agent_run)
+      {
+        agent_run_id: agent_run.id,
+        pull_request_url: agent_run.pull_request_url,
+        pull_request_number: agent_run.pull_request_number,
+        pr_review_phase: agent_run.issue&.pr_review_phase
+      }
+    end
 
     def post_update_comment(client, project, pr_number, agent_run)
       body = build_comment_body(agent_run)

--- a/app/temporal/activities/complete_existing_pr_run_activity.rb
+++ b/app/temporal/activities/complete_existing_pr_run_activity.rb
@@ -75,7 +75,9 @@ module Activities
         agent_run_id: agent_run.id,
         pull_request_url: agent_run.pull_request_url,
         pull_request_number: agent_run.pull_request_number,
-        pr_review_phase: agent_run.issue&.pr_review_phase
+        pr_review_phase: agent_run.issue&.pr_review_phase,
+        skipped: agent_run.pull_request_url.blank?,
+        cancelled: agent_run.status == "cancelled"
       }
     end
 

--- a/app/temporal/activities/complete_issue_goal_activity.rb
+++ b/app/temporal/activities/complete_issue_goal_activity.rb
@@ -7,21 +7,25 @@ module Activities
     def execute(input)
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
+      return result(agent_run) if agent_run.finished?
+
       track_phase(agent_run_id: agent_run_id, phase_key: "complete_issue_goal", phase_group: "post", agent_run: agent_run) do
         if agent_run.created_issue_url.present?
-          agent_run.complete!(
+          completed = agent_run.complete!(
             issue_url: agent_run.created_issue_url,
             issue_number: agent_run.created_issue_number
           )
-          agent_run.log!("system", "Completed: issue ##{agent_run.created_issue_number} created")
+          if completed
+            agent_run.log!("system", "Completed: issue ##{agent_run.created_issue_number} created")
 
-          logger.info(
-            message: "agent_execution.issue_goal_completed",
-            agent_run_id: agent_run_id,
-            issue_url: agent_run.created_issue_url
-          )
+            logger.info(
+              message: "agent_execution.issue_goal_completed",
+              agent_run_id: agent_run_id,
+              issue_url: agent_run.created_issue_url
+            )
 
-          ProcessRunQueueJob.perform_later
+            ProcessRunQueueJob.perform_later
+          end
 
           { agent_run_id: agent_run_id, success: true, issue_created: true }
         else
@@ -35,6 +39,12 @@ module Activities
           { agent_run_id: agent_run_id, success: true, issue_created: false }
         end
       end
+    end
+
+    private
+
+    def result(agent_run)
+      { agent_run_id: agent_run.id, success: agent_run.successful?, issue_created: agent_run.created_issue_url.present? }
     end
   end
 end

--- a/app/temporal/activities/complete_issue_goal_activity.rb
+++ b/app/temporal/activities/complete_issue_goal_activity.rb
@@ -44,7 +44,14 @@ module Activities
     private
 
     def result(agent_run)
-      { agent_run_id: agent_run.id, success: agent_run.successful?, issue_created: agent_run.created_issue_url.present? }
+      {
+        agent_run_id: agent_run.id,
+        success: agent_run.successful?,
+        issue_created: agent_run.created_issue_url.present?,
+        skipped: true,
+        finished: true,
+        cancelled: agent_run.status == "cancelled"
+      }
     end
   end
 end

--- a/app/temporal/activities/complete_review_goal_activity.rb
+++ b/app/temporal/activities/complete_review_goal_activity.rb
@@ -7,6 +7,7 @@ module Activities
     def execute(input)
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
+      return result(agent_run) if agent_run.finished?
 
       track_phase(agent_run_id: agent_run_id, phase_key: "complete_review_goal", phase_group: "post", agent_run: agent_run) do
         if agent_run.review_posted_at.blank?
@@ -27,21 +28,30 @@ module Activities
         # Don't set pull_request_number for review runs — that field represents
         # the PR produced by the run. Review runs use source_pull_request_number
         # to track which PR was reviewed, keeping the two semantics distinct.
-        agent_run.complete!
-        agent_run.issue&.update!(review_goal_retry_count: 0) if agent_run.issue&.review_goal_retry_count&.positive?
-        agent_run.log!("system", "Completed: review goal finished for PR ##{agent_run.source_pull_request_number}")
+        completed = agent_run.complete!
 
-        logger.info(
-          message: "agent_execution.review_goal_completed",
-          agent_run_id: agent_run_id,
-          pr_number: agent_run.source_pull_request_number,
-          review_posted: agent_run.review_posted_at.present?
-        )
+        if completed
+          agent_run.issue&.update!(review_goal_retry_count: 0) if agent_run.issue&.review_goal_retry_count&.positive?
+          agent_run.log!("system", "Completed: review goal finished for PR ##{agent_run.source_pull_request_number}")
 
-        ProcessRunQueueJob.perform_later
+          logger.info(
+            message: "agent_execution.review_goal_completed",
+            agent_run_id: agent_run_id,
+            pr_number: agent_run.source_pull_request_number,
+            review_posted: agent_run.review_posted_at.present?
+          )
 
-        { agent_run_id: agent_run_id, success: true }
+          ProcessRunQueueJob.perform_later
+        end
+
+        result(agent_run.reload)
       end
+    end
+
+    private
+
+    def result(agent_run)
+      { agent_run_id: agent_run.id, success: agent_run.successful? }
     end
   end
 end

--- a/app/temporal/activities/create_github_issue_activity.rb
+++ b/app/temporal/activities/create_github_issue_activity.rb
@@ -53,6 +53,8 @@ module Activities
       upstream_issue = input[:upstream_issue]
       body_override = input[:body_override]
       agent_run = AgentRun.find(agent_run_id)
+      return result(agent_run) if agent_run.finished?
+
       track_phase(agent_run_id: agent_run_id, phase_key: "create_github_issue", phase_group: "post", agent_run: agent_run) do
         project = agent_run.project
 
@@ -74,13 +76,20 @@ module Activities
           labels: issue_labels
         )
 
-        sync_issue_record(project, gh_issue)
+        completed = agent_run.complete!(issue_url: gh_issue.html_url, issue_number: gh_issue.number)
+        unless completed
+          logger.info(
+            message: "agent_execution.github_issue_completion_skipped",
+            agent_run_id: agent_run_id,
+            status: agent_run.reload.status,
+            issue_url: gh_issue.html_url
+          )
 
-        if upstream_issue
-          record_cross_repo_issue(agent_run, project.full_name, gh_issue, role: "downstream")
+          return result(agent_run)
         end
 
-        agent_run.complete!(issue_url: gh_issue.html_url, issue_number: gh_issue.number)
+        sync_issue_record(project, gh_issue)
+        record_cross_repo_issue(agent_run, project.full_name, gh_issue, role: "downstream") if upstream_issue
 
         agent_run.log!("system", "Issue created: #{gh_issue.html_url}")
 
@@ -97,6 +106,14 @@ module Activities
     end
 
     private
+
+    def result(agent_run)
+      {
+        agent_run_id: agent_run.id,
+        issue_url: agent_run.created_issue_url,
+        issue_number: agent_run.created_issue_number
+      }
+    end
 
     def extract_title(summary, _custom_prompt = nil)
       # Try first markdown heading (any level) from agent output

--- a/app/temporal/activities/create_github_issue_activity.rb
+++ b/app/temporal/activities/create_github_issue_activity.rb
@@ -84,22 +84,11 @@ module Activities
             status: agent_run.reload.status,
             issue_url: gh_issue.html_url
           )
-
-          return result(agent_run)
         end
 
-        sync_issue_record(project, gh_issue)
-        record_cross_repo_issue(agent_run, project.full_name, gh_issue, role: "downstream") if upstream_issue
+        reconcile_created_issue(agent_run, project, gh_issue, upstream_issue: upstream_issue)
 
-        agent_run.log!("system", "Issue created: #{gh_issue.html_url}")
-
-        logger.info(
-          message: "agent_execution.github_issue_created",
-          agent_run_id: agent_run_id,
-          issue_url: gh_issue.html_url
-        )
-
-        ProcessRunQueueJob.perform_later
+        ProcessRunQueueJob.perform_later if completed
 
         { agent_run_id: agent_run_id, issue_url: gh_issue.html_url, issue_number: gh_issue.number }
       end
@@ -313,6 +302,21 @@ module Activities
     def append_dependency_text(body, upstream_issue)
       dep_line = "Blocked by #{upstream_issue[:target_repo]}##{upstream_issue[:issue_number]}"
       "#{body}\n\n## Dependencies\n\n- #{dep_line}"
+    end
+
+    def reconcile_created_issue(agent_run, project, gh_issue, upstream_issue:)
+      # Reconcile even when cancellation wins the complete! lock, because the
+      # GitHub issue already exists and should not be left orphaned.
+      sync_issue_record(project, gh_issue)
+      record_cross_repo_issue(agent_run, project.full_name, gh_issue, role: "downstream") if upstream_issue
+
+      agent_run.log!("system", "Issue created: #{gh_issue.html_url}")
+
+      logger.info(
+        message: "agent_execution.github_issue_created",
+        agent_run_id: agent_run.id,
+        issue_url: gh_issue.html_url
+      )
     end
 
     def sync_issue_record(project, gh_issue)

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -48,25 +48,18 @@ module Activities
           pr_url: pr.html_url,
           pr_number: pr.number
         )
-        if completed
-          # Best-effort post-processing — failures here must not cause the
-          # activity to be retried now that the run is already completed.
-          best_effort(agent_run_id, context: "sync_created_pull_request") { sync_pull_request_record(client, project, pr.number) }
-          best_effort(agent_run_id, context: "add_pr_labels") { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
-          best_effort(agent_run_id, context: "log_pr_action") { agent_run.log!("system", "PR #{pr_action}: #{pr.html_url}") }
+        reconcile_pull_request(agent_run, client, project, pr, pr_action, issue: issue)
 
-          best_effort(agent_run_id, context: "structured_log") do
-            logger.info(
-              message: "agent_execution.pull_request_#{pr_action}",
-              agent_run_id: agent_run_id,
-              pull_request_url: pr.html_url
-            )
-          end
-
-          { agent_run_id: agent_run_id, pull_request_url: pr.html_url, pull_request_number: pr.number }
-        else
-          completion_result(agent_run.reload)
+        unless completed
+          logger.info(
+            message: "agent_execution.pull_request_completion_skipped",
+            agent_run_id: agent_run_id,
+            status: agent_run.reload.status,
+            pull_request_url: pr.html_url
+          )
         end
+
+        { agent_run_id: agent_run_id, pull_request_url: pr.html_url, pull_request_number: pr.number }
       end
     end
 
@@ -135,6 +128,24 @@ module Activities
         error_class: e.class.name,
         error: e.message
       )
+    end
+
+    def reconcile_pull_request(agent_run, client, project, pr, pr_action, issue:)
+      agent_run_id = agent_run.id
+
+      # Best-effort post-processing runs even when cancellation wins the
+      # complete! lock, because the GitHub PR already exists at this point.
+      best_effort(agent_run_id, context: "sync_created_pull_request") { sync_pull_request_record(client, project, pr.number) }
+      best_effort(agent_run_id, context: "add_pr_labels") { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
+      best_effort(agent_run_id, context: "log_pr_action") { agent_run.log!("system", "PR #{pr_action}: #{pr.html_url}") }
+
+      best_effort(agent_run_id, context: "structured_log") do
+        logger.info(
+          message: "agent_execution.pull_request_#{pr_action}",
+          agent_run_id: agent_run_id,
+          pull_request_url: pr.html_url
+        )
+      end
     end
 
     def pr_title(issue)

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -7,6 +7,8 @@ module Activities
     def execute(input)
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
+      return completion_result(agent_run) if agent_run.finished?
+
       track_phase(agent_run_id: agent_run_id, phase_key: "create_pull_request", phase_group: "post", agent_run: agent_run) do
         project = agent_run.project
         issue = agent_run.issue
@@ -41,31 +43,42 @@ module Activities
         # Persist completion as the very first step after obtaining the PR,
         # before any best-effort post-processing. This ensures a retry
         # cannot overwrite status via MarkAgentRunFailedActivity.
-        agent_run.complete!(
+        completed = agent_run.complete!(
           result_commit: agent_run.result_commit_sha,
           pr_url: pr.html_url,
           pr_number: pr.number
         )
+        if completed
+          # Best-effort post-processing — failures here must not cause the
+          # activity to be retried now that the run is already completed.
+          best_effort(agent_run_id, context: "sync_created_pull_request") { sync_pull_request_record(client, project, pr.number) }
+          best_effort(agent_run_id, context: "add_pr_labels") { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
+          best_effort(agent_run_id, context: "log_pr_action") { agent_run.log!("system", "PR #{pr_action}: #{pr.html_url}") }
 
-        # Best-effort post-processing — failures here must not cause the
-        # activity to be retried now that the run is already completed.
-        best_effort(agent_run_id, context: "sync_created_pull_request") { sync_pull_request_record(client, project, pr.number) }
-        best_effort(agent_run_id, context: "add_pr_labels") { add_pr_labels(client, project, pr.number, agent_run_id, issue: issue) }
-        best_effort(agent_run_id, context: "log_pr_action") { agent_run.log!("system", "PR #{pr_action}: #{pr.html_url}") }
+          best_effort(agent_run_id, context: "structured_log") do
+            logger.info(
+              message: "agent_execution.pull_request_#{pr_action}",
+              agent_run_id: agent_run_id,
+              pull_request_url: pr.html_url
+            )
+          end
 
-        best_effort(agent_run_id, context: "structured_log") do
-          logger.info(
-            message: "agent_execution.pull_request_#{pr_action}",
-            agent_run_id: agent_run_id,
-            pull_request_url: pr.html_url
-          )
+          { agent_run_id: agent_run_id, pull_request_url: pr.html_url, pull_request_number: pr.number }
+        else
+          completion_result(agent_run.reload)
         end
-
-        { agent_run_id: agent_run_id, pull_request_url: pr.html_url, pull_request_number: pr.number }
       end
     end
 
     private
+
+    def completion_result(agent_run)
+      {
+        agent_run_id: agent_run.id,
+        pull_request_url: agent_run.pull_request_url,
+        pull_request_number: agent_run.pull_request_number
+      }
+    end
 
     # Checks whether the branch exists on GitHub via the refs API.
     # Returns true when confirmed or when the check fails transiently

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -69,7 +69,9 @@ module Activities
       {
         agent_run_id: agent_run.id,
         pull_request_url: agent_run.pull_request_url,
-        pull_request_number: agent_run.pull_request_number
+        pull_request_number: agent_run.pull_request_number,
+        skipped: agent_run.pull_request_url.blank?,
+        cancelled: agent_run.status == "cancelled"
       }
     end
 

--- a/app/temporal/activities/create_upstream_issue_activity.rb
+++ b/app/temporal/activities/create_upstream_issue_activity.rb
@@ -20,6 +20,8 @@ module Activities
       labels = input[:labels] || []
 
       agent_run = AgentRun.find(agent_run_id)
+      return result(agent_run, target_repo) if agent_run.finished?
+
       track_phase(agent_run_id: agent_run_id, phase_key: "create_upstream_issue", phase_group: "post", agent_run: agent_run) do
         project = agent_run.project
         client = resolve_client(project, target_repo)
@@ -54,6 +56,18 @@ module Activities
     end
 
     private
+
+    def result(agent_run, target_repo)
+      {
+        agent_run_id: agent_run.id,
+        issue_url: nil,
+        issue_number: nil,
+        target_repo: target_repo,
+        skipped: true,
+        finished: true,
+        cancelled: agent_run.status == "cancelled"
+      }
+    end
 
     # Uses the current project's GitHub token. All projects in the same
     # account share a token pool, so cross-repo creation within an account

--- a/app/temporal/activities/mark_agent_run_complete_activity.rb
+++ b/app/temporal/activities/mark_agent_run_complete_activity.rb
@@ -8,7 +8,7 @@ module Activities
       agent_run_id = input[:agent_run_id]
       reason = input.fetch(:reason, "no_changes")
       agent_run = AgentRun.find(agent_run_id)
-      return { agent_run_id: agent_run_id } if agent_run.finished?
+      return result(agent_run) if agent_run.finished?
 
       track_phase(agent_run_id: agent_run_id, phase_key: "mark_agent_run_complete", phase_group: "post", agent_run: agent_run, metadata: { reason: reason }) do
         completed = if agent_run.goal == "create_pr"
@@ -33,8 +33,18 @@ module Activities
           ProcessRunQueueJob.perform_later
         end
 
-        { agent_run_id: agent_run_id }
+        result(completed ? agent_run : agent_run.reload)
       end
+    end
+
+    private
+
+    def result(agent_run)
+      {
+        agent_run_id: agent_run.id,
+        skipped: agent_run.status == "cancelled",
+        cancelled: agent_run.status == "cancelled"
+      }
     end
   end
 end

--- a/app/temporal/activities/mark_agent_run_complete_activity.rb
+++ b/app/temporal/activities/mark_agent_run_complete_activity.rb
@@ -8,26 +8,30 @@ module Activities
       agent_run_id = input[:agent_run_id]
       reason = input.fetch(:reason, "no_changes")
       agent_run = AgentRun.find(agent_run_id)
+      return { agent_run_id: agent_run_id } if agent_run.finished?
+
       track_phase(agent_run_id: agent_run_id, phase_key: "mark_agent_run_complete", phase_group: "post", agent_run: agent_run, metadata: { reason: reason }) do
-        if agent_run.goal == "create_pr"
+        completed = if agent_run.goal == "create_pr"
           agent_run.complete_no_output!(reason: reason)
         else
           agent_run.complete!
         end
-        record_draft_review_round_if_needed(agent_run)
-        agent_run.log!("system", "Completed without output: #{reason}")
+        if completed
+          record_draft_review_round_if_needed(agent_run)
+          agent_run.log!("system", "Completed without output: #{reason}")
 
-        if agent_run.issue && agent_run.status != "no_output"
-          agent_run.issue.update!(paid_state: "completed")
+          if agent_run.issue && agent_run.status != "no_output"
+            agent_run.issue.update!(paid_state: "completed")
+          end
+
+          logger.info(
+            message: "agent_execution.completed_without_pr",
+            agent_run_id: agent_run_id,
+            reason: reason
+          )
+
+          ProcessRunQueueJob.perform_later
         end
-
-        logger.info(
-          message: "agent_execution.completed_without_pr",
-          agent_run_id: agent_run_id,
-          reason: reason
-        )
-
-        ProcessRunQueueJob.perform_later
 
         { agent_run_id: agent_run_id }
       end

--- a/app/temporal/activities/mark_agent_run_failed_activity.rb
+++ b/app/temporal/activities/mark_agent_run_failed_activity.rb
@@ -25,12 +25,13 @@ module Activities
       # RunAgentActivity would skip queue processing entirely.
       ProcessRunQueueJob.perform_later
 
-      # Always update issue state so it doesn't stay stuck in "in_progress".
+      # Update issue state for failure statuses so it doesn't stay stuck in
+      # "in_progress". Preserve cancellation and successful terminal states.
       # Review-goal failures restore the issue to "completed" rather than
       # marking it "failed" — the underlying PR work succeeded; only the
       # follow-up review run failed. Using "completed" keeps auto-pick
       # unblocked and lets the scanner re-evaluate the PR on the next cycle.
-      if agent_run.issue && !finished_before_failure
+      if agent_run.issue && agent_run.status.in?(AgentRun::FAILURE_STATUSES)
         target_state = agent_run.review_goal? ? "completed" : "failed"
         if agent_run.issue.paid_state != target_state
           agent_run.issue.update!(paid_state: target_state)

--- a/app/temporal/activities/mark_agent_run_failed_activity.rb
+++ b/app/temporal/activities/mark_agent_run_failed_activity.rb
@@ -8,15 +8,18 @@ module Activities
       agent_run_id = input[:agent_run_id]
       error = input[:error]
       agent_run = AgentRun.find(agent_run_id)
-      finished_before_failure = agent_run.finished?
 
-      # Don't overwrite a more specific terminal status (e.g. "timeout")
-      # that was already set by the activity that detected the failure.
-      if finished_before_failure
-        agent_run.log!("system", "Agent run already #{agent_run.status}, skipping fail! (error: #{error})")
-      else
-        agent_run.fail!(error: error)
-        agent_run.log!("system", "Agent run failed: #{error}")
+      agent_run.with_lock do
+        agent_run.reload
+
+        # Don't overwrite a more specific terminal status (e.g. "timeout")
+        # that was already set by the activity that detected the failure.
+        if agent_run.finished?
+          agent_run.log!("system", "Agent run already #{agent_run.status}, skipping fail! (error: #{error})")
+        else
+          agent_run.fail!(error: error)
+          agent_run.log!("system", "Agent run failed: #{error}")
+        end
       end
 
       # Always trigger queue processing so remaining queued runs get claimed.

--- a/app/temporal/activities/mark_agent_run_failed_activity.rb
+++ b/app/temporal/activities/mark_agent_run_failed_activity.rb
@@ -8,10 +8,11 @@ module Activities
       agent_run_id = input[:agent_run_id]
       error = input[:error]
       agent_run = AgentRun.find(agent_run_id)
+      finished_before_failure = agent_run.finished?
 
       # Don't overwrite a more specific terminal status (e.g. "timeout")
       # that was already set by the activity that detected the failure.
-      if agent_run.finished?
+      if finished_before_failure
         agent_run.log!("system", "Agent run already #{agent_run.status}, skipping fail! (error: #{error})")
       else
         agent_run.fail!(error: error)
@@ -29,7 +30,7 @@ module Activities
       # marking it "failed" — the underlying PR work succeeded; only the
       # follow-up review run failed. Using "completed" keeps auto-pick
       # unblocked and lets the scanner re-evaluate the PR on the next cycle.
-      if agent_run.issue
+      if agent_run.issue && !finished_before_failure
         target_state = agent_run.review_goal? ? "completed" : "failed"
         if agent_run.issue.paid_state != target_state
           agent_run.issue.update!(paid_state: target_state)

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -226,7 +226,7 @@ module Workflows
 
           # Fallback: if the agent didn't create an issue directly, create one
           # from the agent's output using the platform's GitHub integration.
-          if issue_result[:issue_created] == false
+          if issue_result[:issue_created] == false && !issue_result[:skipped]
             # Check for cross-repo issue plan before falling back to single-issue creation
             cross_repo_result = run_activity(Activities::ParseCrossRepoIssuePlanActivity,
               { agent_run_id: agent_run_id }, timeout: 30, retry_policy: NO_RETRY)

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -279,15 +279,17 @@ module Workflows
             pr_result = run_activity(Activities::CreatePullRequestActivity,
               { agent_run_id: agent_run_id }, timeout: 60)
 
-            # Step 7: Update issue with PR link
-            run_activity(Activities::UpdateIssueWithPrActivity,
-              { agent_run_id: agent_run_id, pull_request_url: pr_result[:pull_request_url] }, timeout: 30)
+            unless pr_result[:skipped] || pr_result[:pull_request_url].blank?
+              # Step 7: Update issue with PR link
+              run_activity(Activities::UpdateIssueWithPrActivity,
+                { agent_run_id: agent_run_id, pull_request_url: pr_result[:pull_request_url] }, timeout: 30)
 
-            # Step 8: Request review-bot review on the new draft PR (best-effort)
-            request_review_bot_review(project_id, pr_result[:pull_request_number])
+              # Step 8: Request review-bot review on the new draft PR (best-effort)
+              request_review_bot_review(project_id, pr_result[:pull_request_number])
 
-            # Step 9: Draft a decision record (best-effort)
-            draft_decision_record(agent_run_id)
+              # Step 9: Draft a decision record (best-effort)
+              draft_decision_record(agent_run_id)
+            end
           end
         else
           # No changes produced by agent

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -268,12 +268,14 @@ module Workflows
 
             # New commits invalidate prior bot feedback, so request a fresh
             # review-bot review for any still-active PR phase.
-            if complete_result[:pr_review_phase].in?(%w[draft restarted ready escalated])
-              request_review_bot_review(project_id, source_pull_request_number)
-            end
+            unless complete_result[:skipped]
+              if complete_result[:pr_review_phase].in?(%w[draft restarted ready escalated])
+                request_review_bot_review(project_id, source_pull_request_number)
+              end
 
-            # Draft a decision record for existing PR changes (best-effort)
-            draft_decision_record(agent_run_id)
+              # Draft a decision record for existing PR changes (best-effort)
+              draft_decision_record(agent_run_id)
+            end
           else
             # Step 6: Create PR
             pr_result = run_activity(Activities::CreatePullRequestActivity,
@@ -307,13 +309,13 @@ module Workflows
                 output_present: agent_result.fetch(:output_present, false) }, timeout: 30)
           else
             # Non-issue run or existing-PR run: mark completed
-            run_activity(Activities::MarkAgentRunCompleteActivity,
+            complete_result = run_activity(Activities::MarkAgentRunCompleteActivity,
               { agent_run_id: agent_run_id, reason: "no_changes" }, timeout: 30)
           end
 
           # Still request a review-bot review for existing PR runs: the
           # previous run may have pushed a fix the bot has not reviewed yet.
-          if source_pull_request_number
+          if source_pull_request_number && !complete_result[:skipped]
             request_review_bot_review(project_id, source_pull_request_number)
           end
         end

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ApplicationJob do
   let(:expected_queue_assignments) do
     {
       default: %w[
+        AgentRunCancellationJob
         AnomalyDetectionJob
         AutoReleaseEvaluationJob
         DependabotAutoMergeJob

--- a/spec/jobs/agent_run_cancellation_job_spec.rb
+++ b/spec/jobs/agent_run_cancellation_job_spec.rb
@@ -55,6 +55,15 @@ RSpec.describe AgentRunCancellationJob, type: :job do
       expect(agent_run).to have_received(:cleanup_container).with(force: true)
     end
 
+    it "re-raises Docker cleanup errors for retry_on to handle" do
+      error = Docker::Error::DockerError.new("daemon unavailable")
+      agent_run.update!(container_id: "container-123")
+      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+      allow(agent_run).to receive(:cleanup_container).and_raise(error)
+
+      expect { described_class.new.perform(agent_run.id) }.to raise_error(error)
+    end
+
     it "does not raise when agent run is not found" do
       expect { described_class.perform_now(-1) }.not_to raise_error
     end

--- a/spec/jobs/agent_run_cancellation_job_spec.rb
+++ b/spec/jobs/agent_run_cancellation_job_spec.rb
@@ -47,21 +47,37 @@ RSpec.describe AgentRunCancellationJob, type: :job do
 
     it "cleans up the container when present" do
       agent_run.update!(container_id: "container-123")
-      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
-      allow(agent_run).to receive(:cleanup_container)
+      container = double(id: "container-123")
+      volume = double
+
+      allow(container).to receive(:refresh!)
+      allow(container).to receive(:info).and_return("State" => { "Running" => true })
+      allow(container).to receive(:stop)
+      allow(container).to receive(:delete)
+      allow(Docker::Container).to receive(:get).with("container-123").and_return(container)
+      allow(Docker::Volume).to receive(:get).with("paid-workspace-#{agent_run.id}").and_return(volume)
+      allow(volume).to receive(:remove)
 
       described_class.perform_now(agent_run.id)
 
-      expect(agent_run).to have_received(:cleanup_container).with(force: true)
+      expect(container).to have_received(:stop).with(timeout: 0)
+      expect(container).to have_received(:delete).with(force: true, v: true)
+      expect(volume).to have_received(:remove)
+      expect(agent_run.reload.container_id).to be_nil
     end
 
-    it "re-raises Docker cleanup errors for retry_on to handle" do
-      error = Docker::Error::DockerError.new("daemon unavailable")
+    it "clears the container reference when the container is already missing" do
       agent_run.update!(container_id: "container-123")
-      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
-      allow(agent_run).to receive(:cleanup_container).and_raise(error)
+      allow(Docker::Container).to receive(:get)
+        .with("container-123")
+        .and_raise(Docker::Error::NotFoundError, "not found")
+      allow(Docker::Volume).to receive(:get)
+        .with("paid-workspace-#{agent_run.id}")
+        .and_raise(Docker::Error::NotFoundError, "not found")
 
-      expect { described_class.new.perform(agent_run.id) }.to raise_error(error)
+      expect { described_class.perform_now(agent_run.id) }.not_to raise_error
+
+      expect(agent_run.reload.container_id).to be_nil
     end
 
     it "does not raise when agent run is not found" do

--- a/spec/jobs/agent_run_cancellation_job_spec.rb
+++ b/spec/jobs/agent_run_cancellation_job_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRunCancellationJob, type: :job do
+  describe "#perform" do
+    let(:agent_run) { create(:agent_run, status: "cancelled", completed_at: Time.current) }
+
+    it "cancels the Temporal workflow when present" do
+      handle = double(cancel: true)
+      temporal_client = double(workflow_handle: handle)
+      agent_run.update!(temporal_workflow_id: "workflow-123")
+
+      allow(Paid).to receive(:temporal_client).and_return(temporal_client)
+
+      described_class.perform_now(agent_run.id)
+
+      expect(temporal_client).to have_received(:workflow_handle).with("workflow-123")
+      expect(handle).to have_received(:cancel)
+    end
+
+    it "ignores not-found Temporal workflow errors" do
+      error = Temporalio::Error::RPCError.allocate
+      allow(error).to receive(:code).and_return(Temporalio::Error::RPCError::Code::NOT_FOUND)
+      agent_run.update!(temporal_workflow_id: "workflow-123")
+
+      handle = double
+      allow(handle).to receive(:cancel).and_raise(error)
+      temporal_client = double(workflow_handle: handle)
+      allow(Paid).to receive(:temporal_client).and_return(temporal_client)
+
+      expect { described_class.perform_now(agent_run.id) }.not_to raise_error
+    end
+
+    it "cleans up the container when present" do
+      agent_run.update!(container_id: "container-123")
+      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+      allow(agent_run).to receive(:cleanup_container)
+
+      described_class.perform_now(agent_run.id)
+
+      expect(agent_run).to have_received(:cleanup_container).with(force: true)
+    end
+
+    it "does not raise when agent run is not found" do
+      expect { described_class.perform_now(-1) }.not_to raise_error
+    end
+
+    it "skips Temporal cancellation when no workflow id" do
+      agent_run.update!(temporal_workflow_id: nil)
+      allow(Paid).to receive(:temporal_client)
+
+      described_class.perform_now(agent_run.id)
+
+      expect(Paid).not_to have_received(:temporal_client)
+    end
+  end
+end

--- a/spec/jobs/agent_run_cancellation_job_spec.rb
+++ b/spec/jobs/agent_run_cancellation_job_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe AgentRunCancellationJob, type: :job do
       expect { described_class.perform_now(agent_run.id) }.not_to raise_error
     end
 
+    it "re-raises transient Temporal workflow errors for retry_on to handle" do
+      error = Temporalio::Error::RPCError.allocate
+      allow(error).to receive(:code).and_return(Temporalio::Error::RPCError::Code::UNAVAILABLE)
+      agent_run.update!(temporal_workflow_id: "workflow-123")
+
+      handle = double
+      allow(handle).to receive(:cancel).and_raise(error)
+      temporal_client = double(workflow_handle: handle)
+      allow(Paid).to receive(:temporal_client).and_return(temporal_client)
+
+      expect { described_class.new.perform(agent_run.id) }.to raise_error(Temporalio::Error::RPCError)
+    end
+
     it "cleans up the container when present" do
       agent_run.update!(container_id: "container-123")
       allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -739,6 +739,18 @@ RSpec.describe AgentRun do
           expect(agent_run.duration_seconds).to eq((Time.current - started_time).to_i)
         end
       end
+
+      it "does not overwrite a cancelled run" do
+        agent_run = create(:agent_run, :cancelled, pull_request_url: nil, pull_request_number: nil)
+
+        expect(
+          agent_run.complete!(pr_url: "https://github.com/example/repo/pull/42", pr_number: 42)
+        ).to be false
+
+        expect(agent_run.reload.status).to eq("cancelled")
+        expect(agent_run.pull_request_url).to be_nil
+        expect(agent_run.pull_request_number).to be_nil
+      end
     end
 
     describe "#complete! with issue details" do
@@ -756,6 +768,17 @@ RSpec.describe AgentRun do
           expect(agent_run.created_issue_number).to eq(10)
           expect(agent_run.pull_request_url).to be_nil
         end
+      end
+    end
+
+    describe "#complete_no_output!" do
+      it "does not overwrite a cancelled run" do
+        agent_run = create(:agent_run, :cancelled, error_message: nil)
+
+        expect(agent_run.complete_no_output!(reason: "no_changes")).to be false
+
+        expect(agent_run.reload.status).to eq("cancelled")
+        expect(agent_run.error_message).to be_nil
       end
     end
 

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -1504,13 +1504,13 @@ RSpec.describe "AgentRuns" do
     context "when authenticated" do
       before { sign_in user }
 
-      it "cancels an active run" do
+      it "cancels an active run and enqueues background cleanup" do
         agent_run = create(:agent_run, :running, project: project)
-        allow(AgentRuns::Cancel).to receive(:call)
 
-        post cancel_project_agent_run_path(project, agent_run)
+        expect {
+          post cancel_project_agent_run_path(project, agent_run)
+        }.to have_enqueued_job(AgentRunCancellationJob).with(agent_run.id)
 
-        expect(AgentRuns::Cancel).to have_received(:call).with(agent_run: agent_run, skip_status_update: true)
         expect(agent_run.reload.status).to eq("cancelled")
         expect(response).to redirect_to(project_agent_run_path(project, agent_run))
         expect(flash[:notice]).to eq("Agent run cancelled.")
@@ -1525,22 +1525,15 @@ RSpec.describe "AgentRuns" do
         expect(flash[:notice]).to eq("Agent run is no longer active.")
       end
 
-      it "redirects with alert when external cancellation fails" do
-        agent_run = create(:agent_run, :running, project: project)
-        allow(AgentRuns::Cancel).to receive(:call).and_raise(StandardError, "Temporal unavailable")
-
-        post cancel_project_agent_run_path(project, agent_run)
-
-        expect(response).to redirect_to(project_agent_run_path(project, agent_run))
-        expect(flash[:alert]).to eq("Unable to cancel agent run. Please try again.")
-      end
-
       it "shows finished message when run completes during cancellation" do
         agent_run = create(:agent_run, :running, project: project)
-        allow(AgentRuns::Cancel).to receive(:call) do
-          # Simulate the run finishing between the external cancel and the lock
-          agent_run.update_columns(status: "completed", completed_at: Time.current)
+
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(AgentRun).to receive(:with_lock) do |instance, &block|
+          instance.assign_attributes(status: "completed", completed_at: Time.current)
+          block.call
         end
+        # rubocop:enable RSpec/AnyInstance
 
         post cancel_project_agent_run_path(project, agent_run)
 

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -1525,22 +1525,6 @@ RSpec.describe "AgentRuns" do
         expect(flash[:notice]).to eq("Agent run is no longer active.")
       end
 
-      it "shows finished message when run completes during cancellation" do
-        agent_run = create(:agent_run, :running, project: project)
-
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(AgentRun).to receive(:with_lock) do |instance, &block|
-          instance.assign_attributes(status: "completed", completed_at: Time.current)
-          block.call
-        end
-        # rubocop:enable RSpec/AnyInstance
-
-        post cancel_project_agent_run_path(project, agent_run)
-
-        expect(response).to redirect_to(project_agent_run_path(project, agent_run))
-        expect(flash[:notice]).to eq("Agent run finished before it could be cancelled.")
-      end
-
       it "does not allow cancelling runs from other accounts" do
         other_account = create(:account)
         other_token = create(:github_token, account: other_account)

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -214,22 +214,5 @@ RSpec.describe "Dashboard" do
       expect(response).to have_http_status(:see_other)
       expect(flash[:notice]).to eq("Agent run is no longer active.")
     end
-
-    it "shows a different message when the run finishes during cancellation" do
-      agent_run = create(:agent_run, project: project, status: "running", started_at: 2.minutes.ago)
-
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(AgentRun).to receive(:with_lock) do |instance, &block|
-        instance.assign_attributes(status: "completed", completed_at: Time.current)
-        block.call
-      end
-      # rubocop:enable RSpec/AnyInstance
-
-      post dashboard_cancel_run_path(agent_run)
-
-      expect(response).to redirect_to(dashboard_path)
-      expect(response).to have_http_status(:see_other)
-      expect(flash[:notice]).to eq("Agent run finished before it could be cancelled.")
-    end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe "Dashboard" do
 
       it "includes merged pull requests in the recent activity stream" do
         merged_pr = create(:issue, :pull_request, project: project,
-                                                  pr_review_phase: "merged",
-                                                  github_number: 1234,
-                                                  title: "Ship the thing",
-                                                  github_updated_at: 3.minutes.ago)
+          pr_review_phase: "merged",
+          github_number: 1234,
+          title: "Ship the thing",
+          github_updated_at: 3.minutes.ago)
 
         get dashboard_path
 
@@ -185,30 +185,16 @@ RSpec.describe "Dashboard" do
 
     before { sign_in user }
 
-    it "cancels an active run through AgentRuns::Cancel" do
+    it "cancels an active run and enqueues background cleanup" do
       agent_run = create(:agent_run, project: project, status: "running", started_at: 2.minutes.ago)
 
-      allow(AgentRuns::Cancel).to receive(:call)
-
-      post dashboard_cancel_run_path(agent_run)
+      expect {
+        post dashboard_cancel_run_path(agent_run)
+      }.to have_enqueued_job(AgentRunCancellationJob).with(agent_run.id)
 
       expect(response).to redirect_to(dashboard_path)
       expect(response).to have_http_status(:see_other)
-      expect(AgentRuns::Cancel).to have_received(:call).with(agent_run: agent_run, skip_status_update: true)
       expect(agent_run.reload.status).to eq("cancelled")
-    end
-
-    it "redirects with an alert when external cancellation fails" do
-      agent_run = create(:agent_run, project: project, status: "running", started_at: 2.minutes.ago)
-
-      allow(AgentRuns::Cancel).to receive(:call).and_raise(StandardError, "Temporal unavailable")
-
-      post dashboard_cancel_run_path(agent_run)
-
-      expect(response).to redirect_to(dashboard_path)
-      expect(response).to have_http_status(:see_other)
-      expect(flash[:alert]).to eq("Unable to cancel agent run. Please try again.")
-      expect(agent_run.reload.status).to eq("running")
     end
 
     it "returns not found for a run in another account" do
@@ -229,15 +215,15 @@ RSpec.describe "Dashboard" do
       expect(flash[:notice]).to eq("Agent run is no longer active.")
     end
 
-    it "shows a different message when the run finishes during external cancellation" do
+    it "shows a different message when the run finishes during cancellation" do
       agent_run = create(:agent_run, project: project, status: "running", started_at: 2.minutes.ago)
 
-      # Simulate the run finishing during external cleanup by updating the
-      # database record when Cancel is called.  The controller reloads
-      # @agent_run inside with_lock, so stubbing the instance wouldn't work.
-      allow(AgentRuns::Cancel).to receive(:call) do
-        agent_run.update_column(:status, "completed")
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(AgentRun).to receive(:with_lock) do |instance, &block|
+        instance.assign_attributes(status: "completed", completed_at: Time.current)
+        block.call
       end
+      # rubocop:enable RSpec/AnyInstance
 
       post dashboard_cancel_run_path(agent_run)
 

--- a/spec/temporal/activities/complete_existing_pr_run_activity_spec.rb
+++ b/spec/temporal/activities/complete_existing_pr_run_activity_spec.rb
@@ -86,6 +86,18 @@ RSpec.describe Activities::CompleteExistingPrRunActivity do
         .to have_enqueued_job(ProcessRunQueueJob)
     end
 
+    it "does not add a comment or update the issue when the run is already cancelled" do
+      agent_run.cancel!
+
+      expect(github_client).not_to receive(:pull_request)
+      expect(github_client).not_to receive(:add_comment)
+
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(agent_run.reload.status).to eq("cancelled")
+      expect(issue.reload.paid_state).not_to eq("completed")
+    end
+
     it "increments draft_review_count for successful tracked draft followups" do
       issue.update!(pr_review_phase: "draft", draft_review_count: 2)
       agent_run.update!(

--- a/spec/temporal/activities/complete_existing_pr_run_activity_spec.rb
+++ b/spec/temporal/activities/complete_existing_pr_run_activity_spec.rb
@@ -86,16 +86,17 @@ RSpec.describe Activities::CompleteExistingPrRunActivity do
         .to have_enqueued_job(ProcessRunQueueJob)
     end
 
-    it "does not add a comment or update the issue when the run is already cancelled" do
+    it "reports cancellation when the run is already cancelled" do
       agent_run.cancel!
 
       expect(github_client).not_to receive(:pull_request)
       expect(github_client).not_to receive(:add_comment)
 
-      activity.execute(agent_run_id: agent_run.id)
+      result = activity.execute(agent_run_id: agent_run.id)
 
       expect(agent_run.reload.status).to eq("cancelled")
       expect(issue.reload.paid_state).not_to eq("completed")
+      expect(result).to include(skipped: true, cancelled: true)
     end
 
     it "increments draft_review_count for successful tracked draft followups" do

--- a/spec/temporal/activities/complete_issue_goal_activity_spec.rb
+++ b/spec/temporal/activities/complete_issue_goal_activity_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe Activities::CompleteIssueGoalActivity do
         expect { activity.execute(agent_run_id: agent_run.id) }
           .to have_enqueued_job(ProcessRunQueueJob)
       end
+
+      it "does not log or enqueue when the run is already cancelled" do
+        agent_run = create(:agent_run, :cancelled, project: project,
+          created_issue_url: "https://github.com/example/repo/issues/42",
+          created_issue_number: 42)
+
+        expect {
+          expect {
+            activity.execute(agent_run_id: agent_run.id)
+          }.not_to change(AgentRunLog, :count)
+        }.not_to have_enqueued_job(ProcessRunQueueJob)
+      end
     end
 
     context "when the agent did not create an issue" do

--- a/spec/temporal/activities/complete_issue_goal_activity_spec.rb
+++ b/spec/temporal/activities/complete_issue_goal_activity_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe Activities::CompleteIssueGoalActivity do
           }.not_to change(AgentRunLog, :count)
         }.not_to have_enqueued_job(ProcessRunQueueJob)
       end
+
+      it "reports finished runs as skipped" do
+        agent_run = create(:agent_run, :cancelled, project: project,
+          created_issue_url: "https://github.com/example/repo/issues/42",
+          created_issue_number: 42)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result).to include(
+          success: false,
+          issue_created: true,
+          skipped: true,
+          finished: true,
+          cancelled: true
+        )
+      end
     end
 
     context "when the agent did not create an issue" do
@@ -86,6 +102,20 @@ RSpec.describe Activities::CompleteIssueGoalActivity do
         expect {
           activity.execute(agent_run_id: agent_run.id)
         }.not_to have_enqueued_job(ProcessRunQueueJob)
+      end
+
+      it "reports cancelled runs as skipped instead of fallback candidates" do
+        agent_run = create(:agent_run, :cancelled, project: project)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result).to include(
+          success: false,
+          issue_created: false,
+          skipped: true,
+          finished: true,
+          cancelled: true
+        )
       end
     end
 

--- a/spec/temporal/activities/complete_review_goal_activity_spec.rb
+++ b/spec/temporal/activities/complete_review_goal_activity_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe Activities::CompleteReviewGoalActivity do
 
         expect(issue.reload.review_goal_retry_count).to eq(0)
       end
+
+      it "does not overwrite cancelled runs" do
+        issue = create(:issue, project: project, review_goal_retry_count: 2)
+        agent_run = create(:agent_run, :cancelled, :review_goal, project: project,
+          issue: issue, review_posted_at: 1.minute.ago)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:success]).to be false
+        expect(agent_run.reload.status).to eq("cancelled")
+        expect(issue.reload.review_goal_retry_count).to eq(2)
+      end
     end
 
     context "when no review was posted" do

--- a/spec/temporal/activities/create_github_issue_activity_spec.rb
+++ b/spec/temporal/activities/create_github_issue_activity_spec.rb
@@ -305,6 +305,25 @@ RSpec.describe Activities::CreateGithubIssueActivity do
       expect(synced.github_number).to eq(10)
     end
 
+    it "reconciles a created issue when cancellation wins the completion lock" do
+      allow(github_client).to receive(:create_issue) do
+        agent_run.cancel!
+        issue_response
+      end
+
+      expect {
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:issue_url]).to eq("https://github.com/owner/repo/issues/10")
+        expect(result[:issue_number]).to eq(10)
+      }.to change { project.issues.where(github_issue_id: 12345).count }.by(1)
+
+      agent_run.reload
+      expect(agent_run.status).to eq("cancelled")
+      expect(agent_run.created_issue_url).to be_nil
+      expect(agent_run.created_issue_number).to be_nil
+    end
+
     it "refuses to create a fallback issue from issue-creation failure output" do
       log_failed_issue_creation_attempt
 
@@ -732,6 +751,24 @@ RSpec.describe Activities::CreateGithubIssueActivity do
         activity.execute(agent_run_id: agent_run.id, upstream_issue: upstream_ref)
 
         agent_run.reload
+        expect(agent_run.cross_repo_issues).to include(
+          a_hash_including(
+            "role" => "downstream",
+            "issue_number" => 10
+          )
+        )
+      end
+
+      it "records the downstream issue when cancellation wins the completion lock" do
+        allow(github_client).to receive(:create_issue) do
+          agent_run.cancel!
+          issue_response
+        end
+
+        activity.execute(agent_run_id: agent_run.id, upstream_issue: upstream_ref)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("cancelled")
         expect(agent_run.cross_repo_issues).to include(
           a_hash_including(
             "role" => "downstream",

--- a/spec/temporal/activities/create_github_issue_activity_spec.rb
+++ b/spec/temporal/activities/create_github_issue_activity_spec.rb
@@ -165,6 +165,18 @@ RSpec.describe Activities::CreateGithubIssueActivity do
       activity.execute(agent_run_id: agent_run.id)
     end
 
+    it "does not create an issue when the run is already cancelled" do
+      agent_run.cancel!
+
+      expect(github_client).not_to receive(:create_issue)
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:agent_run_id]).to eq(agent_run.id)
+      expect(result[:issue_url]).to be_nil
+      expect(agent_run.reload.status).to eq("cancelled")
+    end
+
     it "uses first markdown heading as title when agent output has one" do
       agent_run.log!("stdout", "# Authentication System Analysis\n\nThe auth system uses JWT tokens.")
 

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -99,6 +99,16 @@ RSpec.describe Activities::CreatePullRequestActivity do
       expect(agent_run.pull_request_number).to eq(42)
     end
 
+    it "does not create a pull request for cancelled runs" do
+      agent_run = create(:agent_run, :cancelled, :with_git_context, project: project, issue: issue)
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(github_client).not_to have_received(:create_pull_request)
+      expect(result[:agent_run_id]).to eq(agent_run.id)
+      expect(agent_run.reload.status).to eq("cancelled")
+    end
+
     it "syncs a local pull request row immediately after PR creation" do
       expect {
         activity.execute(agent_run_id: agent_run.id)

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -106,6 +106,8 @@ RSpec.describe Activities::CreatePullRequestActivity do
 
       expect(github_client).not_to have_received(:create_pull_request)
       expect(result[:agent_run_id]).to eq(agent_run.id)
+      expect(result[:skipped]).to be true
+      expect(result[:cancelled]).to be true
       expect(agent_run.reload.status).to eq("cancelled")
     end
 

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -119,6 +119,27 @@ RSpec.describe Activities::CreatePullRequestActivity do
       expect(pull_request.labels).to include("paid-generated", "paid-automation")
     end
 
+    it "reconciles a created pull request when cancellation wins the completion lock" do
+      allow(github_client).to receive(:create_pull_request) do
+        agent_run.cancel!
+        pr_response
+      end
+
+      expect {
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:pull_request_url]).to eq("https://github.com/owner/repo/pull/42")
+        expect(result[:pull_request_number]).to eq(42)
+      }.to change { project.issues.pull_requests_only.where(github_number: 42).count }.by(1)
+
+      agent_run.reload
+      expect(agent_run.status).to eq("cancelled")
+      expect(agent_run.pull_request_url).to be_nil
+      expect(github_client).to have_received(:add_labels_to_issue).with(
+        project.full_name, 42, [ "paid-generated", "paid-automation" ]
+      )
+    end
+
     it "adds the generated and automation labels to the PR" do
       expect(github_client).to receive(:add_labels_to_issue).with(
         project.full_name, 42, [ "paid-generated", "paid-automation" ]

--- a/spec/temporal/activities/create_upstream_issue_activity_spec.rb
+++ b/spec/temporal/activities/create_upstream_issue_activity_spec.rb
@@ -112,6 +112,22 @@ RSpec.describe Activities::CreateUpstreamIssueActivity do
       activity.execute(input)
     end
 
+    it "does not create an upstream issue when the run is already cancelled" do
+      agent_run.update!(status: "cancelled", completed_at: Time.current)
+
+      result = activity.execute(input)
+
+      expect(github_client).not_to have_received(:create_issue)
+      expect(result).to include(
+        issue_url: nil,
+        issue_number: nil,
+        target_repo: "upstream-owner/upstream-repo",
+        skipped: true,
+        finished: true,
+        cancelled: true
+      )
+    end
+
     context "when no GitHub token is available" do
       before do
         allow(project).to receive(:github_token).and_return(nil)

--- a/spec/temporal/activities/mark_agent_run_complete_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_complete_activity_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe Activities::MarkAgentRunCompleteActivity do
       expect(issue.reload.paid_state).to eq("in_progress")
     end
 
+    it "does not overwrite or complete issue state for cancelled runs" do
+      issue = create(:issue, :in_progress, project: project)
+      agent_run = create(:agent_run, :cancelled, :create_issue_goal, project: project, issue: issue)
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.not_to have_enqueued_job(ProcessRunQueueJob)
+
+      expect(agent_run.reload.status).to eq("cancelled")
+      expect(issue.reload.paid_state).to eq("in_progress")
+    end
+
     it "enqueues ProcessRunQueueJob" do
       agent_run = create(:agent_run, :running, project: project)
 

--- a/spec/temporal/activities/mark_agent_run_complete_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_complete_activity_spec.rb
@@ -64,16 +64,49 @@ RSpec.describe Activities::MarkAgentRunCompleteActivity do
       expect(issue.reload.paid_state).to eq("in_progress")
     end
 
-    it "does not overwrite or complete issue state for cancelled runs" do
+    it "reports cancellation without completing issue state for cancelled runs" do
       issue = create(:issue, :in_progress, project: project)
       agent_run = create(:agent_run, :cancelled, :create_issue_goal, project: project, issue: issue)
 
+      result = nil
       expect {
-        activity.execute(agent_run_id: agent_run.id)
+        result = activity.execute(agent_run_id: agent_run.id)
       }.not_to have_enqueued_job(ProcessRunQueueJob)
 
+      expect(result).to include(skipped: true, cancelled: true)
       expect(agent_run.reload.status).to eq("cancelled")
       expect(issue.reload.paid_state).to eq("in_progress")
+    end
+
+    it "reports cancellation when completion loses a cancellation race" do
+      issue = create(:issue, :in_progress, project: project)
+      agent_run = create(:agent_run, :running, :create_issue_goal, project: project, issue: issue)
+      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+      allow(agent_run).to receive(:complete!) do
+        agent_run.cancel!
+        false
+      end
+
+      result = nil
+      expect {
+        result = activity.execute(agent_run_id: agent_run.id)
+      }.not_to have_enqueued_job(ProcessRunQueueJob)
+
+      expect(result).to include(skipped: true, cancelled: true)
+      expect(agent_run.reload.status).to eq("cancelled")
+      expect(issue.reload.paid_state).to eq("in_progress")
+    end
+
+    it "reports active completion for completed runs" do
+      agent_run = create(:agent_run, :running, :create_issue_goal, project: project)
+
+      result = nil
+      expect {
+        result = activity.execute(agent_run_id: agent_run.id)
+      }.to have_enqueued_job(ProcessRunQueueJob).once
+
+      expect(result).to include(skipped: false, cancelled: false)
+      expect(agent_run.reload.status).to eq("completed")
     end
 
     it "enqueues ProcessRunQueueJob" do

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
       expect(issue.reload.paid_state).to eq("completed")
     end
 
-    it "does not overwrite timeout status but still updates issue" do
+    it "does not overwrite timeout status or update issue" do
       issue = create(:issue, :in_progress, project: project)
       agent_run = create(:agent_run, :running, project: project, issue: issue)
       agent_run.timeout!(error: "startup_timeout: No output received")
@@ -56,10 +56,10 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
       agent_run.reload
       expect(agent_run.status).to eq("timeout")
       expect(agent_run.error_message).to eq("startup_timeout: No output received")
-      expect(issue.reload.paid_state).to eq("failed")
+      expect(issue.reload.paid_state).to eq("in_progress")
     end
 
-    it "does not overwrite completed status but still updates issue" do
+    it "does not overwrite completed status or update issue" do
       issue = create(:issue, :in_progress, project: project)
       agent_run = create(:agent_run, :running, project: project, issue: issue)
       agent_run.complete!
@@ -68,7 +68,17 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
 
       agent_run.reload
       expect(agent_run.status).to eq("completed")
-      expect(issue.reload.paid_state).to eq("failed")
+      expect(issue.reload.paid_state).to eq("in_progress")
+    end
+
+    it "does not overwrite cancelled status or update issue" do
+      issue = create(:issue, :in_progress, project: project)
+      agent_run = create(:agent_run, :cancelled, project: project, issue: issue)
+
+      activity.execute(agent_run_id: agent_run.id, error: "Activity task failed")
+
+      expect(agent_run.reload.status).to eq("cancelled")
+      expect(issue.reload.paid_state).to eq("in_progress")
     end
 
     it "enqueues ProcessRunQueueJob when status transitions to failed" do

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -81,6 +81,23 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
       expect(issue.reload.paid_state).to eq("in_progress")
     end
 
+    it "does not overwrite cancellation that becomes visible after taking the lock" do
+      issue = create(:issue, :in_progress, project: project)
+      agent_run = create(:agent_run, :running, project: project, issue: issue)
+      allow(agent_run).to receive(:reload) do
+        agent_run.status = "cancelled"
+        agent_run.completed_at = Time.current
+        agent_run
+      end
+      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+      expect(agent_run).not_to receive(:fail!)
+
+      activity.execute(agent_run_id: agent_run.id, error: "Activity task failed")
+
+      expect(agent_run.reload.status).to eq("cancelled")
+      expect(issue.reload.paid_state).to eq("in_progress")
+    end
+
     it "enqueues ProcessRunQueueJob when status transitions to failed" do
       agent_run = create(:agent_run, :running, project: project)
 

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
       expect(issue.reload.paid_state).to eq("completed")
     end
 
-    it "does not overwrite timeout status or update issue" do
+    it "does not overwrite timeout status but updates issue state" do
       issue = create(:issue, :in_progress, project: project)
       agent_run = create(:agent_run, :running, project: project, issue: issue)
       agent_run.timeout!(error: "startup_timeout: No output received")
@@ -56,7 +56,7 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
       agent_run.reload
       expect(agent_run.status).to eq("timeout")
       expect(agent_run.error_message).to eq("startup_timeout: No output received")
-      expect(issue.reload.paid_state).to eq("in_progress")
+      expect(issue.reload.paid_state).to eq("failed")
     end
 
     it "does not overwrite completed status or update issue" do

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger, patched: true)
     end
 
-    def stub_existing_pr_followup(pr_review_phase:)
+    def stub_existing_pr_followup(pr_review_phase:, complete_result: nil)
       allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
         case activity_class.name
         when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
@@ -488,7 +488,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::RunAgentActivity" then { success: true, has_changes: true }
         when "Activities::PushBranchActivity" then {}
         when "Activities::ResolveReviewThreadsActivity" then {}
-        when "Activities::CompleteExistingPrRunActivity" then { pr_review_phase: pr_review_phase }
+        when "Activities::CompleteExistingPrRunActivity" then complete_result || { pr_review_phase: pr_review_phase }
         when "Activities::RequestReviewActivity" then {}
         when "Activities::CleanupContainerActivity" then {}
         when "Activities::CleanupServicesActivity" then {}
@@ -559,6 +559,20 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::RequestReviewActivity, any_args)
+    end
+
+    it "skips existing-PR post-processing when completion reports a finished run without a PR" do
+      stub_existing_pr_followup(
+        pr_review_phase: "ready",
+        complete_result: { pr_review_phase: "ready", skipped: true, cancelled: true }
+      )
+
+      workflow.execute(input)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::RequestReviewActivity, any_args)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::DraftDecisionRecordActivity, any_args)
     end
 
     it "emits the pre-patch activity input shape when the workflow patch is not set" do
@@ -737,6 +751,18 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         .with(Activities::RequestReviewActivity,
           { project_id: 1, pr_number: 42 },
           timeout: 60)
+    end
+
+    it "skips review-bot review when no-change completion reports cancellation" do
+      stub_no_changes_followup
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::MarkAgentRunCompleteActivity, any_args)
+        .and_return({ agent_run_id: 42, skipped: true, cancelled: true })
+
+      workflow.execute(input)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::RequestReviewActivity, any_args)
     end
 
     it "resolves review threads when a no-change PR follow-up reports they were already addressed" do

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -852,6 +852,27 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::RequestReviewActivity, any_args)
     end
+
+    it "skips PR post-processing when PR creation reports a finished run without a PR" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
+        when "Activities::RunAgentActivity" then { success: true, has_changes: true }
+        when "Activities::CreatePullRequestActivity"
+          { agent_run_id: 42, pull_request_url: nil, pull_request_number: nil, skipped: true, cancelled: true }
+        else {}
+        end
+      end
+
+      workflow.execute(input)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::UpdateIssueWithPrActivity, any_args)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::RequestReviewActivity, any_args)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::DraftDecisionRecordActivity, any_args)
+    end
   end
 
   describe "ensure block cleanup and janitor enqueue" do

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -108,6 +108,28 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
               timeout: anything, retry_policy: anything)
     end
 
+    it "skips fallback issue creation when CompleteIssueGoalActivity reports a finished run" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42 }
+        when "Activities::RunAgentActivity" then { success: true }
+        when "Activities::CompleteIssueGoalActivity"
+          { agent_run_id: 42, success: false, issue_created: false, skipped: true, finished: true, cancelled: true }
+        else {}
+        end
+      end
+
+      result = workflow.execute(input)
+
+      expect(result[:success]).to be true
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::ParseCrossRepoIssuePlanActivity, anything,
+          timeout: anything, retry_policy: anything)
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::CreateGithubIssueActivity, anything,
+          timeout: anything, retry_policy: anything)
+    end
+
     it "marks the run failed when fallback issue creation is rejected" do
       stub_issue_creation_rejected
 


### PR DESCRIPTION
## Summary

- Moves Temporal workflow cancellation and Docker container teardown from the synchronous controller path into a new `AgentRunCancellationJob`
- The agent run's status is set to `cancelled` immediately via row-level locking, so the web UI responds instantly
- Heavy cleanup (Temporal cancel + container teardown) runs asynchronously in the background
- `AgentRuns::Cancel` service is preserved for other callers (resume, guardrails, cost budgets)

## Testing

- Added `AgentRunCancellationJob` spec covering Temporal cancel, container cleanup, NOT_FOUND handling, missing workflow/container, and record discard
- Updated request specs for both `Projects::AgentRunsController` and `DashboardController` to assert job enqueue instead of synchronous service call
- All 216 affected tests pass, lint clean