### PR TITLE
Fix #1348: Use released agent-harness version for Codex JSONL transcript parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,9 +46,7 @@ gem "docker-api"
 gem "qdrant-ruby"
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-gem "agent-harness",
-  git: "https://github.com/viamin/agent-harness.git",
-  ref: "5de7133af1481f8a13e9c66ca2e5a231bafe776c"
+gem "agent-harness", "~> 0.10.0"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 gem "ruby-maat"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/viamin/agent-harness.git
-  revision: 5de7133af1481f8a13e9c66ca2e5a231bafe776c
-  ref: 5de7133af1481f8a13e9c66ca2e5a231bafe776c
-  specs:
-    agent-harness (0.9.0)
-      logger (>= 1.6, < 2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -85,6 +77,8 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    agent-harness (0.10.0)
+      logger (>= 1.6, < 2.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -524,7 +518,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness!
+  agent-harness (~> 0.10.0)
   bootsnap
   brakeman
   bundler-audit
@@ -582,7 +576,7 @@ CHECKSUMS
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  agent-harness (0.9.0)
+  agent-harness (0.10.0) sha256=57cc99b70059e0c8223b93d374b485a316aad78ffad04151aab3e81434e345b6
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032


### PR DESCRIPTION
## Summary

Use released agent-harness version for Codex JSONL transcript parser

See #1348 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1348