### PR TITLE
refactor: deduplicate parse_rate_limit_reset by moving to agent-harness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,8 @@ gem "docker-api"
 gem "qdrant-ruby"
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-gem "agent-harness", "~> 0.10.0", ">= 0.10.0"
+# Provider#parse_rate_limit_reset landed in agent-harness 0.8.0; ~> 0.10.0 includes it.
+gem "agent-harness", "~> 0.10.0"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 gem "ruby-maat"

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "docker-api"
 gem "qdrant-ruby"
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-gem "agent-harness", "~> 0.10.0"
+gem "agent-harness", "~> 0.10.0", ">= 0.10.0"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 gem "ruby-maat"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness (~> 0.10.0)
+  agent-harness (~> 0.10.0, >= 0.10.0)
   bootsnap
   brakeman
   bundler-audit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,7 +518,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness (~> 0.10.0, >= 0.10.0)
+  agent-harness (~> 0.10.0)
   bootsnap
   brakeman
   bundler-audit

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -359,7 +359,7 @@ module Providers
     end
 
     def persist_rate_limited_state!(message)
-      reset_at = parse_rate_limit_reset(message)
+      reset_at = rate_limit_reset_at(message)
 
       provider_state_names.each do |provider_name|
         provider.user.provider_states.find_or_create_by!(provider_name: provider_name).mark_rate_limited!(reset_at: reset_at)
@@ -379,48 +379,23 @@ module Providers
       names.uniq
     end
 
-    def parse_rate_limit_reset(message)
-      if (match = message.to_s.match(/retry.?after:?\s*(\d+)/i))
-        match[1].to_i.seconds.from_now
-      elsif (match = message.to_s.match(/reset.?at:?\s*(\d+)/i))
-        reset_time = Time.at(match[1].to_i)
-        reset_time > Time.current ? reset_time : 1.hour.from_now
-      elsif (match = message.to_s.match(/resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\s*\(?\s*UTC\s*\)?/i))
-        hour = match[1].to_i
-        minute = (match[2] || "0").to_i
-        period = match[3].downcase
-
-        hour = if period == "am"
-          hour == 12 ? 0 : hour
-        else
-          hour == 12 ? 12 : hour + 12
-        end
-
-        reset_time = Time.current.utc.change(hour: hour, min: minute, sec: 0)
-        reset_time += 1.day if reset_time <= Time.current.utc
-        reset_time
-      elsif (match = message.to_s.match(/resets?\s+([A-Za-z]{3})\s+(\d{1,2}),\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\s*\(?\s*UTC\s*\)?/i))
-        month = Date::ABBR_MONTHNAMES.index(match[1].capitalize)
-        day = match[2].to_i
-        hour = match[3].to_i
-        minute = (match[4] || "0").to_i
-        period = match[5].downcase
-
-        hour = if period == "am"
-          hour == 12 ? 0 : hour
-        else
-          hour == 12 ? 12 : hour + 12
-        end
-
-        year = Time.current.utc.year
-        reset_time = Time.utc(year, month, day, hour, minute, 0)
-        reset_time = Time.utc(year + 1, month, day, hour, minute, 0) if reset_time <= Time.current.utc
-        reset_time
-      else
+    def rate_limit_reset_at(message)
+      agent_harness_provider = harness_provider
+      agent_harness_provider.parse_rate_limit_reset(message.to_s) ||
+        agent_harness_provider.parse_rate_limit_reset(normalized_rate_limit_reset_text(message)) ||
         1.hour.from_now
-      end
-    rescue StandardError
+    rescue AgentHarness::ConfigurationError, KeyError
       1.hour.from_now
+    end
+
+    def harness_provider
+      AgentHarness.provider(harness_provider_name)
+    end
+
+    def normalized_rate_limit_reset_text(message)
+      message.to_s
+        .gsub(/retry.?after:?\s*(\d+)(?!\s*s)/i, 'retry after \1s')
+        .gsub(/reset.?at:?\s*(\d+)/i, 'reset at \1')
     end
 
     def container_test_context

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -381,9 +381,10 @@ module Providers
 
     def rate_limit_reset_at(message)
       agent_harness_provider = harness_provider
-      agent_harness_provider.parse_rate_limit_reset(message.to_s) ||
+      parsed_reset = agent_harness_provider.parse_rate_limit_reset(message.to_s) ||
         agent_harness_provider.parse_rate_limit_reset(normalized_rate_limit_reset_text(message)) ||
         1.hour.from_now
+      parsed_reset > Time.current ? parsed_reset : 1.hour.from_now
     rescue AgentHarness::ConfigurationError, KeyError
       1.hour.from_now
     end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -692,7 +692,7 @@ module Activities
 
       # Check if this is a rate limit error
       if rate_limit_error?(rate_limit_output)
-        reset_at = parse_rate_limit_reset(rate_limit_output)
+        reset_at = rate_limit_reset_at(provider, rate_limit_output)
         raise ProviderRateLimitError.new("Rate limited by #{provider}", reset_at: reset_at)
       end
 
@@ -704,7 +704,7 @@ module Activities
       # short-circuits on blank.
       timeout_output = recent_timeout_output(agent_run, since: execution_started_at, prompt: prompt)
       if timeout_rate_limit_error?(timeout_output)
-        reset_at = parse_rate_limit_reset(timeout_output)
+        reset_at = rate_limit_reset_at(provider, timeout_output)
         raise ProviderRateLimitError.new("Rate limited by #{provider}", reset_at: reset_at)
       end
 
@@ -719,7 +719,7 @@ module Activities
       # provider quota pattern (e.g. KiloCode "Free tier limit reached").
       # Classify as rate-limited so dashboards and retry logic see the
       # real root cause instead of a generic timeout.
-      reset_at = parse_rate_limit_reset(e.matched_output.to_s)
+      reset_at = rate_limit_reset_at(provider, e.matched_output.to_s)
       raise ProviderRateLimitError.new(
         "Rate limited by #{provider}: #{e.matched_output.to_s.truncate(200)}",
         reset_at: reset_at
@@ -854,55 +854,25 @@ module Activities
       end.join("\n").strip
     end
 
-    # Attempts to parse a rate limit reset time from the output.
-    # Falls back to 1 hour from now if not parseable.
-    #
-    # Supported patterns:
-    #   - "retry after 60" (seconds)
-    #   - "reset at 1234567890" (unix timestamp)
-    #   - "resets 5am (UTC)" or "resets 5:00am (UTC)"
-    def parse_rate_limit_reset(output)
-      if (match = output.match(/retry.?after:?\s*(\d+)/i))
-        match[1].to_i.seconds.from_now
-      elsif (match = output.match(/reset.?at:?\s*(\d+)/i))
-        reset_time = Time.at(match[1].to_i)
-        reset_time > Time.current ? reset_time : 1.hour.from_now
-      elsif (match = output.match(/resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\s*\(?\s*UTC\s*\)?/i))
-        hour = match[1].to_i
-        minute = (match[2] || "0").to_i
-        period = match[3].downcase
-
-        hour = if period == "am"
-          hour == 12 ? 0 : hour
-        else
-          hour == 12 ? 12 : hour + 12
-        end
-
-        reset_time = Time.current.utc.change(hour: hour, min: minute, sec: 0)
-        reset_time += 1.day if reset_time <= Time.current.utc
-        reset_time
-      elsif (match = output.match(/resets?\s+([A-Za-z]{3})\s+(\d{1,2}),\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)\s*\(?\s*UTC\s*\)?/i))
-        month = Date::ABBR_MONTHNAMES.index(match[1].capitalize)
-        day = match[2].to_i
-        hour = match[3].to_i
-        minute = (match[4] || "0").to_i
-        period = match[5].downcase
-
-        hour = if period == "am"
-          hour == 12 ? 0 : hour
-        else
-          hour == 12 ? 12 : hour + 12
-        end
-
-        year = Time.current.utc.year
-        reset_time = Time.utc(year, month, day, hour, minute, 0)
-        reset_time = Time.utc(year + 1, month, day, hour, minute, 0) if reset_time <= Time.current.utc
-        reset_time
-      else
+    def rate_limit_reset_at(provider_key, output)
+      harness_provider = harness_provider_for(provider_key)
+      harness_provider.parse_rate_limit_reset(output.to_s) ||
+        harness_provider.parse_rate_limit_reset(normalized_rate_limit_reset_text(output)) ||
         1.hour.from_now
-      end
-    rescue StandardError
+    rescue AgentHarness::ConfigurationError, KeyError
       1.hour.from_now
+    end
+
+    def harness_provider_for(provider_key)
+      app_provider_key = ProviderSupport.provider_key_for_agent_type(provider_key)
+      harness_key = ProviderSupport.harness_provider_key_for(app_provider_key).to_sym
+      AgentHarness.provider(harness_key)
+    end
+
+    def normalized_rate_limit_reset_text(output)
+      output.to_s
+        .gsub(/retry.?after:?\s*(\d+)(?!\s*s)/i, 'retry after \1s')
+        .gsub(/reset.?at:?\s*(\d+)/i, 'reset at \1')
     end
 
     def review_threads_already_addressed?(stdout:, stderr:, prompt:)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -856,9 +856,10 @@ module Activities
 
     def rate_limit_reset_at(provider_key, output)
       harness_provider = harness_provider_for(provider_key)
-      harness_provider.parse_rate_limit_reset(output.to_s) ||
+      parsed_reset = harness_provider.parse_rate_limit_reset(output.to_s) ||
         harness_provider.parse_rate_limit_reset(normalized_rate_limit_reset_text(output)) ||
         1.hour.from_now
+      parsed_reset > Time.current ? parsed_reset : 1.hour.from_now
     rescue AgentHarness::ConfigurationError, KeyError
       1.hour.from_now
     end

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1058,4 +1058,22 @@ RSpec.describe Providers::TestAgent do
       end
     end
   end
+
+  describe "#rate_limit_reset_at" do
+    before do
+      allow(ProviderSupport).to receive(:harness_provider_key_for).with("claude").and_return("claude")
+    end
+
+    it "falls back when agent-harness parses a stale reset time" do
+      harness_provider = double(parse_rate_limit_reset: 1.hour.ago)
+      allow(AgentHarness).to receive(:provider).with(:claude).and_return(harness_provider)
+
+      freeze_time do
+        service = described_class.new(provider: provider)
+        reset_at = service.send(:rate_limit_reset_at, "Rate limit exceeded. Reset at: 1")
+
+        expect(reset_at).to eq(1.hour.from_now)
+      end
+    end
+  end
 end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2027,6 +2027,24 @@ RSpec.describe Activities::RunAgentActivity do
     end
   end
 
+  describe "#rate_limit_reset_at" do
+    let(:harness_provider) { double(parse_rate_limit_reset: 1.hour.ago) }
+
+    before do
+      allow(ProviderSupport).to receive(:provider_key_for_agent_type).with("claude_code").and_return("claude")
+      allow(ProviderSupport).to receive(:harness_provider_key_for).with("claude").and_return("claude")
+      allow(AgentHarness).to receive(:provider).with(:claude).and_return(harness_provider)
+    end
+
+    it "falls back when agent-harness parses a stale reset time" do
+      freeze_time do
+        reset_at = activity.send(:rate_limit_reset_at, "claude_code", "Rate limit exceeded. Reset at: 1")
+
+        expect(reset_at).to eq(1.hour.from_now)
+      end
+    end
+  end
+
   describe "paused run protection after provider exhaustion" do
     before do
       allow(container_service).to receive(:execute).and_return(exec_failure)


### PR DESCRIPTION
## Summary

refactor: deduplicate parse_rate_limit_reset by moving to agent-harness

See #1299 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1299