### PR TITLE
feat(agent-runs): Add label management and re-evaluation loop for enhance_issue (389-C)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -243,6 +243,8 @@ class ProjectsController < ApplicationController
       :owner_reviewer_login, :merge_method, :max_draft_review_rounds, :auto_pick_enabled, :auto_merge_mode,
       :auto_fix_merge_conflicts, :auto_scan_security,
       :generated_label_name, :automation_label_name,
+      :enhance_issue_needs_input_label_name, :enhance_issue_enhanced_label_name,
+      :max_enhance_issue_reevaluation_rounds,
       :auto_add_labels_enabled, :automation_on_label_enabled, :pr_aggregation_enabled,
       :inherit_priority_labels,
       :auto_release_granularity,

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -55,6 +55,7 @@ class Issue < ApplicationRecord
   before_validation { self.source ||= GITHUB_SOURCE }
   validates :source, presence: true, inclusion: { in: VALID_SOURCES }
   validates :pr_review_phase, inclusion: { in: PR_REVIEW_PHASES }, if: :is_pull_request?
+  validates :enhance_issue_rounds, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validate :parent_issue_belongs_to_same_project, if: -> { parent_issue.present? }
 
   after_commit :broadcast_current_section, on: [ :create, :destroy ]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -155,6 +155,10 @@ class Project < ApplicationRecord
   validates :max_draft_review_rounds, numericality: { greater_than_or_equal_to: 0 }
   validates :generated_label_name, presence: true
   validates :automation_label_name, presence: true
+  validates :enhance_issue_needs_input_label_name, presence: true
+  validates :enhance_issue_enhanced_label_name, presence: true
+  validates :max_enhance_issue_reevaluation_rounds,
+    numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   validates :code_scanning_interval_hours, numericality: { greater_than_or_equal_to: 24 }
   validates :knowledge_status, inclusion: { in: KNOWLEDGE_STATUSES }

--- a/app/services/projects/ensure_standard_labels.rb
+++ b/app/services/projects/ensure_standard_labels.rb
@@ -8,6 +8,8 @@ module Projects
   # Standard labels include:
   # - generated_label_name  (e.g. "paid-generated")
   # - automation_label_name (e.g. "paid-automation")
+  # - enhance_issue_needs_input_label_name (e.g. "paid-needs-input")
+  # - enhance_issue_enhanced_label_name    (e.g. "paid-enhanced")
   # - Priority labels       (P1, P2, P3 by default)
   #
   # @example
@@ -20,6 +22,8 @@ module Projects
     LABEL_DEFINITIONS = {
       generated: { color: "0e8a16", description: "Created by Paid" },
       automation: { color: "1d76db", description: "Triggers Paid automation" },
+      enhance_issue_needs_input: { color: "d876e3", description: "Paid needs answers before enhancing this issue again" },
+      enhance_issue_enhanced: { color: "0e8a16", description: "Paid has added implementation context to this issue" },
       priority: {
         "P1" => { color: "d93f0b", description: "High priority" },
         "P2" => { color: "ff9800", description: "Medium priority" },
@@ -82,6 +86,18 @@ module Projects
         name: project.automation_label_name,
         color: LABEL_DEFINITIONS[:automation][:color],
         description: LABEL_DEFINITIONS[:automation][:description]
+      }
+
+      labels << {
+        name: project.enhance_issue_needs_input_label_name,
+        color: LABEL_DEFINITIONS[:enhance_issue_needs_input][:color],
+        description: LABEL_DEFINITIONS[:enhance_issue_needs_input][:description]
+      }
+
+      labels << {
+        name: project.enhance_issue_enhanced_label_name,
+        color: LABEL_DEFINITIONS[:enhance_issue_enhanced][:color],
+        description: LABEL_DEFINITIONS[:enhance_issue_enhanced][:description]
       }
 
       project.effective_priority_labels.each do |tier, label_name|

--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -46,9 +46,9 @@ module Activities
       response = call_llm(agent_run, prompt_for(project, gh_issue, comments, context))
       parsed = parse_response!(agent_run, response)
       parsed = stop_after_max_rounds(parsed, project, issue)
+      label_result = apply_label_state(client, project, issue, parsed)
       comment_body = comment_body_for(parsed)
       gh_comment = client.add_comment(project.full_name, issue.github_number, comment_body)
-      label_result = apply_label_state(client, project, issue, parsed)
 
       track_tokens(agent_run, response)
       agent_run.log!("stdout", comment_body)
@@ -326,6 +326,7 @@ module Activities
       end
 
       added = labels_added(client, project, issue, [ project.enhance_issue_needs_input_label_name ])
+      require_label_added!(project.enhance_issue_needs_input_label_name, added)
       removed = labels_removed(client, project, issue, [ project.enhance_issue_enhanced_label_name ])
       merge_local_labels(issue, add: added, remove: removed)
       { applied: added.first, max_rounds_reached: false }
@@ -378,6 +379,15 @@ module Activities
 
     def labels_added(client, project, issue, labels)
       labels.select { |label| add_label(client, project, issue, label) }
+    end
+
+    def require_label_added!(label, added)
+      return if added.include?(label)
+
+      raise Temporalio::Error::ApplicationError.new(
+        "Failed to apply enhance_issue control label #{label}",
+        type: "EnhanceIssueLabelAddFailed"
+      )
     end
 
     def labels_removed(client, project, issue, labels)

--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -314,6 +314,7 @@ module Activities
     def apply_label_state(client, project, issue, parsed)
       if parsed[:sufficient_context]
         added = labels_added(client, project, issue, [ project.enhance_issue_enhanced_label_name ])
+        require_label_added!(project.enhance_issue_enhanced_label_name, added)
         removed = labels_removed(client, project, issue, [ project.enhance_issue_needs_input_label_name ])
         merge_local_labels(issue, add: added, remove: removed)
         return { applied: added.first, max_rounds_reached: false }

--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -40,17 +40,19 @@ module Activities
       gh_issue = client.issue(project.full_name, issue.github_number)
       comments = client.issue_comments(project.full_name, issue.github_number)
       existing_comment = enhancement_comment(comments)
-      return complete_existing(agent_run, existing_comment) if existing_comment
+      return complete_existing(agent_run, existing_comment) if existing_comment && issue.enhance_issue_rounds.zero?
 
       context = build_context(project, issue)
       response = call_llm(agent_run, prompt_for(project, gh_issue, comments, context))
       parsed = parse_response!(agent_run, response)
+      parsed = stop_after_max_rounds(parsed, project, issue)
       comment_body = comment_body_for(parsed)
       gh_comment = client.add_comment(project.full_name, issue.github_number, comment_body)
+      label_result = apply_label_state(client, project, issue, parsed)
 
       track_tokens(agent_run, response)
       agent_run.log!("stdout", comment_body)
-      complete_run!(agent_run)
+      complete_run!(agent_run, paid_state_for(parsed, project, issue))
       ProcessRunQueueJob.perform_later
 
       logger.info(
@@ -59,6 +61,9 @@ module Activities
         issue_id: issue.id,
         issue_number: issue.github_number,
         sufficient_context: parsed[:sufficient_context],
+        label_applied: label_result[:applied],
+        max_rounds_reached: label_result[:max_rounds_reached],
+        enhance_issue_rounds: issue.enhance_issue_rounds,
         comment_url: gh_comment.html_url,
         knowledge_results: context[:knowledge_results_count],
         knowledge_sections: context[:bundle_sections]
@@ -68,7 +73,9 @@ module Activities
         agent_run_id: agent_run.id,
         issue_number: issue.github_number,
         comment_url: gh_comment.html_url,
-        sufficient_context: parsed[:sufficient_context]
+        sufficient_context: parsed[:sufficient_context],
+        label_applied: label_result[:applied],
+        max_rounds_reached: label_result[:max_rounds_reached]
       }
     end
 
@@ -86,9 +93,9 @@ module Activities
       }
     end
 
-    def complete_run!(agent_run)
+    def complete_run!(agent_run, paid_state = "completed")
       agent_run.complete!
-      agent_run.issue.update!(paid_state: "completed") if agent_run.issue
+      agent_run.issue.update!(paid_state: paid_state) if agent_run.issue
     end
 
     def build_context(project, issue)
@@ -282,8 +289,94 @@ module Activities
       [ COMMENT_MARKER, parsed[:comment_body].to_s.truncate(MAX_COMMENT_BODY) ].join("\n")
     end
 
+    def stop_after_max_rounds(parsed, project, issue)
+      return parsed if parsed[:sufficient_context]
+      return parsed unless max_rounds_reached?(project, issue)
+
+      parsed.merge(
+        comment_body: <<~COMMENT
+          ## Auto-enhancement stopped
+
+          Paid has reached the configured limit of #{project.max_enhance_issue_reevaluation_rounds} enhancement re-evaluation rounds for this issue.
+
+          Manual review is needed before enhancement can continue.
+
+          ## Latest context
+          #{parsed[:comment_body]}
+        COMMENT
+      )
+    end
+
     def enhancement_comment(comments)
       comments.find { |comment| comment.body.to_s.include?(COMMENT_MARKER) }
+    end
+
+    def apply_label_state(client, project, issue, parsed)
+      if parsed[:sufficient_context]
+        add_label(client, project, issue, project.enhance_issue_enhanced_label_name)
+        remove_label(client, project, issue, project.enhance_issue_needs_input_label_name)
+        merge_local_labels(issue, add: [ project.enhance_issue_enhanced_label_name ],
+          remove: [ project.enhance_issue_needs_input_label_name ])
+        return { applied: project.enhance_issue_enhanced_label_name, max_rounds_reached: false }
+      end
+
+      if max_rounds_reached?(project, issue)
+        remove_label(client, project, issue, project.enhance_issue_needs_input_label_name)
+        merge_local_labels(issue, remove: [ project.enhance_issue_needs_input_label_name ])
+        return { applied: nil, max_rounds_reached: true }
+      end
+
+      add_label(client, project, issue, project.enhance_issue_needs_input_label_name)
+      remove_label(client, project, issue, project.enhance_issue_enhanced_label_name)
+      merge_local_labels(issue, add: [ project.enhance_issue_needs_input_label_name ],
+        remove: [ project.enhance_issue_enhanced_label_name ])
+      { applied: project.enhance_issue_needs_input_label_name, max_rounds_reached: false }
+    end
+
+    def paid_state_for(parsed, project, issue)
+      return "completed" if parsed[:sufficient_context]
+      return "completed" if max_rounds_reached?(project, issue)
+
+      "needs_input"
+    end
+
+    def max_rounds_reached?(project, issue)
+      issue.enhance_issue_rounds >= project.max_enhance_issue_reevaluation_rounds
+    end
+
+    def add_label(client, project, issue, label)
+      client.add_labels_to_issue(project.full_name, issue.github_number, [ label ])
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "agent_execution.enhance_issue_label_add_failed",
+        project_id: project.id,
+        issue_id: issue.id,
+        label: label,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+
+    def remove_label(client, project, issue, label)
+      return unless issue.has_label?(label)
+
+      client.remove_label_from_issue(project.full_name, issue.github_number, label)
+    rescue GithubClient::NotFoundError
+      nil
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "agent_execution.enhance_issue_label_remove_failed",
+        project_id: project.id,
+        issue_id: issue.id,
+        label: label,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+
+    def merge_local_labels(issue, add: [], remove: [])
+      labels = (Array(issue.labels) - remove) | add
+      issue.update!(labels: labels)
     end
 
     def track_tokens(agent_run, response)

--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -80,17 +80,26 @@ module Activities
     end
 
     def complete_existing(agent_run, existing_comment)
-      complete_run!(agent_run)
+      issue = agent_run.issue
+      complete_run!(agent_run, existing_paid_state(issue, existing_comment))
       agent_run.log!("system", "Enhancement comment already exists: #{existing_comment.html_url}")
       ProcessRunQueueJob.perform_later
 
       {
         agent_run_id: agent_run.id,
-        issue_number: agent_run.issue.github_number,
+        issue_number: issue.github_number,
         comment_url: existing_comment.html_url,
         sufficient_context: nil,
         already_enhanced: true
       }
+    end
+
+    def existing_paid_state(issue, existing_comment)
+      return "completed" if existing_comment.body.to_s.include?("## Auto-enhancement stopped")
+      return "needs_input" if issue.has_label?(issue.project.enhance_issue_needs_input_label_name)
+      return "needs_input" if existing_comment.body.to_s.include?("## Clarifying questions")
+
+      "completed"
     end
 
     def complete_run!(agent_run, paid_state = "completed")

--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -313,24 +313,22 @@ module Activities
 
     def apply_label_state(client, project, issue, parsed)
       if parsed[:sufficient_context]
-        add_label(client, project, issue, project.enhance_issue_enhanced_label_name)
-        remove_label(client, project, issue, project.enhance_issue_needs_input_label_name)
-        merge_local_labels(issue, add: [ project.enhance_issue_enhanced_label_name ],
-          remove: [ project.enhance_issue_needs_input_label_name ])
-        return { applied: project.enhance_issue_enhanced_label_name, max_rounds_reached: false }
+        added = labels_added(client, project, issue, [ project.enhance_issue_enhanced_label_name ])
+        removed = labels_removed(client, project, issue, [ project.enhance_issue_needs_input_label_name ])
+        merge_local_labels(issue, add: added, remove: removed)
+        return { applied: added.first, max_rounds_reached: false }
       end
 
       if max_rounds_reached?(project, issue)
-        remove_label(client, project, issue, project.enhance_issue_needs_input_label_name)
-        merge_local_labels(issue, remove: [ project.enhance_issue_needs_input_label_name ])
+        removed = labels_removed(client, project, issue, [ project.enhance_issue_needs_input_label_name ])
+        merge_local_labels(issue, remove: removed)
         return { applied: nil, max_rounds_reached: true }
       end
 
-      add_label(client, project, issue, project.enhance_issue_needs_input_label_name)
-      remove_label(client, project, issue, project.enhance_issue_enhanced_label_name)
-      merge_local_labels(issue, add: [ project.enhance_issue_needs_input_label_name ],
-        remove: [ project.enhance_issue_enhanced_label_name ])
-      { applied: project.enhance_issue_needs_input_label_name, max_rounds_reached: false }
+      added = labels_added(client, project, issue, [ project.enhance_issue_needs_input_label_name ])
+      removed = labels_removed(client, project, issue, [ project.enhance_issue_enhanced_label_name ])
+      merge_local_labels(issue, add: added, remove: removed)
+      { applied: added.first, max_rounds_reached: false }
     end
 
     def paid_state_for(parsed, project, issue)
@@ -346,6 +344,7 @@ module Activities
 
     def add_label(client, project, issue, label)
       client.add_labels_to_issue(project.full_name, issue.github_number, [ label ])
+      true
     rescue GithubClient::Error => e
       logger.warn(
         message: "agent_execution.enhance_issue_label_add_failed",
@@ -355,14 +354,16 @@ module Activities
         error_class: e.class.name,
         error: e.message
       )
+      false
     end
 
     def remove_label(client, project, issue, label)
-      return unless issue.has_label?(label)
+      return true unless issue.has_label?(label)
 
       client.remove_label_from_issue(project.full_name, issue.github_number, label)
+      true
     rescue GithubClient::NotFoundError
-      nil
+      true
     rescue GithubClient::Error => e
       logger.warn(
         message: "agent_execution.enhance_issue_label_remove_failed",
@@ -372,9 +373,20 @@ module Activities
         error_class: e.class.name,
         error: e.message
       )
+      false
+    end
+
+    def labels_added(client, project, issue, labels)
+      labels.select { |label| add_label(client, project, issue, label) }
+    end
+
+    def labels_removed(client, project, issue, labels)
+      labels.select { |label| remove_label(client, project, issue, label) }
     end
 
     def merge_local_labels(issue, add: [], remove: [])
+      return if add.empty? && remove.empty?
+
       labels = (Array(issue.labels) - remove) | add
       issue.update!(labels: labels)
     end

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -63,12 +63,19 @@ module Activities
         project.touch_last_issue_sync_at(sync_started_at - 1.second)
       end
 
-      # Exclude closed issues from downstream processing (DetectLabelsActivity).
+      recheck_issue_ids = enhance_issue_rechecks.map { |recheck| recheck[:issue_id] }.to_set
+
+      # Exclude closed issues and enhance_issue rechecks from downstream
+      # processing (DetectLabelsActivity). Rechecks are returned separately for
+      # the workflow to queue, so evaluating their automation labels in this
+      # poll can incorrectly start a create_pr run before enhancement completes.
       # sync_issue already persisted their github_state to the DB, but passing
       # them downstream could incorrectly trigger agent runs for closed work.
       # Note: parse_issue_relationships receives all synced_issues (including
-      # closed), but filters to github_state: "open" internally (line 227).
-      open_issues = synced_issues.reject { |si| si[:github_state] == "closed" }
+      # closed), but filters to github_state: "open" internally.
+      open_issues = synced_issues.reject do |si|
+        si[:github_state] == "closed" || recheck_issue_ids.include?(si[:id])
+      end
 
       # During incremental fetches, issues whose `updated_at` did not change
       # on GitHub are not returned by the API. However, those issues may still
@@ -245,7 +252,7 @@ module Activities
           issue.update!(paid_state: "completed")
           limit_reached = true
         else
-          issue.update!(enhance_issue_rounds: issue.enhance_issue_rounds + 1, paid_state: "new")
+          issue.update!(enhance_issue_rounds: issue.enhance_issue_rounds + 1, paid_state: "in_progress")
         end
       end
 

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -65,16 +65,19 @@ module Activities
 
       recheck_issue_ids = enhance_issue_rechecks.map { |recheck| recheck[:issue_id] }.to_set
 
-      # Exclude closed issues and enhance_issue rechecks from downstream
+      # Exclude closed issues and enhance_issue waits/rechecks from downstream
       # processing (DetectLabelsActivity). Rechecks are returned separately for
-      # the workflow to queue, so evaluating their automation labels in this
-      # poll can incorrectly start a create_pr run before enhancement completes.
+      # the workflow to queue, and needs-input issues are still waiting on
+      # human answers, so evaluating their automation labels in this poll can
+      # incorrectly start a create_pr run before enhancement completes.
       # sync_issue already persisted their github_state to the DB, but passing
       # them downstream could incorrectly trigger agent runs for closed work.
       # Note: parse_issue_relationships receives all synced_issues (including
       # closed), but filters to github_state: "open" internally.
       open_issues = synced_issues.reject do |si|
-        si[:github_state] == "closed" || recheck_issue_ids.include?(si[:id])
+        si[:github_state] == "closed" ||
+          recheck_issue_ids.include?(si[:id]) ||
+          enhance_issue_needs_input?(project, si)
       end
 
       # During incremental fetches, issues whose `updated_at` did not change
@@ -87,6 +90,7 @@ module Activities
         fetched_ids = open_issues.map { |si| si[:id] }.to_set
         rescannable = project.issues
           .where(github_state: "open", paid_state: %w[new needs_input recommend_close])
+          .where.not("labels @> ?::jsonb", [ project.enhance_issue_needs_input_label_name ].to_json)
           .where.not(id: fetched_ids.to_a)
           .limit(200)
           .pluck(:id, :github_number, :github_state)
@@ -241,6 +245,10 @@ module Activities
 
         enqueue_enhance_issue_recheck(project, issue)
       end
+    end
+
+    def enhance_issue_needs_input?(project, issue_data)
+      Array(issue_data[:labels]).include?(project.enhance_issue_needs_input_label_name)
     end
 
     def enqueue_enhance_issue_recheck(project, issue)

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -237,7 +237,7 @@ module Activities
         next unless Array(issue_data[:removed_labels]).include?(label)
 
         issue = project.issues.find(issue_data[:id])
-        next if issue.is_pull_request? || issue.github_state == "closed"
+        next if issue.is_pull_request? || issue.github_state == "closed" || issue.paid_state != "needs_input"
 
         enqueue_enhance_issue_recheck(project, issue)
       end

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -249,7 +249,6 @@ module Activities
 
       issue.with_lock do
         if issue.enhance_issue_rounds >= max_rounds
-          issue.update!(paid_state: "completed")
           limit_reached = true
         else
           issue.update!(enhance_issue_rounds: issue.enhance_issue_rounds + 1, paid_state: "in_progress")
@@ -272,6 +271,8 @@ module Activities
 
     def stop_enhance_issue_recheck(project, issue, max_rounds)
       post_enhance_issue_limit_comment(project, issue, max_rounds)
+      issue.update!(paid_state: "completed")
+
       logger.info(
         message: "agent_execution.enhance_issue_recheck_limit_reached",
         project_id: project.id,
@@ -281,6 +282,9 @@ module Activities
         max_rounds: max_rounds
       )
       nil
+    rescue GithubClient::Error
+      restore_enhance_issue_recheck_signal(project, issue)
+      raise
     end
 
     def post_enhance_issue_limit_comment(project, issue, max_rounds)
@@ -295,6 +299,15 @@ module Activities
           Manual review is needed before enhancement can continue.
         COMMENT
       )
+    end
+
+    def restore_enhance_issue_recheck_signal(project, issue)
+      issue.with_lock do
+        issue.update!(
+          labels: Array(issue.labels) | [ project.enhance_issue_needs_input_label_name ],
+          paid_state: "needs_input"
+        )
+      end
     end
 
     # Parses dependency and parent/child relationships from issue comments.

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -237,7 +237,7 @@ module Activities
         next unless Array(issue_data[:removed_labels]).include?(label)
 
         issue = project.issues.find(issue_data[:id])
-        next if issue.is_pull_request?
+        next if issue.is_pull_request? || issue.github_state == "closed"
 
         enqueue_enhance_issue_recheck(project, issue)
       end

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -21,6 +21,7 @@ module Activities
 
       synced_issues = github_issues.map { |gi| sync_issue(project, gi) }
       parse_issue_relationships(project, synced_issues) if synced_issues.any?
+      enhance_issue_rechecks = detect_enhance_issue_rechecks(project, synced_issues)
       closed_count = close_stale_issues(project, github_issues, truncated: truncated, incremental: incremental)
       stale_pr_count = reconcile_open_pull_requests(project, client) if incremental && !truncated
 
@@ -96,10 +97,11 @@ module Activities
         closed_count: closed_count,
         stale_pr_count: stale_pr_count || 0,
         incremental: incremental,
+        enhance_issue_recheck_count: enhance_issue_rechecks.size,
         rescan_count: incremental ? open_issues.count { |si| si[:rescan] } : 0
       )
 
-      { issues: open_issues, project_id: project_id }
+      { issues: open_issues, project_id: project_id, enhance_issue_rechecks: enhance_issue_rechecks }
     rescue GithubClient::RateLimitError => e
       raise Temporalio::Error::ApplicationError.new(
         e.message,
@@ -200,6 +202,8 @@ module Activities
     def sync_issue(project, github_issue)
       creator_login = github_issue.user&.login || "unknown"
       trusted = project.trusted_github_user?(creator_login)
+      existing_issue = project.issues.find_by(github_issue_id: github_issue.id)
+      previous_labels = Array(existing_issue&.labels)
 
       unless trusted
         logger.warn(
@@ -217,7 +221,73 @@ module Activities
       )
 
       { id: issue.id, github_number: issue.github_number, labels: issue.labels,
-        github_state: issue.github_state, trusted: trusted }
+        github_state: issue.github_state, trusted: trusted, removed_labels: previous_labels - issue.labels }
+    end
+
+    def detect_enhance_issue_rechecks(project, synced_issues)
+      label = project.enhance_issue_needs_input_label_name
+      synced_issues.filter_map do |issue_data|
+        next unless Array(issue_data[:removed_labels]).include?(label)
+
+        issue = project.issues.find(issue_data[:id])
+        next if issue.is_pull_request?
+
+        enqueue_enhance_issue_recheck(project, issue)
+      end
+    end
+
+    def enqueue_enhance_issue_recheck(project, issue)
+      max_rounds = project.max_enhance_issue_reevaluation_rounds
+      limit_reached = false
+
+      issue.with_lock do
+        if issue.enhance_issue_rounds >= max_rounds
+          issue.update!(paid_state: "completed")
+          limit_reached = true
+        else
+          issue.update!(enhance_issue_rounds: issue.enhance_issue_rounds + 1, paid_state: "new")
+        end
+      end
+
+      return stop_enhance_issue_recheck(project, issue, max_rounds) if limit_reached
+
+      logger.info(
+        message: "agent_execution.enhance_issue_recheck_requested",
+        project_id: project.id,
+        issue_id: issue.id,
+        issue_number: issue.github_number,
+        enhance_issue_rounds: issue.enhance_issue_rounds,
+        max_rounds: max_rounds
+      )
+
+      { issue_id: issue.id, issue_number: issue.github_number, enhance_issue_rounds: issue.enhance_issue_rounds }
+    end
+
+    def stop_enhance_issue_recheck(project, issue, max_rounds)
+      post_enhance_issue_limit_comment(project, issue, max_rounds)
+      logger.info(
+        message: "agent_execution.enhance_issue_recheck_limit_reached",
+        project_id: project.id,
+        issue_id: issue.id,
+        issue_number: issue.github_number,
+        enhance_issue_rounds: issue.enhance_issue_rounds,
+        max_rounds: max_rounds
+      )
+      nil
+    end
+
+    def post_enhance_issue_limit_comment(project, issue, max_rounds)
+      project.github_token.client.add_comment(
+        project.full_name,
+        issue.github_number,
+        <<~COMMENT
+          ## Auto-enhancement stopped
+
+          Paid has reached the configured limit of #{max_rounds} enhancement re-evaluation rounds for this issue.
+
+          Manual review is needed before enhancement can continue.
+        COMMENT
+      )
     end
 
     # Parses dependency and parent/child relationships from issue comments.

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -37,6 +37,8 @@ module Workflows
 
         record_poll_heartbeat(project_id)
 
+        queue_enhance_issue_rechecks(project_id, result[:enhance_issue_rechecks])
+
         if Temporalio::Workflow.patched("batch-evaluate-issues-v1")
           evaluate_issues_batch(project_id, result[:issues])
         else
@@ -85,6 +87,16 @@ module Workflows
     def record_poll_heartbeat(project_id)
       run_activity(Activities::RecordPollHeartbeatActivity,
         { project_id: project_id }, timeout: 10)
+    end
+
+    def queue_enhance_issue_rechecks(project_id, rechecks)
+      Array(rechecks).each do |recheck|
+        run_activity(Activities::QueueAgentRunActivity, {
+          project_id: project_id,
+          issue_id: recheck[:issue_id],
+          goal: "enhance_issue"
+        }, timeout: 30)
+      end
     end
 
     def interruptible_sleep(duration)

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -423,6 +423,30 @@
               <p class="mt-1 text-xs text-gray-500">Label that triggers automatic agent runs when added to issues or PRs.</p>
             </div>
 
+            <div>
+              <%= form.label :enhance_issue_needs_input_label_name, "Enhance Issue Needs Input Label", class: "block text-sm font-medium leading-6 text-gray-900" %>
+              <div class="mt-2">
+                <%= form.text_field :enhance_issue_needs_input_label_name, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">Label added when issue enhancement needs answers before re-evaluation.</p>
+            </div>
+
+            <div>
+              <%= form.label :enhance_issue_enhanced_label_name, "Enhanced Issue Label", class: "block text-sm font-medium leading-6 text-gray-900" %>
+              <div class="mt-2">
+                <%= form.text_field :enhance_issue_enhanced_label_name, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">Label added when issue enhancement has enough implementation context.</p>
+            </div>
+
+            <div>
+              <%= form.label :max_enhance_issue_reevaluation_rounds, "Max Enhance Issue Re-evaluation Rounds", class: "block text-sm font-medium leading-6 text-gray-900" %>
+              <div class="mt-2">
+                <%= form.number_field :max_enhance_issue_reevaluation_rounds, min: 0, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">Maximum automatic re-evaluation rounds after users answer clarifying questions.</p>
+            </div>
+
             <% %w[P1 P2 P3].each do |tier| %>
               <div>
                 <%= form.label "priority_labels_#{tier}", "Priority Label (#{tier})", class: "block text-sm font-medium leading-6 text-gray-900" %>

--- a/db/migrate/20260421082052_add_enhance_issue_loop_settings.rb
+++ b/db/migrate/20260421082052_add_enhance_issue_loop_settings.rb
@@ -1,0 +1,8 @@
+class AddEnhanceIssueLoopSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :enhance_issue_needs_input_label_name, :string, default: "paid-needs-input", null: false
+    add_column :projects, :enhance_issue_enhanced_label_name, :string, default: "paid-enhanced", null: false
+    add_column :projects, :max_enhance_issue_reevaluation_rounds, :integer, default: 3, null: false
+    add_column :issues, :enhance_issue_rounds, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_050706) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_082052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -610,6 +610,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_050706) do
     t.datetime "created_at", null: false
     t.datetime "deployed_at"
     t.integer "draft_review_count", default: 0, null: false
+    t.integer "enhance_issue_rounds", default: 0, null: false
     t.datetime "github_created_at", null: false
     t.string "github_creator_login"
     t.bigint "github_issue_id", null: false
@@ -982,6 +983,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_050706) do
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
     t.string "default_branch", default: "main", null: false
+    t.string "enhance_issue_enhanced_label_name", default: "paid-enhanced", null: false
+    t.string "enhance_issue_needs_input_label_name", default: "paid-needs-input", null: false
     t.jsonb "fitness_settings", default: {}, null: false
     t.jsonb "fitness_weights", default: {}, null: false
     t.string "generated_label_name", default: "paid-generated", null: false
@@ -996,6 +999,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_050706) do
     t.datetime "last_issue_sync_at"
     t.datetime "last_polled_at"
     t.integer "max_draft_review_rounds", default: 10, null: false
+    t.integer "max_enhance_issue_reevaluation_rounds", default: 3, null: false
     t.integer "max_execution_seconds", default: 3600, null: false
     t.integer "max_pr_followup_runs", default: 8, null: false
     t.integer "max_tokens_per_run"

--- a/spec/services/projects/ensure_standard_labels_spec.rb
+++ b/spec/services/projects/ensure_standard_labels_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Projects::EnsureStandardLabels do
   let(:project) do
     Struct.new(:id, :full_name, :owner, :repo, :github_token,
                :generated_label_name, :automation_label_name,
+               :enhance_issue_needs_input_label_name, :enhance_issue_enhanced_label_name,
                :effective_priority_labels, keyword_init: true)
       .new(
         id: 1,
@@ -18,6 +19,8 @@ RSpec.describe Projects::EnsureStandardLabels do
         github_token: github_token_stub,
         generated_label_name: "paid-generated",
         automation_label_name: "paid-automation",
+        enhance_issue_needs_input_label_name: "paid-needs-input",
+        enhance_issue_enhanced_label_name: "paid-enhanced",
         effective_priority_labels: { "P1" => "P1", "P2" => "P2", "P3" => "P3" }
       )
   end
@@ -36,7 +39,8 @@ RSpec.describe Projects::EnsureStandardLabels do
       it "creates all standard labels" do
         result = described_class.call(project: project)
 
-        expect(result.created).to contain_exactly("paid-generated", "paid-automation", "P1", "P2", "P3")
+        expect(result.created).to contain_exactly("paid-generated", "paid-automation",
+          "paid-needs-input", "paid-enhanced", "P1", "P2", "P3")
         expect(result.existing).to be_empty
         expect(result.divergent).to be_empty
         expect(result.errors).to be_empty
@@ -48,6 +52,8 @@ RSpec.describe Projects::EnsureStandardLabels do
         expected_calls = {
           "paid-generated" => { color: "0e8a16", description: "Created by Paid" },
           "paid-automation" => { color: "1d76db", description: "Triggers Paid automation" },
+          "paid-needs-input" => { color: "d876e3", description: "Paid needs answers before enhancing this issue again" },
+          "paid-enhanced" => { color: "0e8a16", description: "Paid has added implementation context to this issue" },
           "P1" => { color: "d93f0b", description: "High priority" },
           "P2" => { color: "ff9800", description: "Medium priority" },
           "P3" => { color: "fbca04", description: "Low priority" }
@@ -66,6 +72,8 @@ RSpec.describe Projects::EnsureStandardLabels do
         allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([
           make_label("paid-generated", color: "0e8a16", description: "Created by Paid"),
           make_label("paid-automation", color: "1d76db", description: "Triggers Paid automation"),
+          make_label("paid-needs-input", color: "d876e3", description: "Paid needs answers before enhancing this issue again"),
+          make_label("paid-enhanced", color: "0e8a16", description: "Paid has added implementation context to this issue"),
           make_label("P1", color: "d93f0b", description: "High priority"),
           make_label("P2", color: "ff9800", description: "Medium priority"),
           make_label("P3", color: "fbca04", description: "Low priority")
@@ -76,7 +84,8 @@ RSpec.describe Projects::EnsureStandardLabels do
         result = described_class.call(project: project)
 
         expect(result.created).to be_empty
-        expect(result.existing).to contain_exactly("paid-generated", "paid-automation", "P1", "P2", "P3")
+        expect(result.existing).to contain_exactly("paid-generated", "paid-automation",
+          "paid-needs-input", "paid-enhanced", "P1", "P2", "P3")
         expect(result.divergent).to be_empty
         expect(result.errors).to be_empty
       end
@@ -87,6 +96,8 @@ RSpec.describe Projects::EnsureStandardLabels do
         allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([
           make_label("paid-generated", color: "0e8a16", description: "Created by Paid"),
           make_label("paid-automation", color: "1d76db", description: "Triggers Paid automation"),
+          make_label("paid-needs-input", color: "d876e3", description: "Paid needs answers before enhancing this issue again"),
+          make_label("paid-enhanced", color: "0e8a16", description: "Paid has added implementation context to this issue"),
           make_label("P1", color: "000000", description: "High priority"),
           make_label("P2", color: "ff9800", description: "Medium priority"),
           make_label("P3", color: "fbca04", description: "Low priority")
@@ -114,7 +125,7 @@ RSpec.describe Projects::EnsureStandardLabels do
       it "records permission errors for each label" do
         result = described_class.call(project: project)
 
-        expect(result.errors.size).to eq(5)
+        expect(result.errors.size).to eq(7)
         result.errors.each do |err|
           expect(err[:error]).to include("Insufficient permissions")
         end
@@ -155,6 +166,7 @@ RSpec.describe Projects::EnsureStandardLabels do
       let(:project) do
         Struct.new(:id, :full_name, :owner, :repo, :github_token,
                    :generated_label_name, :automation_label_name,
+                   :enhance_issue_needs_input_label_name, :enhance_issue_enhanced_label_name,
                    :effective_priority_labels, keyword_init: true)
           .new(
             id: 1,
@@ -164,6 +176,8 @@ RSpec.describe Projects::EnsureStandardLabels do
             github_token: github_token_stub,
             generated_label_name: "paid-generated",
             automation_label_name: "paid-automation",
+            enhance_issue_needs_input_label_name: "paid-needs-input",
+            enhance_issue_enhanced_label_name: "paid-enhanced",
             effective_priority_labels: { "P1" => "critical", "P2" => "medium", "P3" => "low" }
           )
       end
@@ -185,6 +199,8 @@ RSpec.describe Projects::EnsureStandardLabels do
         allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([
           make_label("Paid-Generated", color: "0e8a16", description: "Created by Paid"),
           make_label("PAID-AUTOMATION", color: "1d76db", description: "Triggers Paid automation"),
+          make_label("PAID-NEEDS-INPUT", color: "d876e3", description: "Paid needs answers before enhancing this issue again"),
+          make_label("PAID-ENHANCED", color: "0e8a16", description: "Paid has added implementation context to this issue"),
           make_label("p1", color: "d93f0b", description: "High priority"),
           make_label("p2", color: "ff9800", description: "Medium priority"),
           make_label("p3", color: "fbca04", description: "Low priority")
@@ -195,7 +211,7 @@ RSpec.describe Projects::EnsureStandardLabels do
         result = described_class.call(project: project)
 
         expect(result.created).to be_empty
-        expect(result.existing.size).to eq(5)
+        expect(result.existing.size).to eq(7)
       end
     end
   end

--- a/spec/temporal/activities/enhance_issue_activity_spec.rb
+++ b/spec/temporal/activities/enhance_issue_activity_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Activities::EnhanceIssueActivity do
       expect(issue.labels).to include(project.enhance_issue_needs_input_label_name)
     end
 
-    it "does not persist local labels when adding the GitHub label fails" do
+    it "fails before moving to needs_input when adding the GitHub label fails" do
       allow(client).to receive(:add_labels_to_issue).and_raise(GithubClient::Error.new("GitHub unavailable"))
       allow(llm_response).to receive(:output).and_return(
         {
@@ -150,9 +150,15 @@ RSpec.describe Activities::EnhanceIssueActivity do
         }.to_json
       )
 
-      result = activity.execute(agent_run_id: agent_run.id)
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(
+        Temporalio::Error::ApplicationError,
+        "Failed to apply enhance_issue control label #{project.enhance_issue_needs_input_label_name}"
+      )
 
-      expect(result[:label_applied]).to be_nil
+      expect(client).not_to have_received(:add_comment)
+      expect(issue.reload.paid_state).to eq("in_progress")
       expect(issue.reload.labels).not_to include(project.enhance_issue_needs_input_label_name)
     end
 

--- a/spec/temporal/activities/enhance_issue_activity_spec.rb
+++ b/spec/temporal/activities/enhance_issue_activity_spec.rb
@@ -141,6 +141,21 @@ RSpec.describe Activities::EnhanceIssueActivity do
       expect(issue.labels).to include(project.enhance_issue_needs_input_label_name)
     end
 
+    it "does not persist local labels when adding the GitHub label fails" do
+      allow(client).to receive(:add_labels_to_issue).and_raise(GithubClient::Error.new("GitHub unavailable"))
+      allow(llm_response).to receive(:output).and_return(
+        {
+          sufficient_context: false,
+          comment_body: "## Clarifying questions\n1. Which events should be recorded?"
+        }.to_json
+      )
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:label_applied]).to be_nil
+      expect(issue.reload.labels).not_to include(project.enhance_issue_needs_input_label_name)
+    end
+
     it "posts a manual-review stop comment instead of reapplying needs-input at the max round" do
       issue.update!(enhance_issue_rounds: project.max_enhance_issue_reevaluation_rounds)
       allow(llm_response).to receive(:output).and_return(

--- a/spec/temporal/activities/enhance_issue_activity_spec.rb
+++ b/spec/temporal/activities/enhance_issue_activity_spec.rb
@@ -215,6 +215,39 @@ RSpec.describe Activities::EnhanceIssueActivity do
       expect(issue.reload.paid_state).to eq("completed")
     end
 
+    it "keeps an existing clarifying-question enhancement in needs_input" do
+      issue.update!(labels: [ project.enhance_issue_needs_input_label_name ])
+      existing_comment = OpenStruct.new(
+        body: "#{described_class::COMMENT_MARKER}\n## Clarifying questions\n1. Which events should be recorded?",
+        html_url: "https://github.com/owner/repo/issues/42#issuecomment-0"
+      )
+      allow(client).to receive(:issue_comments).and_return([ existing_comment ])
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:already_enhanced]).to be true
+      expect(client).not_to have_received(:add_comment)
+      expect(AgentHarness).not_to have_received(:send_message)
+      expect(agent_run.reload.status).to eq("completed")
+      expect(issue.reload.paid_state).to eq("needs_input")
+    end
+
+    it "keeps an existing max-round stop comment completed" do
+      existing_comment = OpenStruct.new(
+        body: "#{described_class::COMMENT_MARKER}\n## Auto-enhancement stopped\n\n## Latest context\n## Clarifying questions",
+        html_url: "https://github.com/owner/repo/issues/42#issuecomment-0"
+      )
+      allow(client).to receive(:issue_comments).and_return([ existing_comment ])
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:already_enhanced]).to be true
+      expect(client).not_to have_received(:add_comment)
+      expect(AgentHarness).not_to have_received(:send_message)
+      expect(agent_run.reload.status).to eq("completed")
+      expect(issue.reload.paid_state).to eq("completed")
+    end
+
     it "raises a non-retryable activity error when the LLM output is invalid JSON" do
       allow(llm_response).to receive(:output).and_return("not json")
 

--- a/spec/temporal/activities/enhance_issue_activity_spec.rb
+++ b/spec/temporal/activities/enhance_issue_activity_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe Activities::EnhanceIssueActivity do
     allow(client).to receive(:issue).with(project.full_name, issue.github_number).and_return(gh_issue)
     allow(client).to receive(:issue_comments).with(project.full_name, issue.github_number).and_return(comments)
     allow(client).to receive(:add_comment).and_return(posted_comment)
+    allow(client).to receive(:add_labels_to_issue)
+    allow(client).to receive(:remove_label_from_issue)
     allow(Knowledge::Search).to receive(:call).and_return(
       results: [
         { title: "AuditLog", content: "app/models/audit_log.rb tracks user actions", path: "app/models/audit_log.rb" }
@@ -71,6 +73,22 @@ RSpec.describe Activities::EnhanceIssueActivity do
     allow(ProcessRunQueueJob).to receive(:perform_later)
   end
 
+  def expect_label_added(label)
+    expect(client).to have_received(:add_labels_to_issue).with(
+      project.full_name,
+      issue.github_number,
+      [ label ]
+    )
+  end
+
+  def expect_comment_including(*parts)
+    expect(client).to have_received(:add_comment).with(
+      project.full_name,
+      issue.github_number,
+      a_string_including(*parts)
+    )
+  end
+
   describe "#execute" do
     it "posts an implementation context comment" do
       result = activity.execute(agent_run_id: agent_run.id)
@@ -83,13 +101,11 @@ RSpec.describe Activities::EnhanceIssueActivity do
       )
       expect(client).to have_received(:issue).with(project.full_name, issue.github_number)
       expect(client).to have_received(:issue_comments).with(project.full_name, issue.github_number)
-      expect(client).to have_received(:add_comment).with(
-        project.full_name,
-        issue.github_number,
-        a_string_including(described_class::COMMENT_MARKER, "## Implementation context")
-      )
+      expect_comment_including(described_class::COMMENT_MARKER, "## Implementation context")
       expect(agent_run.reload.status).to eq("completed")
       expect(issue.reload.paid_state).to eq("completed")
+      expect(issue.labels).to include(project.enhance_issue_enhanced_label_name)
+      expect_label_added(project.enhance_issue_enhanced_label_name)
       expect(agent_run.token_usages.last).to have_attributes(
         request_type: "agent",
         metadata: include("operation" => "enhance_issue")
@@ -118,11 +134,33 @@ RSpec.describe Activities::EnhanceIssueActivity do
       result = activity.execute(agent_run_id: agent_run.id)
 
       expect(result[:sufficient_context]).to be false
-      expect(client).to have_received(:add_comment).with(
+      expect(result[:label_applied]).to eq(project.enhance_issue_needs_input_label_name)
+      expect_comment_including("## Clarifying questions", "Which events")
+      expect_label_added(project.enhance_issue_needs_input_label_name)
+      expect(issue.reload.paid_state).to eq("needs_input")
+      expect(issue.labels).to include(project.enhance_issue_needs_input_label_name)
+    end
+
+    it "posts a manual-review stop comment instead of reapplying needs-input at the max round" do
+      issue.update!(enhance_issue_rounds: project.max_enhance_issue_reevaluation_rounds)
+      allow(llm_response).to receive(:output).and_return(
+        {
+          sufficient_context: false,
+          comment_body: "## Clarifying questions\n1. Which events should be recorded?"
+        }.to_json
+      )
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:max_rounds_reached]).to be true
+      expect(result[:label_applied]).to be_nil
+      expect_comment_including("## Auto-enhancement stopped", "Manual review is needed")
+      expect(client).not_to have_received(:add_labels_to_issue).with(
         project.full_name,
         issue.github_number,
-        a_string_including("## Clarifying questions", "Which events")
+        [ project.enhance_issue_needs_input_label_name ]
       )
+      expect(issue.reload.paid_state).to eq("completed")
     end
 
     it "does not post a duplicate enhancement comment when one already exists" do

--- a/spec/temporal/activities/enhance_issue_activity_spec.rb
+++ b/spec/temporal/activities/enhance_issue_activity_spec.rb
@@ -162,6 +162,21 @@ RSpec.describe Activities::EnhanceIssueActivity do
       expect(issue.reload.labels).not_to include(project.enhance_issue_needs_input_label_name)
     end
 
+    it "fails before completing when adding the enhanced GitHub label fails" do
+      allow(client).to receive(:add_labels_to_issue).and_raise(GithubClient::Error.new("GitHub unavailable"))
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(
+        Temporalio::Error::ApplicationError,
+        "Failed to apply enhance_issue control label #{project.enhance_issue_enhanced_label_name}"
+      )
+
+      expect(client).not_to have_received(:add_comment)
+      expect(issue.reload.paid_state).to eq("in_progress")
+      expect(issue.reload.labels).not_to include(project.enhance_issue_enhanced_label_name)
+    end
+
     it "posts a manual-review stop comment instead of reapplying needs-input at the max round" do
       issue.update!(enhance_issue_rounds: project.max_enhance_issue_reevaluation_rounds)
       allow(llm_response).to receive(:output).and_return(

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Activities::FetchIssuesActivity do
           project: project,
           github_issue_id: 9101,
           github_number: 91,
-          labels: [ project.enhance_issue_needs_input_label_name ],
+          labels: [ project.enhance_issue_needs_input_label_name, "paid-build" ],
           enhance_issue_rounds: 0)
       end
 
@@ -193,7 +193,7 @@ RSpec.describe Activities::FetchIssuesActivity do
           title: issue.title,
           body: issue.body,
           state: "open",
-          labels: [],
+          labels: [ OpenStruct.new(name: "paid-build") ],
           pull_request: nil,
           user: OpenStruct.new(login: "viamin"),
           created_at: issue.github_created_at,
@@ -205,14 +205,15 @@ RSpec.describe Activities::FetchIssuesActivity do
         stub_issues_by_label(nil => [ github_issue ])
       end
 
-      it "returns a recheck request and increments the issue round" do
+      it "returns a recheck request and suppresses normal label evaluation" do
         result = activity.execute(project_id: project.id)
 
         expect(result[:enhance_issue_rechecks]).to contain_exactly(
           hash_including(issue_id: issue.id, issue_number: issue.github_number, enhance_issue_rounds: 1)
         )
         expect(issue.reload.enhance_issue_rounds).to eq(1)
-        expect(issue.paid_state).to eq("new")
+        expect(issue.paid_state).to eq("in_progress")
+        expect(result[:issues]).not_to include(hash_including(id: issue.id))
       end
 
       it "posts a stop comment instead of rechecking after the max round" do

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -216,6 +216,17 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(result[:issues]).not_to include(hash_including(id: issue.id))
       end
 
+      it "does not request a recheck for closed issues" do
+        github_issue.state = "closed"
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:enhance_issue_rechecks]).to be_empty
+        expect(issue.reload.enhance_issue_rounds).to eq(0)
+        expect(issue.paid_state).to eq("needs_input")
+        expect(result[:issues]).not_to include(hash_including(id: issue.id))
+      end
+
       it "posts a stop comment instead of rechecking after the max round" do
         project.update!(max_enhance_issue_reevaluation_rounds: 1)
         issue.update!(enhance_issue_rounds: 1)

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -269,6 +269,45 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
     end
 
+    context "when the enhance_issue needs-input label is still present" do
+      let!(:issue) do
+        create(:issue, :needs_input,
+          project: project,
+          github_issue_id: 9102,
+          github_number: 92,
+          labels: [ project.enhance_issue_needs_input_label_name, "paid-build" ])
+      end
+
+      let(:github_issue) do
+        OpenStruct.new(
+          id: issue.github_issue_id,
+          number: issue.github_number,
+          title: issue.title,
+          body: issue.body,
+          state: "open",
+          labels: [
+            OpenStruct.new(name: project.enhance_issue_needs_input_label_name),
+            OpenStruct.new(name: "paid-build")
+          ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: issue.github_created_at,
+          updated_at: Time.current
+        )
+      end
+
+      before do
+        stub_issues_by_label(nil => [ github_issue ])
+      end
+
+      it "suppresses normal label evaluation while waiting for answers" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:enhance_issue_rechecks]).to be_empty
+        expect(result[:issues]).not_to include(hash_including(id: issue.id))
+      end
+    end
+
     context "when rate limited" do
       before do
         allow(github_client).to receive(:issues).and_raise(
@@ -1226,6 +1265,20 @@ RSpec.describe Activities::FetchIssuesActivity do
         returned_ids = result[:issues].map { |i| i[:id] }
         expect(returned_ids).to include(blocked.id)
         expect(returned_ids).not_to include(in_progress.id)
+      end
+
+      it "excludes re-scannable issues still waiting for enhance_issue input" do
+        waiting_for_answers = create(:issue, :needs_input,
+          project: project,
+          github_issue_id: 5002,
+          github_number: 52,
+          github_state: "open",
+          labels: [ project.enhance_issue_needs_input_label_name, "paid-build" ])
+
+        result = activity.execute(project_id: project.id)
+
+        returned_ids = result[:issues].map { |i| i[:id] }
+        expect(returned_ids).not_to include(waiting_for_answers.id)
       end
 
       it "does not duplicate issues already in the incremental fetch results" do

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -227,6 +227,16 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(result[:issues]).not_to include(hash_including(id: issue.id))
       end
 
+      it "does not request a recheck unless the issue is waiting for enhance_issue input" do
+        issue.update!(paid_state: "completed")
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:enhance_issue_rechecks]).to be_empty
+        expect(issue.reload.enhance_issue_rounds).to eq(0)
+        expect(issue.paid_state).to eq("completed")
+      end
+
       it "posts a stop comment instead of rechecking after the max round" do
         project.update!(max_enhance_issue_reevaluation_rounds: 1)
         issue.update!(enhance_issue_rounds: 1)

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Activities::FetchIssuesActivity do
     allow(GithubClient).to receive(:new).and_return(github_client)
     allow(github_client).to receive_messages(issue_comments: [], "rate_limit_remaining!": 100)
     allow(github_client).to receive(:pull_requests).and_return([])
+    allow(github_client).to receive(:add_comment)
   end
 
   # Helper: route github_client.issues calls by label (or nil for unlabeled fetches)
@@ -172,6 +173,62 @@ RSpec.describe Activities::FetchIssuesActivity do
 
         expect(result[:issues]).to eq([])
         expect(project.issues.count).to eq(0)
+      end
+    end
+
+    context "when the enhance_issue needs-input label is removed" do
+      let!(:issue) do
+        create(:issue, :needs_input,
+          project: project,
+          github_issue_id: 9101,
+          github_number: 91,
+          labels: [ project.enhance_issue_needs_input_label_name ],
+          enhance_issue_rounds: 0)
+      end
+
+      let(:github_issue) do
+        OpenStruct.new(
+          id: issue.github_issue_id,
+          number: issue.github_number,
+          title: issue.title,
+          body: issue.body,
+          state: "open",
+          labels: [],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: issue.github_created_at,
+          updated_at: Time.current
+        )
+      end
+
+      before do
+        stub_issues_by_label(nil => [ github_issue ])
+      end
+
+      it "returns a recheck request and increments the issue round" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:enhance_issue_rechecks]).to contain_exactly(
+          hash_including(issue_id: issue.id, issue_number: issue.github_number, enhance_issue_rounds: 1)
+        )
+        expect(issue.reload.enhance_issue_rounds).to eq(1)
+        expect(issue.paid_state).to eq("new")
+      end
+
+      it "posts a stop comment instead of rechecking after the max round" do
+        project.update!(max_enhance_issue_reevaluation_rounds: 1)
+        issue.update!(enhance_issue_rounds: 1)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:enhance_issue_rechecks]).to be_empty
+        expect(github_client).to have_received(:add_comment).with(
+          project.full_name,
+          issue.github_number,
+          a_string_including("## Auto-enhancement stopped", "Manual review is needed")
+        )
+        expect(issue.reload.enhance_issue_rounds).to eq(1)
+        expect(issue.paid_state).to eq("completed")
       end
     end
 

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -252,6 +252,21 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(issue.reload.enhance_issue_rounds).to eq(1)
         expect(issue.paid_state).to eq("completed")
       end
+
+      it "keeps the max-round stop retryable when posting the stop comment fails" do
+        project.update!(max_enhance_issue_reevaluation_rounds: 1)
+        issue.update!(enhance_issue_rounds: 1)
+        allow(github_client).to receive(:add_comment).and_raise(GithubClient::Error.new("GitHub unavailable"))
+
+        expect {
+          activity.execute(project_id: project.id)
+        }.to raise_error(GithubClient::Error, "GitHub unavailable")
+
+        issue.reload
+        expect(issue.enhance_issue_rounds).to eq(1)
+        expect(issue.paid_state).to eq("needs_input")
+        expect(issue.labels).to include(project.enhance_issue_needs_input_label_name)
+      end
     end
 
     context "when rate limited" do

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -234,6 +234,24 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     end
   end
 
+  describe "#queue_enhance_issue_rechecks" do
+    let(:workflow) { described_class.new }
+
+    before do
+      allow(workflow).to receive(:run_activity)
+    end
+
+    it "queues enhance_issue runs for recheck requests" do
+      workflow.send(:queue_enhance_issue_rechecks, 1, [ { issue_id: 42 } ])
+
+      expect(workflow).to have_received(:run_activity).with(
+        Activities::QueueAgentRunActivity,
+        { project_id: 1, issue_id: 42, goal: "enhance_issue" },
+        timeout: 30
+      )
+    end
+  end
+
   describe "#handle_pr_trigger" do
     let(:workflow) { described_class.new }
     let(:project_id) { 1 }


### PR DESCRIPTION
## Summary

feat(agent-runs): Add label management and re-evaluation loop for enhance_issue (389-C)

See #991 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #991