### PR TITLE
fix(ui): fix dark mode by unlayering CSS overrides

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -3,363 +3,528 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* ========================================
-   Dark mode global overrides
+   Dark mode global overrides (unlayered)
    ========================================
    These rules apply dark theme colors to common UI patterns across all views,
    so individual templates don't each need dark: utility classes on every element.
 
-   Wrapped in @layer base so that Tailwind's @layer utilities (including dark:
-   variants) can override these defaults on a per-element basis. */
-
-@layer base {
-  /* Cards and panels */
-  .dark .bg-white {
-    background-color: #1f2937; /* gray-800 */
-  }
-
-  .dark .bg-white\/80 {
-    background-color: rgb(31 41 55 / 0.8); /* gray-800/80 */
-  }
-
-  /* Primary text */
-  .dark .text-gray-900 {
-    color: #f3f4f6; /* gray-100 */
-  }
-
-  .dark .text-gray-800 {
-    color: #e5e7eb; /* gray-200 */
-  }
-
-  .dark .text-gray-700 {
-    color: #d1d5db; /* gray-300 */
-  }
-
-  .dark .text-gray-600 {
-    color: #9ca3af; /* gray-400 */
-  }
-
-  .dark .text-gray-500 {
-    color: #9ca3af; /* gray-400 */
-  }
-
-  .dark .text-gray-400 {
-    color: #9ca3af; /* gray-400 */
-  }
-
-  /* Backgrounds */
-  .dark .bg-gray-50 {
-    background-color: #111827; /* gray-900 */
-  }
-
-  .dark .bg-gray-100 {
-    background-color: #1f2937; /* gray-800 */
-  }
-
-  .dark .bg-gray-200 {
-    background-color: #374151; /* gray-700 */
-  }
-
-  .dark .bg-gray-300 {
-    background-color: #4b5563; /* gray-600 */
-  }
-
-  /* Borders */
-  .dark .border-gray-100 {
-    border-color: #374151; /* gray-700 */
-  }
-
-  .dark .border-gray-200 {
-    border-color: #374151; /* gray-700 */
-  }
-
-  .dark .border-gray-300 {
-    border-color: #4b5563; /* gray-600 */
-  }
-
-  .dark .divide-gray-100 > :not(:last-child),
-  .dark .divide-gray-200 > :not(:last-child),
-  .dark .divide-gray-300 > :not(:last-child) {
-    border-color: #374151; /* gray-700 */
-  }
-
-  .dark .ring-black {
-    --tw-ring-color: #374151; /* gray-700 */
-  }
-
-  .dark .ring-gray-100,
-  .dark .ring-gray-200 {
-    --tw-ring-color: #374151; /* gray-700 */
-  }
-
-  .dark .ring-gray-300 {
-    --tw-ring-color: #4b5563; /* gray-600 */
-  }
-
-  /* Form inputs */
-  .dark input:not([type="checkbox"]):not([type="radio"]),
-  .dark textarea,
-  .dark select {
-    background-color: #374151; /* gray-700 */
-    color: #f3f4f6; /* gray-100 */
-    border-color: #4b5563; /* gray-600 */
-  }
-
-  .dark input::placeholder,
-  .dark textarea::placeholder {
-    color: #6b7280; /* gray-500 */
-  }
-
-  .dark input:not([type="checkbox"]):not([type="radio"]):focus,
-  .dark textarea:focus,
-  .dark select:focus {
-    --tw-ring-color: #818cf8; /* indigo-400 */
-    border-color: #818cf8; /* indigo-400 */
-  }
-
-  /* Status colors - alert boxes */
-  .dark .bg-red-50 {
-    background-color: rgba(127, 29, 29, 0.3);
-  }
-
-  .dark .bg-red-100 {
-    background-color: rgb(127 29 29 / 0.45);
-  }
-
-  .dark .text-red-900,
-  .dark .text-red-800 {
-    color: #fca5a5; /* red-300 */
-  }
-
-  .dark .text-red-700,
-  .dark .text-red-600 {
-    color: #fca5a5;
-  }
-
-  .dark .bg-green-50 {
-    background-color: rgba(20, 83, 45, 0.3);
-  }
-
-  .dark .bg-green-100 {
-    background-color: rgb(20 83 45 / 0.45);
-  }
-
-  .dark .text-green-900,
-  .dark .text-green-800 {
-    color: #86efac; /* green-300 */
-  }
-
-  .dark .text-green-700,
-  .dark .text-green-600 {
-    color: #86efac;
-  }
-
-  .dark .bg-yellow-50 {
-    background-color: rgba(113, 63, 18, 0.3);
-  }
-
-  .dark .bg-yellow-100 {
-    background-color: rgb(113 63 18 / 0.45);
-  }
-
-  .dark .text-yellow-900,
-  .dark .text-yellow-800 {
-    color: #fde047; /* yellow-300 */
-  }
-
-  .dark .text-yellow-700,
-  .dark .text-yellow-600,
-  .dark .text-yellow-500 {
-    color: #fde047;
-  }
-
-  .dark .bg-blue-50 {
-    background-color: rgba(30, 58, 138, 0.3);
-  }
-
-  .dark .bg-blue-100 {
-    background-color: rgb(30 58 138 / 0.45);
-  }
-
-  .dark .text-blue-900,
-  .dark .text-blue-800 {
-    color: #93c5fd; /* blue-300 */
-  }
-
-  .dark .text-blue-700,
-  .dark .text-blue-600,
-  .dark .text-blue-500 {
-    color: #93c5fd;
-  }
-
-  .dark .bg-indigo-50 {
-    background-color: rgba(79, 70, 229, 0.15);
-  }
-
-  .dark .bg-indigo-100 {
-    background-color: rgb(49 46 129 / 0.55);
-  }
-
-  .dark .text-indigo-900,
-  .dark .text-indigo-800,
-  .dark .text-indigo-700,
-  .dark .text-indigo-600 {
-    color: #a5b4fc; /* indigo-300 */
-  }
-
-  .dark .bg-purple-100 {
-    background-color: rgb(88 28 135 / 0.45);
-  }
-
-  .dark .text-purple-900,
-  .dark .text-purple-800,
-  .dark .text-purple-700 {
-    color: #d8b4fe; /* purple-300 */
-  }
-
-  .dark .bg-violet-100 {
-    background-color: rgb(76 29 149 / 0.45);
-  }
-
-  .dark .text-violet-800,
-  .dark .text-violet-700 {
-    color: #c4b5fd; /* violet-300 */
-  }
-
-  .dark .bg-orange-100 {
-    background-color: rgb(124 45 18 / 0.45);
-  }
-
-  .dark .text-orange-900,
-  .dark .text-orange-800,
-  .dark .text-orange-700 {
-    color: #fdba74; /* orange-300 */
-  }
-
-  .dark .bg-amber-100 {
-    background-color: rgb(120 53 15 / 0.45);
-  }
-
-  .dark .text-amber-900,
-  .dark .text-amber-800,
-  .dark .text-amber-700 {
-    color: #fcd34d; /* amber-300 */
-  }
-
-  .dark .bg-sky-50 {
-    background-color: rgb(12 74 110 / 0.3);
-  }
-
-  .dark .bg-sky-100 {
-    background-color: rgb(12 74 110 / 0.45);
-  }
-
-  .dark .text-sky-950,
-  .dark .text-sky-900,
-  .dark .text-sky-800,
-  .dark .text-sky-700 {
-    color: #7dd3fc; /* sky-300 */
-  }
-
-  .dark .border-sky-100,
-  .dark .border-sky-200 {
-    border-color: rgb(14 116 144 / 0.6);
-  }
-
-  .dark .ring-sky-100 {
-    --tw-ring-color: rgb(14 116 144 / 0.6);
-  }
-
-  .dark .bg-teal-100 {
-    background-color: rgb(19 78 74 / 0.45);
-  }
-
-  .dark .text-teal-800,
-  .dark .text-teal-700 {
-    color: #5eead4; /* teal-300 */
-  }
-
-  .dark .bg-slate-100 {
-    background-color: rgb(51 65 85 / 0.65);
-  }
-
-  .dark .text-slate-700,
-  .dark .text-slate-600 {
-    color: #cbd5e1; /* slate-300 */
-  }
-
-  /* Shadows */
-  .dark .shadow,
-  .dark .shadow-sm,
-  .dark .shadow-md,
-  .dark .shadow-lg {
-    --tw-shadow-color: rgba(0, 0, 0, 0.3);
-  }
-
-  /* Links and hover states */
-  .dark .hover\:text-indigo-500:hover {
-    color: #a5b4fc; /* indigo-300 */
-  }
-
-  .dark .hover\:text-indigo-600:hover,
-  .dark .hover\:text-indigo-800:hover,
-  .dark .hover\:text-indigo-900:hover {
-    color: #c7d2fe; /* indigo-200 */
-  }
-
-  .dark .hover\:text-gray-600:hover,
-  .dark .hover\:text-gray-700:hover,
-  .dark .hover\:text-gray-900:hover {
-    color: #f9fafb; /* gray-50 */
-  }
-
-  .dark .hover\:text-red-500:hover,
-  .dark .hover\:text-red-600:hover,
-  .dark .hover\:text-red-700:hover {
-    color: #fecaca; /* red-200 */
-  }
-
-  .dark .hover\:text-emerald-500:hover,
-  .dark .hover\:text-emerald-600:hover {
-    color: #6ee7b7; /* emerald-300 */
-  }
-
-  /* Tables */
-  .dark .hover\:bg-gray-50:hover {
-    background-color: #1f2937;
-  }
-
-  .dark .hover\:bg-gray-100:hover {
-    background-color: #374151;
-  }
-
-  .dark tr.bg-indigo-50 {
-    background-color: rgb(49 46 129 / 0.35);
-  }
-
-  /* Code and pre blocks */
-  .dark pre,
-  .dark code {
-    background-color: #1f2937;
-    color: #e5e7eb;
-  }
-
-  /* Gradient backgrounds on landing page */
-  .dark .from-indigo-50\/80 {
-    --tw-gradient-from: rgba(30, 27, 75, 0.8);
-  }
-
-  .dark .to-white {
-    --tw-gradient-to: #111827;
-  }
-
-  .dark .bg-emerald-100 {
-    background-color: rgb(6 78 59 / 0.45);
-  }
-
-  .dark .text-emerald-700,
-  .dark .text-emerald-600 {
-    color: #6ee7b7; /* emerald-300 */
-  }
+   Intentionally UNLAYERED so they override Tailwind's @layer utilities.
+   In CSS cascade layers, later layers always win regardless of specificity.
+   Tailwind puts utilities in @layer utilities — if these overrides were in
+   @layer base, the utility classes would always defeat them. Keeping them
+   unlayered gives them higher cascade priority than all layered styles. */
+
+/* Cards and panels */
+.dark .bg-white {
+  background-color: #1f2937; /* gray-800 */
+}
+
+.dark .bg-white\/80 {
+  background-color: rgb(31 41 55 / 0.8); /* gray-800/80 */
+}
+
+/* Primary text */
+.dark .text-gray-900 {
+  color: #f3f4f6; /* gray-100 */
+}
+
+.dark .text-gray-800 {
+  color: #e5e7eb; /* gray-200 */
+}
+
+.dark .text-gray-700 {
+  color: #d1d5db; /* gray-300 */
+}
+
+.dark .text-gray-600 {
+  color: #9ca3af; /* gray-400 */
+}
+
+.dark .text-gray-500 {
+  color: #9ca3af; /* gray-400 */
+}
+
+.dark .text-gray-400 {
+  color: #9ca3af; /* gray-400 */
+}
+
+/* Backgrounds */
+.dark .bg-gray-50 {
+  background-color: #111827; /* gray-900 */
+}
+
+.dark .bg-gray-100 {
+  background-color: #1f2937; /* gray-800 */
+}
+
+.dark .bg-gray-200 {
+  background-color: #374151; /* gray-700 */
+}
+
+.dark .bg-gray-300 {
+  background-color: #4b5563; /* gray-600 */
+}
+
+/* Borders */
+.dark .border-gray-100 {
+  border-color: #374151; /* gray-700 */
+}
+
+.dark .border-gray-200 {
+  border-color: #374151; /* gray-700 */
+}
+
+.dark .border-gray-300 {
+  border-color: #4b5563; /* gray-600 */
+}
+
+.dark .divide-gray-100 > :not(:last-child),
+.dark .divide-gray-200 > :not(:last-child),
+.dark .divide-gray-300 > :not(:last-child) {
+  border-color: #374151; /* gray-700 */
+}
+
+.dark .ring-black {
+  --tw-ring-color: #374151; /* gray-700 */
+}
+
+.dark .ring-gray-100,
+.dark .ring-gray-200 {
+  --tw-ring-color: #374151; /* gray-700 */
+}
+
+.dark .ring-gray-300 {
+  --tw-ring-color: #4b5563; /* gray-600 */
+}
+
+/* Form inputs */
+.dark input:not([type="checkbox"]):not([type="radio"]),
+.dark textarea,
+.dark select {
+  background-color: #374151; /* gray-700 */
+  color: #f3f4f6; /* gray-100 */
+  border-color: #4b5563; /* gray-600 */
+}
+
+.dark input::placeholder,
+.dark textarea::placeholder {
+  color: #6b7280; /* gray-500 */
+}
+
+.dark input:not([type="checkbox"]):not([type="radio"]):focus,
+.dark textarea:focus,
+.dark select:focus {
+  --tw-ring-color: #818cf8; /* indigo-400 */
+  border-color: #818cf8; /* indigo-400 */
+}
+
+/* Status colors - alert boxes */
+.dark .bg-red-50 {
+  background-color: rgba(127, 29, 29, 0.3);
+}
+
+.dark .bg-red-100 {
+  background-color: rgb(127 29 29 / 0.45);
+}
+
+.dark .text-red-900,
+.dark .text-red-800 {
+  color: #fca5a5; /* red-300 */
+}
+
+.dark .text-red-700,
+.dark .text-red-600 {
+  color: #fca5a5;
+}
+
+.dark .text-red-400 {
+  color: #fca5a5;
+}
+
+.dark .bg-green-50 {
+  background-color: rgba(20, 83, 45, 0.3);
+}
+
+.dark .bg-green-100 {
+  background-color: rgb(20 83 45 / 0.45);
+}
+
+.dark .text-green-900,
+.dark .text-green-800 {
+  color: #86efac; /* green-300 */
+}
+
+.dark .text-green-700,
+.dark .text-green-600 {
+  color: #86efac;
+}
+
+.dark .text-green-400 {
+  color: #86efac;
+}
+
+.dark .bg-yellow-50 {
+  background-color: rgba(113, 63, 18, 0.3);
+}
+
+.dark .bg-yellow-100 {
+  background-color: rgb(113 63 18 / 0.45);
+}
+
+.dark .text-yellow-900,
+.dark .text-yellow-800 {
+  color: #fde047; /* yellow-300 */
+}
+
+.dark .text-yellow-700,
+.dark .text-yellow-600,
+.dark .text-yellow-500 {
+  color: #fde047;
+}
+
+.dark .text-yellow-400 {
+  color: #fde047;
+}
+
+.dark .bg-blue-50 {
+  background-color: rgba(30, 58, 138, 0.3);
+}
+
+.dark .bg-blue-100 {
+  background-color: rgb(30 58 138 / 0.45);
+}
+
+.dark .text-blue-900,
+.dark .text-blue-800 {
+  color: #93c5fd; /* blue-300 */
+}
+
+.dark .text-blue-700,
+.dark .text-blue-600,
+.dark .text-blue-500 {
+  color: #93c5fd;
+}
+
+.dark .text-blue-400 {
+  color: #93c5fd;
+}
+
+.dark .bg-indigo-50 {
+  background-color: rgba(79, 70, 229, 0.15);
+}
+
+.dark .bg-indigo-100 {
+  background-color: rgb(49 46 129 / 0.55);
+}
+
+.dark .text-indigo-900,
+.dark .text-indigo-800,
+.dark .text-indigo-700,
+.dark .text-indigo-600 {
+  color: #a5b4fc; /* indigo-300 */
+}
+
+.dark .bg-purple-50 {
+  background-color: rgba(88, 28, 135, 0.2);
+}
+
+.dark .bg-purple-100 {
+  background-color: rgb(88 28 135 / 0.45);
+}
+
+.dark .text-purple-900,
+.dark .text-purple-800,
+.dark .text-purple-700 {
+  color: #d8b4fe; /* purple-300 */
+}
+
+.dark .bg-violet-100 {
+  background-color: rgb(76 29 149 / 0.45);
+}
+
+.dark .text-violet-800,
+.dark .text-violet-700 {
+  color: #c4b5fd; /* violet-300 */
+}
+
+.dark .bg-orange-50 {
+  background-color: rgba(124, 45, 18, 0.2);
+}
+
+.dark .bg-orange-100 {
+  background-color: rgb(124 45 18 / 0.45);
+}
+
+.dark .text-orange-900,
+.dark .text-orange-800,
+.dark .text-orange-700 {
+  color: #fdba74; /* orange-300 */
+}
+
+.dark .bg-amber-50 {
+  background-color: rgba(120, 53, 15, 0.2);
+}
+
+.dark .bg-amber-100 {
+  background-color: rgb(120 53 15 / 0.45);
+}
+
+.dark .text-amber-900,
+.dark .text-amber-800,
+.dark .text-amber-700 {
+  color: #fcd34d; /* amber-300 */
+}
+
+.dark .text-amber-600 {
+  color: #fcd34d;
+}
+
+.dark .text-amber-400 {
+  color: #fcd34d;
+}
+
+.dark .bg-sky-50 {
+  background-color: rgb(12 74 110 / 0.3);
+}
+
+.dark .bg-sky-100 {
+  background-color: rgb(12 74 110 / 0.45);
+}
+
+.dark .text-sky-950,
+.dark .text-sky-900,
+.dark .text-sky-800,
+.dark .text-sky-700 {
+  color: #7dd3fc; /* sky-300 */
+}
+
+.dark .border-sky-100,
+.dark .border-sky-200 {
+  border-color: rgb(14 116 144 / 0.6);
+}
+
+.dark .ring-sky-100 {
+  --tw-ring-color: rgb(14 116 144 / 0.6);
+}
+
+.dark .bg-teal-50 {
+  background-color: rgba(19, 78, 74, 0.2);
+}
+
+.dark .bg-teal-100 {
+  background-color: rgb(19 78 74 / 0.45);
+}
+
+.dark .text-teal-800,
+.dark .text-teal-700 {
+  color: #5eead4; /* teal-300 */
+}
+
+.dark .bg-slate-100 {
+  background-color: rgb(51 65 85 / 0.65);
+}
+
+.dark .text-slate-700,
+.dark .text-slate-600 {
+  color: #cbd5e1; /* slate-300 */
+}
+
+.dark .bg-emerald-50 {
+  background-color: rgba(6, 78, 59, 0.2);
+}
+
+.dark .bg-emerald-100 {
+  background-color: rgb(6 78 59 / 0.45);
+}
+
+.dark .text-emerald-700,
+.dark .text-emerald-600 {
+  color: #6ee7b7; /* emerald-300 */
+}
+
+.dark .text-emerald-400 {
+  color: #6ee7b7;
+}
+
+/* Alert/info panel borders */
+.dark .border-red-200 {
+  border-color: rgba(127, 29, 29, 0.6);
+}
+
+.dark .border-green-200 {
+  border-color: rgba(20, 83, 45, 0.6);
+}
+
+.dark .border-blue-200 {
+  border-color: rgba(30, 58, 138, 0.6);
+}
+
+.dark .border-indigo-200 {
+  border-color: rgba(49, 46, 129, 0.6);
+}
+
+.dark .border-yellow-200 {
+  border-color: rgba(113, 63, 18, 0.6);
+}
+
+.dark .border-orange-200 {
+  border-color: rgba(124, 45, 18, 0.6);
+}
+
+.dark .border-amber-200,
+.dark .border-amber-300 {
+  border-color: rgba(120, 53, 15, 0.6);
+}
+
+.dark .border-purple-200 {
+  border-color: rgba(88, 28, 135, 0.6);
+}
+
+/* Ring colors */
+.dark .ring-yellow-200 {
+  --tw-ring-color: rgba(113, 63, 18, 0.6);
+}
+
+.dark .ring-red-200 {
+  --tw-ring-color: rgba(127, 29, 29, 0.6);
+}
+
+.dark .ring-green-200 {
+  --tw-ring-color: rgba(20, 83, 45, 0.6);
+}
+
+/* Shadows */
+.dark .shadow,
+.dark .shadow-sm,
+.dark .shadow-md,
+.dark .shadow-lg {
+  --tw-shadow-color: rgba(0, 0, 0, 0.3);
+}
+
+/* Links and hover states */
+.dark .hover\:text-indigo-500:hover {
+  color: #a5b4fc; /* indigo-300 */
+}
+
+.dark .hover\:text-indigo-600:hover,
+.dark .hover\:text-indigo-800:hover,
+.dark .hover\:text-indigo-900:hover {
+  color: #c7d2fe; /* indigo-200 */
+}
+
+.dark .hover\:text-gray-600:hover,
+.dark .hover\:text-gray-700:hover,
+.dark .hover\:text-gray-900:hover {
+  color: #f9fafb; /* gray-50 */
+}
+
+.dark .hover\:text-red-500:hover,
+.dark .hover\:text-red-600:hover,
+.dark .hover\:text-red-700:hover {
+  color: #fecaca; /* red-200 */
+}
+
+.dark .hover\:text-emerald-500:hover,
+.dark .hover\:text-emerald-600:hover {
+  color: #6ee7b7; /* emerald-300 */
+}
+
+.dark .hover\:text-green-900:hover {
+  color: #86efac;
+}
+
+.dark .hover\:text-purple-900:hover {
+  color: #d8b4fe;
+}
+
+.dark .hover\:text-blue-900:hover {
+  color: #93c5fd;
+}
+
+.dark .hover\:text-amber-900:hover {
+  color: #fcd34d;
+}
+
+.dark .hover\:text-orange-900:hover {
+  color: #fdba74;
+}
+
+.dark .hover\:text-yellow-400:hover {
+  color: #fef08a;
+}
+
+/* Tables */
+.dark .hover\:bg-gray-50:hover {
+  background-color: #1f2937;
+}
+
+.dark .hover\:bg-gray-100:hover {
+  background-color: #374151;
+}
+
+.dark .hover\:bg-yellow-400:hover {
+  background-color: rgb(113 63 18 / 0.8);
+}
+
+.dark tr.bg-indigo-50 {
+  background-color: rgb(49 46 129 / 0.35);
+}
+
+/* Code and pre blocks */
+.dark pre,
+.dark code {
+  background-color: #1f2937;
+  color: #e5e7eb;
+}
+
+/* Gradient backgrounds on landing page */
+.dark .from-indigo-50\/80 {
+  --tw-gradient-from: rgba(30, 27, 75, 0.8);
+}
+
+.dark .to-white {
+  --tw-gradient-to: #111827;
+}
+
+/* Phase bar chart and status indicator colors */
+.dark .bg-slate-400 {
+  background-color: #64748b;
+}
+
+.dark .bg-sky-500 {
+  background-color: #38bdf8;
+}
+
+.dark .bg-violet-500 {
+  background-color: #a78bfa;
+}
+
+.dark .bg-emerald-500 {
+  background-color: #34d399;
+}
+
+.dark .bg-amber-500 {
+  background-color: #fbbf24;
+}
+
+.dark .bg-rose-400 {
+  background-color: #fb7185;
+}
+
+.dark .bg-green-400 {
+  background-color: #4ade80;
+}
+
+.dark .bg-green-500 {
+  background-color: #22c55e;
+}
+
+.dark .bg-red-500 {
+  background-color: #ef4444;
+}
+
+.dark .bg-yellow-500 {
+  background-color: #eab308;
 }
 
 /* Hide action buttons in broadcast-replaced content when user lacks permission.


### PR DESCRIPTION
## Summary

- **Root cause fix**: Dark mode overrides were wrapped in `@layer base`, which has lower cascade priority than Tailwind's `@layer utilities`. Every dark override was silently defeated by the utility class it tried to override, making all of PR #1350 ineffective. Moved overrides out of `@layer base` (unlayered) so they have higher cascade priority than all Tailwind layers.
- **Added ~30 missing class overrides** for alert panel borders (`border-red-200`, `border-green-200`, etc.), `-50` background variants (`bg-purple-50`, `bg-orange-50`, etc.), text colors (`text-red-400`, `text-amber-600`, etc.), ring colors, hover states, and phase/status indicator colors.
- **Normalized indentation** to be consistent across all unlayered rules.

Closes #1319 (for real this time)

## How to verify

1. Switch to dark mode in Settings
2. Browse Dashboard, Projects, Agent Runs, Quality, Knowledge Search, Integrations, Providers, Services, Notifications
3. Confirm that cards, tables, forms, alerts, badges, and text all render with dark backgrounds and light text
4. Compare against the Settings page (the original reference for dark mode quality)