### PR TITLE
fix(review): review agent posts comments but CompleteReviewGoalActivity reports failure

### DIFF
--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -179,21 +179,25 @@ module Api
 
       body = parse_response_body(response.body)
       return unless body.is_a?(Hash) && body["id"].present?
-      return unless body["html_url"].present?
       return if @agent_run.review_posted_at.present? && @agent_run.review_url.present?
 
+      review_url = body["html_url"].presence || review_url_for(match[:number], body["id"])
       @agent_run.update!(
         review_posted_at: @agent_run.review_posted_at || Time.current,
-        review_url: body["html_url"]
+        review_url: review_url
       )
 
       log_info("github_proxy.review_created",
         review_id: body["id"],
-        review_url: body["html_url"])
+        review_url: review_url)
 
       warn_if_missing_inline_comments(body)
     rescue => e
       log_error("github_proxy.track_review_failed", e.message)
+    end
+
+    def review_url_for(pr_number, review_id)
+      "https://github.com/#{@agent_run.project.full_name}/pull/#{pr_number}#pullrequestreview-#{review_id}"
     end
 
     def warn_if_missing_inline_comments(response_body)

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "Api::GithubProxy" do
       expect(agent_run.review_url).to eq("https://github.com/testowner/testrepo/pull/10#pullrequestreview-original")
     end
 
-    it "does not track review when html_url is missing from response" do
+    it "tracks review with a derived URL when html_url is missing from response" do
       no_url_response = { id: 999, body: "Review summary", state: "commented" }.to_json
       stub_request(:post, target_url)
         .to_return(status: 200, body: no_url_response, headers: { "Content-Type" => "application/json" })
@@ -280,8 +280,8 @@ RSpec.describe "Api::GithubProxy" do
         headers: valid_headers
 
       agent_run.reload
-      expect(agent_run.review_posted_at).to be_nil
-      expect(agent_run.review_url).to be_nil
+      expect(agent_run.review_posted_at).to be_present
+      expect(agent_run.review_url).to eq("https://github.com/testowner/testrepo/pull/10#pullrequestreview-999")
     end
 
     it "backfills review_url when review_posted_at is set but review_url is missing" do


### PR DESCRIPTION
## Summary

fix(review): review agent posts comments but CompleteReviewGoalActivity reports failure

See #1360 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1360