### PR TITLE
chore: add backups/ to .gitignore

### DIFF
--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -120,6 +120,7 @@ jobs:
             ".libyaml_src/"
             ".rubocop-cache/"
             ".rubocop_cache/"
+            "backups/"
             ".pg_log.txt"
             ".ruby_env.sh"
             ".aider*"

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ __pycache__/
 
 # Paid heartbeat file (touched by agent CLI hooks during container execution)
 .paid-heartbeat
+
+# Database backups
+/backups/

--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -133,6 +133,8 @@ module Containers
       .rubocop-cache/
       .rubocop_cache/
       .aider*
+      # Database backups
+      backups/
       # Paid heartbeat file (touched by agent CLI hooks)
       .paid-heartbeat
     PATTERNS
@@ -222,6 +224,7 @@ module Containers
       .libyaml_src/
       .rubocop-cache/
       .rubocop_cache/
+      backups/
       .pg_log.txt
       .ruby_env.sh
       .aider*

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -63,7 +63,7 @@ if [[ -n "${COMPOSE_FILE:-}" ]]; then
   COMPOSE_ARGS+=(-f "$COMPOSE_FILE")
 fi
 
-COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1)"
+COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1 || true)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
   docker exec "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 elif [[ -n "$DB_HOST" ]]; then

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -90,11 +90,15 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
 
   pg_dump_args "$COMPOSE_DB_USER"
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
-elif [[ -n "$DB_HOST" ]]; then
+elif [[ -n "$DB_NAME" ]]; then
   pg_dump_args "$DB_USER"
-  PGPASSWORD="$DB_PASSWORD" pg_dump -h "$DB_HOST" "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
+  PG_HOST_ARGS=()
+  if [[ -n "$DB_HOST" ]]; then
+    PG_HOST_ARGS=(-h "$DB_HOST")
+  fi
+  PGPASSWORD="$DB_PASSWORD" pg_dump "${PG_HOST_ARGS[@]}" "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 else
-  echo "Error: No running postgres container found and DB_HOST not set. Start services with 'bin/dev' or set DB_HOST." >&2
+  echo "Error: No running postgres container found and DB_NAME not set. Start services with 'bin/dev' or set DB_NAME." >&2
   exit 1
 fi
 

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$APP_ROOT" || exit
+
 BACKUPS_DIR="${APP_ROOT}/backups"
 
 read_rails_db_config() {

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -43,6 +43,23 @@ DB_USER="${DB_USER-${RAILS_CONFIG[1]:-}}"
 DB_PASSWORD="${DB_PASSWORD-${RAILS_CONFIG[2]:-}}"
 DB_NAME="${DB_NAME-${RAILS_CONFIG[3]:-}}"
 
+read_container_env() {
+  local container="$1"
+  local name="$2"
+
+  docker exec "$container" printenv "$name" 2>/dev/null || true
+}
+
+pg_dump_args() {
+  local user="$1"
+
+  PG_DUMP_ARGS=(--data-only --exclude-table-data=ar_internal_metadata --exclude-table-data=schema_migrations --no-owner --no-privileges -Fc)
+  if [[ -n "$user" ]]; then
+    PG_DUMP_ARGS+=(-U "$user")
+  fi
+  PG_DUMP_ARGS+=("$DB_NAME")
+}
+
 mkdir -p "$BACKUPS_DIR"
 
 if [[ -n "${1:-}" ]]; then
@@ -57,7 +74,6 @@ else
   BACKUP_PATH="$BACKUP_FILE"
 fi
 
-PG_DUMP_ARGS=(--data-only --exclude-table-data=ar_internal_metadata --exclude-table-data=schema_migrations --no-owner --no-privileges -Fc -U "$DB_USER" "$DB_NAME")
 COMPOSE_ARGS=(compose)
 if [[ -n "${COMPOSE_FILE:-}" ]]; then
   COMPOSE_ARGS+=(-f "$COMPOSE_FILE")
@@ -65,8 +81,15 @@ fi
 
 COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1 || true)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
-  docker exec "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
+  COMPOSE_DB_USER="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_USER)"
+  COMPOSE_DB_PASSWORD="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_PASSWORD)"
+  COMPOSE_DB_USER="${COMPOSE_DB_USER:-paid}"
+  COMPOSE_DB_PASSWORD="${COMPOSE_DB_PASSWORD:-paid}"
+
+  pg_dump_args "$COMPOSE_DB_USER"
+  docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 elif [[ -n "$DB_HOST" ]]; then
+  pg_dump_args "$DB_USER"
   PGPASSWORD="$DB_PASSWORD" pg_dump -h "$DB_HOST" "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 else
   echo "Error: No running postgres container found and DB_HOST not set. Start services with 'bin/dev' or set DB_HOST." >&2

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BACKUPS_DIR="${APP_ROOT}/backups"
+
+read_rails_db_config() {
+  bin/rails runner "
+    cfg = ActiveRecord::Base.connection_db_config.configuration_hash
+    puts [cfg[:host].to_s, cfg[:username].to_s, cfg[:password].to_s, cfg[:database].to_s].join(' ')
+  " 2>/dev/null
+}
+
+RAILS_CONFIG="$(read_rails_db_config)"
+RAILS_DB_HOST="$(echo "$RAILS_CONFIG" | cut -d' ' -f1)"
+RAILS_DB_USER="$(echo "$RAILS_CONFIG" | cut -d' ' -f2)"
+RAILS_DB_PASSWORD="$(echo "$RAILS_CONFIG" | cut -d' ' -f3)"
+RAILS_DB_NAME="$(echo "$RAILS_CONFIG" | cut -d' ' -f4)"
+
+DB_HOST="${DB_HOST:-${RAILS_DB_HOST}}"
+DB_NAME="${DB_NAME:-${RAILS_DB_NAME}}"
+DB_USER="${DB_USER:-${RAILS_DB_USER}}"
+DB_PASSWORD="${DB_PASSWORD:-${RAILS_DB_PASSWORD}}"
+
+usage() {
+  echo "Usage: bin/db-dump [BACKUP_FILENAME]"
+  echo ""
+  echo "Dump database data to a custom-format archive in backups/."
+  echo ""
+  echo "Defaults are read from the Rails database config."
+  echo ""
+  echo "Environment variables:"
+  echo "  DB_HOST      Database host (default: from config/database.yml)"
+  echo "  DB_NAME      Database name (default: from config/database.yml)"
+  echo "  DB_USER      Database user (default: from config/database.yml)"
+  echo "  DB_PASSWORD  Database password (default: from config/database.yml)"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+mkdir -p "$BACKUPS_DIR"
+
+if [[ -n "${1:-}" ]]; then
+  BACKUP_FILE="${1}"
+else
+  BACKUP_FILE="${DB_NAME}_dataonly_$(date +%Y%m%d_%H%M%S).dump"
+fi
+
+if [[ "$BACKUP_FILE" != /* ]]; then
+  BACKUP_PATH="${BACKUPS_DIR}/${BACKUP_FILE}"
+else
+  BACKUP_PATH="$BACKUP_FILE"
+fi
+
+PG_DUMP_ARGS=(--data-only --no-owner --no-privileges -Fc -U "$DB_USER" "$DB_NAME")
+
+COMPOSE_CONTAINER="$(docker compose ${COMPOSE_FILE:+-f "$COMPOSE_FILE"} ps -q postgres 2>/dev/null | head -1)"
+if [[ -n "$COMPOSE_CONTAINER" ]]; then
+  docker exec "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
+elif [[ -n "$DB_HOST" ]]; then
+  PGPASSWORD="$DB_PASSWORD" pg_dump -h "$DB_HOST" "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
+else
+  echo "Error: No running postgres container found and DB_HOST not set. Start services with 'bin/dev' or set DB_HOST." >&2
+  exit 1
+fi
+
+FILESIZE=$(du -h "$BACKUP_PATH" | cut -f1)
+echo "Dumped ${DB_NAME} data to ${BACKUP_PATH} (${FILESIZE})"

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -7,20 +7,12 @@ BACKUPS_DIR="${APP_ROOT}/backups"
 read_rails_db_config() {
   bin/rails runner "
     cfg = ActiveRecord::Base.connection_db_config.configuration_hash
-    puts [cfg[:host].to_s, cfg[:username].to_s, cfg[:password].to_s, cfg[:database].to_s].join(' ')
+    puts cfg[:host].to_s
+    puts cfg[:username].to_s
+    puts cfg[:password].to_s
+    puts cfg[:database].to_s
   " 2>/dev/null
 }
-
-RAILS_CONFIG="$(read_rails_db_config)"
-RAILS_DB_HOST="$(echo "$RAILS_CONFIG" | cut -d' ' -f1)"
-RAILS_DB_USER="$(echo "$RAILS_CONFIG" | cut -d' ' -f2)"
-RAILS_DB_PASSWORD="$(echo "$RAILS_CONFIG" | cut -d' ' -f3)"
-RAILS_DB_NAME="$(echo "$RAILS_CONFIG" | cut -d' ' -f4)"
-
-DB_HOST="${DB_HOST:-${RAILS_DB_HOST}}"
-DB_NAME="${DB_NAME:-${RAILS_DB_NAME}}"
-DB_USER="${DB_USER:-${RAILS_DB_USER}}"
-DB_PASSWORD="${DB_PASSWORD:-${RAILS_DB_PASSWORD}}"
 
 usage() {
   echo "Usage: bin/db-dump [BACKUP_FILENAME]"
@@ -41,6 +33,16 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
+if [[ -z "${DB_HOST+x}" || -z "${DB_NAME+x}" || -z "${DB_USER+x}" || -z "${DB_PASSWORD+x}" ]]; then
+  RAILS_CONFIG_OUTPUT="$(read_rails_db_config)"
+  mapfile -t RAILS_CONFIG <<< "$RAILS_CONFIG_OUTPUT"
+fi
+
+DB_HOST="${DB_HOST-${RAILS_CONFIG[0]:-}}"
+DB_USER="${DB_USER-${RAILS_CONFIG[1]:-}}"
+DB_PASSWORD="${DB_PASSWORD-${RAILS_CONFIG[2]:-}}"
+DB_NAME="${DB_NAME-${RAILS_CONFIG[3]:-}}"
+
 mkdir -p "$BACKUPS_DIR"
 
 if [[ -n "${1:-}" ]]; then
@@ -56,8 +58,12 @@ else
 fi
 
 PG_DUMP_ARGS=(--data-only --no-owner --no-privileges -Fc -U "$DB_USER" "$DB_NAME")
+COMPOSE_ARGS=(compose)
+if [[ -n "${COMPOSE_FILE:-}" ]]; then
+  COMPOSE_ARGS+=(-f "$COMPOSE_FILE")
+fi
 
-COMPOSE_CONTAINER="$(docker compose ${COMPOSE_FILE:+-f "$COMPOSE_FILE"} ps -q postgres 2>/dev/null | head -1)"
+COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
   docker exec "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 elif [[ -n "$DB_HOST" ]]; then

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -57,7 +57,7 @@ else
   BACKUP_PATH="$BACKUP_FILE"
 fi
 
-PG_DUMP_ARGS=(--data-only --no-owner --no-privileges -Fc -U "$DB_USER" "$DB_NAME")
+PG_DUMP_ARGS=(--data-only --exclude-table-data=ar_internal_metadata --exclude-table-data=schema_migrations --no-owner --no-privileges -Fc -U "$DB_USER" "$DB_NAME")
 COMPOSE_ARGS=(compose)
 if [[ -n "${COMPOSE_FILE:-}" ]]; then
   COMPOSE_ARGS+=(-f "$COMPOSE_FILE")

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -13,6 +13,7 @@ read_rails_db_config() {
     puts cfg[:username].to_s
     puts cfg[:password].to_s
     puts cfg[:database].to_s
+    puts Rails.env
   " 2>/dev/null
 }
 
@@ -30,6 +31,7 @@ usage() {
   echo "  DB_NAME      Database name (default: from config/database.yml)"
   echo "  DB_USER      Database user (default: from config/database.yml)"
   echo "  DB_PASSWORD  Database password (default: from config/database.yml)"
+  echo "  DB_RESTORE_CONFIRM  Set to DB_NAME to allow production or remote restores"
 }
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
@@ -51,6 +53,7 @@ DB_HOST="${DB_HOST-${RAILS_CONFIG[0]:-}}"
 DB_USER="${DB_USER-${RAILS_CONFIG[1]:-}}"
 DB_PASSWORD="${DB_PASSWORD-${RAILS_CONFIG[2]:-}}"
 DB_NAME="${DB_NAME-${RAILS_CONFIG[3]:-}}"
+RAILS_ENVIRONMENT="${RAILS_ENVIRONMENT-${RAILS_CONFIG[4]:-${RAILS_ENV:-${RACK_ENV:-development}}}}"
 
 read_container_env() {
   local container="$1"
@@ -79,6 +82,45 @@ psql_args() {
   PSQL_ARGS+=(-d "$DB_NAME")
 }
 
+local_db_host() {
+  case "$DB_HOST" in
+    "" | "localhost" | "127."* | "::1" | "0.0.0.0" | "postgres" | "db")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+require_restore_confirmation() {
+  local reason="$1"
+
+  if [[ "${DB_RESTORE_CONFIRM:-}" == "$DB_NAME" ]]; then
+    return
+  fi
+
+  echo "Error: Refusing destructive restore for ${reason} database '${DB_NAME}'." >&2
+  echo "This command truncates every public table before restoring data." >&2
+  echo "Set DB_RESTORE_CONFIRM='${DB_NAME}' only if this is the intended target." >&2
+  exit 1
+}
+
+guard_destructive_restore() {
+  if [[ "$RAILS_ENVIRONMENT" == "production" ]]; then
+    require_restore_confirmation "production"
+  fi
+
+  if ! local_db_host; then
+    require_restore_confirmation "remote"
+  fi
+}
+
+announce_restore() {
+  echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
+  echo "Truncating existing data..."
+}
+
 BACKUP_FILE="${1}"
 
 if [[ "$BACKUP_FILE" != /* ]]; then
@@ -96,9 +138,6 @@ COMPOSE_ARGS=(compose)
 if [[ -n "${COMPOSE_FILE:-}" ]]; then
   COMPOSE_ARGS+=(-f "$COMPOSE_FILE")
 fi
-
-echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
-echo "Truncating existing data..."
 
 TRUNCATE_SQL="
 SET session_replication_role = 'replica';
@@ -122,6 +161,12 @@ SET session_replication_role = 'origin';
 
 COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1 || true)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
+  if [[ "$RAILS_ENVIRONMENT" == "production" ]]; then
+    require_restore_confirmation "production"
+  fi
+
+  announce_restore
+
   COMPOSE_DB_USER="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_USER)"
   COMPOSE_DB_PASSWORD="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_PASSWORD)"
   COMPOSE_DB_USER="${COMPOSE_DB_USER:-paid}"
@@ -132,6 +177,10 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" psql "${PSQL_ARGS[@]}" -c "$TRUNCATE_SQL"
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" pg_restore "${PG_RESTORE_ARGS[@]}" < "$BACKUP_PATH"
 elif [[ -n "$DB_NAME" ]]; then
+  guard_destructive_restore
+
+  announce_restore
+
   pg_restore_args "$DB_USER"
   psql_args "$DB_USER"
   PG_HOST_ARGS=()

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$APP_ROOT" || exit
+
 BACKUPS_DIR="${APP_ROOT}/backups"
 
 read_rails_db_config() {

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -7,20 +7,12 @@ BACKUPS_DIR="${APP_ROOT}/backups"
 read_rails_db_config() {
   bin/rails runner "
     cfg = ActiveRecord::Base.connection_db_config.configuration_hash
-    puts [cfg[:host].to_s, cfg[:username].to_s, cfg[:password].to_s, cfg[:database].to_s].join(' ')
+    puts cfg[:host].to_s
+    puts cfg[:username].to_s
+    puts cfg[:password].to_s
+    puts cfg[:database].to_s
   " 2>/dev/null
 }
-
-RAILS_CONFIG="$(read_rails_db_config)"
-RAILS_DB_HOST="$(echo "$RAILS_CONFIG" | cut -d' ' -f1)"
-RAILS_DB_USER="$(echo "$RAILS_CONFIG" | cut -d' ' -f2)"
-RAILS_DB_PASSWORD="$(echo "$RAILS_CONFIG" | cut -d' ' -f3)"
-RAILS_DB_NAME="$(echo "$RAILS_CONFIG" | cut -d' ' -f4)"
-
-DB_HOST="${DB_HOST:-${RAILS_DB_HOST}}"
-DB_NAME="${DB_NAME:-${RAILS_DB_NAME}}"
-DB_USER="${DB_USER:-${RAILS_DB_USER}}"
-DB_PASSWORD="${DB_PASSWORD:-${RAILS_DB_PASSWORD}}"
 
 usage() {
   echo "Usage: bin/db-restore BACKUP_FILENAME"
@@ -38,10 +30,25 @@ usage() {
   echo "  DB_PASSWORD  Database password (default: from config/database.yml)"
 }
 
-if [[ -z "${1:-}" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "${1:-}" ]]; then
   usage
   exit 1
 fi
+
+if [[ -z "${DB_HOST+x}" || -z "${DB_NAME+x}" || -z "${DB_USER+x}" || -z "${DB_PASSWORD+x}" ]]; then
+  RAILS_CONFIG_OUTPUT="$(read_rails_db_config)"
+  mapfile -t RAILS_CONFIG <<< "$RAILS_CONFIG_OUTPUT"
+fi
+
+DB_HOST="${DB_HOST-${RAILS_CONFIG[0]:-}}"
+DB_USER="${DB_USER-${RAILS_CONFIG[1]:-}}"
+DB_PASSWORD="${DB_PASSWORD-${RAILS_CONFIG[2]:-}}"
+DB_NAME="${DB_NAME-${RAILS_CONFIG[3]:-}}"
 
 BACKUP_FILE="${1}"
 
@@ -57,6 +64,10 @@ if [[ ! -f "$BACKUP_PATH" ]]; then
 fi
 
 PG_RESTORE_ARGS=(--data-only --disable-triggers --no-owner --no-privileges -U "$DB_USER" -d "$DB_NAME")
+COMPOSE_ARGS=(compose)
+if [[ -n "${COMPOSE_FILE:-}" ]]; then
+  COMPOSE_ARGS+=(-f "$COMPOSE_FILE")
+fi
 
 echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
 echo "Truncating existing data..."
@@ -81,7 +92,7 @@ END;
 SET session_replication_role = 'origin';
 "
 
-COMPOSE_CONTAINER="$(docker compose ${COMPOSE_FILE:+-f "$COMPOSE_FILE"} ps -q postgres 2>/dev/null | head -1)"
+COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
   docker exec -i "$COMPOSE_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "$TRUNCATE_SQL"
   docker exec -i "$COMPOSE_CONTAINER" pg_restore "${PG_RESTORE_ARGS[@]}" < "$BACKUP_PATH"

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -92,7 +92,7 @@ END;
 SET session_replication_role = 'origin';
 "
 
-COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1)"
+COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1 || true)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
   docker exec -i "$COMPOSE_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "$TRUNCATE_SQL"
   docker exec -i "$COMPOSE_CONTAINER" pg_restore "${PG_RESTORE_ARGS[@]}" < "$BACKUP_PATH"

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -50,6 +50,33 @@ DB_USER="${DB_USER-${RAILS_CONFIG[1]:-}}"
 DB_PASSWORD="${DB_PASSWORD-${RAILS_CONFIG[2]:-}}"
 DB_NAME="${DB_NAME-${RAILS_CONFIG[3]:-}}"
 
+read_container_env() {
+  local container="$1"
+  local name="$2"
+
+  docker exec "$container" printenv "$name" 2>/dev/null || true
+}
+
+pg_restore_args() {
+  local user="$1"
+
+  PG_RESTORE_ARGS=(--data-only --disable-triggers --no-owner --no-privileges)
+  if [[ -n "$user" ]]; then
+    PG_RESTORE_ARGS+=(-U "$user")
+  fi
+  PG_RESTORE_ARGS+=(-d "$DB_NAME")
+}
+
+psql_args() {
+  local user="$1"
+
+  PSQL_ARGS=()
+  if [[ -n "$user" ]]; then
+    PSQL_ARGS+=(-U "$user")
+  fi
+  PSQL_ARGS+=(-d "$DB_NAME")
+}
+
 BACKUP_FILE="${1}"
 
 if [[ "$BACKUP_FILE" != /* ]]; then
@@ -63,7 +90,6 @@ if [[ ! -f "$BACKUP_PATH" ]]; then
   exit 1
 fi
 
-PG_RESTORE_ARGS=(--data-only --disable-triggers --no-owner --no-privileges -U "$DB_USER" -d "$DB_NAME")
 COMPOSE_ARGS=(compose)
 if [[ -n "${COMPOSE_FILE:-}" ]]; then
   COMPOSE_ARGS+=(-f "$COMPOSE_FILE")
@@ -94,10 +120,19 @@ SET session_replication_role = 'origin';
 
 COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1 || true)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
-  docker exec -i "$COMPOSE_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "$TRUNCATE_SQL"
-  docker exec -i "$COMPOSE_CONTAINER" pg_restore "${PG_RESTORE_ARGS[@]}" < "$BACKUP_PATH"
+  COMPOSE_DB_USER="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_USER)"
+  COMPOSE_DB_PASSWORD="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_PASSWORD)"
+  COMPOSE_DB_USER="${COMPOSE_DB_USER:-paid}"
+  COMPOSE_DB_PASSWORD="${COMPOSE_DB_PASSWORD:-paid}"
+
+  pg_restore_args "$COMPOSE_DB_USER"
+  psql_args "$COMPOSE_DB_USER"
+  docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" psql "${PSQL_ARGS[@]}" -c "$TRUNCATE_SQL"
+  docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" pg_restore "${PG_RESTORE_ARGS[@]}" < "$BACKUP_PATH"
 elif [[ -n "$DB_HOST" ]]; then
-  PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -c "$TRUNCATE_SQL"
+  pg_restore_args "$DB_USER"
+  psql_args "$DB_USER"
+  PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" "${PSQL_ARGS[@]}" -c "$TRUNCATE_SQL"
   PGPASSWORD="$DB_PASSWORD" pg_restore -h "$DB_HOST" "${PG_RESTORE_ARGS[@]}" "$BACKUP_PATH"
 else
   echo "Error: No running postgres container found and DB_HOST not set. Start services with 'bin/dev' or set DB_HOST." >&2

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -131,13 +131,17 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
   psql_args "$COMPOSE_DB_USER"
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" psql "${PSQL_ARGS[@]}" -c "$TRUNCATE_SQL"
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" pg_restore "${PG_RESTORE_ARGS[@]}" < "$BACKUP_PATH"
-elif [[ -n "$DB_HOST" ]]; then
+elif [[ -n "$DB_NAME" ]]; then
   pg_restore_args "$DB_USER"
   psql_args "$DB_USER"
-  PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" "${PSQL_ARGS[@]}" -c "$TRUNCATE_SQL"
-  PGPASSWORD="$DB_PASSWORD" pg_restore -h "$DB_HOST" "${PG_RESTORE_ARGS[@]}" "$BACKUP_PATH"
+  PG_HOST_ARGS=()
+  if [[ -n "$DB_HOST" ]]; then
+    PG_HOST_ARGS=(-h "$DB_HOST")
+  fi
+  PGPASSWORD="$DB_PASSWORD" psql "${PG_HOST_ARGS[@]}" "${PSQL_ARGS[@]}" -c "$TRUNCATE_SQL"
+  PGPASSWORD="$DB_PASSWORD" pg_restore "${PG_HOST_ARGS[@]}" "${PG_RESTORE_ARGS[@]}" "$BACKUP_PATH"
 else
-  echo "Error: No running postgres container found and DB_HOST not set. Start services with 'bin/dev' or set DB_HOST." >&2
+  echo "Error: No running postgres container found and DB_NAME not set. Start services with 'bin/dev' or set DB_NAME." >&2
   exit 1
 fi
 

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BACKUPS_DIR="${APP_ROOT}/backups"
+
+read_rails_db_config() {
+  bin/rails runner "
+    cfg = ActiveRecord::Base.connection_db_config.configuration_hash
+    puts [cfg[:host].to_s, cfg[:username].to_s, cfg[:password].to_s, cfg[:database].to_s].join(' ')
+  " 2>/dev/null
+}
+
+RAILS_CONFIG="$(read_rails_db_config)"
+RAILS_DB_HOST="$(echo "$RAILS_CONFIG" | cut -d' ' -f1)"
+RAILS_DB_USER="$(echo "$RAILS_CONFIG" | cut -d' ' -f2)"
+RAILS_DB_PASSWORD="$(echo "$RAILS_CONFIG" | cut -d' ' -f3)"
+RAILS_DB_NAME="$(echo "$RAILS_CONFIG" | cut -d' ' -f4)"
+
+DB_HOST="${DB_HOST:-${RAILS_DB_HOST}}"
+DB_NAME="${DB_NAME:-${RAILS_DB_NAME}}"
+DB_USER="${DB_USER:-${RAILS_DB_USER}}"
+DB_PASSWORD="${DB_PASSWORD:-${RAILS_DB_PASSWORD}}"
+
+usage() {
+  echo "Usage: bin/db-restore BACKUP_FILENAME"
+  echo ""
+  echo "Restore database data from a custom-format archive."
+  echo "Truncates all existing data before restoring."
+  echo "Requires a freshly migrated database (schema must match the dump)."
+  echo ""
+  echo "Defaults are read from the Rails database config."
+  echo ""
+  echo "Environment variables:"
+  echo "  DB_HOST      Database host (default: from config/database.yml)"
+  echo "  DB_NAME      Database name (default: from config/database.yml)"
+  echo "  DB_USER      Database user (default: from config/database.yml)"
+  echo "  DB_PASSWORD  Database password (default: from config/database.yml)"
+}
+
+if [[ -z "${1:-}" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 1
+fi
+
+BACKUP_FILE="${1}"
+
+if [[ "$BACKUP_FILE" != /* ]]; then
+  BACKUP_PATH="${BACKUPS_DIR}/${BACKUP_FILE}"
+else
+  BACKUP_PATH="$BACKUP_FILE"
+fi
+
+if [[ ! -f "$BACKUP_PATH" ]]; then
+  echo "Error: Backup file not found: ${BACKUP_PATH}" >&2
+  exit 1
+fi
+
+PG_RESTORE_ARGS=(--data-only --disable-triggers --no-owner --no-privileges -U "$DB_USER" -d "$DB_NAME")
+
+echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
+echo "Truncating existing data..."
+
+TRUNCATE_SQL="
+SET session_replication_role = 'replica';
+DO \$\$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN (
+    SELECT tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
+    ORDER BY tablename
+  ) LOOP
+    EXECUTE format('TRUNCATE TABLE %I CASCADE', r.tablename);
+  END LOOP;
+END;
+\$\$;
+SET session_replication_role = 'origin';
+"
+
+COMPOSE_CONTAINER="$(docker compose ${COMPOSE_FILE:+-f "$COMPOSE_FILE"} ps -q postgres 2>/dev/null | head -1)"
+if [[ -n "$COMPOSE_CONTAINER" ]]; then
+  docker exec -i "$COMPOSE_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "$TRUNCATE_SQL"
+  docker exec -i "$COMPOSE_CONTAINER" pg_restore "${PG_RESTORE_ARGS[@]}" < "$BACKUP_PATH"
+elif [[ -n "$DB_HOST" ]]; then
+  PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -c "$TRUNCATE_SQL"
+  PGPASSWORD="$DB_PASSWORD" pg_restore -h "$DB_HOST" "${PG_RESTORE_ARGS[@]}" "$BACKUP_PATH"
+else
+  echo "Error: No running postgres container found and DB_HOST not set. Start services with 'bin/dev' or set DB_HOST." >&2
+  exit 1
+fi
+
+echo "Restore complete."


### PR DESCRIPTION
## Summary

- Add `/backups/` to `.gitignore` to exclude database backup files from version control
- Add `bin/db-dump` — data-only dump of the database (accepts optional filename, defaults to timestamped)
- Add `bin/db-restore` — restore data from a dump into a freshly migrated database (truncates existing data, uses `--disable-triggers` for circular FK constraints)

Both scripts auto-detect DB config from Rails and prefer the docker compose postgres container for version-matched `pg_dump`/`pg_restore`.