### PR TITLE
fix(quality): exclude non-prompt failures from quality pause scoring

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -9,6 +9,7 @@ class AgentRun < ApplicationRecord
   FINISHED_STATUSES = %w[completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
   FAILURE_STATUSES = %w[failed timeout auth_expired rate_limited].freeze
   TERMINAL_FAILURE_STATUSES = (FAILURE_STATUSES + %w[cancelled]).freeze
+  QUALITY_EXCLUDED_STATUSES = %w[timeout auth_expired rate_limited].freeze
   UNFINISHED_STATUSES = %w[queued pending running paused].freeze
   GUARDRAIL_VIOLATION_TYPES = %w[loop_detected token_limit cost_limit time_limit anomaly].freeze
   AUTO_PICK_BLOCKING_STATUSES = UNFINISHED_STATUSES
@@ -560,10 +561,12 @@ class AgentRun < ApplicationRecord
 
     boundary = first_different_owner_run(scope, first)
     same_owner_scope = same_owner_priority_scope(scope, first)
-    same_owner_scope = same_owner_scope.where(
-      "(#{GOAL_PRIORITY_CASE_SQL}, agent_runs.created_at, agent_runs.id) < (?, ?, ?)",
-      boundary.goal_priority.to_i, boundary.created_at, boundary.id
-    ) if boundary
+    if boundary
+      same_owner_scope = same_owner_scope.where(
+        "(#{GOAL_PRIORITY_CASE_SQL}, agent_runs.created_at, agent_runs.id) < (?, ?, ?)",
+        boundary.goal_priority.to_i, boundary.created_at, boundary.id
+      )
+    end
 
     same_owner_scope.reorder(WITHIN_OWNER_QUEUE_ORDER).first || first
   end
@@ -1202,7 +1205,7 @@ class AgentRun < ApplicationRecord
   def draft_review_round_tracking_is_consistent
     return unless count_toward_draft_review_round?
     return unless will_save_change_to_count_toward_draft_review_round? ||
-                  will_save_change_to_expected_draft_review_count?
+      will_save_change_to_expected_draft_review_count?
 
     if expected_draft_review_count.blank?
       errors.add(:expected_draft_review_count, "is required when counting toward draft review rounds")

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -16,6 +16,37 @@ module QualityMetrics
         metric_type: "automated"
       )
       @score_metadata = {}
+
+      if agent_run.status.in?(AgentRun::QUALITY_EXCLUDED_STATUSES)
+        record_excluded_metric
+      else
+        record_quality_metric
+        update_ab_test_variant_stats(automated_metric)
+        update_prompt_version_stats if agent_run.prompt_version.present?
+      end
+
+      enqueue_quality_gate_check
+      automated_metric
+    end
+
+    private
+
+    attr_reader :agent_run, :automated_metric, :score_metadata
+
+    def record_excluded_metric
+      automated_metric.assign_attributes(
+        prompt_version: agent_run.prompt_version,
+        feedback_source: "system",
+        scores: { "excluded_status" => agent_run.status },
+        metadata: (automated_metric.metadata || {}).merge(
+          score_metadata.merge("exclusion_reason" => "non_quality_failure")
+        ),
+        composite_score: nil
+      )
+      automated_metric.save!
+    end
+
+    def record_quality_metric
       scores = build_scores
       weights = QualityMetric::GOAL_WEIGHTS.fetch(agent_run.goal, QualityMetric::SCORE_WEIGHTS)
       automated_metric.assign_attributes(
@@ -26,16 +57,7 @@ module QualityMetrics
         composite_score: QualityMetric.weighted_average(scores, weights: weights)
       )
       automated_metric.save!
-
-      update_ab_test_variant_stats(automated_metric)
-      update_prompt_version_stats if agent_run.prompt_version.present?
-      enqueue_quality_gate_check
-      automated_metric
     end
-
-    private
-
-    attr_reader :agent_run, :automated_metric, :score_metadata
 
     def enqueue_quality_gate_check
       return unless agent_run.project.quality_gates_enabled?
@@ -198,7 +220,7 @@ module QualityMetrics
     def add_variant_score(variant, score)
       score_decimal = BigDecimal(score.to_s)
       variant.sample_count += 1
-      variant.total_quality_score = (variant.total_quality_score || BigDecimal("0")) + score_decimal
+      variant.total_quality_score = (variant.total_quality_score || BigDecimal(0)) + score_decimal
       variant.avg_quality_score = variant.total_quality_score / variant.sample_count
       variant.save!
     end
@@ -206,7 +228,7 @@ module QualityMetrics
     def adjust_variant_aggregates(variant, old_score:, new_score:)
       old_decimal = BigDecimal(old_score.to_s)
       new_decimal = BigDecimal(new_score.to_s)
-      variant.total_quality_score = (variant.total_quality_score || BigDecimal("0")) - old_decimal + new_decimal
+      variant.total_quality_score = (variant.total_quality_score || BigDecimal(0)) - old_decimal + new_decimal
       variant.avg_quality_score = variant.sample_count.positive? ? variant.total_quality_score / variant.sample_count : nil
       variant.save!
     end
@@ -217,9 +239,9 @@ module QualityMetrics
       # Scope to automated metrics only so human feedback doesn't inflate
       # usage_count (which represents distinct runs, not total metric rows).
       stats = QualityMetric.where(prompt_version: pv)
-                           .automated
-                           .with_composite_score
-                           .pick(Arel.sql("COUNT(DISTINCT agent_run_id), AVG(composite_score)"))
+        .automated
+        .with_composite_score
+        .pick(Arel.sql("COUNT(DISTINCT agent_run_id), AVG(composite_score)"))
 
       count, avg = stats
       pv.update_columns(

--- a/app/services/quality_metrics/trend_analysis.rb
+++ b/app/services/quality_metrics/trend_analysis.rb
@@ -22,9 +22,10 @@ module QualityMetrics
     attr_reader :scope, :window_size, :project_id
 
     def initialize(prompt_version_id: nil, project_id: nil, window_size: 20,
-                   include_thresholds: false, include_gate_events: false,
-                   include_prediction: false)
+      include_thresholds: false, include_gate_events: false,
+      include_prediction: false)
       @scope = QualityMetric.with_composite_score
+        .joins(:agent_run).where.not(agent_runs: { status: AgentRun::QUALITY_EXCLUDED_STATUSES })
       @scope = @scope.by_prompt_version(prompt_version_id) if prompt_version_id
       @scope = @scope.by_project(project_id) if project_id
       @window_size = window_size

--- a/app/services/quality_pause/check.rb
+++ b/app/services/quality_pause/check.rb
@@ -86,6 +86,7 @@ module QualityPause
     def metrics_for(metric_type)
       scope = QualityMetric.by_project(project.id)
         .where(agent_runs: { goal: agent_run.goal })
+        .where.not(agent_runs: { status: AgentRun::QUALITY_EXCLUDED_STATUSES })
         .order(created_at: :desc)
 
       if metric_type == "composite_score"

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -154,6 +154,29 @@ RSpec.describe QualityMetrics::Collect do
       end
     end
 
+    context "with excluded status (timeout, auth_expired, rate_limited)" do
+      AgentRun::QUALITY_EXCLUDED_STATUSES.each do |excluded_status|
+        it "records nil composite_score for #{excluded_status} runs" do
+          run = create(:agent_run, status: excluded_status)
+
+          metric = described_class.call(agent_run: run)
+
+          expect(metric.composite_score).to be_nil
+          expect(metric.scores).to eq({ "excluded_status" => excluded_status })
+          expect(metric.metadata["exclusion_reason"]).to eq("non_quality_failure")
+        end
+      end
+
+      it "still records a composite_score for failed (non-excluded) runs" do
+        run = create(:agent_run, :completed)
+
+        metric = described_class.call(agent_run: run)
+
+        expect(metric.composite_score).not_to be_nil
+        expect(metric.scores).not_to include("excluded_status")
+      end
+    end
+
     context "with A/B test assignment" do
       let(:prompt) { create(:prompt, :with_version) }
       let(:ab_test) { create(:ab_test, prompt: prompt, status: "running", started_at: Time.current) }

--- a/spec/services/quality_pause/check_spec.rb
+++ b/spec/services/quality_pause/check_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe QualityPause::Check do
       expect(project.reload.quality_paused?).to be false
     end
 
+    it "excludes timeout, auth_expired, and rate_limited runs from scoring" do
+      good_run = create(:agent_run, :completed, project: project)
+      create(:quality_metric, agent_run: good_run, composite_score: 0.9)
+
+      excluded_statuses = %w[timeout auth_expired rate_limited]
+      excluded_statuses.each do |status|
+        bad_run = create(:agent_run, status: status, project: project, goal: agent_run.goal)
+        create(:quality_metric, agent_run: bad_run, composite_score: 0.0)
+      end
+
+      low_run = create(:agent_run, :completed, project: project)
+      create(:quality_metric, agent_run: low_run, composite_score: 0.2)
+
+      described_class.call(agent_run: agent_run)
+
+      expect(project.reload.quality_paused?).to be false
+    end
+
     it "pauses the project when rolling average falls below threshold" do
       create_quality_metrics(project, scores: [ 0.2, 0.3, 0.1, 0.4, 0.3 ])
       described_class.call(agent_run: agent_run)


### PR DESCRIPTION
## Summary

- Timeout, auth_expired, and rate_limited agent runs now produce `composite_score: nil` instead of a bogus 0.0, preventing infrastructure failures from triggering false quality pauses
- Quality pause scoring and trend analysis queries exclude metrics from these non-quality failure types
- Fixes the repeated quality pausing observed on paid, agent-harness, and railscrawler projects (timeouts scored 0.0 and dragged composites below the 0.5 threshold)

## Changes

- **`AgentRun::QUALITY_EXCLUDED_STATUSES`** — new constant defining statuses excluded from quality scoring (`timeout`, `auth_expired`, `rate_limited`)
- **`QualityMetrics::Collect`** — split into `record_excluded_metric` / `record_quality_metric` paths; excluded runs get `composite_score: nil` and skip A/B test + prompt version stats
- **`QualityPause::Check`** — `metrics_for` query filters out excluded-status agent runs
- **`QualityMetrics::TrendAnalysis`** — base scope excludes excluded-status runs from rolling averages

## Test plan

- [x] 4 new specs for excluded status handling in `collect_spec.rb`
- [x] 1 new spec for exclusion in `check_spec.rb`
- [x] All 34 existing specs pass
- [x] Lint clean

Refs #1376