### PR TITLE
fix(quality): broaden operational failure classification for quality scoring

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -11,15 +11,42 @@ class AgentRun < ApplicationRecord
   TERMINAL_FAILURE_STATUSES = (FAILURE_STATUSES + %w[cancelled]).freeze
   QUALITY_EXCLUDED_STATUSES = %w[timeout auth_expired rate_limited].freeze
 
+  OPERATIONAL_FAILURE_KEYWORDS = [
+    "providers exhausted",
+    "Docker exec",
+    "Activity task timed out",
+    "Activity task failed",
+    "Activity canceled",
+    "worktree",
+    "Worktree path does not exist",
+    "Clone failed",
+    "Push failed",
+    "Fetch failed",
+    "Credential proxy",
+    "Failed to start service",
+    "Failed to start workflow",
+    "Failed to open TCP",
+    "Failed to resolve remote",
+    "Failed to get HEAD SHA",
+    "could not obtain a connection from the pool",
+    "incompatible character encodings",
+    "string contains null byte",
+    "is closed; project resync",
+    "No container provisioned",
+    "commit_uncommitted_changes failed"
+  ].freeze
+
   def self.quality_scoreable_sql
-    arel_table.grouping(
-      arel_table[:status].not_in(QUALITY_EXCLUDED_STATUSES).and(
-        Arel::Nodes::Not.new(
-          arel_table[:status].eq("failed").and(
-            arel_table[:error_message].matches("%All providers exhausted%")
-          )
-        )
+    excluded_status = arel_table[:status].not_in(QUALITY_EXCLUDED_STATUSES)
+
+    failed_operational = OPERATIONAL_FAILURE_KEYWORDS.map { |keyword|
+      arel_table[:status].eq("failed").and(
+        arel_table[:error_message].matches("%#{keyword}%")
       )
+    }.reduce(:or)
+
+    arel_table.grouping(
+      excluded_status.and(Arel::Nodes::Not.new(failed_operational))
     )
   end
   UNFINISHED_STATUSES = %w[queued pending running paused].freeze
@@ -703,8 +730,9 @@ class AgentRun < ApplicationRecord
     return false unless FAILURE_STATUSES.include?(status)
     return true if status.in?(%w[timeout auth_expired rate_limited])
 
-    # "failed" status: only operational when caused by provider exhaustion
-    error_message.to_s.match?(/All providers exhausted/i)
+    OPERATIONAL_FAILURE_KEYWORDS.any? do |keyword|
+      error_message.to_s.downcase.include?(keyword.downcase)
+    end
   end
 
   def total_tokens

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -39,9 +39,14 @@ class AgentRun < ApplicationRecord
   def self.quality_scoreable_sql
     excluded_status = arel_table[:status].not_in(QUALITY_EXCLUDED_STATUSES)
 
+    error_message = Arel::Nodes::NamedFunction.new(
+      "COALESCE",
+      [ arel_table[:error_message], Arel::Nodes.build_quoted("") ]
+    )
+
     failed_operational = OPERATIONAL_FAILURE_KEYWORDS.map { |keyword|
       arel_table[:status].eq("failed").and(
-        arel_table[:error_message].matches("%#{keyword}%")
+        error_message.matches("%#{keyword}%")
       )
     }.reduce(:or)
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -77,8 +77,10 @@ module Activities
         next if result == :skipped
         scanned_count += 1
         issue.update_column(:last_pr_scan_at, Time.current)
-        collect_scan_result(issue, result, prs_to_trigger, automation_results,
-          explicit_pr_decisions:) if result
+        if result
+          collect_scan_result(issue, result, prs_to_trigger, automation_results,
+            explicit_pr_decisions:)
+        end
       rescue Temporalio::Error::ApplicationError => e
         raise unless e.type == "RateLimit"
 
@@ -731,14 +733,26 @@ module Activities
       true
     end
 
-    # Only draft/restarted PRs need a time-based rescan floor. They're the
-    # phases waiting on signals that do not bump GitHub's `updated_at` (bot
-    # review requests, CI state transitions, review-goal retry timers).
-    # `ready`/`escalated` PRs already have a targeted rescan path via
-    # `merge_conflict_rescan_needed?`; bypassing skip here would regress that
+    # Draft/restarted PRs need a time-based rescan floor because they wait on
+    # signals that do not bump GitHub's `updated_at` (bot review requests, CI
+    # state transitions, review-goal retry timers).
+    #
+    # Bot-authored ready-phase PRs (e.g. Dependabot) also need periodic
+    # re-evaluation: the first scan may stamp `last_pr_scan_at` while CI is
+    # still pending, and CI transitions to green do not update the PR's
+    # `updated_at` on GitHub. Without this escape hatch the skip-unchanged
+    # optimization prevents the scanner from ever reconsidering them.
+    #
+    # Human-authored ready/escalated PRs already have a targeted rescan path
+    # via `merge_conflict_rescan_needed?`; expanding that would regress the
     # optimization back into full per-PR scans.
     def scan_age_exceeds_ceiling?(project, issue)
-      return false unless issue.pr_review_phase.in?(%w[draft restarted])
+      draft_or_restarted = issue.pr_review_phase.in?(%w[draft restarted])
+      bot_ready_for_merge = issue.pr_review_phase == "ready" &&
+        bot_user?(issue.github_creator_login) &&
+        project.auto_merge_dependabot?
+
+      return false unless draft_or_restarted || bot_ready_for_merge
 
       ceiling = SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
       stale = issue.last_pr_scan_at < ceiling.seconds.ago
@@ -879,7 +893,7 @@ module Activities
       # Don't retry while a review-goal run is already queued or running.
       return false if review_run_in_progress?(project, issue)
 
-      latest_finished_automatic_review_run(project, issue)&.status.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES)
+      latest_finished_automatic_review_run(project, issue)&.status&.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES)
     end
 
     def last_completed_run(project, issue)
@@ -1137,9 +1151,9 @@ module Activities
         chain = project ? review_bot_request_chain(project) : []
         if chain.any?
           [ { type: "review_bot_review_pending",
-              details: "No review bot review found",
-              request_login: chain.first,
-              request_logins: chain } ]
+            details: "No review bot review found",
+            request_login: chain.first,
+            request_logins: chain } ]
         elsif project&.review_enabled? && project.review_method_enabled?("paid_agent")
           check_paid_agent_review_status(project, issue)
         else
@@ -1192,18 +1206,16 @@ module Activities
             # Treat as still-unaddressed to prevent unrelated changes
             # (e.g. a CI schema fix) from clearing review findings.
             paid_agent_limit_reached_for_latest_review ? body_only_exhausted_triggers : body_only_pending_triggers
-          else
+          elsif ProviderSupport.provider_bot_username_for?("paid_agent", latest&.dig(:user_login))
             # Thread-based bot with all bot threads resolved, or body-only
             # review already addressed by a subsequent agent run whose diff
             # touches at least one reviewed file. Treat as effectively clean
             # to avoid re-requesting reviews that would produce no new
             # comments.
-            if ProviderSupport.provider_bot_username_for?("paid_agent", latest&.dig(:user_login))
-              pending_review = check_paid_agent_review_status(project, issue)
-              pending_review.presence || []
-            else
-              []
-            end
+            pending_review = check_paid_agent_review_status(project, issue)
+            pending_review.presence || []
+          else
+            []
           end
         end
       when :unknown
@@ -1246,8 +1258,8 @@ module Activities
 
       if unfinished_run
         return [ { type: "paid_agent_review_pending",
-                   details: "paid_agent review run is still in progress",
-                   active_run: true } ]
+                 details: "paid_agent review run is still in progress",
+                 active_run: true } ]
       end
 
       return [] if review_goal_retry_limit_reached?(project, issue)
@@ -1278,10 +1290,10 @@ module Activities
       # even when the last finished review attempt post-dates the last create_pr.
       failed_count = review_goal_consecutive_failure_count(project, issue)
       latest_failed_run = latest_finished_automatic_review_run(project, issue)
-      if latest_failed_run&.status.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES)
+      if latest_failed_run&.status&.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES)
         max_retries = review_goal_max_retries(project)
         return [ { type: "paid_agent_review_pending",
-                   details: "Retrying unsuccessful review-goal run (attempt #{failed_count + 1}/#{max_retries})" } ]
+                 details: "Retrying unsuccessful review-goal run (attempt #{failed_count + 1}/#{max_retries})" } ]
       end
 
       # Check whether the most recent finished review-goal run (regardless of

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -615,9 +615,37 @@ RSpec.describe AgentRun do
         expect(agent_run.operational_failure?).to be true
       end
 
-      it "returns false for failed status with code-level error" do
+      it "returns true for failed status with Docker exec error" do
         agent_run = build(:agent_run, :failed,
-          error_message: "An error occurred during execution")
+          error_message: "Docker exec error: {\"message\":\"container abc123...\"}")
+
+        expect(agent_run.operational_failure?).to be true
+      end
+
+      it "returns true for failed status with worktree conflict" do
+        agent_run = build(:agent_run, :failed,
+          error_message: "Branch fix/foo has an active worktree from agent run 1234")
+
+        expect(agent_run.operational_failure?).to be true
+      end
+
+      it "returns true for failed status with Clone failed" do
+        agent_run = build(:agent_run, :failed,
+          error_message: "Clone failed: could not resolve host")
+
+        expect(agent_run.operational_failure?).to be true
+      end
+
+      it "returns false for failed status with agent exit code error" do
+        agent_run = build(:agent_run, :failed,
+          error_message: "Agent exited with code 1: compilation failed")
+
+        expect(agent_run.operational_failure?).to be false
+      end
+
+      it "returns false for failed status with review posting failure" do
+        agent_run = build(:agent_run, :failed,
+          error_message: "No review was posted on PR #1234")
 
         expect(agent_run.operational_failure?).to be false
       end

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -176,6 +176,22 @@ RSpec.describe QualityMetrics::Collect do
         expect(metric.metadata["exclusion_reason"]).to eq("operational_failure")
       end
 
+      it "records nil composite_score for failed runs with Docker exec errors" do
+        run = create(:agent_run, status: "failed", error_message: "Docker exec error: container crashed")
+
+        metric = described_class.call(agent_run: run)
+
+        expect(metric.composite_score).to be_nil
+      end
+
+      it "records nil composite_score for failed runs with worktree conflicts" do
+        run = create(:agent_run, status: "failed", error_message: "Branch foo has an active worktree from agent run 42")
+
+        metric = described_class.call(agent_run: run)
+
+        expect(metric.composite_score).to be_nil
+      end
+
       it "records a composite_score for failed runs with agent-level errors" do
         run = create(:agent_run, status: "failed", error_message: "Agent exited with code 1")
 

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -192,6 +192,15 @@ RSpec.describe QualityMetrics::Collect do
         expect(metric.composite_score).to be_nil
       end
 
+      it "records a composite_score for failed runs with nil error_message" do
+        run = create(:agent_run, status: "failed", error_message: nil)
+
+        metric = described_class.call(agent_run: run)
+
+        expect(metric.composite_score).not_to be_nil
+        expect(metric.scores).not_to include("excluded_status")
+      end
+
       it "records a composite_score for failed runs with agent-level errors" do
         run = create(:agent_run, status: "failed", error_message: "Agent exited with code 1")
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -857,7 +857,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
-                       body: "I found some issues.", submitted_at: 1.hour.ago } ],
+                     body: "I found some issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -889,7 +889,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           checks: [],
           reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
-                       body: "I found some issues.", submitted_at: 1.hour.ago } ],
+                     body: "I found some issues.", submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -913,7 +913,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
-                       body: "I found some issues.", submitted_at: 1.hour.ago } ],
+                     body: "I found some issues.", submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -971,8 +971,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector[bot]", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 2.hours.ago } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 2.hours.ago } ],
           review_threads: [],
           recent_issue_comments: [ clean_comment ]
         )
@@ -1007,8 +1007,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [],
           recent_issue_comments: [ clean_comment, info_comment ]
         )
@@ -1049,8 +1049,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Found issues that still need fixes.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Found issues that still need fixes.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [],
           recent_issue_comments: [ clean_comment ]
         )
@@ -1096,8 +1096,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [],
           recent_issue_comments: [ clean_comment, info_comment ]
         )
@@ -1131,14 +1131,14 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot reviewed 5 out of 5 changed files and generated 2 comments.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Copilot reviewed 5 out of 5 changed files and generated 2 comments.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
               is_resolved: false,
               comments: [ { body: "Fix this", path: "app/model.rb", line: 10,
-                            author: "copilot-pull-request-reviewer[bot]" } ]
+                          author: "copilot-pull-request-reviewer[bot]" } ]
             }
           ],
           recent_issue_comments: [ clean_comment ]
@@ -1173,7 +1173,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector[bot]", state: "COMMENTED",
-                       body: "Found 2 issues.", submitted_at: 10.minutes.ago } ],
+                     body: "Found 2 issues.", submitted_at: 10.minutes.ago } ],
           review_threads: [],
           recent_issue_comments: [ clean_comment ]
         )
@@ -1203,8 +1203,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector[bot]", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [],
           recent_issue_comments: [ stale_clean ]
         )
@@ -1258,8 +1258,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -1287,8 +1287,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 2.hours.ago } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 2.hours.ago } ],
           review_threads: []
         )
       end
@@ -1315,8 +1315,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 30.minutes.ago } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 30.minutes.ago } ],
           review_threads: []
         )
       end
@@ -1345,8 +1345,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 30.minutes.ago } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 30.minutes.ago } ],
           review_threads: []
         )
       end
@@ -1374,16 +1374,16 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
           review_threads: []
         )
         allow(github_client).to receive(:pull_request_review_comments)
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
-              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
-              pull_request_review_id: 1 }
+             created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+             pull_request_review_id: 1 }
           ])
         allow(github_client).to receive(:compare_changed_files)
           .with(project.full_name, "rev_sha", "abc123")
@@ -1413,16 +1413,16 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
           review_threads: []
         )
         allow(github_client).to receive(:pull_request_review_comments)
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
-              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
-              pull_request_review_id: 1 }
+             created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+             pull_request_review_id: 1 }
           ])
         allow(github_client).to receive(:compare_changed_files)
           .with(project.full_name, "rev_sha", "abc123")
@@ -1450,8 +1450,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
           review_threads: []
         )
         allow(github_client).to receive(:pull_request_review_comments)
@@ -1482,16 +1482,16 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-                       body: "Here are some automated review suggestions.",
-                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+                     body: "Here are some automated review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
           review_threads: []
         )
         allow(github_client).to receive(:pull_request_review_comments)
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
-              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
-              pull_request_review_id: 1 }
+             created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+             pull_request_review_id: 1 }
           ])
         allow(github_client).to receive(:compare_changed_files)
           .with(project.full_name, "rev_sha", "abc123")
@@ -1520,16 +1520,16 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Here are some review suggestions.",
-                       submitted_at: 2.hours.ago, commit_id: "abc123" } ],
+                     body: "Here are some review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "abc123" } ],
           review_threads: []
         )
         allow(github_client).to receive(:pull_request_review_comments)
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
-              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
-              pull_request_review_id: 1 }
+             created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+             pull_request_review_id: 1 }
           ])
       end
 
@@ -1560,16 +1560,16 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Here are some review suggestions.",
-                       submitted_at: 30.minutes.ago, commit_id: "abc123" } ],
+                     body: "Here are some review suggestions.",
+                     submitted_at: 30.minutes.ago, commit_id: "abc123" } ],
           review_threads: []
         )
         allow(github_client).to receive(:pull_request_review_comments)
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
-              created_at: 30.minutes.ago, path: "lib/agent_harness/providers/github_copilot.rb",
-              pull_request_review_id: 1 }
+             created_at: 30.minutes.ago, path: "lib/agent_harness/providers/github_copilot.rb",
+             pull_request_review_id: 1 }
           ])
       end
 
@@ -1591,8 +1591,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Here are some review suggestions.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Here are some review suggestions.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -1621,8 +1621,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Here are some review suggestions.",
-                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+                     body: "Here are some review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
           review_threads: []
         )
         allow(github_client).to receive(:pull_request_review_comments)
@@ -1662,16 +1662,16 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Here are some review suggestions.",
-                       submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+                     body: "Here are some review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
           review_threads: []
         )
         allow(github_client).to receive(:pull_request_review_comments)
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
-              created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
-              pull_request_review_id: 1 }
+             created_at: 2.hours.ago, path: "app/services/fetch_issues_activity.rb",
+             pull_request_review_id: 1 }
           ])
         allow(github_client).to receive(:compare_changed_files)
           .with(project.full_name, "rev_sha", "abc123")
@@ -1703,8 +1703,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Here are some review suggestions.",
-                       submitted_at: 30.minutes.ago } ],
+                     body: "Here are some review suggestions.",
+                     submitted_at: 30.minutes.ago } ],
           review_threads: []
         )
       end
@@ -1728,7 +1728,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "claude[bot]", state: "COMMENTED",
-                       body: "I found some issues.", submitted_at: 1.hour.ago } ],
+                     body: "I found some issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -1759,7 +1759,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "claude-code[bot]", state: "COMMENTED",
-                       body: "I found some issues.", submitted_at: 1.hour.ago } ],
+                     body: "I found some issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -1793,9 +1793,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
+             body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
           ],
           review_threads: []
         )
@@ -1823,7 +1823,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago }
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago }
           ],
           review_threads: [
             {
@@ -1887,9 +1887,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
+             body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
           ],
           review_threads: [],
           checks: [ { name: "ci", conclusion: "success" } ]
@@ -1920,9 +1920,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Some old feedback.", submitted_at: 2.hours.ago, commit_id: "rev_sha" }
+             body: "Some old feedback.", submitted_at: 2.hours.ago, commit_id: "rev_sha" }
           ],
           review_threads: []
         )
@@ -1930,7 +1930,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
-              created_at: 2.hours.ago, path: "app/model.rb", pull_request_review_id: 2 }
+             created_at: 2.hours.ago, path: "app/model.rb", pull_request_review_id: 2 }
           ])
         allow(github_client).to receive(:compare_changed_files)
           .with(project.full_name, "rev_sha", "abc123")
@@ -1961,9 +1961,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Some old feedback.", submitted_at: 2.hours.ago, commit_id: "rev_sha" }
+             body: "Some old feedback.", submitted_at: 2.hours.ago, commit_id: "rev_sha" }
           ],
           review_threads: []
         )
@@ -1971,7 +1971,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "chatgpt-codex-connector", body: "Fix this",
-              created_at: 2.hours.ago, path: "app/model.rb", pull_request_review_id: 2 }
+             created_at: 2.hours.ago, path: "app/model.rb", pull_request_review_id: 2 }
           ])
         allow(github_client).to receive(:compare_changed_files)
           .with(project.full_name, "rev_sha", "abc123")
@@ -1999,9 +1999,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Codex reviewed 3 files and generated no new comments.", submitted_at: 30.minutes.ago }
+             body: "Codex reviewed 3 files and generated no new comments.", submitted_at: 30.minutes.ago }
           ],
           review_threads: [],
           checks: [ { name: "ci", conclusion: "success" } ]
@@ -2029,9 +2029,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Please tighten the error handling.", submitted_at: 1.hour.ago },
+             body: "Please tighten the error handling.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Codex reviewed 3 files and generated no new comments.", submitted_at: 30.minutes.ago }
+             body: "Codex reviewed 3 files and generated no new comments.", submitted_at: 30.minutes.ago }
           ],
           review_threads: [],
           checks: [ { name: "ci", conclusion: "success" } ]
@@ -2064,9 +2064,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector[bot]", state: "COMMENTED",
-              body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
+             body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
           ],
           review_threads: [],
           checks: [ { name: "ci", conclusion: "success" } ],
@@ -2100,9 +2100,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
+             body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
           ],
           review_threads: [],
           checks: [ { name: "ci", conclusion: "success" } ],
@@ -2131,11 +2131,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Codex reviewed 3 files and generated no new comments.", submitted_at: 45.minutes.ago },
+             body: "Codex reviewed 3 files and generated no new comments.", submitted_at: 45.minutes.ago },
             { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Please fix the error handling.", submitted_at: 30.minutes.ago }
+             body: "Please fix the error handling.", submitted_at: 30.minutes.ago }
           ],
           review_threads: [],
           checks: [ { name: "ci", conclusion: "success" } ]
@@ -2164,11 +2164,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Codex reviewed 3 files and generated no new comments.", submitted_at: 30.minutes.ago },
+             body: "Codex reviewed 3 files and generated no new comments.", submitted_at: 30.minutes.ago },
             { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Please fix the error handling.", submitted_at: 20.minutes.ago }
+             body: "Please fix the error handling.", submitted_at: 20.minutes.ago }
           ],
           review_threads: [],
           checks: [ { name: "ci", conclusion: "success" } ]
@@ -2196,9 +2196,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "<!-- PAID_AGENT_REVIEW_STATUS: clean -->", submitted_at: 1.hour.ago },
+             body: "<!-- PAID_AGENT_REVIEW_STATUS: clean -->", submitted_at: 1.hour.ago },
             { id: 2, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
+             body: "Here are some suggestions.", submitted_at: 30.minutes.ago }
           ],
           review_threads: []
         )
@@ -2224,8 +2224,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot reviewed 5 out of 5 changed files and generated no comments.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Copilot reviewed 5 out of 5 changed files and generated no comments.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -2283,7 +2283,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 100, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot found issues.", submitted_at: 1.day.ago } ],
+                     body: "Copilot found issues.", submitted_at: 1.day.ago } ],
           checks: [ { name: "ci", conclusion: "success" } ]
         )
       end
@@ -2432,8 +2432,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
-                       submitted_at: 1.hour.ago } ]
+                     body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
+                     submitted_at: 1.hour.ago } ]
         )
         allow(github_client).to receive(:review_threads)
           .with(project.full_name, 42)
@@ -2485,8 +2485,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot reviewed 3 out of 3 changed files and generated 2 comments.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Copilot reviewed 3 out of 3 changed files and generated 2 comments.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -2519,8 +2519,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Looks good. <!-- paid-review-clean -->",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Looks good. <!-- paid-review-clean -->",
+                     submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -2545,8 +2545,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Found a few things to fix in the error handling.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Found a few things to fix in the error handling.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -2576,11 +2576,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Looks good. <!-- paid-review-clean -->",
-              submitted_at: 2.hours.ago },
+             body: "Looks good. <!-- paid-review-clean -->",
+             submitted_at: 2.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found new issues after the latest push.",
-              submitted_at: 1.hour.ago }
+             body: "Found new issues after the latest push.",
+             submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -2617,18 +2617,18 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Looks good. <!-- paid-review-clean -->",
-              submitted_at: 30.minutes.ago },
+             body: "Looks good. <!-- paid-review-clean -->",
+             submitted_at: 30.minutes.ago },
             { id: 2, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
-              submitted_at: 1.hour.ago }
+             body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
+             submitted_at: 1.hour.ago }
           ],
           review_threads: [
             {
               id: "thread_1",
               is_resolved: false,
               comments: [ { body: "Fix this", path: "app/model.rb", line: 10,
-                            author: "copilot-pull-request-reviewer[bot]" } ]
+                          author: "copilot-pull-request-reviewer[bot]" } ]
             }
           ]
         )
@@ -2653,8 +2653,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-                       body: "Looks good. <!-- paid-review-clean -->",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Looks good. <!-- paid-review-clean -->",
+                     submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -2690,11 +2690,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 3.hours.ago },
+             body: "Found issues.", submitted_at: 3.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 2.hours.ago },
+             body: "Still has issues.", submitted_at: 2.hours.ago },
             { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "More issues.", submitted_at: 1.hour.ago }
+             body: "More issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -2735,11 +2735,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 3.hours.ago },
+             body: "Found issues.", submitted_at: 3.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 2.hours.ago },
+             body: "Still has issues.", submitted_at: 2.hours.ago },
             { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Looks good. <!-- paid-review-clean -->", submitted_at: 1.hour.ago }
+             body: "Looks good. <!-- paid-review-clean -->", submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -2778,9 +2778,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 2.hours.ago },
+             body: "Found issues.", submitted_at: 2.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 1.hour.ago }
+             body: "Still has issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -2817,13 +2817,13 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 3.hours.ago },
+             body: "Found issues.", submitted_at: 3.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 2.hours.ago },
+             body: "Still has issues.", submitted_at: 2.hours.ago },
             { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "More issues.", submitted_at: 1.hour.ago },
+             body: "More issues.", submitted_at: 1.hour.ago },
             { id: 4, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Yet more issues.", submitted_at: 30.minutes.ago }
+             body: "Yet more issues.", submitted_at: 30.minutes.ago }
           ],
           review_threads: []
         )
@@ -2860,9 +2860,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 2.hours.ago },
+             body: "Found issues.", submitted_at: 2.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 1.hour.ago }
+             body: "Still has issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -2899,7 +2899,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 1.hour.ago }
+             body: "Found issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -2936,9 +2936,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 2.hours.ago },
+             body: "Found issues.", submitted_at: 2.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 1.hour.ago }
+             body: "Still has issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -2980,11 +2980,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 3.hours.ago },
+             body: "Found issues.", submitted_at: 3.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still issues.", submitted_at: 2.hours.ago },
+             body: "Still issues.", submitted_at: 2.hours.ago },
             { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "More issues.", submitted_at: 1.hour.ago }
+             body: "More issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -3030,11 +3030,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 3.hours.ago },
+             body: "Found issues.", submitted_at: 3.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 2.hours.ago },
+             body: "Still has issues.", submitted_at: 2.hours.ago },
             { id: 3, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot found issues.", submitted_at: 1.hour.ago }
+             body: "Copilot found issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: [ copilot_thread ]
         )
@@ -3078,11 +3078,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot found issues.", submitted_at: 3.hours.ago },
+             body: "Copilot found issues.", submitted_at: 3.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 2.hours.ago },
+             body: "Found issues.", submitted_at: 2.hours.ago },
             { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 1.hour.ago }
+             body: "Still has issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: [ copilot_thread ]
         )
@@ -3122,9 +3122,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 2.hours.ago },
+             body: "Found issues.", submitted_at: 2.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 1.hour.ago }
+             body: "Still has issues.", submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -3161,9 +3161,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 2.hours.ago },
+             body: "Found issues.", submitted_at: 2.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 1.hour.ago }
+             body: "Still has issues.", submitted_at: 1.hour.ago }
           ]
         )
         allow(github_client).to receive(:review_threads)
@@ -3217,8 +3217,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot reviewed 9 out of 9 changed files and generated 2 comments.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Copilot reviewed 9 out of 9 changed files and generated 2 comments.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -3287,7 +3287,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 1, user_login: "alice", state: "APPROVED", body: "LGTM",
-              submitted_at: 1.hour.ago }
+             submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -3321,9 +3321,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 1, user_login: "alice", state: "APPROVED", body: "LGTM",
-              submitted_at: 2.hours.ago },
+             submitted_at: 2.hours.ago },
             { id: 2, user_login: "alice", state: "CHANGES_REQUESTED", body: "Actually, needs fixes",
-              submitted_at: 1.hour.ago }
+             submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -3567,7 +3567,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 1, user_login: "viamin", state: "APPROVED", body: "Approved",
-              submitted_at: 1.hour.ago }
+             submitted_at: 1.hour.ago }
           ],
           review_threads: []
         )
@@ -3779,7 +3779,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           review_threads: [
             { id: "thread_1", is_resolved: false,
-              comments: [ { body: "Fix this", path: "app/model.rb", line: 10, author: "viamin" } ] }
+             comments: [ { body: "Fix this", path: "app/model.rb", line: 10, author: "viamin" } ] }
           ]
         )
       end
@@ -3869,7 +3869,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           author_login: "dependabot[bot]",
           checks: [ { name: "ci", conclusion: "success" } ],
           review_threads: [],
-          reviews: [])
+          reviews: []
+        )
 
         result = activity.execute(project_id: project.id)
 
@@ -3884,7 +3885,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           author_login: "dependabot[bot]",
           checks: [ { name: "ci", conclusion: "failure" } ],
           review_threads: [],
-          reviews: [])
+          reviews: []
+        )
 
         result = activity.execute(project_id: project.id)
 
@@ -3900,7 +3902,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           author_login: "dependabot[bot]",
           checks: [ { name: "ci", conclusion: "success" } ],
           review_threads: [],
-          reviews: [])
+          reviews: []
+        )
 
         result = activity.execute(project_id: project.id)
 
@@ -3916,7 +3919,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           author_login: "dependabot[bot]",
           checks: [ { name: "ci", conclusion: nil } ],
           review_threads: [],
-          reviews: [])
+          reviews: []
+        )
 
         result = activity.execute(project_id: project.id)
 
@@ -3940,7 +3944,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           author_login: "dependabot[bot]",
           checks: [ { name: "ci", conclusion: "success" } ],
           review_threads: [],
-          reviews: [])
+          reviews: []
+        )
 
         result = activity.execute(project_id: project.id)
 
@@ -3955,7 +3960,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           author_login: "dependabot[bot]",
           checks: [ { name: "ci", conclusion: "success" } ],
           review_threads: [],
-          reviews: [])
+          reviews: []
+        )
 
         result = activity.execute(project_id: project.id)
 
@@ -3969,7 +3975,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           author_login: "dependabot[bot]",
           checks: [ { name: "ci", conclusion: "failure" } ],
           review_threads: [],
-          reviews: [])
+          reviews: []
+        )
 
         result = activity.execute(project_id: project.id)
 
@@ -3984,7 +3991,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           author_login: "dependabot[bot]",
           checks: [ { name: "ci", conclusion: "success" } ],
           review_threads: [],
-          reviews: [])
+          reviews: []
+        )
 
         result = activity.execute(project_id: project.id)
 
@@ -4024,7 +4032,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           create_followup_run(
             status: "failed",
             error_message: "All providers exhausted: claude_code, codex",
-            created_at: i.minutes.ago)
+            created_at: i.minutes.ago
+          )
         end
 
         result = activity.execute(project_id: project.id)
@@ -4040,7 +4049,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           create_followup_run(
             status: "timeout",
             error_message: "wall_clock_timeout: exceeded 30 minutes",
-            created_at: i.minutes.ago)
+            created_at: i.minutes.ago
+          )
         end
 
         result = activity.execute(project_id: project.id)
@@ -4081,7 +4091,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           create_followup_run(
             status: "failed",
             error_message: "All providers exhausted: claude_code",
-            created_at: i.minutes.ago)
+            created_at: i.minutes.ago
+          )
         end
 
         result = activity.execute(project_id: project.id)
@@ -4098,7 +4109,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           create_followup_run(
             status: "failed",
             error_message: "All providers exhausted: claude_code",
-            created_at: i.minutes.ago)
+            created_at: i.minutes.ago
+          )
         end
 
         result = activity.execute(project_id: project.id)
@@ -4261,8 +4273,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot reviewed and generated 1 comment.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Copilot reviewed and generated 1 comment.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -4294,8 +4306,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           checks: [],
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot reviewed 20 out of 20 changed files in this pull request and generated 3 comments.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Copilot reviewed 20 out of 20 changed files in this pull request and generated 3 comments.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: []
         )
       end
@@ -4375,12 +4387,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "returns review_bot_review_pending when bot review is non-clean even without fetching threads" do
         non_clean_review = { id: 200, user_login: "copilot-pull-request-reviewer[bot]",
-                             state: "COMMENTED",
-                             body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
-                             submitted_at: 1.hour.ago }
+                            state: "COMMENTED",
+                            body: "Copilot reviewed 3 out of 5 changed files and generated 2 comments.",
+                            submitted_at: 1.hour.ago }
         bot_thread = { id: "thread_bot", is_resolved: false,
-                       comments: [ { body: "Fix this", path: "app/model.rb", line: 5,
-                                     author: "copilot-pull-request-reviewer[bot]" } ] }
+                      comments: [ { body: "Fix this", path: "app/model.rb", line: 5,
+                                  author: "copilot-pull-request-reviewer[bot]" } ] }
         stub_github_for_pr(draft: true, checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [ non_clean_review ], review_threads: [ bot_thread ])
 
@@ -4439,13 +4451,13 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           checks: [ { name: "ci", conclusion: "success" } ],
           reviews: [
             { id: 200, user_login: "chatgpt-codex-connector", state: "COMMENTED",
-              body: "Codex has reviewed the pull request and determined it is ready to merge.",
-              submitted_at: 1.hour.ago }
+             body: "Codex has reviewed the pull request and determined it is ready to merge.",
+             submitted_at: 1.hour.ago }
           ],
           review_threads: [
             { id: "thread_bot", is_resolved: false,
-              comments: [ { body: "Fix this", path: "app/model.rb", line: 5,
-                            author: "chatgpt-codex-connector" } ] }
+             comments: [ { body: "Fix this", path: "app/model.rb", line: 5,
+                         author: "chatgpt-codex-connector" } ] }
           ]
         )
 
@@ -4551,7 +4563,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           reviews: default_clean_copilot_review + [
             { id: 1, user_login: "viamin", state: "APPROVED", body: "", submitted_at: 1.hour.ago },
             { id: 2, user_login: "reviewer", state: "CHANGES_REQUESTED", body: "Needs work",
-              submitted_at: Time.current }
+             submitted_at: Time.current }
           ]
         )
       end
@@ -4958,13 +4970,13 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           reviews: [
             { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-              body: "Copilot reviewed and generated 1 comment.", submitted_at: 1.hour.ago },
+             body: "Copilot reviewed and generated 1 comment.", submitted_at: 1.hour.ago },
             { id: 2, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
           ],
           review_threads: [
             { id: "thread_1", is_resolved: false,
-              comments: [ { body: "Fix this", path: "app/model.rb", line: 10,
-                           author: "copilot-pull-request-reviewer[bot]" } ] }
+             comments: [ { body: "Fix this", path: "app/model.rb", line: 10,
+                         author: "copilot-pull-request-reviewer[bot]" } ] }
           ]
         )
       end
@@ -4994,7 +5006,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           reviews: [
             { id: 1, user_login: "github-actions[bot]", state: "COMMENTED",
-              body: "Codex Review: Found 2 issues.", submitted_at: Time.current },
+             body: "Codex Review: Found 2 issues.", submitted_at: Time.current },
             { id: 2, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
           ]
         )
@@ -5019,8 +5031,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           paid_state: "completed")
         stub_github_for_pr(
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer", state: "COMMENTED",
-                       body: "Copilot reviewed and generated 1 comment.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Copilot reviewed and generated 1 comment.",
+                     submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -5099,7 +5111,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       before do
         stub_github_for_pr(draft: true,
           reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
-                       body: "I found issues.", submitted_at: 1.hour.ago } ],
+                     body: "I found issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -5413,11 +5425,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft: true,
           reviews: [
             { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Found issues.", submitted_at: 3.hours.ago },
+             body: "Found issues.", submitted_at: 3.hours.ago },
             { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "Still has issues.", submitted_at: 2.hours.ago },
+             body: "Still has issues.", submitted_at: 2.hours.ago },
             { id: 3, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-              body: "More issues.", submitted_at: 90.minutes.ago, commit_id: "rev_sha" }
+             body: "More issues.", submitted_at: 90.minutes.ago, commit_id: "rev_sha" }
           ],
           review_threads: []
         )
@@ -5425,8 +5437,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           .with(project.full_name, 42)
           .and_return([
             { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
-              created_at: 90.minutes.ago, path: "app/services/fetch_issues_activity.rb",
-              pull_request_review_id: 3 }
+             created_at: 90.minutes.ago, path: "app/services/fetch_issues_activity.rb",
+             pull_request_review_id: 3 }
           ])
         allow(github_client).to receive(:compare_changed_files)
           .with(project.full_name, "rev_sha", "abc123")
@@ -5785,7 +5797,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         stub_github_for_pr(
           draft: true,
           reviews: [ { id: 1, user_login: "copilot", state: "COMMENTED",
-                       body: "I found issues.", submitted_at: 1.hour.ago } ],
+                     body: "I found issues.", submitted_at: 1.hour.ago } ],
           review_threads: [
             {
               id: "thread_1",
@@ -5892,9 +5904,39 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
       end
 
-      it "does not bypass skip for stale ready PRs (preserves merge-conflict rescan path)" do
+      it "does not bypass skip for stale ready PRs authored by humans (preserves merge-conflict rescan path)" do
         ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
         unchanged_pr.update!(pr_review_phase: "ready")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+        expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
+      end
+
+      it "rescans stale bot-authored ready PRs when Dependabot auto-merge is enabled" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        project.update!(auto_merge_mode: "dependabot_only")
+        unchanged_pr.update!(pr_review_phase: "ready", github_creator_login: "dependabot[bot]")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+        stub_github_for_pr(author_login: "dependabot[bot]")
+
+        activity.execute(project_id: project.id)
+
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
+      end
+
+      it "does not rescan stale bot-authored ready PRs when Dependabot auto-merge is off" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        project.update!(auto_merge_mode: "off")
+        unchanged_pr.update!(pr_review_phase: "ready", github_creator_login: "dependabot[bot]")
         unchanged_pr.update_columns(
           github_updated_at: (ceiling + 60).seconds.ago,
           last_pr_scan_at: (ceiling + 30).seconds.ago
@@ -5971,7 +6013,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           mergeable: false,
           checks: [ { name: "ci", conclusion: "failure" } ],
           reviews: [ { id: 200, user_login: "reviewer", state: "CHANGES_REQUESTED",
-                       body: nil, submitted_at: 1.hour.ago } ]
+                     body: nil, submitted_at: 1.hour.ago } ]
         )
 
         result = activity.execute(project_id: project.id)
@@ -6539,8 +6581,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         end
         stub_github_for_pr(
           reviews: [ { id: 1, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-                       body: "Copilot reviewed 5 out of 5 changed files and generated no comments.",
-                       submitted_at: 1.hour.ago } ],
+                     body: "Copilot reviewed 5 out of 5 changed files and generated no comments.",
+                     submitted_at: 1.hour.ago } ],
           checks: [ { name: "rspec", conclusion: "failure" } ]
         )
       end
@@ -7212,7 +7254,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       stub_github_for_pr(
         reviews: [
           { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-            body: "Review complete.\n<!-- paid-review-clean -->", submitted_at: 2.hours.ago },
+           body: "Review complete.\n<!-- paid-review-clean -->", submitted_at: 2.hours.ago },
           { id: 2, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
         ]
       )
@@ -7625,7 +7667,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         draft_review_count: 0)
       stub_github_for_pr(draft: true, reviews: [
         { id: 200, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-          body: "Review complete.\n<!-- paid-review-clean -->", submitted_at: 1.hour.ago }
+         body: "Review complete.\n<!-- paid-review-clean -->", submitted_at: 1.hour.ago }
       ])
     end
 
@@ -7734,9 +7776,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         draft: true,
         reviews: [
           { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-            body: "Found issues.", submitted_at: 2.hours.ago },
+           body: "Found issues.", submitted_at: 2.hours.ago },
           { id: 2, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
-            body: "Still has issues.", submitted_at: 1.hour.ago }
+           body: "Still has issues.", submitted_at: 1.hour.ago }
         ]
       )
     end
@@ -7896,6 +7938,6 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
   def default_clean_copilot_review
     [ { id: 100, user_login: "copilot-pull-request-reviewer[bot]", state: "COMMENTED",
-        body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago } ]
+      body: "Copilot reviewed 5 out of 5 changed files and generated no comments.", submitted_at: 1.hour.ago } ]
   end
 end


### PR DESCRIPTION
## Summary

The previous fix (commits `7eade548d`, `d6c6d8a8a`, `7b8651870`) only excluded `"All providers exhausted"` from failed run scoring. This was too narrow — the vast majority of infrastructure failures have different error patterns.

Out of 1440 `failed` runs, only 513 matched provider exhaustion. An additional 671 runs with Docker exec errors, worktree conflicts, clone failures, connection timeouts, encoding errors, etc. were being scored as composite 0.0, repeatedly triggering false quality pauses.

## Changes

- **`OPERATIONAL_FAILURE_KEYWORDS`** — list of 22 known infrastructure error patterns, used by both `operational_failure?` (Ruby) and `quality_scoreable_sql` (Arel/SQL)
- **`operational_failure?`** — now checks all keywords instead of just "All providers exhausted"
- **`quality_scoreable_sql`** — generates ILIKE conditions for each keyword, excluding matching failed runs from scoring queries
- Scoreable failed runs drop from ~1184 to ~256 (genuine quality failures only)

## Patterns excluded from scoring

Docker exec errors, worktree conflicts, clone/push/fetch failures, Activity task timeouts, credential proxy failures, connection pool exhaustion, encoding errors, null bytes, closed PRs, container provisioning failures, commit cleanup failures.

## Patterns still scored

Agent exit codes, infinite loops, "No review was posted" (review goal), pre-commit requirement failures.

## Test plan

- [x] 12 `operational_failure?` specs (was 8)
- [x] 29 `Collect` specs including new Docker exec + worktree exclusion tests
- [x] 10 `QualityPause::Check` specs
- [x] 13 `TrendAnalysis` specs
- [x] Lint clean

Refs #1376