### PR TITLE
fix: share Codex auth via writable bind mount

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1546,12 +1546,18 @@ module Containers
 
     def codex_subscription_provider_requested?
       return false unless agent_run
-      return false if agent_run.provider&.api_key? && agent_run.provider.provider_key == "codex"
-      return true if agent_run.provider&.subscription? && agent_run.provider.provider_key == "codex"
-      return true if ProviderSupport.provider_key_for_agent_type(agent_run.agent_type) == "codex"
+
+      providers = codex_resolved_provider_candidates
+      return providers.any? { |provider| provider.provider_key == "codex" && provider.subscription? } if providers.any?
+
+      ProviderSupport.provider_key_for_agent_type(agent_run.agent_type) == "codex"
+    end
+
+    def codex_resolved_provider_candidates
+      return codex_run_provider_candidates if agent_run.provider
 
       settings = resolved_user_settings
-      return false unless settings
+      return [] unless settings
 
       primary = settings.default_provider_identifier_for_goal(agent_run.goal)
       identifiers = [ primary ].compact
@@ -1559,19 +1565,25 @@ module Containers
         identifiers.concat(settings.fallback_priority_for(primary_provider: primary, identifiers: true))
       end
 
-      codex_subscription_identifiers?(
-        identifiers,
-        user: settings.user
-      )
+      providers_for_identifiers(identifiers, user: settings.user)
     end
 
-    def codex_subscription_identifiers?(identifiers, user:)
-      provider_ids = identifiers.filter_map { |identifier| Provider.id_from_routing_key(identifier) }
-      providers_by_id = user.providers.where(id: provider_ids).index_by(&:id)
+    def codex_run_provider_candidates
+      providers = [ agent_run.provider ]
+      settings = resolved_user_settings
+      if settings&.fallback_enabled?
+        providers.concat(providers_for_identifiers(
+          settings.fallback_priority_for(primary_provider: agent_run.provider.routing_key, identifiers: true),
+          user: settings.user
+        ))
+      end
 
-      identifiers.any? do |identifier|
-        provider = providers_by_id[Provider.id_from_routing_key(identifier)]
-        identifier.to_s == "codex" || (provider&.provider_key == "codex" && provider.subscription?)
+      providers.compact
+    end
+
+    def providers_for_identifiers(identifiers, user:)
+      identifiers.filter_map do |identifier|
+        Provider.for_identifier(user, identifier)
       end
     end
 

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -100,6 +100,8 @@ module Containers
       keyword_init: true
     )
 
+    CodexAuthMount = Struct.new(:host_path, :config_path, keyword_init: true)
+
     # File locks to serialize Codex OAuth refreshes when multiple runs share
     # the same host-backed auth.json. The lock key is derived from the
     # credential directory so unrelated Codex homes do not block each other.
@@ -758,24 +760,15 @@ module Containers
 
     def seed_codex_credentials!
       unless codex_subscription_auth?
+        raise_unshared_codex_auth_error! if unshared_codex_subscription_auth?
+
         seed_codex_config!
         return
       end
 
-      host = codex_subscription_auth_host_mount_path
-      if host.present?
-        log_system("container.codex_credentials_shared", source_path: host)
-        seed_sanitized_codex_config!(source_path: host)
-      else
-        seed_local_credentials!(
-          source_path: codex_local_config_path,
-          target_path: "/home/agent/.codex",
-          files: %w[auth.json],
-          success_log_key: "container.codex_credentials_seeded",
-          failure_log_key: "container.codex_credentials_seed_failed"
-        )
-        seed_sanitized_codex_config!(source_path: codex_local_config_path)
-      end
+      mount = codex_subscription_auth_mount
+      log_system("container.codex_credentials_shared", source_path: mount.host_path)
+      seed_sanitized_codex_config!(source_path: mount.config_path)
 
       seed_codex_notify_hook!
     end
@@ -1516,7 +1509,11 @@ module Containers
     end
 
     def codex_config_host_path
-      @codex_config_host_path ||= ENV["CODEX_CONFIG_DIR"].presence || ENV["CODEX_HOME"].presence || detect_host_config_path("/.codex")
+      codex_subscription_auth_host_mount_path
+    end
+
+    def codex_config_candidate_paths
+      [ ENV["CODEX_CONFIG_DIR"].presence, ENV["CODEX_HOME"].presence ].compact
     end
 
     def codex_local_config_path
@@ -1534,17 +1531,78 @@ module Containers
     end
 
     def codex_subscription_auth?
-      paths = [ codex_config_host_path, codex_local_config_path ].compact
-      paths.any? { |base| File.file?(File.join(base, "auth.json")) }
+      codex_subscription_auth_mount.present?
+    end
+
+    def unshared_codex_subscription_auth?
+      unshared_codex_auth_path.present? && codex_subscription_provider_requested?
+    end
+
+    def unshared_codex_auth_path
+      codex_readable_config_paths.find do |path|
+        File.file?(File.join(path, "auth.json")) && docker_host_path_for(path).blank?
+      end
+    end
+
+    def codex_subscription_provider_requested?
+      return false unless agent_run
+      return false if agent_run.provider&.api_key? && agent_run.provider.provider_key == "codex"
+      return true if agent_run.provider&.subscription? && agent_run.provider.provider_key == "codex"
+      return true if ProviderSupport.provider_key_for_agent_type(agent_run.agent_type) == "codex"
+
+      settings = resolved_user_settings
+      return false unless settings
+
+      primary = settings.default_provider_identifier_for_goal(agent_run.goal)
+      identifiers = [ primary ].compact
+      if settings.fallback_enabled?
+        identifiers.concat(settings.fallback_priority_for(primary_provider: primary, identifiers: true))
+      end
+
+      codex_subscription_identifiers?(
+        identifiers,
+        user: settings.user
+      )
+    end
+
+    def codex_subscription_identifiers?(identifiers, user:)
+      provider_ids = identifiers.filter_map { |identifier| Provider.id_from_routing_key(identifier) }
+      providers_by_id = user.providers.where(id: provider_ids).index_by(&:id)
+
+      identifiers.any? do |identifier|
+        provider = providers_by_id[Provider.id_from_routing_key(identifier)]
+        identifier.to_s == "codex" || (provider&.provider_key == "codex" && provider.subscription?)
+      end
+    end
+
+    def raise_unshared_codex_auth_error!
+      raise ProvisionError,
+        "Codex subscription auth was found at #{unshared_codex_auth_path}, but that directory is not available as a Docker bind mount. " \
+        "Set CODEX_HOME or CODEX_CONFIG_DIR to a writable Docker-host path containing auth.json."
     end
 
     def codex_subscription_auth_host_mount_path
-      return @codex_subscription_auth_host_mount_path if defined?(@codex_subscription_auth_host_mount_path)
+      codex_subscription_auth_mount&.host_path
+    end
 
-      base = codex_config_host_path
-      @codex_subscription_auth_host_mount_path = if base.present? && File.directory?(base) && File.file?(File.join(base, "auth.json"))
-        base
+    def codex_subscription_auth_mount
+      return @codex_subscription_auth_mount if defined?(@codex_subscription_auth_mount)
+
+      @codex_subscription_auth_mount = codex_subscription_auth_mount_candidates.find do |mount|
+        mount.host_path.present? &&
+          mount.config_path.present? &&
+          File.file?(File.join(mount.config_path, "auth.json"))
       end
+    end
+
+    def codex_subscription_auth_mount_candidates
+      codex_readable_config_paths.map do |path|
+        CodexAuthMount.new(host_path: docker_host_path_for(path), config_path: path)
+      end + [ detected_codex_auth_mount ].compact
+    end
+
+    def codex_readable_config_paths
+      (codex_config_candidate_paths + [ codex_local_config_path ]).compact.uniq
     end
 
     def codex_subscription_auth_file_binds
@@ -1566,10 +1624,10 @@ module Containers
     end
 
     def codex_auth_lockfile_path
-      base = File.realpath(codex_subscription_auth_host_mount_path || codex_config_host_path)
+      base = codex_subscription_auth_host_mount_path
       digest = Digest::SHA256.hexdigest(base)[0, 16]
       "#{CODEX_AUTH_LOCKFILE_PREFIX}-#{digest}.lock"
-    rescue Errno::ENOENT, TypeError
+    rescue TypeError
       "#{CODEX_AUTH_LOCKFILE_PREFIX}-missing.lock"
     end
 
@@ -1587,13 +1645,54 @@ module Containers
     end
 
     def detect_host_config_path(suffix)
+      detected_config_mount(suffix)&.dig("Source")
+    end
+
+    def detected_codex_auth_mount
+      mount = detected_config_mount("/.codex")
+      return unless mount
+
+      CodexAuthMount.new(host_path: mount["Source"], config_path: mount["Destination"])
+    end
+
+    def detected_config_mount(suffix)
       hostname = Socket.gethostname
       container = Docker::Container.get(hostname)
       mounts = container.info["Mounts"] || []
-      config_mount = mounts.find { |mount| mount["Destination"]&.end_with?(suffix) }
-      config_mount&.dig("Source")
+      mounts.find { |mount| mount["Destination"]&.end_with?(suffix) }
     rescue Docker::Error::DockerError
       nil
+    end
+
+    def docker_host_path_for(path)
+      return if path.blank?
+
+      expanded = File.expand_path(path)
+      mounts = current_container_mounts
+      return expanded if mounts.nil?
+
+      mount = mounts.filter_map do |candidate|
+        destination = candidate["Destination"].to_s
+        source = candidate["Source"].to_s
+        next if destination.blank? || source.blank?
+
+        destination = File.expand_path(destination)
+        next unless expanded == destination || expanded.start_with?("#{destination}/")
+
+        [ destination.length, File.join(source, expanded.delete_prefix(destination).delete_prefix("/")) ]
+      end.max_by(&:first)
+
+      mount&.last
+    end
+
+    def current_container_mounts
+      return @current_container_mounts if defined?(@current_container_mounts)
+
+      hostname = Socket.gethostname
+      container = Docker::Container.get(hostname)
+      @current_container_mounts = container.info["Mounts"] || []
+    rescue Docker::Error::DockerError
+      @current_container_mounts = nil
     end
 
     def local_config_path(dirname)

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1113,6 +1113,8 @@ RSpec.describe Containers::Provision do
       end
 
       it "fails clearly for a Codex subscription run when local auth is not bind-mountable" do
+        codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
+        project.created_by.settings.update!(default_agent_provider: codex_provider.routing_key)
         agent_run.update!(agent_type: "codex")
         current_container = instance_double(Docker::Container, info: { "Mounts" => [] })
         allow(Docker::Container).to receive(:get).with(Socket.gethostname).and_return(current_container)
@@ -1123,6 +1125,22 @@ RSpec.describe Containers::Provision do
           Containers::Provision::ProvisionError,
           /Codex subscription auth was found at .*not available as a Docker bind mount/
         )
+      end
+
+      it "does not fail for an API-key-backed Codex default when local auth is not bind-mountable" do
+        api_key = create(:provider_api_key, user: project.created_by, api_service_type: "openai")
+        codex_provider = create(:provider, :api_key, user: project.created_by, provider_key: "codex", provider_api_key: api_key)
+        project.created_by.settings.update!(default_agent_provider: codex_provider.routing_key)
+        agent_run.update!(agent_type: "codex")
+        current_container = instance_double(Docker::Container, info: { "Mounts" => [] })
+        allow(Docker::Container).to receive(:get).with(Socket.gethostname).and_return(current_container)
+
+        expect(Docker::Container).to receive(:create) do |config|
+          expect(config["Env"]).to include("PAID_CODEX_SUBSCRIPTION_AUTH=0")
+          mock_container
+        end
+
+        expect { service.provision }.not_to raise_error
       end
     end
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1031,7 +1031,7 @@ RSpec.describe Containers::Provision do
       end
     end
 
-    context "with Codex subscription auth from the devcontainer filesystem" do
+    context "with Codex subscription auth from the local filesystem" do
       let(:codex_local_dir) { Dir.mktmpdir("codex-local") }
 
       before do
@@ -1057,9 +1057,10 @@ RSpec.describe Containers::Provision do
         FileUtils.rm_rf(codex_local_dir)
       end
 
-      it "sets the subscription marker without bind-mounting the local path" do
+      it "bind-mounts local Codex auth as the shared writable auth source" do
         expect(Docker::Container).to receive(:create) do |config|
           binds = config["HostConfig"]["Binds"]
+          expect(binds).to include("#{File.join(codex_local_dir, 'auth.json')}:/home/agent/.codex/auth.json:rw")
           expect(binds.none? { |bind| bind.include?(":/home/agent/.codex:rw") }).to be true
           expect(config["Env"]).to include("PAID_CODEX_SUBSCRIPTION_AUTH=1")
 
@@ -1071,14 +1072,10 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "copies local Codex auth and writes sanitized config into the writable tmpfs" do
+      it "uses shared Codex auth and writes sanitized config into the writable tmpfs" do
         service.provision
 
-        expect(mock_container).to have_received(:exec).with(
-          [ "chown", "-R", "agent:agent", "/home/agent/.codex" ],
-          user: "root"
-        )
-        expect(mock_container).to have_received(:exec).with(
+        expect(mock_container).not_to have_received(:exec).with(
           [ "sh", "-lc", satisfy { |cmd|
             cmd.include?("/home/agent/.codex/auth.json") &&
               !cmd.include?("/home/agent/.codex/config.toml")
@@ -1091,6 +1088,40 @@ RSpec.describe Containers::Provision do
               decoded_base64_content(cmd).include?('model = "gpt-5"')
           } ],
           user: "agent"
+        )
+      end
+
+      it "translates a mounted local Codex path to the Docker host bind source" do
+        mount_source = Dir.mktmpdir("codex-host")
+        mount_destination = File.dirname(codex_local_dir)
+        current_container = instance_double(
+          Docker::Container,
+          info: { "Mounts" => [ { "Destination" => mount_destination, "Source" => mount_source } ] }
+        )
+        allow(Docker::Container).to receive(:get).with(Socket.gethostname).and_return(current_container)
+
+        expect(Docker::Container).to receive(:create) do |config|
+          binds = config["HostConfig"]["Binds"]
+          expected_source = File.join(mount_source, File.basename(codex_local_dir), "auth.json")
+          expect(binds).to include("#{expected_source}:/home/agent/.codex/auth.json:rw")
+          mock_container
+        end
+
+        service.provision
+      ensure
+        FileUtils.rm_rf(mount_source) if mount_source
+      end
+
+      it "fails clearly for a Codex subscription run when local auth is not bind-mountable" do
+        agent_run.update!(agent_type: "codex")
+        current_container = instance_double(Docker::Container, info: { "Mounts" => [] })
+        allow(Docker::Container).to receive(:get).with(Socket.gethostname).and_return(current_container)
+
+        expect {
+          service.provision
+        }.to raise_error(
+          Containers::Provision::ProvisionError,
+          /Codex subscription auth was found at .*not available as a Docker bind mount/
         )
       end
     end
@@ -1477,8 +1508,9 @@ RSpec.describe Containers::Provision do
         allow(ENV).to receive(:[]).with("CODEX_CONFIG_DIR").and_return(nil)
         allow(ENV).to receive(:[]).with("CODEX_HOME").and_return(codex_config_dir)
         # Clear memoized values so they pick up the new ENV stubs
-        service.remove_instance_variable(:@codex_subscription_auth_host_mount_path) if service.instance_variable_defined?(:@codex_subscription_auth_host_mount_path)
+        service.remove_instance_variable(:@codex_subscription_auth_mount) if service.instance_variable_defined?(:@codex_subscription_auth_mount)
         service.remove_instance_variable(:@codex_config_host_path) if service.instance_variable_defined?(:@codex_config_host_path)
+        service.remove_instance_variable(:@current_container_mounts) if service.instance_variable_defined?(:@current_container_mounts)
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
           block.call(:stdout, "output\n") if block
           [ [ "output\n" ], [], 0 ]


### PR DESCRIPTION
## Summary
- Share Codex subscription `auth.json` with agent containers via a writable bind mount instead of copying it into tmpfs
- Translate local Codex auth paths through Docker mounts and fail clearly when subscription auth cannot be shared
- Keep sanitized Codex config in tmpfs while preserving the existing auth refresh lock behavior

## Tests
- `bin/rubocop app/services/containers/provision.rb spec/services/containers/provision_spec.rb`
- `COVERAGE=false bin/rspec spec/services/containers/provision_spec.rb spec/services/network_policy_spec.rb`