### PR TITLE
feat(agent-runs): include pre-processed CI failure context in agent prompts

### DIFF
--- a/app/services/ci/failure_context.rb
+++ b/app/services/ci/failure_context.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Ci
+  # Builds bounded, pre-processed CI failure context for agent prompts.
+  class FailureContext
+    GREEN_CONCLUSIONS = %w[success skipped neutral].freeze
+    DEFAULT_MAX_CHARS = LogExtractor::DEFAULT_MAX_CHARS
+
+    attr_reader :checks, :output
+
+    def self.call(...)
+      new(...).build
+    end
+
+    def initialize(repo:, checks:, github_client:, max_chars: DEFAULT_MAX_CHARS)
+      @repo = repo
+      @checks = Array(checks)
+      @github_client = github_client
+      @max_chars = max_chars
+      @output = ""
+    end
+
+    def build
+      @checks = failed_checks
+      @output = extracted_output
+      self
+    end
+
+    def failing?
+      checks.any?
+    end
+
+    private
+
+    attr_reader :repo, :github_client, :max_chars
+
+    def failed_checks
+      checks.select do |check|
+        conclusion = check[:conclusion].to_s
+        conclusion.present? && !GREEN_CONCLUSIONS.include?(conclusion)
+      end
+    end
+
+    def extracted_output
+      remaining = max_chars
+      sections = []
+
+      checks.each do |check|
+        extracted = extract_check_output(check, remaining)
+        next if extracted.blank?
+
+        section = "## #{check[:name]}\n\n#{extracted.strip}"
+        sections << section
+        remaining = max_chars - sections.join("\n\n").length
+        break unless remaining.positive?
+      end
+
+      sections.join("\n\n")
+    end
+
+    def extract_check_output(check, remaining)
+      raw = raw_check_output(check)
+      return "" if raw.blank?
+
+      LogExtractor.call(raw, max_chars: remaining)
+    end
+
+    def raw_check_output(check)
+      [
+        check[:output_text],
+        check_log(check)
+      ].compact_blank.join("\n\n")
+    end
+
+    def check_log(check)
+      github_client.check_run_log(repo, check)
+    rescue GithubClient::Error => e
+      Rails.logger.warn(
+        message: "ci.failure_context_log_fetch_failed",
+        repo: repo,
+        check_name: check[:name],
+        check_run_id: check[:id],
+        error_class: e.class.name
+      )
+      nil
+    end
+  end
+end

--- a/app/services/ci/failure_context.rb
+++ b/app/services/ci/failure_context.rb
@@ -62,7 +62,12 @@ module Ci
       raw = raw_check_output(check)
       return "" if raw.blank?
 
-      LogExtractor.call(raw, max_chars: remaining)
+      LogExtractor.call(redact(raw), max_chars: remaining)
+    end
+
+    def redact(text)
+      normalized = text.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
+      Knowledge::Redaction::Redactor.call(text: normalized).clean_text
     end
 
     def raw_check_output(check)

--- a/app/services/ci/log_extractor.rb
+++ b/app/services/ci/log_extractor.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Ci
+  # Reduces CI logs to prompt-sized failure context.
+  class LogExtractor
+    DEFAULT_MAX_CHARS = 8_000
+    SMALL_LOG_CHARS = 10_000
+    CONTEXT_BEFORE = 2
+    CONTEXT_AFTER = 3
+    ERROR_PATTERN = /\b(error|fail(?:ed|ure|ing)?|exception|assert(?:ion)?|fatal|traceback)\b/i
+
+    def self.call(log_text, max_chars: DEFAULT_MAX_CHARS)
+      new(log_text, max_chars: max_chars).extract
+    end
+
+    def initialize(log_text, max_chars:)
+      @log_text = log_text.to_s
+      @max_chars = max_chars
+    end
+
+    def extract
+      text = normalized_log
+      return "" if text.blank?
+      return truncate(text) if text.length <= SMALL_LOG_CHARS
+
+      truncate(extract_matching_context(text))
+    end
+
+    private
+
+    attr_reader :log_text, :max_chars
+
+    def normalized_log
+      log_text.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
+    end
+
+    def extract_matching_context(text)
+      lines = text.lines
+      ranges = matching_line_indexes(lines).map do |index|
+        ([ index - CONTEXT_BEFORE, 0 ].max)..([ index + CONTEXT_AFTER, lines.length - 1 ].min)
+      end
+
+      merge_ranges(ranges).map { |range| lines[range].join }.join("\n--\n")
+    end
+
+    def matching_line_indexes(lines)
+      lines.each_index.select { |index| lines[index].match?(ERROR_PATTERN) }
+    end
+
+    def merge_ranges(ranges)
+      ranges.each_with_object([]) do |range, merged|
+        if merged.last&.cover?(range.first - 1)
+          merged[-1] = merged.last.first..[ merged.last.last, range.last ].max
+        else
+          merged << range
+        end
+      end
+    end
+
+    def truncate(text)
+      return text if text.length <= max_chars
+
+      "#{text[0, max_chars]}\n... [truncated]"
+    end
+  end
+end

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -389,13 +389,31 @@ class GithubClient
 
       all_check_runs.map do |cr|
         {
+          id: cr.id,
           name: cr.name,
           status: cr.status,
           conclusion: cr.conclusion,
           html_url: cr.html_url,
-          details_url: cr.details_url
+          details_url: cr.details_url,
+          job_id: actions_job_id_from_url(cr.details_url),
+          output_text: check_run_output_text(cr)
         }
       end
+    end
+  end
+
+  # Fetches raw GitHub Actions job logs for a check run when the run is backed
+  # by an Actions job. Non-Actions checks do not expose logs through this API.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param check_run [Hash] Check run hash from +check_runs_for_ref+
+  # @return [String] Raw log text, or an empty string when no job log is available
+  def check_run_log(repo, check_run)
+    job_id = check_run[:job_id] || actions_job_id_from_url(check_run[:details_url])
+    return "" unless job_id
+
+    handle_errors do
+      client.get("#{Octokit::Repository.path(repo)}/actions/jobs/#{job_id}/logs").to_s
     end
   end
 
@@ -1274,6 +1292,17 @@ class GithubClient
     when Time then value
     when String then Time.parse(value)
     end
+  end
+
+  def actions_job_id_from_url(url)
+    url.to_s[%r{/actions/runs/\d+/job/(\d+)}, 1]
+  end
+
+  def check_run_output_text(check_run)
+    output = check_run.output
+    return "" unless output
+
+    [ output.title, output.summary, output.text ].compact_blank.join("\n\n")
   end
 
   def graphql_reaction_to_rest(content)

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -97,7 +97,7 @@ module Prompts
       sections << task_section
       sections << issue_requirements_section if linked_issue?
       sections << merge_conflicts_section unless rebase_succeeded
-      sections << ci_failures_section if failing_checks.any?
+      sections << ci_failures_section if ci_failure_context.failing?
       sections << code_review_section if includes_review_threads?
       sections << conversation_section if trusted_comments.any?
       sections << instructions_and_rules_shell
@@ -132,7 +132,7 @@ module Prompts
     def priority_list
       priorities = []
       priorities << "Resolve merge conflicts" unless rebase_succeeded
-      priorities << "Fix CI failures" if failing_checks.any?
+      priorities << "Fix CI failures" if ci_failure_context.failing?
       priorities << "Close implementation gaps against the linked issue" if linked_issue?
       priorities << "Address code review comments" if includes_review_threads?
       priorities << "Address conversation comments" if trusted_comments.any?
@@ -194,17 +194,32 @@ module Prompts
     end
 
     def ci_failures_section
-      names = failing_checks.map { |c| "- #{c[:name]} (#{c[:conclusion]})" }.join("\n")
+      names = ci_failure_context.checks.map { |c| "- #{c[:name]} (#{c[:conclusion]})" }.join("\n")
+      output = ci_failure_context.output
 
       <<~SECTION
-        # CI Failures
+        # CI Status: FAILING
 
-        The following CI checks are failing:
+        The following CI checks are failing on this branch:
 
         #{names}
 
-        Reproduce these failures locally using the lint and test commands below.
-        Fix the underlying issues — do not skip or disable checks.
+        #{ci_failure_output_section(output)}
+
+        Fix the issue causing these CI failures. Reproduce them locally using the lint
+        and test commands below when possible. Do not skip or disable checks.
+      SECTION
+    end
+
+    def ci_failure_output_section(output)
+      return "No check log output was available from GitHub." if output.blank?
+
+      <<~SECTION
+        Error output (pre-processed):
+
+        ```text
+        #{output}
+        ```
       SECTION
     end
 
@@ -270,10 +285,18 @@ module Prompts
     def failing_checks
       @failing_checks ||= begin
         checks = github_client.check_runs_for_ref(project.full_name, pr_data.head.sha)
-        checks.reject { |c| %w[success skipped neutral].include?(c[:conclusion].to_s) }
+        checks.reject { |c| Ci::FailureContext::GREEN_CONCLUSIONS.include?(c[:conclusion].to_s) }
       rescue GithubClient::Error
         []
       end
+    end
+
+    def ci_failure_context
+      @ci_failure_context ||= Ci::FailureContext.call(
+        repo: project.full_name,
+        checks: failing_checks,
+        github_client: github_client
+      )
     end
 
     def unresolved_threads

--- a/spec/services/ci/failure_context_spec.rb
+++ b/spec/services/ci/failure_context_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ci::FailureContext do
+  let(:github_client) { instance_double(GithubClient) }
+  let(:repo) { "owner/repo" }
+
+  before do
+    allow(github_client).to receive(:check_run_log).and_return("")
+  end
+
+  it "keeps failed checks and extracts their logs" do
+    checks = [
+      { id: 1, name: "rspec", conclusion: "failure", output_text: "role \"root\" does not exist" },
+      { id: 2, name: "rubocop", conclusion: "success", output_text: "ok" }
+    ]
+
+    context = described_class.call(repo: repo, checks: checks, github_client: github_client)
+
+    expect(context).to be_failing
+    expect(context.checks.map { |check| check[:name] }).to eq([ "rspec" ])
+    expect(context.output).to include("## rspec")
+    expect(context.output).to include("role \"root\" does not exist")
+  end
+
+  it "uses GitHub job logs when check output is empty" do
+    check = { id: 1, name: "rspec", conclusion: "failure", output_text: "" }
+    allow(github_client).to receive(:check_run_log)
+      .with(repo, check)
+      .and_return("database \"app_test\" does not exist")
+
+    context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+    expect(context.output).to include("database \"app_test\" does not exist")
+  end
+
+  it "does not treat pending checks as failing" do
+    context = described_class.call(
+      repo: repo,
+      checks: [ { name: "rspec", conclusion: nil } ],
+      github_client: github_client
+    )
+
+    expect(context).not_to be_failing
+    expect(context.output).to eq("")
+  end
+end

--- a/spec/services/ci/failure_context_spec.rb
+++ b/spec/services/ci/failure_context_spec.rb
@@ -35,6 +35,26 @@ RSpec.describe Ci::FailureContext do
     expect(context.output).to include("database \"app_test\" does not exist")
   end
 
+  it "redacts secrets before extracting check output for prompts" do
+    check = {
+      id: 1,
+      name: "rspec",
+      conclusion: "failure",
+      output_text: "api_key=#{'a' * 24}\nFailure: request failed"
+    }
+    token = "ghp_#{'b' * 36}"
+    allow(github_client).to receive(:check_run_log)
+      .with(repo, check)
+      .and_return("GITHUB_TOKEN=#{token}")
+
+    context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+    expect(context.output).to include("[REDACTED:api_key]")
+    expect(context.output).to include("[REDACTED:github_token]")
+    expect(context.output).not_to include("api_key=#{'a' * 24}")
+    expect(context.output).not_to include(token)
+  end
+
   it "does not treat pending checks as failing" do
     context = described_class.call(
       repo: repo,

--- a/spec/services/ci/log_extractor_spec.rb
+++ b/spec/services/ci/log_extractor_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ci::LogExtractor do
+  describe ".call" do
+    it "returns small logs directly" do
+      log = "bundle exec rspec\nrole \"root\" does not exist\n"
+
+      expect(described_class.call(log)).to eq(log)
+    end
+
+    it "extracts error context from large logs" do
+      log = [
+        Array.new(600, "setup noise"),
+        "Running spec/models/user_spec.rb",
+        "expected: true",
+        "     got: false",
+        "Failure/Error: expect(user.active?).to be(true)",
+        "stack frame 1",
+        "stack frame 2",
+        "stack frame 3",
+        Array.new(600, "teardown noise")
+      ].flatten.join("\n")
+
+      extracted = described_class.call(log)
+
+      expect(extracted).to include("expected: true")
+      expect(extracted).to include("Failure/Error")
+      expect(extracted).to include("stack frame 3")
+      expect(extracted).not_to include("setup noise\nsetup noise\nsetup noise\nsetup noise")
+    end
+
+    it "caps extracted output" do
+      log = Array.new(1_200) { |index| "line #{index}: error details" }.join("\n")
+
+      extracted = described_class.call(log, max_chars: 100)
+
+      expect(extracted.length).to be > 100
+      expect(extracted).to include("[truncated]")
+    end
+  end
+end

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -731,17 +731,20 @@ RSpec.describe GithubClient do
           {
             id: 1, name: "rspec", status: "completed", conclusion: "failure",
             html_url: "https://github.com/owner/repo/runs/1",
-            details_url: "https://ci.example.com/jobs/1"
+            details_url: "https://github.com/owner/repo/actions/runs/100/job/1",
+            output: { title: "RSpec", summary: "1 failure", text: "role root does not exist" }
           },
           {
             id: 2, name: "rubocop", status: "completed", conclusion: "success",
             html_url: "https://github.com/owner/repo/runs/2",
-            details_url: "https://ci.example.com/jobs/2"
+            details_url: "https://ci.example.com/jobs/2",
+            output: { title: "Rubocop", summary: "Clean", text: "" }
           },
           {
             id: 3, name: "integration", status: "in_progress", conclusion: nil,
             html_url: "https://github.com/owner/repo/runs/3",
-            details_url: "https://ci.example.com/jobs/3"
+            details_url: "https://ci.example.com/jobs/3",
+            output: nil
           }
         ]
       end
@@ -759,7 +762,15 @@ RSpec.describe GithubClient do
       it "returns check run names, statuses, conclusions, and URLs" do
         result = client.check_runs_for_ref(repo, ref)
 
-        expect(result).to eq(check_runs_payload.map { |cr| cr.except(:id) })
+        expect(result.first).to include(
+          id: 1,
+          name: "rspec",
+          conclusion: "failure",
+          job_id: "1"
+        )
+        expect(result.first[:output_text]).to include("1 failure")
+        expect(result.second).to include(job_id: nil)
+        expect(result.third).to include(output_text: "")
       end
     end
 
@@ -804,6 +815,24 @@ RSpec.describe GithubClient do
         expect(result.last[:name]).to eq("check-101")
         expect(result.last[:conclusion]).to eq("failure")
       end
+    end
+  end
+
+  describe "#check_run_log" do
+    let(:repo) { "owner/repo" }
+
+    it "fetches GitHub Actions job logs for a check run details URL" do
+      stub = stub_request(:get, "#{api_base}/repos/#{repo}/actions/jobs/789/logs")
+        .to_return(status: 200, body: "Failure/Error: expected true", headers: { "Content-Type" => "text/plain" })
+
+      result = client.check_run_log(repo, details_url: "https://github.com/owner/repo/actions/runs/456/job/789")
+
+      expect(result).to eq("Failure/Error: expected true")
+      expect(stub).to have_been_requested.once
+    end
+
+    it "returns an empty string for non-Actions checks" do
+      expect(client.check_run_log(repo, details_url: "https://example.com/build/1")).to eq("")
     end
   end
 

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Prompts::BuildForPr do
     end
 
     it "omits CI failures section when no checks are failing" do
-      expect(prompt).not_to include("CI Failures")
+      expect(prompt).not_to include("CI Status: FAILING")
     end
 
     it "omits code review section when no unresolved threads" do
@@ -229,10 +229,16 @@ RSpec.describe Prompts::BuildForPr do
       allow(github_client).to receive(:check_runs_for_ref)
         .with(project.full_name, "abc123")
         .and_return([
-          { name: "rspec", conclusion: "failure" },
-          { name: "rubocop", conclusion: "success" },
-          { name: "build", conclusion: "cancelled" }
+          { id: 1, name: "rspec", conclusion: "failure", output_text: "role \"root\" does not exist" },
+          { id: 2, name: "rubocop", conclusion: "success", output_text: "ok" },
+          { id: 3, name: "build", conclusion: "cancelled", output_text: "" }
         ])
+      allow(github_client).to receive(:check_run_log)
+        .with(project.full_name, { id: 1, name: "rspec", conclusion: "failure", output_text: "role \"root\" does not exist" })
+        .and_return("")
+      allow(github_client).to receive(:check_run_log)
+        .with(project.full_name, { id: 3, name: "build", conclusion: "cancelled", output_text: "" })
+        .and_return("database \"railscrawler_test\" does not exist")
     end
 
     it "includes failing check names" do
@@ -243,10 +249,46 @@ RSpec.describe Prompts::BuildForPr do
         rebase_succeeded: true
       )
 
-      expect(prompt).to include("CI Failures")
+      expect(prompt).to include("CI Status: FAILING")
       expect(prompt).to include("rspec (failure)")
       expect(prompt).to include("build (cancelled)")
       expect(prompt).not_to include("rubocop (success)")
+    end
+
+    it "includes pre-processed failure output" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include("Error output (pre-processed)")
+      expect(prompt).to include("role \"root\" does not exist")
+      expect(prompt).to include("database \"railscrawler_test\" does not exist")
+      expect(prompt).to include("Fix the issue causing these CI failures")
+    end
+  end
+
+  describe "pending CI checks" do
+    before do
+      allow(github_client).to receive(:check_runs_for_ref)
+        .with(project.full_name, "abc123")
+        .and_return([
+          { name: "rspec", conclusion: nil }
+        ])
+    end
+
+    it "does not present pending checks as failures" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).not_to include("CI Status: FAILING")
+      expect(prompt).not_to include("Fix CI failures")
     end
   end
 
@@ -664,9 +706,10 @@ RSpec.describe Prompts::BuildForPr do
   describe "priority ordering" do
     it "orders priorities correctly with all sections present" do
       allow(github_client).to receive_messages(
-        check_runs_for_ref: [ { name: "ci", conclusion: "failure" } ],
+        check_runs_for_ref: [ { name: "ci", conclusion: "failure", output_text: "failed" } ],
         review_threads: [ { id: "t1", is_resolved: false, comments: [ { body: "fix", path: "a.rb", line: 1, author: "r" } ] } ]
       )
+      allow(github_client).to receive(:check_run_log).and_return("")
       allow(github_client).to receive(:recent_issue_comments)
         .with(project.full_name, 42, pages: 1)
         .and_return([ OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "comment") ])
@@ -699,7 +742,7 @@ RSpec.describe Prompts::BuildForPr do
         rebase_succeeded: true
       )
 
-      expect(prompt).not_to include("CI Failures")
+      expect(prompt).not_to include("CI Status: FAILING")
     end
 
     it "omits review section when review_threads raises" do


### PR DESCRIPTION
## Summary

feat(agent-runs): include pre-processed CI failure context in agent prompts

See #1390 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1390