### PR TITLE
fix(agent-runs): prevent circuit-breaker poisoning from StaleRunDetectorJob timeouts

### DIFF
--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -261,7 +261,12 @@ class StaleRunDetectorJob < ApplicationJob
 
       old_resources = captured_resources(agent_run)
 
-      agent_run.timeout!(error: "#{AgentRun::STALE_DETECTOR_ERROR_PREFIX}: stuck in '#{agent_run.status}' beyond timeout threshold")
+      agent_run.update!(
+        status: "timeout",
+        completed_at: Time.current,
+        error_message: "#{AgentRun::STALE_DETECTOR_ERROR_PREFIX}: stuck in '#{agent_run.status}' beyond timeout threshold",
+        duration_seconds: agent_run.duration
+      )
       agent_run.log!("system", "Run marked as timed out by stale run detector")
 
       if (issue = agent_run.issue)

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -261,7 +261,7 @@ class StaleRunDetectorJob < ApplicationJob
 
       old_resources = captured_resources(agent_run)
 
-      agent_run.timeout!(error: "Stale run detected: stuck in '#{agent_run.status}' beyond timeout threshold")
+      agent_run.timeout!(error: "#{AgentRun::STALE_DETECTOR_ERROR_PREFIX}: stuck in '#{agent_run.status}' beyond timeout threshold")
       agent_run.log!("system", "Run marked as timed out by stale run detector")
 
       if (issue = agent_run.issue)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -72,6 +72,8 @@ class AgentRun < ApplicationRecord
   # circuit-breaker counters on its behalf.
   STALE_CLEANUP_ERROR_PREFIX = "Marked stale on startup"
 
+  STALE_DETECTOR_ERROR_PREFIX = "Stale run detected"
+
   belongs_to :project
   belongs_to :issue, optional: true
   belongs_to :prompt_version, optional: true
@@ -947,13 +949,14 @@ class AgentRun < ApplicationRecord
     )
   end
 
-  # True when this run was force-timed-out by `dev:cleanup` (typically because
-  # `bin/setup --skip-server` is restarting the host process and stopping the
-  # run's container out from under the in-flight Temporal activity). Used by
-  # RunAgentActivity to suppress provider circuit-breaker bookkeeping for
-  # failures that the cleanup itself induced.
+  # True when this run was force-timed-out externally (by `dev:cleanup` or
+  # `StaleRunDetectorJob`), not by the provider itself. The in-flight Temporal
+  # activity uses this to suppress provider circuit-breaker bookkeeping for
+  # failures that the external cleanup induced, not the provider.
   def cancelled_by_cleanup?
-    status == "timeout" && error_message.to_s.start_with?(STALE_CLEANUP_ERROR_PREFIX)
+    return false unless status == "timeout"
+
+    error_message.to_s.start_with?(STALE_CLEANUP_ERROR_PREFIX, STALE_DETECTOR_ERROR_PREFIX)
   end
 
   def retried?

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -941,12 +941,19 @@ class AgentRun < ApplicationRecord
   end
 
   def timeout!(error: nil)
-    update!(
-      status: "timeout",
-      completed_at: Time.current,
-      error_message: error,
-      duration_seconds: duration
-    )
+    with_lock do
+      reload
+      if finished?
+        false
+      else
+        update!(
+          status: "timeout",
+          completed_at: Time.current,
+          error_message: error,
+          duration_seconds: duration
+        )
+      end
+    end
   end
 
   # True when this run was force-timed-out externally (by `dev:cleanup` or

--- a/app/services/agent_runs/cleanup_stale.rb
+++ b/app/services/agent_runs/cleanup_stale.rb
@@ -84,7 +84,8 @@ module AgentRuns
     end
 
     def resolve_stale_running(agent_run)
-      agent_run.timeout!(error: "Manual stale run cleanup: exceeded running timeout")
+      return false unless agent_run.timeout!(error: "Manual stale run cleanup: exceeded running timeout")
+
       agent_run.log!("system", "Run marked as timed out by manual stale run cleanup")
       update_issue_state(agent_run)
       true
@@ -92,7 +93,8 @@ module AgentRuns
 
     def resolve_stale_pending(agent_run)
       if agent_run.stale_requeue_count >= AgentRun::MAX_STALE_REQUEUES
-        agent_run.timeout!(error: "Manual stale run cleanup: exceeded pending requeue limit")
+        return false unless agent_run.timeout!(error: "Manual stale run cleanup: exceeded pending requeue limit")
+
         agent_run.log!("system", "Stale pending run marked as timed out by manual stale run cleanup")
         update_issue_state(agent_run)
         should_cleanup_resources = true

--- a/app/services/agent_runs/execute.rb
+++ b/app/services/agent_runs/execute.rb
@@ -150,7 +150,8 @@ module AgentRuns
 
     def handle_timeout(error)
       effective_timeout = timeout || AgentHarness.configuration.default_timeout
-      agent_run.timeout!
+      return Result.new(success: false, error: error) unless agent_run.timeout!
+
       agent_run.update!(error_message: "Agent execution timed out after #{effective_timeout} seconds")
       agent_run.log!("system", "Execution timed out")
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -356,11 +356,11 @@ module Activities
         # because it indicates an actual execution attempt that should trigger
         # ProcessRunQueueJob to re-schedule work.
         if timeout_error.present?
-          agent_run.timeout!(error: timeout_error) unless agent_run.finished?
+          timed_out = !agent_run.finished? && agent_run.timeout!(error: timeout_error)
           # Skip queue processing when cleanup killed the run — the timeout
           # was not a real provider issue, so there is nothing to re-schedule.
           # (agent_run was reloaded above, so the model method sees current state)
-          ProcessRunQueueJob.perform_later unless agent_run.cancelled_by_cleanup?
+          ProcessRunQueueJob.perform_later if timed_out && !agent_run.cancelled_by_cleanup?
         elsif !agent_run.finished? && (last_error == "rate_limited" || all_skipped_rate_limited)
           provider_list = providers.any? ? provider_attempt_labels(providers, agent_run, user_settings.user).join(", ") : "none"
           agent_run.rate_limit!(

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -504,9 +504,9 @@ module Activities
     end
 
     # True when the agent run we're executing has already been force-timed-out
-    # by `dev:cleanup` (e.g. `bin/setup --skip-server` killed our container).
-    # In that case the failure we just rescued was caused by the cleanup, not
-    # by the provider, so we must not penalize the provider's circuit breaker.
+    # by external cleanup (e.g. `dev:cleanup` or `StaleRunDetectorJob` killed
+    # our container). In that case the failure we just rescued was caused by
+    # cleanup, not by the provider, so we must not penalize the circuit breaker.
     def cancelled_by_cleanup?(agent_run)
       agent_run.reload
       agent_run.cancelled_by_cleanup?
@@ -514,7 +514,7 @@ module Activities
       false
     end
 
-    # Mirror of the failed-attempt bookkeeping for the cleanup-cancelled case:
+    # Mirror of the failed-attempt bookkeeping for externally-cancelled runs:
     # records the attempt with a distinct error_type so the UI can show what
     # happened, but skips both record_provider_failure and the standard warn
     # log (which would imply a real provider problem).

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe StaleRunDetectorJob do
 
       stale_run.reload
       expect(stale_run.status).to eq("timeout")
-      expect(stale_run.error_message).to include("Stale run detected")
+      expect(stale_run.error_message).to start_with(AgentRun::STALE_DETECTOR_ERROR_PREFIX)
       expect(stale_run.completed_at).to be_present
     end
 
@@ -171,7 +171,7 @@ RSpec.describe StaleRunDetectorJob do
 
         stale_run.reload
         expect(stale_run.status).to eq("timeout")
-        expect(stale_run.error_message).to include("Stale run detected")
+        expect(stale_run.error_message).to start_with(AgentRun::STALE_DETECTOR_ERROR_PREFIX)
       end
 
       it "does not touch pending runs within the threshold" do
@@ -403,7 +403,7 @@ RSpec.describe StaleRunDetectorJob do
 
         stale_run.reload
         expect(stale_run.status).to eq("timeout")
-        expect(stale_run.error_message).to include("Stale run detected")
+        expect(stale_run.error_message).to start_with(AgentRun::STALE_DETECTOR_ERROR_PREFIX)
       end
 
       it "times out a stale time-limit paused run with zero iterations" do
@@ -418,7 +418,7 @@ RSpec.describe StaleRunDetectorJob do
         stale_run.reload
         expect(stale_run.status).to eq("timeout")
         expect(stale_run.stale_requeue_count).to eq(0)
-        expect(stale_run.error_message).to include("Stale run detected")
+        expect(stale_run.error_message).to start_with(AgentRun::STALE_DETECTOR_ERROR_PREFIX)
       end
 
       it "requeues a stale time-limit paused run that made progress" do

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -892,6 +892,22 @@ RSpec.describe AgentRun do
           expect(agent_run.duration_seconds).to eq((Time.current - started_time).to_i)
         end
       end
+
+      it "does not overwrite a finished run", :aggregate_failures do
+        completed_at = 10.minutes.ago
+        agent_run = create(:agent_run, :completed,
+          completed_at: completed_at,
+          duration_seconds: 25,
+          error_message: nil)
+
+        expect(agent_run.timeout!(error: "Stale run detected")).to be false
+
+        agent_run.reload
+        expect(agent_run.status).to eq("completed")
+        expect(agent_run.completed_at).to be_within(1.second).of(completed_at)
+        expect(agent_run.duration_seconds).to eq(25)
+        expect(agent_run.error_message).to be_nil
+      end
     end
 
     describe "#retry!" do

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -562,14 +562,21 @@ RSpec.describe AgentRun do
     end
 
     describe "#cancelled_by_cleanup?" do
-      it "returns true when status is timeout and error_message starts with the sentinel prefix" do
+      it "returns true when status is timeout and error_message starts with the dev:cleanup sentinel prefix" do
         agent_run = build(:agent_run, status: "timeout",
           error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted")
 
         expect(agent_run.cancelled_by_cleanup?).to be true
       end
 
-      it "returns false when error_message lacks the sentinel prefix" do
+      it "returns true when status is timeout and error_message starts with the stale detector prefix" do
+        agent_run = build(:agent_run, status: "timeout",
+          error_message: "#{AgentRun::STALE_DETECTOR_ERROR_PREFIX}: stuck in 'running' beyond timeout threshold")
+
+        expect(agent_run.cancelled_by_cleanup?).to be true
+      end
+
+      it "returns false when error_message lacks both sentinel prefixes" do
         agent_run = build(:agent_run, status: "timeout", error_message: "Provider timed out")
 
         expect(agent_run.cancelled_by_cleanup?).to be false

--- a/spec/services/agent_runs/cleanup_stale_spec.rb
+++ b/spec/services/agent_runs/cleanup_stale_spec.rb
@@ -15,6 +15,27 @@ RSpec.describe AgentRuns::CleanupStale do
       expect(stale_run.error_message).to eq("Manual stale run cleanup: exceeded running timeout")
     end
 
+    it "does not run timeout side effects when a stale running run was already finished" do
+      stale_run = create(:agent_run, :running, project: project, started_at: AgentRun.stale_running_cutoff - 1.minute)
+      stale_run.issue.update!(paid_state: "in_progress")
+
+      allow(stale_run).to receive(:timeout!) do
+        stale_run.update!(
+          status: "timeout",
+          completed_at: Time.current,
+          error_message: "#{AgentRun::STALE_DETECTOR_ERROR_PREFIX}: stuck in 'running' beyond timeout threshold"
+        )
+        false
+      end
+      relation = instance_double(ActiveRecord::Relation)
+      allow(project.agent_runs).to receive(:stale_for_cleanup).and_return(relation)
+      allow(relation).to receive(:find_each).and_yield(stale_run)
+
+      expect(described_class.call(project: project)).to eq(0)
+      expect(stale_run.issue.reload.paid_state).to eq("in_progress")
+      expect(stale_run.agent_run_logs.pluck(:content)).not_to include("Run marked as timed out by manual stale run cleanup")
+    end
+
     it "requeues stale pending runs for the project" do
       stale_run = create(:agent_run, status: "pending", project: project)
       stale_run.update_column(:updated_at, AgentRun.stale_pending_cutoff - 1.minute)
@@ -36,6 +57,28 @@ RSpec.describe AgentRuns::CleanupStale do
 
       expect(stale_run.reload.status).to eq("timeout")
       expect(stale_run.error_message).to eq("Manual stale run cleanup: exceeded pending requeue limit")
+    end
+
+    it "does not run timeout side effects when a stale pending run was already finished" do
+      stale_run = create(:agent_run, status: "pending", project: project, stale_requeue_count: AgentRun::MAX_STALE_REQUEUES)
+      stale_run.issue.update!(paid_state: "in_progress")
+      stale_run.update_column(:updated_at, AgentRun.stale_pending_cutoff - 1.minute)
+
+      allow(stale_run).to receive(:timeout!) do
+        stale_run.update!(
+          status: "timeout",
+          completed_at: Time.current,
+          error_message: "#{AgentRun::STALE_DETECTOR_ERROR_PREFIX}: stuck in 'pending' beyond timeout threshold"
+        )
+        false
+      end
+      relation = instance_double(ActiveRecord::Relation)
+      allow(project.agent_runs).to receive(:stale_for_cleanup).and_return(relation)
+      allow(relation).to receive(:find_each).and_yield(stale_run)
+
+      expect(described_class.call(project: project)).to eq(0)
+      expect(stale_run.issue.reload.paid_state).to eq("in_progress")
+      expect(stale_run.agent_run_logs.pluck(:content)).not_to include("Stale pending run marked as timed out by manual stale run cleanup")
     end
 
     it "leaves fresh or non-stale runs untouched" do

--- a/spec/services/agent_runs/execute_spec.rb
+++ b/spec/services/agent_runs/execute_spec.rb
@@ -247,6 +247,23 @@ RSpec.describe AgentRuns::Execute do
         system_logs = agent_run.agent_run_logs.where(log_type: "system")
         expect(system_logs.pluck(:content)).to include("Execution timed out")
       end
+
+      it "does not overwrite a cleanup timeout when another process finished the run first" do
+        sentinel = "#{AgentRun::STALE_DETECTOR_ERROR_PREFIX}: stuck in 'running' beyond timeout threshold"
+        allow(AgentHarness).to receive(:send_message) do
+          agent_run.update!(
+            status: "timeout",
+            completed_at: Time.current,
+            error_message: sentinel
+          )
+          raise AgentHarness::TimeoutError, "Timed out after 600s"
+        end
+
+        described_class.call(agent_run: agent_run, prompt: prompt)
+
+        expect(agent_run.reload.error_message).to eq(sentinel)
+        expect(agent_run.agent_run_logs.pluck(:content)).not_to include("Execution timed out")
+      end
     end
 
     context "when agent times out with nil timeout" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1118,13 +1118,13 @@ RSpec.describe Activities::RunAgentActivity do
       end
     end
 
-    shared_examples "externally cancelled run" do |prefix:, error_message:|
+    shared_examples "externally cancelled run" do |params|
       before do
         allow(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")
         allow(container_service).to receive(:execute) do
           AgentRun.where(id: agent_run.id).update_all(
             status: "timeout",
-            error_message: error_message,
+            error_message: params.fetch(:error_message),
             completed_at: Time.current
           )
           exec_failure
@@ -1134,20 +1134,18 @@ RSpec.describe Activities::RunAgentActivity do
       it "does not increment the provider circuit-breaker failure_count" do
         state = user.provider_states.create!(provider_name: "claude", failure_count: 0, circuit_state: "closed")
 
-        begin
+        expect {
           activity.execute(agent_run_id: agent_run.id)
-        rescue Temporalio::Error::ApplicationError
-        end
+        }.to raise_error(Temporalio::Error::ApplicationError)
 
         expect(state.reload.failure_count).to eq(0)
         expect(state.circuit_state).to eq("closed")
       end
 
       it "records the provider attempt as cancelled_by_cleanup" do
-        begin
+        expect {
           activity.execute(agent_run_id: agent_run.id)
-        rescue Temporalio::Error::ApplicationError
-        end
+        }.to raise_error(Temporalio::Error::ApplicationError)
 
         attempts = agent_run.reload.providers_attempted
         expect(attempts.last["error_type"]).to eq("cancelled_by_cleanup")
@@ -1155,23 +1153,21 @@ RSpec.describe Activities::RunAgentActivity do
       end
 
       it "preserves the cleanup error_message and timeout status on the run" do
-        begin
+        expect {
           activity.execute(agent_run_id: agent_run.id)
-        rescue Temporalio::Error::ApplicationError
-        end
+        }.to raise_error(Temporalio::Error::ApplicationError)
 
         agent_run.reload
         expect(agent_run.status).to eq("timeout")
-        expect(agent_run.error_message).to start_with(prefix)
+        expect(agent_run.error_message).to start_with(params.fetch(:prefix))
       end
 
       it "stops iterating providers instead of attempting fallbacks" do
         user.settings.update!(fallback_enabled: true)
 
-        begin
+        expect {
           activity.execute(agent_run_id: agent_run.id)
-        rescue Temporalio::Error::ApplicationError
-        end
+        }.to raise_error(Temporalio::Error::ApplicationError)
 
         expect(agent_run.reload.providers_attempted.size).to eq(1)
       end
@@ -1179,10 +1175,9 @@ RSpec.describe Activities::RunAgentActivity do
       it "does not enqueue ProcessRunQueueJob" do
         expect(ProcessRunQueueJob).not_to receive(:perform_later)
 
-        begin
+        expect {
           activity.execute(agent_run_id: agent_run.id)
-        rescue Temporalio::Error::ApplicationError
-        end
+        }.to raise_error(Temporalio::Error::ApplicationError)
       end
     end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -750,6 +750,19 @@ RSpec.describe Activities::RunAgentActivity do
     wrapped
   end
 
+  def stub_reconnect_not_found_on_second_attempt
+    attempts = 0
+    allow(Containers::Provision).to receive(:reconnect) do
+      attempts += 1
+      if attempts == 2
+        raise wrap_error(
+          Containers::Provision::ProvisionError.new("Container #{agent_run.container_id} not found")
+        )
+      end
+      container_service
+    end
+  end
+
   describe "#execute" do
     context "when agent succeeds in container" do
       before do
@@ -874,9 +887,11 @@ RSpec.describe Activities::RunAgentActivity do
         allow(activity).to receive(:sleep)
         allow(git_ops).to receive(:commit_uncommitted_changes) do
           commit_attempts += 1
-          raise wrap_error(
-            Containers::Provision::ExecutionError.new("Docker exec error: Connection reset")
-          ) if commit_attempts == 1
+          if commit_attempts == 1
+            raise wrap_error(
+              Containers::Provision::ExecutionError.new("Docker exec error: Connection reset")
+            )
+          end
 
           true
         end
@@ -990,9 +1005,11 @@ RSpec.describe Activities::RunAgentActivity do
         allow(activity).to receive(:sleep)
         allow(Containers::Provision).to receive(:reconnect) do
           attempts += 1
-          raise wrap_error(
-            Containers::Provision::ProvisionError.new("Failed to reconnect to container: connection reset")
-          ) if attempts == 2
+          if attempts == 2
+            raise wrap_error(
+              Containers::Provision::ProvisionError.new("Failed to reconnect to container: connection reset")
+            )
+          end
 
           container_service
         end
@@ -1007,26 +1024,19 @@ RSpec.describe Activities::RunAgentActivity do
 
       it "does not retry permanent container-not-found reconnect failures" do
         allow(activity).to receive(:sleep)
-        attempts = 0
-        allow(Containers::Provision).to receive(:reconnect) do
-          attempts += 1
-          raise wrap_error(
-            Containers::Provision::ProvisionError.new("Container #{agent_run.container_id} not found")
-          ) if attempts == 2
-
-          container_service
-        end
+        stub_reconnect_not_found_on_second_attempt
 
         expect {
           activity.execute(agent_run_id: agent_run.id)
         }.to raise_error(Temporalio::Error::ApplicationError) { |error|
-          expect(error.type).to eq("PostRunBookkeepingFailed")
-          expect(error.non_retryable).to be(true)
-          expect(error.message).to include("Post-run commit_uncommitted_changes failed after 1 attempts")
-          expect(error.message).to include("Containers::Provision::ProvisionError")
-          expect(error.message).to include("not found")
+          aggregate_failures do
+            expect(error.type).to eq("PostRunBookkeepingFailed")
+            expect(error.non_retryable).to be(true)
+            expect(error.message).to include("Post-run commit_uncommitted_changes failed after 1 attempts")
+            expect(error.message).to include("Containers::Provision::ProvisionError")
+            expect(error.message).to include("not found")
+          end
         }
-
         expect(activity).not_to have_received(:sleep)
         expect(Containers::Provision).to have_received(:reconnect).twice
       end
@@ -1108,19 +1118,13 @@ RSpec.describe Activities::RunAgentActivity do
       end
     end
 
-    context "when the run is cancelled by dev:cleanup mid-execution" do
+    shared_examples "externally cancelled run" do |prefix:, error_message:|
       before do
         allow(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")
-        # Simulate dev:cleanup force-timing-out the run from a *different*
-        # process while the container call is in flight. We mutate via
-        # `update_columns` so the in-memory `agent_run` instance held by the
-        # activity stays stale — only the `reload` inside `cancelled_by_cleanup?`
-        # will surface the cleanup mark, which is what happens in production
-        # where the rake task and the Temporal worker are separate processes.
         allow(container_service).to receive(:execute) do
           AgentRun.where(id: agent_run.id).update_all(
             status: "timeout",
-            error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted",
+            error_message: error_message,
             completed_at: Time.current
           )
           exec_failure
@@ -1133,8 +1137,6 @@ RSpec.describe Activities::RunAgentActivity do
         begin
           activity.execute(agent_run_id: agent_run.id)
         rescue Temporalio::Error::ApplicationError
-          # Expected: AllProvidersExhausted is still raised (the run is dead),
-          # but the breaker must remain untouched.
         end
 
         expect(state.reload.failure_count).to eq(0)
@@ -1145,7 +1147,6 @@ RSpec.describe Activities::RunAgentActivity do
         begin
           activity.execute(agent_run_id: agent_run.id)
         rescue Temporalio::Error::ApplicationError
-          # expected
         end
 
         attempts = agent_run.reload.providers_attempted
@@ -1157,12 +1158,11 @@ RSpec.describe Activities::RunAgentActivity do
         begin
           activity.execute(agent_run_id: agent_run.id)
         rescue Temporalio::Error::ApplicationError
-          # expected
         end
 
         agent_run.reload
         expect(agent_run.status).to eq("timeout")
-        expect(agent_run.error_message).to start_with(AgentRun::STALE_CLEANUP_ERROR_PREFIX)
+        expect(agent_run.error_message).to start_with(prefix)
       end
 
       it "stops iterating providers instead of attempting fallbacks" do
@@ -1171,11 +1171,8 @@ RSpec.describe Activities::RunAgentActivity do
         begin
           activity.execute(agent_run_id: agent_run.id)
         rescue Temporalio::Error::ApplicationError
-          # expected
         end
 
-        # Exactly one provider attempt should be recorded (the one that was
-        # mid-flight when cleanup struck) — not one per configured fallback.
         expect(agent_run.reload.providers_attempted.size).to eq(1)
       end
 
@@ -1185,9 +1182,20 @@ RSpec.describe Activities::RunAgentActivity do
         begin
           activity.execute(agent_run_id: agent_run.id)
         rescue Temporalio::Error::ApplicationError
-          # expected
         end
       end
+    end
+
+    context "when the run is cancelled by dev:cleanup mid-execution" do
+      it_behaves_like "externally cancelled run",
+        prefix: AgentRun::STALE_CLEANUP_ERROR_PREFIX,
+        error_message: "#{AgentRun::STALE_CLEANUP_ERROR_PREFIX}: process was restarted"
+    end
+
+    context "when the run is cancelled by StaleRunDetectorJob mid-execution" do
+      it_behaves_like "externally cancelled run",
+        prefix: AgentRun::STALE_DETECTOR_ERROR_PREFIX,
+        error_message: "#{AgentRun::STALE_DETECTOR_ERROR_PREFIX}: stuck in 'running' beyond timeout threshold"
     end
 
     context "when agent hits rate limit (single provider)" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1395,6 +1395,19 @@ RSpec.describe Activities::RunAgentActivity do
         }.to raise_error(Temporalio::Error::ApplicationError)
           .and have_enqueued_job(ProcessRunQueueJob)
       end
+
+      it "does not enqueue ProcessRunQueueJob when another process finished the run first" do
+        allow(container_service).to receive(:execute) do
+          agent_run.update!(status: "completed", completed_at: Time.current)
+          raise Containers::Provision::TimeoutError
+        end
+
+        expect(ProcessRunQueueJob).not_to receive(:perform_later)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError)
+      end
     end
 
     context "when agent hits startup timeout" do


### PR DESCRIPTION
## Summary

- `AgentRun#cancelled_by_cleanup?` now recognizes StaleRunDetectorJob's `"Stale run detected"` error prefix in addition to `dev:cleanup`'s `"Marked stale on startup"` prefix
- Prevents provider circuit-breaker counters from being incremented when the stale detector externally kills an in-flight Temporal activity
- Extracts integration tests into `shared_examples` covering both external cancellation paths

## Problem

When `StaleRunDetectorJob` times out a stuck run that still has an in-flight Temporal activity, the activity doesn't recognize the timeout as externally-induced. It treats the container kill as a real provider failure and:

1. Increments circuit-breaker failure counts for the provider
2. Continues iterating remaining providers (each also fails)
3. All providers get circuit-breaker hits, which can trip breakers and make subsequent runs see all providers as unavailable

## Testing

- Model specs: added test for `STALE_DETECTOR_ERROR_PREFIX` in `cancelled_by_cleanup?`
- Integration specs: refactored existing dev:cleanup tests into `shared_examples "externally cancelled run"` and added parallel StaleRunDetectorJob context (10 assertions total)

Refs #1394