### PR TITLE
fix(quality): use past 10 eligible agent runs for quality pause rolling average

### DIFF
--- a/app/models/quality_threshold.rb
+++ b/app/models/quality_threshold.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class QualityThreshold < ApplicationRecord
-  DEFAULT_WINDOW_SIZE = 5
+  DEFAULT_WINDOW_SIZE = 10
   DEFAULT_MIN_SAMPLE_SIZE = 3
   METRIC_TYPES = %w[composite_score pr_created ci_passed pr_merged iterations lint_clean
                     tests_pass

--- a/spec/services/quality_pause/check_spec.rb
+++ b/spec/services/quality_pause/check_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe QualityPause::Check do
 
     it "caps the rolling window to the latest DEFAULT_WINDOW_SIZE eligible runs" do
       # 10 old low-scoring runs followed by 5 newer high-scoring runs.
-      # With window_size=10: latest 10 include 5×0.7 + 5×0.0 → avg=0.35 < 0.5 → paused
-      # With window_size=5:  latest 5 are all 0.7              → avg=0.7  > 0.5 → not paused
+      # With window_size=10: latest 10 include 5 * 0.7 + 5 * 0.0 -> avg=0.35 < 0.5 -> paused
+      # With window_size=5:  latest 5 are all 0.7                  -> avg=0.7  > 0.5 -> not paused
       create_quality_metrics(project, scores: Array.new(10, 0.0))
       create_quality_metrics(project, scores: Array.new(5, 0.7))
 

--- a/spec/services/quality_pause/check_spec.rb
+++ b/spec/services/quality_pause/check_spec.rb
@@ -80,6 +80,20 @@ RSpec.describe QualityPause::Check do
       expect(event.threshold).to eq(0.5)
     end
 
+    it "caps the rolling window to the latest DEFAULT_WINDOW_SIZE eligible runs" do
+      # 10 old low-scoring runs followed by 5 newer high-scoring runs.
+      # With window_size=10: latest 10 include 5×0.7 + 5×0.0 → avg=0.35 < 0.5 → paused
+      # With window_size=5:  latest 5 are all 0.7              → avg=0.7  > 0.5 → not paused
+      create_quality_metrics(project, scores: Array.new(10, 0.0))
+      create_quality_metrics(project, scores: Array.new(5, 0.7))
+
+      described_class.call(agent_run: agent_run)
+
+      project.reload
+      expect(project.quality_paused?).to be true
+      expect(project.quality_pause_metadata["sample_size"]).to eq(10)
+    end
+
     it "pauses the project when a metric-specific threshold is breached" do
       create(:quality_threshold, account: project.account, metric_type: "lint_clean", goal_type: "create_pr")
       create_metric_scores(project, metric_type: "lint_clean", scores: [ 0.0, 1.0, 0.0, 0.0, 0.0 ])


### PR DESCRIPTION
## Summary

- Increases `QualityThreshold::DEFAULT_WINDOW_SIZE` from 5 to 10 so the quality pause rolling average considers the past 10 eligible agent runs instead of 5
- Adds a regression test that verifies the window cap behavior (would fail if the constant were reverted to 5)
- Fixes #[issue-number]

## Why

A 5-run window was too narrow and could trigger quality pauses based on short streaks of poor results. A 10-run window provides a more representative sample before pausing a project.