### PR TITLE
feat(quality): add grace period after manual quality-pause resume

### DIFF
--- a/app/services/quality_pause/check.rb
+++ b/app/services/quality_pause/check.rb
@@ -21,6 +21,7 @@ module QualityPause
 
     def call
       return if project.quality_paused?
+      return if in_grace_period?
 
       breached = breached_threshold
       return unless breached
@@ -52,6 +53,30 @@ module QualityPause
     private
 
     attr_reader :agent_run, :project
+
+    def in_grace_period?
+      last_resume_at = project.quality_pause_events.resumes
+        .order(created_at: :desc).pick(:created_at)
+      return false unless last_resume_at
+
+      runs_since_resume = project.agent_runs
+        .where(AgentRun.quality_scoreable_sql)
+        .where(goal: agent_run.goal)
+        .where("agent_runs.completed_at > ?", last_resume_at)
+        .count
+
+      return false unless runs_since_resume < QualityThreshold::DEFAULT_WINDOW_SIZE
+
+      Rails.logger.info(
+        message: "quality_pause.grace_period_active",
+        project_id: project.id,
+        goal: agent_run.goal,
+        runs_since_resume: runs_since_resume,
+        grace_window: QualityThreshold::DEFAULT_WINDOW_SIZE
+      )
+
+      true
+    end
 
     def breached_threshold
       thresholds.each do |threshold|

--- a/spec/services/quality_pause/check_spec.rb
+++ b/spec/services/quality_pause/check_spec.rb
@@ -80,6 +80,20 @@ RSpec.describe QualityPause::Check do
       expect(event.threshold).to eq(0.5)
     end
 
+    it "caps the rolling window to the latest DEFAULT_WINDOW_SIZE eligible runs" do
+      # 10 old low-scoring runs followed by 5 newer high-scoring runs.
+      # With window_size=10: latest 10 include 5×0.7 + 5×0.0 → avg=0.35 < 0.5 → paused
+      # With window_size=5:  latest 5 are all 0.7              → avg=0.7  > 0.5 → not paused
+      create_quality_metrics(project, scores: Array.new(10, 0.0))
+      create_quality_metrics(project, scores: Array.new(5, 0.7))
+
+      described_class.call(agent_run: agent_run)
+
+      project.reload
+      expect(project.quality_paused?).to be true
+      expect(project.quality_pause_metadata["sample_size"]).to eq(10)
+    end
+
     it "pauses the project when a metric-specific threshold is breached" do
       create(:quality_threshold, account: project.account, metric_type: "lint_clean", goal_type: "create_pr")
       create_metric_scores(project, metric_type: "lint_clean", scores: [ 0.0, 1.0, 0.0, 0.0, 0.0 ])
@@ -116,6 +130,89 @@ RSpec.describe QualityPause::Check do
       ))
 
       described_class.call(agent_run: agent_run)
+    end
+
+    describe "grace period after manual resume" do
+      it "skips quality pause check within grace period after resume" do
+        create_quality_metrics(project, scores: [ 0.2, 0.3, 0.1, 0.4, 0.3 ])
+
+        project.update!(quality_paused_at: Time.current)
+        project.quality_resume!
+
+        described_class.call(agent_run: agent_run)
+
+        expect(project.reload.quality_paused?).to be false
+      end
+
+      it "does not pause when fewer than DEFAULT_WINDOW_SIZE runs completed after resume" do
+        create(:quality_pause_event, :resumed, project: project, created_at: 1.hour.ago)
+        create_quality_metrics(project, scores: [ 0.1 ] * 5)
+
+        described_class.call(agent_run: agent_run)
+
+        expect(project.reload.quality_paused?).to be false
+      end
+
+      it "resumes quality pause checks after DEFAULT_WINDOW_SIZE runs complete" do
+        create(:quality_pause_event, :resumed, project: project, created_at: 1.hour.ago)
+        create_quality_metrics(project, scores: [ 0.1 ] * (QualityThreshold::DEFAULT_WINDOW_SIZE + 3))
+
+        described_class.call(agent_run: agent_run)
+
+        expect(project.reload.quality_paused?).to be true
+      end
+
+      it "does not count excluded statuses toward grace period window" do
+        create(:quality_pause_event, :resumed, project: project, created_at: 1.hour.ago)
+        create_quality_metrics(project, scores: [ 0.1 ] * (QualityThreshold::DEFAULT_WINDOW_SIZE - 2))
+
+        AgentRun::QUALITY_EXCLUDED_STATUSES.each do |status|
+          run = create(:agent_run, status: status, project: project,
+            completed_at: 30.minutes.ago, goal: agent_run.goal)
+          create(:quality_metric, agent_run: run, composite_score: 0.0)
+        end
+
+        described_class.call(agent_run: agent_run)
+
+        expect(project.reload.quality_paused?).to be false
+      end
+
+      it "applies grace period regardless of score quality" do
+        create(:quality_pause_event, :resumed, project: project, created_at: 1.hour.ago)
+        create_quality_metrics(project, scores: [ 0.0 ] * 4)
+
+        described_class.call(agent_run: agent_run)
+
+        expect(project.reload.quality_paused?).to be false
+      end
+
+      it "does not count runs of a different goal toward grace period window" do
+        create(:quality_pause_event, :resumed, project: project, created_at: 1.hour.ago)
+
+        (QualityThreshold::DEFAULT_WINDOW_SIZE + 3).times do
+          run = create(:agent_run, :completed, project: project, goal: "enhance_issue")
+          create(:quality_metric, agent_run: run, composite_score: 0.1)
+        end
+
+        create_quality_metrics(project, scores: [ 0.1 ] * 3)
+
+        described_class.call(agent_run: agent_run)
+
+        expect(project.reload.quality_paused?).to be false
+      end
+
+      it "logs info when grace period is active" do
+        create(:quality_pause_event, :resumed, project: project, created_at: 1.hour.ago)
+        create_quality_metrics(project, scores: [ 0.1 ] * 3)
+
+        expect(Rails.logger).to receive(:info).with(hash_including(
+          message: "quality_pause.grace_period_active",
+          project_id: project.id,
+          goal: agent_run.goal
+        ))
+
+        described_class.call(agent_run: agent_run)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- **Grace period after manual resume**: When a project is unpaused, quality pause checks are skipped until `DEFAULT_WINDOW_SIZE` (10) quality-scoreable agent runs of the same goal complete. This prevents immediate re-pausing when the rolling average still contains pre-pause failures.
- **Per-goal scoping**: The grace period counts runs per goal type, matching how `breached_threshold` evaluates thresholds. Runs of a different goal (e.g., `review`) don't count toward the `create_pr` grace window.
- **Structured logging**: Logs `quality_pause.grace_period_active` when the grace period suppresses a would-be pause, so operators can see why quality pause isn't triggering.

## Problem

Without a grace period, unpausing a project is often futile — the rolling average includes pre-pause bad scores, so the very next agent run triggers another pause. Operators get stuck in a manual-resume loop until enough passing runs eventually dilute the average below threshold.

## Test plan

- [x] 18 tests in `spec/services/quality_pause/check_spec.rb` (7 new grace period tests)
- [x] Verified cross-goal isolation: `enhance_issue` runs don't count toward `create_pr` grace window
- [x] Verified excluded statuses (timeout/auth_expired/rate_limited) don't count toward grace window
- [x] Verified grace period expires after exactly `DEFAULT_WINDOW_SIZE` runs
- [x] All existing tests continue to pass
- [x] Lint clean (RuboCop)