### PR TITLE
fix(agent-runs): record harness token usage from containers

### DIFF
--- a/app/services/agent_runs/execute.rb
+++ b/app/services/agent_runs/execute.rb
@@ -96,48 +96,7 @@ module AgentRuns
     # - Proxy records exist: run_delta = run_summary - proxy totals (clamped >= 0)
     # - Proxy fully covers run_summary: no run_delta record created
     def track_tokens(response)
-      return unless response.tokens
-
-      run_input = response.input_tokens || 0
-      run_output = response.output_tokens || 0
-
-      # Record full run_summary for auditing (never updates aggregates)
-      TokenUsageTracker.track(
-        agent_run: agent_run,
-        usage: {
-          tokens_input: run_input,
-          tokens_output: run_output,
-          llm_model: response.model,
-          request_type: "run_summary"
-        },
-        update_aggregates: false
-      )
-
-      # Compute delta: what the proxy didn't already track.
-      # Excludes run_summary (audit-only) and run_delta (prior delta records
-      # from retries) so only per-request proxy records are counted.
-      proxy_totals = agent_run.token_usages
-        .where.not(request_type: %w[run_summary run_delta])
-        .pick(Arel.sql("COALESCE(SUM(input_tokens), 0)"), Arel.sql("COALESCE(SUM(output_tokens), 0)"))
-      proxy_input, proxy_output = proxy_totals || [ 0, 0 ]
-
-      delta_input = [ run_input - proxy_input, 0 ].max
-      delta_output = [ run_output - proxy_output, 0 ].max
-
-      return unless (delta_input + delta_output).positive?
-
-      # Persist the delta as a billable TokenUsage record so downstream
-      # aggregation (TokenUsage.billable, TokenUsages::Aggregate) includes
-      # the portion not covered by per-request proxy tracking.
-      TokenUsageTracker.track(
-        agent_run: agent_run,
-        usage: {
-          tokens_input: delta_input,
-          tokens_output: delta_output,
-          llm_model: response.model,
-          request_type: "run_delta"
-        }
-      )
+      AgentRuns::TrackHarnessTokens.call(agent_run: agent_run, response: response)
     end
 
     def handle_auth_error(error)

--- a/app/services/agent_runs/track_harness_tokens.rb
+++ b/app/services/agent_runs/track_harness_tokens.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module AgentRuns
+  class TrackHarnessTokens
+    def initialize(agent_run:, response:, proxy_scope: nil)
+      @agent_run = agent_run
+      @response = response
+      @proxy_scope = proxy_scope
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      return unless response.respond_to?(:tokens) && response.tokens
+
+      track_run_summary
+      track_billable_delta
+    end
+
+    private
+
+    attr_reader :agent_run, :response, :proxy_scope
+
+    def track_run_summary
+      TokenUsageTracker.track(
+        agent_run: agent_run,
+        usage: usage_payload(run_input, run_output, "run_summary"),
+        update_aggregates: false
+      )
+    end
+
+    def track_billable_delta
+      delta_input = [ run_input - proxy_input, 0 ].max
+      delta_output = [ run_output - proxy_output, 0 ].max
+      return unless (delta_input + delta_output).positive?
+
+      TokenUsageTracker.track(
+        agent_run: agent_run,
+        usage: usage_payload(delta_input, delta_output, "run_delta"),
+        enforce_guardrails: false
+      )
+    end
+
+    def proxy_totals
+      @proxy_totals ||= effective_proxy_scope
+        .where.not(request_type: %w[run_summary run_delta])
+        .pick(Arel.sql("COALESCE(SUM(input_tokens), 0)"), Arel.sql("COALESCE(SUM(output_tokens), 0)")) || [ 0, 0 ]
+    end
+
+    def effective_proxy_scope
+      proxy_scope || agent_run.token_usages
+    end
+
+    def proxy_input
+      proxy_totals.first
+    end
+
+    def proxy_output
+      proxy_totals.second
+    end
+
+    def usage_payload(tokens_input, tokens_output, request_type)
+      {
+        tokens_input: tokens_input,
+        tokens_output: tokens_output,
+        llm_model: response.model,
+        request_type: request_type
+      }
+    end
+
+    def run_input
+      @run_input ||= response.input_tokens || 0
+    end
+
+    def run_output
+      @run_output ||= response.output_tokens || 0
+    end
+  end
+end

--- a/app/services/token_usage_tracker.rb
+++ b/app/services/token_usage_tracker.rb
@@ -13,7 +13,10 @@ class TokenUsageTracker
   # @param update_aggregates [Boolean] when false, only creates a TokenUsage record without
   #   updating agent_run/project counters or cost budgets (use for run_summary records
   #   that would otherwise double-count per-request tracking from the secrets proxy)
-  def self.track(agent_run: nil, knowledge_run: nil, usage:, update_aggregates: true)
+  # @param enforce_guardrails [Boolean] when false, updates aggregates without
+  #   applying in-flight token/cost hard-stop behavior. Use for end-of-run
+  #   summary reconciliation after the provider process has already exited.
+  def self.track(agent_run: nil, knowledge_run: nil, usage:, update_aggregates: true, enforce_guardrails: true)
     tracked_run = resolve_tracked_run!(agent_run:, knowledge_run:)
     tokens_input  = usage.fetch(:tokens_input, 0).to_i
     tokens_output = usage.fetch(:tokens_output, 0).to_i
@@ -21,7 +24,7 @@ class TokenUsageTracker
     request_type  = usage.fetch(:request_type, nil).presence || default_request_type_for(tracked_run)
     metadata      = usage.fetch(:metadata, nil).presence || {}
     cost_cents    = calculate_cost(tokens_input, tokens_output, llm_model: llm_model)
-    resolved_hard_limit = tracked_run.effective_max_tokens_per_run if update_aggregates
+    resolved_hard_limit = tracked_run.effective_max_tokens_per_run if update_aggregates && enforce_guardrails
 
     ActiveRecord::Base.transaction do
       record_per_request_usage(
@@ -38,7 +41,7 @@ class TokenUsageTracker
       if update_aggregates
         tracked_run.with_lock do
           update_run_aggregates(tracked_run, tokens_input:, tokens_output:, cost_cents:)
-          apply_token_limit_status(tracked_run, hard_limit: resolved_hard_limit)
+          apply_token_limit_status(tracked_run, hard_limit: resolved_hard_limit) if enforce_guardrails
           tracked_run.save!
         end
 
@@ -57,7 +60,7 @@ class TokenUsageTracker
     # 1. Row locks from the usage write are already released
     # 2. External side-effects (Temporal cancel, container cleanup) don't
     #    run inside a transaction — a failure won't roll back recorded usage
-    enforce_hard_stop_budgets(tracked_run) if update_aggregates && cost_cents.positive? && agent_run.present?
+    enforce_hard_stop_budgets(tracked_run) if enforce_guardrails && update_aggregates && cost_cents.positive? && agent_run.present?
   end
 
   # Evaluates the agent run's cumulative token usage against project limits

--- a/app/services/token_usage_tracker.rb
+++ b/app/services/token_usage_tracker.rb
@@ -24,7 +24,7 @@ class TokenUsageTracker
     request_type  = usage.fetch(:request_type, nil).presence || default_request_type_for(tracked_run)
     metadata      = usage.fetch(:metadata, nil).presence || {}
     cost_cents    = calculate_cost(tokens_input, tokens_output, llm_model: llm_model)
-    resolved_hard_limit = tracked_run.effective_max_tokens_per_run if update_aggregates && enforce_guardrails
+    resolved_hard_limit = tracked_run.effective_max_tokens_per_run if update_aggregates
 
     ActiveRecord::Base.transaction do
       record_per_request_usage(
@@ -41,7 +41,7 @@ class TokenUsageTracker
       if update_aggregates
         tracked_run.with_lock do
           update_run_aggregates(tracked_run, tokens_input:, tokens_output:, cost_cents:)
-          apply_token_limit_status(tracked_run, hard_limit: resolved_hard_limit) if enforce_guardrails
+          apply_token_limit_status(tracked_run, hard_limit: resolved_hard_limit)
           tracked_run.save!
         end
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -908,10 +908,24 @@ module Activities
         exit_code: result[:exit_code],
         duration: harness_duration(execution_started_at)
       )
-      parse_options = { duration: command_result.duration }
-      parse_options[:json_output_requested] = true if harness_provider.is_a?(AgentHarness::Providers::GithubCopilot)
-      response = harness_provider.send(:parse_response, command_result, **parse_options)
+      response = parse_provider_output(harness_provider, command_result)
       apply_runtime_model(response, provider_candidate, user)
+    end
+
+    # Calls the provider's protected parse_response to convert raw container
+    # output into an AgentHarness::Response. This uses send() because
+    # agent-harness only exposes parsing through send_message (which executes
+    # the CLI), but container runs have already executed externally.
+    # TODO: replace with a public parse_container_output method in the
+    # agent-harness provider interface (upstream).
+    def parse_provider_output(provider, command_result)
+      parse_options = { duration: command_result.duration }
+      # Detect json_output_requested support from the method signature
+      # rather than checking for a specific provider class.
+      if provider.method(:parse_response).parameters.any? { |_, name| name == :json_output_requested }
+        parse_options[:json_output_requested] = true
+      end
+      provider.send(:parse_response, command_result, **parse_options)
     end
 
     def harness_response_provider(provider_candidate, provider_key, user)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -872,19 +872,24 @@ module Activities
     end
 
     def track_harness_tokens(agent_run, provider_candidate, provider_key, user, result, execution_started_at)
-      response = parse_harness_response(provider_candidate, provider_key, user, result, execution_started_at)
+      response =
+        begin
+          parse_harness_response(provider_candidate, provider_key, user, result, execution_started_at)
+        rescue => e
+          logger.warn(
+            message: "agent_execution.token_usage_parse_failed",
+            agent_run_id: agent_run.id,
+            provider: provider_key.to_s,
+            error_class: e.class.name,
+            error: e.message
+          )
+          return
+        end
+
       AgentRuns::TrackHarnessTokens.call(
         agent_run: agent_run,
         response: response,
         proxy_scope: token_usage_scope_for_attempt(agent_run, execution_started_at)
-      )
-    rescue => e
-      logger.warn(
-        message: "agent_execution.token_usage_parse_failed",
-        agent_run_id: agent_run.id,
-        provider: provider_key.to_s,
-        error_class: e.class.name,
-        error: e.message
       )
     end
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -675,6 +675,7 @@ module Activities
         end
 
         output_present = stdout.present? || stderr.present?
+        track_harness_tokens(agent_run, provider_candidate, provider, user_settings.user, result, execution_started_at)
         agent_run.log!("system", "Agent execution succeeded with #{provider}")
         return {
           pre_agent_sha: pre_agent_sha,
@@ -868,6 +869,84 @@ module Activities
       app_provider_key = ProviderSupport.provider_key_for_agent_type(provider_key)
       harness_key = ProviderSupport.harness_provider_key_for(app_provider_key).to_sym
       AgentHarness.provider(harness_key)
+    end
+
+    def track_harness_tokens(agent_run, provider_candidate, provider_key, user, result, execution_started_at)
+      response = parse_harness_response(provider_candidate, provider_key, user, result, execution_started_at)
+      AgentRuns::TrackHarnessTokens.call(
+        agent_run: agent_run,
+        response: response,
+        proxy_scope: token_usage_scope_for_attempt(agent_run, execution_started_at)
+      )
+    rescue => e
+      logger.warn(
+        message: "agent_execution.token_usage_parse_failed",
+        agent_run_id: agent_run.id,
+        provider: provider_key.to_s,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+
+    def token_usage_scope_for_attempt(agent_run, execution_started_at)
+      scope = agent_run.token_usages
+      return scope unless execution_started_at
+
+      scope.where("created_at >= ?", execution_started_at)
+    end
+
+    def parse_harness_response(provider_candidate, provider_key, user, result, execution_started_at)
+      harness_provider = harness_response_provider(provider_candidate, provider_key, user)
+      command_result = AgentHarness::CommandExecutor::Result.new(
+        stdout: result[:stdout],
+        stderr: result[:stderr],
+        exit_code: result[:exit_code],
+        duration: harness_duration(execution_started_at)
+      )
+      parse_options = { duration: command_result.duration }
+      parse_options[:json_output_requested] = true if harness_provider.is_a?(AgentHarness::Providers::GithubCopilot)
+      response = harness_provider.send(:parse_response, command_result, **parse_options)
+      apply_runtime_model(response, provider_candidate, user)
+    end
+
+    def harness_response_provider(provider_candidate, provider_key, user)
+      app_provider_key = ProviderSupport.provider_key_for_agent_type(provider_key)
+      harness_key = ProviderSupport.harness_provider_key_for(app_provider_key).to_sym
+      klass = AgentHarness::Providers::Registry.instance.get(harness_key)
+      klass.new(config: harness_response_config(harness_key, provider_candidate, user))
+    end
+
+    def harness_response_config(harness_key, provider_candidate, user)
+      config = AgentHarness::ProviderConfig.new(harness_key)
+      config.externally_sandboxed = true
+      config.model = provider_runtime_model(provider_candidate, user)
+      config
+    end
+
+    def apply_runtime_model(response, provider_candidate, user)
+      model = provider_runtime_model(provider_candidate, user)
+      return response if model.blank? || response.model == model
+
+      AgentHarness::Response.new(
+        output: response.output,
+        exit_code: response.exit_code,
+        duration: response.duration,
+        provider: response.provider,
+        model: model,
+        tokens: response.tokens,
+        metadata: response.metadata,
+        error: response.error
+      )
+    end
+
+    def provider_runtime_model(provider_candidate, user)
+      provider_entry_for(provider_candidate, user)&.agent_harness_provider_runtime&.model
+    end
+
+    def harness_duration(execution_started_at)
+      return 0.0 unless execution_started_at
+
+      Time.current - execution_started_at
     end
 
     def normalized_rate_limit_reset_text(output)

--- a/spec/services/agent_runs/execute_spec.rb
+++ b/spec/services/agent_runs/execute_spec.rb
@@ -49,27 +49,14 @@ RSpec.describe AgentRuns::Execute do
       end
 
       it "records run_summary without aggregates, then persists delta as run_delta when no proxy records exist" do
-        expect(TokenUsageTracker).to receive(:track).with(
-          agent_run: agent_run,
-          usage: {
-            tokens_input: 1500,
-            tokens_output: 800,
-            llm_model: "claude-sonnet-4",
-            request_type: "run_summary"
-          },
-          update_aggregates: false
-        )
-        expect(TokenUsageTracker).to receive(:track).with(
-          agent_run: agent_run,
-          usage: {
-            tokens_input: 1500,
-            tokens_output: 800,
-            llm_model: "claude-sonnet-4",
-            request_type: "run_delta"
-          }
-        )
-
         described_class.call(agent_run: agent_run, prompt: prompt)
+
+        expect(agent_run.token_usages.order(:request_type).pluck(:request_type, :input_tokens, :output_tokens)).to eq([
+          [ "run_delta", 1500, 800 ],
+          [ "run_summary", 1500, 800 ]
+        ])
+        expect(agent_run.reload.tokens_input).to eq(1500)
+        expect(agent_run.tokens_output).to eq(800)
       end
 
       it "skips delta record when proxy records fully cover tracking" do
@@ -107,7 +94,8 @@ RSpec.describe AgentRuns::Execute do
             tokens_output: 300,
             llm_model: "claude-sonnet-4",
             request_type: "run_delta"
-          }
+          },
+          enforce_guardrails: false
         )
 
         described_class.call(agent_run: agent_run, prompt: prompt)

--- a/spec/services/token_usage_tracker_spec.rb
+++ b/spec/services/token_usage_tracker_spec.rb
@@ -145,6 +145,30 @@ RSpec.describe TokenUsageTracker do
       end
     end
 
+    context "when guardrail enforcement is disabled" do
+      before do
+        allow(AgentRuns::Cancel).to receive(:call)
+      end
+
+      it "updates usage counters without pausing a successful run for hard-stop budgets" do
+        create(:cost_budget, :hard_stop, :per_run, project: project, limit_cents: 100)
+
+        described_class.track(
+          agent_run: agent_run,
+          usage: { tokens_input: 1_000_000, tokens_output: 1_000_000, request_type: "run_delta" },
+          enforce_guardrails: false
+        )
+
+        agent_run.reload
+        expect(agent_run.tokens_input).to eq(1_000_000)
+        expect(agent_run.tokens_output).to eq(1_000_000)
+        expect(agent_run.cost_cents).to eq(1800)
+        expect(agent_run.status).to eq("running")
+        expect(agent_run.guardrail_violation_type).to be_nil
+        expect(AgentRuns::Cancel).not_to have_received(:call)
+      end
+    end
+
     context "with a knowledge run" do
       it "increments total_tokens on the knowledge run" do
         expect {
@@ -249,6 +273,15 @@ RSpec.describe TokenUsageTracker do
         agent_run: agent_run,
         usage: { tokens_input: 7000, tokens_output: 4000 },
         update_aggregates: false
+      )
+      expect(agent_run.reload.token_limit_status).to be_nil
+    end
+
+    it "does not check limits when guardrail enforcement is disabled" do
+      described_class.track(
+        agent_run: agent_run,
+        usage: { tokens_input: 7000, tokens_output: 4000 },
+        enforce_guardrails: false
       )
       expect(agent_run.reload.token_limit_status).to be_nil
     end

--- a/spec/services/token_usage_tracker_spec.rb
+++ b/spec/services/token_usage_tracker_spec.rb
@@ -277,13 +277,13 @@ RSpec.describe TokenUsageTracker do
       expect(agent_run.reload.token_limit_status).to be_nil
     end
 
-    it "does not check limits when guardrail enforcement is disabled" do
+    it "still checks limits when guardrail enforcement is disabled" do
       described_class.track(
         agent_run: agent_run,
         usage: { tokens_input: 7000, tokens_output: 4000 },
         enforce_guardrails: false
       )
-      expect(agent_run.reload.token_limit_status).to be_nil
+      expect(agent_run.reload.token_limit_status).to eq("exceeded")
     end
 
     it "transitions from warning to exceeded as usage grows" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -910,6 +910,37 @@ RSpec.describe Activities::RunAgentActivity do
           expect(agent_run.tokens_output).to eq(300)
         end
 
+        it "logs and skips token tracking when harness parsing fails" do
+          logger = instance_double(ActiveSupport::Logger, warn: nil, error: nil, info: nil)
+
+          allow(activity).to receive(:logger).and_return(logger)
+          allow(git_ops).to receive(:has_changes_since?).with("pre_agent_sha_abc123").and_return(false)
+          allow(activity).to receive(:parse_harness_response).and_raise(JSON::ParserError, "bad output")
+
+          result = activity.execute(agent_run_id: agent_run.id)
+
+          expect(result[:success]).to be true
+          expect(agent_run.token_usages).to be_empty
+          expect(logger).to have_received(:warn).with(
+            hash_including(
+              message: "agent_execution.token_usage_parse_failed",
+              agent_run_id: agent_run.id,
+              provider: "kilocode",
+              error_class: "JSON::ParserError",
+              error: "bad output"
+            )
+          )
+        end
+
+        it "raises when token usage persistence fails after parsing succeeds" do
+          allow(git_ops).to receive(:has_changes_since?).with("pre_agent_sha_abc123").and_return(false)
+          allow(AgentRuns::TrackHarnessTokens).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(agent_run))
+
+          expect {
+            activity.execute(agent_run_id: agent_run.id)
+          }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+
         it "does not subtract proxy usage from previous failed provider attempts" do
           TokenUsage.create!(
             agent_run: agent_run,

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -883,6 +883,57 @@ RSpec.describe Activities::RunAgentActivity do
         expect(agent_run.providers_attempted.map { |attempt| attempt["provider"] }).to eq([ "claude_code" ])
       end
 
+      context "when agent-harness can parse token usage from CLI output" do
+        let(:agent_run) { create(:agent_run, :kilocode, :with_git_context, project: project, issue: issue, container_id: "abc123") }
+        let(:exec_success) do
+          Containers::Provision::Result.success(
+            stdout: [
+              { type: "text", text: "Done" }.to_json,
+              { type: "usage", usage: { input_tokens: 1200, output_tokens: 300, total_tokens: 1500 } }.to_json
+            ].join("\n"),
+            stderr: "",
+            exit_code: 0
+          )
+        end
+
+        it "records run summary usage and updates billable run aggregates" do
+          allow(git_ops).to receive(:has_changes_since?).with("pre_agent_sha_abc123").and_return(false)
+
+          activity.execute(agent_run_id: agent_run.id)
+
+          usages = agent_run.token_usages.order(:request_type)
+          expect(usages.pluck(:request_type, :input_tokens, :output_tokens)).to eq([
+            [ "run_delta", 1200, 300 ],
+            [ "run_summary", 1200, 300 ]
+          ])
+          expect(agent_run.reload.tokens_input).to eq(1200)
+          expect(agent_run.tokens_output).to eq(300)
+        end
+
+        it "does not subtract proxy usage from previous failed provider attempts" do
+          TokenUsage.create!(
+            agent_run: agent_run,
+            request_type: "agent",
+            input_tokens: 700,
+            output_tokens: 100,
+            cost_cents: 1,
+            llm_model: "claude-sonnet-4",
+            created_at: 2.hours.ago,
+            updated_at: 2.hours.ago
+          )
+          allow(git_ops).to receive(:has_changes_since?).with("pre_agent_sha_abc123").and_return(false)
+
+          activity.execute(agent_run_id: agent_run.id)
+
+          expect(agent_run.token_usages.find_by!(request_type: "run_delta")).to have_attributes(
+            input_tokens: 1200,
+            output_tokens: 300
+          )
+          expect(agent_run.reload.tokens_input).to eq(1200)
+          expect(agent_run.tokens_output).to eq(300)
+        end
+      end
+
       it "retries transient commit failures before checking for changes" do
         commit_attempts = 0
 


### PR DESCRIPTION
## Summary
- parse successful container-agent CLI output through agent-harness and record token usage for real RunAgentActivity executions
- centralize harness token reconciliation so AgentRuns::Execute and container runs share run_summary/run_delta behavior
- avoid pausing/cancelling completed provider work during end-of-run token reconciliation and scope proxy subtraction to the current provider attempt

## Context
This completes the token usage ingestion work that was previously tracked in #1030, #1031, #1032, and #1033. Those issues covered agent-harness token parsing and the direct AgentRuns::Execute path, but the production container path still discarded parsed harness token data.

## Verification
- bin/rubocop app/services/token_usage_tracker.rb app/services/agent_runs/track_harness_tokens.rb app/services/agent_runs/execute.rb app/temporal/activities/run_agent_activity.rb spec/services/token_usage_tracker_spec.rb spec/services/agent_runs/execute_spec.rb spec/temporal/activities/run_agent_activity_spec.rb
- COVERAGE=false bin/rspec spec/services/token_usage_tracker_spec.rb spec/services/agent_runs/execute_spec.rb spec/temporal/activities/run_agent_activity_spec.rb
- git diff --check