### PR TITLE
fix(scanner): queue paid_agent review run when findings are unaddressed

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1206,7 +1206,18 @@ module Activities
             # touch any file mentioned in the review's inline comments.
             # Treat as still-unaddressed to prevent unrelated changes
             # (e.g. a CI schema fix) from clearing review findings.
-            paid_agent_limit_reached_for_latest_review ? body_only_exhausted_triggers : body_only_pending_triggers
+            if paid_agent_limit_reached_for_latest_review
+              body_only_exhausted_triggers
+            elsif ProviderSupport.provider_bot_username_for?("paid_agent", latest&.dig(:user_login))
+              # Emit paid_agent_review_pending alongside the bot triggers so
+              # the workflow queues a review run. Without this, the scanner
+              # keeps starting create_pr follow-ups that don't touch the
+              # reviewed files, and no fresh review ever re-evaluates the
+              # code (#1395).
+              body_only_pending_triggers + check_paid_agent_review_status(project, issue)
+            else
+              body_only_pending_triggers
+            end
           elsif ProviderSupport.provider_bot_username_for?("paid_agent", latest&.dig(:user_login))
             # Thread-based bot with all bot threads resolved, or body-only
             # review already addressed by a subsequent agent run whose diff

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1630,12 +1630,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           .and_return([])
       end
 
-      it "keeps the review actionable because empty review paths cannot prove it was addressed" do
+      it "keeps the review actionable and queues a paid_agent review run" do
         result = activity.execute(project_id: project.id)
 
         expect(result[:prs_to_trigger].size).to eq(1)
         trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
-        expect(trigger_types).to include("review_bot_comments", "review_bot_review_pending")
+        expect(trigger_types).to include("review_bot_comments", "review_bot_review_pending", "paid_agent_review_pending")
       end
     end
 
@@ -1685,6 +1685,96 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
         expect(trigger_types).to include("paid_agent_review_pending")
         expect(trigger_types).not_to include("ready_for_owner")
+      end
+    end
+
+    context "when paid_agent review pre-dates last run and inline comments were not addressed" do
+      before do
+        enable_paid_agent_review!
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          goal: "create_pr",
+          trigger_type: "automatic",
+          completed_at: 30.minutes.ago)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          goal: "review",
+          trigger_type: "automatic",
+          completed_at: 2.hours.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                     body: "Here are some review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([
+            { id: 10, user_login: "paid-code-reviewer[bot]", body: "Fix this",
+             created_at: 2.hours.ago, path: "app/models/agent_run.rb",
+             pull_request_review_id: 1 }
+          ])
+        allow(github_client).to receive(:compare_changed_files)
+          .with(project.full_name, "rev_sha", "abc123")
+          .and_return([ "app/services/other_service.rb", "db/schema.rb" ])
+      end
+
+      it "queues a paid_agent review run alongside the bot triggers" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("review_bot_comments", "review_bot_review_pending", "paid_agent_review_pending")
+      end
+    end
+
+    context "when paid_agent review is unaddressed but review rounds are exhausted" do
+      before do
+        enable_paid_agent_review!(max_review_rounds: 1)
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 1)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          goal: "create_pr",
+          trigger_type: "automatic",
+          completed_at: 30.minutes.ago)
+        create(:agent_run, :completed,
+          project: project,
+          source_pull_request_number: 42,
+          goal: "review",
+          trigger_type: "automatic",
+          completed_at: 2.hours.ago)
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success", status: "completed" } ],
+          reviews: [ { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+                     body: "Here are some review suggestions.",
+                     submitted_at: 2.hours.ago, commit_id: "rev_sha" } ],
+          review_threads: []
+        )
+        allow(github_client).to receive(:pull_request_review_comments)
+          .with(project.full_name, 42)
+          .and_return([])
+      end
+
+      it "does not emit paid_agent_review_pending when rounds are exhausted" do
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger].size).to eq(1)
+        trigger_types = result[:prs_to_trigger].first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("review_bot_comments")
+        expect(trigger_types).not_to include("paid_agent_review_pending")
       end
     end
 


### PR DESCRIPTION
## Summary

- Fixes an infinite loop where paid_agent review findings that weren't addressed by subsequent code changes caused the scanner to repeatedly start `create_pr` follow-ups without ever queuing a fresh review run
- In the "still unaddressed" body-only branch, calls `check_paid_agent_review_status` for paid_agent bots so `paid_agent_review_pending` is emitted alongside `review_bot_review_pending` + `review_bot_comments`
- The workflow routes the combined triggers to `handle_paid_agent_review_pending`, which queues a review run and applies the hard gate (#1135), breaking the loop

## Problem

When a paid_agent review had findings (inline comments on specific files) and a subsequent `create_pr` follow-up didn't touch those files, the scanner's `review_diff_touches_reviewed_files?` check returned `false`. This pushed the scanner into the "still unaddressed" branch which emitted `review_bot_review_pending` + `review_bot_comments` — but **not** `paid_agent_review_pending`. The workflow then started another `create_pr` follow-up via `handle_review_bot_review_pending`, creating an infinite loop.

On PR #1395, this resulted in 13 consecutive `create_pr` runs with only 1 review run, eventually escalating due to consecutive follow-up failures.

## Testing

- Updated existing test to expect `paid_agent_review_pending` in the no-inline-comments case
- New test: inline comments present but diff doesn't touch those files (the PR #1395 scenario)
- New test: rounds exhausted → `paid_agent_review_pending` is NOT emitted
- All 307 scan activity tests pass, linter clean

Refs #1395