### PR TITLE
fix(devcontainer): align Postgres client tools with pinned server

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && apt-get install -y nodejs
 
 # Install system dependencies
+# Keep client tools on the same Postgres major as the pinned server image.
 # Use CloudFront mirror to avoid Fastly CDN connection drops in OrbStack
 RUN set -e; \
   sources_modified=0; \
@@ -24,7 +25,7 @@ RUN set -e; \
   fi; \
   echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries \
   && apt-get update -qq \
-  && apt-get install -y build-essential cmake shellcheck tmux libpq-dev postgresql-client \
+  && apt-get install -y build-essential cmake shellcheck tmux libpq-dev postgresql-client-16 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install chromium separately for better layer caching (updates more frequently)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,22 +50,36 @@ jobs:
         run: bin/lint
 
       - name: Verify Postgres image pins are in sync
-        # All three files must pin the same postgres:<tag> so that schema.rb
-        # dumps are byte-identical across dev, devcontainer, and CI. Drift
-        # across minor versions causes cosmetic pg_get_expr() churn in schema.rb.
+        # Keep the Postgres server image pin aligned across compose, devcontainer,
+        # and CI, and ensure installed client tools use the same major version.
         run: |
           dev=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .devcontainer/compose.yaml | head -1 | awk '{print $NF}')
           compose=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' docker-compose.yml | head -1 | awk '{print $NF}')
           ci=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/ci.yml | head -1 | awk '{print $NF}')
+          major=${compose#postgres:}
+          major=${major%%.*}
           echo "devcontainer/compose.yaml: ${dev:-<none>}"
           echo "docker-compose.yml:        ${compose:-<none>}"
           echo ".github/workflows/ci.yml:  ${ci:-<none>}"
+          echo "expected client major:     ${major:-<none>}"
           if [ -z "$dev" ] || [ -z "$compose" ] || [ -z "$ci" ]; then
             echo "::error::Postgres image pin missing in one or more files"
             exit 1
           fi
           if [ "$dev" != "$compose" ] || [ "$compose" != "$ci" ]; then
             echo "::error::Postgres image pins are out of sync. Update all three together."
+            exit 1
+          fi
+          if ! grep -q "postgresql-client-${major}" .devcontainer/Dockerfile; then
+            echo "::error::.devcontainer/Dockerfile is not pinned to postgresql-client-${major}"
+            exit 1
+          fi
+          if ! grep -q "postgresql-client-${major}" Dockerfile; then
+            echo "::error::Dockerfile is not pinned to postgresql-client-${major}"
+            exit 1
+          fi
+          if ! grep -q "postgresql-client-${major}" .github/workflows/ci.yml; then
+            echo "::error::.github/workflows/ci.yml is not pinned to postgresql-client-${major}"
             exit 1
           fi
 
@@ -124,7 +138,7 @@ jobs:
         run: bin/install-ast-grep
 
       - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
 
       - name: Build assets
         run: yarn build && yarn build:css
@@ -195,7 +209,7 @@ jobs:
         run: yarn install --frozen-lockfile && bin/yarn-postinstall
 
       - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
 
       - name: Set up database
         run: bin/rails db:prepare

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 WORKDIR /rails
 
 # Install base packages
+# Keep client tools on the same Postgres major as the pinned server image.
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 postgresql-client && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 postgresql-client-16 && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 


### PR DESCRIPTION
## Summary
- pin Postgres client tools to major version 16 in the devcontainer, app image, and CI jobs
- extend the existing pin sync check so CI also verifies the client package major matches the pinned Postgres image
- prevent future pg_dump/pg_restore drift when the server image pin changes

## Testing
- verified the repo pin check logic locally against the current `postgres:16.13` image pins
