### PR TITLE
feat(temporal): propagate tenant context into worker threads

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,7 +1,8 @@
-web: bin/rails server -b 0.0.0.0
+web: GOOD_JOB_EXECUTION_MODE=external bin/rails server -b 0.0.0.0
 js: yarn build --watch
 css: yarn build:css --watch
+jobs: GOOD_JOB_EXECUTION_MODE=external bin/jobs start
 worker: bin/temporal_worker
 
 # Connect to a running process by running `overmind connect <process name>`
-# e.g. `overmind connect web` or `overmind connect worker`
+# e.g. `overmind connect web`, `overmind connect jobs`, or `overmind connect worker`

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ bash .devcontainer/setup-signing-key.sh
 # Prerequisites: Ruby 3.4+, Bundler 2.7.2, PostgreSQL 16+, Node.js 22.x (see .tool-versions for the exact pinned version), Yarn 1.22.22, Docker Engine
 # Also start PostgreSQL, Temporal, and Qdrant locally before running setup.
 bin/setup               # Install deps, prepare DB
-bin/dev                 # Start Rails, JS/CSS watchers, and the Temporal worker
+bin/dev                 # Start Rails, JS/CSS watchers, GoodJob, and the Temporal worker
 ```
 
 `bin/setup` now does more than install Ruby and JS dependencies: it configures git hooks, prepares the database, checks Qdrant connectivity, builds the `paid-agent:latest` Docker image, and cleans up stale dev state. If Docker is unavailable, setup is incomplete.

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -901,6 +901,8 @@ module Activities
       context = Temporalio::Activity::Context.current_or_nil
       return yield unless context
 
+      tenant_account_id = Current.account&.id
+
       # Wrap the worker thread in Rails executor and ActiveRecord connection
       # pool management. The executor handles autoloading/reloading and the
       # with_connection block ensures the DB connection is checked out only
@@ -918,10 +920,23 @@ module Activities
           end
         end
 
+        tenant_scoped = proc do
+          if tenant_account_id
+            tenant_account = TenantContext.with_system_access { Account.find_by(id: tenant_account_id) }
+            if tenant_account
+              TenantContext.with(tenant_account, &db_scoped)
+            else
+              TenantContext.with_system_access(&db_scoped)
+            end
+          else
+            TenantContext.with_system_access(&db_scoped)
+          end
+        end
+
         if executor
-          executor.wrap(&db_scoped)
+          executor.wrap(&tenant_scoped)
         else
-          db_scoped.call
+          tenant_scoped.call
         end
       end
       worker.report_on_exception = false

--- a/spec/migrations/add_account_to_service_containers_spec.rb
+++ b/spec/migrations/add_account_to_service_containers_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     connection.execute("DELETE FROM project_service_containers")
     connection.execute("DELETE FROM service_container_metrics")
     connection.execute("DELETE FROM service_containers")
+    connection.execute("DELETE FROM workflow_states")
     connection.execute("DELETE FROM projects")
     connection.execute("DELETE FROM providers")
     connection.execute("DELETE FROM provider_states")

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -156,6 +156,27 @@ RSpec.describe Activities::RunAgentActivity do
 
       expect(result).to eq(42)
     end
+
+    it "propagates tenant context into the worker thread" do
+      allow(Temporalio::Activity::Context).to receive(:current_or_nil).and_return(mock_context)
+
+      TenantContext.with(user.account) do
+        result = nil
+
+        expect {
+          result = activity.send(:with_periodic_heartbeat, "test", interval: 0.01) do
+            agent_run.log!("system", "tenant context propagated")
+            [
+              Current.account,
+              ActiveRecord::Base.connection.select_value("SELECT paid_current_account_id()")
+            ]
+          end
+        }.to change { agent_run.agent_run_logs.count }.by(1)
+
+        expect(result).to eq([ user.account, user.account.id ])
+        expect(agent_run.agent_run_logs.order(:id).last.content).to eq("tenant context propagated")
+      end
+    end
   end
 
   describe ".container_executable?" do


### PR DESCRIPTION
## Summary

- Propagate tenant account context (`Current.account`) into Temporal activity worker threads
- Ensure proper multi-tenant data isolation for database operations in activities
- Add `GOOD_JOB_EXECUTION_MODE=external` for separate GoodJob process in development
- Update Procfile.dev and README to reflect new job processing setup

## Changes

### Tenant Context Propagation
- Capture `tenant_account_id` before worker thread execution
- Wrap database operations with `TenantContext.with()` for proper scoping
- Fall back to system access when tenant account not found
- Add test coverage for tenant context propagation

### Development Setup
- Add `jobs` process to Procfile.dev with `GOOD_JOB_EXECUTION_MODE=external`
- Update README to mention GoodJob alongside Temporal worker
- Enable better job processing separation in development

## Testing

- Added spec verifying tenant context propagates into worker threads
- Verifies `paid_current_account_id()` returns correct tenant ID
- Ensures agent run logs are created within correct tenant scope