### PR TITLE
fix(containers): clarify git proxy auth failures

### DIFF
--- a/app/controllers/api/git_credentials_controller.rb
+++ b/app/controllers/api/git_credentials_controller.rb
@@ -17,7 +17,7 @@ module Api
       github_token = @agent_run.project.github_token
 
       unless github_token&.active?
-        render plain: "", status: :service_unavailable
+        render json: { error: "Project GitHub token is missing or inactive" }, status: :forbidden
         return
       end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -22,8 +22,6 @@ class ApplicationJob < ActiveJob::Base
     return TenantContext.with(account, &block) if account
 
     TenantContext.with_system_access(&block)
-  ensure
-    TenantContext.clear!
   end
 
   def tenant_account

--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -25,6 +25,11 @@ module Containers
     # Runtime code resolves per-user values via UserSetting.
     DEFAULT_CLONE_TIMEOUT = 600
     DEFAULT_PUSH_TIMEOUT = 60
+    NETWORK_GIT_ENV = {
+      # Disable interactive auth fallback so proxy/credential failures surface
+      # clearly instead of ending with a misleading username prompt.
+      "GIT_TERMINAL_PROMPT" => "0"
+    }.freeze
 
     # Marker comment embedded in all Paid-installed git hooks. Used as a
     # grep guard so Temporal retries don't install duplicate hooks.
@@ -560,7 +565,7 @@ module Containers
     # @return [void]
     # @raise [Error] when the fetch fails
     def fetch_branch(branch)
-      result = execute_git(
+      result = execute_network_git(
         "fetch",
         "origin",
         "refs/heads/#{branch}:refs/remotes/origin/#{branch}"
@@ -639,7 +644,7 @@ module Containers
     end
 
     def push_new_branch
-      result = execute_git("push", "--no-verify", "origin", agent_run.branch_name, timeout: push_timeout)
+      result = execute_network_git("push", "--no-verify", "origin", agent_run.branch_name, timeout: push_timeout)
       return result unless branch_exists_rejection?(result)
 
       recover_existing_new_branch_push(result)
@@ -676,7 +681,7 @@ module Containers
       # --no-verify skips any pre-push hooks. The push is a system operation
       # that runs after the agent has exited — quality was already enforced
       # by the pre-commit hook during agent execution.
-      execute_git(
+      execute_network_git(
         "push",
         "--no-verify",
         "origin",
@@ -738,7 +743,7 @@ module Containers
       check = execute_git("rev-parse", "--is-shallow-repository")
       return if check.success? && check[:stdout].to_s.strip == "false"
 
-      result = execute_git("fetch", "--unshallow", timeout: clone_timeout)
+      result = execute_network_git("fetch", "--unshallow", timeout: clone_timeout)
       return if result.success?
 
       raise Error, "Failed to unshallow repository: #{error_with_stderr(result)}"
@@ -776,7 +781,7 @@ module Containers
       attempt = 0
       loop do
         attempt += 1
-        result = execute_git("clone", "--depth", "1", url, ".", timeout: clone_timeout)
+        result = execute_network_git("clone", "--depth", "1", url, ".", timeout: clone_timeout)
         return if result.success?
 
         stderr = result[:stderr].to_s
@@ -834,7 +839,7 @@ module Containers
       # branch shallowly into refs/remotes/origin/<branch>, then create/reset
       # the local branch from that explicit remote-tracking ref.
       remote_ref = "refs/remotes/origin/#{branch_name}"
-      fetch_result = execute_git(
+      fetch_result = execute_network_git(
         "fetch",
         "--depth",
         "1",
@@ -856,7 +861,7 @@ module Containers
 
       raise CloneError, "Checkout failed (#{checkout_detail})" unless pull_request_number
 
-      pr_fetch = execute_git("fetch", "origin", "refs/pull/#{pull_request_number}/head:#{branch_name}")
+      pr_fetch = execute_network_git("fetch", "origin", "refs/pull/#{pull_request_number}/head:#{branch_name}")
       if pr_fetch.failure?
         raise CloneError,
           "Branch checkout failed; PR ref fetch also failed (#{checkout_detail}; " \
@@ -1215,6 +1220,11 @@ module Containers
     def execute_git(*args, timeout: nil)
       cmd = [ "git" ] + args
       container_service.execute(cmd, timeout: timeout, stream: false)
+    end
+
+    def execute_network_git(*args, timeout: nil)
+      cmd = [ "git" ] + args
+      container_service.execute(cmd, timeout: timeout, stream: false, env: NETWORK_GIT_ENV)
     end
 
     def user_settings

--- a/app/services/tenant_context.rb
+++ b/app/services/tenant_context.rb
@@ -8,10 +8,27 @@ class TenantContext
       set_config("paid.bypass_tenant_rls", false)
     end
 
+    def apply_system_access!
+      Current.account = nil
+      set_config("paid.current_account_id", nil)
+      set_config("paid.bypass_tenant_rls", true)
+    end
+
     def clear!
       Current.account = nil
       set_config("paid.current_account_id", nil)
       set_config("paid.bypass_tenant_rls", false)
+    end
+
+    def bypass_enabled?
+      ActiveModel::Type::Boolean.new.cast(current_setting("paid.bypass_tenant_rls"))
+    end
+
+    def restore!(account:, bypass:)
+      return apply_system_access! if ActiveModel::Type::Boolean.new.cast(bypass)
+      return apply!(account) if account
+
+      clear!
     end
 
     def with(account)
@@ -32,9 +49,7 @@ class TenantContext
       previous_account_id = current_setting("paid.current_account_id")
       previous_bypass = current_setting("paid.bypass_tenant_rls")
 
-      Current.account = nil
-      set_config("paid.current_account_id", nil)
-      set_config("paid.bypass_tenant_rls", true)
+      apply_system_access!
       yield
     ensure
       Current.account = previous_account

--- a/app/temporal/activities/base_activity.rb
+++ b/app/temporal/activities/base_activity.rb
@@ -31,8 +31,6 @@ module Activities
         return TenantContext.with(account, &block) if account
 
         TenantContext.with_system_access(&block)
-      ensure
-        TenantContext.clear!
       end
 
       def tenant_account_from(input)
@@ -81,11 +79,20 @@ module Activities
           ActiveRecord::Base.respond_to?(:connection_pool)
         return block.call unless pool
 
-        begin
-          block.call
-        ensure
-          pool.release_connection if pool.respond_to?(:active_connection?) && pool.active_connection?
-        end
+        block.call
+      ensure
+        restore_outer_tenant_context!(pool) if pool
+      end
+
+      def restore_outer_tenant_context!(pool)
+        return unless pool.respond_to?(:active_connection?) && pool.active_connection?
+
+        restore_account = Current.account if defined?(Current)
+        restore_bypass = TenantContext.bypass_enabled? if defined?(TenantContext)
+        pool.release_connection
+        return unless restore_account || restore_bypass
+
+        TenantContext.restore!(account: restore_account, bypass: restore_bypass)
       end
     end
 

--- a/docker/agent/scripts/git-credential-paid
+++ b/docker/agent/scripts/git-credential-paid
@@ -63,7 +63,12 @@ case "$1" in
             fi
             ;;
           4??)
-            echo "git-credential-paid: proxy returned HTTP ${http_status} (authentication or configuration error), not retrying" >&2
+            error_detail=$(printf '%s' "$response" | sed -n 's/.*"error"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+            if [ -n "$error_detail" ]; then
+              echo "git-credential-paid: proxy returned HTTP ${http_status} (${error_detail}), not retrying" >&2
+            else
+              echo "git-credential-paid: proxy returned HTTP ${http_status} (authentication or configuration error), not retrying" >&2
+            fi
             exit 1
             ;;
           *)

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -28,4 +28,31 @@ RSpec.describe ApplicationJob do
       expect(job.send(:tenant_account)).to eq(account)
     end
   end
+
+  describe "tenant context restoration" do
+    let(:job_class) do
+      Class.new(described_class) do
+        def perform
+        end
+      end
+    end
+
+    let(:job) do
+      stub_const("TenantContextRestorationJob", job_class)
+      TenantContextRestorationJob
+    end
+
+    it "preserves outer system access after perform_now" do
+      TenantContext.with_system_access do
+        job.perform_now
+
+        expect(current_bypass_setting).to eq("true")
+        expect { create(:account) }.not_to raise_error
+      end
+    end
+  end
+
+  def current_bypass_setting
+    ActiveRecord::Base.connection.select_value("SELECT current_setting('paid.bypass_tenant_rls', true)")
+  end
 end

--- a/spec/requests/api/git_credentials_spec.rb
+++ b/spec/requests/api/git_credentials_spec.rb
@@ -105,10 +105,11 @@ RSpec.describe "Api::GitCredentials" do
         github_token.update!(revoked_at: Time.current)
       end
 
-      it "returns service unavailable" do
+      it "returns forbidden with a configuration error" do
         get "/api/proxy/git-credentials", headers: valid_headers
 
-        expect(response).to have_http_status(:service_unavailable)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body).to eq("error" => "Project GitHub token is missing or inactive")
       end
     end
   end

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Containers::GitOperations do
     it "clones the repository inside the container" do
       expect(container_service).to receive(:execute)
         .with([ "git", "clone", "--depth", "1", "https://github.com/#{project.full_name}.git", "." ],
-              timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false)
+              timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       git_ops.clone_and_setup_branch
@@ -56,7 +56,7 @@ RSpec.describe Containers::GitOperations do
 
       expect(container_service).to receive(:execute)
         .with([ "git", "clone", "--depth", "1", "https://github.com/#{project.full_name}.git", "." ],
-              timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false)
+              timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
         .ordered
 
@@ -280,11 +280,11 @@ RSpec.describe Containers::GitOperations do
 
       expect(container_service).to receive(:execute)
         .with([ "git", "clone", "--depth", "1", "https://github.com/#{project.full_name}.git", "." ],
-              timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false)
+              timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/fix-bug-branch:refs/remotes/origin/fix-bug-branch" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/fix-bug-branch:refs/remotes/origin/fix-bug-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       expect(container_service).to receive(:execute)
@@ -312,10 +312,10 @@ RSpec.describe Containers::GitOperations do
 
       expect(container_service).not_to receive(:execute)
         .with([ "git", "clone", "--depth", "1", "https://github.com/#{project.full_name}.git", "." ],
-              timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false)
+              timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false, env: described_class::NETWORK_GIT_ENV)
 
       expect(container_service).not_to receive(:execute)
-        .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/fix-bug-branch:refs/remotes/origin/fix-bug-branch" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/fix-bug-branch:refs/remotes/origin/fix-bug-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
 
       git_ops.clone_and_checkout_branch(branch_name: "fix-bug-branch")
 
@@ -328,7 +328,7 @@ RSpec.describe Containers::GitOperations do
         .and_return(failure_result)
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/nonexistent:refs/remotes/origin/nonexistent" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/nonexistent:refs/remotes/origin/nonexistent" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(failure_result)
 
       expect { git_ops.clone_and_checkout_branch(branch_name: "nonexistent") }
@@ -344,11 +344,11 @@ RSpec.describe Containers::GitOperations do
           .with([ "git", "switch", "--", "deleted-branch" ], timeout: nil, stream: false) { switch_returns.shift }
 
         allow(container_service).to receive(:execute)
-          .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/deleted-branch:refs/remotes/origin/deleted-branch" ], timeout: nil, stream: false)
+          .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/deleted-branch:refs/remotes/origin/deleted-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
           .and_return(failure_result)
 
         expect(container_service).to receive(:execute)
-          .with([ "git", "fetch", "origin", "refs/pull/42/head:deleted-branch" ], timeout: nil, stream: false)
+          .with([ "git", "fetch", "origin", "refs/pull/42/head:deleted-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
           .and_return(success_result)
 
         git_ops.clone_and_checkout_branch(branch_name: "deleted-branch", pull_request_number: 42)
@@ -362,11 +362,11 @@ RSpec.describe Containers::GitOperations do
           .and_return(failure_result)
 
         allow(container_service).to receive(:execute)
-          .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/deleted-branch:refs/remotes/origin/deleted-branch" ], timeout: nil, stream: false)
+          .with([ "git", "fetch", "--depth", "1", "origin", "refs/heads/deleted-branch:refs/remotes/origin/deleted-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
           .and_return(failure_result)
 
         allow(container_service).to receive(:execute)
-          .with([ "git", "fetch", "origin", "refs/pull/42/head:deleted-branch" ], timeout: nil, stream: false)
+          .with([ "git", "fetch", "origin", "refs/pull/42/head:deleted-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
           .and_return(failure_result)
 
         expect { git_ops.clone_and_checkout_branch(branch_name: "deleted-branch", pull_request_number: 42) }
@@ -407,7 +407,7 @@ RSpec.describe Containers::GitOperations do
       create(:worktree, project: project, agent_run: agent_run, branch_name: "paid/test-branch", status: "active")
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch" ], timeout: 60, stream: false)
+        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch" ], timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       sha_result = Containers::Provision::Result.success(stdout: "#{head_sha}\n", stderr: "", exit_code: 0)
@@ -438,7 +438,7 @@ RSpec.describe Containers::GitOperations do
       agent_run.update!(source_pull_request_number: 42)
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       allow(container_service).to receive(:execute)
@@ -446,7 +446,7 @@ RSpec.describe Containers::GitOperations do
         .and_return(Containers::Provision::Result.success(stdout: "#{remote_sha}\n", stderr: "", exit_code: 0))
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch", "--force-with-lease=paid/test-branch:#{remote_sha}" ], timeout: 60, stream: false)
+        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch", "--force-with-lease=paid/test-branch:#{remote_sha}" ], timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       git_ops.push_branch
@@ -463,7 +463,7 @@ RSpec.describe Containers::GitOperations do
 
     it "does not fetch before pushing on new branches" do
       expect(container_service).not_to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
 
       git_ops.push_branch
     end
@@ -472,7 +472,7 @@ RSpec.describe Containers::GitOperations do
       agent_run.update!(source_pull_request_number: 42)
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(failure_result)
 
       expect { git_ops.push_branch }.to raise_error(described_class::PushError, /Fetch failed/)
@@ -488,7 +488,7 @@ RSpec.describe Containers::GitOperations do
       )
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       allow(container_service).to receive(:execute)
@@ -505,7 +505,7 @@ RSpec.describe Containers::GitOperations do
       agent_run.update!(source_pull_request_number: 42)
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
         .ordered
 
@@ -515,7 +515,7 @@ RSpec.describe Containers::GitOperations do
         .ordered
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch", "--force-with-lease=paid/test-branch:#{remote_sha}" ], timeout: 60, stream: false)
+        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch", "--force-with-lease=paid/test-branch:#{remote_sha}" ], timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
         .ordered
 
@@ -600,7 +600,7 @@ RSpec.describe Containers::GitOperations do
       )
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch" ], timeout: 60, stream: false)
+        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch" ], timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
         .ordered
         .and_return(branch_exists_result)
 
@@ -620,7 +620,7 @@ RSpec.describe Containers::GitOperations do
       )
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch" ], timeout: 60, stream: false)
+        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch" ], timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
         .ordered
         .and_return(branch_exists_result)
 
@@ -634,7 +634,7 @@ RSpec.describe Containers::GitOperations do
 
     def expect_refresh_remote_branch(sha, ordered: false)
       receive_fetch = expect(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/paid/test-branch:refs/remotes/origin/paid/test-branch" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
       receive_fetch = receive_fetch.ordered if ordered
 
@@ -646,7 +646,7 @@ RSpec.describe Containers::GitOperations do
 
     def expect_push_with_lease(sha, result, ordered: false)
       receive_push = expect(container_service).to receive(:execute)
-        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch", "--force-with-lease=paid/test-branch:#{sha}" ], timeout: 60, stream: false)
+        .with([ "git", "push", "--no-verify", "origin", "paid/test-branch", "--force-with-lease=paid/test-branch:#{sha}" ], timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(result)
       receive_push.ordered if ordered
     end
@@ -1213,7 +1213,7 @@ RSpec.describe Containers::GitOperations do
   describe "#fetch_branch" do
     it "fetches the specified branch from origin" do
       expect(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       git_ops.fetch_branch("main")
@@ -1221,7 +1221,7 @@ RSpec.describe Containers::GitOperations do
 
     it "raises Error when fetch fails" do
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(failure_result)
 
       expect { git_ops.fetch_branch("main") }.to raise_error(described_class::Error, /Fetch failed/)
@@ -1231,7 +1231,7 @@ RSpec.describe Containers::GitOperations do
   describe "#head_differs_from_remote_branch?" do
     it "returns true when HEAD differs from the remote branch" do
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/feature:refs/remotes/origin/feature" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/feature:refs/remotes/origin/feature" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
       allow(container_service).to receive(:execute)
         .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
@@ -1246,7 +1246,7 @@ RSpec.describe Containers::GitOperations do
     it "returns false when HEAD matches the remote branch" do
       sha = Containers::Provision::Result.success(stdout: "same-sha\n", stderr: "", exit_code: 0)
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/feature:refs/remotes/origin/feature" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/feature:refs/remotes/origin/feature" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
       allow(container_service).to receive(:execute)
         .with([ "git", "rev-parse", "HEAD" ], timeout: nil, stream: false)
@@ -1269,11 +1269,11 @@ RSpec.describe Containers::GitOperations do
         .and_return(shallow_true_result)
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "--unshallow" ], timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false)
+        .with([ "git", "fetch", "--unshallow" ], timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(success_result)
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false)
+        .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
         .and_return(fetch_result)
     end
 
@@ -1295,12 +1295,12 @@ RSpec.describe Containers::GitOperations do
           .ordered
 
         expect(container_service).to receive(:execute)
-          .with([ "git", "fetch", "--unshallow" ], timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false)
+          .with([ "git", "fetch", "--unshallow" ], timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false, env: described_class::NETWORK_GIT_ENV)
           .and_return(success_result)
           .ordered
 
         expect(container_service).to receive(:execute)
-          .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false)
+          .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false, env: described_class::NETWORK_GIT_ENV)
           .and_return(success_result)
           .ordered
 
@@ -1394,7 +1394,7 @@ RSpec.describe Containers::GitOperations do
 
       it "skips unshallow and proceeds with rebase" do
         expect(container_service).not_to receive(:execute)
-          .with([ "git", "fetch", "--unshallow" ], timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false)
+          .with([ "git", "fetch", "--unshallow" ], timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false, env: described_class::NETWORK_GIT_ENV)
 
         expect(git_ops.rebase_onto("main")).to be true
       end
@@ -1403,7 +1403,7 @@ RSpec.describe Containers::GitOperations do
     context "when unshallow fails" do
       before do
         allow(container_service).to receive(:execute)
-          .with([ "git", "fetch", "--unshallow" ], timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false)
+          .with([ "git", "fetch", "--unshallow" ], timeout: described_class::DEFAULT_CLONE_TIMEOUT, stream: false, env: described_class::NETWORK_GIT_ENV)
           .and_return(failure_result)
       end
 

--- a/spec/temporal/activities/base_activity_spec.rb
+++ b/spec/temporal/activities/base_activity_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Activities::BaseActivity do
       allow(TenantContext).to receive(:with_system_access).and_yield
       allow(TenantContext).to receive(:with).and_yield
       allow(TenantContext).to receive(:clear!)
+      allow(TenantContext).to receive(:bypass_enabled?).and_return(false)
+      allow(TenantContext).to receive(:restore!)
       allow(Project).to receive(:find_by)
       allow(ActiveRecord::Base).to receive(:connection_pool).and_return(connection_pool)
       allow(connection_pool).to receive(:active_connection?).and_return(true)
@@ -59,6 +61,29 @@ RSpec.describe Activities::BaseActivity do
       expect { error_activity.execute("project_id" => 789) }.to raise_error(RuntimeError, "activity failed")
       expect(executor).to have_received(:wrap)
       expect(connection_pool).to have_received(:release_connection)
+    end
+
+    it "restores the outer tenant context after releasing the connection" do
+      # rubocop:disable RSpec/VerifiedDoubles,RSpec/VerifiedDoubleReference
+      account = double("Account", id: 123)
+      # rubocop:enable RSpec/VerifiedDoubles,RSpec/VerifiedDoubleReference
+      Current.account = account
+
+      activity.execute("project_id" => 123)
+
+      expect(connection_pool).to have_received(:release_connection).ordered
+      expect(TenantContext).to have_received(:restore!).with(account: account, bypass: false).ordered
+    ensure
+      Current.reset
+    end
+
+    it "restores outer system access after releasing the connection" do
+      allow(TenantContext).to receive(:bypass_enabled?).and_return(true)
+
+      activity.execute("project_id" => 123)
+
+      expect(connection_pool).to have_received(:release_connection).ordered
+      expect(TenantContext).to have_received(:restore!).with(account: nil, bypass: true).ordered
     end
   end
 

--- a/spec/temporal/activities/rebase_branch_activity_spec.rb
+++ b/spec/temporal/activities/rebase_branch_activity_spec.rb
@@ -96,12 +96,22 @@ RSpec.describe Activities::RebaseBranchActivity do
           .and_return(Containers::Provision::Result.success(stdout: "true\n", stderr: "", exit_code: 0))
 
         allow(container_service).to receive(:execute)
-          .with([ "git", "fetch", "--unshallow" ], timeout: Containers::GitOperations::DEFAULT_CLONE_TIMEOUT, stream: false)
+          .with(
+            [ "git", "fetch", "--unshallow" ],
+            timeout: Containers::GitOperations::DEFAULT_CLONE_TIMEOUT,
+            stream: false,
+            env: Containers::GitOperations::NETWORK_GIT_ENV
+          )
           .and_return(success_result)
 
         # fetch succeeds
         allow(container_service).to receive(:execute)
-          .with([ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ], timeout: nil, stream: false)
+          .with(
+            [ "git", "fetch", "origin", "refs/heads/main:refs/remotes/origin/main" ],
+            timeout: nil,
+            stream: false,
+            env: Containers::GitOperations::NETWORK_GIT_ENV
+          )
           .and_return(success_result)
 
         # rebase fails with conflict


### PR DESCRIPTION
## Summary
- disable interactive git auth fallback for networked clone/fetch/push operations so proxy failures surface clearly
- improve git credential helper messaging to include proxy error details and stop retrying on inactive project GitHub tokens
- update request and container git operation specs to cover the new failure behavior

## Testing
- `COVERAGE=false bundle exec rspec spec/requests/api/git_credentials_spec.rb spec/services/containers/git_operations_spec.rb`
- `bundle exec rubocop app/services/containers/git_operations.rb app/controllers/api/git_credentials_controller.rb spec/services/containers/git_operations_spec.rb spec/requests/api/git_credentials_spec.rb`
- `sh -n docker/agent/scripts/git-credential-paid`