### PR TITLE
refactor(test): centralize migration spec cleanup into shared helper

### DIFF
--- a/spec/migrations/add_account_to_service_containers_spec.rb
+++ b/spec/migrations/add_account_to_service_containers_spec.rb
@@ -17,19 +17,10 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     ServiceContainer.reset_column_information
   end
 
+  include MigrationSpecHelpers
+
   after do
-    connection = ActiveRecord::Base.connection
-    connection.execute("DELETE FROM project_service_containers")
-    connection.execute("DELETE FROM service_container_metrics")
-    connection.execute("DELETE FROM service_containers")
-    connection.execute("DELETE FROM workflow_states")
-    connection.execute("DELETE FROM projects")
-    connection.execute("DELETE FROM providers")
-    connection.execute("DELETE FROM provider_states")
-    connection.execute("DELETE FROM account_memberships")
-    connection.execute("DELETE FROM github_tokens")
-    connection.execute("DELETE FROM users")
-    connection.execute("DELETE FROM accounts")
+    truncate_migration_test_data
 
     restore_service_container_account_reference unless service_containers_have_account_reference?
     rls_migration.up if tenant_policy_count.zero?

--- a/spec/migrations/move_co_author_trailer_from_projects_to_providers_spec.rb
+++ b/spec/migrations/move_co_author_trailer_from_projects_to_providers_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe MoveCoAuthorTrailerFromProjectsToProviders, :aggregate_failures d
     Provider.reset_column_information
   end
 
+  include MigrationSpecHelpers
+
   # Ensure the schema ends each example in its post-migration state so the
   # rest of the suite is unaffected. Also clean up data created without
   # transactional rollback.
@@ -49,12 +51,7 @@ RSpec.describe MoveCoAuthorTrailerFromProjectsToProviders, :aggregate_failures d
     end
     Project.reset_column_information
     Provider.reset_column_information
-    # Clean up data that was not rolled back by transactional fixtures. Keep
-    # deletes ordered from child tables to parent tables so this does not need
-    # disable_referential_integrity, which takes broad locks across the suite.
-    %w[projects service_containers providers provider_states account_memberships github_tokens users accounts].each do |table|
-      connection.execute("DELETE FROM #{table}")
-    end
+    truncate_migration_test_data
   end
 
   it "copies a project trailer onto the creator's default subscription provider" do

--- a/spec/support/migration_spec_helpers.rb
+++ b/spec/support/migration_spec_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module MigrationSpecHelpers
+  def truncate_migration_test_data
+    connection = ActiveRecord::Base.connection
+    %w[
+      project_service_containers
+      service_container_metrics
+      service_containers
+      workflow_states
+      projects
+      providers
+      provider_states
+      account_memberships
+      github_tokens
+      users
+      accounts
+    ].each { |table| connection.execute("DELETE FROM #{table}") }
+  end
+end


### PR DESCRIPTION
## Summary

- Extract `MigrationSpecHelpers` module with `truncate_migration_test_data` into `spec/support/` — single source of truth for child-to-parent table deletion ordering across migration specs
- Replace duplicated `DELETE FROM` blocks in both migration specs (`add_account_to_service_containers`, `move_co_author_trailer_from_projects_to_providers`) with the shared helper
- Fixes latent cleanup gap where the trailer spec was missing `workflow_states` in its cleanup list (created by `Project#after_create_commit :start_github_polling`)