### PR TITLE
fix(test): truncate seed data before migration spec runs

### DIFF
--- a/spec/migrations/add_account_to_service_containers_spec.rb
+++ b/spec/migrations/add_account_to_service_containers_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
   let(:migration) { described_class.new }
   let(:rls_migration) { EnableTenantRowLevelSecurity.new }
 
+  include MigrationSpecHelpers
+
   before do
+    truncate_migration_test_data
+
     rls_migration.down if tenant_policy_count.positive?
     restore_service_container_account_reference unless service_containers_have_account_reference?
     migration.down
@@ -18,17 +22,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
   end
 
   after do
-    connection = ActiveRecord::Base.connection
-    connection.execute("DELETE FROM project_service_containers")
-    connection.execute("DELETE FROM service_container_metrics")
-    connection.execute("DELETE FROM service_containers")
-    connection.execute("DELETE FROM projects")
-    connection.execute("DELETE FROM providers")
-    connection.execute("DELETE FROM provider_states")
-    connection.execute("DELETE FROM account_memberships")
-    connection.execute("DELETE FROM github_tokens")
-    connection.execute("DELETE FROM users")
-    connection.execute("DELETE FROM accounts")
+    truncate_migration_test_data
 
     restore_service_container_account_reference unless service_containers_have_account_reference?
     rls_migration.up if tenant_policy_count.zero?

--- a/spec/migrations/move_co_author_trailer_from_projects_to_providers_spec.rb
+++ b/spec/migrations/move_co_author_trailer_from_projects_to_providers_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe MoveCoAuthorTrailerFromProjectsToProviders, :aggregate_failures d
     Provider.reset_column_information
   end
 
+  include MigrationSpecHelpers
+
   # Ensure the schema ends each example in its post-migration state so the
   # rest of the suite is unaffected. Also clean up data created without
   # transactional rollback.
@@ -49,12 +51,7 @@ RSpec.describe MoveCoAuthorTrailerFromProjectsToProviders, :aggregate_failures d
     end
     Project.reset_column_information
     Provider.reset_column_information
-    # Clean up data that was not rolled back by transactional fixtures. Keep
-    # deletes ordered from child tables to parent tables so this does not need
-    # disable_referential_integrity, which takes broad locks across the suite.
-    %w[projects service_containers providers provider_states account_memberships github_tokens users accounts].each do |table|
-      connection.execute("DELETE FROM #{table}")
-    end
+    truncate_migration_test_data
   end
 
   it "copies a project trailer onto the creator's default subscription provider" do

--- a/spec/support/migration_spec_helpers.rb
+++ b/spec/support/migration_spec_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module MigrationSpecHelpers
+  def truncate_migration_test_data
+    connection = ActiveRecord::Base.connection
+    %w[
+      project_service_containers
+      service_container_metrics
+      service_containers
+      workflow_states
+      projects
+      providers
+      provider_states
+      account_memberships
+      github_tokens
+      users
+      accounts
+    ].each { |table| connection.execute("DELETE FROM #{table}") }
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes CI failure in `AddAccountToServiceContainers` migration spec where seed service containers ("postgres", "redis") from `db/seeds/service_containers.rb` inflated the count from 1 to 3
- Root cause: `before` block only adjusted schema (`migration.down`) but never removed seed data — the seed SCs have different names from the test SC and survive the per-name collapse in `migration.down`
- Extracts shared `MigrationSpecHelpers#truncate_migration_test_data` and adds it to both `before` and `after` blocks of both non-transactional migration specs

## Test plan

- [x] All 17 migration specs pass locally with and without seed data present
- [ ] CI passes on this PR