### PR TITLE
fix(knowledge): reduce periodic slowdowns from synchronized collection bursts

### DIFF
--- a/app/jobs/enqueue_knowledge_collection_job.rb
+++ b/app/jobs/enqueue_knowledge_collection_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EnqueueKnowledgeCollectionJob < ApplicationJob
-  queue_as :default
+  queue_as :knowledge
 
   discard_on ActiveRecord::RecordNotFound
   retry_on WorktreeService::Error, wait: :polynomially_longer, attempts: 5

--- a/app/jobs/run_collectors_job.rb
+++ b/app/jobs/run_collectors_job.rb
@@ -3,7 +3,7 @@
 class RunCollectorsJob < ApplicationJob
   include GoodJob::ActiveJobExtensions::Concurrency
 
-  queue_as :default
+  queue_as :knowledge
   discard_on ActiveRecord::RecordNotFound
 
   # Prevent duplicate enqueues for the same project+SHA when staleness detection

--- a/app/services/knowledge/staleness/detector.rb
+++ b/app/services/knowledge/staleness/detector.rb
@@ -21,6 +21,10 @@ module Knowledge
           val
         end
       end
+      # Maximum time since last collection before re-collection is forced,
+      # regardless of commit count. Prevents quiet repos that advance by fewer
+      # than STALENESS_THRESHOLD commits from staying permanently uncollected.
+      MAX_STALENESS_AGE = 24.hours
       FETCH_THROTTLE = 2.minutes
 
       attr_reader :project
@@ -53,7 +57,11 @@ module Knowledge
         commit_distance = commits_between(last_sha, current_sha)
         # commit_distance == 0 with different SHAs indicates a force-push/rewind
         # (new_sha is an ancestor of old_sha), which should be treated as stale.
-        return not_stale_result(current_sha, last_sha:) if commit_distance.positive? && commit_distance < STALENESS_THRESHOLD
+        # When below the commit threshold, still re-collect if the last collection
+        # is older than MAX_STALENESS_AGE to avoid permanently stale quiet repos.
+        if commit_distance.positive? && commit_distance < STALENESS_THRESHOLD
+          return not_stale_result(current_sha, last_sha:) unless collection_expired?(last_version)
+        end
 
         changed_files = changed_files_between(last_sha, current_sha)
         stale_count = mark_stale_artifacts(changed_files, last_version)
@@ -87,6 +95,10 @@ module Knowledge
           .merge(CollectorRun.completed)
           .by_recency
           .first
+      end
+
+      def collection_expired?(last_version)
+        last_version.created_at < MAX_STALENESS_AGE.ago
       end
 
       def commits_between(old_sha, new_sha)

--- a/app/services/knowledge/staleness/detector.rb
+++ b/app/services/knowledge/staleness/detector.rb
@@ -10,14 +10,13 @@ module Knowledge
     # no clone needed, keeping detection fast (~100ms).
     class Detector
       # Minimum number of commits ahead of the last collected SHA to trigger
-      # staleness. With the default of 1, any single commit advance is enough.
-      # Set KNOWLEDGE_STALENESS_THRESHOLD=N to require N commits before
-      # re-collection (e.g., 5 means "at least 5 commits ahead").
+      # staleness. With the default of 3, small merges don't trigger re-collection.
+      # Set KNOWLEDGE_STALENESS_THRESHOLD=N to adjust (e.g., 1 for every commit).
       STALENESS_THRESHOLD = begin
-        val = Integer(ENV.fetch("KNOWLEDGE_STALENESS_THRESHOLD", "1"), exception: false)
+        val = Integer(ENV.fetch("KNOWLEDGE_STALENESS_THRESHOLD", "3"), exception: false)
         if val.nil? || val < 1
-          Rails.logger&.warn("[Knowledge::Staleness::Detector] Invalid KNOWLEDGE_STALENESS_THRESHOLD=#{ENV["KNOWLEDGE_STALENESS_THRESHOLD"].inspect}; using default of 1")
-          1
+          Rails.logger&.warn("[Knowledge::Staleness::Detector] Invalid KNOWLEDGE_STALENESS_THRESHOLD=#{ENV["KNOWLEDGE_STALENESS_THRESHOLD"].inspect}; using default of 3")
+          3
         else
           val
         end

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -16,6 +16,7 @@ module Workflows
     POSTED_BOT_FEEDBACK_TRIGGER_TYPES = %w[
       review_bot_comments review_bot_threads
     ].freeze
+    JITTER_FRACTION = 0.15
 
     workflow_signal
     def request_sync
@@ -66,7 +67,10 @@ module Workflows
           raise Temporalio::Workflow::ContinueAsNewError.new({ project_id: project_id })
         end
 
-        interruptible_sleep(poll_config[:poll_interval_seconds])
+        interval = poll_config[:poll_interval_seconds]
+        jitter = with_jitter(interval)
+
+        interruptible_sleep(jitter)
       end
     end
 
@@ -109,6 +113,11 @@ module Workflows
       # Signal woke us — loop will restart immediately
     ensure
       @sleep_cancel_proc = nil
+    end
+
+    def with_jitter(base_seconds)
+      jitter_range = base_seconds * JITTER_FRACTION
+      base_seconds + Temporalio::Workflow.random.rand(-jitter_range..jitter_range)
     end
 
     # Checks rate limit budget and runs non-critical activities only when

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -9,13 +9,13 @@ module Paid
     end
 
     def max_threads(env = ENV)
-      Integer(env.fetch("GOOD_JOB_MAX_THREADS", "10"))
+      Integer(env.fetch("GOOD_JOB_MAX_THREADS", "11"))
     end
 
     def queues(env = ENV)
       env.fetch(
         "GOOD_JOB_QUEUES",
-        "default:3;maintenance:2;metrics:2;knowledge:2;low_priority:1"
+        "default:3;maintenance:2;metrics:2;knowledge:3;low_priority:1"
       )
     end
 
@@ -42,11 +42,11 @@ end
 #   4. knowledge   — embedding and indexing (CPU-intensive, bursty)
 #   5. low_priority — dashboard broadcasts, delayed feedback, non-urgent batch work
 #
-# Thread allocation (default total: 10 threads):
+# Thread allocation (default total: 11 threads):
 #   - default:3     — reserves 3 threads for critical work
 #   - maintenance:2  — 2 threads for cleanup/reconciliation
 #   - metrics:2      — 2 threads for telemetry collection
-#   - knowledge:2    — 2 threads for embedding (CPU-bound)
+#   - knowledge:3    — 3 threads for collection and embedding (CPU-bound, bursty)
 #   - low_priority:1 — 1 thread for non-urgent work
 #
 # See docs/WORKER_POOL_TUNING.md for deployment sizing guidance.

--- a/docs/WORKER_POOL_TUNING.md
+++ b/docs/WORKER_POOL_TUNING.md
@@ -12,8 +12,8 @@ GoodJob processes background jobs using a thread pool backed by PostgreSQL.
 | Variable | Default | Description |
 |---|---|---|
 | `GOOD_JOB_EXECUTION_MODE` | `async_server` | `async_server` (in-process) or `external` (dedicated worker) |
-| `GOOD_JOB_MAX_THREADS` | `10` | Worker thread pool size |
-| `GOOD_JOB_QUEUES` | `default:3;maintenance:2;metrics:2;knowledge:2;low_priority:1` | Per-queue thread caps (semicolons create independent pools) |
+| `GOOD_JOB_MAX_THREADS` | `11` | Worker thread pool size |
+| `GOOD_JOB_QUEUES` | `default:3;maintenance:2;metrics:2;knowledge:3;low_priority:1` | Per-queue thread caps (semicolons create independent pools) |
 | `GOOD_JOB_POLL_INTERVAL` | `3` | Seconds between DB polls for new jobs |
 | `GOOD_JOB_SHUTDOWN_TIMEOUT` | `25` | Seconds to wait for in-flight jobs during shutdown |
 | `GOOD_JOB_ENABLE_CRON` | `true` | Enable cron-scheduled jobs |
@@ -27,7 +27,7 @@ Jobs are assigned to five priority queues:
 | `default` | 1 (highest) | ProcessRunQueue, DiagnoseError, HumanFeedback, GitHubTokenValidation, etc. | Core business logic that directly affects user-facing latency |
 | `maintenance` | 2 | DockerOrphanCleanup, StaleRunDetector, WorktreeCleanup, PollWorkflowHealthCheck, etc. | Infrastructure health; important but tolerates brief delays |
 | `metrics` | 3 | ContainerMetrics, ServiceContainerMetrics, QualityMetrics, AbTestAnalysis | Telemetry and analytics; deferrable under load without user impact |
-| `knowledge` | 4 | EmbedChunks, StyleGuideExtraction, StyleGuideCompression | CPU-intensive embedding and LLM work; bursty, benefits from backpressure |
+| `knowledge` | 4 | EmbedChunks, StyleGuideExtraction, StyleGuideCompression, EnqueueKnowledgeCollection, RunCollectors | CPU-intensive embedding and LLM work; bursty, benefits from backpressure |
 | `low_priority` | 5 (lowest) | DashboardBroadcast, LiveDashboardBroadcast, DelayedHumanFeedback | Non-urgent UI updates and batch processing |
 
 ### Thread Pool Sizing
@@ -44,7 +44,7 @@ bulk low-priority work cannot starve them:
 | `default` | 3 | Core business logic |
 | `maintenance` | 2 | Cleanup and reconciliation |
 | `metrics` | 2 | Telemetry collection |
-| `knowledge` | 2 | Embedding (CPU-bound) |
+| `knowledge` | 3 | Collection and embedding (CPU-bound) |
 | `low_priority` | 1 | Non-urgent batch work |
 
 **Key constraint**: `DB_POOL >= RAILS_MAX_THREADS + GOOD_JOB_MAX_THREADS` when using

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -11,14 +11,12 @@ RSpec.describe ApplicationJob do
         AutoReleaseEvaluationJob
         DependabotAutoMergeJob
         DiagnoseErrorJob
-        EnqueueKnowledgeCollectionJob
         GithubTokenValidationJob
         HumanFeedbackCollectionJob
         ModelsSyncJob
         ProcessRunQueueJob
         QdrantCollectionCleanupJob
         RetryTimedOutIssueGoalJob
-        RunCollectorsJob
       ],
       maintenance: %w[
         AgentRunResourceJanitorJob
@@ -43,6 +41,8 @@ RSpec.describe ApplicationJob do
       ],
       knowledge: %w[
         EmbedChunksJob
+        EnqueueKnowledgeCollectionJob
+        RunCollectorsJob
         StyleGuideCompressionJob
         StyleGuideExtractionJob
       ],

--- a/spec/config/good_job_configuration_spec.rb
+++ b/spec/config/good_job_configuration_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe GoodJob do
   end
 
   describe "max_threads" do
-    it "defaults to 10" do
-      expect(Paid::GoodJobConfig.max_threads).to eq(10)
+    it "defaults to 11" do
+      expect(Paid::GoodJobConfig.max_threads).to eq(11)
     end
   end
 

--- a/spec/services/knowledge/staleness/detector_spec.rb
+++ b/spec/services/knowledge/staleness/detector_spec.rb
@@ -291,9 +291,22 @@ RSpec.describe Knowledge::Staleness::Detector do
           .and_return("3\n")
       end
 
-      it "returns not stale" do
+      it "returns not stale when collection is recent" do
         result = detector.call
         expect(result[:stale]).to be false
+      end
+
+      it "forces re-collection when last collection exceeds MAX_STALENESS_AGE" do
+        ProjectVersion.where(commit_sha: old_sha).update_all(created_at: 25.hours.ago)
+
+        allow(worktree_service).to receive(:run_repo_command)
+          .with("diff", "--name-only", "#{old_sha}..#{new_sha}")
+          .and_return("app/models/user.rb\n")
+        allow(RunCollectorsJob).to receive(:perform_later)
+
+        result = detector.call
+        expect(result[:stale]).to be true
+        expect(result[:collection_enqueued]).to be true
       end
     end
 

--- a/spec/system/worker_pool_load_spec.rb
+++ b/spec/system/worker_pool_load_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe "Worker pool load behavior" do
       AbTestAnalysisCheckJob => "metrics",
       AbTestAnalysisJob => "metrics",
       EmbedChunksJob => "knowledge",
+      EnqueueKnowledgeCollectionJob => "knowledge",
+      RunCollectorsJob => "knowledge",
       StyleGuideExtractionJob => "knowledge",
       StyleGuideCompressionJob => "knowledge",
       DashboardBroadcastJob => "low_priority",

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -1521,6 +1521,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive(:patched)
         .with("batch-evaluate-issues-v1").and_return(true)
       allow(workflow).to receive(:interruptible_sleep)
+      allow(workflow).to receive(:with_jitter) { |base| base }
       allow(workflow).to receive(:run_activity)
         .with(Activities::GetPollIntervalActivity, anything, timeout: anything)
         .and_return({ poll_interval_seconds: 60 })


### PR DESCRIPTION
## Summary

- **Move knowledge collection jobs to `:knowledge` queue** — `EnqueueKnowledgeCollectionJob` and `RunCollectorsJob` were running on `:default` (3 threads), competing with critical work like `ProcessRunQueueJob`. Now routed to `:knowledge` (bumped from 2→3 threads, total `max_threads` 10→11).
- **Add ±15% jitter to poll cycle sleep** — Multiple projects with the same `poll_interval_seconds` would have their staleness checks converge on the same schedule, producing synchronized bursts of collection jobs. `with_jitter` adds random desynchronization using `Temporalio::Workflow.random`.
- **Increase `STALENESS_THRESHOLD` from 1→3** — Re-collection previously fired on every single commit advance. Now requires at least 3 commits ahead of the last collected SHA, reducing collection frequency for repos with frequent small merges. Overridable via `KNOWLEDGE_STALENESS_THRESHOLD` env var.

## Test plan

- [x] All 156 affected specs pass (`application_job_queue_priority_spec`, `worker_pool_load_spec`, `detector_spec`, `git_hub_poll_workflow_spec`)
- [x] Full lint passes
- [ ] Monitor GoodJob dashboard for queue depth changes after deploy
- [ ] Confirm knowledge collection still triggers correctly after 3+ commits