### PR TITLE
fix(devcontainer): reduce worker defaults to avoid overmind OOMs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,11 +23,22 @@
     "DB_HOST": "postgres",
     "DB_USERNAME": "paid",
     "DB_PASSWORD": "paid",
+    // Keep devcontainer worker concurrency conservative to avoid OOM-killing
+    // Overmind when Rails, GoodJob, Temporal, and asset watchers are all live.
+    "DB_POOL": "10",
     "TEMPORAL_ADDRESS": "temporal:7233",
     "TEMPORAL_NAMESPACE": "default",
     "TEMPORAL_POLL_TASK_QUEUE": "paid-poll-tasks",
     "TEMPORAL_AGENT_TASK_QUEUE": "paid-agent-tasks",
+    "TEMPORAL_WORKFLOW_SLOTS": "4",
+    "TEMPORAL_ACTIVITY_SLOTS": "1",
+    "TEMPORAL_LOCAL_ACTIVITY_SLOTS": "1",
+    "TEMPORAL_POLL_WORKFLOW_SLOTS": "4",
+    "TEMPORAL_POLL_ACTIVITY_SLOTS": "2",
+    "TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS": "2",
     "TEMPORAL_UI_URL": "http://localhost:8080",
+    "GOOD_JOB_MAX_THREADS": "6",
+    "GOOD_JOB_QUEUES": "default:2;maintenance:1;metrics:1;knowledge:1;low_priority:1",
     "QDRANT_URL": "http://qdrant:6333",
     // LLM CLI tools - dangerous/auto-approve mode (container only)
     "CODEX_APPROVAL_POLICY": "never",

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ docker compose up --build
 
 Open in VS Code with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, or use GitHub Codespaces. The `.devcontainer/` configuration provides a complete development environment.
 
+The checked-in devcontainer also applies conservative `TEMPORAL_*`, `GOOD_JOB_*`, and `DB_POOL` defaults so `bin/dev` stays stable under normal development load.
+
 #### Enable Commit Signing in Dev Container
 
 If commit signing is not configured automatically, run:


### PR DESCRIPTION
## Summary
- add conservative devcontainer defaults for Temporal worker concurrency
- reduce GoodJob thread/queue defaults in the devcontainer environment
- document that the devcontainer applies these safer `bin/dev` defaults

## Why
The devcontainer was OOM-killing the Temporal worker under normal `bin/dev` load, which caused Overmind to tear down the whole stack. These defaults trade some background throughput for a much more stable local development experience.

## Testing
- investigated the live OOM shutdown path via `log/dev-update/overmind.log` and supervisor diagnostics
- restarted `bin/dev` with the reduced settings and confirmed the worker stayed healthy instead of exiting `137`
- verified the chosen `DB_POOL` satisfies the Temporal worker's own minimum pool calculation for the reduced slot counts