### PR TITLE
Fix #847: Add truncation with expand/collapse for long log output on agent run page

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -31,11 +31,11 @@ application.register("hello", HelloController)
 import LiveDashboardController from "./live_dashboard_controller"
 application.register("live-dashboard", LiveDashboardController)
 
-import LogTruncateController from "./log_truncate_controller"
-application.register("log-truncate", LogTruncateController)
-
 import LocalTimeController from "./local_time_controller"
 application.register("local-time", LocalTimeController)
+
+import LogTruncateController from "./log_truncate_controller"
+application.register("log-truncate", LogTruncateController)
 
 import MobileMenuController from "./mobile_menu_controller"
 application.register("mobile-menu", MobileMenuController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -31,6 +31,9 @@ application.register("hello", HelloController)
 import LiveDashboardController from "./live_dashboard_controller"
 application.register("live-dashboard", LiveDashboardController)
 
+import LogTruncateController from "./log_truncate_controller"
+application.register("log-truncate", LogTruncateController)
+
 import LocalTimeController from "./local_time_controller"
 application.register("local-time", LocalTimeController)
 

--- a/app/javascript/controllers/log_truncate_controller.js
+++ b/app/javascript/controllers/log_truncate_controller.js
@@ -10,34 +10,42 @@ export default class extends Controller {
 
   truncate() {
     const content = this.contentTarget
-    const fullText = content.textContent
-    const lines = fullText.split("\n")
+    const lineHeight = parseFloat(window.getComputedStyle(content).lineHeight)
 
-    if (lines.length <= this.maxLinesValue) {
+    if (!lineHeight || isNaN(lineHeight)) return
+
+    const maxHeight = lineHeight * this.maxLinesValue
+    const renderedHeight = content.scrollHeight
+
+    if (renderedHeight <= maxHeight) {
       this.toggleTarget.classList.add("hidden")
       return
     }
 
-    this.fullText = fullText
-    this.truncatedText = lines.slice(0, this.maxLinesValue).join("\n")
+    this.maxHeight = maxHeight
     this.expanded = false
-    this.totalLines = lines.length
 
-    content.textContent = this.truncatedText
+    content.style.maxHeight = `${maxHeight}px`
+    content.style.overflow = "hidden"
     this.updateToggle()
   }
 
   toggle() {
     this.expanded = !this.expanded
-    this.contentTarget.textContent = this.expanded ? this.fullText : this.truncatedText
+    const content = this.contentTarget
+
+    if (this.expanded) {
+      content.style.maxHeight = "none"
+      content.style.overflow = "visible"
+    } else {
+      content.style.maxHeight = `${this.maxHeight}px`
+      content.style.overflow = "hidden"
+    }
     this.updateToggle()
   }
 
   updateToggle() {
-    const hiddenCount = this.totalLines - this.maxLinesValue
-    this.toggleTarget.textContent = this.expanded
-      ? "Collapse"
-      : `Show ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`
+    this.toggleTarget.textContent = this.expanded ? "Collapse" : "Show more"
     this.toggleTarget.classList.remove("hidden")
   }
 }

--- a/app/javascript/controllers/log_truncate_controller.js
+++ b/app/javascript/controllers/log_truncate_controller.js
@@ -1,0 +1,43 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content", "toggle"]
+  static values = { maxLines: { type: Number, default: 10 } }
+
+  connect() {
+    this.truncate()
+  }
+
+  truncate() {
+    const content = this.contentTarget
+    const fullText = content.textContent
+    const lines = fullText.split("\n")
+
+    if (lines.length <= this.maxLinesValue) {
+      this.toggleTarget.classList.add("hidden")
+      return
+    }
+
+    this.fullText = fullText
+    this.truncatedText = lines.slice(0, this.maxLinesValue).join("\n")
+    this.expanded = false
+    this.totalLines = lines.length
+
+    content.textContent = this.truncatedText
+    this.updateToggle()
+  }
+
+  toggle() {
+    this.expanded = !this.expanded
+    this.contentTarget.textContent = this.expanded ? this.fullText : this.truncatedText
+    this.updateToggle()
+  }
+
+  updateToggle() {
+    const hiddenCount = this.totalLines - this.maxLinesValue
+    this.toggleTarget.textContent = this.expanded
+      ? "Collapse"
+      : `Show ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`
+    this.toggleTarget.classList.remove("hidden")
+  }
+}

--- a/app/views/projects/agent_runs/show.html.erb
+++ b/app/views/projects/agent_runs/show.html.erb
@@ -45,7 +45,7 @@
                data-controller="log-truncate" data-log-truncate-max-lines-value="10">
             <span class="mr-2 text-gray-400"><%= local_time(log.created_at, format: :time) %></span>
             <span class="mr-2 rounded bg-gray-200 px-1 text-gray-600"><%= log.log_type %></span>
-            <pre class="inline whitespace-pre-wrap" data-log-truncate-target="content"><%= log.content %></pre>
+            <pre class="inline-block whitespace-pre-wrap" data-log-truncate-target="content"><%= log.content %></pre>
             <button type="button" class="mt-1 hidden cursor-pointer text-xs font-medium text-indigo-600 hover:text-indigo-800" data-log-truncate-target="toggle" data-action="log-truncate#toggle"></button>
           </div>
         <% end %>

--- a/app/views/projects/agent_runs/show.html.erb
+++ b/app/views/projects/agent_runs/show.html.erb
@@ -41,10 +41,12 @@
       <h2 class="border-b border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-900">Execution Logs</h2>
       <div class="max-h-96 overflow-auto">
         <% @logs.each do |log| %>
-          <div class="border-b border-gray-100 px-4 py-2 font-mono text-xs last:border-b-0 <%= log.log_type == 'stderr' ? 'bg-red-50 text-red-800' : '' %> <%= log.log_type == 'system' ? 'bg-blue-50 text-blue-800' : '' %>">
+          <div class="border-b border-gray-100 px-4 py-2 font-mono text-xs last:border-b-0 <%= log.log_type == 'stderr' ? 'bg-red-50 text-red-800' : '' %> <%= log.log_type == 'system' ? 'bg-blue-50 text-blue-800' : '' %>"
+               data-controller="log-truncate" data-log-truncate-max-lines-value="10">
             <span class="mr-2 text-gray-400"><%= local_time(log.created_at, format: :time) %></span>
             <span class="mr-2 rounded bg-gray-200 px-1 text-gray-600"><%= log.log_type %></span>
-            <pre class="inline whitespace-pre-wrap"><%= log.content %></pre>
+            <pre class="inline whitespace-pre-wrap" data-log-truncate-target="content"><%= log.content %></pre>
+            <button type="button" class="mt-1 hidden cursor-pointer text-xs font-medium text-indigo-600 hover:text-indigo-800" data-log-truncate-target="toggle" data-action="log-truncate#toggle"></button>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Summary

Add truncation with expand/collapse for long log output on agent run page

See #847 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #847