### PR TITLE
Fix #1254: dev-update: scope detection misses files pulled from unrelated PRs

### DIFF
--- a/bin/dev-update
+++ b/bin/dev-update
@@ -190,9 +190,39 @@ ensure_on_main() {
   fi
 }
 
+PULL_CHANGED_FILES=""
+
 pull_latest() {
+  local pre_head
+  pre_head="$(git rev-parse HEAD)"
+
   log "Pulling latest changes from main..."
   git pull --ff-only origin main
+
+  local post_head
+  post_head="$(git rev-parse HEAD)"
+
+  if [ "$pre_head" != "$post_head" ]; then
+    PULL_CHANGED_FILES="$(git diff --name-only "$pre_head" "$post_head")"
+    if [ -n "$PULL_CHANGED_FILES" ]; then
+      local csv
+      csv="$(newline_list_to_csv "$PULL_CHANGED_FILES")"
+      log "Files changed in pull: $csv"
+    fi
+  fi
+}
+
+restart_required_from_pull() {
+  local file
+
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    if restart_required_for_file "$file"; then
+      return 0
+    fi
+  done <<< "$PULL_CHANGED_FILES"
+
+  return 1
 }
 
 stop_overmind() {
@@ -333,7 +363,20 @@ case "$MODE" in
     log "Starting lightweight update..."
     ensure_on_main
     pull_latest
-    log "Lightweight update complete. Rails will autoload changes."
+    if restart_required_from_pull; then
+      log "Pull included restart-worthy files outside the trigger context; upgrading to full restart."
+      stop_overmind
+      if ! run_setup; then
+        recover_dev_if_needed
+        fail "Full restart aborted because bin/setup --skip-server failed."
+      fi
+      if ! start_dev; then
+        fail "Full restart completed setup but failed to restore a healthy Overmind session."
+      fi
+      log "Full restart update complete."
+    else
+      log "Lightweight update complete. Rails will autoload changes."
+    fi
     ;;
   --full)
     configure_logging

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -220,6 +220,52 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "upgrades lightweight to full restart when pull brings in restart-worthy files" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      diff_files = %w[app/models/user.rb config/initializers/temporal.rb]
+      script_path = prepare_script_fixture(dir, pull_diff_files: diff_files)
+      env = trigger_context_env(dir,
+        "DEV_UPDATE_TRIGGER_MODE" => "lightweight",
+        "DEV_UPDATE_CHANGED_FILES" => "app/models/user.rb")
+
+      stdout, stderr, status = Open3.capture3(env, script_path, "--lightweight", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(File.exist?(File.join(dir, "setup-ran"))).to be(true)
+      expect(File.exist?(File.join(dir, "dev-ran"))).to be(true)
+
+      updater_log = read_updater_log(dir)
+      expect(updater_log).to include("upgrading to full restart")
+      expect(updater_log).to include("Full restart update complete.")
+      expect(updater_log).not_to include("Lightweight update complete.")
+    end
+  end
+
+  it "stays lightweight when pull brings in only autoloadable files" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, pull_diff_files: %w[
+        app/models/user.rb
+        app/services/foo.rb
+      ])
+
+      stdout, stderr, status = Open3.capture3(
+        trigger_context_env(dir,
+          "DEV_UPDATE_TRIGGER_MODE" => "lightweight",
+          "DEV_UPDATE_CHANGED_FILES" => "app/models/user.rb"),
+        script_path,
+        "--lightweight",
+        chdir: dir
+      )
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(File.exist?(File.join(dir, "setup-ran"))).to be(false)
+
+      updater_log = read_updater_log(dir)
+      expect(updater_log).to include("Lightweight update complete.")
+      expect(updater_log).not_to include("upgrading to full restart")
+    end
+  end
+
   it "does not forward STARTUP_CLEANUP_KILL_ALL when unset during full restart" do
     Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, capture_kill_all_in_dev: true)
@@ -346,7 +392,8 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     start_overmind_running: false,
     dev_starts_overmind: true,
     capture_port_in_dev: false,
-    capture_kill_all_in_dev: false
+    capture_kill_all_in_dev: false,
+    pull_diff_files: []
   )
     FileUtils.mkdir_p(File.join(dir, "bin"))
     FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
@@ -387,15 +434,34 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
       BASH
     )
 
+    pull_diff_file = File.join(dir, "pull-diff-files")
+    File.write(pull_diff_file, pull_diff_files.join("\n"))
+
     write_executable(
       File.join(dir, "stubbin", "git"),
       <<~BASH
         #!/usr/bin/env bash
         case "$1" in
           rev-parse)
-            echo "main"
+            case "${2:-}" in
+              --abbrev-ref)
+                echo "main"
+                ;;
+              *)
+                if [ -f "#{dir}/pull-ran" ]; then
+                  echo "post-pull-sha"
+                else
+                  echo "pre-pull-sha"
+                fi
+                ;;
+            esac
             ;;
           pull)
+            touch "#{dir}/pull-ran"
+            exit 0
+            ;;
+          diff)
+            cat "#{pull_diff_file}" 2>/dev/null || true
             exit 0
             ;;
           *)


### PR DESCRIPTION
## Summary

dev-update: scope detection misses files pulled from unrelated PRs

See #1254 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1254