### PR TITLE
Fix #1255: dev-update: deadlocks when working tree has unstaged changes

### DIFF
--- a/bin/dev-update
+++ b/bin/dev-update
@@ -42,6 +42,9 @@ OVERMIND_STOP_POLL_COUNT="${DEV_UPDATE_OVERMIND_STOP_POLL_COUNT:-10}"
 OVERMIND_START_POLL_COUNT="${DEV_UPDATE_OVERMIND_START_POLL_COUNT:-15}"
 OVERMIND_POLL_INTERVAL="${DEV_UPDATE_OVERMIND_POLL_INTERVAL:-1}"
 STARTUP_CLEANUP_KILL_ALL="${DEV_UPDATE_STARTUP_CLEANUP_KILL_ALL:-}"
+STASHED_CHANGES=0
+FAILURE_LOCK_FILE="${APP_ROOT}/tmp/dev-update-failure.lock"
+MAX_CONSECUTIVE_FAILURES="${DEV_UPDATE_MAX_CONSECUTIVE_FAILURES:-3}"
 
 newline_list_to_csv() {
   printf '%s' "${1:-}" | tr '\n' ',' | sed 's/,$//'
@@ -104,6 +107,59 @@ truncate_dev_update_logs() {
   truncate_log_if_oversized "$START_DEV_LOG"
   truncate_log_if_oversized "$TMUX_LOG"
   truncate_log_if_oversized "$OVERMIND_LOG"
+}
+
+tree_is_dirty() {
+  [ -n "$(git status --porcelain 2>/dev/null)" ]
+}
+
+stash_dirty_tree() {
+  if tree_is_dirty; then
+    log "Working tree has uncommitted changes; auto-stashing..."
+    local stash_output
+    stash_output="$(git stash push --include-untracked -m "dev-update-autostash" 2>&1)"
+    log_command_output "git stash" "$stash_output"
+    STASHED_CHANGES=1
+  fi
+}
+
+unstash_dirty_tree() {
+  if [ "$STASHED_CHANGES" -eq 1 ]; then
+    log "Restoring auto-stashed changes..."
+    if ! git stash pop 2>&1; then
+      log "WARNING: git stash pop failed (conflict). Stashed changes preserved in git stash. Run 'git stash pop' manually."
+    fi
+    STASHED_CHANGES=0
+  fi
+}
+
+check_failure_lock() {
+  mkdir -p "$(dirname "$FAILURE_LOCK_FILE")"
+  if [ -f "$FAILURE_LOCK_FILE" ]; then
+    local count
+    count="$(cat "$FAILURE_LOCK_FILE")"
+    if [ "$count" -ge "$MAX_CONSECUTIVE_FAILURES" ]; then
+      log "ERROR: $count consecutive pull failures detected. Manual intervention required."
+      log "Remove $FAILURE_LOCK_FILE after resolving the working tree issue."
+      exit 1
+    fi
+  fi
+}
+
+record_failure() {
+  mkdir -p "$(dirname "$FAILURE_LOCK_FILE")"
+  local count=0
+  [ -f "$FAILURE_LOCK_FILE" ] && count="$(cat "$FAILURE_LOCK_FILE")"
+  count=$((count + 1))
+  echo "$count" > "$FAILURE_LOCK_FILE"
+  log "Recorded pull failure ($count/$MAX_CONSECUTIVE_FAILURES)."
+}
+
+clear_failure_lock() {
+  if [ -f "$FAILURE_LOCK_FILE" ]; then
+    rm -f "$FAILURE_LOCK_FILE"
+    log "Cleared failure lock after successful pull."
+  fi
 }
 
 configure_logging() {
@@ -185,14 +241,22 @@ ensure_on_main() {
   current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
   if [ "$current_branch" != "main" ]; then
+    stash_dirty_tree
     log "Switching to main branch (currently on $current_branch)..."
     git checkout main
   fi
 }
 
 pull_latest() {
+  stash_dirty_tree
   log "Pulling latest changes from main..."
-  git pull --ff-only origin main
+  if ! git pull --ff-only origin main; then
+    record_failure
+    unstash_dirty_tree
+    fail "git pull --ff-only failed. Check for diverged history or upstream issues."
+  fi
+  clear_failure_lock
+  unstash_dirty_tree
 }
 
 stop_overmind() {
@@ -325,6 +389,7 @@ case "$MODE" in
   --lightweight)
     configure_logging
     log_trigger_context
+    check_failure_lock
     enforce_safe_mode
     if [ "$MODE" = "--full" ]; then
       run_full_restart
@@ -338,6 +403,7 @@ case "$MODE" in
   --full)
     configure_logging
     log_trigger_context
+    check_failure_lock
     run_full_restart
     ;;
   *)

--- a/bin/dev-update
+++ b/bin/dev-update
@@ -133,6 +133,7 @@ unstash_dirty_tree() {
       # repo in a broken state that downstream steps (bin/setup, restart) cannot
       # recover from.  The stash entry is preserved so the user can resolve
       # manually with `git stash pop`.
+      record_failure
       fail "git stash pop failed (conflict). Resolve manually with 'git stash pop'."
     else
       log_command_output "git stash pop" "$pop_output"
@@ -252,6 +253,7 @@ ensure_on_main() {
     # Refuse to switch branches with a dirty tree — stashing would carry
     # feature-branch edits onto main when unstash_dirty_tree runs later.
     if tree_is_dirty; then
+      record_failure
       fail "Working tree on '$current_branch' has uncommitted changes. Commit or stash them before running dev-update."
     fi
     log "Switching to main branch (currently on $current_branch)..."

--- a/bin/dev-update
+++ b/bin/dev-update
@@ -129,7 +129,11 @@ unstash_dirty_tree() {
     local pop_output
     if ! pop_output="$(git stash pop 2>&1)"; then
       log_command_output "git stash pop" "$pop_output"
-      log "WARNING: git stash pop failed (conflict). Stashed changes preserved in git stash. Run 'git stash pop' manually."
+      # Abort on conflict — continuing with a conflicted tree would leave the
+      # repo in a broken state that downstream steps (bin/setup, restart) cannot
+      # recover from.  The stash entry is preserved so the user can resolve
+      # manually with `git stash pop`.
+      fail "git stash pop failed (conflict). Resolve manually with 'git stash pop'."
     else
       log_command_output "git stash pop" "$pop_output"
     fi
@@ -245,7 +249,11 @@ ensure_on_main() {
   current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
   if [ "$current_branch" != "main" ]; then
-    stash_dirty_tree
+    # Refuse to switch branches with a dirty tree — stashing would carry
+    # feature-branch edits onto main when unstash_dirty_tree runs later.
+    if tree_is_dirty; then
+      fail "Working tree on '$current_branch' has uncommitted changes. Commit or stash them before running dev-update."
+    fi
     log "Switching to main branch (currently on $current_branch)..."
     git checkout main
   fi

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
-  it "logs git stash pop conflict output and warning when restoring auto-stashed changes fails" do
+  it "aborts with error when git stash pop conflicts during restore" do
     Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(
         dir,
@@ -375,9 +375,9 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
       stdout, stderr, status = Open3.capture3(env, script_path, "--lightweight", chdir: dir)
       updater_log = read_updater_log(dir)
 
-      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(status.success?).to be(false), -> { "expected failure but got success\nstdout: #{stdout}\nstderr: #{stderr}" }
       expect(updater_log).to include("git stash pop: CONFLICT (content): Merge conflict in bin/dev-update")
-      expect(updater_log).to include("WARNING: git stash pop failed (conflict). Stashed changes preserved in git stash. Run 'git stash pop' manually.")
+      expect(updater_log).to include("ERROR: git stash pop failed (conflict). Resolve manually with 'git stash pop'.")
     end
   end
 

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -288,6 +288,87 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "auto-stashes dirty working tree before pulling" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, dirty_tree: true)
+
+      env = poll_env.merge("PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}", "OVERMIND_SOCKET" => ".overmind.sock")
+      stdout, stderr, status = Open3.capture3(env, script_path, "--lightweight", chdir: dir)
+      updater_log = read_updater_log(dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(updater_log).to include("Working tree has uncommitted changes; auto-stashing...")
+      expect(updater_log).to include("Restoring auto-stashed changes...")
+      expect(updater_log).to include("Lightweight update complete.")
+    end
+  end
+
+  it "stops retrying after max consecutive pull failures" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+
+      # Seed the failure lock at the max
+      FileUtils.mkdir_p(File.join(dir, "tmp"))
+      File.write(File.join(dir, "tmp", "dev-update-failure.lock"), "3")
+
+      env = poll_env.merge(
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_UPDATE_MAX_CONSECUTIVE_FAILURES" => "3"
+      )
+      stdout, stderr, status = Open3.capture3(env, script_path, "--lightweight", chdir: dir)
+      updater_log = read_updater_log(dir)
+
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(updater_log).to include("consecutive pull failures detected. Manual intervention required.")
+    end
+  end
+
+  it "records and clears failure lock on pull success" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+
+      # Seed a failure lock below the max
+      FileUtils.mkdir_p(File.join(dir, "tmp"))
+      lock_path = File.join(dir, "tmp", "dev-update-failure.lock")
+      File.write(lock_path, "1")
+
+      env = poll_env.merge(
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_UPDATE_MAX_CONSECUTIVE_FAILURES" => "3"
+      )
+      stdout, stderr, status = Open3.capture3(env, script_path, "--lightweight", chdir: dir)
+      updater_log = read_updater_log(dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(updater_log).to include("Cleared failure lock after successful pull.")
+      expect(File.exist?(lock_path)).to be(false)
+    end
+  end
+
+  it "records pull failure and exits with error" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, pull_exit_status: 1)
+
+      env = poll_env.merge(
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_UPDATE_MAX_CONSECUTIVE_FAILURES" => "3"
+      )
+      stdout, stderr, status = Open3.capture3(env, script_path, "--lightweight", chdir: dir)
+      updater_log = read_updater_log(dir)
+
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(updater_log).to include("Recorded pull failure (1/3).")
+      expect(updater_log).to include("ERROR: git pull --ff-only failed.")
+
+      lock_path = File.join(dir, "tmp", "dev-update-failure.lock")
+      expect(File.exist?(lock_path)).to be(true)
+      expect(File.read(lock_path).strip).to eq("1")
+    end
+  end
+
   def write_executable(path, contents)
     File.write(path, contents)
     FileUtils.chmod("+x", path)
@@ -346,7 +427,9 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     start_overmind_running: false,
     dev_starts_overmind: true,
     capture_port_in_dev: false,
-    capture_kill_all_in_dev: false
+    capture_kill_all_in_dev: false,
+    dirty_tree: false,
+    pull_exit_status: 0
   )
     FileUtils.mkdir_p(File.join(dir, "bin"))
     FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
@@ -387,6 +470,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
       BASH
     )
 
+    dirty_status_output = dirty_tree ? " M dirty-file.txt" : ""
     write_executable(
       File.join(dir, "stubbin", "git"),
       <<~BASH
@@ -395,8 +479,21 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
           rev-parse)
             echo "main"
             ;;
-          pull)
+          status)
+            if [ "${2:-}" = "--porcelain" ]; then
+              printf '%s' "#{dirty_status_output}"
+            fi
             exit 0
+            ;;
+          stash)
+            echo "stash: $*" >> "#{dir}/git-stash.log"
+            exit 0
+            ;;
+          checkout)
+            exit 0
+            ;;
+          pull)
+            exit #{pull_exit_status}
             ;;
           *)
             echo "unexpected git command: $*" >&2


### PR DESCRIPTION
## Summary

dev-update: deadlocks when working tree has unstaged changes

See #1255 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1255