### PR TITLE
feat(infrastructure): expose Flipper percentage rollout and add progressive deployment UI

### DIFF
--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -13,7 +13,7 @@ class TenantConfigurationsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       @tenant_setting.update!(tenant_setting_params)
-      update_feature_flag_rollouts!
+      update_feature_flag_rollouts! if feature_flag_rollout_params.present?
     end
 
     redirect_to edit_tenant_configuration_path, notice: "Tenant configuration saved successfully."
@@ -38,6 +38,11 @@ class TenantConfigurationsController < ApplicationController
   end
 
   def update_feature_flag_rollouts!
+    # Flipper percentage gates are global (not tenant-scoped), so require
+    # the stricter owner-only manage_feature_flags? policy to prevent
+    # cross-tenant privilege escalation in multi-tenant deployments.
+    authorize current_account, :manage_feature_flags?
+
     feature_flag_rollout_params.each do |flag_name, rollout|
       FeatureFlags.enable_percentage_of_actors(flag_name, rollout["percentage_of_actors"])
       FeatureFlags.enable_percentage_of_time(flag_name, rollout["percentage_of_time"])

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -11,12 +11,16 @@ class TenantConfigurationsController < ApplicationController
   def update
     authorize current_account, :update?
 
-    if @tenant_setting.update(tenant_setting_params)
-      redirect_to edit_tenant_configuration_path, notice: "Tenant configuration saved successfully."
-    else
-      load_form_options
-      render :edit, status: :unprocessable_content
+    ActiveRecord::Base.transaction do
+      @tenant_setting.update!(tenant_setting_params)
+      update_feature_flag_rollouts!
     end
+
+    redirect_to edit_tenant_configuration_path, notice: "Tenant configuration saved successfully."
+  rescue ActiveRecord::RecordInvalid, FeatureFlags::InvalidPercentageError => e
+    @tenant_setting.errors.add(:base, e.message) if e.is_a?(FeatureFlags::InvalidPercentageError)
+    load_form_options
+    render :edit, status: :unprocessable_content
   end
 
   private
@@ -28,6 +32,22 @@ class TenantConfigurationsController < ApplicationController
   def load_form_options
     @provider_api_keys = current_account.provider_api_keys.includes(:user).order(:api_service_type, :name)
     @feature_flags = FeatureFlags.definitions
+    @feature_flag_rollouts = @feature_flags.index_with do |definition|
+      FeatureFlags.rollout_status(definition.name)
+    end
+  end
+
+  def update_feature_flag_rollouts!
+    feature_flag_rollout_params.each do |flag_name, rollout|
+      FeatureFlags.enable_percentage_of_actors(flag_name, rollout["percentage_of_actors"])
+      FeatureFlags.enable_percentage_of_time(flag_name, rollout["percentage_of_time"])
+    end
+  end
+
+  def feature_flag_rollout_params
+    params.fetch(:feature_flag_rollouts, ActionController::Parameters.new).permit(
+      FeatureFlags::DEFINITIONS.keys.index_with { %i[percentage_of_actors percentage_of_time] }
+    ).to_h
   end
 
   def tenant_setting_params

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -61,7 +61,7 @@ class TenantConfigurationsController < ApplicationController
   end
 
   def normalize_pct(value)
-    value.to_s.strip == "" ? 0 : Integer(value)
+    value.to_s.strip == "" ? 0 : Integer(value, exception: false) || -1
   end
 
   def feature_flag_rollout_params

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -38,15 +38,30 @@ class TenantConfigurationsController < ApplicationController
   end
 
   def update_feature_flag_rollouts!
+    changed = changed_feature_flag_rollouts
+    return if changed.empty?
+
     # Flipper percentage gates are global (not tenant-scoped), so require
     # the stricter owner-only manage_feature_flags? policy to prevent
     # cross-tenant privilege escalation in multi-tenant deployments.
     authorize current_account, :manage_feature_flags?
 
-    feature_flag_rollout_params.each do |flag_name, rollout|
+    changed.each do |flag_name, rollout|
       FeatureFlags.enable_percentage_of_actors(flag_name, rollout["percentage_of_actors"])
       FeatureFlags.enable_percentage_of_time(flag_name, rollout["percentage_of_time"])
     end
+  end
+
+  def changed_feature_flag_rollouts
+    feature_flag_rollout_params.select do |flag_name, rollout|
+      current = FeatureFlags.rollout_status(flag_name)
+      normalize_pct(rollout["percentage_of_actors"]) != current[:percentage_of_actors] ||
+        normalize_pct(rollout["percentage_of_time"]) != current[:percentage_of_time]
+    end
+  end
+
+  def normalize_pct(value)
+    value.to_s.strip == "" ? 0 : Integer(value)
   end
 
   def feature_flag_rollout_params

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -17,6 +17,13 @@ class AccountPolicy < ApplicationPolicy
     has_account_role?(:owner)
   end
 
+  # Flipper percentage gates are global (not tenant-scoped), so only the
+  # account owner may modify them. In a future multi-tenant deployment,
+  # consider scoping rollouts per-tenant or introducing a platform-admin role.
+  def manage_feature_flags?
+    has_account_role?(:owner)
+  end
+
   private
 
   def user_in_account?

--- a/app/services/feature_flags.rb
+++ b/app/services/feature_flags.rb
@@ -5,6 +5,7 @@ class FeatureFlags
 
   UnknownFlagError = Class.new(ArgumentError)
   InvalidActorError = Class.new(ArgumentError)
+  InvalidPercentageError = Class.new(ArgumentError)
 
   DEFINITIONS = {
     explicit_pr_automation_decisions: Definition.new(
@@ -57,6 +58,34 @@ class FeatureFlags
       feature(flag_name).disable(resolved_actor)
     end
 
+    def enable_percentage_of_actors(flag_name, percentage)
+      update_percentage_gate(feature(flag_name), :actors, percentage)
+    end
+
+    def disable_percentage_of_actors(flag_name)
+      feature(flag_name).disable_percentage_of_actors
+    end
+
+    def enable_percentage_of_time(flag_name, percentage)
+      update_percentage_gate(feature(flag_name), :time, percentage)
+    end
+
+    def disable_percentage_of_time(flag_name)
+      feature(flag_name).disable_percentage_of_time
+    end
+
+    def rollout_status(flag_name)
+      flipper_feature = feature(flag_name)
+
+      {
+        boolean: flipper_feature.boolean_value,
+        percentage_of_actors: flipper_feature.percentage_of_actors_value,
+        percentage_of_time: flipper_feature.percentage_of_time_value,
+        actors: flipper_feature.actors_value.to_a.sort,
+        groups: flipper_feature.groups_value.to_a.sort
+      }
+    end
+
     def snapshot(project: nil, actor: nil)
       DEFINITIONS.keys.index_with do |flag_name|
         enabled?(flag_name, project:, actor:)
@@ -97,6 +126,22 @@ class FeatureFlags
       return actor if actor
 
       nil
+    end
+
+    def update_percentage_gate(flipper_feature, gate, percentage)
+      value = normalize_percentage(percentage)
+      return flipper_feature.public_send("disable_percentage_of_#{gate}") if value.zero?
+
+      flipper_feature.public_send("enable_percentage_of_#{gate}", value)
+    end
+
+    def normalize_percentage(percentage)
+      return 0 if percentage.nil? || percentage == ""
+
+      value = Integer(percentage, exception: false)
+      raise InvalidPercentageError, "Percentage must be an integer between 0 and 100" unless value&.between?(0, 100)
+
+      value
     end
   end
 end

--- a/app/views/tenant_configurations/edit.html.erb
+++ b/app/views/tenant_configurations/edit.html.erb
@@ -109,15 +109,63 @@
         </label>
       </div>
 
-      <div class="mt-6 space-y-3">
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+        Tenant overrides apply only to this account. Percentage rollout controls update the shared Flipper gates for each flag.
+      </p>
+
+      <div class="mt-6 space-y-4">
         <% @feature_flags.each do |definition| %>
-          <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-200">
-            <%= check_box_tag "tenant_setting[features][#{definition.name}]", "1", @tenant_setting.features[definition.name.to_s] == true %>
-            <span>
-              <span class="font-medium"><%= definition.name %></span>
-              <span class="block text-gray-500 dark:text-gray-400"><%= definition.intent %></span>
-            </span>
-          </label>
+          <% rollout = @feature_flag_rollouts.fetch(definition) %>
+          <div class="rounded-md border border-gray-200 p-4 dark:border-gray-700">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div class="max-w-2xl">
+                <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-200">
+                  <%= check_box_tag "tenant_setting[features][#{definition.name}]", "1", @tenant_setting.features[definition.name.to_s] == true %>
+                  <span>
+                    <span class="font-medium"><%= definition.name %></span>
+                    <span class="block text-gray-500 dark:text-gray-400"><%= definition.intent %></span>
+                  </span>
+                </label>
+
+                <dl class="mt-4 grid gap-3 text-sm text-gray-600 dark:text-gray-300 sm:grid-cols-2">
+                  <div>
+                    <dt class="font-medium text-gray-900 dark:text-white">Boolean gate</dt>
+                    <dd><%= rollout[:boolean] ? "Enabled" : "Disabled" %></dd>
+                  </div>
+                  <div>
+                    <dt class="font-medium text-gray-900 dark:text-white">Project overrides</dt>
+                    <dd><%= rollout[:actors].presence&.join(", ") || "None" %></dd>
+                  </div>
+                  <div>
+                    <dt class="font-medium text-gray-900 dark:text-white">Named groups</dt>
+                    <dd><%= rollout[:groups].presence&.join(", ") || "None" %></dd>
+                  </div>
+                </dl>
+              </div>
+
+              <div class="grid gap-4 sm:grid-cols-2 lg:min-w-80">
+                <div>
+                  <%= label_tag "feature_flag_rollouts_#{definition.name}_percentage_of_actors", "Percentage of actors", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                  <%= number_field_tag "feature_flag_rollouts[#{definition.name}][percentage_of_actors]",
+                    rollout[:percentage_of_actors],
+                    id: "feature_flag_rollouts_#{definition.name}_percentage_of_actors",
+                    min: 0,
+                    max: 100,
+                    class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+                </div>
+
+                <div>
+                  <%= label_tag "feature_flag_rollouts_#{definition.name}_percentage_of_time", "Percentage of time", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                  <%= number_field_tag "feature_flag_rollouts[#{definition.name}][percentage_of_time]",
+                    rollout[:percentage_of_time],
+                    id: "feature_flag_rollouts_#{definition.name}_percentage_of_time",
+                    min: 0,
+                    max: 100,
+                    class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+                </div>
+              </div>
+            </div>
+          </div>
         <% end %>
       </div>
     </section>

--- a/lib/tasks/feature_flags.rake
+++ b/lib/tasks/feature_flags.rake
@@ -23,6 +23,23 @@ module FeatureFlagTasks
   def scope_label(project)
     project ? "project #{project.full_name}" : "global"
   end
+
+  def print_status(flag_name, project: nil)
+    definition = FeatureFlags.definition(flag_name)
+    enabled = FeatureFlags.enabled?(definition.name, project:)
+    rollout = FeatureFlags.rollout_status(definition.name)
+
+    puts "#{definition.name}: #{enabled ? 'enabled' : 'disabled'} (#{scope_label(project)})"
+    puts "  owner: #{definition.owner}"
+    puts "  intent: #{definition.intent}"
+    puts "  rollout_plan: #{definition.rollout_plan}"
+    puts "  cleanup_criteria: #{definition.cleanup_criteria}"
+    puts "  boolean: #{rollout[:boolean]}"
+    puts "  percentage_of_actors: #{rollout[:percentage_of_actors]}"
+    puts "  percentage_of_time: #{rollout[:percentage_of_time]}"
+    puts "  actors: #{rollout[:actors].presence || 'none'}"
+    puts "  groups: #{rollout[:groups].presence || 'none'}"
+  end
 end
 
 namespace :feature_flags do
@@ -31,13 +48,7 @@ namespace :feature_flags do
     project = FeatureFlagTasks.project_scope
 
     FeatureFlags.definitions.each do |definition|
-      enabled = FeatureFlags.enabled?(definition.name, project:)
-
-      puts "#{definition.name}: #{enabled ? 'enabled' : 'disabled'} (#{FeatureFlagTasks.scope_label(project)})"
-      puts "  owner: #{definition.owner}"
-      puts "  intent: #{definition.intent}"
-      puts "  rollout_plan: #{definition.rollout_plan}"
-      puts "  cleanup_criteria: #{definition.cleanup_criteria}"
+      FeatureFlagTasks.print_status(definition.name, project:)
     end
   end
 
@@ -55,5 +66,24 @@ namespace :feature_flags do
     FeatureFlags.disable!(args.fetch(:flag), project:)
 
     puts "Disabled #{args.fetch(:flag)} for #{FeatureFlagTasks.scope_label(project)}"
+  end
+
+  desc "Enable a percentage-of-actors rollout globally"
+  task :enable_percentage_of_actors, [ :flag, :percentage ] => :environment do |_task, args|
+    FeatureFlags.enable_percentage_of_actors(args.fetch(:flag), args.fetch(:percentage))
+
+    puts "Enabled #{args.fetch(:flag)} for #{args.fetch(:percentage)}% of actors"
+  end
+
+  desc "Enable a percentage-of-time rollout globally"
+  task :enable_percentage_of_time, [ :flag, :percentage ] => :environment do |_task, args|
+    FeatureFlags.enable_percentage_of_time(args.fetch(:flag), args.fetch(:percentage))
+
+    puts "Enabled #{args.fetch(:flag)} for #{args.fetch(:percentage)}% of time"
+  end
+
+  desc "Show full rollout status for a feature flag"
+  task :status, [ :flag ] => :environment do |_task, args|
+    FeatureFlagTasks.print_status(args.fetch(:flag), project: FeatureFlagTasks.project_scope)
   end
 end

--- a/spec/requests/tenant_configurations_spec.rb
+++ b/spec/requests/tenant_configurations_spec.rb
@@ -134,6 +134,22 @@ RSpec.describe "TenantConfigurations" do
       expect(account.tenant_setting.reload.effective_guardrails["max_concurrent_runs"]).to eq(2)
     end
 
+    it "allows admins to submit the form with unchanged rollout values" do
+      admin = create(:user, :admin, account: account)
+      sign_out user
+      sign_in admin
+
+      patch tenant_configuration_path, params: {
+        tenant_setting: { guardrails: { max_concurrent_runs: "3" } },
+        feature_flag_rollouts: {
+          explicit_pr_automation_decisions: { percentage_of_actors: "0", percentage_of_time: "0" }
+        }
+      }
+
+      expect(response).to redirect_to(edit_tenant_configuration_path)
+      expect(account.tenant_setting.reload.effective_guardrails["max_concurrent_runs"]).to eq(3)
+    end
+
     it "rejects viewers" do
       viewer = create(:user, :viewer, account: account)
       sign_out user

--- a/spec/requests/tenant_configurations_spec.rb
+++ b/spec/requests/tenant_configurations_spec.rb
@@ -105,6 +105,35 @@ RSpec.describe "TenantConfigurations" do
       expect(FeatureFlags.rollout_status(:explicit_pr_automation_decisions)[:percentage_of_actors]).to eq(0)
     end
 
+    it "rejects admins from modifying feature flag rollouts" do
+      admin = create(:user, :admin, account: account)
+      sign_out user
+      sign_in admin
+
+      patch tenant_configuration_path, params: {
+        tenant_setting: { agent_settings: { default_goal: "review", auto_continue: "1" } },
+        feature_flag_rollouts: {
+          explicit_pr_automation_decisions: { percentage_of_actors: "50", percentage_of_time: "0" }
+        }
+      }
+
+      expect(response).to redirect_to(root_path)
+      expect(FeatureFlags.rollout_status(:explicit_pr_automation_decisions)[:percentage_of_actors]).to eq(0)
+    end
+
+    it "allows admins to update tenant settings without feature flag rollouts" do
+      admin = create(:user, :admin, account: account)
+      sign_out user
+      sign_in admin
+
+      patch tenant_configuration_path, params: {
+        tenant_setting: { guardrails: { max_concurrent_runs: "2" } }
+      }
+
+      expect(response).to redirect_to(edit_tenant_configuration_path)
+      expect(account.tenant_setting.reload.effective_guardrails["max_concurrent_runs"]).to eq(2)
+    end
+
     it "rejects viewers" do
       viewer = create(:user, :viewer, account: account)
       sign_out user

--- a/spec/requests/tenant_configurations_spec.rb
+++ b/spec/requests/tenant_configurations_spec.rb
@@ -6,15 +6,21 @@ RSpec.describe "TenantConfigurations" do
   let(:account) { create(:account) }
   let(:user) { create(:user, :owner, account: account) }
 
-  before { sign_in user }
+  before do
+    sign_in user
+    FeatureFlags.flipper.features.each(&:remove)
+  end
 
   describe "GET /tenant_configuration/edit" do
     it "renders the tenant configuration form" do
+      FeatureFlags.enable_percentage_of_actors(:explicit_pr_automation_decisions, 15)
+
       get edit_tenant_configuration_path
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Tenant Configuration")
       expect(response.body).to include("Provider Preferences")
+      expect(response.body).to include("Percentage of actors")
     end
   end
 
@@ -35,6 +41,18 @@ RSpec.describe "TenantConfigurations" do
       expect(setting.effective_quality_thresholds["enabled"]).to be(true)
       expect(setting.effective_agent_settings["default_goal"]).to eq("review")
       expect(setting.features["explicit_pr_automation_decisions"]).to be(true)
+    end
+
+    it "updates feature flag rollout percentages" do
+      api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
+
+      patch tenant_configuration_path, params: tenant_configuration_params(api_key)
+
+      expect(response).to redirect_to(edit_tenant_configuration_path)
+      expect(FeatureFlags.rollout_status(:explicit_pr_automation_decisions)).to include(
+        percentage_of_actors: 25,
+        percentage_of_time: 10
+      )
     end
 
     it "disables auto-continue when the checkbox submits its hidden false value" do
@@ -67,6 +85,26 @@ RSpec.describe "TenantConfigurations" do
       expect(account.tenant_setting.reload.default_goal).to eq("create_pr")
     end
 
+    it "rejects invalid rollout percentages" do
+      patch tenant_configuration_path, params: {
+        tenant_setting: {
+          agent_settings: {
+            default_goal: "review",
+            auto_continue: "1"
+          }
+        },
+        feature_flag_rollouts: {
+          explicit_pr_automation_decisions: {
+            percentage_of_actors: "101",
+            percentage_of_time: "0"
+          }
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(FeatureFlags.rollout_status(:explicit_pr_automation_decisions)[:percentage_of_actors]).to eq(0)
+    end
+
     it "rejects viewers" do
       viewer = create(:user, :viewer, account: account)
       sign_out user
@@ -87,6 +125,12 @@ RSpec.describe "TenantConfigurations" do
         quality_thresholds: quality_thresholds,
         agent_settings: agent_settings,
         features: { explicit_pr_automation_decisions: "1" }
+      },
+      feature_flag_rollouts: {
+        explicit_pr_automation_decisions: {
+          percentage_of_actors: "25",
+          percentage_of_time: "10"
+        }
       }
     }
   end

--- a/spec/services/feature_flags_spec.rb
+++ b/spec/services/feature_flags_spec.rb
@@ -72,6 +72,60 @@ RSpec.describe FeatureFlags do
     end
   end
 
+  describe ".enable_percentage_of_actors" do
+    it "configures a percentage-of-actors rollout" do
+      described_class.enable_percentage_of_actors(:explicit_pr_automation_decisions, 25)
+
+      expect(described_class.rollout_status(:explicit_pr_automation_decisions)).to include(
+        percentage_of_actors: 25,
+        percentage_of_time: 0
+      )
+    end
+
+    it "clears the percentage gate when set to zero" do
+      described_class.enable_percentage_of_actors(:explicit_pr_automation_decisions, 25)
+
+      described_class.enable_percentage_of_actors(:explicit_pr_automation_decisions, 0)
+
+      expect(described_class.rollout_status(:explicit_pr_automation_decisions)[:percentage_of_actors]).to eq(0)
+    end
+
+    it "rejects invalid percentages" do
+      expect {
+        described_class.enable_percentage_of_actors(:explicit_pr_automation_decisions, 101)
+      }.to raise_error(described_class::InvalidPercentageError, /between 0 and 100/)
+    end
+  end
+
+  describe ".enable_percentage_of_time" do
+    it "configures a percentage-of-time rollout" do
+      described_class.enable_percentage_of_time(:explicit_pr_automation_decisions, 10)
+
+      expect(described_class.rollout_status(:explicit_pr_automation_decisions)).to include(
+        percentage_of_actors: 0,
+        percentage_of_time: 10
+      )
+    end
+  end
+
+  describe ".rollout_status" do
+    it "returns the configured boolean, actor, group, and percentage gates" do
+      described_class.enable!(:explicit_pr_automation_decisions)
+      described_class.enable!(:explicit_pr_automation_decisions, project:)
+      described_class.enable_percentage_of_actors(:explicit_pr_automation_decisions, 25)
+      described_class.enable_percentage_of_time(:explicit_pr_automation_decisions, 10)
+      described_class.flipper[:explicit_pr_automation_decisions].enable_group(:beta)
+
+      expect(described_class.rollout_status(:explicit_pr_automation_decisions)).to eq(
+        boolean: true,
+        percentage_of_actors: 25,
+        percentage_of_time: 10,
+        actors: [ project.flipper_id ],
+        groups: [ "beta" ]
+      )
+    end
+  end
+
   describe ".snapshot" do
     it "returns the current boolean state for every registered flag" do
       described_class.enable!(:explicit_pr_automation_decisions, project:)

--- a/spec/tasks/rake/task_feature_flags_tasks_spec.rb
+++ b/spec/tasks/rake/task_feature_flags_tasks_spec.rb
@@ -6,7 +6,10 @@ require "rake"
 RSpec.describe Rake::Task do
   let(:enable_task) { described_class["feature_flags:enable"] }
   let(:disable_task) { described_class["feature_flags:disable"] }
+  let(:enable_percentage_of_actors_task) { described_class["feature_flags:enable_percentage_of_actors"] }
+  let(:enable_percentage_of_time_task) { described_class["feature_flags:enable_percentage_of_time"] }
   let(:list_task) { described_class["feature_flags:list"] }
+  let(:status_task) { described_class["feature_flags:status"] }
 
   around do |example|
     original_project = ENV["PROJECT"]
@@ -26,7 +29,10 @@ RSpec.describe Rake::Task do
     Rails.application.load_tasks unless described_class.task_defined?("feature_flags:list")
     enable_task.reenable
     disable_task.reenable
+    enable_percentage_of_actors_task.reenable
+    enable_percentage_of_time_task.reenable
     list_task.reenable
+    status_task.reenable
     FeatureFlags.flipper.features.each(&:remove)
   end
 
@@ -64,6 +70,29 @@ RSpec.describe Rake::Task do
       expect {
         list_task.invoke
       }.to raise_error(ArgumentError, "PROJECT_ID=-1 does not match an existing project")
+    end
+
+    it "configures percentage-of-actors rollouts" do
+      enable_percentage_of_actors_task.invoke("explicit_pr_automation_decisions", "25")
+
+      expect(FeatureFlags.rollout_status(:explicit_pr_automation_decisions)[:percentage_of_actors]).to eq(25)
+    end
+
+    it "configures percentage-of-time rollouts" do
+      enable_percentage_of_time_task.invoke("explicit_pr_automation_decisions", "10")
+
+      expect(FeatureFlags.rollout_status(:explicit_pr_automation_decisions)[:percentage_of_time]).to eq(10)
+    end
+
+    it "prints full rollout status" do
+      ENV["PROJECT_ID"] = nil
+      FeatureFlags.enable_percentage_of_actors(:explicit_pr_automation_decisions, 25)
+
+      expect {
+        SilenceStreams.call(:stdout) do
+          status_task.invoke("explicit_pr_automation_decisions")
+        end
+      }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## Summary

feat(infrastructure): expose Flipper percentage rollout and add progressive deployment UI

See #1271 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1271