### PR TITLE
fix(service-containers): align service and agent Docker networks for direct-outbound runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
 - **Live Dashboards**: Track active runs, performance, quality, cost, and knowledge-collection health from the UI
 - **Provider and Integration Management**: Test provider auth from the UI and manage GitHub, Linear, and provider API keys
   - Gap: generic integration credentials exist in the data model but are hidden from the main integrations hub pending RBAC/admin-role work; tracked by [#1283](https://github.com/viamin/paid/issues/1283).
-- **Service Containers**: Attach approved supporting services like Postgres, Redis, or Selenium to project runs when agents need dependencies beyond the app code. Service containers are attached to the same Docker network selected for the agent run. Shared-database isolation fallout is tracked separately by [#1280](https://github.com/viamin/paid/issues/1280).
+- **Service Containers**: Attach approved supporting services like Postgres, Redis, or Selenium to project runs when agents need dependencies beyond the app code. Service containers are attached to the same Docker network selected for the agent run across proxy-mode, subscription-auth, and direct-outbound provider runs. Shared-database isolation fallout is tracked separately by [#1280](https://github.com/viamin/paid/issues/1280).
 
 ## How It Works
 

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1383,6 +1383,13 @@ module Containers
     def primary_provider_identifier(settings)
       if runnable_saved_provider?
         agent_run.provider.routing_key
+      elsif agent_run&.provider.present? && settings&.fallback_enabled?
+        # Saved provider exists but isn't container-executable — derive the
+        # effective primary from the same fallback order that
+        # RunAgentActivity#build_provider_order uses: try configured fallbacks
+        # first, only fall through to the goal default when none are runnable.
+        first_runnable_fallback_for_saved_provider(settings) ||
+          settings.default_provider_identifier_for_goal(run_goal)
       elsif agent_run.present? && runnable_agent_type?(agent_run.agent_type)
         agent_run.agent_type
       elsif settings
@@ -1392,6 +1399,16 @@ module Containers
 
     def runnable_saved_provider?
       agent_run&.provider.present? && runnable_provider?(agent_run.provider)
+    end
+
+    def first_runnable_fallback_for_saved_provider(settings)
+      fallbacks = settings.fallback_priority_for(
+        primary_provider: agent_run.provider.routing_key, identifiers: true
+      )
+      fallbacks.find do |identifier|
+        provider = Provider.for_identifier(settings.user, identifier)
+        provider && ProviderSupport.container_executable_provider_key?(provider.provider_key)
+      end
     end
 
     def runnable_provider?(provider)

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1367,12 +1367,8 @@ module Containers
     end
 
     def compute_direct_outbound_provider?
-      return false if agent_run.nil?
-
-      return true if agent_run.agent_type.to_s == "kilocode"
-      return true if agent_run.provider&.requires_direct_outbound?
-
       settings = resolved_user_settings
+      return true if primary_provider_requires_direct_outbound?(settings)
       return false unless settings
 
       return true if settings.fallback_enabled? && fallback_providers_require_direct_outbound?(settings)
@@ -1380,20 +1376,54 @@ module Containers
       rate_limit_fallback_providers_require_direct_outbound?(settings)
     end
 
+    def primary_provider_requires_direct_outbound?(settings)
+      provider_requires_direct_outbound?(primary_provider_identifier(settings), user: settings&.user)
+    end
+
+    def primary_provider_identifier(settings)
+      if runnable_saved_provider?
+        agent_run.provider.routing_key
+      elsif agent_run.present? && runnable_agent_type?(agent_run.agent_type)
+        agent_run.agent_type
+      elsif settings
+        settings.default_provider_identifier_for_goal(run_goal)
+      end
+    end
+
+    def runnable_saved_provider?
+      agent_run&.provider.present? && runnable_provider?(agent_run.provider)
+    end
+
+    def runnable_provider?(provider)
+      ProviderSupport.container_executable_provider_key?(provider.provider_key)
+    end
+
+    def runnable_agent_type?(agent_type)
+      return false unless agent_type.present? && AgentRun::AGENT_TYPES.include?(agent_type)
+
+      provider_key = Provider.provider_key_for_agent_type(agent_type)
+      ProviderSupport.container_executable_provider_key?(provider_key)
+    end
+
+    def run_goal
+      agent_run&.goal || "create_pr"
+    end
+
+    def provider_requires_direct_outbound?(identifier, user:)
+      return false if identifier.blank?
+      return true if identifier.to_s == "kilocode"
+
+      provider = Provider.for_identifier(user, identifier)
+      return true if provider&.provider_key == "kilocode"
+
+      provider&.requires_direct_outbound? || false
+    end
+
     def fallback_providers_require_direct_outbound?(settings)
-      primary_identifier = agent_run.provider&.routing_key || settings.default_provider_identifier_for_goal(agent_run.goal)
+      primary_identifier = primary_provider_identifier(settings)
       fallback_identifiers = settings.fallback_priority_for(primary_provider: primary_identifier, identifiers: true)
-      fallback_providers_by_id = settings.user.providers.where(
-        id: fallback_identifiers.filter_map { |identifier| Provider.id_from_routing_key(identifier) }
-      ).index_by(&:id)
-
       fallback_identifiers.any? do |identifier|
-        provider_id = Provider.id_from_routing_key(identifier)
-        provider = provider_id && fallback_providers_by_id[provider_id]
-
-        next true if identifier.to_s == "kilocode" || provider&.provider_key == "kilocode"
-
-        provider&.requires_direct_outbound?
+        provider_requires_direct_outbound?(identifier, user: settings.user)
       end
     end
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -854,6 +854,31 @@ RSpec.describe Containers::Provision do
 
         service.provision
       end
+
+      it "uses the restricted network when an unrunnable saved provider has a runnable proxy-mode fallback despite a direct-outbound default" do
+        copilot_provider = create(:provider, user: project.created_by, provider_key: "copilot")
+        claude_api_key = create(:provider_api_key, user: project.created_by, api_service_type: "anthropic")
+        claude_fallback = create(:provider, :api_key, user: project.created_by,
+          provider_key: "claude", provider_api_key: claude_api_key)
+
+        direct_outbound_provider.update!(enabled_for_fallback: false)
+        project.created_by.providers.subscription.find_by!(provider_key: "claude")
+          .update!(enabled_for_fallback: false)
+
+        agent_run.update!(provider: copilot_provider, agent_type: "copilot")
+        project.created_by.settings.update!(
+          default_agent_provider: direct_outbound_provider.routing_key,
+          fallback_enabled: true,
+          fallback_providers: [ claude_fallback.routing_key ]
+        )
+
+        expect(Docker::Container).to receive(:create) do |config|
+          expect(config["HostConfig"]["NetworkMode"]).to eq(NetworkPolicy::NETWORK_NAME)
+          mock_container
+        end
+
+        service.provision
+      end
     end
 
     context "with service-container network alignment (#1282)" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -856,6 +856,85 @@ RSpec.describe Containers::Provision do
       end
     end
 
+    context "with service-container network alignment (#1282)" do
+      let(:api_key) { create(:provider_api_key, user: project.created_by, api_service_type: "openrouter") }
+      let!(:direct_outbound_provider) do
+        create(
+          :provider,
+          :api_key,
+          user: project.created_by,
+          provider_key: "opencode",
+          provider_api_key: api_key,
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2.5" } }
+        )
+      end
+
+      it "network_for matches agent container network in proxy mode" do
+        container_network = nil
+
+        expect(Docker::Container).to receive(:create) do |config|
+          container_network = config["HostConfig"]["NetworkMode"]
+          mock_container
+        end
+
+        service.provision
+
+        service_network = described_class.network_for(agent_run: agent_run)
+
+        expect(service_network).to eq(container_network)
+        expect(service_network).to eq(NetworkPolicy::NETWORK_NAME)
+      end
+
+      it "network_for matches agent container network in direct-outbound mode" do
+        copilot_provider = create(:provider, user: project.created_by, provider_key: "copilot")
+        agent_run.update!(provider: copilot_provider, agent_type: "copilot")
+        project.created_by.settings.update!(default_agent_provider: direct_outbound_provider.routing_key, fallback_enabled: false)
+
+        container_network = nil
+
+        expect(Docker::Container).to receive(:create) do |config|
+          container_network = config["HostConfig"]["NetworkMode"]
+          mock_container
+        end
+
+        service.provision
+
+        service_network = described_class.network_for(agent_run: agent_run)
+
+        expect(service_network).to eq(container_network)
+        expect(service_network).to eq(NetworkPolicy::INFRA_NETWORK_NAME)
+      end
+
+      it "network_for matches agent container network in subscription-auth mode" do
+        claude_config_dir = Dir.mktmpdir("claude-config")
+        File.write(File.join(claude_config_dir, ".credentials.json"), "{}")
+
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("CLAUDE_CONFIG_DIR").and_return(claude_config_dir)
+        allow(ENV).to receive(:[]).with("CODEX_CONFIG_DIR").and_return(nil)
+        allow(ENV).to receive(:[]).with("CODEX_HOME").and_return(nil)
+        allow(ENV).to receive(:[]).with("GEMINI_CONFIG_DIR").and_return(nil)
+        allow(ENV).to receive(:[]).with("COPILOT_CONFIG_DIR").and_return(nil)
+        allow(service).to receive_messages(codex_local_config_path: nil, gemini_local_config_path: nil, copilot_local_config_path: nil)
+
+        container_network = nil
+
+        expect(Docker::Container).to receive(:create) do |config|
+          container_network = config["HostConfig"]["NetworkMode"]
+          mock_container
+        end
+
+        service.provision
+
+        service_network = described_class.network_for(agent_run: agent_run)
+
+        expect(service_network).to eq(container_network)
+        expect(service_network).to eq(NetworkPolicy::INFRA_NETWORK_NAME)
+      ensure
+        FileUtils.rm_rf(claude_config_dir)
+      end
+    end
+
     context "with Gemini subscription auth (GEMINI_CONFIG_DIR)" do
       let(:gemini_config_dir) { Dir.mktmpdir("gemini-config") }
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -823,6 +823,39 @@ RSpec.describe Containers::Provision do
       end
     end
 
+    context "with a direct-outbound default provider" do
+      let(:api_key) { create(:provider_api_key, user: project.created_by, api_service_type: "openrouter") }
+      let!(:direct_outbound_provider) do
+        create(
+          :provider,
+          :api_key,
+          user: project.created_by,
+          provider_key: "opencode",
+          provider_api_key: api_key,
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2.5" } }
+        )
+      end
+
+      it "uses the infrastructure network for project-level provisioning when the default provider is direct outbound" do
+        project.created_by.settings.update!(default_agent_provider: direct_outbound_provider.routing_key)
+
+        expect(described_class.new(project: project).network_name).to eq(NetworkPolicy::INFRA_NETWORK_NAME)
+      end
+
+      it "uses the infrastructure network when execution falls back from an unrunnable saved provider to a direct-outbound default" do
+        copilot_provider = create(:provider, user: project.created_by, provider_key: "copilot")
+        agent_run.update!(provider: copilot_provider, agent_type: "copilot")
+        project.created_by.settings.update!(default_agent_provider: direct_outbound_provider.routing_key, fallback_enabled: false)
+
+        expect(Docker::Container).to receive(:create) do |config|
+          expect(config["HostConfig"]["NetworkMode"]).to eq(NetworkPolicy::INFRA_NETWORK_NAME)
+          mock_container
+        end
+
+        service.provision
+      end
+    end
+
     context "with Gemini subscription auth (GEMINI_CONFIG_DIR)" do
       let(:gemini_config_dir) { Dir.mktmpdir("gemini-config") }
 


### PR DESCRIPTION
## Summary

fix(service-containers): align service and agent Docker networks for direct-outbound runs

See #1282 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1282