### PR TITLE
feat(release): evaluate auto-release from poll loop so webhooks are optional

### DIFF
--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -6,7 +6,7 @@
 #
 # Triggered by:
 # - GitHub webhooks (check_suite.completed, pull_request.opened/synchronize/labeled)
-# - Safety-net enqueue from the project poll loop
+# - Poll loop via EvaluateAutoReleaseActivity (every cycle when auto_release enabled)
 #
 # Concurrency: at most one evaluation per project at a time.
 class AutoReleaseEvaluationJob < ApplicationJob

--- a/app/temporal/activities/evaluate_auto_release_activity.rb
+++ b/app/temporal/activities/evaluate_auto_release_activity.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Activities
+  class EvaluateAutoReleaseActivity < BaseActivity
+    def execute(input)
+      project_id = input[:project_id]
+      project = Project.find_by(id: project_id)
+      return { evaluated: false, project_missing: true } unless project
+      return { evaluated: false, reason: "disabled" } unless project.auto_release_enabled?
+
+      AutoReleaseEvaluationJob.perform_later(project_id)
+
+      { evaluated: true }
+    end
+  end
+end

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -147,6 +147,7 @@ module Workflows
       scan_result = maybe_scan_paid_prs(project_id)
       maybe_scan_code_scanning_alerts(project_id)
       maybe_check_knowledge_staleness(project_id)
+      maybe_evaluate_auto_release(project_id)
       scan_result
     end
 
@@ -185,6 +186,24 @@ module Workflows
     rescue => e
       Temporalio::Workflow.logger.warn(
         message: "knowledge.staleness_check_failed",
+        project_id: project_id,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+
+    # Evaluate auto-release for the project's open release-please PRs.
+    # Runs on every poll cycle so webhooks are not required for auto-release.
+    def maybe_evaluate_auto_release(project_id)
+      return unless Temporalio::Workflow.patched("add-auto-release-poll-v1")
+
+      run_activity(Activities::EvaluateAutoReleaseActivity,
+        { project_id: project_id }, timeout: 30)
+    rescue Temporalio::Error::CanceledError
+      raise
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "auto_release.poll_evaluation_failed",
         project_id: project_id,
         error_class: e.class.name,
         error: e.message

--- a/spec/temporal/activities/evaluate_auto_release_activity_spec.rb
+++ b/spec/temporal/activities/evaluate_auto_release_activity_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::EvaluateAutoReleaseActivity do
+  let(:activity) { described_class.new }
+
+  describe "#execute" do
+    let(:project) { create(:project, auto_release_granularity: "all") }
+
+    it "enqueues AutoReleaseEvaluationJob when auto-release is enabled" do
+      expect {
+        activity.execute(project_id: project.id)
+      }.to have_enqueued_job(AutoReleaseEvaluationJob).with(project.id)
+    end
+
+    it "returns evaluated: true when auto-release is enabled" do
+      result = activity.execute(project_id: project.id)
+
+      expect(result).to eq(evaluated: true)
+    end
+
+    it "does not enqueue when auto-release is disabled" do
+      project.update!(auto_release_granularity: "off")
+
+      expect {
+        activity.execute(project_id: project.id)
+      }.not_to have_enqueued_job(AutoReleaseEvaluationJob)
+    end
+
+    it "returns evaluated: false with reason when auto-release is disabled" do
+      project.update!(auto_release_granularity: "off")
+
+      result = activity.execute(project_id: project.id)
+
+      expect(result).to eq(evaluated: false, reason: "disabled")
+    end
+
+    it "returns project_missing when project not found" do
+      result = activity.execute(project_id: -1)
+
+      expect(result).to eq(evaluated: false, project_missing: true)
+    end
+  end
+end

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -192,6 +192,32 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     end
   end
 
+  describe "EvaluateAutoReleaseActivity patch guard" do
+    let(:workflow) { described_class.new }
+
+    before do
+      allow(workflow).to receive(:run_activity).and_return({})
+    end
+
+    it "runs EvaluateAutoReleaseActivity when patched returns true" do
+      allow(Temporalio::Workflow).to receive(:patched).with("add-auto-release-poll-v1").and_return(true)
+
+      workflow.send(:maybe_evaluate_auto_release, 1)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::EvaluateAutoReleaseActivity, { project_id: 1 }, timeout: 30)
+    end
+
+    it "skips EvaluateAutoReleaseActivity when patched returns false" do
+      allow(Temporalio::Workflow).to receive(:patched).with("add-auto-release-poll-v1").and_return(false)
+
+      workflow.send(:maybe_evaluate_auto_release, 1)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::EvaluateAutoReleaseActivity, anything, timeout: anything)
+    end
+  end
+
   describe "#handle_automation_result" do
     let(:workflow) { described_class.new }
     let(:project_id) { 1 }
@@ -1539,6 +1565,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with("add-scan-security-alerts-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("add-check-knowledge-staleness-v1").and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-auto-release-poll-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("queue-agent-run-goal-v1").and_return(true)
       allow(Temporalio::Workflow).to receive(:patched)


### PR DESCRIPTION
## Summary

- Auto-release was only triggered by GitHub webhooks, requiring a `webhook_secret` and manual webhook setup on each repo. Projects without webhooks configured (like agent-harness) would never have their release-please PRs auto-merged.
- Adds `EvaluateAutoReleaseActivity` to the poll workflow's non-critical activity path. It enqueues `AutoReleaseEvaluationJob` on every cycle when `auto_release` is enabled, reusing the job's existing concurrency control (`total_limit: 1`) and the workflow's rate-limit guard.
- Webhooks still work as a faster path when configured, but are no longer required.

## Root Cause

The agent-harness project has `auto_release_granularity: "all"` but `webhook_secret` is nil. Without webhooks, `AutoReleaseEvaluationJob` was never triggered. The job comment claimed a "safety-net enqueue from the project poll loop" existed, but it was never implemented.

## Performance

At agent-harness's 300s poll interval: ~12 job executions/hour × 2-3 API calls = ~36 of 5000 hourly rate limit (0.7%). Bounded by GoodJob concurrency control and the workflow's rate-limit budget guard.

## Testing

- Activity spec covers: enabled/enqueued, disabled/skipped, missing project
- Existing `AutoReleaseEvaluationJob` spec (176 lines) covers the merge logic unchanged