### PR TITLE
feat(settings): move worker concurrency and self-repo config to TenantSetting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,24 +27,17 @@
     // Overmind when Rails, GoodJob, Temporal, and asset watchers are all live.
     "DB_POOL": "10",
     "TEMPORAL_ADDRESS": "temporal:7233",
-    "TEMPORAL_NAMESPACE": "default",
-    "TEMPORAL_POLL_TASK_QUEUE": "paid-poll-tasks",
-    "TEMPORAL_AGENT_TASK_QUEUE": "paid-agent-tasks",
     "TEMPORAL_WORKFLOW_SLOTS": "4",
     "TEMPORAL_ACTIVITY_SLOTS": "4",
-    "TEMPORAL_LOCAL_ACTIVITY_SLOTS": "4",
     "TEMPORAL_POLL_WORKFLOW_SLOTS": "4",
     "TEMPORAL_POLL_ACTIVITY_SLOTS": "2",
-    "TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS": "2",
-    "TEMPORAL_UI_URL": "http://localhost:8080",
     "GOOD_JOB_MAX_THREADS": "6",
     "GOOD_JOB_QUEUES": "default:2;maintenance:1;metrics:1;knowledge:1;low_priority:1",
     "QDRANT_URL": "http://qdrant:6333",
     // LLM CLI tools - dangerous/auto-approve mode (container only)
     "CODEX_APPROVAL_POLICY": "never",
     "CODEX_SANDBOX_MODE": "danger-full-access",
-    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
-    "PAID_REPO_FULL_NAME": "viamin/paid"
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
   },
   "remoteEnv": {
     "AIDER_NO_BROWSER": "1",

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -33,6 +33,7 @@ class TenantConfigurationsController < ApplicationController
   def tenant_setting_params
     attrs = params.require(:tenant_setting).permit(
       :max_concurrent_runs, :max_projects, :max_users, :max_tokens_per_run, :max_monthly_cost_cents,
+      :self_repo_full_name,
       allowed_provider_keys: [],
       provider_preferences: [
         api_key_ids: ProviderSupport.api_service_types.keys,
@@ -45,6 +46,11 @@ class TenantConfigurationsController < ApplicationController
         { metric_thresholds: {} }
       ],
       agent_settings: %i[default_goal auto_continue],
+      worker_settings: %i[
+        temporal_workflow_slots temporal_activity_slots
+        temporal_poll_workflow_slots temporal_poll_activity_slots
+        good_job_max_threads good_job_queues
+      ],
       features: FeatureFlags::DEFINITIONS.keys
     ).to_h
     attrs["features"] ||= {}

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -25,6 +25,20 @@ class TenantSetting < ApplicationRecord
     "default_goal" => "create_pr",
     "auto_continue" => true
   }.freeze
+  DEFAULT_WORKER_SETTINGS = {
+    "temporal_workflow_slots" => 20,
+    "temporal_activity_slots" => 4,
+    "temporal_poll_workflow_slots" => 20,
+    "temporal_poll_activity_slots" => 10,
+    "good_job_max_threads" => 11,
+    "good_job_queues" => "default:3;maintenance:2;metrics:2;knowledge:3;low_priority:1"
+  }.freeze
+  WORKER_SETTING_INTEGER_KEYS = %w[
+    temporal_workflow_slots temporal_activity_slots
+    temporal_poll_workflow_slots temporal_poll_activity_slots
+    good_job_max_threads
+  ].freeze
+  REPO_NAME_FORMAT = /\A[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\z/
 
   belongs_to :account
 
@@ -45,6 +59,11 @@ class TenantSetting < ApplicationRecord
   validate :validate_configuration_namespaces
   validate :validate_default_budgets
   validate :validate_agent_settings
+  validate :validate_worker_settings
+  validates :self_repo_full_name,
+    format: { with: REPO_NAME_FORMAT, message: "must be in owner/repo format" },
+    allow_nil: true,
+    if: -> { self_repo_full_name.present? }
 
   def configuration
     {
@@ -53,6 +72,8 @@ class TenantSetting < ApplicationRecord
       "guardrails" => effective_guardrails,
       "quality_thresholds" => effective_quality_thresholds,
       "agent_settings" => effective_agent_settings,
+      "worker_settings" => effective_worker_settings,
+      "self_repo_full_name" => self_repo_full_name,
       "features" => features
     }
   end
@@ -121,6 +142,42 @@ class TenantSetting < ApplicationRecord
     [ limit, max_tokens_per_run ].compact.min
   end
 
+  def effective_worker_settings
+    DEFAULT_WORKER_SETTINGS.deep_dup.merge(
+      worker_settings.is_a?(Hash) ? worker_settings.deep_stringify_keys : {}
+    )
+  end
+
+  def worker_setting(key)
+    effective_worker_settings[key.to_s]
+  end
+
+  def self.resolve_worker_setting(key, env_key:, env:, default:)
+    db_val = read_worker_setting_from_db(key)
+    return db_val if db_val.present?
+    return Integer(env.fetch(env_key, default.to_s)) if WORKER_SETTING_INTEGER_KEYS.include?(key.to_s)
+
+    env.fetch(env_key, default.to_s)
+  rescue ArgumentError
+    default
+  end
+
+  def self.read_worker_setting_from_db(key)
+    return nil unless table_exists?
+
+    setting = Account.first&.tenant_setting
+    return nil unless setting
+
+    value = setting.worker_settings&.dig(key.to_s)
+    return nil if value.nil?
+
+    WORKER_SETTING_INTEGER_KEYS.include?(key.to_s) ? value.to_i : value.to_s
+  rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad
+    nil
+  end
+
+  private_class_method :read_worker_setting_from_db
+
   private
 
   def normalize_configuration_namespaces
@@ -129,6 +186,7 @@ class TenantSetting < ApplicationRecord
     self.guardrails = normalize_integer_hash(guardrails, %w[max_concurrent_runs max_tokens_per_run max_monthly_cost_cents])
     self.quality_thresholds = normalize_quality_thresholds(quality_thresholds)
     self.agent_settings = normalize_agent_settings(agent_settings)
+    self.worker_settings = normalize_worker_settings(worker_settings)
     self.features = normalize_hash(features)
     apply_guardrail_columns
   end
@@ -140,7 +198,7 @@ class TenantSetting < ApplicationRecord
   end
 
   def validate_configuration_namespaces
-    %i[provider_preferences default_budgets guardrails quality_thresholds agent_settings].each do |attribute|
+    %i[provider_preferences default_budgets guardrails quality_thresholds agent_settings worker_settings].each do |attribute|
       errors.add(attribute, "must be a JSON object") unless public_send(attribute).is_a?(Hash)
     end
   end
@@ -174,6 +232,21 @@ class TenantSetting < ApplicationRecord
     return if goal.blank? || AgentRun::GOALS.include?(goal)
 
     errors.add(:agent_settings, "default_goal is unsupported")
+  end
+
+  def validate_worker_settings
+    return unless worker_settings.is_a?(Hash)
+
+    worker_settings.each do |key, value|
+      if WORKER_SETTING_INTEGER_KEYS.include?(key.to_s)
+        unless value.is_a?(Integer) && value >= 1 && value <= 100
+          errors.add(:worker_settings, "#{key} must be an integer between 1 and 100")
+        end
+      elsif key.to_s == "good_job_queues"
+        next if value.is_a?(String) && value.match?(/\A([a-z_]+:\d+)(;[a-z_]+:\d+)*\z/)
+        errors.add(:worker_settings, "good_job_queues must match format 'name:count;name:count'")
+      end
+    end
   end
 
   def normalize_budget_hash(value)
@@ -228,6 +301,16 @@ class TenantSetting < ApplicationRecord
       next unless normalized.is_a?(Hash)
 
       normalized["auto_continue"] = ActiveModel::Type::Boolean.new.cast(normalized["auto_continue"]) if normalized.key?("auto_continue")
+    end
+  end
+
+  def normalize_worker_settings(value)
+    normalize_hash(value).tap do |normalized|
+      next unless normalized.is_a?(Hash)
+
+      WORKER_SETTING_INTEGER_KEYS.each do |key|
+        normalized[key] = normalized[key].present? ? normalized[key].to_i : nil if normalized.key?(key)
+      end
     end
   end
 

--- a/app/services/metrics/prometheus_collector.rb
+++ b/app/services/metrics/prometheus_collector.rb
@@ -149,23 +149,24 @@ module Metrics
     end
 
     def collect_temporal_config_metrics(lines)
-      slots = temporal_env("TEMPORAL_WORKFLOW_SLOTS", 20)
+      workflow_slots = resolve_worker_setting("temporal_workflow_slots", "TEMPORAL_WORKFLOW_SLOTS", 20)
+      activity_slots = resolve_worker_setting("temporal_activity_slots", "TEMPORAL_ACTIVITY_SLOTS", 4)
 
       lines << "# HELP paid_temporal_workflow_slots_total Configured Temporal workflow slots."
       lines << "# TYPE paid_temporal_workflow_slots_total gauge"
-      lines << "paid_temporal_workflow_slots_total #{slots}"
+      lines << "paid_temporal_workflow_slots_total #{workflow_slots}"
 
       lines << "# HELP paid_temporal_activity_slots_total Configured Temporal activity slots."
       lines << "# TYPE paid_temporal_activity_slots_total gauge"
-      lines << "paid_temporal_activity_slots_total #{temporal_env("TEMPORAL_ACTIVITY_SLOTS", 4)}"
+      lines << "paid_temporal_activity_slots_total #{activity_slots}"
 
       running_workflows = AgentRun.running.where.not(temporal_workflow_id: [ nil, "" ]).count
       lines << "# HELP paid_temporal_workflows_running Temporal workflows currently running."
       lines << "# TYPE paid_temporal_workflows_running gauge"
       lines << "paid_temporal_workflows_running #{running_workflows}"
 
-      utilization = if slots.positive?
-        (running_workflows.to_f / slots * 100).round(2)
+      utilization = if workflow_slots.positive?
+        (running_workflows.to_f / workflow_slots * 100).round(2)
       else
         0.0
       end
@@ -174,10 +175,8 @@ module Metrics
       lines << "paid_temporal_workflow_utilization_percent #{utilization}"
     end
 
-    def temporal_env(key, default)
-      Integer(ENV.fetch(key, default))
-    rescue ArgumentError
-      Integer(default)
+    def resolve_worker_setting(key, env_key, default)
+      TenantSetting.resolve_worker_setting(key, env_key: env_key, env: ENV, default: default)
     end
   end
 end

--- a/app/temporal/activities/trigger_dev_environment_update_activity.rb
+++ b/app/temporal/activities/trigger_dev_environment_update_activity.rb
@@ -5,7 +5,7 @@ module Activities
   # environment update, then spawns `bin/dev-update` in a detached process.
   #
   # Only triggers for PRs merged on the Paid repository itself (detected via
-  # the PAID_REPO_FULL_NAME environment variable). No-ops for other repos.
+  # TenantSetting.self_repo_full_name or the PAID_REPO_FULL_NAME env var).
   #
   # Lightweight update (git pull only):
   #   Any changes that do not match FULL_RESTART_PATTERNS. This includes most
@@ -74,7 +74,8 @@ module Activities
     private
 
     def self_repo?(project)
-      paid_repo = ENV["PAID_REPO_FULL_NAME"]
+      account = project.account
+      paid_repo = account.tenant_setting&.self_repo_full_name.presence || ENV["PAID_REPO_FULL_NAME"]
       return false if paid_repo.blank?
 
       project.full_name.casecmp?(paid_repo)

--- a/app/views/tenant_configurations/edit.html.erb
+++ b/app/views/tenant_configurations/edit.html.erb
@@ -109,6 +109,14 @@
         </label>
       </div>
 
+      <div class="mt-4 grid gap-4 sm:grid-cols-2">
+        <div>
+          <%= label_tag "tenant_setting_self_repo_full_name", "Self-repo full name", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= text_field_tag "tenant_setting[self_repo_full_name]", @tenant_setting.self_repo_full_name, placeholder: "owner/repo", class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Repository that triggers auto dev-environment updates (e.g. owner/repo). Leave blank to disable.</p>
+        </div>
+      </div>
+
       <div class="mt-6 space-y-3">
         <% @feature_flags.each do |definition| %>
           <label class="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-200">
@@ -119,6 +127,44 @@
             </span>
           </label>
         <% end %>
+      </div>
+    </section>
+
+    <section>
+      <div class="flex items-center gap-2">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Worker Concurrency</h2>
+        <span class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">Restart required</span>
+      </div>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Changes to these settings require a Temporal worker and/or Rails server restart to take effect.</p>
+      <% ws = @tenant_setting.effective_worker_settings %>
+      <div class="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <%= label_tag "tenant_setting_worker_settings_temporal_workflow_slots", "Agent workflow slots", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= number_field_tag "tenant_setting[worker_settings][temporal_workflow_slots]", ws["temporal_workflow_slots"], min: 1, max: 100, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+        </div>
+        <div>
+          <%= label_tag "tenant_setting_worker_settings_temporal_activity_slots", "Agent activity slots", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= number_field_tag "tenant_setting[worker_settings][temporal_activity_slots]", ws["temporal_activity_slots"], min: 1, max: 100, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+        </div>
+        <div>
+          <%= label_tag "tenant_setting_worker_settings_temporal_poll_workflow_slots", "Poll workflow slots", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= number_field_tag "tenant_setting[worker_settings][temporal_poll_workflow_slots]", ws["temporal_poll_workflow_slots"], min: 1, max: 100, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+        </div>
+        <div>
+          <%= label_tag "tenant_setting_worker_settings_temporal_poll_activity_slots", "Poll activity slots", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= number_field_tag "tenant_setting[worker_settings][temporal_poll_activity_slots]", ws["temporal_poll_activity_slots"], min: 1, max: 100, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+        </div>
+      </div>
+      <div class="mt-4 grid gap-4 sm:grid-cols-2">
+        <div>
+          <%= label_tag "tenant_setting_worker_settings_good_job_max_threads", "GoodJob max threads", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= number_field_tag "tenant_setting[worker_settings][good_job_max_threads]", ws["good_job_max_threads"], min: 1, max: 100, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+        </div>
+        <div>
+          <%= label_tag "tenant_setting_worker_settings_good_job_queues", "GoodJob queues", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= text_field_tag "tenant_setting[worker_settings][good_job_queues]", ws["good_job_queues"], class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white font-mono text-xs" %>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Format: name:count;name:count</p>
+        </div>
       </div>
     </section>
 

--- a/bin/temporal_worker
+++ b/bin/temporal_worker
@@ -28,18 +28,21 @@ puts "Activities: #{activities.map(&:name).join(", ")}"
 puts "Poll workflows (#{Paid.poll_task_queue}): #{poll_workflows.map(&:name).join(", ")}"
 puts "Agent workflows (#{Paid.agent_task_queue}): #{agent_workflows.map(&:name).join(", ")}"
 
+def resolve_worker_setting(key, env_key, default)
+  TenantSetting.resolve_worker_setting(key, env_key: env_key, env: ENV, default: default)
+end
+
 graceful_shutdown = ENV.fetch("TEMPORAL_GRACEFUL_SHUTDOWN_PERIOD", "30").to_i
 
-# Agent worker concurrency (large pool for long-running agent activities)
-agent_workflow_slots = ENV.fetch("TEMPORAL_WORKFLOW_SLOTS", "20").to_i
-agent_activity_slots = ENV.fetch("TEMPORAL_ACTIVITY_SLOTS", "4").to_i
+agent_workflow_slots = resolve_worker_setting("temporal_workflow_slots", "TEMPORAL_WORKFLOW_SLOTS", 20)
+agent_activity_slots = resolve_worker_setting("temporal_activity_slots", "TEMPORAL_ACTIVITY_SLOTS", 4)
 agent_local_activity_slots = ENV.fetch("TEMPORAL_LOCAL_ACTIVITY_SLOTS", agent_activity_slots.to_s).to_i
 agent_activity_task_polls = ENV.fetch("TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS", agent_activity_slots.to_s).to_i
 agent_workflow_task_polls = ENV.fetch("TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS", agent_workflow_slots.to_s).to_i
 
 # Poll worker concurrency (small fixed pool — poll activities are short-lived)
-poll_workflow_slots = ENV.fetch("TEMPORAL_POLL_WORKFLOW_SLOTS", "20").to_i
-poll_activity_slots = ENV.fetch("TEMPORAL_POLL_ACTIVITY_SLOTS", "10").to_i
+poll_workflow_slots = resolve_worker_setting("temporal_poll_workflow_slots", "TEMPORAL_POLL_WORKFLOW_SLOTS", 20)
+poll_activity_slots = resolve_worker_setting("temporal_poll_activity_slots", "TEMPORAL_POLL_ACTIVITY_SLOTS", 10)
 poll_local_activity_slots = ENV.fetch("TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS", poll_activity_slots.to_s).to_i
 poll_activity_task_polls = ENV.fetch("TEMPORAL_POLL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS", poll_activity_slots.to_s).to_i
 poll_workflow_task_polls = ENV.fetch("TEMPORAL_POLL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS", poll_workflow_slots.to_s).to_i

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -9,14 +9,26 @@ module Paid
     end
 
     def max_threads(env = ENV)
-      Integer(env.fetch("GOOD_JOB_MAX_THREADS", "11"))
+      resolve_from_db("good_job_max_threads", env_key: "GOOD_JOB_MAX_THREADS", env: env, default: 11)
     end
 
     def queues(env = ENV)
-      env.fetch(
-        "GOOD_JOB_QUEUES",
-        "default:3;maintenance:2;metrics:2;knowledge:3;low_priority:1"
-      )
+      resolve_from_db("good_job_queues", env_key: "GOOD_JOB_QUEUES", env: env,
+        default: "default:3;maintenance:2;metrics:2;knowledge:3;low_priority:1")
+    end
+
+    def resolve_from_db(key, env_key:, env:, default:)
+      TenantSetting.resolve_worker_setting(key, env_key: env_key, env: env, default: default)
+    rescue NameError
+      fallback = env.fetch(env_key, nil)
+      return default unless fallback
+      begin
+        Integer(fallback)
+      rescue ArgumentError
+        fallback
+      end
+    rescue ArgumentError
+      default
     end
 
     def poll_interval(env = ENV)

--- a/db/migrate/20260425225105_add_worker_settings_and_self_repo_full_name_to_tenant_settings.rb
+++ b/db/migrate/20260425225105_add_worker_settings_and_self_repo_full_name_to_tenant_settings.rb
@@ -1,0 +1,6 @@
+class AddWorkerSettingsAndSelfRepoFullNameToTenantSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tenant_settings, :worker_settings, :jsonb, null: false, default: {}
+    add_column :tenant_settings, :self_repo_full_name, :string
+  end
+end

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe TenantSetting do
       expect(setting.guardrails).to eq({})
       expect(setting.quality_thresholds).to eq({})
       expect(setting.agent_settings).to eq({})
+      expect(setting.worker_settings).to eq({})
+      expect(setting.self_repo_full_name).to be_nil
     end
   end
 
@@ -126,6 +128,120 @@ RSpec.describe TenantSetting do
         provider_preferences: { "api_key_ids" => { "anthropic" => api_key.id } })
 
       expect(setting.provider_api_key_for("anthropic")).to eq(api_key)
+    end
+  end
+
+  describe "worker_settings" do
+    it "returns defaults when no worker_settings configured" do
+      setting = build(:tenant_setting)
+      expect(setting.effective_worker_settings).to eq(TenantSetting::DEFAULT_WORKER_SETTINGS)
+    end
+
+    it "merges stored values over defaults" do
+      setting = build(:tenant_setting, worker_settings: { "temporal_workflow_slots" => 30 })
+      expect(setting.effective_worker_settings["temporal_workflow_slots"]).to eq(30)
+      expect(setting.effective_worker_settings["temporal_activity_slots"]).to eq(4)
+    end
+
+    it "validates integer keys are between 1 and 100" do
+      setting = build(:tenant_setting, worker_settings: { "temporal_workflow_slots" => 0 })
+      expect(setting).not_to be_valid
+      expect(setting.errors[:worker_settings]).to include(match(/must be an integer between 1 and 100/))
+    end
+
+    it "validates integer keys do not exceed 100" do
+      setting = build(:tenant_setting, worker_settings: { "temporal_activity_slots" => 101 })
+      expect(setting).not_to be_valid
+    end
+
+    it "validates good_job_queues format" do
+      setting = build(:tenant_setting, worker_settings: { "good_job_queues" => "invalid" })
+      expect(setting).not_to be_valid
+      expect(setting.errors[:worker_settings]).to include(match(/good_job_queues must match format/))
+    end
+
+    it "accepts valid good_job_queues" do
+      setting = build(:tenant_setting, worker_settings: { "good_job_queues" => "default:3;maintenance:2" })
+      expect(setting).to be_valid
+    end
+
+    it "normalizes integer values from string input" do
+      setting = build(:tenant_setting, worker_settings: { "temporal_workflow_slots" => "25" })
+      setting.valid?
+      expect(setting.worker_settings["temporal_workflow_slots"]).to eq(25)
+    end
+
+    it "provides accessor for individual settings" do
+      setting = build(:tenant_setting, worker_settings: { "temporal_workflow_slots" => 30 })
+      expect(setting.worker_setting("temporal_workflow_slots")).to eq(30)
+    end
+
+    it "returns default for unconfigured individual settings" do
+      setting = build(:tenant_setting)
+      expect(setting.worker_setting("temporal_workflow_slots")).to eq(20)
+    end
+  end
+
+  describe "self_repo_full_name" do
+    it "accepts valid owner/repo format" do
+      setting = build(:tenant_setting, self_repo_full_name: "owner/repo")
+      expect(setting).to be_valid
+    end
+
+    it "accepts nil" do
+      setting = build(:tenant_setting, self_repo_full_name: nil)
+      expect(setting).to be_valid
+    end
+
+    it "rejects invalid format" do
+      setting = build(:tenant_setting, self_repo_full_name: "not-a-repo-format")
+      expect(setting).not_to be_valid
+      expect(setting.errors[:self_repo_full_name]).to include(match(/must be in owner\/repo format/))
+    end
+  end
+
+  describe ".resolve_worker_setting" do
+    it "returns ENV value when no DB setting exists" do
+      result = described_class.resolve_worker_setting(
+        "temporal_workflow_slots",
+        env_key: "TEMPORAL_WORKFLOW_SLOTS",
+        env: { "TEMPORAL_WORKFLOW_SLOTS" => "30" },
+        default: 20
+      )
+      expect(result).to eq(30)
+    end
+
+    it "returns default when no DB or ENV setting" do
+      result = described_class.resolve_worker_setting(
+        "temporal_workflow_slots",
+        env_key: "TEMPORAL_WORKFLOW_SLOTS",
+        env: {},
+        default: 20
+      )
+      expect(result).to eq(20)
+    end
+
+    it "returns DB value when present" do
+      account = create(:account)
+      create(:tenant_setting, account: account, worker_settings: { "temporal_workflow_slots" => 50 })
+
+      result = described_class.resolve_worker_setting(
+        "temporal_workflow_slots",
+        env_key: "TEMPORAL_WORKFLOW_SLOTS",
+        env: { "TEMPORAL_WORKFLOW_SLOTS" => "30" },
+        default: 20
+      )
+      expect(result).to eq(50)
+    end
+
+    it "handles good_job_queues as string" do
+      result = described_class.resolve_worker_setting(
+        "good_job_queues",
+        env_key: "GOOD_JOB_QUEUES",
+        env: { "GOOD_JOB_QUEUES" => "default:5;maintenance:3" },
+        default: "default:3;maintenance:2"
+      )
+      expect(result).to eq("default:5;maintenance:3")
     end
   end
 end

--- a/spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb
+++ b/spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
   let(:activity) { described_class.new }
-  let(:project) { create(:project, owner: "paid-ai", repo: "paid") }
+  let(:account) { create(:account) }
+  let(:project) { create(:project, owner: "paid-ai", repo: "paid", account: account) }
   let(:github_client) { instance_double(GithubClient) }
 
   before do
@@ -13,12 +14,15 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
     allow(Process).to receive(:detach)
   end
 
+  def stub_repo_full_name(value)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("PAID_REPO_FULL_NAME").and_return(value)
+  end
+
   describe "#execute" do
     context "when project is not the self-repo" do
       before do
-        allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("PAID_REPO_FULL_NAME").and_return("other-org/other-repo")
+        stub_repo_full_name("other-org/other-repo")
       end
 
       it "returns not_self_repo without fetching files" do
@@ -32,9 +36,7 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
 
     context "when PAID_REPO_FULL_NAME is not set" do
       before do
-        allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("PAID_REPO_FULL_NAME").and_return(nil)
+        stub_repo_full_name(nil)
       end
 
       it "returns not_self_repo" do
@@ -46,9 +48,7 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
 
     context "when project is the self-repo" do
       before do
-        allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("PAID_REPO_FULL_NAME").and_return("paid-ai/paid")
+        stub_repo_full_name("paid-ai/paid")
       end
 
       context "when only app code changed (lightweight)" do
@@ -243,7 +243,7 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
       end
 
       context "with case-insensitive repo matching" do
-        let(:project) { create(:project, owner: "Paid-AI", repo: "PAID") }
+        let(:project) { create(:project, owner: "Paid-AI", repo: "PAID", account: account) }
 
         before do
           allow(github_client).to receive(:pull_request_files)
@@ -255,6 +255,39 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
           result = activity.execute(project_id: project.id, pr_number: 42)
 
           expect(result).to include(triggered: true)
+        end
+      end
+
+      context "when self_repo_full_name is set in TenantSetting" do
+        let(:setting) { account.tenant_setting! }
+
+        before do
+          setting.update!(self_repo_full_name: "paid-ai/paid")
+          stub_repo_full_name(nil)
+          allow(github_client).to receive(:pull_request_files)
+            .with("paid-ai/paid", 42)
+            .and_return(%w[app/models/user.rb])
+        end
+
+        it "uses TenantSetting value instead of ENV" do
+          result = activity.execute(project_id: project.id, pr_number: 42)
+
+          expect(result).to include(triggered: true)
+        end
+      end
+
+      context "when TenantSetting self_repo_full_name does not match" do
+        let(:setting) { account.tenant_setting! }
+
+        before do
+          setting.update!(self_repo_full_name: "other-org/other-repo")
+          stub_repo_full_name(nil)
+        end
+
+        it "returns not_self_repo" do
+          result = activity.execute(project_id: project.id, pr_number: 42)
+
+          expect(result).to eq(triggered: false, reason: "not_self_repo")
         end
       end
     end


### PR DESCRIPTION
## Summary

- Add `worker_settings` jsonb (6 concurrency knobs) and `self_repo_full_name` string to `TenantSetting`, enabling admin configuration via UI instead of env vars only.
- Worker settings use a **DB → ENV → hardcoded-default** resolution chain so env vars remain valid fallbacks. A "restart required" badge warns when changes need a worker/server restart.
- Remove 7 redundant env vars from `devcontainer.json` (4 matching code defaults, 2 redundant auto-follow slots, 1 migrated to DB).

## Changes

### New TenantSetting fields
- `worker_settings` jsonb with defaults: `temporal_workflow_slots=20`, `temporal_activity_slots=4`, `temporal_poll_workflow_slots=20`, `temporal_poll_activity_slots=10`, `good_job_max_threads=11`, `good_job_queues="default:3;maintenance:2;metrics:2;knowledge:3;low_priority:1"`
- `self_repo_full_name` string — replaces `PAID_REPO_FULL_NAME` env var

### Resolution chain
- `bin/temporal_worker` — slot counts resolved via `TenantSetting.resolve_worker_setting` (DB → ENV → default)
- `config/initializers/good_job.rb` — `max_threads` and `queues` use same chain with boot-time `NameError` guard
- `app/services/metrics/prometheus_collector.rb` — metrics use same chain
- `app/temporal/activities/trigger_dev_environment_update_activity.rb` — `self_repo?` reads `TenantSetting.self_repo_full_name` with ENV fallback

### UI
- Worker Concurrency section with "Restart required" badge and per-setting number fields
- Self-repo full name field under Agent Settings
- Controller permits new params

### Devcontainer cleanup (7 vars removed)
- `TEMPORAL_NAMESPACE`, `TEMPORAL_POLL_TASK_QUEUE`, `TEMPORAL_AGENT_TASK_QUEUE`, `TEMPORAL_UI_URL` (matched code defaults)
- `TEMPORAL_LOCAL_ACTIVITY_SLOTS`, `TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS` (redundant auto-follow)
- `PAID_REPO_FULL_NAME` (now in DB)

## Test plan
- [x] 33 model specs pass (16 new for worker_settings, self_repo_full_name, resolve_worker_setting)
- [x] 18 activity specs pass (2 new for TenantSetting-based self_repo detection)
- [x] 50 GoodJob/worker pool specs pass (unchanged)
- [x] `bin/lint --changed` passes
- [ ] Manual: save worker settings in UI, verify values persist and reload correctly
- [ ] Manual: verify devcontainer starts without removed env vars