### PR TITLE
feat(agent-runs): create AgentRuns::CreateFollowup service for post-analysis routing

### DIFF
--- a/app/services/agent_runs/create_followup.rb
+++ b/app/services/agent_runs/create_followup.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module AgentRuns
+  class CreateFollowup
+    FOLLOWUP_GOALS = %w[create_pr enhance_issue].freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(agent_run:, goal:)
+      @agent_run = agent_run
+      @goal = goal
+    end
+
+    def call
+      validate!
+
+      followup = create_followup_run
+      ProcessRunQueueJob.perform_later
+      followup
+    rescue ActiveRecord::RecordNotUnique => e
+      message = e.cause&.message || e.message
+      raise unless message&.include?("idx_agent_runs_unique_active_issue")
+
+      handle_duplicate
+    end
+
+    private
+
+    attr_reader :agent_run, :goal
+
+    def validate!
+      raise ArgumentError, "Analysis run must have an associated issue" unless agent_run.issue
+      raise ArgumentError, "Goal must be one of: #{FOLLOWUP_GOALS.join(", ")}" unless FOLLOWUP_GOALS.include?(goal)
+    end
+
+    def create_followup_run
+      provider = resolve_provider
+
+      AgentRun.create!(
+        project: agent_run.project,
+        issue: agent_run.issue,
+        provider: provider,
+        agent_type: provider ? Provider.agent_type_for(provider.provider_key) : "claude_code",
+        status: "queued",
+        trigger_type: "automatic",
+        auto_pick: true,
+        goal: goal
+      )
+    end
+
+    def resolve_provider
+      return agent_run.provider if agent_run.provider
+
+      provider_id, = AgentRuns::ProviderResolver.call(project: agent_run.project, goal: goal)
+      Provider.find_by(id: provider_id) if provider_id
+    end
+
+    def handle_duplicate
+      existing_run = AgentRun.find_by(
+        project: agent_run.project,
+        issue: agent_run.issue,
+        goal: goal,
+        status: AgentRun::AUTO_PICK_BLOCKING_STATUSES
+      )
+
+      if existing_run
+        Rails.logger.info(
+          message: "create_followup.duplicate_existing_run",
+          project_id: agent_run.project_id,
+          issue_id: agent_run.issue_id,
+          agent_run_id: existing_run.id
+        )
+        existing_run
+      else
+        Rails.logger.info(
+          message: "create_followup.duplicate_skipped",
+          project_id: agent_run.project_id,
+          issue_id: agent_run.issue_id
+        )
+        nil
+      end
+    end
+  end
+end

--- a/spec/services/agent_runs/create_followup_spec.rb
+++ b/spec/services/agent_runs/create_followup_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRuns::CreateFollowup do
+  describe ".call" do
+    let(:project) { create(:project) }
+    let(:issue) { create(:issue, project: project) }
+    let(:provider) { create(:provider, user: project.created_by) }
+    let(:analysis_run) do
+      create(:agent_run, :analyze_issue_goal, :completed,
+        project: project,
+        issue: issue,
+        provider: provider)
+    end
+
+    context "when goal is create_pr" do
+      it "creates a queued create_pr run" do
+        followup = described_class.call(agent_run: analysis_run, goal: "create_pr")
+
+        expect(followup).to be_persisted
+        expect(followup.goal).to eq("create_pr")
+        expect(followup.status).to eq("queued")
+      end
+
+      it "inherits project and issue from the analysis run" do
+        followup = described_class.call(agent_run: analysis_run, goal: "create_pr")
+
+        expect(followup.project).to eq(project)
+        expect(followup.issue).to eq(issue)
+      end
+
+      it "inherits provider from the analysis run" do
+        followup = described_class.call(agent_run: analysis_run, goal: "create_pr")
+
+        expect(followup.provider).to eq(provider)
+      end
+
+      it "sets trigger_type to automatic and auto_pick to true" do
+        followup = described_class.call(agent_run: analysis_run, goal: "create_pr")
+
+        expect(followup.trigger_type).to eq("automatic")
+        expect(followup.auto_pick).to be true
+      end
+    end
+
+    context "when goal is enhance_issue" do
+      it "creates a queued enhance_issue run" do
+        followup = described_class.call(agent_run: analysis_run, goal: "enhance_issue")
+
+        expect(followup).to be_persisted
+        expect(followup.goal).to eq("enhance_issue")
+        expect(followup.status).to eq("queued")
+      end
+    end
+
+    context "when analysis run has no issue" do
+      it "raises ArgumentError" do
+        analysis_run.issue = nil
+
+        expect {
+          described_class.call(agent_run: analysis_run, goal: "create_pr")
+        }.to raise_error(ArgumentError, /must have an associated issue/)
+      end
+    end
+
+    context "when goal is invalid" do
+      it "raises ArgumentError" do
+        expect {
+          described_class.call(agent_run: analysis_run, goal: "invalid")
+        }.to raise_error(ArgumentError, /Goal must be one of/)
+      end
+    end
+
+    context "when analysis run has no provider" do
+      let(:analysis_run) do
+        create(:agent_run, :analyze_issue_goal, :completed,
+          project: project,
+          issue: issue,
+          provider: nil)
+      end
+
+      it "resolves a provider via ProviderResolver" do
+        resolved_provider = create(:provider, user: project.created_by)
+        allow(AgentRuns::ProviderResolver).to receive(:call)
+          .and_return([ resolved_provider.id, "claude_code" ])
+
+        followup = described_class.call(agent_run: analysis_run, goal: "create_pr")
+
+        expect(followup.provider).to eq(resolved_provider)
+      end
+    end
+
+    it "enqueues ProcessRunQueueJob" do
+      expect {
+        described_class.call(agent_run: analysis_run, goal: "create_pr")
+      }.to have_enqueued_job(ProcessRunQueueJob)
+    end
+
+    context "when a duplicate active run exists" do
+      let!(:existing_run) do
+        create(:agent_run,
+          project: project,
+          issue: issue,
+          goal: "create_pr",
+          status: "queued")
+      end
+
+      it "returns the existing run instead of raising" do
+        result = described_class.call(agent_run: analysis_run, goal: "create_pr")
+
+        expect(result).to eq(existing_run)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

feat(agent-runs): create AgentRuns::CreateFollowup service for post-analysis routing

See #1414 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1414