### PR TITLE
refactor: upstream error classification patterns to agent-harness

### DIFF
--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -663,12 +663,12 @@ module Providers
     end
 
     def authentication_error_patterns
-      BASE_AUTHENTICATION_ERROR_PATTERNS +
+      @authentication_error_patterns ||= BASE_AUTHENTICATION_ERROR_PATTERNS +
         ProviderSupport.error_classification_patterns_for(provider.provider_key, :authentication)
     end
 
     def noisy_error_line_patterns
-      BASE_NOISY_ERROR_LINES +
+      @noisy_error_line_patterns ||= BASE_NOISY_ERROR_LINES +
         ProviderSupport.aggregated_noisy_error_patterns
     end
 

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -19,23 +19,17 @@ module Providers
     EXPECTED_OUTPUT = "PING OK"
     TIMEOUT = 60
     RATE_LIMIT_PATTERNS = Activities::RunAgentActivity::RATE_LIMIT_PATTERNS
-    AUTHENTICATION_ERROR_PATTERNS = [
+    # Base authentication patterns shared across all providers. Provider-specific
+    # patterns are sourced from agent-harness error_classification_patterns[:authentication].
+    BASE_AUTHENTICATION_ERROR_PATTERNS = [
       /api[_ -]?key/i,
-      /API key not configured for openai/i,
       /API key not configured for/i,
       /auth(?:entication)?/i,
       /oauth/i,
       /token/i,
       /unauthori[sz]ed/i,
       /invalid credentials/i,
-      /session.*expired/i,
-      /ValidationRequiredError/i,
-      /Verify your account to continue\./i,
-      /Please set an Auth method/i,
-      /Missing agent run ID/i,
-      /GEMINI_API_KEY/i,
-      /GOOGLE_GENAI_USE_VERTEXAI/i,
-      /GOOGLE_GENAI_USE_GCA/i
+      /session.*expired/i
     ].freeze
     INSTALLATION_ERROR_PATTERNS = [
       /command not found/i,
@@ -73,7 +67,9 @@ module Providers
       /Connection refused.*?(?=\n|$)/i
     ].freeze
     ANSI_ESCAPE_PATTERN = /\e\[[0-9;?]*[ -\/]*[@-~]/
-    NOISY_ERROR_LINES = [
+    # Base noisy-error patterns shared across all providers. Provider-specific
+    # patterns are sourced from agent-harness noisy_error_patterns.
+    BASE_NOISY_ERROR_LINES = [
       /^INFO\s+\d{4}-\d{2}-\d{2}T/i,
       /^OpenAI Codex v/i,
       /^-+$/,
@@ -94,7 +90,6 @@ module Providers
       /Loaded cached credentials/i,
       /Validation handler failed:/i,
       %r{^\s*at\s+},
-      /Error when talking to Gemini API/i,
       /Full report available at:/i,
       /An unexpected critical error occurred:/i,
       /service=.*\b(status|loading|subscribing|publishing|request|state|using bundled provider)\b/i,
@@ -590,7 +585,7 @@ module Providers
       message = error_message.to_s
 
       return :rate_limited if matches_any_pattern?(message, RATE_LIMIT_PATTERNS)
-      return :authentication if matches_any_pattern?(message, AUTHENTICATION_ERROR_PATTERNS)
+      return :authentication if matches_any_pattern?(message, authentication_error_patterns)
       return :installation if matches_any_pattern?(message, INSTALLATION_ERROR_PATTERNS)
       return :timeout if matches_any_pattern?(message, TIMEOUT_ERROR_PATTERNS)
       return :connection if matches_any_pattern?(message, CONNECTION_ERROR_PATTERNS)
@@ -623,7 +618,7 @@ module Providers
     end
 
     def noisy_error_line?(line)
-      matches_any_pattern?(line, NOISY_ERROR_LINES)
+      matches_any_pattern?(line, noisy_error_line_patterns)
     end
 
     def sanitize_error_message(error_message)
@@ -637,7 +632,21 @@ module Providers
     include OutputSanitizer
 
     def translate_known_provider_errors(message)
-      return "Paid is not configured with a Google API key for containerized Gemini runs." if message.match?(/API key not configured for google/i)
+      # Paid-specific translations that reference container/proxy infrastructure
+      # take priority since they provide more actionable context than generic
+      # agent-harness translations.
+      paid_translation = translate_paid_specific_errors(message)
+      return paid_translation if paid_translation
+
+      # Fall back to the agent-harness provider's translate_error.
+      ProviderSupport.translate_provider_error(provider.provider_key, message)
+    end
+
+    def translate_paid_specific_errors(message)
+      if message.match?(/API key not configured for google/i)
+        return "Paid is not configured with a Google API key for containerized Gemini runs."
+      end
+
       if message.match?(/API key not configured for openai/i)
         return "Paid is not configured with an OpenAI API key for containerized OpenAI-backed runs (Codex or OpenCode)."
       end
@@ -647,8 +656,20 @@ module Providers
       end
 
       if message.match?(/Missing agent run ID/i) && message.match?(%r{/api/proxy/openai/}i)
-        "Codex did not forward the Paid container credentials to the OpenAI proxy."
+        return "Codex did not forward the Paid container credentials to the OpenAI proxy."
       end
+
+      nil
+    end
+
+    def authentication_error_patterns
+      BASE_AUTHENTICATION_ERROR_PATTERNS +
+        ProviderSupport.error_classification_patterns_for(provider.provider_key, :authentication)
+    end
+
+    def noisy_error_line_patterns
+      BASE_NOISY_ERROR_LINES +
+        ProviderSupport.aggregated_noisy_error_patterns
     end
 
     class Result

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -110,7 +110,7 @@ module Activities
     end
 
     def provider_error_patterns
-      ProviderSupport.aggregated_error_classification_patterns(:quota) +
+      @provider_error_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota) +
         SUPPLEMENTARY_ERROR_PATTERNS
     end
 

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -22,23 +22,19 @@ module Activities
     NEEDS_INPUT_COMMENT_MARKER = "<!-- paid:needs-input -->"
     RECOMMEND_CLOSE_COMMENT_MARKER = "<!-- paid:recommend-close -->"
 
-    # Patterns indicating the agent "output" is actually a provider-level
-    # credit/quota/billing error rather than legitimate agent output. When
-    # matched, the output is treated as evidence of a provider failure, not
-    # grounds to recommend closing the issue. Mirrors and extends the patterns
-    # in RunAgentActivity so a provider error that slipped past the primary
-    # detector is still caught here.
-    PROVIDER_ERROR_OUTPUT_PATTERNS = [
-      /requires? more credits/i,
-      /add more credits/i,
-      /insufficient credits/i,
-      /not enough credits/i,
-      /purchase (?:more )?credits/i,
-      /buy (?:more )?credits/i,
+    # Supplementary patterns used alongside quota patterns from agent-harness
+    # to detect provider-level errors in agent output. Includes rate-limit
+    # indicators and credit/quota phrases not yet covered by agent-harness.
+    SUPPLEMENTARY_ERROR_PATTERNS = [
       /quota exceeded/i,
       /rate.?limit/i,
       /too many requests/i,
-      /\b429\b/
+      /\b429\b/,
+      /add more credits/i,
+      /not enough credits/i,
+      /purchase (?:more )?credits/i,
+      /buy (?:more )?credits/i,
+      /requires? more credits/i
     ].freeze
 
     def execute(input)
@@ -110,7 +106,12 @@ module Activities
     def provider_error_output?(text)
       return false if text.blank?
 
-      PROVIDER_ERROR_OUTPUT_PATTERNS.any? { |pattern| text.match?(pattern) }
+      provider_error_patterns.any? { |pattern| text.match?(pattern) }
+    end
+
+    def provider_error_patterns
+      ProviderSupport.aggregated_error_classification_patterns(:quota) +
+        SUPPLEMENTARY_ERROR_PATTERNS
     end
 
     def handle_provider_error(agent_run, agent_summary)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -63,45 +63,6 @@ module Activities
       /out of (?:extra )?usage/i
     ].freeze
 
-    AUTH_EXPIRED_PATTERNS = {
-      "codex" => [
-        /refresh_token_reused/i,
-        /refresh token has already been used to generate a new access token/i,
-        /refresh token was already used/i,
-        /Please log out and sign in again/i,
-        /Your access token could not be refreshed/i
-      ].freeze
-    }.freeze
-
-    # Patterns for provider-level credit/quota exhaustion errors that may be
-    # emitted as agent "output" even when the CLI exits with a zero status
-    # (observed with OpenRouter-backed providers returning a billing error as
-    # the only stdout line). These must be specific enough to avoid matching
-    # ordinary agent prose that mentions credits/billing — they key on phrases
-    # that only appear in provider error responses.
-    INSUFFICIENT_CREDITS_PATTERNS = [
-      /requires? more credits/i,
-      /add more credits/i,
-      /insufficient credits/i,
-      /not enough credits/i,
-      /purchase (?:more )?credits/i,
-      /buy (?:more )?credits/i
-    ].freeze
-
-    # Patterns that indicate a fatal provider quota/billing error where the
-    # CLI is known to hang instead of exiting promptly. When any of these
-    # match streaming stderr, the container is stopped immediately rather
-    # than waiting for an idle or wall-clock timeout.
-    #
-    # These are intentionally a strict subset of RATE_LIMIT_PATTERNS —
-    # only patterns where the CLI is empirically known to hang after emitting
-    # the error. Generic rate-limit messages from CLIs that exit cleanly
-    # should NOT be added here.
-    PROVIDER_ABORT_PATTERNS = [
-      /free tier limit reached/i,
-      /please upgrade to a paid plan/i
-    ].freeze
-
     # Maximum number of log rows to inspect when reclassifying a timeout.
     # Caps memory and DB load on long-running, verbose agent attempts.
     TIMEOUT_RATE_LIMIT_LOG_LIMIT = 200
@@ -657,7 +618,7 @@ module Activities
           env: command_env,
           preparation: command_preparation,
           heartbeat_path: heartbeat.available? ? heartbeat.heartbeat_path : nil,
-          abort_patterns: PROVIDER_ABORT_PATTERNS
+          abort_patterns: aggregated_abort_patterns
         )
       end
       stdout = normalize_output_text(result[:stdout])
@@ -765,7 +726,9 @@ module Activities
     def auth_expired_error?(provider, output)
       return false if output.blank?
 
-      AUTH_EXPIRED_PATTERNS.fetch(provider.to_s, []).any? { |pattern| output.match?(pattern) }
+      provider_key = ProviderSupport.provider_key_for_agent_type(provider)
+      ProviderSupport.error_classification_patterns_for(provider_key, :auth_expired)
+        .any? { |pattern| output.match?(pattern) }
     end
 
     # Detects provider-level credit/quota exhaustion errors surfaced as
@@ -775,7 +738,8 @@ module Activities
     def insufficient_credits_error?(output)
       return false if output.blank?
 
-      INSUFFICIENT_CREDITS_PATTERNS.any? { |pattern| output.match?(pattern) }
+      ProviderSupport.aggregated_error_classification_patterns(:quota)
+        .any? { |pattern| output.match?(pattern) }
     end
 
     def strip_prompt_echo(output, prompt)
@@ -870,6 +834,10 @@ module Activities
       app_provider_key = ProviderSupport.provider_key_for_agent_type(provider_key)
       harness_key = ProviderSupport.harness_provider_key_for(app_provider_key).to_sym
       AgentHarness.provider(harness_key)
+    end
+
+    def aggregated_abort_patterns
+      ProviderSupport.aggregated_error_classification_patterns(:abort)
     end
 
     def track_harness_tokens(agent_run, provider_candidate, provider_key, user, result, execution_started_at)

--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -263,4 +263,40 @@ module ProviderSupport
       [ "sh", "-c", "env #{unset_flags} #{command}" ]
     end
   end
+
+  # Returns an AgentHarness provider instance for the given app-level provider key.
+  def harness_provider_for(provider_key)
+    harness_key = harness_provider_key_for(provider_key).to_sym
+    AgentHarness.provider(harness_key)
+  end
+
+  # Returns error_classification_patterns[category] for a single provider.
+  def error_classification_patterns_for(provider_key, category)
+    harness_provider_for(provider_key).error_classification_patterns.fetch(category, [])
+  rescue AgentHarness::ConfigurationError, KeyError
+    []
+  end
+
+  # Aggregates error_classification_patterns[category] across all supported providers.
+  def aggregated_error_classification_patterns(category)
+    supported_provider_keys.flat_map { |key| error_classification_patterns_for(key, category) }.uniq
+  end
+
+  # Aggregates noisy_error_patterns across all supported providers.
+  def aggregated_noisy_error_patterns
+    supported_provider_keys.flat_map do |key|
+      harness_provider_for(key).noisy_error_patterns
+    rescue AgentHarness::ConfigurationError, KeyError
+      []
+    end.uniq
+  end
+
+  # Translates a raw error message using the given provider's translate_error.
+  # Returns nil if the provider does not translate the message (returns it unchanged).
+  def translate_provider_error(provider_key, message)
+    translated = harness_provider_for(provider_key).translate_error(message)
+    translated == message ? nil : translated
+  rescue AgentHarness::ConfigurationError, KeyError
+    nil
+  end
 end


### PR DESCRIPTION
## Summary

refactor: upstream error classification patterns to agent-harness

See #1302 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1302