### PR TITLE
feat(auto-pick): integrate analyze_issue gate into auto-pick strategy

### DIFF
--- a/app/services/automation/strategies/auto_pick.rb
+++ b/app/services/automation/strategies/auto_pick.rb
@@ -46,7 +46,13 @@ module Automation
         issue = @candidate_source.next_candidate(project)
         return noop_result unless issue
 
-        Result.new(decisions: [ Decision.queue_create_pr_run(issue_id: issue.id) ])
+        decision = if project.auto_enhance_enabled?
+          Decision.queue_analyze_issue_run(issue_id: issue.id)
+        else
+          Decision.queue_create_pr_run(issue_id: issue.id)
+        end
+
+        Result.new(decisions: [ decision ])
       end
 
       private

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -53,7 +53,8 @@ module Issues
       # the rescues below and abort the queue-seed tick.
       return nil unless issue
 
-      agent_run = create_agent_run(issue)
+      goal = decision.type == "queue_analyze_issue_run" ? "analyze_issue" : "create_pr"
+      agent_run = create_agent_run(issue, goal: goal)
 
       Rails.logger.info(
         message: "auto_pick.issue_selected",
@@ -156,8 +157,8 @@ module Issues
       owner.settings.max_auto_pick_open_prs
     end
 
-    def create_agent_run(issue)
-      provider = resolve_provider
+    def create_agent_run(issue, goal: "create_pr")
+      provider = resolve_provider(goal)
       raise NoRunnableProviderError, "No runnable provider could be resolved for this project." unless provider
 
       AgentRun.create!(
@@ -167,12 +168,13 @@ module Issues
         agent_type: Provider.agent_type_for(provider.provider_key),
         status: "queued",
         trigger_type: "automatic",
-        auto_pick: true
+        auto_pick: true,
+        goal: goal
       )
     end
 
-    def resolve_provider
-      provider_id, = AgentRuns::ProviderResolver.call(project: @project, goal: "create_pr")
+    def resolve_provider(goal)
+      provider_id, = AgentRuns::ProviderResolver.call(project: @project, goal: goal)
       Provider.find_by(id: provider_id) if provider_id
     end
   end

--- a/spec/services/automation/strategies/auto_pick_spec.rb
+++ b/spec/services/automation/strategies/auto_pick_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe Automation::Strategies::AutoPick do
       expect(result.decisions.first.payload[:issue_id]).to eq(42)
     end
 
+    it "returns a queue_analyze_issue_run decision when auto_enhance_enabled is true" do
+      project = build_stubbed(:project, auto_pick_enabled: true, auto_enhance_enabled: true)
+      issue = instance_double(Issue, id: 42)
+      allow(candidate_source).to receive(:next_candidate).with(project).and_return(issue)
+
+      result = strategy.evaluate(build_context_for(project))
+
+      expect(result.decisions.size).to eq(1)
+      expect(result.decisions.first.type).to eq("queue_analyze_issue_run")
+      expect(result.decisions.first.payload[:issue_id]).to eq(42)
+    end
+
     it "returns a noop result when auto-pick is disabled on the project" do
       project = build_stubbed(:project, auto_pick_enabled: false)
       allow(candidate_source).to receive(:next_candidate)

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -19,6 +19,28 @@ RSpec.describe Issues::AutoPick do
       expect(result.agent_type).to eq("claude_code")
     end
 
+    it "creates a create_pr run when auto_enhance_enabled is false" do
+      issue = create(:issue, project: project, github_state: "open")
+
+      result = described_class.new(project).call
+
+      expect(result).to be_a(AgentRun)
+      expect(result.goal).to eq("create_pr")
+    end
+
+    it "creates an analyze_issue run when auto_enhance_enabled is true" do
+      project.update!(auto_enhance_enabled: true)
+      issue = create(:issue, project: project, github_state: "open")
+
+      result = described_class.new(project).call
+
+      expect(result).to be_a(AgentRun)
+      expect(result.issue).to eq(issue)
+      expect(result.goal).to eq("analyze_issue")
+      expect(result.status).to eq("queued")
+      expect(result.trigger_type).to eq("automatic")
+    end
+
     it "returns nil when auto_pick is disabled on the project" do
       project.update!(auto_pick_enabled: false)
       create(:issue, project: project, github_state: "open")


### PR DESCRIPTION
## Summary

feat(auto-pick): integrate analyze_issue gate into auto-pick strategy

See #1415 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1415