### PR TITLE
fix(providers): GitHub Copilot Test Agent fails with "unknown option -p"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,8 +46,8 @@ gem "docker-api"
 gem "qdrant-ruby"
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-# Provider#parse_rate_limit_reset landed in agent-harness 0.8.0; ~> 0.10.0 includes it.
-gem "agent-harness", "~> 0.10.0"
+# 0.11.0 fixes GithubCopilot provider CLI version detection for 0.1.x subcommand CLIs.
+gem "agent-harness", "~> 0.11.0"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 gem "ruby-maat"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    agent-harness (0.10.0)
+    agent-harness (0.11.0)
       logger (>= 1.6, < 2.0)
     ast (2.4.3)
     base64 (0.3.0)
@@ -518,7 +518,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness (~> 0.10.0)
+  agent-harness (~> 0.11.0)
   bootsnap
   brakeman
   bundler-audit
@@ -576,7 +576,7 @@ CHECKSUMS
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  agent-harness (0.10.0) sha256=57cc99b70059e0c8223b93d374b485a316aad78ffad04151aab3e81434e345b6
+  agent-harness (0.11.0) sha256=52f85cab6b88770481a170180e327409c7d6ed32c0f2bfec2914688971c7d8e7
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032


### PR DESCRIPTION
## Summary

fix(providers): GitHub Copilot Test Agent fails with "unknown option -p"

See #1313 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1313