### PR TITLE
fix(prompt-evolution): persist review-goal prompt_version_id for sampled runs

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1864,11 +1864,12 @@ module Activities
       end
 
       vars = { base_prompt: prompt, repo: validated_repo_name(agent_run) }
-      rendered = Prompts::Render.call(
+
+      rendered = resolve_and_persist_goal_prompt(
+        agent_run: agent_run,
         slug: ISSUE_GOAL_PROMPT_SLUG,
-        project: agent_run.project,
         variables: vars,
-        fallback: -> { Prompts::Render.interpolate(FALLBACK_ISSUE_GOAL_PROMPT, vars) }
+        fallback_template: FALLBACK_ISSUE_GOAL_PROMPT
       )
 
       maybe_assign_ab_test_variant(agent_run, ISSUE_GOAL_PROMPT_SLUG, rendered, vars)
@@ -1887,11 +1888,12 @@ module Activities
         repo: validated_repo_name(agent_run),
         pr_number: pr_number.to_s
       }
-      rendered = Prompts::Render.call(
+
+      rendered = resolve_and_persist_goal_prompt(
+        agent_run: agent_run,
         slug: REVIEW_GOAL_PROMPT_SLUG,
-        project: agent_run.project,
         variables: vars,
-        fallback: -> { Prompts::Render.interpolate(FALLBACK_REVIEW_GOAL_PROMPT, vars) }
+        fallback_template: FALLBACK_REVIEW_GOAL_PROMPT
       )
 
       maybe_assign_ab_test_variant(agent_run, REVIEW_GOAL_PROMPT_SLUG, rendered, vars)
@@ -1912,14 +1914,32 @@ module Activities
         repo: validated_repo_name(agent_run),
         issue_number: issue.github_number.to_s
       }
-      rendered = Prompts::Render.call(
+
+      rendered = resolve_and_persist_goal_prompt(
+        agent_run: agent_run,
         slug: ENHANCE_ISSUE_GOAL_PROMPT_SLUG,
-        project: agent_run.project,
         variables: vars,
-        fallback: -> { Prompts::Render.interpolate(FALLBACK_ENHANCE_ISSUE_GOAL_PROMPT, vars) }
+        fallback_template: FALLBACK_ENHANCE_ISSUE_GOAL_PROMPT
       )
 
       maybe_assign_ab_test_variant(agent_run, ENHANCE_ISSUE_GOAL_PROMPT_SLUG, rendered, vars)
+    end
+
+    def resolve_and_persist_goal_prompt(agent_run:, slug:, variables:, fallback_template:)
+      prompt_version = Prompts::Resolve.call(slug: slug, project: agent_run.project)
+
+      if prompt_version
+        agent_run.update!(prompt_version: prompt_version) unless agent_run.prompt_version_id
+        prompt_version.render(variables)
+      else
+        Rails.logger.warn(
+          message: "prompts.render_fallback",
+          slug: slug,
+          project_id: agent_run.project_id,
+          reason: "no_active_version"
+        )
+        Prompts::Render.interpolate(fallback_template, variables)
+      end
     end
 
     def maybe_assign_ab_test_variant(agent_run, slug, rendered, vars)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -542,6 +542,62 @@ RSpec.describe Activities::RunAgentActivity do
     end
   end
 
+  describe "goal prompt version persistence" do
+    it "persists prompt_version_id for review-goal runs" do
+      prompt = create(:prompt, :for_project, project: project, slug: described_class::REVIEW_GOAL_PROMPT_SLUG)
+      version = prompt.create_version!(template: "review {{base_prompt}} {{repo}} {{pr_number}}")
+      run = create(:agent_run, :review_goal, project: project)
+
+      activity.send(:augment_prompt_for_review_goal, run, "Review the branch")
+
+      expect(run.reload.prompt_version).to eq(version)
+    end
+
+    it "persists prompt_version_id for issue-goal runs without an existing version" do
+      prompt = create(:prompt, :for_project, project: project, slug: described_class::ISSUE_GOAL_PROMPT_SLUG)
+      version = prompt.create_version!(template: "issue {{base_prompt}} {{repo}}")
+      run = create(:agent_run, :create_issue_goal, project: project)
+
+      activity.send(:augment_prompt_for_issue_goal, run, "Create the issue")
+
+      expect(run.reload.prompt_version).to eq(version)
+    end
+
+    it "persists prompt_version_id for enhance-issue-goal runs" do
+      prompt = create(:prompt, :for_project, project: project, slug: described_class::ENHANCE_ISSUE_GOAL_PROMPT_SLUG)
+      version = prompt.create_version!(template: "enhance {{base_prompt}} {{repo}} {{issue_number}}")
+      run = create(:agent_run, :enhance_issue_goal, project: project, issue: issue)
+      allow(Knowledge::ContextBundle::Build).to receive(:call)
+        .with(issue: issue, project: project, agent_run: run)
+        .and_return(content: "")
+
+      activity.send(:augment_prompt_for_enhance_issue_goal, run, "Enhance this issue")
+
+      expect(run.reload.prompt_version).to eq(version)
+    end
+
+    it "does not overwrite an existing prompt_version_id" do
+      existing_version = create(:prompt_version)
+      prompt = create(:prompt, :for_project, project: project, slug: described_class::ISSUE_GOAL_PROMPT_SLUG)
+      prompt.create_version!(template: "goal {{base_prompt}} {{repo}}")
+      run = create(:agent_run, :create_issue_goal, project: project, prompt_version: existing_version)
+
+      activity.send(:augment_prompt_for_issue_goal, run, "Create the issue")
+
+      expect(run.reload.prompt_version).to eq(existing_version)
+    end
+
+    it "falls back to inline template when no prompt version exists" do
+      allow(Prompt).to receive(:resolve).and_return(nil)
+      run = create(:agent_run, :review_goal, project: project)
+
+      prompt = activity.send(:augment_prompt_for_review_goal, run, "Review the branch")
+
+      expect(run.reload.prompt_version_id).to be_nil
+      expect(prompt).to include("Review the branch")
+    end
+  end
+
   describe "#augment_prompt_for_issue_goal knowledge injection" do
     before do
       allow(Prompt).to receive(:resolve).and_return(nil)


### PR DESCRIPTION
## Summary

fix(prompt-evolution): persist review-goal prompt_version_id for sampled runs

See #1324 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1324