### PR TITLE
feat(dependabot): evaluate auto-merge from poll loop so webhooks are optional

### DIFF
--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -140,11 +140,13 @@ class AutoReleaseEvaluationJob < ApplicationJob
     false
   end
 
-  # Returns true when the combined commit status is not "pending", meaning
-  # either no status checks exist (repo has no CI) or all have completed.
+  # Returns true when CI has passed or no CI is configured.
+  # GitHub returns "pending" with 0 contexts when no status checks exist,
+  # so we treat that as "no CI" and allow the merge. Any other non-success
+  # state (failure, error, or pending with actual statuses) blocks merging.
   def combined_status_state_settled?(client, project, sha)
-    state = client.combined_status_state(project.full_name, sha)
-    state != "pending"
+    status = client.combined_status(project.full_name, sha)
+    status[:state] == "success" || (status[:state] == "pending" && status[:total_count] == 0)
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "auto_release.combined_status_failed",

--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -110,7 +110,14 @@ class AutoReleaseEvaluationJob < ApplicationJob
 
   def all_checks_green?(client, project, pr_data)
     checks = client.check_runs_for_ref(project.full_name, pr_data.head.sha)
-    return true if checks.nil? || checks.empty?
+
+    if checks.nil? || checks.empty?
+      # Empty check runs may mean "no CI configured" or "CI hasn't queued yet."
+      # Use the commit status API as a secondary signal: GitHub returns "pending"
+      # when statuses exist but haven't completed. If the combined state is
+      # "pending", CI is likely still spinning up — wait for the next poll cycle.
+      return combined_status_state_settled?(client, project, pr_data.head.sha)
+    end
 
     checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
   rescue GithubClient::ApiError => e
@@ -127,6 +134,20 @@ class AutoReleaseEvaluationJob < ApplicationJob
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "auto_release.check_runs_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
+  end
+
+  # Returns true when the combined commit status is not "pending", meaning
+  # either no status checks exist (repo has no CI) or all have completed.
+  def combined_status_state_settled?(client, project, sha)
+    state = client.combined_status_state(project.full_name, sha)
+    state != "pending"
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "auto_release.combined_status_failed",
       project_id: project.id,
       error: e.message
     )

--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -113,6 +113,17 @@ class AutoReleaseEvaluationJob < ApplicationJob
     return true if checks.nil? || checks.empty?
 
     checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
+  rescue GithubClient::ApiError => e
+    if e.status == 403
+      Rails.logger.info(
+        message: "auto_release.check_runs_forbidden",
+        project_id: project.id,
+        error: e.message
+      )
+      return true
+    end
+
+    raise
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "auto_release.check_runs_failed",

--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -109,14 +109,11 @@ class AutoReleaseEvaluationJob < ApplicationJob
   end
 
   def all_checks_green?(client, project, pr_data)
-    checks = client.check_runs_for_ref(project.full_name, pr_data.head.sha)
+    sha = pr_data.head.sha
+    checks = client.check_runs_for_ref(project.full_name, sha)
 
     if checks.nil? || checks.empty?
-      # Empty check runs may mean "no CI configured" or "CI hasn't queued yet."
-      # Use the commit status API as a secondary signal: GitHub returns "pending"
-      # when statuses exist but haven't completed. If the combined state is
-      # "pending", CI is likely still spinning up — wait for the next poll cycle.
-      return combined_status_state_settled?(client, project, pr_data.head.sha)
+      return combined_status_state_settled?(client, project, sha)
     end
 
     checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
@@ -127,7 +124,7 @@ class AutoReleaseEvaluationJob < ApplicationJob
         project_id: project.id,
         error: e.message
       )
-      return true
+      return combined_status_state_settled?(client, project, sha)
     end
 
     raise
@@ -144,6 +141,8 @@ class AutoReleaseEvaluationJob < ApplicationJob
   # GitHub returns "pending" with 0 contexts when no status checks exist,
   # so we treat that as "no CI" and allow the merge. Any other non-success
   # state (failure, error, or pending with actual statuses) blocks merging.
+  # This is also the fallback when the token cannot read check runs: we only
+  # proceed after a separate API confirms success or that no statuses exist.
   def combined_status_state_settled?(client, project, sha)
     status = client.combined_status(project.full_name, sha)
     status[:state] == "success" || (status[:state] == "pending" && status[:total_count] == 0)

--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -7,6 +7,7 @@
 #
 # Triggered by:
 # - GitHub webhooks (check_suite.completed, pull_request.opened/synchronize)
+# - Poll loop via EvaluateDependabotAutoMergeActivity (every cycle when auto_merge enabled)
 #
 # Concurrency: at most one evaluation per project+PR at a time.
 class DependabotAutoMergeJob < ApplicationJob
@@ -33,11 +34,13 @@ class DependabotAutoMergeJob < ApplicationJob
     dependabot_pr = find_dependabot_pr(client, project, pr_number)
     return unless dependabot_pr
 
+    pr_num = dependabot_pr.respond_to?(:number) ? dependabot_pr.number : dependabot_pr[:number]
+
     unless mergeable?(dependabot_pr)
       Rails.logger.info(
         message: "dependabot_auto_merge.skipped",
         project_id: project.id,
-        pr_number: pr_number,
+        pr_number: pr_num,
         reason: "not_mergeable"
       )
       return
@@ -47,7 +50,7 @@ class DependabotAutoMergeJob < ApplicationJob
       Rails.logger.info(
         message: "dependabot_auto_merge.skipped",
         project_id: project.id,
-        pr_number: pr_number,
+        pr_number: pr_num,
         reason: "checks_not_green"
       )
       return
@@ -66,7 +69,10 @@ class DependabotAutoMergeJob < ApplicationJob
     end
 
     prs = client.pull_requests(project.full_name, state: "open")
-    prs.find { |pr| dependabot_pr?(pr) && !merged?(pr) }
+    match = prs.find { |pr| dependabot_pr?(pr) && !merged?(pr) }
+    return nil unless match
+
+    client.pull_request(project.full_name, match.number)
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "dependabot_auto_merge.find_pr_failed",
@@ -92,9 +98,20 @@ class DependabotAutoMergeJob < ApplicationJob
   def all_checks_green?(client, project, pr_data)
     sha = pr_data.respond_to?(:head) ? pr_data.head.sha : pr_data.dig(:head, :sha)
     checks = client.check_runs_for_ref(project.full_name, sha)
-    return false if checks.nil? || checks.empty?
+    return true if checks.nil? || checks.empty?
 
     checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
+  rescue GithubClient::ApiError => e
+    if e.status == 403
+      Rails.logger.info(
+        message: "dependabot_auto_merge.check_runs_forbidden",
+        project_id: project.id,
+        error: e.message
+      )
+      return true
+    end
+
+    raise
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "dependabot_auto_merge.check_runs_failed",

--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -100,10 +100,6 @@ class DependabotAutoMergeJob < ApplicationJob
     checks = client.check_runs_for_ref(project.full_name, sha)
 
     if checks.nil? || checks.empty?
-      # Empty check runs may mean "no CI configured" or "CI hasn't queued yet."
-      # Use the commit status API as a secondary signal: GitHub returns "pending"
-      # when statuses exist but haven't completed. If the combined state is
-      # "pending", CI is likely still spinning up — wait for the next poll cycle.
       return combined_status_state_settled?(client, project, sha)
     end
 
@@ -115,7 +111,7 @@ class DependabotAutoMergeJob < ApplicationJob
         project_id: project.id,
         error: e.message
       )
-      return true
+      return combined_status_state_settled?(client, project, sha)
     end
 
     raise
@@ -132,6 +128,8 @@ class DependabotAutoMergeJob < ApplicationJob
   # GitHub returns "pending" with 0 contexts when no status checks exist,
   # so we treat that as "no CI" and allow the merge. Any other non-success
   # state (failure, error, or pending with actual statuses) blocks merging.
+  # This is also the fallback when the token cannot read check runs: we only
+  # proceed after a separate API confirms success or that no statuses exist.
   def combined_status_state_settled?(client, project, sha)
     status = client.combined_status(project.full_name, sha)
     status[:state] == "success" || (status[:state] == "pending" && status[:total_count] == 0)

--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -98,7 +98,14 @@ class DependabotAutoMergeJob < ApplicationJob
   def all_checks_green?(client, project, pr_data)
     sha = pr_data.respond_to?(:head) ? pr_data.head.sha : pr_data.dig(:head, :sha)
     checks = client.check_runs_for_ref(project.full_name, sha)
-    return true if checks.nil? || checks.empty?
+
+    if checks.nil? || checks.empty?
+      # Empty check runs may mean "no CI configured" or "CI hasn't queued yet."
+      # Use the commit status API as a secondary signal: GitHub returns "pending"
+      # when statuses exist but haven't completed. If the combined state is
+      # "pending", CI is likely still spinning up — wait for the next poll cycle.
+      return combined_status_state_settled?(client, project, sha)
+    end
 
     checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
   rescue GithubClient::ApiError => e
@@ -115,6 +122,20 @@ class DependabotAutoMergeJob < ApplicationJob
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "dependabot_auto_merge.check_runs_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
+  end
+
+  # Returns true when the combined commit status is not "pending", meaning
+  # either no status checks exist (repo has no CI) or all have completed.
+  def combined_status_state_settled?(client, project, sha)
+    state = client.combined_status_state(project.full_name, sha)
+    state != "pending"
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "dependabot_auto_merge.combined_status_failed",
       project_id: project.id,
       error: e.message
     )

--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -128,11 +128,13 @@ class DependabotAutoMergeJob < ApplicationJob
     false
   end
 
-  # Returns true when the combined commit status is not "pending", meaning
-  # either no status checks exist (repo has no CI) or all have completed.
+  # Returns true when CI has passed or no CI is configured.
+  # GitHub returns "pending" with 0 contexts when no status checks exist,
+  # so we treat that as "no CI" and allow the merge. Any other non-success
+  # state (failure, error, or pending with actual statuses) blocks merging.
   def combined_status_state_settled?(client, project, sha)
-    state = client.combined_status_state(project.full_name, sha)
-    state != "pending"
+    status = client.combined_status(project.full_name, sha)
+    status[:state] == "success" || (status[:state] == "pending" && status[:total_count] == 0)
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "dependabot_auto_merge.combined_status_failed",

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -417,6 +417,21 @@ class GithubClient
     end
   end
 
+  # Fetches combined commit status with context count for a ref.
+  # Returns both the state and the number of status contexts, which
+  # lets callers distinguish "no CI configured" (pending + 0 contexts)
+  # from "CI is running" (pending + N contexts).
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param ref [String] Git ref (branch name, tag, or SHA)
+  # @return [Hash] { state: String, total_count: Integer }
+  def combined_status(repo, ref)
+    handle_errors do
+      response = client.combined_status(repo, ref)
+      { state: response.state, total_count: response.total_count }
+    end
+  end
+
   # Fetches raw GitHub Actions job logs for a check run when the run is backed
   # by an Actions job. Non-Actions checks do not expose logs through this API.
   #

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -402,6 +402,21 @@ class GithubClient
     end
   end
 
+  # Fetches the combined commit status for a ref via the Status API.
+  # Returns the overall state ("success", "pending", "failure", "error")
+  # which aggregates all status contexts attached to the commit.
+  # Repos with no status contexts return "pending" by default from GitHub.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param ref [String] Git ref (branch name, tag, or SHA)
+  # @return [String] Combined state: "success", "pending", "failure", or "error"
+  def combined_status_state(repo, ref)
+    handle_errors do
+      response = client.combined_status(repo, ref)
+      response.state
+    end
+  end
+
   # Fetches raw GitHub Actions job logs for a check run when the run is backed
   # by an Actions job. Non-Actions checks do not expose logs through this API.
   #

--- a/app/temporal/activities/evaluate_dependabot_auto_merge_activity.rb
+++ b/app/temporal/activities/evaluate_dependabot_auto_merge_activity.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Activities
+  class EvaluateDependabotAutoMergeActivity < BaseActivity
+    def execute(input)
+      project_id = input[:project_id]
+      project = Project.find_by(id: project_id)
+      return { evaluated: false, project_missing: true } unless project
+      return { evaluated: false, reason: "disabled" } unless project.auto_merge_dependabot?
+
+      DependabotAutoMergeJob.perform_later(project_id)
+
+      { evaluated: true }
+    end
+  end
+end

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -505,16 +505,9 @@ module Activities
     end
 
     # Bot-authored PRs (Dependabot, Renovate) skip review requirements.
-    # Auto-merge only needs CI green + mergeable. CI failures trigger follow-up.
+    # Auto-merge is handled by EvaluateDependabotAutoMergeActivity + DependabotAutoMergeJob.
+    # This method only detects follow-up triggers (CI failures, merge conflicts, labels).
     def scan_bot_authored_ready_pr(project, client, issue, pr_data:, checks:, mergeable:)
-      if project.auto_merge_dependabot? &&
-          pr_data.present? &&
-          !checks.nil? && checks.any? &&
-          all_checks_green?(checks) &&
-          mergeable == true
-        return owner_approved_trigger(issue)
-      end
-
       return nil if followup_limit_reached?(project, issue)
 
       ci_triggers = ci_failure_triggers(checks || [])

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -148,6 +148,7 @@ module Workflows
       maybe_scan_code_scanning_alerts(project_id)
       maybe_check_knowledge_staleness(project_id)
       maybe_evaluate_auto_release(project_id)
+      maybe_evaluate_dependabot_auto_merge(project_id)
       scan_result
     end
 
@@ -204,6 +205,24 @@ module Workflows
     rescue => e
       Temporalio::Workflow.logger.warn(
         message: "auto_release.poll_evaluation_failed",
+        project_id: project_id,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+
+    # Evaluate dependabot auto-merge for the project's open Dependabot PRs.
+    # Runs on every poll cycle so webhooks are not required for auto-merge.
+    def maybe_evaluate_dependabot_auto_merge(project_id)
+      return unless Temporalio::Workflow.patched("add-dependabot-auto-merge-poll-v1")
+
+      run_activity(Activities::EvaluateDependabotAutoMergeActivity,
+        { project_id: project_id }, timeout: 30)
+    rescue Temporalio::Error::CanceledError
+      raise
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "dependabot_auto_merge.poll_evaluation_failed",
         project_id: project_id,
         error_class: e.class.name,
         error: e.message

--- a/spec/jobs/auto_release_evaluation_job_spec.rb
+++ b/spec/jobs/auto_release_evaluation_job_spec.rb
@@ -148,6 +148,30 @@ RSpec.describe AutoReleaseEvaluationJob do
       expect(client).not_to have_received(:merge_pull_request)
     end
 
+    it "falls back to combined status when check_runs returns 403 and status is green" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
+      )
+      allow(client).to receive(:combined_status).and_return(state: "success", total_count: 1)
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:combined_status).with(project.full_name, pr_data.head.sha)
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when check_runs returns 403 and combined status is not green" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
+      )
+      allow(client).to receive(:combined_status).and_return(state: "pending", total_count: 2)
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:combined_status).with(project.full_name, pr_data.head.sha)
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
     it "skips when no release PR is found" do
       allow(client).to receive(:pull_requests).and_return([])
 

--- a/spec/jobs/auto_release_evaluation_job_spec.rb
+++ b/spec/jobs/auto_release_evaluation_job_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe AutoReleaseEvaluationJob do
       pull_requests: [ pr_data ],
       pull_request: pr_data,
       contents: manifest_content,
-      check_runs_for_ref: green_checks
+      check_runs_for_ref: green_checks,
+      combined_status_state: "success"
     )
     allow(client).to receive(:merge_pull_request)
     allow(client).to receive(:add_labels_to_issue)
@@ -105,12 +106,21 @@ RSpec.describe AutoReleaseEvaluationJob do
       expect(client).not_to have_received(:merge_pull_request)
     end
 
-    it "merges when no CI checks exist" do
-      allow(client).to receive(:check_runs_for_ref).and_return([])
+    it "merges when no CI checks exist and combined status is not pending" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status_state: "success")
 
       described_class.perform_now(project.id)
 
+      expect(client).to have_received(:combined_status_state)
       expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when no CI checks exist but combined status is pending" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status_state: "pending")
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
     end
 
     it "skips when no release PR is found" do

--- a/spec/jobs/auto_release_evaluation_job_spec.rb
+++ b/spec/jobs/auto_release_evaluation_job_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AutoReleaseEvaluationJob do
       pull_request: pr_data,
       contents: manifest_content,
       check_runs_for_ref: green_checks,
-      combined_status_state: "success"
+      combined_status: { state: "success", total_count: 1 }
     )
     allow(client).to receive(:merge_pull_request)
     allow(client).to receive(:add_labels_to_issue)
@@ -106,17 +106,42 @@ RSpec.describe AutoReleaseEvaluationJob do
       expect(client).not_to have_received(:merge_pull_request)
     end
 
-    it "merges when no CI checks exist and combined status is not pending" do
-      allow(client).to receive_messages(check_runs_for_ref: [], combined_status_state: "success")
+    it "merges when no CI checks exist and combined status is success" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "success", total_count: 1 })
 
       described_class.perform_now(project.id)
 
-      expect(client).to have_received(:combined_status_state)
+      expect(client).to have_received(:combined_status)
       expect(client).to have_received(:merge_pull_request)
     end
 
-    it "skips when no CI checks exist but combined status is pending" do
-      allow(client).to receive_messages(check_runs_for_ref: [], combined_status_state: "pending")
+    it "merges when no CI checks or statuses exist (no CI configured)" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "pending", total_count: 0 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:combined_status)
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when no CI checks exist but combined status is pending with statuses" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "pending", total_count: 2 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when no CI checks exist and combined status is failure" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "failure", total_count: 1 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when no CI checks exist and combined status is error" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "error", total_count: 1 })
 
       described_class.perform_now(project.id)
 

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe DependabotAutoMergeJob do
       pull_requests: [ dependabot_pr ],
       pull_request: dependabot_pr,
       check_runs_for_ref: green_checks,
-      combined_status_state: "success"
+      combined_status: { state: "success", total_count: 1 }
     )
     allow(client).to receive(:merge_pull_request)
     allow(client).to receive(:add_labels_to_issue)
@@ -176,17 +176,42 @@ RSpec.describe DependabotAutoMergeJob do
       expect(client).to have_received(:merge_pull_request)
     end
 
-    it "merges when no CI checks exist and combined status is not pending" do
-      allow(client).to receive_messages(check_runs_for_ref: [], combined_status_state: "success")
+    it "merges when no CI checks exist and combined status is success" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "success", total_count: 1 })
 
       described_class.perform_now(project.id)
 
-      expect(client).to have_received(:combined_status_state)
+      expect(client).to have_received(:combined_status)
       expect(client).to have_received(:merge_pull_request)
     end
 
-    it "skips when no CI checks exist but combined status is pending" do
-      allow(client).to receive_messages(check_runs_for_ref: [], combined_status_state: "pending")
+    it "merges when no CI checks or statuses exist (no CI configured)" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "pending", total_count: 0 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:combined_status)
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when no CI checks exist but combined status is pending with statuses" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "pending", total_count: 2 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when no CI checks exist and combined status is failure" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "failure", total_count: 1 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when no CI checks exist and combined status is error" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status: { state: "error", total_count: 1 })
 
       described_class.perform_now(project.id)
 

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe DependabotAutoMergeJob do
     it "merges a Dependabot PR when all conditions are met" do
       described_class.perform_now(project.id)
 
+      expect(client).to have_received(:pull_requests).with(project.full_name, state: "open")
+      expect(client).to have_received(:pull_request).with(project.full_name, 42)
       expect(client).to have_received(:merge_pull_request).with(
         project.full_name, 42, merge_method: project.merge_method
       )
@@ -173,12 +175,12 @@ RSpec.describe DependabotAutoMergeJob do
       expect(client).to have_received(:merge_pull_request)
     end
 
-    it "skips when no CI checks exist" do
+    it "merges when no CI checks exist" do
       allow(client).to receive(:check_runs_for_ref).and_return([])
 
       described_class.perform_now(project.id)
 
-      expect(client).not_to have_received(:merge_pull_request)
+      expect(client).to have_received(:merge_pull_request)
     end
 
     it "merges when mode is all" do
@@ -187,6 +189,34 @@ RSpec.describe DependabotAutoMergeJob do
       described_class.perform_now(project.id)
 
       expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "merges when check_runs returns 403 (token lacks checks permission)" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
+      )
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when check_runs fails with a non-403 error" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::Error.new("Network timeout")
+      )
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "raises when check_runs fails with a server error" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Internal Server Error", status: 500)
+      )
+
+      expect { described_class.perform_now(project.id) }.to raise_error(GithubClient::ApiError)
     end
   end
 end

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe DependabotAutoMergeJob do
     allow(client).to receive_messages(
       pull_requests: [ dependabot_pr ],
       pull_request: dependabot_pr,
-      check_runs_for_ref: green_checks
+      check_runs_for_ref: green_checks,
+      combined_status_state: "success"
     )
     allow(client).to receive(:merge_pull_request)
     allow(client).to receive(:add_labels_to_issue)
@@ -175,12 +176,21 @@ RSpec.describe DependabotAutoMergeJob do
       expect(client).to have_received(:merge_pull_request)
     end
 
-    it "merges when no CI checks exist" do
-      allow(client).to receive(:check_runs_for_ref).and_return([])
+    it "merges when no CI checks exist and combined status is not pending" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status_state: "success")
 
       described_class.perform_now(project.id)
 
+      expect(client).to have_received(:combined_status_state)
       expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when no CI checks exist but combined status is pending" do
+      allow(client).to receive_messages(check_runs_for_ref: [], combined_status_state: "pending")
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
     end
 
     it "merges when mode is all" do

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -226,14 +226,28 @@ RSpec.describe DependabotAutoMergeJob do
       expect(client).to have_received(:merge_pull_request)
     end
 
-    it "merges when check_runs returns 403 (token lacks checks permission)" do
+    it "falls back to combined status when check_runs returns 403 and status is green" do
       allow(client).to receive(:check_runs_for_ref).and_raise(
         GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
       )
+      allow(client).to receive(:combined_status).and_return(state: "success", total_count: 1)
 
       described_class.perform_now(project.id)
 
+      expect(client).to have_received(:combined_status).with(project.full_name, dependabot_pr.head.sha)
       expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when check_runs returns 403 and combined status is not green" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
+      )
+      allow(client).to receive(:combined_status).and_return(state: "pending", total_count: 2)
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:combined_status).with(project.full_name, dependabot_pr.head.sha)
+      expect(client).not_to have_received(:merge_pull_request)
     end
 
     it "skips when check_runs fails with a non-403 error" do

--- a/spec/temporal/activities/evaluate_dependabot_auto_merge_activity_spec.rb
+++ b/spec/temporal/activities/evaluate_dependabot_auto_merge_activity_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::EvaluateDependabotAutoMergeActivity do
+  let(:activity) { described_class.new }
+
+  describe "#execute" do
+    let(:project) { create(:project, auto_merge_mode: "dependabot_only") }
+
+    it "enqueues DependabotAutoMergeJob when auto-merge is enabled" do
+      expect {
+        activity.execute(project_id: project.id)
+      }.to have_enqueued_job(DependabotAutoMergeJob).with(project.id)
+    end
+
+    it "returns evaluated: true when auto-merge is enabled" do
+      result = activity.execute(project_id: project.id)
+
+      expect(result).to eq(evaluated: true)
+    end
+
+    it "does not enqueue when auto-merge is off" do
+      project.update!(auto_merge_mode: "off")
+
+      expect {
+        activity.execute(project_id: project.id)
+      }.not_to have_enqueued_job(DependabotAutoMergeJob)
+    end
+
+    it "returns evaluated: false with reason when auto-merge is off" do
+      project.update!(auto_merge_mode: "off")
+
+      result = activity.execute(project_id: project.id)
+
+      expect(result).to eq(evaluated: false, reason: "disabled")
+    end
+
+    it "returns project_missing when project not found" do
+      result = activity.execute(project_id: -1)
+
+      expect(result).to eq(evaluated: false, project_missing: true)
+    end
+  end
+end

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -4028,7 +4028,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           github_creator_login: "dependabot[bot]")
       end
 
-      it "auto-merges without review when CI is green and mergeable" do
+      it "does not emit owner_approved — auto-merge is handled by DependabotAutoMergeJob" do
         project.update!(auto_merge_mode: "all", owner_reviewer_login: "viamin")
         stub_github_for_pr(
           author_login: "dependabot[bot]",
@@ -4039,12 +4039,10 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger].size).to eq(1)
-        trigger = result[:prs_to_trigger].first
-        expect(trigger[:triggers].map { |t| t[:type] }).to eq([ "owner_approved" ])
+        expect(result[:prs_to_trigger]).to be_empty
       end
 
-      it "auto-merges in dependabot_only mode without review" do
+      it "does not emit owner_approved in dependabot_only mode" do
         project.update!(auto_merge_mode: "dependabot_only")
         stub_github_for_pr(
           author_login: "dependabot[bot]",
@@ -4055,9 +4053,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         result = activity.execute(project_id: project.id)
 
-        expect(result[:prs_to_trigger].size).to eq(1)
-        trigger = result[:prs_to_trigger].first
-        expect(trigger[:triggers].map { |t| t[:type] }).to eq([ "owner_approved" ])
+        expect(result[:prs_to_trigger]).to be_empty
       end
 
       it "triggers ci_failure follow-up without requiring reviews" do
@@ -4075,7 +4071,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(trigger[:triggers].map { |t| t[:type] }).to include("ci_failure")
       end
 
-      it "does not auto-merge when auto_merge is disabled" do
+      it "returns no triggers when CI is green regardless of auto_merge mode" do
         project.update!(auto_merge_mode: "off")
         stub_github_for_pr(
           author_login: "dependabot[bot]",

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -218,6 +218,32 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     end
   end
 
+  describe "EvaluateDependabotAutoMergeActivity patch guard" do
+    let(:workflow) { described_class.new }
+
+    before do
+      allow(workflow).to receive(:run_activity).and_return({})
+    end
+
+    it "runs EvaluateDependabotAutoMergeActivity when patched returns true" do
+      allow(Temporalio::Workflow).to receive(:patched).with("add-dependabot-auto-merge-poll-v1").and_return(true)
+
+      workflow.send(:maybe_evaluate_dependabot_auto_merge, 1)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::EvaluateDependabotAutoMergeActivity, { project_id: 1 }, timeout: 30)
+    end
+
+    it "skips EvaluateDependabotAutoMergeActivity when patched returns false" do
+      allow(Temporalio::Workflow).to receive(:patched).with("add-dependabot-auto-merge-poll-v1").and_return(false)
+
+      workflow.send(:maybe_evaluate_dependabot_auto_merge, 1)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::EvaluateDependabotAutoMergeActivity, anything, timeout: anything)
+    end
+  end
+
   describe "#handle_automation_result" do
     let(:workflow) { described_class.new }
     let(:project_id) { 1 }
@@ -1613,6 +1639,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with("add-check-knowledge-staleness-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("add-auto-release-poll-v1").and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-dependabot-auto-merge-poll-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("queue-agent-run-goal-v1").and_return(true)
       allow(Temporalio::Workflow).to receive(:patched)


### PR DESCRIPTION
## Summary

- Adds `EvaluateDependabotAutoMergeActivity` to the poll workflow, enqueuing `DependabotAutoMergeJob` every cycle when `auto_merge_dependabot?` is enabled — so webhooks are no longer required for auto-merge (mirrors the auto-release pattern from #1464)
- Fixes `find_dependabot_pr` to re-fetch via the single-PR endpoint for an accurate `mergeable` field (GitHub's list endpoint returns `nil`)
- Handles 403 on `check_runs_for_ref` (token lacks `checks:read`) same as having no CI — proceeds with merge instead of permanently blocking
- Fixes `all_checks_green?` returning `false` for repos without CI checks (now returns `true` for empty checks, matching auto-release)
- Removes duplicate auto-merge path from `ScanPaidPrsActivity#scan_bot_authored_ready_pr` — auto-merge is now a single dedicated path
- Applies the same 403 fix to `AutoReleaseEvaluationJob`

## Test plan

- [ ] Verify railscrawler dependabot PRs are merged on next poll cycle after deployment
- [ ] Confirm `dependabot_auto_merge.merged` appears in logs for project
- [ ] Verify one PR is merged per cycle (sequential merging for lockfile conflict avoidance)