### PR TITLE
Fix #1318: Add provider-contract smoke test for paid-agent image

### DIFF
--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -12,6 +12,7 @@ on:
       - scripts/test-agent-image-inner.sh
       - scripts/test-agent-provider-contracts.sh
       - scripts/test-agent-provider-contracts-inner.sh
+      - app/services/containers/provision.rb
       - lib/provider_support.rb
   push:
     branches: [ main ]
@@ -25,6 +26,7 @@ on:
       - scripts/test-agent-image-inner.sh
       - scripts/test-agent-provider-contracts.sh
       - scripts/test-agent-provider-contracts-inner.sh
+      - app/services/containers/provision.rb
       - lib/provider_support.rb
 
 permissions:

--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -10,6 +10,9 @@ on:
       - scripts/extract-provider-install-contract.rb
       - scripts/test-agent-image.sh
       - scripts/test-agent-image-inner.sh
+      - scripts/test-agent-provider-contracts.sh
+      - scripts/test-agent-provider-contracts-inner.sh
+      - lib/provider_support.rb
   push:
     branches: [ main ]
     paths:
@@ -20,6 +23,9 @@ on:
       - scripts/extract-provider-install-contract.rb
       - scripts/test-agent-image.sh
       - scripts/test-agent-image-inner.sh
+      - scripts/test-agent-provider-contracts.sh
+      - scripts/test-agent-provider-contracts-inner.sh
+      - lib/provider_support.rb
 
 permissions:
   contents: read
@@ -149,3 +155,6 @@ jobs:
 
       - name: Smoke test paid-agent image
         run: ./scripts/test-agent-image.sh
+
+      - name: Provider-contract smoke test
+        run: ./scripts/test-agent-provider-contracts.sh

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -28,6 +28,8 @@ module Containers
   #   end
   #
   class Provision
+    CODEX_NOTIFY_LINE = 'notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]'
+
     # Base error for all container service errors
     class Error < StandardError; end
 
@@ -124,6 +126,10 @@ module Containers
 
     def self.network_for(agent_run:)
       new(agent_run: agent_run).network_name
+    end
+
+    def self.codex_notify_line
+      CODEX_NOTIFY_LINE
     end
 
     # @param agent_run [AgentRun] The agent run to associate logs with
@@ -1720,7 +1726,7 @@ module Containers
     # paths. The agent-harness notify_hook_content returns only a TOML section
     # header; the actual heartbeat command is Paid-specific.
     def codex_notify_line
-      'notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]'
+      self.class.codex_notify_line
     end
 
     def copilot_config_host_path

--- a/scripts/test-agent-provider-contracts-inner.sh
+++ b/scripts/test-agent-provider-contracts-inner.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Provider-contract smoke test executed inside the paid-agent container.
+# Validates that every provider declared container-executable in Paid has a
+# compatible CLI installed in the image, and that known non-runnable providers
+# (e.g. copilot) are not accidentally promoted to container-executable.
+#
+# Also performs a cheap Codex config.toml shape check to catch notify/TOML
+# regressions without requiring real credentials or model calls.
+#
+# Usage (called by test-agent-provider-contracts.sh):
+#   docker run --rm \
+#     -v ./scripts/test-agent-provider-contracts-inner.sh:/tmp/contract-test.sh:ro \
+#     -e CONTAINER_EXECUTABLE_KEYS="aider claude codex cursor gemini kilocode opencode" \
+#     -e CODEX_NOTIFY_LINE='notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]' \
+#     -e CODEX_CONFIG_TOML_BODY='[chatgpt]...' \
+#     paid-agent:latest bash /tmp/contract-test.sh
+
+set -euo pipefail
+
+FAILURES=0
+
+fail() {
+    echo "   FAIL: $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+    echo "   OK: $1"
+}
+
+# ---------------------------------------------------------------------------
+# 1. CLI binary mapping — provider key → expected binary name
+# ---------------------------------------------------------------------------
+# This mapping must stay in sync with docker/agent/Dockerfile installs.
+declare -A PROVIDER_CLI_BINARY
+PROVIDER_CLI_BINARY=(
+    [aider]=aider
+    [claude]=claude
+    [codex]=codex
+    [cursor]=cursor-agent
+    [gemini]=gemini
+    [kilocode]=kilo
+    [opencode]=opencode
+)
+
+echo "=== Provider-contract smoke test ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# 2. Every container-executable provider must have its CLI installed
+# ---------------------------------------------------------------------------
+echo "1. Container-executable provider CLI checks:"
+
+IFS=' ' read -r -a EXEC_KEYS <<< "${CONTAINER_EXECUTABLE_KEYS}"
+
+for key in "${EXEC_KEYS[@]}"; do
+    binary="${PROVIDER_CLI_BINARY[$key]:-}"
+    if [ -z "$binary" ]; then
+        fail "${key}: no CLI binary mapping defined in test"
+        continue
+    fi
+
+    if command -v "$binary" >/dev/null 2>&1; then
+        pass "${key} → ${binary} found at $(command -v "$binary")"
+    else
+        fail "${key} → ${binary} not found in PATH"
+    fi
+done
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 3. Known non-runnable providers must NOT be container-executable
+# ---------------------------------------------------------------------------
+echo "2. Non-runnable provider exclusion checks:"
+
+# Copilot CLI only supports shell/git/gh assist subcommands, not repo-changing
+# agent tasks. It must not appear in the container-executable set.
+COPILOT_FOUND=false
+for key in "${EXEC_KEYS[@]}"; do
+    if [ "$key" = "copilot" ]; then
+        COPILOT_FOUND=true
+        break
+    fi
+done
+
+if [ "$COPILOT_FOUND" = "true" ]; then
+    fail "copilot must not be in CONTAINER_EXECUTABLE_PROVIDER_KEYS"
+else
+    pass "copilot correctly excluded from container-executable set"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. Codex config.toml shape validation
+# ---------------------------------------------------------------------------
+echo "3. Codex config.toml shape validation:"
+
+CODEX_NOTIFY_LINE="${CODEX_NOTIFY_LINE:-}"
+CODEX_CONFIG_TOML_BODY="${CODEX_CONFIG_TOML_BODY:-}"
+
+if [ -z "$CODEX_NOTIFY_LINE" ] || [ -z "$CODEX_CONFIG_TOML_BODY" ]; then
+    fail "CODEX_NOTIFY_LINE or CODEX_CONFIG_TOML_BODY not provided"
+else
+    # Assemble the full config as Paid does: notify line + blank line + TOML body
+    FULL_CONFIG="${CODEX_NOTIFY_LINE}
+
+${CODEX_CONFIG_TOML_BODY}"
+
+    CONFIG_DIR="/home/agent/.codex"
+    CONFIG_FILE="${CONFIG_DIR}/config.toml"
+    mkdir -p "$CONFIG_DIR"
+    printf '%s\n' "$FULL_CONFIG" > "$CONFIG_FILE"
+
+    # Verify the file was written and is non-empty
+    if [ ! -s "$CONFIG_FILE" ]; then
+        fail "config.toml is empty after write"
+    else
+        pass "config.toml written ($(wc -c < "$CONFIG_FILE") bytes)"
+    fi
+
+    # Validate notify is a TOML array of strings (basic shape check)
+    if echo "$CODEX_NOTIFY_LINE" | grep -qE '^notify\s*=\s*\['; then
+        pass "notify line starts with 'notify = ['"
+    else
+        fail "notify line has unexpected shape: ${CODEX_NOTIFY_LINE}"
+    fi
+
+    # Validate the TOML body has a [chatgpt] section header
+    if echo "$CODEX_CONFIG_TOML_BODY" | grep -qE '^\[chatgpt\]'; then
+        pass "config body contains [chatgpt] section"
+    else
+        fail "config body missing [chatgpt] section"
+    fi
+
+    # If codex CLI is available, run a config validation check
+    if command -v codex >/dev/null 2>&1; then
+        # codex --help should still work even with the config present
+        if codex --help >/dev/null 2>&1; then
+            pass "codex --help succeeds with generated config in place"
+        else
+            fail "codex --help failed with generated config in place"
+        fi
+    fi
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if [ "$FAILURES" -gt 0 ]; then
+    echo "FAILED: ${FAILURES} contract check(s) failed"
+    exit 1
+fi
+
+echo "All provider-contract checks passed!"

--- a/scripts/test-agent-provider-contracts.sh
+++ b/scripts/test-agent-provider-contracts.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Provider-contract smoke test for the paid-agent image.
+# Validates that Paid's runnable-provider contract and generated config shape
+# are compatible with the CLIs installed in the agent image.
+#
+# Usage:
+#   ./scripts/test-agent-provider-contracts.sh
+#   IMAGE_NAME=myregistry/paid-agent ./scripts/test-agent-provider-contracts.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INNER_SCRIPT="${SCRIPT_DIR}/test-agent-provider-contracts-inner.sh"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IMAGE_NAME="${IMAGE_NAME:-paid-agent}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+FULL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+
+echo "Provider-contract smoke test: ${FULL_IMAGE}"
+echo "============================================="
+echo ""
+
+# Verify image exists
+if ! docker image inspect "${FULL_IMAGE}" > /dev/null 2>&1; then
+    echo "Error: Image '${FULL_IMAGE}' not found. Build it first with:"
+    echo "  ./scripts/build-agent-image.sh"
+    exit 1
+fi
+
+if [ ! -f "${INNER_SCRIPT}" ]; then
+    echo "Error: inner test script not found: ${INNER_SCRIPT}"
+    exit 1
+fi
+
+# Extract the container-executable provider keys from ProviderSupport.
+# This ensures the test stays in sync with the app's runtime contract without
+# hard-coding the list in the shell script.
+CONTAINER_EXECUTABLE_KEYS=$(cd "${PROJECT_ROOT}" && bundle exec ruby -e "
+  require 'bundler/setup'
+  require 'agent_harness'
+  \$LOAD_PATH.unshift('lib')
+  require 'provider_support'
+  puts ProviderSupport::CONTAINER_EXECUTABLE_PROVIDER_KEYS.to_a.sort.join(' ')
+")
+
+# Generate the Codex config TOML body and notify line as Paid would.
+CODEX_CONFIG_TOML_BODY=$(cd "${PROJECT_ROOT}" && bundle exec ruby -e "
+  require 'bundler/setup'
+  require 'agent_harness'
+  provider = AgentHarness.provider(:codex)
+  puts provider.config_file_content(
+    model_provider: 'test',
+    base_url: 'http://localhost:8080/api/proxy/openai',
+    env_key: 'OPENAI_API_KEY',
+    wire_api: 'responses'
+  )
+")
+
+# The notify line is Paid-specific (lives in Containers::Provision), not in
+# agent-harness. Replicate the exact shape here for validation.
+CODEX_NOTIFY_LINE='notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]'
+
+echo "Container-executable keys: ${CONTAINER_EXECUTABLE_KEYS}"
+echo "Codex notify line: ${CODEX_NOTIFY_LINE}"
+echo ""
+
+docker run --rm \
+    -v "${INNER_SCRIPT}:/tmp/contract-test.sh:ro" \
+    -e "CONTAINER_EXECUTABLE_KEYS=${CONTAINER_EXECUTABLE_KEYS}" \
+    -e "CODEX_NOTIFY_LINE=${CODEX_NOTIFY_LINE}" \
+    -e "CODEX_CONFIG_TOML_BODY=${CODEX_CONFIG_TOML_BODY}" \
+    "${FULL_IMAGE}" bash /tmp/contract-test.sh
+
+echo ""
+echo "============================================="
+echo "Provider-contract smoke test completed successfully!"

--- a/scripts/test-agent-provider-contracts.sh
+++ b/scripts/test-agent-provider-contracts.sh
@@ -33,15 +33,14 @@ if [ ! -f "${INNER_SCRIPT}" ]; then
     exit 1
 fi
 
-# Extract the container-executable provider keys from ProviderSupport.
-# This ensures the test stays in sync with the app's runtime contract without
-# hard-coding the list in the shell script.
+# Extract runtime contract values from app code without booting the full Rails
+# environment or requiring a database connection.
 CONTAINER_EXECUTABLE_KEYS=$(cd "${PROJECT_ROOT}" && bundle exec ruby -e "
   require 'bundler/setup'
   require 'agent_harness'
   \$LOAD_PATH.unshift('lib')
   require 'provider_support'
-  puts ProviderSupport::CONTAINER_EXECUTABLE_PROVIDER_KEYS.to_a.sort.join(' ')
+  puts ProviderSupport.container_executable_provider_keys.sort.join(' ')
 ")
 
 # Generate the Codex config TOML body and notify line as Paid would.
@@ -57,9 +56,11 @@ CODEX_CONFIG_TOML_BODY=$(cd "${PROJECT_ROOT}" && bundle exec ruby -e "
   )
 ")
 
-# The notify line is Paid-specific (lives in Containers::Provision), not in
-# agent-harness. Replicate the exact shape here for validation.
-CODEX_NOTIFY_LINE='notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]'
+CODEX_NOTIFY_LINE=$(cd "${PROJECT_ROOT}" && bundle exec ruby -e "
+  require 'bundler/setup'
+  require_relative 'app/services/containers/provision'
+  puts Containers::Provision.codex_notify_line
+")
 
 echo "Container-executable keys: ${CONTAINER_EXECUTABLE_KEYS}"
 echo "Codex notify line: ${CODEX_NOTIFY_LINE}"

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -342,9 +342,7 @@ RSpec.describe ProviderSupport do
           wire_api: "responses"
         )
       end
-      let(:notify_line) do
-        'notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]'
-      end
+      let(:notify_line) { Containers::Provision.codex_notify_line }
 
       it "generates a TOML body with a [chatgpt] section" do
         expect(config_toml).to match(/^\[chatgpt\]/)

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -300,6 +300,93 @@ RSpec.describe ProviderSupport do
     end
   end
 
+  describe "provider contract smoke checks" do
+    describe "CLI binary mapping completeness" do
+      it "has a CLI binary mapping for every container-executable provider" do
+        cli_binary_for = {
+          "aider" => "aider",
+          "claude" => "claude",
+          "codex" => "codex",
+          "cursor" => "cursor-agent",
+          "gemini" => "gemini",
+          "kilocode" => "kilo",
+          "opencode" => "opencode"
+        }
+
+        described_class::CONTAINER_EXECUTABLE_PROVIDER_KEYS.each do |key|
+          expect(cli_binary_for).to have_key(key),
+            "No CLI binary mapping for container-executable provider '#{key}'. " \
+            "Add it to this test and to scripts/test-agent-provider-contracts-inner.sh."
+        end
+      end
+    end
+
+    describe "agent-harness registry backing" do
+      it "only contains providers backed by the agent-harness registry" do
+        described_class::CONTAINER_EXECUTABLE_PROVIDER_KEYS.each do |key|
+          harness_key = described_class.harness_provider_key_for(key)
+          expect {
+            AgentHarness.provider(harness_key.to_sym)
+          }.not_to raise_error
+        end
+      end
+    end
+
+    describe "Codex config.toml shape" do
+      let(:codex_provider) { AgentHarness.provider(:codex) }
+      let(:config_toml) do
+        codex_provider.config_file_content(
+          model_provider: "paid",
+          base_url: "http://localhost:8080/api/proxy/openai",
+          env_key: "OPENAI_API_KEY",
+          wire_api: "responses"
+        )
+      end
+      let(:notify_line) do
+        'notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]'
+      end
+
+      it "generates a TOML body with a [chatgpt] section" do
+        expect(config_toml).to match(/^\[chatgpt\]/)
+      end
+
+      it "includes required keys in the [chatgpt] section" do
+        expect(config_toml).to include('model_provider = "paid"')
+        expect(config_toml).to include('env_key = "OPENAI_API_KEY"')
+      end
+
+      it "produces a notify line shaped as a TOML string-array assignment" do
+        expect(notify_line).to match(/\Anotify\s*=\s*\[/)
+      end
+
+      it "produces a full config with notify before section header" do
+        full_config = "#{notify_line}\n\n#{config_toml}"
+        lines = full_config.lines.map(&:strip).reject(&:empty?)
+        notify_idx = lines.index { |l| l.start_with?("notify") }
+        section_idx = lines.index { |l| l.start_with?("[chatgpt]") }
+
+        expect(notify_idx).not_to be_nil
+        expect(section_idx).not_to be_nil
+        expect(notify_idx).to be < section_idx
+      end
+
+      it "does not contain bare notify without array brackets" do
+        expect(notify_line).not_to match(/\Anotify\s*=\s*"/)
+        expect(notify_line).not_to match(/\Anotify\s*=\s*'(?!\[)/)
+      end
+    end
+
+    describe "copilot exclusion" do
+      it "is listed in APP_TO_HARNESS_PROVIDER_KEYS as a known provider" do
+        expect(described_class::APP_TO_HARNESS_PROVIDER_KEYS).to have_key("copilot")
+      end
+
+      it "is not addable as a provider" do
+        expect(described_class.addable_provider_key?("copilot")).to be false
+      end
+    end
+  end
+
   describe ".command_with_unset_env" do
     it "returns command unchanged when unset_vars is empty" do
       expect(described_class.command_with_unset_env("my_cmd", [])).to eq("my_cmd")

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe Containers::Provision do
     it "does not include :network in defaults" do
       expect(described_class::DEFAULTS).not_to have_key(:network)
     end
+
+    it "exports the Codex notify line used for seeded config" do
+      expect(described_class.codex_notify_line).to eq(described_class::CODEX_NOTIFY_LINE)
+    end
   end
 
   describe "#initialize" do
@@ -308,6 +312,7 @@ RSpec.describe Containers::Provision do
 
       it "seeds Codex config with the current notify command shape" do
         service.provision
+        notify_line = described_class.codex_notify_line
 
         expect(mock_container).to have_received(:exec).with(
           [
@@ -316,9 +321,9 @@ RSpec.describe Containers::Provision do
             satisfy { |cmd|
               decoded = decoded_base64_content(cmd)
               cmd.include?("/home/agent/.codex/config.toml") &&
-                decoded.include?('notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]') &&
+                decoded.include?(notify_line) &&
                 decoded.include?("[chatgpt]") &&
-                decoded.index('notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]') < decoded.index("[chatgpt]")
+                decoded.index(notify_line) < decoded.index("[chatgpt]")
             }
           ],
           user: "agent"


### PR DESCRIPTION
## Summary

Add provider-contract smoke test for paid-agent image

See #1318 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #1318