### PR TITLE
feat(prompts): add data-driven CI failure debugging guidance

### DIFF
--- a/app/services/ci/failure_context.rb
+++ b/app/services/ci/failure_context.rb
@@ -111,7 +111,7 @@ module Ci
 
     def workflow_path_for_run(run_id)
       run = github_client.actions_run(repo, run_id)
-      run&.path
+      run&.path&.split("@", 2)&.first
     rescue GithubClient::Error
       nil
     end

--- a/app/services/ci/failure_context.rb
+++ b/app/services/ci/failure_context.rb
@@ -1,28 +1,41 @@
 # frozen_string_literal: true
 
 module Ci
-  # Builds bounded, pre-processed CI failure context for agent prompts.
   class FailureContext
     GREEN_CONCLUSIONS = %w[success skipped neutral].freeze
     DEFAULT_MAX_CHARS = LogExtractor::DEFAULT_MAX_CHARS
+    DEFAULT_MAX_WORKFLOW_CHARS = 6_000
 
-    attr_reader :checks, :output
+    FAILURE_TYPE_PATTERNS = {
+      database: /NoDatabaseError|database.*does not exist|PG::ConnectionBad|Mysql2::Error::ConnectionError/i,
+      environment: /command not found|unknown command|no such file or directory.*config/i,
+      dependency: /Gem::(LoadError|MissingSpecError|RequirementNotMetError)|LoadError.*cannot load|npm ERR!.*ENOENT|ModuleNotFoundError/i,
+      service: /Connection refused|ECONNREFUSED|service.*unavailable|could not connect/i,
+      timeout: /Timeout::Error|timed?\s*out|deadline exceeded|Net::ReadTimeout/i
+    }.freeze
+
+    attr_reader :checks, :output, :failure_types, :workflow_content
 
     def self.call(...)
       new(...).build
     end
 
-    def initialize(repo:, checks:, github_client:, max_chars: DEFAULT_MAX_CHARS)
+    def initialize(repo:, checks:, github_client:, max_chars: DEFAULT_MAX_CHARS, ref: nil)
       @repo = repo
       @checks = Array(checks)
       @github_client = github_client
       @max_chars = max_chars
+      @ref = ref
       @output = ""
+      @failure_types = []
+      @workflow_content = ""
     end
 
     def build
       @checks = failed_checks
       @output = extracted_output
+      @failure_types = classify_failure_types
+      @workflow_content = fetch_workflow_content
       self
     end
 
@@ -32,7 +45,7 @@ module Ci
 
     private
 
-    attr_reader :repo, :github_client, :max_chars
+    attr_reader :repo, :github_client, :max_chars, :ref
 
     def failed_checks
       checks.select do |check|
@@ -63,6 +76,61 @@ module Ci
       return "" if raw.blank?
 
       LogExtractor.call(redact(raw), max_chars: remaining)
+    end
+
+    def classify_failure_types
+      return [] if output.blank?
+
+      FAILURE_TYPE_PATTERNS.filter_map do |type, pattern|
+        type if output.match?(pattern)
+      end
+    end
+
+    def fetch_workflow_content
+      return "" if checks.empty?
+
+      run_ids = checks.filter_map { |c| self.class.actions_run_id_from_url(c[:details_url]) }.uniq
+      return "" if run_ids.empty?
+
+      paths = run_ids.filter_map { |rid| workflow_path_for_run(rid) }.uniq
+      return "" if paths.empty?
+
+      fetch_and_combine_workflow_files(paths)
+    rescue GithubClient::Error => e
+      Rails.logger.warn(
+        message: "ci.failure_context_workflow_fetch_failed",
+        repo: repo,
+        error_class: e.class.name
+      )
+      ""
+    end
+
+    def self.actions_run_id_from_url(url)
+      url.to_s[%r{/actions/runs/(\d+)/}, 1]
+    end
+
+    def workflow_path_for_run(run_id)
+      run = github_client.actions_run(repo, run_id)
+      run&.path
+    rescue GithubClient::Error
+      nil
+    end
+
+    def fetch_and_combine_workflow_files(paths)
+      remaining = DEFAULT_MAX_WORKFLOW_CHARS
+      sections = []
+
+      paths.each do |path|
+        content = github_client.file_content(repo, path: path, ref: ref)
+        next if content.blank?
+
+        section = "### #{path}\n\n```yaml\n#{content.strip}\n```"
+        sections << section
+        remaining -= section.length
+        break if remaining <= 0
+      end
+
+      sections.join("\n\n")
     end
 
     def redact(text)

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -126,8 +126,21 @@ class GithubClient
   # @return [Sawyer::Resource] File content data (Base64-encoded)
   # @raise [NotFoundError] if the file does not exist
   # @raise [AuthenticationError] if access is denied
-  def contents(repo, path:)
-    handle_errors { client.contents(repo, path: path) }
+  def contents(repo, path:, ref: nil)
+    opts = { path: path }
+    opts[:ref] = ref if ref
+    handle_errors { client.contents(repo, opts) }
+  end
+
+  def file_content(repo, path:, ref: nil)
+    data = contents(repo, path: path, ref: ref)
+    return nil unless data&.content
+
+    Base64.decode64(data.content).force_encoding("UTF-8")
+  end
+
+  def actions_run(repo, run_id)
+    handle_errors { client.get("#{Octokit::Repository.path(repo)}/actions/runs/#{run_id}") }
   end
 
   # Fetches the full file tree for a repository at a given ref.

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -206,8 +206,9 @@ module Prompts
 
         #{ci_failure_output_section(output)}
 
-        Fix the issue causing these CI failures. Reproduce them locally using the lint
-        and test commands below when possible. Do not skip or disable checks.
+        #{ci_failure_guidance_section}
+
+        Fix the issue causing these CI failures. Do not skip or disable checks.
       SECTION
     end
 
@@ -221,6 +222,62 @@ module Prompts
         #{output}
         ```
       SECTION
+    end
+
+    def ci_failure_guidance_section
+      guidance = Prompts::Render.call(
+        slug: "ci.failure_guidance",
+        project: project,
+        variables: {
+          failure_type_hints: failure_type_hints,
+          workflow_content_section: workflow_content_section
+        },
+        fallback: -> { fallback_ci_failure_guidance }
+      )
+
+      guidance.present? ? guidance : ""
+    end
+
+    def fallback_ci_failure_guidance
+      section = ""
+      section += failure_type_hints if failure_type_hints.present?
+      section += "\n\n#{workflow_content_section}" if workflow_content_section.present?
+      section
+    end
+
+    FAILURE_TYPE_HINTS = {
+      database: "This looks like a **database error**. Check that the CI workflow's database " \
+                "setup step creates the correct database for the test environment. Compare " \
+                "`RAILS_ENV` in the setup step vs the test step — a mismatch can cause the " \
+                "database to be created for `development` but tested under `test`.",
+      environment: "This looks like an **environment error**. A command or configuration file " \
+                   "is missing in CI. Check the CI workflow for missing setup steps or " \
+                   "environment variables.",
+      dependency: "This looks like a **dependency error**. A gem, package, or library is missing " \
+                  "or incompatible. Check the CI workflow's dependency installation step and " \
+                  "compare versions with what's expected.",
+      service: "This looks like a **service connectivity error**. A required service (database, " \
+               "Redis, etc.) is not reachable. Check the CI workflow's service container " \
+               "configuration and health checks.",
+      timeout: "This looks like a **timeout error**. A step or network request took too long. " \
+               "Check the CI workflow for appropriate timeout settings."
+    }.freeze
+
+    def failure_type_hints
+      types = ci_failure_context.failure_types
+      return "" if types.empty?
+
+      hints = types.filter_map { |t| FAILURE_TYPE_HINTS[t] }
+      return "" if hints.empty?
+
+      "### Detected failure types: #{types.map(&:to_s).join(', ')}\n\n" + hints.join("\n\n")
+    end
+
+    def workflow_content_section
+      content = ci_failure_context.workflow_content
+      return "" if content.blank?
+
+      "## CI Workflow Configuration\n\nThe following CI workflow files are active on this branch:\n\n#{content}"
     end
 
     def code_review_section
@@ -295,7 +352,8 @@ module Prompts
       @ci_failure_context ||= Ci::FailureContext.call(
         repo: project.full_name,
         checks: failing_checks,
-        github_client: github_client
+        github_client: github_client,
+        ref: pr_data.head.sha
       )
     end
 

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -163,6 +163,46 @@ upsert_global_prompt.call(
 )
 
 # ----------------------------------------------------------------------------
+# ci.failure_guidance — Data-driven CI failure debugging guidance
+# Used by: Prompts::BuildForPr (rendered and injected into CI failures section)
+# ----------------------------------------------------------------------------
+upsert_global_prompt.call(
+  slug: "ci.failure_guidance",
+  name: "CI Failure Guidance",
+  description: "Provides strategy for debugging CI failures. Rendered with failure_types and workflow_content, then injected into the PR follow-up prompt. A/B testable and evolvable by the meta-agent.",
+  category: "coding",
+  template: <<~'TEMPLATE',
+    ## Debugging Strategy
+
+    First, classify the failure:
+
+    - **Code error** (syntax errors, test assertions, logic bugs): Fix the
+      application code. Reproduce locally using the test command.
+    - **Configuration error** (wrong database config, missing ENV vars in
+      `config/`): Fix the configuration file. Compare how the config is used
+      in CI vs locally.
+    - **CI infrastructure error** (database not created, service unreachable,
+      setup step missing `RAILS_ENV`): Fix the CI workflow file in
+      `.github/workflows/`. These errors often occur because a setup step
+      runs in a different environment (e.g., `development` mode) than the
+      test step (e.g., `test` mode).
+
+    {{failure_type_hints}}
+
+    {{workflow_content_section}}
+
+    **Important:** CI infrastructure errors cannot be reproduced locally — the
+    agent container environment differs from the CI runner environment. Fix the
+    workflow file or configuration directly, commit the change, and do not
+    attempt local reproduction of the infrastructure issue.
+  TEMPLATE
+  variables: [
+    var.call("failure_type_hints", "Targeted hints based on classified failure types", required: false),
+    var.call("workflow_content_section", "CI workflow YAML files when available", required: false)
+  ]
+)
+
+# ----------------------------------------------------------------------------
 # diagnostics.agent_run_failure — Failure diagnosis for failed agent runs
 # Used by: AgentRuns::DiagnoseError
 # ----------------------------------------------------------------------------

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -12,6 +12,7 @@ require "rails_helper"
 # seed metadata, this spec will fail.
 module SeedsPromptsSpec
   EXPECTED_SLUGS = %w[
+    ci.failure_guidance
     coding.issue_implementation
     coding.pr_review_rebase
     diagnostics.agent_run_failure

--- a/spec/services/ci/failure_context_spec.rb
+++ b/spec/services/ci/failure_context_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Ci::FailureContext do
       check = { id: 1, name: "rspec", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/12345/job/67890" }
       allow(github_client).to receive(:check_run_log).with(repo, check).and_return("")
 
-      run_response = double(path: ".github/workflows/test.yml")
+      run_response = double(path: ".github/workflows/test.yml@main")
       allow(github_client).to receive(:actions_run)
         .with(repo, "12345")
         .and_return(run_response)
@@ -150,7 +150,7 @@ RSpec.describe Ci::FailureContext do
       check1 = { id: 1, name: "rspec", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/111/job/1" }
       check2 = { id: 2, name: "rubocop", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/111/job/2" }
 
-      run_response = double(path: ".github/workflows/ci.yml")
+      run_response = double(path: ".github/workflows/ci.yml@main")
       allow(github_client).to receive(:actions_run).with(repo, "111").and_return(run_response)
       allow(github_client).to receive_messages(check_run_log: "", file_content: "name: CI\non: push")
 
@@ -158,6 +158,22 @@ RSpec.describe Ci::FailureContext do
 
       expect(github_client).to have_received(:actions_run).once
       expect(github_client).to have_received(:file_content).once
+    end
+
+    it "strips the @ref suffix from the workflow path returned by the Actions API" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/999/job/1" }
+      allow(github_client).to receive(:check_run_log).with(repo, check).and_return("")
+
+      run_response = double(path: ".github/workflows/deploy.yml@refs/heads/feature")
+      allow(github_client).to receive(:actions_run).with(repo, "999").and_return(run_response)
+      allow(github_client).to receive(:file_content)
+        .with(repo, path: ".github/workflows/deploy.yml", ref: nil)
+        .and_return("name: Deploy")
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.workflow_content).to include(".github/workflows/deploy.yml")
+      expect(context.workflow_content).to include("name: Deploy")
     end
 
     it "returns empty string when no details_url is available" do

--- a/spec/services/ci/failure_context_spec.rb
+++ b/spec/services/ci/failure_context_spec.rb
@@ -65,4 +65,119 @@ RSpec.describe Ci::FailureContext do
     expect(context).not_to be_failing
     expect(context.output).to eq("")
   end
+
+  describe "failure type classification" do
+    it "classifies database errors" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "ActiveRecord::NoDatabaseError: Database not found" }
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.failure_types).to include(:database)
+    end
+
+    it "classifies PG::ConnectionBad as database error" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "PG::ConnectionBad: FATAL: database does not exist" }
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.failure_types).to include(:database)
+    end
+
+    it "classifies dependency errors" do
+      check = { id: 1, name: "build", conclusion: "failure", output_text: "Gem::LoadError: can't activate railties" }
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.failure_types).to include(:dependency)
+    end
+
+    it "classifies service errors" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "Connection refused - connect(2) for 127.0.0.1" }
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.failure_types).to include(:service)
+    end
+
+    it "classifies timeout errors" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "Net::ReadTimeout with API call" }
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.failure_types).to include(:timeout)
+    end
+
+    it "returns empty array when output has no matching patterns" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "Expected 2 to equal 3" }
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.failure_types).to eq([])
+    end
+
+    it "detects multiple failure types from the same output" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "ActiveRecord::NoDatabaseError and Connection refused" }
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.failure_types).to include(:database, :service)
+    end
+  end
+
+  describe "workflow file fetching" do
+    it "fetches workflow files for failed checks" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/12345/job/67890" }
+      allow(github_client).to receive(:check_run_log).with(repo, check).and_return("")
+
+      run_response = double(path: ".github/workflows/test.yml")
+      allow(github_client).to receive(:actions_run)
+        .with(repo, "12345")
+        .and_return(run_response)
+
+      workflow_yaml = "name: Test\non: push\njobs:\n  rspec:\n    runs-on: ubuntu-latest"
+      allow(github_client).to receive(:file_content)
+        .with(repo, path: ".github/workflows/test.yml", ref: "abc123")
+        .and_return(workflow_yaml)
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client, ref: "abc123")
+
+      expect(context.workflow_content).to include(".github/workflows/test.yml")
+      expect(context.workflow_content).to include("name: Test")
+      expect(context.workflow_content).to include("```yaml")
+    end
+
+    it "deduplicates workflow files across multiple checks" do
+      check1 = { id: 1, name: "rspec", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/111/job/1" }
+      check2 = { id: 2, name: "rubocop", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/111/job/2" }
+
+      run_response = double(path: ".github/workflows/ci.yml")
+      allow(github_client).to receive(:actions_run).with(repo, "111").and_return(run_response)
+      allow(github_client).to receive_messages(check_run_log: "", file_content: "name: CI\non: push")
+
+      context = described_class.call(repo: repo, checks: [ check1, check2 ], github_client: github_client)
+
+      expect(github_client).to have_received(:actions_run).once
+      expect(github_client).to have_received(:file_content).once
+    end
+
+    it "returns empty string when no details_url is available" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "failed" }
+      allow(github_client).to receive(:check_run_log).with(repo, check).and_return("failed")
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.workflow_content).to eq("")
+    end
+
+    it "returns empty string when workflow fetch fails" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/12345/job/67890" }
+      allow(github_client).to receive(:check_run_log).with(repo, check).and_return("")
+
+      allow(github_client).to receive(:actions_run).and_raise(GithubClient::ApiError.new("not found"))
+
+      context = described_class.call(repo: repo, checks: [ check ], github_client: github_client)
+
+      expect(context.workflow_content).to eq("")
+    end
+  end
 end

--- a/spec/services/llm_output_metrics/record_spec.rb
+++ b/spec/services/llm_output_metrics/record_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe LlmOutputMetrics::Record do
     end
 
     it "resolves the prompt version from global scope when prompt_project is nil" do
-      prompt = Prompt.global.active.find_by!(slug: "generation.pr_description")
+      prompt = create(:prompt, :global, :with_version, slug: "generation.pr_description")
 
       metric = described_class.call(
         project: project,
@@ -74,7 +74,7 @@ RSpec.describe LlmOutputMetrics::Record do
     end
 
     it "ignores project overrides when prompt_project is nil" do
-      global_prompt = Prompt.global.active.find_by!(slug: "generation.pr_description")
+      global_prompt = create(:prompt, :global, :with_version, slug: "generation.pr_description")
       create(:prompt, :for_project, :with_version,
         slug: "generation.pr_description", project: project)
 

--- a/spec/services/llm_output_metrics/record_spec.rb
+++ b/spec/services/llm_output_metrics/record_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe LlmOutputMetrics::Record do
     end
 
     it "resolves the prompt version from global scope when prompt_project is nil" do
+      Prompt.where(slug: "generation.pr_description", account_id: nil, project_id: nil).destroy_all
       prompt = create(:prompt, :global, :with_version, slug: "generation.pr_description")
 
       metric = described_class.call(
@@ -74,6 +75,7 @@ RSpec.describe LlmOutputMetrics::Record do
     end
 
     it "ignores project overrides when prompt_project is nil" do
+      Prompt.where(slug: "generation.pr_description", account_id: nil, project_id: nil).destroy_all
       global_prompt = create(:prompt, :global, :with_version, slug: "generation.pr_description")
       create(:prompt, :for_project, :with_version,
         slug: "generation.pr_description", project: project)

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -51,7 +51,11 @@ RSpec.describe Prompts::BuildForPr do
 
 
 
-    allow(github_client).to receive_messages(check_runs_for_ref: [], review_threads: [], recent_issue_comments: [])
+    allow(github_client).to receive_messages(
+      check_runs_for_ref: [],
+      review_threads: [],
+      recent_issue_comments: []
+    )
     allow(AgentRuns::UserSettingsResolver).to receive(:call).and_return(user_settings)
   end
 
@@ -267,6 +271,49 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("role \"root\" does not exist")
       expect(prompt).to include("database \"railscrawler_test\" does not exist")
       expect(prompt).to include("Fix the issue causing these CI failures")
+    end
+
+    it "includes CI failure guidance" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include("database error")
+      expect(prompt).to include("RAILS_ENV")
+    end
+
+    it "includes failure type hints for database errors" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include("Detected failure type")
+    end
+
+    it "includes workflow content when available" do
+      check = { id: 1, name: "rspec", conclusion: "failure", output_text: "failed", details_url: "https://github.com/owner/repo/actions/runs/999/job/1" }
+      allow(github_client).to receive(:check_runs_for_ref)
+        .with(project.full_name, "abc123")
+        .and_return([ check ])
+      allow(github_client).to receive(:check_run_log).with(project.full_name, check).and_return("")
+      run_response = double(path: ".github/workflows/test.yml")
+      allow(github_client).to receive_messages(actions_run: run_response, file_content: "name: Test\non: push")
+
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true
+      )
+
+      expect(prompt).to include("CI Workflow Configuration")
+      expect(prompt).to include(".github/workflows/test.yml")
     end
   end
 


### PR DESCRIPTION
## Summary

- Extend `Ci::FailureContext` with failure type classification (database, environment, dependency, service, timeout) and CI workflow YAML file fetching via GitHub Actions API
- Add seeded, A/B-testable `ci.failure_guidance` prompt template that provides targeted debugging strategy for each failure type and includes the actual CI workflow configuration in the agent prompt
- Fix `GithubClient#contents` to not pass `ref: nil` as an empty query param to GitHub's API

## Problem

Paid agents could not fix CI infrastructure errors (e.g., PR [#627 on railscrawler](https://github.com/HuntHelper/railscrawler/pull/627) — `NoDatabaseError` because `db:setup` ran without `RAILS_ENV=test`). The agent kept modifying `config/database.yml` instead of the workflow file because:

1. The CI workflow file content was never included in the prompt
2. The prompt said "reproduce locally" even for infrastructure errors that can't be reproduced locally
3. No failure type classification existed to guide the agent toward the correct fix

## How this moves toward the vision

The debugging strategy is now a **seeded prompt** (`ci.failure_guidance`) that:

- Gets a new version automatically when the template changes
- Can be **A/B tested** against the fallback to measure impact on agent outcomes
- Can be **evolved by the meta-agent** via `PromptEvolution::Mutate`
- Can be **overridden per-project** using 3-tier inheritance (project > account > global)
- Degrades gracefully if the prompt is deactivated

## Files changed

| File | Change |
|------|--------|
| `app/services/github_client.rb` | Add `file_content`, `actions_run` methods; fix `contents` to not pass `ref: nil` |
| `app/services/ci/failure_context.rb` | Add failure type classification, CI workflow file fetching |
| `app/services/prompts/build_for_pr.rb` | Render `ci.failure_guidance` prompt into CI failures section |
| `db/seeds/prompts.rb` | Add `ci.failure_guidance` seeded prompt template |
| Tests | 15 new test cases covering classification, workflow fetching, guidance rendering |