### PR TITLE
fix(knowledge): prevent TypeError from nil artifact_count in schema section

### DIFF
--- a/app/services/knowledge/context_bundle/build.rb
+++ b/app/services/knowledge/context_bundle/build.rb
@@ -156,7 +156,7 @@ module Knowledge
           parts.join("\n")
         end
 
-        { name: :schema, heading: "Data Model", content: lines.join("\n\n") }
+        artifact_section(name: :schema, heading: "Data Model", content: lines.join("\n\n"), artifacts: artifacts)
       end
 
       def build_hotspots_section
@@ -237,6 +237,7 @@ module Knowledge
           routes: "route",
           symbols: "symbol",
           hotspots: "churn_hotspot",
+          schema: "schema",
           stats: "language_stat",
           decisions: "decision_record"
         }.fetch(section_name.to_sym)

--- a/spec/services/knowledge/context_bundle/build_spec.rb
+++ b/spec/services/knowledge/context_bundle/build_spec.rb
@@ -190,6 +190,32 @@ RSpec.describe Knowledge::ContextBundle::Build do
       end
     end
 
+    context "with schema artifacts" do
+      before do
+        create(:knowledge_artifact,
+          project: project,
+          collector_run: collector_run,
+          artifact_type: "schema",
+          identifier: "users",
+          content: "users (id bigint, email text)",
+          status: "active")
+      end
+
+      it "includes a schema section" do
+        result = described_class.call(issue: issue, project: project)
+
+        expect(result[:sections]).to include(:schema)
+        expect(result[:content]).to include("Data Model")
+        expect(result[:content]).to include("users (id bigint, email text)")
+      end
+
+      it "includes schema in artifact_type_counts" do
+        result = described_class.call(issue: issue, project: project, agent_run_id: agent_run.id)
+
+        expect(result[:artifact_type_counts]).to include("schema" => 1)
+      end
+    end
+
     context "with full knowledge base" do
       before do
         create(:knowledge_artifact,
@@ -208,6 +234,10 @@ RSpec.describe Knowledge::ContextBundle::Build do
         create(:decision_record, project: project, title: "Use JWT", status: "active")
         create(:knowledge_artifact,
           project: project, collector_run: collector_run,
+          artifact_type: "schema", identifier: "users",
+          content: "users (id bigint, email text)", status: "active")
+        create(:knowledge_artifact,
+          project: project, collector_run: collector_run,
           artifact_type: "language_stat", identifier: "Ruby",
           content: "stats", metadata: { "code" => 10_000, "files" => 100 },
           status: "active")
@@ -216,7 +246,7 @@ RSpec.describe Knowledge::ContextBundle::Build do
       it "includes all section types in correct order" do
         result = described_class.call(issue: issue, project: project)
 
-        expect(result[:sections]).to eq(%i[routes symbols hotspots decisions stats])
+        expect(result[:sections]).to eq(%i[routes symbols schema hotspots decisions stats])
         expect(result[:content]).to include("Codebase Context")
       end
 


### PR DESCRIPTION
## Summary

- `build_schema_section` returned a bare hash missing `artifact_type` and `artifact_count` keys, causing `TypeError: nil can't be coerced into Integer` when `build_sections` accumulated per-type counts via `+=`
- Switched to the `artifact_section` helper (consistent with all other section builders) and added `schema` to the `section_artifact_type` mapping
- Added test coverage for schema artifacts including `artifact_type_counts` verification

## How verified

- Confirmed the exact error against production AgentRun #10933 via `rails runner`
- Verified the fix resolves the error by re-running the same code path
- Added dedicated spec for schema section rendering and artifact count tracking
- Updated "full knowledge base" spec to include schema artifacts in section order assertion
- RuboCop passes on both changed files