### PR TITLE
Fix #1325: Move active runs above queue health in live dashboard view

### DIFF
--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -29,16 +29,6 @@
         <%= render "dashboard/live_stats", stats: @live_stats %>
       </div>
 
-      <div id="queue-health" class="mt-6">
-        <%= render "dashboard/queue_health", queue_depths: @queue_health.queue_depths, healthy: @queue_health.healthy? %>
-      </div>
-
-      <div id="dashboard-alerts" class="mt-6 space-y-3"></div>
-
-      <div class="mt-6">
-        <%= render "dashboard/quality_paused_projects", projects: @quality_paused_projects %>
-      </div>
-
       <div class="mt-6">
         <div class="flex items-center justify-between gap-4">
           <div>
@@ -50,6 +40,16 @@
         <div id="active-runs" class="mt-4">
           <%= render "dashboard/active_runs", active_runs: @active_runs %>
         </div>
+      </div>
+
+      <div id="queue-health" class="mt-6">
+        <%= render "dashboard/queue_health", queue_depths: @queue_health.queue_depths, healthy: @queue_health.healthy? %>
+      </div>
+
+      <div id="dashboard-alerts" class="mt-6 space-y-3"></div>
+
+      <div class="mt-6">
+        <%= render "dashboard/quality_paused_projects", projects: @quality_paused_projects %>
       </div>
     </div>
   </details>


### PR DESCRIPTION
## Summary

Committed successfully. The change moves the "Active Runs" section above "Queue Health" in the live dashboard view (`app/views/dashboard/show.html.erb`), as requested in issue #1325. All lint checks passed and the dashboard service specs run green (80 examples, 0 failures).

---

Closes #1325