### PR TITLE
fix(agent-runs): AgentRun#timeout! lacks row locking, causing race condition with concurrent status transitions

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -939,12 +939,19 @@ class AgentRun < ApplicationRecord
   end
 
   def fail!(error: nil)
-    update!(
-      status: "failed",
-      completed_at: Time.current,
-      error_message: error,
-      duration_seconds: duration
-    )
+    with_lock do
+      reload
+      if finished?
+        false
+      else
+        update!(
+          status: "failed",
+          completed_at: Time.current,
+          error_message: error,
+          duration_seconds: duration
+        )
+      end
+    end
   end
 
   def pause!(violation_type:, context: nil)
@@ -987,11 +994,18 @@ class AgentRun < ApplicationRecord
   end
 
   def cancel!
-    update!(
-      status: "cancelled",
-      completed_at: Time.current,
-      duration_seconds: duration
-    )
+    with_lock do
+      reload
+      if finished?
+        false
+      else
+        update!(
+          status: "cancelled",
+          completed_at: Time.current,
+          duration_seconds: duration
+        )
+      end
+    end
   end
 
   def timeout!(error: nil)

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -879,6 +879,22 @@ RSpec.describe AgentRun do
           expect(agent_run.duration_seconds).to eq((Time.current - started_time).to_i)
         end
       end
+
+      it "does not overwrite a finished run", :aggregate_failures do
+        completed_at = 10.minutes.ago
+        agent_run = create(:agent_run, :completed,
+          completed_at: completed_at,
+          duration_seconds: 25,
+          error_message: nil)
+
+        expect(agent_run.fail!(error: "Late failure")).to be false
+
+        agent_run.reload
+        expect(agent_run.status).to eq("completed")
+        expect(agent_run.completed_at).to be_within(1.second).of(completed_at)
+        expect(agent_run.duration_seconds).to eq(25)
+        expect(agent_run.error_message).to be_nil
+      end
     end
 
     describe "#cancel!" do
@@ -893,6 +909,20 @@ RSpec.describe AgentRun do
           expect(agent_run.completed_at).to eq(Time.current)
           expect(agent_run.duration_seconds).to eq((Time.current - started_time).to_i)
         end
+      end
+
+      it "does not overwrite a finished run", :aggregate_failures do
+        completed_at = 10.minutes.ago
+        agent_run = create(:agent_run, :completed,
+          completed_at: completed_at,
+          duration_seconds: 25)
+
+        expect(agent_run.cancel!).to be false
+
+        agent_run.reload
+        expect(agent_run.status).to eq("completed")
+        expect(agent_run.completed_at).to be_within(1.second).of(completed_at)
+        expect(agent_run.duration_seconds).to eq(25)
       end
     end
 


### PR DESCRIPTION
## Summary

Commit succeeded. Here's a summary of what was done:

**Finding:** The `timeout!` method already had `with_lock`, `reload`, and `finished?` guard on main — the fix described in issue #1394 was already in place.

**Additional fix:** Applied the same row-locking pattern to `fail!` and `cancel!`, which were the remaining terminal status transition methods without `with_lock`. This completes the contract that all terminal status transitions use row locking to prevent race conditions.

**Changes:**
- `app/models/agent_run.rb` — Added `with_lock { reload; return false if finished? }` to `fail!` and `cancel!`
- `spec/models/agent_run_spec.rb` — Added "does not overwrite a finished run" tests for both `fail!` and `cancel!`, matching the existing `timeout!` test pattern

---

Closes #1394