### PR TITLE
feat(agent-runs): add GitHub circuit breaker to pause dispatching during outages

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -118,11 +118,7 @@ class ProcessRunQueueJob < ApplicationJob
   # Checks GitHub circuit breaker state. Attempts recovery if the
   # timeout has elapsed, allowing a half-open probe.
   def github_circuit_open?
-    state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
-    return false unless state
-
-    state.check_circuit_recovery!
-    state.unavailable?
+    !GithubHealthState.github_available_with_recovery?
   end
 
   # Checks per-user capacity using an in-memory cache. The active count

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -38,6 +38,13 @@ class ProcessRunQueueJob < ApplicationJob
     return unless acquired
 
     begin
+      if github_circuit_open?
+        Rails.logger.info(
+          message: "process_run_queue.skipped_github_circuit_open"
+        )
+        return
+      end
+
       consecutive_failures = 0
       starts_count = 0
       iterations = 0
@@ -107,6 +114,16 @@ class ProcessRunQueueJob < ApplicationJob
   end
 
   private
+
+  # Checks GitHub circuit breaker state. Attempts recovery if the
+  # timeout has elapsed, allowing a half-open probe.
+  def github_circuit_open?
+    state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
+    return false unless state
+
+    state.check_circuit_recovery!
+    state.unavailable?
+  end
 
   # Checks per-user capacity using an in-memory cache. The active count
   # is fetched from the DB on first access per user, then updated

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -120,13 +120,8 @@ class StaleRunDetectorJob < ApplicationJob
 
   private
 
-  # Checks whether the GitHub circuit breaker is open (infrastructure outage).
   def github_circuit_open?
-    state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
-    return false unless state
-
-    state.check_circuit_recovery!
-    state.unavailable?
+    !GithubHealthState.github_available_with_recovery?
   end
 
   # Uses the default timeout rather than per-user maximums. Individual run

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -64,7 +64,15 @@ class StaleRunDetectorJob < ApplicationJob
       )
     end
 
+    github_down = github_circuit_open?
+
     stale_pending_runs(pending_threshold).find_each do |agent_run|
+      if github_down
+        skipped += 1
+        log_skip(agent_run, "github_circuit_open")
+        next
+      end
+
       case requeue_stale_pending_run(agent_run)
       when :requeued
         requeued += 1
@@ -111,6 +119,15 @@ class StaleRunDetectorJob < ApplicationJob
   end
 
   private
+
+  # Checks whether the GitHub circuit breaker is open (infrastructure outage).
+  def github_circuit_open?
+    state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
+    return false unless state
+
+    state.check_circuit_recovery!
+    state.unavailable?
+  end
 
   # Uses the default timeout rather than per-user maximums. Individual run
   # timeouts are enforced by the Temporal workflow; this job is a safety net

--- a/app/models/github_health_state.rb
+++ b/app/models/github_health_state.rb
@@ -34,6 +34,16 @@ class GithubHealthState < ApplicationRecord
     !state.circuit_open?
   end
 
+  # Checks recovery timeout, then returns true if GitHub is available.
+  # Consolidates the check-then-query pattern used by multiple jobs.
+  def self.github_available_with_recovery?(endpoint: DEFAULT_ENDPOINT)
+    state = find_by(endpoint: endpoint)
+    return true unless state
+
+    state.check_circuit_recovery!
+    !state.unavailable?
+  end
+
   # Records an infrastructure failure and opens the circuit when the
   # threshold is reached.
   def record_failure!(threshold: DEFAULT_FAILURE_THRESHOLD, error_message: nil)
@@ -58,10 +68,14 @@ class GithubHealthState < ApplicationRecord
   end
 
   # Records a successful GitHub API call and resets the circuit.
+  # Only half_open → closed transitions are allowed on success;
+  # an in-flight success while circuit is open must not bypass the
+  # recovery timeout.
   def record_success!
     return if circuit_state == "closed" && failure_count.zero?
+    return if circuit_open?
 
-    was_open = circuit_open? || circuit_half_open?
+    was_half_open = circuit_half_open?
 
     update!(
       failure_count: 0,
@@ -70,7 +84,7 @@ class GithubHealthState < ApplicationRecord
       last_error_message: nil
     )
 
-    if was_open
+    if was_half_open
       Rails.logger.info(
         message: "github_health.circuit_closed",
         endpoint: endpoint

--- a/app/models/github_health_state.rb
+++ b/app/models/github_health_state.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Circuit breaker for GitHub API availability.
+#
+# Tracks consecutive infrastructure failures (5xx, network errors) and
+# transitions through closed → open → half_open states following the
+# same pattern as ProviderState. A singleton row per endpoint allows
+# the system to pause dispatching during GitHub outages.
+class GithubHealthState < ApplicationRecord
+  CIRCUIT_STATES = %w[closed open half_open].freeze
+  DEFAULT_ENDPOINT = "api"
+  DEFAULT_FAILURE_THRESHOLD = 5
+  DEFAULT_RECOVERY_TIMEOUT = 300
+
+  validates :endpoint, presence: true, length: { maximum: 50 }, uniqueness: true
+  validates :circuit_state, presence: true, inclusion: { in: CIRCUIT_STATES }
+  validates :failure_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  scope :for_endpoint, ->(name) { where(endpoint: name) }
+
+  # Returns the singleton state for the default GitHub API endpoint,
+  # creating it if it does not exist.
+  def self.current(endpoint: DEFAULT_ENDPOINT)
+    find_or_create_by!(endpoint: endpoint)
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(endpoint: endpoint)
+  end
+
+  # Returns true if GitHub is currently unavailable (circuit open).
+  def self.github_available?(endpoint: DEFAULT_ENDPOINT)
+    state = find_by(endpoint: endpoint)
+    return true unless state
+
+    !state.circuit_open?
+  end
+
+  # Records an infrastructure failure and opens the circuit when the
+  # threshold is reached.
+  def record_failure!(threshold: DEFAULT_FAILURE_THRESHOLD, error_message: nil)
+    with_lock do
+      new_count = failure_count + 1
+      attrs = { failure_count: new_count, last_error_message: error_message&.truncate(500) }
+
+      if new_count >= threshold && circuit_state == "closed"
+        attrs[:circuit_state] = "open"
+        attrs[:circuit_opened_at] = Time.current
+
+        Rails.logger.warn(
+          message: "github_health.circuit_opened",
+          endpoint: endpoint,
+          failure_count: new_count,
+          last_error: error_message&.truncate(200)
+        )
+      end
+
+      update!(attrs)
+    end
+  end
+
+  # Records a successful GitHub API call and resets the circuit.
+  def record_success!
+    return if circuit_state == "closed" && failure_count.zero?
+
+    was_open = circuit_open? || circuit_half_open?
+
+    update!(
+      failure_count: 0,
+      circuit_state: "closed",
+      circuit_opened_at: nil,
+      last_error_message: nil
+    )
+
+    if was_open
+      Rails.logger.info(
+        message: "github_health.circuit_closed",
+        endpoint: endpoint
+      )
+    end
+  end
+
+  # Transitions from open → half_open after the recovery timeout.
+  #
+  # @param timeout [Integer] Seconds to wait before attempting recovery
+  # @return [Boolean] true if transitioned to half_open
+  def check_circuit_recovery!(timeout: DEFAULT_RECOVERY_TIMEOUT)
+    return false unless circuit_state == "open"
+    return false unless circuit_opened_at.present?
+    return false unless circuit_opened_at + timeout.seconds <= Time.current
+
+    update!(circuit_state: "half_open")
+
+    Rails.logger.info(
+      message: "github_health.circuit_half_open",
+      endpoint: endpoint
+    )
+    true
+  end
+
+  def circuit_open?
+    circuit_state == "open"
+  end
+
+  def circuit_half_open?
+    circuit_state == "half_open"
+  end
+
+  def circuit_closed?
+    circuit_state == "closed"
+  end
+
+  # Returns true when dispatching should be paused.
+  def unavailable?
+    circuit_open?
+  end
+end

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -1352,7 +1352,9 @@ class GithubClient
   end
 
   def handle_errors
-    yield
+    result = yield
+    record_github_health_success
+    result
   rescue Octokit::Unauthorized => e
     raise AuthenticationError, e.message
   rescue Octokit::NotFound => e
@@ -1366,8 +1368,36 @@ class GithubClient
       raise RateLimitError.new(reset_at)
     end
     raise ApiError.new(e.message, status: 403)
+  rescue Octokit::ServerError => e
+    record_github_health_failure(e.message)
+    status = e.respond_to?(:response_status) ? e.response_status : nil
+    raise ApiError.new(e.message, status: status)
   rescue Octokit::Error => e
     status = e.respond_to?(:response_status) ? e.response_status : nil
     raise ApiError.new(e.message, status: status)
+  rescue Faraday::Error => e
+    record_github_health_failure(e.message)
+    raise
+  end
+
+  def record_github_health_failure(error_message)
+    GithubHealthState.current.record_failure!(error_message: error_message)
+  rescue => e
+    Rails.logger.warn(
+      message: "github_client.health_state_record_failed",
+      error: e.message
+    )
+  end
+
+  def record_github_health_success
+    state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
+    return unless state && (state.failure_count > 0 || !state.circuit_closed?)
+
+    state.record_success!
+  rescue => e
+    Rails.logger.warn(
+      message: "github_client.health_state_record_failed",
+      error: e.message
+    )
   end
 end

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -10,6 +10,15 @@ module Activities
 
     def execute(input)
       project_id = input[:project_id]
+
+      unless GithubHealthState.github_available?
+        logger.info(
+          message: "fetch_issues.skipped_github_circuit_open",
+          project_id: project_id
+        )
+        return { issues: [], project_id: project_id, github_circuit_open: true }
+      end
+
       project = Project.find_by(id: project_id)
       return { issues: [], project_id: project_id, project_missing: true } unless project
 

--- a/db/migrate/20260427141851_create_git_hub_health_states.rb
+++ b/db/migrate/20260427141851_create_git_hub_health_states.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateGitHubHealthStates < ActiveRecord::Migration[8.1]
+  def change
+    create_table :github_health_states do |t|
+      t.string :endpoint, limit: 50, null: false, default: "api"
+      t.string :circuit_state, limit: 20, null: false, default: "closed"
+      t.integer :failure_count, null: false, default: 0
+      t.datetime :circuit_opened_at
+      t.text :last_error_message
+
+      t.timestamps
+    end
+
+    add_index :github_health_states, :endpoint, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1182,6 +1182,41 @@ ALTER SEQUENCE public.flipper_gates_id_seq OWNED BY public.flipper_gates.id;
 
 
 --
+-- Name: github_health_states; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.github_health_states (
+    id bigint NOT NULL,
+    endpoint character varying(50) DEFAULT 'api'::character varying NOT NULL,
+    circuit_state character varying(20) DEFAULT 'closed'::character varying NOT NULL,
+    failure_count integer DEFAULT 0 NOT NULL,
+    circuit_opened_at timestamp(6) without time zone,
+    last_error_message text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: github_health_states_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.github_health_states_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: github_health_states_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.github_health_states_id_seq OWNED BY public.github_health_states.id;
+
+
+--
 -- Name: github_tokens; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3487,6 +3522,13 @@ ALTER TABLE ONLY public.flipper_gates ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: github_health_states id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.github_health_states ALTER COLUMN id SET DEFAULT nextval('public.github_health_states_id_seq'::regclass);
+
+
+--
 -- Name: github_tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4030,6 +4072,14 @@ ALTER TABLE ONLY public.flipper_features
 
 ALTER TABLE ONLY public.flipper_gates
     ADD CONSTRAINT flipper_gates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: github_health_states github_health_states_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.github_health_states
+    ADD CONSTRAINT github_health_states_pkey PRIMARY KEY (id);
 
 
 --
@@ -5476,6 +5526,13 @@ CREATE UNIQUE INDEX index_flipper_features_on_key ON public.flipper_features USI
 --
 
 CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON public.flipper_gates USING btree (feature_key, key, value);
+
+
+--
+-- Name: index_github_health_states_on_endpoint; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_github_health_states_on_endpoint ON public.github_health_states USING btree (endpoint);
 
 
 --
@@ -9429,6 +9486,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260427141851'),
 ('20260426114303'),
 ('20260426011810'),
 ('20260425225105'),

--- a/spec/factories/github_health_states.rb
+++ b/spec/factories/github_health_states.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :github_health_state do
+    endpoint { "api" }
+    circuit_state { "closed" }
+    failure_count { 0 }
+
+    trait :circuit_open do
+      circuit_state { "open" }
+      failure_count { 5 }
+      circuit_opened_at { Time.current }
+    end
+
+    trait :circuit_half_open do
+      circuit_state { "half_open" }
+      failure_count { 5 }
+      circuit_opened_at { 10.minutes.ago }
+    end
+  end
+end

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -450,6 +450,29 @@ RSpec.describe ProcessRunQueueJob do
       expect(normal_run.reload.status).to eq("pending")
     end
 
+    context "when GitHub circuit is open" do
+      it "skips dispatching entirely" do
+        create(:github_health_state, :circuit_open)
+        create(:agent_run, :queued)
+
+        expect(temporal_client).not_to receive(:start_workflow)
+
+        described_class.new.perform
+      end
+
+      it "attempts circuit recovery when timeout has elapsed" do
+        state = create(:github_health_state, circuit_state: "open",
+          circuit_opened_at: 10.minutes.ago, failure_count: 5)
+        create(:agent_run, :queued)
+
+        expect(temporal_client).to receive(:start_workflow).and_return(workflow_handle)
+
+        described_class.new.perform
+
+        expect(state.reload.circuit_state).to eq("half_open")
+      end
+    end
+
     it "includes workflow input fields from the agent run" do
       issue = create(:issue)
       queued_run = create(:agent_run, :queued,

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -424,6 +424,31 @@ RSpec.describe StaleRunDetectorJob do
       end
     end
 
+    context "when GitHub circuit is open" do
+      it "skips requeuing stale pending runs" do
+        create(:github_health_state, :circuit_open)
+
+        stale_run = create(:agent_run, status: "pending")
+        stale_run.update_columns(updated_at: (pending_threshold + 60).seconds.ago)
+
+        described_class.perform_now
+
+        expect(stale_run.reload.status).to eq("pending")
+      end
+
+      it "still resolves stale running runs" do
+        create(:github_health_state, :circuit_open)
+
+        stale_run = create(:agent_run, :running, started_at: (running_threshold + 60).seconds.ago)
+        allow(Containers::ServiceProvisioner).to receive(:new)
+          .and_return(instance_double(Containers::ServiceProvisioner, cleanup: nil))
+
+        described_class.perform_now
+
+        expect(stale_run.reload.status).to eq("timeout")
+      end
+    end
+
     context "with stale paused runs" do
       it "requeues a stale paused run that has not exhausted requeue budget" do
         stale_run = create(:agent_run, :paused, paused_at: (paused_threshold + 60).seconds.ago)

--- a/spec/models/github_health_state_spec.rb
+++ b/spec/models/github_health_state_spec.rb
@@ -46,6 +46,23 @@ RSpec.describe GithubHealthState do
     end
   end
 
+  describe ".github_available_with_recovery?" do
+    it "returns true when no state exists" do
+      expect(described_class.github_available_with_recovery?).to be true
+    end
+
+    it "returns false when circuit is open and timeout has not elapsed" do
+      create(:github_health_state, circuit_state: "open", circuit_opened_at: 1.minute.ago)
+      expect(described_class.github_available_with_recovery?).to be false
+    end
+
+    it "transitions to half_open and returns true when timeout has elapsed" do
+      state = create(:github_health_state, circuit_state: "open", circuit_opened_at: 10.minutes.ago)
+      expect(described_class.github_available_with_recovery?).to be true
+      expect(state.reload.circuit_state).to eq("half_open")
+    end
+  end
+
   describe "#record_failure!" do
     it "increments failure_count" do
       state = create(:github_health_state, failure_count: 2)
@@ -91,8 +108,8 @@ RSpec.describe GithubHealthState do
   end
 
   describe "#record_success!" do
-    it "resets failure_count and closes the circuit" do
-      state = create(:github_health_state, :circuit_open)
+    it "resets failure_count and closes the circuit from half_open" do
+      state = create(:github_health_state, :circuit_half_open)
       state.record_success!
 
       state.reload
@@ -102,8 +119,8 @@ RSpec.describe GithubHealthState do
       expect(state.last_error_message).to be_nil
     end
 
-    it "logs when closing an open circuit" do
-      state = create(:github_health_state, :circuit_open)
+    it "logs when closing a half_open circuit" do
+      state = create(:github_health_state, :circuit_half_open)
 
       expect(Rails.logger).to receive(:info).with(hash_including(
         message: "github_health.circuit_closed"
@@ -112,11 +129,26 @@ RSpec.describe GithubHealthState do
       state.record_success!
     end
 
+    it "is a no-op when circuit is open (must go through half_open first)" do
+      state = create(:github_health_state, :circuit_open)
+
+      expect(state).not_to receive(:update!)
+      state.record_success!
+    end
+
     it "is a no-op when already closed with zero failures" do
       state = create(:github_health_state)
 
       expect(state).not_to receive(:update!)
       state.record_success!
+    end
+
+    it "resets failure_count when closed but has accumulated failures" do
+      state = create(:github_health_state, failure_count: 3)
+      state.record_success!
+
+      state.reload
+      expect(state.failure_count).to eq(0)
     end
   end
 

--- a/spec/models/github_health_state_spec.rb
+++ b/spec/models/github_health_state_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GithubHealthState do
+  describe "validations" do
+    subject { build(:github_health_state) }
+
+    it { is_expected.to validate_presence_of(:endpoint) }
+    it { is_expected.to validate_length_of(:endpoint).is_at_most(50) }
+    it { is_expected.to validate_uniqueness_of(:endpoint) }
+    it { is_expected.to validate_presence_of(:circuit_state) }
+    it { is_expected.to validate_inclusion_of(:circuit_state).in_array(described_class::CIRCUIT_STATES) }
+    it { is_expected.to validate_numericality_of(:failure_count).only_integer.is_greater_than_or_equal_to(0) }
+  end
+
+  describe ".current" do
+    it "creates a new record when none exists" do
+      expect { described_class.current }.to change(described_class, :count).by(1)
+    end
+
+    it "returns the existing record when one exists" do
+      existing = create(:github_health_state)
+      expect(described_class.current).to eq(existing)
+    end
+  end
+
+  describe ".github_available?" do
+    it "returns true when no state record exists" do
+      expect(described_class.github_available?).to be true
+    end
+
+    it "returns true when circuit is closed" do
+      create(:github_health_state)
+      expect(described_class.github_available?).to be true
+    end
+
+    it "returns false when circuit is open" do
+      create(:github_health_state, :circuit_open)
+      expect(described_class.github_available?).to be false
+    end
+
+    it "returns true when circuit is half_open" do
+      create(:github_health_state, :circuit_half_open)
+      expect(described_class.github_available?).to be true
+    end
+  end
+
+  describe "#record_failure!" do
+    it "increments failure_count" do
+      state = create(:github_health_state, failure_count: 2)
+      state.record_failure!
+
+      expect(state.reload.failure_count).to eq(3)
+    end
+
+    it "opens the circuit when threshold is reached" do
+      state = create(:github_health_state, failure_count: 4, circuit_state: "closed")
+      state.record_failure!(threshold: 5)
+
+      state.reload
+      expect(state.circuit_state).to eq("open")
+      expect(state.circuit_opened_at).to be_present
+    end
+
+    it "does not reopen an already open circuit" do
+      opened_at = 1.hour.ago
+      state = create(:github_health_state, failure_count: 6, circuit_state: "open", circuit_opened_at: opened_at)
+      state.record_failure!(threshold: 5)
+
+      expect(state.reload.failure_count).to eq(7)
+      expect(state.circuit_state).to eq("open")
+    end
+
+    it "stores the error message truncated to 500 chars" do
+      state = create(:github_health_state)
+      state.record_failure!(error_message: "x" * 600)
+
+      expect(state.reload.last_error_message.length).to eq(500)
+    end
+
+    it "logs when opening the circuit" do
+      state = create(:github_health_state, failure_count: 4, circuit_state: "closed")
+
+      expect(Rails.logger).to receive(:warn).with(hash_including(
+        message: "github_health.circuit_opened"
+      ))
+
+      state.record_failure!(threshold: 5)
+    end
+  end
+
+  describe "#record_success!" do
+    it "resets failure_count and closes the circuit" do
+      state = create(:github_health_state, :circuit_open)
+      state.record_success!
+
+      state.reload
+      expect(state.failure_count).to eq(0)
+      expect(state.circuit_state).to eq("closed")
+      expect(state.circuit_opened_at).to be_nil
+      expect(state.last_error_message).to be_nil
+    end
+
+    it "logs when closing an open circuit" do
+      state = create(:github_health_state, :circuit_open)
+
+      expect(Rails.logger).to receive(:info).with(hash_including(
+        message: "github_health.circuit_closed"
+      ))
+
+      state.record_success!
+    end
+
+    it "is a no-op when already closed with zero failures" do
+      state = create(:github_health_state)
+
+      expect(state).not_to receive(:update!)
+      state.record_success!
+    end
+  end
+
+  describe "#check_circuit_recovery!" do
+    it "transitions from open to half_open after timeout" do
+      state = create(:github_health_state, circuit_state: "open", circuit_opened_at: 10.minutes.ago)
+      result = state.check_circuit_recovery!(timeout: 300)
+
+      expect(result).to be true
+      expect(state.reload.circuit_state).to eq("half_open")
+    end
+
+    it "does not transition if timeout has not elapsed" do
+      state = create(:github_health_state, circuit_state: "open", circuit_opened_at: 1.minute.ago)
+      result = state.check_circuit_recovery!(timeout: 300)
+
+      expect(result).to be false
+      expect(state.reload.circuit_state).to eq("open")
+    end
+
+    it "returns false for closed circuits" do
+      state = create(:github_health_state, circuit_state: "closed")
+      expect(state.check_circuit_recovery!(timeout: 300)).to be false
+    end
+  end
+
+  describe "#circuit_open?" do
+    it { expect(build(:github_health_state, circuit_state: "open")).to be_circuit_open }
+    it { expect(build(:github_health_state, circuit_state: "closed")).not_to be_circuit_open }
+  end
+
+  describe "#circuit_half_open?" do
+    it { expect(build(:github_health_state, :circuit_half_open)).to be_circuit_half_open }
+    it { expect(build(:github_health_state)).not_to be_circuit_half_open }
+  end
+
+  describe "#circuit_closed?" do
+    it { expect(build(:github_health_state)).to be_circuit_closed }
+    it { expect(build(:github_health_state, :circuit_open)).not_to be_circuit_closed }
+  end
+
+  describe "#unavailable?" do
+    it "returns true when circuit is open" do
+      state = build(:github_health_state, :circuit_open)
+      expect(state).to be_unavailable
+    end
+
+    it "returns false when circuit is closed" do
+      state = build(:github_health_state)
+      expect(state).not_to be_unavailable
+    end
+
+    it "returns false when circuit is half_open" do
+      state = build(:github_health_state, :circuit_half_open)
+      expect(state).not_to be_unavailable
+    end
+  end
+end

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -2083,4 +2083,43 @@ RSpec.describe GithubClient do
       end
     end
   end
+
+  describe "GitHub health state integration" do
+    it "records a failure on server errors" do
+      stub_request(:get, "#{api_base}/user")
+        .to_return(status: 500,
+          body: { message: "Internal Server Error" }.to_json,
+          headers: { "Content-Type" => "application/json" })
+
+      state = create(:github_health_state)
+
+      expect { client.validate_token }.to raise_error(GithubClient::ApiError)
+      expect(state.reload.failure_count).to be >= 1
+    end
+
+    it "records a success on successful calls" do
+      stub_request(:get, "#{api_base}/user")
+        .to_return(
+          status: 200,
+          body: { login: "testuser", id: 1, name: "Test", email: "t@t.com" }.to_json,
+          headers: { "Content-Type" => "application/json", "X-OAuth-Scopes" => "repo" }
+        )
+
+      state = create(:github_health_state, failure_count: 3)
+
+      client.validate_token
+
+      expect(state.reload.failure_count).to eq(0)
+    end
+
+    it "does not record a failure on 404 errors" do
+      stub_request(:get, "#{api_base}/repos/owner/repo")
+        .to_return(status: 404, body: { message: "Not Found" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      state = create(:github_health_state)
+
+      expect { client.repository("owner/repo") }.to raise_error(GithubClient::NotFoundError)
+      expect(state.reload.failure_count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Only the `.claude/settings.json` changes remain (not related to this task). The commit is clean.

Here's a summary of what was implemented:

## Changes Made

### New Files
- **`app/models/github_health_state.rb`** — Circuit breaker model with `closed → open → half_open` state machine, following the `ProviderState` pattern. Singleton per endpoint with configurable failure threshold (default: 5) and recovery timeout (default: 300s).
- **`db/migrate/20260427141851_create_git_hub_health_states.rb`** — Migration creating the `github_health_states` table with endpoint, circuit_state, failure_count, circuit_opened_at, and last_error_message columns.
- **`spec/models/github_health_state_spec.rb`** — 32 examples covering validations, state transitions, failure recording, success recording, and circuit recovery.
- **`spec/factories/github_health_states.rb`** — Factory with `:circuit_open` and `:circuit_half_open` traits.

### Modified Files
- **`app/services/github_client.rb`** — `handle_errors` now records successes on all successful API calls and records failures on `Octokit::ServerError` (5xx) and `Faraday::Error` (network errors).
- **`app/jobs/process_run_queue_job.rb`** — Checks circuit state at the start of `perform`; skips all dispatching when open. Attempts recovery when timeout has elapsed.
- **`app/jobs/stale_run_detector_job.rb`** — Skips requeuing stale pending runs when circuit is open (prevents futile retry cycles). Still resolves stale running runs.
- **`app/temporal/activities/fetch_issues_activity.rb`** — Skips GitHub polling when circuit is open, returning early with `github_circuit_open: true`.
- **`db/structure.sql`** — Updated with new table definition and migration version.
- **`spec/jobs/process_run_queue_job_spec.rb`** — 2 new tests for circuit breaker integration.
- **`spec/jobs/stale_run_detector_job_spec.rb`** — 2 new tests for circuit breaker integration.
- **`spec/services/github_client_spec.rb`** — 3 new tests for health state recording.

---

Closes #1423