### PR TITLE
feat(github-tokens): trigger focused token validation on auth-related run failures

### DIFF
--- a/app/services/github_tokens/auth_failure_checker.rb
+++ b/app/services/github_tokens/auth_failure_checker.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module GithubTokens
+  class AuthFailureChecker
+    # Git clone / fetch authentication failures
+    GIT_AUTH_PATTERNS = [
+      /Authentication failed/i,
+      /fatal: could not read Username/i,
+      /HTTP 403/,
+      /HTTP 401/,
+      /could not read Password/i,
+      /Invalid credentials/i,
+      /The requested URL returned error: 403/i,
+      /The requested URL returned error: 401/i
+    ].freeze
+
+    # Proxy 503 responses from credential/proxy controllers
+    PROXY_AUTH_PATTERNS = [
+      /proxy.*503/i,
+      /GitCredentials.*503/i,
+      /GithubProxy.*503/i,
+      /Service Unavailable.*credential/i
+    ].freeze
+
+    # GithubClient errors
+    CLIENT_AUTH_PATTERNS = [
+      /GithubClient::AuthenticationError/,
+      /Invalid or expired GitHub token/i,
+      /Token is invalid or has been revoked/i,
+      /Bad credentials/i,
+      /Unauthorized/i
+    ].freeze
+
+    ALL_PATTERNS = (GIT_AUTH_PATTERNS + PROXY_AUTH_PATTERNS + CLIENT_AUTH_PATTERNS).freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(error_message:)
+      @error_message = error_message.to_s
+    end
+
+    def call
+      return nil if @error_message.blank?
+
+      ALL_PATTERNS.find { |pattern| @error_message.match?(pattern) }
+    end
+
+    def auth_failure?
+      call.present?
+    end
+  end
+end

--- a/app/services/github_tokens/auth_failure_checker.rb
+++ b/app/services/github_tokens/auth_failure_checker.rb
@@ -28,7 +28,7 @@ module GithubTokens
       /Invalid or expired GitHub token/i,
       /Token is invalid or has been revoked/i,
       /Bad credentials/i,
-      /Unauthorized/i
+      /\bUnauthorized\b/i
     ].freeze
 
     ALL_PATTERNS = (GIT_AUTH_PATTERNS + PROXY_AUTH_PATTERNS + CLIENT_AUTH_PATTERNS).freeze

--- a/app/temporal/activities/mark_agent_run_failed_activity.rb
+++ b/app/temporal/activities/mark_agent_run_failed_activity.rb
@@ -47,7 +47,29 @@ module Activities
         error: error
       )
 
+      check_auth_failure(agent_run, error)
+
       { agent_run_id: agent_run_id }
+    end
+
+    private
+
+    def check_auth_failure(agent_run, error_message)
+      checker = GithubTokens::AuthFailureChecker.new(error_message: error_message)
+      matched_pattern = checker.call
+      return unless matched_pattern
+
+      github_token = agent_run.project&.github_token
+      return unless github_token
+
+      logger.info(
+        message: "github_token.auth_failure_check",
+        agent_run_id: agent_run.id,
+        token_id: github_token.id,
+        error_pattern: matched_pattern.source
+      )
+
+      GithubTokenValidationJob.perform_later(github_token.id)
     end
   end
 end

--- a/app/temporal/activities/mark_agent_run_failed_activity.rb
+++ b/app/temporal/activities/mark_agent_run_failed_activity.rb
@@ -70,6 +70,13 @@ module Activities
       )
 
       GithubTokenValidationJob.perform_later(github_token.id)
+    rescue => e
+      logger.warn(
+        message: "github_token.auth_failure_check_error",
+        agent_run_id: agent_run.id,
+        error_class: e.class.name,
+        error_message: e.message.to_s.truncate(200)
+      )
     end
   end
 end

--- a/spec/services/github_tokens/auth_failure_checker_spec.rb
+++ b/spec/services/github_tokens/auth_failure_checker_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GithubTokens::AuthFailureChecker do
+  describe "#auth_failure?" do
+    it "detects git clone authentication failures" do
+      [
+        "fatal: Authentication failed for 'https://github.com/org/repo.git'",
+        "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+        "The requested URL returned error: 403 Forbidden",
+        "The requested URL returned error: 401 Unauthorized",
+        "HTTP 403: access denied",
+        "HTTP 401: unauthorized"
+      ].each do |msg|
+        checker = described_class.new(error_message: msg)
+        expect(checker.auth_failure?).to be(true), "Expected auth failure for: #{msg}"
+      end
+    end
+
+    it "detects proxy 503 responses" do
+      [
+        "GitCredentials proxy returned 503",
+        "GithubProxy responded with 503",
+        "proxy error 503"
+      ].each do |msg|
+        checker = described_class.new(error_message: msg)
+        expect(checker.auth_failure?).to be(true), "Expected auth failure for: #{msg}"
+      end
+    end
+
+    it "detects GithubClient authentication errors" do
+      [
+        "GithubClient::AuthenticationError: Invalid or expired GitHub token",
+        "Token is invalid or has been revoked: Bad credentials",
+        "Bad credentials",
+        "Unauthorized"
+      ].each do |msg|
+        checker = described_class.new(error_message: msg)
+        expect(checker.auth_failure?).to be(true), "Expected auth failure for: #{msg}"
+      end
+    end
+
+    it "returns false for non-auth errors" do
+      [
+        "Container crashed with exit code 1",
+        "Timeout after 300 seconds",
+        "No changes detected",
+        "Rate limit exceeded",
+        ""
+      ].each do |msg|
+        checker = described_class.new(error_message: msg)
+        expect(checker.auth_failure?).to be(false), "Expected no auth failure for: #{msg.inspect}"
+      end
+    end
+
+    it "returns false for nil error message" do
+      checker = described_class.new(error_message: nil)
+      expect(checker.auth_failure?).to be(false)
+    end
+  end
+
+  describe "#call" do
+    it "returns the matched pattern for auth errors" do
+      checker = described_class.new(error_message: "Authentication failed for repo")
+      expect(checker.call).to be_a(Regexp)
+    end
+
+    it "returns nil for non-auth errors" do
+      checker = described_class.new(error_message: "Container crashed")
+      expect(checker.call).to be_nil
+    end
+  end
+end

--- a/spec/services/github_tokens/auth_failure_checker_spec.rb
+++ b/spec/services/github_tokens/auth_failure_checker_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe GithubTokens::AuthFailureChecker do
         "Timeout after 300 seconds",
         "No changes detected",
         "Rate limit exceeded",
+        "PermissionUnauthorizedError in module",
         ""
       ].each do |msg|
         checker = described_class.new(error_message: msg)

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -113,6 +113,54 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
         .to have_enqueued_job(ProcessRunQueueJob)
     end
 
+    context "with auth failure detection" do
+      it "enqueues GithubTokenValidationJob for auth-related errors" do
+        agent_run = create(:agent_run, :running, project: project)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id, error: "Authentication failed for 'https://github.com/org/repo.git'")
+        }.to have_enqueued_job(GithubTokenValidationJob).with(project.github_token.id)
+      end
+
+      it "enqueues GithubTokenValidationJob for GithubClient::AuthenticationError" do
+        agent_run = create(:agent_run, :running, project: project)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id, error: "GithubClient::AuthenticationError: Invalid or expired GitHub token")
+        }.to have_enqueued_job(GithubTokenValidationJob).with(project.github_token.id)
+      end
+
+      it "enqueues GithubTokenValidationJob for proxy 503 errors" do
+        agent_run = create(:agent_run, :running, project: project)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id, error: "GitCredentials proxy returned 503")
+        }.to have_enqueued_job(GithubTokenValidationJob).with(project.github_token.id)
+      end
+
+      it "does not enqueue validation for non-auth errors" do
+        agent_run = create(:agent_run, :running, project: project)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id, error: "Container crashed")
+        }.not_to have_enqueued_job(GithubTokenValidationJob)
+      end
+
+      it "handles missing github_token gracefully" do
+        agent_run = create(:agent_run, :running, project: project)
+        # Simulate a project whose token was deleted after the run started
+        allow(project).to receive(:github_token).and_return(nil)
+        allow(Project).to receive(:find).and_return(project)
+        agent_run_double = agent_run
+        allow(agent_run_double).to receive(:project).and_return(project)
+        allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run_double)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id, error: "Authentication failed")
+        }.not_to have_enqueued_job(GithubTokenValidationJob)
+      end
+    end
+
     it "raises ActiveRecord::RecordNotFound for invalid agent_run_id" do
       expect {
         activity.execute(agent_run_id: -1, error: "error")

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -146,6 +146,16 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
         }.not_to have_enqueued_job(GithubTokenValidationJob)
       end
 
+      it "does not break the main flow when auth check raises" do
+        agent_run = create(:agent_run, :running, project: project)
+        allow(GithubTokens::AuthFailureChecker).to receive(:new).and_raise(StandardError, "Redis down")
+
+        result = activity.execute(agent_run_id: agent_run.id, error: "Authentication failed")
+
+        expect(result).to eq({ agent_run_id: agent_run.id })
+        expect(agent_run.reload.status).to eq("failed")
+      end
+
       it "handles missing github_token gracefully" do
         agent_run = create(:agent_run, :running, project: project)
         # Simulate a project whose token was deleted after the run started


### PR DESCRIPTION
## Summary

Commit succeeded. Here's a summary of what was implemented:

**New files:**
- `app/services/github_tokens/auth_failure_checker.rb` — Centralized service that detects auth-related errors by matching against three categories of patterns:
  - Git clone/fetch auth failures (`Authentication failed`, `HTTP 403/401`, `could not read Username`, etc.)
  - Proxy 503 responses from credential/proxy controllers
  - GithubClient errors (`AuthenticationError`, `Bad credentials`, `Unauthorized`, etc.)

- `spec/services/github_tokens/auth_failure_checker_spec.rb` — Tests covering all pattern categories and negative cases

**Modified files:**
- `app/temporal/activities/mark_agent_run_failed_activity.rb` — Added `check_auth_failure` private method that runs after marking the run as failed. If an auth pattern matches and the project has a github_token, it logs a structured `github_token.auth_failure_check` message and enqueues `GithubTokenValidationJob`.

- `spec/temporal/activities/mark_agent_run_failed_activity_spec.rb` — Added 5 tests covering: auth error detection for git/API/proxy patterns, non-auth errors being ignored, and graceful handling of missing tokens.

---

Closes #1427