### PR TITLE
Fix #1456: Simplify agent-run provider selection into a single mode selector

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -393,7 +393,26 @@ class ProvidersController < ApplicationController
       end
     end
 
+    expand_combined_provider_mode!(permitted)
+
     permitted
+  end
+
+  # Parses the combined provider_mode param into provider_selection_mode
+  # and default_agent_provider. Values are either "single:<identifier>"
+  # for a specific provider, or "round_robin"/"random" for multi-provider
+  # distribution.
+  def expand_combined_provider_mode!(permitted)
+    combined = params.dig(:user_setting, :provider_mode).to_s.strip
+    return if combined.blank?
+
+    if combined.start_with?("single:")
+      provider_identifier = combined.delete_prefix("single:")
+      permitted[:provider_selection_mode] = "single"
+      permitted[:default_agent_provider] = provider_identifier
+    elsif UserSetting::PROVIDER_SELECTION_MODES.include?(combined)
+      permitted[:provider_selection_mode] = combined
+    end
   end
 
   # Applies per-provider weight updates from form params. Each entry must

--- a/app/javascript/controllers/goal_toggle_controller.js
+++ b/app/javascript/controllers/goal_toggle_controller.js
@@ -138,6 +138,9 @@ export default class extends Controller {
   syncProviderDefault(previousGoal, goal) {
     if (!this.hasProviderSelectTarget) return
 
+    // When "Inherit" (empty value) is selected, keep it as-is across goal changes
+    if (this.providerSelectTarget.value === "") return
+
     const previousDefault = this.defaultProviderForGoal(previousGoal)
     const nextDefault = this.defaultProviderForGoal(goal)
     if (!nextDefault) return

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -133,8 +133,9 @@
           <h2 class="text-base font-semibold text-gray-900">Provider</h2>
           <div class="mt-4">
             <select name="provider" id="provider" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" data-action="change->goal-toggle#providerChanged" data-goal-toggle-target="providerSelect">
+              <option value="" selected>Inherit (from provider settings)</option>
               <% @available_run_provider_options.each do |label, identifier| %>
-                <option value="<%= identifier %>" <%= "selected" if identifier == @default_provider_identifier %>>
+                <option value="<%= identifier %>">
                   <%= label %>
                 </option>
               <% end %>

--- a/app/views/providers/_settings.html.erb
+++ b/app/views/providers/_settings.html.erb
@@ -31,33 +31,37 @@
       <% end %>
 
       <div class="space-y-6">
+        <%
+          current_mode = @user_setting.provider_selection_mode
+          combined_value = if current_mode == "single"
+            "single:#{@default_provider_identifier}"
+          else
+            current_mode
+          end
+          combined_options = @enabled_agent_providers.map do |provider|
+            [ @provider_labels[provider] || provider.titleize, "single:#{provider}" ]
+          end
+          if @enabled_agent_providers.length > 1
+            combined_options += [
+              [ "Round Robin (cycle through all providers, respecting weights)", "round_robin" ],
+              [ "Random (pick at random, respecting weights)", "random" ]
+            ]
+          end
+        %>
         <div>
-          <%= form.label :default_agent_provider, "Automated Provider", class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <label for="user_setting_provider_mode" class="block text-sm font-medium leading-6 text-gray-900">Automated Provider</label>
           <div class="mt-2">
-            <%= form.select :default_agent_provider,
-                @enabled_agent_providers.map { |provider| [ @provider_labels[provider] || provider.titleize, provider ] },
-                { selected: @default_provider_identifier },
-                class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+            <select name="user_setting[provider_mode]" id="user_setting_provider_mode"
+                    class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+              <% combined_options.each do |label, value| %>
+                <option value="<%= value %>" <%= "selected" if value == combined_value %>><%= label %></option>
+              <% end %>
+            </select>
           </div>
-          <p class="mt-1 text-xs text-gray-500">In Single mode this provider is always tried first for new agent runs.</p>
+          <p class="mt-1 text-xs text-gray-500">Choose a single provider for all automated agent runs, or distribute across all enabled providers.</p>
         </div>
 
         <% if @enabled_agent_providers.length > 1 %>
-          <div>
-            <%= form.label :provider_selection_mode, "Selection Mode", class: "block text-sm font-medium leading-6 text-gray-900" %>
-            <div class="mt-2">
-              <%= form.select :provider_selection_mode,
-                  [
-                    [ "Single (use automated provider)", "single" ],
-                    [ "Round Robin (cycle through enabled providers, respecting weights)", "round_robin" ],
-                    [ "Random (pick at random, respecting weights)", "random" ]
-                  ],
-                  { selected: @user_setting.provider_selection_mode },
-                  class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
-            </div>
-            <p class="mt-1 text-xs text-gray-500">Round Robin and Random modes pick from all providers enabled for agent runs, weighted by the values below.</p>
-          </div>
-
           <div>
             <h3 class="block text-sm font-medium leading-6 text-gray-900">Provider Weights</h3>
             <p class="mt-1 text-xs text-gray-500">A provider with weight N is picked N times more often in Random mode and used N consecutive times in Round Robin mode. Default is 1.</p>

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -759,7 +759,7 @@ RSpec.describe "AgentRuns" do
         expect(provider["data-action"]).to include("change->goal-toggle#providerChanged")
       end
 
-      it "pre-selects the goal-specific provider when goal=review" do
+      it "defaults to Inherit in the provider dropdown" do
         owner = project.created_by
         codex = owner.providers.create!(
           provider_key: "codex",
@@ -775,7 +775,8 @@ RSpec.describe "AgentRuns" do
         provider_select = doc.at_css("#provider")
         selected_option = provider_select.at_css("option[selected]")
 
-        expect(selected_option["value"]).to eq(codex.routing_key)
+        expect(selected_option["value"]).to eq("")
+        expect(selected_option.text.strip).to eq("Inherit (from provider settings)")
       end
 
       it "renders enhance_issue as a selectable goal with the issue picker active" do

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -103,16 +103,16 @@ RSpec.describe "Providers" do
         expect(response.body).not_to match(/Kimi K2\.5.*Circuit Open/m)
       end
 
-      it "renders selection mode controls only when more than one provider is enabled" do
+      it "renders multi-provider options only when more than one provider is enabled" do
         get providers_path
-        expect(response.body).not_to include("Selection Mode")
+        expect(response.body).not_to include("Round Robin")
         expect(response.body).not_to include("Provider Weights")
 
         allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[claude cursor])
         user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true)
 
         get providers_path
-        expect(response.body).to include("Selection Mode")
+        expect(response.body).to include("Round Robin")
         expect(response.body).to include("Provider Weights")
       end
 
@@ -279,13 +279,12 @@ RSpec.describe "Providers" do
       expect(user.providers.find_by(provider_key: "cursor").enabled_for_fallback).to be(true)
     end
 
-    it "persists provider_selection_mode and per-provider weights" do
+    it "persists provider_selection_mode and per-provider weights via combined provider_mode" do
       cursor = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true)
 
       patch settings_providers_path, params: {
         user_setting: {
-          default_agent_provider: "claude",
-          provider_selection_mode: "round_robin",
+          provider_mode: "round_robin",
           provider_weights: { cursor.id.to_s => "5" },
           fallback_enabled: false,
           fallback_providers: [].to_json
@@ -295,6 +294,23 @@ RSpec.describe "Providers" do
       expect(response).to redirect_to(providers_path)
       expect(user.reload.settings.provider_selection_mode).to eq("round_robin")
       expect(cursor.reload.weight).to eq(5)
+    end
+
+    it "sets single mode and default_agent_provider from combined provider_mode" do
+      cursor = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true)
+
+      patch settings_providers_path, params: {
+        user_setting: {
+          provider_mode: "single:#{cursor.routing_key}",
+          fallback_enabled: false,
+          fallback_providers: [].to_json
+        }
+      }
+
+      expect(response).to redirect_to(providers_path)
+      settings = user.reload.settings
+      expect(settings.provider_selection_mode).to eq("single")
+      expect(settings.default_agent_provider).to eq(cursor.routing_key)
     end
 
     it "rejects an invalid provider_selection_mode by ignoring the change" do
@@ -320,8 +336,7 @@ RSpec.describe "Providers" do
 
       patch settings_providers_path, params: {
         user_setting: {
-          default_agent_provider: "claude",
-          provider_selection_mode: "round_robin",
+          provider_mode: "round_robin",
           provider_weights: { cursor.id.to_s => "0" },
           fallback_enabled: false,
           fallback_providers: [].to_json


### PR DESCRIPTION
## Summary

Done. Here's a summary of the changes:

**Provider Settings UI** (`_settings.html.erb`):
- Replaced two separate dropdowns ("Automated Provider" + "Selection Mode") with a single combined "Automated Provider" selector
- Options: each enabled provider (for single-provider mode), plus "Round Robin" and "Random" (for multi-provider distribution) when >1 providers exist
- Provider Weights section still shows when multiple providers are enabled

**Controller** (`providers_controller.rb`):
- Added `expand_combined_provider_mode!` method that parses the combined `provider_mode` param (`single:<identifier>`, `round_robin`, or `random`) into the existing `provider_selection_mode` and `default_agent_provider` columns
- No database changes needed — the existing columns continue to work as before

**Trigger Agent Run form** (`new.html.erb`):
- Added "Inherit (from provider settings)" as the default selected option with empty value
- Removed per-provider pre-selection logic

**JS Controller** (`goal_toggle_controller.js`):
- When "Inherit" (empty value) is selected, skip goal-based provider syncing to keep the inherit selection stable

**Tests**: Updated 3 specs to match the new UI behavior (52 provider tests + 191 agent run tests all passing).

---

Closes #1456