### PR TITLE
feat(ux): show in-progress phase in agent run timeline

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -841,8 +841,28 @@ class AgentRun < ApplicationRecord
     }
   end
 
+  PHASE_GROUP_ORDER = %w[queue setup prompt agent post cleanup].freeze
+
   def phase_timeline
     agent_run_phases
+  end
+
+  # Infers which phase group is currently in progress based on the run's
+  # status and completed phases. Returns nil for finished runs or when
+  # the active phase cannot be determined.
+  def current_phase_group(phases: nil)
+    return nil unless status.in?(%w[queued pending running])
+
+    return "queue" if status.in?(%w[queued pending])
+
+    phases ||= phase_timeline.to_a
+    completed_groups = phases.map(&:phase_group).uniq
+    last_completed_index = PHASE_GROUP_ORDER.rindex { |g| completed_groups.include?(g) }
+
+    return "setup" unless last_completed_index
+
+    next_index = last_completed_index + 1
+    PHASE_GROUP_ORDER[next_index] if next_index < PHASE_GROUP_ORDER.size
   end
 
   def phase_summary(phases: nil)

--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -184,6 +184,7 @@
   <% phase_summary = local_assigns.fetch(:phase_summary) { agent_run.phase_summary } %>
   <% phase_timeline = local_assigns.fetch(:phase_timeline) { agent_run.phase_timeline } %>
   <% phases = phase_timeline.to_a %>
+  <% active_phase_group = agent_run.current_phase_group(phases: phases) %>
 
   <div class="mt-6 rounded-lg bg-white p-4 shadow">
     <div class="flex items-start justify-between gap-4">
@@ -196,6 +197,7 @@
       </span>
     </div>
 
+    <% completed_groups = phases.map(&:phase_group).uniq %>
     <div class="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-6">
       <% {
         "queue" => phase_summary[:queue_seconds],
@@ -205,9 +207,34 @@
         "post" => phase_summary[:post_seconds],
         "cleanup" => phase_summary[:cleanup_seconds]
       }.each do |phase_group, seconds| %>
-        <div class="rounded-lg border border-gray-200 px-3 py-3">
-          <div class="text-xs font-medium uppercase tracking-wide text-gray-500"><%= phase_group_label(phase_group) %></div>
-          <div class="mt-2 text-xl font-semibold text-gray-900"><%= format_duration(seconds) %></div>
+        <% is_active = active_phase_group == phase_group %>
+        <% is_completed = phase_group == "queue" ? phases.any? : completed_groups.include?(phase_group) %>
+        <% is_pending = !is_active && !is_completed && active_phase_group.present? %>
+        <div class="rounded-lg border px-3 py-3 <%= if is_active
+          'border-blue-400 bg-blue-50'
+        elsif is_pending
+          'border-gray-200 opacity-50'
+        else
+          'border-gray-200'
+        end %>">
+          <div class="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide <%= is_active ? 'text-blue-600' : 'text-gray-500' %>">
+            <% if is_active %>
+              <span class="relative flex h-2 w-2">
+                <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75"></span>
+                <span class="relative inline-flex h-2 w-2 rounded-full bg-blue-500"></span>
+              </span>
+            <% end %>
+            <%= phase_group_label(phase_group) %>
+          </div>
+          <div class="mt-2 text-xl font-semibold <%= is_active ? 'text-blue-900' : 'text-gray-900' %>">
+            <% if is_active %>
+              <span class="text-blue-600">In Progress</span>
+            <% elsif is_pending %>
+              &mdash;
+            <% else %>
+              <%= format_duration(seconds) %>
+            <% end %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -208,7 +208,7 @@
         "cleanup" => phase_summary[:cleanup_seconds]
       }.each do |phase_group, seconds| %>
         <% is_active = active_phase_group == phase_group %>
-        <% is_completed = phase_group == "queue" ? phases.any? : completed_groups.include?(phase_group) %>
+        <% is_completed = phase_group == "queue" ? (phases.any? || agent_run.status == "running") : completed_groups.include?(phase_group) %>
         <% is_pending = !is_active && !is_completed && active_phase_group.present? %>
         <div class="rounded-lg border px-3 py-3 <%= if is_active
           'border-blue-400 bg-blue-50'

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2645,6 +2645,51 @@ RSpec.describe AgentRun do
     end
   end
 
+  describe "#current_phase_group" do
+    it "returns 'queue' for queued runs" do
+      agent_run = create(:agent_run, status: "queued")
+      expect(agent_run.current_phase_group).to eq("queue")
+    end
+
+    it "returns 'queue' for pending runs" do
+      agent_run = create(:agent_run, status: "pending")
+      expect(agent_run.current_phase_group).to eq("queue")
+    end
+
+    it "returns 'setup' for running runs with no completed phases" do
+      agent_run = create(:agent_run, status: "running", started_at: 1.minute.ago)
+      expect(agent_run.current_phase_group).to eq("setup")
+    end
+
+    it "returns the next phase group after the last completed one" do
+      agent_run = create(:agent_run, status: "running", started_at: 5.minutes.ago)
+      setup_phase = create(:agent_run_phase, agent_run: agent_run, phase_group: "setup",
+        phase_key: "provision_container", started_at: 4.minutes.ago, finished_at: 3.minutes.ago, duration_seconds: 60)
+      prompt_phase = create(:agent_run_phase, agent_run: agent_run, phase_group: "prompt",
+        phase_key: "prepare_pr_prompt", started_at: 3.minutes.ago, finished_at: 2.minutes.ago, duration_seconds: 60)
+
+      expect(agent_run.current_phase_group(phases: [ setup_phase, prompt_phase ])).to eq("agent")
+    end
+
+    it "returns nil for completed runs" do
+      agent_run = create(:agent_run, :completed)
+      expect(agent_run.current_phase_group).to be_nil
+    end
+
+    it "returns nil for failed runs" do
+      agent_run = create(:agent_run, status: "failed", started_at: 5.minutes.ago, completed_at: Time.current, duration_seconds: 300)
+      expect(agent_run.current_phase_group).to be_nil
+    end
+
+    it "returns nil when cleanup is the last completed phase" do
+      agent_run = create(:agent_run, status: "running", started_at: 5.minutes.ago)
+      cleanup_phase = create(:agent_run_phase, agent_run: agent_run, phase_group: "cleanup",
+        phase_key: "cleanup_container", started_at: 2.minutes.ago, finished_at: 1.minute.ago, duration_seconds: 60)
+
+      expect(agent_run.current_phase_group(phases: [ cleanup_phase ])).to be_nil
+    end
+  end
+
   describe "#phase_summary" do
     def set_run_timestamps(agent_run, base_time)
       agent_run.update_columns(


### PR DESCRIPTION
## Summary

All 8 tests pass, no failures. Here's a summary of the changes:

## Summary

**3 files changed** to implement Phase 1 of issue #1490:

### `app/models/agent_run.rb`
- Added `PHASE_GROUP_ORDER` constant defining the ordered phase sequence: `queue -> setup -> prompt -> agent -> post -> cleanup`
- Added `#current_phase_group` method that infers the currently active phase without model changes:
  - Returns `"queue"` for queued/pending runs
  - Returns `"setup"` for running runs with no completed phases
  - Returns the next phase group after the last completed one for running runs with completed phases
  - Returns `nil` for finished runs or when cleanup is the last completed phase

### `app/views/agent_runs/_detail.html.erb`
- Phase cards now show three visual states:
  - **Active** (blue border, blue background, pulsing dot, "In Progress" text)
  - **Pending** (dimmed at 50% opacity, shows em-dash instead of "0.0s")
  - **Completed** (normal style, shows duration as before)

### `spec/models/agent_run_spec.rb`
- Added 7 specs covering all `#current_phase_group` scenarios (queued, pending, running with/without phases, completed, failed, cleanup-last)

---

Closes #1490