### PR TITLE
feat(agent-runs): intelligent model selection based on task complexity

### DIFF
--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -23,15 +23,15 @@ module Models
       candidates = available_candidates(tier: initial_tier)
       return nil if candidates.empty?
 
-      # When the provider has pinned a specific tier model the candidate pool is
-      # a single entry — skip the LLM round-trip and return it directly.
+      # When the candidate pool contains a single entry — whether from a provider
+      # tier pin or a global pool with one active model — skip the LLM round-trip.
       if candidates.size == 1
         only = candidates.first
         return {
           model: only,
           selector_type: "meta_agent",
           tier: initial_tier,
-          reasoning: "Single candidate from provider tier configuration; LLM selection skipped",
+          reasoning: "Single candidate in pool; LLM selection skipped",
           candidates: [ { model_id: only.model_id, score: only.capability_score.to_f } ],
           complexity_score: initial_complexity
         }

--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -23,6 +23,20 @@ module Models
       candidates = available_candidates(tier: initial_tier)
       return nil if candidates.empty?
 
+      # When the provider has pinned a specific tier model the candidate pool is
+      # a single entry — skip the LLM round-trip and return it directly.
+      if candidates.size == 1
+        only = candidates.first
+        return {
+          model: only,
+          selector_type: "meta_agent",
+          tier: initial_tier,
+          reasoning: "Single candidate from provider tier configuration; LLM selection skipped",
+          candidates: [ { model_id: only.model_id, score: only.capability_score.to_f } ],
+          complexity_score: initial_complexity
+        }
+      end
+
       response = request_selection(candidates)
       return nil unless response
 

--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -2,6 +2,8 @@
 
 module Models
   class MetaAgentSelector
+    include ProviderTierLookup
+
     MODEL = "claude-haiku-4-5-20251001"
     TIMEOUT = 15
     MAX_BODY_LENGTH = 2000
@@ -61,7 +63,7 @@ module Models
 
       # Prefer the provider's explicitly configured tier model when available
       provider_model = provider_tier_model(tier)
-      if provider_model && !(excluded.is_a?(Array) && excluded.include?(provider_model.model_id))
+      if provider_model && !excluded_model?(provider_model, excluded)
         return [ provider_model ]
       end
 
@@ -73,15 +75,6 @@ module Models
       end
 
       scope.order(Arel.sql("capability_score DESC NULLS LAST")).to_a
-    end
-
-    def provider_tier_model(tier)
-      return nil unless tier
-
-      model_id = agent_run.provider&.tier_model_ids&.dig(tier)
-      return nil if model_id.blank?
-
-      LlmModel.active.find_by(model_id: model_id)
     end
 
     def request_selection(candidates)

--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -59,6 +59,12 @@ module Models
       excluded = agent_run.project.model_preferences["excluded_model_ids"]
       scope = scope.where.not(model_id: excluded) if excluded.present?
 
+      # Prefer the provider's explicitly configured tier model when available
+      provider_model = provider_tier_model(tier)
+      if provider_model && !(excluded.is_a?(Array) && excluded.include?(provider_model.model_id))
+        return [ provider_model ]
+      end
+
       if tier
         tier_candidates = scope.by_tier(tier).order(Arel.sql("capability_score DESC NULLS LAST")).to_a
         # Fall back to the full pool when the tier is empty so the meta-agent
@@ -67,6 +73,15 @@ module Models
       end
 
       scope.order(Arel.sql("capability_score DESC NULLS LAST")).to_a
+    end
+
+    def provider_tier_model(tier)
+      return nil unless tier
+
+      model_id = agent_run.provider&.tier_model_ids&.dig(tier)
+      return nil if model_id.blank?
+
+      LlmModel.active.find_by(model_id: model_id)
     end
 
     def request_selection(candidates)

--- a/app/services/models/provider_tier_lookup.rb
+++ b/app/services/models/provider_tier_lookup.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Models
+  # Shared helpers for resolving provider-specific tier models and checking
+  # project-level model exclusions. Included by Select, RulesBasedSelector,
+  # and MetaAgentSelector to keep the logic in one place.
+  module ProviderTierLookup
+    private
+
+    def provider_tier_model(tier)
+      return nil unless tier
+
+      model_id = agent_run.provider&.tier_model_ids&.dig(tier)
+      return nil if model_id.blank?
+
+      LlmModel.active.find_by(model_id: model_id)
+    end
+
+    def excluded_model?(model, excluded)
+      excluded.is_a?(Array) && excluded.include?(model.model_id)
+    end
+  end
+end

--- a/app/services/models/rules_based_selector.rb
+++ b/app/services/models/rules_based_selector.rb
@@ -43,7 +43,10 @@ module Models
         body_length = agent_run.issue.body.to_s.length
         score += 1.0 if body_length > 500
         score += 1.0 if body_length > 1000
-        score += 1.0 if body_length > 3000
+        # Heavily-specified issues (>3000 chars) get a larger bump so the
+        # "high" tier remains reachable through rules-based selection even
+        # with the low default base (max score: 3+1+1+2+1 = 8 > mid_max).
+        score += 2.0 if body_length > 3000
       end
 
       score += 1.0 if agent_run.existing_pr?

--- a/app/services/models/rules_based_selector.rb
+++ b/app/services/models/rules_based_selector.rb
@@ -33,13 +33,15 @@ module Models
     # Public so collaborators (e.g. MetaAgentSelector) can reuse the same
     # heuristic to establish an initial tier before the LLM meta-agent runs.
     def estimate_complexity
-      score = 5.0
+      # Start low so that simple tasks default to the cheapest appropriate tier.
+      # Signals that indicate genuine complexity bump the score upward.
+      score = 3.0
 
       if agent_run.issue.present?
         body_length = agent_run.issue.body.to_s.length
+        score += 1.0 if body_length > 500
         score += 1.0 if body_length > 1000
         score += 1.0 if body_length > 3000
-        score -= 1.0 if body_length < 200
       end
 
       score += 1.0 if agent_run.existing_pr?
@@ -59,12 +61,29 @@ module Models
       excluded = agent_run.project.model_preferences["excluded_model_ids"]
       scope = scope.where.not(model_id: excluded) if excluded.present?
 
+      # Prefer the provider's explicitly configured tier model when available
+      provider_model = provider_tier_model(tier)
+      return [ provider_model ] if provider_model && !excluded_model?(provider_model, excluded)
+
       tier_candidates = tier ? tier_scope(scope, tier).to_a : []
       # Fall back to the broader pool when the tier has no active models, so a
       # missing tier mapping never leaves the system with zero candidates.
       return tier_candidates if tier_candidates.any?
 
       fallback_candidates(scope, complexity)
+    end
+
+    def provider_tier_model(tier)
+      return nil unless tier
+
+      model_id = agent_run.provider&.tier_model_ids&.dig(tier)
+      return nil if model_id.blank?
+
+      LlmModel.active.find_by(model_id: model_id)
+    end
+
+    def excluded_model?(model, excluded)
+      excluded.is_a?(Array) && excluded.include?(model.model_id)
     end
 
     def tier_scope(scope, tier)

--- a/app/services/models/rules_based_selector.rb
+++ b/app/services/models/rules_based_selector.rb
@@ -2,6 +2,8 @@
 
 module Models
   class RulesBasedSelector
+    include ProviderTierLookup
+
     def self.call(...)
       new(...).call
     end
@@ -71,19 +73,6 @@ module Models
       return tier_candidates if tier_candidates.any?
 
       fallback_candidates(scope, complexity)
-    end
-
-    def provider_tier_model(tier)
-      return nil unless tier
-
-      model_id = agent_run.provider&.tier_model_ids&.dig(tier)
-      return nil if model_id.blank?
-
-      LlmModel.active.find_by(model_id: model_id)
-    end
-
-    def excluded_model?(model, excluded)
-      excluded.is_a?(Array) && excluded.include?(model.model_id)
     end
 
     def tier_scope(scope, tier)

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -73,7 +73,7 @@ module Models
       excluded = project.model_preferences["excluded_model_ids"]
       provider_model = provider_tier_model(tier)
       provider_model = nil if provider_model && excluded_model?(provider_model, excluded)
-      model = provider_model || LlmModel.active.by_tier(tier).by_capability.first
+      model = provider_model || LlmModel.active.where.not(model_id: excluded.presence).by_tier(tier).by_capability.first
       return nil unless model
 
       {

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -72,7 +72,7 @@ module Models
 
       excluded = project.model_preferences["excluded_model_ids"]
       provider_model = provider_tier_model(tier)
-      provider_model = nil if excluded_model?(provider_model, excluded)
+      provider_model = nil if provider_model && excluded_model?(provider_model, excluded)
       model = provider_model || LlmModel.active.by_tier(tier).by_capability.first
       return nil unless model
 

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -2,6 +2,8 @@
 
 module Models
   class Select
+    include ProviderTierLookup
+
     attr_reader :agent_run
 
     def self.call(...)
@@ -68,7 +70,10 @@ module Models
       tier = QualityRecovery::ModelEscalation.target_tier(project)
       return nil unless tier
 
-      model = provider_tier_model(tier) || LlmModel.active.by_tier(tier).by_capability.first
+      excluded = project.model_preferences["excluded_model_ids"]
+      provider_model = provider_tier_model(tier)
+      provider_model = nil if excluded_model?(provider_model, excluded)
+      model = provider_model || LlmModel.active.by_tier(tier).by_capability.first
       return nil unless model
 
       {
@@ -150,13 +155,6 @@ module Models
         complexity: complexity_score,
         provider: agent_run.provider
       )
-    end
-
-    def provider_tier_model(tier)
-      model_id = agent_run.provider&.tier_model_ids&.dig(tier)
-      return nil if model_id.blank?
-
-      LlmModel.active.find_by(model_id: model_id)
     end
 
     def escalation_reason

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -68,7 +68,7 @@ module Models
       tier = QualityRecovery::ModelEscalation.target_tier(project)
       return nil unless tier
 
-      model = LlmModel.active.by_tier(tier).by_capability.first
+      model = provider_tier_model(tier) || LlmModel.active.by_tier(tier).by_capability.first
       return nil unless model
 
       {
@@ -150,6 +150,13 @@ module Models
         complexity: complexity_score,
         provider: agent_run.provider
       )
+    end
+
+    def provider_tier_model(tier)
+      model_id = agent_run.provider&.tier_model_ids&.dig(tier)
+      return nil if model_id.blank?
+
+      LlmModel.active.find_by(model_id: model_id)
     end
 
     def escalation_reason

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -73,7 +73,9 @@ module Models
       excluded = project.model_preferences["excluded_model_ids"]
       provider_model = provider_tier_model(tier)
       provider_model = nil if provider_model && excluded_model?(provider_model, excluded)
-      model = provider_model || LlmModel.active.where.not(model_id: excluded.presence).by_tier(tier).by_capability.first
+      scope = LlmModel.active.by_tier(tier).by_capability
+      scope = scope.where.not(model_id: excluded) if excluded.present?
+      model = provider_model || scope.first
       return nil unless model
 
       {

--- a/spec/services/models/meta_agent_selector_spec.rb
+++ b/spec/services/models/meta_agent_selector_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe Models::MetaAgentSelector do
       result = described_class.call(agent_run: agent_run)
 
       # Default factory issue body is short, so the rules-based estimator
-      # returns complexity ~4.0 which maps to "mid" with default thresholds
+      # returns complexity 3.0 which maps to "low" with default thresholds
       # (low_max=3, mid_max=7). The LLM's reported complexity_score (7.5) is
       # recorded separately but does NOT change the tier — keeping the tier
       # in sync with the candidate pool the LLM was actually given to choose
       # from is essential for consistent model_selection.tier analytics.
-      expect(result[:tier]).to eq("mid")
+      expect(result[:tier]).to eq("low")
       expect(result[:complexity_score]).to eq(7.5)
     end
 

--- a/spec/services/models/rules_based_selector_spec.rb
+++ b/spec/services/models/rules_based_selector_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Models::RulesBasedSelector do
 
     it "selects higher capability models for complex tasks" do
       agent_run.issue.update!(body: "A" * 5000)
+      agent_run.update!(source_pull_request_number: 99)
 
       result = described_class.call(agent_run: agent_run)
 
@@ -58,9 +59,20 @@ RSpec.describe Models::RulesBasedSelector do
         expect(result[:model]).to eq(low_model)
       end
 
+      it "routes simple tasks to the low tier by default" do
+        # Short issue body yields complexity 3.0 which lands in "low" with the
+        # default thresholds (low_max=3, mid_max=7), ensuring we default to
+        # the cheapest appropriate model.
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:tier]).to eq("low")
+        expect(result[:model]).to eq(low_model)
+      end
+
       it "routes medium tasks to the mid tier" do
-        # Short issue body yields complexity 4.0 which lands in "mid" with the
-        # default thresholds (low_max=3, mid_max=7).
+        # body > 1000 bumps complexity to 5.0 which lands in "mid"
+        agent_run.issue.update!(body: "A" * 1500)
+
         result = described_class.call(agent_run: agent_run)
 
         expect(result[:tier]).to eq("mid")
@@ -68,8 +80,13 @@ RSpec.describe Models::RulesBasedSelector do
       end
 
       it "routes complex tasks to the high tier" do
+        # body > 3000 + existing_pr → complexity 3+1+1+1+1 = 7.0
+        # Lower mid_max so 7.0 > 6 routes to "high"
         agent_run.issue.update!(body: "A" * 5000)
         agent_run.update!(source_pull_request_number: 99)
+        agent_run.project.update!(
+          model_preferences: { "complexity_thresholds" => { "low_max" => 3, "mid_max" => 6 } }
+        )
 
         result = described_class.call(agent_run: agent_run)
 
@@ -79,21 +96,23 @@ RSpec.describe Models::RulesBasedSelector do
 
       it "respects project excluded_model_ids even within a tier" do
         agent_run.project.update!(
-          model_preferences: { "excluded_model_ids" => [ mid_model.model_id ] }
+          model_preferences: { "excluded_model_ids" => [ low_model.model_id ] }
         )
-        # Default complexity is 5.0 => mid tier. Excluding mid_model should
+        # Default complexity is 3.0 => low tier. Excluding low_model should
         # yield zero tier candidates, so the fallback pool is used instead.
         result = described_class.call(agent_run: agent_run)
 
-        expect(result[:model]).not_to eq(mid_model)
+        expect(result[:model]).not_to eq(low_model)
       end
 
       it "honors project-level threshold overrides" do
+        # body > 1000 gives complexity 5.0 which is "mid" with defaults, but
+        # with low_max=6 it falls into "low".
+        agent_run.issue.update!(body: "A" * 1500)
         agent_run.project.update!(
           model_preferences: { "complexity_thresholds" => { "low_max" => 6, "mid_max" => 8 } }
         )
-        # Complexity 4.0 (short body) now falls into the "low" tier with
-        # low_max=6.
+
         result = described_class.call(agent_run: agent_run)
 
         expect(result[:tier]).to eq("low")
@@ -102,12 +121,12 @@ RSpec.describe Models::RulesBasedSelector do
 
       it "honors provider-level threshold overrides on the agent run" do
         provider = create(:provider, user: agent_run.project.effective_owner)
-        provider.update!(complexity_thresholds: { "low_max" => 3, "mid_max" => 9 })
+        provider.update!(complexity_thresholds: { "low_max" => 2, "mid_max" => 9 })
         agent_run.update!(provider: provider)
+        # Give enough body to bump complexity above low_max=2
+        agent_run.issue.update!(body: "A" * 600)
 
-        # Complexity 4.0 (short body) → above low_max=3, below mid_max=9 →
-        # "mid". With default thresholds (mid_max=7) this would also be "mid",
-        # so the next update below proves thresholds are actually used.
+        # Complexity 4.0 (body > 500) → above low_max=2, below mid_max=9 → "mid"
         result = described_class.call(agent_run: agent_run)
 
         expect(result[:tier]).to eq("mid")
@@ -128,12 +147,60 @@ RSpec.describe Models::RulesBasedSelector do
         high_model.update!(active: false)
         agent_run.issue.update!(body: "A" * 5000)
         agent_run.update!(source_pull_request_number: 99)
+        # Lower mid_max so complexity 7.0 routes to "high"
+        agent_run.project.update!(
+          model_preferences: { "complexity_thresholds" => { "low_max" => 3, "mid_max" => 6 } }
+        )
 
         result = described_class.call(agent_run: agent_run)
 
         expect(result).to be_present
         expect(result[:tier]).to eq("high")
         expect(result[:model]).to eq(untiered_high)
+      end
+    end
+
+    describe "provider tier_model_ids routing" do
+      let!(:low_model)  { create(:llm_model, :cheap, model_id: "tier-low", tier: "low",  capability_score: 4.0) }
+      let!(:mid_model)  { create(:llm_model,         model_id: "tier-mid", tier: "mid",  capability_score: 7.0) }
+      let!(:custom_low) { create(:llm_model, :cheap, model_id: "custom-low", tier: "low", capability_score: 3.5) }
+
+      before do
+        LlmModel.where.not(id: [ low_model.id, mid_model.id, custom_low.id ]).destroy_all
+      end
+
+      it "prefers the provider's configured tier model over the global pool" do
+        provider = create(:provider, user: agent_run.project.effective_owner,
+          tier_model_ids: { "low" => custom_low.model_id })
+        agent_run.update!(provider: provider)
+
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:model]).to eq(custom_low)
+      end
+
+      it "falls back to global pool when provider tier model is inactive" do
+        custom_low.update!(active: false)
+        provider = create(:provider, user: agent_run.project.effective_owner,
+          tier_model_ids: { "low" => custom_low.model_id })
+        agent_run.update!(provider: provider)
+
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:model]).to eq(low_model)
+      end
+
+      it "respects excluded_model_ids even for provider tier models" do
+        provider = create(:provider, user: agent_run.project.effective_owner,
+          tier_model_ids: { "low" => custom_low.model_id })
+        agent_run.update!(provider: provider)
+        agent_run.project.update!(
+          model_preferences: { "excluded_model_ids" => [ custom_low.model_id ] }
+        )
+
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:model]).not_to eq(custom_low)
       end
     end
   end

--- a/spec/services/models/rules_based_selector_spec.rb
+++ b/spec/services/models/rules_based_selector_spec.rb
@@ -80,13 +80,9 @@ RSpec.describe Models::RulesBasedSelector do
       end
 
       it "routes complex tasks to the high tier" do
-        # body > 3000 + existing_pr → complexity 3+1+1+1+1 = 7.0
-        # Lower mid_max so 7.0 > 6 routes to "high"
+        # body > 3000 + existing_pr → complexity 3+1+1+2+1 = 8.0 > mid_max(7)
         agent_run.issue.update!(body: "A" * 5000)
         agent_run.update!(source_pull_request_number: 99)
-        agent_run.project.update!(
-          model_preferences: { "complexity_thresholds" => { "low_max" => 3, "mid_max" => 6 } }
-        )
 
         result = described_class.call(agent_run: agent_run)
 
@@ -145,12 +141,9 @@ RSpec.describe Models::RulesBasedSelector do
         # the floor when high-tier candidates are exhausted.
         untiered_high = create(:llm_model, model_id: "untiered-high", capability_score: 9.0)
         high_model.update!(active: false)
+        # body > 3000 + existing_pr → complexity 8.0 > mid_max(7) → "high"
         agent_run.issue.update!(body: "A" * 5000)
         agent_run.update!(source_pull_request_number: 99)
-        # Lower mid_max so complexity 7.0 routes to "high"
-        agent_run.project.update!(
-          model_preferences: { "complexity_thresholds" => { "low_max" => 3, "mid_max" => 6 } }
-        )
 
         result = described_class.call(agent_run: agent_run)
 

--- a/spec/services/quality_recovery/model_escalation_spec.rb
+++ b/spec/services/quality_recovery/model_escalation_spec.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QualityRecovery::ModelEscalation do
+  let(:project) { create(:project) }
+  let(:agent_run) { create(:agent_run, project: project) }
+  let!(:mid_model) { create(:llm_model, model_id: "mid-model", tier: "mid", capability_score: 7.0) }
+  let!(:high_model) { create(:llm_model, model_id: "high-model", tier: "high", capability_score: 9.5) }
+
+  let(:threshold_obj) { Struct.new(:min_value).new(0.5) }
+  let(:breach) { { average: 0.35, threshold: threshold_obj } }
+
+  describe ".start" do
+    context "when no escalation is active" do
+      before do
+        create(:model_selection, agent_run: agent_run, tier: "mid", llm_model: mid_model)
+      end
+
+      it "starts escalation and records the action" do
+        result = described_class.start(project: project, agent_run: agent_run, breach: breach)
+
+        expect(result).to be_started
+        expect(result).to be_defer_pause
+        expect(result.state["status"]).to eq("active")
+        expect(result.state["from_tier"]).to eq("mid")
+        expect(result.state["to_tier"]).to eq("high")
+      end
+
+      it "persists escalation state in project model_preferences" do
+        described_class.start(project: project, agent_run: agent_run, breach: breach)
+
+        project.reload
+        state = project.model_preferences["quality_triggered_escalation"]
+        expect(state["status"]).to eq("active")
+        expect(state["trigger"]).to eq("quality_drop")
+      end
+
+      it "creates a quality recovery action record" do
+        expect {
+          described_class.start(project: project, agent_run: agent_run, breach: breach)
+        }.to change(QualityRecoveryAction, :count).by(1)
+      end
+    end
+
+    context "when escalation is already active" do
+      before do
+        project.update!(model_preferences: {
+          "quality_triggered_escalation" => {
+            "status" => "active",
+            "from_tier" => "mid",
+            "to_tier" => "high"
+          }
+        })
+      end
+
+      it "does not start a new escalation" do
+        result = described_class.start(project: project, agent_run: agent_run, breach: breach)
+
+        expect(result).not_to be_started
+        expect(result.reason).to eq("already_active")
+      end
+    end
+
+    context "when already at the highest tier" do
+      before do
+        create(:model_selection, agent_run: agent_run, tier: "high", llm_model: high_model)
+      end
+
+      it "does not start escalation (no higher tier available)" do
+        result = described_class.start(project: project, agent_run: agent_run, breach: breach)
+
+        expect(result).not_to be_started
+        expect(result.reason).to eq("no_higher_tier")
+        expect(result).to be_pause
+      end
+    end
+
+    context "when escalation was previously exhausted" do
+      before do
+        project.update!(model_preferences: {
+          "quality_triggered_escalation" => { "status" => "exhausted" }
+        })
+      end
+
+      it "does not restart escalation" do
+        result = described_class.start(project: project, agent_run: agent_run, breach: breach)
+
+        expect(result).not_to be_started
+        expect(result.reason).to eq("quality_recovery_exhausted")
+        expect(result).to be_pause
+      end
+    end
+  end
+
+  describe ".active?" do
+    it "returns true when status is active" do
+      project.update!(model_preferences: {
+        "quality_triggered_escalation" => { "status" => "active" }
+      })
+
+      expect(described_class.active?(project)).to be true
+    end
+
+    it "returns true when prompt_evolution_requested" do
+      project.update!(model_preferences: {
+        "quality_triggered_escalation" => { "status" => "prompt_evolution_requested" }
+      })
+
+      expect(described_class.active?(project)).to be true
+    end
+
+    it "returns false when exhausted" do
+      project.update!(model_preferences: {
+        "quality_triggered_escalation" => { "status" => "exhausted" }
+      })
+
+      expect(described_class.active?(project)).to be false
+    end
+
+    it "returns false when no escalation state exists" do
+      expect(described_class.active?(project)).to be false
+    end
+  end
+
+  describe ".target_tier" do
+    it "returns the to_tier when escalation is active" do
+      project.update!(model_preferences: {
+        "quality_triggered_escalation" => {
+          "status" => "active",
+          "to_tier" => "high"
+        }
+      })
+
+      expect(described_class.target_tier(project)).to eq("high")
+    end
+
+    it "returns nil when escalation is not active" do
+      expect(described_class.target_tier(project)).to be_nil
+    end
+  end
+
+  describe ".evaluate" do
+    let(:escalation_started_at) { 1.hour.ago.iso8601 }
+
+    context "when escalation is active with sufficient passing samples" do
+      before do
+        project.update!(model_preferences: {
+          "quality_triggered_escalation" => {
+            "status" => "active",
+            "goal" => agent_run.goal,
+            "from_tier" => "mid",
+            "to_tier" => "high",
+            "started_at" => escalation_started_at,
+            "threshold" => 0.5,
+            "evaluation_window" => 3
+          }
+        })
+
+        3.times do
+          run = create(:agent_run, project: project, goal: agent_run.goal)
+          create(:model_selection, agent_run: run, selector_type: "quality_escalation", tier: "high", llm_model: high_model)
+          create(:quality_metric, agent_run: run, composite_score: 0.8)
+        end
+      end
+
+      it "recovers when escalated runs meet the threshold" do
+        result = described_class.evaluate(project: project, agent_run: agent_run)
+
+        expect(result.reason).to eq("model_escalation_recovered")
+        project.reload
+        expect(project.model_preferences.dig("quality_triggered_escalation", "status")).to eq("recovered")
+      end
+    end
+
+    context "when escalation is active with insufficient samples" do
+      before do
+        project.update!(model_preferences: {
+          "quality_triggered_escalation" => {
+            "status" => "active",
+            "goal" => agent_run.goal,
+            "from_tier" => "mid",
+            "to_tier" => "high",
+            "started_at" => escalation_started_at,
+            "threshold" => 0.5,
+            "evaluation_window" => 3
+          }
+        })
+
+        run = create(:agent_run, project: project, goal: agent_run.goal)
+        create(:model_selection, agent_run: run, selector_type: "quality_escalation", tier: "high", llm_model: high_model)
+        create(:quality_metric, agent_run: run, composite_score: 0.8)
+      end
+
+      it "keeps escalation active while waiting for more samples" do
+        result = described_class.evaluate(project: project, agent_run: agent_run)
+
+        expect(result.reason).to eq("model_escalation_active")
+        expect(result).to be_defer_pause
+      end
+    end
+
+    context "when escalation is active but quality still fails" do
+      before do
+        project.update!(model_preferences: {
+          "quality_triggered_escalation" => {
+            "status" => "active",
+            "goal" => agent_run.goal,
+            "from_tier" => "mid",
+            "to_tier" => "high",
+            "started_at" => escalation_started_at,
+            "threshold" => 0.5,
+            "evaluation_window" => 3,
+            "prompt_id" => 999
+          }
+        })
+
+        3.times do
+          run = create(:agent_run, project: project, goal: agent_run.goal)
+          create(:model_selection, agent_run: run, selector_type: "quality_escalation", tier: "high", llm_model: high_model)
+          create(:quality_metric, agent_run: run, composite_score: 0.3)
+        end
+      end
+
+      it "requests prompt evolution" do
+        result = described_class.evaluate(project: project, agent_run: agent_run)
+
+        expect(result.reason).to eq("prompt_evolution_requested")
+        project.reload
+        expect(project.model_preferences.dig("quality_triggered_escalation", "status")).to eq("prompt_evolution_requested")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

All done. Here's a summary of what was implemented:

## Changes Made

### Problem
The model selection system had infrastructure for per-provider tier configurations (UI, validation, storage) but the actual selection logic never consulted those configurations. Additionally, the default complexity bias of 5.0 meant most runs defaulted to the "mid" tier, not the cheapest appropriate tier.

### Solution

**1. Wired provider `tier_model_ids` into the selection pipeline** (`rules_based_selector.rb`, `meta_agent_selector.rb`, `select.rb`)
- Both `RulesBasedSelector` and `MetaAgentSelector` now check the provider's `tier_model_ids` mapping before falling back to the global `LlmModel` pool
- Quality escalation in `Models::Select` also respects provider tier mappings
- Provider-configured models are skipped if they're inactive or in the project's exclusion list

**2. Lowered default complexity bias from 5.0 to 3.0** (`rules_based_selector.rb`)
- Agent runs now default to the cheapest appropriate model tier (acceptance criterion #1)
- Added a new complexity signal for medium-length issue bodies (>500 chars)
- Removed the penalty for very short bodies (starting low is sufficient)

**3. Added `QualityRecovery::ModelEscalation` spec** (new file)
- 15 examples covering `start`, `evaluate`, `active?`, and `target_tier` lifecycle
- Tests escalation start, already-active guard, highest-tier guard, exhausted guard
- Tests recovery on passing quality, insufficient samples, and prompt evolution fallback

**4. Updated existing specs** for the new complexity behavior
- All 207 related specs pass (100 model selection + 107 model/provider specs)
- Only pre-existing failures remain (database role guard, unrelated to changes)

---

Closes #760