### PR TITLE
refactor(agent-image): delegate Kilocode CLI installation to agent-harness

### DIFF
--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -121,6 +121,19 @@ jobs:
           fi
           echo "package=$package" >> "$GITHUB_OUTPUT"
 
+      - name: Extract Kilocode CLI install contract from agent-harness
+        id: kilocode-contract
+        run: |
+          contract=$(bundle exec ruby scripts/extract-provider-install-contract.rb kilocode)
+          install_command=$(echo "$contract" | sed -n 's/^INSTALL_COMMAND=//p')
+          if [ -z "$install_command" ]; then
+            echo "Failed to extract Kilocode CLI install command from agent-harness" >&2
+            exit 1
+          fi
+          echo "install_command<<PAID_EOF" >> "$GITHUB_OUTPUT"
+          echo "$install_command" >> "$GITHUB_OUTPUT"
+          echo "PAID_EOF" >> "$GITHUB_OUTPUT"
+
       - name: Extract Gemini CLI install contract from agent-harness
         id: gemini-contract
         run: |
@@ -151,6 +164,7 @@ jobs:
             CURSOR_BINARY_NAME=${{ steps.cursor-contract.outputs.binary_name }}
             CURSOR_GLOBAL_PATH=${{ steps.cursor-contract.outputs.global_path }}
             CODEX_PACKAGE=${{ steps.codex-contract.outputs.package }}
+            KILOCODE_INSTALL_COMMAND=${{ steps.kilocode-contract.outputs.install_command }}
             GEMINI_CLI_INSTALL_COMMAND=${{ steps.gemini-contract.outputs.install_command }}
           cache-from: type=gha,scope=paid-agent
           cache-to: type=gha,mode=max,scope=paid-agent

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -185,7 +185,22 @@ RUN if [ -z "${GEMINI_CLI_INSTALL_COMMAND}" ]; then \
     && echo "Installing Gemini CLI via agent-harness contract: ${GEMINI_CLI_INSTALL_COMMAND}" \
     && eval "${GEMINI_CLI_INSTALL_COMMAND}"
 
-RUN npm install -g --ignore-scripts @kilocode/cli@7.1.3
+# Kilocode CLI: version is owned by agent-harness (installation_contract).
+# KILOCODE_INSTALL_COMMAND is extracted from agent-harness at build time by
+# build-agent-image.sh / agent-image.yml — Paid no longer pins this version.
+# Supply-chain hardening: enforce --ignore-scripts regardless of what the
+# contract returns, matching the policy applied to every other npm install above.
+ARG KILOCODE_INSTALL_COMMAND
+RUN if [ -z "${KILOCODE_INSTALL_COMMAND}" ]; then \
+        echo "ERROR: KILOCODE_INSTALL_COMMAND not set; aborting build" >&2; \
+        exit 1; \
+    fi \
+    && case "${KILOCODE_INSTALL_COMMAND}" in \
+        *--ignore-scripts*) ;; \
+        *) echo "ERROR: KILOCODE_INSTALL_COMMAND must include --ignore-scripts for supply-chain safety" >&2; exit 1 ;; \
+    esac \
+    && echo "Installing Kilocode CLI via agent-harness contract: ${KILOCODE_INSTALL_COMMAND}" \
+    && eval "${KILOCODE_INSTALL_COMMAND}"
 
 # NOTE: End-to-end execution depends on agent-harness build_command support (agent-harness#32).
 RUN npm install -g --ignore-scripts opencode-ai@1.3.2

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -92,6 +92,15 @@ if [ -z "${CODEX_PACKAGE}" ]; then
     exit 1
 fi
 
+# Extract Kilocode CLI install command from agent-harness (single source of truth).
+KILOCODE_CONTRACT=$(bundle exec ruby "${PROJECT_ROOT}/scripts/extract-provider-install-contract.rb" kilocode)
+KILOCODE_INSTALL_COMMAND=$(echo "${KILOCODE_CONTRACT}" | sed -n 's/^INSTALL_COMMAND=//p')
+
+if [ -z "${KILOCODE_INSTALL_COMMAND}" ]; then
+    echo "ERROR: Could not extract Kilocode CLI install command from agent-harness" >&2
+    exit 1
+fi
+
 # Extract Gemini CLI install command from agent-harness (single source of truth).
 GEMINI_CONTRACT=$(bundle exec ruby "${PROJECT_ROOT}/scripts/extract-provider-install-contract.rb" gemini)
 GEMINI_CLI_INSTALL_COMMAND=$(echo "${GEMINI_CONTRACT}" | sed -n 's/^INSTALL_COMMAND=//p')
@@ -108,6 +117,7 @@ echo "  ruby-maat: ${RUBY_MAAT_VERSION}"
 echo "  claude-install: via agent-harness contract"
 echo "  cursor-install: via agent-harness contract"
 echo "  codex: ${CODEX_PACKAGE}"
+echo "  kilocode-cli: ${KILOCODE_INSTALL_COMMAND}"
 echo "  gemini-cli: ${GEMINI_CLI_INSTALL_COMMAND}"
 
 "${DOCKER_BUILD_ENV[@]}" docker build \
@@ -121,6 +131,7 @@ echo "  gemini-cli: ${GEMINI_CLI_INSTALL_COMMAND}"
     --build-arg "CURSOR_BINARY_NAME=${CURSOR_BINARY_NAME}" \
     --build-arg "CURSOR_GLOBAL_PATH=${CURSOR_GLOBAL_PATH}" \
     --build-arg "CODEX_PACKAGE=${CODEX_PACKAGE}" \
+    --build-arg "KILOCODE_INSTALL_COMMAND=${KILOCODE_INSTALL_COMMAND}" \
     --build-arg "GEMINI_CLI_INSTALL_COMMAND=${GEMINI_CLI_INSTALL_COMMAND}" \
     "${PROJECT_ROOT}/docker/agent/"
 

--- a/scripts/extract-provider-install-contract.rb
+++ b/scripts/extract-provider-install-contract.rb
@@ -65,12 +65,16 @@ end
 # Support all contract shapes:
 # - Shell-based (Claude): {install: {command:, post_install_binary_path:}, supported_versions: {default:}}
 # - npm-based (Codex):    {source: :npm, package:, install_command: [...], version:}
+# - npm-nested (Kilocode): {source: {type: :npm, package:}, install_command: [...], default_version:}
 # - Flat (Gemini):        {install_command_string:, default_version:}
-if contract[:source] == :npm
+source = contract[:source]
+is_npm = source == :npm || (source.is_a?(Hash) && source[:type] == :npm)
+if is_npm
+  package = contract[:package] || (source.is_a?(Hash) && source[:package])
   puts "SOURCE=npm"
-  puts "PACKAGE=#{contract[:package]}"
+  puts "PACKAGE=#{package}"
   puts "INSTALL_COMMAND=#{contract[:install_command]&.join(" ")}"
-  puts "SUPPORTED_VERSION=#{contract[:version]}"
+  puts "SUPPORTED_VERSION=#{contract[:version] || contract[:default_version]}"
 else
   install_command = contract.dig(:install, :command) || contract[:install_command_string]
   post_install_path = contract.dig(:install, :post_install_binary_path)


### PR DESCRIPTION
## Summary

Commit succeeded. All pre-commit checks passed. Here's a summary of the changes:

**Files changed:**

1. **`docker/agent/Dockerfile`** — Replaced hardcoded `npm install -g --ignore-scripts @kilocode/cli@7.1.3` with a `KILOCODE_INSTALL_COMMAND` build-arg pattern (matching Gemini's approach), including `--ignore-scripts` supply-chain enforcement.

2. **`scripts/build-agent-image.sh`** — Added extraction of Kilocode CLI install command from agent-harness via the existing `extract-provider-install-contract.rb` script, passing it as a Docker build-arg.

3. **`.github/workflows/agent-image.yml`** — Added a CI step to extract the Kilocode install contract and pass `KILOCODE_INSTALL_COMMAND` as a build-arg to the Docker build.

4. **`scripts/extract-provider-install-contract.rb`** — Extended the npm source detection to handle the nested hash shape `{source: {type: :npm, package:}}` that Kilocode's `installation_contract` returns (vs Codex's flat `{source: :npm}`). Also handles `default_version` fallback.

---

Closes #791