### PR TITLE
feat(knowledge): add KnowledgeRecommendation model and knowledge_evolution_enabled project setting

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -275,6 +275,7 @@ class ProjectsController < ApplicationController
       :auto_add_labels_enabled, :automation_on_label_enabled, :pr_aggregation_enabled,
       :inherit_priority_labels,
       :auto_enhance_enabled,
+      :knowledge_evolution_enabled,
       :auto_release_granularity,
       allowed_github_usernames: [],
       priority_labels: Project::PRIORITY_TIERS)

--- a/app/models/knowledge_recommendation.rb
+++ b/app/models/knowledge_recommendation.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class KnowledgeRecommendation < ApplicationRecord
+  belongs_to :project
+
+  RECOMMENDATION_TYPES = %w[add_collector remove_collector improve_collector knowledge_gap].freeze
+  PRIORITIES = %w[low medium high critical].freeze
+  STATUSES = %w[pending accepted dismissed implemented].freeze
+
+  validates :recommendation_type, presence: true, inclusion: { in: RECOMMENDATION_TYPES }
+  validates :priority, presence: true, inclusion: { in: PRIORITIES }
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :description, presence: true
+
+  scope :pending, -> { where(status: "pending") }
+  scope :accepted, -> { where(status: "accepted") }
+  scope :by_priority, -> { in_order_of(:priority, PRIORITIES) }
+
+  def dismiss!(reason:)
+    update!(status: "dismissed", dismissed_at: Time.current, dismissal_reason: reason)
+  end
+
+  def accept!
+    update!(status: "accepted")
+  end
+end

--- a/app/models/knowledge_recommendation.rb
+++ b/app/models/knowledge_recommendation.rb
@@ -14,7 +14,7 @@ class KnowledgeRecommendation < ApplicationRecord
 
   scope :pending, -> { where(status: "pending") }
   scope :accepted, -> { where(status: "accepted") }
-  scope :by_priority, -> { in_order_of(:priority, PRIORITIES) }
+  scope :by_priority, -> { in_order_of(:priority, PRIORITIES.reverse) }
 
   def dismiss!(reason:)
     update!(status: "dismissed", dismissed_at: Time.current, dismissal_reason: reason)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -88,7 +88,9 @@ class Project < ApplicationRecord
     { label: "Inherit Priority Labels", attribute: :inherit_priority_labels,
      description: "When Paid creates a PR for an issue, copy any user-defined priority labels (P1/P2/P3) from the issue onto the new PR." }.freeze,
     { label: "Auto-enhance before PR", attribute: :auto_enhance_enabled,
-     description: "Analyze issue context readiness before auto-pick creates a PR run" }.freeze
+     description: "Analyze issue context readiness before auto-pick creates a PR run" }.freeze,
+    { label: "Knowledge evolution", attribute: :knowledge_evolution_enabled,
+     description: "Weekly analysis of knowledge gaps and collector effectiveness" }.freeze
   ].freeze
 
   AUTO_MERGE_MODE_OPTIONS = [
@@ -145,6 +147,7 @@ class Project < ApplicationRecord
   has_many :context_intake_sessions, dependent: :destroy
   has_one :tracker_configuration, as: :configurable, dependent: :destroy
   has_many :quality_pause_events, dependent: :destroy
+  has_many :knowledge_recommendations, dependent: :destroy
 
   encrypts :webhook_secret
 

--- a/db/migrate/20260427223003_create_knowledge_recommendations.rb
+++ b/db/migrate/20260427223003_create_knowledge_recommendations.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateKnowledgeRecommendations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :knowledge_recommendations do |t|
+      t.references :project, null: false, foreign_key: { on_delete: :cascade }, index: true
+      t.string :recommendation_type, null: false, limit: 50
+      t.string :collector_type, limit: 100
+      t.string :priority, default: "medium", null: false, limit: 20
+      t.text :description
+      t.jsonb :evidence, default: {}, null: false
+      t.string :status, default: "pending", null: false, limit: 20
+      t.datetime :dismissed_at
+      t.text :dismissal_reason
+      t.timestamps
+    end
+
+    add_index :knowledge_recommendations, [ :project_id, :status ]
+    add_index :knowledge_recommendations, [ :project_id, :recommendation_type ]
+  end
+end

--- a/db/migrate/20260427223009_add_knowledge_evolution_enabled_to_projects.rb
+++ b/db/migrate/20260427223009_add_knowledge_evolution_enabled_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddKnowledgeEvolutionEnabledToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :knowledge_evolution_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260427225726_enable_rls_on_knowledge_recommendations.rb
+++ b/db/migrate/20260427225726_enable_rls_on_knowledge_recommendations.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class EnableRlsOnKnowledgeRecommendations < ActiveRecord::Migration[8.1]
+  def up
+    execute "ALTER TABLE knowledge_recommendations ENABLE ROW LEVEL SECURITY"
+    execute "ALTER TABLE knowledge_recommendations FORCE ROW LEVEL SECURITY"
+    execute <<~SQL
+      CREATE POLICY tenant_isolation ON knowledge_recommendations
+      AS PERMISSIVE
+      FOR ALL
+      USING (
+        paid_tenant_bypass() OR (
+          EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = knowledge_recommendations.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        )
+      )
+      WITH CHECK (
+        paid_tenant_bypass() OR (
+          EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = knowledge_recommendations.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        )
+      )
+    SQL
+  end
+
+  def down
+    execute "DROP POLICY IF EXISTS tenant_isolation ON knowledge_recommendations"
+    execute "ALTER TABLE knowledge_recommendations NO FORCE ROW LEVEL SECURITY"
+    execute "ALTER TABLE knowledge_recommendations DISABLE ROW LEVEL SECURITY"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1568,7 +1568,8 @@ CREATE TABLE public.issues (
     operational_failure_reset_at timestamp(6) without time zone,
     ci_action_dispatched_at timestamp(6) without time zone,
     deployed_at timestamp(6) without time zone,
-    enhance_issue_rounds integer DEFAULT 0 NOT NULL
+    enhance_issue_rounds integer DEFAULT 0 NOT NULL,
+    ci_retry_requested_at timestamp(6) without time zone
 );
 
 ALTER TABLE ONLY public.issues FORCE ROW LEVEL SECURITY;
@@ -1731,6 +1732,45 @@ CREATE SEQUENCE public.knowledge_links_id_seq
 --
 
 ALTER SEQUENCE public.knowledge_links_id_seq OWNED BY public.knowledge_links.id;
+
+
+--
+-- Name: knowledge_recommendations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.knowledge_recommendations (
+    id bigint NOT NULL,
+    project_id bigint NOT NULL,
+    recommendation_type character varying(50) NOT NULL,
+    collector_type character varying(100),
+    priority character varying(20) DEFAULT 'medium'::character varying NOT NULL,
+    description text,
+    evidence jsonb DEFAULT '{}'::jsonb NOT NULL,
+    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
+    dismissed_at timestamp(6) without time zone,
+    dismissal_reason text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: knowledge_recommendations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.knowledge_recommendations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: knowledge_recommendations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.knowledge_recommendations_id_seq OWNED BY public.knowledge_recommendations.id;
 
 
 --
@@ -1922,8 +1962,6 @@ CREATE TABLE public.llm_output_metrics (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
-
-ALTER TABLE ONLY public.llm_output_metrics ENABLE ROW LEVEL SECURITY;
 
 ALTER TABLE ONLY public.llm_output_metrics FORCE ROW LEVEL SECURITY;
 
@@ -2486,7 +2524,8 @@ CREATE TABLE public.projects (
     max_enhance_issue_reevaluation_rounds integer DEFAULT 3 NOT NULL,
     auto_enhance_enabled boolean DEFAULT false NOT NULL,
     scheduler_paused_at timestamp(6) without time zone,
-    scheduler_pause_reason character varying
+    scheduler_pause_reason character varying,
+    knowledge_evolution_enabled boolean DEFAULT false NOT NULL
 );
 
 ALTER TABLE ONLY public.projects FORCE ROW LEVEL SECURITY;
@@ -3684,6 +3723,13 @@ ALTER TABLE ONLY public.knowledge_links ALTER COLUMN id SET DEFAULT nextval('pub
 
 
 --
+-- Name: knowledge_recommendations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.knowledge_recommendations ALTER COLUMN id SET DEFAULT nextval('public.knowledge_recommendations_id_seq'::regclass);
+
+
+--
 -- Name: knowledge_runs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4309,6 +4355,14 @@ ALTER TABLE ONLY public.knowledge_links
 
 
 --
+-- Name: knowledge_recommendations knowledge_recommendations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.knowledge_recommendations
+    ADD CONSTRAINT knowledge_recommendations_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: knowledge_runs knowledge_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4783,6 +4837,27 @@ CREATE UNIQUE INDEX idx_knowledge_usage_stats_unique ON public.knowledge_usage_s
 
 
 --
+-- Name: idx_llm_output_metrics_project_type_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_llm_output_metrics_project_type_time ON public.llm_output_metrics USING btree (project_id, output_type, created_at);
+
+
+--
+-- Name: idx_llm_output_metrics_slug_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_llm_output_metrics_slug_version ON public.llm_output_metrics USING btree (prompt_slug, prompt_version_id);
+
+
+--
+-- Name: idx_llm_output_metrics_unique_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_llm_output_metrics_unique_source ON public.llm_output_metrics USING btree (project_id, output_type, source_type, source_id);
+
+
+--
 -- Name: idx_on_account_id_config_key_status_a42f39cd2a; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4815,6 +4890,13 @@ CREATE INDEX idx_on_configuration_experiment_id_6532d1a5ed ON public.configurati
 --
 
 CREATE INDEX idx_on_configuration_experiment_variant_id_9de5ff7df6 ON public.configuration_experiment_assignments USING btree (configuration_experiment_variant_id);
+
+
+--
+-- Name: idx_on_project_id_recommendation_type_333faaed2e; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_project_id_recommendation_type_333faaed2e ON public.knowledge_recommendations USING btree (project_id, recommendation_type);
 
 
 --
@@ -6148,6 +6230,20 @@ CREATE INDEX index_knowledge_links_on_target_chunk_id ON public.knowledge_links 
 
 
 --
+-- Name: index_knowledge_recommendations_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_knowledge_recommendations_on_project_id ON public.knowledge_recommendations USING btree (project_id);
+
+
+--
+-- Name: index_knowledge_recommendations_on_project_id_and_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_knowledge_recommendations_on_project_id_and_status ON public.knowledge_recommendations USING btree (project_id, status);
+
+
+--
 -- Name: index_knowledge_runs_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6264,27 +6360,6 @@ CREATE INDEX index_llm_models_on_provider_and_active ON public.llm_models USING 
 --
 
 CREATE INDEX index_llm_models_on_tier ON public.llm_models USING btree (tier);
-
-
---
--- Name: idx_llm_output_metrics_project_type_time; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_llm_output_metrics_project_type_time ON public.llm_output_metrics USING btree (project_id, output_type, created_at);
-
-
---
--- Name: idx_llm_output_metrics_slug_version; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_llm_output_metrics_slug_version ON public.llm_output_metrics USING btree (prompt_slug, prompt_version_id);
-
-
---
--- Name: idx_llm_output_metrics_unique_source; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX idx_llm_output_metrics_unique_source ON public.llm_output_metrics USING btree (project_id, output_type, source_type, source_id);
 
 
 --
@@ -8103,6 +8178,14 @@ ALTER TABLE ONLY public.agent_run_logs
 
 
 --
+-- Name: knowledge_recommendations fk_rails_d08a6763c1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.knowledge_recommendations
+    ADD CONSTRAINT fk_rails_d08a6763c1 FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
 -- Name: user_settings fk_rails_d1371c6356; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8567,6 +8650,12 @@ ALTER TABLE public.knowledge_usage_stats ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.linear_tokens ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: llm_output_metrics; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.llm_output_metrics ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: mcp_server_definitions; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -8883,21 +8972,21 @@ CREATE POLICY tenant_isolation ON public.chat_session_projects USING ((public.pa
 -- Name: chat_sessions tenant_isolation; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY tenant_isolation ON public.chat_sessions USING ((public.paid_tenant_bypass() OR ((chat_sessions.account_id = public.paid_current_account_id()) AND ((chat_sessions.project_id IS NULL) OR (EXISTS ( SELECT 1
+CREATE POLICY tenant_isolation ON public.chat_sessions USING ((public.paid_tenant_bypass() OR ((account_id = public.paid_current_account_id()) AND ((project_id IS NULL) OR (EXISTS ( SELECT 1
    FROM public.projects
-  WHERE ((projects.id = chat_sessions.project_id) AND (projects.account_id = public.paid_current_account_id()))))) AND ((chat_sessions.provider_id IS NULL) OR (EXISTS ( SELECT 1
+  WHERE ((projects.id = chat_sessions.project_id) AND (projects.account_id = public.paid_current_account_id()))))) AND ((provider_id IS NULL) OR (EXISTS ( SELECT 1
    FROM public.providers
   WHERE ((providers.id = chat_sessions.provider_id) AND (providers.user_id IN ( SELECT users.id
            FROM public.users
-          WHERE (users.account_id = public.paid_current_account_id()))))))) AND ((chat_sessions.created_by_id IS NULL) OR (EXISTS ( SELECT 1
+          WHERE (users.account_id = public.paid_current_account_id()))))))) AND ((created_by_id IS NULL) OR (EXISTS ( SELECT 1
    FROM public.users
-  WHERE ((users.id = chat_sessions.created_by_id) AND (users.account_id = public.paid_current_account_id())))))))) WITH CHECK ((public.paid_tenant_bypass() OR ((chat_sessions.account_id = public.paid_current_account_id()) AND ((chat_sessions.project_id IS NULL) OR (EXISTS ( SELECT 1
+  WHERE ((users.id = chat_sessions.created_by_id) AND (users.account_id = public.paid_current_account_id())))))))) WITH CHECK ((public.paid_tenant_bypass() OR ((account_id = public.paid_current_account_id()) AND ((project_id IS NULL) OR (EXISTS ( SELECT 1
    FROM public.projects
-  WHERE ((projects.id = chat_sessions.project_id) AND (projects.account_id = public.paid_current_account_id()))))) AND ((chat_sessions.provider_id IS NULL) OR (EXISTS ( SELECT 1
+  WHERE ((projects.id = chat_sessions.project_id) AND (projects.account_id = public.paid_current_account_id()))))) AND ((provider_id IS NULL) OR (EXISTS ( SELECT 1
    FROM public.providers
   WHERE ((providers.id = chat_sessions.provider_id) AND (providers.user_id IN ( SELECT users.id
            FROM public.users
-          WHERE (users.account_id = public.paid_current_account_id()))))))) AND ((chat_sessions.created_by_id IS NULL) OR (EXISTS ( SELECT 1
+          WHERE (users.account_id = public.paid_current_account_id()))))))) AND ((created_by_id IS NULL) OR (EXISTS ( SELECT 1
    FROM public.users
   WHERE ((users.id = chat_sessions.created_by_id) AND (users.account_id = public.paid_current_account_id()))))))));
 
@@ -9829,7 +9918,10 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260427223009'),
+('20260427223003'),
 ('20260427143916'),
+('20260427135718'),
 ('20260426231639'),
 ('20260426231603'),
 ('20260426231602'),
@@ -10053,3 +10145,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260128004342'),
 ('20260128004305'),
 ('20260127154444');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1753,6 +1753,8 @@ CREATE TABLE public.knowledge_recommendations (
     updated_at timestamp(6) without time zone NOT NULL
 );
 
+ALTER TABLE ONLY public.knowledge_recommendations FORCE ROW LEVEL SECURITY;
+
 
 --
 -- Name: knowledge_recommendations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -8632,6 +8634,12 @@ ALTER TABLE public.knowledge_chunks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.knowledge_links ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: knowledge_recommendations; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.knowledge_recommendations ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: knowledge_runs; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -9189,6 +9197,17 @@ CREATE POLICY tenant_isolation ON public.knowledge_links USING ((public.paid_ten
    FROM (public.knowledge_chunks
      JOIN public.projects ON ((projects.id = knowledge_chunks.project_id)))
   WHERE ((knowledge_chunks.id = knowledge_links.target_chunk_id) AND (projects.account_id = public.paid_current_account_id())))))));
+
+
+--
+-- Name: knowledge_recommendations tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.knowledge_recommendations USING ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.projects
+  WHERE ((projects.id = knowledge_recommendations.project_id) AND (projects.account_id = public.paid_current_account_id())))))) WITH CHECK ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.projects
+  WHERE ((projects.id = knowledge_recommendations.project_id) AND (projects.account_id = public.paid_current_account_id()))))));
 
 
 --
@@ -9918,6 +9937,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260427225726'),
 ('20260427223009'),
 ('20260427223003'),
 ('20260427143916'),

--- a/spec/factories/knowledge_recommendations.rb
+++ b/spec/factories/knowledge_recommendations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :knowledge_recommendation do
+    project
+    recommendation_type { "knowledge_gap" }
+    priority { "medium" }
+    status { "pending" }
+    description { "Missing documentation for authentication flow" }
+    evidence { { source: "gap_analysis", confidence: 0.85 } }
+  end
+end

--- a/spec/migrations/add_account_to_service_containers_spec.rb
+++ b/spec/migrations/add_account_to_service_containers_spec.rb
@@ -7,6 +7,7 @@ require Rails.root.join("db/migrate/20260425113212_enable_rls_on_knowledge_usage
 require Rails.root.join("db/migrate/20260425060000_enable_rls_on_notification_rule_states")
 require Rails.root.join("db/migrate/20260426011810_enable_rls_on_llm_output_metrics")
 require Rails.root.join("db/migrate/20260426231639_enable_rls_on_chat_tables")
+require Rails.root.join("db/migrate/20260427225726_enable_rls_on_knowledge_recommendations")
 
 RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
   self.use_transactional_tests = false
@@ -17,6 +18,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
   let(:notification_rls_migration) { EnableRlsOnNotificationRuleStates.new }
   let(:llm_output_metrics_rls_migration) { EnableRlsOnLlmOutputMetrics.new }
   let(:chat_rls_migration) { EnableRlsOnChatTables.new }
+  let(:knowledge_recommendations_rls_migration) { EnableRlsOnKnowledgeRecommendations.new }
 
   include MigrationSpecHelpers
 
@@ -24,6 +26,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     truncate_migration_test_data
 
     if tenant_policy_count.positive?
+      knowledge_recommendations_rls_migration.down if knowledge_recommendations_has_rls?
       chat_rls_migration.down if chat_tables_have_rls?
       llm_output_metrics_rls_migration.down if llm_output_metrics_has_rls?
       knowledge_rls_migration.down if knowledge_usage_stats_has_rls?
@@ -47,6 +50,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
       knowledge_rls_migration.up unless knowledge_usage_stats_has_rls?
       llm_output_metrics_rls_migration.up unless llm_output_metrics_has_rls?
       chat_rls_migration.up unless chat_tables_have_rls?
+      knowledge_recommendations_rls_migration.up unless knowledge_recommendations_has_rls?
     end
     ServiceContainer.reset_column_information
   end
@@ -201,6 +205,12 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(DISTINCT service_container_id) FROM project_service_containers"
     )
+  end
+
+  def knowledge_recommendations_has_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'knowledge_recommendations' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
   end
 
   def knowledge_usage_stats_has_rls?

--- a/spec/models/knowledge_recommendation_spec.rb
+++ b/spec/models/knowledge_recommendation_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe KnowledgeRecommendation do
         create(:knowledge_recommendation, project: project, priority: "medium")
 
         priorities = described_class.by_priority.pluck(:priority)
-        expect(priorities).to eq(%w[low medium high critical])
+        expect(priorities).to eq(%w[critical high medium low])
       end
     end
   end

--- a/spec/models/knowledge_recommendation_spec.rb
+++ b/spec/models/knowledge_recommendation_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe KnowledgeRecommendation do
+  subject(:recommendation) { build(:knowledge_recommendation) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:project) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:recommendation_type) }
+    it { is_expected.to validate_inclusion_of(:recommendation_type).in_array(described_class::RECOMMENDATION_TYPES) }
+    it { is_expected.to validate_presence_of(:priority) }
+    it { is_expected.to validate_inclusion_of(:priority).in_array(described_class::PRIORITIES) }
+    it { is_expected.to validate_presence_of(:status) }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+    it { is_expected.to validate_presence_of(:description) }
+  end
+
+  describe "scopes" do
+    let(:project) { create(:project) }
+
+    describe ".pending" do
+      it "returns only pending recommendations" do
+        pending_rec = create(:knowledge_recommendation, project: project, status: "pending")
+        create(:knowledge_recommendation, project: project, status: "accepted")
+
+        expect(described_class.pending).to contain_exactly(pending_rec)
+      end
+    end
+
+    describe ".accepted" do
+      it "returns only accepted recommendations" do
+        create(:knowledge_recommendation, project: project, status: "pending")
+        accepted_rec = create(:knowledge_recommendation, project: project, status: "accepted")
+
+        expect(described_class.accepted).to contain_exactly(accepted_rec)
+      end
+    end
+
+    describe ".by_priority" do
+      it "orders by priority level" do
+        create(:knowledge_recommendation, project: project, priority: "high")
+        create(:knowledge_recommendation, project: project, priority: "low")
+        create(:knowledge_recommendation, project: project, priority: "critical")
+        create(:knowledge_recommendation, project: project, priority: "medium")
+
+        priorities = described_class.by_priority.pluck(:priority)
+        expect(priorities).to eq(%w[low medium high critical])
+      end
+    end
+  end
+
+  describe "#dismiss!" do
+    let(:recommendation) { create(:knowledge_recommendation) }
+
+    it "sets status to dismissed with reason and timestamp" do
+      freeze_time do
+        recommendation.dismiss!(reason: "Not relevant")
+
+        expect(recommendation.reload).to have_attributes(
+          status: "dismissed",
+          dismissal_reason: "Not relevant",
+          dismissed_at: Time.current
+        )
+      end
+    end
+  end
+
+  describe "#accept!" do
+    let(:recommendation) { create(:knowledge_recommendation) }
+
+    it "sets status to accepted" do
+      recommendation.accept!
+      expect(recommendation.reload.status).to eq("accepted")
+    end
+  end
+end

--- a/spec/security/tenant_context_spec.rb
+++ b/spec/security/tenant_context_spec.rb
@@ -6,6 +6,7 @@ require Rails.root.join("db/migrate/20260425113212_enable_rls_on_knowledge_usage
 require Rails.root.join("db/migrate/20260425060000_enable_rls_on_notification_rule_states")
 require Rails.root.join("db/migrate/20260426011810_enable_rls_on_llm_output_metrics")
 require Rails.root.join("db/migrate/20260426231639_enable_rls_on_chat_tables")
+require Rails.root.join("db/migrate/20260427225726_enable_rls_on_knowledge_recommendations")
 
 RSpec.describe TenantContext, :tenant_isolation do
   around do |example|
@@ -142,6 +143,7 @@ RSpec.describe TenantContext, :tenant_isolation do
 
   def install_tenant_policies
     ActiveRecord::Migration.suppress_messages do
+      EnableRlsOnKnowledgeRecommendations.new.down if knowledge_recommendations_has_rls?
       EnableRlsOnChatTables.new.down if chat_tables_have_rls?
       EnableRlsOnLlmOutputMetrics.new.down if llm_output_metrics_has_rls?
       EnableRlsOnKnowledgeUsageStats.new.down if knowledge_usage_stats_has_rls?
@@ -152,6 +154,7 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnKnowledgeUsageStats.new.up unless knowledge_usage_stats_has_rls?
       EnableRlsOnLlmOutputMetrics.new.up unless llm_output_metrics_has_rls?
       EnableRlsOnChatTables.new.up unless chat_tables_have_rls?
+      EnableRlsOnKnowledgeRecommendations.new.up unless knowledge_recommendations_has_rls?
     end
     ActiveRecord::Base.connection.execute("RESET ROLE")
     cleanup_restricted_role
@@ -165,12 +168,19 @@ RSpec.describe TenantContext, :tenant_isolation do
     ActiveRecord::Base.connection.execute("RESET ROLE")
     cleanup_restricted_role
     ActiveRecord::Migration.suppress_messages do
+      EnableRlsOnKnowledgeRecommendations.new.down if knowledge_recommendations_has_rls?
       EnableRlsOnChatTables.new.down if chat_tables_have_rls?
       EnableRlsOnLlmOutputMetrics.new.down if llm_output_metrics_has_rls?
       EnableRlsOnKnowledgeUsageStats.new.down if knowledge_usage_stats_has_rls?
       EnableRlsOnNotificationRuleStates.new.down
       EnableTenantRowLevelSecurity.new.down
     end
+  end
+
+  def knowledge_recommendations_has_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'knowledge_recommendations' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
   end
 
   def knowledge_usage_stats_has_rls?


### PR DESCRIPTION
## Summary

All done. The commit passed all pre-commit hooks (RuboCop, ESLint, etc.). Here's a summary of what was implemented:

**New files:**
- `app/models/knowledge_recommendation.rb` — Model with validations, scopes (`pending`, `accepted`, `by_priority`), and `dismiss!`/`accept!` methods
- `db/migrate/..._create_knowledge_recommendations.rb` — Table with project FK, recommendation_type, collector_type, priority, description, evidence (jsonb), status, dismissed_at, dismissal_reason, plus composite indexes
- `db/migrate/..._add_knowledge_evolution_enabled_to_projects.rb` — Boolean column defaulting to `false`
- `spec/factories/knowledge_recommendations.rb` — Factory for tests
- `spec/models/knowledge_recommendation_spec.rb` — 13 tests covering associations, validations, scopes, and instance methods

**Modified files:**
- `app/models/project.rb` — Added `has_many :knowledge_recommendations` and Knowledge evolution entry to `AUTOMATION_SETTINGS`
- `app/controllers/projects_controller.rb` — Added `:knowledge_evolution_enabled` to permitted params
- `db/structure.sql` — Updated by pg_dump with new schema

---

Closes #1419