### PR TITLE
fix(cost-dashboard): label token usages by provider when model id is absent

### DIFF
--- a/app/services/agent_runs/track_harness_tokens.rb
+++ b/app/services/agent_runs/track_harness_tokens.rb
@@ -65,9 +65,16 @@ module AgentRuns
       {
         tokens_input: tokens_input,
         tokens_output: tokens_output,
-        llm_model: response.model,
+        llm_model: llm_model_label,
         request_type: request_type
       }
+    end
+
+    # Falls back to the provider name when the harness response has no model
+    # id — common for Claude Code runs where the CLI selects the model at
+    # runtime rather than the runtime override pinning one.
+    def llm_model_label
+      response.model.presence || response.provider.to_s.presence
     end
 
     def run_input

--- a/db/migrate/20260428025840_backfill_null_llm_model_on_token_usages.rb
+++ b/db/migrate/20260428025840_backfill_null_llm_model_on_token_usages.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Backfills llm_model on existing token_usages rows that were written with
+# nil because the harness response didn't carry a model id. The mapping
+# matches the runtime fallback now applied in
+# AgentRuns::TrackHarnessTokens#llm_model_label, so legacy rows merge into
+# the same dashboard buckets as new rows instead of staying in "Unknown".
+class BackfillNullLlmModelOnTokenUsages < ActiveRecord::Migration[8.1]
+  # Values are the AgentHarness provider_name symbols (as strings) that the
+  # runtime fallback in AgentRuns::TrackHarnessTokens writes via
+  # `response.provider.to_s`. Keeping these in sync ensures backfilled rows
+  # bucket alongside future writes in the cost dashboard. The "api" agent
+  # type is intentionally omitted — its harness provider returns nil for
+  # provider_name, so the runtime fallback also leaves llm_model nil.
+  AGENT_TYPE_TO_PROVIDER = {
+    "claude_code" => "claude",
+    "cursor" => "cursor",
+    "codex" => "codex",
+    "copilot" => "github_copilot",
+    "aider" => "aider",
+    "gemini" => "gemini",
+    "opencode" => "opencode",
+    "kilocode" => "kilocode"
+  }.freeze
+
+  def up
+    TenantContext.with_system_access do
+      AGENT_TYPE_TO_PROVIDER.each do |agent_type, provider_label|
+        execute(ActiveRecord::Base.sanitize_sql_array([ <<~SQL, provider_label, agent_type ]))
+          UPDATE token_usages
+          SET llm_model = ?
+          FROM agent_runs
+          WHERE token_usages.agent_run_id = agent_runs.id
+            AND token_usages.llm_model IS NULL
+            AND agent_runs.agent_type = ?
+        SQL
+      end
+    end
+  end
+
+  # Forward-only: rolling back the version is fine; the backfilled values
+  # stay in place. Re-running #up is idempotent because of the IS NULL
+  # filter and merges cleanly with rows already labeled by the runtime path.
+  def down; end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9937,6 +9937,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260428025840'),
 ('20260427225726'),
 ('20260427223009'),
 ('20260427223003'),

--- a/spec/services/agent_runs/track_harness_tokens_spec.rb
+++ b/spec/services/agent_runs/track_harness_tokens_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRuns::TrackHarnessTokens do
+  let(:project) { create(:project) }
+  let(:agent_run) { create(:agent_run, project: project, agent_type: "claude_code") }
+
+  def build_response(model:, provider: :claude, input: 1000, output: 200)
+    AgentHarness::Response.new(
+      output: "ok",
+      exit_code: 0,
+      duration: 1.0,
+      provider: provider,
+      model: model,
+      tokens: { input: input, output: output, total: input + output }
+    )
+  end
+
+  describe "#call" do
+    context "when response has a model" do
+      it "stores the response model on the run_summary record" do
+        described_class.call(agent_run: agent_run, response: build_response(model: "claude-sonnet-4"))
+
+        expect(agent_run.token_usages.find_by!(request_type: "run_summary").llm_model).to eq("claude-sonnet-4")
+      end
+    end
+
+    context "when response.model is nil" do
+      it "falls back to the provider name" do
+        described_class.call(agent_run: agent_run, response: build_response(model: nil, provider: :anthropic))
+
+        expect(agent_run.token_usages.find_by!(request_type: "run_summary").llm_model).to eq("anthropic")
+        expect(agent_run.token_usages.find_by!(request_type: "run_delta").llm_model).to eq("anthropic")
+      end
+    end
+
+    context "when response.model is blank" do
+      it "still falls back to the provider name" do
+        described_class.call(agent_run: agent_run, response: build_response(model: "", provider: :claude))
+
+        expect(agent_run.token_usages.find_by!(request_type: "run_summary").llm_model).to eq("claude")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Cost dashboard's "Cost by Model" section was showing every cost as **Unknown**. All 1,080 `token_usages` rows in this database were persisted with `llm_model: nil` because subscription Claude Code runs (and other CLI agents that pick the model at runtime) never populate `response.model` on the harness response. `AgentRuns::TrackHarnessTokens` was writing the bare `nil` straight to the column.
- Fall back to the harness provider symbol (`response.provider.to_s`) when `response.model` is blank. Subscription Claude Code rows now bucket as `claude`; codex, cursor, etc. likewise label by provider.
- One-shot data migration mirrors the runtime fallback per `agent_type` so legacy null rows merge into the same dashboard buckets as new writes (the cost dashboard is not time-windowed, so without a backfill the "Unknown" bucket would persist alongside the new `claude`/`codex` buckets indefinitely).

### Why the cheap fix instead of routing Claude Code through the secrets proxy

The "proper fix" would be to route Claude Code's LLM calls through Paid's secrets proxy so per-call usage with the real model id (`claude-opus-4-7`, etc.) gets recorded. That is incompatible with the project's current Claude provider auth_type of `subscription`: the proxy injects an API key, which would convert subscription usage into metered API billing, fail outright when no API key is configured, and break Claude Code's native OAuth/MCP session flow that lives in `~/.claude`. `Containers::Provision` already opts subscription users out of the proxy on purpose. Dropping in a coarser provider-grain label is the right move until subscription-aware per-call tracking is designed.

### Why an explicit per-`agent_type` mapping in the migration

`response.provider.to_s` produces the harness `provider_name` symbol, which is the source of truth at runtime. The migration mirrors that mapping by `agent_type` so backfilled rows match what new writes produce — verified live against `AgentHarness::Providers::Registry`. Two specific gotchas that the verification caught: `gemini`, not `gemini_cli`, is the agent_type; and the GitHub Copilot harness emits `:github_copilot`, not `:copilot`.

### Verification

- Migration applied locally: `claude: 518`, `codex: 562`, 0 remaining nulls.
- `db:migrate:redo:primary` re-applied cleanly (idempotent via `WHERE llm_model IS NULL`).
- Spec covers fallback paths in `AgentRuns::TrackHarnessTokens`.

## Test plan

- [ ] CI green (RSpec, RuboCop, structure.sql check)
- [ ] On a staging environment with existing null `token_usages`, run the migration and confirm the cost dashboard's "Cost by Model" section no longer shows "Unknown" for backfilled rows
- [ ] Trigger a fresh subscription Claude Code agent run and confirm the resulting `run_summary`/`run_delta` rows persist `llm_model = "claude"`
- [ ] Trigger a Codex agent run and confirm rows persist `llm_model = "codex"`
- [ ] (If a Copilot run is feasible in staging) confirm rows persist `llm_model = "github_copilot"` so they bucket alongside any backfilled copilot rows