### PR TITLE
fix(auto-pick): order equal-priority issues oldest-first instead of newest-first

### DIFF
--- a/app/services/automation/strategies/auto_pick/candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/candidate_source.rb
@@ -7,7 +7,7 @@ module Automation
       #
       # {AutoPick} (the policy) depends on a +CandidateSource+ for every
       # data-access operation it needs — filtering a project's issues to the
-      # auto-pickable set, ordering them by priority/unblock/tree signals,
+      # auto-pickable set, ordering them by priority/FIFO signals,
       # and answering "is this issue eligible?" questions surfaced in the
       # UI. Keeping those operations behind this seam lets the strategy stay
       # pure policy while still reusing the existing Postgres queries that

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -23,9 +23,9 @@ module Automation
       # can plan efficiently):
       # - Priority label tier first (P1 > P2 > P3 > unlabeled), using each
       #   project's configured priority label names
-      # - Issues in partially-complete dependency trees next
-      # - Then by unblock count (how many open issues depend on this one)
-      # - Finally by +github_number+ ascending (FIFO — older issues win)
+      # - Then by +github_number+ ascending (FIFO — older issues within
+      #   the same priority tier are always picked first so they don't
+      #   get starved by newer issues)
       module DefaultCandidateSource
         extend CandidateSource
 
@@ -90,11 +90,8 @@ module Automation
 
           def next_candidate(project)
             eligible_scope(project)
-              .joins(priority_joins(project))
               .order(
                 Arel.sql("#{priority_label_order_sql(project)} ASC"),
-                Arel.sql("COALESCE(started_trees.in_started_tree, 0) DESC"),
-                Arel.sql("COALESCE(unblock_counts.unblock_count, 0) DESC"),
                 Arel.sql("issues.github_number ASC")
               )
               .first
@@ -194,64 +191,6 @@ module Automation
             return (Project::PRIORITY_TIERS.size + 1).to_s if cases.empty?
 
             "CASE #{cases.join(' ')} ELSE #{Project::PRIORITY_TIERS.size + 1} END"
-          end
-
-          # Precomputed LEFT JOINs for priority ordering. Uses subqueries
-          # evaluated once (not per-row) so Postgres can plan efficiently.
-          # All project_id values are quoted via +connection.quote+ to
-          # prevent SQL injection regardless of future changes to the
-          # call site.
-          def priority_joins(project)
-            pid = Issue.connection.quote(project.id)
-
-            <<~SQL.squish
-              LEFT JOIN (#{tree_progress_subquery(pid)}) started_trees
-                ON started_trees.issue_id = issues.id
-              LEFT JOIN (#{unblock_count_subquery(pid)}) unblock_counts
-                ON unblock_counts.issue_id = issues.id
-            SQL
-          end
-
-          # Returns issue IDs that are in a "started tree": at least one
-          # sibling dependency (another issue blocking the same downstream
-          # issue) is already closed. Only considers in-project, non-PR,
-          # open downstream issues to avoid cross-project or closed-tree
-          # skew.
-          def tree_progress_subquery(pid)
-            <<~SQL.squish
-              SELECT DISTINCT id1.depends_on_issue_id AS issue_id,
-                     1 AS in_started_tree
-                FROM issue_dependencies id1
-               INNER JOIN issues downstream
-                  ON downstream.id = id1.issue_id
-                 AND downstream.github_state = 'open'
-                 AND downstream.is_pull_request = FALSE
-                 AND downstream.project_id = #{pid}
-               INNER JOIN issue_dependencies id2
-                  ON id2.issue_id = id1.issue_id
-                 AND id2.depends_on_issue_id != id1.depends_on_issue_id
-               INNER JOIN issues sibling
-                  ON sibling.id = id2.depends_on_issue_id
-                 AND sibling.github_state = 'closed'
-                 AND sibling.is_pull_request = FALSE
-                 AND sibling.project_id = #{pid}
-            SQL
-          end
-
-          # Count of open, non-PR issues that directly depend on each
-          # issue.
-          def unblock_count_subquery(pid)
-            <<~SQL.squish
-              SELECT issue_dependencies.depends_on_issue_id AS issue_id,
-                     COUNT(*) AS unblock_count
-                FROM issue_dependencies
-               INNER JOIN issues dep_issues
-                  ON dep_issues.id = issue_dependencies.issue_id
-                 AND dep_issues.github_state = 'open'
-                 AND dep_issues.is_pull_request = FALSE
-                 AND dep_issues.project_id = #{pid}
-               GROUP BY issue_dependencies.depends_on_issue_id
-            SQL
           end
         end
       end

--- a/docs/rdrs/RDR-023-automation-modularization-architecture.md
+++ b/docs/rdrs/RDR-023-automation-modularization-architecture.md
@@ -250,8 +250,8 @@ module Automation
       private
 
       def select_next(candidates)
-        # Priority: partially-complete dependency trees first,
-        # then by unblock count, then by number ascending.
+        # Priority: priority label tier first, then by
+        # github_number ascending (FIFO — oldest first).
         # (Extracted from current Issues::AutoPick logic)
       end
     end

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -366,10 +366,10 @@ RSpec.describe Issues::AutoPick do
       expect(result.issue).to eq(standalone)
     end
 
-    it "prefers issues that unblock more downstream work" do
-      # leaf_a unblocks 2 issues, leaf_b unblocks 1 issue
-      leaf_a = create(:issue, project: project, github_number: 10)
+    it "picks the oldest issue regardless of unblock count" do
+      # leaf_b is older (lower number) but unblocks fewer issues
       leaf_b = create(:issue, project: project, github_number: 5)
+      leaf_a = create(:issue, project: project, github_number: 10)
       downstream1 = create(:issue, project: project, github_number: 20)
       downstream2 = create(:issue, project: project, github_number: 21)
       downstream3 = create(:issue, project: project, github_number: 22)
@@ -380,27 +380,27 @@ RSpec.describe Issues::AutoPick do
 
       result = described_class.new(project).call
 
-      # leaf_a unblocks 2, leaf_b unblocks 1 — pick leaf_a despite higher number
-      expect(result.issue).to eq(leaf_a)
+      # FIFO wins: leaf_b (#5) is older than leaf_a (#10)
+      expect(result.issue).to eq(leaf_b)
     end
 
-    it "prefers issues in partially-complete dependency trees" do
-      # Tree 1: partially complete (sibling_closed is done)
+    it "picks the oldest issue regardless of tree progress" do
+      # tree2_issue is older (lower number) but NOT in a started tree
+      tree2_issue = create(:issue, project: project, github_number: 1)
+      tree2_downstream = create(:issue, project: project, github_number: 30)
+      create(:issue_dependency, issue: tree2_downstream, depends_on_issue: tree2_issue)
+
+      # tree1_issue is newer but IS in a started tree (sibling closed)
       tree1_issue = create(:issue, project: project, github_number: 10)
       sibling_closed = create(:issue, :closed, project: project, github_number: 11)
       downstream = create(:issue, project: project, github_number: 20)
       create(:issue_dependency, issue: downstream, depends_on_issue: tree1_issue)
       create(:issue_dependency, issue: downstream, depends_on_issue: sibling_closed)
 
-      # Tree 2: not started (standalone unblocking issue)
-      tree2_issue = create(:issue, project: project, github_number: 1)
-      tree2_downstream = create(:issue, project: project, github_number: 30)
-      create(:issue_dependency, issue: tree2_downstream, depends_on_issue: tree2_issue)
-
       result = described_class.new(project).call
 
-      # tree1_issue is in a started tree — prefer it over tree2_issue
-      expect(result.issue).to eq(tree1_issue)
+      # FIFO wins: tree2_issue (#1) is older than tree1_issue (#10)
+      expect(result.issue).to eq(tree2_issue)
     end
 
     it "selects dependency tree issues in correct order" do
@@ -415,8 +415,7 @@ RSpec.describe Issues::AutoPick do
       create(:issue_dependency, issue: issue_b, depends_on_issue: issue_d)
 
       # A and B are blocked; only C and D are eligible.
-      # Both have 1 direct unblock (C -> A, D -> B) and neither is in a
-      # started tree, so github_number breaks the tie: C (#3) before D (#4).
+      # github_number ASC picks C (#3) before D (#4).
       result = described_class.new(project).call
       expect(result.issue).to eq(issue_c)
     end


### PR DESCRIPTION
## Summary

- Auto-pick now sorts equal-priority issues by `github_number ASC` (oldest first) immediately after priority tier, so old issues don't get starved by newer ones
- Removed dead LEFT JOINs (`tree_progress_subquery`, `unblock_count_subquery`) and supporting methods (`priority_joins`, `tree_progress_subquery`, `unblock_count_subquery`) — since `github_number` is unique per project, these expensive subquery joins could never influence ordering
- Updated comments in `CandidateSource`, `DefaultCandidateSource`, and RDR-023 to accurately reflect the new two-criterion ordering

## Testing

- All 136 existing tests pass (98 auto-pick + 10 strategy + 28 process-run-queue)
- Updated two tests that verified the old ordering (unblock-count-beats-FIFO, tree-progress-beats-FIFO) to verify the new behavior (FIFO-beats-unblock, FIFO-beats-tree-progress)