### PR TITLE
fix(pr-scanner): rescan ready/escalated PRs when auto-merge is enabled

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -808,16 +808,21 @@ module Activities
     # `updated_at` on GitHub. Without this escape hatch the skip-unchanged
     # optimization prevents the scanner from ever reconsidering them.
     #
-    # Human-authored ready/escalated PRs already have a targeted rescan path
-    # via `merge_conflict_rescan_needed?`; expanding that would regress the
-    # optimization back into full per-PR scans.
+    # Human-authored ready-phase PRs with auto-merge enabled face the same
+    # problem: CI transitions from pending to green (or owner approvals
+    # arriving) don't always bump `github_updated_at`, so the PR is never
+    # re-evaluated and sits stuck in "ready" despite meeting all auto-merge
+    # conditions.
     def scan_age_exceeds_ceiling?(project, issue)
       draft_or_restarted = issue.pr_review_phase.in?(%w[draft restarted])
       bot_ready_for_merge = issue.pr_review_phase == "ready" &&
         bot_user?(issue.github_creator_login) &&
         project.auto_merge_dependabot?
+      human_ready_auto_merge = issue.pr_review_phase == "ready" &&
+        !bot_user?(issue.github_creator_login) &&
+        project.auto_merge_enabled?
 
-      return false unless draft_or_restarted || bot_ready_for_merge
+      return false unless draft_or_restarted || bot_ready_for_merge || human_ready_auto_merge
 
       ceiling = SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
       stale = issue.last_pr_scan_at < ceiling.seconds.ago

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -808,21 +808,24 @@ module Activities
     # `updated_at` on GitHub. Without this escape hatch the skip-unchanged
     # optimization prevents the scanner from ever reconsidering them.
     #
-    # Human-authored ready-phase PRs with auto-merge enabled face the same
-    # problem: CI transitions from pending to green (or owner approvals
-    # arriving) don't always bump `github_updated_at`, so the PR is never
-    # re-evaluated and sits stuck in "ready" despite meeting all auto-merge
-    # conditions.
+    # Human-authored ready/escalated PRs with auto_merge_mode "all" face the
+    # same problem: CI transitions from pending to green do not update the
+    # PR's `updated_at` on GitHub. Owner approvals do update it, but if the
+    # owner approves before CI settles, the scan stamps `last_pr_scan_at`
+    # while CI is still pending, and the subsequent green transition never
+    # triggers a rescan. Restricted to auto_merge_mode "all" (not
+    # "dependabot_only") because only "all" enables auto-merge for
+    # non-Dependabot PRs.
     def scan_age_exceeds_ceiling?(project, issue)
       draft_or_restarted = issue.pr_review_phase.in?(%w[draft restarted])
       bot_ready_for_merge = issue.pr_review_phase == "ready" &&
         bot_user?(issue.github_creator_login) &&
         project.auto_merge_dependabot?
-      human_ready_auto_merge = issue.pr_review_phase == "ready" &&
+      human_auto_merge = issue.pr_review_phase.in?(%w[ready escalated]) &&
         !bot_user?(issue.github_creator_login) &&
-        project.auto_merge_enabled?
+        project.auto_merge_mode == "all"
 
-      return false unless draft_or_restarted || bot_ready_for_merge || human_ready_auto_merge
+      return false unless draft_or_restarted || bot_ready_for_merge || human_auto_merge
 
       ceiling = SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
       stale = issue.last_pr_scan_at < ceiling.seconds.ago

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -6198,6 +6198,36 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
       end
 
+      it "rescans stale human-authored ready PRs when auto-merge is enabled" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        project.update!(auto_merge_mode: "all")
+        unchanged_pr.update!(pr_review_phase: "ready")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+        stub_github_for_pr
+
+        activity.execute(project_id: project.id)
+
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
+      end
+
+      it "does not rescan stale human-authored ready PRs when auto-merge is off" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        project.update!(auto_merge_mode: "off")
+        unchanged_pr.update!(pr_review_phase: "ready")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+        expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
+      end
+
       it "scans ready PRs for merge conflicts when auto-fix is enabled" do
         project.update!(auto_fix_merge_conflicts: true)
         unchanged_pr.update!(pr_review_phase: "ready")

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -6198,7 +6198,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
       end
 
-      it "rescans stale human-authored ready PRs when auto-merge is enabled" do
+      it "rescans stale human-authored ready PRs when auto-merge mode is all" do
         ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
         project.update!(auto_merge_mode: "all")
         unchanged_pr.update!(pr_review_phase: "ready")
@@ -6211,6 +6211,36 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         activity.execute(project_id: project.id)
 
         expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
+      end
+
+      it "rescans stale human-authored escalated PRs when auto-merge mode is all" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        project.update!(auto_merge_mode: "all")
+        unchanged_pr.update!(pr_review_phase: "escalated")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+        stub_github_for_pr
+
+        activity.execute(project_id: project.id)
+
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
+      end
+
+      it "does not rescan stale human-authored ready PRs when auto-merge is dependabot_only" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        project.update!(auto_merge_mode: "dependabot_only")
+        unchanged_pr.update!(pr_review_phase: "ready")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+        expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
       end
 
       it "does not rescan stale human-authored ready PRs when auto-merge is off" do


### PR DESCRIPTION
## Summary

- Extend `scan_age_exceeds_ceiling?` to cover human-authored ready/escalated PRs when `auto_merge_mode == "all"`, so CI transitions from pending to green trigger a rescan and unblock auto-merge.
- Restricted to mode `"all"` (not `auto_merge_enabled?`) to avoid unnecessary API calls on `dependabot_only` projects where auto-merge never applies to human-authored PRs.
- Covers both `ready` and `escalated` phases since `scan_escalated_pr` has the same auto-merge logic and the same wedge scenario.

## Problem

Ready-phase human-authored PRs with `auto_merge_mode: "all"` could sit indefinitely without auto-merging. The root cause: `skip_unchanged_pr?` prevents re-evaluation when `github_updated_at` hasn't changed, but CI transitions (pending → green) don't update `github_updated_at` on GitHub. If the scanner stamps `last_pr_scan_at` while CI is still pending, the PR is permanently skipped even after CI goes green.

## Test plan

- [x] New test: stale human-authored ready PRs ARE rescanned when `auto_merge_mode: "all"`
- [x] New test: stale human-authored escalated PRs ARE rescanned when `auto_merge_mode: "all"`
- [x] New test: stale human-authored ready PRs are NOT rescanned when `auto_merge_mode: "dependabot_only"`
- [x] Existing test preserved: stale human-authored ready PRs are NOT rescanned when `auto_merge_mode: "off"`
- [x] All 29 tests in the skip-unchanged context pass