### PR TITLE
refactor(agent-image): delegate Aider CLI installation to agent-harness

### DIFF
--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -158,6 +158,19 @@ jobs:
           echo "$install_command" >> "$GITHUB_OUTPUT"
           echo "PAID_EOF" >> "$GITHUB_OUTPUT"
 
+      - name: Extract Aider CLI install contract from agent-harness
+        id: aider-contract
+        run: |
+          contract=$(bundle exec ruby scripts/extract-provider-install-contract.rb aider)
+          install_command=$(echo "$contract" | sed -n 's/^INSTALL_COMMAND=//p')
+          if [ -z "$install_command" ]; then
+            echo "Failed to extract Aider CLI install command from agent-harness" >&2
+            exit 1
+          fi
+          echo "install_command<<PAID_EOF" >> "$GITHUB_OUTPUT"
+          echo "$install_command" >> "$GITHUB_OUTPUT"
+          echo "PAID_EOF" >> "$GITHUB_OUTPUT"
+
       - name: Build paid-agent image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -178,6 +191,7 @@ jobs:
             OPENCODE_PACKAGE=${{ steps.opencode-contract.outputs.package }}
             KILOCODE_INSTALL_COMMAND=${{ steps.kilocode-contract.outputs.install_command }}
             GEMINI_CLI_INSTALL_COMMAND=${{ steps.gemini-contract.outputs.install_command }}
+            AIDER_INSTALL_COMMAND=${{ steps.aider-contract.outputs.install_command }}
           cache-from: type=gha,scope=paid-agent
           cache-to: type=gha,mode=max,scope=paid-agent
 

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -239,19 +239,16 @@ RUN if [ -z "${CURSOR_ARTIFACT_URL}" ]; then echo "ERROR: CURSOR_ARTIFACT_URL bu
     && ln -sf "/opt/cursor-agent/${CURSOR_BINARY_NAME}" "${CURSOR_GLOBAL_PATH}" \
     && rm -rf /tmp/cursor-artifact.tar.gz /tmp/dist-package
 
-# Install Aider CLI.
-# Follow the official Aider "Install with uv" flow so the tool lives in its own
-# isolated environment instead of the system Python:
-# https://aider.chat/docs/install.html#install-with-uv
-# Pin both uv and aider-chat for reproducible builds.
-ARG UV_VERSION=0.8.17
-ARG AIDER_CHAT_VERSION=0.86.2
-ENV UV_TOOL_BIN_DIR=/usr/local/bin
-ENV UV_TOOL_DIR=/opt/uv/tools
-ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
-RUN mkdir -p "${UV_TOOL_DIR}" "${UV_PYTHON_INSTALL_DIR}" \
-    && python3 -m pip install --no-cache-dir --break-system-packages "uv==${UV_VERSION}" \
-    && uv tool install --force --python python3.12 --with pip "aider-chat==${AIDER_CHAT_VERSION}"
+# Install Aider CLI via agent-harness install contract.
+# agent-harness owns the Aider install recipe, uv bootstrap, and version pin.
+# The install command is extracted at build time by
+# scripts/build-agent-image.sh / agent-image.yml — Paid no longer pins these versions.
+ARG AIDER_INSTALL_COMMAND
+RUN if [ -z "${AIDER_INSTALL_COMMAND}" ]; then \
+        echo "ERROR: AIDER_INSTALL_COMMAND build-arg is required (sourced from agent-harness)" >&2; \
+        exit 1; \
+    fi \
+    && eval "${AIDER_INSTALL_COMMAND}"
 
 # Install git credential helper for proxy-based authentication.
 # This allows git clone/push inside the container without exposing GitHub tokens.

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -119,6 +119,16 @@ if [ -z "${GEMINI_CLI_INSTALL_COMMAND}" ]; then
     exit 1
 fi
 
+# Extract Aider CLI install command from agent-harness (single source of truth).
+# agent-harness owns the uv bootstrap, aider-chat version pin, and install recipe.
+AIDER_CONTRACT=$(bundle exec ruby "${PROJECT_ROOT}/scripts/extract-provider-install-contract.rb" aider)
+AIDER_INSTALL_COMMAND=$(echo "${AIDER_CONTRACT}" | sed -n 's/^INSTALL_COMMAND=//p')
+
+if [ -z "${AIDER_INSTALL_COMMAND}" ]; then
+    echo "ERROR: Could not extract Aider CLI install command from agent-harness" >&2
+    exit 1
+fi
+
 echo "Building agent container image..."
 echo "  Image: ${FULL_IMAGE}"
 echo "  Context: ${PROJECT_ROOT}/docker/agent"
@@ -129,6 +139,7 @@ echo "  codex: ${CODEX_PACKAGE}"
 echo "  opencode: ${OPENCODE_PACKAGE}"
 echo "  kilocode-cli: ${KILOCODE_INSTALL_COMMAND}"
 echo "  gemini-cli: ${GEMINI_CLI_INSTALL_COMMAND}"
+echo "  aider-cli: via agent-harness contract"
 
 "${DOCKER_BUILD_ENV[@]}" docker build \
     -t "${FULL_IMAGE}" \
@@ -144,6 +155,7 @@ echo "  gemini-cli: ${GEMINI_CLI_INSTALL_COMMAND}"
     --build-arg "OPENCODE_PACKAGE=${OPENCODE_PACKAGE}" \
     --build-arg "KILOCODE_INSTALL_COMMAND=${KILOCODE_INSTALL_COMMAND}" \
     --build-arg "GEMINI_CLI_INSTALL_COMMAND=${GEMINI_CLI_INSTALL_COMMAND}" \
+    --build-arg "AIDER_INSTALL_COMMAND=${AIDER_INSTALL_COMMAND}" \
     "${PROJECT_ROOT}/docker/agent/"
 
 echo ""

--- a/scripts/extract-provider-install-contract.rb
+++ b/scripts/extract-provider-install-contract.rb
@@ -67,9 +67,34 @@ end
 # - npm-based (Codex):    {source: :npm, package:, install_command: [...], version:}
 # - npm-nested (Kilocode): {source: {type: :npm, package:}, install_command: [...], default_version:}
 # - Flat (Gemini):        {install_command_string:, default_version:}
+# - uv-tool (Aider):      {source: :uv_tool, bootstrap_commands: [...], install_environment: {...},
+#                           install_command: [...], package:, version:}
 source = contract[:source]
 is_npm = source == :npm || (source.is_a?(Hash) && source[:type] == :npm)
-if is_npm
+if source == :uv_tool
+  # Compose a single install command string from the structured contract:
+  #   1. Create directories referenced by install_environment
+  #   2. Run bootstrap commands (e.g., install uv via pip)
+  #   3. Run the install command (e.g., uv tool install aider-chat)
+  # Environment variables are inlined per-command so no persistent ENV is needed.
+  env_hash = contract[:install_environment] || {}
+  env_prefix = env_hash.map { |k, v| "#{k}=#{v}" }.join(" ")
+  dir_values = env_hash.values.select { |v| v.start_with?("/") }
+
+  parts = []
+  parts << "mkdir -p #{dir_values.join(" ")}" if dir_values.any?
+
+  (contract[:bootstrap_commands] || []).each do |cmd_array|
+    parts << "#{env_prefix} #{cmd_array.join(" ")}"
+  end
+
+  parts << "#{env_prefix} #{contract[:install_command].join(" ")}"
+
+  puts "SOURCE=uv_tool"
+  puts "INSTALL_COMMAND=#{parts.join(" && ")}"
+  puts "PACKAGE=#{contract[:package]}"
+  puts "SUPPORTED_VERSION=#{contract[:version]}"
+elsif is_npm
   package = contract[:package] || (source.is_a?(Hash) && source[:package])
   puts "SOURCE=npm"
   puts "PACKAGE=#{package}"


### PR DESCRIPTION
## Summary

Done. Here's a summary of the changes:

**4 files changed** across the Dockerfile, build script, extract script, and CI workflow:

1. **`docker/agent/Dockerfile`** — Replaced the hardcoded Aider install block (pinned `UV_VERSION=0.8.17`, `AIDER_CHAT_VERSION=0.86.2`, ENV vars, and `uv tool install` command) with a single `AIDER_INSTALL_COMMAND` build-arg that's sourced from agent-harness at build time.

2. **`scripts/extract-provider-install-contract.rb`** — Added support for the `uv_tool` source type that Aider's `installation_contract` returns. It composes the bootstrap commands (uv pip install), environment variables, and install command into a single shell string.

3. **`scripts/build-agent-image.sh`** — Added Aider contract extraction and `--build-arg` passthrough, matching the existing pattern for other providers.

4. **`.github/workflows/agent-image.yml`** — Added "Extract Aider CLI install contract from agent-harness" step and the `AIDER_INSTALL_COMMAND` build-arg to the Docker build step.

---

Closes #795