### PR TITLE
fix(devcontainer): remove redundant PG 15 feature and add pg_dump to agent container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,7 @@
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
       "moby": false
-    },
-    "ghcr.io/rails/devcontainer/features/postgres-client": {}
+    }
   },
   "containerEnv": {
     "TZ": "${localEnv:TZ:UTC}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,18 +56,20 @@ jobs:
           dev=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .devcontainer/compose.yaml | head -1 | awk '{print $NF}')
           compose=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' docker-compose.yml | head -1 | awk '{print $NF}')
           ci=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/ci.yml | head -1 | awk '{print $NF}')
+          systest=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/system_tests.yml | head -1 | awk '{print $NF}')
           major=${compose#postgres:}
           major=${major%%.*}
-          echo "devcontainer/compose.yaml: ${dev:-<none>}"
-          echo "docker-compose.yml:        ${compose:-<none>}"
-          echo ".github/workflows/ci.yml:  ${ci:-<none>}"
-          echo "expected client major:     ${major:-<none>}"
-          if [ -z "$dev" ] || [ -z "$compose" ] || [ -z "$ci" ]; then
+          echo "devcontainer/compose.yaml:       ${dev:-<none>}"
+          echo "docker-compose.yml:              ${compose:-<none>}"
+          echo ".github/workflows/ci.yml:        ${ci:-<none>}"
+          echo ".github/workflows/system_tests:  ${systest:-<none>}"
+          echo "expected client major:           ${major:-<none>}"
+          if [ -z "$dev" ] || [ -z "$compose" ] || [ -z "$ci" ] || [ -z "$systest" ]; then
             echo "::error::Postgres image pin missing in one or more files"
             exit 1
           fi
-          if [ "$dev" != "$compose" ] || [ "$compose" != "$ci" ]; then
-            echo "::error::Postgres image pins are out of sync. Update all three together."
+          if [ "$dev" != "$compose" ] || [ "$compose" != "$ci" ] || [ "$ci" != "$systest" ]; then
+            echo "::error::Postgres image pins are out of sync. Update all four together."
             exit 1
           fi
           if ! grep -q "postgresql-client-${major}" .devcontainer/Dockerfile; then
@@ -78,8 +80,16 @@ jobs:
             echo "::error::Dockerfile is not pinned to postgresql-client-${major}"
             exit 1
           fi
+          if ! grep -q "postgresql-client-${major}" docker/agent/Dockerfile; then
+            echo "::error::docker/agent/Dockerfile is not pinned to postgresql-client-${major}"
+            exit 1
+          fi
           if ! grep -q "postgresql-client-${major}" .github/workflows/ci.yml; then
             echo "::error::.github/workflows/ci.yml is not pinned to postgresql-client-${major}"
+            exit 1
+          fi
+          if ! grep -q "postgresql-client-${major}" .github/workflows/system_tests.yml; then
+            echo "::error::.github/workflows/system_tests.yml is not pinned to postgresql-client-${major}"
             exit 1
           fi
 

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -39,6 +39,7 @@ RUN NODE_VERSION=22.13.0 \
     && rm "${TARBALL}"
 
 # Install Ruby build dependencies, runtime deps, Python, PostgreSQL client libs, and ShellCheck
+# Keep client tools on the same Postgres major as the pinned server image.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
     bison \
@@ -49,6 +50,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libffi-dev \
     libgdbm-dev \
     libpq-dev \
+    postgresql-client-16 \
     rustc \
     shellcheck \
     python3 \
@@ -75,7 +77,7 @@ RUN RUBY_VERSION=3.4.8 \
 # Remove some build-only dependencies to reduce image size and attack surface.
 # We intentionally keep the corresponding *-dev packages (libssl-dev, libreadline-dev, zlib1g-dev,
 # libyaml-dev, libffi-dev, libgdbm-dev, libpq-dev) so native extensions (e.g., Ruby gems like pg)
-# can be compiled inside this agent image.
+# can be compiled inside this agent image. We also keep postgresql-client-16 for schema dumps.
 RUN apt-get update && apt-get purge -y --auto-remove \
     autoconf \
     bison \


### PR DESCRIPTION
## Summary

- Remove `ghcr.io/rails/devcontainer/features/postgres-client` from devcontainer.json — it installed an unnecessary `postgresql-client-15` alongside the explicitly-pinned `postgresql-client-16` from PGDG, causing `pg_wrapper` version resolution ambiguity
- Add `postgresql-client-16` to `docker/agent/Dockerfile` so the agent container can run `pg_dump` for schema dumps during `db:migrate` (previously had only `libpq.so`, no client tools)
- Extend CI sync check to also verify `docker/agent/Dockerfile` and `.github/workflows/system_tests.yml`, both of which had pins but were not enforced

## Why

The agent container had no `pg_dump` at all, so any `structure.sql` committed by the agent was suspect. The devcontainer had two competing PG client versions (15 and 16) that could produce different `pg_dump` output depending on `pg_wrapper` resolution. This is the root cause of persistent minor `db/structure.sql` drift.

> Note: Ubuntu 24.04's `postgresql-client-16` will be a different minor version (e.g. 16.2) than the PGDG 16.13 in the devcontainer. A follow-up could add PGDG to the agent Dockerfile for exact version parity.