### PR TITLE
fix(notifications): fix Pagy pagination crash and mark-all-read UX

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -61,12 +61,15 @@ class NotificationsController < ApplicationController
         render turbo_stream: [
           turbo_stream.replace("notification_bell", partial: "notifications/bell", locals: { account: current_account }),
           turbo_stream.replace("notification_nav_badges", partial: "notifications/nav_badges", locals: { account: current_account }),
-          turbo_stream.replace("notifications_list") {
+          turbo_stream.update("notifications_list") {
             render_to_string(partial: "notifications/notification", collection: @notifications, as: :notification)
           }
         ]
       end
-      format.html { redirect_to notifications_path, notice: "All notifications marked as read." }
+      format.html do
+        redirect_params = { filter: params[:filter], severity: params[:severity], source: params[:source] }.compact_blank
+        redirect_to notifications_path(**redirect_params), notice: "All notifications marked as read."
+      end
     end
   end
 end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -8,15 +8,16 @@
       <p class="mt-1 text-sm text-gray-500">Review and manage system notifications.</p>
     </div>
     <div class="mt-4 sm:mt-0">
-      <%= button_to "Mark all read", mark_all_read_notifications_path, method: :post, class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+      <%= button_to "Mark all read", mark_all_read_notifications_path, method: :post, class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500", form: { data: { turbo: false } } %>
     </div>
   </div>
 
   <div class="mt-4 flex gap-2">
-    <%= link_to "All", notifications_path, class: "rounded-md px-3 py-1.5 text-sm font-medium #{params[:filter].blank? ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700'}" %>
-    <%= link_to "Unread", notifications_path(filter: "unread"), class: "rounded-md px-3 py-1.5 text-sm font-medium #{params[:filter] == 'unread' ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700'}" %>
+    <% severity_active = params[:severity].in?(%w[info warning error]) %>
+    <%= link_to "All", notifications_path(severity: severity_active ? params[:severity] : nil), class: "rounded-md px-3 py-1.5 text-sm font-medium #{params[:filter].blank? ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700'}" %>
+    <%= link_to "Unread", notifications_path(filter: "unread", severity: severity_active ? params[:severity] : nil), class: "rounded-md px-3 py-1.5 text-sm font-medium #{params[:filter] == 'unread' ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700'}" %>
     <% %w[info warning error].each do |sev| %>
-      <%= link_to sev.capitalize, notifications_path(severity: sev), class: "rounded-md px-3 py-1.5 text-sm font-medium #{params[:severity] == sev ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700'}" %>
+      <%= link_to sev.capitalize, notifications_path(severity: sev, filter: params[:filter]), class: "rounded-md px-3 py-1.5 text-sm font-medium #{params[:severity] == sev ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700'}" %>
     <% end %>
   </div>
 
@@ -53,8 +54,8 @@
         Showing <span class="font-medium"><%= @pagy.from %></span> to <span class="font-medium"><%= @pagy.to %></span> of <span class="font-medium"><%= @pagy.count %></span> notifications
       </p>
       <nav class="flex gap-1">
-        <% if @pagy.prev %>
-          <%= link_to "Previous", notifications_path(page: @pagy.prev, filter: params[:filter], severity: params[:severity], source: params[:source]), class: "rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
+        <% if @pagy.previous %>
+          <%= link_to "Previous", notifications_path(page: @pagy.previous, filter: params[:filter], severity: params[:severity], source: params[:source]), class: "rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
         <% end %>
         <% if @pagy.next %>
           <%= link_to "Next", notifications_path(page: @pagy.next, filter: params[:filter], severity: params[:severity], source: params[:source]), class: "rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -8,7 +8,7 @@
       <p class="mt-1 text-sm text-gray-500">Review and manage system notifications.</p>
     </div>
     <div class="mt-4 sm:mt-0">
-      <%= button_to "Mark all read", mark_all_read_notifications_path, method: :post, class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500", form: { data: { turbo: false } } %>
+      <%= button_to "Mark all read", mark_all_read_notifications_path, method: :post, params: request.query_parameters.slice("filter", "severity", "source"), class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500", form: { data: { turbo: false } } %>
     </div>
   </div>
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -121,6 +121,23 @@ RSpec.describe "Notifications" do
       expect(n2.reload.read_at).to be_present
       expect(already_read.reload.read_at).to be_present
     end
+
+    it "preserves the current query params in the mark all read form" do
+      get notifications_path(filter: "unread", severity: "error", source: "quality_gate")
+
+      doc = Nokogiri::HTML(response.body)
+      form = doc.at_css("form.button_to[action='#{mark_all_read_notifications_path}']")
+
+      expect(form.at_css("input[name='filter']")["value"]).to eq("unread")
+      expect(form.at_css("input[name='severity']")["value"]).to eq("error")
+      expect(form.at_css("input[name='source']")["value"]).to eq("quality_gate")
+    end
+
+    it "redirects back to the filtered index for HTML requests" do
+      post mark_all_read_notifications_path, params: { filter: "unread", severity: "error", source: "quality_gate" }
+
+      expect(response).to redirect_to(notifications_path(filter: "unread", severity: "error", source: "quality_gate"))
+    end
   end
 
   describe "multi-tenant scoping" do


### PR DESCRIPTION
## Summary
- Fix `NoMethodError: undefined method 'prev'` crash on notifications index page (Pagy 43.x renamed `prev` → `previous`)
- Fix `mark_all_read` turbo_stream destroying `<tbody id="notifications_list">` by changing `replace` → `update` (replace swapped the element with bare `<tr>` fragments, losing the wrapper and its `id`)
- Fix index page "Mark all read" leaving stale pagination/filter state by bypassing Turbo for a full page reload
- Fix `mark_all_read` HTML redirect dropping `filter`, `severity`, and `source` params
- Fix filter links to compose — severity links now preserve the read-status filter and vice versa