### PR TITLE
fix(opencode): pre-seed opencode database into container tmpfs

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -878,7 +878,7 @@ module Containers
     end
 
     def seed_opencode_database!
-      return unless container_executable_opencode?
+      return unless opencode_provider_requested?
 
       result = container.exec(
         [ "sh", "-c",
@@ -896,8 +896,13 @@ module Containers
       log_system("container.opencode_database_seed_failed", error: e.message)
     end
 
-    def container_executable_opencode?
-      ProviderSupport.container_executable_provider_key?("opencode")
+    def opencode_provider_requested?
+      return false unless agent_run
+
+      providers = resolved_run_provider_candidates
+      return providers.any? { |provider| provider.provider_key == "opencode" } if providers.any?
+
+      ProviderSupport.provider_key_for_agent_type(agent_run.agent_type) == "opencode"
     end
 
     def seed_gemini_credentials!
@@ -1649,14 +1654,14 @@ module Containers
     def codex_subscription_provider_requested?
       return false unless agent_run
 
-      providers = codex_resolved_provider_candidates
+      providers = resolved_run_provider_candidates
       return providers.any? { |provider| provider.provider_key == "codex" && provider.subscription? } if providers.any?
 
       ProviderSupport.provider_key_for_agent_type(agent_run.agent_type) == "codex"
     end
 
-    def codex_resolved_provider_candidates
-      return codex_run_provider_candidates if agent_run.provider
+    def resolved_run_provider_candidates
+      return run_provider_candidates if agent_run.provider
 
       settings = resolved_user_settings
       return [] unless settings
@@ -1670,7 +1675,7 @@ module Containers
       providers_for_identifiers(identifiers, user: settings.user)
     end
 
-    def codex_run_provider_candidates
+    def run_provider_candidates
       providers = [ agent_run.provider ]
       settings = resolved_user_settings
       if settings&.fallback_enabled?

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -175,6 +175,7 @@ module Containers
       @container = create_container
       start_container
       fix_all_ownership!
+      seed_opencode_database!
       seed_codex_credentials!
       seed_gemini_credentials!
       seed_copilot_credentials!
@@ -874,6 +875,29 @@ module Containers
         f.flock(File::LOCK_UN)
         log_system("container.codex_auth_lock.released", lockfile: lockfile)
       end
+    end
+
+    def seed_opencode_database!
+      return unless container_executable_opencode?
+
+      result = container.exec(
+        [ "sh", "-c",
+          "if [ -d /opt/opencode-seed ]; then " \
+          "cp -a /opt/opencode-seed/. /home/agent/.local/share/opencode/ && " \
+          "chown -R agent:agent /home/agent/.local/share/opencode; " \
+          "fi" ],
+        user: "root"
+      )
+      exit_code = result.is_a?(Array) ? result[2].to_i : 0
+      raise Docker::Error::DockerError, "opencode database seed exited with #{exit_code}" unless exit_code == 0
+
+      log_system("container.opencode_database_seeded")
+    rescue Docker::Error::DockerError => e
+      log_system("container.opencode_database_seed_failed", error: e.message)
+    end
+
+    def container_executable_opencode?
+      ProviderSupport.container_executable_provider_key?("opencode")
     end
 
     def seed_gemini_credentials!

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -277,10 +277,18 @@ RUN useradd -m -s /bin/bash agent \
 # into stdout, which breaks the Test Agent ping response matching.
 # The opencode binary creates its DB on first run; this step discards the
 # network-dependent output and only keeps the migrated SQLite file.
+#
+# The pre-seeded DB is copied to /opt/opencode-seed so it survives the tmpfs
+# mount that Provision#host_config places at /home/agent/.local/share/opencode
+# at runtime. Containers::Provision#seed_opencode_database! copies it from
+# /opt into the tmpfs after the container starts.
 USER agent
 RUN mkdir -p /home/agent/.local/share/opencode \
     && timeout 10s opencode run "OK" > /dev/null 2>&1 || true
 USER root
+RUN mkdir -p /opt/opencode-seed \
+    && cp -a /home/agent/.local/share/opencode/. /opt/opencode-seed/ \
+    && chown -R agent:agent /opt/opencode-seed
 
 # Set up working directory
 WORKDIR /workspace

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -206,8 +206,6 @@ RSpec.describe Containers::Provision do
           metadata: hash_including(network: NetworkPolicy::NETWORK_NAME)).ordered
         expect(agent_run).to receive(:log!).with("system", "container.ownership_batch_fixed",
           metadata: hash_including(dirs_count: 12)).ordered
-        expect(agent_run).to receive(:log!).with("system", "container.opencode_database_seeded",
-          metadata: {}).ordered
         expect(agent_run).to receive(:log!).with("system", "container.codex_config_seeded",
           metadata: {}).ordered
         expect(agent_run).to receive(:log!).with("system", "container.firewall.applied",
@@ -216,6 +214,15 @@ RSpec.describe Containers::Provision do
           metadata: hash_including(container_id: "abc123container")).ordered
 
         service.provision
+      end
+
+      it "skips OpenCode database seeding when the run does not resolve to opencode" do
+        service.provision
+
+        expect(mock_container).not_to have_received(:exec).with(
+          [ "sh", "-c", include("/opt/opencode-seed") ],
+          user: "root"
+        )
       end
 
       it "batches all ownership fixes into a single exec call" do
@@ -1499,9 +1506,21 @@ RSpec.describe Containers::Provision do
   end
 
   describe "#seed_opencode_database!" do
+    let(:api_key) { create(:provider_api_key, user: project.created_by, api_service_type: "openrouter") }
+    let!(:opencode_provider) do
+      create(
+        :provider,
+        :api_key,
+        user: project.created_by,
+        provider_key: "opencode",
+        provider_api_key: api_key,
+        config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2.5" } }
+      )
+    end
     let(:service) { described_class.new(agent_run: agent_run, worktree_path: worktree_path) }
 
     before do
+      project.created_by.settings.update!(default_agent_provider: opencode_provider.routing_key)
       allow(Docker::Container).to receive(:create).and_return(mock_container)
       allow(mock_container).to receive(:start)
       allow(NetworkPolicy).to receive_messages(ensure_network!: mock_network, apply_firewall_rules: nil)
@@ -1528,6 +1547,17 @@ RSpec.describe Containers::Provision do
 
       expect(agent_run).to have_received(:log!).with("system", "container.opencode_database_seeded",
         metadata: {})
+    end
+
+    it "does not seed when the run resolves to a different provider" do
+      project.created_by.settings.update!(default_agent_provider: "claude")
+
+      service.provision
+
+      expect(mock_container).not_to have_received(:exec).with(
+        [ "sh", "-c", include("/opt/opencode-seed") ],
+        user: "root"
+      )
     end
 
     context "when Docker exec fails during opencode seed" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -206,6 +206,8 @@ RSpec.describe Containers::Provision do
           metadata: hash_including(network: NetworkPolicy::NETWORK_NAME)).ordered
         expect(agent_run).to receive(:log!).with("system", "container.ownership_batch_fixed",
           metadata: hash_including(dirs_count: 12)).ordered
+        expect(agent_run).to receive(:log!).with("system", "container.opencode_database_seeded",
+          metadata: {}).ordered
         expect(agent_run).to receive(:log!).with("system", "container.codex_config_seeded",
           metadata: {}).ordered
         expect(agent_run).to receive(:log!).with("system", "container.firewall.applied",
@@ -1492,6 +1494,76 @@ RSpec.describe Containers::Provision do
         expect(NetworkPolicy).not_to receive(:apply_firewall_rules)
 
         service.provision
+      end
+    end
+  end
+
+  describe "#seed_opencode_database!" do
+    let(:service) { described_class.new(agent_run: agent_run, worktree_path: worktree_path) }
+
+    before do
+      allow(Docker::Container).to receive(:create).and_return(mock_container)
+      allow(mock_container).to receive(:start)
+      allow(NetworkPolicy).to receive_messages(ensure_network!: mock_network, apply_firewall_rules: nil)
+      allow(Docker::Volume).to receive(:create).and_return(mock_volume)
+      allow(Docker::Volume).to receive(:get).and_raise(Docker::Error::NotFoundError)
+      allow(agent_run).to receive(:log!)
+    end
+
+    it "copies pre-seeded database from /opt/opencode-seed into the tmpfs" do
+      service.provision
+
+      expect(mock_container).to have_received(:exec).with(
+        [ "sh", "-c",
+          satisfy { |script|
+            script.include?("/opt/opencode-seed") &&
+              script.include?("/home/agent/.local/share/opencode")
+          } ],
+        user: "root"
+      )
+    end
+
+    it "logs the seeding success" do
+      service.provision
+
+      expect(agent_run).to have_received(:log!).with("system", "container.opencode_database_seeded",
+        metadata: {})
+    end
+
+    context "when Docker exec fails during opencode seed" do
+      before do
+        allow(mock_container).to receive(:exec) do |cmd, **opts|
+          if cmd.is_a?(Array) && cmd[0] == "sh" && cmd[1] == "-c" && cmd.last.include?("/opt/opencode-seed")
+            raise Docker::Error::DockerError, "copy failed"
+          end
+          nil
+        end
+      end
+
+      it "logs the failure but does not raise" do
+        expect { service.provision }.not_to raise_error
+
+        expect(agent_run).to have_received(:log!).with("system", "container.opencode_database_seed_failed",
+          metadata: hash_including(error: "copy failed"))
+      end
+    end
+
+    context "when the cp command exits non-zero" do
+      before do
+        allow(mock_container).to receive(:exec) do |cmd, **opts|
+          if cmd.is_a?(Array) && cmd[0] == "sh" && cmd[1] == "-c" && cmd.last.include?("/opt/opencode-seed")
+            [ [], [], 1 ]
+          else
+            nil
+          end
+        end
+      end
+
+      it "logs the failure with the exit code" do
+        expect { service.provision }.not_to raise_error
+
+        expect(agent_run).to have_received(:log!).with("system", "container.opencode_database_seed_failed",
+          metadata: hash_including(error: "opencode database seed exited with 1"))
       end
     end
   end


### PR DESCRIPTION
## Summary

- The Dockerfile pre-seeds the opencode SQLite database at `/home/agent/.local/share/opencode/`, but the container config mounts a tmpfs at that path (`provision.rb:1338`), hiding the pre-seeded DB and triggering the "Performing one time database migration..." message on every container start
- Copies the pre-seeded DB to `/opt/opencode-seed` (outside the tmpfs overlay) during image build, then restores it into the tmpfs during container provisioning via `seed_opencode_database!`
- Follows the exit-code checking pattern from `seed_codex_notify_hook!` — non-zero exits are caught and logged as failures rather than silently swallowed

## Testing

- Added 4 tests: successful copy, success logging, Docker exec error handling, non-zero exit code handling
- All 162 provision spec tests pass, 0 failures
- RuboCop clean

## Related

- Depends on: viamin/agent-harness#173 (upstream timeout fix for slow models)
- Tracks: viamin/paid#1538