### PR TITLE
fix(agent-runs): remove hardcoded Claude preference from provider fallback paths

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -247,13 +247,12 @@ class Provider < ApplicationRecord
   end
 
   # Returns the provider key that must always exist and remain enabled for
-  # agent runs. Prefers "claude" when container-executable, otherwise falls
-  # back to the first available container-executable provider. Returns nil
-  # when no container-executable providers are available, so callers can
-  # surface a user-facing error instead of a 500.
+  # agent runs. Returns the first container-executable provider key in
+  # supported order, with no hardcoded preference for any specific provider.
+  # Returns nil when no container-executable providers are available, so
+  # callers can surface a user-facing error instead of a 500.
   def self.default_provider_key
-    executable_keys = ProviderSupport.container_executable_provider_keys
-    executable_keys.include?("claude") ? "claude" : executable_keys.first
+    ProviderSupport.container_executable_provider_keys.first
   end
 
   def self.ensure_default_for(user)
@@ -263,6 +262,13 @@ class Provider < ApplicationRecord
     user.providers.find_or_create_by!(provider_key: key, auth_type: "subscription")
   rescue ActiveRecord::RecordNotUnique
     user.providers.find_by!(provider_key: key, auth_type: "subscription")
+  end
+
+  def self.first_enabled_for_owner(owner)
+    return unless owner
+
+    executable_keys = ProviderSupport.container_executable_provider_keys
+    owner.providers.for_agent_runs.where(provider_key: executable_keys).ordered.first
   end
 
   def self.display_name_for(provider_key)

--- a/app/services/agent_runs/create_followup.rb
+++ b/app/services/agent_runs/create_followup.rb
@@ -42,7 +42,7 @@ module AgentRuns
         project: agent_run.project,
         issue: agent_run.issue,
         provider: provider,
-        agent_type: provider ? Provider.agent_type_for(provider.provider_key) : "claude_code",
+        agent_type: provider ? Provider.agent_type_for(provider.provider_key) : fallback_agent_type,
         status: "queued",
         trigger_type: "automatic",
         auto_pick: true,
@@ -55,6 +55,14 @@ module AgentRuns
 
       provider_id, = AgentRuns::ProviderResolver.call(project: agent_run.project, goal: goal)
       Provider.find_by(id: provider_id) if provider_id
+    end
+
+    def fallback_agent_type
+      enabled = Provider.first_enabled_for_owner(agent_run.project.effective_owner)
+      return Provider.agent_type_for(enabled.provider_key) if enabled
+
+      first_key = ProviderSupport.container_executable_provider_keys.first
+      first_key ? Provider.agent_type_for(first_key) : "claude_code"
     end
 
     def handle_duplicate

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -25,7 +25,7 @@ module AgentRuns
       provider = default_provider
       return [ provider.id, Provider.agent_type_for(provider.provider_key) ] if provider
 
-      [ nil, "claude_code" ]
+      fallback_from_settings
     end
 
     private
@@ -117,6 +117,15 @@ module AgentRuns
         requested_provider_id: requested_provider_id,
         requested_agent_type: requested_agent_type
       )
+    end
+
+    def fallback_from_settings
+      enabled = Provider.first_enabled_for_owner(project.effective_owner)
+      return [ enabled.id, Provider.agent_type_for(enabled.provider_key) ] if enabled
+
+      first_key = ProviderSupport.container_executable_provider_keys.first
+      agent_type = first_key ? Provider.agent_type_for(first_key) : "claude_code"
+      [ nil, agent_type ]
     end
   end
 end

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -4,6 +4,8 @@ module Activities
   class CreateAgentRunActivity < BaseActivity
     activity_name "CreateAgentRun"
 
+    NON_CONTAINER_GOALS = %w[enhance_issue analyze_issue].freeze
+
     def execute(input)
       agent_run_id = input[:agent_run_id]
 
@@ -32,7 +34,7 @@ module Activities
         respect_requested: input.key?(:agent_type) || input.key?(:provider_id)
       )
 
-      validate_runnable_provider!(provider_id, agent_type)
+      validate_runnable_provider!(provider_id, agent_type, goal: goal)
 
       # Resolve and render prompt version if no custom prompt is provided.
       # Skip for untrusted issues to match the safety behavior in AgentRun#prompt_for_issue.
@@ -257,7 +259,9 @@ module Activities
       )
     end
 
-    def validate_runnable_provider!(provider_id, agent_type)
+    def validate_runnable_provider!(provider_id, agent_type, goal:)
+      return if goal.in?(NON_CONTAINER_GOALS)
+
       return if provider_id.present?
 
       provider_key = ProviderSupport.provider_key_for_agent_type(agent_type)

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -32,6 +32,8 @@ module Activities
         respect_requested: input.key?(:agent_type) || input.key?(:provider_id)
       )
 
+      validate_runnable_provider!(provider_id, agent_type)
+
       # Resolve and render prompt version if no custom prompt is provided.
       # Skip for untrusted issues to match the safety behavior in AgentRun#prompt_for_issue.
       prompt_version = nil
@@ -252,6 +254,19 @@ module Activities
       Prompts::LanguageCommands::LANGUAGE_LINT_COMMANDS.fetch(
         Prompts::LanguageCommands.detected_language(project),
         "echo \"No lint command configured\""
+      )
+    end
+
+    def validate_runnable_provider!(provider_id, agent_type)
+      return if provider_id.present?
+
+      provider_key = ProviderSupport.provider_key_for_agent_type(agent_type)
+      return if ProviderSupport.container_executable_provider_key?(provider_key)
+
+      raise Temporalio::Error::ApplicationError.new(
+        "No runnable provider available for project (agent_type=#{agent_type})",
+        type: "NoRunnableProvider",
+        non_retryable: true
       )
     end
   end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -496,9 +496,12 @@ module Activities
     end
 
     def default_provider_candidates(agent_run, user_settings)
+      first_key = ProviderSupport.container_executable_provider_keys.first
+      default_fallback = first_key ? ProviderSupport.agent_type_for(first_key) : "claude_code"
+
       candidates = [
         user_settings.default_provider_identifier_for_goal(agent_run.goal),
-        "claude_code"
+        default_fallback
       ].compact_blank
 
       seen = Set.new
@@ -687,6 +690,8 @@ module Activities
         "Rate limited by #{provider}: #{e.matched_output.to_s.truncate(200)}",
         reset_at: reset_at
       )
+    rescue Containers::Provision::ExecutionError => e
+      raise ProviderExecutionError, "Docker exec error: #{e.message}"
     end
 
     # Checks if the agent run is stuck in an infinite loop by analyzing

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -392,24 +392,28 @@ RSpec.describe Provider do
 
     it "creates the default provider when missing" do
       user.providers.delete_all
+      default_key = described_class.default_provider_key
 
       expect { described_class.ensure_default_for(user) }
-        .to change { user.providers.where(provider_key: "claude").count }
+        .to change { user.providers.where(provider_key: default_key).count }
         .from(0).to(1)
     end
 
     it "creates a subscription provider by default" do
       user.providers.delete_all
+      default_key = described_class.default_provider_key
 
       described_class.ensure_default_for(user)
-      provider = user.providers.find_by(provider_key: "claude")
+      provider = user.providers.find_by(provider_key: default_key)
 
       expect(provider.auth_type).to eq("subscription")
     end
 
     it "is idempotent" do
+      default_key = described_class.default_provider_key
+
       expect { described_class.ensure_default_for(user) }
-        .not_to change { user.providers.where(provider_key: "claude").count }
+        .not_to change { user.providers.where(provider_key: default_key).count }
     end
   end
 

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -612,7 +612,10 @@ RSpec.describe Issues::AutoPick do
 
     it "returns nil and warns when no runnable provider can be resolved" do
       create(:issue, project: project)
-      allow(Provider).to receive(:ensure_default_for).and_return(nil)
+      allow(Provider).to receive_messages(
+        ensure_default_for: nil,
+        first_enabled_for_owner: nil
+      )
       allow(AgentRuns::UserSettingsResolver).to receive(:call).and_return(nil)
       allow(Rails.logger).to receive(:warn)
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `claude_code` fallbacks in `ProviderResolver`, `CreateFollowup`, and `RunAgentActivity` with dynamic resolution that queries enabled providers first via new `Provider.first_enabled_for-owner`
- Add `Containers::Provision::ExecutionError` rescue in `RunAgentActivity` so Docker exec errors trigger provider fallback instead of failing the entire run
- Add provider validation in `CreateAgentRunActivity` to fail fast when no runnable provider is available
- Remove hardcoded Claude preference from `Provider.default_provider_key`

## Root Cause

When Claude becomes rate-limited and is removed from the round-robin provider rotation (leaving only Codex), agent runs still fail because `"claude_code"` is hardcoded as the default agent_type in 5 fallback paths. The system keeps attempting Claude even when it's unavailable, consuming the full timeout budget before falling back to Codex (or failing entirely if fallback is disabled).

## Test plan

- [x] All 288 existing tests pass (`spec/models/provider_spec.rb`, `spec/services/agent_runs/*`, `spec/temporal/activities/*`)
- [x] Lint clean (`bin/lint --changed`)
- [ ] Manual: disable Claude provider, verify agent runs use Codex without hardcoded Claude fallback
- [ ] Manual: verify Docker exec errors trigger provider fallback instead of failing the run

## Related issues

- #1541 — Projects permanently stuck in scheduler_paused after token re-validation (P1)
- #1542 — Circuit breaker record_success! race condition (P2)
- #1544 — Auth failure checker false positives (P2)
- #1550 — Critical test gaps for provider selection and fallback (P2)