### PR TITLE
fix(containers): mount host-visible heartbeat directory into container

### DIFF
--- a/app/services/containers/heartbeat_setup.rb
+++ b/app/services/containers/heartbeat_setup.rb
@@ -10,53 +10,48 @@ module Containers
   # then uses the file's mtime to distinguish "agent is thinking" from "agent
   # is stuck", suppressing idle/startup timeouts while the agent is active.
   #
+  # The heartbeat file lives on a dedicated bind-mounted directory
+  # (/paid-heartbeat inside the container) so it is visible to both the
+  # container-side hooks and the host-side watchdog.
+  #
   # @example
-  #   setup = Containers::HeartbeatSetup.new(provider: "claude", worktree_path: "/var/paid/ws/123")
-  #   setup.heartbeat_path       # => "/var/paid/ws/123/.paid-heartbeat"
-  #   setup.preparation          # => AgentHarness::ExecutionPreparation (with file writes)
-  #   setup.env                  # => { "AGENT_HEARTBEAT_PATH" => "/workspace/.paid-heartbeat" }
+  #   setup = Containers::HeartbeatSetup.new(
+  #     provider: "claude",
+  #     worktree_path: "/workspace",
+  #     host_heartbeat_path: "/tmp/paid-heartbeat-abc123/.paid-heartbeat"
+  #   )
+  #   setup.heartbeat_path  # => "/tmp/paid-heartbeat-abc123/.paid-heartbeat"
+  #   setup.preparation     # => AgentHarness::ExecutionPreparation (with file writes)
+  #   setup.env             # => { "AGENT_HEARTBEAT_PATH" => "/paid-heartbeat/.paid-heartbeat" }
   class HeartbeatSetup
     HEARTBEAT_FILENAME = ".paid-heartbeat"
 
-    # Container-side path where the heartbeat file is touched.
-    CONTAINER_HEARTBEAT_PATH = "/workspace/#{HEARTBEAT_FILENAME}"
+    CONTAINER_HEARTBEAT_PATH = "/paid-heartbeat/#{HEARTBEAT_FILENAME}"
 
-    # Providers that support heartbeat hooks.
-    # Codex heartbeat is handled by Provision#seed_codex_notify_hook! which
-    # appends a notify command to the full config.toml written during
-    # container provisioning. HeartbeatSetup still advertises availability so
-    # the container watchdog checks the host-visible heartbeat file.
     SUPPORTED_PROVIDERS = %w[claude codex].freeze
 
-    attr_reader :provider, :worktree_path
+    attr_reader :provider, :worktree_path, :host_heartbeat_path
 
-    def initialize(provider:, worktree_path:)
+    def initialize(provider:, worktree_path:, host_heartbeat_path: nil)
       @provider = provider.to_s
       @worktree_path = worktree_path
+      @host_heartbeat_path = host_heartbeat_path
     end
 
-    # Host-visible path the watchdog checks via File.mtime.
-    # Returns nil when the workspace is not bind-mounted (Docker volume).
     def heartbeat_path
-      return nil unless worktree_path.present?
-
-      File.join(worktree_path, HEARTBEAT_FILENAME)
+      host_heartbeat_path
     end
 
-    # Whether this provider/workspace combination supports heartbeat.
     def available?
-      heartbeat_path.present? && SUPPORTED_PROVIDERS.include?(canonical_provider)
+      host_heartbeat_path.present? && SUPPORTED_PROVIDERS.include?(canonical_provider)
     end
 
-    # Environment variables to inject into the agent command.
     def env
       return {} unless available?
 
       { "AGENT_HEARTBEAT_PATH" => CONTAINER_HEARTBEAT_PATH }
     end
 
-    # Execution preparation with provider-specific config file writes.
-    # Returns nil when heartbeat is not available.
     def preparation
       return nil unless available?
 

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -460,6 +460,7 @@ module Containers
     # @param force [Boolean] Force kill if container doesn't stop gracefully
     # @return [void]
     def cleanup(force: false)
+      cleanup_heartbeat_dir!
       return unless container
 
       log_system("container.cleanup.start", container_id: container.id)
@@ -479,7 +480,6 @@ module Containers
         @container = nil
         cleanup_workspace_volume
         cleanup_claimed_pool_entry
-        cleanup_heartbeat_dir!
       end
     end
 
@@ -1214,9 +1214,12 @@ module Containers
     end
 
     def valid_heartbeat_dir?(path)
-      return false unless path.start_with?("#{Dir.tmpdir}/")
+      return false unless path.is_a?(String) && path.start_with?("#{Dir.tmpdir}/")
 
-      File.basename(path).match?(HEARTBEAT_DIR_PATTERN)
+      realpath = File.realpath(path) rescue nil
+      return false unless realpath && realpath.start_with?("#{Dir.tmpdir}/")
+
+      File.basename(realpath).match?(HEARTBEAT_DIR_PATTERN)
     end
 
     def cleanup_workspace_volume

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -3,6 +3,7 @@
 require "base64"
 require "digest"
 require "docker-api"
+require "securerandom"
 require "shellwords"
 
 module Containers
@@ -28,7 +29,8 @@ module Containers
   #   end
   #
   class Provision
-    CODEX_NOTIFY_LINE = 'notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]'
+    CODEX_NOTIFY_LINE = 'notify = ["sh", "-lc", "date +%s > /paid-heartbeat/.paid-heartbeat"]'
+    HEARTBEAT_MOUNT_POINT = "/paid-heartbeat"
 
     # Base error for all container service errors
     class Error < StandardError; end
@@ -122,7 +124,7 @@ module Containers
       workspace_mount: "/workspace"
     }.freeze
 
-    attr_reader :agent_run, :project, :worktree_path, :container, :options, :workspace_volume, :pool_entry
+    attr_reader :agent_run, :project, :worktree_path, :container, :options, :workspace_volume, :pool_entry, :heartbeat_dir_host
 
     def self.network_for(agent_run:)
       new(agent_run: agent_run).network_name
@@ -162,6 +164,7 @@ module Containers
       @container = nil
       @heartbeat_age_cache = {}
       @heartbeat_age_cache_mutex = Mutex.new
+      @heartbeat_dir_host = nil
     end
 
     # Provisions a new container with security hardening.
@@ -172,6 +175,7 @@ module Containers
     def provision
       log_system("container.provision.start", image: options[:image])
 
+      prepare_heartbeat_dir!
       prepare_workspace!
       ensure_network!
       @container = create_container
@@ -421,6 +425,19 @@ module Containers
         end
 
         log_system("container.execute.failed", error: e.message)
+
+        begin
+          container.refresh!
+          cstate = container.info["State"] || {}
+          log_system("container.execute.container_state",
+            running: cstate["Running"],
+            exit_code: cstate["ExitCode"],
+            oom_killed: cstate["OOMKilled"],
+            error: cstate["Error"],
+            finished_at: cstate["FinishedAt"])
+        rescue Docker::Error::DockerError
+        end
+
         raise ExecutionError.new("Docker exec error: #{e.message}")
       ensure
         watchdog_mutex.synchronize { exec_completed = true }
@@ -462,6 +479,7 @@ module Containers
         @container = nil
         cleanup_workspace_volume
         cleanup_claimed_pool_entry
+        cleanup_heartbeat_dir!
       end
     end
 
@@ -477,6 +495,12 @@ module Containers
       false
     end
 
+    def heartbeat_host_path
+      return nil unless heartbeat_dir_host.present?
+
+      File.join(heartbeat_dir_host, HeartbeatSetup::HEARTBEAT_FILENAME)
+    end
+
     # Attaches an existing Docker container to this service instance.
     # Used by .reconnect to rehydrate container state without reaching into ivars.
     #
@@ -486,6 +510,7 @@ module Containers
       @container = container
       @workspace_volume = workspace_volume if workspace_volume.present?
       @pool_entry = pool_entry if pool_entry.present?
+      restore_heartbeat_dir!
       self
     end
 
@@ -1150,6 +1175,50 @@ module Containers
       container.exec([ "sh", "-lc", cmd ], user: "agent")
     end
 
+    def prepare_heartbeat_dir!
+      dir = File.join(Dir.tmpdir, "paid-heartbeat-#{SecureRandom.hex(8)}")
+      FileUtils.mkdir_p(dir)
+      @heartbeat_dir_host = dir
+      File.chmod(0o777, dir)
+      log_system("container.heartbeat_dir_prepared", path: dir)
+    end
+
+    HEARTBEAT_DIR_PATTERN = /\Apaid-heartbeat-[0-9a-f]{16}\z/
+
+    def restore_heartbeat_dir!
+      return if @heartbeat_dir_host.present?
+
+      label = container.info&.dig("Config", "Labels", "paid.heartbeat_dir")
+      return unless label.present? && valid_heartbeat_dir?(label)
+
+      @heartbeat_dir_host = label
+    rescue => e
+      Rails.logger.warn(
+        message: "container_manager.heartbeat_dir_restore_failed",
+        agent_run_id: agent_run&.id,
+        error: e.message
+      )
+    end
+
+    def cleanup_heartbeat_dir!
+      return unless @heartbeat_dir_host && valid_heartbeat_dir?(@heartbeat_dir_host)
+
+      FileUtils.rm_rf(@heartbeat_dir_host)
+      @heartbeat_dir_host = nil
+    rescue => e
+      Rails.logger.warn(
+        message: "container_manager.heartbeat_cleanup_failed",
+        agent_run_id: agent_run&.id,
+        error: e.message
+      )
+    end
+
+    def valid_heartbeat_dir?(path)
+      return false unless path.start_with?("#{Dir.tmpdir}/")
+
+      File.basename(path).match?(HEARTBEAT_DIR_PATTERN)
+    end
+
     def cleanup_workspace_volume
       volume_name = @workspace_volume
       volume_name ||= "paid-workspace-#{agent_run.id}" if worktree_path.blank? && agent_run.present? && !pooled_container?
@@ -1202,6 +1271,7 @@ module Containers
         labels["paid.agent_run_id"] = agent_run.id.to_s
       end
 
+      labels["paid.heartbeat_dir"] = heartbeat_dir_host if heartbeat_dir_host
       labels
     end
 
@@ -1215,6 +1285,7 @@ module Containers
 
     # Writable directories inside the container:
     #   /workspace          - bind mount of workspace dir (rw, for git clone and code changes)
+    #   /paid-heartbeat     - bind mount of host temp dir (rw, for heartbeat file shared with watchdog)
     #   /tmp                - tmpfs (1GB, for scratch files)
     #   /home/agent/.cache  - tmpfs (512MB, for tool caches: Codex CLI, npm, etc.)
     #   /home/agent/.claude - tmpfs (256MB, for Claude CLI session/project data)
@@ -1255,6 +1326,8 @@ module Containers
       elsif worktree_path.present?
         binds << "#{worktree_path}:#{options[:workspace_mount]}:rw"
       end
+
+      binds << "#{heartbeat_dir_host}:#{HEARTBEAT_MOUNT_POINT}:rw" if heartbeat_dir_host
 
       # Mount the host's Claude config as read-only at a staging path.
       # Credentials are copied into the writable /home/agent/.claude tmpfs

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1563,7 +1563,7 @@ module Activities
     end
 
     def container_dead_after_exec_error?(agent_run, error)
-      return false unless error.message.include?("container") && error.message.include?("is not running")
+      return false unless error.message.match?(/container.*is not running/i)
       return false if agent_run.container_id.blank?
 
       container_service = reconnect_container(agent_run) rescue nil

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1567,7 +1567,9 @@ module Activities
       return false if agent_run.container_id.blank?
 
       container_service = reconnect_container(agent_run) rescue nil
-      !container_service&.container_running?
+      return false unless container_service
+
+      !container_service.container_running?
     end
 
     def container_exit_diagnostics(container_service)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -291,6 +291,16 @@ module Activities
             record_provider_failure(user_settings, provider_state_name, provider_states)
             agent_run.record_provider_attempt(attempt_label, success: false, error_type: "error")
             logger.warn(message: "agent_execution.provider_failed", provider: provider, agent_run_id: agent_run.id, error: e.message)
+
+            if container_dead_after_exec_error?(agent_run, e)
+              logger.error(
+                message: "agent_execution.container_dead_breaking_provider_loop",
+                agent_run_id: agent_run.id,
+                container_id: agent_run.container_id,
+                error: e.message
+              )
+              break
+            end
           end
 
           index += 1
@@ -540,6 +550,13 @@ module Activities
     # @return [Hash] The pre-agent SHA and whether output was present
     def run_agent_with_provider(agent_run, provider_candidate, prompt, user_settings)
       container_service = reconnect_container(agent_run)
+
+      unless container_service.container_running?
+        container_exit_info = container_exit_diagnostics(container_service)
+        raise ProviderExecutionError,
+          "Container #{agent_run.container_id} is not running. #{container_exit_info}"
+      end
+
       provider = provider_command_key(provider_candidate, agent_run, user_settings.user)
 
       unless self.class.container_executable?(provider)
@@ -567,7 +584,8 @@ module Activities
 
       heartbeat = Containers::HeartbeatSetup.new(
         provider: provider,
-        worktree_path: agent_run.worktree_path
+        worktree_path: agent_run.worktree_path,
+        host_heartbeat_path: container_service.heartbeat_host_path
       )
       if heartbeat.available?
         command_env = command_env.merge(heartbeat.env)
@@ -1542,6 +1560,36 @@ module Activities
       error_or_cause_matches?(error, Containers::Provision::ProvisionError) do |candidate|
         candidate.message.start_with?("Failed to reconnect to container:")
       end
+    end
+
+    def container_dead_after_exec_error?(agent_run, error)
+      return false unless error.message.include?("container") && error.message.include?("is not running")
+      return false if agent_run.container_id.blank?
+
+      container_service = reconnect_container(agent_run) rescue nil
+      !container_service&.container_running?
+    end
+
+    def container_exit_diagnostics(container_service)
+      container = container_service.container
+      return "Container object unavailable." unless container
+
+      container.refresh!
+      state = container.info["State"] || {}
+      exit_code = state["ExitCode"]
+      oom_killed = state["OOMKilled"]
+      error_msg = state["Error"]
+      finished_at = state["FinishedAt"]
+
+      reasons = []
+      reasons << "OOM killed" if oom_killed
+      reasons << "exit code #{exit_code}" if exit_code && exit_code != 0
+      reasons << "error: #{error_msg}" if error_msg.present?
+      reasons << "finished at #{finished_at}" if finished_at.present?
+
+      "Container state: #{reasons.join(', ').presence || 'unknown'}"
+    rescue Docker::Error::DockerError => e
+      "Could not inspect container: #{e.message}"
     end
 
     def error_or_cause_matches?(error, klass, &block)

--- a/spec/services/containers/heartbeat_setup_spec.rb
+++ b/spec/services/containers/heartbeat_setup_spec.rb
@@ -4,71 +4,67 @@ require "rails_helper"
 
 RSpec.describe Containers::HeartbeatSetup do
   let(:worktree_path) { "/var/paid/workspaces/abc/123" }
+  let(:host_heartbeat_path) { "/tmp/paid-heartbeat-abc123/.paid-heartbeat" }
 
   describe "#heartbeat_path" do
-    it "returns host-side path for bind-mounted workspace" do
-      setup = described_class.new(provider: "claude", worktree_path: worktree_path)
-      expect(setup.heartbeat_path).to eq("/var/paid/workspaces/abc/123/.paid-heartbeat")
+    it "returns host_heartbeat_path when provided" do
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expect(setup.heartbeat_path).to eq(host_heartbeat_path)
     end
 
-    it "returns nil when worktree_path is nil" do
-      setup = described_class.new(provider: "claude", worktree_path: nil)
-      expect(setup.heartbeat_path).to be_nil
-    end
-
-    it "returns nil when worktree_path is blank" do
-      setup = described_class.new(provider: "claude", worktree_path: "")
+    it "returns nil when host_heartbeat_path is nil" do
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
       expect(setup.heartbeat_path).to be_nil
     end
   end
 
   describe "#available?" do
-    it "returns true for claude with worktree" do
-      setup = described_class.new(provider: "claude", worktree_path: worktree_path)
+    it "returns true for claude with host_heartbeat_path" do
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup).to be_available
     end
 
-    it "returns true for claude_code with worktree" do
-      setup = described_class.new(provider: "claude_code", worktree_path: worktree_path)
+    it "returns true for claude_code with host_heartbeat_path" do
+      setup = described_class.new(provider: "claude_code", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup).to be_available
     end
 
-    it "returns true for codex with worktree" do
-      setup = described_class.new(provider: "codex", worktree_path: worktree_path)
+    it "returns true for codex with host_heartbeat_path" do
+      setup = described_class.new(provider: "codex", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup).to be_available
     end
 
     it "returns false for unsupported provider" do
-      setup = described_class.new(provider: "gemini", worktree_path: worktree_path)
+      setup = described_class.new(provider: "gemini", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup).not_to be_available
     end
 
-    it "returns false without worktree_path" do
-      setup = described_class.new(provider: "claude", worktree_path: nil)
+    it "returns false without host_heartbeat_path" do
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
       expect(setup).not_to be_available
     end
   end
 
   describe "#env" do
     it "returns AGENT_HEARTBEAT_PATH for supported provider" do
-      setup = described_class.new(provider: "claude", worktree_path: worktree_path)
-      expect(setup.env).to eq("AGENT_HEARTBEAT_PATH" => "/workspace/.paid-heartbeat")
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expect(setup.env).to eq("AGENT_HEARTBEAT_PATH" => "/paid-heartbeat/.paid-heartbeat")
     end
 
     it "returns empty hash for unsupported provider" do
-      setup = described_class.new(provider: "gemini", worktree_path: worktree_path)
+      setup = described_class.new(provider: "gemini", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup.env).to eq({})
     end
 
-    it "returns empty hash without worktree_path" do
-      setup = described_class.new(provider: "claude", worktree_path: nil)
+    it "returns empty hash without host_heartbeat_path" do
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
       expect(setup.env).to eq({})
     end
   end
 
   describe "#preparation" do
     context "with claude provider" do
-      let(:setup) { described_class.new(provider: "claude", worktree_path: worktree_path) }
+      let(:setup) { described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path) }
 
       it "returns preparation with Claude settings file write" do
         preparation = setup.preparation
@@ -81,7 +77,7 @@ RSpec.describe Containers::HeartbeatSetup do
         settings = JSON.parse(write.content)
         hook = settings.dig("hooks", "PostToolUse", 0, "hooks", 0)
         expect(hook["type"]).to eq("command")
-        expect(hook["command"]).to include("touch /workspace/.paid-heartbeat")
+        expect(hook["command"]).to include("touch /paid-heartbeat/.paid-heartbeat")
       end
 
       context "with existing project settings" do
@@ -101,13 +97,13 @@ RSpec.describe Containers::HeartbeatSetup do
           FileUtils.mkdir_p(settings_dir)
           File.write(File.join(settings_dir, "settings.json"), JSON.generate(existing_settings))
 
-          setup = described_class.new(provider: "claude", worktree_path: worktree_path)
+          setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
           preparation = setup.preparation
           settings = JSON.parse(preparation.file_writes.first.content)
 
           expect(settings["permissions"]).to eq("allow" => [ "Read", "Write" ])
           expect(settings.dig("hooks", "PreToolUse")).to eq(existing_settings["hooks"]["PreToolUse"])
-          expect(settings.dig("hooks", "PostToolUse", 0, "hooks", 0, "command")).to include("touch /workspace/.paid-heartbeat")
+          expect(settings.dig("hooks", "PostToolUse", 0, "hooks", 0, "command")).to include("touch /paid-heartbeat/.paid-heartbeat")
         end
 
         it "handles malformed existing settings gracefully" do
@@ -115,7 +111,7 @@ RSpec.describe Containers::HeartbeatSetup do
           FileUtils.mkdir_p(settings_dir)
           File.write(File.join(settings_dir, "settings.json"), "not valid json")
 
-          setup = described_class.new(provider: "claude", worktree_path: worktree_path)
+          setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
           preparation = setup.preparation
           settings = JSON.parse(preparation.file_writes.first.content)
           expect(settings.dig("hooks", "PostToolUse")).to be_present
@@ -124,7 +120,7 @@ RSpec.describe Containers::HeartbeatSetup do
     end
 
     context "with claude_code provider" do
-      let(:setup) { described_class.new(provider: "claude_code", worktree_path: worktree_path) }
+      let(:setup) { described_class.new(provider: "claude_code", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path) }
 
       it "generates claude heartbeat config" do
         preparation = setup.preparation
@@ -134,7 +130,7 @@ RSpec.describe Containers::HeartbeatSetup do
     end
 
     context "with codex provider" do
-      let(:setup) { described_class.new(provider: "codex", worktree_path: worktree_path) }
+      let(:setup) { described_class.new(provider: "codex", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path) }
 
       it "returns nil because codex config is handled by Provision" do
         expect(setup.preparation).to be_nil
@@ -142,15 +138,15 @@ RSpec.describe Containers::HeartbeatSetup do
     end
 
     context "with unsupported provider" do
-      let(:setup) { described_class.new(provider: "gemini", worktree_path: worktree_path) }
+      let(:setup) { described_class.new(provider: "gemini", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path) }
 
       it "returns nil" do
         expect(setup.preparation).to be_nil
       end
     end
 
-    context "without worktree_path" do
-      let(:setup) { described_class.new(provider: "claude", worktree_path: nil) }
+    context "without host_heartbeat_path" do
+      let(:setup) { described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil) }
 
       it "returns nil" do
         expect(setup.preparation).to be_nil

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -202,6 +202,8 @@ RSpec.describe Containers::Provision do
       it "logs the provision start and success" do
         expect(agent_run).to receive(:log!).with("system", "container.provision.start",
           metadata: hash_including(image: "paid-agent:latest")).ordered
+        expect(agent_run).to receive(:log!).with("system", "container.heartbeat_dir_prepared",
+          metadata: hash_including(:path)).ordered
         expect(agent_run).to receive(:log!).with("system", "container.network.ready",
           metadata: hash_including(network: NetworkPolicy::NETWORK_NAME)).ordered
         expect(agent_run).to receive(:log!).with("system", "container.ownership_batch_fixed",

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Activities::RunAgentActivity do
     allow(Containers::Provision).to receive(:reconnect)
       .with(agent_run: agent_run, container_id: "abc123")
       .and_return(container_service)
+    allow(container_service).to receive_messages(container_running?: true, container: nil, heartbeat_host_path: "/tmp/paid-heartbeat-test/.paid-heartbeat")
     allow(Containers::GitOperations).to receive(:new)
       .with(container_service: container_service, agent_run: agent_run)
       .and_return(git_ops)
@@ -1832,7 +1833,7 @@ RSpec.describe Activities::RunAgentActivity do
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
             idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
-            heartbeat_path: File.join(agent_run.worktree_path, ".paid-heartbeat")
+            heartbeat_path: "/tmp/paid-heartbeat-test/.paid-heartbeat"
           )
         ).and_return(exec_success)
 


### PR DESCRIPTION
## Summary

- The heartbeat file was written to `/workspace/.paid-heartbeat` inside the container, but `/workspace` is a Docker volume invisible to the host. The watchdog's `File.mtime` always failed silently, so heartbeat suppression never worked — agents waiting for LLM responses were killed by idle/startup timeouts.
- Creates a host temp directory (`/tmp/paid-heartbeat-*`) before container creation, bind-mounts it at `/paid-heartbeat` in the container, and stores the path in container labels for reconnect. Both Claude (PostToolUse hook) and Codex (notify hook) write heartbeat files to this mount; the host-side watchdog reads them via the same host path.
- Path validation on cleanup (`valid_heartbeat_dir?`) prevents `rm_rf` of arbitrary directories if container labels are tampered with.

Closes #1540

## Test plan

- [x] `bin/lint --changed` passes (6 files, 0 offenses)
- [x] `bin/rspec spec/services/containers/heartbeat_setup_spec.rb` — 17 examples, 0 failures
- [x] `bin/rspec spec/services/containers/provision_spec.rb` — 158 examples, 0 failures
- [x] `bin/rspec spec/temporal/activities/run_agent_activity_spec.rb` — 152 examples, 0 failures
- [ ] Deploy to staging and verify heartbeat file appears on host at `/tmp/paid-heartbeat-*/.paid-heartbeat` during agent execution
- [ ] Verify watchdog suppresses idle timeout when agent is silent but heartbeat file is being touched