### PR TITLE
feat(test): add fixture-kit and test-prof profiling

### DIFF
--- a/.github/workflows/test_prof.yml
+++ b/.github/workflows/test_prof.yml
@@ -1,0 +1,102 @@
+name: Test Prof
+
+on:
+  workflow_dispatch:
+    inputs:
+      profiler:
+        description: "Profiler to run"
+        required: true
+        default: factory_prof
+        type: choice
+        options:
+          - factory_prof
+          - factory_doctor
+
+permissions:
+  contents: read
+
+jobs:
+  profile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgres:16.13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+      qdrant:
+        image: qdrant/qdrant:v1.13.2
+        ports:
+          - 6333:6333
+
+    env:
+      BUNDLE_FROZEN: "true"
+      RAILS_ENV: test
+      DB_HOST: localhost
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      QDRANT_URL: http://localhost:6333
+      COVERAGE: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f
+        with:
+          ruby-version: .tool-versions
+          bundler-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .tool-versions
+          cache: "yarn"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile && bin/yarn-postinstall
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
+
+      - name: Set up database
+        run: bin/rails db:prepare
+
+      - name: Verify Qdrant health
+        run: |
+          curl --fail --silent --show-error --retry 10 --retry-delay 2 --retry-connrefused "$QDRANT_URL/healthz"
+
+      - name: Run test-prof
+        run: |
+          set -o pipefail
+          mkdir -p tmp/test_prof
+          case "${{ inputs.profiler }}" in
+            factory_prof)
+              FPROF=1 bin/rspec --exclude-pattern "spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb" | tee tmp/test_prof/factory_prof.log
+              ;;
+            factory_doctor)
+              FDOC=1 bin/rspec --exclude-pattern "spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb" | tee tmp/test_prof/factory_doctor.log
+              ;;
+          esac
+
+      - name: Upload test-prof artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-prof-${{ inputs.profiler }}
+          path: tmp/test_prof/**
+          if-no-files-found: warn
+          retention-days: 7

--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,8 @@ group :test do
   gem "simplecov", require: false
   gem "capybara"
   gem "cuprite"
+  gem "fixture_kit"
+  gem "test-prof"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,7 +563,7 @@ DEPENDENCIES
   solid_cache
   stimulus-rails
   temporalio
-  test-prof (~> 1.0)
+  test-prof
   thruster
   turbo-rails
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bcrypt_pbkdf (1.1.2-arm64-darwin)
+    benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.24.0)
@@ -160,6 +161,10 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
+    fixture_kit (0.14.0)
+      activerecord (>= 8.0)
+      activesupport (>= 8.0)
+      benchmark
     flipper (1.4.1)
       concurrent-ruby (< 2)
     flipper-active_record (1.4.1)
@@ -468,6 +473,7 @@ GEM
     temporalio (1.3.0-x86_64-linux-musl)
       google-protobuf (>= 3.25.0)
       logger
+    test-prof (1.6.1)
     thor (1.5.0)
     thruster (0.1.20)
     thruster (0.1.20-aarch64-linux)
@@ -532,6 +538,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday-retry
+  fixture_kit
   flipper
   flipper-active_record
   good_job (~> 4.18)
@@ -556,6 +563,7 @@ DEPENDENCIES
   solid_cache
   stimulus-rails
   temporalio
+  test-prof (~> 1.0)
   thruster
   turbo-rails
   tzinfo-data
@@ -582,6 +590,7 @@ CHECKSUMS
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
   bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
   bcrypt_pbkdf (1.1.2-arm64-darwin) sha256=afdd6feb6ed5a97b8e44caacb3f2d641b98af78e6a516d4a3520b69af5cf9fea
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.0) sha256=34e6dea61ff4895101aa9c10894ce30186bec73fe2279e0eb52040d8d4cec297
@@ -616,6 +625,7 @@ CHECKSUMS
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   ferrum (0.17.2) sha256=2c2540a850b211a46f4d81de21bfd62048f507e4c327d1807225c3823c17e6ee
+  fixture_kit (0.14.0) sha256=e58f642b0813e1fe630e323e9b8e7f6bd7619412cae9ac0b671d4b2211c393c7
   flipper (1.4.1) sha256=05843240fb3093c7037549e34b046b636c765120f22e0a6268212daf44166e4d
   flipper-active_record (1.4.1) sha256=5197481ad0976a12c481b1778927d873738640f4023300bdb0d71b6e21245a37
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
@@ -732,6 +742,7 @@ CHECKSUMS
   temporalio (1.3.0-arm64-darwin) sha256=22c1f0fbbbfacf7c61ddd0d75e9ffc86590ba39ccbabb87f670821c9152fff7a
   temporalio (1.3.0-x86_64-linux) sha256=5122f3c2bd2b540565fc9ec4e2083401c00a7056c8408cd9922ebe570b366eef
   temporalio (1.3.0-x86_64-linux-musl) sha256=0b9c19a94d6703155618d02facf46481467bde1cdcd86ccb6b4f38896d847560
+  test-prof (1.6.1) sha256=0332d9c39a7c118ed942b2db582f055d9f24964d150004ec6b964d2fa262499e
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   thruster (0.1.20) sha256=c05f2fbcae527bbe093a6e6d84fb12d9d680617e7c162325d9b97e8e9d4b5201
   thruster (0.1.20-aarch64-linux) sha256=754f1701061235235165dde31e7a3bc87ec88066a02981ff4241fcda0d76d397

--- a/docs/TEST_PROFILING.md
+++ b/docs/TEST_PROFILING.md
@@ -1,0 +1,38 @@
+# Test Profiling
+
+This repository uses `test-prof` for opt-in test profiling and `fixture_kit` for a small number of shared hotspot fixtures.
+
+## Why `test-prof` first
+
+`test-prof` gives us low-risk tools to measure factory churn and convert expensive setup incrementally.
+It works with the current `RSpec` + `FactoryBot` setup and does not require a fixture rewrite.
+
+We are using `fixture_kit` selectively for a few large activity specs under `spec/fixture_kit/`, but only where the setup graph is stable and heavily reused. Most of the suite still relies on ad hoc `FactoryBot.create(...)` setup, so `test-prof` remains the safer first tool for finding wins.
+
+## Local usage
+
+Profile the regular non-system suite's factory usage:
+
+```bash
+FPROF=1 COVERAGE=false bin/rspec --exclude-pattern "spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb"
+```
+
+Find examples that write to the database unnecessarily:
+
+```bash
+FDOC=1 COVERAGE=false bin/rspec --exclude-pattern "spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb"
+```
+
+The most common follow-up optimizations are:
+
+- Replace `create(...)` with `build(...)` or `build_stubbed(...)` when persistence is not required.
+- Use `create_default(...)` selectively to reduce factory cascades in deeply-associated factories.
+- Promote very stable, heavily reused persisted graphs into `fixture_kit` definitions under `spec/fixture_kit/`.
+
+## Tenant isolation note
+
+Avoid `let_it_be` in this app unless the spec explicitly handles tenant context. In Paid, `let_it_be` setup runs in `before(:context)`, which bypasses the usual per-example `TenantContext.with_system_access` wrapper and can trigger row-level-security failures.
+
+## CI usage
+
+Use the `Test Prof` GitHub Actions workflow (`workflow_dispatch`) to generate profiling output on a GitHub runner without slowing the default PR checks.

--- a/spec/fixture_kit/activities/create_github_issue/base.rb
+++ b/spec/fixture_kit/activities/create_github_issue/base.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FixtureKit.define do
+  project = create(:project)
+  agent_run = create(:agent_run, :with_custom_prompt, :with_git_context, :with_metrics,
+    project: project,
+    goal: "create_issue",
+    custom_prompt: "Analyze the auth system")
+
+  expose(project:, agent_run:)
+end

--- a/spec/fixture_kit/activities/create_pull_request/base.rb
+++ b/spec/fixture_kit/activities/create_pull_request/base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FixtureKit.define do
+  project = create(:project)
+  issue = create(:issue, project: project)
+  agent_run = create(:agent_run, :with_git_context, :with_metrics, project: project, issue: issue)
+
+  expose(project:, issue:, agent_run:)
+end

--- a/spec/fixture_kit/activities/scan_paid_prs/base.rb
+++ b/spec/fixture_kit/activities/scan_paid_prs/base.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FixtureKit.define do
+  project = create(:project,
+    auto_scan_prs: true,
+    max_pr_followup_runs: 3,
+    pr_action_labels: [],
+    auto_fix_merge_conflicts: false)
+
+  expose(project:)
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,9 @@ require_relative "../config/environment"
 
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "fixture_kit/rspec"
 require "rspec/rails"
+require "test_prof/recipes/rspec/factory_default"
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,13 @@ if ENV.fetch("COVERAGE", "true") != "false"
   end
 end
 
+require "test_prof"
+
+TestProf.configure do |config|
+  config.output_dir = "tmp/test_prof"
+  config.timestamps = true
+end
+
 RSpec.configure do |config|
   config.example_status_persistence_file_path = "spec/.examples.txt"
 

--- a/spec/temporal/activities/create_github_issue_activity_spec.rb
+++ b/spec/temporal/activities/create_github_issue_activity_spec.rb
@@ -3,12 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Activities::CreateGithubIssueActivity do
+  fixture "activities/create_github_issue/base"
+
   let(:activity) { described_class.new }
-  let(:project) { create(:project) }
-  let(:agent_run) do
-    create(:agent_run, :with_custom_prompt, :with_git_context, :with_metrics,
-      project: project, goal: "create_issue", custom_prompt: "Analyze the auth system")
-  end
+  let(:fixture_repository) { instance_variable_get(:@_fixture_kit_repository) }
+  let(:project) { fixture_repository.project }
+  let(:agent_run) { fixture_repository.agent_run }
   let(:github_client) { instance_double(GithubClient) }
   let(:issue_response) do
     Struct.new(:html_url, :number, :id, :title, :body, :state, :user, :labels, :pull_request, :created_at, :updated_at).new(

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -4,10 +4,13 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe Activities::CreatePullRequestActivity do
+  fixture "activities/create_pull_request/base"
+
   let(:activity) { described_class.new }
-  let(:project) { create(:project) }
-  let(:issue) { create(:issue, project: project) }
-  let(:agent_run) { create(:agent_run, :with_git_context, :with_metrics, project: project, issue: issue) }
+  let(:fixture_repository) { instance_variable_get(:@_fixture_kit_repository) }
+  let(:project) { fixture_repository.project }
+  let(:issue) { fixture_repository.issue }
+  let(:agent_run) { fixture_repository.agent_run }
   let(:github_client) { instance_double(GithubClient) }
   let(:pr_response) { Struct.new(:html_url, :number, :body).new("https://github.com/owner/repo/pull/42", 42, "PR body") }
   let(:issue_response) do
@@ -283,6 +286,7 @@ RSpec.describe Activities::CreatePullRequestActivity do
         create(:project, priority_labels: { "P1" => "critical", "P2" => "high", "P3" => "low" })
       end
       let(:issue) { create(:issue, project: project, labels: [ "critical", "bug" ]) }
+      let(:agent_run) { create(:agent_run, :with_git_context, :with_metrics, project: project, issue: issue) }
 
       it "copies matching priority labels from the issue to the PR" do
         activity.execute(agent_run_id: agent_run.id)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -4,14 +4,11 @@ require "rails_helper"
 require "ostruct"
 
 RSpec.describe Activities::ScanPaidPrsActivity do
+  fixture "activities/scan_paid_prs/base"
+
   let(:activity) { described_class.new }
-  let(:project) do
-    create(:project,
-      auto_scan_prs: true,
-      max_pr_followup_runs: 3,
-      pr_action_labels: [],
-      auto_fix_merge_conflicts: false)
-  end
+  let(:fixture_repository) { instance_variable_get(:@_fixture_kit_repository) }
+  let(:project) { fixture_repository.project }
   let(:octokit_client) { instance_double(Octokit::Client) }
   let(:github_client) { instance_double(GithubClient, client: octokit_client) }
 


### PR DESCRIPTION
## Summary
- add `test-prof` and `fixture_kit` test dependencies plus baseline RSpec configuration
- add shared `fixture_kit` definitions for the largest activity-spec setup graphs and switch three hotspot specs to reuse them
- add a manual GitHub Actions workflow and local docs for running `test-prof` profiling safely in CI

## Verification
- `COVERAGE=false bin/rspec spec/temporal/activities/create_pull_request_activity_spec.rb spec/temporal/activities/scan_paid_prs_activity_spec.rb spec/temporal/activities/create_github_issue_activity_spec.rb spec/services/anomalies/detect_spec.rb spec/models/worktree_spec.rb`

## Notes
- kept `Anomalies::Detect` and `Worktree` on regular factories because `fixture_kit`/`let_it_be` patterns were not safe there under the app's tenant/RLS behavior
- docs now warn against using `let_it_be` naively in this repo for the same reason