### PR TITLE
fix(agent-runs): improve timeout observability, extend abort to stdout, fix auth lock contention

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1225,13 +1225,14 @@ class AgentRun < ApplicationRecord
   # @param provider [String] The provider name
   # @param success [Boolean] Whether the attempt succeeded
   # @param error_type [String, nil] Type of error if failed (e.g., "rate_limited", "error")
-  def record_provider_attempt(provider, success:, error_type: nil)
+  def record_provider_attempt(provider, success:, error_type: nil, duration_seconds: nil)
     attempt = {
       "provider" => provider,
       "success" => success,
       "attempted_at" => Time.current.iso8601
     }
     attempt["error_type"] = error_type if error_type.present?
+    attempt["duration_seconds"] = duration_seconds if duration_seconds.present?
 
     self.providers_attempted = (providers_attempted || []) + [ attempt ]
     save!

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -309,21 +309,23 @@ module Containers
           when :stderr
             stderr_buffer << normalized_chunk
             log_output(:stderr, normalized_chunk) if stream
+          end
 
-            # Check stderr against abort patterns — if the CLI emits a fatal
-            # error but hangs instead of exiting, stop the container immediately
-            # rather than waiting for the idle/wall-clock timeout.
-            if abort_patterns&.any? && abort_matched_output.nil?
-              matched = abort_patterns.any? { |pat| normalized_chunk.match?(pat) }
-              if matched
-                abort_matched_output = normalized_chunk
-                log_system("container.execute.abort_pattern_matched",
-                  output: normalized_chunk.truncate(200))
-                begin
-                  container.stop(timeout: 0)
-                rescue Docker::Error::DockerError => e
-                  log_system("container.execute.abort_stop_failed", error: e.message)
-                end
+          # Check both stdout and stderr against abort patterns — if the CLI
+          # emits a fatal error but hangs instead of exiting, stop the container
+          # immediately rather than waiting for the idle/wall-clock timeout.
+          # JSON-mode CLIs (e.g. Codex --json) may emit fatal errors on stdout.
+          if abort_patterns&.any? && abort_matched_output.nil?
+            matched = abort_patterns.any? { |pat| normalized_chunk.match?(pat) }
+            if matched
+              abort_matched_output = normalized_chunk
+              log_system("container.execute.abort_pattern_matched",
+                stream: stream_type.to_s,
+                output: normalized_chunk.truncate(200))
+              begin
+                container.stop(timeout: 0)
+              rescue Docker::Error::DockerError => e
+                log_system("container.execute.abort_stop_failed", error: e.message)
               end
             end
           end
@@ -380,7 +382,11 @@ module Containers
       rescue StartupTimeoutError, IdleTimeoutError => e
         log_partial_output(stdout_buffer, stderr_buffer)
         timeout_value = e.is_a?(StartupTimeoutError) ? startup_timeout : idle_timeout
-        log_system("container.execute.timeout", timeout_type: e.class.name.demodulize, timeout: timeout_value)
+        log_system("container.execute.timeout",
+          timeout_type: e.class.name.demodulize,
+          timeout: timeout_value,
+          **timeout_diagnostics(started_at, output_received, last_activity_at, heartbeat_path),
+          **output_summary_diagnostics(stdout_buffer, stderr_buffer))
         raise
       rescue TimeoutError
         log_partial_output(stdout_buffer, stderr_buffer)
@@ -405,7 +411,9 @@ module Containers
           log_system(
             "container.execute.timeout",
             timeout_type: timeout_error.class.name.demodulize,
-            timeout: timeout_value
+            timeout: timeout_value,
+            **timeout_diagnostics(started_at, output_received, last_activity_at, heartbeat_path),
+            **output_summary_diagnostics(stdout_buffer, stderr_buffer)
           )
           raise
         end
@@ -420,7 +428,9 @@ module Containers
           log_system(
             "container.execute.timeout",
             timeout_type: timeout_error.class.name.demodulize,
-            timeout: timeout_value
+            timeout: timeout_value,
+            **timeout_diagnostics(started_at, output_received, last_activity_at, heartbeat_path),
+            **output_summary_diagnostics(stdout_buffer, stderr_buffer)
           )
           raise
         end
@@ -889,19 +899,57 @@ module Containers
     # Serializes only Codex CLI executions that share a host-backed auth.json.
     # Other container commands keep full parallelism, and different credential
     # directories map to different lockfiles.
+    #
+    # Uses a non-blocking lock with retries instead of indefinite blocking to
+    # prevent a hung container from stalling all other runs sharing the same
+    # auth.json. After lock_timeout_seconds, logs a warning and proceeds
+    # without the lock — a concurrent OAuth refresh may fail with
+    # refresh_token_reused, which Paid classifies as auth_expired and handles
+    # via the standard provider fallback path.
     def with_codex_auth_lock(command)
       return yield unless codex_auth_lock_required?(command)
 
       lockfile = codex_auth_lockfile_path
-      log_system("container.codex_auth_lock.waiting")
+      lock_timeout = codex_auth_lock_timeout
+
       File.open(lockfile, File::WRONLY | File::CREAT, 0o600) do |f|
-        f.flock(File::LOCK_EX)
-        log_system("container.codex_auth_lock.acquired", lockfile: lockfile)
-        yield
+        log_system("container.codex_auth_lock.waiting", lockfile: lockfile, lock_timeout_seconds: lock_timeout)
+
+        acquired = false
+        acquired = acquire_lock_with_timeout(f, lock_timeout)
+
+        if acquired
+          log_system("container.codex_auth_lock.acquired", lockfile: lockfile)
+          yield
+        else
+          log_system("container.codex_auth_lock.timeout",
+            lockfile: lockfile,
+            lock_timeout_seconds: lock_timeout)
+          yield
+        end
       ensure
-        f.flock(File::LOCK_UN)
-        log_system("container.codex_auth_lock.released", lockfile: lockfile)
+        if acquired
+          f.flock(File::LOCK_UN)
+          acquired = false
+          log_system("container.codex_auth_lock.released", lockfile: lockfile)
+        end
       end
+    end
+
+    def acquire_lock_with_timeout(file, timeout)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      loop do
+        return true if file.flock(File::LOCK_EX | File::LOCK_NB)
+        remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        return false if remaining <= 0
+        sleep [ remaining, 0.5 ].min
+      end
+    end
+
+    def codex_auth_lock_timeout
+      config = codex_harness_provider.auth_lock_config
+      timeout = config&.dig(:timeout)
+      timeout.is_a?(Numeric) ? timeout : 30
     end
 
     def seed_opencode_database!
@@ -2029,7 +2077,14 @@ module Containers
       when :idle
         raise IdleTimeoutError, "No output received for #{timeout_check.idle_timeout} seconds"
       when :wall_clock
-        log_system("container.execute.timeout", timeout_type: "wall_clock", timeout: timeout_check.timeout)
+        elapsed_seconds = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - timeout_check.started_at)).round(1)
+        hb_age = heartbeat_age_seconds(timeout_check.heartbeat_path)
+        log_system("container.execute.timeout",
+          timeout_type: "wall_clock",
+          timeout: timeout_check.timeout,
+          elapsed_seconds: elapsed_seconds,
+          heartbeat_active: hb_age && hb_age <= elapsed_seconds,
+          heartbeat_age_seconds: hb_age&.round(1))
         raise TimeoutError, "Command timed out after #{timeout_check.timeout} seconds"
       end
     end
@@ -2063,7 +2118,10 @@ module Containers
       elsif output_received && tc.idle_timeout && elapsed_since_activity >= tc.idle_timeout
         raise IdleTimeoutError, "No output received for #{tc.idle_timeout} seconds"
       elsif tc.timeout && elapsed_since_start >= tc.timeout
-        log_system("container.execute.timeout", timeout_type: "wall_clock", timeout: tc.timeout)
+        log_system("container.execute.timeout",
+          timeout_type: "wall_clock",
+          timeout: tc.timeout,
+          **timeout_diagnostics_from_elapsed(elapsed_since_start, elapsed_since_activity, output_received, tc.heartbeat_path, heartbeat_age))
         raise TimeoutError, "Command timed out after #{tc.timeout} seconds"
       end
     end
@@ -2157,6 +2215,40 @@ module Containers
     # Extracted as a method so tests can override with a shorter interval.
     def watchdog_poll_interval
       1
+    end
+
+    def timeout_diagnostics(started_at, output_received, last_activity_at, heartbeat_path)
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      elapsed_since_start = (now - started_at).round(1)
+      elapsed_since_activity = output_received ? (now - last_activity_at).round(1) : nil
+      hb_age = heartbeat_age_seconds(heartbeat_path)
+
+      {
+        elapsed_seconds: elapsed_since_start,
+        idle_seconds: elapsed_since_activity,
+        output_received: output_received,
+        heartbeat_active: hb_age && hb_age <= elapsed_since_start,
+        heartbeat_age_seconds: hb_age&.round(1)
+      }
+    end
+
+    def timeout_diagnostics_from_elapsed(elapsed_since_start, elapsed_since_activity, output_received, heartbeat_path, heartbeat_age)
+      {
+        elapsed_seconds: elapsed_since_start.round(1),
+        idle_seconds: output_received ? elapsed_since_activity.round(1) : nil,
+        output_received: output_received,
+        heartbeat_active: heartbeat_age && heartbeat_age <= elapsed_since_start,
+        heartbeat_age_seconds: heartbeat_age&.round(1)
+      }
+    end
+
+    def output_summary_diagnostics(stdout_buffer, stderr_buffer)
+      stderr_text = stderr_buffer.join
+      {
+        stdout_bytes: stdout_buffer.sum(&:bytesize),
+        stderr_bytes: stderr_buffer.sum(&:bytesize),
+        last_stderr: stderr_text.present? ? stderr_text.last(200).encode("UTF-8", invalid: :replace) : nil
+      }
     end
 
     # Returns the age in seconds of the heartbeat file at +heartbeat_path+, or

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -177,13 +177,15 @@ module Activities
 
           begin
             last_attempted_label = attempt_label
+            attempt_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             provider_result = run_agent_with_provider(agent_run, provider_candidate, prompt, user_settings)
+            attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             pre_agent_sha = provider_result.fetch(:pre_agent_sha)
 
             # Success - heartbeat and record final provider
             heartbeat("provider_completed", provider)
             record_provider_success(user_settings, provider_state_name, provider_states)
-            agent_run.record_provider_attempt(attempt_label, success: true)
+            agent_run.record_provider_attempt(attempt_label, success: true, duration_seconds: attempt_duration)
             # Persist the routing key so multiple entries sharing the same
             # provider_key (e.g. several OpenCode API-key entries with
             # different models) remain distinguishable in UI and retry logic.
@@ -228,10 +230,11 @@ module Activities
             }
           rescue ProviderRateLimitError => e
             last_error = "rate_limited"
+            attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             rate_limit_reset_at = [ rate_limit_reset_at, e.reset_at ].compact.min
             persist_rate_limit(user_settings, provider_state_name, provider_states, e.reset_at)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "rate_limited")
-            logger.info(message: "agent_execution.rate_limited", provider: provider, agent_run_id: agent_run.id)
+            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "rate_limited", duration_seconds: attempt_duration)
+            logger.info(message: "agent_execution.rate_limited", provider: provider, agent_run_id: agent_run.id, duration_seconds: attempt_duration)
             insert_rate_limit_fallbacks!(
               providers: providers,
               index: index,
@@ -241,13 +244,14 @@ module Activities
             )
           rescue InfiniteLoopError => e
             last_error = "infinite_loop"
+            attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             if cancelled_by_cleanup?(agent_run)
               record_cleanup_cancelled_attempt(agent_run, attempt_label, provider, e)
               break
             end
             record_provider_failure(user_settings, provider_state_name, provider_states)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "infinite_loop")
-            logger.warn(message: "agent_execution.infinite_loop_detected", agent_run_id: agent_run.id, reason: e.message)
+            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "infinite_loop", duration_seconds: attempt_duration)
+            logger.warn(message: "agent_execution.infinite_loop_detected", agent_run_id: agent_run.id, reason: e.message, duration_seconds: attempt_duration)
 
             result = Guardrails::ViolationHandler.call(
               agent_run: agent_run,
@@ -266,31 +270,34 @@ module Activities
             )
           rescue ProviderTimeoutError => e
             last_error = "timeout"
+            attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             timeout_error ||= e.message
             if cancelled_by_cleanup?(agent_run)
               record_cleanup_cancelled_attempt(agent_run, attempt_label, provider, e)
               break
             end
             record_provider_failure(user_settings, provider_state_name, provider_states)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "timeout")
-            logger.warn(message: "agent_execution.provider_timeout", provider: provider, agent_run_id: agent_run.id, error: e.message)
+            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "timeout", duration_seconds: attempt_duration)
+            logger.warn(message: "agent_execution.provider_timeout", provider: provider, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
             break
           rescue ProviderAuthExpiredError => e
             last_error = "auth_expired"
+            attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             auth_provider = ProviderSupport.harness_provider_key_for(e.provider)
             agent_run.auth_expire!(error: e.message, provider: auth_provider)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "auth_expired")
-            logger.warn(message: "agent_execution.auth_expired", provider: provider, agent_run_id: agent_run.id, error: e.message)
+            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "auth_expired", duration_seconds: attempt_duration)
+            logger.warn(message: "agent_execution.auth_expired", provider: provider, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
             break
           rescue ProviderExecutionError => e
             last_error = "error"
+            attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             if cancelled_by_cleanup?(agent_run)
               record_cleanup_cancelled_attempt(agent_run, attempt_label, provider, e)
               break
             end
             record_provider_failure(user_settings, provider_state_name, provider_states)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "error")
-            logger.warn(message: "agent_execution.provider_failed", provider: provider, agent_run_id: agent_run.id, error: e.message)
+            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "error", duration_seconds: attempt_duration)
+            logger.warn(message: "agent_execution.provider_failed", provider: provider, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
 
             if container_dead_after_exec_error?(agent_run, e)
               logger.error(
@@ -859,8 +866,15 @@ module Activities
       AgentHarness.provider(harness_key)
     end
 
+    CODEX_SANDBOX_ABORT_PATTERNS = [
+      /bwrap.*no permissions/i,
+      /no permissions to create a new namespace/i,
+      /unprivileged.*namespace/i
+    ].freeze
+
     def aggregated_abort_patterns
-      ProviderSupport.aggregated_error_classification_patterns(:abort)
+      base = ProviderSupport.aggregated_error_classification_patterns(:abort)
+      (base + CODEX_SANDBOX_ABORT_PATTERNS).uniq
     end
 
     def track_harness_tokens(agent_run, provider_candidate, provider_key, user, result, execution_started_at)


### PR DESCRIPTION
## Summary

- Adds diagnostic metadata (elapsed time, heartbeat status, output sizes, last stderr preview) to all `container.execute.timeout` log events
- Extends abort pattern matching to check both stdout and stderr (previously stderr-only) so JSON-mode CLIs like Codex trigger immediate container stop on fatal errors
- Adds Codex sandbox failure patterns (bwrap namespace errors) to the abort list
- Replaces indefinite `flock` with a 30s non-blocking acquire loop for Codex auth lock to prevent a hung container from stalling all other runs sharing the same `auth.json`
- Tracks per-provider-attempt `duration_seconds` in `providers_attempted` JSON

## Context

Agent runs are timing out during the Codex execution phase. The root cause is the heartbeat file visibility bug (#1558, fixed in the previous commit). This PR improves observability so future timeout events carry enough diagnostic data to distinguish failure modes without re-deploying.

## Observability fields added to timeout logs

| Field | What it tells you |
|-------|-------------------|
| `elapsed_seconds` | Total wall-clock time before timeout |
| `idle_seconds` | Time since last stdout/heartbeat (nil = no output ever) |
| `output_received` | Whether any stdout was produced |
| `heartbeat_active` | Whether heartbeat file was touched during execution |
| `heartbeat_age_seconds` | Age of the heartbeat file |
| `stdout_bytes` | Byte count of stdout produced |
| `stderr_bytes` | Byte count of stderr produced |
| `last_stderr` | Last 200 chars of stderr |
| `duration_seconds` (per provider attempt) | How long each provider ran |

## Related

- Depends on viamin/agent-harness#178, viamin/agent-harness#179, viamin/agent-harness#180 (P1 upstream issues for streaming JSONL parsing, pre-flight checks, structured error classification)
- Blocked Paid issues: #1565, #1566, #1567