### PR TITLE
fix(kilocode): inject PAID_KILOCODE_CONFIG_B64 into container env

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1170,9 +1170,11 @@ module Activities
       provider_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
       return direct_outbound_execution_plan(provider_entry, prompt).env if provider_entry&.agent_harness_runtime?
       return {} unless provider_entry
-      return api_key_command_env(provider_entry) if provider_entry.api_key?
 
-      {}
+      env = {}
+      env.merge!(provider_entry.direct_outbound_exec_env) if provider_entry.requires_direct_outbound?
+      env.merge!(api_key_command_env(provider_entry)) if provider_entry.api_key?
+      env
     end
 
     def command_preparation_for(command_context, prompt)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -499,6 +499,39 @@ RSpec.describe Activities::RunAgentActivity do
         expect(command).to eq([ "env", "-u", "OPENAI_HEADER_X_AGENT_RUN_ID", "-u", "OPENAI_HEADER_X_PROXY_TOKEN", "opencode", "run", prompt ])
       end
     end
+
+    context "with a direct-outbound kilocode provider" do
+      it "includes PAID_KILOCODE_CONFIG_B64 in command env alongside PAID_PROVIDER_ID" do
+        context = build_kilocode_context(user)
+
+        command = activity.send(:build_command, context, "ping")
+        env = activity.send(:command_env_for, context, "ping")
+
+        expect(command[0]).to eq("sh")
+        expect(command[1]).to eq("-lc")
+        expect(command[2]).to include("PAID_KILOCODE_CONFIG_B64")
+        expect(command[2]).to include("kilo run --format json")
+        expect(command.last).to eq("ping")
+
+        expect(env).to have_key("PAID_KILOCODE_CONFIG_B64")
+        expect(env).to have_key("PAID_PROVIDER_ID")
+        config_json = JSON.parse(Base64.strict_decode64(env["PAID_KILOCODE_CONFIG_B64"]))
+        expect(config_json["model"]).to eq("claude-sonnet-4-20250514")
+      end
+
+      it "does not include PAID_KILOCODE_CONFIG_B64 for subscription kilocode providers" do
+        subscription_provider = create(:provider, user: user, provider_key: "kilocode", auth_type: "subscription")
+        context = described_class::CommandContext.new(
+          provider_candidate: subscription_provider.routing_key,
+          provider: "kilocode",
+          user: user
+        )
+
+        env = activity.send(:command_env_for, context, "ping")
+
+        expect(env).not_to have_key("PAID_KILOCODE_CONFIG_B64")
+      end
+    end
   end
 
   describe "#provider_entry_for" do
@@ -765,6 +798,25 @@ RSpec.describe Activities::RunAgentActivity do
     described_class::CommandContext.new(
       provider_candidate: provider.routing_key,
       provider: "opencode",
+      user: user
+    )
+  end
+
+  def build_kilocode_context(user)
+    api_key = create(:provider_api_key, user: user, api_service_type: "anthropic", api_key: "sk-anthropic-secret")
+    provider = create(
+      :provider,
+      user: user,
+      auth_type: "api_key",
+      provider_api_key: api_key,
+      provider_key: "kilocode",
+      name: "Kilocode Claude",
+      config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-20250514" } }
+    )
+
+    described_class::CommandContext.new(
+      provider_candidate: provider.routing_key,
+      provider: "kilocode",
       user: user
     )
   end


### PR DESCRIPTION
## Summary

- Fixes the kilo CLI hanging for the full 3600s wall-clock timeout when used as a fallback provider
- `command_env_for` in `run_agent_activity.rb` never called `Provider#direct_outbound_exec_env` for kilocode providers, so `PAID_KILOCODE_CONFIG_B64` was unset in the container environment
- The shell command writes config via `$PAID_KILOCODE_CONFIG_B64 | base64 -d > config.json` — with the var empty, the kilo CLI started with no provider/model and hung silently

## Root Cause

`command_env_for` had two paths: `agent_harness_runtime?` (opencode/copilot) and `api_key?` (everyone else with an API key). Kilocode is `requires_direct_outbound?` → true AND `api_key?` → true, so it fell through to the `api_key?` path which only returns `{"PAID_PROVIDER_ID" => "11"}`. The `direct_outbound_exec_env` method that provides `PAID_KILOCODE_CONFIG_B64` existed but was dead code for production runs.

## Impact

~170 timeouts over 3 days (20.7% of all runs) via the cascade: codex/claude rate-limited → fallback to kilocode → empty config → 60min hang. ~170 hours of container compute wasted.

## Changes

- `app/temporal/activities/run_agent_activity.rb`: `command_env_for` now merges `direct_outbound_exec_env` when `requires_direct_outbound?` is true
- `spec/temporal/activities/run_agent_activity_spec.rb`: Tests for both direct-outbound kilocode (config injected) and subscription kilocode (config not injected)