### PR TITLE
fix(agent-runs): extend idle timeout for providers with coarse heartbeat signals

### DIFF
--- a/app/services/containers/heartbeat_setup.rb
+++ b/app/services/containers/heartbeat_setup.rb
@@ -30,6 +30,16 @@ module Containers
 
     SUPPORTED_PROVIDERS = %w[claude codex].freeze
 
+    # Providers with per-tool heartbeat hooks (e.g. Claude PostToolUse)
+    # that fire frequently enough to suppress idle timeouts reliably
+    # during long subprocess execution. Providers in SUPPORTED_PROVIDERS
+    # but NOT listed here use coarser heartbeat signals that only fire
+    # between CLI turns, so they need a longer idle timeout to avoid
+    # false positives during long-running commands like `bundle exec rspec`.
+    RELIABLE_HEARTBEAT_PROVIDERS = %w[claude].freeze
+
+    COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER = 3
+
     attr_reader :provider, :worktree_path, :host_heartbeat_path
 
     def initialize(provider:, worktree_path:, host_heartbeat_path: nil)
@@ -44,6 +54,20 @@ module Containers
 
     def available?
       host_heartbeat_path.present? && SUPPORTED_PROVIDERS.include?(canonical_provider)
+    end
+
+    # Returns the effective idle timeout for this provider given a base
+    # timeout selected by goal type. Returns nil for providers without
+    # heartbeat support (idle timeout disabled entirely).
+    def idle_timeout_for(base_timeout)
+      return nil unless available?
+      return base_timeout if reliable_heartbeat? || base_timeout.nil?
+
+      base_timeout * COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER
+    end
+
+    def reliable_heartbeat?
+      RELIABLE_HEARTBEAT_PROVIDERS.include?(canonical_provider)
     end
 
     def env

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -642,7 +642,7 @@ module Activities
         container_service.execute(
           command,
           timeout: effective_timeout,
-          idle_timeout: heartbeat.available? ? effective_idle_timeout : nil,
+          idle_timeout: heartbeat.idle_timeout_for(effective_idle_timeout),
           env: command_env,
           preparation: command_preparation,
           heartbeat_path: heartbeat.available? ? heartbeat.heartbeat_path : nil,

--- a/spec/services/containers/heartbeat_setup_spec.rb
+++ b/spec/services/containers/heartbeat_setup_spec.rb
@@ -153,4 +153,51 @@ RSpec.describe Containers::HeartbeatSetup do
       end
     end
   end
+
+  describe "#reliable_heartbeat?" do
+    it "returns true for claude" do
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expect(setup).to be_reliable_heartbeat
+    end
+
+    it "returns true for claude_code" do
+      setup = described_class.new(provider: "claude_code", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expect(setup).to be_reliable_heartbeat
+    end
+
+    it "returns false for codex" do
+      setup = described_class.new(provider: "codex", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expect(setup).not_to be_reliable_heartbeat
+    end
+  end
+
+  describe "#idle_timeout_for" do
+    let(:base_timeout) { 300 }
+
+    it "returns nil for unsupported providers" do
+      setup = described_class.new(provider: "gemini", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expect(setup.idle_timeout_for(base_timeout)).to be_nil
+    end
+
+    it "returns nil without host_heartbeat_path" do
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
+      expect(setup.idle_timeout_for(base_timeout)).to be_nil
+    end
+
+    it "returns base timeout for reliable heartbeat providers" do
+      setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expect(setup.idle_timeout_for(base_timeout)).to eq(300)
+    end
+
+    it "returns extended timeout for coarse heartbeat providers" do
+      setup = described_class.new(provider: "codex", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expected = base_timeout * described_class::COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER
+      expect(setup.idle_timeout_for(base_timeout)).to eq(expected)
+    end
+
+    it "returns nil for coarse heartbeat provider with nil base timeout" do
+      setup = described_class.new(provider: "codex", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
+      expect(setup.idle_timeout_for(nil)).to be_nil
+    end
+  end
 end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1874,17 +1874,19 @@ RSpec.describe Activities::RunAgentActivity do
         activity.execute(agent_run_id: agent_run.id)
       end
 
-      it "applies idle timeout and heartbeat path to codex" do
+      it "applies extended idle timeout to codex for coarse heartbeat" do
         agent_run.update!(agent_type: "codex")
         project.update!(max_execution_seconds: 86_400)
         allow(container_service).to receive(:execute).and_return(exec_success)
         allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
 
+        expected_idle = described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT * Containers::HeartbeatSetup::COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER
+
         expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
+            idle_timeout: expected_idle,
             heartbeat_path: "/tmp/paid-heartbeat-test/.paid-heartbeat"
           )
         ).and_return(exec_success)


### PR DESCRIPTION
## Summary

- Extends idle timeout 3x for providers whose heartbeat only fires between CLI turns (codex), not during subprocess execution
- Codex's notify hook doesn't fire during long `bundle exec rspec` runs, causing 32 false-positive idle timeouts over 3 days where the agent was actively working (high CPU)
- `HeartbeatSetup` now distinguishes reliable heartbeat providers (claude: per-tool PostToolUse hook) from coarse heartbeat providers (codex: per-turn notify)

## Root Cause

Codex buffers subprocess output and only emits JSONL events when a subprocess completes. Its `notify` hook fires between turns, not during `command_execution` items. When a test suite runs for >300s without stdout, the idle timeout kills the run even though codex is actively working.

Claude avoids this because its PostToolUse hook fires after every tool call (Bash, Read, Write, etc.), touching the heartbeat file every few seconds on average.

## Changes

- `app/services/containers/heartbeat_setup.rb`: Add `RELIABLE_HEARTBEAT_PROVIDERS`, `COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER = 3`, `idle_timeout_for(base)`, and `reliable_heartbeat?`
- `app/temporal/activities/run_agent_activity.rb`: Delegate idle timeout calculation to `heartbeat.idle_timeout_for(effective_idle_timeout)`

## Effective Timeouts

| Provider | create_pr | issue_goal | review |
|----------|-----------|------------|--------|
| claude (reliable) | 300s | 120s | 300s |
| codex (coarse, 3x) | 900s | 360s | 900s |
| no heartbeat | disabled | disabled | disabled |