### PR TITLE
fix(agent-runs): improve provider fallback diagnostics

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -2,6 +2,12 @@
 
 class AgentRun < ApplicationRecord
   MAX_PROVIDER_ATTEMPT_ERROR_MESSAGE_LENGTH = 500
+  PROVIDER_ATTEMPT_SECRET_PATTERNS = [
+    [ /\bsk-[A-Za-z0-9][A-Za-z0-9_-]{10,}\b/, "[REDACTED:api_key]" ],
+    [ /\b(?:ghp_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,}|gh[oushr]_[A-Za-z0-9]{36,})\b/, "[REDACTED:github_token]" ],
+    [ %r{x-access-token:[^@/\s]+@github\.com}, "x-access-token:[REDACTED]@github.com" ],
+    [ /(Bearer\s)[A-Za-z0-9\-._~+\/]+=*/i, "\\1[REDACTED]" ]
+  ].freeze
   STATUSES = %w[queued pending running paused completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
   AGENT_TYPES = %w[claude_code cursor codex copilot aider gemini opencode kilocode api].freeze
   # analyze_issue is automation-only (triggered via Automation::Decision), not exposed in the manual run form.
@@ -1409,7 +1415,14 @@ class AgentRun < ApplicationRecord
 
     normalized = normalize_log_content(message)
     redacted = Knowledge::Redaction::Redactor.call(text: normalized).clean_text
+    redacted = redact_provider_attempt_secrets(redacted)
     redacted.truncate(MAX_PROVIDER_ATTEMPT_ERROR_MESSAGE_LENGTH)
+  end
+
+  def redact_provider_attempt_secrets(text)
+    PROVIDER_ATTEMPT_SECRET_PATTERNS.reduce(text) do |result, (pattern, replacement)|
+      result.gsub(pattern, replacement)
+    end
   end
 
   def logs_text(log_type:, limit:)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AgentRun < ApplicationRecord
+  MAX_PROVIDER_ATTEMPT_ERROR_MESSAGE_LENGTH = 500
   STATUSES = %w[queued pending running paused completed no_output failed cancelled timeout retried auth_expired rate_limited].freeze
   AGENT_TYPES = %w[claude_code cursor codex copilot aider gemini opencode kilocode api].freeze
   # analyze_issue is automation-only (triggered via Automation::Decision), not exposed in the manual run form.
@@ -1225,13 +1226,15 @@ class AgentRun < ApplicationRecord
   # @param provider [String] The provider name
   # @param success [Boolean] Whether the attempt succeeded
   # @param error_type [String, nil] Type of error if failed (e.g., "rate_limited", "error")
-  def record_provider_attempt(provider, success:, error_type: nil, duration_seconds: nil)
+  def record_provider_attempt(provider, success:, error_type: nil, error_message: nil, duration_seconds: nil)
     attempt = {
       "provider" => provider,
       "success" => success,
       "attempted_at" => Time.current.iso8601
     }
     attempt["error_type"] = error_type if error_type.present?
+    sanitized_error_message = sanitize_provider_attempt_error_message(error_message)
+    attempt["error_message"] = sanitized_error_message if sanitized_error_message.present?
     attempt["duration_seconds"] = duration_seconds if duration_seconds.present?
 
     self.providers_attempted = (providers_attempted || []) + [ attempt ]
@@ -1401,6 +1404,14 @@ class AgentRun < ApplicationRecord
     return text.delete("\x00") if text.encoding == Encoding::UTF_8 && text.valid_encoding?
 
     text.dup.force_encoding(Encoding::UTF_8).scrub.delete("\x00")
+  end
+
+  def sanitize_provider_attempt_error_message(message)
+    return nil if message.blank?
+
+    normalized = normalize_log_content(message)
+    redacted = Knowledge::Redaction::Redactor.call(text: normalized).clean_text
+    redacted.truncate(MAX_PROVIDER_ATTEMPT_ERROR_MESSAGE_LENGTH)
   end
 
   def logs_text(log_type:, limit:)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1211,8 +1211,6 @@ class AgentRun < ApplicationRecord
     owner = project&.effective_owner
     return {} unless owner
 
-    return {} unless provider_switches.positive?
-
     routing_ids = providers_attempted.filter_map do |attempt|
       Provider.id_from_routing_key(attempt["provider"])
     end

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -317,6 +317,18 @@ module Containers
       stripped.match?(/\A\{\s*(?:"|\z)/)
     end
 
+    private def final_abort_pattern_candidate(stdout_buffer)
+      return nil if stdout_buffer.blank?
+
+      if structured_jsonl_line?(stdout_buffer)
+        structured_jsonl_abort_candidate(stdout_buffer)
+      elsif stdout_buffer.lstrip.start_with?("{")
+        stdout_buffer
+      else
+        stdout_buffer
+      end
+    end
+
     private def structured_jsonl_failure_text(payload)
       [
         payload["message"],
@@ -421,6 +433,21 @@ module Containers
                 log_system("container.execute.abort_stop_failed", error: e.message)
               end
               break
+            end
+          end
+        end
+
+        if abort_patterns&.any? && abort_matched_output.nil?
+          candidate = final_abort_pattern_candidate(stdout_abort_buffer)
+          if candidate.present? && abort_patterns.any? { |pat| candidate.match?(pat) }
+            abort_matched_output = candidate
+            log_system("container.execute.abort_pattern_matched",
+              stream: "stdout",
+              output: candidate.truncate(200))
+            begin
+              container.stop(timeout: 0)
+            rescue Docker::Error::DockerError => e
+              log_system("container.execute.abort_stop_failed", error: e.message)
             end
           end
         end

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -254,9 +254,17 @@ module Containers
           line
         end
       end
-      if stdout_buffer.present? && !stdout_buffer.lstrip.start_with?("{")
-        candidates << stdout_buffer.dup
-        stdout_buffer.clear
+      if stdout_buffer.present?
+        if stdout_buffer.lstrip.start_with?("{")
+          if structured_jsonl_line?(stdout_buffer)
+            candidate = structured_jsonl_abort_candidate(stdout_buffer)
+            candidates << candidate if candidate.present?
+            stdout_buffer.clear
+          end
+        else
+          candidates << stdout_buffer.dup
+          stdout_buffer.clear
+        end
       end
 
       candidates

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -260,6 +260,8 @@ module Containers
             candidate = structured_jsonl_abort_candidate(stdout_buffer)
             candidates << candidate if candidate.present?
             stdout_buffer.clear
+          elsif !buffered_structured_json_transcript?(stdout_buffer)
+            candidates << stdout_buffer.dup
           end
         else
           candidates << stdout_buffer.dup
@@ -297,6 +299,13 @@ module Containers
       parsed
     rescue JSON::ParserError, TypeError
       nil
+    end
+
+    private def buffered_structured_json_transcript?(text)
+      type = text.to_s.match(/"type"\s*:\s*"([^"]*)/)&.captures&.first
+      return false if type.blank?
+
+      !type.match?(/(?:^|[._-])(error|failed|failure|rate_limit|rate_limited)(?:$|[._-])/i)
     end
 
     private def structured_jsonl_failure_text(payload)

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -247,7 +247,13 @@ module Containers
       complete_lines = combined.end_with?("\n") ? lines : lines[0...-1]
       stdout_buffer.replace(combined.end_with?("\n") ? "" : lines.last.to_s)
 
-      candidates = complete_lines.reject { |line| structured_jsonl_line?(line) }
+      candidates = complete_lines.filter_map do |line|
+        if structured_jsonl_line?(line)
+          structured_jsonl_abort_candidate(line)
+        else
+          line
+        end
+      end
       if stdout_buffer.present? && !stdout_buffer.lstrip.start_with?("{")
         candidates << stdout_buffer.dup
         stdout_buffer.clear
@@ -257,13 +263,44 @@ module Containers
     end
 
     private def structured_jsonl_line?(line)
+      structured_jsonl_payload(line).present?
+    end
+
+    private def structured_jsonl_abort_candidate(line)
+      payload = structured_jsonl_payload(line)
+      return nil unless payload
+
+      type = payload["type"].to_s
+      failure_text = structured_jsonl_failure_text(payload)
+      return nil if failure_text.blank?
+
+      return failure_text if type.match?(/(?:^|[._-])(error|failed|failure|rate_limit|rate_limited)(?:$|[._-])/i)
+
+      nil
+    end
+
+    private def structured_jsonl_payload(line)
       stripped = line.to_s.strip
-      return false if stripped.blank?
+      return nil if stripped.blank?
 
       parsed = JSON.parse(stripped)
-      parsed.is_a?(Hash) && parsed["type"].present?
+      return nil unless parsed.is_a?(Hash) && parsed["type"].present?
+
+      parsed
     rescue JSON::ParserError, TypeError
-      false
+      nil
+    end
+
+    private def structured_jsonl_failure_text(payload)
+      [
+        payload["message"],
+        payload.dig("error", "message"),
+        payload["output"],
+        payload["stderr"],
+        payload.dig("item", "output"),
+        payload.dig("item", "stderr"),
+        payload.dig("item", "message")
+      ].find(&:present?)
     end
 
     private def execute_unlocked(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil, abort_patterns: nil)

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -260,8 +260,9 @@ module Containers
             candidate = structured_jsonl_abort_candidate(stdout_buffer)
             candidates << candidate if candidate.present?
             stdout_buffer.clear
-          elsif !buffered_structured_json_transcript?(stdout_buffer)
+          elsif complete_json_object?(stdout_buffer) || !potential_json_object_prefix?(stdout_buffer)
             candidates << stdout_buffer.dup
+            stdout_buffer.clear
           end
         else
           candidates << stdout_buffer.dup
@@ -301,11 +302,19 @@ module Containers
       nil
     end
 
-    private def buffered_structured_json_transcript?(text)
-      type = text.to_s.match(/"type"\s*:\s*"([^"]*)/)&.captures&.first
-      return false if type.blank?
+    private def complete_json_object?(text)
+      stripped = text.to_s.strip
+      return false unless stripped.start_with?("{")
 
-      !type.match?(/(?:^|[._-])(error|failed|failure|rate_limit|rate_limited)(?:$|[._-])/i)
+      parsed = JSON.parse(stripped)
+      parsed.is_a?(Hash)
+    rescue JSON::ParserError, TypeError
+      false
+    end
+
+    private def potential_json_object_prefix?(text)
+      stripped = text.to_s.lstrip
+      stripped.match?(/\A\{\s*(?:"|\z)/)
     end
 
     private def structured_jsonl_failure_text(payload)

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -3,6 +3,7 @@
 require "base64"
 require "digest"
 require "docker-api"
+require "json"
 require "securerandom"
 require "shellwords"
 
@@ -238,6 +239,33 @@ module Containers
       network_contract.network
     end
 
+    private def abort_pattern_candidates(stream_type, normalized_chunk, stdout_buffer:)
+      return [ normalized_chunk ] unless stream_type == :stdout
+
+      combined = stdout_buffer << normalized_chunk.to_s
+      lines = combined.lines(chomp: true)
+      complete_lines = combined.end_with?("\n") ? lines : lines[0...-1]
+      stdout_buffer.replace(combined.end_with?("\n") ? "" : lines.last.to_s)
+
+      candidates = complete_lines.reject { |line| structured_jsonl_line?(line) }
+      if stdout_buffer.present? && !stdout_buffer.lstrip.start_with?("{")
+        candidates << stdout_buffer.dup
+        stdout_buffer.clear
+      end
+
+      candidates
+    end
+
+    private def structured_jsonl_line?(line)
+      stripped = line.to_s.strip
+      return false if stripped.blank?
+
+      parsed = JSON.parse(stripped)
+      parsed.is_a?(Hash) && parsed["type"].present?
+    rescue JSON::ParserError, TypeError
+      false
+    end
+
     private def execute_unlocked(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil, abort_patterns: nil)
       timeout ||= options[:timeout_seconds]
       cmd_array = command.is_a?(Array) ? command : [ "sh", "-c", command ]
@@ -265,6 +293,7 @@ module Containers
       timeout_reason = nil # :startup, :idle, or :wall_clock, set by watchdog
       timeout_reason_ref = -> { timeout_reason }
       abort_matched_output = nil # set when an abort_pattern matches stderr
+      stdout_abort_buffer = +""
       watchdog = nil
 
       timeout_check = TimeoutCheckState.new(
@@ -316,17 +345,19 @@ module Containers
           # immediately rather than waiting for the idle/wall-clock timeout.
           # JSON-mode CLIs (e.g. Codex --json) may emit fatal errors on stdout.
           if abort_patterns&.any? && abort_matched_output.nil?
-            matched = abort_patterns.any? { |pat| normalized_chunk.match?(pat) }
-            if matched
-              abort_matched_output = normalized_chunk
+            abort_pattern_candidates(stream_type, normalized_chunk, stdout_buffer: stdout_abort_buffer).each do |candidate|
+              next unless abort_patterns.any? { |pat| candidate.match?(pat) }
+
+              abort_matched_output = candidate
               log_system("container.execute.abort_pattern_matched",
                 stream: stream_type.to_s,
-                output: normalized_chunk.truncate(200))
+                output: candidate.truncate(200))
               begin
                 container.stop(timeout: 0)
               rescue Docker::Error::DockerError => e
                 log_system("container.execute.abort_stop_failed", error: e.message)
               end
+              break
             end
           end
         end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -163,7 +163,17 @@ module Activities
             state = provider_states[provider_state_name]
             error_type = state&.rate_limited? ? "rate_limited" : "unavailable"
             skipped_rate_limited_count += 1 if error_type == "rate_limited"
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: error_type)
+            error_message = if error_type == "rate_limited" && state&.rate_limited_until.present?
+              "Skipped due to cached rate limit until #{state.rate_limited_until.iso8601}"
+            elsif error_type == "unavailable" && state&.circuit_open?
+              "Skipped because provider circuit is open"
+            end
+            agent_run.record_provider_attempt(
+              attempt_label,
+              success: false,
+              error_type: error_type,
+              error_message: error_message
+            )
             index += 1
             next
           end
@@ -233,7 +243,13 @@ module Activities
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             rate_limit_reset_at = [ rate_limit_reset_at, e.reset_at ].compact.min
             persist_rate_limit(user_settings, provider_state_name, provider_states, e.reset_at)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "rate_limited", duration_seconds: attempt_duration)
+            agent_run.record_provider_attempt(
+              attempt_label,
+              success: false,
+              error_type: "rate_limited",
+              error_message: e.message,
+              duration_seconds: attempt_duration
+            )
             logger.info(message: "agent_execution.rate_limited", provider: provider, agent_run_id: agent_run.id, duration_seconds: attempt_duration)
             insert_rate_limit_fallbacks!(
               providers: providers,
@@ -250,7 +266,13 @@ module Activities
               break
             end
             record_provider_failure(user_settings, provider_state_name, provider_states)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "infinite_loop", duration_seconds: attempt_duration)
+            agent_run.record_provider_attempt(
+              attempt_label,
+              success: false,
+              error_type: "infinite_loop",
+              error_message: e.message,
+              duration_seconds: attempt_duration
+            )
             logger.warn(message: "agent_execution.infinite_loop_detected", agent_run_id: agent_run.id, reason: e.message, duration_seconds: attempt_duration)
 
             result = Guardrails::ViolationHandler.call(
@@ -277,7 +299,13 @@ module Activities
               break
             end
             record_provider_failure(user_settings, provider_state_name, provider_states)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "timeout", duration_seconds: attempt_duration)
+            agent_run.record_provider_attempt(
+              attempt_label,
+              success: false,
+              error_type: "timeout",
+              error_message: e.message,
+              duration_seconds: attempt_duration
+            )
             logger.warn(message: "agent_execution.provider_timeout", provider: provider, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
             break
           rescue ProviderAuthExpiredError => e
@@ -285,7 +313,13 @@ module Activities
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             auth_provider = ProviderSupport.harness_provider_key_for(e.provider)
             agent_run.auth_expire!(error: e.message, provider: auth_provider)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "auth_expired", duration_seconds: attempt_duration)
+            agent_run.record_provider_attempt(
+              attempt_label,
+              success: false,
+              error_type: "auth_expired",
+              error_message: e.message,
+              duration_seconds: attempt_duration
+            )
             logger.warn(message: "agent_execution.auth_expired", provider: provider, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
             break
           rescue ProviderExecutionError => e
@@ -296,7 +330,13 @@ module Activities
               break
             end
             record_provider_failure(user_settings, provider_state_name, provider_states)
-            agent_run.record_provider_attempt(attempt_label, success: false, error_type: "error", duration_seconds: attempt_duration)
+            agent_run.record_provider_attempt(
+              attempt_label,
+              success: false,
+              error_type: "error",
+              error_message: e.message,
+              duration_seconds: attempt_duration
+            )
             logger.warn(message: "agent_execution.provider_failed", provider: provider, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
 
             if container_dead_after_exec_error?(agent_run, e)

--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -497,17 +497,18 @@
     </div>
   <% end %>
 
-  <% if agent_run.provider_switches > 0 %>
+  <% provider_attempts = Array(agent_run.providers_attempted) %>
+  <% if provider_attempts.any? %>
     <% attempted_providers_by_routing_key = local_assigns.fetch(:attempted_providers_by_routing_key, {}) %>
     <div class="mt-6 rounded-lg border border-amber-200 bg-amber-50 p-4">
       <div class="flex items-center justify-between">
-        <h2 class="text-sm font-semibold text-amber-800">Provider Fallback</h2>
+        <h2 class="text-sm font-semibold text-amber-800"><%= agent_run.provider_switches.positive? ? "Provider Fallback" : "Provider Attempts" %></h2>
         <span class="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
-          <%= pluralize(agent_run.provider_switches, "switch") %>
+          <%= agent_run.provider_switches.positive? ? pluralize(agent_run.provider_switches, "switch") : pluralize(provider_attempts.size, "attempt") %>
         </span>
       </div>
       <div class="mt-3 flex flex-wrap items-center gap-2">
-        <% agent_run.providers_attempted.each_with_index do |attempt, index| %>
+        <% provider_attempts.each_with_index do |attempt, index| %>
           <% if index > 0 %>
             <svg class="h-4 w-4 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -522,6 +523,18 @@
           </span>
         <% end %>
       </div>
+      <% attempt_failures = provider_attempts.filter { |attempt| !attempt["success"] && attempt["error_message"].present? } %>
+      <% if attempt_failures.any? %>
+        <div class="mt-3 space-y-2">
+          <% attempt_failures.each do |attempt| %>
+            <% attempt_provider = attempted_providers_by_routing_key[attempt["provider"]] %>
+            <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
+              <p class="text-xs font-medium text-amber-900"><%= provider_label.call(attempt["provider"], attempt_provider) %></p>
+              <p class="mt-1 text-xs text-amber-800"><%= truncate(redacted_error_message(attempt["error_message"]), length: 300) %></p>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
       <% if agent_run.final_provider.present? %>
         <p class="mt-2 text-xs text-amber-700">
           <% final_prov = attempted_providers_by_routing_key[agent_run.final_provider] %>

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2232,6 +2232,26 @@ RSpec.describe AgentRun do
       expect(attempt["error_type"]).to eq("rate_limited")
     end
 
+    it "records error_message for failed attempts" do
+      agent_run = create(:agent_run)
+      agent_run.record_provider_attempt("claude", success: false, error_type: "error", error_message: "Configuration is invalid")
+
+      attempt = agent_run.reload.providers_attempted.last
+      expect(attempt["error_message"]).to eq("Configuration is invalid")
+    end
+
+    it "redacts and truncates error_message for failed attempts" do
+      agent_run = create(:agent_run)
+      secret = "sk-test-super-secret-value"
+      long_message = "Error: #{secret} " + ("x" * 600)
+
+      agent_run.record_provider_attempt("claude", success: false, error_type: "error", error_message: long_message)
+
+      attempt = agent_run.reload.providers_attempted.last
+      expect(attempt["error_message"]).not_to include(secret)
+      expect(attempt["error_message"].length).to be <= AgentRun::MAX_PROVIDER_ATTEMPT_ERROR_MESSAGE_LENGTH
+    end
+
     it "accumulates multiple attempts" do
       agent_run = create(:agent_run)
       agent_run.record_provider_attempt("claude", success: false, error_type: "rate_limited")

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -641,7 +641,9 @@ RSpec.describe "AgentRuns" do
 
         expect(response.body).to include("Provider Attempts")
         expect(response.body).to include("1 attempt")
+        expect(response.body).to include(initial_provider.display_name)
         expect(response.body).to include("Skipped due to cached rate limit until 2026-04-30T05:59:15Z")
+        expect(response.body).not_to include("Deleted provider entry")
       end
 
       it "shows auth type in provider section when provider record exists" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -599,6 +599,51 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("Provider Switches")
       end
 
+      it "shows provider attempt error details in the fallback panel" do
+        owner = project.effective_owner
+        initial_provider = owner.providers.find_by!(provider_key: "claude", auth_type: "subscription")
+        fallback_provider = create_opencode_fallback_provider(user: owner, name: "Kimi K2", model: "moonshotai/kimi-k2-0905")
+        agent_run = create(
+          :agent_run,
+          :failed,
+          project: project,
+          agent_type: "claude_code",
+          provider: initial_provider,
+          provider_switches: 1,
+          providers_attempted: [
+            provider_attempt(initial_provider.routing_key, "rate_limited", "Skipped due to cached rate limit until 2026-04-30T05:59:15Z"),
+            provider_attempt(fallback_provider.routing_key, "error", "Configuration is invalid at /home/agent/.config/opencode/opencode.json")
+          ]
+        )
+
+        get project_agent_run_path(project, agent_run)
+
+        expect(response.body).to include("Skipped due to cached rate limit until 2026-04-30T05:59:15Z")
+        expect(response.body).to include("Configuration is invalid at /home/agent/.config/opencode/opencode.json")
+      end
+
+      it "shows provider attempts even when no fallback switch occurred" do
+        owner = project.effective_owner
+        initial_provider = owner.providers.find_by!(provider_key: "claude", auth_type: "subscription")
+        agent_run = create(
+          :agent_run,
+          :failed,
+          project: project,
+          agent_type: "claude_code",
+          provider: initial_provider,
+          provider_switches: 0,
+          providers_attempted: [
+            provider_attempt(initial_provider.routing_key, "rate_limited", "Skipped due to cached rate limit until 2026-04-30T05:59:15Z")
+          ]
+        )
+
+        get project_agent_run_path(project, agent_run)
+
+        expect(response.body).to include("Provider Attempts")
+        expect(response.body).to include("1 attempt")
+        expect(response.body).to include("Skipped due to cached rate limit until 2026-04-30T05:59:15Z")
+      end
+
       it "shows auth type in provider section when provider record exists" do
         owner = project.effective_owner
         provider = owner.providers.find_by!(provider_key: "claude", auth_type: "subscription")
@@ -2089,6 +2134,20 @@ RSpec.describe "AgentRuns" do
       config: { "opencode" => { "api_provider" => "openrouter", "model" => model } },
       **attrs
     )
+  end
+
+  def create_opencode_fallback_provider(user:, name:, model:)
+    api_key = create(:provider_api_key, user: user, api_service_type: "openrouter")
+    create_opencode_provider_entry(user: user, api_key: api_key, name: name, model: model)
+  end
+
+  def provider_attempt(provider, error_type, error_message)
+    {
+      "provider" => provider,
+      "success" => false,
+      "error_type" => error_type,
+      "error_message" => error_message
+    }
   end
 
   describe "POST /projects/:project_id/agent_runs/:id/diagnose_error" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1844,6 +1844,27 @@ RSpec.describe Containers::Provision do
         expect(result.success?).to be true
         expect(mock_container).not_to have_received(:stop)
       end
+
+      it "still aborts on structured stdout failure events" do
+        structured_error = {
+          "type" => "response.failed",
+          "error" => {
+            "message" => "Error: Free tier limit reached. Please upgrade to a paid plan."
+          }
+        }.to_json + "\n"
+
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stdout, structured_error) if block
+          [ [ structured_error ], [], 1 ]
+        end
+
+        expect { service.execute("codex exec --json", abort_patterns: abort_patterns) }
+          .to raise_error(described_class::OutputAbortError) { |e|
+            expect(e.matched_output).to include("Free tier limit reached")
+          }
+
+        expect(mock_container).to have_received(:stop).with(timeout: 0)
+      end
     end
 
     context "when container is not provisioned" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1845,6 +1845,22 @@ RSpec.describe Containers::Provision do
         expect(mock_container).not_to have_received(:stop)
       end
 
+      it "buffers a partial structured event until the type field arrives" do
+        partial_start = "{\"item\":{\"aggregated_output\":\"Free tier limit reached. Please upgrade to a paid plan.\"}"
+        partial_end = ",\"type\":\"item.completed\"}\n"
+
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stdout, partial_start) if block
+          block.call(:stdout, partial_end) if block
+          [ [ partial_start, partial_end ], [], 0 ]
+        end
+
+        result = service.execute("codex exec --json", abort_patterns: abort_patterns)
+
+        expect(result.success?).to be true
+        expect(mock_container).not_to have_received(:stop)
+      end
+
       it "still aborts on structured stdout failure events" do
         structured_error = {
           "type" => "response.failed",

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1886,6 +1886,22 @@ RSpec.describe Containers::Provision do
 
         expect(mock_container).to have_received(:stop).with(timeout: 0)
       end
+
+      it "falls back to raw stdout matching for malformed brace-prefixed fatal output" do
+        malformed_error = "{Error: Free tier limit reached. Please upgrade to a paid plan."
+
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stdout, malformed_error) if block
+          [ [ malformed_error ], [], 1 ]
+        end
+
+        expect { service.execute("codex exec --json", abort_patterns: abort_patterns) }
+          .to raise_error(described_class::OutputAbortError) { |e|
+            expect(e.matched_output).to include("Free tier limit reached")
+          }
+
+        expect(mock_container).to have_received(:stop).with(timeout: 0)
+      end
     end
 
     context "when container is not provisioned" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1865,6 +1865,27 @@ RSpec.describe Containers::Provision do
 
         expect(mock_container).to have_received(:stop).with(timeout: 0)
       end
+
+      it "aborts on a complete structured stdout failure event without a trailing newline" do
+        structured_error = {
+          "type" => "response.failed",
+          "error" => {
+            "message" => "Error: Free tier limit reached. Please upgrade to a paid plan."
+          }
+        }.to_json
+
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stdout, structured_error) if block
+          [ [ structured_error ], [], 1 ]
+        end
+
+        expect { service.execute("codex exec --json", abort_patterns: abort_patterns) }
+          .to raise_error(described_class::OutputAbortError) { |e|
+            expect(e.matched_output).to include("Free tier limit reached")
+          }
+
+        expect(mock_container).to have_received(:stop).with(timeout: 0)
+      end
     end
 
     context "when container is not provisioned" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1918,6 +1918,22 @@ RSpec.describe Containers::Provision do
 
         expect(mock_container).to have_received(:stop).with(timeout: 0)
       end
+
+      it "checks a buffered brace-prefixed fatal fragment when the stream ends" do
+        truncated_error = "{\"error\":\"Free tier limit reached. Please upgrade to a paid plan."
+
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stdout, truncated_error) if block
+          [ [ truncated_error ], [], 1 ]
+        end
+
+        expect { service.execute("codex exec --json", abort_patterns: abort_patterns) }
+          .to raise_error(described_class::OutputAbortError) { |e|
+            expect(e.matched_output).to include("Free tier limit reached")
+          }
+
+        expect(mock_container).to have_received(:stop).with(timeout: 0)
+      end
     end
 
     context "when container is not provisioned" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1796,6 +1796,56 @@ RSpec.describe Containers::Provision do
       end
     end
 
+    context "when stdout is structured JSONL that embeds abort-like text" do
+      let(:abort_patterns) { [ /free tier limit reached/i ] }
+      let(:jsonl_chunk) do
+        {
+          "type" => "item.completed",
+          "item" => {
+            "id" => "item_1",
+            "type" => "command_execution",
+            "aggregated_output" => "spec text: Free tier limit reached. Please upgrade to a paid plan."
+          }
+        }.to_json + "\n"
+      end
+
+      before do
+        allow(mock_container).to receive(:stop)
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stdout, jsonl_chunk) if block
+          [ [ jsonl_chunk ], [], 0 ]
+        end
+      end
+
+      it "does not raise OutputAbortError" do
+        result = service.execute("codex exec --json", abort_patterns: abort_patterns)
+
+        expect(result.success?).to be true
+      end
+
+      it "does not stop the container" do
+        service.execute("codex exec --json", abort_patterns: abort_patterns)
+
+        expect(mock_container).not_to have_received(:stop)
+      end
+
+      it "does not abort when a JSONL line is split across stdout chunks" do
+        partial_start = "{\"type\":\"item.completed\",\"item\":{\"aggregated_output\":\"Free tier "
+        partial_end = "limit reached. Please upgrade to a paid plan.\"}}\n"
+
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stdout, partial_start) if block
+          block.call(:stdout, partial_end) if block
+          [ [ partial_start, partial_end ], [], 0 ]
+        end
+
+        result = service.execute("codex exec --json", abort_patterns: abort_patterns)
+
+        expect(result.success?).to be true
+        expect(mock_container).not_to have_received(:stop)
+      end
+    end
+
     context "when container is not provisioned" do
       let(:unprovisioned_service) { described_class.new(agent_run: agent_run, worktree_path: worktree_path) }
 


### PR DESCRIPTION
## Summary
- avoid false provider aborts when Codex emits structured JSONL stdout that happens to contain abort-pattern text
- persist sanitized per-attempt provider error details for cached skips and execution failures
- show provider attempt diagnostics on the agent run page even when no fallback switch occurred

## Testing
- `bundle exec rspec spec/services/containers/provision_spec.rb spec/models/agent_run_spec.rb spec/requests/agent_runs_spec.rb`
- `bundle exec rspec spec/temporal/activities/run_agent_activity_spec.rb`
- `bundle exec rubocop app/services/containers/provision.rb app/models/agent_run.rb app/temporal/activities/run_agent_activity.rb spec/services/containers/provision_spec.rb spec/models/agent_run_spec.rb spec/requests/agent_runs_spec.rb`

## Notes
- narrow `rspec` runs still trip the repository SimpleCov minimum-coverage gate even when the targeted examples pass