### PR TITLE
fix(agent-runs): prevent false-positive quota error on substantial agent output

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -801,12 +801,21 @@ module Activities
         .any? { |pattern| output.match?(pattern) }
     end
 
+    QUOTA_ERROR_MAX_OUTPUT_LENGTH = 500
+
     # Detects provider-level credit/quota exhaustion errors surfaced as
     # agent output. Used in the successful-exit-code path to catch cases
     # where a provider (e.g. OpenRouter) returns a billing error as the
     # only stdout content with exit code 0.
+    #
+    # Real billing/quota errors are short standalone messages. If the
+    # sanitized output exceeds QUOTA_ERROR_MAX_OUTPUT_LENGTH, the agent
+    # clearly produced substantial work and should not be misclassified
+    # as a quota error even if a pattern substring appears in structured
+    # output (e.g. JSONL streaming events containing rspec test names).
     def insufficient_credits_error?(output)
       return false if output.blank?
+      return false if output.length > QUOTA_ERROR_MAX_OUTPUT_LENGTH
 
       ProviderSupport.aggregated_error_classification_patterns(:quota)
         .any? { |pattern| output.match?(pattern) }

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2181,6 +2181,34 @@ RSpec.describe Activities::RunAgentActivity do
         expect(agent_run.providers_attempted.first["error_type"]).to eq("rate_limited")
       end
 
+      it "detects a real quota error returned with exit code 0" do
+        quota_success = Containers::Provision::Result.success(
+          stdout: "Error: Your billing limit has been reached. Please add credits.", stderr: "", exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(quota_success)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("failed")
+        expect(agent_run.providers_attempted.first["error_type"]).to eq("error")
+        expect(agent_run.providers_attempted.first["error_message"]).to include("credit/quota error")
+      end
+
+      it "does not misclassify substantial agent output as a quota error when pattern appears in test descriptions" do
+        long_stdout = (1..40).map { |i| "includes test case number #{i} for the billing and rate limit patterns" }.join("\n")
+        long_output_success = Containers::Provision::Result.success(
+          stdout: long_stdout, stderr: "", exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(long_output_success)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:success]).to be true
+      end
+
       it "preserves timeout handling when the timeout happens before provider execution starts" do
         allow(activity).to receive(:augment_prompt_for_goal)
           .and_raise(Containers::Provision::TimeoutError, "took too long before exec")


### PR DESCRIPTION
## Summary

- Prevents the `insufficient_credits_error?` check from falsely classifying completed agent runs as quota errors when the output is substantial (>500 chars) but happens to contain words matching quota patterns (e.g. "billing" and "limit" in rspec test descriptions embedded in codex JSONL streaming output)
- Adds `QUOTA_ERROR_MAX_OUTPUT_LENGTH = 500` guard — real billing/quota errors are short standalone messages; if the agent produced substantial output, it clearly did work
- Adds two regression tests: positive case (short billing error on exit 0 detected) and negative case (long output with coincidental pattern match not misclassified)

## Context

Agent run #11612 (codex fallback) was marked as failed with "exhausted fallback" despite the agent successfully running rubocop, rspec, and committing code (`e010b76`). The quota pattern `/billing.*limit/i` matched across rspec test descriptions in the JSONL streaming output: `"includes guidance about billing in the error message"` ... `.*` ... `"includes rate limit patterns"`.

## Testing

- `bin/rspec spec/temporal/activities/run_agent_activity_spec.rb` — 156 examples, 0 failures
- `bin/rubocop app/temporal/activities/run_agent_activity.rb` — no offenses

@codex review