### PR TITLE
fix: Heartbeat disabled for Docker volume workspaces causes idle timeout false positives

### DIFF
--- a/app/services/containers/heartbeat_setup.rb
+++ b/app/services/containers/heartbeat_setup.rb
@@ -11,8 +11,14 @@ module Containers
   # is stuck", suppressing idle/startup timeouts while the agent is active.
   #
   # The heartbeat file lives on a dedicated bind-mounted directory
-  # (/paid-heartbeat inside the container) so it is visible to both the
-  # container-side hooks and the host-side watchdog.
+  # (/paid-heartbeat inside the container) so it is usually visible to both
+  # the container-side hooks and the host-side watchdog.
+  #
+  # When the host path is unavailable (for example, reconnecting to a
+  # volume-backed workspace where only the container can see /paid-heartbeat),
+  # the setup still enables provider hooks and returns the container path.
+  # The watchdog must then inspect that path from inside the container rather
+  # than reading it directly from the host filesystem.
   #
   # @example
   #   setup = Containers::HeartbeatSetup.new(
@@ -49,11 +55,11 @@ module Containers
     end
 
     def heartbeat_path
-      host_heartbeat_path
+      host_heartbeat_path.presence || CONTAINER_HEARTBEAT_PATH
     end
 
     def available?
-      host_heartbeat_path.present? && SUPPORTED_PROVIDERS.include?(canonical_provider)
+      SUPPORTED_PROVIDERS.include?(canonical_provider)
     end
 
     # Returns the effective idle timeout for this provider given a base

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -219,11 +219,12 @@ module Containers
     #   stops flowing for longer than this duration.
     # @param stream [Boolean] Whether to stream output to agent logs
     # @param env [Hash] Environment variables for the exec invocation
-    # @param heartbeat_path [String, nil] Optional host-visible path to a
-    #   heartbeat file. When provided, the watchdog treats a recent mtime on
-    #   this file as activity equivalent to stdout output. Agents that wait
-    #   for LLM responses without producing output can touch this file (e.g.
-    #   via Claude Code +PostToolUse+ or Codex +notify+ hooks) to signal
+    # @param heartbeat_path [String, nil] Optional heartbeat file path.
+    #   Host-visible paths are read directly. Container-only paths under
+    #   /paid-heartbeat are probed with Docker exec so volume-backed
+    #   workspaces can still suppress false startup/idle timeouts during
+    #   long, silent LLM inference. Agents can touch this file (e.g. via
+    #   Claude Code +PostToolUse+ or Codex +notify+ hooks) to signal
     #   "still working" and avoid startup/idle timeouts.
     # @return [Result] Result with stdout, stderr, and exit_code
     # @raise [StartupTimeoutError] when no output is received within +startup_timeout+ seconds
@@ -2382,7 +2383,9 @@ module Containers
     def heartbeat_age_seconds(heartbeat_path)
       return nil if heartbeat_path.blank?
 
-      mtime = File.mtime(heartbeat_path)
+      mtime = heartbeat_mtime(heartbeat_path)
+      return nil unless mtime
+
       observed_at_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       observed_age = Time.now - mtime
 
@@ -2401,6 +2404,32 @@ module Containers
         end
       end
     rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR
+      nil
+    end
+
+    def heartbeat_mtime(heartbeat_path)
+      if container_heartbeat_path?(heartbeat_path)
+        container_heartbeat_mtime(heartbeat_path)
+      else
+        File.mtime(heartbeat_path)
+      end
+    end
+
+    def container_heartbeat_path?(heartbeat_path)
+      heartbeat_path.start_with?("#{HEARTBEAT_MOUNT_POINT}/")
+    end
+
+    def container_heartbeat_mtime(heartbeat_path)
+      stdout, = container.exec(
+        [ "sh", "-lc", "test -e #{Shellwords.escape(heartbeat_path)} && stat -c %Y #{Shellwords.escape(heartbeat_path)}" ],
+        wait: 5,
+        user: "agent"
+      )
+      mtime_seconds = stdout.join.to_s.strip
+      return nil if mtime_seconds.blank?
+
+      Time.at(Integer(mtime_seconds))
+    rescue Docker::Error::DockerError, ArgumentError
       nil
     end
 

--- a/spec/services/containers/heartbeat_setup_spec.rb
+++ b/spec/services/containers/heartbeat_setup_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Containers::HeartbeatSetup do
       expect(setup.heartbeat_path).to eq(host_heartbeat_path)
     end
 
-    it "returns nil when host_heartbeat_path is nil" do
+    it "falls back to the container heartbeat path when host_heartbeat_path is nil" do
       setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
-      expect(setup.heartbeat_path).to be_nil
+      expect(setup.heartbeat_path).to eq(described_class::CONTAINER_HEARTBEAT_PATH)
     end
   end
 
@@ -39,9 +39,9 @@ RSpec.describe Containers::HeartbeatSetup do
       expect(setup).not_to be_available
     end
 
-    it "returns false without host_heartbeat_path" do
+    it "returns true without host_heartbeat_path for supported providers" do
       setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
-      expect(setup).not_to be_available
+      expect(setup).to be_available
     end
   end
 
@@ -56,9 +56,9 @@ RSpec.describe Containers::HeartbeatSetup do
       expect(setup.env).to eq({})
     end
 
-    it "returns empty hash without host_heartbeat_path" do
+    it "returns AGENT_HEARTBEAT_PATH without host_heartbeat_path" do
       setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
-      expect(setup.env).to eq({})
+      expect(setup.env).to eq("AGENT_HEARTBEAT_PATH" => "/paid-heartbeat/.paid-heartbeat")
     end
   end
 
@@ -148,8 +148,8 @@ RSpec.describe Containers::HeartbeatSetup do
     context "without host_heartbeat_path" do
       let(:setup) { described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil) }
 
-      it "returns nil" do
-        expect(setup.preparation).to be_nil
+      it "still writes Claude heartbeat settings" do
+        expect(setup.preparation).to be_a(AgentHarness::ExecutionPreparation)
       end
     end
   end
@@ -179,9 +179,9 @@ RSpec.describe Containers::HeartbeatSetup do
       expect(setup.idle_timeout_for(base_timeout)).to be_nil
     end
 
-    it "returns nil without host_heartbeat_path" do
+    it "returns base timeout without host_heartbeat_path" do
       setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
-      expect(setup.idle_timeout_for(base_timeout)).to be_nil
+      expect(setup.idle_timeout_for(base_timeout)).to eq(base_timeout)
     end
 
     it "returns base timeout for reliable heartbeat providers" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -2467,7 +2467,7 @@ RSpec.describe Containers::Provision do
         result = service.execute(
           "working_silently",
           timeout: 10,
-          idle_timeout: 0.2,
+          idle_timeout: 1.1,
           heartbeat_path: heartbeat_path
         )
         expect(result).to be_success
@@ -2565,6 +2565,27 @@ RSpec.describe Containers::Provision do
         )
         expect(result).to be_success
       end
+
+      it "suppresses idle timeout when the heartbeat is only visible inside the container" do
+        heartbeat_path = "#{described_class::HEARTBEAT_MOUNT_POINT}/.paid-heartbeat"
+
+        allow(mock_container).to receive(:exec).with([ "sh", "-c", "working_silently" ], any_args) do |_, **_opts, &block|
+          block.call(:stdout, "initial output\n") if block
+          10.times { sleep 0.05 }
+          [ [ "initial output\n" ], [], 0 ]
+        end
+        allow(service).to receive(:watchdog_poll_interval).and_return(0.05)
+        allow(service).to receive(:container_heartbeat_mtime).with(heartbeat_path) { Time.now }
+
+        result = service.execute(
+          "working_silently",
+          timeout: 10,
+          idle_timeout: 1.2,
+          heartbeat_path: heartbeat_path
+        )
+        expect(result).to be_success
+        expect(container_stopped.true?).to be false
+      end
     end
   end
 
@@ -2642,6 +2663,25 @@ RSpec.describe Containers::Provision do
 
       expect(first_age).to eq(10.0)
       expect(second_age).to eq(15.0)
+    end
+
+    it "reads container-visible heartbeat mtimes via docker exec" do
+      service.with_existing_container(mock_container)
+      heartbeat_path = "#{described_class::HEARTBEAT_MOUNT_POINT}/.paid-heartbeat"
+      heartbeat_mtime = Time.utc(2026, 4, 29, 12, 0, 0)
+
+      allow(mock_container).to receive(:exec).with(
+        [ "sh", "-lc", "test -e /paid-heartbeat/.paid-heartbeat && stat -c %Y /paid-heartbeat/.paid-heartbeat" ],
+        wait: 5,
+        user: "agent"
+      ).and_return([ [ "#{heartbeat_mtime.to_i}\n" ], [], 0 ])
+      allow(Process).to receive(:clock_gettime).and_call_original
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0)
+      allow(Time).to receive(:now).and_return(heartbeat_mtime + 10)
+
+      age = service.send(:heartbeat_age_seconds, heartbeat_path)
+
+      expect(age).to eq(10.0)
     end
   end
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -2467,7 +2467,7 @@ RSpec.describe Containers::Provision do
         result = service.execute(
           "working_silently",
           timeout: 10,
-          idle_timeout: 1.1,
+          idle_timeout: 0.2,
           heartbeat_path: heartbeat_path
         )
         expect(result).to be_success

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1893,6 +1893,24 @@ RSpec.describe Activities::RunAgentActivity do
 
         activity.execute(agent_run_id: agent_run.id)
       end
+
+      it "falls back to the container heartbeat path for volume-backed workspaces" do
+        agent_run.update!(worktree_path: nil)
+        project.update!(max_execution_seconds: 86_400)
+        allow(container_service).to receive_messages(execute: exec_success, heartbeat_host_path: nil)
+        allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+
+        expect(container_service).to receive(:execute).with(
+          anything,
+          hash_including(
+            timeout: AGENT_TIMEOUT_DEFAULT,
+            idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
+            heartbeat_path: Containers::HeartbeatSetup::CONTAINER_HEARTBEAT_PATH
+          )
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
     end
 
     context "with fallback enabled" do


### PR DESCRIPTION
## Summary

Implemented the heartbeat fix for Docker volume workspaces and committed it on the current feature branch.

The change keeps heartbeat monitoring enabled for supported providers even when `worktree_path` is `nil`, falls back to the container-visible heartbeat path (`/paid-heartbeat/agent-heartbeat`) when there is no host-visible file, and teaches `Containers::Provision` to read heartbeat mtimes via `docker exec` for those container-only paths. I also updated the heartbeat setup docs and added coverage around the volume-backed workspace path.

Verification is complete: `bundle exec rubocop` passed, and `bundle exec rspec` passed with `9572 examples, 0 failures, 2 pending` (the existing pending Qdrant live specs). `db:prepare` succeeded using the provided Postgres service with `PAID_SKIP_DATABASE_RUNTIME_ROLE_GUARD=true` plus explicit `DB_HOST`/`DB_USERNAME`/`DB_PASSWORD` from `DATABASE_URL`.

Commits:
- `5966039` `fix(containers): keep heartbeats active for volume workspaces`
- `670e498` `fix(tests): restore direct heartbeat timeout coverage`

Working tree is clean.

---

Closes #1543