### PR TITLE
fix(providers): generate record-format provider in kilocode and opencode CLI configs

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -202,8 +202,12 @@ class Provider < ApplicationRecord
 
     {
       provider: { kilocode_provider_key => {} },
-      model: "#{kilocode_provider_key}/#{model_id}"
+      model: kilocode_qualified_model(kilocode_provider_key, model_id)
     }.to_json
+  end
+
+  def kilocode_qualified_model(provider_key, model_id)
+    model_id.include?("/") ? model_id : "#{provider_key}/#{model_id}"
   end
 
   def direct_outbound_exec_env

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -198,12 +198,12 @@ class Provider < ApplicationRecord
     raise ArgumentError, "Missing KiloCode model id for provider #{id || provider_key}" if model_id.blank?
 
     api_config = DIRECT_OUTBOUND_API_PROVIDERS.fetch(kilocode_api_provider, DIRECT_OUTBOUND_API_PROVIDERS["anthropic"])
-    api_adapter = api_config[:kilocode_api] || "openai-compatible"
+    kilocode_provider_key = api_config[:kilocode_api] || "openai"
 
-    AgentHarness.provider(:kilocode).config_file_content(
-      api_provider: api_adapter,
-      model_id: model_id
-    )
+    {
+      provider: { kilocode_provider_key => {} },
+      model: "#{kilocode_provider_key}/#{model_id}"
+    }.to_json
   end
 
   def direct_outbound_exec_env
@@ -597,12 +597,18 @@ class Provider < ApplicationRecord
 
     api_config = DIRECT_OUTBOUND_API_PROVIDERS.fetch(opencode_api_provider, DIRECT_OUTBOUND_API_PROVIDERS["openrouter"])
 
+    env = { "OPENAI_API_KEY" => provider_api_key&.api_key.to_s }
+    env["OPENAI_BASE_URL"] = api_config[:base_url] if api_config[:base_url]
+
     AgentHarness::ProviderRuntime.new(
       model: model_id,
-      base_url: api_config[:base_url],
-      api_provider: opencode_api_provider,
-      env: { "OPENAI_API_KEY" => provider_api_key&.api_key.to_s },
-      unset_env: %w[OPENAI_HEADER_X_AGENT_RUN_ID OPENAI_HEADER_X_PROXY_TOKEN]
+      env: env,
+      unset_env: %w[OPENAI_HEADER_X_AGENT_RUN_ID OPENAI_HEADER_X_PROXY_TOKEN],
+      metadata: {
+        config: {
+          "provider" => { opencode_api_provider => {} }
+        }
+      }
     )
   end
 end

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -286,7 +286,7 @@ module Providers
     # provision.rb ensure block), which removes the config before the
     # subsequent smoke test runs.
     def prepare_kilocode_config!(run)
-      config_json = kilocode_container_config_json
+      config_json = provider.kilocode_config_json
       run.execute_in_container(
         [ "sh", "-c",
           "mkdir -p /home/agent/.config/kilo && " \
@@ -294,29 +294,6 @@ module Providers
         timeout: 30,
         env: { "KILOCODE_CONFIG_B64" => Base64.strict_encode64(config_json) }
       )
-    end
-
-    # Generates a kilo CLI config JSON compatible with v7.1.3.
-    #
-    # The kilo CLI expects provider to be a record (e.g. {"openai": {}}),
-    # not a string. For OpenAI-compatible backends (z.ai, DeepSeek, etc.),
-    # the "openai" provider is used with OPENAI_BASE_URL overridden via env.
-    def kilocode_container_config_json
-      api_provider = provider.kilocode_api_provider
-      api_config = Provider::DIRECT_OUTBOUND_API_PROVIDERS.fetch(
-        api_provider, Provider::DIRECT_OUTBOUND_API_PROVIDERS["anthropic"]
-      )
-
-      kilocode_provider_key = if api_config[:kilocode_api]
-        api_config[:kilocode_api]
-      else
-        "openai"
-      end
-
-      {
-        provider: { kilocode_provider_key => {} },
-        model: "#{kilocode_provider_key}/#{provider.kilocode_model_id}"
-      }.to_json
     end
 
     def build_test_run

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -490,10 +490,14 @@ RSpec.describe Provider do
       runtime = provider.agent_harness_provider_runtime
 
       expect(runtime.model).to eq("moonshotai/kimi-k2-0905")
-      expect(runtime.api_provider).to eq("openrouter")
-      expect(runtime.base_url).to eq("https://openrouter.ai/api/v1")
-      expect(runtime.env).to include("OPENAI_API_KEY" => "sk-openrouter-secret")
+      expect(runtime.api_provider).to be_nil
+      expect(runtime.base_url).to be_nil
+      expect(runtime.env).to include(
+        "OPENAI_API_KEY" => "sk-openrouter-secret",
+        "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1"
+      )
       expect(runtime.unset_env).to include("OPENAI_HEADER_X_AGENT_RUN_ID", "OPENAI_HEADER_X_PROXY_TOKEN")
+      expect(runtime.metadata[:config]["provider"]).to eq({ "openrouter" => {} })
     end
 
     it "does not enable direct outbound when the OpenCode model id is missing" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -472,6 +472,49 @@ RSpec.describe Provider do
     end
   end
 
+  describe "KiloCode config generation" do
+    let(:user) { create(:user) }
+    let(:api_key) { create(:provider_api_key, user: user, api_service_type: "anthropic") }
+    let(:provider) do
+      create(
+        :provider,
+        user: user,
+        provider_key: "kilocode",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-20250514" } }
+      )
+    end
+
+    it "generates provider as a record with prefixed model" do
+      config = JSON.parse(provider.kilocode_config_json)
+
+      expect(config["provider"]).to eq({ "anthropic" => {} })
+      expect(config["model"]).to eq("anthropic/claude-sonnet-4-20250514")
+    end
+
+    it "does not double-prefix already-qualified model ids" do
+      provider.update!(config: { "kilocode" => { "api_provider" => "anthropic", "model" => "anthropic/claude-opus-4" } })
+
+      config = JSON.parse(provider.kilocode_config_json)
+
+      expect(config["model"]).to eq("anthropic/claude-opus-4")
+    end
+
+    it "uses openai as default provider key for OpenAI-compatible backends" do
+      zai_key = create(:provider_api_key, user: user, api_service_type: "zai_coding")
+      provider.update!(
+        provider_api_key: zai_key,
+        config: { "kilocode" => { "api_provider" => "zai_coding", "model" => "glm-5.1" } }
+      )
+
+      config = JSON.parse(provider.kilocode_config_json)
+
+      expect(config["provider"]).to eq({ "openai" => {} })
+      expect(config["model"]).to eq("openai/glm-5.1")
+    end
+  end
+
   describe "OpenCode agent-harness runtime helpers" do
     let(:user) { create(:user) }
     let(:api_key) { create(:provider_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret") }

--- a/spec/services/providers/harness_execution_plan_spec.rb
+++ b/spec/services/providers/harness_execution_plan_spec.rb
@@ -23,8 +23,27 @@ RSpec.describe Providers::HarnessExecutionPlan do
         "OPENAI_API_KEY" => "sk-openrouter-secret",
         "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1"
       )
+    end
+
+    it "writes opencode.json with provider as record, not string" do
+      user = create(:user)
+      api_key = create(:provider_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret")
+      provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2-0905" } }
+      )
+
+      plan = described_class.call(provider: provider, prompt: "ping")
+
       expect(plan.preparation.file_writes.first.path).to eq("~/.config/opencode/opencode.json")
-      expect(plan.preparation.file_writes.first.content).to include("\"provider\": \"openrouter\"")
+      parsed = JSON.parse(plan.preparation.file_writes.first.content)
+      expect(parsed["provider"]).to eq({ "openrouter" => {} })
+      expect(parsed["model"]).to eq("moonshotai/kimi-k2-0905")
+      expect(parsed).not_to have_key("baseURL")
     end
   end
 end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -516,7 +516,8 @@ RSpec.describe Activities::RunAgentActivity do
         expect(env).to have_key("PAID_KILOCODE_CONFIG_B64")
         expect(env).to have_key("PAID_PROVIDER_ID")
         config_json = JSON.parse(Base64.strict_decode64(env["PAID_KILOCODE_CONFIG_B64"]))
-        expect(config_json["model"]).to eq("claude-sonnet-4-20250514")
+        expect(config_json["model"]).to eq("anthropic/claude-sonnet-4-20250514")
+        expect(config_json["provider"]).to eq({ "anthropic" => {} })
       end
 
       it "does not include PAID_KILOCODE_CONFIG_B64 for subscription kilocode providers" do


### PR DESCRIPTION
## Summary

- Fixes Kilocode and OpenCode CLI config generation to produce `"provider": {"key": {}}` (record) instead of `"provider": "key"` (string), which both CLIs reject with config validation errors
- Removes invalid `"baseURL"` key from OpenCode config (base URL is correctly set via `OPENAI_BASE_URL` env var instead)
- Defensively guards against nil `base_url` in env hash to prevent `ArgumentError` from `ProviderRuntime` validation
- Root cause of agent run 11942 where all three fallback providers failed with `'expected record, received string provider'`

## Root cause

The agent-harness gem's `config_file_content` (kilocode) and `opencode_config_payload` (opencode) both generate `"provider": "string"` format. Kilo CLI v7.1.3 and OpenCode CLI v1.3.2 require `"provider": {"key": {}}` (record/object).

**Before (broken):**
```json
{"provider": "openai-compatible", "model": "glm-5.1"}
```

**After (correct):**
```json
{"provider": {"openai": {}}, "model": "openai/glm-5.1"}
```

## Test plan

- [x] `spec/models/provider_spec.rb` — updated expectations for new runtime shape
- [x] `spec/services/providers/harness_execution_plan_spec.rb` — new test verifying record-format provider and absence of baseURL
- [x] `spec/temporal/activities/run_agent_activity_spec.rb` — updated kilocode config expectations
- [x] All 137 provider specs pass
- [x] All 154 run_agent_activity specs pass
- [x] Pre-commit hooks pass (RuboCop, ESLint, markdownlint, ShellCheck)

## Follow-up

- The gem's `config_file_content` (kilocode) and `opencode_config_payload` (opencode) should be fixed upstream in agent-harness so the Paid workarounds can be removed