### PR TITLE
fix: Auth failure checker false positives on rate-limit 403s and infrastructure 503s

### DIFF
--- a/app/jobs/github_token_validation_job.rb
+++ b/app/jobs/github_token_validation_job.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class GithubTokenValidationJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
   queue_as :default
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: -> { "github_token_validation_#{arguments.first}" }
+  )
 
   retry_on GithubClient::RateLimitError, wait: :polynomially_longer, attempts: 3
   discard_on ActiveRecord::RecordNotFound

--- a/app/services/github_tokens/auth_failure_checker.rb
+++ b/app/services/github_tokens/auth_failure_checker.rb
@@ -2,11 +2,18 @@
 
 module GithubTokens
   class AuthFailureChecker
+    RATE_LIMIT_PATTERNS = [
+      /secondary rate limit/i,
+      /rate limit exceeded/i,
+      /too many requests/i,
+      /retry-after/i
+    ].freeze
+
     # Git clone / fetch authentication failures
     GIT_AUTH_PATTERNS = [
       /Authentication failed/i,
       /fatal: could not read Username/i,
-      /HTTP 403/,
+      /HTTP 403(?::|\b).*(access denied|authentication failed|bad credentials|invalid credentials)/i,
       /HTTP 401/,
       /could not read Password/i,
       /Invalid credentials/i,
@@ -16,10 +23,9 @@ module GithubTokens
 
     # Proxy 503 responses from credential/proxy controllers
     PROXY_AUTH_PATTERNS = [
-      /proxy.*503/i,
-      /GitCredentials.*503/i,
-      /GithubProxy.*503/i,
-      /Service Unavailable.*credential/i
+      /GitCredentials.*Project GitHub token is missing or inactive/i,
+      /GithubProxy.*GitHub token not available/i,
+      /Service Unavailable.*(GitHub token not available|Project GitHub token is missing or inactive)/i
     ].freeze
 
     # GithubClient errors
@@ -43,12 +49,19 @@ module GithubTokens
 
     def call
       return nil if @error_message.blank?
+      return nil if rate_limited?
 
       ALL_PATTERNS.find { |pattern| @error_message.match?(pattern) }
     end
 
     def auth_failure?
       call.present?
+    end
+
+    private
+
+    def rate_limited?
+      RATE_LIMIT_PATTERNS.any? { |pattern| @error_message.match?(pattern) }
     end
   end
 end

--- a/app/services/github_tokens/auth_failure_checker.rb
+++ b/app/services/github_tokens/auth_failure_checker.rb
@@ -21,7 +21,7 @@ module GithubTokens
       /The requested URL returned error: 401/i
     ].freeze
 
-    # Proxy 503 responses from credential/proxy controllers
+    # Credential-unavailable responses from proxy/credential controllers (any status code)
     PROXY_AUTH_PATTERNS = [
       /GitCredentials.*Project GitHub token is missing or inactive/i,
       /GithubProxy.*GitHub token not available/i,

--- a/spec/jobs/github_token_validation_job_spec.rb
+++ b/spec/jobs/github_token_validation_job_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe GithubTokenValidationJob do
   let(:account) { create(:account) }
   let(:github_token) { create(:github_token, :pending_validation, account: account) }
 
+  describe "GoodJob concurrency" do
+    it "serializes validation per GitHub token" do
+      config = described_class.good_job_concurrency_config
+
+      expect(config[:total_limit]).to eq(1)
+      expect(config[:enqueue_limit]).to eq(1)
+      expect(described_class.new(github_token.id).good_job_concurrency_key).to eq("github_token_validation_#{github_token.id}")
+    end
+  end
+
   describe "#perform" do
     context "when token is valid" do
       before do

--- a/spec/services/github_tokens/auth_failure_checker_spec.rb
+++ b/spec/services/github_tokens/auth_failure_checker_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe GithubTokens::AuthFailureChecker do
 
     it "detects proxy 503 responses" do
       [
-        "GitCredentials proxy returned 503",
-        "GithubProxy responded with 503",
-        "proxy error 503"
+        "GitCredentials returned 503: Project GitHub token is missing or inactive",
+        "GithubProxy responded with 503: GitHub token not available",
+        "Service Unavailable: GitHub token not available"
       ].each do |msg|
         checker = described_class.new(error_message: msg)
         expect(checker.auth_failure?).to be(true), "Expected auth failure for: #{msg}"
@@ -47,6 +47,8 @@ RSpec.describe GithubTokens::AuthFailureChecker do
         "Timeout after 300 seconds",
         "No changes detected",
         "Rate limit exceeded",
+        "HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+        "GithubProxy responded with 503: upstream proxy overload",
         "PermissionUnauthorizedError in module",
         ""
       ].each do |msg|

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -134,8 +134,27 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
         agent_run = create(:agent_run, :running, project: project)
 
         expect {
-          activity.execute(agent_run_id: agent_run.id, error: "GitCredentials proxy returned 503")
+          activity.execute(agent_run_id: agent_run.id, error: "GithubProxy responded with 503: GitHub token not available")
         }.to have_enqueued_job(GithubTokenValidationJob).with(project.github_token.id)
+      end
+
+      it "does not enqueue validation for secondary rate-limit 403s" do
+        agent_run = create(:agent_run, :running, project: project)
+
+        expect {
+          activity.execute(
+            agent_run_id: agent_run.id,
+            error: "HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again."
+          )
+        }.not_to have_enqueued_job(GithubTokenValidationJob)
+      end
+
+      it "does not enqueue validation for generic proxy 503s" do
+        agent_run = create(:agent_run, :running, project: project)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id, error: "GithubProxy responded with 503: upstream proxy overload")
+        }.not_to have_enqueued_job(GithubTokenValidationJob)
       end
 
       it "does not enqueue validation for non-auth errors" do


### PR DESCRIPTION
## Summary

Implemented and committed the fix on the current issue branch as `6b96f9c` with message `fix(github-tokens): avoid transient auth validation storms`.

The change narrows `GithubTokens::AuthFailureChecker` so rate-limit 403s and generic proxy 503s no longer look like auth failures, while still matching credential-specific proxy failures like missing/inactive GitHub tokens. `GithubTokenValidationJob` now uses `good_job_control_concurrency_with` to serialize validation per token and cap duplicate enqueues. I also updated the affected specs to cover the new false-negative and false-positive boundaries.

Verification ran clean:
`bundle exec rubocop`
`bundle exec rspec`
The pre-commit hook also passed on commit. The full suite finished with `9603 examples, 0 failures, 2 pending` where the two pending Qdrant live specs were expected.

---

Closes #1544