### PR TITLE
fix: Provider validation missing at agent run creation time

### DIFF
--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -6,6 +6,12 @@ module AgentRuns
       new(...).call
     end
 
+    def self.selected_provider(project:, provider_id:)
+      return if provider_id.blank?
+
+      project.effective_owner&.providers&.find_by(id: provider_id)
+    end
+
     def initialize(project:, goal:, requested_agent_type: nil, requested_provider_id: nil, respect_requested: true, logger: nil)
       @project = project
       @goal = goal
@@ -94,9 +100,7 @@ module AgentRuns
     end
 
     def provider_for_id(provider_id)
-      return if provider_id.blank?
-
-      project.effective_owner&.providers&.find_by(id: provider_id)
+      self.class.selected_provider(project: project, provider_id: provider_id)
     end
 
     def provider_runnable?(provider)

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -33,6 +33,11 @@ module Activities
         goal: goal,
         respect_requested: input.key?(:agent_type) || input.key?(:provider_id)
       )
+      validate_requested_provider_resolution!(
+        project: project,
+        requested_provider_id: input[:provider_id],
+        resolved_provider_id: provider_id
+      )
 
       validate_runnable_provider!(project: project, provider_id: provider_id, agent_type: agent_type, goal: goal)
 
@@ -255,7 +260,7 @@ module Activities
     def validate_runnable_provider!(project:, provider_id:, agent_type:, goal:)
       return if goal.in?(NON_CONTAINER_GOALS)
 
-      provider = AgentRuns::ProviderResolver.selected_provider(project: project, provider_id: provider_id)
+      provider = resolved_provider!(project: project, provider_id: provider_id)
       if provider
         raise_no_runnable_provider!(
           "No runnable provider available for project (provider_id=#{provider.id}, enabled_for_agent_runs=#{provider.enabled_for_agent_runs?})"
@@ -269,6 +274,27 @@ module Activities
       return if ProviderSupport.container_executable_provider_key?(provider_key)
 
       raise_no_runnable_provider!("No runnable provider available for project (agent_type=#{agent_type})")
+    end
+
+    def resolved_provider!(project:, provider_id:)
+      provider = AgentRuns::ProviderResolver.selected_provider(project: project, provider_id: provider_id)
+      raise_unresolved_provider!(project: project, provider_id: provider_id) if provider_id.present? && provider.nil?
+
+      provider
+    end
+
+    def validate_requested_provider_resolution!(project:, requested_provider_id:, resolved_provider_id:)
+      return if requested_provider_id.blank?
+      return if requested_provider_id.to_s == resolved_provider_id.to_s
+      return if AgentRuns::ProviderResolver.selected_provider(project: project, provider_id: requested_provider_id)
+
+      raise_unresolved_provider!(project: project, provider_id: requested_provider_id)
+    end
+
+    def raise_unresolved_provider!(project:, provider_id:)
+      return if provider_id.blank?
+
+      raise_no_runnable_provider!("No runnable provider available for project (project_id=#{project.id}, provider_id=#{provider_id}, resolved=false)")
     end
 
     def warn_if_rate_limited(provider, project:, goal:)

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -34,7 +34,7 @@ module Activities
         respect_requested: input.key?(:agent_type) || input.key?(:provider_id)
       )
 
-      validate_runnable_provider!(provider_id, agent_type, goal: goal)
+      validate_runnable_provider!(project: project, provider_id: provider_id, agent_type: agent_type, goal: goal)
 
       # Resolve and render prompt version if no custom prompt is provided.
       # Skip for untrusted issues to match the safety behavior in AgentRun#prompt_for_issue.
@@ -259,16 +259,44 @@ module Activities
       )
     end
 
-    def validate_runnable_provider!(provider_id, agent_type, goal:)
+    def validate_runnable_provider!(project:, provider_id:, agent_type:, goal:)
       return if goal.in?(NON_CONTAINER_GOALS)
 
-      return if provider_id.present?
+      provider = AgentRuns::ProviderResolver.selected_provider(project: project, provider_id: provider_id)
+      if provider
+        raise_no_runnable_provider!(
+          "No runnable provider available for project (provider_id=#{provider.id}, enabled_for_agent_runs=#{provider.enabled_for_agent_runs?})"
+        ) unless provider.enabled_for_agent_runs?
+
+        warn_if_rate_limited(provider, project: project, goal: goal)
+        return
+      end
 
       provider_key = ProviderSupport.provider_key_for_agent_type(agent_type)
       return if ProviderSupport.container_executable_provider_key?(provider_key)
 
+      raise_no_runnable_provider!("No runnable provider available for project (agent_type=#{agent_type})")
+    end
+
+    def warn_if_rate_limited(provider, project:, goal:)
+      provider_state = provider.user.provider_states.find_by(provider_name: provider.state_key)
+      return unless provider_state&.rate_limited?
+
+      logger.warn(
+        message: "agent_execution.selected_provider_rate_limited",
+        project_id: project.id,
+        provider_id: provider.id,
+        provider_key: provider.provider_key,
+        provider_state_name: provider.state_key,
+        agent_type: Provider.agent_type_for(provider.provider_key),
+        goal: goal,
+        rate_limited_until: provider_state.rate_limited_until
+      )
+    end
+
+    def raise_no_runnable_provider!(message)
       raise Temporalio::Error::ApplicationError.new(
-        "No runnable provider available for project (agent_type=#{agent_type})",
+        message,
         type: "NoRunnableProvider",
         non_retryable: true
       )

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -146,21 +146,14 @@ module Activities
     end
 
     def refresh_automatic_run_provider!(agent_run)
-      return unless agent_run.automatic?
+      return [ agent_run.provider_id, agent_run.agent_type ] unless agent_run.automatic?
 
-      provider_id, agent_type = resolve_provider_selection(
+      resolve_provider_selection(
         project: agent_run.project,
         requested_agent_type: nil,
         requested_provider_id: nil,
         goal: agent_run.goal,
         respect_requested: false
-      )
-      provider = Provider.find_by(id: provider_id) if provider_id
-      return unless provider
-
-      agent_run.update!(
-        provider: provider,
-        agent_type: agent_type
       )
     end
 
@@ -168,10 +161,10 @@ module Activities
       agent_run = AgentRun.find(agent_run_id)
 
       if agent_run.queued?
-        refresh_automatic_run_provider!(agent_run)
+        validate_and_sync_resumed_provider!(agent_run)
         agent_run.update!(status: "pending")
       elsif agent_run.status == "pending"
-        refresh_automatic_run_provider!(agent_run)
+        validate_and_sync_resumed_provider!(agent_run)
       else
         # "queued" and "pending" are the expected statuses here; ProcessRunQueueJob
         # may claim runs (queued->pending) before starting the workflow. Only warn
@@ -291,6 +284,26 @@ module Activities
         agent_type: Provider.agent_type_for(provider.provider_key),
         goal: goal,
         rate_limited_until: provider_state.rate_limited_until
+      )
+    end
+
+    def validate_and_sync_resumed_provider!(agent_run)
+      provider_id, agent_type = refresh_automatic_run_provider!(agent_run)
+      validate_runnable_provider!(
+        project: agent_run.project,
+        provider_id: provider_id,
+        agent_type: agent_type,
+        goal: agent_run.goal
+      )
+      sync_provider_selection!(agent_run, provider_id: provider_id, agent_type: agent_type)
+    end
+
+    def sync_provider_selection!(agent_run, provider_id:, agent_type:)
+      return if agent_run.provider_id == provider_id && agent_run.agent_type == agent_type
+
+      agent_run.update!(
+        provider: Provider.find_by(id: provider_id),
+        agent_type: agent_type
       )
     end
 

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -113,6 +113,23 @@ RSpec.describe Activities::CreateAgentRunActivity do
       }
     end
 
+    it "fails fast when an explicit provider_id no longer resolves" do
+      missing_provider_id = create(:provider, user: project.created_by, provider_key: "cursor").id
+      Provider.find(missing_provider_id).destroy!
+
+      expect {
+        activity.execute(
+          project_id: project.id,
+          issue_id: issue.id,
+          provider_id: missing_provider_id,
+          agent_type: "claude_code"
+        )
+      }.to raise_error(Temporalio::Error::ApplicationError) { |error|
+        expect(error.type).to eq("NoRunnableProvider")
+        expect(error.non_retryable).to be(true)
+      }
+    end
+
     it "uses the goal-specific provider for fresh review runs" do
       codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
       project.created_by.settings.update!(default_agent_providers_by_goal: { "review" => codex_provider.routing_key })

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -101,6 +101,15 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(agent_run.agent_type).to eq("codex")
     end
 
+    it "fails fast when a selected provider is disabled for agent runs" do
+      codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
+      codex_provider.update!(enabled_for_agent_runs: false)
+
+      expect {
+        activity.execute(project_id: project.id, issue_id: issue.id, provider_id: codex_provider.id)
+      }.to raise_error(Temporalio::Error::ApplicationError, /No runnable provider/)
+    end
+
     it "uses the goal-specific provider for fresh review runs" do
       codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
       project.created_by.settings.update!(default_agent_providers_by_goal: { "review" => codex_provider.routing_key })
@@ -230,6 +239,31 @@ RSpec.describe Activities::CreateAgentRunActivity do
       result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "claude_code")
 
       expect(result[:provider_attempt_count]).to eq(3)
+    end
+
+    it "warns when the selected provider is already rate limited" do
+      logger = instance_spy(Logger, info: nil, warn: nil)
+      allow(activity).to receive(:logger).and_return(logger)
+
+      create(
+        :provider_state,
+        :rate_limited,
+        user: project.created_by,
+        provider_name: "claude"
+      )
+
+      activity.execute(project_id: project.id, issue_id: issue.id)
+
+      expect(logger).to have_received(:warn).with(
+        hash_including(
+          message: "agent_execution.selected_provider_rate_limited",
+          project_id: project.id,
+          provider_key: "claude",
+          provider_state_name: "claude",
+          agent_type: "claude_code",
+          goal: "create_pr"
+        )
+      )
     end
 
     it "updates the issue paid_state to in_progress" do

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -107,7 +107,10 @@ RSpec.describe Activities::CreateAgentRunActivity do
 
       expect {
         activity.execute(project_id: project.id, issue_id: issue.id, provider_id: codex_provider.id)
-      }.to raise_error(Temporalio::Error::ApplicationError, /No runnable provider/)
+      }.to raise_error(Temporalio::Error::ApplicationError) { |error|
+        expect(error.type).to eq("NoRunnableProvider")
+        expect(error.non_retryable).to be(true)
+      }
     end
 
     it "uses the goal-specific provider for fresh review runs" do
@@ -145,6 +148,26 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(agent_run.provider).to eq(codex_provider)
       expect(agent_run.agent_type).to eq("codex")
       expect(agent_run.status).to eq("pending")
+    end
+
+    it "fails fast when a resumed queued run refreshes to a provider now disabled for agent runs" do
+      codex_provider = create(:provider, user: project.created_by, provider_key: "codex")
+      claude_provider = project.created_by.providers.find_by!(provider_key: "claude")
+      queued_run = create(:agent_run, :queued, :automatic,
+        project: project, issue: issue, provider: claude_provider, agent_type: "claude_code")
+      codex_provider.update!(enabled_for_agent_runs: false)
+      allow(activity).to receive(:resolve_provider_selection).and_return([ codex_provider.id, "codex" ])
+
+      expect {
+        activity.execute(agent_run_id: queued_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError) { |error|
+        expect(error.type).to eq("NoRunnableProvider")
+        expect(error.non_retryable).to be(true)
+      }
+
+      expect(queued_run.reload.provider).to eq(claude_provider)
+      expect(queued_run.agent_type).to eq("claude_code")
+      expect(queued_run.status).to eq("queued")
     end
 
     it "persists draft review round tracking metadata when provided" do


### PR DESCRIPTION
## Summary

Added provider validation to `CreateAgentRunActivity` so resolved provider selections now fail fast when the selected provider record is disabled for agent runs, while still allowing provider-less runs when the `agent_type` maps to a container-executable provider. It also logs a warning if the selected provider’s `ProviderState` is already rate-limited. I factored provider lookup through `AgentRuns::ProviderResolver.selected_provider` and added activity specs for the disabled-provider error and the rate-limit warning.

Verification passed with `bin/rails db:prepare`, full `bundle exec rubocop`, and full `bundle exec rspec` using the provided Postgres service. The suite finished with `9602 examples, 0 failures, 2 pending` on the expected Qdrant-live specs. Commit: `ab331fe` (`fix(agent-runs): validate provider availability at creation`).

---

Closes #1548