### PR TITLE
fix: Circuit breaker record_success! race condition allows overwriting open state

### DIFF
--- a/app/models/github_health_state.rb
+++ b/app/models/github_health_state.rb
@@ -82,23 +82,25 @@ class GithubHealthState < ApplicationRecord
   # an in-flight success while circuit is open must not bypass the
   # recovery timeout.
   def record_success!
-    return if circuit_state == "closed" && failure_count.zero?
-    return if circuit_open?
+    with_lock do
+      return if circuit_state == "closed" && failure_count.zero?
+      return if circuit_open?
 
-    was_half_open = circuit_half_open?
+      was_half_open = circuit_half_open?
 
-    update!(
-      failure_count: 0,
-      circuit_state: "closed",
-      circuit_opened_at: nil,
-      last_error_message: nil
-    )
-
-    if was_half_open
-      Rails.logger.info(
-        message: "github_health.circuit_closed",
-        endpoint: endpoint
+      update!(
+        failure_count: 0,
+        circuit_state: "closed",
+        circuit_opened_at: nil,
+        last_error_message: nil
       )
+
+      if was_half_open
+        Rails.logger.info(
+          message: "github_health.circuit_closed",
+          endpoint: endpoint
+        )
+      end
     end
   end
 
@@ -107,17 +109,19 @@ class GithubHealthState < ApplicationRecord
   # @param timeout [Integer] Seconds to wait before attempting recovery
   # @return [Boolean] true if transitioned to half_open
   def check_circuit_recovery!(timeout: DEFAULT_RECOVERY_TIMEOUT)
-    return false unless circuit_state == "open"
-    return false unless circuit_opened_at.present?
-    return false unless circuit_opened_at + timeout.seconds <= Time.current
+    with_lock do
+      return false unless circuit_state == "open"
+      return false unless circuit_opened_at.present?
+      return false unless circuit_opened_at + timeout.seconds <= Time.current
 
-    update!(circuit_state: "half_open")
+      update!(circuit_state: "half_open")
 
-    Rails.logger.info(
-      message: "github_health.circuit_half_open",
-      endpoint: endpoint
-    )
-    true
+      Rails.logger.info(
+        message: "github_health.circuit_half_open",
+        endpoint: endpoint
+      )
+      true
+    end
   end
 
   def circuit_open?

--- a/spec/models/github_health_state_spec.rb
+++ b/spec/models/github_health_state_spec.rb
@@ -3,6 +3,67 @@
 require "rails_helper"
 
 RSpec.describe GithubHealthState do
+  def wait_for_queue(queue, timeout: 5)
+    Timeout.timeout(timeout) { queue.pop }
+  end
+
+  def run_success_failure_race(state)
+    success_state = described_class.find(state.id)
+    failure_state = described_class.find(state.id)
+    update_started = Queue.new
+    continue_update = Queue.new
+    failure_started = Queue.new
+    failure_updated = Queue.new
+
+    allow(success_state).to receive(:update!).and_wrap_original do |method, *args|
+      update_started << true
+      wait_for_queue(continue_update)
+      method.call(*args)
+    end
+    allow(failure_state).to receive(:with_lock).and_wrap_original do |method, *args, &block|
+      failure_started << true
+      method.call(*args, &block)
+    end
+    allow(failure_state).to receive(:update!).and_wrap_original do |method, *args|
+      failure_updated << true
+      method.call(*args)
+    end
+
+    success_thread = Thread.new { success_state.record_success! }
+    wait_for_queue(update_started)
+    failure_thread = Thread.new { failure_state.record_failure!(error_message: "probe failed") }
+    wait_for_queue(failure_started)
+
+    expect { wait_for_queue(failure_updated, timeout: 0.1) }.to raise_error(Timeout::Error)
+
+    continue_update << true
+    [ success_thread, failure_thread ].each(&:join)
+  end
+
+  def run_recovery_race(state)
+    first_state = described_class.find(state.id)
+    second_state = described_class.find(state.id)
+    update_started = Queue.new
+    continue_update = Queue.new
+
+    allow(first_state).to receive(:update!).and_wrap_original do |method, *args|
+      update_started << true
+      wait_for_queue(continue_update)
+      method.call(*args)
+    end
+
+    first_result = nil
+    second_result = nil
+
+    first_thread = Thread.new { first_result = first_state.check_circuit_recovery!(timeout: 300) }
+    wait_for_queue(update_started)
+    second_thread = Thread.new { second_result = second_state.check_circuit_recovery!(timeout: 300) }
+    continue_update << true
+
+    [ first_thread, second_thread ].each(&:join)
+    [ first_result, second_result ]
+  end
+
   describe "validations" do
     subject { build(:github_health_state) }
 
@@ -169,6 +230,16 @@ RSpec.describe GithubHealthState do
       state.reload
       expect(state.failure_count).to eq(0)
     end
+
+    it "does not overwrite an open circuit when a failure races with success" do
+      state = create(:github_health_state, :circuit_half_open)
+      run_success_failure_race(state)
+
+      state.reload
+      expect(state.circuit_state).to eq("closed")
+      expect(state.failure_count).to eq(1)
+      expect(state.last_error_message).to eq("probe failed")
+    end
   end
 
   describe "#check_circuit_recovery!" do
@@ -191,6 +262,14 @@ RSpec.describe GithubHealthState do
     it "returns false for closed circuits" do
       state = create(:github_health_state, circuit_state: "closed")
       expect(state.check_circuit_recovery!(timeout: 300)).to be false
+    end
+
+    it "allows only one concurrent recovery transition" do
+      state = create(:github_health_state, circuit_state: "open", circuit_opened_at: 10.minutes.ago)
+      first_result, second_result = run_recovery_race(state)
+
+      expect([ first_result, second_result ].count(true)).to eq(1)
+      expect(state.reload.circuit_state).to eq("half_open")
     end
   end
 

--- a/spec/models/github_health_state_spec.rb
+++ b/spec/models/github_health_state_spec.rb
@@ -30,12 +30,20 @@ RSpec.describe GithubHealthState do
       method.call(*args)
     end
 
-    success_thread = Thread.new { success_state.record_success! }
+    success_thread = Thread.new do
+      success_state.record_success!
+    ensure
+      ActiveRecord::Base.connection_pool.release_connection
+    end
     wait_for_queue(update_started)
-    failure_thread = Thread.new { failure_state.record_failure!(error_message: "probe failed") }
+    failure_thread = Thread.new do
+      failure_state.record_failure!(error_message: "probe failed")
+    ensure
+      ActiveRecord::Base.connection_pool.release_connection
+    end
     wait_for_queue(failure_started)
 
-    expect { wait_for_queue(failure_updated, timeout: 0.1) }.to raise_error(Timeout::Error)
+    expect { wait_for_queue(failure_updated, timeout: 2) }.to raise_error(Timeout::Error)
 
     continue_update << true
     [ success_thread, failure_thread ].each(&:value)
@@ -56,9 +64,17 @@ RSpec.describe GithubHealthState do
     first_result = nil
     second_result = nil
 
-    first_thread = Thread.new { first_result = first_state.check_circuit_recovery!(timeout: 300) }
+    first_thread = Thread.new do
+      first_result = first_state.check_circuit_recovery!(timeout: 300)
+    ensure
+      ActiveRecord::Base.connection_pool.release_connection
+    end
     wait_for_queue(update_started)
-    second_thread = Thread.new { second_result = second_state.check_circuit_recovery!(timeout: 300) }
+    second_thread = Thread.new do
+      second_result = second_state.check_circuit_recovery!(timeout: 300)
+    ensure
+      ActiveRecord::Base.connection_pool.release_connection
+    end
     continue_update << true
 
     [ first_thread, second_thread ].each(&:value)

--- a/spec/models/github_health_state_spec.rb
+++ b/spec/models/github_health_state_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "timeout"
 
 RSpec.describe GithubHealthState do
   def wait_for_queue(queue, timeout: 5)
@@ -37,7 +38,7 @@ RSpec.describe GithubHealthState do
     expect { wait_for_queue(failure_updated, timeout: 0.1) }.to raise_error(Timeout::Error)
 
     continue_update << true
-    [ success_thread, failure_thread ].each(&:join)
+    [ success_thread, failure_thread ].each(&:value)
   end
 
   def run_recovery_race(state)
@@ -60,7 +61,7 @@ RSpec.describe GithubHealthState do
     second_thread = Thread.new { second_result = second_state.check_circuit_recovery!(timeout: 300) }
     continue_update << true
 
-    [ first_thread, second_thread ].each(&:join)
+    [ first_thread, second_thread ].each(&:value)
     [ first_result, second_result ]
   end
 


### PR DESCRIPTION
## Summary

Updated `GithubHealthState` so both `record_success!` and `check_circuit_recovery!` run inside `with_lock`, which closes the race where a concurrent failure could reopen the circuit and then get overwritten back to `closed`. I also added regression coverage in `spec/models/github_health_state_spec.rb` for the success/failure interleaving and concurrent recovery transition.

Validation ran clean: `bin/rails db:prepare`, full `bundle exec rubocop`, full `bundle exec rspec` (`9602 examples, 0 failures, 2 pending`), and the pre-commit hook passed on commit. Commit: `0d76e52` (`fix(github-health): lock success and recovery transitions`).

---

Closes #1542