### PR TITLE
chore: add fasterer gem and fix performance lint findings

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -1,0 +1,25 @@
+speedups:
+  rescue_vs_respond_to: true
+  module_eval: true
+  shuffle_first_vs_sample: true
+  for_loop_vs_each: true
+  each_with_index_vs_while: false
+  map_flatten_vs_flat_map: true
+  reverse_each_vs_reverse_each: true
+  select_first_vs_detect: true
+  sort_vs_sort_by: true
+  fetch_with_argument_vs_block: false # handled better by rubocop-performance
+  keys_each_vs_each_key: true
+  hash_merge_bang_vs_hash_brackets: true
+  block_vs_symbol_to_proc: true
+  proc_call_vs_yield: true
+  gsub_vs_tr: true
+  select_last_vs_reverse_detect: true
+  getter_vs_attr_reader: true
+  setter_vs_attr_writer: true
+
+exclude_paths:
+  - "vendor/**/*"
+  - "node_modules/**/*"
+  - "db/**/*"
+  - "config/**/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,23 @@ jobs:
       - name: Run query performance benchmarks
         run: COVERAGE=false bin/rspec spec/performance
 
+  fasterer:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_FROZEN: "true"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f
+        with:
+          ruby-version: .tool-versions
+          bundler-cache: true
+
+      - name: Run fasterer
+        run: bundle exec fasterer
+
   performance:
     runs-on: ubuntu-latest
 

--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,9 @@ group :development, :test do
   # Additional RuboCop extensions
   gem "rubocop-rspec", require: false
 
+  # Performance suggestions for Ruby code [https://github.com/fasterer/fasterer]
+  gem "fasterer", require: false
+
   # Testing framework
   gem "rspec-rails"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,8 @@ GEM
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
+    fasterer (0.11.0)
+      ruby_parser (>= 3.19.1)
     ferrum (0.17.2)
       addressable (~> 2.5)
       base64 (~> 0.2)
@@ -426,10 +428,14 @@ GEM
       rexml (~> 3.2)
       rover-df (~> 0.3)
     ruby-progressbar (1.13.0)
+    ruby_parser (3.22.0)
+      racc (~> 1.5)
+      sexp_processor (~> 4.16)
     sawyer (0.9.3)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
+    sexp_processor (4.17.5)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
     simplecov (0.22.0)
@@ -540,6 +546,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday-retry
+  fasterer
   fixture_kit
   flipper
   flipper-active_record
@@ -627,6 +634,7 @@ CHECKSUMS
   faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
+  fasterer (0.11.0) sha256=9c38b77583584f3339a729eb077fd8f2856a317abe747528f6563d7c23e9dda8
   ferrum (0.17.2) sha256=2c2540a850b211a46f4d81de21bfd62048f507e4c327d1807225c3823c17e6ee
   fixture_kit (0.14.0) sha256=e58f642b0813e1fe630e323e9b8e7f6bd7619412cae9ac0b671d4b2211c393c7
   flipper (1.4.1) sha256=05843240fb3093c7037549e34b046b636c765120f22e0a6268212daf44166e4d
@@ -729,8 +737,10 @@ CHECKSUMS
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   ruby-maat (1.2.0) sha256=558797d7e1267126a56fbfc9db2d29002a5e5d2bc330b8a45ba106c0771ff844
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23
   sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  sexp_processor (4.17.5) sha256=ae2b48ba98353d5d465ce8759836b7a05f2e12c5879fcd14d7815b026de32f0e
   shoulda-matchers (7.0.1) sha256=b4bfd8744c10e0a36c8ac1a687f921ee7e25ed529e50488d61b79a8688749c77
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -66,13 +66,13 @@ class TenantConfigurationsController < ApplicationController
   end
 
   def feature_flag_rollout_params
-    params.fetch(:feature_flag_rollouts, ActionController::Parameters.new).permit(
+    params.fetch(:feature_flag_rollouts) { ActionController::Parameters.new }.permit(
       FeatureFlags::DEFINITIONS.keys.index_with { %i[percentage_of_actors percentage_of_time] }
     ).to_h
   end
 
   def feature_flag_rollout_original_params
-    params.fetch(:feature_flag_rollout_originals, ActionController::Parameters.new).permit(
+    params.fetch(:feature_flag_rollout_originals) { ActionController::Parameters.new }.permit(
       FeatureFlags::DEFINITIONS.keys.index_with { %i[percentage_of_actors percentage_of_time] }
     ).to_h
   end
@@ -101,7 +101,7 @@ class TenantConfigurationsController < ApplicationController
       features: FeatureFlags::DEFINITIONS.keys
     ).to_h
     attrs["features"] ||= {}
-    FeatureFlags::DEFINITIONS.keys.each do |flag_name|
+    FeatureFlags::DEFINITIONS.each_key do |flag_name|
       attrs["features"][flag_name.to_s] = ActiveModel::Type::Boolean.new.cast(attrs["features"][flag_name.to_s])
     end
     attrs

--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -97,7 +97,15 @@ class AutoReleaseEvaluationJob < ApplicationJob
 
   def fetch_previous_version(client, project)
     content = client.contents(project.full_name, path: ".release-please-manifest.json")
-    return nil unless content.respond_to?(:content)
+    unless content.respond_to?(:content)
+      Rails.logger.warn(
+        message: "auto_release.fetch_version_failed",
+        project_id: project.id,
+        error: "Expected file content response for .release-please-manifest.json",
+        response_class: content.class.name
+      )
+      return nil
+    end
 
     manifest = JSON.parse(Base64.decode64(content.content))
     manifest["."]

--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -97,9 +97,11 @@ class AutoReleaseEvaluationJob < ApplicationJob
 
   def fetch_previous_version(client, project)
     content = client.contents(project.full_name, path: ".release-please-manifest.json")
+    return nil unless content.respond_to?(:content)
+
     manifest = JSON.parse(Base64.decode64(content.content))
     manifest["."]
-  rescue GithubClient::Error, JSON::ParserError, NoMethodError => e
+  rescue GithubClient::Error, JSON::ParserError => e
     Rails.logger.warn(
       message: "auto_release.fetch_version_failed",
       project_id: project.id,

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1360,14 +1360,14 @@ class AgentRun < ApplicationRecord
   # @param options [Hash] Override default container options
   # @yield [self] The agent run with provisioned container
   # @return [Object] The return value of the block
-  def with_container(**options, &block)
+  def with_container(**options, &)
     Containers::Provision.with_container(
       agent_run: self,
       worktree_path: worktree_path.presence,
       **options
     ) do |service|
       @container_service = service
-      block.call(self)
+      yield(self)
     ensure
       @container_service = nil
     end

--- a/app/models/token_usage.rb
+++ b/app/models/token_usage.rb
@@ -75,7 +75,7 @@ class TokenUsage < ApplicationRecord
   private
 
   def exactly_one_run_present
-    present_count = [ agent_run_id, knowledge_run_id, chat_session_id ].count { |id| id.present? }
+    present_count = [ agent_run_id, knowledge_run_id, chat_session_id ].count(&:present?)
     return if present_count == 1
 
     errors.add(:base, "must belong to exactly one of agent_run, knowledge_run, or chat_session")

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -2081,7 +2081,7 @@ module Containers
     end
 
     def local_config_path(dirname)
-      path = File.join(ENV.fetch("HOME") { "/home/vscode" }, dirname)
+      path = File.join(ENV.fetch("HOME", "/home/vscode"), dirname)
       File.directory?(path) ? path : nil
     end
 

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1991,14 +1991,15 @@ module Containers
     end
 
     def codex_auth_lockfile_path
-      lock_config = codex_harness_provider.auth_lock_config
+      provider = codex_harness_provider
+      lock_config = provider.respond_to?(:auth_lock_config) ? provider.auth_lock_config : nil
       base_path = lock_config&.dig(:path)&.sub(/\.lock\z/, "")
       raise TypeError, "no lock path configured" unless base_path
 
       host_mount = codex_subscription_auth_host_mount_path
       digest = Digest::SHA256.hexdigest(host_mount)[0, 16]
       "#{base_path}-#{digest}.lock"
-    rescue TypeError, NoMethodError
+    rescue TypeError
       base = lock_config&.dig(:path)&.sub(/\.lock\z/, "") || "/tmp/codex-auth"
       "#{base}-missing.lock"
     end
@@ -2080,7 +2081,7 @@ module Containers
     end
 
     def local_config_path(dirname)
-      path = File.join(ENV.fetch("HOME", "/home/vscode"), dirname)
+      path = File.join(ENV.fetch("HOME") { "/home/vscode" }, dirname)
       File.directory?(path) ? path : nil
     end
 

--- a/app/services/knowledge/context_bundle/build.rb
+++ b/app/services/knowledge/context_bundle/build.rb
@@ -106,7 +106,7 @@ module Knowledge
           chunks = a.active_ordered_chunks.to_a
           total_chunks += chunks.size
           if chunks.any?
-            chunk_lines = chunks.map { |c| "- #{c.content.gsub("\n", " ").truncate(200)}" }
+            chunk_lines = chunks.map { |c| "- #{c.content.tr("\n", " ").truncate(200)}" }
             "#### #{section_title}\n#{chunk_lines.join("\n")}"
           else
             "#### #{section_title}\n- #{a.content.to_s.truncate(300)}"

--- a/app/services/prompt_evolution/sample_runs.rb
+++ b/app/services/prompt_evolution/sample_runs.rb
@@ -107,7 +107,7 @@ module PromptEvolution
       end
 
       if sampled_ids.size < sample_size
-        sampled_ids.concat(leftover_ids.shuffle(random: random).first(sample_size - sampled_ids.size))
+        sampled_ids.concat(leftover_ids.sample(sample_size - sampled_ids.size, random: random))
       end
 
       AgentRun.where(id: sampled_ids.first(sample_size))

--- a/app/services/prompts/build_for_issue.rb
+++ b/app/services/prompts/build_for_issue.rb
@@ -135,8 +135,10 @@ module Prompts
     def self.fetch_trusted_comments(github_client:, repo:, number:, project:, max_comments: DEFAULT_MAX_COMMENTS)
       all_comments = github_client.issue_comments(repo, number)
       all_comments
+        .reverse
         .select { |c| project.trusted_github_user?(c.user&.login) }
-        .last(max_comments)
+        .first(max_comments)
+        .reverse
     rescue GithubClient::Error
       []
     end

--- a/app/services/prompts/build_for_issue.rb
+++ b/app/services/prompts/build_for_issue.rb
@@ -134,11 +134,13 @@ module Prompts
 
     def self.fetch_trusted_comments(github_client:, repo:, number:, project:, max_comments: DEFAULT_MAX_COMMENTS)
       all_comments = github_client.issue_comments(repo, number)
-      all_comments
-        .reverse
-        .select { |c| project.trusted_github_user?(c.user&.login) }
-        .first(max_comments)
-        .reverse
+      trusted = []
+      all_comments.reverse_each do |c|
+        next unless project.trusted_github_user?(c.user&.login)
+        trusted << c
+        break if trusted.size >= max_comments
+      end
+      trusted.reverse
     rescue GithubClient::Error
       []
     end

--- a/app/services/prompts/build_for_issue.rb
+++ b/app/services/prompts/build_for_issue.rb
@@ -133,6 +133,7 @@ module Prompts
     end
 
     def self.fetch_trusted_comments(github_client:, repo:, number:, project:, max_comments: DEFAULT_MAX_COMMENTS)
+      return [] if max_comments <= 0
       all_comments = github_client.issue_comments(repo, number)
       trusted = []
       all_comments.reverse_each do |c|

--- a/app/temporal/activities/base_activity.rb
+++ b/app/temporal/activities/base_activity.rb
@@ -65,7 +65,7 @@ module Activities
       def with_rails_executor(&block)
         executor = Rails.application.executor if defined?(Rails) && Rails.respond_to?(:application) &&
           Rails.application.respond_to?(:executor)
-        return block.call unless executor
+        return yield unless executor
 
         executor.wrap(&block)
       end
@@ -74,12 +74,12 @@ module Activities
       # holding one for the entire activity duration. Activities often perform
       # long-running external I/O (container ops, GitHub calls) and keeping a
       # connection checked out would starve the pool.
-      def with_connection_cleanup(&block)
+      def with_connection_cleanup
         pool = ActiveRecord::Base.connection_pool if defined?(ActiveRecord::Base) &&
           ActiveRecord::Base.respond_to?(:connection_pool)
-        return block.call unless pool
+        return yield unless pool
 
-        block.call
+        yield
       ensure
         restore_outer_tenant_context!(pool) if pool
       end

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -51,7 +51,7 @@ module Activities
         # `updated_at` second as the watermark), use the exact timestamp
         # to guarantee forward progress. Some same-second issues may be
         # skipped, but permanent re-fetch of the same window is worse.
-        latest_updated = github_issues.filter_map { |gi| gi.updated_at }.max
+        latest_updated = github_issues.filter_map(&:updated_at).max
         if latest_updated
           inclusive_cursor = latest_updated - 1.second
           # `incremental` is only true when `last_issue_sync_at` is present,

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1659,11 +1659,11 @@ module Activities
       "Could not inspect container: #{e.message}"
     end
 
-    def error_or_cause_matches?(error, klass, &block)
+    def error_or_cause_matches?(error, klass, &)
       current = error
 
       while current
-        return true if current.is_a?(klass) && (!block || block.call(current))
+        return true if current.is_a?(klass) && (!block_given? || yield(current))
 
         break unless current.respond_to?(:cause)
         current = current.cause

--- a/scripts/extract-provider-install-contract.rb
+++ b/scripts/extract-provider-install-contract.rb
@@ -51,8 +51,13 @@ rescue AgentHarness::ConfigurationError
   # instead of the generic registry method. Fall back to that API.
   begin
     provider_class = AgentHarness::Providers.const_get(provider.split("_").map(&:capitalize).join)
-    contract = provider_class.installation_contract
-  rescue NameError, NoMethodError => e
+    if provider_class.respond_to?(:installation_contract)
+      contract = provider_class.installation_contract
+    else
+      warn "No install contract found for provider: #{provider}"
+      exit 1
+    end
+  rescue NameError => e
     warn "No install contract found for provider: #{provider} (#{e.message})"
     exit 1
   end

--- a/spec/jobs/auto_release_evaluation_job_spec.rb
+++ b/spec/jobs/auto_release_evaluation_job_spec.rb
@@ -187,6 +187,22 @@ RSpec.describe AutoReleaseEvaluationJob do
       expect(client).to have_received(:merge_pull_request)
     end
 
+    it "warns and skips when manifest lookup returns a non-file response" do
+      allow(client).to receive(:contents).and_return([])
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.perform_now(project.id)
+
+      expect(Rails.logger).to have_received(:warn).with(
+        hash_including(
+          message: "auto_release.fetch_version_failed",
+          project_id: project.id,
+          response_class: "Array"
+        )
+      )
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
     it "handles expected merge failures gracefully" do
       allow(client).to receive(:merge_pull_request).and_raise(
         GithubClient::ApiError.new("Merge conflict", status: 409)


### PR DESCRIPTION
## Summary

- Add `fasterer` gem as a development dependency with `.fasterer.yml` config (disables `fetch_with_argument_vs_block` and `each_with_index_vs_while`, excludes config/vendor/db paths)
- Add lightweight `fasterer` CI job to `ci.yml` (Ruby-only, no DB or services needed)
- Fix 12 source files for remaining performance issues: `rescue NoMethodError` → `respond_to?` guards, `block.call` → `yield`, symbol-to-proc, `keys.each` → `each_key`, `gsub` → `tr`, `shuffle.first` → `sample`, `select.last` → `reverse.detect`

## Test plan

- [x] `bundle exec fasterer` passes with 0 offenses
- [x] `bin/lint --changed` passes
- [x] New CI `fasterer` job will validate on this PR