### PR TITLE
test(profiling): add test-prof audit workflow and trim request setup

### DIFF
--- a/bin/test-prof-audit
+++ b/bin/test-prof-audit
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 OUTPUT_DIR="tmp/test_prof"
 EXCLUDE_PATTERN="spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb"
+FAILED_RUNS=()
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -37,6 +38,7 @@ EOF
 
 run_and_capture() {
   local name="$1"
+  local status
   shift
 
   echo
@@ -44,6 +46,12 @@ run_and_capture() {
   echo "Command: $*"
 
   TEST_PROF_REPORT="$name" COVERAGE=false "$@" | tee "${OUTPUT_DIR}/${name}.log"
+  status=${PIPESTATUS[0]}
+
+  if (( status != 0 )); then
+    echo "Run failed with exit status ${status}; keeping ${OUTPUT_DIR}/${name}.log for inspection."
+    FAILED_RUNS+=("${name}:${status}")
+  fi
 }
 
 run_hotspot_map() {
@@ -99,3 +107,10 @@ case "${1:-}" in
     exit 1
     ;;
 esac
+
+if (( ${#FAILED_RUNS[@]} > 0 )); then
+  echo
+  echo "Completed with failed profiling runs:"
+  printf '  %s\n' "${FAILED_RUNS[@]}"
+  exit 1
+fi

--- a/bin/test-prof-audit
+++ b/bin/test-prof-audit
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+OUTPUT_DIR="tmp/test_prof"
+EXCLUDE_PATTERN="spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb"
+
+mkdir -p "$OUTPUT_DIR"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bin/test-prof-audit hotspot-map
+  bin/test-prof-audit requests-deep
+  bin/test-prof-audit type-breakdown
+  bin/test-prof-audit file PROFILE_TARGET
+
+Commands:
+  hotspot-map
+    Runs plain RSpec profiling on the main hotspot directories.
+
+  requests-deep
+    Runs the deeper request-spec audit passes used in the May 2026 test-prof audit:
+    FPROF, FDOC, EVENT_PROF(sql.active_record), RD_PROF, and TPS_PROF.
+
+  type-breakdown
+    Runs TAG_PROF=type across the broader suite so request/model/service/job types
+    can actually be compared.
+
+  file PROFILE_TARGET
+    Runs plain profile + FPROF + FDOC + EVENT_PROF(sql.active_record) + RD_PROF
+    for one file.
+EOF
+}
+
+run_and_capture() {
+  local name="$1"
+  shift
+
+  echo
+  echo "==> ${name}"
+  echo "Command: $*"
+
+  TEST_PROF_REPORT="$name" COVERAGE=false "$@" | tee "${OUTPUT_DIR}/${name}.log"
+}
+
+run_hotspot_map() {
+  run_and_capture requests_profile bundle exec rspec --profile 20 spec/requests --exclude-pattern "$EXCLUDE_PATTERN"
+  run_and_capture models_profile bundle exec rspec --profile 20 spec/models --exclude-pattern "$EXCLUDE_PATTERN"
+  run_and_capture services_profile bundle exec rspec --profile 20 spec/services --exclude-pattern "$EXCLUDE_PATTERN"
+  run_and_capture temporal_profile bundle exec rspec --profile 20 spec/temporal --exclude-pattern "$EXCLUDE_PATTERN"
+}
+
+run_requests_deep() {
+  run_and_capture requests_fprof env FPROF=1 bundle exec rspec spec/requests --exclude-pattern "$EXCLUDE_PATTERN"
+  run_and_capture requests_fdoc env FDOC=1 bundle exec rspec spec/requests --exclude-pattern "$EXCLUDE_PATTERN"
+  run_and_capture requests_event_sql env EVENT_PROF=sql.active_record EVENT_PROF_EXAMPLES=1 bundle exec rspec spec/requests --exclude-pattern "$EXCLUDE_PATTERN"
+  run_and_capture requests_rd_prof env RD_PROF=1 bundle exec rspec spec/requests --exclude-pattern "$EXCLUDE_PATTERN"
+  run_and_capture requests_tps env TPS_PROF=10 bundle exec rspec spec/requests --exclude-pattern "$EXCLUDE_PATTERN"
+}
+
+run_type_breakdown() {
+  run_and_capture suite_tag_type env TAG_PROF=type bundle exec rspec spec --exclude-pattern "$EXCLUDE_PATTERN"
+}
+
+run_file_deep() {
+  local target="$1"
+  local base
+  base="$(basename "$target" .rb)"
+
+  run_and_capture "${base}_profile" bundle exec rspec --profile 20 "$target"
+  run_and_capture "${base}_fprof" env FPROF=1 bundle exec rspec "$target"
+  run_and_capture "${base}_fdoc" env FDOC=1 bundle exec rspec "$target"
+  run_and_capture "${base}_event_sql" env EVENT_PROF=sql.active_record EVENT_PROF_EXAMPLES=1 bundle exec rspec "$target"
+  run_and_capture "${base}_rd_prof" env RD_PROF=1 bundle exec rspec "$target"
+}
+
+case "${1:-}" in
+  hotspot-map)
+    run_hotspot_map
+    ;;
+  requests-deep)
+    run_requests_deep
+    ;;
+  type-breakdown)
+    run_type_breakdown
+    ;;
+  file)
+    if [[ $# -ne 2 ]]; then
+      usage
+      exit 1
+    fi
+    run_file_deep "$2"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/docs/TEST_PROFILING.md
+++ b/docs/TEST_PROFILING.md
@@ -11,6 +11,30 @@ We are using `fixture_kit` selectively for a few large activity specs under `spe
 
 ## Local usage
 
+Generate the hotspot map used in the May 2026 deep-dive audit:
+
+```bash
+bin/test-prof-audit hotspot-map
+```
+
+Run the deeper request-spec audit passes in one shot:
+
+```bash
+bin/test-prof-audit requests-deep
+```
+
+Compare runtime by RSpec metadata type across the broader suite:
+
+```bash
+bin/test-prof-audit type-breakdown
+```
+
+Run the core profiling passes for one hotspot file:
+
+```bash
+bin/test-prof-audit file spec/requests/github_tokens_spec.rb
+```
+
 Profile the regular non-system suite's factory usage:
 
 ```bash
@@ -23,11 +47,42 @@ Find examples that write to the database unnecessarily:
 FDOC=1 COVERAGE=false bin/rspec --exclude-pattern "spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb"
 ```
 
+Profile SQL-heavy examples:
+
+```bash
+EVENT_PROF=sql.active_record EVENT_PROF_EXAMPLES=1 COVERAGE=false bin/rspec spec/requests/github_tokens_spec.rb
+```
+
+Profile setup-heavy examples:
+
+```bash
+RD_PROF=1 COVERAGE=false bin/rspec spec/requests/github_tokens_spec.rb
+```
+
+Compare the shape of large example groups:
+
+```bash
+TPS_PROF=10 COVERAGE=false bin/rspec spec/requests --exclude-pattern "spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb"
+```
+
+Compare runtime by RSpec metadata type:
+
+```bash
+TAG_PROF=type COVERAGE=false bin/rspec spec --exclude-pattern "spec/performance/**/*_spec.rb,spec/system/**/*_spec.rb"
+```
+
 The most common follow-up optimizations are:
 
 - Replace `create(...)` with `build(...)` or `build_stubbed(...)` when persistence is not required.
 - Use `create_default(...)` selectively to reduce factory cascades in deeply-associated factories.
-- Promote very stable, heavily reused persisted graphs into `fixture_kit` definitions under `spec/fixture_kit/`.
+- Collapse repeated factory graphs by reusing already-created account/user/project fixtures inside a spec when creator fields are not part of the assertion.
+- Promote very stable, heavily reused persisted graphs into `fixture_kit` definitions under `spec/fixture_kit/` only when the profiling data shows that the extra risk is justified.
+
+## Deep-Dive Findings
+
+The one-time May 2026 audit, including before/after results for `spec/requests/github_tokens_spec.rb`
+and `spec/requests/agent_runs_spec.rb`, is documented in
+[`docs/TEST_PROF_AUDIT_2026-05.md`](./TEST_PROF_AUDIT_2026-05.md).
 
 ## Tenant isolation note
 

--- a/docs/TEST_PROF_AUDIT_2026-05.md
+++ b/docs/TEST_PROF_AUDIT_2026-05.md
@@ -1,0 +1,163 @@
+# TestProf Audit - May 2026
+
+## Summary
+
+This audit used `test-prof 1.6.1` beyond the repo's existing `FPROF` / `FDOC` workflow and focused on:
+
+1. factory churn
+2. SQL/event volume
+3. RSpec setup and `let` overhead
+4. slow example-group shape
+5. CPU-heavy outliers
+
+Two request-spec hotspots were optimized as part of the audit:
+
+- [`spec/requests/github_tokens_spec.rb`](../spec/requests/github_tokens_spec.rb)
+- [`spec/requests/agent_runs_spec.rb`](../spec/requests/agent_runs_spec.rb)
+
+Both were spending time on factory-created `created_by` users and projects that the assertions never used. The fixes stayed low risk and spec-local: reuse the already-created request user/account/project graph instead of letting `github_token` and `project` factories create extra users implicitly.
+
+## Commands
+
+The audit command wrapper added in this pass is [`bin/test-prof-audit`](../bin/test-prof-audit).
+
+Most useful entrypoints:
+
+```bash
+bin/test-prof-audit hotspot-map
+bin/test-prof-audit requests-deep
+bin/test-prof-audit type-breakdown
+bin/test-prof-audit file spec/requests/github_tokens_spec.rb
+```
+
+All profiling runs use `COVERAGE=false` and write logs/artifacts under `tmp/test_prof`.
+
+## Ranked File Hotspots
+
+Only successful profiling runs are ranked here. Targets with failing or incomplete runs are listed later under blockers so they do not distort prioritization.
+
+| Hotspot | Runtime | Dominant profiler signal | Likely root cause | Low-risk fix | Expected impact |
+| --- | ---: | --- | --- | --- | --- |
+| `spec/temporal/activities/run_agent_activity_spec.rb` | `67.08s` | plain profile shows a few very heavy timeout/fallback examples | expensive fallback/log-scan scenarios and container-oriented setup | isolate log fixtures, shrink fallback scenario setup, and use targeted `TEST_STACK_PROF` on top 3 examples | `large` |
+| `spec/services/containers/git_operations_spec.rb` | `59.44s` | plain profile; top examples are shell/fs heavy | expensive git sandbox setup and repeated hook-install scenarios | share more fixture repos/helpers and stub shell boundaries earlier in examples | `large` |
+| `spec/temporal/activities/scan_paid_prs_activity_spec.rb` | `56.28s` | plain profile shows repeated review-goal state-machine scenarios | many complex PR/review-run graphs per example | collapse helper graphs so each example creates only the required issues/runs | `large` |
+| `spec/requests/agent_runs_spec.rb` | `52.75s` before, `41.44s` after | `FPROF`, `EVENT_PROF`, `RD_PROF` | repeated request-spec setup, heavy `project` / `user` / `agent_run` graphs, lots of SQL | reuse current-account creator fixtures; keep narrowing top-level lazy setup, especially `project` and `issue` | `large` |
+| `spec/services/containers/provision_spec.rb` | `51.22s` | plain profile shows watchdog/timeout concentration | timeout simulation and container-watchdog scaffolding dominate | extract lighter timeout helpers and reduce duplicated heartbeat/clock setup | `medium` |
+| `spec/requests/projects_spec.rb` | `22.12s` | plain profile shows request-spec setup and sort/metrics scenarios | similar request-spec factory graph pressure to `agent_runs_spec` | apply the same creator-reuse pattern for `project` / `github_token` / metric fixtures | `medium` |
+| `spec/requests/github_tokens_spec.rb` | `6.06s` before, `4.18s` after | `FPROF`, `EVENT_PROF`, `RD_PROF` | extra `user` creation through `github_token.created_by` and `project.created_by` | reuse current-account creator fixtures and keep project setup narrow | `medium` |
+| `spec/services/github_client_spec.rb` | `2.68s` | plain profile only | not a current hotspot; mostly fast mocked API behavior | no immediate work; leave out of next optimization wave | `small` |
+
+## Top 20 Slow Examples Observed
+
+These are the slowest examples surfaced during the audit runs across the inspected hotspot files.
+
+| Example | Runtime |
+| --- | ---: |
+| `Containers::GitOperations#commit_uncommitted_changes rejects commits with binary files` | `4.24s` |
+| `Activities::RunAgentActivity loop guardrail handling returns a paused result when the run was already paused during loop handling` | `2.79s` |
+| `AgentRuns POST /projects/:project_id/agent_runs/quick_create when not authenticated redirects to the sign in page` | `2.40s` |
+| `AgentRun scopes .finished includes completed, failed, cancelled, timeout, retried, auth_expired, and rate_limited runs` | `2.29s` |
+| `Activities::RunAgentActivity#execute with fallback enabled reclassifies timeout output as rate limited when quota message is within the log scan window` | `2.06s` |
+| `AgentRuns POST /projects/:project_id/agent_runs/:id/retry when not authenticated redirects to the sign in page` | `2.01s` |
+| `AgentRuns GET /agent_runs when authenticated sorts agent runs ascending via Ransack sort params` | `1.92s` |
+| `Containers::GitOperations#clone_and_setup_branch raises CloneError when partial clone cleanup fails` | `1.88s` |
+| `AgentRuns GET /projects/:project_id/agent_runs/new when authenticated exposes goal-specific provider defaults to the goal toggle controller` | `1.83s` |
+| `AgentRun scopes .search_by_goal matches by goal column value` | `1.78s` |
+| `AgentRun.claim_next_queued_run claims a specific queued run and transitions to pending` | `1.68s` |
+| `Activities::ScanPaidPrsActivity when paid_agent is enabled and the last create_pr run is newer than the last review emits a paid_agent_review_pending trigger` | `1.61s` |
+| `Activities::RunAgentActivity#execute with fallback enabled does not reclassify timeout when quota message falls outside the bounded log scan window` | `1.56s` |
+| `Containers::GitOperations#clone_and_setup_branch when clone fails with a transient DNS/network error retries on 'Temporary failure in name resolution'` | `1.53s` |
+| `AgentRuns POST /projects/:project_id/agent_runs/:id/terminate when authenticated cancels a paused run without marking it failed` | `1.41s` |
+| `GithubTokens POST /github_tokens/:id/retry_validation when authenticated resets stuck validating tokens and enqueues job` | `1.30s` |
+| `GithubTokens GET /github_tokens/:id/validation_status when authenticated shows stuck state for stale pending tokens` | `1.22s` |
+| `AgentRun scopes .search_by_goal returns all runs when query is blank` | `1.21s` |
+| `AgentRun scopes .active includes pending and running runs but not queued` | `1.14s` |
+| `AgentRun.next_queued_run with all 6 priority tiers produces correct ordering across all tiers` | `1.12s` |
+
+## Request-Suite Shape Findings
+
+`TPS_PROF=10` and `TAG_PROF=type` were especially useful for broad prioritization, but they answer different questions:
+
+- `TPS_PROF=10` on `spec/requests` tells us which request suites have poor examples-per-second.
+- `TAG_PROF=type` only becomes useful when run across the broader `spec` tree, not just `spec/requests`, because every request spec already has the same `type`.
+
+- Lowest-TPS request suites in the full `spec/requests` pass were:
+  - `AgentRuns` at `4.81 TPS`
+  - `GithubTokens` at `4.2 TPS`
+  - `Api::SecretsProxy` at `4.49 TPS`
+  - `Knowledge::Search` at `4.2 TPS`
+  - `Api::GithubProxy` at `4.76 TPS`
+- Additional high-cost request subareas surfaced by the accompanying `--profile` output during the request-suite run were:
+  - `Projects::PreCommitRequirements` at `11.29s / 10 examples`
+  - `Projects::PrTemplates` at `2.93s / 5 examples`
+  - `Api::Proxy::KnowledgeSearch` at `4.25s / 8 examples`
+  - `Projects::ServiceContainers` at `3.48s / 10 examples`
+  - `Projects::CostDashboards` at `1.77s / 6 examples`
+
+This shifted the next request-spec queue slightly: after `Projects`, the next high-value audit targets are no longer just the biggest files by line count, but the lowest-TPS groups and the highest average-cost subareas.
+
+## Implemented Improvements
+
+### `spec/requests/github_tokens_spec.rb`
+
+- Reused the already-created request `user` as `created_by` for same-account `github_token` fixtures.
+- Reused the same `user` as `created_by` for supporting `project` fixtures.
+- Used `:without_creator` for foreign-account tokens that are only needed for authorization coverage.
+
+Measured improvement:
+
+| Metric | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Plain runtime | `6.06s` | `4.18s` | `-31.0%` |
+| `FPROF` total factories | `191` | `151` | `-20.9%` |
+| `FPROF` `user` factory calls | `94` | `54` | `-42.6%` |
+| `FPROF` factory time | `3.142s` | `2.160s` | `-31.3%` |
+| `RD_PROF` setup time | `2.415s` | `2.197s` | `-9.0%` |
+
+### `spec/requests/agent_runs_spec.rb`
+
+- Reused the already-created request `user` as `created_by` for the top-level `github_token`.
+- Reused the same `user` as `created_by` for the top-level `project`.
+- Reused the same `user` for same-account secondary projects in sort scenarios.
+- Used `:without_creator` / `:without_creator`-project for foreign-account authorization scenarios.
+
+Measured improvement:
+
+| Metric | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Plain runtime | `52.75s` | `41.44s` | `-21.4%` |
+| `FPROF` total factories | `1383` | `1042` | `-24.7%` |
+| `FPROF` `user` factory calls | `531` | `190` | `-64.2%` |
+| `FPROF` factory time | `37.965s` | `28.091s` | `-26.0%` |
+| `RD_PROF` setup time | `14.123s` | `12.036s` | `-14.8%` |
+
+## FactoryDoctor Findings
+
+Targeted `FDOC=1` runs on the two optimized request hotspots both reported `Looks good to me!`.
+
+- `spec/requests/github_tokens_spec.rb`
+- `spec/requests/agent_runs_spec.rb`
+
+That is useful signal: the next improvements here should stay focused on factory graph size, setup placement, and high-SQL examples, not on replacing `create` calls that are already persistence-justified.
+
+## Next Fixes To Implement
+
+These are the next low-risk candidates, in order:
+
+1. `spec/requests/projects_spec.rb`
+   Reuse the request user as `created_by` for same-account `project` and `github_token` fixtures; trim metric/setup graphs in sort and dashboard-style examples.
+2. `spec/requests/agent_runs_spec.rb`
+   Narrow the expensive `project` and `issue` lazy setup further in the slowest `new`, `retry`, and `authorization` examples.
+3. `spec/models/agent_run_spec.rb`
+   Fix the Docker boot/test constant issue, then run `FPROF` and trim queue-ordering scenario factories.
+4. `spec/services/containers/git_operations_spec.rb`
+   Focus on the binary-file and clone-failure examples with helper consolidation and fewer real-ish sandbox setups.
+5. `spec/temporal/activities/run_agent_activity_spec.rb`
+   Use `TEST_STACK_PROF` on the timeout/fallback outliers after first trimming repeated log and provider setup.
+
+## Notes and Blockers
+
+- `let_it_be` remains out of scope. The repo's tenant-context wrapper still makes `before(:context)` setup risky.
+- `spec/models/agent_run_spec.rb` had 15 failures because `Docker` was not loaded in this environment. The passing-example timings are still useful as a hotspot signal, but a clean rerun is required before making file-level optimization decisions there.
+- `spec/temporal/workflows/git_hub_poll_workflow_spec.rb` had 1 failure due `Temporalio::Workflow::Definition::VersioningBehavior` not being available during the run. Fix that first, then re-profile.
+- `FDOC` is now wired into the audit runner, but this report intentionally prioritizes the stronger signals already captured from `FPROF`, `EVENT_PROF`, `RD_PROF`, `TPS_PROF`, and the measured request-spec improvements. Run `bin/test-prof-audit file <path>` or `bin/test-prof-audit requests-deep` to collect the current FactoryDoctor output before the next optimization wave.

--- a/docs/TEST_PROF_AUDIT_2026-05.md
+++ b/docs/TEST_PROF_AUDIT_2026-05.md
@@ -119,7 +119,7 @@ Measured improvement:
 - Reused the already-created request `user` as `created_by` for the top-level `github_token`.
 - Reused the same `user` as `created_by` for the top-level `project`.
 - Reused the same `user` for same-account secondary projects in sort scenarios.
-- Used `:without_creator` / `:without_creator`-project for foreign-account authorization scenarios.
+- Used `:without_creator` for both `github_token` and `project` in foreign-account authorization scenarios.
 
 Measured improvement:
 
@@ -159,5 +159,5 @@ These are the next low-risk candidates, in order:
 
 - `let_it_be` remains out of scope. The repo's tenant-context wrapper still makes `before(:context)` setup risky.
 - `spec/models/agent_run_spec.rb` had 15 failures because `Docker` was not loaded in this environment. The passing-example timings are still useful as a hotspot signal, but a clean rerun is required before making file-level optimization decisions there.
-- `spec/temporal/workflows/git_hub_poll_workflow_spec.rb` had 1 failure due `Temporalio::Workflow::Definition::VersioningBehavior` not being available during the run. Fix that first, then re-profile.
+- `spec/temporal/workflows/git_hub_poll_workflow_spec.rb` had 1 failure due to `Temporalio::Workflow::Definition::VersioningBehavior` not being available during the run. Fix that first, then re-profile.
 - `FDOC` is now wired into the audit runner, but this report intentionally prioritizes the stronger signals already captured from `FPROF`, `EVENT_PROF`, `RD_PROF`, `TPS_PROF`, and the measured request-spec improvements. Run `bin/test-prof-audit file <path>` or `bin/test-prof-audit requests-deep` to collect the current FactoryDoctor output before the next optimization wave.

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe "AgentRuns" do
   let(:account) { create(:account) }
   let(:user) { create(:user, account: account) }
-  let(:github_token) { create(:github_token, account: account) }
-  let(:project) { create(:project, account: account, github_token: github_token) }
+  let(:github_token) { create(:github_token, account: account, created_by: user) }
+  let(:project) { create(:project, account: account, github_token: github_token, created_by: user) }
 
   describe "GET /agent_runs" do
     context "when not authenticated" do
@@ -65,7 +65,7 @@ RSpec.describe "AgentRuns" do
       end
 
       it "sorts agent runs ascending via Ransack sort params" do
-        other_project = create(:project, account: account, github_token: github_token)
+        other_project = create(:project, account: account, github_token: github_token, created_by: user)
         create(:agent_run, project: project, agent_type: "claude_code", status: "completed", created_at: 2.days.ago)
         create(:agent_run, project: other_project, agent_type: "claude_code", status: "completed", created_at: 1.day.ago)
 
@@ -76,7 +76,7 @@ RSpec.describe "AgentRuns" do
       end
 
       it "sorts agent runs descending via Ransack sort params" do
-        other_project = create(:project, account: account, github_token: github_token)
+        other_project = create(:project, account: account, github_token: github_token, created_by: user)
         create(:agent_run, project: project, agent_type: "claude_code", status: "completed", created_at: 2.days.ago)
         create(:agent_run, project: other_project, agent_type: "claude_code", status: "completed", created_at: 1.day.ago)
 
@@ -124,8 +124,8 @@ RSpec.describe "AgentRuns" do
 
       it "does not show runs from other accounts" do
         other_account = create(:account)
-        other_token = create(:github_token, account: other_account)
-        other_project = create(:project, account: other_account, github_token: other_token)
+        other_token = create(:github_token, :without_creator, account: other_account)
+        other_project = create(:project, :without_creator, account: other_account, github_token: other_token)
         create(:agent_run, project: other_project, agent_type: "claude_code", status: "completed")
 
         get agent_runs_path
@@ -385,8 +385,8 @@ RSpec.describe "AgentRuns" do
 
       it "does not show runs from other accounts" do
         other_account = create(:account)
-        other_token = create(:github_token, account: other_account)
-        other_project = create(:project, account: other_account, github_token: other_token)
+        other_token = create(:github_token, :without_creator, account: other_account)
+        other_project = create(:project, :without_creator, account: other_account, github_token: other_token)
         get project_agent_runs_path(other_project)
         expect(response).to have_http_status(:not_found)
       end
@@ -681,8 +681,8 @@ RSpec.describe "AgentRuns" do
 
       it "does not show runs from other accounts" do
         other_account = create(:account)
-        other_token = create(:github_token, account: other_account)
-        other_project = create(:project, account: other_account, github_token: other_token)
+        other_token = create(:github_token, :without_creator, account: other_account)
+        other_project = create(:project, :without_creator, account: other_account, github_token: other_token)
         other_run = create(:agent_run, project: other_project)
         get project_agent_run_path(other_project, other_run)
         expect(response).to have_http_status(:not_found)
@@ -1609,8 +1609,8 @@ RSpec.describe "AgentRuns" do
 
       it "does not allow cancelling runs from other accounts" do
         other_account = create(:account)
-        other_token = create(:github_token, account: other_account)
-        other_project = create(:project, account: other_account, github_token: other_token)
+        other_token = create(:github_token, :without_creator, account: other_account)
+        other_project = create(:project, :without_creator, account: other_account, github_token: other_token)
         other_run = create(:agent_run, :running, project: other_project)
 
         post cancel_project_agent_run_path(other_project, other_run)
@@ -1941,8 +1941,8 @@ RSpec.describe "AgentRuns" do
 
       it "does not allow retrying runs from other accounts" do
         other_account = create(:account)
-        other_token = create(:github_token, account: other_account)
-        other_project = create(:project, account: other_account, github_token: other_token)
+        other_token = create(:github_token, :without_creator, account: other_account)
+        other_project = create(:project, :without_creator, account: other_account, github_token: other_token)
         other_run = create(:agent_run, :failed, project: other_project)
 
         post retry_project_agent_run_path(other_project, other_run)
@@ -2115,8 +2115,8 @@ RSpec.describe "AgentRuns" do
 
       it "does not allow refreshing runs from other accounts" do
         other_account = create(:account)
-        other_token = create(:github_token, account: other_account)
-        other_project = create(:project, account: other_account, github_token: other_token)
+        other_token = create(:github_token, :without_creator, account: other_account)
+        other_project = create(:project, :without_creator, account: other_account, github_token: other_token)
         other_run = create(:agent_run, :auth_expired, project: other_project)
 
         post refresh_auth_project_agent_run_path(other_project, other_run), params: { auth_code: "abc" }
@@ -2213,8 +2213,8 @@ RSpec.describe "AgentRuns" do
 
       it "does not allow diagnosing runs from other accounts" do
         other_account = create(:account)
-        other_token = create(:github_token, account: other_account)
-        other_project = create(:project, account: other_account, github_token: other_token)
+        other_token = create(:github_token, :without_creator, account: other_account)
+        other_project = create(:project, :without_creator, account: other_account, github_token: other_token)
         other_run = create(:agent_run, :failed, project: other_project)
 
         post diagnose_error_project_agent_run_path(other_project, other_run)

--- a/spec/requests/github_tokens_spec.rb
+++ b/spec/requests/github_tokens_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe "GithubTokens" do
   let(:account) { create(:account) }
   let(:user) { create(:user, account: account) }
 
+  def create_current_account_token(*traits, **attrs)
+    create(:github_token, *traits, account: account, created_by: user, **attrs)
+  end
+
+  def create_current_account_project(github_token:, **attrs)
+    create(:project, account: account, created_by: user, github_token: github_token, **attrs)
+  end
+
   describe "GET /github_tokens" do
     context "when not authenticated" do
       it "redirects to the sign in page" do
@@ -24,72 +32,72 @@ RSpec.describe "GithubTokens" do
       end
 
       it "shows the user's tokens" do
-        create(:github_token, account: account, name: "My Token")
+        create_current_account_token(name: "My Token")
         get github_tokens_path
         expect(response.body).to include("My Token")
       end
 
       it "does not show tokens from other accounts" do
         other_account = create(:account)
-        create(:github_token, account: other_account, name: "Other Token")
+        create(:github_token, :without_creator, account: other_account, name: "Other Token")
         get github_tokens_path
         expect(response.body).not_to include("Other Token")
       end
 
       it "shows status indicators for active tokens" do
-        create(:github_token, account: account, name: "Active Token")
+        create_current_account_token(name: "Active Token")
         get github_tokens_path
         expect(response.body).to include("Active")
       end
 
       it "shows status indicators for expired tokens" do
-        create(:github_token, :expired, account: account, name: "Expired Token")
+        create_current_account_token(:expired, name: "Expired Token")
         get github_tokens_path
         expect(response.body).to include("Expired")
       end
 
       it "shows status indicators for revoked tokens" do
-        create(:github_token, :revoked, account: account, name: "Revoked Token")
+        create_current_account_token(:revoked, name: "Revoked Token")
         get github_tokens_path
         expect(response.body).to include("Revoked")
       end
 
       it "shows expiring soon warning for tokens expiring within 7 days" do
-        create(:github_token, account: account, name: "Expiring Token", expires_at: 6.days.from_now)
+        create_current_account_token(name: "Expiring Token", expires_at: 6.days.from_now)
         get github_tokens_path
         expect(response.body).to include("Expiring Soon")
       end
 
       it "shows validating status for pending tokens" do
-        create(:github_token, :pending_validation, account: account, name: "Pending Token")
+        create_current_account_token(:pending_validation, name: "Pending Token")
         get github_tokens_path
         expect(response.body).to include("Validating...")
       end
 
       it "shows validation failed status" do
-        create(:github_token, :validation_failed, account: account, name: "Failed Token")
+        create_current_account_token(:validation_failed, name: "Failed Token")
         get github_tokens_path
         expect(response.body).to include("Validation Failed")
       end
 
       it "shows validation stuck status for stale validating tokens" do
-        token = create(:github_token, :validating, account: account, name: "Stuck Token")
+        token = create_current_account_token(:validating, name: "Stuck Token")
         token.update_column(:updated_at, 3.minutes.ago)
         get github_tokens_path
         expect(response.body).to include("Validation Stuck")
       end
 
       it "shows validation stuck status for stale pending tokens" do
-        token = create(:github_token, :pending_validation, account: account, name: "Stuck Pending Token")
+        token = create_current_account_token(:pending_validation, name: "Stuck Pending Token")
         token.update_column(:updated_at, 3.minutes.ago)
         get github_tokens_path
         expect(response.body).to include("Validation Stuck")
       end
 
       it "shows the projects count from counter cache" do
-        token = create(:github_token, account: account)
-        create(:project, account: account, github_token: token, owner: "acme", repo: "web")
-        create(:project, account: account, github_token: token, owner: "acme", repo: "api")
+        token = create_current_account_token
+        create_current_account_project(github_token: token, owner: "acme", repo: "web")
+        create_current_account_project(github_token: token, owner: "acme", repo: "api")
         get github_tokens_path
         document = Nokogiri::HTML(response.body)
         row = document.css("tr").detect { |tr| tr.text.include?(token.name) }
@@ -98,7 +106,7 @@ RSpec.describe "GithubTokens" do
       end
 
       it "does not show a Deactivate button" do
-        create(:github_token, account: account, name: "My Token")
+        create_current_account_token(name: "My Token")
         get github_tokens_path
         document = Nokogiri::HTML(response.body)
         deactivate_elements = document.css("button, input[type='submit'], a").select do |node|
@@ -229,7 +237,7 @@ RSpec.describe "GithubTokens" do
   describe "GET /github_tokens/:id" do
     context "when not authenticated" do
       it "redirects to the sign in page" do
-        token = create(:github_token, account: account)
+        token = create_current_account_token
         get github_token_path(token)
         expect(response).to redirect_to(new_user_session_path)
       end
@@ -239,68 +247,68 @@ RSpec.describe "GithubTokens" do
       before { sign_in user }
 
       it "shows the token details" do
-        token = create(:github_token, account: account, name: "My Token")
+        token = create_current_account_token(name: "My Token")
         get github_token_path(token)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("My Token")
       end
 
       it "masks the token value" do
-        token = create(:github_token, account: account)
+        token = create_current_account_token
         get github_token_path(token)
         expect(response.body).to include("****")
         expect(response.body).not_to include(token.token[9...-5])
       end
 
       it "shows scopes" do
-        token = create(:github_token, account: account, scopes: [ "repo", "read:org" ])
+        token = create_current_account_token(scopes: [ "repo", "read:org" ])
         get github_token_path(token)
         expect(response.body).to include("repo")
         expect(response.body).to include("read:org")
       end
 
       it "shows expiration warning for tokens expiring soon" do
-        token = create(:github_token, account: account, expires_at: 6.days.from_now)
+        token = create_current_account_token(expires_at: 6.days.from_now)
         get github_token_path(token)
         expect(response.body).to include("Token Expiring Soon")
       end
 
       it "does not allow viewing tokens from other accounts" do
         other_account = create(:account)
-        other_token = create(:github_token, account: other_account)
+        other_token = create(:github_token, :without_creator, account: other_account)
         get github_token_path(other_token)
         expect(response).to have_http_status(:not_found)
       end
 
       it "shows validating status for pending tokens" do
-        token = create(:github_token, :pending_validation, account: account)
+        token = create_current_account_token(:pending_validation)
         get github_token_path(token)
         expect(response.body).to include("Validating...")
       end
 
       it "shows validation failed badge for failed tokens" do
-        token = create(:github_token, :validation_failed, account: account)
+        token = create_current_account_token(:validation_failed)
         get github_token_path(token)
         expect(response.body).to include("Validation Failed")
       end
 
       it "shows validation stuck badge for stale validating tokens" do
-        token = create(:github_token, :validating, account: account)
+        token = create_current_account_token(:validating)
         token.update_column(:updated_at, 3.minutes.ago)
         get github_token_path(token)
         expect(response.body).to include("Validation Stuck")
       end
 
       it "shows validation stuck badge for stale pending tokens" do
-        token = create(:github_token, :pending_validation, account: account)
+        token = create_current_account_token(:pending_validation)
         token.update_column(:updated_at, 3.minutes.ago)
         get github_token_path(token)
         expect(response.body).to include("Validation Stuck")
       end
 
       it "shows associated projects with active badge" do
-        token = create(:github_token, account: account)
-        create(:project, account: account, github_token: token, owner: "acme", repo: "web", active: true)
+        token = create_current_account_token
+        create_current_account_project(github_token: token, owner: "acme", repo: "web", active: true)
         get github_token_path(token)
         document = Nokogiri::HTML(response.body)
         project_item = document.css("li").detect { |li| li.text.include?("acme/web") }
@@ -309,8 +317,8 @@ RSpec.describe "GithubTokens" do
       end
 
       it "shows associated projects with inactive badge" do
-        token = create(:github_token, account: account)
-        create(:project, :inactive, account: account, github_token: token, owner: "acme", repo: "api")
+        token = create_current_account_token
+        create_current_account_project(github_token: token, owner: "acme", repo: "api", active: false)
         get github_token_path(token)
         document = Nokogiri::HTML(response.body)
         project_item = document.css("li").detect { |li| li.text.include?("acme/api") }
@@ -319,13 +327,13 @@ RSpec.describe "GithubTokens" do
       end
 
       it "does not show projects section when no projects exist" do
-        token = create(:github_token, account: account)
+        token = create_current_account_token
         get github_token_path(token)
         expect(response.body).not_to include("Projects (")
       end
 
       it "shows Deactivate button for active tokens" do
-        token = create(:github_token, account: account)
+        token = create_current_account_token
         get github_token_path(token)
         document = Nokogiri::HTML(response.body)
         deactivate_elements = document.css("button, input[type='submit'], a").select do |node|
@@ -341,21 +349,21 @@ RSpec.describe "GithubTokens" do
       before { sign_in user }
 
       it "shows validating state for pending tokens" do
-        token = create(:github_token, :pending_validation, account: account)
+        token = create_current_account_token(:pending_validation)
         get validation_status_github_token_path(token)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Validating token with GitHub")
       end
 
       it "shows success state for validated tokens" do
-        token = create(:github_token, account: account, accessible_repositories: [ { "id" => 1, "full_name" => "owner/repo" } ])
+        token = create_current_account_token(accessible_repositories: [ { "id" => 1, "full_name" => "owner/repo" } ])
         get validation_status_github_token_path(token)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("validated successfully")
       end
 
       it "shows error state for failed tokens" do
-        token = create(:github_token, :validation_failed, account: account)
+        token = create_current_account_token(:validation_failed)
         get validation_status_github_token_path(token)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Validation Failed")
@@ -363,7 +371,7 @@ RSpec.describe "GithubTokens" do
       end
 
       it "shows stuck state for stale validating tokens" do
-        token = create(:github_token, :validating, account: account)
+        token = create_current_account_token(:validating)
         token.update_column(:updated_at, 3.minutes.ago)
         get validation_status_github_token_path(token)
         expect(response).to have_http_status(:ok)
@@ -372,7 +380,7 @@ RSpec.describe "GithubTokens" do
       end
 
       it "shows stuck state for stale pending tokens" do
-        token = create(:github_token, :pending_validation, account: account)
+        token = create_current_account_token(:pending_validation)
         token.update_column(:updated_at, 3.minutes.ago)
         get validation_status_github_token_path(token)
         expect(response).to have_http_status(:ok)
@@ -387,7 +395,7 @@ RSpec.describe "GithubTokens" do
       before { sign_in user }
 
       it "resets validation status and enqueues job" do
-        token = create(:github_token, :validation_failed, account: account)
+        token = create_current_account_token(:validation_failed)
         expect {
           post retry_validation_github_token_path(token)
         }.to have_enqueued_job(GithubTokenValidationJob)
@@ -396,7 +404,7 @@ RSpec.describe "GithubTokens" do
       end
 
       it "resets stuck validating tokens and enqueues job" do
-        token = create(:github_token, :validating, account: account)
+        token = create_current_account_token(:validating)
         token.update_column(:updated_at, 3.minutes.ago)
         expect {
           post retry_validation_github_token_path(token)
@@ -406,7 +414,7 @@ RSpec.describe "GithubTokens" do
       end
 
       it "resets stuck pending tokens and enqueues job" do
-        token = create(:github_token, :pending_validation, account: account)
+        token = create_current_account_token(:pending_validation)
         token.update_column(:updated_at, 3.minutes.ago)
         expect {
           post retry_validation_github_token_path(token)
@@ -420,7 +428,7 @@ RSpec.describe "GithubTokens" do
   describe "DELETE /github_tokens/:id" do
     context "when not authenticated" do
       it "redirects to the sign in page" do
-        token = create(:github_token, account: account)
+        token = create_current_account_token
         delete github_token_path(token)
         expect(response).to redirect_to(new_user_session_path)
       end
@@ -433,14 +441,14 @@ RSpec.describe "GithubTokens" do
         # First user in account automatically gets owner role via User#assign_owner_role_if_first_user
 
         it "revokes the token" do
-          token = create(:github_token, account: account)
+          token = create_current_account_token
           expect {
             delete github_token_path(token)
           }.to change { token.reload.revoked? }.from(false).to(true)
         end
 
         it "redirects with success message" do
-          token = create(:github_token, account: account)
+          token = create_current_account_token
           delete github_token_path(token)
           expect(response).to redirect_to(github_tokens_path)
           expect(flash[:notice]).to include("deactivated")
@@ -454,7 +462,7 @@ RSpec.describe "GithubTokens" do
         before { sign_in non_owner_user }
 
         it "redirects with authorization error" do
-          token = create(:github_token, account: account)
+          token = create_current_account_token
           delete github_token_path(token)
           expect(response).to redirect_to(root_path)
           expect(flash[:alert]).to include("not authorized")


### PR DESCRIPTION
## Summary
- add a rerunnable `test-prof` audit runner and expand profiling docs
- add a May 2026 audit report with ranked hotspots, blockers, and follow-up targets
- trim request-spec setup in `github_tokens_spec` and `agent_runs_spec` by reusing existing creator fixtures

## Verification
- `bash -n bin/test-prof-audit`
- `COVERAGE=false bundle exec rspec spec/requests/github_tokens_spec.rb`
- `COVERAGE=false bundle exec rspec spec/requests/agent_runs_spec.rb`
- `COVERAGE=false bundle exec rspec spec/requests/github_tokens_spec.rb spec/requests/agent_runs_spec.rb`
- targeted `FDOC=1` reruns for both optimized request hotspots