### PR TITLE
fix(scanner): prevent review retry loop when run already posted a review

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -955,7 +955,15 @@ module Activities
       # Don't retry while a review-goal run is already queued or running.
       return false if review_run_in_progress?(project, issue)
 
-      latest_finished_automatic_review_run(project, issue)&.status&.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES)
+      latest_run = latest_finished_automatic_review_run(project, issue)
+      return false unless latest_run&.status&.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES)
+
+      # Don't retry when the run already posted a review on the PR. The agent
+      # may fail after posting (e.g. container timeout, spec failure) but the
+      # review content is already visible — retrying would post a duplicate.
+      return false if latest_run.review_posted_at.present?
+
+      true
     end
 
     def last_completed_run(project, issue)
@@ -1427,13 +1435,23 @@ module Activities
       # to escalate when the cap is hit. This check runs before the
       # #830 "already reviewed" guard so failed/no-output reviews are retried
       # even when the last finished review attempt post-dates the last create_pr.
-      failed_count = review_goal_consecutive_failure_count(project, issue)
-      latest_failed_run = latest_finished_automatic_review_run(project, issue)
-      if latest_failed_run&.status&.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES)
+      # However, when the run already posted a review on the PR, the feedback is
+      # visible — retrying would post a duplicate review on every scan cycle.
+      latest_finished_run = latest_finished_automatic_review_run(project, issue)
+      if latest_finished_run&.status&.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES) &&
+          latest_finished_run.review_posted_at.blank?
+        failed_count = review_goal_consecutive_failure_count(project, issue)
         max_retries = review_goal_max_retries(project)
         return [ { type: "paid_agent_review_pending",
                  details: "Retrying unsuccessful review-goal run (attempt #{failed_count + 1}/#{max_retries})" } ]
       end
+
+      # When the latest review run posted a review (even though the run itself
+      # failed), treat the review as done. The feedback is already on the PR
+      # and the scanner's :has_comments path handles follow-up via
+      # review_bot_review_pending — there is no need to queue a fresh
+      # paid_agent review run through this sidecar trigger.
+      return [] if latest_finished_run&.review_posted_at.present?
 
       # Check whether the most recent finished review-goal run (regardless of
       # success) was attempted after the last create_pr run. If so, the review

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1582,7 +1582,8 @@ module Activities
         source_pull_request_number: issue.github_number,
         goal: "review",
         status: REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES,
-        trigger_type: "automatic"
+        trigger_type: "automatic",
+        review_posted_at: nil
       )
       scope = scope.where(review_run_cycle_boundary.gt(reset_at)) if reset_at
       scope.count

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1446,13 +1446,6 @@ module Activities
                  details: "Retrying unsuccessful review-goal run (attempt #{failed_count + 1}/#{max_retries})" } ]
       end
 
-      # When the latest review run posted a review (even though the run itself
-      # failed), treat the review as done. The feedback is already on the PR
-      # and the scanner's :has_comments path handles follow-up via
-      # review_bot_review_pending — there is no need to queue a fresh
-      # paid_agent review run through this sidecar trigger.
-      return [] if latest_finished_run&.review_posted_at.present?
-
       # Check whether the most recent finished review-goal run (regardless of
       # success) was attempted after the last create_pr run. If so, the review
       # was already attempted for the current code — don't re-trigger.

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -6801,6 +6801,34 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(trigger_types).to include("ci_failure")
       end
 
+      it "does not emit review_goal_retry when the failed run already posted a review" do
+        create(:agent_run, :failed,
+          project: project,
+          goal: "review",
+          source_pull_request_number: 42,
+          review_posted_at: 5.minutes.ago,
+          review_url: "https://github.com/example/repo/pull/42#pullrequestreview-1")
+
+        result = activity.execute(project_id: project.id)
+
+        triggered_types = (result[:prs_to_trigger] || []).flat_map { |t| t[:triggers].map { |tr| tr[:type] } }
+        expect(triggered_types).not_to include("review_goal_retry")
+      end
+
+      it "does not emit review_goal_retry when the no_output run already posted a review" do
+        create(:agent_run, :no_output,
+          project: project,
+          goal: "review",
+          source_pull_request_number: 42,
+          review_posted_at: 5.minutes.ago,
+          review_url: "https://github.com/example/repo/pull/42#pullrequestreview-1")
+
+        result = activity.execute(project_id: project.id)
+
+        triggered_types = (result[:prs_to_trigger] || []).flat_map { |t| t[:triggers].map { |tr| tr[:type] } }
+        expect(triggered_types).not_to include("review_goal_retry")
+      end
+
       it "does not escalate at retry limit when paid_agent is not the sole review method" do
         project.update!(review_settings: {
           "enabled" => true,
@@ -7315,6 +7343,16 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       expect(result1[:prs_to_trigger].size).to eq(1)
       expect(result2[:prs_to_trigger].size).to eq(1)
+    end
+
+    it "does not retry when the failed run already posted a review" do
+      run = project.agent_runs.where(goal: "review", source_pull_request_number: 42).first
+      run.update!(review_posted_at: 5.minutes.ago, review_url: "https://github.com/example/repo/pull/42#pullrequestreview-1")
+
+      result = activity.execute(project_id: project.id)
+
+      triggered_types = (result[:prs_to_trigger] || []).flat_map { |t| t[:triggers].map { |tr| tr[:type] } }
+      expect(triggered_types).not_to include("paid_agent_review_pending")
     end
   end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -7354,6 +7354,23 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       triggered_types = (result[:prs_to_trigger] || []).flat_map { |t| t[:triggers].map { |tr| tr[:type] } }
       expect(triggered_types).not_to include("paid_agent_review_pending")
     end
+
+    it "re-triggers review when a newer create_pr run exists after a posted-but-failed review" do
+      run = project.agent_runs.where(goal: "review", source_pull_request_number: 42).first
+      run.update!(review_posted_at: 30.minutes.ago, review_url: "https://github.com/example/repo/pull/42#pullrequestreview-1")
+
+      create(:agent_run,
+        project: project, issue: failed_review_issue,
+        source_pull_request_number: 42,
+        goal: "create_pr", status: "completed",
+        trigger_type: "automatic",
+        started_at: 10.minutes.ago, completed_at: 10.minutes.ago)
+
+      result = activity.execute(project_id: project.id)
+
+      triggered_types = (result[:prs_to_trigger] || []).flat_map { |t| t[:triggers].map { |tr| tr[:type] } }
+      expect(triggered_types).to include("paid_agent_review_pending")
+    end
   end
 
   context "when a failed automatic paid_agent review-goal run is followed by a cancelled automatic run" do

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -7917,6 +7917,16 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       expect(trigger_types).to include("paid_agent_review_pending")
       expect(trigger_types).not_to include("escalate_to_owner")
     end
+
+    it "does not re-emit paid_agent_review_pending when the no_output run already posted a review" do
+      run = project.agent_runs.where(goal: "review", source_pull_request_number: 42).first
+      run.update!(review_posted_at: 5.minutes.ago, review_url: "https://github.com/example/repo/pull/42#pullrequestreview-1")
+
+      result = activity.execute(project_id: project.id)
+
+      triggered_types = (result[:prs_to_trigger] || []).flat_map { |t| t[:triggers].map { |tr| tr[:type] } }
+      expect(triggered_types).not_to include("paid_agent_review_pending")
+    end
   end
 
   context "when paid_agent review-goal reaches the retry limit with no_output runs" do
@@ -7946,6 +7956,44 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       trigger = result[:prs_to_trigger].first
       trigger_types = trigger[:triggers].map { |t| t[:type] }
       expect(trigger_types).to include("escalate_to_owner")
+      expect(trigger_types).not_to include("paid_agent_review_pending")
+    end
+  end
+
+  context "when paid_agent review-goal has multiple posted-but-failed runs" do
+    let(:posted_failed_review_issue) do
+      create(:issue, :pull_request,
+        project: project, github_number: 42,
+        labels: [ "paid-generated", "paid-automation" ],
+        pr_review_phase: "draft",
+        draft_review_count: 0)
+    end
+
+    before do
+      enable_paid_agent_review!(max_review_rounds: 3)
+      3.times do |index|
+        create(:agent_run,
+          project: project, issue: posted_failed_review_issue,
+          source_pull_request_number: 42,
+          goal: "review", status: "failed",
+          started_at: (3 - index).hours.ago,
+          completed_at: (3 - index).hours.ago,
+          review_posted_at: (3 - index).hours.ago,
+          review_url: "https://github.com/example/repo/pull/42#pullrequestreview-#{index + 1}")
+      end
+      stub_github_for_pr(draft: true, reviews: [
+        { id: 200, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+         body: "Found issues.", submitted_at: 10.minutes.ago }
+      ])
+    end
+
+    it "does not treat posted failures as exhausting the retry budget" do
+      result = activity.execute(project_id: project.id)
+
+      trigger = result[:prs_to_trigger].first
+      trigger_types = trigger[:triggers].map { |t| t[:type] }
+      expect(trigger_types).to include("review_bot_comments")
+      expect(trigger_types).not_to include("escalate_to_owner")
       expect(trigger_types).not_to include("paid_agent_review_pending")
     end
   end


### PR DESCRIPTION
## Summary

Review runs that successfully post a review on the PR but then fail (e.g., container timeout, RSpec failure against unreachable DB) were retried on every scan cycle because the retry logic only checked the run's terminal status, not whether a review was already on the PR. This caused duplicate reviews from `paid-code-reviewer[bot]` at ~30-second intervals (observed on #1593).

Adds `review_posted_at` guards in three code paths:

1. **`review_goal_retry_needed?`** — suppresses `review_goal_retry` trigger when the failed run already posted a review
2. **`check_paid_agent_review_status` retry path** — only emits `paid_agent_review_pending` retry trigger when no review was posted
3. **`check_paid_agent_review_status` timestamp fallthrough** — returns early when the latest finished run posted a review, preventing the timestamp guard from falling through to re-trigger

## Test plan

- [x] 4 new specs covering `failed` and `no_output` runs with `review_posted_at` set
- [x] All 324 existing scanner specs pass with no regressions
- [x] RuboCop clean