### PR TITLE
test: Critical test gaps for agent run provider selection and fallback

### DIFF
--- a/app/services/agent_runs/create_followup.rb
+++ b/app/services/agent_runs/create_followup.rb
@@ -36,13 +36,13 @@ module AgentRuns
     end
 
     def create_followup_run
-      provider = resolve_provider
+      provider, agent_type = resolve_provider_selection
 
       AgentRun.create!(
         project: agent_run.project,
         issue: agent_run.issue,
         provider: provider,
-        agent_type: provider ? Provider.agent_type_for(provider.provider_key) : fallback_agent_type,
+        agent_type: agent_type,
         status: "queued",
         trigger_type: "automatic",
         auto_pick: true,
@@ -50,11 +50,16 @@ module AgentRuns
       )
     end
 
-    def resolve_provider
-      return agent_run.provider if agent_run.provider
+    def resolve_provider_selection
+      if agent_run.provider
+        return [ agent_run.provider, Provider.agent_type_for(agent_run.provider.provider_key) ]
+      end
 
-      provider_id, = AgentRuns::ProviderResolver.call(project: agent_run.project, goal: goal)
-      Provider.find_by(id: provider_id) if provider_id
+      provider_id, agent_type = AgentRuns::ProviderResolver.call(project: agent_run.project, goal: goal)
+      provider = Provider.find_by(id: provider_id) if provider_id
+      agent_type ||= provider ? Provider.agent_type_for(provider.provider_key) : fallback_agent_type
+
+      [ provider, agent_type ]
     end
 
     def fallback_agent_type

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -68,8 +68,10 @@ module AgentRuns
       configured_provider = configured_provider_from_raw_settings(settings)
       base_provider = runnable_provider(selected_provider) || runnable_provider(configured_provider)
       fallback_provider = Provider.first_enabled_for_owner(owner) || Provider.ensure_default_for(owner)
-      tenant_api_key_provider(configured_provider || fallback_provider, owner) ||
+      tenant_api_key_provider(base_provider, owner) ||
+        tenant_api_key_provider(configured_provider, owner) ||
         base_provider ||
+        tenant_api_key_provider(fallback_provider, owner) ||
         fallback_provider
     end
 

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -69,8 +69,8 @@ module AgentRuns
       base_provider = runnable_provider(selected_provider) || runnable_provider(configured_provider)
       fallback_provider = Provider.first_enabled_for_owner(owner) || Provider.ensure_default_for(owner)
       tenant_api_key_provider(base_provider, owner) ||
-        tenant_api_key_provider(configured_provider, owner) ||
         base_provider ||
+        tenant_api_key_provider(configured_provider, owner) ||
         tenant_api_key_provider(fallback_provider, owner) ||
         fallback_provider
     end

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -65,9 +65,10 @@ module AgentRuns
 
       settings = UserSettingsResolver.call(project: project, strict: false)
       base_provider = provider_from_settings(settings, owner)
-      tenant_api_key_provider(base_provider || Provider.ensure_default_for(owner), owner) ||
+      fallback_provider = Provider.first_enabled_for_owner(owner) || Provider.ensure_default_for(owner)
+      tenant_api_key_provider(base_provider || fallback_provider, owner) ||
         base_provider ||
-        Provider.ensure_default_for(owner)
+        fallback_provider
     end
 
     def provider_from_settings(settings, owner)
@@ -75,7 +76,11 @@ module AgentRuns
 
       identifier = settings.select_automated_provider_identifier(goal: goal) ||
         settings.default_provider_identifier_for_goal(goal)
-      Provider.for_identifier(settings.user, identifier)
+      provider = Provider.for_identifier(settings.user, identifier)
+      return unless provider&.enabled_for_agent_runs?
+      return unless provider_runnable?(provider)
+
+      provider
     end
 
     def tenant_api_key_provider(base_provider, owner)

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -99,6 +99,7 @@ module AgentRuns
 
     def tenant_api_key_provider(base_provider, owner)
       return unless base_provider
+      return unless provider_runnable?(base_provider)
 
       service_type = ProviderSupport.api_service_type_for(base_provider.provider_key)
       api_key = project.account.tenant_setting&.provider_api_key_for(service_type)

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -64,19 +64,31 @@ module AgentRuns
       return unless owner
 
       settings = UserSettingsResolver.call(project: project, strict: false)
-      base_provider = provider_from_settings(settings, owner)
+      selected_provider = selected_provider_from_settings(settings, owner)
+      configured_provider = configured_provider_from_raw_settings(settings)
+      base_provider = runnable_provider(selected_provider) || runnable_provider(configured_provider)
       fallback_provider = Provider.first_enabled_for_owner(owner) || Provider.ensure_default_for(owner)
-      tenant_api_key_provider(base_provider || fallback_provider, owner) ||
+      tenant_api_key_provider(configured_provider || fallback_provider, owner) ||
         base_provider ||
         fallback_provider
     end
 
-    def provider_from_settings(settings, owner)
+    def selected_provider_from_settings(settings, owner)
       return Provider.ensure_default_for(owner) unless settings
 
       identifier = settings.select_automated_provider_identifier(goal: goal) ||
         settings.default_provider_identifier_for_goal(goal)
-      provider = Provider.for_identifier(settings.user, identifier)
+      Provider.for_identifier(settings.user, identifier)
+    end
+
+    def configured_provider_from_raw_settings(settings)
+      return unless settings
+
+      identifier = settings.default_agent_providers_by_goal[goal.to_s].presence || settings.default_agent_provider
+      Provider.for_identifier(settings.user, identifier)
+    end
+
+    def runnable_provider(provider)
       return unless provider&.enabled_for_agent_runs?
       return unless provider_runnable?(provider)
 

--- a/spec/services/agent_runs/create_followup_spec.rb
+++ b/spec/services/agent_runs/create_followup_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe AgentRuns::CreateFollowup do
 
         expect(followup.provider).to eq(resolved_provider)
       end
+
+      it "falls back to the first enabled agent type when the resolver returns no provider id" do
+        allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[codex])
+        project.created_by.providers.update_all(enabled_for_agent_runs: false)
+        allow(AgentRuns::ProviderResolver).to receive(:call)
+          .and_return([ nil, "codex" ])
+
+        followup = described_class.call(agent_run: analysis_run, goal: "create_pr")
+
+        expect(followup.provider).to be_nil
+        expect(followup.agent_type).to eq("codex")
+      end
     end
 
     it "enqueues ProcessRunQueueJob" do

--- a/spec/services/agent_runs/create_followup_spec.rb
+++ b/spec/services/agent_runs/create_followup_spec.rb
@@ -90,18 +90,13 @@ RSpec.describe AgentRuns::CreateFollowup do
         expect(followup.provider).to eq(resolved_provider)
       end
 
-      it "derives agent_type from fallback_agent_type, not the resolver, when provider_id is nil" do
-        allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[codex])
-        project.created_by.providers.update_all(enabled_for_agent_runs: false)
-        # CreateFollowup destructures only provider_id from the resolver;
-        # the resolver's agent_type ("ignored") is intentionally unused.
+      it "preserves the resolver agent_type when provider_id is nil" do
         allow(AgentRuns::ProviderResolver).to receive(:call)
-          .and_return([ nil, "ignored" ])
+          .and_return([ nil, "codex" ])
 
         followup = described_class.call(agent_run: analysis_run, goal: "create_pr")
 
         expect(followup.provider).to be_nil
-        # agent_type comes from fallback_agent_type (first runnable key), not the resolver
         expect(followup.agent_type).to eq("codex")
       end
     end

--- a/spec/services/agent_runs/create_followup_spec.rb
+++ b/spec/services/agent_runs/create_followup_spec.rb
@@ -90,15 +90,18 @@ RSpec.describe AgentRuns::CreateFollowup do
         expect(followup.provider).to eq(resolved_provider)
       end
 
-      it "falls back to the first enabled agent type when the resolver returns no provider id" do
+      it "derives agent_type from fallback_agent_type, not the resolver, when provider_id is nil" do
         allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[codex])
         project.created_by.providers.update_all(enabled_for_agent_runs: false)
+        # CreateFollowup destructures only provider_id from the resolver;
+        # the resolver's agent_type ("ignored") is intentionally unused.
         allow(AgentRuns::ProviderResolver).to receive(:call)
-          .and_return([ nil, "codex" ])
+          .and_return([ nil, "ignored" ])
 
         followup = described_class.call(agent_run: analysis_run, goal: "create_pr")
 
         expect(followup.provider).to be_nil
+        # agent_type comes from fallback_agent_type (first runnable key), not the resolver
         expect(followup.agent_type).to eq("codex")
       end
     end

--- a/spec/services/agent_runs/provider_resolver_spec.rb
+++ b/spec/services/agent_runs/provider_resolver_spec.rb
@@ -84,6 +84,29 @@ RSpec.describe AgentRuns::ProviderResolver do
       expect(agent_type).to eq("claude_code")
     end
 
+    it "keeps the configured provider family for tenant API-key selection before falling back" do
+      project = create(:project)
+      owner = project.created_by
+      cursor_provider = create(:provider, user: owner, provider_key: "cursor")
+      owner.settings.update!(default_agent_provider: "cursor")
+      cursor_provider.update!(enabled_for_agent_runs: false)
+
+      api_key = create(:provider_api_key, user: owner, api_service_type: "anthropic")
+      create(:tenant_setting, account: project.account,
+        provider_preferences: { "api_key_ids" => { "anthropic" => api_key.id } })
+
+      provider_id, agent_type = described_class.call(project: project, goal: "create_pr")
+      provider = Provider.find(provider_id)
+
+      expect(agent_type).to eq("cursor")
+      expect(provider).to have_attributes(
+        user: owner,
+        provider_key: "cursor",
+        auth_type: "api_key",
+        provider_api_key: api_key
+      )
+    end
+
     it "falls back to a nil provider id with the first runnable agent type when no owner providers are available" do
       allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[codex])
 

--- a/spec/services/agent_runs/provider_resolver_spec.rb
+++ b/spec/services/agent_runs/provider_resolver_spec.rb
@@ -84,12 +84,41 @@ RSpec.describe AgentRuns::ProviderResolver do
       expect(agent_type).to eq("claude_code")
     end
 
-    it "keeps the configured provider family for tenant API-key selection before falling back" do
+    it "prefers the automated runnable provider family for tenant API-key selection" do
+      project = create(:project)
+      owner, settings = project.created_by, project.created_by.settings
+      cursor_provider = create(:provider, user: owner, provider_key: "cursor")
+      codex_provider = create(:provider, user: owner, provider_key: "codex")
+      owner.settings.update!(default_agent_provider: "cursor", provider_selection_mode: "round_robin")
+      allow(AgentRuns::UserSettingsResolver).to receive(:call).with(project: project, strict: false).and_return(settings)
+      allow(settings).to receive(:select_automated_provider_identifier).with(goal: "create_pr").and_return(codex_provider.routing_key)
+
+      api_key = create(:provider_api_key, user: owner, api_service_type: "openai")
+      create(:tenant_setting, account: project.account,
+        provider_preferences: { "api_key_ids" => { "openai" => api_key.id } })
+
+      provider_id, agent_type = described_class.call(project: project, goal: "create_pr")
+      provider = Provider.find(provider_id)
+
+      expect(agent_type).to eq("codex")
+      expect(provider).to have_attributes(
+        user: owner,
+        provider_key: "codex",
+        auth_type: "api_key",
+        provider_api_key: api_key
+      )
+      expect(provider_id).not_to eq(cursor_provider.id)
+    end
+
+    it "keeps the configured provider family for tenant API-key selection when the automated provider is stale" do
       project = create(:project)
       owner = project.created_by
+      settings = owner.settings
       cursor_provider = create(:provider, user: owner, provider_key: "cursor")
       owner.settings.update!(default_agent_provider: "cursor")
       cursor_provider.update!(enabled_for_agent_runs: false)
+      allow(AgentRuns::UserSettingsResolver).to receive(:call).with(project: project, strict: false).and_return(settings)
+      allow(settings).to receive(:select_automated_provider_identifier).with(goal: "create_pr").and_return(cursor_provider.routing_key)
 
       api_key = create(:provider_api_key, user: owner, api_service_type: "anthropic")
       create(:tenant_setting, account: project.account,

--- a/spec/services/agent_runs/provider_resolver_spec.rb
+++ b/spec/services/agent_runs/provider_resolver_spec.rb
@@ -68,5 +68,32 @@ RSpec.describe AgentRuns::ProviderResolver do
       expect(Provider.find(provider_id)).to eq(project.created_by.providers.find_by!(provider_key: "claude"))
       expect(agent_type).to eq("claude_code")
     end
+
+    it "falls back to the first enabled runnable provider when the saved setting points to a disabled provider" do
+      allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[claude cursor])
+
+      project = create(:project)
+      owner = project.created_by
+      cursor_provider = create(:provider, user: owner, provider_key: "cursor")
+      owner.settings.update!(default_agent_provider: "cursor")
+      cursor_provider.update!(enabled_for_agent_runs: false)
+
+      provider_id, agent_type = described_class.call(project: project, goal: "create_pr")
+
+      expect(provider_id).to eq(owner.providers.find_by!(provider_key: "claude").id)
+      expect(agent_type).to eq("claude_code")
+    end
+
+    it "falls back to a nil provider id with the first runnable agent type when no owner providers are available" do
+      allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[codex])
+
+      project = build_stubbed(:project)
+      allow(project).to receive(:effective_owner).and_return(nil)
+
+      provider_id, agent_type = described_class.new(project: project, goal: "create_pr").send(:fallback_from_settings)
+
+      expect(provider_id).to be_nil
+      expect(agent_type).to eq("codex")
+    end
   end
 end

--- a/spec/services/agent_runs/provider_resolver_spec.rb
+++ b/spec/services/agent_runs/provider_resolver_spec.rb
@@ -136,6 +136,31 @@ RSpec.describe AgentRuns::ProviderResolver do
       )
     end
 
+    it "does not create a tenant API-key provider for a non-runnable configured provider key" do
+      allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[claude])
+      allow(ProviderSupport).to receive(:container_executable_provider_key?) do |key|
+        key == "claude"
+      end
+
+      project = create(:project)
+      owner = project.created_by
+      # Use a valid provider key (cursor) but stub it as non-runnable
+      stale_provider = create(:provider, user: owner, provider_key: "cursor", enabled_for_agent_runs: true)
+      owner.settings.update!(default_agent_provider: "cursor")
+
+      api_key = create(:provider_api_key, user: owner, api_service_type: "anthropic")
+      create(:tenant_setting, account: project.account,
+        provider_preferences: { "api_key_ids" => { "anthropic" => api_key.id } })
+
+      provider_id, agent_type = described_class.call(project: project, goal: "create_pr")
+
+      # Should not select the non-runnable cursor provider via tenant API key
+      expect(provider_id).not_to eq(stale_provider.id)
+      resolved_provider = Provider.find(provider_id)
+      expect(resolved_provider.provider_key).to eq("claude")
+      expect(agent_type).to eq("claude_code")
+    end
+
     it "falls back to a nil provider id with the first runnable agent type when no owner providers are available" do
       allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[codex])
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2426,26 +2426,28 @@ RSpec.describe Activities::RunAgentActivity do
       end
 
       it "caps fallback attempts to the remaining project time budget" do
-        agent_run.update!(status: "running", started_at: 10.seconds.ago)
-        project.update!(max_execution_seconds: 90)
+        freeze_time do
+          agent_run.update!(status: "running", started_at: 10.seconds.ago)
+          project.update!(max_execution_seconds: 90)
 
-        call_count = 0
-        expect(container_service).to receive(:execute).twice do |_cmd, **opts|
-          call_count += 1
-          if call_count == 1
-            expect(opts[:timeout]).to eq(80)
-            agent_run.update!(started_at: 89.seconds.ago)
-            exec_failure
-          else
-            expect(opts[:timeout]).to eq(1)
-            exec_success
+          call_count = 0
+          expect(container_service).to receive(:execute).twice do |_cmd, **opts|
+            call_count += 1
+            if call_count == 1
+              expect(opts[:timeout]).to eq(80)
+              agent_run.update!(started_at: 89.seconds.ago)
+              exec_failure
+            else
+              expect(opts[:timeout]).to eq(1)
+              exec_success
+            end
           end
+
+          result = activity.execute(agent_run_id: agent_run.id)
+
+          expect(result[:success]).to be true
+          expect(result[:final_provider]).to eq("cursor")
         end
-
-        result = activity.execute(agent_run_id: agent_run.id)
-
-        expect(result[:success]).to be true
-        expect(result[:final_provider]).to eq("cursor")
       end
     end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -804,7 +804,10 @@ RSpec.describe Activities::RunAgentActivity do
     it "drops stale default-provider entries and keeps the first runnable fallback" do
       allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[codex])
       agent_run.update!(provider: nil, agent_type: "claude_code")
-      user.settings.update_columns(fallback_enabled: false, default_agent_provider: "claude")
+      # Persist a stale saved default plus fallback flag exactly as they could
+      # exist from older settings before provider availability changed.
+      user.settings.assign_attributes(fallback_enabled: false, default_agent_provider: "claude")
+      user.settings.save!(validate: false)
 
       providers = activity.send(:build_provider_order, agent_run, user.settings)
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -790,6 +790,26 @@ RSpec.describe Activities::RunAgentActivity do
       expect(providers).to eq([ user.providers.find_by!(provider_key: "claude").routing_key ])
       expect(providers).not_to include(copilot_provider.routing_key)
     end
+
+    it "keeps a runnable non-default agent type when no provider is saved" do
+      allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[claude codex])
+      agent_run.update!(provider: nil, agent_type: "codex")
+      user.settings.update!(fallback_enabled: false)
+
+      providers = activity.send(:build_provider_order, agent_run, user.settings)
+
+      expect(providers).to eq([ "codex" ])
+    end
+
+    it "drops stale default-provider entries and keeps the first runnable fallback" do
+      allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[codex])
+      agent_run.update!(provider: nil, agent_type: "claude_code")
+      user.settings.update_columns(fallback_enabled: false, default_agent_provider: "claude")
+
+      providers = activity.send(:build_provider_order, agent_run, user.settings)
+
+      expect(providers).to eq([ "codex" ])
+    end
   end
 
   def build_opencode_context(user)
@@ -1946,6 +1966,28 @@ RSpec.describe Activities::RunAgentActivity do
         expect(result[:final_provider]).to eq("cursor")
       end
 
+      it "falls back to the next provider on docker exec failures" do
+        call_count = 0
+        allow(container_service).to receive(:execute) do |_cmd, **_opts|
+          call_count += 1
+          if call_count == 1
+            raise Containers::Provision::ExecutionError, "Connection reset by peer"
+          end
+
+          exec_success
+        end
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:success]).to be true
+        expect(result[:final_provider]).to eq("cursor")
+        expect(agent_run.reload.providers_attempted).to contain_exactly(
+          hash_including("provider" => "claude_code", "success" => false, "error_type" => "error",
+            "error_message" => include("Docker exec error")),
+          hash_including("provider" => "cursor", "success" => true)
+        )
+      end
+
       it "includes configured fallback-only providers even when saved fallback order is empty" do
         user.providers.find_by!(provider_key: "cursor").update!(
           enabled_for_agent_runs: false,
@@ -2381,6 +2423,29 @@ RSpec.describe Activities::RunAgentActivity do
         agent_run.reload
         expect(agent_run.status).to eq("timeout")
         expect(agent_run.error_message).to include("wall_clock_timeout")
+      end
+
+      it "caps fallback attempts to the remaining project time budget" do
+        agent_run.update!(status: "running", started_at: 10.seconds.ago)
+        project.update!(max_execution_seconds: 90)
+
+        call_count = 0
+        expect(container_service).to receive(:execute).twice do |_cmd, **opts|
+          call_count += 1
+          if call_count == 1
+            expect(opts[:timeout]).to eq(80)
+            agent_run.update!(started_at: 89.seconds.ago)
+            exec_failure
+          else
+            expect(opts[:timeout]).to eq(1)
+            exec_success
+          end
+        end
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:success]).to be true
+        expect(result[:final_provider]).to eq("cursor")
       end
     end
 


### PR DESCRIPTION
## Summary

Added the missing provider-selection and fallback coverage, and tightened `AgentRuns::ProviderResolver` so stale disabled configured providers no longer win over enabled runnable providers.

The new specs cover:
- stale configured provider fallback in `ProviderResolver`
- nil-provider followup creation fallback in `CreateFollowup`
- provider-order construction for nil-provider/non-default agent types and stale default entries
- Docker exec failure triggering fallback
- remaining time budget shrinking across fallback attempts

Checks passed:
- `bin/rails db:prepare` with `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent`
- `bundle exec rubocop`
- `bundle exec rspec` (`9739 examples, 0 failures, 2 pending`)

Committed as `0016b9e` with message `test(agent-runs): cover provider fallback selection gaps`. Working tree is clean.

---

Closes #1550