### PR TITLE
feat(notifications): allow users to subscribe to issue/PR merge events

### DIFF
--- a/app/controllers/api/github_webhooks_controller.rb
+++ b/app/controllers/api/github_webhooks_controller.rb
@@ -80,6 +80,8 @@ module Api
         return
       end
 
+      notify_merge_subscribers(pr["number"])
+
       agent_run = find_agent_run(pr["number"])
       unless agent_run
         head :ok
@@ -246,6 +248,15 @@ module Api
         .where(created_issue_number: issue_number, status: "completed")
         .order(created_at: :desc)
         .first
+    end
+
+    def notify_merge_subscribers(pr_number)
+      return unless @project && pr_number
+
+      issue = @project.issues.find_by(github_number: pr_number, is_pull_request: true)
+      return unless issue
+
+      IssueMergeSubscriptions::Deliver.call(issue: issue, event: :merged)
     end
 
     def invalidate_cache(event)

--- a/app/controllers/projects/issue_merge_subscriptions_controller.rb
+++ b/app/controllers/projects/issue_merge_subscriptions_controller.rb
@@ -5,22 +5,30 @@ module Projects
     before_action :set_project
     before_action :set_issue
 
+    def show
+      authorize @issue, policy_class: IssueMergeSubscriptionPolicy
+
+      render_subscription_state
+    end
+
     def create
       authorize @issue, policy_class: IssueMergeSubscriptionPolicy
 
       retries = 0
-      current_user.issue_merge_subscriptions.find_or_create_by!(
-        issue: @issue,
-        subscription_type: IssueMergeSubscription::ON_MERGE
-      )
+      begin
+        current_user.issue_merge_subscriptions.find_or_create_by!(
+          issue: @issue,
+          subscription_type: IssueMergeSubscription::ON_MERGE
+        )
+      rescue ActiveRecord::RecordNotUnique
+        raise if (retries += 1) > 2
+
+        retry
+      end
 
       respond_with_subscription_state(
         notice: "You will be notified when #{notification_target}."
       )
-    rescue ActiveRecord::RecordNotUnique
-      raise if (retries += 1) > 2
-
-      retry
     end
 
     def destroy
@@ -44,22 +52,28 @@ module Projects
     end
 
     def respond_with_subscription_state(notice:)
-      subscribed = current_user.issue_merge_subscriptions.on_merge.exists?(issue: @issue)
-
       respond_to do |format|
         format.turbo_stream do
           render turbo_stream: turbo_stream.replace(
             view_context.dom_id(@issue, :merge_subscription),
             partial: "projects/issue_merge_subscription",
-            locals: {
-              issue: @issue,
-              project: @project,
-              subscribed: subscribed
-            }
+            locals: subscription_state_locals
           )
         end
         format.html { redirect_to project_path(@project, anchor: view_context.dom_id(@issue)), notice: notice }
       end
+    end
+
+    def render_subscription_state
+      render partial: "projects/issue_merge_subscription", locals: subscription_state_locals
+    end
+
+    def subscription_state_locals
+      {
+        issue: @issue,
+        project: @project,
+        subscribed: current_user.issue_merge_subscriptions.on_merge.exists?(issue: @issue)
+      }
     end
 
     def notification_target

--- a/app/controllers/projects/issue_merge_subscriptions_controller.rb
+++ b/app/controllers/projects/issue_merge_subscriptions_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Projects
+  class IssueMergeSubscriptionsController < ApplicationController
+    before_action :set_project
+    before_action :set_issue
+
+    def create
+      authorize @issue, policy_class: IssueMergeSubscriptionPolicy
+
+      retries = 0
+      current_user.issue_merge_subscriptions.find_or_create_by!(
+        issue: @issue,
+        subscription_type: IssueMergeSubscription::ON_MERGE
+      )
+
+      respond_with_subscription_state(
+        notice: "You will be notified when #{notification_target}."
+      )
+    rescue ActiveRecord::RecordNotUnique
+      raise if (retries += 1) > 2
+
+      retry
+    end
+
+    def destroy
+      authorize @issue, policy_class: IssueMergeSubscriptionPolicy
+
+      current_user.issue_merge_subscriptions.on_merge.where(issue: @issue).delete_all
+
+      respond_with_subscription_state(
+        notice: "Notifications for #{notification_target} were removed."
+      )
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).find(params[:project_id])
+    end
+
+    def set_issue
+      @issue = @project.issues.find(params[:issue_id])
+    end
+
+    def respond_with_subscription_state(notice:)
+      subscribed = current_user.issue_merge_subscriptions.on_merge.exists?(issue: @issue)
+
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            view_context.dom_id(@issue, :merge_subscription),
+            partial: "projects/issue_merge_subscription",
+            locals: {
+              issue: @issue,
+              project: @project,
+              subscribed: subscribed
+            }
+          )
+        end
+        format.html { redirect_to project_path(@project, anchor: view_context.dom_id(@issue)), notice: notice }
+      end
+    end
+
+    def notification_target
+      if @issue.is_pull_request?
+        "PR ##{@issue.github_number} is merged"
+      else
+        "issue ##{@issue.github_number} is completed"
+      end
+    end
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -33,6 +33,10 @@ class ProjectsController < ApplicationController
       project: @project, issue_ids: @issues.map(&:id)
     )
     @pull_requests = open_items.pull_requests_only.limit(settings.max_prs_per_page)
+    visible_issue_ids = @issues.map(&:id) + @pull_requests.map(&:id)
+    @merge_notification_issue_ids = current_user.issue_merge_subscriptions.on_merge
+      .where(issue_id: visible_issue_ids)
+      .pluck(:issue_id)
     @pr_numbers_with_queued_auto_continue = @project.pr_numbers_with_queued_auto_continue
     @pr_numbers_with_active_runs = @project.pr_numbers_with_active_runs
     @cost_budgets = @project.cost_budgets.load

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -35,6 +35,7 @@ class Issue < ApplicationRecord
   has_many :sub_issues, class_name: "Issue", foreign_key: :parent_issue_id,
                         inverse_of: :parent_issue, dependent: :nullify
   has_many :agent_runs, dependent: :nullify
+  has_many :issue_merge_subscriptions, dependent: :destroy
 
   has_many :issue_dependencies, dependent: :destroy
   has_many :dependencies, through: :issue_dependencies, source: :depends_on_issue

--- a/app/models/issue_merge_subscription.rb
+++ b/app/models/issue_merge_subscription.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class IssueMergeSubscription < ApplicationRecord
+  ON_MERGE = "on_merge"
+
+  belongs_to :issue
+  belongs_to :user
+
+  validates :subscription_type, presence: true, inclusion: { in: [ ON_MERGE ] }
+  validates :issue_id, uniqueness: { scope: [ :user_id, :subscription_type ] }
+  validate :user_and_issue_belong_to_same_account
+
+  before_validation :default_subscription_type
+
+  scope :on_merge, -> { where(subscription_type: ON_MERGE) }
+
+  private
+
+  def default_subscription_type
+    self.subscription_type ||= ON_MERGE
+  end
+
+  def user_and_issue_belong_to_same_account
+    return unless user && issue
+    return if user.account_id == issue.project.account_id
+
+    errors.add(:user, "must belong to the same account as the issue")
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -480,8 +480,7 @@ class Project < ApplicationRecord
       partial: "projects/issues",
       locals: { project: self, issues: displayed,
                 issue_lifecycle_statuses: lifecycle_statuses,
-                paid_prs_by_issue_id: paid_prs_by_issue_id,
-                broadcast: true }
+                paid_prs_by_issue_id: paid_prs_by_issue_id }
     )
   end
 
@@ -507,8 +506,7 @@ class Project < ApplicationRecord
         project: self,
         pull_requests: open_items.pull_requests_only.limit(25),
         pr_numbers_with_queued_auto_continue: pr_numbers_with_queued_auto_continue,
-        pr_numbers_with_active_runs: pr_numbers_with_active_runs,
-        broadcast: true
+        pr_numbers_with_active_runs: pr_numbers_with_active_runs
       }
     )
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -480,7 +480,8 @@ class Project < ApplicationRecord
       partial: "projects/issues",
       locals: { project: self, issues: displayed,
                 issue_lifecycle_statuses: lifecycle_statuses,
-                paid_prs_by_issue_id: paid_prs_by_issue_id }
+                paid_prs_by_issue_id: paid_prs_by_issue_id,
+                broadcast: true }
     )
   end
 
@@ -506,7 +507,8 @@ class Project < ApplicationRecord
         project: self,
         pull_requests: open_items.pull_requests_only.limit(25),
         pr_numbers_with_queued_auto_continue: pr_numbers_with_queued_auto_continue,
-        pr_numbers_with_active_runs: pr_numbers_with_active_runs
+        pr_numbers_with_active_runs: pr_numbers_with_active_runs,
+        broadcast: true
       }
     )
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -480,7 +480,8 @@ class Project < ApplicationRecord
       partial: "projects/issues",
       locals: { project: self, issues: displayed,
                 issue_lifecycle_statuses: lifecycle_statuses,
-                paid_prs_by_issue_id: paid_prs_by_issue_id }
+                paid_prs_by_issue_id: paid_prs_by_issue_id,
+                merge_notification_issue_ids: Set.new }
     )
   end
 
@@ -506,7 +507,8 @@ class Project < ApplicationRecord
         project: self,
         pull_requests: open_items.pull_requests_only.limit(25),
         pr_numbers_with_queued_auto_continue: pr_numbers_with_queued_auto_continue,
-        pr_numbers_with_active_runs: pr_numbers_with_active_runs
+        pr_numbers_with_active_runs: pr_numbers_with_active_runs,
+        merge_notification_issue_ids: Set.new
       }
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :member_accounts, through: :account_memberships, source: :account
   has_many :project_memberships, dependent: :destroy
   has_many :member_projects, through: :project_memberships, source: :project
+  has_many :issue_merge_subscriptions, dependent: :destroy
   has_many :created_github_tokens, class_name: "GithubToken", foreign_key: :created_by_id, dependent: :nullify, inverse_of: :created_by
   has_many :created_integration_credentials, class_name: "IntegrationCredential", foreign_key: :created_by_id, dependent: :nullify, inverse_of: :created_by
   has_many :created_projects, class_name: "Project", foreign_key: :created_by_id, dependent: :nullify, inverse_of: :created_by

--- a/app/policies/issue_merge_subscription_policy.rb
+++ b/app/policies/issue_merge_subscription_policy.rb
@@ -12,7 +12,9 @@ class IssueMergeSubscriptionPolicy < ApplicationPolicy
   private
 
   def allowed?
-    record.github_state == "open" && ProjectPolicy.new(user, record.project).show?
+    record.github_state == "open" &&
+      record.source == Issue::GITHUB_SOURCE &&
+      ProjectPolicy.new(user, record.project).show?
   end
 
   def account_for_record

--- a/app/policies/issue_merge_subscription_policy.rb
+++ b/app/policies/issue_merge_subscription_policy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class IssueMergeSubscriptionPolicy < ApplicationPolicy
+  def create?
+    allowed?
+  end
+
+  def destroy?
+    allowed?
+  end
+
+  private
+
+  def allowed?
+    record.github_state == "open" && ProjectPolicy.new(user, record.project).show?
+  end
+
+  def account_for_record
+    record.project.account
+  end
+end

--- a/app/policies/issue_merge_subscription_policy.rb
+++ b/app/policies/issue_merge_subscription_policy.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class IssueMergeSubscriptionPolicy < ApplicationPolicy
+  def show?
+    allowed?
+  end
+
   def create?
     allowed?
   end

--- a/app/services/issue_merge_subscriptions/deliver.rb
+++ b/app/services/issue_merge_subscriptions/deliver.rb
@@ -2,9 +2,6 @@
 
 module IssueMergeSubscriptions
   class Deliver
-    include ActionView::RecordIdentifier
-    include Rails.application.routes.url_helpers
-
     EVENT_CONFIG = {
       merged: {
         item_name: "PR",
@@ -27,10 +24,10 @@ module IssueMergeSubscriptions
     end
 
     def call
-      subscriptions = issue.issue_merge_subscriptions.on_merge.includes(:user).to_a
-      return 0 if subscriptions.empty?
-
       IssueMergeSubscription.transaction do
+        subscriptions = issue.issue_merge_subscriptions.on_merge.lock.to_a
+        return 0 if subscriptions.empty?
+
         subscriptions.each do |subscription|
           Notifications::Publish.call(
             account: issue.project.account,
@@ -39,16 +36,15 @@ module IssueMergeSubscriptions
             subject: issue,
             severity: :info,
             title: notification_title,
-            action_url: project_path(issue.project, anchor: dom_id(issue)),
+            action_url: issue.github_url,
             nav_section: "projects",
             metadata: notification_metadata
           )
         end
 
         IssueMergeSubscription.where(id: subscriptions.map(&:id)).delete_all
+        subscriptions.size
       end
-
-      subscriptions.size
     end
 
     private

--- a/app/services/issue_merge_subscriptions/deliver.rb
+++ b/app/services/issue_merge_subscriptions/deliver.rb
@@ -25,7 +25,7 @@ module IssueMergeSubscriptions
 
     def call
       IssueMergeSubscription.transaction do
-        subscriptions = issue.issue_merge_subscriptions.on_merge.lock.to_a
+        subscriptions = issue.issue_merge_subscriptions.on_merge.includes(:user).lock.to_a
         return 0 if subscriptions.empty?
 
         subscriptions.each do |subscription|

--- a/app/services/issue_merge_subscriptions/deliver.rb
+++ b/app/services/issue_merge_subscriptions/deliver.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module IssueMergeSubscriptions
+  class Deliver
+    include ActionView::RecordIdentifier
+    include Rails.application.routes.url_helpers
+
+    EVENT_CONFIG = {
+      merged: {
+        item_name: "PR",
+        verb: "merged"
+      },
+      completed: {
+        item_name: "Issue",
+        verb: "completed"
+      }
+    }.freeze
+    SOURCE = "issue_merge_subscription"
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(issue:, event:)
+      @issue = issue
+      @event = event.to_sym
+    end
+
+    def call
+      subscriptions = issue.issue_merge_subscriptions.on_merge.includes(:user).to_a
+      return 0 if subscriptions.empty?
+
+      IssueMergeSubscription.transaction do
+        subscriptions.each do |subscription|
+          Notifications::Publish.call(
+            account: issue.project.account,
+            user: subscription.user,
+            source: SOURCE,
+            subject: issue,
+            severity: :info,
+            title: notification_title,
+            action_url: project_path(issue.project, anchor: dom_id(issue)),
+            nav_section: "projects",
+            metadata: notification_metadata
+          )
+        end
+
+        IssueMergeSubscription.where(id: subscriptions.map(&:id)).delete_all
+      end
+
+      subscriptions.size
+    end
+
+    private
+
+    attr_reader :issue, :event
+
+    def notification_title
+      config = EVENT_CONFIG.fetch(event)
+      "#{config[:item_name]} ##{issue.github_number} was #{config[:verb]}: #{issue.title}"
+    end
+
+    def notification_metadata
+      {
+        "event" => event.to_s,
+        "github_number" => issue.github_number,
+        "issue_id" => issue.id,
+        "project_id" => issue.project_id
+      }
+    end
+  end
+end

--- a/app/services/issues/upsert_from_github.rb
+++ b/app/services/issues/upsert_from_github.rb
@@ -18,7 +18,7 @@ module Issues
         github_updated_at: github_issue.updated_at
       )
 
-      deliver_completion_notifications(issue, was_open: was_open)
+      deliver_completion_notifications(issue, github_issue: github_issue, was_open: was_open)
       issue
     end
 
@@ -32,13 +32,19 @@ module Issues
     end
     private_class_method :pull_request_payload
 
-    def self.deliver_completion_notifications(issue, was_open:)
+    def self.deliver_completion_notifications(issue, github_issue:, was_open:)
       return unless was_open
       return unless issue.github_state == "closed"
-      return if issue.is_pull_request?
+      return unless closed_as_completed?(github_issue)
 
-      IssueMergeSubscriptions::Deliver.call(issue: issue, event: :completed)
+      event = issue.is_pull_request? ? :merged : :completed
+      IssueMergeSubscriptions::Deliver.call(issue: issue, event: event)
     end
     private_class_method :deliver_completion_notifications
+
+    def self.closed_as_completed?(github_issue)
+      github_issue.respond_to?(:state_reason) && github_issue.state_reason == "completed"
+    end
+    private_class_method :closed_as_completed?
   end
 end

--- a/app/services/issues/upsert_from_github.rb
+++ b/app/services/issues/upsert_from_github.rb
@@ -4,6 +4,8 @@ module Issues
   class UpsertFromGithub
     def self.call(project:, github_issue:, body: github_issue.body)
       issue = project.issues.find_or_initialize_by(github_issue_id: github_issue.id)
+      was_open = issue.github_state == "open"
+
       issue.update!(
         github_number: github_issue.number,
         title: github_issue.title,
@@ -15,6 +17,8 @@ module Issues
         github_created_at: github_issue.created_at,
         github_updated_at: github_issue.updated_at
       )
+
+      deliver_completion_notifications(issue, was_open: was_open)
       issue
     end
 
@@ -27,5 +31,14 @@ module Issues
       github_issue.respond_to?(:pull_request) ? github_issue.pull_request : nil
     end
     private_class_method :pull_request_payload
+
+    def self.deliver_completion_notifications(issue, was_open:)
+      return unless was_open
+      return unless issue.github_state == "closed"
+      return if issue.is_pull_request?
+
+      IssueMergeSubscriptions::Deliver.call(issue: issue, event: :completed)
+    end
+    private_class_method :deliver_completion_notifications
   end
 end

--- a/app/services/notifications/broadcasting.rb
+++ b/app/services/notifications/broadcasting.rb
@@ -4,9 +4,12 @@ module Notifications
   module Broadcasting
     private
 
-    def broadcast_notification_updates(account)
-      # Compute counts here because Devise helpers (current_user, current_account)
-      # are unavailable in broadcast/background contexts.
+    def broadcast_notification_updates(account, user: nil)
+      broadcast_account_notification_updates(account)
+      broadcast_user_notification_updates(account, user) if user
+    end
+
+    def broadcast_account_notification_updates(account)
       # Account-wide broadcasts show only account-wide (user_id: nil) notifications,
       # since we cannot know which user is viewing the page.
       account_notifications = Notification.where(account: account, user_id: nil)
@@ -23,6 +26,30 @@ module Notifications
 
       Turbo::StreamsChannel.broadcast_replace_to(
         account, :notification_updates,
+        target: "notification_nav_badges",
+        partial: "notifications/nav_badges",
+        locals: { account: account, badge_counts: badge_counts }
+      )
+    end
+
+    def broadcast_user_notification_updates(account, user)
+      # User-scoped notifications (e.g. merge subscriptions) need a separate
+      # broadcast to the user's personal stream so the bell badge updates
+      # without a page reload.
+      user_visible = Notification.where(account: account, user_id: [ nil, user.id ])
+      active_unread = user_visible.active.unread
+      unread_count = active_unread.count
+      badge_counts = active_unread.where.not(nav_section: nil).group(:nav_section).count
+
+      Turbo::StreamsChannel.broadcast_replace_to(
+        user, :notification_updates,
+        target: "notification_bell",
+        partial: "notifications/bell",
+        locals: { account: account, unread_count: unread_count }
+      )
+
+      Turbo::StreamsChannel.broadcast_replace_to(
+        user, :notification_updates,
         target: "notification_nav_badges",
         partial: "notifications/nav_badges",
         locals: { account: account, badge_counts: badge_counts }

--- a/app/services/notifications/publish.rb
+++ b/app/services/notifications/publish.rb
@@ -43,7 +43,7 @@ module Notifications
       )
 
       notification.save!
-      broadcast_notification_updates(account)
+      broadcast_notification_updates(account, user: user)
       notification
     rescue ActiveRecord::RecordNotUnique
       retries ||= 0

--- a/app/services/notifications/resolve.rb
+++ b/app/services/notifications/resolve.rb
@@ -27,7 +27,7 @@ module Notifications
       return unless notification
 
       notification.update!(resolved_at: Time.current)
-      broadcast_notification_updates(account)
+      broadcast_notification_updates(account, user: user)
       notification
     end
 

--- a/app/temporal/activities/merge_pull_request_activity.rb
+++ b/app/temporal/activities/merge_pull_request_activity.rb
@@ -49,6 +49,7 @@ module Activities
 
       if merged
         issue.update!(pr_review_phase: "merged")
+        IssueMergeSubscriptions::Deliver.call(issue: issue, event: :merged)
         # Only label and comment on PRs that this activity actually merged —
         # already-merged PRs may have been merged manually by a human.
         unless pr_data.merged

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,7 @@
   <body class="min-h-screen bg-gray-50 dark:bg-gray-900 dark:text-gray-100">
     <% if user_signed_in? %>
       <%= turbo_stream_from current_account, :notification_updates %>
+      <%= turbo_stream_from current_user, :notification_updates %>
       <%= render "notifications/nav_badges", account: current_account %>
     <% end %>
     <nav class="bg-white shadow-sm dark:bg-gray-800 dark:shadow-gray-700/30" data-controller="mobile-menu">

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -18,10 +18,11 @@
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= issue_lifecycle_badge(local_assigns.fetch(:lifecycle_status, :eligible)) %>
-    <%= render "projects/issue_merge_subscription",
-               issue: issue,
-               project: project,
-               subscribed: local_assigns.fetch(:merge_notification_issue_ids, []).include?(issue.id) %>
+    <% subscription_locals = { issue: issue, project: project } %>
+    <% if local_assigns.key?(:merge_notification_issue_ids) %>
+      <% subscription_locals[:subscribed] = local_assigns[:merge_notification_issue_ids].include?(issue.id) %>
+    <% end %>
+    <%= render "projects/issue_merge_subscription", **subscription_locals %>
     <% paid_pr = local_assigns.fetch(:paid_pr, nil) %>
     <%# Prefer the paid-generated PR when one exists; otherwise fall back to
         any open associated PR so manually-opened PRs still get a visible

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -22,8 +22,6 @@
       <% subscription_locals = { issue: issue, project: project } %>
       <% if local_assigns.key?(:merge_notification_issue_ids) %>
         <% subscription_locals[:subscribed] = local_assigns[:merge_notification_issue_ids].include?(issue.id) %>
-      <% elsif local_assigns.fetch(:broadcast, false) %>
-        <% subscription_locals[:broadcast] = true %>
       <% end %>
       <%= render "projects/issue_merge_subscription", **subscription_locals %>
     <% end %>

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -18,6 +18,10 @@
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= issue_lifecycle_badge(local_assigns.fetch(:lifecycle_status, :eligible)) %>
+    <%= render "projects/issue_merge_subscription",
+               issue: issue,
+               project: project,
+               subscribed: local_assigns.fetch(:merge_notification_issue_ids, []).include?(issue.id) %>
     <% paid_pr = local_assigns.fetch(:paid_pr, nil) %>
     <%# Prefer the paid-generated PR when one exists; otherwise fall back to
         any open associated PR so manually-opened PRs still get a visible

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -18,11 +18,15 @@
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= issue_lifecycle_badge(local_assigns.fetch(:lifecycle_status, :eligible)) %>
-    <% subscription_locals = { issue: issue, project: project } %>
-    <% if local_assigns.key?(:merge_notification_issue_ids) %>
-      <% subscription_locals[:subscribed] = local_assigns[:merge_notification_issue_ids].include?(issue.id) %>
+    <% if issue.source == Issue::GITHUB_SOURCE %>
+      <% subscription_locals = { issue: issue, project: project } %>
+      <% if local_assigns.key?(:merge_notification_issue_ids) %>
+        <% subscription_locals[:subscribed] = local_assigns[:merge_notification_issue_ids].include?(issue.id) %>
+      <% elsif local_assigns.fetch(:broadcast, false) %>
+        <% subscription_locals[:broadcast] = true %>
+      <% end %>
+      <%= render "projects/issue_merge_subscription", **subscription_locals %>
     <% end %>
-    <%= render "projects/issue_merge_subscription", **subscription_locals %>
     <% paid_pr = local_assigns.fetch(:paid_pr, nil) %>
     <%# Prefer the paid-generated PR when one exists; otherwise fall back to
         any open associated PR so manually-opened PRs still get a visible

--- a/app/views/projects/_issue_merge_subscription.html.erb
+++ b/app/views/projects/_issue_merge_subscription.html.erb
@@ -1,12 +1,7 @@
-<% frame_options =
-  if local_assigns.key?(:subscribed)
-    {}
-  else
-    { src: project_issue_merge_subscription_path(project, issue), loading: :lazy }
-  end %>
-
-<%= turbo_frame_tag dom_id(issue, :merge_subscription), **frame_options do %>
-  <% if local_assigns.key?(:subscribed) %>
+<%# When rendered from a broadcast (no user context), output an inert frame
+    that preserves the DOM slot without triggering a lazy-load GET per row. %>
+<% if local_assigns.key?(:subscribed) %>
+  <%= turbo_frame_tag dom_id(issue, :merge_subscription) do %>
     <% if subscribed %>
       <%= button_to issue.is_pull_request? ? "Stop merge alerts" : "Stop completion alerts",
                     project_issue_merge_subscription_path(project, issue),
@@ -20,7 +15,13 @@
                     class: "text-xs font-medium text-indigo-600 hover:text-indigo-900",
                     form: { data: { turbo_stream: true } } %>
     <% end %>
-  <% else %>
+  <% end %>
+<% elsif local_assigns.fetch(:broadcast, false) %>
+  <%= turbo_frame_tag dom_id(issue, :merge_subscription) %>
+<% else %>
+  <%= turbo_frame_tag dom_id(issue, :merge_subscription),
+        src: project_issue_merge_subscription_path(project, issue),
+        loading: :lazy do %>
     <span class="text-xs font-medium text-gray-400">Loading alerts...</span>
   <% end %>
 <% end %>

--- a/app/views/projects/_issue_merge_subscription.html.erb
+++ b/app/views/projects/_issue_merge_subscription.html.erb
@@ -1,0 +1,15 @@
+<%= turbo_frame_tag dom_id(issue, :merge_subscription) do %>
+  <% if subscribed %>
+    <%= button_to issue.is_pull_request? ? "Stop merge alerts" : "Stop completion alerts",
+                  project_issue_merge_subscription_path(project, issue),
+                  method: :delete,
+                  class: "text-xs font-medium text-gray-600 hover:text-gray-900",
+                  form: { data: { turbo_stream: true } } %>
+  <% else %>
+    <%= button_to issue.is_pull_request? ? "Notify on merge" : "Notify on completion",
+                  project_issue_merge_subscription_path(project, issue),
+                  method: :post,
+                  class: "text-xs font-medium text-indigo-600 hover:text-indigo-900",
+                  form: { data: { turbo_stream: true } } %>
+  <% end %>
+<% end %>

--- a/app/views/projects/_issue_merge_subscription.html.erb
+++ b/app/views/projects/_issue_merge_subscription.html.erb
@@ -1,15 +1,26 @@
-<%= turbo_frame_tag dom_id(issue, :merge_subscription) do %>
-  <% if subscribed %>
-    <%= button_to issue.is_pull_request? ? "Stop merge alerts" : "Stop completion alerts",
-                  project_issue_merge_subscription_path(project, issue),
-                  method: :delete,
-                  class: "text-xs font-medium text-gray-600 hover:text-gray-900",
-                  form: { data: { turbo_stream: true } } %>
+<% frame_options =
+  if local_assigns.key?(:subscribed)
+    {}
+  else
+    { src: project_issue_merge_subscription_path(project, issue), loading: :lazy }
+  end %>
+
+<%= turbo_frame_tag dom_id(issue, :merge_subscription), **frame_options do %>
+  <% if local_assigns.key?(:subscribed) %>
+    <% if subscribed %>
+      <%= button_to issue.is_pull_request? ? "Stop merge alerts" : "Stop completion alerts",
+                    project_issue_merge_subscription_path(project, issue),
+                    method: :delete,
+                    class: "text-xs font-medium text-gray-600 hover:text-gray-900",
+                    form: { data: { turbo_stream: true } } %>
+    <% else %>
+      <%= button_to issue.is_pull_request? ? "Notify on merge" : "Notify on completion",
+                    project_issue_merge_subscription_path(project, issue),
+                    method: :post,
+                    class: "text-xs font-medium text-indigo-600 hover:text-indigo-900",
+                    form: { data: { turbo_stream: true } } %>
+    <% end %>
   <% else %>
-    <%= button_to issue.is_pull_request? ? "Notify on merge" : "Notify on completion",
-                  project_issue_merge_subscription_path(project, issue),
-                  method: :post,
-                  class: "text-xs font-medium text-indigo-600 hover:text-indigo-900",
-                  form: { data: { turbo_stream: true } } %>
+    <span class="text-xs font-medium text-gray-400">Loading alerts...</span>
   <% end %>
 <% end %>

--- a/app/views/projects/_issue_merge_subscription.html.erb
+++ b/app/views/projects/_issue_merge_subscription.html.erb
@@ -1,5 +1,3 @@
-<%# When rendered from a broadcast (no user context), output an inert frame
-    that preserves the DOM slot without triggering a lazy-load GET per row. %>
 <% if local_assigns.key?(:subscribed) %>
   <%= turbo_frame_tag dom_id(issue, :merge_subscription) do %>
     <% if subscribed %>
@@ -16,8 +14,6 @@
                     form: { data: { turbo_stream: true } } %>
     <% end %>
   <% end %>
-<% elsif local_assigns.fetch(:broadcast, false) %>
-  <%= turbo_frame_tag dom_id(issue, :merge_subscription) %>
 <% else %>
   <%= turbo_frame_tag dom_id(issue, :merge_subscription),
         src: project_issue_merge_subscription_path(project, issue),

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -8,12 +8,14 @@
         <ul role="list" class="divide-y divide-gray-200">
           <% statuses = local_assigns.fetch(:issue_lifecycle_statuses, {}) %>
           <% paid_prs_by_issue_id = local_assigns.fetch(:paid_prs_by_issue_id, {}) %>
+          <% merge_notification_issue_ids = local_assigns.fetch(:merge_notification_issue_ids, []) %>
           <% issues.each do |issue| %>
             <%= render "projects/issue",
                       issue: issue,
                       project: project,
                       lifecycle_status: statuses[issue.id],
-                      paid_pr: paid_prs_by_issue_id[issue.id] %>
+                      paid_pr: paid_prs_by_issue_id[issue.id],
+                      merge_notification_issue_ids: merge_notification_issue_ids %>
           <% end %>
         </ul>
       </div>

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -17,8 +17,6 @@
             } %>
             <% if local_assigns.key?(:merge_notification_issue_ids) %>
               <% issue_locals[:merge_notification_issue_ids] = local_assigns[:merge_notification_issue_ids] %>
-            <% elsif local_assigns.fetch(:broadcast, false) %>
-              <% issue_locals[:broadcast] = true %>
             <% end %>
             <%= render "projects/issue", **issue_locals %>
           <% end %>

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -8,14 +8,17 @@
         <ul role="list" class="divide-y divide-gray-200">
           <% statuses = local_assigns.fetch(:issue_lifecycle_statuses, {}) %>
           <% paid_prs_by_issue_id = local_assigns.fetch(:paid_prs_by_issue_id, {}) %>
-          <% merge_notification_issue_ids = local_assigns.fetch(:merge_notification_issue_ids, []) %>
           <% issues.each do |issue| %>
-            <%= render "projects/issue",
-                      issue: issue,
-                      project: project,
-                      lifecycle_status: statuses[issue.id],
-                      paid_pr: paid_prs_by_issue_id[issue.id],
-                      merge_notification_issue_ids: merge_notification_issue_ids %>
+            <% issue_locals = {
+              issue: issue,
+              project: project,
+              lifecycle_status: statuses[issue.id],
+              paid_pr: paid_prs_by_issue_id[issue.id]
+            } %>
+            <% if local_assigns.key?(:merge_notification_issue_ids) %>
+              <% issue_locals[:merge_notification_issue_ids] = local_assigns[:merge_notification_issue_ids] %>
+            <% end %>
+            <%= render "projects/issue", **issue_locals %>
           <% end %>
         </ul>
       </div>

--- a/app/views/projects/_issues.html.erb
+++ b/app/views/projects/_issues.html.erb
@@ -17,6 +17,8 @@
             } %>
             <% if local_assigns.key?(:merge_notification_issue_ids) %>
               <% issue_locals[:merge_notification_issue_ids] = local_assigns[:merge_notification_issue_ids] %>
+            <% elsif local_assigns.fetch(:broadcast, false) %>
+              <% issue_locals[:broadcast] = true %>
             <% end %>
             <%= render "projects/issue", **issue_locals %>
           <% end %>

--- a/app/views/projects/_pull_request.html.erb
+++ b/app/views/projects/_pull_request.html.erb
@@ -25,6 +25,8 @@
     <% subscription_locals = { issue: pull_request, project: project } %>
     <% if local_assigns.key?(:merge_notification_issue_ids) %>
       <% subscription_locals[:subscribed] = local_assigns[:merge_notification_issue_ids].include?(pull_request.id) %>
+    <% elsif local_assigns.fetch(:broadcast, false) %>
+      <% subscription_locals[:broadcast] = true %>
     <% end %>
     <%= render "projects/issue_merge_subscription", **subscription_locals %>
     <% if automation_enabled %>

--- a/app/views/projects/_pull_request.html.erb
+++ b/app/views/projects/_pull_request.html.erb
@@ -22,6 +22,10 @@
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= paid_state_badge(pull_request.paid_state) %>
+    <%= render "projects/issue_merge_subscription",
+               issue: pull_request,
+               project: project,
+               subscribed: local_assigns.fetch(:merge_notification_issue_ids, []).include?(pull_request.id) %>
     <% if automation_enabled %>
       <%= button_to toggle_auto_continue_pause_project_agent_runs_path(project, pull_request_id: pull_request.id),
                     method: :post,

--- a/app/views/projects/_pull_request.html.erb
+++ b/app/views/projects/_pull_request.html.erb
@@ -22,10 +22,11 @@
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
     <%= paid_state_badge(pull_request.paid_state) %>
-    <%= render "projects/issue_merge_subscription",
-               issue: pull_request,
-               project: project,
-               subscribed: local_assigns.fetch(:merge_notification_issue_ids, []).include?(pull_request.id) %>
+    <% subscription_locals = { issue: pull_request, project: project } %>
+    <% if local_assigns.key?(:merge_notification_issue_ids) %>
+      <% subscription_locals[:subscribed] = local_assigns[:merge_notification_issue_ids].include?(pull_request.id) %>
+    <% end %>
+    <%= render "projects/issue_merge_subscription", **subscription_locals %>
     <% if automation_enabled %>
       <%= button_to toggle_auto_continue_pause_project_agent_runs_path(project, pull_request_id: pull_request.id),
                     method: :post,

--- a/app/views/projects/_pull_request.html.erb
+++ b/app/views/projects/_pull_request.html.erb
@@ -25,8 +25,6 @@
     <% subscription_locals = { issue: pull_request, project: project } %>
     <% if local_assigns.key?(:merge_notification_issue_ids) %>
       <% subscription_locals[:subscribed] = local_assigns[:merge_notification_issue_ids].include?(pull_request.id) %>
-    <% elsif local_assigns.fetch(:broadcast, false) %>
-      <% subscription_locals[:broadcast] = true %>
     <% end %>
     <%= render "projects/issue_merge_subscription", **subscription_locals %>
     <% if automation_enabled %>

--- a/app/views/projects/_pull_requests.html.erb
+++ b/app/views/projects/_pull_requests.html.erb
@@ -15,8 +15,6 @@
             } %>
             <% if local_assigns.key?(:merge_notification_issue_ids) %>
               <% pull_request_locals[:merge_notification_issue_ids] = local_assigns[:merge_notification_issue_ids] %>
-            <% elsif local_assigns.fetch(:broadcast, false) %>
-              <% pull_request_locals[:broadcast] = true %>
             <% end %>
             <%= render "projects/pull_request", **pull_request_locals %>
           <% end %>

--- a/app/views/projects/_pull_requests.html.erb
+++ b/app/views/projects/_pull_requests.html.erb
@@ -6,8 +6,10 @@
     <div class="mt-4 overflow-hidden bg-white shadow sm:rounded-lg">
       <div class="max-h-96 overflow-y-auto">
         <ul role="list" class="divide-y divide-gray-200">
+          <% merge_notification_issue_ids = local_assigns.fetch(:merge_notification_issue_ids, []) %>
           <% pull_requests.each do |pr| %>
             <%= render "projects/pull_request", pull_request: pr, project: project,
+                     merge_notification_issue_ids: merge_notification_issue_ids,
                      pr_numbers_with_queued_auto_continue: pr_numbers_with_queued_auto_continue,
                      pr_numbers_with_active_runs: pr_numbers_with_active_runs %>
           <% end %>

--- a/app/views/projects/_pull_requests.html.erb
+++ b/app/views/projects/_pull_requests.html.erb
@@ -6,12 +6,17 @@
     <div class="mt-4 overflow-hidden bg-white shadow sm:rounded-lg">
       <div class="max-h-96 overflow-y-auto">
         <ul role="list" class="divide-y divide-gray-200">
-          <% merge_notification_issue_ids = local_assigns.fetch(:merge_notification_issue_ids, []) %>
           <% pull_requests.each do |pr| %>
-            <%= render "projects/pull_request", pull_request: pr, project: project,
-                     merge_notification_issue_ids: merge_notification_issue_ids,
-                     pr_numbers_with_queued_auto_continue: pr_numbers_with_queued_auto_continue,
-                     pr_numbers_with_active_runs: pr_numbers_with_active_runs %>
+            <% pull_request_locals = {
+              pull_request: pr,
+              project: project,
+              pr_numbers_with_queued_auto_continue: pr_numbers_with_queued_auto_continue,
+              pr_numbers_with_active_runs: pr_numbers_with_active_runs
+            } %>
+            <% if local_assigns.key?(:merge_notification_issue_ids) %>
+              <% pull_request_locals[:merge_notification_issue_ids] = local_assigns[:merge_notification_issue_ids] %>
+            <% end %>
+            <%= render "projects/pull_request", **pull_request_locals %>
           <% end %>
         </ul>
       </div>

--- a/app/views/projects/_pull_requests.html.erb
+++ b/app/views/projects/_pull_requests.html.erb
@@ -15,6 +15,8 @@
             } %>
             <% if local_assigns.key?(:merge_notification_issue_ids) %>
               <% pull_request_locals[:merge_notification_issue_ids] = local_assigns[:merge_notification_issue_ids] %>
+            <% elsif local_assigns.fetch(:broadcast, false) %>
+              <% pull_request_locals[:broadcast] = true %>
             <% end %>
             <%= render "projects/pull_request", **pull_request_locals %>
           <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -193,9 +193,11 @@
 
     <%= render "projects/issues", project: @project, issues: @issues,
                issue_lifecycle_statuses: @issue_lifecycle_statuses,
-               paid_prs_by_issue_id: @paid_prs_by_issue_id %>
+               paid_prs_by_issue_id: @paid_prs_by_issue_id,
+               merge_notification_issue_ids: @merge_notification_issue_ids %>
 
     <%= render "projects/pull_requests", project: @project, pull_requests: @pull_requests,
+               merge_notification_issue_ids: @merge_notification_issue_ids,
                pr_numbers_with_queued_auto_continue: @pr_numbers_with_queued_auto_continue,
                pr_numbers_with_active_runs: @pr_numbers_with_active_runs %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,10 @@ Rails.application.routes.draw do
     resources :pr_templates, only: [ :index, :show, :create, :update, :destroy ],
       controller: "projects/pr_templates"
     resources :project_service_containers, only: [ :create, :destroy ], controller: "projects/service_containers"
+    resources :issues, only: [] do
+      resource :merge_subscription, only: [ :create, :destroy ],
+        controller: "projects/issue_merge_subscriptions"
+    end
     post :detect_services, on: :member
     resource :context_intake, only: [ :show, :create, :update ],
       controller: "knowledge/context_intake" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,7 +152,7 @@ Rails.application.routes.draw do
       controller: "projects/pr_templates"
     resources :project_service_containers, only: [ :create, :destroy ], controller: "projects/service_containers"
     resources :issues, only: [] do
-      resource :merge_subscription, only: [ :create, :destroy ],
+      resource :merge_subscription, only: [ :show, :create, :destroy ],
         controller: "projects/issue_merge_subscriptions"
     end
     post :detect_services, on: :member

--- a/db/migrate/20260502231624_create_issue_merge_subscriptions.rb
+++ b/db/migrate/20260502231624_create_issue_merge_subscriptions.rb
@@ -1,0 +1,18 @@
+class CreateIssueMergeSubscriptions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :issue_merge_subscriptions,
+      comment: "One-shot per-user subscriptions for issue completion or pull request merge notifications." do |t|
+      t.references :issue, null: false, foreign_key: true,
+        comment: "The synced issue row. Pull requests also use the issues table."
+      t.references :user, null: false, foreign_key: true,
+        comment: "The user who should receive the notification."
+      t.string :subscription_type, null: false, default: "on_merge",
+        comment: "Notification trigger type. on_merge covers PR merges and issue completion."
+
+      t.timestamps
+    end
+
+    add_index :issue_merge_subscriptions, [ :issue_id, :user_id, :subscription_type ],
+      unique: true, name: "index_issue_merge_subscriptions_on_dedup"
+  end
+end

--- a/db/migrate/20260503093418_enable_rls_on_issue_merge_subscriptions.rb
+++ b/db/migrate/20260503093418_enable_rls_on_issue_merge_subscriptions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class EnableRlsOnIssueMergeSubscriptions < ActiveRecord::Migration[8.1]
+  def up
+    execute "ALTER TABLE issue_merge_subscriptions ENABLE ROW LEVEL SECURITY"
+    execute "ALTER TABLE issue_merge_subscriptions FORCE ROW LEVEL SECURITY"
+    execute <<~SQL
+      CREATE POLICY tenant_isolation ON issue_merge_subscriptions
+      AS PERMISSIVE
+      FOR ALL
+      USING (
+        paid_tenant_bypass() OR (
+          EXISTS (
+            SELECT 1 FROM issues
+            INNER JOIN projects ON projects.id = issues.project_id
+            WHERE issues.id = issue_merge_subscriptions.issue_id
+              AND projects.account_id = paid_current_account_id()
+          )
+          AND EXISTS (
+            SELECT 1 FROM users
+            WHERE users.id = issue_merge_subscriptions.user_id
+              AND users.account_id = paid_current_account_id()
+          )
+        )
+      )
+      WITH CHECK (
+        paid_tenant_bypass() OR (
+          EXISTS (
+            SELECT 1 FROM issues
+            INNER JOIN projects ON projects.id = issues.project_id
+            WHERE issues.id = issue_merge_subscriptions.issue_id
+              AND projects.account_id = paid_current_account_id()
+          )
+          AND EXISTS (
+            SELECT 1 FROM users
+            WHERE users.id = issue_merge_subscriptions.user_id
+              AND users.account_id = paid_current_account_id()
+          )
+        )
+      )
+    SQL
+  end
+
+  def down
+    execute "DROP POLICY IF EXISTS tenant_isolation ON issue_merge_subscriptions"
+    execute "ALTER TABLE issue_merge_subscriptions NO FORCE ROW LEVEL SECURITY"
+    execute "ALTER TABLE issue_merge_subscriptions DISABLE ROW LEVEL SECURITY"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2035,6 +2035,67 @@ ALTER SEQUENCE public.issue_dependencies_id_seq OWNED BY public.issue_dependenci
 
 
 --
+-- Name: issue_merge_subscriptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.issue_merge_subscriptions (
+    id bigint NOT NULL,
+    issue_id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    subscription_type character varying DEFAULT 'on_merge'::character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE issue_merge_subscriptions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.issue_merge_subscriptions IS 'One-shot per-user subscriptions for issue completion or pull request merge notifications.';
+
+
+--
+-- Name: COLUMN issue_merge_subscriptions.issue_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.issue_merge_subscriptions.issue_id IS 'The synced issue row. Pull requests also use the issues table.';
+
+
+--
+-- Name: COLUMN issue_merge_subscriptions.user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.issue_merge_subscriptions.user_id IS 'The user who should receive the notification.';
+
+
+--
+-- Name: COLUMN issue_merge_subscriptions.subscription_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.issue_merge_subscriptions.subscription_type IS 'Notification trigger type. on_merge covers PR merges and issue completion.';
+
+
+--
+-- Name: issue_merge_subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.issue_merge_subscriptions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: issue_merge_subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.issue_merge_subscriptions_id_seq OWNED BY public.issue_merge_subscriptions.id;
+
+
+--
 -- Name: issues; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4666,6 +4727,13 @@ ALTER TABLE ONLY public.issue_dependencies ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
+-- Name: issue_merge_subscriptions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.issue_merge_subscriptions ALTER COLUMN id SET DEFAULT nextval('public.issue_merge_subscriptions_id_seq'::regclass);
+
+
+--
 -- Name: issues id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5299,6 +5367,14 @@ ALTER TABLE ONLY public.integration_credentials
 
 ALTER TABLE ONLY public.issue_dependencies
     ADD CONSTRAINT issue_dependencies_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: issue_merge_subscriptions issue_merge_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.issue_merge_subscriptions
+    ADD CONSTRAINT issue_merge_subscriptions_pkey PRIMARY KEY (id);
 
 
 --
@@ -7091,6 +7167,27 @@ CREATE INDEX index_issue_dependencies_on_issue_id ON public.issue_dependencies U
 
 
 --
+-- Name: index_issue_merge_subscriptions_on_dedup; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_issue_merge_subscriptions_on_dedup ON public.issue_merge_subscriptions USING btree (issue_id, user_id, subscription_type);
+
+
+--
+-- Name: index_issue_merge_subscriptions_on_issue_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_issue_merge_subscriptions_on_issue_id ON public.issue_merge_subscriptions USING btree (issue_id);
+
+
+--
+-- Name: index_issue_merge_subscriptions_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_issue_merge_subscriptions_on_user_id ON public.issue_merge_subscriptions USING btree (user_id);
+
+
+--
 -- Name: index_issues_on_github_creator_login; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8405,6 +8502,14 @@ ALTER TABLE ONLY public.tracker_configurations
 
 
 --
+-- Name: issue_merge_subscriptions fk_rails_0655eb72fb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.issue_merge_subscriptions
+    ADD CONSTRAINT fk_rails_0655eb72fb FOREIGN KEY (issue_id) REFERENCES public.issues(id);
+
+
+--
 -- Name: agent_runs fk_rails_0779afb693; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9186,6 +9291,14 @@ ALTER TABLE ONLY public.billing_invoices
 
 ALTER TABLE ONLY public.notification_rule_states
     ADD CONSTRAINT fk_rails_c198fcfeea FOREIGN KEY (account_id) REFERENCES public.accounts(id);
+
+
+--
+-- Name: issue_merge_subscriptions fk_rails_c19cf2967e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.issue_merge_subscriptions
+    ADD CONSTRAINT fk_rails_c19cf2967e FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -11019,6 +11132,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260502231624'),
 ('20260502201828'),
 ('20260502200141'),
 ('20260502014212'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2047,6 +2047,8 @@ CREATE TABLE public.issue_merge_subscriptions (
     updated_at timestamp(6) without time zone NOT NULL
 );
 
+ALTER TABLE ONLY public.issue_merge_subscriptions FORCE ROW LEVEL SECURITY;
+
 
 --
 -- Name: TABLE issue_merge_subscriptions; Type: COMMENT; Schema: public; Owner: -
@@ -9788,6 +9790,12 @@ ALTER TABLE public.integration_credentials ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.issue_dependencies ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: issue_merge_subscriptions; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.issue_merge_subscriptions ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: issues; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -10325,6 +10333,23 @@ CREATE POLICY tenant_isolation ON public.issue_dependencies USING ((public.paid_
    FROM (public.issues depends_on_issues
      JOIN public.projects ON ((projects.id = depends_on_issues.project_id)))
   WHERE ((depends_on_issues.id = issue_dependencies.depends_on_issue_id) AND (projects.account_id = public.paid_current_account_id()))))))));
+
+
+--
+-- Name: issue_merge_subscriptions tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.issue_merge_subscriptions USING ((public.paid_tenant_bypass() OR ((EXISTS ( SELECT 1
+   FROM (public.issues
+     JOIN public.projects ON ((projects.id = issues.project_id)))
+  WHERE ((issues.id = issue_merge_subscriptions.issue_id) AND (projects.account_id = public.paid_current_account_id())))) AND (EXISTS ( SELECT 1
+   FROM public.users
+  WHERE ((users.id = issue_merge_subscriptions.user_id) AND (users.account_id = public.paid_current_account_id()))))))) WITH CHECK ((public.paid_tenant_bypass() OR ((EXISTS ( SELECT 1
+   FROM (public.issues
+     JOIN public.projects ON ((projects.id = issues.project_id)))
+  WHERE ((issues.id = issue_merge_subscriptions.issue_id) AND (projects.account_id = public.paid_current_account_id())))) AND (EXISTS ( SELECT 1
+   FROM public.users
+  WHERE ((users.id = issue_merge_subscriptions.user_id) AND (users.account_id = public.paid_current_account_id())))))));
 
 
 --
@@ -11132,6 +11157,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260503093418'),
 ('20260502231624'),
 ('20260502201828'),
 ('20260502200141'),

--- a/spec/factories/issue_merge_subscriptions.rb
+++ b/spec/factories/issue_merge_subscriptions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :issue_merge_subscription do
+    issue
+    user { issue.project.account.users.first || association(:user, account: issue.project.account) }
+    subscription_type { IssueMergeSubscription::ON_MERGE }
+  end
+end

--- a/spec/migrations/add_account_to_service_containers_spec.rb
+++ b/spec/migrations/add_account_to_service_containers_spec.rb
@@ -8,6 +8,7 @@ require Rails.root.join("db/migrate/20260425060000_enable_rls_on_notification_ru
 require Rails.root.join("db/migrate/20260426011810_enable_rls_on_llm_output_metrics")
 require Rails.root.join("db/migrate/20260426231639_enable_rls_on_chat_tables")
 require Rails.root.join("db/migrate/20260427225726_enable_rls_on_knowledge_recommendations")
+require Rails.root.join("db/migrate/20260503093418_enable_rls_on_issue_merge_subscriptions")
 
 RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
   self.use_transactional_tests = false
@@ -19,6 +20,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
   let(:llm_output_metrics_rls_migration) { EnableRlsOnLlmOutputMetrics.new }
   let(:chat_rls_migration) { EnableRlsOnChatTables.new }
   let(:knowledge_recommendations_rls_migration) { EnableRlsOnKnowledgeRecommendations.new }
+  let(:issue_merge_subscriptions_rls_migration) { EnableRlsOnIssueMergeSubscriptions.new }
 
   include MigrationSpecHelpers
 
@@ -26,6 +28,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     truncate_migration_test_data
 
     if tenant_policy_count.positive?
+      issue_merge_subscriptions_rls_migration.down if issue_merge_subscriptions_have_rls?
       knowledge_recommendations_rls_migration.down if knowledge_recommendations_has_rls?
       chat_rls_migration.down if chat_tables_have_rls?
       llm_output_metrics_rls_migration.down if llm_output_metrics_has_rls?
@@ -51,6 +54,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
       llm_output_metrics_rls_migration.up unless llm_output_metrics_has_rls?
       chat_rls_migration.up unless chat_tables_have_rls?
       knowledge_recommendations_rls_migration.up unless knowledge_recommendations_has_rls?
+      issue_merge_subscriptions_rls_migration.up unless issue_merge_subscriptions_have_rls?
     end
     ServiceContainer.reset_column_information
   end
@@ -228,6 +232,12 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
   def llm_output_metrics_has_rls?
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'llm_output_metrics' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
+  end
+
+  def issue_merge_subscriptions_have_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'issue_merge_subscriptions' AND policyname = 'tenant_isolation'"
     ).to_i.positive?
   end
 

--- a/spec/models/issue_merge_subscription_spec.rb
+++ b/spec/models/issue_merge_subscription_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IssueMergeSubscription, type: :model do
+  it "defaults the subscription type to on_merge" do
+    subscription = build(:issue_merge_subscription, subscription_type: nil)
+
+    subscription.validate
+
+    expect(subscription.subscription_type).to eq("on_merge")
+  end
+
+  it "requires the user and issue to belong to the same account" do
+    issue = create(:issue)
+    other_user = create(:user)
+    subscription = build(:issue_merge_subscription, issue: issue, user: other_user)
+
+    expect(subscription).not_to be_valid
+    expect(subscription.errors[:user]).to include("must belong to the same account as the issue")
+  end
+end

--- a/spec/requests/api/github_webhooks_spec.rb
+++ b/spec/requests/api/github_webhooks_spec.rb
@@ -203,6 +203,11 @@ RSpec.describe "Api::GithubWebhooks" do
     end
 
     context "with pull_request event (merge)" do
+      let!(:subscribed_pull_request) do
+        create(:issue, :pull_request, project: project, github_number: agent_run.pull_request_number, title: "Fix login timeout")
+      end
+      let!(:subscriber) { create(:user, account: project.account) }
+
       let(:payload) do
         {
           action: "closed",
@@ -215,6 +220,10 @@ RSpec.describe "Api::GithubWebhooks" do
             full_name: project.full_name
           }
         }
+      end
+
+      before do
+        create(:issue_merge_subscription, issue: subscribed_pull_request, user: subscriber)
       end
 
       it "records pr_merged feedback when PR is merged" do
@@ -236,6 +245,29 @@ RSpec.describe "Api::GithubWebhooks" do
 
         metric = agent_run.quality_metrics.human.last
         expect(metric.scores["pr_merged"]).to eq(1.0)
+      end
+
+      it "creates a notification for subscribed users" do
+        body, signature = sign_payload(payload, project.webhook_secret)
+
+        expect {
+          post webhook_url,
+            params: body,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-GitHub-Event" => "pull_request",
+              "X-Hub-Signature-256" => signature
+            }
+        }.to change(Notification, :count).by(1)
+
+        notification = Notification.last
+        expect(notification).to have_attributes(
+          account: project.account,
+          user: subscriber,
+          source: "issue_merge_subscription",
+          subject: subscribed_pull_request,
+          title: "PR ##{agent_run.pull_request_number} was merged: Fix login timeout"
+        )
       end
 
       it "ignores closed-but-not-merged PRs" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -256,6 +256,24 @@ RSpec.describe "Projects" do
 
       expect(response).to have_http_status(:not_found)
     end
+
+    it "does not allow subscriptions for synthetic non-GitHub issues" do
+      synthetic_issue = create(
+        :issue,
+        project: project,
+        source: Issue::SYNTHETIC_CODE_SCANNING_SOURCE,
+        github_number: 99,
+        title: "Code scanning alert",
+        github_state: "open"
+      )
+
+      expect {
+        post project_issue_merge_subscription_path(project, synthetic_issue)
+      }.not_to change(IssueMergeSubscription, :count)
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+    end
   end
 
   describe "GET /projects/new" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -195,6 +195,60 @@ RSpec.describe "Projects" do
     end
   end
 
+  describe "merge notification subscriptions" do
+    let(:project) { create(:project, account: account, github_token: github_token) }
+    let(:issue) { create(:issue, project: project, github_number: 14, title: "Fix flaky spec") }
+    let(:pull_request) { create(:issue, :pull_request, project: project, github_number: 28, title: "Improve CI") }
+
+    before { sign_in user }
+
+    it "shows subscribe controls for issues and pull requests" do
+      issue
+      pull_request
+
+      get project_path(project)
+
+      expect(response.body).to include("Notify on completion")
+      expect(response.body).to include("Notify on merge")
+    end
+
+    it "creates a subscription and redirects back to the project anchor" do
+      post project_issue_merge_subscription_path(project, issue)
+
+      expect(response).to redirect_to(project_path(project, anchor: ActionView::RecordIdentifier.dom_id(issue)))
+      expect(user.issue_merge_subscriptions.on_merge.find_by(issue: issue)).to be_present
+    end
+
+    it "shows the unsubscribe control for subscribed issues" do
+      create(:issue_merge_subscription, issue: issue, user: user)
+
+      get project_path(project)
+
+      expect(response.body).to include("Stop completion alerts")
+    end
+
+    it "removes a subscription" do
+      create(:issue_merge_subscription, issue: issue, user: user)
+
+      delete project_issue_merge_subscription_path(project, issue)
+
+      expect(response).to redirect_to(project_path(project, anchor: ActionView::RecordIdentifier.dom_id(issue)))
+      expect(user.issue_merge_subscriptions.on_merge.find_by(issue: issue)).to be_nil
+    end
+
+    it "does not allow users from another account to subscribe" do
+      other_user = create(:user)
+      sign_out user
+      sign_in other_user
+
+      expect {
+        post project_issue_merge_subscription_path(project, issue)
+      }.not_to change(IssueMergeSubscription, :count)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "GET /projects/new" do
     context "when not authenticated" do
       it "redirects to the sign in page" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -227,6 +227,15 @@ RSpec.describe "Projects" do
       expect(response.body).to include("Stop completion alerts")
     end
 
+    it "renders the current subscription state for turbo-frame refreshes" do
+      create(:issue_merge_subscription, issue: issue, user: user)
+
+      get project_issue_merge_subscription_path(project, issue)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Stop completion alerts")
+    end
+
     it "removes a subscription" do
       create(:issue_merge_subscription, issue: issue, user: user)
 

--- a/spec/security/tenant_context_spec.rb
+++ b/spec/security/tenant_context_spec.rb
@@ -7,6 +7,7 @@ require Rails.root.join("db/migrate/20260425060000_enable_rls_on_notification_ru
 require Rails.root.join("db/migrate/20260426011810_enable_rls_on_llm_output_metrics")
 require Rails.root.join("db/migrate/20260426231639_enable_rls_on_chat_tables")
 require Rails.root.join("db/migrate/20260427225726_enable_rls_on_knowledge_recommendations")
+require Rails.root.join("db/migrate/20260503093418_enable_rls_on_issue_merge_subscriptions")
 
 RSpec.describe TenantContext, :tenant_isolation do
   around do |example|
@@ -42,6 +43,25 @@ RSpec.describe TenantContext, :tenant_isolation do
     as_restricted_role do
       described_class.with(account_a) do
         expect(AgentRun.all).to contain_exactly(run_a)
+      end
+    end
+  end
+
+  it "filters issue merge subscriptions and rejects cross-tenant users at the database policy" do
+    subscription_a = described_class.with_system_access do
+      issue = create(:issue, project: create(:project, account: account_a))
+      create(:issue_merge_subscription, issue:)
+    end
+    issue_a = subscription_a.issue
+    user_b = described_class.with_system_access { create(:user, account: account_b) }
+    described_class.with_system_access do
+      create(:issue_merge_subscription, issue: create(:issue, project: create(:project, account: account_b)))
+    end
+
+    as_restricted_role do
+      described_class.with(account_a) do
+        expect(IssueMergeSubscription.all).to contain_exactly(subscription_a)
+        expect_rls_rejection { insert_issue_merge_subscription(issue_a, user_b) }
       end
     end
   end
@@ -153,6 +173,7 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnLlmOutputMetrics.new.down if llm_output_metrics_has_rls?
       EnableRlsOnKnowledgeUsageStats.new.down if knowledge_usage_stats_has_rls?
       EnableRlsOnNotificationRuleStates.new.down
+      EnableRlsOnIssueMergeSubscriptions.new.down if issue_merge_subscriptions_has_rls?
       EnableTenantRowLevelSecurity.new.down
       EnableTenantRowLevelSecurity.new.up
       EnableRlsOnNotificationRuleStates.new.up
@@ -160,6 +181,7 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnLlmOutputMetrics.new.up unless llm_output_metrics_has_rls?
       EnableRlsOnChatTables.new.up unless chat_tables_have_rls?
       EnableRlsOnKnowledgeRecommendations.new.up unless knowledge_recommendations_has_rls?
+      EnableRlsOnIssueMergeSubscriptions.new.up unless issue_merge_subscriptions_has_rls?
     end
     ActiveRecord::Base.connection.execute("RESET ROLE")
     cleanup_restricted_role
@@ -178,6 +200,7 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnLlmOutputMetrics.new.down if llm_output_metrics_has_rls?
       EnableRlsOnKnowledgeUsageStats.new.down if knowledge_usage_stats_has_rls?
       EnableRlsOnNotificationRuleStates.new.down
+      EnableRlsOnIssueMergeSubscriptions.new.down if issue_merge_subscriptions_has_rls?
       EnableTenantRowLevelSecurity.new.down
     end
   end
@@ -203,6 +226,12 @@ RSpec.describe TenantContext, :tenant_isolation do
   def llm_output_metrics_has_rls?
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'llm_output_metrics' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
+  end
+
+  def issue_merge_subscriptions_has_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'issue_merge_subscriptions' AND policyname = 'tenant_isolation'"
     ).to_i.positive?
   end
 
@@ -249,6 +278,13 @@ RSpec.describe TenantContext, :tenant_isolation do
     ActiveRecord::Base.connection.execute(<<~SQL.squish)
       INSERT INTO project_service_containers (project_id, service_container_id, created_at, updated_at)
       VALUES (#{project.id}, #{service_container.id}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    SQL
+  end
+
+  def insert_issue_merge_subscription(issue, user)
+    ActiveRecord::Base.connection.execute(<<~SQL.squish)
+      INSERT INTO issue_merge_subscriptions (issue_id, user_id, subscription_type, created_at, updated_at)
+      VALUES (#{issue.id}, #{user.id}, 'on_merge', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
     SQL
   end
 

--- a/spec/services/issue_merge_subscriptions/deliver_spec.rb
+++ b/spec/services/issue_merge_subscriptions/deliver_spec.rb
@@ -8,10 +8,7 @@ RSpec.describe IssueMergeSubscriptions::Deliver do
     let(:issue) { create(:issue, project: project, github_number: 42, title: "Fix login timeout") }
     let(:user) { create(:user, account: project.account) }
     let(:expected_action_url) do
-      Rails.application.routes.url_helpers.project_path(
-        project,
-        anchor: ActionView::RecordIdentifier.dom_id(issue)
-      )
+      issue.github_url
     end
     let(:expected_metadata) do
       {
@@ -60,6 +57,7 @@ RSpec.describe IssueMergeSubscriptions::Deliver do
       described_class.call(issue: pull_request, event: :merged)
 
       expect(Notification.last.title).to eq("PR #77 was merged: Improve CI")
+      expect(Notification.last.action_url).to eq(pull_request.github_url)
     end
   end
 end

--- a/spec/services/issue_merge_subscriptions/deliver_spec.rb
+++ b/spec/services/issue_merge_subscriptions/deliver_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IssueMergeSubscriptions::Deliver do
+  describe ".call" do
+    let(:project) { create(:project) }
+    let(:issue) { create(:issue, project: project, github_number: 42, title: "Fix login timeout") }
+    let(:user) { create(:user, account: project.account) }
+    let(:expected_action_url) do
+      Rails.application.routes.url_helpers.project_path(
+        project,
+        anchor: ActionView::RecordIdentifier.dom_id(issue)
+      )
+    end
+    let(:expected_metadata) do
+      {
+        "event" => "completed",
+        "github_number" => 42,
+        "issue_id" => issue.id,
+        "project_id" => project.id
+      }
+    end
+
+    it "creates a user-scoped notification and deletes the subscription" do
+      create(:issue_merge_subscription, issue: issue, user: user)
+
+      expect {
+        described_class.call(issue: issue, event: :completed)
+      }.to change(Notification, :count).by(1)
+        .and change(IssueMergeSubscription, :count).by(-1)
+
+      notification = Notification.last
+      expect(notification).to have_attributes(
+        account: project.account,
+        user: user,
+        source: "issue_merge_subscription",
+        subject: issue,
+        title: "Issue #42 was completed: Fix login timeout",
+        action_url: expected_action_url,
+        nav_section: "projects"
+      )
+      expect(notification.metadata).to include(expected_metadata)
+    end
+
+    it "is idempotent after subscriptions are consumed" do
+      create(:issue_merge_subscription, issue: issue, user: user)
+
+      described_class.call(issue: issue, event: :completed)
+
+      expect {
+        described_class.call(issue: issue, event: :completed)
+      }.not_to change(Notification, :count)
+    end
+
+    it "formats pull request merge notifications correctly" do
+      pull_request = create(:issue, :pull_request, project: project, github_number: 77, title: "Improve CI")
+      create(:issue_merge_subscription, issue: pull_request, user: user)
+
+      described_class.call(issue: pull_request, event: :merged)
+
+      expect(Notification.last.title).to eq("PR #77 was merged: Improve CI")
+    end
+  end
+end

--- a/spec/services/issues/upsert_from_github_spec.rb
+++ b/spec/services/issues/upsert_from_github_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Issues::UpsertFromGithub do
         state: "open",
         labels: [ OpenStruct.new(name: "paid-generated"), "P1" ],
         pull_request: OpenStruct.new(html_url: "https://github.com/test/repo/pull/42"),
+        state_reason: nil,
         user: OpenStruct.new(login: "viamin"),
         created_at: Time.zone.parse("2026-04-14 00:00:00 UTC"),
         updated_at: Time.zone.parse("2026-04-14 00:01:00 UTC")
@@ -79,6 +80,7 @@ RSpec.describe Issues::UpsertFromGithub do
 
       github_issue.state = "closed"
       github_issue.pull_request = nil
+      github_issue.state_reason = "completed"
 
       expect {
         described_class.call(project: project, github_issue: github_issue)
@@ -87,12 +89,29 @@ RSpec.describe Issues::UpsertFromGithub do
       expect(Notification.last.title).to eq("Issue #42 was completed: Sync me")
     end
 
-    it "does not deliver close notifications for pull requests from issue sync" do
+    it "delivers merge notifications for pull requests closed as completed from issue sync" do
       user = create(:user, account: project.account)
       issue = create(:issue, :pull_request, project: project, github_issue_id: 1234, github_number: 42, github_state: "open")
       create(:issue_merge_subscription, issue: issue, user: user)
 
       github_issue.state = "closed"
+      github_issue.state_reason = "completed"
+
+      expect {
+        described_class.call(project: project, github_issue: github_issue)
+      }.to change(Notification, :count).by(1)
+
+      expect(Notification.last.title).to eq("PR #42 was merged: Sync me")
+    end
+
+    it "does not deliver completion notifications for issues closed as not planned" do
+      user = create(:user, account: project.account)
+      issue = create(:issue, project: project, github_issue_id: 1234, github_number: 42, github_state: "open")
+      create(:issue_merge_subscription, issue: issue, user: user)
+
+      github_issue.state = "closed"
+      github_issue.pull_request = nil
+      github_issue.state_reason = "not_planned"
 
       expect {
         described_class.call(project: project, github_issue: github_issue)

--- a/spec/services/issues/upsert_from_github_spec.rb
+++ b/spec/services/issues/upsert_from_github_spec.rb
@@ -71,5 +71,32 @@ RSpec.describe Issues::UpsertFromGithub do
 
       expect(issue.is_pull_request).to be(false)
     end
+
+    it "delivers completion notifications when an open issue closes" do
+      user = create(:user, account: project.account)
+      issue = create(:issue, project: project, github_issue_id: 1234, github_number: 42, github_state: "open")
+      create(:issue_merge_subscription, issue: issue, user: user)
+
+      github_issue.state = "closed"
+      github_issue.pull_request = nil
+
+      expect {
+        described_class.call(project: project, github_issue: github_issue)
+      }.to change(Notification, :count).by(1)
+
+      expect(Notification.last.title).to eq("Issue #42 was completed: Sync me")
+    end
+
+    it "does not deliver close notifications for pull requests from issue sync" do
+      user = create(:user, account: project.account)
+      issue = create(:issue, :pull_request, project: project, github_issue_id: 1234, github_number: 42, github_state: "open")
+      create(:issue_merge_subscription, issue: issue, user: user)
+
+      github_issue.state = "closed"
+
+      expect {
+        described_class.call(project: project, github_issue: github_issue)
+      }.not_to change(Notification, :count)
+    end
   end
 end

--- a/spec/temporal/activities/merge_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/merge_pull_request_activity_spec.rb
@@ -92,6 +92,13 @@ RSpec.describe Activities::MergePullRequestActivity do
 
         expect(result[:merged]).to be true
       end
+
+      it "delivers merge subscription notifications" do
+        expect(IssueMergeSubscriptions::Deliver).to receive(:call)
+          .with(issue: issue, event: :merged)
+
+        activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
+      end
     end
 
     context "when PR is already merged" do
@@ -136,6 +143,13 @@ RSpec.describe Activities::MergePullRequestActivity do
         activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
 
         expect(provider).not_to have_received(:add_comment)
+      end
+
+      it "delivers merge subscription notifications" do
+        expect(IssueMergeSubscriptions::Deliver).to receive(:call)
+          .with(issue: issue, event: :merged)
+
+        activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
       end
     end
 
@@ -238,6 +252,12 @@ RSpec.describe Activities::MergePullRequestActivity do
         activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
 
         expect(provider).not_to have_received(:add_labels)
+      end
+
+      it "does not deliver merge subscription notifications" do
+        expect(IssueMergeSubscriptions::Deliver).not_to receive(:call)
+
+        activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
       end
     end
 

--- a/spec/views/projects/issue_merge_subscription_partial_spec.rb
+++ b/spec/views/projects/issue_merge_subscription_partial_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "projects/_issue_merge_subscription", type: :view do
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project) }
+
+  it "renders a lazy-loaded frame when no subscription state is provided" do
+    render partial: "projects/issue_merge_subscription", locals: { project: project, issue: issue }
+
+    expect(rendered).to include(%(id="#{dom_id(issue, :merge_subscription)}"))
+    expect(rendered).to include(%(src="#{project_issue_merge_subscription_path(project, issue)}"))
+    expect(rendered).to include("Loading alerts...")
+  end
+end


### PR DESCRIPTION
## Summary

Implemented merge/completion subscriptions for synced issues and PRs, including a new `IssueMergeSubscription` model, subscribe/unsubscribe controls on the project issue/PR lists, delivery into the existing notifications menu, and one-shot notification fanout on issue close and PR merge. Delivery is wired through GitHub PR merge handling plus issue sync close detection, and subscriptions are cleared after firing.

Committed as `28ce016` with message `feat(notifications): add merge subscriptions for issues and prs`.

Verification:
- `bin/rails db:prepare` passed with the repo’s DB host/user envs set for this environment
- `bundle exec rubocop` passed
- `bundle exec rspec` passed: `9762 examples, 0 failures, 2 pending`

Working tree is clean.

---

Closes #1262