### PR TITLE
fix(auto-merge): verify CI via Actions API to prevent unsafe Dependabot merges

### DIFF
--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -11,6 +11,7 @@
 # Concurrency: at most one evaluation per project at a time.
 class AutoReleaseEvaluationJob < ApplicationJob
   include GoodJob::ActiveJobExtensions::Concurrency
+  include CiStatusVerification
 
   queue_as :default
 
@@ -118,81 +119,8 @@ class AutoReleaseEvaluationJob < ApplicationJob
     nil
   end
 
-  def all_checks_green?(client, project, pr_data)
-    sha = pr_data.head.sha
-    checks = client.check_runs_for_ref(project.full_name, sha)
-
-    if checks.nil? || checks.empty?
-      return combined_status_ok?(client, project, sha, strict: false)
-    end
-
-    conclusions_green?(checks)
-  rescue GithubClient::ApiError => e
-    raise unless e.status == 403
-
-    Rails.logger.info(
-      message: "auto_release.check_runs_forbidden",
-      project_id: project.id,
-      error: e.message
-    )
-    workflow_runs_or_status_green?(client, project, sha)
-  rescue GithubClient::Error => e
-    Rails.logger.warn(
-      message: "auto_release.check_runs_failed",
-      project_id: project.id,
-      error: e.message
-    )
-    false
-  end
-
-  # Reached when the Checks API is forbidden (e.g., fine-grained tokens have
-  # no Checks permission). Verifies CI via the Actions API instead. If Actions
-  # is also unavailable or empty, only an explicit "success" combined status
-  # passes — "pending + 0 contexts" is not safe here because we never confirmed
-  # the absence of check runs from non-Actions GitHub Apps.
-  def workflow_runs_or_status_green?(client, project, sha)
-    runs = client.workflow_runs_for_sha(project.full_name, sha)
-    return conclusions_green?(runs) if runs.any?
-
-    combined_status_ok?(client, project, sha, strict: true)
-  rescue GithubClient::ApiError => e
-    raise unless e.status == 403
-
-    Rails.logger.info(
-      message: "auto_release.workflow_runs_forbidden",
-      project_id: project.id,
-      error: e.message
-    )
-    combined_status_ok?(client, project, sha, strict: true)
-  rescue GithubClient::Error => e
-    Rails.logger.warn(
-      message: "auto_release.workflow_runs_failed",
-      project_id: project.id,
-      error: e.message
-    )
-    false
-  end
-
-  def conclusions_green?(items)
-    items.all? { |i| %w[success skipped neutral].include?(i[:conclusion]) }
-  end
-
-  # When +strict+ is false, "pending + 0 contexts" counts as "no CI configured"
-  # and allows the merge — safe only when the caller has positive evidence (an
-  # empty check_runs response) that no check runs exist either. When +strict+
-  # is true (e.g., the Checks API was forbidden), only an explicit "success"
-  # passes, since absence of statuses cannot prove absence of check runs.
-  def combined_status_ok?(client, project, sha, strict:)
-    status = client.combined_status(project.full_name, sha)
-    return true if status[:state] == "success"
-    !strict && status[:state] == "pending" && status[:total_count] == 0
-  rescue GithubClient::Error => e
-    Rails.logger.warn(
-      message: "auto_release.combined_status_failed",
-      project_id: project.id,
-      error: e.message
-    )
-    false
+  def ci_log_component
+    "auto_release"
   end
 
   def merge_release_pr(client, project, result)

--- a/app/jobs/auto_release_evaluation_job.rb
+++ b/app/jobs/auto_release_evaluation_job.rb
@@ -123,21 +123,19 @@ class AutoReleaseEvaluationJob < ApplicationJob
     checks = client.check_runs_for_ref(project.full_name, sha)
 
     if checks.nil? || checks.empty?
-      return combined_status_state_settled?(client, project, sha)
+      return combined_status_ok?(client, project, sha, strict: false)
     end
 
-    checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
+    conclusions_green?(checks)
   rescue GithubClient::ApiError => e
-    if e.status == 403
-      Rails.logger.info(
-        message: "auto_release.check_runs_forbidden",
-        project_id: project.id,
-        error: e.message
-      )
-      return combined_status_state_settled?(client, project, sha)
-    end
+    raise unless e.status == 403
 
-    raise
+    Rails.logger.info(
+      message: "auto_release.check_runs_forbidden",
+      project_id: project.id,
+      error: e.message
+    )
+    workflow_runs_or_status_green?(client, project, sha)
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "auto_release.check_runs_failed",
@@ -147,15 +145,47 @@ class AutoReleaseEvaluationJob < ApplicationJob
     false
   end
 
-  # Returns true when CI has passed or no CI is configured.
-  # GitHub returns "pending" with 0 contexts when no status checks exist,
-  # so we treat that as "no CI" and allow the merge. Any other non-success
-  # state (failure, error, or pending with actual statuses) blocks merging.
-  # This is also the fallback when the token cannot read check runs: we only
-  # proceed after a separate API confirms success or that no statuses exist.
-  def combined_status_state_settled?(client, project, sha)
+  # Reached when the Checks API is forbidden (e.g., fine-grained tokens have
+  # no Checks permission). Verifies CI via the Actions API instead. If Actions
+  # is also unavailable or empty, only an explicit "success" combined status
+  # passes — "pending + 0 contexts" is not safe here because we never confirmed
+  # the absence of check runs from non-Actions GitHub Apps.
+  def workflow_runs_or_status_green?(client, project, sha)
+    runs = client.workflow_runs_for_sha(project.full_name, sha)
+    return conclusions_green?(runs) if runs.any?
+
+    combined_status_ok?(client, project, sha, strict: true)
+  rescue GithubClient::ApiError => e
+    raise unless e.status == 403
+
+    Rails.logger.info(
+      message: "auto_release.workflow_runs_forbidden",
+      project_id: project.id,
+      error: e.message
+    )
+    combined_status_ok?(client, project, sha, strict: true)
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "auto_release.workflow_runs_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
+  end
+
+  def conclusions_green?(items)
+    items.all? { |i| %w[success skipped neutral].include?(i[:conclusion]) }
+  end
+
+  # When +strict+ is false, "pending + 0 contexts" counts as "no CI configured"
+  # and allows the merge — safe only when the caller has positive evidence (an
+  # empty check_runs response) that no check runs exist either. When +strict+
+  # is true (e.g., the Checks API was forbidden), only an explicit "success"
+  # passes, since absence of statuses cannot prove absence of check runs.
+  def combined_status_ok?(client, project, sha, strict:)
     status = client.combined_status(project.full_name, sha)
-    status[:state] == "success" || (status[:state] == "pending" && status[:total_count] == 0)
+    return true if status[:state] == "success"
+    !strict && status[:state] == "pending" && status[:total_count] == 0
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "auto_release.combined_status_failed",

--- a/app/jobs/concerns/ci_status_verification.rb
+++ b/app/jobs/concerns/ci_status_verification.rb
@@ -48,7 +48,7 @@ module CiStatusVerification
   # the absence of check runs from non-Actions GitHub Apps.
   def workflow_runs_or_status_green?(client, project, sha)
     runs = client.workflow_runs_for_sha(project.full_name, sha)
-    return conclusions_green?(runs) if runs.any?
+    return workflow_runs_and_statuses_green?(client, project, sha, runs) if runs.any?
 
     combined_status_ok?(client, project, sha, strict: true)
   rescue GithubClient::ApiError => e
@@ -69,6 +69,15 @@ module CiStatusVerification
     false
   end
 
+  # When Actions runs are available, they prove GitHub Actions is green but do
+  # not cover third-party CI providers that only publish commit-status
+  # contexts. Consult combined_status as an additional gate when possible so a
+  # failing status context still blocks the merge. "pending + 0 contexts" means
+  # no status-based CI was reported, so green workflow runs remain sufficient.
+  def workflow_runs_and_statuses_green?(client, project, sha, runs)
+    conclusions_green?(runs) && combined_status_ok?(client, project, sha, strict: false, allow_forbidden: true)
+  end
+
   def conclusions_green?(items)
     items.all? { |i| %w[success skipped neutral].include?(i[:conclusion]) }
   end
@@ -78,10 +87,26 @@ module CiStatusVerification
   # empty check_runs response) that no check runs exist either. When +strict+
   # is true (e.g., the Checks API was forbidden), only an explicit "success"
   # passes, since absence of statuses cannot prove absence of check runs.
-  def combined_status_ok?(client, project, sha, strict:)
+  def combined_status_ok?(client, project, sha, strict:, allow_forbidden: false)
     status = client.combined_status(project.full_name, sha)
     return true if status[:state] == "success"
     !strict && status[:state] == "pending" && status[:total_count] == 0
+  rescue GithubClient::ApiError => e
+    if allow_forbidden && e.status == 403
+      Rails.logger.info(
+        message: "#{ci_log_component}.combined_status_forbidden",
+        project_id: project.id,
+        error: e.message
+      )
+      return true
+    end
+
+    Rails.logger.warn(
+      message: "#{ci_log_component}.combined_status_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "#{ci_log_component}.combined_status_failed",

--- a/app/jobs/concerns/ci_status_verification.rb
+++ b/app/jobs/concerns/ci_status_verification.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Shared CI-status verification logic for auto-merge jobs.
+#
+# Including classes must define +ci_log_component+ (e.g. "dependabot_auto_merge"
+# or "auto_release") so log messages are attributed to the correct subsystem.
+module CiStatusVerification
+  extend ActiveSupport::Concern
+
+  private
+
+  # Override in the including class to set the log-message prefix.
+  def ci_log_component
+    raise NotImplementedError, "#{self.class} must define #ci_log_component"
+  end
+
+  def all_checks_green?(client, project, pr_data)
+    sha = pr_data.respond_to?(:head) ? pr_data.head.sha : pr_data.dig(:head, :sha)
+    checks = client.check_runs_for_ref(project.full_name, sha)
+
+    if checks.nil? || checks.empty?
+      return combined_status_ok?(client, project, sha, strict: false)
+    end
+
+    conclusions_green?(checks)
+  rescue GithubClient::ApiError => e
+    raise unless e.status == 403
+
+    Rails.logger.info(
+      message: "#{ci_log_component}.check_runs_forbidden",
+      project_id: project.id,
+      error: e.message
+    )
+    workflow_runs_or_status_green?(client, project, sha)
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "#{ci_log_component}.check_runs_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
+  end
+
+  # Reached when the Checks API is forbidden (e.g., fine-grained tokens have
+  # no Checks permission). Verifies CI via the Actions API instead. If Actions
+  # is also unavailable or empty, only an explicit "success" combined status
+  # passes — "pending + 0 contexts" is not safe here because we never confirmed
+  # the absence of check runs from non-Actions GitHub Apps.
+  def workflow_runs_or_status_green?(client, project, sha)
+    runs = client.workflow_runs_for_sha(project.full_name, sha)
+    return conclusions_green?(runs) if runs.any?
+
+    combined_status_ok?(client, project, sha, strict: true)
+  rescue GithubClient::ApiError => e
+    raise unless e.status == 403
+
+    Rails.logger.info(
+      message: "#{ci_log_component}.workflow_runs_forbidden",
+      project_id: project.id,
+      error: e.message
+    )
+    combined_status_ok?(client, project, sha, strict: true)
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "#{ci_log_component}.workflow_runs_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
+  end
+
+  def conclusions_green?(items)
+    items.all? { |i| %w[success skipped neutral].include?(i[:conclusion]) }
+  end
+
+  # When +strict+ is false, "pending + 0 contexts" counts as "no CI configured"
+  # and allows the merge — safe only when the caller has positive evidence (an
+  # empty check_runs response) that no check runs exist either. When +strict+
+  # is true (e.g., the Checks API was forbidden), only an explicit "success"
+  # passes, since absence of statuses cannot prove absence of check runs.
+  def combined_status_ok?(client, project, sha, strict:)
+    status = client.combined_status(project.full_name, sha)
+    return true if status[:state] == "success"
+    !strict && status[:state] == "pending" && status[:total_count] == 0
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "#{ci_log_component}.combined_status_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
+  end
+end

--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -100,21 +100,19 @@ class DependabotAutoMergeJob < ApplicationJob
     checks = client.check_runs_for_ref(project.full_name, sha)
 
     if checks.nil? || checks.empty?
-      return combined_status_state_settled?(client, project, sha)
+      return combined_status_ok?(client, project, sha, strict: false)
     end
 
-    checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
+    conclusions_green?(checks)
   rescue GithubClient::ApiError => e
-    if e.status == 403
-      Rails.logger.info(
-        message: "dependabot_auto_merge.check_runs_forbidden",
-        project_id: project.id,
-        error: e.message
-      )
-      return combined_status_state_settled?(client, project, sha)
-    end
+    raise unless e.status == 403
 
-    raise
+    Rails.logger.info(
+      message: "dependabot_auto_merge.check_runs_forbidden",
+      project_id: project.id,
+      error: e.message
+    )
+    workflow_runs_or_status_green?(client, project, sha)
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "dependabot_auto_merge.check_runs_failed",
@@ -124,15 +122,47 @@ class DependabotAutoMergeJob < ApplicationJob
     false
   end
 
-  # Returns true when CI has passed or no CI is configured.
-  # GitHub returns "pending" with 0 contexts when no status checks exist,
-  # so we treat that as "no CI" and allow the merge. Any other non-success
-  # state (failure, error, or pending with actual statuses) blocks merging.
-  # This is also the fallback when the token cannot read check runs: we only
-  # proceed after a separate API confirms success or that no statuses exist.
-  def combined_status_state_settled?(client, project, sha)
+  # Reached when the Checks API is forbidden (e.g., fine-grained tokens have
+  # no Checks permission). Verifies CI via the Actions API instead. If Actions
+  # is also unavailable or empty, only an explicit "success" combined status
+  # passes — "pending + 0 contexts" is not safe here because we never confirmed
+  # the absence of check runs from non-Actions GitHub Apps.
+  def workflow_runs_or_status_green?(client, project, sha)
+    runs = client.workflow_runs_for_sha(project.full_name, sha)
+    return conclusions_green?(runs) if runs.any?
+
+    combined_status_ok?(client, project, sha, strict: true)
+  rescue GithubClient::ApiError => e
+    raise unless e.status == 403
+
+    Rails.logger.info(
+      message: "dependabot_auto_merge.workflow_runs_forbidden",
+      project_id: project.id,
+      error: e.message
+    )
+    combined_status_ok?(client, project, sha, strict: true)
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "dependabot_auto_merge.workflow_runs_failed",
+      project_id: project.id,
+      error: e.message
+    )
+    false
+  end
+
+  def conclusions_green?(items)
+    items.all? { |i| %w[success skipped neutral].include?(i[:conclusion]) }
+  end
+
+  # When +strict+ is false, "pending + 0 contexts" counts as "no CI configured"
+  # and allows the merge — safe only when the caller has positive evidence (an
+  # empty check_runs response) that no check runs exist either. When +strict+
+  # is true (e.g., the Checks API was forbidden), only an explicit "success"
+  # passes, since absence of statuses cannot prove absence of check runs.
+  def combined_status_ok?(client, project, sha, strict:)
     status = client.combined_status(project.full_name, sha)
-    status[:state] == "success" || (status[:state] == "pending" && status[:total_count] == 0)
+    return true if status[:state] == "success"
+    !strict && status[:state] == "pending" && status[:total_count] == 0
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "dependabot_auto_merge.combined_status_failed",

--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -12,6 +12,7 @@
 # Concurrency: at most one evaluation per project+PR at a time.
 class DependabotAutoMergeJob < ApplicationJob
   include GoodJob::ActiveJobExtensions::Concurrency
+  include CiStatusVerification
 
   queue_as :default
 
@@ -95,81 +96,8 @@ class DependabotAutoMergeJob < ApplicationJob
     pr_data.respond_to?(:mergeable) ? pr_data.mergeable == true : pr_data[:mergeable] == true
   end
 
-  def all_checks_green?(client, project, pr_data)
-    sha = pr_data.respond_to?(:head) ? pr_data.head.sha : pr_data.dig(:head, :sha)
-    checks = client.check_runs_for_ref(project.full_name, sha)
-
-    if checks.nil? || checks.empty?
-      return combined_status_ok?(client, project, sha, strict: false)
-    end
-
-    conclusions_green?(checks)
-  rescue GithubClient::ApiError => e
-    raise unless e.status == 403
-
-    Rails.logger.info(
-      message: "dependabot_auto_merge.check_runs_forbidden",
-      project_id: project.id,
-      error: e.message
-    )
-    workflow_runs_or_status_green?(client, project, sha)
-  rescue GithubClient::Error => e
-    Rails.logger.warn(
-      message: "dependabot_auto_merge.check_runs_failed",
-      project_id: project.id,
-      error: e.message
-    )
-    false
-  end
-
-  # Reached when the Checks API is forbidden (e.g., fine-grained tokens have
-  # no Checks permission). Verifies CI via the Actions API instead. If Actions
-  # is also unavailable or empty, only an explicit "success" combined status
-  # passes — "pending + 0 contexts" is not safe here because we never confirmed
-  # the absence of check runs from non-Actions GitHub Apps.
-  def workflow_runs_or_status_green?(client, project, sha)
-    runs = client.workflow_runs_for_sha(project.full_name, sha)
-    return conclusions_green?(runs) if runs.any?
-
-    combined_status_ok?(client, project, sha, strict: true)
-  rescue GithubClient::ApiError => e
-    raise unless e.status == 403
-
-    Rails.logger.info(
-      message: "dependabot_auto_merge.workflow_runs_forbidden",
-      project_id: project.id,
-      error: e.message
-    )
-    combined_status_ok?(client, project, sha, strict: true)
-  rescue GithubClient::Error => e
-    Rails.logger.warn(
-      message: "dependabot_auto_merge.workflow_runs_failed",
-      project_id: project.id,
-      error: e.message
-    )
-    false
-  end
-
-  def conclusions_green?(items)
-    items.all? { |i| %w[success skipped neutral].include?(i[:conclusion]) }
-  end
-
-  # When +strict+ is false, "pending + 0 contexts" counts as "no CI configured"
-  # and allows the merge — safe only when the caller has positive evidence (an
-  # empty check_runs response) that no check runs exist either. When +strict+
-  # is true (e.g., the Checks API was forbidden), only an explicit "success"
-  # passes, since absence of statuses cannot prove absence of check runs.
-  def combined_status_ok?(client, project, sha, strict:)
-    status = client.combined_status(project.full_name, sha)
-    return true if status[:state] == "success"
-    !strict && status[:state] == "pending" && status[:total_count] == 0
-  rescue GithubClient::Error => e
-    Rails.logger.warn(
-      message: "dependabot_auto_merge.combined_status_failed",
-      project_id: project.id,
-      error: e.message
-    )
-    false
+  def ci_log_component
+    "dependabot_auto_merge"
   end
 
   def merge_dependabot_pr(client, project, pr_data)

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -463,7 +463,9 @@ class GithubClient
     handle_errors do
       response = client.repository_workflow_runs(repo, head_sha: sha, per_page: WORKFLOW_RUNS_PER_PAGE)
 
-      if response.total_count > WORKFLOW_RUNS_PER_PAGE
+      truncated = response.total_count > WORKFLOW_RUNS_PER_PAGE
+
+      if truncated
         Rails.logger.warn(
           message: "github_client.workflow_runs_pagination_truncated",
           repo: repo,
@@ -478,7 +480,7 @@ class GithubClient
         latest_per_workflow[wr.workflow_id] ||= wr
       end
 
-      latest_per_workflow.values.map do |wr|
+      runs = latest_per_workflow.values.map do |wr|
         {
           id: wr.id,
           workflow_id: wr.workflow_id,
@@ -489,6 +491,24 @@ class GithubClient
           html_url: wr.html_url
         }
       end
+
+      # When the response is truncated, older workflow runs may have been
+      # omitted — some of which could be failing or in-progress. Inject a
+      # synthetic non-green entry so callers (conclusions_green?) refuse to
+      # merge rather than treating a partial page as authoritative.
+      if truncated
+        runs << {
+          id: 0,
+          workflow_id: 0,
+          name: "truncated_results_sentinel",
+          status: "completed",
+          conclusion: "failure",
+          head_sha: sha,
+          html_url: ""
+        }
+      end
+
+      runs
     end
   end
 

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -17,6 +17,7 @@ require "faraday/retry"
 class GithubClient
   DEFAULT_CHECK_RUNS_PER_PAGE = 100
   DEFAULT_CHECK_RUNS_MAX_PAGES = 10
+  WORKFLOW_RUNS_PER_PAGE = 100
   RETRY_MAX = 3
   RETRY_INTERVAL = 0.5
   RETRY_INTERVAL_RANDOMNESS = 0.5
@@ -440,6 +441,54 @@ class GithubClient
     handle_errors do
       response = client.combined_status(repo, ref)
       { state: response.state, total_count: response.total_count }
+    end
+  end
+
+  # Lists GitHub Actions workflow runs for a specific commit SHA, deduped to
+  # the latest run per workflow file. Used as a fallback CI verifier when
+  # callers cannot read the Checks API (e.g., fine-grained tokens, which
+  # expose +Actions: Read+ but no Checks permission).
+  #
+  # Deduping is required because "Re-run all jobs" creates a new workflow_run
+  # sharing the same head_sha, leaving the original (failed) run in place;
+  # without deduping, a stale failure would block a now-green merge. GitHub
+  # returns runs newest-first by created_at, so keeping the first occurrence
+  # per workflow_id wins.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param sha [String] Commit SHA
+  # @return [Array<Hash>] Workflow runs with :id, :workflow_id, :name, :status,
+  #   :conclusion, :head_sha, and :html_url keys
+  def workflow_runs_for_sha(repo, sha)
+    handle_errors do
+      response = client.repository_workflow_runs(repo, head_sha: sha, per_page: WORKFLOW_RUNS_PER_PAGE)
+
+      if response.total_count > WORKFLOW_RUNS_PER_PAGE
+        Rails.logger.warn(
+          message: "github_client.workflow_runs_pagination_truncated",
+          repo: repo,
+          sha: sha,
+          total_count: response.total_count,
+          fetched_count: response.workflow_runs.size
+        )
+      end
+
+      latest_per_workflow = {}
+      response.workflow_runs.each do |wr|
+        latest_per_workflow[wr.workflow_id] ||= wr
+      end
+
+      latest_per_workflow.values.map do |wr|
+        {
+          id: wr.id,
+          workflow_id: wr.workflow_id,
+          name: wr.name,
+          status: wr.status,
+          conclusion: wr.conclusion,
+          head_sha: wr.head_sha,
+          html_url: wr.html_url
+        }
+      end
     end
   end
 

--- a/app/views/github_tokens/new.html.erb
+++ b/app/views/github_tokens/new.html.erb
@@ -35,22 +35,18 @@
                 <li><strong>Metadata:</strong> Read-only - required for API access (automatically included)</li>
               </ul>
               <p class="mt-3 text-xs text-blue-600">
-                <strong>Optional:</strong> For GitHub Projects V2 integration, also add <strong>Projects: Read and write</strong> permission.
-              </p>
-              <p class="mt-1 text-xs text-blue-600">
                 <strong>Optional:</strong> If your repository uses GitHub Actions and you want Paid to be able to edit workflow files
                 (<code>.github/workflows/</code>), also add the <strong>Workflows: Read and write</strong> permission.
-                For classic tokens, this is the <strong>workflow</strong> scope.
-                Without this, pushes that modify workflow files will be rejected by GitHub.
               </p>
               <p class="mt-1 text-xs text-blue-600">
-                <strong>Optional:</strong> To enable Dependabot auto-merge, auto-release, or CI-gated auto-merge, also add
-                <strong>Checks: Read-only</strong> permission. For classic tokens, this is included in the <strong>repo</strong> scope.
+                <strong>Optional:</strong> To enable Dependabot auto-merge, auto-release, or CI-gated auto-merge, add
+                <strong>Actions: Read-only</strong> so Paid can verify GitHub Actions workflow runs before merging.
+                For repositories using third-party CI that posts via the commit-statuses API, also add
+                <strong>Commit statuses: Read-only</strong>.
               </p>
               <p class="mt-1 text-xs text-blue-600">
                 <strong>Optional:</strong> To enable code scanning alert monitoring (auto-scan security), also add
-                <strong>Code scanning alerts: Read-only</strong> permission under Repository permissions.
-                For classic tokens, this is the <strong>security_events</strong> scope.
+                <strong>Code scanning alerts: Read-only</strong> permission.
               </p>
             </div>
           </div>
@@ -95,7 +91,7 @@
           <div>
             <%= form.label :token, "Personal Access Token", class: "block text-sm font-medium leading-6 text-gray-900" %>
             <div class="mt-2">
-              <%= form.text_field :token, class: "block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: "ghp_xxxx or github_pat_xxxx", autocomplete: "off", spellcheck: false, required: true %>
+              <%= form.text_field :token, class: "block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: "github_pat_xxxx", autocomplete: "off", spellcheck: false, required: true %>
             </div>
             <p class="mt-1 text-xs text-gray-500">Your token is encrypted at rest and never displayed after saving.</p>
           </div>

--- a/app/views/github_tokens/new.html.erb
+++ b/app/views/github_tokens/new.html.erb
@@ -35,6 +35,9 @@
                 <li><strong>Metadata:</strong> Read-only - required for API access (automatically included)</li>
               </ul>
               <p class="mt-3 text-xs text-blue-600">
+                <strong>Optional:</strong> For GitHub Projects V2 integration, also add <strong>Projects: Read and write</strong> permission.
+              </p>
+              <p class="mt-1 text-xs text-blue-600">
                 <strong>Optional:</strong> If your repository uses GitHub Actions and you want Paid to be able to edit workflow files
                 (<code>.github/workflows/</code>), also add the <strong>Workflows: Read and write</strong> permission.
               </p>
@@ -91,7 +94,7 @@
           <div>
             <%= form.label :token, "Personal Access Token", class: "block text-sm font-medium leading-6 text-gray-900" %>
             <div class="mt-2">
-              <%= form.text_field :token, class: "block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: "github_pat_xxxx", autocomplete: "off", spellcheck: false, required: true %>
+              <%= form.text_field :token, class: "block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: "ghp_xxxx or github_pat_xxxx", autocomplete: "off", spellcheck: false, required: true %>
             </div>
             <p class="mt-1 text-xs text-gray-500">Your token is encrypted at rest and never displayed after saving.</p>
           </div>

--- a/app/views/onboarding/steps/_github_token.html.erb
+++ b/app/views/onboarding/steps/_github_token.html.erb
@@ -19,7 +19,7 @@
           <li><strong>Metadata:</strong> Read-only</li>
         </ul>
         <p class="mt-2 text-xs text-blue-600">
-          <strong>Optional:</strong> Add <strong>Actions: Read-only</strong> for Dependabot auto-merge and CI-gated auto-merge.
+          <strong>Optional:</strong> Add <strong>Actions: Read-only</strong> for Dependabot auto-merge, auto-release, and CI-gated auto-merge.
           For repositories using third-party CI (e.g. CircleCI, Buildkite), also add
           <strong>Commit statuses: Read-only</strong>.
           Add <strong>Code scanning alerts: Read-only</strong> for security monitoring.

--- a/app/views/onboarding/steps/_github_token.html.erb
+++ b/app/views/onboarding/steps/_github_token.html.erb
@@ -19,8 +19,10 @@
           <li><strong>Metadata:</strong> Read-only</li>
         </ul>
         <p class="mt-2 text-xs text-blue-600">
-          <strong>Optional:</strong> Add <strong>Actions: Read-only</strong> for Dependabot auto-merge and CI-gated auto-merge,
-          and <strong>Code scanning alerts: Read-only</strong> for security monitoring.
+          <strong>Optional:</strong> Add <strong>Actions: Read-only</strong> for Dependabot auto-merge and CI-gated auto-merge.
+          For repositories using third-party CI (e.g. CircleCI, Buildkite), also add
+          <strong>Commit statuses: Read-only</strong>.
+          Add <strong>Code scanning alerts: Read-only</strong> for security monitoring.
         </p>
       </div>
     </div>
@@ -43,7 +45,7 @@
       <div class="mt-2">
         <%= form.password_field "github_token[token]",
             class: "block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6",
-            placeholder: "github_pat_xxxx", autocomplete: "off", spellcheck: false, required: true %>
+            placeholder: "ghp_xxxx or github_pat_xxxx", autocomplete: "off", spellcheck: false, required: true %>
       </div>
       <p class="mt-1 text-xs text-gray-500">Your token is encrypted at rest and never displayed after saving.</p>
     </div>

--- a/app/views/onboarding/steps/_github_token.html.erb
+++ b/app/views/onboarding/steps/_github_token.html.erb
@@ -19,10 +19,8 @@
           <li><strong>Metadata:</strong> Read-only</li>
         </ul>
         <p class="mt-2 text-xs text-blue-600">
-          <strong>Optional:</strong> Add <strong>Checks: Read-only</strong> for Dependabot/auto-merge
-          (included in <strong>repo</strong> scope for classic tokens) and
-          <strong>Code scanning alerts: Read-only</strong> for security monitoring
-          (<strong>security_events</strong> scope for classic tokens).
+          <strong>Optional:</strong> Add <strong>Actions: Read-only</strong> for Dependabot auto-merge and CI-gated auto-merge,
+          and <strong>Code scanning alerts: Read-only</strong> for security monitoring.
         </p>
       </div>
     </div>
@@ -45,7 +43,7 @@
       <div class="mt-2">
         <%= form.password_field "github_token[token]",
             class: "block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6",
-            placeholder: "ghp_xxxx or github_pat_xxxx", autocomplete: "off", spellcheck: false, required: true %>
+            placeholder: "github_pat_xxxx", autocomplete: "off", spellcheck: false, required: true %>
       </div>
       <p class="mt-1 text-xs text-gray-500">Your token is encrypted at rest and never displayed after saving.</p>
     </div>

--- a/spec/jobs/auto_release_evaluation_job_spec.rb
+++ b/spec/jobs/auto_release_evaluation_job_spec.rb
@@ -148,28 +148,96 @@ RSpec.describe AutoReleaseEvaluationJob do
       expect(client).not_to have_received(:merge_pull_request)
     end
 
-    it "falls back to combined status when check_runs returns 403 and status is green" do
+    it "merges via workflow_runs when check_runs is forbidden and workflow runs are green" do
       allow(client).to receive(:check_runs_for_ref).and_raise(
         GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_return([
+        { conclusion: "success", name: "ci.yml" }
+      ])
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:workflow_runs_for_sha).with(project.full_name, pr_data.head.sha)
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips via workflow_runs when check_runs is forbidden and any workflow run failed" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_return([
+        { conclusion: "success", name: "lint.yml" },
+        { conclusion: "failure", name: "test.yml" }
+      ])
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "falls through to combined status when check_runs is forbidden and workflow_runs is empty" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive_messages(workflow_runs_for_sha: [], combined_status: { state: "success", total_count: 1 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when check_runs is forbidden, workflow_runs is empty, and combined_status reports no contexts" do
+      # Safety regression test: previously this case would merge by treating
+      # "pending + 0 contexts" as "no CI configured", even though the Checks
+      # API was forbidden so we never confirmed the absence of check runs.
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive_messages(workflow_runs_for_sha: [], combined_status: { state: "pending", total_count: 0 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when check_runs is forbidden and combined_status reports a non-success state" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive_messages(workflow_runs_for_sha: [], combined_status: { state: "pending", total_count: 2 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when both check_runs and workflow_runs are forbidden and no statuses are configured" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:combined_status).and_return(state: "pending", total_count: 0)
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "merges when both check_runs and workflow_runs are forbidden but combined_status reports success" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
       )
       allow(client).to receive(:combined_status).and_return(state: "success", total_count: 1)
 
       described_class.perform_now(project.id)
 
-      expect(client).to have_received(:combined_status).with(project.full_name, pr_data.head.sha)
       expect(client).to have_received(:merge_pull_request)
-    end
-
-    it "skips when check_runs returns 403 and combined status is not green" do
-      allow(client).to receive(:check_runs_for_ref).and_raise(
-        GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
-      )
-      allow(client).to receive(:combined_status).and_return(state: "pending", total_count: 2)
-
-      described_class.perform_now(project.id)
-
-      expect(client).to have_received(:combined_status).with(project.full_name, pr_data.head.sha)
-      expect(client).not_to have_received(:merge_pull_request)
     end
 
     it "skips when no release PR is found" do

--- a/spec/jobs/auto_release_evaluation_job_spec.rb
+++ b/spec/jobs/auto_release_evaluation_job_spec.rb
@@ -176,6 +176,23 @@ RSpec.describe AutoReleaseEvaluationJob do
       expect(client).not_to have_received(:merge_pull_request)
     end
 
+    it "skips when check_runs is forbidden, workflow runs are green, and commit statuses fail" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive_messages(
+        workflow_runs_for_sha: [
+          { conclusion: "success", name: "lint.yml" },
+          { conclusion: "success", name: "test.yml" }
+        ],
+        combined_status: { state: "failure", total_count: 1 }
+      )
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
     it "falls through to combined status when check_runs is forbidden and workflow_runs is empty" do
       allow(client).to receive(:check_runs_for_ref).and_raise(
         GithubClient::ApiError.new("Forbidden", status: 403)

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -254,6 +254,23 @@ RSpec.describe DependabotAutoMergeJob do
       expect(client).not_to have_received(:merge_pull_request)
     end
 
+    it "skips when check_runs is forbidden, workflow runs are green, and commit statuses fail" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive_messages(
+        workflow_runs_for_sha: [
+          { conclusion: "success", name: "lint.yml" },
+          { conclusion: "success", name: "test.yml" }
+        ],
+        combined_status: { state: "failure", total_count: 1 }
+      )
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
     it "skips via workflow_runs when check_runs is forbidden and a workflow run is still in progress" do
       allow(client).to receive(:check_runs_for_ref).and_raise(
         GithubClient::ApiError.new("Forbidden", status: 403)

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -226,28 +226,110 @@ RSpec.describe DependabotAutoMergeJob do
       expect(client).to have_received(:merge_pull_request)
     end
 
-    it "falls back to combined status when check_runs returns 403 and status is green" do
+    it "merges via workflow_runs when check_runs is forbidden and workflow runs are green" do
       allow(client).to receive(:check_runs_for_ref).and_raise(
         GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_return([
+        { conclusion: "success", name: "ci.yml" }
+      ])
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:workflow_runs_for_sha).with(project.full_name, dependabot_pr.head.sha)
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips via workflow_runs when check_runs is forbidden and any workflow run failed" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_return([
+        { conclusion: "success", name: "lint.yml" },
+        { conclusion: "failure", name: "test.yml" }
+      ])
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips via workflow_runs when check_runs is forbidden and a workflow run is still in progress" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_return([
+        { conclusion: "success", name: "lint.yml", status: "completed" },
+        { conclusion: nil, name: "test.yml", status: "in_progress" }
+      ])
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "falls through to combined status when check_runs is forbidden and workflow_runs is empty" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive_messages(workflow_runs_for_sha: [], combined_status: { state: "success", total_count: 1 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:merge_pull_request)
+    end
+
+    it "skips when check_runs is forbidden, workflow_runs is empty, and combined_status reports no contexts" do
+      # Safety regression test: previously this case would merge by treating
+      # "pending + 0 contexts" as "no CI configured", even though the Checks
+      # API was forbidden so we never confirmed the absence of check runs.
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive_messages(workflow_runs_for_sha: [], combined_status: { state: "pending", total_count: 0 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when check_runs is forbidden and combined_status reports a non-success state" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive_messages(workflow_runs_for_sha: [], combined_status: { state: "pending", total_count: 2 })
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "skips when both check_runs and workflow_runs are forbidden and no statuses are configured" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:combined_status).and_return(state: "pending", total_count: 0)
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "merges when both check_runs and workflow_runs are forbidden but combined_status reports success" do
+      allow(client).to receive(:check_runs_for_ref).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
+      )
+      allow(client).to receive(:workflow_runs_for_sha).and_raise(
+        GithubClient::ApiError.new("Forbidden", status: 403)
       )
       allow(client).to receive(:combined_status).and_return(state: "success", total_count: 1)
 
       described_class.perform_now(project.id)
 
-      expect(client).to have_received(:combined_status).with(project.full_name, dependabot_pr.head.sha)
       expect(client).to have_received(:merge_pull_request)
-    end
-
-    it "skips when check_runs returns 403 and combined status is not green" do
-      allow(client).to receive(:check_runs_for_ref).and_raise(
-        GithubClient::ApiError.new("Resource not accessible by personal access token", status: 403)
-      )
-      allow(client).to receive(:combined_status).and_return(state: "pending", total_count: 2)
-
-      described_class.perform_now(project.id)
-
-      expect(client).to have_received(:combined_status).with(project.full_name, dependabot_pr.head.sha)
-      expect(client).not_to have_received(:merge_pull_request)
     end
 
     it "skips when check_runs fails with a non-403 error" do

--- a/spec/requests/github_tokens_spec.rb
+++ b/spec/requests/github_tokens_spec.rb
@@ -157,12 +157,11 @@ RSpec.describe "GithubTokens" do
       it "displays the optional Code scanning alerts permission hint" do
         get new_github_token_path
         expect(response.body).to include("Code scanning alerts")
-        expect(response.body).to include("security_events")
       end
 
-      it "displays the optional Checks permission hint" do
+      it "displays the optional Actions permission hint for auto-merge" do
         get new_github_token_path
-        expect(response.body).to include("Checks")
+        expect(response.body).to include("Actions: Read-only")
         expect(response.body).to include("Dependabot auto-merge")
       end
     end

--- a/spec/requests/github_tokens_spec.rb
+++ b/spec/requests/github_tokens_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe "GithubTokens" do
         get new_github_token_path
         expect(response.body).to include("Actions: Read-only")
         expect(response.body).to include("Dependabot auto-merge")
+        expect(response.body).to include("auto-release")
       end
     end
   end

--- a/spec/requests/onboarding_spec.rb
+++ b/spec/requests/onboarding_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe "Onboarding" do
         get onboarding_path
         expect(response).to redirect_to(dashboard_path)
       end
+
+      it "mentions auto-release in the GitHub token permission guidance" do
+        Onboarding::CompleteStep.call(account: account, step: "account_profile")
+
+        get onboarding_path
+
+        expect(response.body).to include("Actions: Read-only")
+        expect(response.body).to include("Dependabot auto-merge")
+        expect(response.body).to include("auto-release")
+      end
     end
   end
 

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -818,6 +818,110 @@ RSpec.describe GithubClient do
     end
   end
 
+  describe "#workflow_runs_for_sha" do
+    let(:repo) { "owner/repo" }
+    let(:sha) { "abc123" }
+
+    def stub_workflow_runs(workflow_runs, total_count: nil)
+      total_count ||= workflow_runs.size
+      stub_request(:get, "#{api_base}/repos/#{repo}/actions/runs")
+        .with(query: hash_including("head_sha" => sha, "per_page" => "100"))
+        .to_return(
+          status: 200,
+          body: { total_count: total_count, workflow_runs: workflow_runs }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    end
+
+    context "when workflow runs exist" do
+      before do
+        stub_workflow_runs([
+          { id: 11, workflow_id: 1, name: "CI", status: "completed", conclusion: "success",
+            head_sha: sha, html_url: "https://github.com/owner/repo/actions/runs/11" },
+          { id: 12, workflow_id: 2, name: "Lint", status: "completed", conclusion: "failure",
+            head_sha: sha, html_url: "https://github.com/owner/repo/actions/runs/12" }
+        ])
+      end
+
+      it "returns simplified workflow run hashes for the commit" do
+        result = client.workflow_runs_for_sha(repo, sha)
+
+        expect(result).to eq([
+          { id: 11, workflow_id: 1, name: "CI", status: "completed", conclusion: "success",
+            head_sha: sha, html_url: "https://github.com/owner/repo/actions/runs/11" },
+          { id: 12, workflow_id: 2, name: "Lint", status: "completed", conclusion: "failure",
+            head_sha: sha, html_url: "https://github.com/owner/repo/actions/runs/12" }
+        ])
+      end
+    end
+
+    context "when 'Re-run all jobs' has produced multiple runs for the same workflow" do
+      before do
+        # API returns newest first; the most recent re-run succeeded but the
+        # original failed run is still present. Without dedup, the failure
+        # would block a now-green merge.
+        stub_workflow_runs([
+          { id: 22, workflow_id: 1, name: "CI", status: "completed", conclusion: "success",
+            head_sha: sha, html_url: "https://github.com/owner/repo/actions/runs/22" },
+          { id: 11, workflow_id: 1, name: "CI", status: "completed", conclusion: "failure",
+            head_sha: sha, html_url: "https://github.com/owner/repo/actions/runs/11" }
+        ])
+      end
+
+      it "returns only the latest run per workflow_id" do
+        result = client.workflow_runs_for_sha(repo, sha)
+
+        expect(result.size).to eq(1)
+        expect(result.first).to include(id: 22, conclusion: "success")
+      end
+    end
+
+    context "when no workflow runs exist for the commit" do
+      before { stub_workflow_runs([]) }
+
+      it "returns an empty array" do
+        expect(client.workflow_runs_for_sha(repo, sha)).to eq([])
+      end
+    end
+
+    context "when total_count exceeds the per-page limit" do
+      before do
+        stub_workflow_runs(
+          [ { id: 1, workflow_id: 1, name: "CI", status: "completed", conclusion: "success",
+              head_sha: sha, html_url: "https://example" } ],
+          total_count: 250
+        )
+      end
+
+      it "logs a pagination_truncated warning" do
+        allow(Rails.logger).to receive(:warn)
+
+        client.workflow_runs_for_sha(repo, sha)
+
+        expect(Rails.logger).to have_received(:warn).with(
+          hash_including(message: "github_client.workflow_runs_pagination_truncated", total_count: 250)
+        )
+      end
+    end
+
+    context "when the token cannot read Actions" do
+      before do
+        stub_request(:get, "#{api_base}/repos/#{repo}/actions/runs")
+          .with(query: hash_including("head_sha" => sha))
+          .to_return(
+            status: 403,
+            body: { message: "Resource not accessible by personal access token" }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "raises ApiError with status 403" do
+        expect { client.workflow_runs_for_sha(repo, sha) }
+          .to raise_error(GithubClient::ApiError) { |e| expect(e.status).to eq(403) }
+      end
+    end
+  end
+
   describe "#check_run_log" do
     let(:repo) { "owner/repo" }
 

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -902,6 +902,16 @@ RSpec.describe GithubClient do
           hash_including(message: "github_client.workflow_runs_pagination_truncated", total_count: 250)
         )
       end
+
+      it "appends a non-green sentinel so callers refuse to merge on partial data" do
+        allow(Rails.logger).to receive(:warn)
+
+        runs = client.workflow_runs_for_sha(repo, sha)
+        sentinel = runs.find { |r| r[:name] == "truncated_results_sentinel" }
+
+        expect(sentinel).to be_present
+        expect(sentinel[:conclusion]).to eq("failure")
+      end
     end
 
     context "when the token cannot read Actions" do


### PR DESCRIPTION
## Summary

- Closes a safety hole in Dependabot/auto-release auto-merge: when the Checks API returned 403 (typical for fine-grained PATs), the previous fallback treated `combined_status: pending + 0 contexts` as "no CI configured" and merged. GitHub Actions check runs do not appear in `combined_status`, so this silently auto-merged red Dependabot PRs on Actions-CI repos.
- Adds `GithubClient#workflow_runs_for_sha` as the primary fallback when Checks is forbidden. Dedupes by `workflow_id` so "Re-run all jobs" stale failures don't block now-green merges.
- Tightens the combined-status fallback to strict mode (only explicit `success`) when reached via the 403 path.
- Refuses to merge if both Checks and Actions APIs are unavailable and no explicit success status is reported — never merges blind.
- Updates the Add-Token and onboarding views to recommend `Actions: Read-only` (with `Commit statuses: Read-only` for third-party CI via the statuses API).

## Test plan

- [x] `bin/rspec spec/jobs/dependabot_auto_merge_job_spec.rb spec/jobs/auto_release_evaluation_job_spec.rb spec/services/github_client_spec.rb` — 171 examples, 0 failures
- [x] `bin/rubocop` — clean on all touched files
- [x] Regression spec: `check_runs 403 + workflow_runs empty + combined_status pending+0` now skips (previously merged)
- [x] Spec: workflow-runs dedup keeps newest run per `workflow_id`
- [x] Spec: in-progress workflow run blocks merge
- [x] Spec: pagination warning fires when total_count > 100
- [ ] Manual verification on `HuntHelper/railscrawler` after a token with `Actions: Read-only` is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)