### PR TITLE
feat(integrations): expose generic integration credentials in the integrations hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
 - **Knowledge Base**: Index repos into PostgreSQL + Qdrant for hybrid exact/semantic search and richer prompt context
   - Gap: some goal and prompt paths still need knowledge injection or container-accessible search; tracked by [#1265](https://github.com/viamin/paid/issues/1265) and [#1272](https://github.com/viamin/paid/issues/1272).
 - **Live Dashboards**: Track active runs, performance, quality, cost, and knowledge-collection health from the UI
-- **Provider and Integration Management**: Test provider auth from the UI and manage GitHub, Linear, and provider API keys
-  - Gap: generic integration credentials exist in the data model but are hidden from the main integrations hub pending RBAC/admin-role work; tracked by [#1283](https://github.com/viamin/paid/issues/1283).
+- **Provider and Integration Management**: Test provider auth from the UI and manage GitHub, Linear, provider API keys, and generic integration credentials (GitLab, Jira, Azure DevOps, signing) for account admins
 - **Service Containers**: Attach approved supporting services like Postgres, Redis, or Selenium to project runs when agents need dependencies beyond the app code. Service containers are attached to the same Docker network selected for the agent run across proxy-mode, subscription-auth, and direct-outbound provider runs. Shared-database isolation fallout is tracked separately by [#1280](https://github.com/viamin/paid/issues/1280).
 
 ## How It Works

--- a/app/controllers/integration_credentials_controller.rb
+++ b/app/controllers/integration_credentials_controller.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
-# TODO: The integration credentials UI is hidden from the integrations hub until RBAC is
-# implemented. Once an account admin role exists, restore the hub links so account admins
-# can manage account-scoped credentials (GitLab, Jira, signing, per-provider LLM tokens).
-# The routes, controller, and views remain intact for direct access.
 class IntegrationCredentialsController < ApplicationController
   before_action :set_filter_context, only: [ :index, :new, :create ]
   before_action :set_integration_credential, only: [ :show, :destroy ]
-  skip_after_action :verify_authorized, only: :index
+  skip_after_action :verify_policy_scoped, only: :index
 
   def index
+    authorize IntegrationCredential
     @integration_credentials = filtered_scope.order(created_at: :desc)
   end
 

--- a/app/controllers/integration_credentials_controller.rb
+++ b/app/controllers/integration_credentials_controller.rb
@@ -3,7 +3,6 @@
 class IntegrationCredentialsController < ApplicationController
   before_action :set_filter_context, only: [ :index, :new, :create ]
   before_action :set_integration_credential, only: [ :show, :destroy ]
-  skip_after_action :verify_policy_scoped, only: :index
 
   def index
     authorize IntegrationCredential

--- a/app/policies/integration_credential_policy.rb
+++ b/app/policies/integration_credential_policy.rb
@@ -21,6 +21,18 @@ class IntegrationCredentialPolicy < ApplicationPolicy
     destroy?
   end
 
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      raise Pundit::NotAuthorizedError, "must be logged in" unless user
+
+      if user.has_role?(:owner, user.account) || user.has_role?(:admin, user.account)
+        scope.where(account: user.account)
+      else
+        scope.none
+      end
+    end
+  end
+
   private
 
   def account_for_record

--- a/app/policies/integration_credential_policy.rb
+++ b/app/policies/integration_credential_policy.rb
@@ -1,7 +1,29 @@
 # frozen_string_literal: true
 
 class IntegrationCredentialPolicy < ApplicationPolicy
+  def index?
+    has_any_account_role?(:owner, :admin)
+  end
+
+  def show?
+    has_any_account_role?(:owner, :admin)
+  end
+
+  def create?
+    has_any_account_role?(:owner, :admin)
+  end
+
+  def destroy?
+    has_any_account_role?(:owner, :admin)
+  end
+
   def revoke?
-    update?
+    destroy?
+  end
+
+  private
+
+  def account_for_record
+    record.respond_to?(:account) ? record.account : user&.account
   end
 end

--- a/app/services/integrations/credential_catalog.rb
+++ b/app/services/integrations/credential_catalog.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module Integrations
-  # TODO: This catalog will serve the integrations hub UI once RBAC is implemented.
-  # Account admin role users will be able to add/manage account-scoped credentials
-  # for GitLab, Jira, signing, and per-provider LLM tokens via this catalog.
   module CredentialCatalog
     CATEGORY_DETAILS = {
       repository: {

--- a/app/services/integrations/hub.rb
+++ b/app/services/integrations/hub.rb
@@ -39,7 +39,7 @@ module Integrations
         end
 
         if user.has_any_role?(:admin, :owner, account)
-          credentials = account.integration_credentials.active.order(created_at: :desc).load
+          credentials = account.integration_credentials.order(created_at: :desc).load
           if credentials.any?
             sections << Section.new(
               key: :integration_credentials,

--- a/app/services/integrations/hub.rb
+++ b/app/services/integrations/hub.rb
@@ -39,7 +39,7 @@ module Integrations
         end
 
         if user.has_any_role?(:admin, :owner, account)
-          credentials = account.integration_credentials.order(created_at: :desc).load
+          credentials = account.integration_credentials.active.order(created_at: :desc).load
           if credentials.any?
             sections << Section.new(
               key: :integration_credentials,

--- a/app/services/integrations/hub.rb
+++ b/app/services/integrations/hub.rb
@@ -2,11 +2,6 @@
 
 module Integrations
   class Hub
-    # TODO: Restore integration_credentials (GitLab, Jira, signing, per-provider LLM tokens)
-    # to the integrations UI once RBAC is implemented. Account admin role users should be
-    # able to manage account-scoped credentials via IntegrationCredential. The model,
-    # controller, and views are intact — just hidden from the hub until then.
-
     Section = Data.define(:key, :label, :description, :records)
 
     class << self
@@ -41,6 +36,18 @@ module Integrations
             description: "API keys for AI providers used by agent runs.",
             records: provider_api_keys
           )
+        end
+
+        if user.has_any_role?(:admin, :owner, account)
+          credentials = account.integration_credentials.active.order(created_at: :desc).load
+          if credentials.any?
+            sections << Section.new(
+              key: :integration_credentials,
+              label: "Integration Credentials",
+              description: "Account-managed credentials for additional providers and integrations.",
+              records: credentials
+            )
+          end
         end
 
         sections

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -22,7 +22,7 @@
             <thead class="bg-gray-50">
               <tr>
                 <th scope="col" class="py-3 pl-4 pr-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500 sm:pl-6">Name</th>
-                <% if section.key == :llm_provider %>
+                <% if section.key.in?([ :llm_provider, :integration_credentials ]) %>
                   <th scope="col" class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Service</th>
                 <% end %>
                 <th scope="col" class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Status</th>
@@ -36,6 +36,8 @@
                   <td class="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6"><%= record.name %></td>
                   <% if section.key == :llm_provider %>
                     <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= record.display_api_service_type %></td>
+                  <% elsif section.key == :integration_credentials %>
+                    <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= record.service_definition&.dig(:label) || record.service_key %></td>
                   <% end %>
                   <td class="whitespace-nowrap px-3 py-3 text-sm">
                     <%= render_integration_status(record) %>

--- a/app/views/integrations/new.html.erb
+++ b/app/views/integrations/new.html.erb
@@ -30,6 +30,13 @@
           <h3 class="text-sm font-semibold text-gray-900">LLM provider API key</h3>
           <p class="mt-1 text-sm text-gray-500">Add an API key for an AI provider such as Anthropic, OpenAI, OpenRouter, or Google.</p>
         <% end %>
+
+        <% if policy(IntegrationCredential.new(account: current_account)).create? %>
+          <%= link_to new_integration_credential_path, class: "block py-4 hover:bg-gray-50 -mx-6 px-6 transition-colors" do %>
+            <h3 class="text-sm font-semibold text-gray-900">Integration credential</h3>
+            <p class="mt-1 text-sm text-gray-500">Add an account-managed credential for services like GitLab, Jira, Azure DevOps, or commit signing.</p>
+          <% end %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/integrations/new.html.erb
+++ b/app/views/integrations/new.html.erb
@@ -31,6 +31,8 @@
           <p class="mt-1 text-sm text-gray-500">Add an API key for an AI provider such as Anthropic, OpenAI, OpenRouter, or Google.</p>
         <% end %>
 
+        <%# The generic credential form validates auth_kind against the selected service on submit,
+            so services like GitHub Signing that require signing_token will reject invalid auth_kinds. %>
         <% if policy(IntegrationCredential.new(account: current_account)).create? %>
           <%= link_to new_integration_credential_path, class: "block py-4 hover:bg-gray-50 -mx-6 px-6 transition-colors" do %>
             <h3 class="text-sm font-semibold text-gray-900">Integration credential</h3>

--- a/spec/requests/integration_credentials_spec.rb
+++ b/spec/requests/integration_credentials_spec.rb
@@ -18,6 +18,31 @@ RSpec.describe "IntegrationCredentials" do
       expect(response.body).to include(matching.name)
       expect(response.body).not_to include("GitLab Token")
     end
+
+    context "when user is an admin" do
+      let(:admin_user) { create(:user, :admin, account: user.account) }
+
+      before { sign_in admin_user }
+
+      it "allows access" do
+        get integration_credentials_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when user is a member" do
+      let(:member_user) { create(:user, :member, account: user.account) }
+
+      before { sign_in member_user }
+
+      it "denies access" do
+        get integration_credentials_path
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("not authorized")
+      end
+    end
   end
 
   describe "GET /integration_credentials/new" do
@@ -29,6 +54,19 @@ RSpec.describe "IntegrationCredentials" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Add Credential")
       expect(response.body).to include("GitHub Signing")
+    end
+
+    context "when user is a member" do
+      let(:member_user) { create(:user, :member, account: user.account) }
+
+      before { sign_in member_user }
+
+      it "denies access" do
+        get new_integration_credential_path
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("not authorized")
+      end
     end
   end
 
@@ -66,6 +104,27 @@ RSpec.describe "IntegrationCredentials" do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("is not supported for GitHub Signing")
     end
+
+    context "when user is a member" do
+      let(:member_user) { create(:user, :member, account: user.account) }
+
+      before { sign_in member_user }
+
+      it "denies access" do
+        post integration_credentials_path, params: {
+          integration_credential: {
+            name: "Test",
+            service_key: "gitlab",
+            category: "repository",
+            auth_kind: "api_key",
+            secret: "secret-123"
+          }
+        }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("not authorized")
+      end
+    end
   end
 
   describe "GET /integration_credentials/:id" do
@@ -87,6 +146,21 @@ RSpec.describe "IntegrationCredentials" do
       get integration_credential_path(other_credential)
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    context "when user is a member" do
+      let(:member_user) { create(:user, :member, account: user.account) }
+
+      before { sign_in member_user }
+
+      it "denies access" do
+        credential = create(:integration_credential, account: user.account, created_by: user, name: "My Key")
+
+        get integration_credential_path(credential)
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("not authorized")
+      end
     end
   end
 
@@ -114,10 +188,25 @@ RSpec.describe "IntegrationCredentials" do
       end
     end
 
-    context "when user does not have owner role" do
-      let(:non_owner) { create(:user, account: user.account) }
+    context "when user has admin role" do
+      let(:admin_user) { create(:user, :admin, account: user.account) }
 
-      before { sign_in non_owner }
+      before { sign_in admin_user }
+
+      it "revokes the credential" do
+        credential = create(:integration_credential, account: user.account, created_by: user)
+
+        delete integration_credential_path(credential)
+
+        expect(credential.reload).to be_revoked
+        expect(response).to redirect_to(integration_credentials_path(category: credential.category))
+      end
+    end
+
+    context "when user is a member" do
+      let(:member_user) { create(:user, :member, account: user.account) }
+
+      before { sign_in member_user }
 
       it "denies access" do
         credential = create(:integration_credential, account: user.account, created_by: user)

--- a/spec/requests/integration_credentials_spec.rb
+++ b/spec/requests/integration_credentials_spec.rb
@@ -3,14 +3,17 @@
 require "rails_helper"
 
 RSpec.describe "IntegrationCredentials" do
-  let(:user) { create(:user) }
+  let(:account) { create(:account) }
+  let(:owner_user) { create(:user, account: account) }
+  let(:admin_user) { create(:user, :admin, account: account) }
+  let(:member_user) { create(:user, :member, account: account) }
 
   describe "GET /integration_credentials" do
-    before { sign_in user }
+    before { sign_in owner_user }
 
     it "filters credentials by category" do
-      matching = create(:integration_credential, account: user.account, created_by: user, service_key: "claude", category: "llm_provider", name: "Claude Token")
-      create(:integration_credential, :gitlab, account: user.account, created_by: user, name: "GitLab Token")
+      matching = create(:integration_credential, account: account, created_by: owner_user, service_key: "claude", category: "llm_provider", name: "Claude Token")
+      create(:integration_credential, :gitlab, account: account, created_by: owner_user, name: "GitLab Token")
 
       get integration_credentials_path(category: "llm_provider")
 
@@ -20,8 +23,6 @@ RSpec.describe "IntegrationCredentials" do
     end
 
     context "when user is an admin" do
-      let(:admin_user) { create(:user, :admin, account: user.account) }
-
       before { sign_in admin_user }
 
       it "allows access" do
@@ -32,8 +33,6 @@ RSpec.describe "IntegrationCredentials" do
     end
 
     context "when user is a member" do
-      let(:member_user) { create(:user, :member, account: user.account) }
-
       before { sign_in member_user }
 
       it "denies access" do
@@ -46,7 +45,7 @@ RSpec.describe "IntegrationCredentials" do
   end
 
   describe "GET /integration_credentials/new" do
-    before { sign_in user }
+    before { sign_in owner_user }
 
     it "prefills service-specific forms from query params" do
       get new_integration_credential_path(service_key: "github_signing", category: "signing")
@@ -57,8 +56,6 @@ RSpec.describe "IntegrationCredentials" do
     end
 
     context "when user is a member" do
-      let(:member_user) { create(:user, :member, account: user.account) }
-
       before { sign_in member_user }
 
       it "denies access" do
@@ -71,7 +68,7 @@ RSpec.describe "IntegrationCredentials" do
   end
 
   describe "POST /integration_credentials" do
-    before { sign_in user }
+    before { sign_in owner_user }
 
     it "creates provider credentials" do
       post integration_credentials_path, params: {
@@ -87,7 +84,7 @@ RSpec.describe "IntegrationCredentials" do
       credential = IntegrationCredential.last
       expect(response).to redirect_to(integration_credential_path(credential, category: credential.category))
       expect(credential.service_key).to eq("gemini")
-      expect(credential.created_by).to eq(user)
+      expect(credential.created_by).to eq(owner_user)
     end
 
     it "rejects invalid signing auth types" do
@@ -106,8 +103,6 @@ RSpec.describe "IntegrationCredentials" do
     end
 
     context "when user is a member" do
-      let(:member_user) { create(:user, :member, account: user.account) }
-
       before { sign_in member_user }
 
       it "denies access" do
@@ -128,10 +123,10 @@ RSpec.describe "IntegrationCredentials" do
   end
 
   describe "GET /integration_credentials/:id" do
-    before { sign_in user }
+    before { sign_in owner_user }
 
     it "shows the credential details" do
-      credential = create(:integration_credential, account: user.account, created_by: user, name: "My Claude Key")
+      credential = create(:integration_credential, account: account, created_by: owner_user, name: "My Claude Key")
 
       get integration_credential_path(credential)
 
@@ -149,27 +144,24 @@ RSpec.describe "IntegrationCredentials" do
     end
 
     context "when user is a member" do
-      let(:member_user) { create(:user, :member, account: user.account) }
-
       before { sign_in member_user }
 
       it "denies access" do
-        credential = create(:integration_credential, account: user.account, created_by: user, name: "My Key")
+        credential = create(:integration_credential, account: account, created_by: owner_user, name: "My Key")
 
         get integration_credential_path(credential)
 
-        expect(response).to redirect_to(root_path)
-        expect(flash[:alert]).to include("not authorized")
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
 
   describe "DELETE /integration_credentials/:id" do
     context "when user has owner role" do
-      before { sign_in user }
+      before { sign_in owner_user }
 
       it "revokes the credential and redirects to index" do
-        credential = create(:integration_credential, account: user.account, created_by: user)
+        credential = create(:integration_credential, account: account, created_by: owner_user)
 
         delete integration_credential_path(credential)
 
@@ -180,7 +172,7 @@ RSpec.describe "IntegrationCredentials" do
       end
 
       it "preserves return filter params when provided" do
-        credential = create(:integration_credential, account: user.account, created_by: user, service_key: "claude", category: "llm_provider")
+        credential = create(:integration_credential, account: account, created_by: owner_user, service_key: "claude", category: "llm_provider")
 
         delete integration_credential_path(credential, category: "llm_provider", service_key: "claude")
 
@@ -189,12 +181,10 @@ RSpec.describe "IntegrationCredentials" do
     end
 
     context "when user has admin role" do
-      let(:admin_user) { create(:user, :admin, account: user.account) }
-
       before { sign_in admin_user }
 
       it "revokes the credential" do
-        credential = create(:integration_credential, account: user.account, created_by: user)
+        credential = create(:integration_credential, account: account, created_by: owner_user)
 
         delete integration_credential_path(credential)
 
@@ -204,22 +194,19 @@ RSpec.describe "IntegrationCredentials" do
     end
 
     context "when user is a member" do
-      let(:member_user) { create(:user, :member, account: user.account) }
-
       before { sign_in member_user }
 
       it "denies access" do
-        credential = create(:integration_credential, account: user.account, created_by: user)
+        credential = create(:integration_credential, account: account, created_by: owner_user)
 
         delete integration_credential_path(credential)
 
-        expect(response).to redirect_to(root_path)
-        expect(flash[:alert]).to include("not authorized")
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     context "when credential belongs to another account" do
-      before { sign_in user }
+      before { sign_in owner_user }
 
       it "is not accessible" do
         other_account = create(:account)

--- a/spec/requests/integration_credentials_spec.rb
+++ b/spec/requests/integration_credentials_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "IntegrationCredentials" do
   let(:account) { create(:account) }
-  let(:owner_user) { create(:user, account: account) }
+  let(:owner_user) { create(:user, :owner, account: account) }
   let(:admin_user) { create(:user, :admin, account: account) }
   let(:member_user) { create(:user, :member, account: account) }
 
@@ -55,6 +55,16 @@ RSpec.describe "IntegrationCredentials" do
       expect(response.body).to include("GitHub Signing")
     end
 
+    context "when user is an admin" do
+      before { sign_in admin_user }
+
+      it "allows access" do
+        get new_integration_credential_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     context "when user is a member" do
       before { sign_in member_user }
 
@@ -85,6 +95,42 @@ RSpec.describe "IntegrationCredentials" do
       expect(response).to redirect_to(integration_credential_path(credential, category: credential.category))
       expect(credential.service_key).to eq("gemini")
       expect(credential.created_by).to eq(owner_user)
+    end
+
+    context "when user is an admin" do
+      before { sign_in admin_user }
+
+      it "creates a credential" do
+        post integration_credentials_path, params: {
+          integration_credential: {
+            name: "Admin GitLab",
+            service_key: "gitlab",
+            category: "repository",
+            auth_kind: "api_key",
+            secret: "secret-456"
+          }
+        }
+
+        expect(IntegrationCredential.last.name).to eq("Admin GitLab")
+        expect(response).to redirect_to(integration_credential_path(IntegrationCredential.last, category: "repository"))
+      end
+    end
+
+    it "creates signing credentials with valid auth_kind" do
+      post integration_credentials_path, params: {
+        integration_credential: {
+          name: "My Signing Key",
+          service_key: "github_signing",
+          category: "signing",
+          auth_kind: "signing_token",
+          secret: "signing-secret-123"
+        }
+      }
+
+      credential = IntegrationCredential.last
+      expect(response).to redirect_to(integration_credential_path(credential, category: "signing"))
+      expect(credential.service_key).to eq("github_signing")
+      expect(credential.auth_kind).to eq("signing_token")
     end
 
     it "rejects invalid signing auth types" do
@@ -132,6 +178,19 @@ RSpec.describe "IntegrationCredentials" do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("My Claude Key")
+    end
+
+    context "when user is an admin" do
+      before { sign_in admin_user }
+
+      it "shows the credential" do
+        credential = create(:integration_credential, account: account, created_by: owner_user, name: "Admin Visible Key")
+
+        get integration_credential_path(credential)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Admin Visible Key")
+      end
     end
 
     it "does not show credentials from other accounts" do

--- a/spec/requests/integrations_spec.rb
+++ b/spec/requests/integrations_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Integrations" do
   let(:account) { create(:account) }
-  let(:owner_user) { create(:user, account: account) }
+  let(:owner_user) { create(:user, :owner, account: account) }
   let(:admin_user) { create(:user, :admin, account: account) }
   let(:member_user) { create(:user, :member, account: account) }
 
@@ -63,7 +63,8 @@ RSpec.describe "Integrations" do
         expect(response.body).to include("GitLab Prod")
       end
 
-      it "shows revoked and expired integration credentials with status" do
+      it "excludes revoked and expired integration credentials" do
+        create(:integration_credential, :gitlab, account: account, created_by: owner_user, name: "Active Cred")
         create(:integration_credential, :gitlab, :revoked, account: account, created_by: owner_user, name: "Revoked Cred")
         create(
           :integration_credential,
@@ -76,10 +77,9 @@ RSpec.describe "Integrations" do
 
         get integrations_path
 
-        expect(response.body).to include("Revoked Cred")
-        expect(response.body).to include("Expired Cred")
-        expect(response.body).to include("Revoked")
-        expect(response.body).to include("Expired")
+        expect(response.body).to include("Active Cred")
+        expect(response.body).not_to include("Revoked Cred")
+        expect(response.body).not_to include("Expired Cred")
       end
     end
 

--- a/spec/requests/integrations_spec.rb
+++ b/spec/requests/integrations_spec.rb
@@ -45,6 +45,40 @@ RSpec.describe "Integrations" do
         expect(response.body).to include(provider_key.name)
         expect(response.body).not_to include("Issue Tracking")
       end
+
+      it "shows integration credentials section for admin users" do
+        credential = create(:integration_credential, :gitlab, account: user.account, created_by: user, name: "GitLab Prod")
+
+        get integrations_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Integration Credentials")
+        expect(response.body).to include("GitLab Prod")
+      end
+
+      it "does not show revoked integration credentials" do
+        create(:integration_credential, :gitlab, :revoked, account: user.account, created_by: user, name: "Revoked Cred")
+
+        get integrations_path
+
+        expect(response.body).not_to include("Revoked Cred")
+      end
+
+      context "when user is a member" do
+        let(:member_user) { create(:user, :member, account: user.account) }
+
+        before { sign_in member_user }
+
+        it "does not show integration credentials section" do
+          create(:integration_credential, :gitlab, account: user.account, created_by: user, name: "GitLab Prod")
+
+          get integrations_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).not_to include("Integration Credentials")
+          expect(response.body).not_to include("GitLab Prod")
+        end
+      end
     end
   end
 
@@ -68,6 +102,25 @@ RSpec.describe "Integrations" do
         expect(response.body).to include("Source code access token")
         expect(response.body).to include("Issue tracker API key")
         expect(response.body).to include("LLM provider API key")
+      end
+
+      it "shows integration credential option for admin users" do
+        get new_integration_path
+
+        expect(response.body).to include("Integration credential")
+        expect(response.body).to include("GitLab, Jira, Azure DevOps")
+      end
+
+      context "when user is a member" do
+        let(:member_user) { create(:user, :member, account: user.account) }
+
+        before { sign_in member_user }
+
+        it "does not show integration credential option" do
+          get new_integration_path
+
+          expect(response.body).not_to include("Integration credential")
+        end
       end
     end
   end

--- a/spec/requests/integrations_spec.rb
+++ b/spec/requests/integrations_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Integrations" do
-  let(:user) { create(:user) }
+  let(:account) { create(:account) }
+  let(:owner_user) { create(:user, account: account) }
+  let(:admin_user) { create(:user, :admin, account: account) }
+  let(:member_user) { create(:user, :member, account: account) }
 
   describe "GET /integrations" do
     context "when not authenticated" do
@@ -14,8 +17,8 @@ RSpec.describe "Integrations" do
       end
     end
 
-    context "when authenticated" do
-      before { sign_in user }
+    context "when signed in as the account owner" do
+      before { sign_in owner_user }
 
       it "renders the integrations page" do
         get integrations_path
@@ -33,8 +36,8 @@ RSpec.describe "Integrations" do
       end
 
       it "shows configured integrations grouped by type" do
-        github_token = create(:github_token, account: user.account)
-        provider_key = create(:provider_api_key, user: user)
+        github_token = create(:github_token, account: account)
+        provider_key = create(:provider_api_key, user: owner_user)
 
         get integrations_path
 
@@ -45,9 +48,13 @@ RSpec.describe "Integrations" do
         expect(response.body).to include(provider_key.name)
         expect(response.body).not_to include("Issue Tracking")
       end
+    end
+
+    context "when signed in as an admin" do
+      before { sign_in admin_user }
 
       it "shows integration credentials section for admin users" do
-        credential = create(:integration_credential, :gitlab, account: user.account, created_by: user, name: "GitLab Prod")
+        create(:integration_credential, :gitlab, account: account, created_by: owner_user, name: "GitLab Prod")
 
         get integrations_path
 
@@ -56,28 +63,37 @@ RSpec.describe "Integrations" do
         expect(response.body).to include("GitLab Prod")
       end
 
-      it "does not show revoked integration credentials" do
-        create(:integration_credential, :gitlab, :revoked, account: user.account, created_by: user, name: "Revoked Cred")
+      it "shows revoked and expired integration credentials with status" do
+        create(:integration_credential, :gitlab, :revoked, account: account, created_by: owner_user, name: "Revoked Cred")
+        create(
+          :integration_credential,
+          :gitlab,
+          account: account,
+          created_by: owner_user,
+          expires_at: 1.day.ago,
+          name: "Expired Cred"
+        )
 
         get integrations_path
 
-        expect(response.body).not_to include("Revoked Cred")
+        expect(response.body).to include("Revoked Cred")
+        expect(response.body).to include("Expired Cred")
+        expect(response.body).to include("Revoked")
+        expect(response.body).to include("Expired")
       end
+    end
 
-      context "when user is a member" do
-        let(:member_user) { create(:user, :member, account: user.account) }
+    context "when user is a member" do
+      before { sign_in member_user }
 
-        before { sign_in member_user }
+      it "does not show integration credentials section" do
+        create(:integration_credential, :gitlab, account: account, created_by: owner_user, name: "GitLab Prod")
 
-        it "does not show integration credentials section" do
-          create(:integration_credential, :gitlab, account: user.account, created_by: user, name: "GitLab Prod")
+        get integrations_path
 
-          get integrations_path
-
-          expect(response).to have_http_status(:ok)
-          expect(response.body).not_to include("Integration Credentials")
-          expect(response.body).not_to include("GitLab Prod")
-        end
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("Integration Credentials")
+        expect(response.body).not_to include("GitLab Prod")
       end
     end
   end
@@ -91,8 +107,8 @@ RSpec.describe "Integrations" do
       end
     end
 
-    context "when authenticated" do
-      before { sign_in user }
+    context "when signed in as the account owner" do
+      before { sign_in owner_user }
 
       it "renders the type chooser page" do
         get new_integration_path
@@ -103,6 +119,10 @@ RSpec.describe "Integrations" do
         expect(response.body).to include("Issue tracker API key")
         expect(response.body).to include("LLM provider API key")
       end
+    end
+
+    context "when signed in as an admin" do
+      before { sign_in admin_user }
 
       it "shows integration credential option for admin users" do
         get new_integration_path
@@ -110,17 +130,15 @@ RSpec.describe "Integrations" do
         expect(response.body).to include("Integration credential")
         expect(response.body).to include("GitLab, Jira, Azure DevOps")
       end
+    end
 
-      context "when user is a member" do
-        let(:member_user) { create(:user, :member, account: user.account) }
+    context "when user is a member" do
+      before { sign_in member_user }
 
-        before { sign_in member_user }
+      it "does not show integration credential option" do
+        get new_integration_path
 
-        it "does not show integration credential option" do
-          get new_integration_path
-
-          expect(response.body).not_to include("Integration credential")
-        end
+        expect(response.body).not_to include("Integration credential")
       end
     end
   end


### PR DESCRIPTION
## Summary

Commit succeeded. Here's a summary of what was done:

## Changes made for #1283

**RBAC decision**: Integration credential management is gated to **admin and owner** roles, matching the existing `ServiceContainerPolicy` pattern for account-scoped administrative resources.

**Files changed:**

1. **`app/policies/integration_credential_policy.rb`** — All actions (index, show, create, destroy, revoke) now require admin or owner role. Overrides `account_for_record` to fall back to `user.account` for class-level authorization.

2. **`app/services/integrations/hub.rb`** — Added integration credentials section for admin/owner users, showing only active (non-revoked, non-expired) credentials. Removed TODO comment.

3. **`app/controllers/integration_credentials_controller.rb`** — Replaced `skip_after_action :verify_authorized` with `authorize IntegrationCredential` in index action. Removed TODO comment.

4. **`app/views/integrations/index.html.erb`** — Added service column rendering for integration_credentials section.

5. **`app/views/integrations/new.html.erb`** — Added "Integration credential" link for admin+ users, gated by policy check.

6. **`app/services/integrations/credential_catalog.rb`** — Removed TODO comment.

7. **`README.md`** — Replaced gap caveat with feature description.

8. **`spec/requests/integration_credentials_spec.rb`** — Added tests for admin access, member denial on index/new/create/show/destroy.

9. **`spec/requests/integrations_spec.rb`** — Added tests for integration credentials section visibility for admin users, hidden from members, and revoked credentials excluded.

---

Closes #1283