### PR TITLE
fix(agent-runs): extend abort pattern matching to stdout for JSON-mode providers

### DIFF
--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1763,7 +1763,11 @@ RSpec.describe Containers::Provision do
       it "logs the abort pattern match with stream type" do
         allow(agent_run).to receive(:log!)
 
-        service.execute("kilo run --auto", abort_patterns: abort_patterns) rescue nil
+        begin
+          service.execute("kilo run --auto", abort_patterns: abort_patterns)
+        rescue described_class::OutputAbortError
+          # expected — we are testing the log side-effect, not the raise
+        end
 
         expect(agent_run).to have_received(:log!).with(
           "system", "container.execute.abort_pattern_matched",
@@ -1886,27 +1890,22 @@ RSpec.describe Containers::Provision do
       end
 
       it "logs stdout as the stream type when structured JSONL triggers abort" do
-        structured_error = {
-          "type" => "response.failed",
-          "error" => {
-            "message" => "Error: Free tier limit reached. Please upgrade to a paid plan."
-          }
-        }.to_json + "\n"
-
+        error_json = { "type" => "response.failed",
+                       "error" => { "message" => "Error: Free tier limit reached." } }.to_json + "\n"
         allow(agent_run).to receive(:log!)
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
-          block.call(:stdout, structured_error) if block
-          [ [ structured_error ], [], 1 ]
+          block.call(:stdout, error_json) if block
+          [ [ error_json ], [], 1 ]
         end
 
-        service.execute("codex exec --json", abort_patterns: abort_patterns) rescue nil
+        begin
+          service.execute("codex exec --json", abort_patterns: abort_patterns)
+        rescue described_class::OutputAbortError # expected
+        end
 
         expect(agent_run).to have_received(:log!).with(
           "system", "container.execute.abort_pattern_matched",
-          metadata: hash_including(
-            stream: "stdout",
-            output: a_string_matching(/Free tier limit reached/)
-          )
+          metadata: hash_including(stream: "stdout", output: a_string_matching(/Free tier limit reached/))
         )
       end
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1763,11 +1763,8 @@ RSpec.describe Containers::Provision do
       it "logs the abort pattern match with stream type" do
         allow(agent_run).to receive(:log!)
 
-        begin
-          service.execute("kilo run --auto", abort_patterns: abort_patterns)
-        rescue described_class::OutputAbortError
-          # expected — we are testing the log side-effect, not the raise
-        end
+        expect { service.execute("kilo run --auto", abort_patterns: abort_patterns) }
+          .to raise_error(described_class::OutputAbortError)
 
         expect(agent_run).to have_received(:log!).with(
           "system", "container.execute.abort_pattern_matched",
@@ -1898,10 +1895,8 @@ RSpec.describe Containers::Provision do
           [ [ error_json ], [], 1 ]
         end
 
-        begin
-          service.execute("codex exec --json", abort_patterns: abort_patterns)
-        rescue described_class::OutputAbortError # expected
-        end
+        expect { service.execute("codex exec --json", abort_patterns: abort_patterns) }
+          .to raise_error(described_class::OutputAbortError)
 
         expect(agent_run).to have_received(:log!).with(
           "system", "container.execute.abort_pattern_matched",

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1760,14 +1760,17 @@ RSpec.describe Containers::Provision do
         expect(mock_container).to have_received(:stop).with(timeout: 0)
       end
 
-      it "logs the abort pattern match" do
+      it "logs the abort pattern match with stream type" do
         allow(agent_run).to receive(:log!)
 
         service.execute("kilo run --auto", abort_patterns: abort_patterns) rescue nil
 
         expect(agent_run).to have_received(:log!).with(
           "system", "container.execute.abort_pattern_matched",
-          metadata: hash_including(output: a_string_matching(/Free tier limit reached/))
+          metadata: hash_including(
+            stream: "stderr",
+            output: a_string_matching(/Free tier limit reached/)
+          )
         )
       end
     end
@@ -1880,6 +1883,31 @@ RSpec.describe Containers::Provision do
           }
 
         expect(mock_container).to have_received(:stop).with(timeout: 0)
+      end
+
+      it "logs stdout as the stream type when structured JSONL triggers abort" do
+        structured_error = {
+          "type" => "response.failed",
+          "error" => {
+            "message" => "Error: Free tier limit reached. Please upgrade to a paid plan."
+          }
+        }.to_json + "\n"
+
+        allow(agent_run).to receive(:log!)
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stdout, structured_error) if block
+          [ [ structured_error ], [], 1 ]
+        end
+
+        service.execute("codex exec --json", abort_patterns: abort_patterns) rescue nil
+
+        expect(agent_run).to have_received(:log!).with(
+          "system", "container.execute.abort_pattern_matched",
+          metadata: hash_including(
+            stream: "stdout",
+            output: a_string_matching(/Free tier limit reached/)
+          )
+        )
       end
 
       it "aborts on a complete structured stdout failure event without a trailing newline" do


### PR DESCRIPTION
## Summary

Commit succeeded. Here's a summary of what was done:

The implementation for issue #1567 was already complete in the codebase:
1. **Abort patterns check both stdout and stderr** - `provision.rb:449-468` runs outside the `case stream_type` block
2. **JSONL error events from stdout trigger abort** - `structured_jsonl_abort_candidate` parses JSONL and extracts failure text from error-type events
3. **Sandbox failure patterns added** - `CODEX_SANDBOX_ABORT_PATTERNS` in `run_agent_activity.rb` includes `bwrap`, namespace permission patterns
4. **Abort log includes stream type** - `stream: stream_type.to_s` in the log call

The only gap was **test coverage for the stream type in log assertions**:
- Updated the existing stderr abort log test to verify `stream: "stderr"` is in metadata
- Added a new test verifying that structured JSONL stdout abort logs `stream: "stdout"`

All 185 provision tests pass, rubocop is clean.

---

Closes #1567