### PR TITLE
refactor: Use plan-only API from agent-harness instead of ExecutorCapture

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,8 @@ gem "docker-api", require: false
 gem "qdrant-ruby", require: false
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-# 0.11.0 fixes GithubCopilot provider CLI version detection for 0.1.x subcommand CLIs.
-gem "agent-harness", "~> 0.11.3"
+# Pin the merged plan_execution work until the next gem release lands.
+gem "agent-harness", git: "https://github.com/viamin/agent-harness.git", ref: "e4d2c1fa025bb36192e14d95fee018a23d4a309a"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 # Defer loading — invoked as CLI binary, not via Ruby API.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/viamin/agent-harness.git
+  revision: e4d2c1fa025bb36192e14d95fee018a23d4a309a
+  ref: e4d2c1fa025bb36192e14d95fee018a23d4a309a
+  specs:
+    agent-harness (0.15.0)
+      logger (>= 1.6, < 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -77,8 +85,6 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    agent-harness (0.11.3)
-      logger (>= 1.6, < 2.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -533,7 +539,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness (~> 0.11.3)
+  agent-harness!
   bootsnap
   brakeman
   bundler-audit
@@ -596,7 +602,7 @@ CHECKSUMS
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  agent-harness (0.11.3) sha256=70f5376ff08024f921bc02b2fa462fd522b8fd0e53c143fbd7edddd4b86fdf3d
+  agent-harness (0.15.0)
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032

--- a/app/services/containers/streaming_event_processor.rb
+++ b/app/services/containers/streaming_event_processor.rb
@@ -205,7 +205,8 @@ module Containers
     end
 
     def error_message(event)
-      (event_value(event, "message") || event_dig(event, "error", "message") || event.respond_to?(:error_message) && event.error_message).to_s.truncate(500)
+      msg = event_value(event, "message") || event_dig(event, "error", "message") || (event.error_message if event.respond_to?(:error_message))
+      msg.to_s.truncate(500)
     end
 
     def token_counts(event)
@@ -220,7 +221,15 @@ module Containers
 
     def event_value(event, key)
       raw_event = event.respond_to?(:raw_event) ? event.raw_event : event
-      return raw_event[key] if raw_event.respond_to?(:[])
+      if raw_event.is_a?(Hash)
+        return raw_event[key] if raw_event.key?(key)
+      elsif raw_event.respond_to?(:[])
+        begin
+          return raw_event[key]
+        rescue NameError
+          # Struct-like objects raise NameError for missing keys; fall through
+        end
+      end
 
       event.public_send(key) if event.respond_to?(key)
     end

--- a/app/services/containers/streaming_event_processor.rb
+++ b/app/services/containers/streaming_event_processor.rb
@@ -38,7 +38,7 @@ module Containers
       parsed = parse_jsonl_event(stripped)
       return nil unless parsed
 
-      event_type = parsed["type"].to_s
+      event_type = event_value(parsed, "type").to_s
       return nil if event_type.blank?
 
       { type: classify_event(event_type), event: parsed, raw_type: event_type }
@@ -97,7 +97,7 @@ module Containers
 
     def parse_jsonl_event(line)
       if harness_streaming_available?
-        AgentHarness::Providers::Codex.parse_streaming_event(line)
+        AgentHarness::Providers::Codex.parse_streaming_event(line) || fallback_parse(line)
       else
         fallback_parse(line)
       end
@@ -130,22 +130,25 @@ module Containers
     end
 
     def log_progress_event(event)
+      tokens = token_counts(event)
+
       log_streaming("container.execute.progress",
-        event_type: event["type"],
+        event_type: event_type(event),
         turn_number: @turns_completed + 1,
-        tokens_input: event.dig("usage", "input_tokens") || event["input_tokens"],
-        tokens_output: event.dig("usage", "output_tokens") || event["output_tokens"])
+        tokens_input: tokens[:input],
+        tokens_output: tokens[:output])
     end
 
     def record_turn_complete(event)
       @turns_completed += 1
+      tokens = token_counts(event)
 
       turn_data = {
         "turn_number" => @turns_completed,
         "completed_at" => Time.current.iso8601,
-        "input_tokens" => event.dig("usage", "input_tokens") || event["input_tokens"],
-        "output_tokens" => event.dig("usage", "output_tokens") || event["output_tokens"],
-        "duration_ms" => event["duration_ms"] || event.dig("metrics", "duration_ms")
+        "input_tokens" => tokens[:input],
+        "output_tokens" => tokens[:output],
+        "duration_ms" => event_value(event, "duration_ms") || event_dig(event, "metrics", "duration_ms")
       }.compact
 
       @turns_data << turn_data
@@ -159,14 +162,15 @@ module Containers
 
     def record_turn_failed(event)
       @turns_completed += 1
+      tokens = token_counts(event)
 
       turn_data = {
         "turn_number" => @turns_completed,
         "completed_at" => Time.current.iso8601,
         "status" => "failed",
-        "error" => (event["message"] || event.dig("error", "message")).to_s.truncate(500),
-        "input_tokens" => event.dig("usage", "input_tokens") || event["input_tokens"],
-        "output_tokens" => event.dig("usage", "output_tokens") || event["output_tokens"]
+        "error" => error_message(event),
+        "input_tokens" => tokens[:input],
+        "output_tokens" => tokens[:output]
       }.compact
 
       @turns_data << turn_data
@@ -177,11 +181,9 @@ module Containers
     end
 
     def log_error_event(event)
-      error_message = (event["message"] || event.dig("error", "message")).to_s.truncate(500)
-
       log_streaming("container.execute.streaming_error",
-        event_type: event["type"],
-        error: error_message)
+        event_type: event_type(event),
+        error: error_message(event))
     end
 
     def renumbered_turns(offset)
@@ -196,6 +198,38 @@ module Containers
       elsif @agent_run
         @agent_run.log!("system", message, metadata: metadata)
       end
+    end
+
+    def event_type(event)
+      event_value(event, "type")
+    end
+
+    def error_message(event)
+      (event_value(event, "message") || event_dig(event, "error", "message") || event.respond_to?(:error_message) && event.error_message).to_s.truncate(500)
+    end
+
+    def token_counts(event)
+      tokens = event.respond_to?(:tokens) ? event.tokens : nil
+      return tokens if tokens.is_a?(Hash)
+
+      {
+        input: event_dig(event, "usage", "input_tokens") || event_value(event, "input_tokens"),
+        output: event_dig(event, "usage", "output_tokens") || event_value(event, "output_tokens")
+      }
+    end
+
+    def event_value(event, key)
+      raw_event = event.respond_to?(:raw_event) ? event.raw_event : event
+      return raw_event[key] if raw_event.respond_to?(:[])
+
+      event.public_send(key) if event.respond_to?(key)
+    end
+
+    def event_dig(event, *keys)
+      raw_event = event.respond_to?(:raw_event) ? event.raw_event : event
+      return raw_event.dig(*keys) if raw_event.respond_to?(:dig)
+
+      nil
     end
   end
 end

--- a/app/services/providers/harness_execution_plan.rb
+++ b/app/services/providers/harness_execution_plan.rb
@@ -31,29 +31,16 @@ module Providers
     def self.for_provider_key(provider_key:, prompt:, options: {})
       harness_key = ProviderSupport.harness_provider_key_for(provider_key).to_sym
       klass = AgentHarness::Providers::Registry.instance.get(harness_key)
-      capture = ExecutorCapture.new
 
       config = AgentHarness::ProviderConfig.new(harness_key)
       config.externally_sandboxed = true
 
-      provider_instance = klass.new(executor: capture, config: config)
-      provider_instance.send_message(prompt: prompt, **options)
-
-      Result.new(
-        command: capture.command,
-        env: capture.env,
-        preparation: capture.preparation
-      )
+      provider_instance = klass.new(config: config)
+      Result.new(**provider_instance.plan_execution(prompt: prompt, **options))
     end
 
     def call
-      harness_provider.send_message(prompt: @prompt, provider_runtime: provider_runtime, **@options)
-
-      Result.new(
-        command: capture_executor.command,
-        env: capture_executor.env,
-        preparation: capture_executor.preparation
-      )
+      Result.new(**harness_provider.plan_execution(prompt: @prompt, provider_runtime: provider_runtime, **@options))
     end
 
     private
@@ -61,12 +48,8 @@ module Providers
     def harness_provider
       @harness_provider ||= begin
         klass = AgentHarness::Providers::Registry.instance.get(harness_provider_name)
-        klass.new(executor: capture_executor)
+        klass.new
       end
-    end
-
-    def capture_executor
-      @capture_executor ||= ExecutorCapture.new
     end
 
     def harness_provider_name
@@ -75,23 +58,6 @@ module Providers
 
     def provider_runtime
       @provider.agent_harness_provider_runtime
-    end
-
-    class ExecutorCapture
-      attr_reader :command, :env, :preparation
-
-      def execute(command, env: {}, preparation: nil, **)
-        @command = command
-        @env = env
-        @preparation = preparation
-
-        AgentHarness::CommandExecutor::Result.new(
-          stdout: "",
-          stderr: "",
-          exit_code: 0,
-          duration: 0.0
-        )
-      end
     end
   end
 end

--- a/app/services/providers/harness_execution_plan.rb
+++ b/app/services/providers/harness_execution_plan.rb
@@ -30,12 +30,7 @@ module Providers
     # @return [Result] command, env, and preparation
     def self.for_provider_key(provider_key:, prompt:, options: {})
       harness_key = ProviderSupport.harness_provider_key_for(provider_key).to_sym
-      klass = AgentHarness::Providers::Registry.instance.get(harness_key)
-
-      config = AgentHarness::ProviderConfig.new(harness_key)
-      config.externally_sandboxed = true
-
-      provider_instance = klass.new(config: config)
+      provider_instance = build_harness_provider(harness_key)
       Result.new(**provider_instance.plan_execution(prompt: prompt, **options))
     end
 
@@ -45,11 +40,17 @@ module Providers
 
     private
 
+    def self.build_harness_provider(harness_key)
+      klass = AgentHarness::Providers::Registry.instance.get(harness_key)
+
+      config = AgentHarness::ProviderConfig.new(harness_key)
+      config.externally_sandboxed = true
+
+      klass.new(config: config)
+    end
+
     def harness_provider
-      @harness_provider ||= begin
-        klass = AgentHarness::Providers::Registry.instance.get(harness_provider_name)
-        klass.new
-      end
+      @harness_provider ||= self.class.build_harness_provider(harness_provider_name)
     end
 
     def harness_provider_name

--- a/app/services/providers/harness_execution_plan.rb
+++ b/app/services/providers/harness_execution_plan.rb
@@ -48,9 +48,10 @@ module Providers
 
       klass.new(config: config)
     end
+    private_class_method :build_harness_provider
 
     def harness_provider
-      @harness_provider ||= self.class.build_harness_provider(harness_provider_name)
+      @harness_provider ||= self.class.send(:build_harness_provider, harness_provider_name)
     end
 
     def harness_provider_name

--- a/spec/services/containers/streaming_event_processor_spec.rb
+++ b/spec/services/containers/streaming_event_processor_spec.rb
@@ -240,6 +240,25 @@ RSpec.describe Containers::StreamingEventProcessor do
       expect(logged_events.last[:message]).to eq("container.execute.streaming_error")
       expect(logged_events.last[:error]).to eq("API error")
     end
+
+    it "logs agent-harness struct events using raw_event and tokens" do
+      event_class = Struct.new(:type, :tokens, :error_message, :raw_event, keyword_init: true)
+      parsed = {
+        type: :progress,
+        raw_type: "item.completed",
+        event: event_class.new(
+          type: :progress,
+          tokens: { input: 100, output: 50 },
+          raw_event: { "type" => "item.completed" }
+        )
+      }
+
+      expect(processor.process(parsed)).to eq(:activity)
+      expect(logged_events.last[:message]).to eq("container.execute.progress")
+      expect(logged_events.last[:event_type]).to eq("item.completed")
+      expect(logged_events.last[:tokens_input]).to eq(100)
+      expect(logged_events.last[:tokens_output]).to eq(50)
+    end
   end
 
   describe "agent-harness fallback" do

--- a/spec/services/providers/harness_execution_plan_spec.rb
+++ b/spec/services/providers/harness_execution_plan_spec.rb
@@ -45,5 +45,25 @@ RSpec.describe Providers::HarnessExecutionPlan do
       expect(parsed["model"]).to eq("moonshotai/kimi-k2-0905")
       expect(parsed).not_to have_key("baseURL")
     end
+
+    it "constructs the harness provider with external sandboxing enabled" do
+      provider = instance_double(Provider, provider_key: "claude", agent_harness_provider_runtime: nil)
+      harness_provider = double(plan_execution: { command: %w[claude ping], env: {}, preparation: nil })
+      provider_class = Class.new do
+        def self.new(config:)
+          raise "stub me"
+        end
+      end
+
+      expect(AgentHarness::Providers::Registry.instance).to receive(:get).with(:claude).and_return(provider_class)
+      expect(provider_class).to receive(:new) do |config:|
+        expect(config).to be_a(AgentHarness::ProviderConfig)
+        expect(config.name).to eq(:claude)
+        expect(config.externally_sandboxed).to be(true)
+        harness_provider
+      end
+
+      described_class.call(provider: provider, prompt: "ping")
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implemented the refactor in [app/services/providers/harness_execution_plan.rb](/workspace/app/services/providers/harness_execution_plan.rb) to use `provider.plan_execution(...)` and removed the local `ExecutorCapture` shim. I also pinned `agent-harness` to the merged upstream PR head in [Gemfile](/workspace/Gemfile) and updated [Gemfile.lock](/workspace/Gemfile.lock) so the public planning API is available.

Validation status:
`bundle exec rubocop` passed.
`RAILS_ENV=test bin/rails db:prepare` passed.
Focused specs covering the new planning path passed, including [spec/services/providers/harness_execution_plan_spec.rb](/workspace/spec/services/providers/harness_execution_plan_spec.rb) and the relevant [run_agent_activity` examples](/workspace/spec/temporal/activities/run_agent_activity_spec.rb:247).

I was not able to finish the requested commit. The pre-commit hook runs the full `bundle exec rspec`, and that hook run is failing outside the touched files after a long execution, with at least one transient PostgreSQL deadlock observed and then multiple later failures in the full suite. Because of that, I did not get a clean commit through the hook, and the repo still has staged/uncommitted changes.

---

Closes #1561