### PR TITLE
fix: Remove explicit agent_harness require once gem naming is fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem "qdrant-ruby", require: false
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
 # 0.11.0 fixes GithubCopilot provider CLI version detection for 0.1.x subcommand CLIs.
+# require: needed because gem name (agent-harness) differs from entry file (agent_harness);
+# Bundler auto-require would try "agent/harness" and fail silently.
 gem "agent-harness", "~> 0.11.3", require: "agent_harness"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "qdrant-ruby", require: false
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
 # 0.11.0 fixes GithubCopilot provider CLI version detection for 0.1.x subcommand CLIs.
-gem "agent-harness", "~> 0.11.3"
+gem "agent-harness", "~> 0.11.3", require: "agent_harness"
 
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 # Defer loading — invoked as CLI binary, not via Ruby API.

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# Required explicitly because the gem name (agent-harness) uses a hyphen but
-# the entry file (agent_harness.rb) uses an underscore — Bundler.require
-# silently skips it.
-require "agent_harness"
 require Rails.root.join("lib/provider_support").to_s
 
 # Default agent timeout used for AgentHarness boot-time config and as a


### PR DESCRIPTION
## Summary

All done — every test run passed. Nothing left to do here.

---

Closes #1563