### PR TITLE
Fix #1312: Hide review settings fields until review type is selected

### DIFF
--- a/app/javascript/controllers/collapsible_panel_controller.js
+++ b/app/javascript/controllers/collapsible_panel_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+const COLLAPSED_CLASSES = ["max-h-0", "overflow-hidden", "opacity-0"]
+const EXPANDED_CLASSES = ["max-h-[2000px]", "opacity-100"]
+
+export default class extends Controller {
+  static targets = ["checkbox", "panel"]
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    const expanded = this.checkboxTarget.checked
+
+    this.checkboxTarget.setAttribute("aria-expanded", expanded.toString())
+    this.panelTarget.hidden = false
+    this.panelTarget.setAttribute("aria-hidden", (!expanded).toString())
+
+    COLLAPSED_CLASSES.forEach((className) => {
+      this.panelTarget.classList.toggle(className, !expanded)
+    })
+
+    EXPANDED_CLASSES.forEach((className) => {
+      this.panelTarget.classList.toggle(className, expanded)
+    })
+  }
+}

--- a/app/javascript/controllers/collapsible_panel_controller.js
+++ b/app/javascript/controllers/collapsible_panel_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
     const expanded = this.checkboxTarget.checked
 
     this.checkboxTarget.setAttribute("aria-expanded", expanded.toString())
-    this.panelTarget.hidden = false
+    this.panelTarget.hidden = !expanded
     this.panelTarget.setAttribute("aria-hidden", (!expanded).toString())
 
     COLLAPSED_CLASSES.forEach((className) => {

--- a/app/javascript/controllers/collapsible_panel_controller.js
+++ b/app/javascript/controllers/collapsible_panel_controller.js
@@ -7,22 +7,21 @@ export default class extends Controller {
   static targets = ["checkbox", "panel"]
 
   connect() {
-    this.toggle()
+    this.applyState()
   }
 
   toggle() {
+    this.applyState()
+  }
+
+  applyState() {
     const expanded = this.checkboxTarget.checked
 
     this.checkboxTarget.setAttribute("aria-expanded", expanded.toString())
-    this.panelTarget.hidden = !expanded
     this.panelTarget.setAttribute("aria-hidden", (!expanded).toString())
+    this.panelTarget.inert = !expanded
 
-    COLLAPSED_CLASSES.forEach((className) => {
-      this.panelTarget.classList.toggle(className, !expanded)
-    })
-
-    EXPANDED_CLASSES.forEach((className) => {
-      this.panelTarget.classList.toggle(className, expanded)
-    })
+    COLLAPSED_CLASSES.forEach((cls) => this.panelTarget.classList.toggle(cls, !expanded))
+    EXPANDED_CLASSES.forEach((cls) => this.panelTarget.classList.toggle(cls, expanded))
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("checkbox-toggle", CheckboxToggleController)
 import ChatController from "./chat_controller"
 application.register("chat", ChatController)
 
+import CollapsiblePanelController from "./collapsible_panel_controller"
+application.register("collapsible-panel", CollapsiblePanelController)
+
 import ChatInputController from "./chat_input_controller"
 application.register("chat-input", ChatInputController)
 

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -281,6 +281,7 @@
                 </div>
                 <div id="review_copilot_settings"
                   class="ml-7 grid grid-cols-2 gap-3 transition-all duration-200 ease-in-out <%= copilot["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  aria-hidden="<%= copilot["enabled"] ? "false" : "true" %>"
                   <%= "hidden" unless copilot["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <div>
@@ -328,6 +329,7 @@
                 </div>
                 <div id="review_paid_agent_settings"
                   class="ml-7 grid grid-cols-2 gap-3 transition-all duration-200 ease-in-out <%= paid["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  aria-hidden="<%= paid["enabled"] ? "false" : "true" %>"
                   <%= "hidden" unless paid["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <div>
@@ -376,6 +378,7 @@
                 </div>
                 <div id="review_codex_settings"
                   class="space-y-3 transition-all duration-200 ease-in-out <%= codex["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  aria-hidden="<%= codex["enabled"] ? "false" : "true" %>"
                   <%= "hidden" unless codex["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <p class="ml-7 text-xs text-gray-500">Waits for the <code>chatgpt-codex-connector</code> bot to review the PR and resolve its threads before advancing.</p>
@@ -426,6 +429,7 @@
                 </div>
                 <div id="review_ci_action_settings"
                   class="ml-7 space-y-3 transition-all duration-200 ease-in-out <%= ci["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  aria-hidden="<%= ci["enabled"] ? "false" : "true" %>"
                   <%= "hidden" unless ci["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <div>
@@ -485,6 +489,7 @@
                 </div>
                 <div id="review_manual_settings"
                   class="ml-7 space-y-3 transition-all duration-200 ease-in-out <%= manual["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  aria-hidden="<%= manual["enabled"] ? "false" : "true" %>"
                   <%= "hidden" unless manual["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <div>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -265,16 +265,24 @@
 
               <%# GitHub Copilot %>
               <% copilot = rs.dig("methods", "copilot") || {} %>
-              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3">
+              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
+                data-controller="collapsible-panel">
                 <div class="flex items-center">
                   <input type="hidden" name="project[review_settings][methods][copilot][enabled]" value="0" />
                   <input type="checkbox" name="project[review_settings][methods][copilot][enabled]" value="1" id="review_copilot_enabled"
                     <%= "checked" if copilot["enabled"] %>
-                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                    aria-controls="review_copilot_settings"
+                    aria-expanded="<%= copilot["enabled"] ? "true" : "false" %>"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    data-action="change->collapsible-panel#toggle"
+                    data-collapsible-panel-target="checkbox" />
                   <label for="review_copilot_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">GitHub Copilot</label>
                   <span class="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">GitHub-hosted only</span>
                 </div>
-                <div class="ml-7 grid grid-cols-2 gap-3">
+                <div id="review_copilot_settings"
+                  class="ml-7 grid grid-cols-2 gap-3 transition-all duration-200 ease-in-out <%= copilot["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  <%= "hidden" unless copilot["enabled"] %>
+                  data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_copilot_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                     <input type="number" name="project[review_settings][methods][copilot][termination][max_review_rounds]" id="review_copilot_max_rounds"
@@ -305,15 +313,23 @@
 
               <%# Paid PR Code Review Agent %>
               <% paid = rs.dig("methods", "paid_agent") || {} %>
-              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3">
+              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
+                data-controller="collapsible-panel">
                 <div class="flex items-center">
                   <input type="hidden" name="project[review_settings][methods][paid_agent][enabled]" value="0" />
                   <input type="checkbox" name="project[review_settings][methods][paid_agent][enabled]" value="1" id="review_paid_agent_enabled"
                     <%= "checked" if paid["enabled"] %>
-                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                    aria-controls="review_paid_agent_settings"
+                    aria-expanded="<%= paid["enabled"] ? "true" : "false" %>"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    data-action="change->collapsible-panel#toggle"
+                    data-collapsible-panel-target="checkbox" />
                   <label for="review_paid_agent_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Paid PR Code Review Agent</label>
                 </div>
-                <div class="ml-7 grid grid-cols-2 gap-3">
+                <div id="review_paid_agent_settings"
+                  class="ml-7 grid grid-cols-2 gap-3 transition-all duration-200 ease-in-out <%= paid["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  <%= "hidden" unless paid["enabled"] %>
+                  data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_paid_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                     <input type="number" name="project[review_settings][methods][paid_agent][termination][max_review_rounds]" id="review_paid_max_rounds"
@@ -344,56 +360,74 @@
 
               <%# OpenAI Codex %>
               <% codex = rs.dig("methods", "codex") || {} %>
-              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3">
+              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
+                data-controller="collapsible-panel">
                 <div class="flex items-center">
                   <input type="hidden" name="project[review_settings][methods][codex][enabled]" value="0" />
                   <input type="checkbox" name="project[review_settings][methods][codex][enabled]" value="1" id="review_codex_enabled"
                     <%= "checked" if codex["enabled"] %>
-                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                    aria-controls="review_codex_settings"
+                    aria-expanded="<%= codex["enabled"] ? "true" : "false" %>"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    data-action="change->collapsible-panel#toggle"
+                    data-collapsible-panel-target="checkbox" />
                   <label for="review_codex_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">OpenAI Codex</label>
                   <span class="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">GitHub-hosted only</span>
                 </div>
-                <p class="ml-7 text-xs text-gray-500">Waits for the <code>chatgpt-codex-connector</code> bot to review the PR and resolve its threads before advancing.</p>
-                <div class="ml-7 grid grid-cols-2 gap-3">
-                  <div>
-                    <label for="review_codex_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
-                    <input type="number" name="project[review_settings][methods][codex][termination][max_review_rounds]" id="review_codex_max_rounds"
-                      value="<%= codex.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
-                  </div>
-                  <div>
-                    <label for="review_codex_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
-                    <input type="number" name="project[review_settings][methods][codex][termination][timeout_minutes]" id="review_codex_timeout"
-                      value="<%= codex.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 60"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
-                  </div>
-                  <div>
-                    <label for="review_codex_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
-                    <input type="text" name="project[review_settings][methods][codex][termination][quality_threshold]" id="review_codex_quality"
-                      value="<%= codex.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
-                  </div>
-                  <div class="flex items-center col-span-2">
-                    <input type="hidden" name="project[review_settings][methods][codex][termination][stop_when_no_comments]" value="0" />
-                    <input type="checkbox" name="project[review_settings][methods][codex][termination][stop_when_no_comments]" value="1" id="review_codex_stop_no_comments"
-                      <%= "checked" if codex.dig("termination", "stop_when_no_comments") %>
-                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
-                    <label for="review_codex_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
+                <div id="review_codex_settings"
+                  class="space-y-3 transition-all duration-200 ease-in-out <%= codex["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  <%= "hidden" unless codex["enabled"] %>
+                  data-collapsible-panel-target="panel">
+                  <p class="ml-7 text-xs text-gray-500">Waits for the <code>chatgpt-codex-connector</code> bot to review the PR and resolve its threads before advancing.</p>
+                  <div class="ml-7 grid grid-cols-2 gap-3">
+                    <div>
+                      <label for="review_codex_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
+                      <input type="number" name="project[review_settings][methods][codex][termination][max_review_rounds]" id="review_codex_max_rounds"
+                        value="<%= codex.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                    </div>
+                    <div>
+                      <label for="review_codex_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
+                      <input type="number" name="project[review_settings][methods][codex][termination][timeout_minutes]" id="review_codex_timeout"
+                        value="<%= codex.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 60"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                    </div>
+                    <div>
+                      <label for="review_codex_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
+                      <input type="text" name="project[review_settings][methods][codex][termination][quality_threshold]" id="review_codex_quality"
+                        value="<%= codex.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                    </div>
+                    <div class="flex items-center col-span-2">
+                      <input type="hidden" name="project[review_settings][methods][codex][termination][stop_when_no_comments]" value="0" />
+                      <input type="checkbox" name="project[review_settings][methods][codex][termination][stop_when_no_comments]" value="1" id="review_codex_stop_no_comments"
+                        <%= "checked" if codex.dig("termination", "stop_when_no_comments") %>
+                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                      <label for="review_codex_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
+                    </div>
                   </div>
                 </div>
               </div>
 
               <%# CI Review Action %>
               <% ci = rs.dig("methods", "ci_action") || {} %>
-              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3">
+              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
+                data-controller="collapsible-panel">
                 <div class="flex items-center">
                   <input type="hidden" name="project[review_settings][methods][ci_action][enabled]" value="0" />
                   <input type="checkbox" name="project[review_settings][methods][ci_action][enabled]" value="1" id="review_ci_action_enabled"
                     <%= "checked" if ci["enabled"] %>
-                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                    aria-controls="review_ci_action_settings"
+                    aria-expanded="<%= ci["enabled"] ? "true" : "false" %>"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    data-action="change->collapsible-panel#toggle"
+                    data-collapsible-panel-target="checkbox" />
                   <label for="review_ci_action_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">CI Review Action</label>
                 </div>
-                <div class="ml-7 space-y-3">
+                <div id="review_ci_action_settings"
+                  class="ml-7 space-y-3 transition-all duration-200 ease-in-out <%= ci["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  <%= "hidden" unless ci["enabled"] %>
+                  data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_ci_action_name" class="block text-xs font-medium text-gray-600">Action Name</label>
                     <input type="text" name="project[review_settings][methods][ci_action][action_name]" id="review_ci_action_name"
@@ -436,15 +470,23 @@
 
               <%# Manual Review %>
               <% manual = rs.dig("methods", "manual") || {} %>
-              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3">
+              <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
+                data-controller="collapsible-panel">
                 <div class="flex items-center">
                   <input type="hidden" name="project[review_settings][methods][manual][enabled]" value="0" />
                   <input type="checkbox" name="project[review_settings][methods][manual][enabled]" value="1" id="review_manual_enabled"
                     <%= "checked" if manual["enabled"] %>
-                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                    aria-controls="review_manual_settings"
+                    aria-expanded="<%= manual["enabled"] ? "true" : "false" %>"
+                    class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                    data-action="change->collapsible-panel#toggle"
+                    data-collapsible-panel-target="checkbox" />
                   <label for="review_manual_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Manual Review</label>
                 </div>
-                <div class="ml-7 space-y-3">
+                <div id="review_manual_settings"
+                  class="ml-7 space-y-3 transition-all duration-200 ease-in-out <%= manual["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
+                  <%= "hidden" unless manual["enabled"] %>
+                  data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_manual_reviewer_login" class="block text-xs font-medium text-gray-600">Reviewer Login</label>
                     <input type="text" name="project[review_settings][methods][manual][reviewer_login]" id="review_manual_reviewer_login"
@@ -452,31 +494,31 @@
                       class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
                   </div>
                   <div class="grid grid-cols-2 gap-3">
-                  <div>
-                    <label for="review_manual_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
-                    <input type="number" name="project[review_settings][methods][manual][termination][max_review_rounds]" id="review_manual_max_rounds"
-                      value="<%= manual.dig("termination", "max_review_rounds") %>" min="1" placeholder="optional"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
-                  </div>
-                  <div>
-                    <label for="review_manual_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
-                    <input type="number" name="project[review_settings][methods][manual][termination][timeout_minutes]" id="review_manual_timeout"
-                      value="<%= manual.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 1440 (24h)"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
-                  </div>
-                  <div>
-                    <label for="review_manual_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
-                    <input type="text" name="project[review_settings][methods][manual][termination][quality_threshold]" id="review_manual_quality"
-                      value="<%= manual.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
-                  </div>
-                  <div class="flex items-center">
-                    <input type="hidden" name="project[review_settings][methods][manual][termination][stop_when_no_comments]" value="0" />
-                    <input type="checkbox" name="project[review_settings][methods][manual][termination][stop_when_no_comments]" value="1" id="review_manual_stop_no_comments"
-                      <%= "checked" if manual.dig("termination", "stop_when_no_comments") %>
-                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
-                    <label for="review_manual_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
-                  </div>
+                    <div>
+                      <label for="review_manual_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
+                      <input type="number" name="project[review_settings][methods][manual][termination][max_review_rounds]" id="review_manual_max_rounds"
+                        value="<%= manual.dig("termination", "max_review_rounds") %>" min="1" placeholder="optional"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                    </div>
+                    <div>
+                      <label for="review_manual_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
+                      <input type="number" name="project[review_settings][methods][manual][termination][timeout_minutes]" id="review_manual_timeout"
+                        value="<%= manual.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 1440 (24h)"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                    </div>
+                    <div>
+                      <label for="review_manual_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
+                      <input type="text" name="project[review_settings][methods][manual][termination][quality_threshold]" id="review_manual_quality"
+                        value="<%= manual.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                    </div>
+                    <div class="flex items-center">
+                      <input type="hidden" name="project[review_settings][methods][manual][termination][stop_when_no_comments]" value="0" />
+                      <input type="checkbox" name="project[review_settings][methods][manual][termination][stop_when_no_comments]" value="1" id="review_manual_stop_no_comments"
+                        <%= "checked" if manual.dig("termination", "stop_when_no_comments") %>
+                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                      <label for="review_manual_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -272,7 +272,6 @@
                   <input type="checkbox" name="project[review_settings][methods][copilot][enabled]" value="1" id="review_copilot_enabled"
                     <%= "checked" if copilot["enabled"] %>
                     aria-controls="review_copilot_settings"
-                    aria-expanded="<%= copilot["enabled"] ? "true" : "false" %>"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
                     data-collapsible-panel-target="checkbox" />
@@ -281,8 +280,7 @@
                 </div>
                 <div id="review_copilot_settings"
                   class="ml-7 grid grid-cols-2 gap-3 transition-all duration-200 ease-in-out <%= copilot["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  aria-hidden="<%= copilot["enabled"] ? "false" : "true" %>"
-                  <%= "hidden" unless copilot["enabled"] %>
+                  <%= "inert" unless copilot["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_copilot_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
@@ -321,7 +319,6 @@
                   <input type="checkbox" name="project[review_settings][methods][paid_agent][enabled]" value="1" id="review_paid_agent_enabled"
                     <%= "checked" if paid["enabled"] %>
                     aria-controls="review_paid_agent_settings"
-                    aria-expanded="<%= paid["enabled"] ? "true" : "false" %>"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
                     data-collapsible-panel-target="checkbox" />
@@ -329,8 +326,7 @@
                 </div>
                 <div id="review_paid_agent_settings"
                   class="ml-7 grid grid-cols-2 gap-3 transition-all duration-200 ease-in-out <%= paid["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  aria-hidden="<%= paid["enabled"] ? "false" : "true" %>"
-                  <%= "hidden" unless paid["enabled"] %>
+                  <%= "inert" unless paid["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_paid_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
@@ -369,7 +365,6 @@
                   <input type="checkbox" name="project[review_settings][methods][codex][enabled]" value="1" id="review_codex_enabled"
                     <%= "checked" if codex["enabled"] %>
                     aria-controls="review_codex_settings"
-                    aria-expanded="<%= codex["enabled"] ? "true" : "false" %>"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
                     data-collapsible-panel-target="checkbox" />
@@ -378,8 +373,7 @@
                 </div>
                 <div id="review_codex_settings"
                   class="space-y-3 transition-all duration-200 ease-in-out <%= codex["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  aria-hidden="<%= codex["enabled"] ? "false" : "true" %>"
-                  <%= "hidden" unless codex["enabled"] %>
+                  <%= "inert" unless codex["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <p class="ml-7 text-xs text-gray-500">Waits for the <code>chatgpt-codex-connector</code> bot to review the PR and resolve its threads before advancing.</p>
                   <div class="ml-7 grid grid-cols-2 gap-3">
@@ -421,7 +415,6 @@
                   <input type="checkbox" name="project[review_settings][methods][ci_action][enabled]" value="1" id="review_ci_action_enabled"
                     <%= "checked" if ci["enabled"] %>
                     aria-controls="review_ci_action_settings"
-                    aria-expanded="<%= ci["enabled"] ? "true" : "false" %>"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
                     data-collapsible-panel-target="checkbox" />
@@ -429,8 +422,7 @@
                 </div>
                 <div id="review_ci_action_settings"
                   class="ml-7 space-y-3 transition-all duration-200 ease-in-out <%= ci["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  aria-hidden="<%= ci["enabled"] ? "false" : "true" %>"
-                  <%= "hidden" unless ci["enabled"] %>
+                  <%= "inert" unless ci["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_ci_action_name" class="block text-xs font-medium text-gray-600">Action Name</label>
@@ -481,7 +473,6 @@
                   <input type="checkbox" name="project[review_settings][methods][manual][enabled]" value="1" id="review_manual_enabled"
                     <%= "checked" if manual["enabled"] %>
                     aria-controls="review_manual_settings"
-                    aria-expanded="<%= manual["enabled"] ? "true" : "false" %>"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
                     data-collapsible-panel-target="checkbox" />
@@ -489,8 +480,7 @@
                 </div>
                 <div id="review_manual_settings"
                   class="ml-7 space-y-3 transition-all duration-200 ease-in-out <%= manual["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  aria-hidden="<%= manual["enabled"] ? "false" : "true" %>"
-                  <%= "hidden" unless manual["enabled"] %>
+                  <%= "inert" unless manual["enabled"] %>
                   data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_manual_reviewer_login" class="block text-xs font-medium text-gray-600">Reviewer Login</label>

--- a/lib/screenshots/capture.rb
+++ b/lib/screenshots/capture.rb
@@ -188,7 +188,7 @@ module Screenshots
         agent_run = project.agent_runs.where(custom_prompt: "Capture screenshot route coverage").first_or_create!(
           agent_type: "codex",
           goal: "create_pr",
-          status: "pending"
+          status: "queued"
         )
 
         prompt = Prompt.find_or_create_by!(account: account, slug: "screenshots.prompt") do |record|

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1045,6 +1045,51 @@ RSpec.describe "Projects" do
         expect(response.body).to include("Automatic work is not paused by quality gates.")
         expect(response.body).not_to include(quality_resume_project_path(project))
       end
+
+      it "hides review method settings for disabled review types" do
+        project = create(:project, account: account, github_token: github_token, review_settings: {
+          "enabled" => false,
+          "methods" => {
+            "copilot" => { "enabled" => false, "termination" => { "max_review_rounds" => 3 } }
+          }
+        })
+
+        get edit_project_path(project)
+
+        doc = Nokogiri::HTML(response.body)
+        panel = doc.at_css("#review_copilot_settings")
+        checkbox = doc.at_css("#review_copilot_enabled")
+
+        expect(panel).to be_present
+        expect(panel["hidden"]).to eq("")
+        expect(panel["data-collapsible-panel-target"]).to eq("panel")
+        expect(checkbox["data-action"]).to eq("change->collapsible-panel#toggle")
+        expect(checkbox["aria-expanded"]).to eq("false")
+      end
+
+      it "shows review method settings for enabled review types" do
+        project = create(:project, account: account, github_token: github_token, review_settings: {
+          "enabled" => true,
+          "methods" => {
+            "manual" => {
+              "enabled" => true,
+              "reviewer_login" => "octocat",
+              "termination" => { "max_review_rounds" => 2 }
+            }
+          }
+        })
+
+        get edit_project_path(project)
+
+        doc = Nokogiri::HTML(response.body)
+        panel = doc.at_css("#review_manual_settings")
+        checkbox = doc.at_css("#review_manual_enabled")
+
+        expect(panel).to be_present
+        expect(panel["hidden"]).to be_nil
+        expect(panel["class"]).to include("max-h-[2000px]")
+        expect(checkbox["aria-expanded"]).to eq("true")
+      end
     end
   end
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1061,11 +1061,9 @@ RSpec.describe "Projects" do
         checkbox = doc.at_css("#review_copilot_enabled")
 
         expect(panel).to be_present
-        expect(panel["hidden"]).to eq("")
+        expect(panel.has_attribute?("inert")).to be true
         expect(panel["data-collapsible-panel-target"]).to eq("panel")
-        expect(panel["aria-hidden"]).to eq("true")
         expect(checkbox["data-action"]).to eq("change->collapsible-panel#toggle")
-        expect(checkbox["aria-expanded"]).to eq("false")
       end
 
       it "shows review method settings for enabled review types" do
@@ -1087,10 +1085,8 @@ RSpec.describe "Projects" do
         checkbox = doc.at_css("#review_manual_enabled")
 
         expect(panel).to be_present
-        expect(panel["hidden"]).to be_nil
+        expect(panel.has_attribute?("inert")).to be false
         expect(panel["class"]).to include("max-h-[2000px]")
-        expect(panel["aria-hidden"]).to eq("false")
-        expect(checkbox["aria-expanded"]).to eq("true")
       end
     end
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1063,6 +1063,7 @@ RSpec.describe "Projects" do
         expect(panel).to be_present
         expect(panel["hidden"]).to eq("")
         expect(panel["data-collapsible-panel-target"]).to eq("panel")
+        expect(panel["aria-hidden"]).to eq("true")
         expect(checkbox["data-action"]).to eq("change->collapsible-panel#toggle")
         expect(checkbox["aria-expanded"]).to eq("false")
       end
@@ -1088,6 +1089,7 @@ RSpec.describe "Projects" do
         expect(panel).to be_present
         expect(panel["hidden"]).to be_nil
         expect(panel["class"]).to include("max-h-[2000px]")
+        expect(panel["aria-hidden"]).to eq("false")
         expect(checkbox["aria-expanded"]).to eq("true")
       end
     end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1082,7 +1082,6 @@ RSpec.describe "Projects" do
 
         doc = Nokogiri::HTML(response.body)
         panel = doc.at_css("#review_manual_settings")
-        checkbox = doc.at_css("#review_manual_enabled")
 
         expect(panel).to be_present
         expect(panel.has_attribute?("inert")).to be false


### PR DESCRIPTION
## Summary

Implemented on branch `paid/1312-hide-review-settings-fields-until-review-type-is-s-745b1c` and committed as `feat(projects): collapse inactive review settings` (`527f034`).

The project settings page now keeps each review method’s config collapsed until its checkbox is enabled. I added a small Stimulus controller for the per-method show/hide behavior, wired the review-method cards in [app/views/projects/edit.html.erb](/workspace/app/views/projects/edit.html.erb), and added request coverage in [spec/requests/projects_spec.rb](/workspace/spec/requests/projects_spec.rb) for hidden vs visible method panels.

Validation passed: `yarn install`, `bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec`. The full suite finished with `9913 examples, 0 failures, 2 pending` where the pending specs are the existing Qdrant live tests.

---

Closes #1312