### PR TITLE
Fix #1457: Make notifications table horizontally scrollable on mobile

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -22,14 +22,15 @@
   </div>
 
   <div class="mt-6 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+    <div class="overflow-x-auto">
     <table class="min-w-full divide-y divide-gray-300">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Severity</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Notification</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Source</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Time</th>
-          <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6"><span class="sr-only">Actions</span></th>
+          <th scope="col" class="min-w-[5rem] py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Severity</th>
+          <th scope="col" class="min-w-[16rem] px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Notification</th>
+          <th scope="col" class="min-w-[6rem] px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Source</th>
+          <th scope="col" class="min-w-[7rem] px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Time</th>
+          <th scope="col" class="min-w-[6rem] relative py-3.5 pl-3 pr-4 sm:pr-6"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>
       <%= tag.tbody id: "notifications_list", class: "divide-y divide-gray-200 bg-white" do %>
@@ -46,6 +47,7 @@
         <% end %>
       <% end %>
     </table>
+    </div>
   </div>
 
   <% if @pagy.pages > 1 %>

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe "Notifications" do
       expect(response.body).to include("Test alert")
     end
 
+    it "renders the table with mobile horizontal scrolling constraints" do
+      create(:notification, account: account, title: "Scrollable alert")
+
+      get notifications_path
+
+      doc = Nokogiri::HTML(response.body)
+      scroll_wrapper = doc.at_css("div.overflow-x-auto > table.min-w-full")
+      header_classes = doc.css("table thead th").map { |header| header["class"] }
+
+      expect(scroll_wrapper).to be_present
+      expect(header_classes).to include(a_string_including("min-w-[5rem]"))
+      expect(header_classes).to include(a_string_including("min-w-[16rem]"))
+      expect(header_classes).to include(a_string_including("min-w-[6rem]"))
+      expect(header_classes).to include(a_string_including("min-w-[7rem]"))
+    end
+
     it "filters by unread" do
       unread = create(:notification, account: account, title: "Unread alert")
       create(:notification, :read, account: account, title: "Read alert")

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Notifications", type: :system do
+  let!(:account) { create(:account) }
+  let!(:user) { create(:user, :owner, account: account, email: "notify@example.com", password: "password123") }
+
+  before do
+    create(:notification, account: account, title: "Mobile scroll test")
+    visit new_user_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    click_button "Sign in"
+  end
+
+  describe "mobile horizontal scrolling", :js do
+    it "wraps the table in a horizontally scrollable container" do
+      skip "requires a real browser (Cuprite/Chromium)" if SYSTEM_DRIVER == :rack_test
+
+      visit notifications_path
+      expect(page).to have_content("Mobile scroll test")
+
+      page.driver.resize(375, 812) # iPhone-sized viewport
+
+      scroll_width = page.evaluate_script(
+        "document.querySelector('.overflow-x-auto').scrollWidth"
+      )
+      client_width = page.evaluate_script(
+        "document.querySelector('.overflow-x-auto').clientWidth"
+      )
+
+      expect(scroll_width).to be > client_width
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Committed successfully. Here's what I changed:

**`app/views/notifications/index.html.erb`** — two changes:

1. **Wrapped the `<table>` in a `<div class="overflow-x-auto">`** — enables horizontal scrolling on mobile instead of squishing columns.
2. **Added `min-w-[...]` classes to each `<th>`** — prevents columns from collapsing below readable widths (Severity: 5rem, Notification: 16rem, Source: 6rem, Time: 7rem, Actions: 6rem).

On desktop, the table still renders normally since `min-w-full` keeps it filling the container. On mobile, the minimum widths cause the table to exceed the viewport width, and `overflow-x-auto` provides a scrollbar.

---

Closes #1457