### PR TITLE
fix: HarnessExecutor which/available always returns truthy, masking missing binaries

### DIFF
--- a/app/services/containers/harness_executor.rb
+++ b/app/services/containers/harness_executor.rb
@@ -35,7 +35,7 @@ module Containers
 
     def which(binary)
       result = @agent_run.execute_in_container(
-        [ "which", binary.to_s ],
+        [ "sh", "-c", "command -v -- #{Shellwords.escape(binary.to_s)}" ],
         stream: false,
         env: {},
         preparation: nil

--- a/app/services/containers/harness_executor.rb
+++ b/app/services/containers/harness_executor.rb
@@ -14,6 +14,7 @@ module Containers
     def execute(command, timeout: nil, env: {}, preparation: nil, **)
       unset_vars, set_vars = partition_env(env)
       effective_command = inject_kilocode_auto_flags(wrapped_command(command, unset_vars))
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       result = @agent_run.execute_in_container(
         effective_command,
@@ -22,21 +23,31 @@ module Containers
         env: set_vars,
         preparation: preparation
       )
+      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
 
       AgentHarness::CommandExecutor::Result.new(
         stdout: result[:stdout].to_s,
         stderr: result[:stderr].to_s,
         exit_code: result.success? ? (result[:exit_code] || 0) : (result[:exit_code] || 1),
-        duration: 0.0
+        duration: duration
       )
     end
 
     def which(binary)
-      "/usr/local/bin/#{binary}"
+      result = @agent_run.execute_in_container(
+        [ "which", binary.to_s ],
+        stream: false,
+        env: {},
+        preparation: nil
+      )
+
+      return unless result.success?
+
+      result[:stdout].to_s.strip.presence
     end
 
-    def available?(_binary)
-      true
+    def available?(binary)
+      which(binary).present?
     end
 
     private

--- a/spec/services/containers/harness_executor_spec.rb
+++ b/spec/services/containers/harness_executor_spec.rb
@@ -172,7 +172,24 @@ RSpec.describe Containers::HarnessExecutor do
 
       expect(executor.which("claude")).to eq("/usr/local/bin/claude")
       expect(agent_run).to have_received(:execute_in_container).with(
-        [ "which", "claude" ],
+        [ "sh", "-c", "command -v -- claude" ],
+        stream: false,
+        env: {},
+        preparation: nil
+      )
+    end
+
+    it "shell-escapes the binary name for the command probe" do
+      container_result = Containers::Provision::Result.success(
+        stdout: "", stderr: "", exit_code: 0
+      )
+      allow(agent_run).to receive(:execute_in_container).and_return(container_result)
+      binary = "claude; rm -rf /"
+
+      executor.which(binary)
+
+      expect(agent_run).to have_received(:execute_in_container).with(
+        [ "sh", "-c", "command -v -- #{Shellwords.escape(binary)}" ],
         stream: false,
         env: {},
         preparation: nil

--- a/spec/services/containers/harness_executor_spec.rb
+++ b/spec/services/containers/harness_executor_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Containers::HarnessExecutor do
       container_result = Containers::Provision::Result.success(
         stdout: "OK", stderr: "", exit_code: 0
       )
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 100.25)
       allow(agent_run).to receive(:execute_in_container).and_return(container_result)
 
       result = executor.execute(%w[echo hello], timeout: 30, env: { "FOO" => "bar" })
@@ -19,6 +20,7 @@ RSpec.describe Containers::HarnessExecutor do
       expect(result.stdout).to eq("OK")
       expect(result.stderr).to eq("")
       expect(result.exit_code).to eq(0)
+      expect(result.duration).to eq(0.25)
       expect(result).to be_success
     end
 
@@ -162,8 +164,42 @@ RSpec.describe Containers::HarnessExecutor do
   end
 
   describe "#which" do
-    it "returns a truthy path for any binary" do
-      expect(executor.which("claude")).to be_truthy
+    it "returns the resolved path for an installed binary" do
+      container_result = Containers::Provision::Result.success(
+        stdout: "/usr/local/bin/claude\n", stderr: "", exit_code: 0
+      )
+      allow(agent_run).to receive(:execute_in_container).and_return(container_result)
+
+      expect(executor.which("claude")).to eq("/usr/local/bin/claude")
+      expect(agent_run).to have_received(:execute_in_container).with(
+        [ "which", "claude" ],
+        stream: false,
+        env: {},
+        preparation: nil
+      )
+    end
+
+    it "returns nil when the binary is not installed" do
+      container_result = Containers::Provision::Result.failure(
+        error: "not found", stdout: "", stderr: "", exit_code: 1
+      )
+      allow(agent_run).to receive(:execute_in_container).and_return(container_result)
+
+      expect(executor.which("claude")).to be_nil
+    end
+  end
+
+  describe "#available?" do
+    it "returns true when which resolves a binary" do
+      allow(executor).to receive(:which).with("claude").and_return("/usr/local/bin/claude")
+
+      expect(executor.available?("claude")).to be(true)
+    end
+
+    it "returns false when which does not resolve a binary" do
+      allow(executor).to receive(:which).with("claude").and_return(nil)
+
+      expect(executor.available?("claude")).to be(false)
     end
   end
 end


### PR DESCRIPTION
## Summary

Implemented in [app/services/containers/harness_executor.rb](/workspace/app/services/containers/harness_executor.rb) and [spec/services/containers/harness_executor_spec.rb](/workspace/spec/services/containers/harness_executor_spec.rb). `which` now runs `which <binary>` inside the container and returns the resolved path or `nil`, `available?` reflects that result, and `execute` now records monotonic wall-clock duration instead of hardcoding `0.0`.

Validation passed. I ran `bundle install`, `yarn install`, `bin/rails db:prepare`, full `bundle exec rubocop`, and full `bundle exec rspec`. The full spec run finished with `9938 examples, 0 failures, 2 pending` where the pending examples are the existing Qdrant live-spec skips. The commit hook initially failed because RuboCop’s default cache path was out of space, so I retried the commit with `XDG_CACHE_HOME=/workspace/.cache`; the commit then succeeded.

Commit: `f8472a7`  
Message: `fix(containers): probe harness binaries in executor`

---

Closes #1545