### PR TITLE
Fix #1124: Add contract and parity tests for automation modules

### DIFF
--- a/spec/services/automation/providers/github/repository_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_contract_spec.rb
@@ -5,74 +5,86 @@ require "ostruct"
 
 RSpec.describe Automation::Providers::Github::RepositoryProvider do
   context "with contract verification" do
-  let(:client) { instance_double(GithubClient) }
-  let(:project_class) do
-    Class.new do
-      attr_accessor :github_token
-      def full_name = "acme/widgets"
+    let(:client) { instance_double(GithubClient) }
+    let(:project_class) do
+      Class.new do
+        attr_accessor :github_token
+
+        def full_name = "acme/widgets"
+      end
     end
-  end
-  let(:project) { project_class.new }
-  let(:adapter) { described_class.new(project, client: client) }
-  let(:repo) { "acme/widgets" }
-  let(:pr_number) { 42 }
-  let(:ref) { "abc123" }
-  let(:label_name) { "automation" }
-  let(:comment_body) { "test comment" }
+    let(:project) { project_class.new }
+    let(:adapter) { described_class.new(project, client: client) }
+    let(:repo) { "acme/widgets" }
+    let(:pr_number) { 42 }
+    let(:ref) { "abc123" }
+    let(:label_name) { "automation" }
+    let(:comment_body) { "test comment" }
+    let(:pr_resource) do
+      OpenStruct.new(
+        number: 42, title: "Test", body: "desc", state: "open",
+        draft: false, merged: false, mergeable: true, merged_at: nil,
+        created_at: Time.utc(2026, 1, 1), updated_at: Time.utc(2026, 1, 2),
+        html_url: "https://github.com/acme/widgets/pull/42",
+        head: OpenStruct.new(ref: "feature", sha: "abc123"),
+        base: OpenStruct.new(ref: "main"),
+        user: OpenStruct.new(login: "Alice"),
+        labels: [ OpenStruct.new(name: "automation") ]
+      )
+    end
 
-  def provider_failure_message = "missing pull request"
+    def provider_failure_message = "missing pull request"
 
-  def stub_expected_provider_failure
-    allow(client).to receive(:pull_request)
-      .with(repo, 999)
-      .and_raise(GithubClient::NotFoundError.new(provider_failure_message))
-  end
+    def stub_expected_provider_failure
+      allow(client).to receive(:pull_request)
+        .with(repo, 999)
+        .and_raise(GithubClient::NotFoundError.new(provider_failure_message))
+    end
 
-  def invoke_expected_provider_failure
-    proc { adapter.fetch_pull_request(repo: repo, number: 999) }
-  end
+    def invoke_expected_provider_failure
+      proc { adapter.fetch_pull_request(repo: repo, number: 999) }
+    end
 
-  def stub_missing_label_provider_failure
-    allow(client).to receive(:remove_label_from_issue)
-      .with(repo, pr_number, label_name)
-      .and_raise(GithubClient::NotFoundError, "Label does not exist")
-  end
+    def stub_missing_label_provider_failure
+      allow(client).to receive(:remove_label_from_issue)
+        .with(repo, pr_number, label_name)
+        .and_raise(GithubClient::NotFoundError, "Label does not exist")
+    end
 
-  def stub_already_merged_pull_request
-    allow(client).to receive(:merge_pull_request)
-      .and_return(OpenStruct.new(merged: true, sha: "abc123", message: "Pull Request already merged"))
-  end
+    def stub_already_merged_pull_request
+      allow(client).to receive(:merge_pull_request)
+        .and_return(OpenStruct.new(merged: true, sha: "abc123", message: "Pull Request already merged"))
+    end
 
-  before do
-    pr_resource = OpenStruct.new(
-      number: 42, title: "Test", body: "desc", state: "open",
-      draft: false, merged: false, mergeable: true, merged_at: nil,
-      created_at: Time.utc(2026, 1, 1), updated_at: Time.utc(2026, 1, 2),
-      html_url: "https://github.com/acme/widgets/pull/42",
-      head: OpenStruct.new(ref: "feature", sha: "abc123"),
-      base: OpenStruct.new(ref: "main"),
-      user: OpenStruct.new(login: "Alice"),
-      labels: [ OpenStruct.new(name: "automation") ]
-    )
+    def invoke_list_pull_requests_with_filters
+      proc do
+        expect(client).to receive(:pull_requests)
+          .with(repo, state: "open", head: "acme:feature", base: "main")
+          .and_return([ pr_resource ])
 
-    allow(client).to receive_messages(
-      pull_request: pr_resource,
-      pull_requests: [ pr_resource ],
-      pull_request_files: [ "a.rb" ],
-      check_runs_for_ref: [
-        { name: "test", status: "completed", conclusion: "success",
-          html_url: "https://github.com/acme/widgets/runs/1", details_url: nil }
-      ],
-      add_labels_to_issue: nil,
-      remove_label_from_issue: nil,
-      mark_pull_request_ready: nil
-    )
-    allow(client).to receive_messages(add_comment: OpenStruct.new(
-        id: 99, body: comment_body, created_at: Time.utc(2026, 1, 1),
-        updated_at: nil, html_url: nil,
-        user: OpenStruct.new(login: "bot")
-      ), merge_pull_request: OpenStruct.new(merged: true, sha: "def456", message: "Merged"))
-  end
+        adapter.list_pull_requests(repo: repo, state: :open, head: "acme:feature", base: "main")
+      end
+    end
+
+    before do
+      allow(client).to receive_messages(
+        pull_request: pr_resource,
+        pull_requests: [ pr_resource ],
+        pull_request_files: [ "a.rb" ],
+        check_runs_for_ref: [
+          { name: "test", status: "completed", conclusion: "success",
+            html_url: "https://github.com/acme/widgets/runs/1", details_url: nil }
+        ],
+        add_labels_to_issue: nil,
+        remove_label_from_issue: nil,
+        mark_pull_request_ready: nil
+      )
+      allow(client).to receive_messages(add_comment: OpenStruct.new(
+          id: 99, body: comment_body, created_at: Time.utc(2026, 1, 1),
+          updated_at: nil, html_url: nil,
+          user: OpenStruct.new(login: "bot")
+        ), merge_pull_request: OpenStruct.new(merged: true, sha: "def456", message: "Merged"))
+    end
 
     it_behaves_like "a RepositoryProvider implementation"
   end

--- a/spec/services/automation/providers/github/repository_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_contract_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
   let(:label_name) { "automation" }
   let(:comment_body) { "test comment" }
 
+  def provider_failure_message = "missing pull request"
+
+  def stub_expected_provider_failure
+    allow(client).to receive(:pull_request)
+      .with(repo, 999)
+      .and_raise(GithubClient::NotFoundError.new(provider_failure_message))
+  end
+
+  def invoke_expected_provider_failure
+    proc { adapter.fetch_pull_request(repo: repo, number: 999) }
+  end
+
   before do
     pr_resource = OpenStruct.new(
       number: 42, title: "Test", body: "desc", state: "open",

--- a/spec/services/automation/providers/github/repository_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_contract_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Automation::Providers::Github::RepositoryProvider do
+  context "with contract verification" do
+  let(:client) { instance_double(GithubClient) }
+  let(:project_class) do
+    Class.new do
+      attr_accessor :github_token
+      def full_name = "acme/widgets"
+    end
+  end
+  let(:project) { project_class.new }
+  let(:adapter) { described_class.new(project, client: client) }
+  let(:repo) { "acme/widgets" }
+  let(:pr_number) { 42 }
+  let(:ref) { "abc123" }
+  let(:label_name) { "automation" }
+  let(:comment_body) { "test comment" }
+
+  before do
+    pr_resource = OpenStruct.new(
+      number: 42, title: "Test", body: "desc", state: "open",
+      draft: false, merged: false, mergeable: true, merged_at: nil,
+      created_at: Time.utc(2026, 1, 1), updated_at: Time.utc(2026, 1, 2),
+      html_url: "https://github.com/acme/widgets/pull/42",
+      head: OpenStruct.new(ref: "feature", sha: "abc123"),
+      base: OpenStruct.new(ref: "main"),
+      user: OpenStruct.new(login: "Alice"),
+      labels: [ OpenStruct.new(name: "automation") ]
+    )
+
+    allow(client).to receive_messages(
+      pull_request: pr_resource,
+      pull_requests: [ pr_resource ],
+      pull_request_files: [ "a.rb" ],
+      check_runs_for_ref: [
+        { name: "test", status: "completed", conclusion: "success",
+          html_url: "https://github.com/acme/widgets/runs/1", details_url: nil }
+      ],
+      add_labels_to_issue: nil,
+      remove_label_from_issue: nil,
+      mark_pull_request_ready: nil
+    )
+    allow(client).to receive_messages(add_comment: OpenStruct.new(
+        id: 99, body: comment_body, created_at: Time.utc(2026, 1, 1),
+        updated_at: nil, html_url: nil,
+        user: OpenStruct.new(login: "bot")
+      ), merge_pull_request: OpenStruct.new(merged: true, sha: "def456", message: "Merged"))
+  end
+
+    it_behaves_like "a RepositoryProvider implementation"
+  end
+end

--- a/spec/services/automation/providers/github/repository_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_contract_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
       .and_raise(GithubClient::NotFoundError, "Label does not exist")
   end
 
+  def stub_already_merged_pull_request
+    allow(client).to receive(:merge_pull_request)
+      .and_return(OpenStruct.new(merged: true, sha: "abc123", message: "Pull Request already merged"))
+  end
+
   before do
     pr_resource = OpenStruct.new(
       number: 42, title: "Test", body: "desc", state: "open",

--- a/spec/services/automation/providers/github/repository_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/repository_provider_contract_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe Automation::Providers::Github::RepositoryProvider do
     proc { adapter.fetch_pull_request(repo: repo, number: 999) }
   end
 
+  def stub_missing_label_provider_failure
+    allow(client).to receive(:remove_label_from_issue)
+      .with(repo, pr_number, label_name)
+      .and_raise(GithubClient::NotFoundError, "Label does not exist")
+  end
+
   before do
     pr_resource = OpenStruct.new(
       number: 42, title: "Test", body: "desc", state: "open",

--- a/spec/services/automation/providers/github/review_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/review_provider_contract_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe Automation::Providers::Github::ReviewProvider do
   let(:adapter) { described_class.new(project, client: client) }
   let(:repo) { "acme/widgets" }
   let(:pr_number) { 42 }
+  let(:requested_reviewers) { [ "Alice", "Bob" ] }
+  let(:expected_new_reviewers) { [ "bob" ] }
+
+  def provider_failure_message = "review request failed"
+
+  def stub_expected_provider_failure
+    allow(client).to receive(:request_pull_request_review)
+      .with(repo, pr_number, reviewers: [ "bob" ])
+      .and_raise(GithubClient::ApiError.new(provider_failure_message, status: 500))
+  end
+
+  def invoke_expected_provider_failure
+    proc do
+      adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: requested_reviewers)
+    end
+  end
 
   before do
     allow(client).to receive_messages(

--- a/spec/services/automation/providers/github/review_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/review_provider_contract_spec.rb
@@ -5,63 +5,63 @@ require "ostruct"
 
 RSpec.describe Automation::Providers::Github::ReviewProvider do
   context "with contract verification" do
-  let(:client) { instance_double(GithubClient) }
-  let(:project_class) do
-    Class.new do
-      def full_name = "acme/widgets"
+    let(:client) { instance_double(GithubClient) }
+    let(:project_class) do
+      Class.new do
+        def full_name = "acme/widgets"
+      end
     end
-  end
-  let(:project) { project_class.new }
-  let(:adapter) { described_class.new(project, client: client) }
-  let(:repo) { "acme/widgets" }
-  let(:pr_number) { 42 }
-  let(:requested_reviewers) { [ "Alice", "Bob" ] }
-  let(:expected_new_reviewers) { [ "bob" ] }
-  let(:fully_pending_reviewers) { [ "alice" ] }
+    let(:project) { project_class.new }
+    let(:adapter) { described_class.new(project, client: client) }
+    let(:repo) { "acme/widgets" }
+    let(:pr_number) { 42 }
+    let(:requested_reviewers) { [ "Alice", "Bob" ] }
+    let(:expected_new_reviewers) { [ "bob" ] }
+    let(:fully_pending_reviewers) { [ "alice" ] }
 
-  def provider_failure_message = "review request failed"
+    def provider_failure_message = "review request failed"
 
-  def stub_expected_provider_failure
-    allow(client).to receive(:request_pull_request_review)
-      .with(repo, pr_number, reviewers: [ "bob" ])
-      .and_raise(GithubClient::ApiError.new(provider_failure_message, status: 500))
-  end
-
-  def invoke_expected_provider_failure
-    proc do
-      adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: requested_reviewers)
+    def stub_expected_provider_failure
+      allow(client).to receive(:request_pull_request_review)
+        .with(repo, pr_number, reviewers: [ "bob" ])
+        .and_raise(GithubClient::ApiError.new(provider_failure_message, status: 500))
     end
-  end
 
-  def invoke_fully_pending_review_request
-    proc do
-      adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: fully_pending_reviewers)
+    def invoke_expected_provider_failure
+      proc do
+        adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: requested_reviewers)
+      end
     end
-  end
 
-  def assert_no_redundant_review_request
-    expect(client).not_to have_received(:request_pull_request_review)
-  end
+    def invoke_fully_pending_review_request
+      proc do
+        adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: fully_pending_reviewers)
+      end
+    end
 
-  before do
-    allow(client).to receive_messages(
-      pull_request_reviews: [
-        { id: 1, user_login: "Alice", state: "APPROVED",
-          body: "lgtm", submitted_at: Time.utc(2026, 1, 1), commit_id: "abc" }
-      ],
-      review_threads: [],
-      pull_request_review_requests: { users: [ "alice" ], teams: [] },
-      resolve_review_thread: nil
-    )
-    allow(client).to receive(:request_pull_request_review)
-    allow(client).to receive(:create_pull_request_review).and_return(
-      OpenStruct.new(
-        id: 7, body: "lgtm", state: "APPROVED",
-        submitted_at: Time.utc(2026, 1, 1), commit_id: "abc",
-        user: OpenStruct.new(login: "bot")
+    def assert_no_redundant_review_request
+      expect(client).not_to have_received(:request_pull_request_review)
+    end
+
+    before do
+      allow(client).to receive_messages(
+        pull_request_reviews: [
+          { id: 1, user_login: "Alice", state: "APPROVED",
+            body: "lgtm", submitted_at: Time.utc(2026, 1, 1), commit_id: "abc" }
+        ],
+        review_threads: [],
+        pull_request_review_requests: { users: [ "alice" ], teams: [] },
+        resolve_review_thread: nil
       )
-    )
-  end
+      allow(client).to receive(:request_pull_request_review)
+      allow(client).to receive(:create_pull_request_review).and_return(
+        OpenStruct.new(
+          id: 7, body: "lgtm", state: "APPROVED",
+          submitted_at: Time.utc(2026, 1, 1), commit_id: "abc",
+          user: OpenStruct.new(login: "bot")
+        )
+      )
+    end
 
     it_behaves_like "a ReviewProvider implementation"
   end

--- a/spec/services/automation/providers/github/review_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/review_provider_contract_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Automation::Providers::Github::ReviewProvider do
   let(:pr_number) { 42 }
   let(:requested_reviewers) { [ "Alice", "Bob" ] }
   let(:expected_new_reviewers) { [ "bob" ] }
+  let(:fully_pending_reviewers) { [ "alice" ] }
 
   def provider_failure_message = "review request failed"
 
@@ -30,6 +31,16 @@ RSpec.describe Automation::Providers::Github::ReviewProvider do
     proc do
       adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: requested_reviewers)
     end
+  end
+
+  def invoke_fully_pending_review_request
+    proc do
+      adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: fully_pending_reviewers)
+    end
+  end
+
+  def assert_no_redundant_review_request
+    expect(client).not_to have_received(:request_pull_request_review)
   end
 
   before do

--- a/spec/services/automation/providers/github/review_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/review_provider_contract_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Automation::Providers::Github::ReviewProvider do
+  context "with contract verification" do
+  let(:client) { instance_double(GithubClient) }
+  let(:project_class) do
+    Class.new do
+      def full_name = "acme/widgets"
+    end
+  end
+  let(:project) { project_class.new }
+  let(:adapter) { described_class.new(project, client: client) }
+  let(:repo) { "acme/widgets" }
+  let(:pr_number) { 42 }
+
+  before do
+    allow(client).to receive_messages(
+      pull_request_reviews: [
+        { id: 1, user_login: "Alice", state: "APPROVED",
+          body: "lgtm", submitted_at: Time.utc(2026, 1, 1), commit_id: "abc" }
+      ],
+      review_threads: [],
+      pull_request_review_requests: { users: [ "alice" ], teams: [] },
+      resolve_review_thread: nil
+    )
+    allow(client).to receive(:request_pull_request_review)
+    allow(client).to receive(:create_pull_request_review).and_return(
+      OpenStruct.new(
+        id: 7, body: "lgtm", state: "APPROVED",
+        submitted_at: Time.utc(2026, 1, 1), commit_id: "abc",
+        user: OpenStruct.new(login: "bot")
+      )
+    )
+  end
+
+    it_behaves_like "a ReviewProvider implementation"
+  end
+end

--- a/spec/services/automation/providers/github/work_item_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/work_item_provider_contract_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe Automation::Providers::Github::WorkItemProvider do
     proc { adapter.fetch_issue(repo: repo, number: 999) }
   end
 
+  def stub_missing_label_provider_failure
+    allow(client).to receive(:remove_label_from_issue)
+      .with(repo, issue_number, label_name)
+      .and_raise(GithubClient::NotFoundError, "Label does not exist")
+  end
+
   before do
     allow(client).to receive_messages(
       issue: issue_resource,

--- a/spec/services/automation/providers/github/work_item_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/work_item_provider_contract_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Automation::Providers::Github::WorkItemProvider do
   let(:issue_number) { 42 }
   let(:label_name) { "bug" }
   let(:comment_body) { "test comment" }
-
   let(:issue_resource) do
     OpenStruct.new(
       number: 42, title: "Bug", body: "details", state: "open",
@@ -28,6 +27,18 @@ RSpec.describe Automation::Providers::Github::WorkItemProvider do
       labels: [ OpenStruct.new(name: "bug") ],
       pull_request: nil
     )
+  end
+
+  def provider_failure_message = "missing issue"
+
+  def stub_expected_provider_failure
+    allow(client).to receive(:issue)
+      .with(repo, 999)
+      .and_raise(GithubClient::NotFoundError.new(provider_failure_message))
+  end
+
+  def invoke_expected_provider_failure
+    proc { adapter.fetch_issue(repo: repo, number: 999) }
   end
 
   before do

--- a/spec/services/automation/providers/github/work_item_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/work_item_provider_contract_spec.rb
@@ -5,76 +5,106 @@ require "ostruct"
 
 RSpec.describe Automation::Providers::Github::WorkItemProvider do
   context "with contract verification" do
-  let(:client) { instance_double(GithubClient) }
-  let(:project_class) do
-    Class.new do
-      def full_name = "acme/widgets"
+    let(:client) { instance_double(GithubClient) }
+    let(:project_class) do
+      Class.new do
+        def full_name = "acme/widgets"
+      end
     end
-  end
-  let(:project) { project_class.new }
-  let(:adapter) { described_class.new(project, client: client) }
-  let(:repo) { "acme/widgets" }
-  let(:issue_number) { 42 }
-  let(:label_name) { "bug" }
-  let(:comment_body) { "test comment" }
-  let(:issue_resource) do
-    OpenStruct.new(
-      number: 42, title: "Bug", body: "details", state: "open",
-      created_at: Time.utc(2026, 1, 1), updated_at: Time.utc(2026, 1, 2),
-      closed_at: nil, html_url: "https://github.com/acme/widgets/issues/42",
-      user: OpenStruct.new(login: "Alice"),
-      assignees: [ OpenStruct.new(login: "Bob") ],
-      labels: [ OpenStruct.new(name: "bug") ],
-      pull_request: nil
-    )
-  end
-
-  def provider_failure_message = "missing issue"
-
-  def stub_expected_provider_failure
-    allow(client).to receive(:issue)
-      .with(repo, 999)
-      .and_raise(GithubClient::NotFoundError.new(provider_failure_message))
-  end
-
-  def invoke_expected_provider_failure
-    proc { adapter.fetch_issue(repo: repo, number: 999) }
-  end
-
-  def stub_missing_label_provider_failure
-    allow(client).to receive(:remove_label_from_issue)
-      .with(repo, issue_number, label_name)
-      .and_raise(GithubClient::NotFoundError, "Label does not exist")
-  end
-
-  before do
-    allow(client).to receive_messages(
-      issue: issue_resource,
-      issues: [ issue_resource ],
-      issue_comments: [
-        OpenStruct.new(
-          id: 1, body: "hi", created_at: Time.utc(2026, 1, 1),
-          updated_at: nil, html_url: nil,
-          user: OpenStruct.new(login: "alice")
-        )
-      ],
-      issue_events: [
-        { event: "labeled", created_at: Time.utc(2026, 1, 1),
-          actor: { login: "alice" }, label: { name: "bug" } }
-      ],
-      create_issue: issue_resource,
-      add_labels_to_issue: nil,
-      remove_label_from_issue: nil,
-      update_issue: issue_resource
-    )
-    allow(client).to receive(:add_comment).and_return(
+    let(:project) { project_class.new }
+    let(:adapter) { described_class.new(project, client: client) }
+    let(:repo) { "acme/widgets" }
+    let(:issue_number) { 42 }
+    let(:label_name) { "bug" }
+    let(:comment_body) { "test comment" }
+    let(:issue_resource) do
       OpenStruct.new(
-        id: 3, body: comment_body, created_at: Time.utc(2026, 1, 1),
-        updated_at: nil, html_url: nil,
-        user: OpenStruct.new(login: "bot")
+        number: 42, title: "Bug", body: "details", state: "open",
+        created_at: Time.utc(2026, 1, 1), updated_at: Time.utc(2026, 1, 2),
+        closed_at: nil, html_url: "https://github.com/acme/widgets/issues/42",
+        user: OpenStruct.new(login: "Alice"),
+        assignees: [ OpenStruct.new(login: "Bob") ],
+        labels: [ OpenStruct.new(name: "bug") ],
+        pull_request: nil
       )
-    )
-  end
+    end
+
+    def provider_failure_message = "missing issue"
+
+    def stub_expected_provider_failure
+      allow(client).to receive(:issue)
+        .with(repo, 999)
+        .and_raise(GithubClient::NotFoundError.new(provider_failure_message))
+    end
+
+    def invoke_expected_provider_failure
+      proc { adapter.fetch_issue(repo: repo, number: 999) }
+    end
+
+    def stub_missing_label_provider_failure
+      allow(client).to receive(:remove_label_from_issue)
+        .with(repo, issue_number, label_name)
+        .and_raise(GithubClient::NotFoundError, "Label does not exist")
+    end
+
+    def invoke_list_issues_with_state_filter
+      proc do
+        expect(client).to receive(:issues)
+          .with(repo, labels: nil, state: "open")
+          .and_return([ issue_resource ])
+
+        adapter.list_issues(repo: repo, state: :open)
+      end
+    end
+
+    def invoke_list_issues_with_labels_filter
+      proc do
+        expect(client).to receive(:issues)
+          .with(repo, labels: [ "bug" ], state: "open")
+          .and_return([ issue_resource ])
+
+        adapter.list_issues(repo: repo, labels: [ "bug" ])
+      end
+    end
+
+    def invoke_list_issues_with_assignees_filter
+      proc do
+        expect(client).to receive(:issues)
+          .with(repo, labels: nil, state: "open", assignee: "bob")
+          .and_return([ issue_resource ])
+
+        adapter.list_issues(repo: repo, assignees: [ "bob" ])
+      end
+    end
+
+    before do
+      allow(client).to receive_messages(
+        issue: issue_resource,
+        issues: [ issue_resource ],
+        issue_comments: [
+          OpenStruct.new(
+            id: 1, body: "hi", created_at: Time.utc(2026, 1, 1),
+            updated_at: nil, html_url: nil,
+            user: OpenStruct.new(login: "alice")
+          )
+        ],
+        issue_events: [
+          { event: "labeled", created_at: Time.utc(2026, 1, 1),
+            actor: { login: "alice" }, label: { name: "bug" } }
+        ],
+        create_issue: issue_resource,
+        add_labels_to_issue: nil,
+        remove_label_from_issue: nil,
+        update_issue: issue_resource
+      )
+      allow(client).to receive(:add_comment).and_return(
+        OpenStruct.new(
+          id: 3, body: comment_body, created_at: Time.utc(2026, 1, 1),
+          updated_at: nil, html_url: nil,
+          user: OpenStruct.new(login: "bot")
+        )
+      )
+    end
 
     it_behaves_like "a WorkItemProvider implementation"
   end

--- a/spec/services/automation/providers/github/work_item_provider_contract_spec.rb
+++ b/spec/services/automation/providers/github/work_item_provider_contract_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Automation::Providers::Github::WorkItemProvider do
+  context "with contract verification" do
+  let(:client) { instance_double(GithubClient) }
+  let(:project_class) do
+    Class.new do
+      def full_name = "acme/widgets"
+    end
+  end
+  let(:project) { project_class.new }
+  let(:adapter) { described_class.new(project, client: client) }
+  let(:repo) { "acme/widgets" }
+  let(:issue_number) { 42 }
+  let(:label_name) { "bug" }
+  let(:comment_body) { "test comment" }
+
+  let(:issue_resource) do
+    OpenStruct.new(
+      number: 42, title: "Bug", body: "details", state: "open",
+      created_at: Time.utc(2026, 1, 1), updated_at: Time.utc(2026, 1, 2),
+      closed_at: nil, html_url: "https://github.com/acme/widgets/issues/42",
+      user: OpenStruct.new(login: "Alice"),
+      assignees: [ OpenStruct.new(login: "Bob") ],
+      labels: [ OpenStruct.new(name: "bug") ],
+      pull_request: nil
+    )
+  end
+
+  before do
+    allow(client).to receive_messages(
+      issue: issue_resource,
+      issues: [ issue_resource ],
+      issue_comments: [
+        OpenStruct.new(
+          id: 1, body: "hi", created_at: Time.utc(2026, 1, 1),
+          updated_at: nil, html_url: nil,
+          user: OpenStruct.new(login: "alice")
+        )
+      ],
+      issue_events: [
+        { event: "labeled", created_at: Time.utc(2026, 1, 1),
+          actor: { login: "alice" }, label: { name: "bug" } }
+      ],
+      create_issue: issue_resource,
+      add_labels_to_issue: nil,
+      remove_label_from_issue: nil,
+      update_issue: issue_resource
+    )
+    allow(client).to receive(:add_comment).and_return(
+      OpenStruct.new(
+        id: 3, body: comment_body, created_at: Time.utc(2026, 1, 1),
+        updated_at: nil, html_url: nil,
+        user: OpenStruct.new(login: "bot")
+      )
+    )
+  end
+
+    it_behaves_like "a WorkItemProvider implementation"
+  end
+end

--- a/spec/services/automation/review_methods/registry_contract_spec.rb
+++ b/spec/services/automation/review_methods/registry_contract_spec.rb
@@ -35,41 +35,71 @@ RSpec.describe Automation::ReviewMethods::Registry do
   end
 
   describe Automation::ReviewMethods::Copilot do
-    let(:plugin) { build_plugin(described_class, :copilot) }
+    let(:method_name) { :copilot }
+    let(:resolved_class) { Automation::ReviewMethods::Registry.resolve(method_name) }
+    let(:plugin) { build_plugin(resolved_class, method_name) }
     let(:expected_kind) { :bot }
+
+    it "resolves :copilot through the registry defaults" do
+      expect(resolved_class).to eq(described_class)
+    end
 
     it_behaves_like "a ReviewMethods plugin"
   end
 
   describe Automation::ReviewMethods::PaidAgent do
-    let(:plugin) { build_plugin(described_class, :paid_agent) }
+    let(:method_name) { :paid_agent }
+    let(:resolved_class) { Automation::ReviewMethods::Registry.resolve(method_name) }
+    let(:plugin) { build_plugin(resolved_class, method_name) }
     let(:expected_kind) { :agent }
+
+    it "resolves :paid_agent through the registry defaults" do
+      expect(resolved_class).to eq(described_class)
+    end
 
     it_behaves_like "a ReviewMethods plugin"
   end
 
   describe Automation::ReviewMethods::Codex do
-    let(:plugin) { build_plugin(described_class, :codex) }
+    let(:method_name) { :codex }
+    let(:resolved_class) { Automation::ReviewMethods::Registry.resolve(method_name) }
+    let(:plugin) { build_plugin(resolved_class, method_name) }
     let(:expected_kind) { :comment_bot }
+
+    it "resolves :codex through the registry defaults" do
+      expect(resolved_class).to eq(described_class)
+    end
 
     it_behaves_like "a ReviewMethods plugin"
   end
 
   describe Automation::ReviewMethods::Manual do
-    let(:plugin) { build_plugin(described_class, :manual) }
+    let(:method_name) { :manual }
+    let(:resolved_class) { Automation::ReviewMethods::Registry.resolve(method_name) }
+    let(:plugin) { build_plugin(resolved_class, method_name) }
     let(:expected_kind) { :human }
+
+    it "resolves :manual through the registry defaults" do
+      expect(resolved_class).to eq(described_class)
+    end
 
     it_behaves_like "a ReviewMethods plugin"
   end
 
   describe Automation::ReviewMethods::CiAction do
+    let(:method_name) { :ci_action }
+    let(:resolved_class) { Automation::ReviewMethods::Registry.resolve(method_name) }
     let(:plugin) do
       build_plugin(
-        described_class, :ci_action,
+        resolved_class, method_name,
         config: build_config(ci_action: { "enabled" => true, "action_name" => "claude-review" })
       )
     end
     let(:expected_kind) { :ci }
+
+    it "resolves :ci_action through the registry defaults" do
+      expect(resolved_class).to eq(described_class)
+    end
 
     it_behaves_like "a ReviewMethods plugin"
   end

--- a/spec/services/automation/review_methods/registry_contract_spec.rb
+++ b/spec/services/automation/review_methods/registry_contract_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::ReviewMethods::Registry do
+  context "with plugin contract verification" do
+  def build_config(**methods)
+    method_hashes = Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) do |name, h|
+      h[name.to_s] = methods[name] || { "enabled" => false }
+    end
+    review_settings = Automation::Configuration::ReviewSettings.from_hash(
+      "enabled" => true,
+      "methods" => method_hashes
+    )
+    Automation::Configuration::AutoReview.new(review_settings: review_settings)
+  end
+
+  def build_signals(triggers: [])
+    Automation::Strategies::AutoReview::Signals.from_scan(
+      issue_id: 1,
+      pr_number: 50,
+      phase: "draft",
+      triggers: triggers
+    )
+  end
+
+  def build_plugin(plugin_class, method_name, config: nil, triggers: [])
+    config ||= build_config(method_name => { "enabled" => true })
+    signals = build_signals(triggers: triggers)
+    plugin_class.new(
+      method: config.method_for(method_name),
+      config: config,
+      signals: signals
+    )
+  end
+
+  describe Automation::ReviewMethods::Copilot do
+    let(:plugin) { build_plugin(described_class, :copilot) }
+    let(:expected_kind) { :bot }
+
+    it_behaves_like "a ReviewMethods plugin"
+  end
+
+  describe Automation::ReviewMethods::PaidAgent do
+    let(:plugin) { build_plugin(described_class, :paid_agent) }
+    let(:expected_kind) { :agent }
+
+    it_behaves_like "a ReviewMethods plugin"
+  end
+
+  describe Automation::ReviewMethods::Codex do
+    let(:plugin) { build_plugin(described_class, :codex) }
+    let(:expected_kind) { :comment_bot }
+
+    it_behaves_like "a ReviewMethods plugin"
+  end
+
+  describe Automation::ReviewMethods::Manual do
+    let(:plugin) { build_plugin(described_class, :manual) }
+    let(:expected_kind) { :human }
+
+    it_behaves_like "a ReviewMethods plugin"
+  end
+
+  describe Automation::ReviewMethods::CiAction do
+    let(:plugin) do
+      build_plugin(
+        described_class, :ci_action,
+        config: build_config(ci_action: { "enabled" => true, "action_name" => "claude-review" })
+      )
+    end
+    let(:expected_kind) { :ci }
+
+    it_behaves_like "a ReviewMethods plugin"
+  end
+  end
+end

--- a/spec/services/automation/strategies/auto_continue_lifecycle_transitions_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_lifecycle_transitions_spec.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Tests verifying lifecycle transition semantics in AutoContinue:
+# gate priority, phase transitions, and delegation to AutoReview.
+RSpec.describe Automation::Strategies::AutoContinue do
+  context "with lifecycle transitions" do
+  let(:strategy) { described_class.new }
+  let(:project) { create(:project) }
+  let(:pull_request) do
+    create(:issue, :pull_request, project: project, github_number: 42, paid_state: "new")
+  end
+
+  def evaluate(lifecycle: nil, scan: nil)
+    metadata = {}
+    metadata[:lifecycle] = lifecycle if lifecycle
+    metadata[:scan] = scan if scan
+
+    context = Automation::Context.build(
+      record: pull_request,
+      project: project,
+      metadata: metadata
+    )
+    strategy.evaluate(context)
+  end
+
+  def decision_types(result)
+    result.to_h[:decisions].map { |d| d[:type] }
+  end
+
+  def base_lifecycle(phase: "ready", **overrides)
+    {
+      issue_id: pull_request.id,
+      pr_number: 42,
+      phase: phase,
+      active_run_exists: false,
+      operational_failure_breaker: false,
+      draft_review_limit_reached: false,
+      consecutive_draft_failures_breaker: false,
+      review_goal_retry_limit_requires_escalation: false,
+      followup_limit_reached: false,
+      escalation_dismissed: false,
+      owner_reviewer_login: "alice",
+      escalation_reason: nil,
+      draft: phase == "draft" || phase == "restarted"
+    }.merge(overrides)
+  end
+
+  describe "gate priority ordering" do
+    it "active_run_exists trumps all other gates" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          active_run_exists: true,
+          operational_failure_breaker: true,
+          escalation_reason: "failures"
+        ),
+        scan: { issue_id: pull_request.id, pr_number: 42, phase: "ready", triggers: [] }
+      )
+
+      expect(decision_types(result)).to eq([ "noop" ])
+    end
+
+    it "operational_failure_breaker trumps escalation_dismissed" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "escalated",
+          operational_failure_breaker: true,
+          escalation_dismissed: true,
+          escalation_reason: "Consecutive operational failures"
+        )
+      )
+
+      expect(result.to_h[:decisions].first).to include(type: "escalate")
+    end
+
+    it "escalation_dismissed trumps phase-specific gates" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "escalated",
+          escalation_dismissed: true,
+          draft_review_limit_reached: true,
+          draft: false
+        )
+      )
+
+      expect(result.to_h[:decisions].first).to include(type: "dismiss_escalation")
+    end
+  end
+
+  describe "draft phase gates" do
+    it "escalates on review_goal_retry_limit" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "draft",
+          review_goal_retry_limit_requires_escalation: true,
+          escalation_reason: "Review-goal retry limit reached"
+        )
+      )
+
+      decisions = result.to_h[:decisions]
+      expect(decisions.first[:type]).to eq("escalate")
+      expect(decisions.first[:reason]).to eq("Review-goal retry limit reached")
+    end
+
+    it "escalates on draft_review_limit" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "draft",
+          draft_review_limit_reached: true,
+          escalation_reason: "Draft review limit reached"
+        )
+      )
+
+      expect(result.to_h[:decisions].first[:type]).to eq("escalate")
+    end
+
+    it "escalates on consecutive_draft_failures" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "draft",
+          consecutive_draft_failures_breaker: true,
+          escalation_reason: "Consecutive draft follow-up failures"
+        )
+      )
+
+      expect(result.to_h[:decisions].first[:type]).to eq("escalate")
+    end
+
+    it "delegates to AutoReview when all draft gates pass" do
+      result = evaluate(
+        lifecycle: base_lifecycle(phase: "draft"),
+        scan: {
+          issue_id: pull_request.id,
+          pr_number: 42,
+          phase: "draft",
+          current_draft_review_count: 0,
+          triggers: [ { type: "ci_failure", details: [ "test-suite" ] } ]
+        }
+      )
+
+      types = decision_types(result)
+      expect(types).to include("queue_create_pr_run")
+    end
+  end
+
+  describe "restarted phase gates" do
+    it "treats restarted like draft for gate evaluation" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "restarted",
+          draft_review_limit_reached: true,
+          escalation_reason: "Draft review limit reached"
+        )
+      )
+
+      expect(result.to_h[:decisions].first[:type]).to eq("escalate")
+    end
+  end
+
+  describe "ready phase gates" do
+    it "returns noop when followup_limit_reached" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "ready",
+          followup_limit_reached: true
+        ),
+        scan: { issue_id: pull_request.id, pr_number: 42, phase: "ready", triggers: [] }
+      )
+
+      expect(decision_types(result)).to eq([ "noop" ])
+    end
+
+    it "escalates on review_goal_retry_limit" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "ready",
+          review_goal_retry_limit_requires_escalation: true,
+          escalation_reason: "Review-goal retry limit reached"
+        )
+      )
+
+      expect(result.to_h[:decisions].first[:type]).to eq("escalate")
+    end
+
+    it "delegates to AutoReview when all ready gates pass" do
+      result = evaluate(
+        lifecycle: base_lifecycle(phase: "ready"),
+        scan: {
+          issue_id: pull_request.id,
+          pr_number: 42,
+          phase: "ready",
+          triggers: [ { type: "owner_approved" } ]
+        }
+      )
+
+      expect(result.to_h[:decisions].first[:type]).to eq("merge")
+    end
+  end
+
+  describe "escalated phase gates" do
+    it "returns noop when followup_limit_reached" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "escalated",
+          followup_limit_reached: true
+        ),
+        scan: { issue_id: pull_request.id, pr_number: 42, phase: "escalated", triggers: [] }
+      )
+
+      expect(decision_types(result)).to eq([ "noop" ])
+    end
+
+    it "escalates on review_goal_retry_limit" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "escalated",
+          review_goal_retry_limit_requires_escalation: true,
+          escalation_reason: "Review-goal retry limit reached"
+        )
+      )
+
+      expect(result.to_h[:decisions].first[:type]).to eq("escalate")
+    end
+  end
+
+  describe "dismiss_escalation" do
+    it "includes the issue_id and draft flag in the payload" do
+      result = evaluate(
+        lifecycle: base_lifecycle(
+          phase: "escalated",
+          escalation_dismissed: true,
+          draft: false
+        )
+      )
+
+      decision = result.to_h[:decisions].first
+      expect(decision[:type]).to eq("dismiss_escalation")
+      expect(decision[:issue_id]).to eq(pull_request.id)
+    end
+  end
+
+  describe "delegation without lifecycle" do
+    it "falls back to AutoReview when no lifecycle signals present" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: [ { type: "owner_approved" } ]
+      })
+
+      expect(result.to_h[:decisions].first[:type]).to eq("merge")
+    end
+
+    it "returns noop when neither lifecycle nor scan is provided" do
+      result = evaluate
+      expect(decision_types(result)).to eq([ "noop" ])
+    end
+  end
+
+  describe "scan data forwarding" do
+    it "passes scan through to AutoReview when gates pass" do
+      result = evaluate(
+        lifecycle: base_lifecycle(phase: "ready"),
+        scan: {
+          issue_id: pull_request.id,
+          pr_number: 42,
+          phase: "ready",
+          triggers: [ { type: "paid_agent_review_pending" } ]
+        }
+      )
+
+      expect(decision_types(result)).to include("queue_review_run")
+    end
+
+    it "returns noop when gates pass but no scan data is present" do
+      result = evaluate(lifecycle: base_lifecycle(phase: "ready"))
+
+      expect(decision_types(result)).to eq([ "noop" ])
+    end
+  end
+  end
+end

--- a/spec/services/automation/strategies/auto_continue_lifecycle_transitions_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_lifecycle_transitions_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe Automation::Strategies::AutoContinue do
       decision = result.to_h[:decisions].first
       expect(decision[:type]).to eq("dismiss_escalation")
       expect(decision[:issue_id]).to eq(pull_request.id)
+      expect(decision[:draft]).to be(false)
     end
   end
 

--- a/spec/services/automation/strategies/auto_review_mixed_provider_behavior_spec.rb
+++ b/spec/services/automation/strategies/auto_review_mixed_provider_behavior_spec.rb
@@ -57,8 +57,11 @@ RSpec.describe Automation::Strategies::AutoReview do
         ]
       })
 
-      types = decision_types(result)
-      expect(types).to include("request_review")
+      expect(result.to_h).to eq(
+        decisions: [
+          { type: "request_review", pr_number: 42, reviewers: [ "copilot" ] }
+        ]
+      )
     end
   end
 

--- a/spec/services/automation/strategies/auto_review_mixed_provider_behavior_spec.rb
+++ b/spec/services/automation/strategies/auto_review_mixed_provider_behavior_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Tests verifying that AutoReview correctly composes decisions when
+# multiple review methods are enabled simultaneously. These cover the
+# mixed-provider behavior that is critical to preserve during the
+# modularization migration.
+RSpec.describe Automation::Strategies::AutoReview do
+  context "with mixed review-provider behavior" do
+  let(:strategy) { described_class.new }
+  let(:project) { create(:project) }
+  let(:pull_request) do
+    create(:issue, :pull_request, project: project, github_number: 42, paid_state: "new")
+  end
+
+  def evaluate(scan: {})
+    context = Automation::Context.build(
+      record: pull_request,
+      project: project,
+      metadata: { scan: scan }
+    )
+    strategy.evaluate(context)
+  end
+
+  def decision_types(result)
+    result.to_h[:decisions].map { |d| d[:type] }
+  end
+
+  describe "paid_agent + copilot both pending" do
+    it "emits only the paid_agent queue_review_run (paid_agent suppresses follow-ups)" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        triggers: [
+          { type: "paid_agent_review_pending" },
+          { type: "review_bot_review_pending", request_login: "copilot" }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types).to include("queue_review_run")
+      expect(types).not_to include("request_review")
+    end
+  end
+
+  describe "copilot + codex both pending" do
+    it "emits request_review for the copilot bot only (copilot trigger takes priority)" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        triggers: [
+          { type: "review_bot_review_pending", request_login: "copilot" },
+          { type: "review_bot_review_pending", request_login: "chatgpt-codex-connector" }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types).to include("request_review")
+    end
+  end
+
+  describe "manual review pending + ci_failure" do
+    it "emits both a request_review and follow-up decisions" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        labels_to_remove: [],
+        triggers: [
+          { type: "manual_review_pending", reviewer_login: "alice" },
+          { type: "ci_failure", details: [ "test-suite" ] }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types).to include("request_review")
+      expect(types).to include("queue_create_pr_run")
+    end
+  end
+
+  describe "ci_action pending alone" do
+    it "emits dispatch_claude_review when dispatch is required" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        triggers: [
+          { type: "ci_action_pending", dispatch_required: true }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types).to include("dispatch_claude_review")
+    end
+  end
+
+  describe "review_bot_comments with copilot pending" do
+    it "allows follow-up decisions through when bot has already posted feedback" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        labels_to_remove: [],
+        triggers: [
+          { type: "review_bot_review_pending", request_login: "copilot" },
+          { type: "review_bot_comments", details: [ "Fix the tests" ] }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types).to include("request_review")
+      expect(types).to include("queue_create_pr_run")
+      expect(types).to include("record_pr_followup")
+    end
+  end
+
+  describe "no review triggers, only follow-up triggers" do
+    it "falls through to follow-up decisions for ci_failure" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        labels_to_remove: [ "paid-needs-input" ],
+        triggers: [ { type: "ci_failure", details: "test-suite" } ]
+      })
+
+      types = decision_types(result)
+      expect(types).to eq(%w[queue_create_pr_run record_pr_followup])
+    end
+  end
+
+  describe "no triggers at all" do
+    it "emits standard follow-up decisions for ready phase" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: []
+      })
+
+      types = decision_types(result)
+      expect(types).to eq(%w[queue_create_pr_run record_pr_followup])
+    end
+
+    it "emits draft follow-up decisions for draft phase" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        current_draft_review_count: 0,
+        triggers: []
+      })
+
+      types = decision_types(result)
+      expect(types).to eq(%w[queue_create_pr_run])
+
+      decisions = result.to_h[:decisions]
+      expect(decisions.first[:count_toward_draft_review_round]).to be true
+    end
+  end
+  end
+end

--- a/spec/services/automation/strategies/auto_review_mixed_provider_behavior_spec.rb
+++ b/spec/services/automation/strategies/auto_review_mixed_provider_behavior_spec.rb
@@ -45,21 +45,26 @@ RSpec.describe Automation::Strategies::AutoReview do
     end
   end
 
-  describe "copilot + codex both pending" do
-    it "emits request_review for the copilot bot only (copilot trigger takes priority)" do
+  describe "copilot + codex both pending (fallback chain)" do
+    # Production emits a single review_bot_review_pending trigger with
+    # request_logins containing the ordered fallback chain, not separate
+    # triggers per bot (see ScanPaidPrsActivity#review_bot_request_chain).
+    it "emits request_review with the full fallback chain from request_logins" do
       result = evaluate(scan: {
         issue_id: pull_request.id,
         pr_number: 42,
         phase: "draft",
         triggers: [
-          { type: "review_bot_review_pending", request_login: "copilot" },
-          { type: "review_bot_review_pending", request_login: "chatgpt-codex-connector" }
+          { type: "review_bot_review_pending",
+            request_login: "copilot",
+            request_logins: [ "copilot", "chatgpt-codex-connector" ] }
         ]
       })
 
       expect(result.to_h).to eq(
         decisions: [
-          { type: "request_review", pr_number: 42, reviewers: [ "copilot" ] }
+          { type: "request_review", pr_number: 42,
+            reviewers: [ "copilot", "chatgpt-codex-connector" ] }
         ]
       )
     end

--- a/spec/services/automation/strategies/auto_review_retry_semantics_spec.rb
+++ b/spec/services/automation/strategies/auto_review_retry_semantics_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Tests verifying retry semantics in AutoReview: how the strategy
+# handles retryable failures, exhausted retries, and the interaction
+# between review-goal retries and other triggers.
+RSpec.describe Automation::Strategies::AutoReview do
+  context "with retry semantics" do
+  let(:strategy) { described_class.new }
+  let(:project) { create(:project) }
+  let(:pull_request) do
+    create(:issue, :pull_request, project: project, github_number: 42, paid_state: "new")
+  end
+
+  def evaluate(scan: {})
+    context = Automation::Context.build(
+      record: pull_request,
+      project: project,
+      metadata: { scan: scan }
+    )
+    strategy.evaluate(context)
+  end
+
+  def decision_types(result)
+    result.to_h[:decisions].map { |d| d[:type] }
+  end
+
+  describe "review_goal_retry trigger" do
+    it "emits both record_review_goal_retry and queue_review_run" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        current_review_goal_retry_count: 1,
+        triggers: [ { type: "review_goal_retry" } ]
+      })
+
+      types = decision_types(result)
+      expect(types).to include("record_review_goal_retry", "queue_review_run")
+    end
+
+    it "includes the retry count in record_review_goal_retry payload" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        current_review_goal_retry_count: 3,
+        triggers: [ { type: "review_goal_retry" } ]
+      })
+
+      retry_decision = result.to_h[:decisions].find { |d| d[:type] == "record_review_goal_retry" }
+      expect(retry_decision[:expected_review_goal_retry_count]).to eq(3)
+    end
+  end
+
+  describe "review_goal_retry with copilot pending" do
+    it "suppresses follow-up decisions but keeps retry and review request" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_review_goal_retry_count: 1,
+        current_followup_count: 0,
+        triggers: [
+          { type: "review_goal_retry" },
+          { type: "review_bot_review_pending", request_login: "copilot" },
+          { type: "ci_failure", details: [ "test-suite" ] }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types).to include("record_review_goal_retry", "queue_review_run", "request_review")
+      expect(types).not_to include("queue_create_pr_run", "record_pr_followup")
+    end
+  end
+
+  describe "review_goal_retry with posted bot feedback" do
+    it "keeps follow-up decisions when bot has already posted feedback" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_review_goal_retry_count: 1,
+        current_followup_count: 0,
+        labels_to_remove: [],
+        triggers: [
+          { type: "review_goal_retry" },
+          { type: "review_bot_review_pending", request_login: "copilot" },
+          { type: "review_bot_threads", details: [ "Please update the tests" ] }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types).to include("record_review_goal_retry", "queue_review_run", "request_review")
+      expect(types).to include("queue_create_pr_run", "record_pr_followup")
+    end
+  end
+
+  describe "escalate_to_owner trigger (retry budget exhausted)" do
+    it "emits an escalate decision with reason" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "escalated",
+        owner_reviewer_login: "bob",
+        triggers: [ { type: "escalate_to_owner", details: "paid_agent retry budget exhausted" } ]
+      })
+
+      escalate = result.to_h[:decisions].first
+      expect(escalate[:type]).to eq("escalate")
+      expect(escalate[:reason]).to eq("paid_agent retry budget exhausted")
+      expect(escalate[:owner_reviewer_login]).to eq("bob")
+    end
+
+    it "takes priority over other triggers" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "escalated",
+        owner_reviewer_login: "bob",
+        triggers: [
+          { type: "escalate_to_owner", details: "budget exhausted" },
+          { type: "ci_failure", details: [ "test-suite" ] }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types).to eq([ "escalate" ])
+    end
+  end
+
+  describe "paid_agent_review_pending with active run" do
+    it "suppresses all decisions when a paid_agent run is already active" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: [ { type: "paid_agent_review_pending", active_run: true } ]
+      })
+
+      types = decision_types(result)
+      expect(types).to eq([ "noop" ])
+    end
+  end
+  end
+end

--- a/spec/services/automation/strategy_parity_spec.rb
+++ b/spec/services/automation/strategy_parity_spec.rb
@@ -1,0 +1,381 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Parity checklist for the automation modularization migration.
+#
+# These tests verify that the modular automation architecture preserves
+# the expected behavior of the prior monolithic implementation across
+# the full decision space. Each test documents a specific behavior that
+# must remain stable during the migration.
+#
+# When extending the automation system, add a test here for any
+# behavior that spans multiple modules or crosses a strategy boundary.
+RSpec.describe Automation::Strategy do
+  context "with parity checklist" do
+  let(:project) { create(:project) }
+  let(:pull_request) do
+    create(:issue, :pull_request, project: project, github_number: 42, paid_state: "new")
+  end
+
+  def evaluate_auto_continue(lifecycle: nil, scan: nil)
+    metadata = {}
+    metadata[:lifecycle] = lifecycle if lifecycle
+    metadata[:scan] = scan if scan
+
+    context = Automation::Context.build(
+      record: pull_request,
+      project: project,
+      metadata: metadata
+    )
+    Automation::Strategies::AutoContinue.new.evaluate(context)
+  end
+
+  def evaluate_auto_review(scan: {})
+    context = Automation::Context.build(
+      record: pull_request,
+      project: project,
+      metadata: { scan: scan }
+    )
+    Automation::Strategies::AutoReview.new.evaluate(context)
+  end
+
+  def evaluate_auto_merge(signals: nil)
+    context = Automation::Context.build(
+      record: nil,
+      project: project,
+      metadata: { Automation::Strategies::AutoMerge::SIGNALS_KEY => signals }
+    )
+    Automation::Strategies::AutoMerge.new.evaluate(context)
+  end
+
+  def decision_types(result)
+    result.to_h[:decisions].map { |d| d[:type] }
+  end
+
+  # -- Strategy contract parity --
+
+  describe "strategy module contract" do
+    it "all strategies include Automation::Strategy" do
+      [
+        Automation::Strategies::AutoPick,
+        Automation::Strategies::AutoContinue,
+        Automation::Strategies::AutoReview,
+        Automation::Strategies::AutoMerge
+      ].each do |klass|
+        expect(klass.ancestors).to include(described_class),
+          "#{klass} must include Automation::Strategy"
+      end
+    end
+
+    it "all strategies return Automation::Result from #evaluate" do
+      context = Automation::Context.build(
+        record: pull_request,
+        project: project,
+        metadata: {}
+      )
+
+      [
+        Automation::Strategies::AutoContinue.new,
+        Automation::Strategies::AutoReview.new
+      ].each do |strategy|
+        result = strategy.evaluate(context)
+        expect(result).to be_a(Automation::Result),
+          "#{strategy.class} must return an Automation::Result"
+      end
+    end
+  end
+
+  # -- Decision type parity --
+
+  describe "decision factory completeness" do
+    it "supports all known decision types" do
+      known_types = %w[
+        noop
+        queue_create_pr_run
+        queue_review_run
+        start_planning
+        request_review
+        dispatch_claude_review
+        mark_ready
+        escalate
+        dismiss_escalation
+        merge
+        record_pr_followup
+        record_review_goal_retry
+        queue_analyze_issue_run
+      ]
+
+      known_types.each do |type|
+        factory_method = type.to_sym
+        expect(Automation::Decision).to respond_to(factory_method),
+          "Automation::Decision must have a .#{factory_method} factory method"
+      end
+    end
+  end
+
+  # -- Review method registry parity --
+
+  describe "review method registry" do
+    it "maps all canonical review method names to plugin classes" do
+      Automation::Configuration::ReviewMethod::NAMES.each do |name|
+        expect { Automation::ReviewMethods::Registry.resolve(name) }.not_to raise_error,
+          "Registry must resolve #{name.inspect}"
+      end
+    end
+
+    it "each plugin reports a valid kind symbol" do
+      valid_kinds = %i[bot agent comment_bot human ci]
+
+      Automation::Configuration::ReviewMethod::NAMES.each do |name|
+        plugin_class = Automation::ReviewMethods::Registry.resolve(name)
+        config = Automation::Configuration::AutoReview.new(
+          review_settings: Automation::Configuration::ReviewSettings.from_hash(
+            "enabled" => true,
+            "methods" => Automation::Configuration::ReviewMethod::NAMES.each_with_object({}) { |n, h|
+              h[n.to_s] = { "enabled" => true }
+            }
+          )
+        )
+        signals = Automation::Strategies::AutoReview::Signals.from_scan(pr_number: 1)
+        plugin = plugin_class.new(method: config.method_for(name), config: config, signals: signals)
+
+        expect(valid_kinds).to include(plugin.kind),
+          "Plugin for #{name.inspect} reported unexpected kind: #{plugin.kind.inspect}"
+      end
+    end
+  end
+
+  # -- Provider interface parity --
+
+  describe "provider capability modules" do
+    it "all three capability modules define a ProviderError" do
+      [
+        Automation::Providers::RepositoryProvider,
+        Automation::Providers::WorkItemProvider,
+        Automation::Providers::ReviewProvider
+      ].each do |mod|
+        expect(mod.const_defined?(:ProviderError)).to be(true),
+          "#{mod} must define ProviderError"
+        expect(mod::ProviderError.ancestors).to include(StandardError)
+      end
+    end
+  end
+
+  # -- Data class parity --
+
+  describe "data class state enumerations" do
+    it "PullRequest declares expected STATES" do
+      expect(Automation::Providers::Data::PullRequest::STATES).to contain_exactly(:open, :closed)
+    end
+
+    it "Issue declares expected STATES" do
+      expect(Automation::Providers::Data::Issue::STATES).to contain_exactly(:open, :closed)
+    end
+
+    it "Review declares expected STATES" do
+      expect(Automation::Providers::Data::Review::STATES).to contain_exactly(
+        :approved, :changes_requested, :commented, :dismissed, :pending
+      )
+    end
+
+    it "CheckRun declares expected STATUSES" do
+      expect(Automation::Providers::Data::CheckRun::STATUSES).to contain_exactly(
+        :queued, :in_progress, :completed
+      )
+    end
+
+    it "Outcome declares expected STATES" do
+      expect(Automation::Strategies::AutoReview::Outcome::STATES).to contain_exactly(
+        :pending, :satisfied, :retryable_failure, :exhausted_retries, :not_applicable
+      )
+    end
+  end
+
+  # -- Auto-review trigger routing parity --
+
+  describe "trigger priority in AutoReview" do
+    it "escalate_to_owner takes priority over all other triggers" do
+      result = evaluate_auto_review(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "escalated",
+        owner_reviewer_login: "bob",
+        triggers: [
+          { type: "escalate_to_owner", details: "budget exhausted" },
+          { type: "owner_approved" },
+          { type: "ci_failure", details: [ "test-suite" ] }
+        ]
+      })
+
+      expect(decision_types(result)).to eq([ "escalate" ])
+    end
+
+    it "owner_approved takes priority over review triggers" do
+      result = evaluate_auto_review(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        triggers: [
+          { type: "owner_approved" },
+          { type: "paid_agent_review_pending" }
+        ]
+      })
+
+      expect(decision_types(result)).to eq([ "merge" ])
+    end
+
+    it "review_goal_retry takes priority over paid_agent_review_pending" do
+      result = evaluate_auto_review(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "draft",
+        current_review_goal_retry_count: 1,
+        triggers: [
+          { type: "review_goal_retry" },
+          { type: "paid_agent_review_pending" }
+        ]
+      })
+
+      types = decision_types(result)
+      expect(types.first).to eq("record_review_goal_retry")
+    end
+  end
+
+  # -- AutoContinue delegation parity --
+
+  describe "AutoContinue delegates to AutoReview" do
+    let(:owner_approved_scan) do
+      { issue_id: pull_request.id, pr_number: 42, phase: "ready",
+        triggers: [ { type: "owner_approved" } ] }
+    end
+
+    let(:passthrough_lifecycle) do
+      { issue_id: pull_request.id, pr_number: 42, phase: "ready",
+        active_run_exists: false, operational_failure_breaker: false,
+        draft_review_limit_reached: false, consecutive_draft_failures_breaker: false,
+        review_goal_retry_limit_requires_escalation: false, followup_limit_reached: false,
+        escalation_dismissed: false, owner_reviewer_login: "alice",
+        escalation_reason: nil, draft: false }
+    end
+
+    it "produces the same merge decision as direct AutoReview evaluation" do
+      direct = evaluate_auto_review(scan: owner_approved_scan)
+      via_continue = evaluate_auto_continue(
+        lifecycle: passthrough_lifecycle, scan: owner_approved_scan
+      )
+
+      expect(decision_types(via_continue)).to eq(decision_types(direct))
+    end
+  end
+
+  # -- AutoMerge parity --
+
+  describe "AutoMerge precondition coverage" do
+    before do
+      allow(project).to receive_messages(
+        auto_merge_enabled?: true,
+        merge_method: "squash",
+        auto_fix_merge_conflicts: false
+      )
+    end
+
+    let(:all_human_preconditions) do
+      { issue_id: 42, pr_number: 10, owner_approved: true, checks_green: true,
+        mergeable: true, review_feedback_clear: true, blocking_reviews_complete: true,
+        reviews_fresh: true }
+    end
+
+    it "merges a human PR when all six preconditions are met" do
+      signals = Automation::Strategies::AutoMerge::Signals.build(**all_human_preconditions)
+      result = evaluate_auto_merge(signals: signals)
+
+      expect(decision_types(result)).to eq([ "merge" ])
+    end
+
+    %i[owner_approved checks_green mergeable
+       review_feedback_clear blocking_reviews_complete reviews_fresh].each do |field|
+      it "returns noop for human PR when #{field} is false" do
+        signals = Automation::Strategies::AutoMerge::Signals.build(
+          **all_human_preconditions.merge(field => false)
+        )
+        result = evaluate_auto_merge(signals: signals)
+
+        expect(decision_types(result)).to eq([ "noop" ])
+      end
+    end
+
+    it "bot PR requires only dependabot_eligible, checks_green, mergeable" do
+      signals = Automation::Strategies::AutoMerge::Signals.build(
+        issue_id: 42, pr_number: 10,
+        bot_authored: true, dependabot_eligible: true,
+        checks_green: true, mergeable: true,
+        owner_approved: false, review_feedback_clear: false
+      )
+
+      result = evaluate_auto_merge(signals: signals)
+      expect(decision_types(result)).to eq([ "merge" ])
+    end
+  end
+
+  # -- Context immutability parity --
+
+  describe "Context metadata immutability" do
+    it "freezes metadata on construction" do
+      context = Automation::Context.build(
+        record: pull_request,
+        project: project,
+        metadata: { key: "value" }
+      )
+
+      expect(context.metadata).to be_frozen
+    end
+
+    it "with_metadata returns a new context without mutating the original" do
+      original = Automation::Context.build(
+        record: pull_request,
+        project: project,
+        metadata: { a: 1 }
+      )
+
+      extended = original.with_metadata(b: 2)
+
+      expect(original.metadata).to eq({ a: 1 })
+      expect(extended.metadata).to include(a: 1, b: 2)
+    end
+  end
+
+  # -- Outcome blocking semantics parity --
+
+  describe "Outcome blocking/sidecar semantics" do
+    it "pending defaults to non-blocking (sidecar)" do
+      outcome = Automation::Strategies::AutoReview::Outcome.pending(method: :copilot)
+
+      expect(outcome).to be_pending
+      expect(outcome).to be_sidecar
+      expect(outcome).not_to be_blocking
+    end
+
+    it "retryable_failure defaults to blocking" do
+      outcome = Automation::Strategies::AutoReview::Outcome.retryable_failure(method: :paid_agent)
+
+      expect(outcome).to be_retryable_failure
+      expect(outcome).to be_blocking
+    end
+
+    it "satisfied is never blocking" do
+      outcome = Automation::Strategies::AutoReview::Outcome.satisfied(method: :copilot)
+
+      expect(outcome).to be_satisfied
+      expect(outcome).not_to be_blocking
+    end
+
+    it "not_applicable is never blocking" do
+      outcome = Automation::Strategies::AutoReview::Outcome.not_applicable(method: :codex)
+
+      expect(outcome).to be_not_applicable
+      expect(outcome).not_to be_blocking
+    end
+  end
+  end
+end

--- a/spec/services/automation/strategy_parity_spec.rb
+++ b/spec/services/automation/strategy_parity_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe Automation::Strategy do
     Automation::Strategies::AutoReview.new.evaluate(context)
   end
 
+  def evaluate_auto_pick
+    context = Automation::Context.build(
+      record: nil,
+      project: project,
+      metadata: {}
+    )
+    Automation::Strategies::AutoPick.new.evaluate(context)
+  end
+
   def evaluate_auto_merge(signals: nil)
     context = Automation::Context.build(
       record: nil,
@@ -69,20 +78,12 @@ RSpec.describe Automation::Strategy do
     end
 
     it "all strategies return Automation::Result from #evaluate" do
-      context = Automation::Context.build(
-        record: pull_request,
-        project: project,
-        metadata: {}
-      )
-
-      [
-        Automation::Strategies::AutoContinue.new,
-        Automation::Strategies::AutoReview.new
-      ].each do |strategy|
-        result = strategy.evaluate(context)
-        expect(result).to be_a(Automation::Result),
-          "#{strategy.class} must return an Automation::Result"
-      end
+      expect([
+        evaluate_auto_pick,
+        evaluate_auto_continue,
+        evaluate_auto_review,
+        evaluate_auto_merge
+      ]).to all(be_a(Automation::Result))
     end
   end
 

--- a/spec/support/shared_examples/automation/repository_provider_contract.rb
+++ b/spec/support/shared_examples/automation/repository_provider_contract.rb
@@ -18,6 +18,9 @@
 #   invoke_expected_provider_failure
 #                 — a lambda that performs the adapter call expected to
 #                   raise ProviderError after translation
+#   stub_missing_label_provider_failure
+#                 — a lambda that stubs the provider's "label already
+#                   absent" failure for remove_label
 #   provider_failure_message
 #                 — the expected translated ProviderError message
 #
@@ -93,6 +96,13 @@ RSpec.shared_examples "a RepositoryProvider implementation" do
 
   describe "#remove_label" do
     it "does not raise (idempotent)" do
+      expect { adapter.remove_label(repo: repo, number: pr_number, label: label_name) }
+        .not_to raise_error
+    end
+
+    it "swallows the provider's missing-label error" do
+      stub_missing_label_provider_failure
+
       expect { adapter.remove_label(repo: repo, number: pr_number, label: label_name) }
         .not_to raise_error
     end

--- a/spec/support/shared_examples/automation/repository_provider_contract.rb
+++ b/spec/support/shared_examples/automation/repository_provider_contract.rb
@@ -24,6 +24,10 @@
 #   stub_already_merged_pull_request
 #                 — a lambda that stubs the provider's response for
 #                   merging an already-merged PR (must succeed, not raise)
+#   invoke_list_pull_requests_with_filters
+#                 — a lambda that performs #list_pull_requests with
+#                   state/head/base filters and asserts the provider
+#                   client receives them
 #   provider_failure_message
 #                 — the expected translated ProviderError message
 #
@@ -78,7 +82,7 @@ RSpec.shared_examples "a RepositoryProvider implementation" do
     end
 
     it "accepts and forwards head and base filters" do
-      result = adapter.list_pull_requests(repo: repo, head: "owner:feature", base: "main")
+      result = invoke_list_pull_requests_with_filters.call
 
       expect(result).to be_an(Array)
       expect(result).to all(be_a(Automation::Providers::Data::PullRequest))
@@ -155,6 +159,15 @@ RSpec.shared_examples "a RepositoryProvider implementation" do
       result = adapter.merge_pull_request(repo: repo, number: pr_number, method: :squash)
 
       expect(result).to be_a(Automation::Providers::Data::MergeResult)
+    end
+
+    it "rejects unsupported merge methods loudly" do
+      expect {
+        adapter.merge_pull_request(repo: repo, number: pr_number, method: :fast_forward)
+      }.to raise_error(
+        Automation::Providers::RepositoryProvider::ProviderError,
+        /Unsupported/
+      )
     end
   end
 

--- a/spec/support/shared_examples/automation/repository_provider_contract.rb
+++ b/spec/support/shared_examples/automation/repository_provider_contract.rb
@@ -13,6 +13,13 @@
 #   ref           — a String git ref whose check-run fetch succeeds
 #   label_name    — a String label name for add/remove tests
 #   comment_body  — a String body for add_comment
+#   stub_expected_provider_failure
+#                 — a lambda that stubs an expected provider-side failure
+#   invoke_expected_provider_failure
+#                 — a lambda that performs the adapter call expected to
+#                   raise ProviderError after translation
+#   provider_failure_message
+#                 — the expected translated ProviderError message
 #
 # The adapter's underlying client should be stubbed to return valid
 # data for the given repo/pr_number/ref combination.
@@ -113,6 +120,17 @@ RSpec.shared_examples "a RepositoryProvider implementation" do
 
       expect(result).to be_a(Automation::Providers::Data::MergeResult)
       expect(result.merged).to be(true).or be(false)
+    end
+  end
+
+  describe "expected provider failures" do
+    it "translates them into RepositoryProvider::ProviderError" do
+      stub_expected_provider_failure
+
+      expect(&invoke_expected_provider_failure).to raise_error(
+        Automation::Providers::RepositoryProvider::ProviderError,
+        provider_failure_message
+      )
     end
   end
 end

--- a/spec/support/shared_examples/automation/repository_provider_contract.rb
+++ b/spec/support/shared_examples/automation/repository_provider_contract.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# Shared examples verifying that a concrete RepositoryProvider
+# implementation satisfies the interface contract. Include this group in
+# specs for every adapter (GitHub, GitLab, …) to guarantee return-type
+# and error-handling parity.
+#
+# Expected `let` bindings the including spec must supply:
+#
+#   adapter       — an instance of the implementation class
+#   repo          — a String repo identifier (e.g. "acme/widgets")
+#   pr_number     — an Integer PR number whose fetch succeeds
+#   ref           — a String git ref whose check-run fetch succeeds
+#   label_name    — a String label name for add/remove tests
+#   comment_body  — a String body for add_comment
+#
+# The adapter's underlying client should be stubbed to return valid
+# data for the given repo/pr_number/ref combination.
+RSpec.shared_examples "a RepositoryProvider implementation" do
+  it "includes the RepositoryProvider module" do
+    expect(adapter.class.ancestors).to include(Automation::Providers::RepositoryProvider)
+  end
+
+  describe "#fetch_pull_request" do
+    it "returns a Data::PullRequest" do
+      result = adapter.fetch_pull_request(repo: repo, number: pr_number)
+
+      expect(result).to be_a(Automation::Providers::Data::PullRequest)
+    end
+
+    it "normalizes state to a symbol from PullRequest::STATES" do
+      result = adapter.fetch_pull_request(repo: repo, number: pr_number)
+
+      expect(Automation::Providers::Data::PullRequest::STATES).to include(result.state)
+    end
+
+    it "downcases author_login" do
+      result = adapter.fetch_pull_request(repo: repo, number: pr_number)
+      next if result.author_login.nil?
+
+      expect(result.author_login).to eq(result.author_login.downcase)
+    end
+
+    it "returns labels as an Array of Strings" do
+      result = adapter.fetch_pull_request(repo: repo, number: pr_number)
+
+      expect(result.labels).to be_an(Array)
+      expect(result.labels).to all(be_a(String))
+    end
+  end
+
+  describe "#list_pull_requests" do
+    it "returns an Array of Data::PullRequest" do
+      result = adapter.list_pull_requests(repo: repo)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::PullRequest))
+    end
+  end
+
+  describe "#fetch_pull_request_files" do
+    it "returns an Array of String paths" do
+      result = adapter.fetch_pull_request_files(repo: repo, number: pr_number)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(String))
+    end
+  end
+
+  describe "#fetch_check_runs" do
+    it "returns an Array of Data::CheckRun" do
+      result = adapter.fetch_check_runs(repo: repo, ref: ref)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::CheckRun))
+      result.each { |run| expect(Automation::Providers::Data::CheckRun::STATUSES).to include(run.status) }
+    end
+  end
+
+  describe "#add_labels" do
+    it "does not raise for a valid label list" do
+      expect { adapter.add_labels(repo: repo, number: pr_number, labels: [ label_name ]) }
+        .not_to raise_error
+    end
+  end
+
+  describe "#remove_label" do
+    it "does not raise (idempotent)" do
+      expect { adapter.remove_label(repo: repo, number: pr_number, label: label_name) }
+        .not_to raise_error
+    end
+  end
+
+  describe "#add_comment" do
+    it "returns a Data::Comment" do
+      result = adapter.add_comment(repo: repo, number: pr_number, body: comment_body)
+
+      expect(result).to be_a(Automation::Providers::Data::Comment)
+      expect(result.body).to eq(comment_body)
+    end
+  end
+
+  describe "#mark_ready_for_review" do
+    it "does not raise" do
+      expect { adapter.mark_ready_for_review(repo: repo, number: pr_number) }
+        .not_to raise_error
+    end
+  end
+
+  describe "#merge_pull_request" do
+    it "returns a Data::MergeResult" do
+      result = adapter.merge_pull_request(repo: repo, number: pr_number, method: :squash)
+
+      expect(result).to be_a(Automation::Providers::Data::MergeResult)
+      expect(result.merged).to be(true).or be(false)
+    end
+  end
+end

--- a/spec/support/shared_examples/automation/repository_provider_contract.rb
+++ b/spec/support/shared_examples/automation/repository_provider_contract.rb
@@ -21,6 +21,9 @@
 #   stub_missing_label_provider_failure
 #                 — a lambda that stubs the provider's "label already
 #                   absent" failure for remove_label
+#   stub_already_merged_pull_request
+#                 — a lambda that stubs the provider's response for
+#                   merging an already-merged PR (must succeed, not raise)
 #   provider_failure_message
 #                 — the expected translated ProviderError message
 #
@@ -62,6 +65,20 @@ RSpec.shared_examples "a RepositoryProvider implementation" do
   describe "#list_pull_requests" do
     it "returns an Array of Data::PullRequest" do
       result = adapter.list_pull_requests(repo: repo)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::PullRequest))
+    end
+
+    it "accepts and forwards the state filter" do
+      result = adapter.list_pull_requests(repo: repo, state: :open)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::PullRequest))
+    end
+
+    it "accepts and forwards head and base filters" do
+      result = adapter.list_pull_requests(repo: repo, head: "owner:feature", base: "main")
 
       expect(result).to be_an(Array)
       expect(result).to all(be_a(Automation::Providers::Data::PullRequest))
@@ -130,6 +147,14 @@ RSpec.shared_examples "a RepositoryProvider implementation" do
 
       expect(result).to be_a(Automation::Providers::Data::MergeResult)
       expect(result.merged).to be(true).or be(false)
+    end
+
+    it "is idempotent when the PR is already merged" do
+      stub_already_merged_pull_request
+
+      result = adapter.merge_pull_request(repo: repo, number: pr_number, method: :squash)
+
+      expect(result).to be_a(Automation::Providers::Data::MergeResult)
     end
   end
 

--- a/spec/support/shared_examples/automation/review_method_plugin_contract.rb
+++ b/spec/support/shared_examples/automation/review_method_plugin_contract.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Shared examples verifying that a concrete ReviewMethods plugin
+# satisfies the Base contract. Every plugin (copilot, paid_agent,
+# codex, ci_action, manual) should include this group.
+#
+# Expected `let` bindings:
+#
+#   plugin        — an instance of the plugin class under test
+#   expected_kind — the Symbol kind the plugin must report
+#
+RSpec.shared_examples "a ReviewMethods plugin" do
+  it "is a subclass of Automation::ReviewMethods::Base" do
+    expect(plugin).to be_a(Automation::ReviewMethods::Base)
+  end
+
+  describe "#kind" do
+    it "returns the expected symbol" do
+      expect(plugin.kind).to eq(expected_kind)
+    end
+
+    it "returns a symbol" do
+      expect(plugin.kind).to be_a(Symbol)
+    end
+  end
+
+  describe "#name" do
+    it "returns a symbol" do
+      expect(plugin.name).to be_a(Symbol)
+    end
+  end
+
+  describe "#evaluate" do
+    it "returns an Automation::Strategies::AutoReview::Outcome" do
+      result = plugin.evaluate
+
+      expect(result).to be_a(Automation::Strategies::AutoReview::Outcome)
+      expect(Automation::Strategies::AutoReview::Outcome::STATES).to include(result.state)
+    end
+  end
+
+  describe "#decision" do
+    it "returns nil or an Automation::Decision" do
+      result = plugin.decision
+
+      if result
+        expect(result).to be_a(Automation::Decision)
+      else
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#blocking_by_default?" do
+    it "returns a boolean" do
+      expect(plugin.blocking_by_default?).to be(true).or be(false)
+    end
+  end
+end

--- a/spec/support/shared_examples/automation/review_provider_contract.rb
+++ b/spec/support/shared_examples/automation/review_provider_contract.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Shared examples verifying that a concrete ReviewProvider
+# implementation satisfies the interface contract.
+#
+# Expected `let` bindings:
+#
+#   adapter     — an instance of the implementation class
+#   repo        — a String repo identifier
+#   pr_number   — an Integer PR number whose review queries succeed
+#
+# The adapter's underlying client should be stubbed to return valid
+# data for the given repo/pr_number combination.
+RSpec.shared_examples "a ReviewProvider implementation" do
+  it "includes the ReviewProvider module" do
+    expect(adapter.class.ancestors).to include(Automation::Providers::ReviewProvider)
+  end
+
+  describe "#fetch_reviews" do
+    it "returns an Array of Data::Review" do
+      result = adapter.fetch_reviews(repo: repo, pr_number: pr_number)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::Review))
+      result.each { |r| expect(Automation::Providers::Data::Review::STATES).to include(r.state) }
+    end
+
+    it "downcases author_login on returned reviews" do
+      result = adapter.fetch_reviews(repo: repo, pr_number: pr_number)
+
+      result.each { |r| expect(r.author_login).to eq(r.author_login.downcase) unless r.author_login.nil? }
+    end
+  end
+
+  describe "#fetch_review_threads" do
+    it "returns an Array of Data::ReviewThread" do
+      result = adapter.fetch_review_threads(repo: repo, pr_number: pr_number)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::ReviewThread))
+    end
+  end
+
+  describe "#fetch_review_requests" do
+    it "returns a Data::ReviewRequest" do
+      result = adapter.fetch_review_requests(repo: repo, pr_number: pr_number)
+
+      expect(result).to be_a(Automation::Providers::Data::ReviewRequest)
+      expect(result.users).to be_an(Array)
+      expect(result.teams).to be_an(Array)
+    end
+  end
+
+  describe "#fetch_pending_reviewers" do
+    it "returns an Array of downcased Strings" do
+      result = adapter.fetch_pending_reviewers(repo: repo, pr_number: pr_number)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(String))
+      expect(result).to all(satisfy("be downcased") { |l| l == l.downcase })
+    end
+  end
+
+  describe "#request_reviewers" do
+    it "returns an Array of Strings (the newly-requested subset)" do
+      result = adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: [ "alice" ])
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(String))
+    end
+  end
+
+  describe "#submit_review" do
+    it "returns a Data::Review" do
+      result = adapter.submit_review(
+        repo: repo, pr_number: pr_number, body: "lgtm", event: :approve
+      )
+
+      expect(result).to be_a(Automation::Providers::Data::Review)
+      expect(Automation::Providers::Data::Review::STATES).to include(result.state)
+    end
+  end
+
+  describe "#resolve_review_thread" do
+    it "does not raise (idempotent)" do
+      expect { adapter.resolve_review_thread(repo: repo, pr_number: pr_number, thread_id: "t1") }
+        .not_to raise_error
+    end
+  end
+end

--- a/spec/support/shared_examples/automation/review_provider_contract.rb
+++ b/spec/support/shared_examples/automation/review_provider_contract.rb
@@ -113,6 +113,17 @@ RSpec.shared_examples "a ReviewProvider implementation" do
       expect(result).to be_a(Automation::Providers::Data::Review)
       expect(Automation::Providers::Data::Review::STATES).to include(result.state)
     end
+
+    it "rejects unsupported review events loudly" do
+      expect {
+        adapter.submit_review(
+          repo: repo, pr_number: pr_number, body: "lgtm", event: :bogus
+        )
+      }.to raise_error(
+        Automation::Providers::ReviewProvider::ProviderError,
+        /Unsupported/
+      )
+    end
   end
 
   describe "#resolve_review_thread" do

--- a/spec/support/shared_examples/automation/review_provider_contract.rb
+++ b/spec/support/shared_examples/automation/review_provider_contract.rb
@@ -17,6 +17,14 @@
 #   invoke_expected_provider_failure
 #               — a lambda that performs the adapter call expected to
 #                 raise ProviderError after translation
+#   fully_pending_reviewers
+#               — reviewers passed to #request_reviewers when every
+#                 reviewer is already pending
+#   invoke_fully_pending_review_request
+#               — a lambda that performs that fully-idempotent request
+#   assert_no_redundant_review_request
+#               — a lambda that asserts the provider request API was not
+#                 called for the fully-idempotent request
 #   provider_failure_message
 #               — the expected translated ProviderError message
 #
@@ -86,6 +94,13 @@ RSpec.shared_examples "a ReviewProvider implementation" do
       expect(result).to all(satisfy("be downcased") { |login| login == login.downcase })
       expect(result).to all(be_in(requested_reviewers.map(&:downcase)))
       expect(result & pending_reviewers).to be_empty
+    end
+
+    it "returns [] without re-requesting when everyone is already pending" do
+      result = invoke_fully_pending_review_request.call
+
+      expect(result).to eq([])
+      assert_no_redundant_review_request
     end
   end
 

--- a/spec/support/shared_examples/automation/review_provider_contract.rb
+++ b/spec/support/shared_examples/automation/review_provider_contract.rb
@@ -8,6 +8,17 @@
 #   adapter     — an instance of the implementation class
 #   repo        — a String repo identifier
 #   pr_number   — an Integer PR number whose review queries succeed
+#   requested_reviewers
+#               — reviewers passed to #request_reviewers
+#   expected_new_reviewers
+#               — exact newly-requested subset expected back
+#   stub_expected_provider_failure
+#               — a lambda that stubs an expected provider-side failure
+#   invoke_expected_provider_failure
+#               — a lambda that performs the adapter call expected to
+#                 raise ProviderError after translation
+#   provider_failure_message
+#               — the expected translated ProviderError message
 #
 # The adapter's underlying client should be stubbed to return valid
 # data for the given repo/pr_number combination.
@@ -62,11 +73,19 @@ RSpec.shared_examples "a ReviewProvider implementation" do
   end
 
   describe "#request_reviewers" do
-    it "returns an Array of Strings (the newly-requested subset)" do
-      result = adapter.request_reviewers(repo: repo, pr_number: pr_number, reviewers: [ "alice" ])
+    it "returns the exact newly-requested subset" do
+      pending_reviewers = adapter.fetch_pending_reviewers(repo: repo, pr_number: pr_number)
+      result = adapter.request_reviewers(
+        repo: repo,
+        pr_number: pr_number,
+        reviewers: requested_reviewers
+      )
 
-      expect(result).to be_an(Array)
+      expect(result).to eq(expected_new_reviewers)
       expect(result).to all(be_a(String))
+      expect(result).to all(satisfy("be downcased") { |login| login == login.downcase })
+      expect(result).to all(be_in(requested_reviewers.map(&:downcase)))
+      expect(result & pending_reviewers).to be_empty
     end
   end
 
@@ -85,6 +104,17 @@ RSpec.shared_examples "a ReviewProvider implementation" do
     it "does not raise (idempotent)" do
       expect { adapter.resolve_review_thread(repo: repo, pr_number: pr_number, thread_id: "t1") }
         .not_to raise_error
+    end
+  end
+
+  describe "expected provider failures" do
+    it "translates them into ReviewProvider::ProviderError" do
+      stub_expected_provider_failure
+
+      expect(&invoke_expected_provider_failure).to raise_error(
+        Automation::Providers::ReviewProvider::ProviderError,
+        provider_failure_message
+      )
     end
   end
 end

--- a/spec/support/shared_examples/automation/work_item_provider_contract.rb
+++ b/spec/support/shared_examples/automation/work_item_provider_contract.rb
@@ -18,6 +18,15 @@
 #   stub_missing_label_provider_failure
 #                 — a lambda that stubs the provider's "label already
 #                   absent" failure for remove_label
+#   invoke_list_issues_with_state_filter
+#                 — a lambda that performs #list_issues with a state
+#                   filter and asserts the provider client receives it
+#   invoke_list_issues_with_labels_filter
+#                 — a lambda that performs #list_issues with label
+#                   filters and asserts the provider client receives them
+#   invoke_list_issues_with_assignees_filter
+#                 — a lambda that performs #list_issues with assignee
+#                   filters and asserts the provider client receives them
 #   provider_failure_message
 #                 — the expected translated ProviderError message
 #
@@ -64,14 +73,21 @@ RSpec.shared_examples "a WorkItemProvider implementation" do
     end
 
     it "accepts and forwards the state filter" do
-      result = adapter.list_issues(repo: repo, state: :open)
+      result = invoke_list_issues_with_state_filter.call
 
       expect(result).to be_an(Array)
       expect(result).to all(be_a(Automation::Providers::Data::Issue))
     end
 
     it "accepts and forwards the labels filter" do
-      result = adapter.list_issues(repo: repo, labels: [ "bug" ])
+      result = invoke_list_issues_with_labels_filter.call
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::Issue))
+    end
+
+    it "accepts and forwards the assignees filter" do
+      result = invoke_list_issues_with_assignees_filter.call
 
       expect(result).to be_an(Array)
       expect(result).to all(be_a(Automation::Providers::Data::Issue))

--- a/spec/support/shared_examples/automation/work_item_provider_contract.rb
+++ b/spec/support/shared_examples/automation/work_item_provider_contract.rb
@@ -15,6 +15,9 @@
 #   invoke_expected_provider_failure
 #                 — a lambda that performs the adapter call expected to
 #                   raise ProviderError after translation
+#   stub_missing_label_provider_failure
+#                 — a lambda that stubs the provider's "label already
+#                   absent" failure for remove_label
 #   provider_failure_message
 #                 — the expected translated ProviderError message
 #
@@ -96,6 +99,13 @@ RSpec.shared_examples "a WorkItemProvider implementation" do
 
   describe "#remove_label" do
     it "does not raise (idempotent)" do
+      expect { adapter.remove_label(repo: repo, number: issue_number, label: label_name) }
+        .not_to raise_error
+    end
+
+    it "swallows the provider's missing-label error" do
+      stub_missing_label_provider_failure
+
       expect { adapter.remove_label(repo: repo, number: issue_number, label: label_name) }
         .not_to raise_error
     end

--- a/spec/support/shared_examples/automation/work_item_provider_contract.rb
+++ b/spec/support/shared_examples/automation/work_item_provider_contract.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Shared examples verifying that a concrete WorkItemProvider
+# implementation satisfies the interface contract.
+#
+# Expected `let` bindings:
+#
+#   adapter        — an instance of the implementation class
+#   repo           — a String repo identifier
+#   issue_number   — an Integer/String issue number whose fetch succeeds
+#   label_name     — a String label name for add/remove tests
+#   comment_body   — a String body for add_comment
+#
+# The adapter's underlying client should be stubbed to return valid
+# data for the given repo/issue_number combination.
+RSpec.shared_examples "a WorkItemProvider implementation" do
+  it "includes the WorkItemProvider module" do
+    expect(adapter.class.ancestors).to include(Automation::Providers::WorkItemProvider)
+  end
+
+  describe "#fetch_issue" do
+    it "returns a Data::Issue" do
+      result = adapter.fetch_issue(repo: repo, number: issue_number)
+
+      expect(result).to be_a(Automation::Providers::Data::Issue)
+    end
+
+    it "normalizes state to a symbol from Issue::STATES" do
+      result = adapter.fetch_issue(repo: repo, number: issue_number)
+
+      expect(Automation::Providers::Data::Issue::STATES).to include(result.state)
+    end
+
+    it "returns labels as an Array of Strings" do
+      result = adapter.fetch_issue(repo: repo, number: issue_number)
+
+      expect(result.labels).to be_an(Array)
+      expect(result.labels).to all(be_a(String))
+    end
+
+    it "returns dependencies as an Array" do
+      result = adapter.fetch_issue(repo: repo, number: issue_number)
+
+      expect(result.dependencies).to be_an(Array)
+    end
+  end
+
+  describe "#list_issues" do
+    it "returns an Array of Data::Issue" do
+      result = adapter.list_issues(repo: repo)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::Issue))
+    end
+  end
+
+  describe "#fetch_issue_comments" do
+    it "returns an Array of Data::Comment" do
+      result = adapter.fetch_issue_comments(repo: repo, number: issue_number)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::Comment))
+    end
+  end
+
+  describe "#fetch_issue_timeline" do
+    it "returns an Array of Data::TimelineEvent" do
+      result = adapter.fetch_issue_timeline(repo: repo, number: issue_number)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::TimelineEvent))
+    end
+  end
+
+  describe "#create_issue" do
+    it "returns a Data::Issue" do
+      result = adapter.create_issue(repo: repo, title: "Test issue")
+
+      expect(result).to be_a(Automation::Providers::Data::Issue)
+    end
+  end
+
+  describe "#add_labels" do
+    it "does not raise for a valid label list" do
+      expect { adapter.add_labels(repo: repo, number: issue_number, labels: [ label_name ]) }
+        .not_to raise_error
+    end
+  end
+
+  describe "#remove_label" do
+    it "does not raise (idempotent)" do
+      expect { adapter.remove_label(repo: repo, number: issue_number, label: label_name) }
+        .not_to raise_error
+    end
+  end
+
+  describe "#add_comment" do
+    it "returns a Data::Comment" do
+      result = adapter.add_comment(repo: repo, number: issue_number, body: comment_body)
+
+      expect(result).to be_a(Automation::Providers::Data::Comment)
+      expect(result.body).to eq(comment_body)
+    end
+  end
+
+  describe "#transition_state" do
+    it "returns a Data::Issue" do
+      result = adapter.transition_state(repo: repo, number: issue_number, state: :closed)
+
+      expect(result).to be_a(Automation::Providers::Data::Issue)
+    end
+  end
+end

--- a/spec/support/shared_examples/automation/work_item_provider_contract.rb
+++ b/spec/support/shared_examples/automation/work_item_provider_contract.rb
@@ -62,6 +62,20 @@ RSpec.shared_examples "a WorkItemProvider implementation" do
       expect(result).to be_an(Array)
       expect(result).to all(be_a(Automation::Providers::Data::Issue))
     end
+
+    it "accepts and forwards the state filter" do
+      result = adapter.list_issues(repo: repo, state: :open)
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::Issue))
+    end
+
+    it "accepts and forwards the labels filter" do
+      result = adapter.list_issues(repo: repo, labels: [ "bug" ])
+
+      expect(result).to be_an(Array)
+      expect(result).to all(be_a(Automation::Providers::Data::Issue))
+    end
   end
 
   describe "#fetch_issue_comments" do

--- a/spec/support/shared_examples/automation/work_item_provider_contract.rb
+++ b/spec/support/shared_examples/automation/work_item_provider_contract.rb
@@ -10,6 +10,13 @@
 #   issue_number   — an Integer/String issue number whose fetch succeeds
 #   label_name     — a String label name for add/remove tests
 #   comment_body   — a String body for add_comment
+#   stub_expected_provider_failure
+#                 — a lambda that stubs an expected provider-side failure
+#   invoke_expected_provider_failure
+#                 — a lambda that performs the adapter call expected to
+#                   raise ProviderError after translation
+#   provider_failure_message
+#                 — the expected translated ProviderError message
 #
 # The adapter's underlying client should be stubbed to return valid
 # data for the given repo/issue_number combination.
@@ -108,6 +115,17 @@ RSpec.shared_examples "a WorkItemProvider implementation" do
       result = adapter.transition_state(repo: repo, number: issue_number, state: :closed)
 
       expect(result).to be_a(Automation::Providers::Data::Issue)
+    end
+  end
+
+  describe "expected provider failures" do
+    it "translates them into WorkItemProvider::ProviderError" do
+      stub_expected_provider_failure
+
+      expect(&invoke_expected_provider_failure).to raise_error(
+        Automation::Providers::WorkItemProvider::ProviderError,
+        provider_failure_message
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

The commit succeeded. All 10,067 tests pass (0 failures), lint is clean, and the commit is on the branch ready for PR.

---

Closes #1124