### PR TITLE
fix(auto-pick): recover issues stuck in completed state and classify infrastructure errors

### DIFF
--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -63,7 +63,7 @@ module Automation
           end
 
           def eligible_scope(project)
-            blocking_run_ids = AgentRun.where(
+            blocking_issue_ids = AgentRun.where(
               project: project, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES
             ).where.not(issue_id: nil).select(:issue_id)
 
@@ -72,7 +72,7 @@ module Automation
             ).where.not(parent_issue_id: nil).distinct.select(:parent_issue_id)
 
             base = Issue.ready_for_work(project)
-              .where.not(id: blocking_run_ids)
+              .where.not(id: blocking_issue_ids)
               .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
               .where.not(id: subissue_parent_ids)
               .where.not(id: Issue.open_pull_request_parent_issue_ids(project: project).distinct)
@@ -86,12 +86,22 @@ module Automation
 
             scope = base.where(paid_state: %w[new planning failed])
 
-            pr_produced_ids = AgentRun.where(
-              project: project, status: "completed"
+            recoverable_completed_issue_ids = AgentRun.where(
+              project: project,
+              status: "completed",
+              trigger_type: "automatic",
+              goal: "create_pr",
+              auto_pick: true,
+              pull_request_number: nil
+            ).where.not(issue_id: nil).select(:issue_id)
+
+            pr_produced_issue_ids = AgentRun.where(
+              project: project, status: "completed", goal: "create_pr"
             ).where.not(pull_request_number: nil).where.not(issue_id: nil).select(:issue_id)
 
             scope = scope.or(
-              base.where(paid_state: "completed").where.not(id: pr_produced_ids)
+              base.where(paid_state: "completed", id: recoverable_completed_issue_ids)
+                .where.not(id: pr_produced_issue_ids)
             )
 
             blocked_ids = tracker_ids_blocked_by_open_references(scope, project)

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -63,25 +63,37 @@ module Automation
           end
 
           def eligible_scope(project)
-            scope = Issue.ready_for_work(project)
-              .where(paid_state: %w[new planning failed])
-              .where.not(id: AgentRun.where(project: project, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES).where.not(issue_id: nil).select(:issue_id))
+            blocking_run_ids = AgentRun.where(
+              project: project, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES
+            ).where.not(issue_id: nil).select(:issue_id)
+
+            subissue_parent_ids = Issue.where(
+              project: project, is_pull_request: false
+            ).where.not(parent_issue_id: nil).distinct.select(:parent_issue_id)
+
+            base = Issue.ready_for_work(project)
+              .where.not(id: blocking_run_ids)
               .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
-              .where.not(id: Issue.where(project: project, is_pull_request: false).where.not(parent_issue_id: nil).distinct.select(:parent_issue_id))
+              .where.not(id: subissue_parent_ids)
               .where.not(id: Issue.open_pull_request_parent_issue_ids(project: project).distinct)
 
             trusted_usernames = Array(project.allowed_github_usernames).presence
-            scope = scope.where(github_creator_login: trusted_usernames) if trusted_usernames
+            base = base.where(github_creator_login: trusted_usernames) if trusted_usernames
 
-            scope = EXCLUDED_LABELS.reduce(scope) do |s, label|
+            base = EXCLUDED_LABELS.reduce(base) do |s, label|
               s.where.not("labels @> ?::jsonb", [ label ].to_json)
             end
 
-            # Exclude tracker/meta issues that still have open referenced
-            # issues. Trackers are pickable only once every issue referenced
-            # in their body is closed (per collaborator feedback). The
-            # ILIKE scan runs against +scope+ (not all open issues) to
-            # limit query cost.
+            scope = base.where(paid_state: %w[new planning failed])
+
+            pr_produced_ids = AgentRun.where(
+              project: project, status: "completed"
+            ).where.not(pull_request_number: nil).where.not(issue_id: nil).select(:issue_id)
+
+            scope = scope.or(
+              base.where(paid_state: "completed").where.not(id: pr_produced_ids)
+            )
+
             blocked_ids = tracker_ids_blocked_by_open_references(scope, project)
             scope = scope.where.not(id: blocked_ids) if blocked_ids.present?
 

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -108,6 +108,18 @@ module Issues
     # Matches same-project references like #123
     ISSUE_REF_PATTERN = /\#(\d+)/
 
+    # Section headings that list child/sub-issues. Inline dependency phrases
+    # within these sections describe relationships between the listed
+    # sub-issues (e.g. "- [ ] #453 — ... (depends on #452)"), not dependencies
+    # of the current issue, so the entire section must be excluded from inline
+    # extraction. Matches headings containing child/sub keywords anywhere in
+    # the heading text (e.g. "## Sub-Issues", "## Implementation Sub-Issues").
+    CHILD_LISTING_SECTION_PATTERN = /
+      ^\#+[^\n]*\b(?:child\s+issues?|sub[- ]?issues?|sub[- ]?tasks?)\b[^\n]*\n
+      [\s\S]*?
+      (?=^\#|\z)
+    /xim
+
     attr_reader :issue, :adjacency, :comments
 
     def initialize(issue:, adjacency: nil, comments: [])
@@ -212,13 +224,17 @@ module Issues
 
     # Extracts refs from body using both dependency sections and inline patterns.
     # Only dependency-scoped text is parsed — incidental #N mentions (e.g. in a
-    # "Notes" section) are intentionally ignored.
+    # "Notes" section) are intentionally ignored. Child/sub-issue listing
+    # sections are stripped before inline extraction so dependency phrases
+    # describing inter-sub-issue relationships are not attributed to the
+    # current issue.
     def extract_body_refs(body, local_deps, cross_deps)
       body.scan(DEPENDENCY_SECTION_PATTERN) do |(section_body)|
         extract_section_refs(section_body, local_deps, cross_deps)
       end
 
-      extract_inline_refs(body, local_deps, cross_deps)
+      inline_text = body.gsub(CHILD_LISTING_SECTION_PATTERN, "")
+      extract_inline_refs(inline_text, local_deps, cross_deps)
     end
 
     # Within a "## Dependencies" section, recognise both explicit

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -56,12 +56,6 @@ module Issues
   # @example
   #   Issues::ParseDependencies.call(issue: issue, comments: ["Depends on #101"])
   class ParseDependencies
-    DEPENDENCY_SECTION_PATTERN = /
-      ^\#+\s*Dependenc(?:y|ies)\b[^\n]*\n  # Header line (## Dependencies, etc.)
-      ([\s\S]*?)                           # Section body (non-greedy, up to next heading)
-      (?=^\#|\z)                           # Lookahead for next heading or end
-    /xim
-
     INLINE_DEPENDS_PATTERN = /
       \b(?:depends?\s+on|blocked?\s+by)\b   # Keyword
       :?\s*                                 # Optional colon
@@ -108,17 +102,10 @@ module Issues
     # Matches same-project references like #123
     ISSUE_REF_PATTERN = /\#(\d+)/
 
-    # Section headings that list child/sub-issues. Inline dependency phrases
-    # within these sections describe relationships between the listed
-    # sub-issues (e.g. "- [ ] #453 — ... (depends on #452)"), not dependencies
-    # of the current issue, so the entire section must be excluded from inline
-    # extraction. Matches headings containing child/sub keywords anywhere in
-    # the heading text (e.g. "## Sub-Issues", "## Implementation Sub-Issues").
-    CHILD_LISTING_SECTION_PATTERN = /
-      ^\#+[^\n]*\b(?:child\s+issues?|sub[- ]?issues?|sub[- ]?tasks?)\b[^\n]*\n
-      [\s\S]*?
-      (?=^\#|\z)
-    /xim
+    DEPENDENCY_HEADING_PATTERN = /\bdependenc(?:y|ies)\b/i
+    CHILD_LISTING_HEADING_PATTERN = /\b(?:child\s+issues?|sub[- ]?issues?|sub[- ]?tasks?)\b/i
+    MARKDOWN_HEADING_PATTERN = /^[ \t]{0,3}\#{1,6}[ \t]+(.+?)\s*#*\s*$/
+    FENCED_CODE_BLOCK_PATTERN = /^[ \t]{0,3}(```|~~~)/
 
     attr_reader :issue, :adjacency, :comments
 
@@ -229,11 +216,11 @@ module Issues
     # describing inter-sub-issue relationships are not attributed to the
     # current issue.
     def extract_body_refs(body, local_deps, cross_deps)
-      body.scan(DEPENDENCY_SECTION_PATTERN) do |(section_body)|
+      markdown_sections(body, heading_pattern: DEPENDENCY_HEADING_PATTERN).each do |section_body|
         extract_section_refs(section_body, local_deps, cross_deps)
       end
 
-      inline_text = body.gsub(CHILD_LISTING_SECTION_PATTERN, "")
+      inline_text = strip_markdown_sections(body, heading_pattern: CHILD_LISTING_HEADING_PATTERN)
       extract_inline_refs(inline_text, local_deps, cross_deps)
     end
 
@@ -413,6 +400,69 @@ module Issues
       return if dependency.requires_deployment == requires_deployment
 
       dependency.update!(requires_deployment: requires_deployment)
+    end
+
+    def markdown_sections(text, heading_pattern:)
+      sections = []
+      buffer = nil
+
+      each_markdown_line(text) do |line, in_fenced_code_block|
+        if in_fenced_code_block
+          buffer << line if buffer
+          next
+        end
+
+        heading = markdown_heading_text(line)
+        if heading
+          sections << buffer.join if buffer
+          buffer = heading.match?(heading_pattern) ? [] : nil
+          next
+        end
+
+        buffer << line if buffer
+      end
+
+      sections << buffer.join if buffer
+      sections
+    end
+
+    def strip_markdown_sections(text, heading_pattern:)
+      output = +""
+      skipping = false
+
+      each_markdown_line(text) do |line, in_fenced_code_block|
+        if in_fenced_code_block
+          output << line unless skipping
+          next
+        end
+
+        heading = markdown_heading_text(line)
+        if heading
+          skipping = heading.match?(heading_pattern)
+          output << line unless skipping
+          next
+        end
+
+        output << line unless skipping
+      end
+
+      output
+    end
+
+    def each_markdown_line(text)
+      return enum_for(__method__, text) unless block_given?
+
+      in_fenced_code_block = false
+
+      text.to_s.scan(/.*?(?:\r?\n|\z)/) do |line|
+        yield line, in_fenced_code_block
+        in_fenced_code_block = !in_fenced_code_block if line.match?(FENCED_CODE_BLOCK_PATTERN)
+      end
+    end
+
+    def markdown_heading_text(line)
+      match_data = MARKDOWN_HEADING_PATTERN.match(line)
+      match_data[1] if match_data
     end
 
     # Batch-loads projects for all unique owner/repo pairs in cross_refs

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -136,11 +136,24 @@ module Activities
     def handle_provider_error(agent_run, agent_summary)
       agent_run.fail!(error: "Provider error detected in output: #{agent_summary.to_s.truncate(500)}")
       agent_run.log!("system", "Failed: provider error detected in output (not a real agent response)")
+      transition_issue_to_failed(agent_run)
     end
 
     def handle_infrastructure_error(agent_run, agent_summary)
       agent_run.fail!(error: "Infrastructure error detected in output: #{agent_summary.to_s.truncate(500)}")
       agent_run.log!("system", "Failed: infrastructure error detected in output (container/sandbox failure)")
+      transition_issue_to_failed(agent_run)
+    end
+
+    # Transitions the issue to "failed" so it doesn't stay stuck in
+    # "in_progress". This mirrors MarkAgentRunFailedActivity's issue
+    # state handling — necessary here because this activity runs on
+    # the success path, so MarkAgentRunFailedActivity won't execute.
+    def transition_issue_to_failed(agent_run)
+      issue = agent_run.issue
+      return unless issue
+
+      issue.update!(paid_state: "failed") if issue.paid_state != "failed"
     end
 
     def handle_needs_input(client, agent_run, agent_summary)

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -22,9 +22,6 @@ module Activities
     NEEDS_INPUT_COMMENT_MARKER = "<!-- paid:needs-input -->"
     RECOMMEND_CLOSE_COMMENT_MARKER = "<!-- paid:recommend-close -->"
 
-    # Supplementary patterns used alongside quota patterns from agent-harness
-    # to detect provider-level errors in agent output. Includes rate-limit
-    # indicators and credit/quota phrases not yet covered by agent-harness.
     SUPPLEMENTARY_ERROR_PATTERNS = [
       /quota exceeded/i,
       /rate.?limit/i,
@@ -35,6 +32,20 @@ module Activities
       /purchase (?:more )?credits/i,
       /buy (?:more )?credits/i,
       /requires? more credits/i
+    ].freeze
+
+    INFRASTRUCTURE_ERROR_PATTERNS = [
+      /bwrap:.*namespace/i,
+      /no permissions to create a new namespace/i,
+      /non-privileged user namespaces/i,
+      /cannot create namespace/i,
+      /unshare failed/i,
+      /bubblewrap.*(error|fail)/i,
+      /container.*failed to start/i,
+      /failed to create container/i,
+      /sandbox.*error/i,
+      /docker.*permission denied/i,
+      /exec format error/i
     ].freeze
 
     def execute(input)
@@ -59,6 +70,8 @@ module Activities
         case outcome
         when "provider_error"
           handle_provider_error(agent_run, agent_summary)
+        when "infrastructure_error"
+          handle_infrastructure_error(agent_run, agent_summary)
         when "needs_input"
           handle_needs_input(client, agent_run, agent_summary)
           agent_run.complete!
@@ -94,10 +107,10 @@ module Activities
       # Guard: if the agent produced output but shows no evidence of having
       # actually run (zero iterations AND zero cost), the "output" is likely
       # a provider-level error (e.g. credit exhaustion) rather than a real
-      # agent response. Confirm by checking the output for provider error
-      # patterns.
+      # agent response. Confirm by checking the output for error patterns.
       if agent_run.iterations.to_i.zero? && agent_run.cost_cents.to_i.zero?
         return "provider_error" if provider_error_output?(agent_summary)
+        return "infrastructure_error" if infrastructure_error_output?(agent_summary)
       end
 
       "recommend_close"
@@ -109,6 +122,12 @@ module Activities
       provider_error_patterns.any? { |pattern| text.match?(pattern) }
     end
 
+    def infrastructure_error_output?(text)
+      return false if text.blank?
+
+      INFRASTRUCTURE_ERROR_PATTERNS.any? { |pattern| text.match?(pattern) }
+    end
+
     def provider_error_patterns
       @provider_error_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota) +
         SUPPLEMENTARY_ERROR_PATTERNS
@@ -117,6 +136,11 @@ module Activities
     def handle_provider_error(agent_run, agent_summary)
       agent_run.fail!(error: "Provider error detected in output: #{agent_summary.to_s.truncate(500)}")
       agent_run.log!("system", "Failed: provider error detected in output (not a real agent response)")
+    end
+
+    def handle_infrastructure_error(agent_run, agent_summary)
+      agent_run.fail!(error: "Infrastructure error detected in output: #{agent_summary.to_s.truncate(500)}")
+      agent_run.log!("system", "Failed: infrastructure error detected in output (container/sandbox failure)")
     end
 
     def handle_needs_input(client, agent_run, agent_summary)

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
     it "includes completed issues with no PR-producing run (infrastructure failure recovery)" do
       issue = create(:issue, project: project, paid_state: "completed")
-      create(:agent_run, :completed, project: project, issue: issue, pull_request_number: nil)
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "create_pr", auto_pick: true, pull_request_number: nil, pull_request_url: nil)
 
       scope = described_class.eligible_scope(project)
 
@@ -47,7 +48,8 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
     it "excludes completed issues that had a PR-producing run" do
       issue = create(:issue, project: project, paid_state: "completed")
-      create(:agent_run, :completed, project: project, issue: issue, pull_request_number: 42)
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "create_pr", auto_pick: true, pull_request_number: 42, pull_request_url: "https://example.test/pr/42")
 
       scope = described_class.eligible_scope(project)
 
@@ -56,13 +58,28 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
     it "includes completed issues even when other PR-producing runs have NULL issue_id" do
       issue = create(:issue, project: project, paid_state: "completed")
-      create(:agent_run, :completed, project: project, issue: issue, pull_request_number: nil)
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "create_pr", auto_pick: true, pull_request_number: nil, pull_request_url: nil)
       create(:agent_run, :completed, project: project, issue: nil, pull_request_number: 99,
         custom_prompt: "manual PR run")
 
       scope = described_class.eligible_scope(project)
 
       expect(scope.pluck(:id)).to contain_exactly(issue.id)
+    end
+
+    it "excludes completed issues whose completed run was not an auto-pick create_pr run" do
+      manual_issue = create(:issue, project: project, paid_state: "completed", github_number: 50)
+      analyze_issue = create(:issue, project: project, paid_state: "completed", github_number: 51)
+
+      create(:agent_run, :completed, :manual, project: project, issue: manual_issue,
+        goal: "create_pr", auto_pick: false, pull_request_number: nil, pull_request_url: nil)
+      create(:agent_run, :completed, :automatic, project: project, issue: analyze_issue,
+        goal: "analyze_issue", auto_pick: false, pull_request_number: nil, pull_request_url: nil)
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to be_empty
     end
   end
 

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -35,6 +35,35 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
       expect(scope.pluck(:id)).to contain_exactly(eligible.id)
     end
+
+    it "includes completed issues with no PR-producing run (infrastructure failure recovery)" do
+      issue = create(:issue, project: project, paid_state: "completed")
+      create(:agent_run, :completed, project: project, issue: issue, pull_request_number: nil)
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(issue.id)
+    end
+
+    it "excludes completed issues that had a PR-producing run" do
+      issue = create(:issue, project: project, paid_state: "completed")
+      create(:agent_run, :completed, project: project, issue: issue, pull_request_number: 42)
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to be_empty
+    end
+
+    it "includes completed issues even when other PR-producing runs have NULL issue_id" do
+      issue = create(:issue, project: project, paid_state: "completed")
+      create(:agent_run, :completed, project: project, issue: issue, pull_request_number: nil)
+      create(:agent_run, :completed, project: project, issue: nil, pull_request_number: 99,
+        custom_prompt: "manual PR run")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(issue.id)
+    end
   end
 
   describe ".eligible_issue_ids" do

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -223,6 +223,37 @@ RSpec.describe Issues::ParseDependencies do
             "Expected no dependencies for heading in: #{body_text.inspect}"
         end
       end
+
+      it "does not stop stripping a child section at plain issue-number lines" do
+        create(:issue, project: project, github_number: 9024)
+        create(:issue, project: project, github_number: 9025)
+        body = <<~BODY
+          ## Sub-Issues
+          - [ ] #9024 initial work
+          #9025 follow-up task (depends on #9024)
+        BODY
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to be_empty
+      end
+
+      it "does not stop stripping a child section inside fenced code blocks" do
+        create(:issue, project: project, github_number: 9026)
+        body = <<~BODY
+          ## Implementation Sub-Issues
+          ```text
+          # not a heading
+          depends on #9026
+          ```
+        BODY
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to be_empty
+      end
     end
 
     context "with cross-project references" do

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -170,6 +170,61 @@ RSpec.describe Issues::ParseDependencies do
       expect(issue.dependencies).to contain_exactly(dep)
     end
 
+    context "when child/sub-issue sections contain dependency phrases" do
+      it "ignores inline dependency phrases inside sub-issue sections" do
+        _dep_target = create(:issue, project: project, github_number: 9016)
+        create(:issue, project: project, github_number: 9017)
+        create(:issue, project: project, github_number: 9018)
+        body = <<~BODY
+          ## Implementation Sub-Issues
+
+          - [ ] #9017 — Add feature (depends on #9016)
+          - [ ] #9018 — Add tests (depends on #9017)
+        BODY
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to be_empty
+      end
+
+      it "still parses inline dependencies outside child sections" do
+        dep = create(:issue, project: project, github_number: 9019)
+        create(:issue, project: project, github_number: 9020)
+        body = <<~BODY
+          Depends on #9019
+
+          ## Sub-Issues
+
+          - [ ] #9020 — Some work
+        BODY
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to contain_exactly(dep)
+      end
+
+      it "recognizes 'Child Issues', 'Sub-Issues', and 'Subtasks' headings" do
+        create(:issue, project: project, github_number: 9021)
+        create(:issue, project: project, github_number: 9022)
+        create(:issue, project: project, github_number: 9023)
+
+        bodies = [
+          "## Child Issues\n- [ ] #9021 (depends on #9022)\n",
+          "## Sub-Issues\n- [ ] #9021 (depends on #9022)\n",
+          "## Subtasks\n- [ ] #9021 (depends on #9022)\n"
+        ]
+
+        bodies.each do |body_text|
+          issue = create(:issue, project: project, body: body_text)
+          described_class.call(issue: issue)
+          expect(issue.dependencies).to be_empty,
+            "Expected no dependencies for heading in: #{body_text.inspect}"
+        end
+      end
+    end
+
     context "with cross-project references" do
       let(:account) { project.account }
       let(:other_project) { create(:project, account: account, owner: "viamin", repo: "agent-harness") }

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -342,6 +342,69 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
       end
     end
 
+    context "when output is present but agent hit infrastructure errors" do
+      let(:bwrap_error) do
+        "I'm blocked by the local execution environment. " \
+          "bwrap: No permissions to create a new namespace, likely because " \
+          "the kernel does not allow non-privileged user namespaces."
+      end
+
+      it "classifies as infrastructure_error when iterations and cost are zero" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", bwrap_error)
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("infrastructure_error")
+      end
+
+      it "fails the run instead of completing it" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", bwrap_error)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(agent_run.reload.status).to eq("failed")
+      end
+
+      it "does not transition issue to recommend_close" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", bwrap_error)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(issue.reload.paid_state).not_to eq("recommend_close")
+      end
+
+      it "detects sandbox error variants" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "sandbox error: cannot create namespace")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("infrastructure_error")
+      end
+
+      it "allows recommend_close when agent has iterations > 0 despite bwrap mention" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
+        agent_run.log!("stdout", "Checked the code and bwrap config looks fine")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("recommend_close")
+      end
+    end
+
     context "when GitHub comment would contain provider error text" do
       it "redacts provider error lines from recommend_close comments" do
         issue = create(:issue, :in_progress, project: project)

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         expect(agent_run.reload.status).to eq("failed")
       end
 
-      it "does not transition issue to recommend_close" do
+      it "transitions issue to failed so it is retryable by auto-pick" do
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue,
           iterations: 0, cost_cents: 0)
@@ -272,7 +272,7 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
-        expect(issue.reload.paid_state).not_to eq("recommend_close")
+        expect(issue.reload.paid_state).to eq("failed")
       end
 
       it "does not post a recommend-close comment on GitHub" do
@@ -371,7 +371,7 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         expect(agent_run.reload.status).to eq("failed")
       end
 
-      it "does not transition issue to recommend_close" do
+      it "transitions issue to failed so it is retryable by auto-pick" do
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue,
           iterations: 0, cost_cents: 0)
@@ -379,7 +379,7 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
-        expect(issue.reload.paid_state).not_to eq("recommend_close")
+        expect(issue.reload.paid_state).to eq("failed")
       end
 
       it "detects sandbox error variants" do


### PR DESCRIPTION
## Summary

- **ParseDependencies**: Strip child/sub-issue listing sections before inline dependency extraction so "depends on #N" phrases describing inter-sub-issue relationships are not falsely attributed to the parent issue
- **HandleNoOutputIssueRunActivity**: Add `INFRASTRUCTURE_ERROR_PATTERNS` (bwrap, sandbox, container errors) so container failures are classified as `infrastructure_error` and fail the run instead of completing it, keeping the issue eligible for retry
- **DefaultCandidateSource**: Add recovery path in `eligible_scope` for issues with `paid_state: completed` that never had a PR-producing completed run, so infrastructure-failure victims are automatically re-pickable

## Root Cause

Issue #453 (P2, depends on closed #452) was invisible to auto-pick due to two compounding bugs:

1. **#451 was falsely blocked**: ParseDependencies parsed `(depends on #452)` inside #451 `## Implementation Sub-Issues` section as a dependency of #451 itself
2. **#453 was stuck in completed**: AgentRun #3175 hit a container sandbox error (bwrap namespace) classified as `recommend_close` instead of `failed`, setting `paid_state: completed` with no PR and no recovery path

## Test plan

- [x] 115 existing + new tests pass across all three affected specs
- [x] Lint clean (RuboCop, ESLint, markdownlint, ShellCheck)
- [x] Verified #453 is now the top auto-pick candidate via Rails runner
- [x] NULL-in-NOT-IN edge case covered (completed PR runs with nil issue_id)