### PR TITLE
fix: Docker API timeout races with watchdog, misclassifying errors as non-timeout

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -34,6 +34,11 @@ module Containers
     HEARTBEAT_MOUNT_POINT = "/paid-heartbeat"
     MAX_STREAMING_LINE_BUFFER_BYTES = 64 * 1024
 
+    # Maximum clock skew tolerance (seconds) between the Docker daemon's
+    # `wait:` timer and Ruby's CLOCK_MONOTONIC when reclassifying a Docker
+    # transport error as a timeout. Kept small to avoid false reclassification.
+    DOCKER_TIMEOUT_SKEW_TOLERANCE = 0.5
+
     # Base error for all container service errors
     class Error < StandardError; end
 
@@ -619,17 +624,20 @@ module Containers
         # same wall-clock timeout. If Docker fires first, elapsed time from
         # Ruby's monotonic clock may still be fractionally below the timeout
         # threshold (clock skew between the Docker daemon and CLOCK_MONOTONIC).
-        # Clamp tolerance to at most half the timeout so short-timeout execs
-        # don't reclassify every Docker error as a timeout.
+        # Use a small fixed tolerance (0.5s) to cover typical clock skew
+        # without being so wide that unrelated Docker errors get reclassified.
+        # Clamp to at most half the timeout so short-timeout execs are safe.
         if timeout
           elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
-          tolerance = [ watchdog_poll_interval, timeout * 0.5 ].min
+          tolerance = [ DOCKER_TIMEOUT_SKEW_TOLERANCE, timeout * 0.5 ].min
           if elapsed >= timeout - tolerance
             log_system("container.execute.timeout",
               timeout_type: "wall_clock",
               timeout: timeout,
               elapsed_seconds: elapsed.round(1),
-              source: "docker_api_reclassified")
+              source: "docker_api_reclassified",
+              **timeout_diagnostics(started_at, output_received, last_activity_at, heartbeat_path),
+              **output_summary_diagnostics(stdout_buffer, stderr_buffer))
             raise TimeoutError, "Command timed out after #{timeout} seconds"
           end
         end

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -615,6 +615,24 @@ module Containers
           raise
         end
 
+        # The Docker API `wait:` parameter and the watchdog both track the
+        # same wall-clock timeout. If Docker fires first, elapsed time from
+        # Ruby's monotonic clock may still be fractionally below the timeout
+        # threshold (clock skew between the Docker daemon and CLOCK_MONOTONIC).
+        # Use a tolerance of the watchdog poll interval so the Docker API
+        # timeout is not misclassified as a generic execution error.
+        if timeout
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+          if elapsed >= timeout - watchdog_poll_interval
+            log_system("container.execute.timeout",
+              timeout_type: "wall_clock",
+              timeout: timeout,
+              elapsed_seconds: elapsed.round(1),
+              source: "docker_api_reclassified")
+            raise TimeoutError, "Command timed out after #{timeout} seconds"
+          end
+        end
+
         log_system("container.execute.failed", error: e.message)
 
         begin

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -619,11 +619,12 @@ module Containers
         # same wall-clock timeout. If Docker fires first, elapsed time from
         # Ruby's monotonic clock may still be fractionally below the timeout
         # threshold (clock skew between the Docker daemon and CLOCK_MONOTONIC).
-        # Use a tolerance of the watchdog poll interval so the Docker API
-        # timeout is not misclassified as a generic execution error.
+        # Clamp tolerance to at most half the timeout so short-timeout execs
+        # don't reclassify every Docker error as a timeout.
         if timeout
           elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
-          if elapsed >= timeout - watchdog_poll_interval
+          tolerance = [ watchdog_poll_interval, timeout * 0.5 ].min
+          if elapsed >= timeout - tolerance
             log_system("container.execute.timeout",
               timeout_type: "wall_clock",
               timeout: timeout,

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -2579,36 +2579,34 @@ RSpec.describe Containers::Provision do
         }.to raise_error(described_class::TimeoutError, /timed out after 0.1 seconds/)
       end
 
-      it "reclassifies Docker API timeout as TimeoutError when elapsed is within poll interval of timeout" do
-        # The Docker API `wait:` parameter fires at ~timeout seconds, but
-        # Ruby's monotonic clock may show elapsed < timeout by a small margin.
-        # The reclassification check uses a tolerance of min(poll_interval, timeout*0.5)
-        # so this is caught as a TimeoutError instead of ExecutionError.
-        # With poll_interval=0.05 and timeout=0.1, tolerance=0.05 so the
-        # threshold is 0.05s — sleep 0.08 lands inside the window.
+      it "reclassifies Docker API timeout race as TimeoutError when elapsed is near the timeout" do
+        # Simulates the Docker `wait:` timer firing slightly before Ruby's
+        # monotonic clock reaches the timeout value — the exact race from #1547.
+        # We use a 1s timeout and sleep just under it so elapsed lands within
+        # the DOCKER_TIMEOUT_SKEW_TOLERANCE (0.5s) window, triggering
+        # reclassification of the Docker transport error as a TimeoutError.
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
-          sleep 0.08 # close to but potentially under the 0.1s timeout
+          sleep 0.85 # near but below the 1s timeout
           raise Docker::Error::DockerError, "read: connection reset by peer"
         end
-        allow(service).to receive(:watchdog_poll_interval).and_return(0.05)
+        allow(service).to receive(:watchdog_poll_interval).and_return(10)
 
         expect {
-          service.execute("hung_command", timeout: 0.1)
-        }.to raise_error(described_class::TimeoutError, /timed out after 0.1 seconds/)
+          service.execute("hung_command", timeout: 1)
+        }.to raise_error(described_class::TimeoutError, /timed out after 1 seconds/)
       end
 
       it "does not reclassify Docker error as timeout when elapsed is well below threshold" do
-        # A Docker error that occurs early in the timeout window should NOT be
-        # reclassified. With poll_interval=0.05 and timeout=0.5, tolerance=0.05
-        # so the threshold is 0.45s — sleep 0.01 is well outside the window.
+        # A Docker error that occurs well before the timeout should NOT be
+        # reclassified — it is a genuine transport failure, not a timeout race.
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
           sleep 0.01
           raise Docker::Error::DockerError, "connection refused"
         end
-        allow(service).to receive(:watchdog_poll_interval).and_return(0.05)
+        allow(service).to receive(:watchdog_poll_interval).and_return(10)
 
         expect {
-          service.execute("normal_command", timeout: 0.5)
+          service.execute("normal_command", timeout: 2)
         }.to raise_error(described_class::ExecutionError, /connection refused/)
       end
     end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -2582,17 +2582,34 @@ RSpec.describe Containers::Provision do
       it "reclassifies Docker API timeout as TimeoutError when elapsed is within poll interval of timeout" do
         # The Docker API `wait:` parameter fires at ~timeout seconds, but
         # Ruby's monotonic clock may show elapsed < timeout by a small margin.
-        # The reclassification check uses a tolerance of watchdog_poll_interval
+        # The reclassification check uses a tolerance of min(poll_interval, timeout*0.5)
         # so this is caught as a TimeoutError instead of ExecutionError.
+        # With poll_interval=0.05 and timeout=0.1, tolerance=0.05 so the
+        # threshold is 0.05s — sleep 0.08 lands inside the window.
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
           sleep 0.08 # close to but potentially under the 0.1s timeout
           raise Docker::Error::DockerError, "read: connection reset by peer"
         end
-        allow(service).to receive(:watchdog_poll_interval).and_return(10)
+        allow(service).to receive(:watchdog_poll_interval).and_return(0.05)
 
         expect {
           service.execute("hung_command", timeout: 0.1)
         }.to raise_error(described_class::TimeoutError, /timed out after 0.1 seconds/)
+      end
+
+      it "does not reclassify Docker error as timeout when elapsed is well below threshold" do
+        # A Docker error that occurs early in the timeout window should NOT be
+        # reclassified. With poll_interval=0.05 and timeout=0.5, tolerance=0.05
+        # so the threshold is 0.45s — sleep 0.01 is well outside the window.
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
+          sleep 0.01
+          raise Docker::Error::DockerError, "connection refused"
+        end
+        allow(service).to receive(:watchdog_poll_interval).and_return(0.05)
+
+        expect {
+          service.execute("normal_command", timeout: 0.5)
+        }.to raise_error(described_class::ExecutionError, /connection refused/)
       end
     end
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -2578,6 +2578,22 @@ RSpec.describe Containers::Provision do
           service.execute("hung_command", timeout: 0.1)
         }.to raise_error(described_class::TimeoutError, /timed out after 0.1 seconds/)
       end
+
+      it "reclassifies Docker API timeout as TimeoutError when elapsed is within poll interval of timeout" do
+        # The Docker API `wait:` parameter fires at ~timeout seconds, but
+        # Ruby's monotonic clock may show elapsed < timeout by a small margin.
+        # The reclassification check uses a tolerance of watchdog_poll_interval
+        # so this is caught as a TimeoutError instead of ExecutionError.
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
+          sleep 0.08 # close to but potentially under the 0.1s timeout
+          raise Docker::Error::DockerError, "read: connection reset by peer"
+        end
+        allow(service).to receive(:watchdog_poll_interval).and_return(10)
+
+        expect {
+          service.execute("hung_command", timeout: 0.1)
+        }.to raise_error(described_class::TimeoutError, /timed out after 0.1 seconds/)
+      end
     end
 
     context "without startup and idle timeouts" do


### PR DESCRIPTION
## Summary

fix: Docker API timeout races with watchdog, misclassifying errors as non-timeout

See #1547 for context.

---

Closes #1547