### PR TITLE
fix: GithubTokenHealthCheckJob auto-pauses without was_already_failed guard

### DIFF
--- a/app/jobs/github_token_health_check_job.rb
+++ b/app/jobs/github_token_health_check_job.rb
@@ -64,7 +64,6 @@ class GithubTokenHealthCheckJob < ApplicationJob
   end
 
   def check_token(token)
-    was_already_failed = token.validation_failed?
     token.mark_validating!
 
     result = token.validate_with_github!
@@ -85,7 +84,9 @@ class GithubTokenHealthCheckJob < ApplicationJob
       github_token_id: token.id,
       error: e.message
     )
-    GithubTokens::AutoPauseProjects.call(github_token: token) unless was_already_failed
+    # Always auto-pause: the service is idempotent (skips already-paused projects),
+    # and projects can be associated with a failed token after the initial failure.
+    GithubTokens::AutoPauseProjects.call(github_token: token)
     false
   rescue GithubClient::RateLimitError, GithubClient::ApiError => e
     # Transient GitHub errors should not mark the token as failed.

--- a/app/jobs/github_token_health_check_job.rb
+++ b/app/jobs/github_token_health_check_job.rb
@@ -64,6 +64,7 @@ class GithubTokenHealthCheckJob < ApplicationJob
   end
 
   def check_token(token)
+    was_already_failed = token.validation_failed?
     token.mark_validating!
 
     result = token.validate_with_github!
@@ -84,7 +85,7 @@ class GithubTokenHealthCheckJob < ApplicationJob
       github_token_id: token.id,
       error: e.message
     )
-    GithubTokens::AutoPauseProjects.call(github_token: token)
+    GithubTokens::AutoPauseProjects.call(github_token: token) unless was_already_failed
     false
   rescue GithubClient::RateLimitError, GithubClient::ApiError => e
     # Transient GitHub errors should not mark the token as failed.

--- a/app/jobs/github_token_health_check_job.rb
+++ b/app/jobs/github_token_health_check_job.rb
@@ -84,8 +84,11 @@ class GithubTokenHealthCheckJob < ApplicationJob
       github_token_id: token.id,
       error: e.message
     )
-    # Always auto-pause: the service is idempotent (skips already-paused projects),
-    # and projects can be associated with a failed token after the initial failure.
+    # No was_already_failed guard here intentionally: the service is idempotent
+    # (only pauses projects where scheduler_paused_at IS NULL), and new projects
+    # can be associated with a failed token between health-check runs. Skipping
+    # this call when the token was already failed would leave those new projects
+    # unpaused until the token is fixed and fails again.
     GithubTokens::AutoPauseProjects.call(github_token: token)
     false
   rescue GithubClient::RateLimitError, GithubClient::ApiError => e

--- a/spec/jobs/github_token_health_check_job_spec.rb
+++ b/spec/jobs/github_token_health_check_job_spec.rb
@@ -109,10 +109,10 @@ RSpec.describe GithubTokenHealthCheckJob do
         expect(token.reload.validation_status).to eq("failed")
       end
 
-      it "does not auto-pause projects again" do
+      it "still auto-pauses to catch newly associated projects" do
         allow(GithubTokens::AutoPauseProjects).to receive(:call)
         described_class.perform_now
-        expect(GithubTokens::AutoPauseProjects).not_to have_received(:call)
+        expect(GithubTokens::AutoPauseProjects).to have_received(:call).with(github_token: token)
       end
     end
 

--- a/spec/jobs/github_token_health_check_job_spec.rb
+++ b/spec/jobs/github_token_health_check_job_spec.rb
@@ -109,10 +109,14 @@ RSpec.describe GithubTokenHealthCheckJob do
         expect(token.reload.validation_status).to eq("failed")
       end
 
-      it "still auto-pauses to catch newly associated projects" do
-        allow(GithubTokens::AutoPauseProjects).to receive(:call)
+      it "pauses a project associated after the initial token failure" do
+        # Simulate a project added after the token was already in failed state
+        project = create(:project, github_token: token, account: account)
+
         described_class.perform_now
-        expect(GithubTokens::AutoPauseProjects).to have_received(:call).with(github_token: token)
+
+        expect(project.reload.scheduler_paused_at).to be_present
+        expect(project.scheduler_pause_reason).to include("failed validation")
       end
     end
 

--- a/spec/jobs/github_token_health_check_job_spec.rb
+++ b/spec/jobs/github_token_health_check_job_spec.rb
@@ -99,6 +99,23 @@ RSpec.describe GithubTokenHealthCheckJob do
       end
     end
 
+    context "when token was already failed before health check" do
+      let!(:token) { create(:github_token, :validation_failed, account: account) }
+
+      before { stub_auth_error_octokit }
+
+      it "marks token as failed" do
+        described_class.perform_now
+        expect(token.reload.validation_status).to eq("failed")
+      end
+
+      it "does not auto-pause projects again" do
+        allow(GithubTokens::AutoPauseProjects).to receive(:call)
+        described_class.perform_now
+        expect(GithubTokens::AutoPauseProjects).not_to have_received(:call)
+      end
+    end
+
     context "when GitHub returns a transient API error" do
       let!(:token) { create(:github_token, :pending_validation, account: account) }
 


### PR DESCRIPTION
## Summary

fix: GithubTokenHealthCheckJob auto-pauses without was_already_failed guard

See #1549 for context.

---

Closes #1549