### PR TITLE
fix: /token/i pattern in test_agent.rb misclassifies non-auth errors as authentication

### DIFF
--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -27,9 +27,11 @@ module Providers
       /API key not configured for/i,
       /\bauth(?:entication)?\b/i,
       /oauth/i,
-      # Token-auth patterns — split for readability. The lookbehind prevents
-      # "unexpected token" (JSON parse errors) from matching.
-      /(?<!unexpected\s)token\s+(?:expired|revoked|invalid|not found)/i,
+      # Token-auth patterns — split for readability. Each pattern requires
+      # "token" adjacent to an auth-specific qualifier (expired/revoked/invalid/
+      # not found), so unrelated uses like "CSRF token" or "unexpected token"
+      # naturally fall through without matching.
+      /token\s+(?:expired|revoked|invalid|not found)/i,
       /(?:invalid|expired|revoked)\s+token/i,
       /api[_ -]?key.*token/i,
       /unauthori[sz]ed/i,

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -25,9 +25,9 @@ module Providers
     BASE_AUTHENTICATION_ERROR_PATTERNS = [
       /api[_ -]?key/i,
       /API key not configured for/i,
-      /auth(?:entication)?/i,
+      /\bauth(?:entication)?\b/i,
       /oauth/i,
-      /token/i,
+      /(?<!unexpected\s)token.*(?:expired|revoked|invalid|not found)|(?:invalid|expired|revoked)\s+token|api[_ -]?key.*token/i,
       /unauthori[sz]ed/i,
       /invalid credentials/i,
       /session.*expired/i

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -27,7 +27,11 @@ module Providers
       /API key not configured for/i,
       /\bauth(?:entication)?\b/i,
       /oauth/i,
-      /(?<!unexpected\s)token.*(?:expired|revoked|invalid|not found)|(?:invalid|expired|revoked)\s+token|api[_ -]?key.*token/i,
+      # Token-auth patterns — split for readability. The lookbehind prevents
+      # "unexpected token" (JSON parse errors) from matching.
+      /(?<!unexpected\s)token\s+(?:expired|revoked|invalid|not found)/i,
+      /(?:invalid|expired|revoked)\s+token/i,
+      /api[_ -]?key.*token/i,
       /unauthori[sz]ed/i,
       /invalid credentials/i,
       /session.*expired/i

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -913,6 +913,49 @@ RSpec.describe Providers::TestAgent do
     end
   end
 
+  describe "#classify_failed_response" do
+    subject(:service) { described_class.new(provider: provider) }
+
+    before do
+      allow(ProviderSupport).to receive_messages(
+        supported_provider_key?: true,
+        container_executable_provider_key?: true,
+        harness_provider_key_for: "claude",
+        error_classification_patterns_for: []
+      )
+    end
+
+    it "does not misclassify 'unexpected token' JSON parse errors as authentication" do
+      result = service.send(:classify_failed_response, "SyntaxError: unexpected token '<' at position 0")
+      expect(result).not_to eq(:authentication)
+    end
+
+    it "does not misclassify 'CSRF token mismatch' as authentication" do
+      result = service.send(:classify_failed_response, "CSRF token mismatch")
+      expect(result).not_to eq(:authentication)
+    end
+
+    it "does not misclassify 'unexpected token in JSON' as authentication" do
+      result = service.send(:classify_failed_response, "JSON.parse: unexpected token at line 1 column 1")
+      expect(result).not_to eq(:authentication)
+    end
+
+    it "correctly classifies a real token expiration as authentication" do
+      result = service.send(:classify_failed_response, "token expired")
+      expect(result).to eq(:authentication)
+    end
+
+    it "correctly classifies 'invalid token' as authentication" do
+      result = service.send(:classify_failed_response, "invalid token")
+      expect(result).to eq(:authentication)
+    end
+
+    it "correctly classifies 'revoked token' as authentication" do
+      result = service.send(:classify_failed_response, "revoked token")
+      expect(result).to eq(:authentication)
+    end
+  end
+
   describe "#rate_limit_reset_at" do
     before do
       allow(ProviderSupport).to receive(:harness_provider_key_for).with("claude").and_return("claude")

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -913,46 +913,63 @@ RSpec.describe Providers::TestAgent do
     end
   end
 
-  describe "#classify_failed_response" do
-    subject(:service) { described_class.new(provider: provider) }
+  describe "token and auth pattern classification via .call" do
+    let(:provider_record) { user.providers.find_or_create_by!(provider_key: "claude").tap { |p| p.update!(enabled_for_agent_runs: true, enabled_for_fallback: false) } }
 
     before do
       allow(ProviderSupport).to receive_messages(
         supported_provider_key?: true,
         container_executable_provider_key?: true,
-        harness_provider_key_for: "claude",
-        error_classification_patterns_for: []
+        harness_provider_key_for: "claude"
       )
     end
 
+    def call_with_message(message)
+      stub_container_smoke_test(
+        name: :claude, status: "error", message: message,
+        latency_ms: 10, error_category: nil, check: :smoke_test
+      )
+      described_class.call(provider: provider)
+    end
+
     it "does not misclassify 'unexpected token' JSON parse errors as authentication" do
-      result = service.send(:classify_failed_response, "SyntaxError: unexpected token '<' at position 0")
-      expect(result).not_to eq(:authentication)
+      result = call_with_message("SyntaxError: unexpected token '<' at position 0")
+      expect(result.error_type).not_to eq(:authentication)
     end
 
     it "does not misclassify 'CSRF token mismatch' as authentication" do
-      result = service.send(:classify_failed_response, "CSRF token mismatch")
-      expect(result).not_to eq(:authentication)
+      result = call_with_message("CSRF token mismatch")
+      expect(result.error_type).not_to eq(:authentication)
     end
 
     it "does not misclassify 'unexpected token in JSON' as authentication" do
-      result = service.send(:classify_failed_response, "JSON.parse: unexpected token at line 1 column 1")
-      expect(result).not_to eq(:authentication)
+      result = call_with_message("JSON.parse: unexpected token at line 1 column 1")
+      expect(result.error_type).not_to eq(:authentication)
+    end
+
+    it "does not misclassify 'Invalid authenticity token' as authentication" do
+      result = call_with_message("ActionController::InvalidAuthenticityToken: Invalid authenticity token")
+      expect(result.error_type).not_to eq(:authentication)
+    end
+
+    it "does not misclassify 'authorization failed' as authentication" do
+      result = call_with_message("authorization failed: insufficient permissions")
+      expect(result.error_type).not_to eq(:authentication)
     end
 
     it "correctly classifies a real token expiration as authentication" do
-      result = service.send(:classify_failed_response, "token expired")
-      expect(result).to eq(:authentication)
+      result = call_with_message("token expired")
+      expect(result.error_type).to eq(:authentication)
     end
 
     it "correctly classifies 'invalid token' as authentication" do
-      result = service.send(:classify_failed_response, "invalid token")
-      expect(result).to eq(:authentication)
+      result = call_with_message("invalid token")
+      expect(result.error_type).to eq(:authentication)
     end
 
     it "correctly classifies 'revoked token' as authentication" do
-      result = service.send(:classify_failed_response, "revoked token")
-      expect(result).to eq(:authentication)
+      result = call_with_message("revoked token")
+      expect(result.error_type).to eq(:authentication)
     end
   end
 


### PR DESCRIPTION
## Summary

fix: /token/i pattern in test_agent.rb misclassifies non-auth errors as authentication

See #1546 for context.

---

Closes #1546