### PR TITLE
feat(agent-runs): adopt agent-harness heartbeat support for OpenCode/KiloCode fallbacks

### DIFF
--- a/app/services/containers/heartbeat_setup.rb
+++ b/app/services/containers/heartbeat_setup.rb
@@ -136,13 +136,14 @@ module Containers
     end
 
     def upstream_integration
-      @upstream_integration ||= begin
-        return {} unless @harness_provider.respond_to?(:heartbeat_integration)
-
-        @harness_provider.heartbeat_integration(
-          heartbeat_file_path: CONTAINER_HEARTBEAT_PATH
-        ) || {}
-      end
+      @upstream_integration ||=
+        if @harness_provider.respond_to?(:heartbeat_integration)
+          @harness_provider.heartbeat_integration(
+            heartbeat_file_path: CONTAINER_HEARTBEAT_PATH
+          ) || {}
+        else
+          {}
+        end
     end
 
     def local_preparation

--- a/app/services/containers/heartbeat_setup.rb
+++ b/app/services/containers/heartbeat_setup.rb
@@ -128,16 +128,21 @@ module Containers
 
     def upstream_heartbeat_supported?
       return false unless @harness_provider
+      return false unless @harness_provider.respond_to?(:supports_activity_heartbeat?)
+      return false unless @harness_provider.supports_activity_heartbeat?
 
-      @harness_provider.supports_activity_heartbeat?
-    rescue NoMethodError
-      false
+      integration = upstream_integration
+      integration.is_a?(Hash) && integration[:supported] == true
     end
 
     def upstream_integration
-      @upstream_integration ||= @harness_provider.heartbeat_integration(
-        heartbeat_file_path: CONTAINER_HEARTBEAT_PATH
-      )
+      @upstream_integration ||= begin
+        return {} unless @harness_provider.respond_to?(:heartbeat_integration)
+
+        @harness_provider.heartbeat_integration(
+          heartbeat_file_path: CONTAINER_HEARTBEAT_PATH
+        ) || {}
+      end
     end
 
     def local_preparation

--- a/app/services/containers/heartbeat_setup.rb
+++ b/app/services/containers/heartbeat_setup.rb
@@ -20,11 +20,17 @@ module Containers
   # The watchdog must then inspect that path from inside the container rather
   # than reading it directly from the host filesystem.
   #
+  # Heartbeat availability is determined by querying the upstream agent-harness
+  # provider for +supports_activity_heartbeat?+ and its +heartbeat_integration+
+  # contract. Providers that the harness does not yet cover (Claude, Codex)
+  # fall back to locally managed heartbeat configuration.
+  #
   # @example
   #   setup = Containers::HeartbeatSetup.new(
   #     provider: "claude",
   #     worktree_path: "/workspace",
-  #     host_heartbeat_path: "/tmp/paid-heartbeat-abc123/.paid-heartbeat"
+  #     host_heartbeat_path: "/tmp/paid-heartbeat-abc123/.paid-heartbeat",
+  #     harness_provider: AgentHarness.provider(:claude)
   #   )
   #   setup.heartbeat_path  # => "/tmp/paid-heartbeat-abc123/.paid-heartbeat"
   #   setup.preparation     # => AgentHarness::ExecutionPreparation (with file writes)
@@ -34,24 +40,31 @@ module Containers
 
     CONTAINER_HEARTBEAT_PATH = "/paid-heartbeat/#{HEARTBEAT_FILENAME}"
 
-    SUPPORTED_PROVIDERS = %w[claude codex].freeze
+    # Providers with locally managed heartbeat configuration.
+    # These are providers where agent-harness does not yet provide
+    # heartbeat integration, so Paid handles the setup directly.
+    LOCAL_HEARTBEAT_PROVIDERS = %w[claude codex].freeze
 
     # Providers with per-tool heartbeat hooks (e.g. Claude PostToolUse)
     # that fire frequently enough to suppress idle timeouts reliably
-    # during long subprocess execution. Providers in SUPPORTED_PROVIDERS
-    # but NOT listed here use coarser heartbeat signals that only fire
-    # between CLI turns, so they need a longer idle timeout to avoid
-    # false positives during long-running commands like `bundle exec rspec`.
-    RELIABLE_HEARTBEAT_PROVIDERS = %w[claude].freeze
+    # during long subprocess execution. Providers using coarser heartbeat
+    # signals that only fire between CLI turns need a longer idle timeout
+    # to avoid false positives during long-running commands.
+    LOCAL_RELIABLE_HEARTBEAT_PROVIDERS = %w[claude].freeze
+
+    # Upstream heartbeat granularities considered reliable (fire often
+    # enough within a single tool execution to suppress idle timeout).
+    RELIABLE_GRANULARITIES = %i[tool_call].freeze
 
     COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER = 3
 
     attr_reader :provider, :worktree_path, :host_heartbeat_path
 
-    def initialize(provider:, worktree_path:, host_heartbeat_path: nil)
+    def initialize(provider:, worktree_path:, host_heartbeat_path: nil, harness_provider: nil)
       @provider = provider.to_s
       @worktree_path = worktree_path
       @host_heartbeat_path = host_heartbeat_path
+      @harness_provider = harness_provider
     end
 
     def heartbeat_path
@@ -59,7 +72,7 @@ module Containers
     end
 
     def available?
-      SUPPORTED_PROVIDERS.include?(canonical_provider)
+      local_heartbeat_provider? || upstream_heartbeat_supported?
     end
 
     # Returns the effective idle timeout for this provider given a base
@@ -73,22 +86,31 @@ module Containers
     end
 
     def reliable_heartbeat?
-      RELIABLE_HEARTBEAT_PROVIDERS.include?(canonical_provider)
+      if upstream_heartbeat_supported?
+        RELIABLE_GRANULARITIES.include?(upstream_integration[:granularity])
+      else
+        LOCAL_RELIABLE_HEARTBEAT_PROVIDERS.include?(canonical_provider)
+      end
     end
 
     def env
       return {} unless available?
 
-      { "AGENT_HEARTBEAT_PATH" => CONTAINER_HEARTBEAT_PATH }
+      if upstream_heartbeat_supported?
+        upstream_integration[:env] || {}
+      else
+        { "AGENT_HEARTBEAT_PATH" => CONTAINER_HEARTBEAT_PATH }
+      end
     end
 
     def preparation
       return nil unless available?
 
-      file_writes = preparation_file_writes
-      return nil if file_writes.empty?
-
-      AgentHarness::ExecutionPreparation.new(file_writes: file_writes)
+      if upstream_heartbeat_supported?
+        upstream_integration[:preparation]
+      else
+        local_preparation
+      end
     end
 
     private
@@ -100,7 +122,32 @@ module Containers
       end
     end
 
-    def preparation_file_writes
+    def local_heartbeat_provider?
+      LOCAL_HEARTBEAT_PROVIDERS.include?(canonical_provider)
+    end
+
+    def upstream_heartbeat_supported?
+      return false unless @harness_provider
+
+      @harness_provider.supports_activity_heartbeat?
+    rescue NoMethodError
+      false
+    end
+
+    def upstream_integration
+      @upstream_integration ||= @harness_provider.heartbeat_integration(
+        heartbeat_file_path: CONTAINER_HEARTBEAT_PATH
+      )
+    end
+
+    def local_preparation
+      file_writes = local_preparation_file_writes
+      return nil if file_writes.empty?
+
+      AgentHarness::ExecutionPreparation.new(file_writes: file_writes)
+    end
+
+    def local_preparation_file_writes
       case canonical_provider
       when "claude" then claude_file_writes
       when "codex" then []

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -635,10 +635,17 @@ module Activities
       command_env = command_env_for(command_context, prompt)
       command_preparation = command_preparation_for(command_context, prompt)
 
+      resolved_harness_provider = begin
+        harness_provider_for(provider)
+      rescue AgentHarness::ConfigurationError, KeyError
+        nil
+      end
+
       heartbeat = Containers::HeartbeatSetup.new(
         provider: provider,
         worktree_path: agent_run.worktree_path,
-        host_heartbeat_path: container_service.heartbeat_host_path
+        host_heartbeat_path: container_service.heartbeat_host_path,
+        harness_provider: resolved_harness_provider
       )
       if heartbeat.available?
         command_env = command_env.merge(heartbeat.env)

--- a/spec/services/containers/heartbeat_setup_spec.rb
+++ b/spec/services/containers/heartbeat_setup_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Containers::HeartbeatSetup do
       expect(setup).to be_available
     end
 
-    it "returns false for unsupported provider" do
+    it "returns false for unsupported provider without harness support" do
       setup = described_class.new(provider: "gemini", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup).not_to be_available
     end
@@ -43,10 +43,58 @@ RSpec.describe Containers::HeartbeatSetup do
       setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
       expect(setup).to be_available
     end
+
+    context "with upstream harness provider support" do
+      let(:harness_provider) { instance_double(AgentHarness::Providers::Base) }
+
+      it "returns true for opencode when harness reports heartbeat support" do
+        allow(harness_provider).to receive(:supports_activity_heartbeat?).and_return(true)
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).to be_available
+      end
+
+      it "returns true for kilocode when harness reports heartbeat support" do
+        allow(harness_provider).to receive(:supports_activity_heartbeat?).and_return(true)
+        setup = described_class.new(
+          provider: "kilocode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).to be_available
+      end
+
+      it "returns false when harness provider does not support heartbeat" do
+        allow(harness_provider).to receive(:supports_activity_heartbeat?).and_return(false)
+        setup = described_class.new(
+          provider: "gemini", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).not_to be_available
+      end
+
+      it "handles harness provider that does not respond to supports_activity_heartbeat?" do
+        harness_provider = Object.new
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).not_to be_available
+      end
+
+      it "handles nil harness_provider gracefully" do
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: nil
+        )
+        expect(setup).not_to be_available
+      end
+    end
   end
 
   describe "#env" do
-    it "returns AGENT_HEARTBEAT_PATH for supported provider" do
+    it "returns AGENT_HEARTBEAT_PATH for locally supported provider" do
       setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup.env).to eq("AGENT_HEARTBEAT_PATH" => "/paid-heartbeat/.paid-heartbeat")
     end
@@ -59,6 +107,23 @@ RSpec.describe Containers::HeartbeatSetup do
     it "returns AGENT_HEARTBEAT_PATH without host_heartbeat_path" do
       setup = described_class.new(provider: "claude", worktree_path: worktree_path, host_heartbeat_path: nil)
       expect(setup.env).to eq("AGENT_HEARTBEAT_PATH" => "/paid-heartbeat/.paid-heartbeat")
+    end
+
+    context "with upstream harness provider" do
+      let(:harness_provider) { instance_double(AgentHarness::Providers::Base) }
+      let(:upstream_env) { { "OPENCODE_HEARTBEAT_FILE" => "/paid-heartbeat/.paid-heartbeat" } }
+
+      before do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: upstream_env, preparation: nil, granularity: :tool_call })
+      end
+
+      it "returns upstream env for harness-supported provider" do
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup.env).to eq(upstream_env)
+      end
     end
   end
 
@@ -152,6 +217,31 @@ RSpec.describe Containers::HeartbeatSetup do
         expect(setup.preparation).to be_a(AgentHarness::ExecutionPreparation)
       end
     end
+
+    context "with upstream harness provider" do
+      let(:harness_provider) { instance_double(AgentHarness::Providers::Base) }
+      let(:upstream_preparation) { AgentHarness::ExecutionPreparation.new(file_writes: []) }
+
+      before do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: {}, preparation: upstream_preparation, granularity: :tool_call })
+      end
+
+      it "returns upstream preparation for opencode" do
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup.preparation).to eq(upstream_preparation)
+      end
+
+      it "returns upstream preparation for kilocode" do
+        setup = described_class.new(
+          provider: "kilocode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup.preparation).to eq(upstream_preparation)
+      end
+    end
   end
 
   describe "#reliable_heartbeat?" do
@@ -168,6 +258,37 @@ RSpec.describe Containers::HeartbeatSetup do
     it "returns false for codex" do
       setup = described_class.new(provider: "codex", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup).not_to be_reliable_heartbeat
+    end
+
+    context "with upstream harness provider" do
+      let(:harness_provider) { instance_double(AgentHarness::Providers::Base) }
+
+      it "returns true for tool_call granularity" do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: {}, preparation: nil, granularity: :tool_call })
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).to be_reliable_heartbeat
+      end
+
+      it "returns false for turn granularity" do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: {}, preparation: nil, granularity: :turn })
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).not_to be_reliable_heartbeat
+      end
+
+      it "returns false for progress granularity" do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: {}, preparation: nil, granularity: :progress })
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).not_to be_reliable_heartbeat
+      end
     end
   end
 
@@ -198,6 +319,29 @@ RSpec.describe Containers::HeartbeatSetup do
     it "returns nil for coarse heartbeat provider with nil base timeout" do
       setup = described_class.new(provider: "codex", worktree_path: worktree_path, host_heartbeat_path: host_heartbeat_path)
       expect(setup.idle_timeout_for(nil)).to be_nil
+    end
+
+    context "with upstream harness provider" do
+      let(:harness_provider) { instance_double(AgentHarness::Providers::Base) }
+
+      it "returns base timeout for upstream provider with tool_call granularity" do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: {}, preparation: nil, granularity: :tool_call })
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup.idle_timeout_for(base_timeout)).to eq(base_timeout)
+      end
+
+      it "returns extended timeout for upstream provider with turn granularity" do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: {}, preparation: nil, granularity: :turn })
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expected = base_timeout * described_class::COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER
+        expect(setup.idle_timeout_for(base_timeout)).to eq(expected)
+      end
     end
   end
 end

--- a/spec/services/containers/heartbeat_setup_spec.rb
+++ b/spec/services/containers/heartbeat_setup_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Containers::HeartbeatSetup do
       let(:harness_provider) { instance_double(AgentHarness::Providers::Base) }
 
       it "returns true for opencode when harness reports heartbeat support" do
-        allow(harness_provider).to receive(:supports_activity_heartbeat?).and_return(true)
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: {}, preparation: nil, granularity: :tool_call })
         setup = described_class.new(
           provider: "opencode", worktree_path: worktree_path,
           host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
@@ -57,7 +57,7 @@ RSpec.describe Containers::HeartbeatSetup do
       end
 
       it "returns true for kilocode when harness reports heartbeat support" do
-        allow(harness_provider).to receive(:supports_activity_heartbeat?).and_return(true)
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: true, env: {}, preparation: nil, granularity: :tool_call })
         setup = described_class.new(
           provider: "kilocode", worktree_path: worktree_path,
           host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
@@ -69,6 +69,24 @@ RSpec.describe Containers::HeartbeatSetup do
         allow(harness_provider).to receive(:supports_activity_heartbeat?).and_return(false)
         setup = described_class.new(
           provider: "gemini", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).not_to be_available
+      end
+
+      it "returns false when heartbeat_integration reports supported: false" do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: { supported: false, env: {}, preparation: nil })
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
+          host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
+        )
+        expect(setup).not_to be_available
+      end
+
+      it "returns false when heartbeat_integration returns nil" do
+        allow(harness_provider).to receive_messages(supports_activity_heartbeat?: true, heartbeat_integration: nil)
+        setup = described_class.new(
+          provider: "opencode", worktree_path: worktree_path,
           host_heartbeat_path: host_heartbeat_path, harness_provider: harness_provider
         )
         expect(setup).not_to be_available

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1991,7 +1991,7 @@ RSpec.describe Activities::RunAgentActivity do
       end
 
       it "does not apply idle timeout to providers without heartbeat support" do
-        agent_run.update!(agent_type: "kilocode")
+        agent_run.update!(agent_type: "gemini")
         project.update!(max_execution_seconds: 86_400)
         allow(container_service).to receive(:execute).and_return(exec_success)
         allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
@@ -2002,6 +2002,42 @@ RSpec.describe Activities::RunAgentActivity do
             timeout: AGENT_TIMEOUT_DEFAULT,
             idle_timeout: nil,
             heartbeat_path: nil
+          )
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "applies heartbeat-backed idle timeout to kilocode via upstream harness" do
+        agent_run.update!(agent_type: "kilocode")
+        project.update!(max_execution_seconds: 86_400)
+        allow(container_service).to receive(:execute).and_return(exec_success)
+        allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+
+        expect(container_service).to receive(:execute).with(
+          anything,
+          hash_including(
+            timeout: AGENT_TIMEOUT_DEFAULT,
+            idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
+            heartbeat_path: "/tmp/paid-heartbeat-test/.paid-heartbeat"
+          )
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "applies heartbeat-backed idle timeout to opencode via upstream harness" do
+        agent_run.update!(agent_type: "opencode")
+        project.update!(max_execution_seconds: 86_400)
+        allow(container_service).to receive(:execute).and_return(exec_success)
+        allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+
+        expect(container_service).to receive(:execute).with(
+          anything,
+          hash_including(
+            timeout: AGENT_TIMEOUT_DEFAULT,
+            idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
+            heartbeat_path: "/tmp/paid-heartbeat-test/.paid-heartbeat"
           )
         ).and_return(exec_success)
 


### PR DESCRIPTION
## Summary

feat(agent-runs): adopt agent-harness heartbeat support for OpenCode/KiloCode fallbacks

See #1569 for context.

---

Closes #1569