### PR TITLE
fix(ci): switch pr-screenshots to ghcr.io browserless image

### DIFF
--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -82,7 +82,7 @@ jobs:
           --health-retries=5
 
       chrome:
-        image: ghcr.io/browserless/chromium:latest
+        image: ghcr.io/browserless/chromium:1.61.0
         ports:
           - 9222:3000
         options: >-

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -82,7 +82,7 @@ jobs:
           --health-retries=5
 
       chrome:
-        image: browserless/chromium:2.18.0
+        image: ghcr.io/browserless/chromium:latest
         ports:
           - 9222:3000
         options: >-

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -82,7 +82,7 @@ jobs:
           --health-retries=5
 
       chrome:
-        image: ghcr.io/browserless/chromium:2.48.2
+        image: ghcr.io/browserless/chromium:v2.48.2
         ports:
           - 9222:3000
         options: >-

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -82,7 +82,7 @@ jobs:
           --health-retries=5
 
       chrome:
-        image: ghcr.io/browserless/chromium:1.61.0
+        image: ghcr.io/browserless/chromium:2.48.2
         ports:
           - 9222:3000
         options: >-


### PR DESCRIPTION
## Summary
- Switch the pr-screenshots workflow from `browserless/chromium:2.18.0` (Docker Hub) to `ghcr.io/browserless/chromium:<pinned_version>`