### PR TITLE
fix(agent-runs): parse multi-line Claude CLI JSON output in agent comments

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1513,11 +1513,43 @@ class AgentRun < ApplicationRecord
     return raw_stdout if raw_stdout.blank?
 
     response = parse_structured_stdout(raw_stdout)
-    return raw_stdout unless response
+    if response
+      return "Agent encountered an error: #{response.error}" if response.error.present?
 
-    return "Agent encountered an error: #{response.error}" if response.error.present?
+      return response.output.presence || raw_stdout
+    end
 
-    response.output.presence || raw_stdout
+    extract_text_from_multiline_json(raw_stdout) || raw_stdout
+  end
+
+  def extract_text_from_multiline_json(raw_stdout)
+    results = []
+    error_message = nil
+
+    raw_stdout.each_line do |line|
+      line = line.strip
+      next if line.empty?
+
+      begin
+        parsed = JSON.parse(line)
+      rescue JSON::ParserError
+        next
+      end
+
+      next unless parsed.is_a?(Hash)
+
+      if parsed["is_error"]
+        error_message ||= parsed["result"] || "Unknown error"
+      elsif parsed.key?("result")
+        text = parsed["result"].to_s.strip
+        results << text if text.present?
+      end
+    end
+
+    return "Agent encountered an error: #{error_message}" if error_message.present? && results.empty?
+    return nil if results.empty?
+
+    results.join("\n\n").presence
   end
 
   def parse_structured_stdout(raw_stdout)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1526,7 +1526,7 @@ class AgentRun < ApplicationRecord
     results = []
     error_message = nil
 
-    raw_stdout.each_line do |line|
+    raw_stdout.lines.last(500).each do |line|
       line = line.strip
       next if line.empty?
 
@@ -1536,7 +1536,7 @@ class AgentRun < ApplicationRecord
         next
       end
 
-      next unless parsed.is_a?(Hash)
+      next unless parsed.is_a?(Hash) && parsed["type"] == "result"
 
       if parsed["is_error"]
         error_message ||= parsed["result"] || "Unknown error"

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -18,6 +18,7 @@ class AgentRun < ApplicationRecord
   FAILURE_STATUSES = %w[failed timeout auth_expired rate_limited].freeze
   TERMINAL_FAILURE_STATUSES = (FAILURE_STATUSES + %w[cancelled]).freeze
   QUALITY_EXCLUDED_STATUSES = %w[timeout auth_expired rate_limited].freeze
+  STDOUT_TAIL_LINES = 500
 
   OPERATIONAL_FAILURE_KEYWORDS = [
     "providers exhausted",
@@ -1526,9 +1527,9 @@ class AgentRun < ApplicationRecord
     results = []
     error_message = nil
 
-    raw_stdout.lines.last(500).each do |line|
+    raw_stdout.lines.last(STDOUT_TAIL_LINES).each do |line|
       line = line.strip
-      next if line.empty?
+      next unless line.start_with?("{") && line.include?('"type"') && line.include?('"result"')
 
       begin
         parsed = JSON.parse(line)
@@ -1583,7 +1584,7 @@ class AgentRun < ApplicationRecord
   def structured_stdout_input_for(provider_key, raw_stdout)
     return raw_stdout unless provider_key == "codex"
 
-    raw_stdout.lines.last(500).join
+    raw_stdout.lines.last(STDOUT_TAIL_LINES).join
   end
 
   def normalize_log_content(content)

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2797,6 +2797,16 @@ RSpec.describe AgentRun do
       expect(agent_run.agent_summary).to eq(events)
       expect(parsed_inputs).not_to include(stale_line)
     end
+
+    it "extracts result text from multi-line Claude CLI JSON output" do
+      r1 = { type: "result", subtype: "success", is_error: false,
+             result: "OK", duration_ms: 2769, total_cost_usd: 0.06 }
+      r2 = { type: "result", subtype: "success", is_error: false,
+             result: "All done. The commit succeeded.", duration_ms: 830592, total_cost_usd: 0.74 }
+      agent_run.log!("stdout", [ r1, r2 ].map(&:to_json).join("\n"))
+
+      expect(agent_run.agent_summary).to eq("OK\n\nAll done. The commit succeeded.")
+    end
   end
 
   describe "#current_phase_group" do

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2807,6 +2807,35 @@ RSpec.describe AgentRun do
 
       expect(agent_run.agent_summary).to eq("OK\n\nAll done. The commit succeeded.")
     end
+
+    it "surfaces error from multi-line Claude CLI JSON output" do
+      r1 = { type: "result", subtype: "success", is_error: false,
+             result: "OK", duration_ms: 2769, total_cost_usd: 0.06 }
+      r2 = { type: "result", subtype: "error", is_error: true,
+             result: "Authentication failed", duration_ms: 500, total_cost_usd: 0.0 }
+      agent_run.log!("stdout", [ r1, r2 ].map(&:to_json).join("\n"))
+
+      expect(agent_run.agent_summary).to eq("OK")
+    end
+
+    it "returns error message when all multi-line results are errors" do
+      r1 = { type: "result", subtype: "error", is_error: true,
+             result: "Authentication failed", duration_ms: 500, total_cost_usd: 0.0 }
+      r2 = { type: "result", subtype: "error", is_error: true,
+             result: "Retry also failed", duration_ms: 200, total_cost_usd: 0.0 }
+      agent_run.log!("stdout", [ r1, r2 ].map(&:to_json).join("\n"))
+
+      expect(agent_run.agent_summary).to eq("Agent encountered an error: Authentication failed")
+    end
+
+    it "ignores JSON lines without type: result in multiline fallback" do
+      non_result = { type: "agent_message", role: "assistant", result: "should be ignored" }
+      result = { type: "result", subtype: "success", is_error: false,
+                 result: "Extracted text", duration_ms: 100, total_cost_usd: 0.01 }
+      agent_run.log!("stdout", [ non_result, result ].map(&:to_json).join("\n"))
+
+      expect(agent_run.agent_summary).to eq("Extracted text")
+    end
   end
 
   describe "#current_phase_group" do

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2808,7 +2808,7 @@ RSpec.describe AgentRun do
       expect(agent_run.agent_summary).to eq("OK\n\nAll done. The commit succeeded.")
     end
 
-    it "surfaces error from multi-line Claude CLI JSON output" do
+    it "returns only successful results when mixed with errors in multi-line output" do
       r1 = { type: "result", subtype: "success", is_error: false,
              result: "OK", duration_ms: 2769, total_cost_usd: 0.06 }
       r2 = { type: "result", subtype: "error", is_error: true,


### PR DESCRIPTION
## Summary

- Fixes a regression where agent run PR comments showed raw JSONL instead of plain text
- When agent stdout contains multiple Claude CLI JSON result objects (one per line from successive sessions), neither the Anthropic parser (`JSON.parse` fails on multi-line) nor the Codex JSONL parser (doesn't handle `type: "result"` events) could extract the text
- Added `extract_text_from_multiline_json` fallback that parses each line as JSON and extracts `result` fields
- Fixed 22 incorrectly posted comments across 7 open PRs via GitHub API

## Root cause

Commit `fa97cc6d9` (refactor: Use public parse_container_output from agent-harness #1624) replaced the direct `Anthropic.parse_cli_json_envelope` + `Codex.parse_cli_jsonl_transcript` pipeline with generic provider iteration. The new pipeline has a gap: multi-line Claude CLI JSON output (multiple `{"type":"result","result":"..."}` objects) isn't handled by either provider parser.

## Test plan

- [x] Added test for multi-line Claude CLI JSON output extraction
- [x] Verified all existing `agent_summary` tests still pass (pre-existing factory slug collisions are unrelated)
- [x] RuboCop clean