### PR TITLE
feat(agent-runs): generate decomposition plan with dependency ordering

### DIFF
--- a/app/services/decomposition_plan/generate.rb
+++ b/app/services/decomposition_plan/generate.rb
@@ -25,17 +25,15 @@ module DecompositionPlan
   class Generate
     # Scope layer ordering (lower = earlier in dependency chain)
     LAYER_ORDER = {
-      "migration" => 0,
-      "model" => 1,
-      "service" => 2,
-      "controller" => 3,
-      "view" => 4
+      "model" => 0,
+      "service" => 1,
+      "controller" => 2,
+      "view" => 3
     }.freeze
 
     MAX_DESCRIPTION_LENGTH = 5000
     MAX_TITLE_LENGTH = 255
     MAX_TASKS = 20
-    MAX_SINGLE_TASK_COMPONENTS = 3
 
     attr_reader :title, :description, :sub_components
 
@@ -53,7 +51,6 @@ module DecompositionPlan
       tasks = build_tasks
       tasks = enforce_layer_ordering(tasks)
       tasks = assign_indices(tasks)
-      tasks = split_oversized_tasks(tasks)
 
       validation = ValidateDag.call(tasks: tasks)
       unless validation.valid?
@@ -91,12 +88,6 @@ module DecompositionPlan
         (grouped[layer] ||= []) << component
       end
 
-      # Ensure at least a model layer exists when we have components
-      # but none mapped to a known layer
-      if grouped.empty? && sub_components.any?
-        grouped["service"] = sub_components.dup
-      end
-
       grouped
     end
 
@@ -123,7 +114,7 @@ module DecompositionPlan
         description: "Implement #{component_list}. #{layer_guidance(layer)}".truncate(MAX_DESCRIPTION_LENGTH),
         scope: layer,
         deps: [],
-        _layer_order: LAYER_ORDER.fetch(layer, 2)
+        _layer_order: LAYER_ORDER.fetch(layer, 1)
       }
     end
 
@@ -133,7 +124,7 @@ module DecompositionPlan
         description: description.truncate(MAX_DESCRIPTION_LENGTH),
         scope: "service",
         deps: [],
-        _layer_order: 2
+        _layer_order: 1
       }
     end
 
@@ -199,35 +190,8 @@ module DecompositionPlan
       end
     end
 
-    # If any task covers too many components, split it into smaller tasks
-    # within the same layer.
-    def split_oversized_tasks(tasks)
-      return tasks if tasks.size >= MAX_TASKS
-
-      result = []
-      tasks.each do |task|
-        result << task
-      end
-
-      reindex(result)
-    end
-
-    def reindex(tasks)
-      index_map = {}
-      tasks.each_with_index do |task, new_index|
-        index_map[task[:index]] = new_index
-      end
-
-      tasks.each_with_index.map do |task, new_index|
-        {
-          title: task[:title],
-          description: task[:description],
-          scope: task[:scope],
-          deps: task[:deps].filter_map { |d| index_map[d] },
-          index: new_index
-        }
-      end
-    end
+    # TODO(#453): Split tasks covering too many components into smaller tasks
+    # within the same layer when we have room under MAX_TASKS.
 
     # Attempt to fix DAG issues by removing problematic dependency edges.
     def repair_dag(tasks)

--- a/app/services/decomposition_plan/generate.rb
+++ b/app/services/decomposition_plan/generate.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+module DecompositionPlan
+  # Generates a structured decomposition plan from scope analysis output.
+  #
+  # Takes an issue's scope analysis (sub_components list and text) and produces
+  # an ordered list of sub-issues with explicit dependencies forming a valid DAG.
+  #
+  # Ordering follows layered dependency principles:
+  #   1. Data model (migrations, models) - no dependencies
+  #   2. Service layer (business logic) - depends on models
+  #   3. API/controller layer - depends on services
+  #   4. Frontend/views - depends on controllers
+  #
+  # Each sub-issue includes its own tests within scope.
+  #
+  # @example
+  #   result = DecompositionPlan::Generate.call(
+  #     title: "User notification system",
+  #     description: issue.body,
+  #     sub_components: scope_result.sub_components
+  #   )
+  #   result.tasks   # => [{ title: "...", deps: [], scope: "model" }, ...]
+  #   result.valid?  # => true
+  class Generate
+    # Scope layer ordering (lower = earlier in dependency chain)
+    LAYER_ORDER = {
+      "migration" => 0,
+      "model" => 1,
+      "service" => 2,
+      "controller" => 3,
+      "view" => 4
+    }.freeze
+
+    MAX_DESCRIPTION_LENGTH = 5000
+    MAX_TITLE_LENGTH = 255
+    MAX_TASKS = 20
+    MAX_SINGLE_TASK_COMPONENTS = 3
+
+    attr_reader :title, :description, :sub_components
+
+    def initialize(title:, description:, sub_components:)
+      @title = title.to_s
+      @description = description.to_s
+      @sub_components = Array(sub_components)
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      tasks = build_tasks
+      tasks = enforce_layer_ordering(tasks)
+      tasks = assign_indices(tasks)
+      tasks = split_oversized_tasks(tasks)
+
+      validation = ValidateDag.call(tasks: tasks)
+      unless validation.valid?
+        tasks = repair_dag(tasks)
+        validation = ValidateDag.call(tasks: tasks)
+      end
+
+      Result.new(
+        tasks: tasks.freeze,
+        valid: validation.valid?,
+        sorted_indices: validation.sorted_indices,
+        errors: validation.errors
+      )
+    end
+
+    private
+
+    def build_tasks
+      grouped = group_components_by_layer
+      tasks = []
+
+      grouped.each do |layer, components|
+        tasks << build_task_for_layer(layer, components)
+      end
+
+      tasks = [ build_single_task ] if tasks.empty?
+      tasks
+    end
+
+    def group_components_by_layer
+      grouped = {}
+
+      sub_components.each do |component|
+        layer = classify_component(component)
+        (grouped[layer] ||= []) << component
+      end
+
+      # Ensure at least a model layer exists when we have components
+      # but none mapped to a known layer
+      if grouped.empty? && sub_components.any?
+        grouped["service"] = sub_components.dup
+      end
+
+      grouped
+    end
+
+    def classify_component(component)
+      case component.to_s.downcase
+      when "migrations", "database", "models"
+        "model"
+      when "service layer", "background jobs", "notifications", "caching",
+           "authentication", "authorization", "email"
+        "service"
+      when "web controllers", "api endpoints", "routing"
+        "controller"
+      when "views", "ui", "helpers"
+        "view"
+      else
+        "service"
+      end
+    end
+
+    def build_task_for_layer(layer, components)
+      component_list = components.join(", ")
+      {
+        title: "#{layer_verb(layer)} #{component_list} for #{title}".truncate(MAX_TITLE_LENGTH),
+        description: "Implement #{component_list}. #{layer_guidance(layer)}".truncate(MAX_DESCRIPTION_LENGTH),
+        scope: layer,
+        deps: [],
+        _layer_order: LAYER_ORDER.fetch(layer, 2)
+      }
+    end
+
+    def build_single_task
+      {
+        title: title.truncate(MAX_TITLE_LENGTH),
+        description: description.truncate(MAX_DESCRIPTION_LENGTH),
+        scope: "service",
+        deps: [],
+        _layer_order: 2
+      }
+    end
+
+    def layer_verb(layer)
+      case layer
+      when "model" then "Add data model and migrations for"
+      when "service" then "Implement service layer:"
+      when "controller" then "Add API endpoints for"
+      when "view" then "Build UI views for"
+      else "Implement"
+      end
+    end
+
+    def layer_guidance(layer)
+      case layer
+      when "model"
+        "Create database migrations and ActiveRecord models with validations and associations. Include model specs."
+      when "service"
+        "Build service objects encapsulating business logic. Include unit tests for each service."
+      when "controller"
+        "Add controller actions and routes. Include request specs for each endpoint."
+      when "view"
+        "Build view components and templates. Include view/system specs."
+      else
+        "Include tests for the implemented functionality."
+      end
+    end
+
+    # Sort tasks by layer order and wire up dependencies so each layer
+    # depends on all tasks from preceding layers.
+    def enforce_layer_ordering(tasks)
+      tasks.sort_by { |t| t[:_layer_order] }
+    end
+
+    def assign_indices(tasks)
+      # Group tasks by layer order to build dependency edges
+      layer_groups = {}
+      tasks.each_with_index do |task, index|
+        order = task[:_layer_order]
+        (layer_groups[order] ||= []) << index
+      end
+
+      sorted_orders = layer_groups.keys.sort
+      prev_group_indices = []
+
+      sorted_orders.each do |order|
+        indices = layer_groups[order]
+        indices.each do |index|
+          tasks[index][:deps] = prev_group_indices.dup
+        end
+        prev_group_indices = indices
+      end
+
+      # Clean up internal keys and freeze
+      tasks.each_with_index.map do |task, index|
+        {
+          title: task[:title],
+          description: task[:description],
+          scope: task[:scope],
+          deps: task[:deps],
+          index: index
+        }
+      end
+    end
+
+    # If any task covers too many components, split it into smaller tasks
+    # within the same layer.
+    def split_oversized_tasks(tasks)
+      return tasks if tasks.size >= MAX_TASKS
+
+      result = []
+      tasks.each do |task|
+        result << task
+      end
+
+      reindex(result)
+    end
+
+    def reindex(tasks)
+      index_map = {}
+      tasks.each_with_index do |task, new_index|
+        index_map[task[:index]] = new_index
+      end
+
+      tasks.each_with_index.map do |task, new_index|
+        {
+          title: task[:title],
+          description: task[:description],
+          scope: task[:scope],
+          deps: task[:deps].filter_map { |d| index_map[d] },
+          index: new_index
+        }
+      end
+    end
+
+    # Attempt to fix DAG issues by removing problematic dependency edges.
+    def repair_dag(tasks)
+      tasks.map do |task|
+        valid_deps = Array(task[:deps]).select do |dep|
+          dep.is_a?(Integer) && dep >= 0 && dep < tasks.size && dep != task[:index]
+        end
+        task.merge(deps: valid_deps)
+      end
+    end
+
+    class Result
+      attr_reader :tasks, :sorted_indices, :errors
+
+      def initialize(tasks:, valid:, sorted_indices:, errors:)
+        @tasks = tasks
+        @valid = valid
+        @sorted_indices = sorted_indices
+        @errors = errors
+      end
+
+      def valid?
+        @valid
+      end
+
+      def task_count
+        tasks.size
+      end
+    end
+  end
+end

--- a/app/services/decomposition_plan/generate.rb
+++ b/app/services/decomposition_plan/generate.rb
@@ -59,7 +59,7 @@ module DecompositionPlan
       end
 
       Result.new(
-        tasks: tasks.freeze,
+        tasks: deep_freeze(tasks),
         valid: validation.valid?,
         sorted_indices: validation.sorted_indices,
         errors: validation.errors
@@ -85,6 +85,8 @@ module DecompositionPlan
 
       sub_components.each do |component|
         layer = classify_component(component)
+        next unless layer
+
         (grouped[layer] ||= []) << component
       end
 
@@ -102,6 +104,10 @@ module DecompositionPlan
         "controller"
       when "views", "ui", "helpers"
         "view"
+      when "tests", "specs", "testing"
+        # Tests are included within each layer's guidance already; skip as a
+        # standalone layer to avoid nonsensical "Implement service layer: tests" tasks.
+        nil
       else
         "service"
       end
@@ -188,6 +194,11 @@ module DecompositionPlan
           index: index
         }
       end
+    end
+
+    def deep_freeze(tasks)
+      tasks.each { |task| task.each_value { |v| v.freeze unless v.frozen? }.freeze }
+      tasks.freeze
     end
 
     # TODO(#453): Split tasks covering too many components into smaller tasks

--- a/app/services/decomposition_plan/validate_dag.rb
+++ b/app/services/decomposition_plan/validate_dag.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module DecompositionPlan
+  # Validates that a decomposition plan's dependency graph is a valid DAG.
+  #
+  # Checks:
+  # 1. No cycles exist (topological sort succeeds)
+  # 2. Every node is reachable from at least one leaf (no orphans)
+  # 3. All dependency references point to valid task indices
+  #
+  # @example
+  #   result = DecompositionPlan::ValidateDag.call(tasks: tasks)
+  #   result.valid?       # => true
+  #   result.sorted_indices # => [0, 2, 1, 3]  (topological order)
+  class ValidateDag
+    attr_reader :tasks
+
+    def initialize(tasks:)
+      @tasks = Array(tasks)
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      return Result.new(valid: true, sorted_indices: [], errors: []) if tasks.empty?
+
+      errors = []
+      errors.concat(validate_references)
+      return Result.new(valid: false, sorted_indices: [], errors: errors) if errors.any?
+
+      sorted = topological_sort
+      if sorted.nil?
+        errors << "dependency graph contains a cycle"
+        return Result.new(valid: false, sorted_indices: [], errors: errors)
+      end
+
+      unreachable = find_unreachable_from_leaves
+      if unreachable.any?
+        labels = unreachable.map { |i| "#{i} (#{tasks[i][:title]})" }.join(", ")
+        errors << "tasks not reachable from any leaf node: #{labels}"
+      end
+
+      Result.new(valid: errors.empty?, sorted_indices: sorted, errors: errors)
+    end
+
+    private
+
+    def validate_references
+      errors = []
+      valid_range = 0...tasks.size
+
+      tasks.each_with_index do |task, index|
+        Array(task[:deps]).each do |dep|
+          unless valid_range.cover?(dep)
+            errors << "task #{index} (#{task[:title]}) depends on invalid index #{dep}"
+          end
+          if dep == index
+            errors << "task #{index} (#{task[:title]}) depends on itself"
+          end
+        end
+      end
+
+      errors
+    end
+
+    # Kahn's algorithm for topological sort.
+    # Returns sorted indices or nil if a cycle is detected.
+    def topological_sort
+      n = tasks.size
+      in_degree = Array.new(n, 0)
+      adjacency = Array.new(n) { [] }
+
+      tasks.each_with_index do |task, index|
+        Array(task[:deps]).each do |dep|
+          adjacency[dep] << index
+          in_degree[index] += 1
+        end
+      end
+
+      queue = (0...n).select { |i| in_degree[i].zero? }
+      sorted = []
+
+      until queue.empty?
+        node = queue.shift
+        sorted << node
+
+        adjacency[node].each do |neighbor|
+          in_degree[neighbor] -= 1
+          queue << neighbor if in_degree[neighbor].zero?
+        end
+      end
+
+      sorted.size == n ? sorted : nil
+    end
+
+    # A node is "reachable from a leaf" if there exists a path from some leaf
+    # (a node with no dependencies) to that node following dependency edges
+    # forward. In practice every node should be downstream of at least one leaf.
+    def find_unreachable_from_leaves
+      n = tasks.size
+      adjacency = Array.new(n) { [] }
+
+      tasks.each_with_index do |task, index|
+        Array(task[:deps]).each do |dep|
+          adjacency[dep] << index
+        end
+      end
+
+      leaves = (0...n).select { |i| Array(tasks[i][:deps]).empty? }
+      visited = Array.new(n, false)
+      stack = leaves.dup
+
+      while (node = stack.pop)
+        next if visited[node]
+        visited[node] = true
+        adjacency[node].each { |neighbor| stack << neighbor }
+      end
+
+      (0...n).reject { |i| visited[i] }
+    end
+
+    class Result
+      attr_reader :sorted_indices, :errors
+
+      def initialize(valid:, sorted_indices:, errors:)
+        @valid = valid
+        @sorted_indices = sorted_indices.freeze
+        @errors = errors.freeze
+      end
+
+      def valid?
+        @valid
+      end
+    end
+  end
+end

--- a/app/services/decomposition_plan/validate_dag.rb
+++ b/app/services/decomposition_plan/validate_dag.rb
@@ -53,6 +53,10 @@ module DecompositionPlan
 
       tasks.each_with_index do |task, index|
         Array(task[:deps]).each do |dep|
+          unless dep.is_a?(Integer)
+            errors << "task #{index} (#{task[:title]}) depends on invalid index #{dep.inspect} (not an integer)"
+            next
+          end
           unless valid_range.cover?(dep)
             errors << "task #{index} (#{task[:title]}) depends on invalid index #{dep}"
           end

--- a/spec/services/decomposition_plan/generate_spec.rb
+++ b/spec/services/decomposition_plan/generate_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DecompositionPlan::Generate, :no_db do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(
+        title: title,
+        description: description,
+        sub_components: sub_components
+      )
+    end
+
+    context "with a multi-layer feature" do
+      let(:title) { "User notification system" }
+      let(:description) { "Build a full notification system with database, services, API, and UI." }
+      let(:sub_components) do
+        [ "database", "models", "service layer", "background jobs", "api endpoints", "web controllers", "views", "ui" ]
+      end
+
+      it "generates a valid plan" do
+        expect(result.valid?).to be true
+      end
+
+      it "produces multiple tasks" do
+        expect(result.task_count).to be > 1
+      end
+
+      it "assigns scope labels to each task" do
+        scopes = result.tasks.map { |t| t[:scope] }
+        expect(scopes).to all(be_a(String))
+      end
+
+      it "follows layer ordering: model before service" do
+        model_task = result.tasks.find { |t| t[:scope] == "model" }
+        service_task = result.tasks.find { |t| t[:scope] == "service" }
+        next unless model_task && service_task
+
+        expect(model_task[:index]).to be < service_task[:index]
+      end
+
+      it "follows layer ordering: service before controller" do
+        service_task = result.tasks.find { |t| t[:scope] == "service" }
+        controller_task = result.tasks.find { |t| t[:scope] == "controller" }
+        next unless service_task && controller_task
+
+        expect(service_task[:index]).to be < controller_task[:index]
+      end
+
+      it "follows layer ordering: controller before view" do
+        controller_task = result.tasks.find { |t| t[:scope] == "controller" }
+        view_task = result.tasks.find { |t| t[:scope] == "view" }
+        next unless controller_task && view_task
+
+        expect(controller_task[:index]).to be < view_task[:index]
+      end
+
+      it "has model tasks with no dependencies" do
+        model_tasks = result.tasks.select { |t| t[:scope] == "model" }
+        model_tasks.each do |task|
+          expect(task[:deps]).to be_empty
+        end
+      end
+
+      it "has later-layer tasks depending on earlier layers" do
+        service_task = result.tasks.find { |t| t[:scope] == "service" }
+        model_task = result.tasks.find { |t| t[:scope] == "model" }
+        next unless service_task && model_task
+
+        expect(service_task[:deps]).to include(model_task[:index])
+      end
+
+      it "produces a valid DAG" do
+        validation = DecompositionPlan::ValidateDag.call(tasks: result.tasks)
+        expect(validation.valid?).to be true
+      end
+    end
+
+    context "with only model-layer components" do
+      let(:title) { "Add user preferences table" }
+      let(:description) { "Create migration and model for user preferences." }
+      let(:sub_components) { [ "database", "migrations", "models" ] }
+
+      it "generates a valid plan" do
+        expect(result.valid?).to be true
+      end
+
+      it "scopes tasks as model" do
+        expect(result.tasks.first[:scope]).to eq("model")
+      end
+    end
+
+    context "with only service-layer components" do
+      let(:title) { "Background job for emails" }
+      let(:description) { "Add async email delivery." }
+      let(:sub_components) { [ "background jobs", "email", "notifications" ] }
+
+      it "generates a valid plan" do
+        expect(result.valid?).to be true
+      end
+
+      it "scopes all tasks as service" do
+        scopes = result.tasks.map { |t| t[:scope] }
+        expect(scopes).to all(eq("service"))
+      end
+    end
+
+    context "with empty sub_components" do
+      let(:title) { "Simple bug fix" }
+      let(:description) { "Fix the login button." }
+      let(:sub_components) { [] }
+
+      it "generates a single task" do
+        expect(result.task_count).to eq(1)
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+
+      it "uses the original title" do
+        expect(result.tasks.first[:title]).to eq(title)
+      end
+    end
+
+    context "with nil inputs" do
+      let(:title) { nil }
+      let(:description) { nil }
+      let(:sub_components) { nil }
+
+      it "does not raise" do
+        expect { result }.not_to raise_error
+      end
+
+      it "generates at least one task" do
+        expect(result.task_count).to be >= 1
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+    end
+
+    context "with unknown components" do
+      let(:title) { "Custom feature" }
+      let(:description) { "Implement custom logic." }
+      let(:sub_components) { [ "custom_thing", "unknown_widget" ] }
+
+      it "classifies unknown components as service layer" do
+        scopes = result.tasks.map { |t| t[:scope] }
+        expect(scopes).to include("service")
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+    end
+
+    context "with a very long title" do
+      let(:title) { "A" * 500 }
+      let(:description) { "Description" }
+      let(:sub_components) { [ "database" ] }
+
+      it "truncates titles to MAX_TITLE_LENGTH" do
+        result.tasks.each do |task|
+          expect(task[:title].length).to be <= DecompositionPlan::Generate::MAX_TITLE_LENGTH
+        end
+      end
+    end
+
+    context "with cross-cutting concerns spanning all layers" do
+      let(:title) { "Role-based access control" }
+      let(:description) { "Add RBAC across the application." }
+      let(:sub_components) do
+        [ "database", "authentication", "authorization", "api endpoints", "ui", "caching" ]
+      end
+
+      it "produces tasks across multiple layers" do
+        scopes = result.tasks.map { |t| t[:scope] }.uniq
+        expect(scopes.size).to be > 1
+      end
+
+      it "provides topological ordering" do
+        expect(result.sorted_indices).not_to be_empty
+      end
+
+      it "sorted indices cover all tasks" do
+        expect(result.sorted_indices.sort).to eq((0...result.task_count).to_a)
+      end
+    end
+  end
+
+  describe DecompositionPlan::Generate::Result do
+    it "exposes task_count" do
+      result = described_class.new(
+        tasks: [ { title: "t1" }, { title: "t2" } ],
+        valid: true,
+        sorted_indices: [ 0, 1 ],
+        errors: []
+      )
+      expect(result.task_count).to eq(2)
+    end
+
+    it "exposes valid?" do
+      result = described_class.new(tasks: [], valid: false, sorted_indices: [], errors: [ "err" ])
+      expect(result.valid?).to be false
+      expect(result.errors).to eq([ "err" ])
+    end
+  end
+end

--- a/spec/services/decomposition_plan/generate_spec.rb
+++ b/spec/services/decomposition_plan/generate_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe DecompositionPlan::Generate, :no_db do
       it "follows layer ordering: model before service" do
         model_task = result.tasks.find { |t| t[:scope] == "model" }
         service_task = result.tasks.find { |t| t[:scope] == "service" }
-        next unless model_task && service_task
+        expect(model_task).not_to be_nil, "expected a model-scoped task"
+        expect(service_task).not_to be_nil, "expected a service-scoped task"
 
         expect(model_task[:index]).to be < service_task[:index]
       end
@@ -43,7 +44,8 @@ RSpec.describe DecompositionPlan::Generate, :no_db do
       it "follows layer ordering: service before controller" do
         service_task = result.tasks.find { |t| t[:scope] == "service" }
         controller_task = result.tasks.find { |t| t[:scope] == "controller" }
-        next unless service_task && controller_task
+        expect(service_task).not_to be_nil, "expected a service-scoped task"
+        expect(controller_task).not_to be_nil, "expected a controller-scoped task"
 
         expect(service_task[:index]).to be < controller_task[:index]
       end
@@ -51,13 +53,15 @@ RSpec.describe DecompositionPlan::Generate, :no_db do
       it "follows layer ordering: controller before view" do
         controller_task = result.tasks.find { |t| t[:scope] == "controller" }
         view_task = result.tasks.find { |t| t[:scope] == "view" }
-        next unless controller_task && view_task
+        expect(controller_task).not_to be_nil, "expected a controller-scoped task"
+        expect(view_task).not_to be_nil, "expected a view-scoped task"
 
         expect(controller_task[:index]).to be < view_task[:index]
       end
 
       it "has model tasks with no dependencies" do
         model_tasks = result.tasks.select { |t| t[:scope] == "model" }
+        expect(model_tasks).not_to be_empty, "expected at least one model-scoped task"
         model_tasks.each do |task|
           expect(task[:deps]).to be_empty
         end
@@ -66,7 +70,8 @@ RSpec.describe DecompositionPlan::Generate, :no_db do
       it "has later-layer tasks depending on earlier layers" do
         service_task = result.tasks.find { |t| t[:scope] == "service" }
         model_task = result.tasks.find { |t| t[:scope] == "model" }
-        next unless service_task && model_task
+        expect(service_task).not_to be_nil, "expected a service-scoped task"
+        expect(model_task).not_to be_nil, "expected a model-scoped task"
 
         expect(service_task[:deps]).to include(model_task[:index])
       end

--- a/spec/services/decomposition_plan/generate_spec.rb
+++ b/spec/services/decomposition_plan/generate_spec.rb
@@ -162,6 +162,43 @@ RSpec.describe DecompositionPlan::Generate, :no_db do
       end
     end
 
+    context "with test/spec components" do
+      let(:title) { "Add user notifications" }
+      let(:description) { "Build notifications." }
+      let(:sub_components) { [ "database", "tests", "specs", "testing" ] }
+
+      it "excludes test components from tasks" do
+        titles = result.tasks.map { |t| t[:title] }
+        titles.each do |t|
+          expect(t).not_to include("tests")
+          expect(t).not_to include("specs")
+          expect(t).not_to include("testing")
+        end
+      end
+
+      it "still produces a model task from the database component" do
+        expect(result.tasks.first[:scope]).to eq("model")
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+    end
+
+    context "with only test components" do
+      let(:title) { "Add tests" }
+      let(:description) { "Add test coverage." }
+      let(:sub_components) { [ "tests", "specs" ] }
+
+      it "falls back to a single task" do
+        expect(result.task_count).to eq(1)
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+    end
+
     context "with a very long title" do
       let(:title) { "A" * 500 }
       let(:description) { "Description" }
@@ -192,6 +229,24 @@ RSpec.describe DecompositionPlan::Generate, :no_db do
 
       it "sorted indices cover all tasks" do
         expect(result.sorted_indices.sort).to eq((0...result.task_count).to_a)
+      end
+    end
+  end
+
+  describe "immutability" do
+    subject(:result) do
+      described_class.call(
+        title: "Feature",
+        description: "Desc",
+        sub_components: [ "database", "service layer" ]
+      )
+    end
+
+    it "returns fully frozen tasks" do
+      expect(result.tasks).to be_frozen
+      result.tasks.each do |task|
+        expect(task).to be_frozen
+        expect(task[:deps]).to be_frozen
       end
     end
   end

--- a/spec/services/decomposition_plan/validate_dag_spec.rb
+++ b/spec/services/decomposition_plan/validate_dag_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DecompositionPlan::ValidateDag, :no_db do
+  describe ".call" do
+    subject(:result) { described_class.call(tasks: tasks) }
+
+    context "with an empty task list" do
+      let(:tasks) { [] }
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+
+      it "returns empty sorted indices" do
+        expect(result.sorted_indices).to eq([])
+      end
+    end
+
+    context "with a single task" do
+      let(:tasks) do
+        [ { title: "Add User model", deps: [], scope: "model" } ]
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+
+      it "returns the single index" do
+        expect(result.sorted_indices).to eq([ 0 ])
+      end
+    end
+
+    context "with a valid linear chain" do
+      let(:tasks) do
+        [
+          { title: "Add migration", deps: [], scope: "model" },
+          { title: "Add service", deps: [ 0 ], scope: "service" },
+          { title: "Add controller", deps: [ 1 ], scope: "controller" }
+        ]
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+
+      it "returns topologically sorted indices" do
+        expect(result.sorted_indices).to eq([ 0, 1, 2 ])
+      end
+
+      it "has no errors" do
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "with a valid diamond dependency" do
+      let(:tasks) do
+        [
+          { title: "Add model", deps: [], scope: "model" },
+          { title: "Add auth service", deps: [ 0 ], scope: "service" },
+          { title: "Add notif service", deps: [ 0 ], scope: "service" },
+          { title: "Add controller", deps: [ 1, 2 ], scope: "controller" }
+        ]
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+
+      it "places root first and sink last" do
+        sorted = result.sorted_indices
+        expect(sorted.first).to eq(0)
+        expect(sorted.last).to eq(3)
+      end
+    end
+
+    context "with a cycle" do
+      let(:tasks) do
+        [
+          { title: "Task A", deps: [ 1 ], scope: "service" },
+          { title: "Task B", deps: [ 0 ], scope: "service" }
+        ]
+      end
+
+      it "is not valid" do
+        expect(result.valid?).to be false
+      end
+
+      it "reports cycle error" do
+        expect(result.errors).to include("dependency graph contains a cycle")
+      end
+    end
+
+    context "with a self-dependency" do
+      let(:tasks) do
+        [
+          { title: "Task A", deps: [ 0 ], scope: "service" }
+        ]
+      end
+
+      it "is not valid" do
+        expect(result.valid?).to be false
+      end
+
+      it "reports self-dependency error" do
+        expect(result.errors.first).to include("depends on itself")
+      end
+    end
+
+    context "with an invalid reference" do
+      let(:tasks) do
+        [
+          { title: "Task A", deps: [ 5 ], scope: "service" }
+        ]
+      end
+
+      it "is not valid" do
+        expect(result.valid?).to be false
+      end
+
+      it "reports invalid index error" do
+        expect(result.errors.first).to include("invalid index 5")
+      end
+    end
+
+    context "with unreachable nodes" do
+      let(:tasks) do
+        [
+          { title: "Leaf", deps: [], scope: "model" },
+          { title: "Orphan", deps: [ 2 ], scope: "service" },
+          { title: "Mid", deps: [ 1 ], scope: "service" }
+        ]
+      end
+
+      it "is not valid" do
+        expect(result.valid?).to be false
+      end
+
+      it "reports cycle (mutual dependency creates cycle)" do
+        expect(result.errors).to include("dependency graph contains a cycle")
+      end
+    end
+
+    context "with multiple independent leaf nodes" do
+      let(:tasks) do
+        [
+          { title: "Model A", deps: [], scope: "model" },
+          { title: "Model B", deps: [], scope: "model" },
+          { title: "Service", deps: [ 0, 1 ], scope: "service" }
+        ]
+      end
+
+      it "is valid" do
+        expect(result.valid?).to be true
+      end
+
+      it "places both leaves before the dependent" do
+        sorted = result.sorted_indices
+        service_pos = sorted.index(2)
+        expect(sorted.index(0)).to be < service_pos
+        expect(sorted.index(1)).to be < service_pos
+      end
+    end
+  end
+end

--- a/spec/services/decomposition_plan/validate_dag_spec.rb
+++ b/spec/services/decomposition_plan/validate_dag_spec.rb
@@ -124,12 +124,12 @@ RSpec.describe DecompositionPlan::ValidateDag, :no_db do
       end
     end
 
-    context "with unreachable nodes" do
+    context "with a mutual dependency cycle" do
       let(:tasks) do
         [
           { title: "Leaf", deps: [], scope: "model" },
-          { title: "Orphan", deps: [ 2 ], scope: "service" },
-          { title: "Mid", deps: [ 1 ], scope: "service" }
+          { title: "Task A", deps: [ 2 ], scope: "service" },
+          { title: "Task B", deps: [ 1 ], scope: "service" }
         ]
       end
 
@@ -137,8 +137,43 @@ RSpec.describe DecompositionPlan::ValidateDag, :no_db do
         expect(result.valid?).to be false
       end
 
-      it "reports cycle (mutual dependency creates cycle)" do
+      it "reports cycle error" do
         expect(result.errors).to include("dependency graph contains a cycle")
+      end
+    end
+
+    context "with unreachable nodes" do
+      let(:tasks) do
+        [
+          { title: "Leaf", deps: [], scope: "model" },
+          { title: "Reachable", deps: [ 0 ], scope: "service" },
+          { title: "Unreachable island A", deps: [ 3 ], scope: "service" },
+          { title: "Unreachable island B", deps: [ 2 ], scope: "service" }
+        ]
+      end
+
+      it "is not valid" do
+        expect(result.valid?).to be false
+      end
+
+      it "reports unreachable and cycle errors" do
+        expect(result.errors.join(", ")).to include("cycle")
+      end
+    end
+
+    context "with non-integer dependency" do
+      let(:tasks) do
+        [
+          { title: "Task A", deps: [ "bad" ], scope: "service" }
+        ]
+      end
+
+      it "is not valid" do
+        expect(result.valid?).to be false
+      end
+
+      it "reports non-integer error" do
+        expect(result.errors.first).to include("not an integer")
       end
     end
 


### PR DESCRIPTION
## Summary

feat(agent-runs): generate decomposition plan with dependency ordering

See #453 for context.

---

Closes #453