### PR TITLE
fix(providers): add local provider smoke coverage

### DIFF
--- a/app/javascript/controllers/test_agent_controller.js
+++ b/app/javascript/controllers/test_agent_controller.js
@@ -2,18 +2,23 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["button", "result", "status"]
-  static values = { url: String }
+  static values = { url: String, csrfToken: String }
 
   async test() {
     this.showLoading()
+    const csrfToken = this.csrfToken
 
     try {
       const response = await fetch(this.urlValue, {
         method: "POST",
+        credentials: "same-origin",
         headers: {
-          "X-CSRF-Token": this.csrfToken,
-          "Accept": "application/json"
+          "X-CSRF-Token": csrfToken,
+          "Accept": "application/json",
+          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+          "X-Requested-With": "XMLHttpRequest"
         },
+        body: new window.URLSearchParams({ authenticity_token: csrfToken }),
         redirect: "follow"
       })
 
@@ -174,6 +179,8 @@ export default class extends Controller {
   }
 
   get csrfToken() {
+    if (this.hasCsrfTokenValue) return this.csrfTokenValue
+
     const meta = document.querySelector("meta[name=csrf-token]")
     return meta ? meta.content : ""
   }

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1513,11 +1513,43 @@ class AgentRun < ApplicationRecord
     return raw_stdout if raw_stdout.blank?
 
     response = parse_structured_stdout(raw_stdout)
-    return raw_stdout unless response
+    if response
+      return "Agent encountered an error: #{response.error}" if response.error.present?
 
-    return "Agent encountered an error: #{response.error}" if response.error.present?
+      return response.output.presence || raw_stdout
+    end
 
-    response.output.presence || raw_stdout
+    extract_text_from_multiline_json(raw_stdout) || raw_stdout
+  end
+
+  def extract_text_from_multiline_json(raw_stdout)
+    results = []
+    error_message = nil
+
+    raw_stdout.each_line do |line|
+      line = line.strip
+      next if line.empty?
+
+      begin
+        parsed = JSON.parse(line)
+      rescue JSON::ParserError
+        next
+      end
+
+      next unless parsed.is_a?(Hash)
+
+      if parsed["is_error"]
+        error_message ||= parsed["result"] || "Unknown error"
+      elsif parsed.key?("result")
+        text = parsed["result"].to_s.strip
+        results << text if text.present?
+      end
+    end
+
+    return "Agent encountered an error: #{error_message}" if error_message.present? && results.empty?
+    return nil if results.empty?
+
+    results.join("\n\n").presence
   end
 
   def parse_structured_stdout(raw_stdout)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -71,6 +71,7 @@ class AgentRun < ApplicationRecord
   MAX_STALE_REQUEUES = 2
   MAX_STALE_SKIPS = 3
   CLAIMED_SENTINEL = "claimed"
+  SMOKE_TEST_CUSTOM_PROMPT = "smoke_test"
   STALE_CLAIMED_TIMEOUT = 15.minutes
   STALE_PAUSED_TIMEOUT = 2.hours
   STALE_RUNNING_GRACE_PERIOD = 10.minutes

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -22,16 +22,20 @@ class Provider < ApplicationRecord
   # The opencode_npm / kilocode_api keys default to the openai-compatible
   # adapter and are overridden only for Anthropic.
   DIRECT_OUTBOUND_API_PROVIDERS = {
-    "openrouter" => { label: "OpenRouter", base_url: "https://openrouter.ai/api/v1", service_type: "openrouter" },
+    "openrouter" => { label: "OpenRouter", base_url: "https://openrouter.ai/api/v1", service_type: "openrouter",
+                      opencode_model_provider: "openrouter" },
     "anthropic" => { label: "Anthropic", base_url: "https://api.anthropic.com", service_type: "anthropic",
-                     opencode_npm: "@ai-sdk/anthropic", kilocode_api: "anthropic" },
-    "openai" => { label: "OpenAI", base_url: "https://api.openai.com/v1", service_type: "openai" },
-    "inception" => { label: "InceptionLabs", base_url: "https://api.inceptionlabs.ai/v1", service_type: "inception" },
+                     opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic" },
+    "openai" => { label: "OpenAI", base_url: "https://api.openai.com/v1", service_type: "openai",
+                  kilocode_provider_id: "openai" },
+    "inception" => { label: "InceptionLabs", base_url: "https://api.inceptionlabs.ai/v1", service_type: "inception",
+                     kilocode_provider_id: "inception" },
     "deepseek" => { label: "DeepSeek", base_url: "https://api.deepseek.com/v1", service_type: "deepseek" },
     "mistral" => { label: "Mistral", base_url: "https://api.mistral.ai/v1", service_type: "mistral" },
     "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai" },
     "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai" },
-    "zai_coding" => { label: "z.ai (Coding Plan)", base_url: "https://api.z.ai/api/coding/paas/v4", service_type: "zai_coding" }
+    "zai_coding" => { label: "z.ai (Coding Plan)", base_url: "https://api.z.ai/api/coding/paas/v4", service_type: "zai_coding",
+                      kilocode_provider_id: "zai-coding-plan" }
   }.freeze
 
   DIRECT_OUTBOUND_SERVICE_TYPES = DIRECT_OUTBOUND_API_PROVIDERS.values.map { |c| c[:service_type] }.to_set.freeze
@@ -198,21 +202,61 @@ class Provider < ApplicationRecord
     raise ArgumentError, "Missing KiloCode model id for provider #{id || provider_key}" if model_id.blank?
 
     api_config = DIRECT_OUTBOUND_API_PROVIDERS.fetch(kilocode_api_provider, DIRECT_OUTBOUND_API_PROVIDERS["anthropic"])
-    kilocode_provider_key = api_config[:kilocode_api] || "openai"
+    kilocode_provider_id = api_config[:kilocode_provider_id] || "openai-compatible"
+    options = { "apiKey" => "{env:#{kilocode_api_key_env_var}}" }
+    base_url = api_config[:base_url]
+    default_openai_url = DIRECT_OUTBOUND_API_PROVIDERS.dig("openai", :base_url)
+    options["baseURL"] = base_url if base_url.present? && base_url != default_openai_url
 
     {
-      provider: { kilocode_provider_key => {} },
-      model: kilocode_qualified_model(kilocode_provider_key, model_id)
+      provider: {
+        kilocode_provider_id => {
+          options: options,
+          models: {
+            model_id => {
+              name: model_id,
+              id: model_id,
+              tool_call: true
+            }
+          }
+        }
+      },
+      model: kilocode_qualified_model(kilocode_provider_id, model_id)
     }.to_json
   end
 
-  def kilocode_qualified_model(provider_key, model_id)
-    model_id.include?("/") ? model_id : "#{provider_key}/#{model_id}"
+  def kilocode_qualified_model(provider_id, model_id)
+    model_id.start_with?("#{provider_id}/") ? model_id : "#{provider_id}/#{model_id}"
+  end
+
+  def opencode_qualified_model
+    model_id = opencode_model_id
+    return if model_id.blank?
+
+    api_config = DIRECT_OUTBOUND_API_PROVIDERS.fetch(opencode_api_provider, DIRECT_OUTBOUND_API_PROVIDERS["openrouter"])
+    provider_id = api_config[:opencode_model_provider]
+    return model_id if provider_id.blank? || model_id.start_with?("#{provider_id}/")
+
+    "#{provider_id}/#{model_id}"
+  end
+
+  def kilocode_api_key_env_var
+    service_type = kilocode_required_api_service_type
+    return "OPENAI_API_KEY" if service_type.blank?
+
+    "#{service_type.upcase.tr('-', '_')}_API_KEY"
+  end
+
+  def kilocode_runtime_env
+    api_key = provider_api_key&.api_key.to_s
+    return {} if api_key.blank?
+
+    { kilocode_api_key_env_var => api_key }
   end
 
   def direct_outbound_exec_env
     if kilocode_direct_outbound?
-      { "PAID_KILOCODE_CONFIG_B64" => Base64.strict_encode64(kilocode_config_json) }
+      kilocode_runtime_env.merge("PAID_KILOCODE_CONFIG_B64" => Base64.strict_encode64(kilocode_config_json))
     else
       {}
     end
@@ -596,12 +640,13 @@ class Provider < ApplicationRecord
   end
 
   def opencode_provider_runtime
-    model_id = opencode_model_id
+    model_id = opencode_qualified_model
     raise ArgumentError, "Missing OpenCode model id for provider #{id || provider_key}" if model_id.blank?
 
     api_config = DIRECT_OUTBOUND_API_PROVIDERS.fetch(opencode_api_provider, DIRECT_OUTBOUND_API_PROVIDERS["openrouter"])
 
-    env = { "OPENAI_API_KEY" => provider_api_key&.api_key.to_s }
+    env_var = "#{api_config[:service_type].upcase.tr('-', '_')}_API_KEY"
+    env = { env_var => provider_api_key&.api_key.to_s }
     env["OPENAI_BASE_URL"] = api_config[:base_url] if api_config[:base_url]
 
     AgentHarness::ProviderRuntime.new(

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -2242,7 +2242,7 @@ module Containers
 
     def build_streaming_event_processor(command)
       return nil unless agent_run && streaming_event_command?(command)
-      return nil if agent_run.custom_prompt == "smoke_test"
+      return nil if agent_run.custom_prompt == AgentRun::SMOKE_TEST_CUSTOM_PROMPT
 
       StreamingEventProcessor.new(
         agent_run: agent_run,

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -2242,6 +2242,7 @@ module Containers
 
     def build_streaming_event_processor(command)
       return nil unless agent_run && streaming_event_command?(command)
+      return nil if agent_run.custom_prompt == "smoke_test"
 
       StreamingEventProcessor.new(
         agent_run: agent_run,

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -57,6 +57,7 @@ module Providers
       /ECONN/i
     ].freeze
     USER_FACING_ERROR_EXTRACTORS = [
+      /Model not found:.*?(?=\n|$)/i,
       /Free model usage limit reached\..*?(?="|\n|$)/i,
       /\[API Error: \{"error":"API key not configured for google"\}\]/i,
       /\[API Error: \{"error":"API key not configured for openai"\}\]/i,
@@ -212,13 +213,16 @@ module Providers
     def process_harness_result(result)
       status = result[:status].to_s
       message = normalize_output_text(result[:message]).presence || "Provider health check returned no message"
+      output = normalize_output_text(result[:output]).presence
 
-      if status == "ok"
+      if status == "ok" || smoke_test_output_success?(output || message)
         Result.new(success: true, error_type: nil, message: "Agent is healthy")
       else
-        error_type = map_harness_error_category(result[:error_category]) ||
-          classify_failed_response(message)
         translated_message = translate_and_extract_error(message)
+        error_type = resolve_error_type(
+          harness_error_type: map_harness_error_category(result[:error_category]),
+          message: translated_message.presence || message
+        )
 
         Result.new(
           success: false,
@@ -228,10 +232,23 @@ module Providers
       end
     end
 
+    def smoke_test_output_success?(text)
+      text.to_s.strip.match?(/\AOK[.!]?\z/i)
+    end
+
     def map_harness_error_category(category)
       return nil unless category
 
       HARNESS_ERROR_CATEGORY_MAP[category.to_sym]
+    end
+
+    def resolve_error_type(harness_error_type:, message:)
+      classified_error_type = classify_failed_response(message)
+      return :unexpected if message.match?(/Model not found:/i)
+      return classified_error_type if harness_error_type.nil? || harness_error_type == :unexpected
+      return classified_error_type if harness_error_type == :rate_limited && classified_error_type != :rate_limited
+
+      harness_error_type
     end
 
     # Builds a ProviderRuntime for container-based smoke tests.
@@ -240,12 +257,25 @@ module Providers
     # the provider's full runtime with env/base_url overrides. For kilocode
     # direct-outbound, this builds a runtime with the upstream API key env
     # (config file bootstrap is handled by prepare_kilocode_config!).
-    # For standard subscription-auth providers, this returns nil (the provider
-    # runs through the Paid proxy with inherited container env).
+    # For subscription-auth providers, this strips the Paid proxy credential
+    # env vars so the CLI uses its mounted local auth state, matching the
+    # behavior of RunAgentActivity.subscription_auth_command.
     def container_provider_runtime
       return kilocode_provider_runtime if kilocode_direct_outbound?
+      return subscription_provider_runtime if subscription_provider_runtime?
 
       provider.agent_harness_provider_runtime
+    end
+
+    def subscription_provider_runtime?
+      provider.subscription? &&
+        ProviderSupport.subscription_auth_unset_vars_for(provider.provider_key).any?
+    end
+
+    def subscription_provider_runtime
+      AgentHarness::ProviderRuntime.new(
+        unset_env: ProviderSupport.subscription_auth_unset_vars_for(provider.provider_key)
+      )
     end
 
     # Builds a ProviderRuntime for kilocode direct-outbound smoke tests.
@@ -253,32 +283,9 @@ module Providers
     # Kilocode reads its model/provider config from ~/.config/kilo/config.json
     # (materialized by prepare_kilocode_config!) and picks up the upstream API
     # key from environment variables. This runtime passes the API key through
-    # the correct env var for the configured upstream provider.
+    # the env var referenced by the generated config.
     def kilocode_provider_runtime
-      api_key = provider.provider_api_key&.api_key.to_s
-      api_provider = provider.kilocode_api_provider
-      api_config = Provider::DIRECT_OUTBOUND_API_PROVIDERS.fetch(
-        api_provider, Provider::DIRECT_OUTBOUND_API_PROVIDERS["anthropic"]
-      )
-
-      env_var = if api_config[:kilocode_api] && api_config[:kilocode_api] != "openai-compatible"
-        "#{api_provider.upcase}_API_KEY"
-      else
-        "OPENAI_API_KEY"
-      end
-
-      env = { env_var => api_key }
-      base_url = api_config[:base_url]
-      if base_url && !api_config[:kilocode_api]
-        default_openai_url = Provider::DIRECT_OUTBOUND_API_PROVIDERS.dig("openai", :base_url)
-        env["OPENAI_BASE_URL"] = base_url if base_url != default_openai_url
-      end
-
-      AgentHarness::ProviderRuntime.new(
-        model: provider.kilocode_model_id,
-        api_provider: api_provider,
-        env: env
-      )
+      AgentHarness::ProviderRuntime.new(env: provider.kilocode_runtime_env)
     end
 
     def kilocode_direct_outbound?

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -323,7 +323,7 @@ module Providers
           temporal_workflow_id: AgentRun::CLAIMED_SENTINEL,
           goal: "create_pr",
           trigger_type: "manual",
-          custom_prompt: "smoke_test",
+          custom_prompt: AgentRun::SMOKE_TEST_CUSTOM_PROMPT,
           proxy_token: SecureRandom.hex(32),
           created_at: now,
           updated_at: now

--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -35,7 +35,11 @@
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white">
         <% @providers.each do |provider| %>
-          <tr data-controller="test-agent" data-test-agent-url-value="<%= test_agent_provider_path(provider) %>">
+          <tr
+            data-controller="test-agent"
+            data-test-agent-url-value="<%= test_agent_provider_path(provider) %>"
+            data-test-agent-csrf-token-value="<%= form_authenticity_token %>"
+          >
             <td class="px-4 py-3 text-sm font-medium text-gray-900">
               <%= provider.display_name %>
             </td>

--- a/bin/provider-smoke
+++ b/bin/provider-smoke
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "shellwords"
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+
+require "bundler/setup"
+require_relative "../config/environment"
+require_relative "../spec/support/provider_smoke_helpers"
+
+def usage
+  puts <<~USAGE
+    Usage:
+      bin/provider-smoke
+      bin/provider-smoke list
+      bin/provider-smoke service [SCENARIO_OR_PRESET...]
+      bin/provider-smoke ui [SCENARIO_OR_PRESET...]
+      bin/provider-smoke all [SCENARIO_OR_PRESET...]
+
+    Defaults:
+      `bin/provider-smoke` runs the service smoke matrix for the `current-enabled` preset.
+
+    Presets:
+  USAGE
+
+  ProviderSmokeHelpers::PRESETS.each do |name, scenarios|
+    puts "      #{name}: #{scenarios.join(', ')}"
+  end
+
+  puts "    Scenarios:"
+  ProviderSmokeHelpers::SCENARIOS.each_value do |scenario|
+    detail = if scenario.api_key?
+      default_model = scenario.default_model ? ", default model: #{scenario.default_model}" : ""
+      "#{scenario.provider_key} via #{scenario.api_provider} (model env: #{scenario.model_env}#{default_model})"
+    else
+      "#{scenario.provider_key} subscription"
+    end
+    puts "      #{scenario.name}: #{detail}"
+  end
+end
+
+def expand_targets(targets)
+  selected = targets.presence || [ "current-enabled" ]
+  selected.flat_map { |name| ProviderSmokeHelpers.expand_name(name) }
+end
+
+def validate_targets!(targets)
+  unknown = targets.reject do |name|
+    ProviderSmokeHelpers::PRESETS.key?(name) || ProviderSmokeHelpers::SCENARIOS.key?(name)
+  end
+  return if unknown.empty?
+
+  warn "Unknown provider smoke target(s): #{unknown.join(', ')}"
+  usage
+  exit 1
+end
+
+def run_rspec!(spec_paths:, scenario_names:)
+  env = {
+    "RUN_PROVIDER_SMOKE" => "true",
+    "COVERAGE" => "false",
+    "PAID_SMOKE_SCENARIOS" => scenario_names.join(",")
+  }
+  command = [ "bundle", "exec", "rspec", *spec_paths ]
+
+  puts "Running #{Shellwords.join(command)}"
+  puts "PAID_SMOKE_SCENARIOS=#{env.fetch('PAID_SMOKE_SCENARIOS')}"
+
+  success = system(env, *command)
+  exit($CHILD_STATUS.exitstatus || 1) unless success
+end
+
+command = ARGV.shift || "service"
+targets = ARGV
+
+case command
+when "list", "--help", "-h", "help"
+  usage
+when "service"
+  validate_targets!(targets)
+  run_rspec!(
+    spec_paths: [ "spec/services/providers/test_agent_local_smoke_spec.rb" ],
+    scenario_names: expand_targets(targets)
+  )
+when "ui"
+  validate_targets!(targets)
+  run_rspec!(
+    spec_paths: [ "spec/system/providers/provider_smoke_spec.rb" ],
+    scenario_names: expand_targets(targets)
+  )
+when "all"
+  validate_targets!(targets)
+  scenario_names = expand_targets(targets)
+  run_rspec!(
+    spec_paths: [
+      "spec/services/providers/test_agent_local_smoke_spec.rb",
+      "spec/system/providers/provider_smoke_spec.rb"
+    ],
+    scenario_names: scenario_names
+  )
+else
+  warn "Unknown command: #{command}"
+  usage
+  exit 1
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,7 +174,7 @@ Rails.application.routes.draw do
   namespace :api do
     get "metrics", to: "metrics#show"
     match "proxy/anthropic/*path", to: "secrets_proxy#anthropic", via: :post, format: false
-    match "proxy/openai/*path", to: "secrets_proxy#openai", via: :post, format: false
+    match "proxy/openai/*path", to: "secrets_proxy#openai", via: [ :get, :post ], format: false
     match "proxy/google/*path", to: "secrets_proxy#google", via: :post, format: false
     match "proxy/github/*path", to: "github_proxy#proxy", via: [ :get, :post, :patch ], format: false
     get "proxy/knowledge/search", to: "proxy/knowledge_search#search"

--- a/spec/lib/provider_smoke_helpers_spec.rb
+++ b/spec/lib/provider_smoke_helpers_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProviderSmokeHelpers do
+  around do |example|
+    original = ENV["PAID_SMOKE_SCENARIOS"]
+    example.run
+  ensure
+    original ? ENV["PAID_SMOKE_SCENARIOS"] = original : ENV.delete("PAID_SMOKE_SCENARIOS")
+  end
+
+  describe ".scenario_names_from_env" do
+    it "defaults to the current-enabled preset" do
+      ENV.delete("PAID_SMOKE_SCENARIOS")
+
+      expect(described_class.scenario_names_from_env).to eq(%w[
+        claude-subscription
+        codex-subscription
+        kilocode-zai
+        opencode-openrouter
+        kilocode-inception
+      ])
+    end
+
+    it "expands preset names from the environment" do
+      ENV["PAID_SMOKE_SCENARIOS"] = "current-enabled"
+
+      expect(described_class.scenario_names_from_env).to eq(described_class::PRESETS.fetch("current-enabled"))
+    end
+
+    it "preserves duplicate scenario names for distinct matrix entries" do
+      ENV["PAID_SMOKE_SCENARIOS"] = "kilocode-zai,kilocode-inception"
+
+      expect(described_class.scenario_names_from_env).to eq(%w[kilocode-zai kilocode-inception])
+    end
+  end
+
+  describe ".scenario_for" do
+    it "includes the expected built-in default models for current enabled api-key scenarios" do
+      expect(described_class.scenario_for("kilocode-zai").default_model).to eq("glm-5.1")
+      expect(described_class.scenario_for("opencode-openrouter").default_model).to eq("moonshotai/kimi-k2")
+      expect(described_class.scenario_for("kilocode-inception").default_model).to eq("mercury-2")
+    end
+
+    it "raises a helpful error for unknown names" do
+      expect { described_class.scenario_for("unknown-provider") }
+        .to raise_error(ProviderSmokeHelpers::ScenarioUnavailableError, /Unknown provider smoke scenario/)
+    end
+  end
+
+  describe ".build_direct_outbound_provider!" do
+    let(:account) { create(:account, slug: "provider-smoke-helpers-account") }
+    let(:user) { create(:user, account: account, email: "provider-smoke-helpers@example.com") }
+    let(:scenario) { described_class.scenario_for("opencode-openrouter") }
+
+    it "prefers the scenario default model over the development-db fallback model" do
+      allow(described_class).to receive(:development_provider_info_for).with(scenario).and_return(
+        { "model" => "moonshotai/kimi-k2-0905", "api_key" => "sk-test" }
+      )
+
+      provider = described_class.build_direct_outbound_provider!(user: user, scenario: scenario)
+
+      expect(provider.opencode_model_id).to eq("moonshotai/kimi-k2")
+    end
+  end
+end

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2797,6 +2797,16 @@ RSpec.describe AgentRun do
       expect(agent_run.agent_summary).to eq(events)
       expect(parsed_inputs).not_to include(stale_line)
     end
+
+    it "extracts result text from multi-line Claude CLI JSON output" do
+      r1 = { type: "result", subtype: "success", is_error: false,
+             result: "OK", duration_ms: 2769, total_cost_usd: 0.06 }
+      r2 = { type: "result", subtype: "success", is_error: false,
+             result: "All done. The commit succeeded.", duration_ms: 830592, total_cost_usd: 0.74 }
+      agent_run.log!("stdout", [ r1, r2 ].map(&:to_json).join("\n"))
+
+      expect(agent_run.agent_summary).to eq("OK\n\nAll done. The commit succeeded.")
+    end
   end
 
   describe "#current_phase_group" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "securerandom"
 
 RSpec.describe Provider do
   describe "associations" do
@@ -199,8 +200,9 @@ RSpec.describe Provider do
     end
 
     it "prevents duplicate subscription entries for the same user and provider_key" do
-      create(:provider, user: provider.user, provider_key: "cursor", auth_type: "subscription")
-      duplicate = build(:provider, user: provider.user, provider_key: "cursor", auth_type: "subscription")
+      user = create(:user)
+      create(:provider, user: user, provider_key: "cursor", auth_type: "subscription")
+      duplicate = build(:provider, user: user, provider_key: "cursor", auth_type: "subscription")
 
       expect(duplicate).not_to be_valid
       expect(duplicate.errors[:provider_key]).to include("already has a subscription entry")
@@ -473,7 +475,8 @@ RSpec.describe Provider do
   end
 
   describe "KiloCode config generation" do
-    let(:user) { create(:user) }
+    let(:account) { create(:account, slug: "provider-kilocode-#{SecureRandom.hex(6)}") }
+    let(:user) { create(:user, account: account, email: "provider-kilocode-#{SecureRandom.hex(6)}@example.com") }
     let(:api_key) { create(:provider_api_key, user: user, api_service_type: "anthropic") }
     let(:provider) do
       create(
@@ -489,7 +492,21 @@ RSpec.describe Provider do
     it "generates provider as a record with prefixed model" do
       config = JSON.parse(provider.kilocode_config_json)
 
-      expect(config["provider"]).to eq({ "anthropic" => {} })
+      expect(config["provider"]).to eq({
+        "anthropic" => {
+          "options" => {
+            "apiKey" => "{env:ANTHROPIC_API_KEY}",
+            "baseURL" => "https://api.anthropic.com"
+          },
+          "models" => {
+            "claude-sonnet-4-20250514" => {
+              "name" => "claude-sonnet-4-20250514",
+              "id" => "claude-sonnet-4-20250514",
+              "tool_call" => true
+            }
+          }
+        }
+      })
       expect(config["model"]).to eq("anthropic/claude-sonnet-4-20250514")
     end
 
@@ -501,7 +518,7 @@ RSpec.describe Provider do
       expect(config["model"]).to eq("anthropic/claude-opus-4")
     end
 
-    it "uses openai as default provider key for OpenAI-compatible backends" do
+    it "uses the native zai-coding-plan provider id for z.ai coding plan backends" do
       zai_key = create(:provider_api_key, user: user, api_service_type: "zai_coding")
       provider.update!(
         provider_api_key: zai_key,
@@ -510,8 +527,22 @@ RSpec.describe Provider do
 
       config = JSON.parse(provider.kilocode_config_json)
 
-      expect(config["provider"]).to eq({ "openai" => {} })
-      expect(config["model"]).to eq("openai/glm-5.1")
+      expect(config["provider"]).to eq({
+        "zai-coding-plan" => {
+          "options" => {
+            "apiKey" => "{env:ZAI_CODING_API_KEY}",
+            "baseURL" => "https://api.z.ai/api/coding/paas/v4"
+          },
+          "models" => {
+            "glm-5.1" => {
+              "name" => "glm-5.1",
+              "id" => "glm-5.1",
+              "tool_call" => true
+            }
+          }
+        }
+      })
+      expect(config["model"]).to eq("zai-coding-plan/glm-5.1")
     end
   end
 
@@ -532,11 +563,11 @@ RSpec.describe Provider do
     it "builds provider runtime inputs instead of a local bootstrap wrapper" do
       runtime = provider.agent_harness_provider_runtime
 
-      expect(runtime.model).to eq("moonshotai/kimi-k2-0905")
+      expect(runtime.model).to eq("openrouter/moonshotai/kimi-k2-0905")
       expect(runtime.api_provider).to be_nil
       expect(runtime.base_url).to be_nil
       expect(runtime.env).to include(
-        "OPENAI_API_KEY" => "sk-openrouter-secret",
+        "OPENROUTER_API_KEY" => "sk-openrouter-secret",
         "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1"
       )
       expect(runtime.unset_env).to include("OPENAI_HEADER_X_AGENT_RUN_ID", "OPENAI_HEADER_X_PROXY_TOKEN")

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -488,6 +488,20 @@ RSpec.describe Provider do
         config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-20250514" } }
       )
     end
+    let(:expected_kilocode_model_entry) do
+      {
+        "name" => "claude-sonnet-4-20250514",
+        "id" => "claude-sonnet-4-20250514",
+        "tool_call" => true
+      }
+    end
+    let(:expected_zai_model_entry) do
+      {
+        "name" => "glm-5.1",
+        "id" => "glm-5.1",
+        "tool_call" => true
+      }
+    end
 
     it "generates provider as a record with prefixed model" do
       config = JSON.parse(provider.kilocode_config_json)
@@ -499,11 +513,7 @@ RSpec.describe Provider do
             "baseURL" => "https://api.anthropic.com"
           },
           "models" => {
-            "claude-sonnet-4-20250514" => {
-              "name" => "claude-sonnet-4-20250514",
-              "id" => "claude-sonnet-4-20250514",
-              "tool_call" => true
-            }
+            "claude-sonnet-4-20250514" => expected_kilocode_model_entry
           }
         }
       })
@@ -534,11 +544,7 @@ RSpec.describe Provider do
             "baseURL" => "https://api.z.ai/api/coding/paas/v4"
           },
           "models" => {
-            "glm-5.1" => {
-              "name" => "glm-5.1",
-              "id" => "glm-5.1",
-              "tool_call" => true
-            }
+            "glm-5.1" => expected_zai_model_entry
           }
         }
       })

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,10 @@ rescue ActiveRecord::ConnectionNotEstablished => e
 end
 
 RSpec.configure do |config|
+  if ENV["CI"].present? || ENV["GITHUB_ACTIONS"].present?
+    config.filter_run_excluding local_only: true
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [ Rails.root.join("spec/fixtures") ]
 
@@ -75,6 +79,23 @@ RSpec.configure do |config|
   # Reset memoized provider support data between tests
   config.after do
     ProviderSupport.reset_supported_provider_keys!
+  end
+
+  config.before(:each, :provider_smoke) do
+    next if ENV["RUN_PROVIDER_SMOKE"] == "true"
+
+    skip "Set RUN_PROVIDER_SMOKE=true to run local provider smoke specs"
+  end
+
+  config.around(:each, :provider_smoke) do |example|
+    # Provider smoke specs intentionally exercise the real Docker/container and
+    # provider auth paths, which use Excon over the local Docker Unix socket and
+    # may also reach upstream provider APIs. Allow real connections only for
+    # these explicitly opt-in local specs, then restore the repo default.
+    WebMock.allow_net_connect!
+    example.run
+  ensure
+    WebMock.disable_net_connect!(allow_localhost: true)
   end
 
   config.around do |example|

--- a/spec/services/providers/harness_execution_plan_spec.rb
+++ b/spec/services/providers/harness_execution_plan_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "securerandom"
 
 RSpec.describe Providers::HarnessExecutionPlan do
   describe ".for_provider_key" do
@@ -30,7 +31,11 @@ RSpec.describe Providers::HarnessExecutionPlan do
 
   describe ".call" do
     it "builds the OpenCode execution contract through agent-harness" do
-      user = create(:user)
+      user = create(
+        :user,
+        email: "harness-execution-plan-#{SecureRandom.hex(6)}@example.com",
+        account: create(:account, slug: "harness-execution-plan-#{SecureRandom.hex(6)}")
+      )
       api_key = create(:provider_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret")
       provider = create(
         :provider,
@@ -45,13 +50,17 @@ RSpec.describe Providers::HarnessExecutionPlan do
 
       expect(plan.command).to eq(%w[opencode run ping])
       expect(plan.env).to include(
-        "OPENAI_API_KEY" => "sk-openrouter-secret",
+        "OPENROUTER_API_KEY" => "sk-openrouter-secret",
         "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1"
       )
     end
 
     it "writes opencode.json with provider as record, not string" do
-      user = create(:user)
+      user = create(
+        :user,
+        email: "harness-execution-plan-#{SecureRandom.hex(6)}@example.com",
+        account: create(:account, slug: "harness-execution-plan-#{SecureRandom.hex(6)}")
+      )
       api_key = create(:provider_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret")
       provider = create(
         :provider,
@@ -67,7 +76,7 @@ RSpec.describe Providers::HarnessExecutionPlan do
       expect(plan.preparation.file_writes.first.path).to eq("~/.config/opencode/opencode.json")
       parsed = JSON.parse(plan.preparation.file_writes.first.content)
       expect(parsed["provider"]).to eq({ "openrouter" => {} })
-      expect(parsed["model"]).to eq("moonshotai/kimi-k2-0905")
+      expect(parsed["model"]).to eq("openrouter/moonshotai/kimi-k2-0905")
       expect(parsed).not_to have_key("baseURL")
     end
 

--- a/spec/services/providers/test_agent_local_smoke_spec.rb
+++ b/spec/services/providers/test_agent_local_smoke_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "securerandom"
+
+RSpec.describe Providers::TestAgent, :local_only, :provider_smoke do
+  ProviderSmokeHelpers.scenarios_from_env.each do |scenario|
+    it "passes the real smoke test for #{scenario.label}" do
+      unique_suffix = SecureRandom.hex(6)
+      account = create(:account, slug: "provider-smoke-local-#{unique_suffix}")
+      user = create(:user, :owner, account: account, email: "provider-smoke-local-#{unique_suffix}@example.com")
+      ProviderSmokeHelpers.create_smoke_project!(user: user)
+      provider = ProviderSmokeHelpers.build_provider!(user: user, scenario: scenario)
+
+      result = described_class.call(provider: provider)
+
+      expect(result).to be_success, "#{scenario.name} smoke test failed: #{result.error_type} - #{result.message}"
+    rescue ProviderSmokeHelpers::ScenarioUnavailableError => e
+      skip e.message
+    end
+  end
+end

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "securerandom"
 
 RSpec.describe Providers::TestAgent do
   # Clear provider API keys that control harness-vs-container path selection
@@ -15,8 +16,8 @@ RSpec.describe Providers::TestAgent do
     original_google ? ENV["GOOGLE_API_KEY"] = original_google : ENV.delete("GOOGLE_API_KEY")
   end
 
-  let(:account) { create(:account) }
-  let(:user) { create(:user, account: account) }
+  let(:account) { create(:account, slug: "providers-test-agent-#{SecureRandom.hex(6)}") }
+  let(:user) { create(:user, account: account, email: "providers-test-agent-#{SecureRandom.hex(6)}@example.com") }
   let(:github_token) { create(:github_token, account: account, created_by: user) }
   let!(:project) { create(:project, account: account, github_token: github_token, created_by: user) }
   let(:provider_record) { user.providers.find_or_create_by!(provider_key: "claude") }
@@ -76,8 +77,28 @@ RSpec.describe Providers::TestAgent do
           :claude,
           timeout: 60,
           executor: an_instance_of(Containers::HarnessExecutor),
-          provider_runtime: nil
+          provider_runtime: an_instance_of(AgentHarness::ProviderRuntime)
         )
+      end
+    end
+
+    context "when a provider returns the smoke-test success text with trailing punctuation" do
+      let(:provider_record) { user.providers.find_or_create_by!(provider_key: "kilocode").tap { |p| p.update!(enabled_for_agent_runs: true, enabled_for_fallback: false) } }
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode, status: "error", message: "OK.", output: "OK.",
+          latency_ms: 10, error_category: nil, check: :smoke_test
+        )
+      end
+
+      it "treats the result as a successful smoke test" do
+        result = described_class.call(provider: provider)
+
+        expect(result).to be_success
+        expect(result.message).to eq("Agent is healthy")
       end
     end
 
@@ -330,7 +351,7 @@ RSpec.describe Providers::TestAgent do
           :codex,
           timeout: 60,
           executor: an_instance_of(Containers::HarnessExecutor),
-          provider_runtime: nil
+          provider_runtime: an_instance_of(AgentHarness::ProviderRuntime)
         )
       end
     end
@@ -631,7 +652,21 @@ RSpec.describe Providers::TestAgent do
         expect(captured_env).to include("KILOCODE_CONFIG_B64")
         config = JSON.parse(Base64.strict_decode64(captured_env["KILOCODE_CONFIG_B64"]))
         expect(config).to eq({
-          "provider" => { "anthropic" => {} },
+          "provider" => {
+            "anthropic" => {
+              "options" => {
+                "apiKey" => "{env:ANTHROPIC_API_KEY}",
+                "baseURL" => "https://api.anthropic.com"
+              },
+              "models" => {
+                "claude-sonnet-4-20250514" => {
+                  "name" => "claude-sonnet-4-20250514",
+                  "id" => "claude-sonnet-4-20250514",
+                  "tool_call" => true
+                }
+              }
+            }
+          },
           "model" => "anthropic/claude-sonnet-4-20250514"
         })
       end
@@ -879,7 +914,7 @@ RSpec.describe Providers::TestAgent do
       it "prefers the harness-classified error category over pattern matching" do
         stub_container_smoke_test(
           name: :gemini, status: "error",
-          message: "Process exited abnormally",
+          message: "Rate limit exceeded. Retry after 60",
           latency_ms: 10, error_category: :rate_limited, check: :smoke_test
         )
 
@@ -887,6 +922,31 @@ RSpec.describe Providers::TestAgent do
 
         expect(result).not_to be_success
         expect(result.error_type).to eq(:rate_limited)
+      end
+    end
+
+    context "when the harness marks a noisy provider failure as rate limited" do
+      let(:provider_record) { create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode,
+          status: "error",
+          message: "Performing one time database migration, may take a few minutes...\nModel not found: openai/glm-5.1.",
+          latency_ms: 10,
+          error_category: :rate_limited,
+          check: :smoke_test
+        )
+      end
+
+      it "uses the extracted provider failure instead of the noisy rate-limit classification" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:unexpected)
+        expect(result.message).to eq("Model not found: openai/glm-5.1.")
       end
     end
 
@@ -974,6 +1034,9 @@ RSpec.describe Providers::TestAgent do
   end
 
   describe "#rate_limit_reset_at" do
+    let(:account) { create(:account, slug: "test-agent-rate-limit-reset-account") }
+    let(:user) { create(:user, account: account, email: "test-agent-rate-limit-reset@example.com") }
+
     before do
       allow(ProviderSupport).to receive(:harness_provider_key_for).with("claude").and_return("claude")
     end

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -50,6 +50,31 @@ RSpec.describe Providers::TestAgent do
     allow(AgentHarness).to receive(:check_provider).and_return(harness_result)
   end
 
+  def decoded_kilocode_config(encoded_config)
+    JSON.parse(Base64.strict_decode64(encoded_config))
+  end
+
+  def expected_anthropic_kilocode_config
+    {
+      "provider" => {
+        "anthropic" => {
+          "options" => {
+            "apiKey" => "{env:ANTHROPIC_API_KEY}",
+            "baseURL" => "https://api.anthropic.com"
+          },
+          "models" => {
+            "claude-sonnet-4-20250514" => {
+              "name" => "claude-sonnet-4-20250514",
+              "id" => "claude-sonnet-4-20250514",
+              "tool_call" => true
+            }
+          }
+        }
+      },
+      "model" => "anthropic/claude-sonnet-4-20250514"
+    }
+  end
+
   describe ".call" do
     context "when claude smoke test succeeds via container" do
       let(:provider_record) { user.providers.find_or_create_by!(provider_key: "claude").tap { |p| p.update!(enabled_for_agent_runs: true, enabled_for_fallback: false) } }
@@ -650,25 +675,7 @@ RSpec.describe Providers::TestAgent do
         described_class.call(provider: provider)
 
         expect(captured_env).to include("KILOCODE_CONFIG_B64")
-        config = JSON.parse(Base64.strict_decode64(captured_env["KILOCODE_CONFIG_B64"]))
-        expect(config).to eq({
-          "provider" => {
-            "anthropic" => {
-              "options" => {
-                "apiKey" => "{env:ANTHROPIC_API_KEY}",
-                "baseURL" => "https://api.anthropic.com"
-              },
-              "models" => {
-                "claude-sonnet-4-20250514" => {
-                  "name" => "claude-sonnet-4-20250514",
-                  "id" => "claude-sonnet-4-20250514",
-                  "tool_call" => true
-                }
-              }
-            }
-          },
-          "model" => "anthropic/claude-sonnet-4-20250514"
-        })
+        expect(decoded_kilocode_config(captured_env["KILOCODE_CONFIG_B64"])).to eq(expected_anthropic_kilocode_config)
       end
     end
 

--- a/spec/support/provider_smoke_helpers.rb
+++ b/spec/support/provider_smoke_helpers.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+
+module ProviderSmokeHelpers
+  Scenario = Struct.new(
+    :name,
+    :provider_key,
+    :auth_type,
+    :api_provider,
+    :model_env,
+    :default_model,
+    :label,
+    keyword_init: true
+  ) do
+    def subscription?
+      auth_type == "subscription"
+    end
+
+    def api_key?
+      auth_type == "api_key"
+    end
+  end
+
+  ScenarioUnavailableError = Class.new(StandardError)
+
+  SERVICE_TYPE_ENV_VARS = {
+    "anthropic" => "ANTHROPIC_API_KEY",
+    "openai" => "OPENAI_API_KEY",
+    "openrouter" => "OPENROUTER_API_KEY",
+    "google" => "GOOGLE_API_KEY",
+    "inception" => "INCEPTION_API_KEY",
+    "deepseek" => "DEEPSEEK_API_KEY",
+    "mistral" => "MISTRAL_API_KEY",
+    "xai" => "XAI_API_KEY",
+    "zai" => "ZAI_API_KEY",
+    "zai_coding" => "ZAI_CODING_API_KEY"
+  }.freeze
+  DEFAULT_SCENARIO_NAMES = %w[
+    claude-subscription
+    codex-subscription
+    kilocode-zai
+    opencode-openrouter
+    kilocode-inception
+  ].freeze
+  SCENARIOS = {
+    "claude-subscription" => Scenario.new(
+      name: "claude-subscription",
+      provider_key: "claude",
+      auth_type: "subscription",
+      label: "Claude subscription"
+    ),
+    "cursor-subscription" => Scenario.new(
+      name: "cursor-subscription",
+      provider_key: "cursor",
+      auth_type: "subscription",
+      label: "Cursor subscription"
+    ),
+    "codex-subscription" => Scenario.new(
+      name: "codex-subscription",
+      provider_key: "codex",
+      auth_type: "subscription",
+      label: "Codex subscription"
+    ),
+    "gemini-subscription" => Scenario.new(
+      name: "gemini-subscription",
+      provider_key: "gemini",
+      auth_type: "subscription",
+      label: "Gemini subscription"
+    ),
+    "aider-subscription" => Scenario.new(
+      name: "aider-subscription",
+      provider_key: "aider",
+      auth_type: "subscription",
+      label: "Aider subscription"
+    ),
+    "opencode-openrouter" => Scenario.new(
+      name: "opencode-openrouter",
+      provider_key: "opencode",
+      auth_type: "api_key",
+      api_provider: "openrouter",
+      model_env: "PAID_SMOKE_OPENCODE_OPENROUTER_MODEL",
+      default_model: "moonshotai/kimi-k2",
+      label: "OpenCode with OpenRouter API key"
+    ),
+    "kilocode-zai" => Scenario.new(
+      name: "kilocode-zai",
+      provider_key: "kilocode",
+      auth_type: "api_key",
+      api_provider: "zai_coding",
+      model_env: "PAID_SMOKE_KILOCODE_ZAI_MODEL",
+      default_model: "glm-5.1",
+      label: "KiloCode with z.ai API key"
+    ),
+    "kilocode-inception" => Scenario.new(
+      name: "kilocode-inception",
+      provider_key: "kilocode",
+      auth_type: "api_key",
+      api_provider: "inception",
+      model_env: "PAID_SMOKE_KILOCODE_INCEPTION_MODEL",
+      default_model: "mercury-2",
+      label: "KiloCode with Inception API key"
+    )
+  }.freeze
+  PRESETS = {
+    "current-enabled" => DEFAULT_SCENARIO_NAMES,
+    "all-scenarios" => SCENARIOS.keys
+  }.freeze
+
+  module_function
+
+  def scenario_names_from_env
+    configured = ENV["PAID_SMOKE_SCENARIOS"].to_s.split(",").map(&:strip).reject(&:blank?)
+    (configured.presence || DEFAULT_SCENARIO_NAMES).flat_map { |name| expand_name(name) }
+  end
+
+  def scenarios_from_env
+    scenario_names_from_env.map { |name| scenario_for(name) }
+  end
+
+  def scenario_for(name)
+    SCENARIOS.fetch(name)
+  rescue KeyError
+    raise ScenarioUnavailableError, "Unknown provider smoke scenario #{name.inspect}"
+  end
+
+  def expand_name(name)
+    PRESETS.fetch(name, [ name ])
+  end
+
+  def build_provider!(user:, scenario:)
+    unless ProviderSupport.container_executable_provider_key?(scenario.provider_key)
+      raise ScenarioUnavailableError,
+        "#{scenario.label} is not runnable because #{scenario.provider_key} is not installed in the agent container"
+    end
+
+    if scenario.subscription?
+      build_subscription_provider!(user: user, scenario: scenario)
+    else
+      build_direct_outbound_provider!(user: user, scenario: scenario)
+    end
+  end
+
+  def build_subscription_provider!(user:, scenario:)
+    user.providers.find_or_create_by!(provider_key: scenario.provider_key, auth_type: "subscription").tap do |provider|
+      provider.update!(
+        enabled_for_agent_runs: true,
+        enabled_for_fallback: provider.enabled_for_fallback?
+      )
+    end
+  end
+
+  def build_direct_outbound_provider!(user:, scenario:)
+    service_type = Provider::DIRECT_OUTBOUND_API_PROVIDERS.dig(scenario.api_provider, :service_type)
+    if service_type.blank?
+      raise ScenarioUnavailableError,
+        "Unsupported #{scenario.provider_key} api provider #{scenario.api_provider.inspect} for #{scenario.label}"
+    end
+
+    dev_provider = development_provider_info_for(scenario)
+    model_id = ENV[scenario.model_env].to_s.strip.presence ||
+      scenario.default_model.presence ||
+      dev_provider&.fetch("model", nil).to_s.presence
+    if model_id.blank?
+      raise ScenarioUnavailableError, "Set #{scenario.model_env} to run #{scenario.label}"
+    end
+
+    api_key = api_key_for_service_type(service_type, scenario: scenario, development_provider: dev_provider)
+    if api_key.blank?
+      raise ScenarioUnavailableError,
+        "Set #{SERVICE_TYPE_ENV_VARS.fetch(service_type)} or create a matching provider/api key in the development DB to run #{scenario.label}"
+    end
+
+    provider_api_key = FactoryBot.create(
+      :provider_api_key,
+      user: user,
+      api_service_type: service_type,
+      api_key: api_key,
+      name: "#{scenario.name} key"
+    )
+
+    provider = user.providers.api_key.find_or_initialize_by(
+      provider_key: scenario.provider_key,
+      provider_api_key: provider_api_key,
+      name: scenario.label
+    )
+    provider.assign_attributes(
+      enabled_for_agent_runs: true,
+      enabled_for_fallback: false,
+      config: {
+        scenario.provider_key => {
+          "api_provider" => scenario.api_provider,
+          "model" => model_id
+        }
+      }
+    )
+    provider.save!
+    provider
+  end
+
+  def api_key_for_service_type(service_type, scenario:, development_provider: nil)
+    env_var = SERVICE_TYPE_ENV_VARS.fetch(service_type)
+    ENV[env_var].to_s.strip.presence ||
+      development_provider&.fetch("api_key", nil).to_s.strip.presence
+  end
+
+  def create_smoke_project!(user:)
+    account = user.account
+    github_token = FactoryBot.create(:github_token, account: account, created_by: user)
+    FactoryBot.create(:project, account: account, created_by: user, github_token: github_token)
+  end
+
+  def development_provider_info_for(scenario)
+    @development_provider_info_cache ||= {}
+    return @development_provider_info_cache[scenario.name] if @development_provider_info_cache.key?(scenario.name)
+
+    service_type = Provider::DIRECT_OUTBOUND_API_PROVIDERS.dig(scenario.api_provider, :service_type)
+    desired_model = ENV[scenario.model_env].to_s.strip.presence || scenario.default_model
+    payload = {
+      provider_key: scenario.provider_key,
+      auth_type: scenario.auth_type,
+      api_provider: scenario.api_provider,
+      service_type: service_type,
+      desired_model: desired_model
+    }
+    runner_script = <<~'RUBY'
+      require "json"
+
+      scenario = JSON.parse(ENV.fetch("PAID_SMOKE_SCENARIO_JSON"))
+
+      result = TenantContext.with_system_access do
+        candidates = Provider.includes(:provider_api_key)
+          .where(provider_key: scenario.fetch("provider_key"), auth_type: scenario.fetch("auth_type"))
+          .select do |provider|
+            next false unless provider.provider_api_key&.api_service_type == scenario.fetch("service_type")
+
+            config = provider.config.is_a?(Hash) ? provider.config.fetch(scenario.fetch("provider_key"), {}) : {}
+            config["api_provider"].to_s == scenario.fetch("api_provider")
+          end
+
+        if candidates.empty?
+          { found: false }
+        else
+          desired = scenario["desired_model"].to_s
+          exact = desired.present? ? candidates.select { |provider|
+            config = provider.config.is_a?(Hash) ? provider.config.fetch(scenario.fetch("provider_key"), {}) : {}
+            config["model"].to_s == desired
+          } : []
+          chosen = exact.one? ? exact.first : candidates.first
+          config = chosen.config.is_a?(Hash) ? chosen.config.fetch(scenario.fetch("provider_key"), {}) : {}
+
+          {
+            found: true,
+            provider_name: chosen.name,
+            api_key_name: chosen.provider_api_key&.name,
+            api_key: chosen.provider_api_key&.api_key,
+            model: config["model"],
+            candidate_names: candidates.map { |provider| provider.name.presence || "provider ##{provider.id}" }
+          }
+        end
+      end
+
+      puts JSON.generate(result)
+    RUBY
+
+    stdout, _stderr, status = Open3.capture3(
+      {
+        "RAILS_ENV" => "development",
+        "PAID_SMOKE_SCENARIO_JSON" => JSON.generate(payload)
+      },
+      "bundle", "exec", "rails", "runner", runner_script
+    )
+
+    return @development_provider_info_cache[scenario.name] = nil unless status.success?
+
+    parsed = JSON.parse(stdout.lines.last.to_s)
+    return @development_provider_info_cache[scenario.name] = nil unless parsed["found"]
+
+    if parsed["candidate_names"].is_a?(Array) && parsed["candidate_names"].uniq.many? && parsed["model"].to_s != desired_model.to_s
+      raise ScenarioUnavailableError,
+        "Multiple development DB providers match #{scenario.label}: #{parsed['candidate_names'].join(', ')}. Set #{scenario.model_env} to disambiguate."
+    end
+
+    @development_provider_info_cache[scenario.name] = parsed
+  rescue JSON::ParserError
+    nil
+  end
+end

--- a/spec/system/providers/provider_smoke_spec.rb
+++ b/spec/system/providers/provider_smoke_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "securerandom"
+require "warden/test/helpers"
+
+RSpec.describe "Provider smoke test UI", :local_only, :provider_smoke, type: :system do
+  include Warden::Test::Helpers
+
+  let(:scenario) { ProviderSmokeHelpers.scenarios_from_env.first }
+  let(:unique_suffix) { SecureRandom.hex(6) }
+  let!(:account) { create(:account, slug: "provider-smoke-ui-#{unique_suffix}") }
+  let!(:user) do
+    create(
+      :user,
+      :owner,
+      account: account,
+      email: "provider-smoke-ui-#{unique_suffix}@example.com",
+      password: "password123"
+    )
+  end
+  let!(:provider) { ProviderSmokeHelpers.build_provider!(user: user, scenario: scenario) }
+
+  before do
+    Warden.test_mode!
+    login_as(user, scope: :user)
+    ProviderSmokeHelpers.create_smoke_project!(user: user)
+  end
+
+  after do
+    Warden.test_reset!
+  end
+
+  it "runs the provider smoke test from the providers page" do
+    skip "No provider smoke scenarios configured" if scenario.nil?
+
+    visit providers_path
+
+    using_wait_time 90 do
+      within("tr", text: provider.display_name) do
+        click_button "Test Agent"
+        expect(page).to have_content("Agent is healthy")
+      end
+    end
+  rescue ProviderSmokeHelpers::ScenarioUnavailableError => e
+    skip e.message
+  end
+end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -51,6 +51,21 @@ RSpec.describe Activities::RunAgentActivity do
     variant_version
   end
 
+  def expected_kilocode_model_config
+    {
+      "anthropic" => {
+        "options" => { "apiKey" => "{env:ANTHROPIC_API_KEY}" },
+        "models" => {
+          "claude-sonnet-4-20250514" => {
+            "name" => "claude-sonnet-4-20250514",
+            "id" => "claude-sonnet-4-20250514",
+            "tool_call" => true
+          }
+        }
+      }
+    }
+  end
+
   def create_running_ab_test(slug:)
     prompt = create(:prompt, :for_project, project: project, slug: slug)
     control_version = prompt.create_version!(template: "control {{base_prompt}} {{repo}}")
@@ -490,9 +505,9 @@ RSpec.describe Activities::RunAgentActivity do
         preparation = activity.send(:command_preparation_for, opencode_context, "ping")
 
         expect(command).to eq([ "env", "-u", "OPENAI_HEADER_X_AGENT_RUN_ID", "-u", "OPENAI_HEADER_X_PROXY_TOKEN", "opencode", "run", "ping" ])
-        expect(env).to include("OPENAI_API_KEY" => "sk-openrouter-secret", "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1")
+        expect(env).to include("OPENROUTER_API_KEY" => "sk-openrouter-secret", "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1")
         expect(preparation.file_writes.first.path).to eq("~/.config/opencode/opencode.json")
-        expect(preparation.file_writes.first.content).to include("\"model\": \"moonshotai/kimi-k2-0905\"")
+        expect(preparation.file_writes.first.content).to include("\"model\": \"openrouter/moonshotai/kimi-k2-0905\"")
       end
 
       it "preserves multi-line prompts when wrapping the harness runtime command" do
@@ -519,10 +534,11 @@ RSpec.describe Activities::RunAgentActivity do
         expect(command.last).to eq("ping")
 
         expect(env).to have_key("PAID_KILOCODE_CONFIG_B64")
+        expect(env).to include("ANTHROPIC_API_KEY" => "sk-anthropic-secret")
         expect(env).to have_key("PAID_PROVIDER_ID")
         config_json = JSON.parse(Base64.strict_decode64(env["PAID_KILOCODE_CONFIG_B64"]))
         expect(config_json["model"]).to eq("anthropic/claude-sonnet-4-20250514")
-        expect(config_json["provider"]).to eq({ "anthropic" => {} })
+        expect(config_json["provider"]).to eq(expected_kilocode_model_config)
       end
 
       it "does not include PAID_KILOCODE_CONFIG_B64 for subscription kilocode providers" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -54,7 +54,10 @@ RSpec.describe Activities::RunAgentActivity do
   def expected_kilocode_model_config
     {
       "anthropic" => {
-        "options" => { "apiKey" => "{env:ANTHROPIC_API_KEY}" },
+        "options" => {
+          "apiKey" => "{env:ANTHROPIC_API_KEY}",
+          "baseURL" => "https://api.anthropic.com"
+        },
         "models" => {
           "claude-sonnet-4-20250514" => {
             "name" => "claude-sonnet-4-20250514",


### PR DESCRIPTION
## Summary
- add a local-only provider smoke test matrix and `bin/provider-smoke` runner for the current enabled providers
- fix direct-outbound provider smoke/runtime behavior for OpenCode and KiloCode, including model/provider config generation and smoke-result handling
- harden the Providers page test-agent UI flow and add a browser smoke spec for the page interaction

## Testing
- `COVERAGE=false bundle exec rspec spec/models/provider_spec.rb spec/services/providers/harness_execution_plan_spec.rb spec/services/providers/test_agent_spec.rb spec/lib/provider_smoke_helpers_spec.rb`
- `bin/provider-smoke`
- `RUN_PROVIDER_SMOKE=true PAID_SMOKE_SCENARIOS=claude-subscription COVERAGE=false bundle exec rspec spec/system/providers/provider_smoke_spec.rb`