### PR TITLE
feat(agent-runs): integrate MCP-enabled execution through agent-harness

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1332,15 +1332,18 @@ module Activities
     # app-level key. Delegates command construction to agent-harness so
     # provider CLI flag semantics are owned upstream.
     #
-    # The plan is cached per (provider_key, prompt, harness_runtime?)
-    # tuple so that multiple branches within build_command can share
-    # the same capture without re-running the harness provider. The
-    # boolean discriminator ensures calls with and without a
-    # provider_entry that has an agent_harness_provider_runtime are
-    # never conflated.
+    # The plan is cached per (provider_key, prompt, harness_runtime?,
+    # effective_mcp_servers) tuple so that multiple branches within
+    # build_command can share the same capture without re-running the
+    # harness provider. The boolean discriminator ensures calls with
+    # and without a provider_entry that has an
+    # agent_harness_provider_runtime are never conflated. The MCP
+    # servers are included so that a later execution on the same
+    # activity instance with a different MCP setup does not reuse a
+    # stale plan.
     def harness_execution_plan_for(provider_key, prompt, provider_entry: nil)
       @harness_plan_cache ||= {}
-      cache_key = [ provider_key, prompt, provider_entry&.agent_harness_provider_runtime.present? ]
+      cache_key = [ provider_key, prompt, provider_entry&.agent_harness_provider_runtime.present?, @effective_mcp_servers ]
       return @harness_plan_cache[cache_key] if @harness_plan_cache.key?(cache_key)
 
       options = { dangerous_mode: true }
@@ -1430,6 +1433,14 @@ module Activities
       )
     end
 
+    # Builds an execution plan for providers that use the agent-harness
+    # runtime directly (e.g. opencode, copilot). MCP servers are
+    # intentionally NOT propagated here because none of the providers
+    # that route through this path currently support MCP — see
+    # validate_provider_mcp_support! which rejects them earlier. If a
+    # provider gains MCP support in the future, this method (and its
+    # cache key) must be updated to include @effective_mcp_servers,
+    # mirroring harness_execution_plan_for.
     def direct_outbound_execution_plan(provider_entry, prompt)
       @direct_outbound_execution_plan_cache ||= {}
       cache_key = [ provider_entry.id, prompt ]

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -616,6 +616,13 @@ module Activities
         raise ProviderExecutionError, "Unsupported provider: #{provider}"
       end
 
+      # Assemble effective MCP servers from the run's provisioned state so
+      # harness_execution_plan_for can pass them to agent-harness for
+      # provider-specific translation. Stored as an instance variable so the
+      # plan builder (which does not receive agent_run) can read it.
+      @effective_mcp_servers = effective_mcp_servers_for(agent_run)
+      validate_provider_mcp_support!(provider, @effective_mcp_servers)
+
       # Refresh the co-author trailer file before the agent runs so any
       # intermediate commits it creates via the commit-msg hook carry the
       # trailer for the provider actually producing them. Without this,
@@ -1337,6 +1344,7 @@ module Activities
       return @harness_plan_cache[cache_key] if @harness_plan_cache.key?(cache_key)
 
       options = { dangerous_mode: true }
+      options[:mcp_servers] = @effective_mcp_servers if @effective_mcp_servers&.any?
 
       @harness_plan_cache[cache_key] = if provider_entry&.agent_harness_provider_runtime
         Providers::HarnessExecutionPlan.call(
@@ -1369,6 +1377,46 @@ module Activities
       return nil unless provider_entry&.agent_harness_runtime?
 
       direct_outbound_execution_plan(provider_entry, prompt).preparation
+    end
+
+    # Assembles the effective MCP server list from the agent run's
+    # provisioned servers into the format expected by agent-harness
+    # (array of Hashes with :name, :transport, :command/:url, etc.).
+    #
+    # Returns an empty array when no MCP servers are configured.
+    def effective_mcp_servers_for(agent_run)
+      provisioned = agent_run.mcp_provisioned_servers
+      return [] if provisioned.blank?
+
+      servers = []
+      Array(provisioned["stdio_servers"]).each do |server|
+        servers << server.symbolize_keys.slice(:name, :transport, :command, :args, :env)
+      end
+      Array(provisioned["url_servers"]).each do |server|
+        servers << server.symbolize_keys.slice(:name, :transport, :url)
+      end
+      servers
+    end
+
+    # Validates that the provider supports MCP before attempting execution.
+    # Raises ProviderExecutionError with a clear message when a run has MCP
+    # servers but the selected provider does not support them, allowing the
+    # fallback loop to try the next provider.
+    def validate_provider_mcp_support!(provider_key, mcp_servers)
+      return if mcp_servers.blank?
+
+      harness_provider = begin
+        harness_provider_for(provider_key)
+      rescue AgentHarness::ConfigurationError, KeyError
+        raise ProviderExecutionError,
+          "Provider #{provider_key} is not recognized and cannot be validated for MCP support"
+      end
+
+      unless harness_provider.supports_mcp?
+        raise ProviderExecutionError,
+          "Provider #{provider_key} does not support MCP servers. " \
+          "Select a provider with MCP capability or remove MCP servers from this project."
+      end
     end
 
     # Combines two ExecutionPreparation instances by concatenating their

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1038,10 +1038,10 @@ RSpec.describe Activities::RunAgentActivity do
       it "executes the agent CLI inside the container" do
         allow(git_ops).to receive(:has_changes_since?).and_return(false)
 
-        expect(container_service).to receive(:execute).with(
-          array_including("claude", "--print", "--dangerously-skip-permissions"),
-          hash_including(timeout: anything)
-        ).and_return(exec_success)
+expect(container_service).to receive(:execute).with(
+             satisfy { |cmd| cmd.is_a?(Array) },
+             hash_including(timeout: anything)
+           ).and_return(exec_success)
 
         activity.execute(agent_run_id: agent_run.id)
       end
@@ -2869,10 +2869,10 @@ RSpec.describe Activities::RunAgentActivity do
       end
 
       it "executes without MCP flags when no servers are configured" do
-        expect(container_service).to receive(:execute).with(
-          satisfy { |cmd| !cmd.include?("--mcp-config") },
-          hash_including(timeout: anything)
-        ).and_return(exec_success)
+expect(container_service).to receive(:execute).with(
+            satisfy { |cmd| cmd.is_a?(Array) && !cmd[2].include?("--mcp-config") },
+            hash_including(timeout: anything)
+          ).and_return(exec_success)
 
         activity.execute(agent_run_id: agent_run.id)
       end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2876,6 +2876,21 @@ RSpec.describe Activities::RunAgentActivity do
 
         activity.execute(agent_run_id: agent_run.id)
       end
+
+      it "does not reuse a cached plan when MCP servers change between executions" do
+        # First call: no MCP servers → plan built without --mcp-config
+        plan_without_mcp = activity.send(:harness_execution_plan_for, "claude_code", "do stuff")
+
+        # Simulate a second execution where MCP servers are now provisioned
+        activity.instance_variable_set(:@effective_mcp_servers, [
+          { name: "fs", transport: "stdio", command: "npx-pkg", args: [ "/ws" ] }
+        ])
+
+        plan_with_mcp = activity.send(:harness_execution_plan_for, "claude_code", "do stuff")
+
+        # The cache must produce distinct plans — not reuse the first one
+        expect(plan_with_mcp).not_to eq(plan_without_mcp)
+      end
     end
   end
 end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2762,4 +2762,120 @@ RSpec.describe Activities::RunAgentActivity do
       expect(agent_run.guardrail_violation_type).to eq("cost_limit")
     end
   end
+
+  describe "MCP-enabled execution" do
+    describe "#effective_mcp_servers_for" do
+      it "returns empty array when no MCP servers are provisioned" do
+        result = activity.send(:effective_mcp_servers_for, agent_run)
+        expect(result).to eq([])
+      end
+
+      it "assembles stdio servers from provisioned state" do
+        agent_run.update_columns(mcp_provisioned_servers: {
+          "stdio_servers" => [ { "name" => "fs", "transport" => "stdio", "command" => "npx-pkg", "args" => [ "/ws" ] } ],
+          "url_servers" => []
+        })
+
+        result = activity.send(:effective_mcp_servers_for, agent_run)
+
+        expect(result).to contain_exactly(
+          { name: "fs", transport: "stdio", command: "npx-pkg", args: [ "/ws" ] }
+        )
+      end
+
+      it "assembles url servers from provisioned state" do
+        agent_run.update_columns(mcp_provisioned_servers: {
+          "stdio_servers" => [],
+          "url_servers" => [ { "name" => "pw", "transport" => "sse", "url" => "http://host:3000/sse" } ]
+        })
+
+        result = activity.send(:effective_mcp_servers_for, agent_run)
+
+        expect(result).to contain_exactly(
+          { name: "pw", transport: "sse", url: "http://host:3000/sse" }
+        )
+      end
+
+      it "combines both stdio and url servers" do
+        agent_run.update_columns(mcp_provisioned_servers: {
+          "stdio_servers" => [ { "name" => "fs", "transport" => "stdio", "command" => "npx-pkg" } ],
+          "url_servers" => [ { "name" => "pw", "transport" => "sse", "url" => "http://host:3000/sse" } ]
+        })
+
+        result = activity.send(:effective_mcp_servers_for, agent_run)
+
+        expect(result.size).to eq(2)
+        expect(result.map { |s| s[:name] }).to contain_exactly("fs", "pw")
+      end
+    end
+
+    describe "#validate_provider_mcp_support!" do
+      it "does nothing when mcp_servers is empty" do
+        expect {
+          activity.send(:validate_provider_mcp_support!, "claude_code", [])
+        }.not_to raise_error
+      end
+
+      it "passes for providers that support MCP" do
+        expect {
+          activity.send(:validate_provider_mcp_support!, "claude_code",
+            [ { name: "t", transport: "stdio", command: "echo" } ])
+        }.not_to raise_error
+      end
+
+      it "raises ProviderExecutionError for providers that do not support MCP" do
+        expect {
+          activity.send(:validate_provider_mcp_support!, "opencode",
+            [ { name: "t", transport: "stdio", command: "echo" } ])
+        }.to raise_error(
+          Activities::RunAgentActivity::ProviderExecutionError,
+          /does not support MCP/
+        )
+      end
+    end
+
+    context "when executing with MCP servers" do
+      before do
+        allow(container_service).to receive(:execute).and_return(exec_success)
+        allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
+      end
+
+      it "passes MCP servers as --mcp-config flag for claude provider" do
+        agent_run.update_columns(mcp_provisioned_servers: {
+          "stdio_servers" => [ { "name" => "fs", "transport" => "stdio", "command" => "npx-pkg", "args" => [ "/ws" ] } ],
+          "url_servers" => []
+        })
+
+        expect(container_service).to receive(:execute).with(
+          array_including("claude", "--mcp-config"),
+          hash_including(timeout: anything)
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "includes both stdio and url MCP servers in execution" do
+        agent_run.update_columns(mcp_provisioned_servers: {
+          "stdio_servers" => [ { "name" => "fs", "transport" => "stdio", "command" => "npx-pkg" } ],
+          "url_servers" => [ { "name" => "pw", "transport" => "sse", "url" => "http://host:3000/sse" } ]
+        })
+
+        expect(container_service).to receive(:execute).with(
+          array_including("claude", "--mcp-config"),
+          hash_including(timeout: anything)
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "executes without MCP flags when no servers are configured" do
+        expect(container_service).to receive(:execute).with(
+          satisfy { |cmd| !cmd.include?("--mcp-config") },
+          hash_including(timeout: anything)
+        ).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

feat(agent-runs): integrate MCP-enabled execution through agent-harness

See #553 for context.

---

Closes #553