### PR TITLE
fix(ci): use runner Chrome instead of browserless service container

### DIFF
--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -81,16 +81,6 @@ jobs:
           --health-timeout=5s
           --health-retries=5
 
-      chrome:
-        image: ghcr.io/browserless/chromium:v2.48.2
-        ports:
-          - 9222:3000
-        options: >-
-          --health-cmd="curl -sf http://localhost:3000/json/version || exit 1"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
     env:
       BUNDLE_FROZEN: "true"
       RAILS_ENV: test
@@ -98,7 +88,6 @@ jobs:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
       SCREENSHOT_OUTPUT_DIR: tmp/screenshots
-      CHROME_URL: http://localhost:9222
 
     steps:
       - name: Checkout code
@@ -125,14 +114,22 @@ jobs:
       - name: Install PostgreSQL client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
 
-      - name: Verify Chrome service
-        # The workflow requires the dedicated Chrome service container so the
-        # capture environment matches the CI contract for screenshot rendering.
+      - name: Verify Chrome binary
         run: |
-          if curl -sf http://localhost:9222/json/version > /dev/null 2>&1; then
-            echo "Chrome service container is available via CHROME_URL"
+          chrome_path="${CHROMIUM_PATH:-}"
+          if [ -z "$chrome_path" ]; then
+            for candidate in /usr/bin/google-chrome /usr/bin/chromium /usr/bin/chromium-browser; do
+              if [ -x "$candidate" ]; then
+                chrome_path="$candidate"
+                break
+              fi
+            done
+          fi
+          if [ -n "$chrome_path" ] && [ -x "$chrome_path" ]; then
+            echo "Chrome found at ${chrome_path}"
+            "$chrome_path" --version
           else
-            echo "::error::Chrome service container is not reachable at http://localhost:9222/json/version"
+            echo "::error::No Chrome/Chromium binary found"
             exit 1
           fi
 
@@ -141,18 +138,6 @@ jobs:
           UI_FILES_B64: ${{ needs.detect.outputs.ui_files }}
         run: |
           printf 'CHANGED_FILES<<EOF\n%s\nEOF\n' "$(printf '%s' "$UI_FILES_B64" | base64 -d)" >> "$GITHUB_ENV"
-
-      - name: Configure remote Capybara host
-        run: |
-          # Service containers share the runner's Docker network; use the
-          # runner's primary IP (not the upstream gateway) so Chrome can
-          # connect back to Puma.
-          host_ip="$(hostname -I | awk '{print $1}')"
-          if [ -z "$host_ip" ]; then
-            echo "::error::Could not determine the runner host IP for the Chrome service container."
-            exit 1
-          fi
-          echo "CAPYBARA_APP_HOST=$host_ip" >> "$GITHUB_ENV"
 
       - name: Build assets
         run: yarn build && yarn build:css

--- a/lib/screenshots/capture.rb
+++ b/lib/screenshots/capture.rb
@@ -17,8 +17,10 @@ module Screenshots
   # Intended to run in CI against a booted Rails server with seeded data so
   # reviewers can see actual rendered pages rather than mocks.
   #
-  # The Chrome process is provided by a Chrome service container in CI or by
-  # a locally installed Chromium on the developer machine.
+  # Chrome is launched locally by Ferrum (via Cuprite). In CI this uses the
+  # runner's pre-installed Chrome; locally it finds Chromium via CHROMIUM_PATH
+  # or find_chrome_binary. A remote Chrome can be used by setting CHROME_URL
+  # and CAPYBARA_APP_HOST.
   #
   # @example
   #   paths = Screenshots::Capture.call(


### PR DESCRIPTION
## Summary

- Removes the `ghcr.io/browserless/chromium` service container from the PR screenshots workflow
- Uses the pre-installed Chrome on the `ubuntu-latest` runner instead
- Updates the Chrome binary verification step to mirror `find_chrome_binary`'s search order
- Updates stale doc comment in `capture.rb` to reflect the new Chrome launch strategy

## Why

The browserless container's Chrome reports its WebSocket URL as `ws://0.0.0.0:3000` (the internal container address). Ferrum resolves this from `/json/version` and then fails with `ECONNREFUSED` because that address is unreachable from the GitHub Actions runner.

Using the runner's locally-installed Chrome avoids this Docker networking issue entirely — Ferrum launches Chrome directly and connects via the local Puma server on `127.0.0.1`.

## Test plan

- [ ] Merge this PR and verify the PR Screenshots workflow succeeds on a PR with UI changes
- [ ] Verify screenshots are captured and uploaded as artifacts