### PR TITLE
fix(agent-runs): handle type:error JSONL and blank structured parser output in agent comments

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1515,22 +1515,21 @@ class AgentRun < ApplicationRecord
     return raw_stdout if raw_stdout.blank?
 
     response = parse_structured_stdout(raw_stdout)
-    if response
-      return "Agent encountered an error: #{response.error}" if response.error.present?
-
-      return response.output.presence || raw_stdout
+    if response&.error.present?
+      return "Agent encountered an error: #{response.error}"
     end
+    return response.output if response&.output.present?
 
     extract_text_from_multiline_json(raw_stdout) || raw_stdout
   end
 
   def extract_text_from_multiline_json(raw_stdout)
     results = []
-    error_message = nil
+    error_messages = []
 
     raw_stdout.lines.last(STDOUT_TAIL_LINES).each do |line|
       line = line.strip
-      next unless line.start_with?("{") && line.include?('"type"') && line.include?('"result"')
+      next unless line.start_with?("{") && line.include?('"type"')
 
       begin
         parsed = JSON.parse(line)
@@ -1538,17 +1537,34 @@ class AgentRun < ApplicationRecord
         next
       end
 
-      next unless parsed.is_a?(Hash) && parsed["type"] == "result"
+      next unless parsed.is_a?(Hash)
 
-      if parsed["is_error"]
-        error_message ||= parsed["result"] || "Unknown error"
-      elsif parsed.key?("result")
-        text = parsed["result"].to_s.strip
+      case parsed["type"]
+      when "result"
+        if parsed["is_error"]
+          error_messages << (parsed["result"] || "Unknown error").to_s
+        elsif parsed.key?("result")
+          text = parsed["result"].to_s.strip
+          results << text if text.present?
+        end
+      when "error"
+        error_obj = parsed["error"]
+        if error_obj.is_a?(Hash)
+          msg = error_obj.dig("data", "message") || error_obj["message"] || error_obj["name"]
+          error_messages << msg.to_s
+        else
+          error_messages << error_obj.to_s
+        end
+      when "text"
+        part = parsed["part"]
+        text = part.is_a?(Hash) ? part["text"].to_s.strip : parsed["text"].to_s.strip
         results << text if text.present?
       end
     end
 
-    return "Agent encountered an error: #{error_message}" if error_message.present? && results.empty?
+    if error_messages.present? && results.empty?
+      return "Agent encountered an error: #{error_messages.uniq.first.truncate(500)}"
+    end
     return nil if results.empty?
 
     results.join("\n\n").presence

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1552,8 +1552,12 @@ class AgentRun < ApplicationRecord
         if error_obj.is_a?(Hash)
           msg = error_obj.dig("data", "message") || error_obj["message"] || error_obj["name"]
           error_messages << msg.to_s
-        else
+        elsif error_obj.present?
           error_messages << error_obj.to_s
+        end
+        # Also capture top-level "message" field (e.g., {"type":"error","message":"fatal API error"})
+        if parsed.key?("message") && parsed["message"].present?
+          error_messages << parsed["message"].to_s
         end
       when "text"
         part = parsed["part"]

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2836,6 +2836,80 @@ RSpec.describe AgentRun do
 
       expect(agent_run.agent_summary).to eq("Extracted text")
     end
+
+    it "extracts error message from type:error JSONL lines" do
+      errors = [
+        { type: "error", timestamp: 1777909018637, sessionID: "ses_abc",
+          error: { name: "UnknownError", data: { message: "Model not found: openai/glm-5.1." } } },
+        { type: "error", timestamp: 1777909064953, sessionID: "ses_def",
+          error: { name: "UnknownError", data: { message: "Model not found: openai/glm-5.1." } } }
+      ].map(&:to_json).join("\n")
+      agent_run.log!("stdout", errors)
+
+      expect(agent_run.agent_summary).to eq("Agent encountered an error: Model not found: openai/glm-5.1.")
+    end
+
+    it "extracts error message from type:error with message field" do
+      error_line = { type: "error", error: { name: "FatalError", message: "Connection refused" } }.to_json
+      agent_run.log!("stdout", error_line)
+
+      expect(agent_run.agent_summary).to eq("Agent encountered an error: Connection refused")
+    end
+
+    it "extracts error message from type:error with string error" do
+      error_line = { type: "error", error: "Something went wrong" }.to_json
+      agent_run.log!("stdout", error_line)
+
+      expect(agent_run.agent_summary).to eq("Agent encountered an error: Something went wrong")
+    end
+
+    it "prefers result text over error JSONL when both present" do
+      mixed = [
+        { type: "result", subtype: "success", is_error: false, result: "OK", duration_ms: 100 },
+        { type: "error", error: { name: "Warn", data: { message: "Rate limit warning" } } }
+      ].map(&:to_json).join("\n")
+      agent_run.log!("stdout", mixed)
+
+      expect(agent_run.agent_summary).to eq("OK")
+    end
+
+    it "falls through to multiline JSON when structured parser returns blank output" do
+      envelope = { type: "result", subtype: "success", is_error: false,
+                   result: "OK", duration_ms: 2769, total_cost_usd: 0.06 }.to_json
+      allow(agent_run).to receive(:parse_structured_stdout).and_return(
+        double(error: nil, output: "")
+      )
+      agent_run.log!("stdout", envelope)
+
+      expect(agent_run.agent_summary).to eq("OK")
+    end
+
+    it "extracts text from opencode-style type:text JSONL with part.text" do
+      events = [
+        { type: "step_start", timestamp: 1777913612201, sessionID: "ses_abc",
+          part: { id: "prt_1", type: "step-start" } },
+        { type: "text", timestamp: 1777913612207, sessionID: "ses_abc",
+          part: { id: "prt_2", type: "text", text: "OK",
+                  time: { start: 1777913612203, end: 1777913612203 } } },
+        { type: "step_finish", timestamp: 1777913612232, sessionID: "ses_abc",
+          part: { id: "prt_3", type: "step-finish", reason: "stop" } }
+      ].map(&:to_json).join("\n")
+      agent_run.log!("stdout", events)
+
+      expect(agent_run.agent_summary).to eq("OK")
+    end
+
+    it "extracts text from opencode JSONL ignoring non-text event types" do
+      events = [
+        { type: "step_start", part: { type: "step-start" } },
+        { type: "tool_use", part: { type: "tool", tool: "bash" } },
+        { type: "text", part: { type: "text", text: "All done" } },
+        { type: "step_finish", part: { type: "step-finish" } }
+      ].map(&:to_json).join("\n")
+      agent_run.log!("stdout", events)
+
+      expect(agent_run.agent_summary).to eq("All done")
+    end
   end
 
   describe "#current_phase_group" do

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2863,6 +2863,13 @@ RSpec.describe AgentRun do
       expect(agent_run.agent_summary).to eq("Agent encountered an error: Something went wrong")
     end
 
+    it "extracts error from type:error with top-level message field" do
+      error_line = { type: "error", message: "fatal API error" }.to_json
+      agent_run.log!("stdout", error_line)
+
+      expect(agent_run.agent_summary).to eq("Agent encountered an error: fatal API error")
+    end
+
     it "prefers result text over error JSONL when both present" do
       mixed = [
         { type: "result", subtype: "success", is_error: false, result: "OK", duration_ms: 100 },
@@ -2876,7 +2883,9 @@ RSpec.describe AgentRun do
     it "falls through to multiline JSON when structured parser returns blank output" do
       envelope = { type: "result", subtype: "success", is_error: false,
                    result: "OK", duration_ms: 2769, total_cost_usd: 0.06 }.to_json
-      allow(agent_run).to receive(:parse_structured_stdout).and_return(
+      mock_provider = instance_double(AgentHarness::Providers::Base)
+      allow(AgentHarness).to receive(:provider).and_return(mock_provider)
+      allow(mock_provider).to receive(:parse_container_output).and_return(
         double(error: nil, output: "")
       )
       agent_run.log!("stdout", envelope)


### PR DESCRIPTION
## Summary

- Fixes two remaining gaps in agent comment parsing that caused raw JSONL to appear in PR comments
- PR #1650 added `extract_text_from_multiline_json` for `type: "result"` JSONL but two gaps remained:
  1. **`type: "error"` JSONL not handled** — error lines like `{"type":"error","error":{"name":"UnknownError","data":{"message":"Model not found..."}}}` were ignored by the line filter and had no matching case, so the raw JSONL was posted as the comment body
  2. **Blank structured parser output returned raw stdout** — when `parse_structured_stdout` returned a response with empty output (and no error), `extract_text_from_stdout` returned the raw stdout instead of falling through to the multiline JSON fallback

## Root cause

`extract_text_from_multiline_json` line filter required `'"result"'` as a substring, excluding `type: "error"` lines entirely. And `extract_text_from_stdout` used `response.output.presence || raw_stdout` which short-circuited to raw stdout when structured parsers returned blank output, bypassing the multiline JSON fallback.

## Test plan

- [x] Added tests for `type: "error"` JSONL extraction (with `data.message`, `message` field, and string error)
- [x] Added test for mixed result+error lines preferring result text
- [x] Added test for blank structured parser output falling through to multiline JSON
- [x] All 31 existing `agent_summary` tests still pass
- [x] RuboCop clean
- [x] Fixed 21 existing JSONL comments across 5 open PRs via GitHub API