### PR TITLE
fix(screenshots): resolve Ferrum base_url error in CI screenshot capture

### DIFF
--- a/lib/screenshots/capture.rb
+++ b/lib/screenshots/capture.rb
@@ -49,7 +49,7 @@ module Screenshots
 
       captured = []
       failures = []
-      session = Capybara::Session.new(:paid_screenshots)
+      session = Capybara::Session.new(:paid_screenshots, Capybara.app)
       begin
         seed_data = ensure_seed_data!
         targets = Screenshots::CaptureTargets.call(changed_files: @changed_files)
@@ -102,6 +102,7 @@ module Screenshots
 
         options[:browser_path] = browser_path if browser_path
         options[:url] = chrome_url if chrome_url
+        options[:base_url] = Capybara.app_host if Capybara.app_host
 
         Capybara::Cuprite::Driver.new(app, **options)
       end

--- a/spec/lib/screenshots/capture_spec.rb
+++ b/spec/lib/screenshots/capture_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe Screenshots::Capture do
   end
 
   before do
-    allow(Capybara::Session).to receive(:new).with(:paid_screenshots).and_return(session)
+    allow(Capybara::Session).to receive(:new)
+      .with(:paid_screenshots, Capybara.app)
+      .and_return(session)
     allow(session).to receive_messages(driver: driver, has_no_css?: true)
     allow(session).to receive(:visit)
     allow(session).to receive(:save_screenshot)
@@ -72,5 +74,44 @@ RSpec.describe Screenshots::Capture do
       RuntimeError,
       /CAPYBARA_APP_HOST must be set/
     )
+  end
+
+  describe "#register_driver" do
+    it "passes base_url to Cuprite when app_host is set" do
+      capture = described_class.new(output_dir: output_dir, changed_files: [])
+      app_host = "http://127.0.0.1:3001"
+      cuprite_driver = instance_double(Capybara::Cuprite::Driver)
+
+      allow(Capybara).to receive(:app_host).and_return(app_host)
+      allow(Capybara::Cuprite::Driver).to receive(:new).and_return(cuprite_driver)
+
+      capture.send(:register_driver)
+
+      # Trigger the registered driver block by calling it with a mock app
+      mock_app = instance_double(Rack::Builder)
+      Capybara.drivers[:paid_screenshots].call(mock_app)
+
+      expect(Capybara::Cuprite::Driver).to have_received(:new) do |app, **options|
+        expect(app).to eq(mock_app)
+        expect(options[:base_url]).to eq(app_host)
+      end
+    end
+
+    it "omits base_url from Cuprite when app_host is nil" do
+      capture = described_class.new(output_dir: output_dir, changed_files: [])
+      cuprite_driver = instance_double(Capybara::Cuprite::Driver)
+
+      allow(Capybara).to receive(:app_host).and_return(nil)
+      allow(Capybara::Cuprite::Driver).to receive(:new).and_return(cuprite_driver)
+
+      capture.send(:register_driver)
+
+      mock_app = instance_double(Rack::Builder)
+      Capybara.drivers[:paid_screenshots].call(mock_app)
+
+      expect(Capybara::Cuprite::Driver).to have_received(:new) do |_app, **options|
+        expect(options).not_to have_key(:base_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Pass `Capybara.app` (Rails.application) to `Capybara::Session.new` so the Puma server boots and Capybara can resolve relative URLs via `server_url`
- Pass `Capybara.app_host` as `base_url` to the Cuprite/Ferrum driver options, since Ferrum 0.17.2 strictly requires either an absolute URL or an explicit `base_url` when navigating to relative paths

## Context

The PR Screenshots CI workflow started failing with:

```
Set :base_url browser's option or use absolute url in `go_to`, you passed: /users/sign_in
```

Two issues caused this:

1. **No Puma server booted** — `Capybara::Session.new(:paid_screenshots)` was called without passing the Rack app, so `@app` was nil, `@server` was nil, and `server_url` returned nil. Without `server_url`, Capybara's `visit` method couldn't resolve relative paths to absolute URLs before passing them to the driver.

2. **No Ferrum `base_url` fallback** — Ferrum 0.17.2 requires an explicit `base_url` option to resolve relative URLs. Previously this was handled implicitly. Adding `base_url: Capybara.app_host` gives Ferrum a direct fallback.