### PR TITLE
Fix #1665: Move upcoming queue above queue health section on dashboard

### DIFF
--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -42,12 +42,12 @@
         </div>
       </div>
 
-      <div id="queue-health" class="mt-6">
-        <%= render "dashboard/queue_health", queue_depths: @queue_health.queue_depths, healthy: @queue_health.healthy? %>
-      </div>
-
       <div class="mt-6">
         <%= render "dashboard/queue_preview", queue_preview: @queue_preview %>
+      </div>
+
+      <div id="queue-health" class="mt-6">
+        <%= render "dashboard/queue_health", queue_depths: @queue_health.queue_depths, healthy: @queue_health.healthy? %>
       </div>
 
       <div id="dashboard-alerts" class="mt-6 space-y-3"></div>


### PR DESCRIPTION
## Summary

OK

Done. The change swaps the queue preview (upcoming queue) and queue health sections in `app/views/dashboard/show.html.erb` so the upcoming queue now appears above queue health. All 27 dashboard tests pass and lint is clean.

---

Closes #1665