### PR TITLE
feat(providers): tie model selection to direct-outbound provider capabilities

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -71,6 +71,7 @@ class Provider < ApplicationRecord
   scope :rate_limit_fallback, -> { where(fallback_role: "rate_limit_fallback") }
 
   before_validation :normalize_agent_co_author_trailer
+  before_validation :clear_stale_direct_outbound_tier_models
   before_save :sync_direct_outbound_tier_models
 
   validates :weight, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_WEIGHT }
@@ -483,12 +484,24 @@ class Provider < ApplicationRecord
   private
 
   def sync_direct_outbound_tier_models
-    return unless direct_outbound_model_id.present?
     return unless requires_direct_outbound?
+    return unless direct_outbound_model_id.present?
     return unless will_save_change_to_config? || tier_model_ids.blank?
 
     model = ensure_direct_outbound_llm_model!
     self.tier_model_ids = LlmModel::TIERS.each_with_object({}) { |t, h| h[t] = model.model_id }
+  end
+
+  def clear_stale_direct_outbound_tier_models
+    return unless tier_model_ids.present?
+    return unless direct_outbound_capable_provider?
+    return if requires_direct_outbound? && direct_outbound_model_id.present?
+
+    self.tier_model_ids = {}
+  end
+
+  def direct_outbound_capable_provider?
+    %w[kilocode opencode aider].include?(provider_key)
   end
 
   def direct_outbound_display_name(model_id)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -49,6 +49,15 @@ class Provider < ApplicationRecord
   KILOCODE_API_PROVIDER_KEYS = DIRECT_OUTBOUND_API_PROVIDERS.keys.freeze
   KILOCODE_DEFAULT_API_PROVIDER = "anthropic"
 
+  AIDER_API_PROVIDER_KEYS = DIRECT_OUTBOUND_API_PROVIDERS.keys.freeze
+  AIDER_DEFAULT_API_PROVIDER = "openrouter"
+
+  DIRECT_OUTBOUND_MODEL_TIER_HINTS = {
+    "glm-5.1" => "high",
+    "glm-4.7" => "mid",
+    "glm-4.5-air" => "low"
+  }.freeze
+
   belongs_to :user
   belongs_to :provider_api_key, optional: true
 
@@ -62,6 +71,7 @@ class Provider < ApplicationRecord
   scope :rate_limit_fallback, -> { where(fallback_role: "rate_limit_fallback") }
 
   before_validation :normalize_agent_co_author_trailer
+  before_save :sync_direct_outbound_tier_models
 
   validates :weight, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_WEIGHT }
   validates :provider_key, presence: true, length: { maximum: 50 }
@@ -84,6 +94,7 @@ class Provider < ApplicationRecord
   validate :api_key_entry_must_be_unique
   validate :opencode_api_key_config_must_be_valid
   validate :kilocode_api_key_config_must_be_valid
+  validate :aider_api_key_config_must_be_valid
   validate :tier_model_ids_must_be_valid
   validate :complexity_thresholds_must_be_valid
   validate :agent_co_author_trailer_is_single_line
@@ -110,6 +121,7 @@ class Provider < ApplicationRecord
     model_id = case provider_key
     when "opencode" then opencode_model_id
     when "kilocode" then kilocode_model_id
+    when "aider" then aider_model_id
     end
     label += " #{model_id}" if model_id.present?
     label += " (API Key)" if api_key?
@@ -184,11 +196,30 @@ class Provider < ApplicationRecord
     DIRECT_OUTBOUND_API_PROVIDERS.dig(kilocode_api_provider, :service_type)
   end
 
-  def requires_direct_outbound?
-    return true if opencode_direct_outbound?
-    return true if kilocode_direct_outbound?
+  def aider_config
+    config.is_a?(Hash) ? config.fetch("aider", {}) : {}
+  end
 
-    false
+  def aider_api_provider
+    return nil unless provider_key == "aider"
+
+    aider_config["api_provider"].presence || AIDER_DEFAULT_API_PROVIDER
+  end
+
+  def aider_model_id
+    return nil unless provider_key == "aider"
+
+    aider_config["model"].to_s.presence
+  end
+
+  def aider_required_api_service_type
+    return nil unless provider_key == "aider"
+
+    DIRECT_OUTBOUND_API_PROVIDERS.dig(aider_api_provider, :service_type)
+  end
+
+  def requires_direct_outbound?
+    opencode_direct_outbound? || kilocode_direct_outbound? || aider_direct_outbound?
   end
 
   def opencode_required_api_service_type
@@ -292,6 +323,40 @@ class Provider < ApplicationRecord
 
   def copilot_agent_harness_runtime?
     provider_key == "copilot"
+  end
+
+  def direct_outbound_model_id
+    case provider_key
+    when "kilocode" then kilocode_model_id
+    when "opencode" then opencode_model_id
+    when "aider" then aider_model_id
+    end
+  end
+
+  def direct_outbound_llm_model_provider
+    case provider_key
+    when "kilocode" then kilocode_required_api_service_type
+    when "opencode" then opencode_required_api_service_type
+    when "aider" then aider_required_api_service_type
+    end
+  end
+
+  def ensure_direct_outbound_llm_model!
+    model_id = direct_outbound_model_id
+    raise ArgumentError, "No direct-outbound model configured" if model_id.blank?
+
+    provider_slug = direct_outbound_llm_model_provider || "unknown"
+    tier = DIRECT_OUTBOUND_MODEL_TIER_HINTS[model_id] || "mid"
+
+    LlmModel.find_or_create_by!(model_id: model_id) do |m|
+      m.display_name = direct_outbound_display_name(model_id)
+      m.provider = provider_slug
+      m.category = "coding"
+      m.tier = tier
+      m.active = true
+    end
+  rescue ActiveRecord::RecordNotUnique
+    LlmModel.find_by!(model_id: model_id)
   end
 
   # Returns the provider key that must always exist and remain enabled for
@@ -411,6 +476,20 @@ class Provider < ApplicationRecord
   end
 
   private
+
+  def sync_direct_outbound_tier_models
+    return unless direct_outbound_model_id.present?
+    return unless requires_direct_outbound?
+    return unless will_save_change_to_config? || tier_model_ids.blank?
+
+    model = ensure_direct_outbound_llm_model!
+    self.tier_model_ids = LlmModel::TIERS.each_with_object({}) { |t, h| h[t] = model.model_id }
+  end
+
+  def direct_outbound_display_name(model_id)
+    base = model_id.include?("/") ? model_id.split("/").last : model_id
+    base.tr("_-", " ").split.map(&:capitalize).join(" ")
+  end
 
   def normalize_agent_co_author_trailer
     stripped = agent_co_author_trailer.to_s.strip
@@ -550,7 +629,7 @@ class Provider < ApplicationRecord
     end
 
     expected_provider = Providers::DefaultTierModelIds::PROVIDER_KEY_TO_MODEL_PROVIDER[provider_key.to_s]
-    if expected_provider.nil?
+    if expected_provider.nil? && !requires_direct_outbound?
       errors.add(:tier_model_ids, "is not configurable for provider #{provider_key}")
       return
     end
@@ -561,7 +640,7 @@ class Provider < ApplicationRecord
       model = LlmModel.find_by(model_id: model_id)
       if model.nil?
         errors.add(:tier_model_ids, "references unknown model #{model_id} for tier #{tier}")
-      elsif model.provider != expected_provider
+      elsif expected_provider && model.provider != expected_provider
         errors.add(:tier_model_ids, "model #{model_id} does not belong to provider #{provider_key}")
       end
     end
@@ -618,9 +697,23 @@ class Provider < ApplicationRecord
     end
   end
 
+  def aider_api_key_config_must_be_valid
+    return unless provider_key == "aider"
+    return unless api_key?
+
+    unless AIDER_API_PROVIDER_KEYS.include?(aider_api_provider)
+      errors.add(:config, "must include a supported Aider API provider")
+    end
+
+    if aider_model_id.blank?
+      errors.add(:config, "must include an Aider model id")
+    end
+  end
+
   def required_api_service_type
     return opencode_required_api_service_type if provider_key == "opencode"
     return kilocode_required_api_service_type if provider_key == "kilocode"
+    return aider_required_api_service_type if provider_key == "aider"
 
     self.class.api_service_type_for(provider_key)
   end
@@ -637,6 +730,13 @@ class Provider < ApplicationRecord
       api_key? &&
       KILOCODE_API_PROVIDER_KEYS.include?(kilocode_api_provider) &&
       kilocode_model_id.present?
+  end
+
+  def aider_direct_outbound?
+    provider_key == "aider" &&
+      api_key? &&
+      AIDER_API_PROVIDER_KEYS.include?(aider_api_provider) &&
+      aider_model_id.present?
   end
 
   def opencode_provider_runtime

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -661,6 +661,17 @@ class Provider < ApplicationRecord
       return
     end
 
+    # Direct-outbound providers must map ALL tiers to the configured model.
+    # Partial mappings would let unmapped tiers fall back to the global
+    # LlmModel pool, reintroducing the wrong-model selection this PR fixes.
+    if requires_direct_outbound? && !will_save_change_to_config?
+      missing_tiers = LlmModel::TIERS.select { |t| tier_model_ids[t].blank? }
+      if missing_tiers.any?
+        errors.add(:tier_model_ids, "must map all tiers for direct-outbound providers (missing: #{missing_tiers.join(', ')})")
+        return
+      end
+    end
+
     tier_model_ids.each do |tier, model_id|
       next if model_id.blank?
 
@@ -738,9 +749,14 @@ class Provider < ApplicationRecord
   # NOTE: The provider UI/controller does not yet permit nested aider config
   # keys (api_provider, model). This validation is prep work for when the
   # controller is updated to support Aider API-key providers.
+  #
+  # Guard: ProviderResolver#tenant_api_key_provider auto-materializes api_key
+  # providers without config. Those tenant-key entries must remain valid —
+  # only enforce config requirements when aider-specific config is present.
   def aider_api_key_config_must_be_valid
     return unless provider_key == "aider"
     return unless api_key?
+    return unless config.is_a?(Hash) && config.key?("aider")
 
     unless AIDER_API_PROVIDER_KEYS.include?(aider_api_provider)
       errors.add(:config, "must include a supported Aider API provider")

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -218,8 +218,13 @@ class Provider < ApplicationRecord
     DIRECT_OUTBOUND_API_PROVIDERS.dig(aider_api_provider, :service_type)
   end
 
+  # NOTE: Aider is excluded here because the execution path does not yet have
+  # direct-outbound plumbing (no agent_harness_provider_runtime, no
+  # direct_outbound_exec_env/exec_command support). The config infrastructure
+  # (aider_config, aider_api_provider, aider_model_id) exists as prep work;
+  # add aider_direct_outbound? here once the runtime path is implemented.
   def requires_direct_outbound?
-    opencode_direct_outbound? || kilocode_direct_outbound? || aider_direct_outbound?
+    opencode_direct_outbound? || kilocode_direct_outbound?
   end
 
   def opencode_required_api_service_type
@@ -640,7 +645,7 @@ class Provider < ApplicationRecord
       model = LlmModel.find_by(model_id: model_id)
       if model.nil?
         errors.add(:tier_model_ids, "references unknown model #{model_id} for tier #{tier}")
-      elsif expected_provider && model.provider != expected_provider
+      elsif expected_provider && !requires_direct_outbound? && model.provider != expected_provider
         errors.add(:tier_model_ids, "model #{model_id} does not belong to provider #{provider_key}")
       end
     end
@@ -697,6 +702,9 @@ class Provider < ApplicationRecord
     end
   end
 
+  # NOTE: The provider UI/controller does not yet permit nested aider config
+  # keys (api_provider, model). This validation is prep work for when the
+  # controller is updated to support Aider API-key providers.
   def aider_api_key_config_must_be_valid
     return unless provider_key == "aider"
     return unless api_key?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -354,13 +354,18 @@ class Provider < ApplicationRecord
     provider_slug = direct_outbound_llm_model_provider || "unknown"
     tier = DIRECT_OUTBOUND_MODEL_TIER_HINTS[model_id] || "mid"
 
-    LlmModel.find_or_create_by!(model_id: model_id) do |m|
+    model = LlmModel.find_or_create_by!(model_id: model_id) do |m|
       m.display_name = direct_outbound_display_name(model_id)
       m.provider = provider_slug
       m.category = "coding"
       m.tier = tier
       m.active = true
     end
+    # Reactivate if an existing row was returned inactive — model selection
+    # resolves via LlmModel.active so an inactive record would silently
+    # fall back to the global pool.
+    model.update!(active: true, provider: provider_slug, tier: tier) unless model.active?
+    model
   rescue ActiveRecord::RecordNotUnique
     LlmModel.find_by!(model_id: model_id)
   end
@@ -501,7 +506,11 @@ class Provider < ApplicationRecord
   end
 
   def direct_outbound_capable_provider?
-    %w[kilocode opencode aider].include?(provider_key)
+    # NOTE: Aider is intentionally excluded — it is still mapped as a standard
+    # Anthropic provider in DefaultTierModelIds::PROVIDER_KEY_TO_MODEL_PROVIDER,
+    # so including it here would cause clear_stale_direct_outbound_tier_models
+    # to erase its valid standard tier mappings on every save.
+    %w[kilocode opencode].include?(provider_key)
   end
 
   def direct_outbound_display_name(model_id)
@@ -658,7 +667,18 @@ class Provider < ApplicationRecord
       model = LlmModel.find_by(model_id: model_id)
       if model.nil?
         errors.add(:tier_model_ids, "references unknown model #{model_id} for tier #{tier}")
-      elsif expected_provider && !requires_direct_outbound? && model.provider != expected_provider
+      elsif requires_direct_outbound?
+        # Direct-outbound providers must use their configured model — reject
+        # crafted updates that try to pin a different model_id. Skip when
+        # config is changing because sync_direct_outbound_tier_models will
+        # overwrite tier_model_ids during save.
+        next if will_save_change_to_config?
+        configured = direct_outbound_model_id
+        if configured.present? && model_id != configured
+          errors.add(:tier_model_ids, "must match the configured direct-outbound model #{configured}")
+          return
+        end
+      elsif expected_provider && model.provider != expected_provider
         errors.add(:tier_model_ids, "model #{model_id} does not belong to provider #{provider_key}")
       end
     end

--- a/app/services/providers/default_tier_model_ids.rb
+++ b/app/services/providers/default_tier_model_ids.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 module Providers
-  # Returns a sensible default {tier => model_id} mapping for a provider_key.
-  # Used to seed Provider#tier_model_ids on create and as a fallback when a
-  # provider has not been explicitly configured.
   class DefaultTierModelIds
-    # Maps a Paid provider_key to the LlmModel.provider value its API talks to.
     PROVIDER_KEY_TO_MODEL_PROVIDER = {
       "claude" => "anthropic",
       "cursor" => "anthropic",
@@ -13,6 +9,8 @@ module Providers
       "codex" => "openai",
       "gemini" => "google"
     }.freeze
+
+    DIRECT_OUTBOUND_PROVIDER_KEYS = %w[aider kilocode opencode].freeze
 
     def self.call(provider_key:)
       new(provider_key: provider_key).call
@@ -24,8 +22,18 @@ module Providers
 
     def call
       model_provider = PROVIDER_KEY_TO_MODEL_PROVIDER[@provider_key]
-      return {} if model_provider.blank?
+      return {} if model_provider.blank? && !DIRECT_OUTBOUND_PROVIDER_KEYS.include?(@provider_key)
 
+      if model_provider
+        tier_defaults_for_standard_provider(model_provider)
+      else
+        {}
+      end
+    end
+
+    private
+
+    def tier_defaults_for_standard_provider(model_provider)
       LlmModel::TIERS.each_with_object({}) do |tier, mapping|
         model = LlmModel.active.by_provider(model_provider).by_tier(tier).by_capability.first
         mapping[tier] = model.model_id if model

--- a/app/services/providers/default_tier_model_ids.rb
+++ b/app/services/providers/default_tier_model_ids.rb
@@ -10,7 +10,9 @@ module Providers
       "gemini" => "google"
     }.freeze
 
-    DIRECT_OUTBOUND_PROVIDER_KEYS = %w[aider kilocode opencode].freeze
+    # Aider is excluded until its execution path supports direct-outbound
+    # plumbing (see Provider#requires_direct_outbound? for details).
+    DIRECT_OUTBOUND_PROVIDER_KEYS = %w[kilocode opencode].freeze
 
     def self.call(provider_key:)
       new(provider_key: provider_key).call

--- a/db/migrate/20260504222628_backfill_direct_outbound_provider_tier_models.rb
+++ b/db/migrate/20260504222628_backfill_direct_outbound_provider_tier_models.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Backfills tier_model_ids for existing direct-outbound providers (KiloCode,
+# OpenCode) that already have a configured model in their config JSONB but
+# were saved before the sync_direct_outbound_tier_models callback existed.
+# Re-saving each matching provider triggers the before_save callback which
+# creates/finds the LlmModel record and populates tier_model_ids.
+class BackfillDirectOutboundProviderTierModels < ActiveRecord::Migration[8.1]
+  def up
+    Provider.where(auth_type: "api_key", provider_key: %w[kilocode opencode]).find_each do |provider|
+      next unless provider.requires_direct_outbound?
+      next if provider.tier_model_ids.present?
+
+      provider.save!
+    rescue => e # rubocop:disable Style/RescueStandardError
+      Rails.logger.warn(
+        message: "backfill_direct_outbound_tier_models.skip",
+        provider_id: provider.id,
+        error: e.message
+      )
+    end
+  end
+
+  def down
+    # No-op: removing tier_model_ids could break model selection for active
+    # providers, so we intentionally leave them populated on rollback.
+  end
+end

--- a/db/migrate/20260504222628_backfill_direct_outbound_provider_tier_models.rb
+++ b/db/migrate/20260504222628_backfill_direct_outbound_provider_tier_models.rb
@@ -5,19 +5,30 @@
 # were saved before the sync_direct_outbound_tier_models callback existed.
 # Re-saving each matching provider triggers the before_save callback which
 # creates/finds the LlmModel record and populates tier_model_ids.
+#
+# Uses the live Provider model for the sync callback. This is acceptable
+# because: (1) fresh installs have no data to backfill; (2) schema loads
+# (db:schema:load) skip migrations entirely; (3) the callback is idempotent.
 class BackfillDirectOutboundProviderTierModels < ActiveRecord::Migration[8.1]
   def up
+    failures = []
     Provider.where(auth_type: "api_key", provider_key: %w[kilocode opencode]).find_each do |provider|
       next unless provider.requires_direct_outbound?
       next if provider.tier_model_ids.present?
 
       provider.save!
     rescue => e # rubocop:disable Style/RescueStandardError
+      failures << { id: provider.id, error: e.message }
       Rails.logger.warn(
         message: "backfill_direct_outbound_tier_models.skip",
         provider_id: provider.id,
         error: e.message
       )
+    end
+
+    if failures.any?
+      summary = failures.map { |f| "provider ##{f[:id]}: #{f[:error]}" }.join("; ")
+      raise "BackfillDirectOutboundProviderTierModels failed for #{failures.size} provider(s): #{summary}"
     end
   end
 

--- a/db/migrate/20260504222628_backfill_direct_outbound_provider_tier_models.rb
+++ b/db/migrate/20260504222628_backfill_direct_outbound_provider_tier_models.rb
@@ -17,7 +17,7 @@ class BackfillDirectOutboundProviderTierModels < ActiveRecord::Migration[8.1]
       next if provider.tier_model_ids.present?
 
       provider.save!
-    rescue => e # rubocop:disable Style/RescueStandardError
+    rescue StandardError => e
       failures << { id: provider.id, error: e.message }
       Rails.logger.warn(
         message: "backfill_direct_outbound_tier_models.skip",

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11173,6 +11173,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260504222628'),
 ('20260504105047'),
 ('20260504100425'),
 ('20260503093418'),

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -616,7 +616,7 @@ RSpec.describe Provider do
       expect(provider.requires_direct_outbound?).to be(false)
     end
 
-    it "validates api_provider presence for API-key aider providers" do
+    it "validates model presence for API-key aider providers when api_provider is set" do
       provider = build(
         :provider,
         user: user,
@@ -660,7 +660,81 @@ RSpec.describe Provider do
     it "skips aider config validation for subscription providers" do
       provider = build(:provider, provider_key: "aider", auth_type: "subscription")
 
+      provider.valid?
       expect(provider.errors[:config]).to be_empty
+    end
+  end
+
+  describe "sync_direct_outbound_tier_models callback" do
+    let(:account) { create(:account, slug: "sync-tier-#{SecureRandom.hex(6)}") }
+    let(:user) { create(:user, account: account, email: "sync-tier-#{SecureRandom.hex(6)}@example.com") }
+    let(:api_key) { create(:provider_api_key, user: user, api_service_type: "openrouter") }
+
+    it "clears stale tier_model_ids when provider no longer qualifies for direct-outbound" do
+      provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "opencode" => { "api_provider" => "openrouter", "model" => "test-model-1" } }
+      )
+
+      expect(provider.tier_model_ids).to be_present
+
+      provider.update_columns(config: { "opencode" => { "api_provider" => "openrouter" } })
+
+      provider.valid?
+      expect(provider.tier_model_ids).to be_blank
+    end
+
+    it "clears stale tier_model_ids when model is removed from config" do
+      provider = create(
+        :provider,
+        user: user,
+        provider_key: "kilocode",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "kilocode" => { "api_provider" => "openrouter", "model" => "test-model-2" } }
+      )
+
+      expect(provider.tier_model_ids).to be_present
+
+      provider.update_columns(config: { "kilocode" => { "api_provider" => "openrouter", "model" => "" } })
+
+      provider.valid?
+      expect(provider.tier_model_ids).to be_blank
+    end
+
+    it "preserves tier_model_ids on unrelated attribute saves when config is unchanged" do
+      provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "opencode" => { "api_provider" => "openrouter", "model" => "test-model-3" } }
+      )
+
+      original_tier_model_ids = provider.tier_model_ids.dup
+      provider.update!(name: "Renamed Provider")
+
+      expect(provider.reload.tier_model_ids).to eq(original_tier_model_ids)
+    end
+
+    it "updates tier_model_ids when the configured model changes" do
+      provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "opencode" => { "api_provider" => "openrouter", "model" => "test-model-old" } }
+      )
+
+      provider.update!(config: { "opencode" => { "api_provider" => "openrouter", "model" => "test-model-new" } })
+
+      expect(provider.reload.tier_model_ids.values.uniq).to eq([ "test-model-new" ])
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -153,10 +153,28 @@ RSpec.describe Provider do
           auth_type: "api_key",
           provider_api_key: api_key,
           config: { "kilocode" => { "api_provider" => "zai", "model" => "glm-5.1" } },
-          tier_model_ids: { "high" => "glm-5.1" }
+          tier_model_ids: { "high" => "glm-5.1", "mid" => "glm-5.1", "low" => "glm-5.1" }
         )
 
         expect(provider).to be_valid
+      end
+
+      it "rejects partial tier_model_ids for direct-outbound providers" do
+        user = create(:user)
+        api_key = create(:provider_api_key, user: user, api_service_type: "zai")
+        create(:llm_model, model_id: "glm-5.1", provider: "zai", tier: "high")
+        provider = create(
+          :provider,
+          user: user,
+          provider_key: "kilocode",
+          auth_type: "api_key",
+          provider_api_key: api_key,
+          config: { "kilocode" => { "api_provider" => "zai", "model" => "glm-5.1" } }
+        )
+
+        provider.tier_model_ids = { "high" => "glm-5.1" }
+        expect(provider).not_to be_valid
+        expect(provider.errors[:tier_model_ids].join).to include("must map all tiers")
       end
 
       it "rejects crafted tier_model_ids that pin a direct-outbound provider to a different model" do
@@ -173,7 +191,7 @@ RSpec.describe Provider do
           config: { "kilocode" => { "api_provider" => "zai", "model" => "glm-5.1" } }
         )
 
-        provider.tier_model_ids = { "high" => wrong_model.model_id }
+        provider.tier_model_ids = { "high" => wrong_model.model_id, "mid" => wrong_model.model_id, "low" => wrong_model.model_id }
         expect(provider).not_to be_valid
         expect(provider.errors[:tier_model_ids].join).to include("must match the configured direct-outbound model")
       end
@@ -678,6 +696,22 @@ RSpec.describe Provider do
 
     it "skips aider config validation for subscription providers" do
       provider = build(:provider, provider_key: "aider", auth_type: "subscription")
+
+      provider.valid?
+      expect(provider.errors[:config]).to be_empty
+    end
+
+    it "skips aider config validation for tenant-key providers with no config" do
+      user = create(:user)
+      api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "aider",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: nil
+      )
 
       provider.valid?
       expect(provider.errors[:config]).to be_empty

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -141,6 +141,23 @@ RSpec.describe Provider do
         expect(unmapped).not_to be_valid
         expect(unmapped.errors[:tier_model_ids].join).to include("not configurable")
       end
+
+      it "allows direct-outbound providers to reference models from any upstream provider" do
+        user = create(:user)
+        api_key = create(:provider_api_key, user: user, api_service_type: "zai")
+        create(:llm_model, model_id: "glm-5.1", provider: "zai", tier: "high")
+        provider = build(
+          :provider,
+          user: user,
+          provider_key: "kilocode",
+          auth_type: "api_key",
+          provider_api_key: api_key,
+          config: { "kilocode" => { "api_provider" => "zai", "model" => "glm-5.1" } },
+          tier_model_ids: { "high" => "glm-5.1" }
+        )
+
+        expect(provider).to be_valid
+      end
     end
 
     it "validates auth_type inclusion" do
@@ -549,6 +566,101 @@ RSpec.describe Provider do
         }
       })
       expect(config["model"]).to eq("zai-coding-plan/glm-5.1")
+    end
+  end
+
+  describe "Aider config infrastructure" do
+    let(:account) { create(:account, slug: "provider-aider-#{SecureRandom.hex(6)}") }
+    let(:user) { create(:user, account: account, email: "provider-aider-#{SecureRandom.hex(6)}@example.com") }
+    let(:api_key) { create(:provider_api_key, user: user, api_service_type: "zai") }
+
+    it "reads aider config accessors from the config hash" do
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "aider",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "aider" => { "api_provider" => "zai", "model" => "glm-5.1" } }
+      )
+
+      expect(provider.aider_api_provider).to eq("zai")
+      expect(provider.aider_model_id).to eq("glm-5.1")
+      expect(provider.aider_required_api_service_type).to eq("zai")
+    end
+
+    it "defaults api_provider to openrouter when unset" do
+      provider = build(:provider, provider_key: "aider", auth_type: "api_key",
+        user: user, provider_api_key: api_key, config: { "aider" => { "model" => "glm-5.1" } })
+
+      expect(provider.aider_api_provider).to eq("openrouter")
+    end
+
+    it "returns nil accessors for non-aider providers" do
+      provider = build(:provider, provider_key: "claude")
+
+      expect(provider.aider_api_provider).to be_nil
+      expect(provider.aider_model_id).to be_nil
+    end
+
+    it "is not direct-outbound even when fully configured (no execution plumbing yet)" do
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "aider",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "aider" => { "api_provider" => "zai", "model" => "glm-5.1" } }
+      )
+
+      expect(provider.requires_direct_outbound?).to be(false)
+    end
+
+    it "validates api_provider presence for API-key aider providers" do
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "aider",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "aider" => { "api_provider" => "zai" } }
+      )
+
+      expect(provider).not_to be_valid
+      expect(provider.errors[:config].join).to include("Aider model id")
+    end
+
+    it "validates model presence for API-key aider providers" do
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "aider",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "aider" => {} }
+      )
+
+      expect(provider).not_to be_valid
+      expect(provider.errors[:config].join).to include("Aider model id")
+    end
+
+    it "accepts a fully configured API-key aider provider" do
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "aider",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "aider" => { "api_provider" => "zai", "model" => "glm-5.1" } }
+      )
+
+      expect(provider).to be_valid
+    end
+
+    it "skips aider config validation for subscription providers" do
+      provider = build(:provider, provider_key: "aider", auth_type: "subscription")
+
+      expect(provider.errors[:config]).to be_empty
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -158,6 +158,25 @@ RSpec.describe Provider do
 
         expect(provider).to be_valid
       end
+
+      it "rejects crafted tier_model_ids that pin a direct-outbound provider to a different model" do
+        user = create(:user)
+        api_key = create(:provider_api_key, user: user, api_service_type: "zai")
+        create(:llm_model, model_id: "glm-5.1", provider: "zai", tier: "high")
+        wrong_model = create(:llm_model, model_id: "claude-sonnet-4-6", provider: "anthropic", tier: "high")
+        provider = create(
+          :provider,
+          user: user,
+          provider_key: "kilocode",
+          auth_type: "api_key",
+          provider_api_key: api_key,
+          config: { "kilocode" => { "api_provider" => "zai", "model" => "glm-5.1" } }
+        )
+
+        provider.tier_model_ids = { "high" => wrong_model.model_id }
+        expect(provider).not_to be_valid
+        expect(provider.errors[:tier_model_ids].join).to include("must match the configured direct-outbound model")
+      end
     end
 
     it "validates auth_type inclusion" do
@@ -735,6 +754,22 @@ RSpec.describe Provider do
       provider.update!(config: { "opencode" => { "api_provider" => "openrouter", "model" => "test-model-new" } })
 
       expect(provider.reload.tier_model_ids.values.uniq).to eq([ "test-model-new" ])
+    end
+
+    it "reactivates an inactive LlmModel when reused for a direct-outbound provider" do
+      inactive_model = create(:llm_model, model_id: "inactive-test-model", provider: "zai", tier: "mid", active: false)
+
+      provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "opencode" => { "api_provider" => "openrouter", "model" => "inactive-test-model" } }
+      )
+
+      expect(inactive_model.reload).to be_active
+      expect(provider.tier_model_ids.values.uniq).to eq([ "inactive-test-model" ])
     end
   end
 


### PR DESCRIPTION
## Summary

- Direct-outbound providers (Kilocode, OpenCode) with configured models now auto-populate `tier_model_ids` so model selection resolves the correct LLM model instead of falling back to the global `LlmModel` pool
- Before this fix, every Kilocode GLM-5.1 run recorded `claude-sonnet-4-6` as its model selection because the system had no way to tie the provider's configured model to the tier system
- Adds Aider config infrastructure (accessors, validation, tier hints) as scaffolding for future direct-outbound execution support. **Aider is not yet wired into `requires_direct_outbound?`** because its execution path lacks the direct-outbound plumbing (no `agent_harness_provider_runtime`, no `direct_outbound_exec_env`/`exec_command` support). The config accessors and validation exist as prep work.

## Root Cause

Model selection (`Models::Select`) and provider execution were completely decoupled for direct-outbound providers. The model selection system only queried the global `LlmModel` table (Anthropic/OpenAI/Google models), so every Kilocode GLM-5.1 run recorded `claude-sonnet-4-6` — even though the container was correctly configured to hit z.ai. The `tier_model_ids` mechanism that should have pinned the model was blocked by validation that excluded Kilocode/OpenCode providers.

## Changes

| File | Change |
|------|--------|
| `app/models/provider.rb` | Added `before_save :sync_direct_outbound_tier_models` callback, `before_validation :clear_stale_direct_outbound_tier_models` cleanup, Aider config infrastructure (`aider_config`, `aider_api_provider`, `aider_model_id`), `DIRECT_OUTBOUND_MODEL_TIER_HINTS`, `ensure_direct_outbound_llm_model!` with race-safe `find_or_create_by!`, display name fix for slash-containing model IDs |
| `app/services/providers/default_tier_model_ids.rb` | Added `DIRECT_OUTBOUND_PROVIDER_KEYS` to recognize direct-outbound providers, refactored to separate standard vs direct-outbound paths |

## Code Review Fixes Applied

- **F1**: Race condition — replaced TOCTOU `find_by` + `create!` with `find_or_create_by!` + `RecordNotUnique` rescue
- **F2**: Tier hardcoded to "mid" — added `DIRECT_OUTBOUND_MODEL_TIER_HINTS` (GLM-5.1=high, GLM-4.7=mid, GLM-4.5-Air=low)
- **F3**: Callback fires on every save — guarded with `will_save_change_to_config? || tier_model_ids.blank?`
- **F4**: Aider config scaffolding — added Aider accessors and validation for future direct-outbound support (execution path not yet wired)
- **F5**: Display name breaks for slash-containing model IDs — strips provider prefix before titleizing
- **F6**: Dead code footgun — removed `direct_outbound_llm_model` (returned unsaved records) and `build_direct_outbound_llm_model`
- **F7**: Stale tier_model_ids — added `before_validation` cleanup that clears tier_model_ids when a direct-outbound capable provider no longer qualifies (defensive against manual edits or `update_columns` bypassing callbacks)
- **F8**: Migration safety — migration now raises on backfill failures instead of silently swallowing them

## Test plan

- [x] `bin/rspec spec/models/provider_spec.rb` — 95 examples, 0 failures
- [x] `bin/rspec spec/services/models/` — 85 examples, 0 failures
- [x] `bin/rspec spec/services/providers/` — 76 examples, 0 failures, 5 pending
- [x] `bin/rubocop` — no offenses
- [x] Backfilled existing providers in dev DB with correct tier_model_ids and LlmModel records
- [ ] Verify agent run with Kilocode GLM 5.1 provider now records correct model selection