### PR TITLE
chore: add devcontainer-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ __pycache__/
 
 # Database backups
 /backups/
+
+# Dev Container feature lockfile (machine-generated, not reproducible across machines)
+.devcontainer/devcontainer-lock.json


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer-lock.json` to `.gitignore`
- This file is machine-generated and pins devcontainer feature digests; it provides no reproducibility benefit across machines since `devcontainer.json` already specifies feature versions