### PR TITLE
feat(screenshots): inline image display in PR comments for current workflow

### DIFF
--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -3,9 +3,12 @@ name: PR Screenshots
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+  # Clean up screenshot directories when PRs are closed/merged
+  pull_request_target:
+    types: [ closed ]
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 
@@ -16,6 +19,7 @@ concurrency:
 
 jobs:
   detect:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:
       has_ui_changes: ${{ steps.check.outputs.has_ui_changes }}
@@ -149,7 +153,7 @@ jobs:
         id: capture_screenshots
         run: bin/rails screenshots:capture
 
-      - name: Upload screenshots
+      - name: Upload screenshots to artifacts
         id: upload_screenshots
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -159,6 +163,67 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+      - name: Push screenshots to branch
+        id: push_screenshots
+        if: >-
+          steps.capture_screenshots.outcome == 'success'
+          && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          short_sha="${COMMIT_SHA:0:8}"
+          screenshot_dir="screenshots/${PR_NUMBER}/${short_sha}"
+
+          # Configure git for the push
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Fetch the screenshots branch or create it as an orphan
+          if git ls-remote --exit-code origin refs/heads/screenshots >/dev/null 2>&1; then
+            git fetch origin screenshots --depth=1
+            git checkout screenshots
+          else
+            git checkout --orphan screenshots
+            git rm -rf . 2>/dev/null || true
+            git clean -fd
+            echo "# Screenshots Branch" > README.md
+            echo "" >> README.md
+            echo "This branch stores PR screenshot images for inline display in PR comments." >> README.md
+            echo "Do not merge this branch into main." >> README.md
+            git add README.md
+            git commit -m "chore: initialize screenshots branch"
+          fi
+
+          # Create directory structure and copy screenshots
+          mkdir -p "${screenshot_dir}"
+          cp tmp/screenshots/*.png "${screenshot_dir}/"
+
+          # Stage and commit
+          git add "${screenshot_dir}"
+          git commit -m "screenshots: PR #${PR_NUMBER} @ ${short_sha}"
+
+          # Push with retry for concurrent PR conflicts
+          push_attempts=0
+          max_attempts=3
+          while [ "$push_attempts" -lt "$max_attempts" ]; do
+            if git push origin screenshots; then
+              echo "push_success=true" >> "$GITHUB_OUTPUT"
+              echo "screenshot_dir=${screenshot_dir}" >> "$GITHUB_OUTPUT"
+              echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            push_attempts=$((push_attempts + 1))
+            if [ "$push_attempts" -lt "$max_attempts" ]; then
+              echo "Push failed, retrying (attempt $((push_attempts + 1))/${max_attempts})..."
+              git pull --rebase origin screenshots
+            fi
+          done
+
+          echo "push_success=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::Failed to push screenshots to branch after ${max_attempts} attempts"
+
       - name: Refresh PR screenshot comment
         if: >-
           always()
@@ -166,29 +231,45 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           screenshot_count=$(find tmp/screenshots -name '*.png' 2>/dev/null | wc -l)
           capture_outcome="${{ steps.capture_screenshots.outcome }}"
           upload_outcome="${{ steps.upload_screenshots.outcome }}"
+          push_success="${{ steps.push_screenshots.outputs.push_success }}"
+          short_sha="${COMMIT_SHA:0:8}"
 
           if [ "$capture_outcome" = "success" ] && [ "$upload_outcome" = "success" ] && [ "$screenshot_count" -gt 0 ]; then
             body="## 📸 UI Screenshots\n\n"
             body+="This PR includes **UI-facing changes**. "
-            body+="Screenshots of the rendered pages have been captured and uploaded as artifacts.\n\n"
-            body+="**${screenshot_count} screenshot(s)** captured from key application pages.\n\n"
-            body+="### How to review\n"
-            body+="1. Go to the **Actions** tab for this PR\n"
-            body+="2. Open the **PR Screenshots** workflow run\n"
-            body+="3. Download the **pr-screenshots** artifact\n"
-            body+="4. Review the \`.png\` files to verify the UI renders correctly\n\n"
-            body+="### Pages captured\n"
-            for file in tmp/screenshots/*.png; do
-              name=$(basename "$file" .png)
-              body+="- ✅ \`${name}\`\n"
-            done
+
+            if [ "$push_success" = "true" ]; then
+              body+="Screenshots of the rendered pages are displayed inline below.\n\n"
+              body+="**${screenshot_count} screenshot(s)** captured at commit \`${short_sha}\`.\n\n"
+              body+="| Page | Screenshot |\n"
+              body+="| :--- | :---: |\n"
+              for file in tmp/screenshots/*.png; do
+                name=$(basename "$file" .png)
+                raw_url="https://raw.githubusercontent.com/${{ github.repository }}/refs/heads/screenshots/${PR_NUMBER}/${short_sha}/${name}.png"
+                body+="| \`${name}\` | ![${name}](${raw_url}) |\n"
+              done
+            else
+              body+="Screenshots have been uploaded as artifacts (inline display unavailable).\n\n"
+              body+="**${screenshot_count} screenshot(s)** captured from key application pages.\n\n"
+              body+="### How to review\n"
+              body+="1. Go to the **Actions** tab for this PR\n"
+              body+="2. Open the **PR Screenshots** workflow run\n"
+              body+="3. Download the **pr-screenshots** artifact\n"
+              body+="4. Review the \`.png\` files to verify the UI renders correctly\n\n"
+              body+="### Pages captured\n"
+              for file in tmp/screenshots/*.png; do
+                name=$(basename "$file" .png)
+                body+="- ✅ \`${name}\`\n"
+              done
+            fi
           else
             body="## 📸 UI Screenshots\n\n"
-            body+="This PR still includes **UI-facing changes**, but screenshot capture for commit \`${{ github.event.pull_request.head.sha }}\` did not complete successfully.\n\n"
+            body+="This PR still includes **UI-facing changes**, but screenshot capture for commit \`${short_sha}\` did not complete successfully.\n\n"
             body+="Any screenshots linked from an earlier workflow run are now stale and should not be used for review.\n\n"
             body+="### What happened\n"
             body+="- Capture step: \`${capture_outcome}\`\n"
@@ -256,3 +337,33 @@ jobs:
             "repos/${{ github.repository }}/issues/comments/${existing_comment_id}" \
             --method PATCH \
             --field "body=@-"
+
+  # Clean up screenshot directories when a PR is closed or merged
+  cleanup-branch:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout screenshots branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: screenshots
+          fetch-depth: 1
+
+      - name: Remove PR screenshot directory
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          pr_dir="screenshots/${PR_NUMBER}"
+
+          if [ ! -d "$pr_dir" ]; then
+            echo "No screenshot directory for PR #${PR_NUMBER}, nothing to clean up."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git rm -rf "${pr_dir}"
+          git commit -m "cleanup: remove screenshots for PR #${PR_NUMBER}"
+          git push origin screenshots

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -7,20 +7,22 @@ on:
   pull_request_target:
     types: [ closed ]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+# Permissions are set per-job to minimize blast radius.
+# The capture job only needs read; the push-screenshots job needs write.
 
 # Cancel in-progress screenshot runs on the same PR when a new commit is pushed.
+# Uses PR number instead of github.ref so pull_request_target events (which resolve
+# to the base branch) don't collide across PRs.
 concurrency:
-  group: pr-screenshots-${{ github.workflow }}-${{ github.ref }}
+  group: pr-screenshots-${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   detect:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       has_ui_changes: ${{ steps.check.outputs.has_ui_changes }}
       ui_files: ${{ steps.check.outputs.ui_files }}
@@ -70,6 +72,8 @@ jobs:
     if: needs.detect.outputs.has_ui_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     services:
       postgres:
@@ -163,20 +167,45 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  # Separate job for pushing screenshots to the branch and commenting on the PR.
+  # This job only consumes uploaded artifacts, so granting contents: write here
+  # does not give PR code access to a write-capable token.
+  publish:
+    needs: [detect, capture]
+    if: >-
+      always()
+      && needs.capture.result != 'skipped'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Download screenshot artifacts
+        id: download_screenshots
+        if: needs.capture.result == 'success'
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+        with:
+          name: pr-screenshots
+          path: screenshots-download
+
       - name: Push screenshots to branch
         id: push_screenshots
-        if: >-
-          steps.capture_screenshots.outcome == 'success'
-          && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.download_screenshots.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           short_sha="${COMMIT_SHA:0:8}"
           screenshot_dir="screenshots/${PR_NUMBER}/${short_sha}"
 
-          # Configure git for the push
+          # Set up a fresh repo for the screenshots branch
+          git init screenshots-repo
+          cd screenshots-repo
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -186,8 +215,6 @@ jobs:
             git checkout screenshots
           else
             git checkout --orphan screenshots
-            git rm -rf . 2>/dev/null || true
-            git clean -fd
             echo "# Screenshots Branch" > README.md
             echo "" >> README.md
             echo "This branch stores PR screenshot images for inline display in PR comments." >> README.md
@@ -196,15 +223,25 @@ jobs:
             git commit -m "chore: initialize screenshots branch"
           fi
 
-          # Create directory structure and copy screenshots
+          # Copy downloaded screenshots into place
           mkdir -p "${screenshot_dir}"
-          cp tmp/screenshots/*.png "${screenshot_dir}/"
+          cp ../screenshots-download/*.png "${screenshot_dir}/"
 
-          # Stage and commit
+          # Stage and commit (skip if screenshots are identical to a previous run)
           git add "${screenshot_dir}"
+          if git diff --cached --quiet; then
+            echo "Screenshots already committed for this SHA, nothing to update."
+            echo "push_success=true" >> "$GITHUB_OUTPUT"
+            echo "screenshot_dir=${screenshot_dir}" >> "$GITHUB_OUTPUT"
+            echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git commit -m "screenshots: PR #${PR_NUMBER} @ ${short_sha}"
 
-          # Push with retry for concurrent PR conflicts
+          # Push with retry for concurrent PR conflicts.
+          # On retry, fetch the remote branch and reset to it before re-applying
+          # our changes. This handles both normal conflicts and the race where
+          # multiple runs create independent orphan histories.
           push_attempts=0
           max_attempts=3
           while [ "$push_attempts" -lt "$max_attempts" ]; do
@@ -217,7 +254,14 @@ jobs:
             push_attempts=$((push_attempts + 1))
             if [ "$push_attempts" -lt "$max_attempts" ]; then
               echo "Push failed, retrying (attempt $((push_attempts + 1))/${max_attempts})..."
-              git pull --rebase origin screenshots
+              git fetch origin screenshots
+              git reset --hard origin/screenshots
+              mkdir -p "${screenshot_dir}"
+              cp ../screenshots-download/*.png "${screenshot_dir}/"
+              git add "${screenshot_dir}"
+              if ! git diff --cached --quiet; then
+                git commit -m "screenshots: PR #${PR_NUMBER} @ ${short_sha}"
+              fi
             fi
           done
 
@@ -225,21 +269,24 @@ jobs:
           echo "::warning::Failed to push screenshots to branch after ${max_attempts} attempts"
 
       - name: Refresh PR screenshot comment
-        if: >-
-          always()
-          && github.event.pull_request.head.repo.full_name == github.repository
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          screenshot_count=$(find tmp/screenshots -name '*.png' 2>/dev/null | wc -l)
-          capture_outcome="${{ steps.capture_screenshots.outcome }}"
-          upload_outcome="${{ steps.upload_screenshots.outcome }}"
+          capture_result="${{ needs.capture.result }}"
           push_success="${{ steps.push_screenshots.outputs.push_success }}"
           short_sha="${COMMIT_SHA:0:8}"
 
-          if [ "$capture_outcome" = "success" ] && [ "$upload_outcome" = "success" ] && [ "$screenshot_count" -gt 0 ]; then
+          if [ "$capture_result" = "success" ]; then
+            screenshot_count=0
+            if [ -d screenshots-download ]; then
+              screenshot_count=$(find screenshots-download -name '*.png' 2>/dev/null | wc -l)
+            fi
+          else
+            screenshot_count=0
+          fi
+
+          if [ "$capture_result" = "success" ] && [ "$screenshot_count" -gt 0 ]; then
             body="## 📸 UI Screenshots\n\n"
             body+="This PR includes **UI-facing changes**. "
 
@@ -248,9 +295,9 @@ jobs:
               body+="**${screenshot_count} screenshot(s)** captured at commit \`${short_sha}\`.\n\n"
               body+="| Page | Screenshot |\n"
               body+="| :--- | :---: |\n"
-              for file in tmp/screenshots/*.png; do
+              for file in screenshots-download/*.png; do
                 name=$(basename "$file" .png)
-                raw_url="https://raw.githubusercontent.com/${{ github.repository }}/refs/heads/screenshots/${PR_NUMBER}/${short_sha}/${name}.png"
+                raw_url="https://raw.githubusercontent.com/${{ github.repository }}/refs/heads/screenshots/screenshots/${PR_NUMBER}/${short_sha}/${name}.png"
                 body+="| \`${name}\` | ![${name}](${raw_url}) |\n"
               done
             else
@@ -262,7 +309,7 @@ jobs:
               body+="3. Download the **pr-screenshots** artifact\n"
               body+="4. Review the \`.png\` files to verify the UI renders correctly\n\n"
               body+="### Pages captured\n"
-              for file in tmp/screenshots/*.png; do
+              for file in screenshots-download/*.png; do
                 name=$(basename "$file" .png)
                 body+="- ✅ \`${name}\`\n"
               done
@@ -272,8 +319,7 @@ jobs:
             body+="This PR still includes **UI-facing changes**, but screenshot capture for commit \`${short_sha}\` did not complete successfully.\n\n"
             body+="Any screenshots linked from an earlier workflow run are now stale and should not be used for review.\n\n"
             body+="### What happened\n"
-            body+="- Capture step: \`${capture_outcome}\`\n"
-            body+="- Upload step: \`${upload_outcome}\`\n\n"
+            body+="- Capture: \`${capture_result}\`\n\n"
             body+="Open the latest [PR Screenshots](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow run to inspect the failure.\n"
           fi
 
@@ -312,6 +358,10 @@ jobs:
       && github.event.action == 'synchronize'
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Update stale screenshot comment
         env:
@@ -340,16 +390,23 @@ jobs:
 
   # Clean up screenshot directories when a PR is closed or merged
   cleanup-branch:
-    if: github.event.action == 'closed'
+    if: >-
+      github.event.action == 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout screenshots branch
+        id: checkout_screenshots
+        continue-on-error: true
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: screenshots
           fetch-depth: 1
 
       - name: Remove PR screenshot directory
+        if: steps.checkout_screenshots.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -254,7 +254,7 @@ jobs:
             push_attempts=$((push_attempts + 1))
             if [ "$push_attempts" -lt "$max_attempts" ]; then
               echo "Push failed, retrying (attempt $((push_attempts + 1))/${max_attempts})..."
-              git fetch origin screenshots
+              git fetch --depth=1 origin screenshots
               git reset --hard origin/screenshots
               mkdir -p "${screenshot_dir}"
               cp ../screenshots-download/*.png "${screenshot_dir}/"
@@ -316,10 +316,15 @@ jobs:
             fi
           else
             body="## 📸 UI Screenshots\n\n"
-            body+="This PR still includes **UI-facing changes**, but screenshot capture for commit \`${short_sha}\` did not complete successfully.\n\n"
+            body+="This PR still includes **UI-facing changes**, but screenshots for commit \`${short_sha}\` are not available.\n\n"
             body+="Any screenshots linked from an earlier workflow run are now stale and should not be used for review.\n\n"
             body+="### What happened\n"
-            body+="- Capture: \`${capture_result}\`\n\n"
+            if [ "$capture_result" != "success" ]; then
+              body+="- Capture: \`${capture_result}\` (screenshot capture did not complete successfully)\n"
+            else
+              body+="- Capture: \`success\` but no screenshot files were found (artifact download may have failed)\n"
+            fi
+            body+="\n"
             body+="Open the latest [PR Screenshots](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow run to inspect the failure.\n"
           fi
 
@@ -408,7 +413,6 @@ jobs:
       - name: Remove PR screenshot directory
         if: steps.checkout_screenshots.outcome == 'success'
         env:
-          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           pr_dir="screenshots/${PR_NUMBER}"

--- a/spec/support/temporal.rb
+++ b/spec/support/temporal.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Eager-load the Temporalio::Client class so that instance_double
-# references in specs can verify against the real interface.
-# The production initializer (config/initializers/temporal.rb) loads
-# this lazily, but RSpec's verifying doubles need the constant at
-# define-time.
-require "temporalio/client"

--- a/spec/support/temporal.rb
+++ b/spec/support/temporal.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Eager-load the Temporalio::Client class so that instance_double
+# references in specs can verify against the real interface.
+# The production initializer (config/initializers/temporal.rb) loads
+# this lazily, but RSpec's verifying doubles need the constant at
+# define-time.
+require "temporalio/client"


### PR DESCRIPTION
## Summary

OK

Commit succeeded. Here's a summary of what was implemented:

**Changes to `.github/workflows/pr-screenshots.yml`:**

1. **New "Push screenshots to branch" step** — After capturing screenshots, commits them to a `screenshots` orphan branch at `screenshots/{pr_number}/{short_sha}/`. Creates the branch if it doesn't exist. Includes retry logic (3 attempts with rebase) for handling concurrent pushes from multiple PRs.

2. **Inline image display in PR comments** — When the branch push succeeds, the comment renders screenshots in a markdown table using `![name](raw.githubusercontent.com/...)` URLs. Each row shows the page name and its screenshot inline.

3. **Fallback to artifact-only comment** — If the branch push fails, falls back to the previous behavior (download instructions pointing to the Actions artifacts tab).

4. **Cleanup on PR close/merge** — Added `pull_request_target: [closed]` trigger with a `cleanup-branch` job that removes the PR's screenshot directory from the branch.

5. **Permission upgrade** — `contents: read` → `contents: write` to allow pushing to the screenshots branch.

---

Closes #1671