### PR TITLE
fix(dev): disable Rails log rotation to prevent development.log deletion

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,13 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
+  # Disable Rails' built-in log rotation (shift_age/shift_size), which renames
+  # development.log to .0 and can leave it missing if recreation fails.  The
+  # 7.1 framework defaults enable rotation at 100 MB for local envs, but
+  # bin/setup already removes stale logs at startup, and Paid::LogTruncator
+  # handles unbounded growth for dev-update logs.
+  config.log_file_size = nil
+
   # Allow agent containers to reach the web service via Docker network aliases.
   config.hosts << "web"
 


### PR DESCRIPTION
## Summary

- Disables Rails' built-in log rotation (`config.log_file_size = nil`) in the development environment, which was enabled by the `config.load_defaults 8.1` → 7.1 framework defaults chain setting `log_file_size = 100MB` for local environments.
- Ruby's `Logger#shift_log_age` renames `development.log` to `.0` and attempts to recreate it, but `lock_shift_log` silently swallows creation failures (`rescue; warn(...)`) at [`log_device.rb:189`](https://github.com/ruby/ruby/blob/v3_4_0/lib/logger/log_device.rb#L189), leaving `development.log` missing.
- `bin/setup` already cleans stale logs at startup, so explicit rotation is unnecessary in development.

## How to verify

1. Boot the dev server (`bin/dev`) and confirm `log/development.log` is created and written to normally.
2. Confirm no `.0` rotation files are created as the log grows.