### PR TITLE
fix(agent-runs): skip harness preflight for subscription-auth providers

### DIFF
--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -339,6 +339,7 @@ module Providers
     end
 
     def harness_health_check_supported?
+      return false if provider.subscription?
       api_key_name = ProviderSupport.proxy_health_check_api_key_for(provider.provider_key)
       !!(api_key_name && proxy_api_key_configured?(api_key_name))
     end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -801,7 +801,7 @@ module Activities
       # correct environment and will catch real auth failures.
       provider_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
       subscription_auth = provider_entry&.subscription? &&
-        ProviderSupport.subscription_auth_unset_vars_for(provider).any?
+        ProviderSupport.subscription_auth_unset_vars_for(provider_entry.provider_key).any?
       harness_provider = preflight_provider_instance(command_context)
       if harness_provider && !subscription_auth
         run_harness_preflight!(

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -792,8 +792,18 @@ module Activities
       # OPENAI_BASE_URL reachability) when available — fails fast before
       # the smoke exec below.  The smoke exec always runs as a safety
       # net regardless of whether the harness supports preflight_check.
+      #
+      # Skip the harness preflight for subscription-auth providers: it
+      # runs outside the container where OAuth credentials (auth.json,
+      # .credentials.json) are unavailable.  The harness auth check only
+      # understands API keys, so subscription auth always appears invalid.
+      # The smoke-exec preflight below runs inside the container with the
+      # correct environment and will catch real auth failures.
+      provider_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
+      subscription_auth = provider_entry&.subscription? &&
+        ProviderSupport.subscription_auth_unset_vars_for(provider).any?
       harness_provider = preflight_provider_instance(command_context)
-      if harness_provider
+      if harness_provider && !subscription_auth
         run_harness_preflight!(
           agent_run: agent_run,
           harness_provider: harness_provider,

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -222,7 +222,8 @@ RSpec.describe Providers::TestAgent do
     end
 
     context "when codex has a Paid-managed OpenAI API key configured" do
-      let(:provider_record) { create(:provider, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+      let(:api_key_record) { create(:provider_api_key, user: user, api_service_type: "openai") }
+      let(:provider_record) { create(:provider, :api_key, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: api_key_record) }
       let(:health_result) { { name: :codex, status: "ok", message: "All checks passed", latency_ms: 12 } }
 
       before do
@@ -241,7 +242,8 @@ RSpec.describe Providers::TestAgent do
     end
 
     context "when agent-harness returns a binary-encoded failure message" do
-      let(:provider_record) { create(:provider, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+      let(:api_key_record) { create(:provider_api_key, user: user, api_service_type: "openai") }
+      let(:provider_record) { create(:provider, :api_key, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: api_key_record) }
       let(:health_result) { { name: :codex, status: "error", message: "bad \xFF auth\x00".b, latency_ms: 12 } }
 
       before do
@@ -261,7 +263,8 @@ RSpec.describe Providers::TestAgent do
     end
 
     context "when agent-harness returns valid UTF-8 bytes tagged as binary" do
-      let(:provider_record) { create(:provider, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+      let(:api_key_record) { create(:provider_api_key, user: user, api_service_type: "openai") }
+      let(:provider_record) { create(:provider, :api_key, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: api_key_record) }
       let(:health_result) { { name: :codex, status: "error", message: "caf\xC3\xA9 auth".b, latency_ms: 12 } }
 
       before do
@@ -289,13 +292,13 @@ RSpec.describe Providers::TestAgent do
       end
 
       it "clears the stale provider state" do
-        codex_provider = create(:provider, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false)
+        codex_provider = create(:provider, :api_key, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: create(:provider_api_key, user: user, api_service_type: "openai"))
         provider_state = create(
           :provider_state,
           :rate_limited,
           :circuit_half_open,
           user: user,
-          provider_name: "codex"
+          provider_name: codex_provider.state_key
         )
 
         result = described_class.call(provider: codex_provider)
@@ -319,7 +322,7 @@ RSpec.describe Providers::TestAgent do
 
       it "persists the provider rate limit state using the absolute reset timestamp" do
         travel_to Time.utc(2026, 4, 5, 12, 0, 0) do
-          codex_provider = create(:provider, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false)
+          codex_provider = create(:provider, :api_key, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: create(:provider_api_key, user: user, api_service_type: "openai"))
           reset_at = Time.utc(2026, 4, 6, 10, 0, 0)
           allow(AgentHarness).to receive(:check_provider).and_return(
             name: :codex,
@@ -333,14 +336,14 @@ RSpec.describe Providers::TestAgent do
           expect(result).not_to be_success
           expect(result.error_type).to eq(:rate_limited)
 
-          provider_state = user.provider_states.find_by!(provider_name: "codex")
+          provider_state = user.provider_states.find_by!(provider_name: codex_provider.state_key)
           expect(provider_state.rate_limited_until).to eq(reset_at)
         end
       end
     end
 
     context "when gemini has a Paid-managed Google API key configured" do
-      let(:provider_record) { create(:provider, user: user, provider_key: "gemini", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+      let(:provider_record) { create(:provider, :api_key, user: user, provider_key: "gemini", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: create(:provider_api_key, user: user, api_service_type: "google")) }
       let(:health_result) { { name: :gemini, status: "ok", message: "All checks passed", latency_ms: 12 } }
 
       before do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1789,6 +1789,50 @@ expect(container_service).to receive(:execute).with(
           timeout: described_class::PREFLIGHT_TIMEOUT_SECONDS
         )
       end
+
+      context "when codex subscription auth is active" do
+        let(:codex_provider) do
+          user.providers.find_or_create_by!(provider_key: "codex").tap do |p|
+            p.update!(auth_type: "subscription")
+          end
+        end
+        let(:agent_run) do
+          create(:agent_run, :with_git_context,
+            project: project,
+            issue: issue,
+            agent_type: "codex",
+            provider: codex_provider,
+            container_id: "abc123")
+        end
+
+        before do
+          user.providers.find_or_create_by!(provider_key: "cursor")
+          user.settings.update!(fallback_enabled: true, fallback_providers: [ "cursor" ])
+          allow(activity).to receive(:logger).and_return(instance_double(ActiveSupport::Logger, info: nil, warn: nil, error: nil))
+          allow(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")
+          allow(activity).to receive(:run_provider_preflight!).and_call_original
+          allow(activity).to receive(:run_harness_preflight!).and_call_original
+        end
+
+        it "skips harness preflight and uses smoke exec preflight instead" do
+          harness_provider = instance_double(AgentHarness::Providers::Codex)
+          allow(activity).to receive(:preflight_provider_instance).and_return(harness_provider)
+          # If harness preflight were called, it would raise — proving the skip works.
+          allow(harness_provider).to receive(:preflight_check).and_raise(
+            "harness preflight should not be called for subscription auth"
+          )
+          allow(container_service).to receive(:execute).and_return(exec_success)
+          allow(git_ops).to receive(:commit_uncommitted_changes).and_return(false)
+          allow(git_ops).to receive(:has_changes_since?).with("pre_agent_sha_abc123").and_return(false)
+
+          result = activity.execute(agent_run_id: agent_run.id)
+
+          agent_run.reload
+          expect(result).to include(success: true)
+          expect(agent_run.status).to eq("running")
+          expect(container_service).to have_received(:execute).at_least(:twice)
+        end
+      end
     end
 
     context "when agent times out (wall clock)" do


### PR DESCRIPTION
## Summary

- **Skip harness preflight for subscription-auth providers** in `run_provider_preflight!` — the codex harness `preflight_check` runs outside the container where OAuth credentials (`auth.json`) are unavailable, causing "No OpenAI API key found" errors for subscription providers
- **Force container smoke test for subscription providers** in `TestAgent.harness_health_check_supported?` — the lightweight harness health check doesn't validate subscription auth at all; subscription providers should always use the container path
- **Fix test that didn't verify the skip** — the outer `before` stubbed `run_harness_preflight!` as a no-op, so the new subscription-auth test would pass regardless of whether the skip logic worked

Fixes the root cause of codex subscription auth always falling back to claude during preflight, which becomes critical when claude is rate-limited.

## Testing

- All 230 tests in affected spec files pass
- New test verified to catch regressions (tested with skip disabled — fails as expected)
- Existing harness health check tests updated to use API key providers (correct code path)