### PR TITLE
Fix #1538: Smoke test timeout (30s) too short for slow models like GLM 5.1

### DIFF
--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -12,11 +12,12 @@ require Rails.root.join("lib/provider_support").to_s
 # ships the upstream fix.
 # TODO(#1538): remove this monkey-patch when agent-harness ships the upstream fix
 module AgentHarnessSmokeTestTimeoutProviderPatch
-  def smoke_test(timeout:, provider_runtime:)
-    super(
-      timeout: effective_smoke_test_timeout(timeout),
-      provider_runtime: provider_runtime
-    )
+  def smoke_test(*args, **kwargs, &block)
+    if kwargs.key?(:timeout)
+      kwargs = kwargs.merge(timeout: effective_smoke_test_timeout(kwargs[:timeout]))
+    end
+
+    super(*args, **kwargs, &block)
   end
 
   private
@@ -38,10 +39,10 @@ end
 module AgentHarnessSmokeTestTimeoutPatch
   private
 
-  def perform_check(provider_name, start_time, timeout:, executor:, provider_runtime:)
+  def perform_check(*args, timeout: nil, **kwargs, &block)
     previous_timeout = Thread.current[:paid_agent_harness_smoke_test_timeout]
     Thread.current[:paid_agent_harness_smoke_test_timeout] = timeout
-    super
+    super(*args, timeout: timeout, **kwargs, &block)
   ensure
     Thread.current[:paid_agent_harness_smoke_test_timeout] = previous_timeout
   end
@@ -59,7 +60,7 @@ module AgentHarnessSmokeTestTimeoutPatch
 end
 
 agent_harness_version = Gem.loaded_specs.fetch("agent-harness").version
-if agent_harness_version < Gem::Version.new("0.18.0")
+if agent_harness_version == Gem::Version.new("0.17.0")
   AgentHarness::ProviderHealthCheck.singleton_class.prepend(AgentHarnessSmokeTestTimeoutPatch)
 end
 

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -2,196 +2,66 @@
 
 require Rails.root.join("lib/provider_support").to_s
 
-# Backport fix for viamin/agent-harness#173 — the gem's
-# ProviderHealthCheck.perform_check passes `nil` as the smoke-test timeout
-# when a contract exists, so the adapter falls back to the contract's 30s
-# default. Slow models (e.g. Kilocode GLM 5.1) need the caller-specified
-# timeout honoured. This patch forwards `max(caller_timeout, contract_timeout)`
-# instead of nil. Remove once agent-harness >= 0.18 ships the fix.
+# Backport fix for viamin/agent-harness#173 — agent-harness 0.17.x passes
+# `nil` as the smoke-test timeout when a contract exists, so the adapter
+# falls back to the contract's 30s default. Slow models (e.g. Kilocode
+# GLM 5.1) need the caller-specified timeout honoured.
+#
+# Keep this patch narrow and version-gated: only intercept the nil timeout
+# forwarded into the provider smoke test, and only until agent-harness 0.18
+# ships the upstream fix.
 # TODO(#1538): remove this monkey-patch when agent-harness ships the upstream fix
+module AgentHarnessSmokeTestTimeoutProviderPatch
+  def smoke_test(timeout:, provider_runtime:)
+    super(
+      timeout: effective_smoke_test_timeout(timeout),
+      provider_runtime: provider_runtime
+    )
+  end
+
+  private
+
+  def effective_smoke_test_timeout(timeout)
+    return timeout unless timeout.nil?
+
+    caller_timeout = instance_variable_get(:@paid_smoke_test_timeout)
+    contract_timeout = smoke_test_contract&.dig(:timeout)
+
+    if caller_timeout.is_a?(Numeric) && contract_timeout.is_a?(Numeric)
+      [ caller_timeout, contract_timeout ].max
+    else
+      caller_timeout || contract_timeout
+    end
+  end
+end
+
 module AgentHarnessSmokeTestTimeoutPatch
   private
 
   def perform_check(provider_name, start_time, timeout:, executor:, provider_runtime:)
-    registry = AgentHarness::Providers::Registry.instance
-    unless registry.registered?(provider_name)
-      return build_result(
-        name: provider_name,
-        status: "error",
-        message: "Provider not registered",
-        start_time: start_time,
-        error_category: :installation,
-        check: :registration
-      )
-    end
+    previous_timeout = Thread.current[:paid_agent_harness_smoke_test_timeout]
+    Thread.current[:paid_agent_harness_smoke_test_timeout] = timeout
+    super
+  ensure
+    Thread.current[:paid_agent_harness_smoke_test_timeout] = previous_timeout
+  end
 
-    klass = registry.get(provider_name)
-    provider_instance = build_provider(provider_name, klass, executor: executor)
-    host_preflight_allowed = host_preflight_allowed?(executor: executor, provider_runtime: provider_runtime)
-    provider_preflight_allowed = provider_preflight_allowed?(executor: executor)
-
-    auth_degraded = false
-    if host_preflight_allowed
-      if executor.nil? && !klass.available?
-        return build_result(
-          name: provider_name,
-          status: "error",
-          message: "Provider '#{klass.binary_name}' is not available (#{klass}.available? returned false)",
-          start_time: start_time,
-          error_category: :installation,
-          check: :availability
-        )
-      end
-
-      unless provider_instance.executor.which(klass.binary_name)
-        return build_result(
-          name: provider_name,
-          status: "error",
-          message: "CLI '#{klass.binary_name}' not found in PATH",
-          start_time: start_time,
-          error_category: :installation,
-          check: :availability
-        )
-      end
-
-      auth = AgentHarness::Authentication.auth_status(provider_name)
-      unless auth[:valid]
-        unless auth_not_implemented?(auth)
-          return build_result(
-            name: provider_name,
-            status: "error",
-            message: auth[:error] || "Authentication failed",
-            start_time: start_time,
-            error_category: :authentication,
-            check: :authentication
-          )
-        end
-        auth_degraded = true
-      end
-
-      health = provider_instance.health_status
-      unless health[:healthy]
-        return build_result(
-          name: provider_name,
-          status: "degraded",
-          message: health[:message] || "Provider health check failed",
-          start_time: start_time,
-          error_category: :transient,
-          check: :provider_health
-        )
-      end
-    end
-
-    validation = provider_instance.validate_config
-    unless validation[:valid]
-      errors_msg = Array(validation[:errors]).join(", ")
-      errors_msg = "check provider configuration" if errors_msg.empty?
-      return build_result(
-        name: provider_name,
-        status: "degraded",
-        message: "Configuration issues: #{errors_msg}",
-        start_time: start_time,
-        error_category: :configuration,
-        check: :configuration
-      )
-    end
-
-    if provider_preflight_allowed
-      preflight_env = build_preflight_env(provider_instance, provider_runtime)
-      preflight = provider_instance.preflight_check(env: preflight_env, timeout: timeout)
-      unless preflight[:healthy]
-        return build_result(
-          name: provider_name,
-          status: "error",
-          message: preflight[:reason] || "Preflight check failed",
-          start_time: start_time,
-          error_category: normalize_preflight_error_category(preflight[:error_category]),
-          check: :preflight
-        )
-      end
-    end
-
-    smoke_contract = provider_instance.smoke_test_contract
-    if smoke_contract.nil? && !provider_overrides_method?(provider_instance, :smoke_test)
-      message = if host_preflight_allowed && auth_degraded
-        "Auth status check not implemented; health and config checks passed (smoke test unavailable)"
-      elsif host_preflight_allowed && (provider_overrides_method?(provider_instance, :health_status) ||
-        provider_overrides_method?(provider_instance, :validate_config))
-        "Health and config checks passed (smoke test unavailable)"
-      elsif host_preflight_allowed
-        "Registered and authenticated; health/config checks use defaults and smoke test is unavailable"
-      elsif provider_overrides_method?(provider_instance, :validate_config)
-        "Configuration checks passed, but smoke test is unavailable for the supplied execution context"
-      else
-        "Smoke test is unavailable for the supplied execution context"
-      end
-
-      return build_result(
-        name: provider_name,
-        status: "degraded",
-        message: message,
-        start_time: start_time,
-        error_category: :configuration,
-        check: :smoke_test
-      )
-    end
-
-    # --- PATCHED: pass max(caller_timeout, contract_timeout) instead of nil ---
-    smoke_timeout = if smoke_contract
-      contract_timeout = smoke_contract[:timeout]
-      if timeout.is_a?(Numeric) && contract_timeout.is_a?(Numeric)
-        [ timeout, contract_timeout ].max
-      else
-        timeout || contract_timeout
-      end
-    else
-      timeout
-    end
-    smoke = provider_instance.smoke_test(timeout: smoke_timeout, provider_runtime: provider_runtime)
-    unless smoke[:ok]
-      return build_result(
-        name: provider_name,
-        status: smoke[:status] || "error",
-        message: smoke[:message] || "Smoke test failed",
-        start_time: start_time,
-        error_category: normalize_smoke_error_category(smoke[:error_category], smoke[:message]),
-        check: :smoke_test
-      )
-    end
-
-    if auth_degraded
-      return build_result(
-        name: provider_name,
-        status: "degraded",
-        message: "Auth status check not implemented; health, config, and smoke tests passed",
-        start_time: start_time,
-        error_category: :authentication,
-        check: :authentication
-      )
-    end
-
-    message = if !host_preflight_allowed && provider_overrides_method?(provider_instance, :validate_config)
-      "Configuration and smoke test passed using the supplied execution context"
-    elsif !host_preflight_allowed
-      "Smoke test passed using the supplied execution context"
-    elsif provider_overrides_method?(provider_instance, :health_status) ||
-        provider_overrides_method?(provider_instance, :validate_config)
-      "All checks passed"
-    else
-      "Registered, authenticated, and smoke test passed (health/config checks use defaults)"
-    end
-
-    build_result(
-      name: provider_name,
-      status: "ok",
-      message: message,
-      start_time: start_time,
-      check: :smoke_test
+  def build_provider(provider_name, klass, executor:)
+    provider_instance = super
+    provider_instance.instance_variable_set(
+      :@paid_smoke_test_timeout,
+      Thread.current[:paid_agent_harness_smoke_test_timeout]
     )
+    provider_instance.singleton_class.prepend(AgentHarnessSmokeTestTimeoutProviderPatch) unless
+      provider_instance.singleton_class < AgentHarnessSmokeTestTimeoutProviderPatch
+    provider_instance
   end
 end
 
-AgentHarness::ProviderHealthCheck.singleton_class.prepend(AgentHarnessSmokeTestTimeoutPatch)
+agent_harness_version = Gem.loaded_specs.fetch("agent-harness").version
+if agent_harness_version < Gem::Version.new("0.18.0")
+  AgentHarness::ProviderHealthCheck.singleton_class.prepend(AgentHarnessSmokeTestTimeoutPatch)
+end
 
 # Default agent timeout used for AgentHarness boot-time config and as a
 # fallback when per-user settings are unavailable. Runtime code should

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -2,6 +2,197 @@
 
 require Rails.root.join("lib/provider_support").to_s
 
+# Backport fix for viamin/agent-harness#173 — the gem's
+# ProviderHealthCheck.perform_check passes `nil` as the smoke-test timeout
+# when a contract exists, so the adapter falls back to the contract's 30s
+# default. Slow models (e.g. Kilocode GLM 5.1) need the caller-specified
+# timeout honoured. This patch forwards `max(caller_timeout, contract_timeout)`
+# instead of nil. Remove once agent-harness >= 0.18 ships the fix.
+# TODO(#1538): remove this monkey-patch when agent-harness ships the upstream fix
+module AgentHarnessSmokeTestTimeoutPatch
+  private
+
+  def perform_check(provider_name, start_time, timeout:, executor:, provider_runtime:)
+    registry = AgentHarness::Providers::Registry.instance
+    unless registry.registered?(provider_name)
+      return build_result(
+        name: provider_name,
+        status: "error",
+        message: "Provider not registered",
+        start_time: start_time,
+        error_category: :installation,
+        check: :registration
+      )
+    end
+
+    klass = registry.get(provider_name)
+    provider_instance = build_provider(provider_name, klass, executor: executor)
+    host_preflight_allowed = host_preflight_allowed?(executor: executor, provider_runtime: provider_runtime)
+    provider_preflight_allowed = provider_preflight_allowed?(executor: executor)
+
+    auth_degraded = false
+    if host_preflight_allowed
+      if executor.nil? && !klass.available?
+        return build_result(
+          name: provider_name,
+          status: "error",
+          message: "Provider '#{klass.binary_name}' is not available (#{klass}.available? returned false)",
+          start_time: start_time,
+          error_category: :installation,
+          check: :availability
+        )
+      end
+
+      unless provider_instance.executor.which(klass.binary_name)
+        return build_result(
+          name: provider_name,
+          status: "error",
+          message: "CLI '#{klass.binary_name}' not found in PATH",
+          start_time: start_time,
+          error_category: :installation,
+          check: :availability
+        )
+      end
+
+      auth = AgentHarness::Authentication.auth_status(provider_name)
+      unless auth[:valid]
+        unless auth_not_implemented?(auth)
+          return build_result(
+            name: provider_name,
+            status: "error",
+            message: auth[:error] || "Authentication failed",
+            start_time: start_time,
+            error_category: :authentication,
+            check: :authentication
+          )
+        end
+        auth_degraded = true
+      end
+
+      health = provider_instance.health_status
+      unless health[:healthy]
+        return build_result(
+          name: provider_name,
+          status: "degraded",
+          message: health[:message] || "Provider health check failed",
+          start_time: start_time,
+          error_category: :transient,
+          check: :provider_health
+        )
+      end
+    end
+
+    validation = provider_instance.validate_config
+    unless validation[:valid]
+      errors_msg = Array(validation[:errors]).join(", ")
+      errors_msg = "check provider configuration" if errors_msg.empty?
+      return build_result(
+        name: provider_name,
+        status: "degraded",
+        message: "Configuration issues: #{errors_msg}",
+        start_time: start_time,
+        error_category: :configuration,
+        check: :configuration
+      )
+    end
+
+    if provider_preflight_allowed
+      preflight_env = build_preflight_env(provider_instance, provider_runtime)
+      preflight = provider_instance.preflight_check(env: preflight_env, timeout: timeout)
+      unless preflight[:healthy]
+        return build_result(
+          name: provider_name,
+          status: "error",
+          message: preflight[:reason] || "Preflight check failed",
+          start_time: start_time,
+          error_category: normalize_preflight_error_category(preflight[:error_category]),
+          check: :preflight
+        )
+      end
+    end
+
+    smoke_contract = provider_instance.smoke_test_contract
+    if smoke_contract.nil? && !provider_overrides_method?(provider_instance, :smoke_test)
+      message = if host_preflight_allowed && auth_degraded
+        "Auth status check not implemented; health and config checks passed (smoke test unavailable)"
+      elsif host_preflight_allowed && (provider_overrides_method?(provider_instance, :health_status) ||
+        provider_overrides_method?(provider_instance, :validate_config))
+        "Health and config checks passed (smoke test unavailable)"
+      elsif host_preflight_allowed
+        "Registered and authenticated; health/config checks use defaults and smoke test is unavailable"
+      elsif provider_overrides_method?(provider_instance, :validate_config)
+        "Configuration checks passed, but smoke test is unavailable for the supplied execution context"
+      else
+        "Smoke test is unavailable for the supplied execution context"
+      end
+
+      return build_result(
+        name: provider_name,
+        status: "degraded",
+        message: message,
+        start_time: start_time,
+        error_category: :configuration,
+        check: :smoke_test
+      )
+    end
+
+    # --- PATCHED: pass max(caller_timeout, contract_timeout) instead of nil ---
+    smoke_timeout = if smoke_contract
+      contract_timeout = smoke_contract[:timeout]
+      if timeout.is_a?(Numeric) && contract_timeout.is_a?(Numeric)
+        [ timeout, contract_timeout ].max
+      else
+        timeout || contract_timeout
+      end
+    else
+      timeout
+    end
+    smoke = provider_instance.smoke_test(timeout: smoke_timeout, provider_runtime: provider_runtime)
+    unless smoke[:ok]
+      return build_result(
+        name: provider_name,
+        status: smoke[:status] || "error",
+        message: smoke[:message] || "Smoke test failed",
+        start_time: start_time,
+        error_category: normalize_smoke_error_category(smoke[:error_category], smoke[:message]),
+        check: :smoke_test
+      )
+    end
+
+    if auth_degraded
+      return build_result(
+        name: provider_name,
+        status: "degraded",
+        message: "Auth status check not implemented; health, config, and smoke tests passed",
+        start_time: start_time,
+        error_category: :authentication,
+        check: :authentication
+      )
+    end
+
+    message = if !host_preflight_allowed && provider_overrides_method?(provider_instance, :validate_config)
+      "Configuration and smoke test passed using the supplied execution context"
+    elsif !host_preflight_allowed
+      "Smoke test passed using the supplied execution context"
+    elsif provider_overrides_method?(provider_instance, :health_status) ||
+        provider_overrides_method?(provider_instance, :validate_config)
+      "All checks passed"
+    else
+      "Registered, authenticated, and smoke test passed (health/config checks use defaults)"
+    end
+
+    build_result(
+      name: provider_name,
+      status: "ok",
+      message: message,
+      start_time: start_time,
+      check: :smoke_test
+    )
+  end
+end
+
+AgentHarness::ProviderHealthCheck.singleton_class.prepend(AgentHarnessSmokeTestTimeoutPatch)
+
 # Default agent timeout used for AgentHarness boot-time config and as a
 # fallback when per-user settings are unavailable. Runtime code should
 # prefer UserSetting#agent_timeout_seconds resolved via

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1044,30 +1044,93 @@ RSpec.describe Providers::TestAgent do
   end
 
   describe "smoke test timeout forwarding (issue #1538)" do
-    it "forwards max(caller_timeout, contract_timeout) to the provider smoke_test" do
-      provider_instance = instance_double(
-        AgentHarness::Providers::Base,
-        executor: instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/kilo"),
-        validate_config: { valid: true, errors: [] },
-        smoke_test_contract: { prompt: "Reply with exactly OK.", timeout: 30, expected_output: "OK", require_output: true },
-        smoke_test: { ok: true, status: "ok", message: "Smoke test passed" }
-      )
+    let(:provider_class) do
+      Class.new(AgentHarness::Providers::Base) do
+        class << self
+          attr_accessor :contract_timeout, :provider_instance
 
+          def provider_name
+            :kilocode
+          end
+
+          def binary_name
+            "kilo"
+          end
+
+          def available?
+            true
+          end
+
+          def smoke_test_contract
+            {
+              prompt: "Reply with exactly OK.",
+              timeout: contract_timeout,
+              expected_output: "OK",
+              require_output: true
+            }
+          end
+
+          private
+
+          def build_provider_instance(config:, executor:, logger:)
+            provider_instance || new(config: config, executor: executor, logger: logger)
+          end
+        end
+
+        attr_reader :received_smoke_test_timeout, :received_provider_runtime
+
+        def validate_config
+          { valid: true, errors: [] }
+        end
+
+        def smoke_test(timeout:, provider_runtime:)
+          @received_smoke_test_timeout = timeout
+          @received_provider_runtime = provider_runtime
+          { ok: true, status: "ok", message: "Smoke test passed" }
+        end
+      end
+    end
+
+    def run_health_check(provider_instance:, contract_timeout:, caller_timeout:)
       allow(AgentHarness::Providers::Registry.instance).to receive(:registered?).with(:kilocode).and_return(true)
-      allow(AgentHarness::Providers::Registry.instance).to receive(:get).with(:kilocode).and_return(AgentHarness::Providers::Kilocode)
+      allow(AgentHarness::Providers::Registry.instance).to receive(:get).with(:kilocode).and_return(provider_class)
       allow(AgentHarness::Providers::Registry.instance).to receive(:canonical_name).with(:kilocode).and_return(:kilocode)
-      allow(AgentHarness::Providers::Registry.instance).to receive(:smoke_test_contract).with(:kilocode).and_return({ timeout: 30 })
-      allow(AgentHarness::ProviderHealthCheck).to receive(:build_provider).and_return(provider_instance)
+      allow(AgentHarness::Providers::Registry.instance).to receive(:smoke_test_contract).with(:kilocode).and_return({ timeout: contract_timeout })
+      provider_class.contract_timeout = contract_timeout
+      provider_class.provider_instance = provider_instance
 
       executor = instance_double(AgentHarness::DockerCommandExecutor)
       runtime = AgentHarness::ProviderRuntime.new(env: { "FOO" => "bar" })
 
-      AgentHarness::ProviderHealthCheck.check(:kilocode, timeout: 60, executor: executor, provider_runtime: runtime)
-
-      expect(provider_instance).to have_received(:smoke_test).with(
-        timeout: 60,
+      AgentHarness::ProviderHealthCheck.check(
+        :kilocode,
+        timeout: caller_timeout,
+        executor: executor,
         provider_runtime: runtime
       )
+      runtime
+    end
+
+    it "uses the caller timeout when it exceeds the smoke-test contract timeout" do
+      provider_instance = provider_class.new(
+        executor: instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/kilo")
+      )
+
+      runtime = run_health_check(provider_instance: provider_instance, contract_timeout: 30, caller_timeout: 60)
+
+      expect(provider_instance.received_smoke_test_timeout).to eq(60)
+      expect(provider_instance.received_provider_runtime).to eq(runtime)
+    end
+
+    it "preserves the smoke-test contract timeout when it exceeds the caller timeout" do
+      provider_instance = provider_class.new(
+        executor: instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/kilo")
+      )
+
+      runtime = run_health_check(provider_instance: provider_instance, contract_timeout: 90, caller_timeout: 60)
+
+      expect(provider_instance.received_smoke_test_timeout).to eq(90)
+      expect(provider_instance.received_provider_runtime).to eq(runtime)
     end
   end
 

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1132,6 +1132,52 @@ RSpec.describe Providers::TestAgent do
       expect(provider_instance.received_smoke_test_timeout).to eq(90)
       expect(provider_instance.received_provider_runtime).to eq(runtime)
     end
+
+    it "forwards unrelated smoke-test keywords while replacing a nil timeout" do
+      provider_instance = Class.new do
+        attr_reader :received_kwargs
+
+        def smoke_test_contract
+          { timeout: 30 }
+        end
+
+        def smoke_test(*args, **kwargs)
+          @received_kwargs = kwargs
+          { ok: true }
+        end
+      end.new
+
+      provider_instance.instance_variable_set(:@paid_smoke_test_timeout, 60)
+      provider_instance.singleton_class.prepend(AgentHarnessSmokeTestTimeoutProviderPatch)
+
+      provider_instance.smoke_test(timeout: nil, provider_runtime: :runtime, sentinel: :value)
+
+      expect(provider_instance.received_kwargs).to eq(
+        timeout: 60,
+        provider_runtime: :runtime,
+        sentinel: :value
+      )
+    end
+
+    it "forwards unrelated health-check keywords while storing the caller timeout" do
+      health_check_class = Class.new do
+        class << self
+          attr_reader :received_args, :received_kwargs
+
+          def perform_check(*args, **kwargs)
+            @received_args = args
+            @received_kwargs = kwargs
+          end
+        end
+      end
+      health_check_class.singleton_class.prepend(AgentHarnessSmokeTestTimeoutPatch)
+
+      health_check_class.send(:perform_check, :kilocode, :start, timeout: 60, sentinel: :value)
+
+      expect(health_check_class.received_args).to eq([ :kilocode, :start ])
+      expect(health_check_class.received_kwargs).to eq(timeout: 60, sentinel: :value)
+      expect(Thread.current[:paid_agent_harness_smoke_test_timeout]).to be_nil
+    end
   end
 
   describe "#rate_limit_reset_at" do

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1043,6 +1043,34 @@ RSpec.describe Providers::TestAgent do
     end
   end
 
+  describe "smoke test timeout forwarding (issue #1538)" do
+    it "forwards max(caller_timeout, contract_timeout) to the provider smoke_test" do
+      provider_instance = instance_double(
+        AgentHarness::Providers::Base,
+        executor: instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/kilo"),
+        validate_config: { valid: true, errors: [] },
+        smoke_test_contract: { prompt: "Reply with exactly OK.", timeout: 30, expected_output: "OK", require_output: true },
+        smoke_test: { ok: true, status: "ok", message: "Smoke test passed" }
+      )
+
+      allow(AgentHarness::Providers::Registry.instance).to receive(:registered?).with(:kilocode).and_return(true)
+      allow(AgentHarness::Providers::Registry.instance).to receive(:get).with(:kilocode).and_return(AgentHarness::Providers::Kilocode)
+      allow(AgentHarness::Providers::Registry.instance).to receive(:canonical_name).with(:kilocode).and_return(:kilocode)
+      allow(AgentHarness::Providers::Registry.instance).to receive(:smoke_test_contract).with(:kilocode).and_return({ timeout: 30 })
+      allow(AgentHarness::ProviderHealthCheck).to receive(:build_provider).and_return(provider_instance)
+
+      executor = instance_double(AgentHarness::DockerCommandExecutor)
+      runtime = AgentHarness::ProviderRuntime.new(env: { "FOO" => "bar" })
+
+      AgentHarness::ProviderHealthCheck.check(:kilocode, timeout: 60, executor: executor, provider_runtime: runtime)
+
+      expect(provider_instance).to have_received(:smoke_test).with(
+        timeout: 60,
+        provider_runtime: runtime
+      )
+    end
+  end
+
   describe "#rate_limit_reset_at" do
     let(:account) { create(:account, slug: "test-agent-rate-limit-reset-account") }
     let(:user) { create(:user, account: account, email: "test-agent-rate-limit-reset@example.com") }


### PR DESCRIPTION
## Summary

OK

Clean (the settings.json changes are unrelated). Here's a summary of what was done:

**Problem**: The agent-harness gem's `ProviderHealthCheck#perform_check` passes `nil` as the smoke-test timeout when a contract exists, causing it to fall back to the contract's hardcoded 30s default. Paid passes `timeout: 60`, but this is only used for the outer `Timeout.timeout` wrapper — the inner smoke test still uses 30s, which is too short for slow models like Kilocode GLM 5.1.

**Fix**: Since the upstream fix (viamin/agent-harness#173) hasn't been released yet, I applied a monkey-patch via `prepend` in `config/initializers/agent_harness.rb` that overrides `perform_check` to pass `max(caller_timeout, contract_timeout)` instead of `nil` to the smoke test. This ensures Paid's 60s timeout is honored while still respecting the contract timeout as a minimum.

**Changes**:
- `config/initializers/agent_harness.rb` — Added `AgentHarnessSmokeTestTimeoutPatch` module prepended onto `ProviderHealthCheck.singleton_class`
- `spec/services/providers/test_agent_spec.rb` — Added test verifying that `smoke_test` receives `timeout: 60` (not 30) when the caller passes 60s and the contract specifies 30s

---

Closes #1538