### PR TITLE
feat(auto-pick): handle parent issues instead of silently skipping them

### DIFF
--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -92,7 +92,7 @@ module Automation
           end
 
           def review_required_parent_scope(project)
-            with_open_non_pr_subissues(base_scope(project))
+            with_open_non_pr_subissues(parent_review_scope(project))
               .where(id: blocking_parent_issue_ids(project))
           end
 
@@ -195,6 +195,11 @@ module Automation
             EXCLUDED_LABELS.reduce(base) do |scope, label|
               scope.where.not("labels @> ?::jsonb", [ label ].to_json)
             end
+          end
+
+          def parent_review_scope(project)
+            Issue.where(project: project, github_state: "open", is_pull_request: false)
+              .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
           end
 
           def without_open_non_pr_subissues(scope)

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -14,7 +14,7 @@ module Automation
       # - No unfinished agent run already attached to the issue
       # - No open PR linked back to the issue via +parent_issue_id+
       # - Not labeled with any of {EXCLUDED_LABELS}
-      # - Not a parent/tracking issue (has sub-issues), and not a tracker /
+      # - Not a parent issue with still-open sub-issues, and not a tracker /
       #   meta issue whose body still references open work items
       # - Issue creator is in the project's trusted allowlist when one is
       #   configured
@@ -63,26 +63,7 @@ module Automation
           end
 
           def eligible_scope(project)
-            blocking_issue_ids = AgentRun.where(
-              project: project, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES
-            ).where.not(issue_id: nil).select(:issue_id)
-
-            subissue_parent_ids = Issue.where(
-              project: project, is_pull_request: false
-            ).where.not(parent_issue_id: nil).distinct.select(:parent_issue_id)
-
-            base = Issue.ready_for_work(project)
-              .where.not(id: blocking_issue_ids)
-              .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
-              .where.not(id: subissue_parent_ids)
-              .where.not(id: Issue.open_pull_request_parent_issue_ids(project: project).distinct)
-
-            trusted_usernames = Array(project.allowed_github_usernames).presence
-            base = base.where(github_creator_login: trusted_usernames) if trusted_usernames
-
-            base = EXCLUDED_LABELS.reduce(base) do |s, label|
-              s.where.not("labels @> ?::jsonb", [ label ].to_json)
-            end
+            base = without_open_non_pr_subissues(base_scope(project))
 
             scope = base.where(paid_state: %w[new planning failed])
 
@@ -108,6 +89,11 @@ module Automation
             scope = scope.where.not(id: blocked_ids) if blocked_ids.present?
 
             scope
+          end
+
+          def review_required_parent_scope(project)
+            with_open_non_pr_subissues(base_scope(project))
+              .where(id: blocking_parent_issue_ids(project))
           end
 
           def next_candidate(project)
@@ -192,6 +178,58 @@ module Automation
           end
 
           private
+
+          def base_scope(project)
+            blocking_issue_ids = AgentRun.where(
+              project: project, status: AgentRun::AUTO_PICK_BLOCKING_STATUSES
+            ).where.not(issue_id: nil).select(:issue_id)
+
+            base = Issue.ready_for_work(project)
+              .where.not(id: blocking_issue_ids)
+              .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
+              .where.not(id: Issue.open_pull_request_parent_issue_ids(project: project).distinct)
+
+            trusted_usernames = Array(project.allowed_github_usernames).presence
+            base = base.where(github_creator_login: trusted_usernames) if trusted_usernames
+
+            EXCLUDED_LABELS.reduce(base) do |scope, label|
+              scope.where.not("labels @> ?::jsonb", [ label ].to_json)
+            end
+          end
+
+          def without_open_non_pr_subissues(scope)
+            scope.where(<<~SQL.squish)
+              NOT EXISTS (
+                SELECT 1
+                FROM issues sub_issues
+                WHERE sub_issues.parent_issue_id = issues.id
+                  AND sub_issues.project_id = issues.project_id
+                  AND sub_issues.is_pull_request = FALSE
+                  AND sub_issues.github_state = 'open'
+              )
+            SQL
+          end
+
+          def with_open_non_pr_subissues(scope)
+            scope.where(<<~SQL.squish)
+              EXISTS (
+                SELECT 1
+                FROM issues sub_issues
+                WHERE sub_issues.parent_issue_id = issues.id
+                  AND sub_issues.project_id = issues.project_id
+                  AND sub_issues.is_pull_request = FALSE
+                  AND sub_issues.github_state = 'open'
+              )
+            SQL
+          end
+
+          def blocking_parent_issue_ids(project)
+            IssueDependency.joins(:issue)
+              .where(issues: { project_id: project.id, github_state: "open", is_pull_request: false })
+              .where.not(depends_on_issue_id: nil)
+              .distinct
+              .select(:depends_on_issue_id)
+          end
 
           # Returns a CASE expression that maps each issue to a numeric
           # priority rank based on the project's configured priority

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -25,6 +25,7 @@ module Issues
     NoRunnableProviderError = Class.new(StandardError)
 
     PAID_READY_LABEL = "paid-ready"
+    BLOCKING_PARENT_REVIEW_SOURCE = "blocking_parent_issue_review"
 
     # Returns the Set of issue IDs from +displayed_issues+ that are
     # currently eligible for auto-picking (per-issue criteria only;
@@ -41,6 +42,8 @@ module Issues
     end
 
     def call
+      sync_blocking_parent_review_notifications if should_sync_blocking_parent_reviews?
+
       result = strategy.evaluate(build_context)
       decision = result.decisions.first
       return nil if decision.nil? || decision.type == "noop"
@@ -107,6 +110,74 @@ module Issues
 
     def strategy
       @strategy ||= Automation::Strategies::AutoPick.new
+    end
+
+    def should_sync_blocking_parent_reviews?
+      @project.auto_pick_enabled? && !@project.quality_paused?
+    end
+
+    def sync_blocking_parent_review_notifications
+      review_issues = Automation::Strategies::AutoPick::DefaultCandidateSource
+        .review_required_parent_scope(@project)
+        .includes(:sub_issues)
+        .to_a
+
+      review_issues.each { |issue| publish_blocking_parent_review_notification(issue) }
+
+      unresolved_blocking_parent_notifications(review_issues.map(&:id)).find_each do |notification|
+        Notifications::Resolve.call(
+          account: notification.account,
+          user: notification.user,
+          source: BLOCKING_PARENT_REVIEW_SOURCE,
+          subject: notification.subject
+        )
+      end
+    end
+
+    def publish_blocking_parent_review_notification(issue)
+      open_child_numbers = issue.sub_issues
+        .select { |sub_issue| !sub_issue.is_pull_request? && sub_issue.github_state == "open" }
+        .map(&:github_number)
+        .sort
+
+      blocking_issue_count = IssueDependency.joins(:issue)
+        .where(depends_on_issue: issue)
+        .where(issues: { project_id: @project.id, github_state: "open", is_pull_request: false })
+        .distinct
+        .count(:issue_id)
+
+      Notifications::Publish.call(
+        account: @project.account,
+        user: @project.effective_owner,
+        source: BLOCKING_PARENT_REVIEW_SOURCE,
+        subject: issue,
+        severity: :warning,
+        title: "Parent issue ##{issue.github_number} is blocking auto-pick",
+        description: "Open child issues: #{open_child_numbers.map { |n| "##{n}" }.join(", ")}. " \
+          "Review close-out work so #{blocking_issue_count} blocked issue#{'s' unless blocking_issue_count == 1} can move forward.",
+        nav_section: "dashboard",
+        action_url: "/projects/#{@project.id}",
+        metadata: {
+          issue_number: issue.github_number,
+          open_child_issue_numbers: open_child_numbers,
+          blocking_issue_count: blocking_issue_count
+        }
+      )
+    end
+
+    def unresolved_blocking_parent_notifications(active_issue_ids)
+      scope = Notification.where(
+        account: @project.account,
+        user: @project.effective_owner,
+        source: BLOCKING_PARENT_REVIEW_SOURCE,
+        subject_type: "Issue",
+        subject_id: @project.issues.select(:id),
+        resolved_at: nil
+      )
+
+      return scope if active_issue_ids.empty?
+
+      scope.where.not(subject_id: active_issue_ids)
     end
 
     def build_context

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -81,6 +81,48 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
       expect(scope.pluck(:id)).to be_empty
     end
+
+    it "keeps a parent issue eligible when all of its sub-issues are closed" do
+      parent = create(:issue, project: project, github_number: 1)
+      create(:issue, :closed, project: project, github_number: 2, parent_issue: parent)
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(parent.id)
+    end
+
+    it "excludes a parent issue while it still has open non-PR sub-issues" do
+      parent = create(:issue, project: project, github_number: 1)
+      child = create(:issue, project: project, github_number: 2, parent_issue: parent)
+      standalone = create(:issue, project: project, github_number: 3)
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(child.id, standalone.id)
+    end
+  end
+
+  describe ".review_required_parent_scope" do
+    it "returns blocking parent issues that still have open sub-issues" do
+      parent = create(:issue, project: project, github_number: 1)
+      child = create(:issue, project: project, github_number: 2, parent_issue: parent)
+      blocked = create(:issue, project: project, github_number: 3)
+      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
+
+      scope = described_class.review_required_parent_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(parent.id)
+      expect(child).to be_present
+    end
+
+    it "does not return parents that are not blocking downstream issues" do
+      parent = create(:issue, project: project, github_number: 1)
+      create(:issue, project: project, github_number: 2, parent_issue: parent)
+
+      scope = described_class.review_required_parent_scope(project)
+
+      expect(scope).to be_empty
+    end
   end
 
   describe ".eligible_issue_ids" do

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -115,6 +115,29 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
       expect(child).to be_present
     end
 
+    it "returns blocking parent issues even when auto-pick label exclusions make them ineligible" do
+      parent = create(:issue, project: project, github_number: 1, labels: [ "tracking" ])
+      create(:issue, project: project, github_number: 2, parent_issue: parent)
+      blocked = create(:issue, project: project, github_number: 3)
+      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
+
+      scope = described_class.review_required_parent_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(parent.id)
+    end
+
+    it "returns blocking parent issues even when trusted-user auto-pick filters exclude them" do
+      project.update!(allowed_github_usernames: [ "trusted-user" ])
+      parent = create(:issue, project: project, github_number: 1, github_creator_login: "external-user")
+      create(:issue, project: project, github_number: 2, parent_issue: parent)
+      blocked = create(:issue, project: project, github_number: 3)
+      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
+
+      scope = described_class.review_required_parent_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(parent.id)
+    end
+
     it "does not return parents that are not blocking downstream issues" do
       parent = create(:issue, project: project, github_number: 1)
       create(:issue, project: project, github_number: 2, parent_issue: parent)

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -398,6 +398,22 @@ RSpec.describe Issues::AutoPick do
       )
     end
 
+    it "publishes a review notification for a blocking parent even when auto-pick excludes it by label" do
+      parent = create(:issue, project: project, github_number: 1, labels: [ "epic" ])
+      create(:issue, project: project, github_number: 2, parent_issue: parent)
+      blocked = create(:issue, project: project, github_number: 3)
+      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
+
+      described_class.new(project).call
+
+      expect(Notification.find_by(
+        account: project.account,
+        user: project.effective_owner,
+        source: "blocking_parent_issue_review",
+        subject: parent
+      )).to be_present
+    end
+
     it "resolves a blocking-parent review notification once the parent is no longer blocking" do
       parent = create(:issue, project: project, github_number: 1)
       child = create(:issue, project: project, github_number: 2, parent_issue: parent)

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -355,15 +355,68 @@ RSpec.describe Issues::AutoPick do
       end
     end
 
-    it "skips parent issues that have sub-issues" do
+    it "picks a parent issue when all of its sub-issues are closed" do
+      parent = create(:issue, project: project, github_number: 1)
+      create(:issue, :closed, project: project, github_number: 3, parent_issue: parent)
+      create(:issue, project: project, github_number: 2)
+
+      result = described_class.new(project).call
+
+      expect(result.issue).to eq(parent)
+    end
+
+    it "skips parent issues that still have open sub-issues" do
       parent = create(:issue, project: project, github_number: 1)
       create(:issue, project: project, github_number: 3, parent_issue: parent)
       standalone = create(:issue, project: project, github_number: 2)
 
       result = described_class.new(project).call
 
-      # Parent (github_number: 1) is skipped; standalone (#2) picked over sub-issue (#3)
       expect(result.issue).to eq(standalone)
+    end
+
+    it "publishes a review notification for a blocking parent with open sub-issues" do
+      parent = create(:issue, project: project, github_number: 1)
+      create(:issue, project: project, github_number: 2, parent_issue: parent)
+      blocked = create(:issue, project: project, github_number: 3)
+      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
+
+      described_class.new(project).call
+
+      notification = Notification.find_by!(
+        account: project.account,
+        user: project.effective_owner,
+        source: "blocking_parent_issue_review",
+        subject: parent
+      )
+
+      expect(notification.severity).to eq("warning")
+      expect(notification.title).to eq("Parent issue ##{parent.github_number} is blocking auto-pick")
+      expect(notification.metadata).to include(
+        "open_child_issue_numbers" => [ 2 ],
+        "blocking_issue_count" => 1
+      )
+    end
+
+    it "resolves a blocking-parent review notification once the parent is no longer blocking" do
+      parent = create(:issue, project: project, github_number: 1)
+      child = create(:issue, project: project, github_number: 2, parent_issue: parent)
+      blocked = create(:issue, project: project, github_number: 3)
+      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
+
+      described_class.new(project).call
+
+      child.update!(github_state: "closed")
+      described_class.new(project).call
+
+      notification = Notification.find_by!(
+        account: project.account,
+        user: project.effective_owner,
+        source: "blocking_parent_issue_review",
+        subject: parent
+      )
+
+      expect(notification.resolved_at).to be_present
     end
 
     it "picks the oldest issue regardless of unblock count" do


### PR DESCRIPTION
## Summary

Implemented and committed on the existing feature branch as `81476a2` with message `feat(auto-pick): handle blocking parent issues`.

The change does two things: parent issues are no longer blanket-excluded from auto-pick when all non-PR children are closed, and blocking parents with open children now trigger a deduped review notification instead of being silently skipped. I also added spec coverage for both the refined eligibility behavior and the notification/resolution path.

Verification: `bin/rails db:prepare` passed after supplying `DB_HOST/DB_USERNAME/DB_PASSWORD` from the provided `DATABASE_URL`; `bundle exec rubocop` passed; full `bundle exec rspec` ran with `10486 examples, 0 failures, 9 pending`. A plain full RSpec run exits non-zero in this repo because SimpleCov enforces an 80% global threshold, so the successful commit used the repo-supported `COVERAGE=false` env for the hook run.

---

Closes #1686