### PR TITLE
fix(agent-runs): main index agent runs table has column header/value mismatch

### DIFF
--- a/app/controllers/agent_runs_controller.rb
+++ b/app/controllers/agent_runs_controller.rb
@@ -5,7 +5,7 @@ class AgentRunsController < ApplicationController
   skip_after_action :verify_authorized, only: :index
 
   def index
-    base_scope = policy_scope(AgentRun).includes(:project, issue: :project)
+    base_scope = policy_scope(AgentRun).includes(:provider, project: [ :created_by, :account ], issue: :project)
     @q = base_scope.ransack(params[:q])
 
     if params[:sort] == "queue" && queue_sort_compatible?

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -11,7 +11,7 @@ module Projects
 
     def index
       authorize @project, :show?
-      base_scope = @project.agent_runs.includes(issue: :project)
+      base_scope = @project.agent_runs.includes(:provider, project: [ :created_by, :account ], issue: :project)
       @q = base_scope.ransack(params[:q])
       @q.sorts = "created_at desc" if @q.sorts.empty?
       @pagy, @agent_runs = pagy(@q.result)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -493,7 +493,7 @@ module ApplicationHelper
     return provider.display_name if provider
     return MISSING_PROVIDER_ENTRY_LABEL if Provider.routing_key?(identifier)
 
-    Provider.display_name_for(identifier)
+    Provider.display_name_for(normalized_provider_identifier(identifier))
   end
 
   def provider_for_identifier(run, configured_providers_by_owner_and_key, routed_providers_by_owner_and_id)
@@ -503,7 +503,9 @@ module ApplicationHelper
       return routed_providers_by_owner_and_id[[ owner_id, provider_id ]]
     end
 
-    configured_providers_by_owner_and_key[[ run.project&.effective_owner&.id, run.final_provider ]] ||
+    normalized_identifier = normalized_provider_identifier(run.final_provider)
+
+    configured_providers_by_owner_and_key[[ run.project&.effective_owner&.id, normalized_identifier ]] ||
       (run.provider if run.provider&.matches_identifier?(run.final_provider))
   end
 
@@ -530,7 +532,7 @@ module ApplicationHelper
       owner_id = run.project&.effective_owner&.id
       next unless owner_id
 
-      provider_keys[run.final_provider] << owner_id
+      provider_keys[normalized_provider_identifier(run.final_provider)] << owner_id
     end
     return {} if owner_ids_by_provider_key.empty?
 
@@ -545,6 +547,10 @@ module ApplicationHelper
     yield
   rescue Propshaft::MissingAssetError
     raise unless Rails.env.test?
+  end
+
+  def normalized_provider_identifier(identifier)
+    ProviderSupport.provider_key_for_agent_type(identifier)
   end
 
   def safe_return_path?(path)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,11 +81,32 @@ module ApplicationHelper
     )
   end
 
-  def agent_run_provider_display(run)
-    return run.effective_provider_record.display_name if run.effective_provider_record
-    return MISSING_PROVIDER_ENTRY_LABEL if Provider.routing_key?(run.final_provider)
+  def agent_run_provider_displays(runs)
+    runs = runs.to_a
+    final_provider_keys = runs.map(&:final_provider).compact_blank.uniq
+    routed_providers_by_id = Provider.where(id: final_provider_keys.filter_map { |identifier| Provider.id_from_routing_key(identifier) })
+      .index_by(&:id)
+    configured_providers_by_owner_and_key = configured_providers_for_runs(runs)
 
-    Provider.display_name_for(run.effective_provider)
+    runs.each_with_object({}) do |run, displays|
+      displays[run.id] =
+        if run.final_provider.present?
+          provider_display_for_identifier(
+            run.final_provider,
+            provider: provider_for_identifier(run, configured_providers_by_owner_and_key, routed_providers_by_id)
+          )
+        elsif run.provider.present?
+          run.provider.display_name
+        else
+          Provider.display_name_for(run.effective_provider)
+        end
+    end
+  end
+
+  def agent_run_provider_display(run, provider_displays = nil)
+    return provider_displays.fetch(run.id) if provider_displays
+
+    agent_run_provider_displays([ run ]).fetch(run.id)
   end
 
   PAID_STATE_STYLES = {
@@ -468,6 +489,38 @@ module ApplicationHelper
     return nil unless run.source_pull_request_number.present? && run.project.present?
 
     "#{run.project.github_url}/pull/#{run.source_pull_request_number}"
+  end
+
+  def provider_display_for_identifier(identifier, provider: nil)
+    return provider.display_name if provider
+    return MISSING_PROVIDER_ENTRY_LABEL if Provider.routing_key?(identifier)
+
+    Provider.display_name_for(identifier)
+  end
+
+  def provider_for_identifier(run, configured_providers_by_owner_and_key, routed_providers_by_id)
+    return routed_providers_by_id[Provider.id_from_routing_key(run.final_provider)] if Provider.routing_key?(run.final_provider)
+
+    configured_providers_by_owner_and_key[[ run.project&.effective_owner&.id, run.final_provider ]] ||
+      (run.provider if run.provider&.matches_identifier?(run.final_provider))
+  end
+
+  def configured_providers_for_runs(runs)
+    owner_ids_by_provider_key = runs.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |run, provider_keys|
+      next if run.final_provider.blank? || Provider.routing_key?(run.final_provider)
+
+      owner_id = run.project&.effective_owner&.id
+      next unless owner_id
+
+      provider_keys[run.final_provider] << owner_id
+    end
+    return {} if owner_ids_by_provider_key.empty?
+
+    Provider.where(
+      user_id: owner_ids_by_provider_key.values.flatten.uniq,
+      provider_key: owner_ids_by_provider_key.keys
+    ).ordered.group_by { |provider| [ provider.user_id, provider.provider_key ] }
+      .transform_values { |providers| providers.find(&:subscription?) || providers.first }
   end
 
   def safe_asset_tag

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,9 +83,7 @@ module ApplicationHelper
 
   def agent_run_provider_displays(runs)
     runs = runs.to_a
-    final_provider_keys = runs.map(&:final_provider).compact_blank.uniq
-    routed_providers_by_id = Provider.where(id: final_provider_keys.filter_map { |identifier| Provider.id_from_routing_key(identifier) })
-      .index_by(&:id)
+    routed_providers_by_owner_and_id = routed_providers_for_runs(runs)
     configured_providers_by_owner_and_key = configured_providers_for_runs(runs)
 
     runs.each_with_object({}) do |run, displays|
@@ -93,7 +91,7 @@ module ApplicationHelper
         if run.final_provider.present?
           provider_display_for_identifier(
             run.final_provider,
-            provider: provider_for_identifier(run, configured_providers_by_owner_and_key, routed_providers_by_id)
+            provider: provider_for_identifier(run, configured_providers_by_owner_and_key, routed_providers_by_owner_and_id)
           )
         elsif run.provider.present?
           run.provider.display_name
@@ -498,11 +496,31 @@ module ApplicationHelper
     Provider.display_name_for(identifier)
   end
 
-  def provider_for_identifier(run, configured_providers_by_owner_and_key, routed_providers_by_id)
-    return routed_providers_by_id[Provider.id_from_routing_key(run.final_provider)] if Provider.routing_key?(run.final_provider)
+  def provider_for_identifier(run, configured_providers_by_owner_and_key, routed_providers_by_owner_and_id)
+    if Provider.routing_key?(run.final_provider)
+      owner_id = run.project&.effective_owner&.id
+      provider_id = Provider.id_from_routing_key(run.final_provider)
+      return routed_providers_by_owner_and_id[[ owner_id, provider_id ]]
+    end
 
     configured_providers_by_owner_and_key[[ run.project&.effective_owner&.id, run.final_provider ]] ||
       (run.provider if run.provider&.matches_identifier?(run.final_provider))
+  end
+
+  def routed_providers_for_runs(runs)
+    provider_ids_by_owner_id = runs.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |run, provider_ids|
+      next unless Provider.routing_key?(run.final_provider)
+
+      owner_id = run.project&.effective_owner&.id
+      provider_id = Provider.id_from_routing_key(run.final_provider)
+      next unless owner_id && provider_id
+
+      provider_ids[owner_id] << provider_id
+    end
+    return {} if provider_ids_by_owner_id.empty?
+
+    Provider.where(user_id: provider_ids_by_owner_id.keys, id: provider_ids_by_owner_id.values.flatten.uniq)
+      .index_by { |provider| [ provider.user_id, provider.id ] }
   end
 
   def configured_providers_for_runs(runs)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  MISSING_PROVIDER_ENTRY_LABEL = "Deleted provider entry"
+
   # Dark-mode colors for these badges are handled by the global unlayered
   # overrides in application.tailwind.css (e.g. `.dark .bg-indigo-100`),
   # which have higher cascade priority than Tailwind dark: utilities.
@@ -77,6 +79,13 @@ module ApplicationHelper
       run.queue_priority_label,
       class: "inline-flex items-center rounded-md #{styles[:bg]} px-2 py-1 text-xs font-medium #{styles[:text]}"
     )
+  end
+
+  def agent_run_provider_display(run)
+    return run.effective_provider_record.display_name if run.effective_provider_record
+    return MISSING_PROVIDER_ENTRY_LABEL if Provider.routing_key?(run.final_provider)
+
+    Provider.display_name_for(run.effective_provider)
   end
 
   PAID_STATE_STYLES = {

--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -6,28 +6,19 @@
           <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Agent Run #<%= agent_run.id %></h1>
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
             <% final_provider_record = local_assigns.fetch(:final_provider_record, nil) %>
-            <% missing_provider_entry_label = ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL %>
-            <% provider_label = lambda do |identifier, resolved_provider = nil|
-                 resolved_provider&.display_name ||
-                   if Provider.routing_key?(identifier)
-                     missing_provider_entry_label
-                   else
-                     identifier.to_s.titleize
-                   end
-               end %>
             <% header_provider_name =
                  if agent_run.provider.present?
                    if final_provider_record && !agent_run.provider.matches_identifier?(agent_run.final_provider)
                      final_provider_record.display_name
                    elsif agent_run.final_provider.present? && !agent_run.provider.matches_identifier?(agent_run.final_provider)
-                     provider_label.call(agent_run.final_provider)
+                     provider_display_for_identifier(agent_run.final_provider)
                    else
                      agent_run.provider.display_name
                    end
                  elsif final_provider_record
                    final_provider_record.display_name
                  elsif agent_run.final_provider.present?
-                   provider_label.call(agent_run.final_provider)
+                   provider_display_for_identifier(agent_run.final_provider)
                  else
                    agent_run.agent_type.titleize
                  end %>
@@ -518,7 +509,7 @@
           <% end %>
           <% attempt_provider = attempted_providers_by_routing_key[attempt["provider"]] %>
           <span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium <%= attempt['success'] ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %>">
-            <%= provider_label.call(attempt["provider"], attempt_provider) %>
+            <%= provider_display_for_identifier(attempt["provider"], provider: attempt_provider) %>
             <% if attempt['error_type'].present? %>
               <span class="ml-1 text-xs opacity-75">(<%= attempt['error_type'] %>)</span>
             <% end %>
@@ -531,7 +522,7 @@
           <% attempt_failures.each do |attempt| %>
             <% attempt_provider = attempted_providers_by_routing_key[attempt["provider"]] %>
             <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2 dark:border-amber-800 dark:bg-amber-950/50">
-              <p class="text-xs font-medium text-amber-900 dark:text-amber-100"><%= provider_label.call(attempt["provider"], attempt_provider) %></p>
+              <p class="text-xs font-medium text-amber-900 dark:text-amber-100"><%= provider_display_for_identifier(attempt["provider"], provider: attempt_provider) %></p>
               <p class="mt-1 text-xs text-amber-800 dark:text-amber-200"><%= truncate(redacted_error_message(attempt["error_message"]), length: 300) %></p>
             </div>
           <% end %>
@@ -540,7 +531,7 @@
       <% if agent_run.final_provider.present? %>
         <p class="mt-2 text-xs text-amber-700 dark:text-amber-300">
           <% final_prov = attempted_providers_by_routing_key[agent_run.final_provider] %>
-          Final provider: <span class="font-medium"><%= provider_label.call(agent_run.final_provider, final_prov) %></span>
+          Final provider: <span class="font-medium"><%= provider_display_for_identifier(agent_run.final_provider, provider: final_prov) %></span>
         </p>
       <% end %>
     </div>

--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -6,7 +6,7 @@
           <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Agent Run #<%= agent_run.id %></h1>
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
             <% final_provider_record = local_assigns.fetch(:final_provider_record, nil) %>
-            <% missing_provider_entry_label = "Deleted provider entry" %>
+            <% missing_provider_entry_label = ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL %>
             <% provider_label = lambda do |identifier, resolved_provider = nil|
                  resolved_provider&.display_name ||
                    if Provider.routing_key?(identifier)

--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -14,6 +14,9 @@
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
                   Priority
                 </th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                  Provider
+                </th>
                 <% if show_project %>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Project</th>
                 <% end %>
@@ -42,6 +45,9 @@
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <%= agent_run_priority_badge(run) %>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <%= agent_run_provider_display(run) %>
                   </td>
                   <% if show_project %>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -1,5 +1,6 @@
 <% show_project = local_assigns.fetch(:show_project, false) %>
 <% runs = agent_runs.to_a %>
+<% provider_displays = agent_run_provider_displays(runs) %>
 <% if runs.any? %>
   <div class="mt-4 flow-root">
     <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
@@ -47,7 +48,7 @@
                     <%= agent_run_priority_badge(run) %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <%= agent_run_provider_display(run) %>
+                    <%= agent_run_provider_display(run, provider_displays) %>
                   </td>
                   <% if show_project %>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -103,6 +103,17 @@ RSpec.describe "AgentRuns" do
         expect(response.body).not_to include(other_provider.display_name)
       end
 
+      it "normalizes legacy final_provider aliases in the Provider column" do
+        run = create(:agent_run, :with_custom_prompt, project: project, provider: nil,
+          final_provider: "claude_code", agent_type: "claude_code")
+
+        get agent_runs_path
+
+        provider_cell = cell_for_run(parsed_html, run, "Provider")
+
+        expect(provider_cell.text.squish).to eq(Provider.display_name_for("claude"))
+      end
+
       it "prefers the issue title over custom prompt text" do
         issue = create(:issue, project: project, title: "Fix flaky webhook retry handling")
         run = create(:agent_run, :with_custom_prompt, project: project, issue: issue,
@@ -714,6 +725,16 @@ RSpec.describe "AgentRuns" do
 
         expect(response.body).to include(ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL)
         expect(response.body).not_to include("Provider:999999")
+      end
+
+      it "normalizes legacy final_provider aliases in the header provider label" do
+        agent_run = create(:agent_run, :completed, project: project, provider: nil,
+          agent_type: "claude_code", final_provider: "claude_code")
+
+        get project_agent_run_path(project, agent_run)
+
+        expect(response.body).to include(Provider.display_name_for("claude"))
+        expect(response.body).not_to include(">Claude Code<")
       end
 
       it "shows metrics" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -74,7 +74,19 @@ RSpec.describe "AgentRuns" do
 
         provider_cell = cell_for_run(parsed_html, run, "Provider")
 
-        expect(provider_cell.text.squish).to eq("Deleted provider entry")
+        expect(provider_cell.text.squish).to eq(ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL)
+      end
+
+      it "shows the deleted-provider fallback label when the final routed provider is missing" do
+        initial_provider = project.effective_owner.providers.find_by!(provider_key: "claude", auth_type: "subscription")
+        run = create(:agent_run, :with_custom_prompt, project: project, provider: initial_provider,
+          final_provider: "provider:999999")
+
+        get agent_runs_path
+
+        provider_cell = cell_for_run(parsed_html, run, "Provider")
+
+        expect(provider_cell.text.squish).to eq(ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL)
       end
 
       it "prefers the issue title over custom prompt text" do
@@ -686,7 +698,7 @@ RSpec.describe "AgentRuns" do
 
         get project_agent_run_path(project, agent_run)
 
-        expect(response.body).to include("Deleted provider entry")
+        expect(response.body).to include(ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL)
         expect(response.body).not_to include("Provider:999999")
       end
 
@@ -775,7 +787,7 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("1 attempt")
         expect(response.body).to include(initial_provider.display_name)
         expect(response.body).to include("Skipped due to cached rate limit until 2026-04-30T05:59:15Z")
-        expect(response.body).not_to include("Deleted provider entry")
+        expect(response.body).not_to include(ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL)
       end
 
       it "shows auth type in provider section when provider record exists" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -89,6 +89,20 @@ RSpec.describe "AgentRuns" do
         expect(provider_cell.text.squish).to eq(ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL)
       end
 
+      it "does not show another owner's routed provider label in the Provider column" do
+        other_user = create(:user)
+        other_provider = create(:provider, user: other_user, provider_key: "cursor", name: "Other Owner Cursor")
+        run = create(:agent_run, :with_custom_prompt, project: project, provider: nil,
+          final_provider: other_provider.routing_key)
+
+        get agent_runs_path
+
+        provider_cell = cell_for_run(parsed_html, run, "Provider")
+
+        expect(provider_cell.text.squish).to eq(ApplicationHelper::MISSING_PROVIDER_ENTRY_LABEL)
+        expect(response.body).not_to include(other_provider.display_name)
+      end
+
       it "prefers the issue title over custom prompt text" do
         issue = create(:issue, project: project, title: "Fix flaky webhook retry handling")
         run = create(:agent_run, :with_custom_prompt, project: project, issue: issue,

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -48,6 +48,35 @@ RSpec.describe "AgentRuns" do
         expect(goal_cell.at_css('[data-controller="tooltip"]')).to be_present
       end
 
+      it "aligns the Provider header with provider values in each row" do
+        owner = project.effective_owner
+        configured_provider = owner.providers.create!(
+          provider_key: "cursor",
+          auth_type: "subscription",
+          name: "Cursor Stable",
+          enabled_for_agent_runs: true
+        )
+        run = create(:agent_run, :with_custom_prompt, project: project, provider: configured_provider,
+          final_provider: configured_provider.routing_key)
+
+        get agent_runs_path
+
+        provider_cell = cell_for_run(parsed_html, run, "Provider")
+
+        expect(provider_cell.text.squish).to eq(configured_provider.display_name)
+      end
+
+      it "shows a deleted-provider fallback label in the Provider column" do
+        run = create(:agent_run, :with_custom_prompt, project: project, provider: nil,
+          final_provider: "provider:999999")
+
+        get agent_runs_path
+
+        provider_cell = cell_for_run(parsed_html, run, "Provider")
+
+        expect(provider_cell.text.squish).to eq("Deleted provider entry")
+      end
+
       it "prefers the issue title over custom prompt text" do
         issue = create(:issue, project: project, title: "Fix flaky webhook retry handling")
         run = create(:agent_run, :with_custom_prompt, project: project, issue: issue,
@@ -2332,15 +2361,7 @@ RSpec.describe "AgentRuns" do
   end
 
   def goal_cell_for_run(document, run)
-    row = row_for_run(document, run)
-    index = goal_column_index(document)
-
-    expect(index).not_to be_nil, "Expected a 'Goal' header column in the table but none was found"
-
-    goal_cell = row.css("td")[index]
-
-    expect(goal_cell).to be_present
-    goal_cell
+    cell_for_run(document, run, "Goal")
   end
 
   def row_for_run(document, run)
@@ -2351,7 +2372,23 @@ RSpec.describe "AgentRuns" do
     row
   end
 
+  def cell_for_run(document, run, header_text)
+    row = row_for_run(document, run)
+    index = column_index(document, header_text)
+
+    expect(index).not_to be_nil, "Expected a '#{header_text}' header column in the table but none was found"
+
+    cell = row.css("td")[index]
+
+    expect(cell).to be_present
+    cell
+  end
+
   def goal_column_index(document)
-    document.css("table thead th").find_index { |header| header.text.squish == "Goal" }
+    column_index(document, "Goal")
+  end
+
+  def column_index(document, header_text)
+    document.css("table thead th").find_index { |header| header.text.squish == header_text }
   end
 end


### PR DESCRIPTION
## Summary

Aligned the main agent runs index table so the new `Provider` column is rendered in both the header and row body from the same ordering, and added a shared helper to display configured providers plus the deleted-provider fallback label. The main changes are in [app/views/agent_runs/_index_table.html.erb](/workspace/app/views/agent_runs/_index_table.html.erb), [app/helpers/application_helper.rb](/workspace/app/helpers/application_helper.rb), and request coverage in [spec/requests/agent_runs_spec.rb](/workspace/spec/requests/agent_runs_spec.rb).

Verification: `bundle exec rubocop` passed, `COVERAGE=false bundle exec rspec` passed (`10492 examples, 0 failures`), and the commit hook’s full `bundle exec rspec` also passed with 94.12% line coverage. `bin/rails db:prepare` did not work in this environment because Rails tried to connect over a local Postgres socket even though `psql "$DATABASE_URL"` succeeded against the provided service, so that command remains the only unresolved setup check here.

Committed as `1536b92` with message `fix(agent-runs): align provider column on main index`.

---

Closes #1690