### PR TITLE
feat(agent-runs): add provider column to dashboard and agent run index tables

### DIFF
--- a/app/controllers/agent_runs_controller.rb
+++ b/app/controllers/agent_runs_controller.rb
@@ -5,7 +5,7 @@ class AgentRunsController < ApplicationController
   skip_after_action :verify_authorized, only: :index
 
   def index
-    base_scope = policy_scope(AgentRun).includes(:project, issue: :project)
+    base_scope = policy_scope(AgentRun).includes(:provider, issue: :project, project: [ :created_by, :account ])
     @q = base_scope.ransack(params[:q])
 
     if params[:sort] == "queue" && queue_sort_compatible?

--- a/app/controllers/agent_runs_controller.rb
+++ b/app/controllers/agent_runs_controller.rb
@@ -17,6 +17,7 @@ class AgentRunsController < ApplicationController
     end
 
     @pagy, @agent_runs = pagy(@agent_runs)
+    AgentRun.preload_final_provider_records(@agent_runs)
     AgentRun.preload_source_pull_requests(@agent_runs)
     cache_key = AgentRun.provider_options_cache_key_for(account_id: current_account.id)
     @provider_options = base_scope.distinct_effective_providers(cache_key: cache_key)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -20,7 +20,7 @@ class DashboardController < ApplicationController
     @live_stats = Dashboard::LiveStats.call(account: current_account)
     @queue_health = Scaling::QueueMonitor.call(account: current_account)
     @queue_preview = Dashboard::QueuePreview.call(user: current_user)
-    @active_runs = live_agent_runs.active.includes(:project, :issue, :model_selection)
+    @active_runs = live_agent_runs.active.includes(:provider, :issue, :model_selection, project: [ :created_by, :account ])
       .order("agent_runs.created_at DESC")
       .limit(20)
     @quality_paused_projects = current_account.projects

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -23,6 +23,7 @@ class DashboardController < ApplicationController
     @active_runs = live_agent_runs.active.includes(:provider, :issue, :model_selection, project: [ :created_by, :account ])
       .order("agent_runs.created_at DESC")
       .limit(20)
+    AgentRun.preload_final_provider_records(@active_runs)
     @quality_paused_projects = current_account.projects
       .where.not(quality_paused_at: nil)
       .order(quality_paused_at: :desc)

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -15,6 +15,7 @@ module Projects
       @q = base_scope.ransack(params[:q])
       @q.sorts = "created_at desc" if @q.sorts.empty?
       @pagy, @agent_runs = pagy(@q.result)
+      AgentRun.preload_final_provider_records(@agent_runs)
       AgentRun.preload_source_pull_requests(@agent_runs)
       cache_key = AgentRun.provider_options_cache_key_for(account_id: @project.account_id, project_id: @project.id)
       @provider_options = base_scope.distinct_effective_providers(cache_key: cache_key)

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -11,7 +11,7 @@ module Projects
 
     def index
       authorize @project, :show?
-      base_scope = @project.agent_runs.includes(issue: :project)
+      base_scope = @project.agent_runs.includes(:provider, issue: :project, project: [ :created_by, :account ])
       @q = base_scope.ransack(params[:q])
       @q.sorts = "created_at desc" if @q.sorts.empty?
       @pagy, @agent_runs = pagy(@q.result)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -22,6 +22,7 @@ class ProjectsController < ApplicationController
   def show
     authorize @project
     @recent_agent_runs = @project.agent_runs.recent.includes(:provider, :issue, project: [ :created_by, :account ]).limit(10).to_a
+    AgentRun.preload_final_provider_records(@recent_agent_runs)
     @stale_agent_runs_count = @project.agent_runs.stale_for_cleanup.count
     @show_stale_cleanup_action = policy(@project).update? && @stale_agent_runs_count.positive?
     AgentRun.preload_source_pull_requests(@recent_agent_runs)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,7 +21,7 @@ class ProjectsController < ApplicationController
 
   def show
     authorize @project
-    @recent_agent_runs = @project.agent_runs.recent.includes(:issue).limit(10).to_a
+    @recent_agent_runs = @project.agent_runs.recent.includes(:provider, :issue, project: [ :created_by, :account ]).limit(10).to_a
     @stale_agent_runs_count = @project.agent_runs.stale_for_cleanup.count
     @show_stale_cleanup_action = policy(@project).update? && @stale_agent_runs_count.positive?
     AgentRun.preload_source_pull_requests(@recent_agent_runs)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,8 +83,7 @@ module ApplicationHelper
     final_identifier = run.final_provider.presence
 
     if final_identifier.present?
-      provider = run.preloaded_final_provider_record
-      provider ||= run.provider if run.provider.present? && run.provider.matches_identifier?(final_identifier)
+      provider = final_provider_display_record(run, final_identifier)
       return provider.display_name if provider.present?
 
       return missing_provider_label if Provider.routing_key?(final_identifier)
@@ -99,17 +98,6 @@ module ApplicationHelper
 
     provider_display_label(identifier)
   end
-
-  private
-
-  def provider_display_label(identifier)
-    provider_key = Provider.provider_key_for_agent_type(identifier)
-    return identifier.to_s.titleize unless Provider.supported_provider_key?(provider_key)
-
-    Provider.display_name_for(provider_key)
-  end
-
-  public
 
   PAID_STATE_STYLES = {
     "new" => { bg: "bg-gray-100", text: "text-gray-700", label: "New" },
@@ -360,6 +348,20 @@ module ApplicationHelper
   end
 
   private
+
+  def provider_display_label(identifier)
+    provider_key = Provider.provider_key_for_agent_type(identifier)
+    return identifier.to_s.titleize unless Provider.supported_provider_key?(provider_key)
+
+    Provider.display_name_for(provider_key)
+  end
+
+  def final_provider_display_record(run, final_identifier)
+    return run.provider if run.provider.present? && run.provider.matches_identifier?(final_identifier)
+    return run.preloaded_final_provider_record if run.preloaded_final_provider_record_loaded
+
+    run.final_provider_record
+  end
 
   def create_pr_context(run)
     if run.issue.present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,14 +80,17 @@ module ApplicationHelper
   end
 
   def agent_run_provider_display(run, placeholder: "-", missing_provider_label: "Deleted provider entry")
-    provider = run.effective_provider_record
+    provider = run.final_provider_record || run.provider
     return provider.display_name if provider.present?
 
     identifier = run.final_provider.presence || run.effective_provider.presence
     return placeholder if identifier.blank?
     return missing_provider_label if Provider.routing_key?(identifier)
 
-    Provider.display_name_for(Provider.provider_key_for_agent_type(identifier))
+    provider_key = Provider.provider_key_for_agent_type(identifier)
+    return identifier.to_s.titleize unless Provider.supported_provider_key?(provider_key)
+
+    Provider.display_name_for(provider_key)
   end
 
   PAID_STATE_STYLES = {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,6 +79,17 @@ module ApplicationHelper
     )
   end
 
+  def agent_run_provider_display(run, placeholder: "-", missing_provider_label: "Deleted provider entry")
+    provider = run.effective_provider_record
+    return provider.display_name if provider.present?
+
+    identifier = run.final_provider.presence || run.effective_provider.presence
+    return placeholder if identifier.blank?
+    return missing_provider_label if Provider.routing_key?(identifier)
+
+    Provider.display_name_for(Provider.provider_key_for_agent_type(identifier))
+  end
+
   PAID_STATE_STYLES = {
     "new" => { bg: "bg-gray-100", text: "text-gray-700", label: "New" },
     "planning" => { bg: "bg-purple-100", text: "text-purple-700", label: "Planning" },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,18 +80,36 @@ module ApplicationHelper
   end
 
   def agent_run_provider_display(run, placeholder: "-", missing_provider_label: "Deleted provider entry")
-    provider = run.final_provider_record || run.provider
-    return provider.display_name if provider.present?
+    final_identifier = run.final_provider.presence
 
-    identifier = run.final_provider.presence || run.effective_provider.presence
+    if final_identifier.present?
+      provider = run.preloaded_final_provider_record
+      provider ||= run.provider if run.provider.present? && run.provider.matches_identifier?(final_identifier)
+      return provider.display_name if provider.present?
+
+      return missing_provider_label if Provider.routing_key?(final_identifier)
+
+      return provider_display_label(final_identifier)
+    end
+
+    return run.provider.display_name if run.provider.present?
+
+    identifier = run.effective_provider.presence
     return placeholder if identifier.blank?
-    return missing_provider_label if Provider.routing_key?(identifier)
 
+    provider_display_label(identifier)
+  end
+
+  private
+
+  def provider_display_label(identifier)
     provider_key = Provider.provider_key_for_agent_type(identifier)
     return identifier.to_s.titleize unless Provider.supported_provider_key?(provider_key)
 
     Provider.display_name_for(provider_key)
   end
+
+  public
 
   PAID_STATE_STYLES = {
     "new" => { bg: "bg-gray-100", text: "text-gray-700", label: "New" },

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AgentRun < ApplicationRecord
-  attr_accessor :preloaded_final_provider_record
+  attr_accessor :preloaded_final_provider_record, :preloaded_final_provider_record_loaded
 
   MAX_PROVIDER_ATTEMPT_ERROR_MESSAGE_LENGTH = 500
   PROVIDER_ATTEMPT_SECRET_PATTERNS = [
@@ -307,6 +307,7 @@ class AgentRun < ApplicationRecord
       final_identifier = run.final_provider.presence
       next if final_identifier.blank?
 
+      run.preloaded_final_provider_record_loaded = true
       run.preloaded_final_provider_record =
         if run.provider.present? && run.provider.matches_identifier?(final_identifier)
           run.provider

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AgentRun < ApplicationRecord
+  attr_accessor :preloaded_final_provider_record
+
   MAX_PROVIDER_ATTEMPT_ERROR_MESSAGE_LENGTH = 500
   PROVIDER_ATTEMPT_SECRET_PATTERNS = [
     [ /\bsk-[A-Za-z0-9][A-Za-z0-9_-]{10,}\b/, "[REDACTED:api_key]" ],
@@ -292,12 +294,85 @@ class AgentRun < ApplicationRecord
     keys.each { |key| Rails.cache.delete(key) }
   end
 
+  def self.preload_final_provider_records(runs)
+    runs = runs.to_a
+    return runs if runs.empty?
+
+    fallback_owner_ids = fallback_owner_ids_by_account(
+      runs.filter_map { |run| run.project&.account_id if run.project&.created_by_id.nil? }.uniq
+    )
+    records_by_lookup = final_provider_records_by_lookup(runs, fallback_owner_ids)
+
+    runs.each do |run|
+      final_identifier = run.final_provider.presence
+      next if final_identifier.blank?
+
+      run.preloaded_final_provider_record =
+        if run.provider.present? && run.provider.matches_identifier?(final_identifier)
+          run.provider
+        else
+          owner_id = effective_owner_id_for(run, fallback_owner_ids)
+          records_by_lookup[[ owner_id, final_identifier ]]
+        end
+    end
+
+    runs
+  end
+
   def self.compute_distinct_effective_providers
     pluck(Arel.sql("DISTINCT #{effective_provider_sql}"))
       .compact
       .sort
   end
   private_class_method :compute_distinct_effective_providers
+
+  def self.final_provider_records_by_lookup(runs, fallback_owner_ids)
+    lookup_pairs = runs.filter_map do |run|
+      final_identifier = run.final_provider.presence
+      next unless Provider.routing_key?(final_identifier)
+
+      owner_id = effective_owner_id_for(run, fallback_owner_ids)
+      next unless owner_id
+
+      [ owner_id, final_identifier ]
+    end.uniq
+    return {} if lookup_pairs.empty?
+
+    provider_ids = lookup_pairs.map { |(_, identifier)| Provider.id_from_routing_key(identifier) }.uniq
+    owner_ids = lookup_pairs.map(&:first).uniq
+
+    Provider.where(id: provider_ids, user_id: owner_ids).index_by { |provider| [ provider.user_id, provider.routing_key ] }
+  end
+  private_class_method :final_provider_records_by_lookup
+
+  def self.effective_owner_id_for(run, fallback_owner_ids)
+    project = run.project
+    return unless project
+
+    project.created_by_id || fallback_owner_ids[project.account_id]
+  end
+  private_class_method :effective_owner_id_for
+
+  def self.fallback_owner_ids_by_account(account_ids)
+    account_ids = account_ids.compact.uniq
+    return {} if account_ids.empty?
+
+    owner_ids = AccountMembership.where(account_id: account_ids, role: :owner)
+      .order(:account_id, :id)
+      .pluck(:account_id, :user_id)
+      .each_with_object({}) { |(account_id, user_id), memo| memo[account_id] ||= user_id }
+
+    missing_account_ids = account_ids - owner_ids.keys
+    return owner_ids if missing_account_ids.empty?
+
+    User.where(account_id: missing_account_ids)
+      .order(:account_id, :id)
+      .pluck(:account_id, :id)
+      .each { |account_id, user_id| owner_ids[account_id] ||= user_id }
+
+    owner_ids
+  end
+  private_class_method :fallback_owner_ids_by_account
 
   def duration
     return nil unless started_at

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -429,7 +429,8 @@ class Project < ApplicationRecord
   end
 
   def broadcast_agent_runs_update
-    runs = agent_runs.recent.includes(:issue).limit(10).to_a
+    runs = agent_runs.recent.includes(:provider, :issue, project: [ :created_by, :account ]).limit(10).to_a
+    AgentRun.preload_final_provider_records(runs)
     AgentRun.preload_source_pull_requests(runs)
     broadcast_replace_to(
       self, :project_updates,
@@ -440,7 +441,8 @@ class Project < ApplicationRecord
   end
 
   def broadcast_agent_runs_list_update
-    runs = agent_runs.recent.includes(:issue).limit(50).to_a
+    runs = agent_runs.recent.includes(:provider, :issue, project: [ :created_by, :account ]).limit(50).to_a
+    AgentRun.preload_final_provider_records(runs)
     AgentRun.preload_source_pull_requests(runs)
     broadcast_replace_to(
       self, :agent_runs_list,

--- a/app/services/dashboard/live_broadcaster.rb
+++ b/app/services/dashboard/live_broadcaster.rb
@@ -32,9 +32,11 @@ module Dashboard
     end
 
     def broadcast_active_runs
-      active_runs = account_agent_runs.active.includes(:project, :issue, :model_selection)
+      active_runs = account_agent_runs.active.includes(:provider, :issue, :model_selection, project: [ :created_by, :account ])
         .order("agent_runs.created_at DESC")
         .limit(20)
+        .to_a
+      AgentRun.preload_final_provider_records(active_runs)
 
       Turbo::StreamsChannel.broadcast_update_to(
         stream_name,

--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -24,6 +24,9 @@
                   Context
                 </th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                  Provider
+                </th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
                   <%= sort_link_to "Duration", :duration_seconds, q %>
                 </th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
@@ -53,6 +56,9 @@
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <%= agent_run_context_display(run) %>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <%= agent_run_provider_display(run) %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <% if run.duration_seconds.present? %>

--- a/app/views/dashboard/_active_run_row.html.erb
+++ b/app/views/dashboard/_active_run_row.html.erb
@@ -17,6 +17,7 @@
     <% end %>
   </td>
   <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500"><%= run.goal.titleize %></td>
+  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500"><%= agent_run_provider_display(run) %></td>
   <td class="whitespace-nowrap px-4 py-3 text-sm">
     <% run_tier = run.model_selection&.tier %>
     <% if run_tier.present? %>

--- a/app/views/dashboard/_active_runs.html.erb
+++ b/app/views/dashboard/_active_runs.html.erb
@@ -7,6 +7,7 @@
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Project</th>
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Context</th>
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Goal</th>
+          <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Provider</th>
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Tier</th>
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Duration</th>
           <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Actions</th>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -30,6 +30,9 @@
     <% end %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+    <%= agent_run_provider_display(agent_run) %>
+  </td>
+  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
     <% elapsed = if agent_run.duration_seconds.present?
          agent_run.duration_seconds
        elsif agent_run.running? && agent_run.started_at.present?

--- a/app/views/projects/_agent_runs.html.erb
+++ b/app/views/projects/_agent_runs.html.erb
@@ -26,6 +26,7 @@
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Priority</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Goal</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Context</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Provider</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Duration</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Started</th>
                   <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">

--- a/app/views/projects/agent_runs/_table.html.erb
+++ b/app/views/projects/agent_runs/_table.html.erb
@@ -10,6 +10,7 @@
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Status</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Context</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Provider</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Duration</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Started</th>
                   <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
@@ -25,6 +26,9 @@
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <%= agent_run_context_display(run) %>
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                      <%= agent_run_provider_display(run) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <% if run.duration_seconds.present? %>

--- a/spec/helpers/application_helper_agent_run_provider_spec.rb
+++ b/spec/helpers/application_helper_agent_run_provider_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#agent_run_provider_display" do
+    let(:account) { create(:account) }
+    let(:user) { create(:user, account: account) }
+    let(:project) { create(:project, account: account, created_by: user) }
+
+    it "uses the preloaded provider association without extra provider queries" do
+      provider = create(:provider, user: user, provider_key: "codex")
+      run = create(:agent_run, project: project, provider: provider, final_provider: nil)
+      preloaded_run = AgentRun.includes(:provider).find(run.id)
+
+      queries = capture_queries do
+        expect(helper.agent_run_provider_display(preloaded_run)).to eq(provider.display_name)
+      end
+
+      provider_queries = queries.grep(/FROM "providers"/)
+      expect(provider_queries).to be_empty
+    end
+
+    it "renders a placeholder for unsupported provider identifiers" do
+      run = create(:agent_run, project: project, provider: nil, final_provider: "api", agent_type: "api")
+
+      expect(helper.agent_run_provider_display(run)).to eq("Api")
+    end
+  end
+end

--- a/spec/helpers/application_helper_agent_run_provider_spec.rb
+++ b/spec/helpers/application_helper_agent_run_provider_spec.rb
@@ -21,6 +21,28 @@ RSpec.describe ApplicationHelper do
       expect(provider_queries).to be_empty
     end
 
+    it "uses the preloaded final provider record for routed fallback runs without extra provider queries" do
+      initial_provider = create(:provider, user: user, provider_key: "codex")
+      fallback_provider = create(:provider, user: user, provider_key: "cursor")
+      run = create(:agent_run, project: project, provider: initial_provider, final_provider: fallback_provider.routing_key)
+      preloaded_run = AgentRun.includes(:provider, project: [ :created_by, :account ]).find(run.id)
+      AgentRun.preload_final_provider_records([ preloaded_run ])
+
+      queries = capture_queries do
+        expect(helper.agent_run_provider_display(preloaded_run)).to eq(fallback_provider.display_name)
+      end
+
+      provider_queries = queries.grep(/FROM "providers"/)
+      expect(provider_queries).to be_empty
+    end
+
+    it "prefers the final provider identifier when it differs from the originally requested provider" do
+      initial_provider = create(:provider, user: user, provider_key: "codex")
+      run = create(:agent_run, project: project, provider: initial_provider, final_provider: "cursor")
+
+      expect(helper.agent_run_provider_display(run)).to eq(Provider.display_name_for("cursor"))
+    end
+
     it "renders a placeholder for unsupported provider identifiers" do
       run = create(:agent_run, project: project, provider: nil, final_provider: "api", agent_type: "api")
 

--- a/spec/helpers/application_helper_agent_run_provider_spec.rb
+++ b/spec/helpers/application_helper_agent_run_provider_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe ApplicationHelper do
       expect(provider_queries).to be_empty
     end
 
+    it "resolves an unloaded routed fallback run to the final provider record" do
+      initial_provider = create(:provider, user: user, provider_key: "codex")
+      fallback_provider = create(:provider, user: user, provider_key: "cursor")
+      run = create(:agent_run, project: project, provider: initial_provider, final_provider: fallback_provider.routing_key)
+
+      expect(helper.agent_run_provider_display(run)).to eq(fallback_provider.display_name)
+    end
+
     it "prefers the final provider identifier when it differs from the originally requested provider" do
       initial_provider = create(:provider, user: user, provider_key: "codex")
       run = create(:agent_run, project: project, provider: initial_provider, final_provider: "cursor")

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -147,6 +147,15 @@ RSpec.describe "AgentRuns" do
         expect(cell_for_run(parsed_html, run, "Provider").text.squish).to eq("Deleted provider entry")
       end
 
+      it "renders unsupported provider identifiers without error" do
+        run = create(:agent_run, project: project, provider: nil, final_provider: "api", agent_type: "api")
+
+        get agent_runs_path
+
+        expect(response).to have_http_status(:ok)
+        expect(cell_for_run(parsed_html, run, "Provider").text.squish).to eq("Api")
+      end
+
       it "shows empty state when no runs exist" do
         get agent_runs_path
         expect(response.body).to include("No agent runs yet")
@@ -509,6 +518,15 @@ RSpec.describe "AgentRuns" do
 
         expect(column_index(document, "Provider")).not_to be_nil
         expect(cell_for_run(document, run, "Provider").text.squish).to eq(provider.display_name)
+      end
+
+      it "renders unsupported provider identifiers without error" do
+        run = create(:agent_run, project: project, provider: nil, final_provider: "api", agent_type: "api")
+
+        get project_agent_runs_path(project)
+
+        expect(response).to have_http_status(:ok)
+        expect(cell_for_run(parsed_html, run, "Provider").text.squish).to eq("Api")
       end
 
       it "shows PR link in actions column for completed create_pr runs" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -127,6 +127,26 @@ RSpec.describe "AgentRuns" do
         expect(truncated_span["title"]).not_to include(token)
       end
 
+      it "shows the provider column with the resolved provider name" do
+        provider = create(:provider, user: user, provider_key: "codex")
+        run = create(:agent_run, project: project, provider: provider, final_provider: provider.routing_key)
+
+        get agent_runs_path
+
+        document = parsed_html
+
+        expect(column_index(document, "Provider")).not_to be_nil
+        expect(cell_for_run(document, run, "Provider").text.squish).to eq(provider.display_name)
+      end
+
+      it "shows a fallback label when the final provider record is missing" do
+        run = create(:agent_run, project: project, final_provider: "provider:999999")
+
+        get agent_runs_path
+
+        expect(cell_for_run(parsed_html, run, "Provider").text.squish).to eq("Deleted provider entry")
+      end
+
       it "shows empty state when no runs exist" do
         get agent_runs_path
         expect(response.body).to include("No agent runs yet")
@@ -477,6 +497,18 @@ RSpec.describe "AgentRuns" do
         get project_agent_runs_path(project)
         expect(response.body).to include("Review")
         expect(response.body).to include("https://github.com/example/repo/pull/10#pullrequestreview-123456")
+      end
+
+      it "shows the provider column with the resolved provider name" do
+        provider = create(:provider, user: user, provider_key: "cursor")
+        run = create(:agent_run, project: project, provider: provider, final_provider: provider.routing_key)
+
+        get project_agent_runs_path(project)
+
+        document = parsed_html
+
+        expect(column_index(document, "Provider")).not_to be_nil
+        expect(cell_for_run(document, run, "Provider").text.squish).to eq(provider.display_name)
       end
 
       it "shows PR link in actions column for completed create_pr runs" do
@@ -2332,15 +2364,7 @@ RSpec.describe "AgentRuns" do
   end
 
   def goal_cell_for_run(document, run)
-    row = row_for_run(document, run)
-    index = goal_column_index(document)
-
-    expect(index).not_to be_nil, "Expected a 'Goal' header column in the table but none was found"
-
-    goal_cell = row.css("td")[index]
-
-    expect(goal_cell).to be_present
-    goal_cell
+    cell_for_run(document, run, "Goal")
   end
 
   def row_for_run(document, run)
@@ -2352,6 +2376,22 @@ RSpec.describe "AgentRuns" do
   end
 
   def goal_column_index(document)
-    document.css("table thead th").find_index { |header| header.text.squish == "Goal" }
+    column_index(document, "Goal")
+  end
+
+  def cell_for_run(document, run, header_text)
+    row = row_for_run(document, run)
+    index = column_index(document, header_text)
+
+    expect(index).not_to be_nil, "Expected a '#{header_text}' header column in the table but none was found"
+
+    cell = row.css("td")[index]
+
+    expect(cell).to be_present
+    cell
+  end
+
+  def column_index(document, header_text)
+    document.css("table thead th").find_index { |header| header.text.squish == header_text }
   end
 end

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -147,6 +147,15 @@ RSpec.describe "AgentRuns" do
         expect(cell_for_run(parsed_html, run, "Provider").text.squish).to eq("Deleted provider entry")
       end
 
+      it "shows the final provider label for legacy fallback runs" do
+        initial_provider = create(:provider, user: user, provider_key: "codex")
+        run = create(:agent_run, project: project, provider: initial_provider, final_provider: "cursor")
+
+        get agent_runs_path
+
+        expect(cell_for_run(parsed_html, run, "Provider").text.squish).to eq(Provider.display_name_for("cursor"))
+      end
+
       it "renders unsupported provider identifiers without error" do
         run = create(:agent_run, project: project, provider: nil, final_provider: "api", agent_type: "api")
 
@@ -518,6 +527,15 @@ RSpec.describe "AgentRuns" do
 
         expect(column_index(document, "Provider")).not_to be_nil
         expect(cell_for_run(document, run, "Provider").text.squish).to eq(provider.display_name)
+      end
+
+      it "shows the final provider label for legacy fallback runs" do
+        initial_provider = create(:provider, user: user, provider_key: "codex")
+        run = create(:agent_run, project: project, provider: initial_provider, final_provider: "cursor")
+
+        get project_agent_runs_path(project)
+
+        expect(cell_for_run(parsed_html, run, "Provider").text.squish).to eq(Provider.display_name_for("cursor"))
       end
 
       it "renders unsupported provider identifiers without error" do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -140,6 +140,17 @@ RSpec.describe "Dashboard" do
         expect(row.text).to include(provider.display_name)
       end
 
+      it "shows the final provider label for legacy fallback runs in the active runs table" do
+        initial_provider = create(:provider, user: user, provider_key: "codex")
+        run = create(:agent_run, :running, project: project, provider: initial_provider, final_provider: "cursor")
+
+        get dashboard_path
+
+        row = Nokogiri::HTML(response.body).at_css(%(tr[id="#{ActionView::RecordIdentifier.dom_id(run, :dashboard_row)}"]))
+        expect(row).to be_present
+        expect(row.text).to include(Provider.display_name_for("cursor"))
+      end
+
       it "renders unsupported provider identifiers in the active runs table without error" do
         run = create(:agent_run, :running, project: project, provider: nil, final_provider: "api", agent_type: "api")
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -140,6 +140,17 @@ RSpec.describe "Dashboard" do
         expect(row.text).to include(provider.display_name)
       end
 
+      it "renders unsupported provider identifiers in the active runs table without error" do
+        run = create(:agent_run, :running, project: project, provider: nil, final_provider: "api", agent_type: "api")
+
+        get dashboard_path
+
+        expect(response).to have_http_status(:ok)
+        row = Nokogiri::HTML(response.body).at_css(%(tr[id="#{ActionView::RecordIdentifier.dom_id(run, :dashboard_row)}"]))
+        expect(row).to be_present
+        expect(row.text).to include("Api")
+      end
+
       it "shows quality-paused projects on the dashboard" do
         project.update!(
           name: "Paused Project",

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Dashboard" do
     context "when authenticated" do
       let(:account) { create(:account, name: "Test Company") }
       let(:user) { create(:user, account: account, name: "John Doe") }
-      let(:project) { create(:project, account: account) }
+      let(:project) { create(:project, account: account, created_by: user) }
 
       before { sign_in user }
 
@@ -120,6 +120,24 @@ RSpec.describe "Dashboard" do
 
         expect(response.body).to include(project.full_name)
         expect(response.body).to include("42s")
+      end
+
+      it "shows the provider column in the active runs table" do
+        provider = create(:provider, user: user, provider_key: "codex")
+        run = create(:agent_run, :running, project: project, provider: provider, final_provider: provider.routing_key)
+
+        get dashboard_path
+
+        document = Nokogiri::HTML(response.body)
+        table = document.at_css("#active-runs table")
+
+        expect(table).to be_present
+        expect(table.css("thead th").map { |header| header.text.squish }).to include("Provider")
+
+        row = document.at_css(%(tr[id="#{ActionView::RecordIdentifier.dom_id(run, :dashboard_row)}"]))
+
+        expect(row).to be_present
+        expect(row.text).to include(provider.display_name)
       end
 
       it "shows quality-paused projects on the dashboard" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -565,6 +565,21 @@ RSpec.describe "Projects" do
         expect(row.text).to include(provider.display_name)
       end
 
+      it "renders unsupported provider identifiers in recent agent runs without error" do
+        project = create(:project, account: account, github_token: github_token, created_by: user)
+        run = create(:agent_run, project: project, provider: nil, final_provider: "api", agent_type: "api")
+
+        get project_path(project)
+
+        document = Nokogiri::HTML(response.body)
+        section = document.at_css(%(div[id="#{ActionView::RecordIdentifier.dom_id(project, :agent_runs)}"]))
+        row = section.at_css(%(a[href="#{project_agent_run_path(project, run)}"]))&.ancestors("tr")&.first
+
+        expect(response).to have_http_status(:ok)
+        expect(row).to be_present
+        expect(row.text).to include("Api")
+      end
+
       it "links to PR in context column for review goal runs on project page" do
         project = create(:project, account: account, github_token: github_token)
         run = create(:agent_run, :review_goal, :completed, project: project)

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -565,6 +565,21 @@ RSpec.describe "Projects" do
         expect(row.text).to include(provider.display_name)
       end
 
+      it "shows the final provider label for legacy fallback runs in recent agent runs" do
+        project = create(:project, account: account, github_token: github_token, created_by: user)
+        initial_provider = create(:provider, user: user, provider_key: "codex")
+        run = create(:agent_run, project: project, provider: initial_provider, final_provider: "cursor")
+
+        get project_path(project)
+
+        document = Nokogiri::HTML(response.body)
+        section = document.at_css(%(div[id="#{ActionView::RecordIdentifier.dom_id(project, :agent_runs)}"]))
+        row = section.at_css(%(a[href="#{project_agent_run_path(project, run)}"]))&.ancestors("tr")&.first
+
+        expect(row).to be_present
+        expect(row.text).to include(Provider.display_name_for("cursor"))
+      end
+
       it "renders unsupported provider identifiers in recent agent runs without error" do
         project = create(:project, account: account, github_token: github_token, created_by: user)
         run = create(:agent_run, project: project, provider: nil, final_provider: "api", agent_type: "api")

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -546,6 +546,25 @@ RSpec.describe "Projects" do
         expect(response.body).to include(project_agent_run_path(project, run))
       end
 
+      it "shows the provider column for recent agent runs" do
+        project = create(:project, account: account, github_token: github_token, created_by: user)
+        provider = create(:provider, user: user, provider_key: "codex")
+        run = create(:agent_run, project: project, provider: provider, final_provider: provider.routing_key)
+
+        get project_path(project)
+
+        document = Nokogiri::HTML(response.body)
+        section = document.at_css(%(div[id="#{ActionView::RecordIdentifier.dom_id(project, :agent_runs)}"]))
+
+        expect(section).to be_present
+        expect(section.css("thead th").map { |header| header.text.squish }).to include("Provider")
+
+        row = section.at_css(%(a[href="#{project_agent_run_path(project, run)}"]))&.ancestors("tr")&.first
+
+        expect(row).to be_present
+        expect(row.text).to include(provider.display_name)
+      end
+
       it "links to PR in context column for review goal runs on project page" do
         project = create(:project, account: account, github_token: github_token)
         run = create(:agent_run, :review_goal, :completed, project: project)

--- a/spec/services/dashboard/live_broadcaster_spec.rb
+++ b/spec/services/dashboard/live_broadcaster_spec.rb
@@ -6,10 +6,14 @@ RSpec.describe Dashboard::LiveBroadcaster do
   describe ".call" do
     let(:account) { create(:account) }
     let(:project) { create(:project, account: account) }
+    let(:owner) { project.effective_owner }
     let(:agent_run) { create(:agent_run, project: project, status: "running", started_at: 2.minutes.ago) }
+    let(:broadcast_updates) { [] }
 
     before do
-      allow(Turbo::StreamsChannel).to receive(:broadcast_update_to)
+      allow(Turbo::StreamsChannel).to receive(:broadcast_update_to) do |*args|
+        broadcast_updates << args
+      end
       allow(Turbo::StreamsChannel).to receive(:broadcast_prepend_to)
     end
 
@@ -23,6 +27,27 @@ RSpec.describe Dashboard::LiveBroadcaster do
       expect(Turbo::StreamsChannel).to have_received(:broadcast_update_to).with(
         [ account, :live_dashboard ],
         hash_including(target: "active-runs", partial: "dashboard/active_runs")
+      )
+    end
+
+    it "preloads final provider records for active-run fallback rows" do
+      initial_provider = create(:provider, user: owner, provider_key: "codex")
+      fallback_provider = create(:provider, user: owner, provider_key: "cursor")
+      active_run = create(:agent_run,
+        project: project,
+        status: "running",
+        started_at: 1.minute.ago,
+        provider: initial_provider,
+        final_provider: fallback_provider.routing_key)
+
+      described_class.call(account: account, agent_run: active_run)
+
+      expect(broadcasted_active_runs).to include(
+        have_attributes(
+          id: active_run.id,
+          preloaded_final_provider_record: fallback_provider,
+          preloaded_final_provider_record_loaded: true
+        )
       )
     end
 
@@ -95,5 +120,10 @@ RSpec.describe Dashboard::LiveBroadcaster do
         )
       )
     end
+  end
+
+  def broadcasted_active_runs
+    _stream, options = broadcast_updates.find { |_target, locals| locals[:target] == "active-runs" }
+    options.dig(:locals, :active_runs)
   end
 end


### PR DESCRIPTION
## Summary

Added a shared provider display helper and inserted a `Provider` column into all agent run list tables covered by the issue: dashboard active runs, the main agent runs index, the project agent runs index, and the project show page’s recent runs table. The helper prefers the effective/final provider label, falls back cleanly for missing data, and shows `Deleted provider entry` when a historical routing-key reference no longer resolves.

Request coverage was added for the global index, project index, project show, and dashboard surfaces. I ran `bundle install`, `yarn install`, `bin/rails db:prepare` after exporting `DB_*` from the provided `DATABASE_URL`, then `bundle exec rubocop` and the full `bundle exec rspec` suite. The commit hook reran staged lint/tests and passed. Commit: `bfcdcb9` (`feat(agent-runs): show provider in run tables`).

---

Closes #1688