### PR TITLE
fix(test): suppress third-party gem warnings in RSpec output

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,8 +51,8 @@ RSpec.configure do |config|
     class << self
       alias_method :warn_without_filter, :warn
 
-      def warn(message, category: nil, **)
-        super unless message.include?("/gems/")
+      def warn(message, category: nil, **kwargs)
+        warn_without_filter(message, category: category, **kwargs) unless message.include?("/gems/")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,16 @@ RSpec.configure do |config|
   # This setting enables warnings.
   config.warnings = true
 
+  module Warning
+    class << self
+      alias_method :warn_without_filter, :warn
+
+      def warn(message, category: nil, **)
+        super unless message.include?("/gems/")
+      end
+    end
+  end
+
   # Print the 10 slowest examples at the end of the spec run.
   config.profile_examples = 10 if config.files_to_run.one?
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,57 @@ TestProf.configure do |config|
   config.timestamps = true
 end
 
+module Warning
+  APP_WARNING_PATHS = %w[app config lib spec].map do |path|
+    File.expand_path(path, File.expand_path("..", __dir__))
+  end.freeze
+  private_constant :APP_WARNING_PATHS
+
+  GEM_WARNING_PATHS ||= (
+    Gem.path + [ Gem.default_dir, Gem.user_dir ]
+  ).flat_map do |path|
+    [ File.join(path, "gems"), File.join(path, "bundler", "gems") ]
+  end.map { |path| File.expand_path(path) }
+    .uniq
+    .freeze
+  private_constant :GEM_WARNING_PATHS
+
+  class << self
+    unless method_defined?(:warn_without_gem_noise)
+      alias_method :warn_without_gem_noise, :warn
+
+      def warn(message, category: nil, **kwargs)
+        return if gem_warning?(message)
+
+        warn_without_gem_noise(message, category: category, **kwargs)
+      end
+
+      private
+
+      def gem_warning?(message)
+        paths = warning_paths(message)
+        return false if paths.empty?
+        return false if app_warning?(paths)
+
+        paths.any? do |source_path|
+          GEM_WARNING_PATHS.any? { |path| source_path.start_with?("#{path}/") }
+        end
+      end
+
+      def app_warning?(paths)
+        paths.any? do |source_path|
+          APP_WARNING_PATHS.any? { |path| source_path.start_with?("#{path}/") }
+        end
+      end
+
+      def warning_paths(message)
+        warning_line = message.lines.first.to_s
+        warning_line.scan(%r{/(?:[^:\s]|:(?!\d))+}).map { |path| File.expand_path(path) }.uniq
+      end
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.example_status_persistence_file_path = "spec/.examples.txt"
 
@@ -46,16 +97,6 @@ RSpec.configure do |config|
 
   # This setting enables warnings.
   config.warnings = true
-
-  module Warning
-    class << self
-      alias_method :warn_without_filter, :warn
-
-      def warn(message, category: nil, **kwargs)
-        warn_without_filter(message, category: category, **kwargs) unless message.include?("/gems/")
-      end
-    end
-  end
 
   # Print the 10 slowest examples at the end of the spec run.
   config.profile_examples = 10 if config.files_to_run.one?


### PR DESCRIPTION
## Summary
- Override `Warning.warn` in `spec_helper.rb` to suppress warnings originating from `/gems/` paths
- Preserves warnings from app code (`app/`, `lib/`, etc.) — only gem noise is filtered
- Eliminates ~17 noisy warnings from ransack, devise, warden, temporalio, turbo-rails, capybara, and actioncable that were filling multiple screens of output with zero actionable signal

## Context
All warnings came from third-party gems (method redefined, circular requires, deprecated APIs). `config.warnings = true` enables Ruby's `$VERBOSE` mode which reports warnings from all loaded code including gems. This override keeps the useful behavior (catching app-code warnings) while removing the noise.