### PR TITLE
feat(knowledge): add health monitoring and alerting for knowledge base LLM operations

### DIFF
--- a/app/models/knowledge_run.rb
+++ b/app/models/knowledge_run.rb
@@ -3,6 +3,7 @@
 class KnowledgeRun < ApplicationRecord
   STATUSES = %w[pending running completed failed].freeze
   ACTIVE_STATUSES = %w[pending running].freeze
+  FINISHED_STATUSES = %w[completed failed].freeze
   OPERATION_TYPES = %w[embedding decision_drafting].freeze
   TOKEN_LIMIT_STATUSES = AgentRun::TOKEN_LIMIT_STATUSES
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000
@@ -20,6 +21,7 @@ class KnowledgeRun < ApplicationRecord
   validates :total_tokens, numericality: { greater_than_or_equal_to: 0 }
 
   scope :active, -> { where(status: ACTIVE_STATUSES) }
+  scope :finished, -> { where(status: FINISHED_STATUSES) }
 
   def active?
     ACTIVE_STATUSES.include?(status)
@@ -27,6 +29,10 @@ class KnowledgeRun < ApplicationRecord
 
   def effective_max_tokens_per_run
     max_tokens || DEFAULT_MAX_TOKENS_PER_RUN
+  end
+
+  def effective_provider
+    final_provider.presence || provider_attempts.last&.fetch("provider", nil) || "unknown"
   end
 
   def record_provider_attempt(provider)
@@ -50,6 +56,14 @@ class KnowledgeRun < ApplicationRecord
     end
 
     proxy_token
+  end
+
+  def complete!
+    update!(status: "completed") if active?
+  end
+
+  def fail!
+    update!(status: "failed") if active?
   end
 
   private

--- a/app/services/knowledge/dashboard_stats.rb
+++ b/app/services/knowledge/dashboard_stats.rb
@@ -4,8 +4,6 @@ module Knowledge
   class DashboardStats
     CACHE_TTL = 60.seconds
     PIPELINE_LOOKBACK = 30.days
-    FINISHED_STATUSES_SQL = KnowledgeRun::FINISHED_STATUSES.map { |status| "'#{status}'" }.join(", ").freeze
-
     attr_reader :account
 
     def initialize(account:)
@@ -250,10 +248,10 @@ module Knowledge
         .pluck(
           Arel.sql("knowledge_runs.operation_type"),
           Arel.sql("COUNT(*)"),
-          Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status IN (#{FINISHED_STATUSES_SQL}))"),
+          Arel.sql("COUNT(*)"),
           Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status = 'completed')"),
           Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status = 'failed')"),
-          Arel.sql("AVG(EXTRACT(EPOCH FROM (knowledge_runs.updated_at - knowledge_runs.created_at))) FILTER (WHERE knowledge_runs.status IN (#{FINISHED_STATUSES_SQL}))")
+          Arel.sql("AVG(EXTRACT(EPOCH FROM (knowledge_runs.updated_at - knowledge_runs.created_at)))")
         )
         .map do |operation_type, total_runs, finished_runs, successful_runs, failed_runs, avg_duration_seconds|
           {
@@ -275,9 +273,9 @@ module Knowledge
           Arel.sql("knowledge_runs.operation_type"),
           Arel.sql("#{effective_provider_sql}"),
           Arel.sql("COUNT(*)"),
-          Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status IN (#{FINISHED_STATUSES_SQL}))"),
+          Arel.sql("COUNT(*)"),
           Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status = 'completed')"),
-          Arel.sql("AVG(EXTRACT(EPOCH FROM (knowledge_runs.updated_at - knowledge_runs.created_at))) FILTER (WHERE knowledge_runs.status IN (#{FINISHED_STATUSES_SQL}))")
+          Arel.sql("AVG(EXTRACT(EPOCH FROM (knowledge_runs.updated_at - knowledge_runs.created_at)))")
         )
         .map do |operation_type, provider, run_count, finished_runs, successful_runs, avg_duration_seconds|
           {
@@ -291,7 +289,7 @@ module Knowledge
     end
 
     def pipeline_runs
-      knowledge_runs.where(created_at: PIPELINE_LOOKBACK.ago..Time.current)
+      knowledge_runs.finished.where(created_at: PIPELINE_LOOKBACK.ago..Time.current)
     end
 
     def effective_provider_sql

--- a/app/services/knowledge/dashboard_stats.rb
+++ b/app/services/knowledge/dashboard_stats.rb
@@ -2,6 +2,9 @@
 
 module Knowledge
   class DashboardStats
+    CACHE_TTL = 60.seconds
+    PIPELINE_LOOKBACK = 30.days
+
     attr_reader :account
 
     def initialize(account:)
@@ -21,6 +24,9 @@ module Knowledge
         stale_percent: stale_percent,
         artifacts_by_type: artifacts_by_type,
         last_collection_at: last_collection_at,
+        provider_health: provider_health,
+        operational_status: operational_status,
+        pipeline_metrics: pipeline_metrics,
         token_usage_summary: token_usage_summary,
         knowledge_usage_summary: knowledge_usage_summary,
         usage_by_goal: usage_by_goal
@@ -88,6 +94,32 @@ module Knowledge
         .where(projects: { account_id: account.id })
     end
 
+    def provider_health
+      @provider_health ||= Rails.cache.fetch(provider_health_cache_key, expires_in: CACHE_TTL) do
+        build_provider_health
+      end
+    end
+
+    def operational_status
+      return "healthy" if provider_health[:embedding_available] && provider_health[:chat_available]
+      return "degraded" if provider_health[:embedding_available] || provider_health[:chat_available]
+
+      "unavailable"
+    end
+
+    def pipeline_metrics
+      @pipeline_metrics ||= begin
+        runs_by_operation = knowledge_runs.where(created_at: PIPELINE_LOOKBACK.ago..Time.current)
+          .order(created_at: :desc)
+          .to_a
+          .group_by(&:operation_type)
+
+        KnowledgeRun::OPERATION_TYPES.index_with do |operation_type|
+          summarize_pipeline_runs(runs_by_operation.fetch(operation_type, []))
+        end
+      end
+    end
+
     def knowledge_usage_summary
       @knowledge_usage_summary ||= KnowledgeUsageStat
         .joins(:project)
@@ -104,6 +136,142 @@ module Knowledge
         .group(:goal)
         .sum(:artifact_count)
         .sort_by { |_, v| -v }
+    end
+
+    def provider_health_cache_key
+      [
+        "knowledge/dashboard_stats/provider_health",
+        account.id,
+        owner&.id || "none",
+        user_setting&.updated_at&.to_i || "none"
+      ].join("/")
+    end
+
+    def build_provider_health
+      return empty_provider_health unless user_setting && owner
+
+      embedding_providers = configured_providers_for(:embedding)
+      chat_providers = configured_providers_for(:chat)
+      provider_states = owner.provider_states
+        .where(provider_name: (embedding_providers + chat_providers).uniq)
+        .index_by(&:provider_name)
+
+      {
+        embedding: embedding_providers.map { |provider| provider_status(provider, provider_states) },
+        chat: chat_providers.map { |provider| provider_status(provider, provider_states) },
+        embedding_available: embedding_providers.any? { |provider| provider_available?(provider, provider_states) },
+        chat_available: chat_providers.any? { |provider| provider_available?(provider, provider_states) }
+      }
+    end
+
+    def empty_provider_health
+      {
+        embedding: [],
+        chat: [],
+        embedding_available: false,
+        chat_available: false
+      }
+    end
+
+    def configured_providers_for(operation)
+      return [] unless user_setting
+
+      providers =
+        case operation.to_sym
+        when :embedding
+          [ user_setting.kb_embedding_provider, *Array(user_setting.kb_embedding_fallback_providers) ]
+        when :chat
+          [ user_setting.kb_chat_provider, *Array(user_setting.kb_chat_fallback_providers) ]
+        else
+          []
+        end
+
+      providers.filter_map { |provider| provider.to_s.strip.downcase.presence }
+        .uniq
+        .select { |provider| supported_providers_for(operation).include?(provider) }
+    end
+
+    def supported_providers_for(operation)
+      case operation.to_sym
+      when :embedding
+        UserSetting::KB_EMBEDDING_PROVIDERS
+      when :chat
+        UserSetting::KB_CHAT_PROVIDERS
+      else
+        []
+      end
+    end
+
+    def provider_status(provider, provider_states)
+      state = provider_states[provider]
+      state.check_circuit_recovery!(timeout: user_setting.circuit_breaker_timeout_seconds) if state
+
+      {
+        provider: provider,
+        circuit_state: state&.circuit_state || "closed",
+        rate_limited: state&.rate_limited? || false,
+        rate_limited_until: state&.rate_limited_until,
+        recent_failures: state&.failure_count || 0,
+        available: state.nil? || !state.unavailable?
+      }
+    end
+
+    def provider_available?(provider, provider_states)
+      provider_status(provider, provider_states)[:available]
+    end
+
+    def summarize_pipeline_runs(runs)
+      finished_runs = runs.select { |run| KnowledgeRun::FINISHED_STATUSES.include?(run.status) }
+      successful_runs = finished_runs.count { |run| run.status == "completed" }
+      failed_runs = finished_runs.count { |run| run.status == "failed" }
+
+      {
+        lookback_days: PIPELINE_LOOKBACK / 1.day,
+        total_runs: runs.size,
+        finished_runs: finished_runs.size,
+        successful_runs: successful_runs,
+        failed_runs: failed_runs,
+        success_rate: percentage(successful_runs, finished_runs.size),
+        avg_duration_seconds: average_duration(finished_runs),
+        provider_distribution: summarize_provider_distribution(runs)
+      }
+    end
+
+    def summarize_provider_distribution(runs)
+      runs.group_by(&:effective_provider)
+        .sort_by { |provider, provider_runs| [ -provider_runs.size, provider ] }
+        .map do |provider, provider_runs|
+          finished_runs = provider_runs.select { |run| KnowledgeRun::FINISHED_STATUSES.include?(run.status) }
+          successful_runs = finished_runs.count { |run| run.status == "completed" }
+
+          {
+            provider: provider,
+            run_count: provider_runs.size,
+            success_rate: percentage(successful_runs, finished_runs.size),
+            avg_duration_seconds: average_duration(finished_runs)
+          }
+        end
+    end
+
+    def average_duration(runs)
+      return 0.0 if runs.empty?
+
+      total_duration = runs.sum { |run| run.updated_at - run.created_at }
+      (total_duration / runs.size).round(2)
+    end
+
+    def percentage(numerator, denominator)
+      return 0.0 if denominator.zero?
+
+      ((numerator.to_f / denominator) * 100).round(1)
+    end
+
+    def owner
+      @owner ||= account.fallback_owner
+    end
+
+    def user_setting
+      @user_setting ||= owner&.settings
     end
   end
 end

--- a/app/services/knowledge/dashboard_stats.rb
+++ b/app/services/knowledge/dashboard_stats.rb
@@ -4,6 +4,7 @@ module Knowledge
   class DashboardStats
     CACHE_TTL = 60.seconds
     PIPELINE_LOOKBACK = 30.days
+    FINISHED_STATUSES_SQL = KnowledgeRun::FINISHED_STATUSES.map { |status| "'#{status}'" }.join(", ").freeze
 
     attr_reader :account
 
@@ -108,15 +109,8 @@ module Knowledge
     end
 
     def pipeline_metrics
-      @pipeline_metrics ||= begin
-        runs_by_operation = knowledge_runs.where(created_at: PIPELINE_LOOKBACK.ago..Time.current)
-          .order(created_at: :desc)
-          .to_a
-          .group_by(&:operation_type)
-
-        KnowledgeRun::OPERATION_TYPES.index_with do |operation_type|
-          summarize_pipeline_runs(runs_by_operation.fetch(operation_type, []))
-        end
+      @pipeline_metrics ||= Rails.cache.fetch(pipeline_metrics_cache_key, expires_in: CACHE_TTL) do
+        build_pipeline_metrics
       end
     end
 
@@ -156,11 +150,14 @@ module Knowledge
         .where(provider_name: (embedding_providers + chat_providers).uniq)
         .index_by(&:provider_name)
 
+      embedding = embedding_providers.map { |provider| provider_status(provider, provider_states) }
+      chat = chat_providers.map { |provider| provider_status(provider, provider_states) }
+
       {
-        embedding: embedding_providers.map { |provider| provider_status(provider, provider_states) },
-        chat: chat_providers.map { |provider| provider_status(provider, provider_states) },
-        embedding_available: embedding_providers.any? { |provider| provider_available?(provider, provider_states) },
-        chat_available: chat_providers.any? { |provider| provider_available?(provider, provider_states) }
+        embedding: embedding,
+        chat: chat,
+        embedding_available: embedding.any? { |provider| provider[:available] },
+        chat_available: chat.any? { |provider| provider[:available] }
       }
     end
 
@@ -216,48 +213,98 @@ module Knowledge
       }
     end
 
-    def provider_available?(provider, provider_states)
-      provider_status(provider, provider_states)[:available]
+    def pipeline_metrics_cache_key
+      relation = knowledge_runs.where(created_at: PIPELINE_LOOKBACK.ago..Time.current)
+      [
+        "knowledge/dashboard_stats/pipeline_metrics",
+        account.id,
+        relation.maximum(:updated_at)&.to_i || "none",
+        relation.count
+      ].join("/")
     end
 
-    def summarize_pipeline_runs(runs)
-      finished_runs = runs.select { |run| KnowledgeRun::FINISHED_STATUSES.include?(run.status) }
-      successful_runs = finished_runs.count { |run| run.status == "completed" }
-      failed_runs = finished_runs.count { |run| run.status == "failed" }
+    def build_pipeline_metrics
+      operation_summaries = pipeline_operation_summaries.index_by { |summary| summary[:operation_type] }
+      distributions = pipeline_provider_distribution.group_by { |summary| summary[:operation_type] }
 
-      {
-        lookback_days: PIPELINE_LOOKBACK / 1.day,
-        total_runs: runs.size,
-        finished_runs: finished_runs.size,
-        successful_runs: successful_runs,
-        failed_runs: failed_runs,
-        success_rate: percentage(successful_runs, finished_runs.size),
-        avg_duration_seconds: average_duration(finished_runs),
-        provider_distribution: summarize_provider_distribution(runs)
-      }
+      KnowledgeRun::OPERATION_TYPES.index_with do |operation_type|
+        summary = operation_summaries[operation_type]
+        provider_distribution = Array(distributions[operation_type]).sort_by { |provider| [ -provider[:run_count], provider[:provider] ] }
+
+        {
+          lookback_days: PIPELINE_LOOKBACK / 1.day,
+          total_runs: summary&.fetch(:total_runs, 0) || 0,
+          finished_runs: summary&.fetch(:finished_runs, 0) || 0,
+          successful_runs: summary&.fetch(:successful_runs, 0) || 0,
+          failed_runs: summary&.fetch(:failed_runs, 0) || 0,
+          success_rate: summary&.fetch(:success_rate, 0.0) || 0.0,
+          avg_duration_seconds: summary&.fetch(:avg_duration_seconds, 0.0) || 0.0,
+          provider_distribution: provider_distribution
+        }
+      end
     end
 
-    def summarize_provider_distribution(runs)
-      runs.group_by(&:effective_provider)
-        .sort_by { |provider, provider_runs| [ -provider_runs.size, provider ] }
-        .map do |provider, provider_runs|
-          finished_runs = provider_runs.select { |run| KnowledgeRun::FINISHED_STATUSES.include?(run.status) }
-          successful_runs = finished_runs.count { |run| run.status == "completed" }
-
+    def pipeline_operation_summaries
+      pipeline_runs
+        .group(:operation_type)
+        .pluck(
+          Arel.sql("knowledge_runs.operation_type"),
+          Arel.sql("COUNT(*)"),
+          Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status IN (#{FINISHED_STATUSES_SQL}))"),
+          Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status = 'completed')"),
+          Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status = 'failed')"),
+          Arel.sql("AVG(EXTRACT(EPOCH FROM (knowledge_runs.updated_at - knowledge_runs.created_at))) FILTER (WHERE knowledge_runs.status IN (#{FINISHED_STATUSES_SQL}))")
+        )
+        .map do |operation_type, total_runs, finished_runs, successful_runs, failed_runs, avg_duration_seconds|
           {
-            provider: provider,
-            run_count: provider_runs.size,
-            success_rate: percentage(successful_runs, finished_runs.size),
-            avg_duration_seconds: average_duration(finished_runs)
+            operation_type: operation_type,
+            total_runs: total_runs,
+            finished_runs: finished_runs,
+            successful_runs: successful_runs,
+            failed_runs: failed_runs,
+            success_rate: percentage(successful_runs, finished_runs),
+            avg_duration_seconds: avg_duration_seconds.to_f.round(2)
           }
         end
     end
 
-    def average_duration(runs)
-      return 0.0 if runs.empty?
+    def pipeline_provider_distribution
+      pipeline_runs
+        .group(:operation_type, Arel.sql(effective_provider_sql))
+        .pluck(
+          Arel.sql("knowledge_runs.operation_type"),
+          Arel.sql("#{effective_provider_sql}"),
+          Arel.sql("COUNT(*)"),
+          Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status IN (#{FINISHED_STATUSES_SQL}))"),
+          Arel.sql("COUNT(*) FILTER (WHERE knowledge_runs.status = 'completed')"),
+          Arel.sql("AVG(EXTRACT(EPOCH FROM (knowledge_runs.updated_at - knowledge_runs.created_at))) FILTER (WHERE knowledge_runs.status IN (#{FINISHED_STATUSES_SQL}))")
+        )
+        .map do |operation_type, provider, run_count, finished_runs, successful_runs, avg_duration_seconds|
+          {
+            operation_type: operation_type,
+            provider: provider,
+            run_count: run_count,
+            success_rate: percentage(successful_runs, finished_runs),
+            avg_duration_seconds: avg_duration_seconds.to_f.round(2)
+          }
+        end
+    end
 
-      total_duration = runs.sum { |run| run.updated_at - run.created_at }
-      (total_duration / runs.size).round(2)
+    def pipeline_runs
+      knowledge_runs.where(created_at: PIPELINE_LOOKBACK.ago..Time.current)
+    end
+
+    def effective_provider_sql
+      <<~SQL.squish
+        COALESCE(
+          NULLIF(final_provider, ''),
+          CASE
+            WHEN jsonb_array_length(COALESCE(provider_attempts, '[]'::jsonb)) > 0
+              THEN COALESCE(provider_attempts, '[]'::jsonb) -> (jsonb_array_length(COALESCE(provider_attempts, '[]'::jsonb)) - 1) ->> 'provider'
+          END,
+          'unknown'
+        )
+      SQL
     end
 
     def percentage(numerator, denominator)

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -109,7 +109,17 @@ module Knowledge
       def send_to_llm_containerized(prompt)
         success = false
         knowledge_run = create_knowledge_run!
-        providers = supported_chat_providers
+        configured_providers = chat_providers
+        providers = configured_providers.select { |provider| Knowledge::AnalysisRunner.supported_provider?(provider) }
+
+        if providers.empty?
+          log_all_providers_unavailable(
+            knowledge_run,
+            reason: "no_supported_container_providers",
+            providers: configured_providers
+          )
+          return nil
+        end
 
         runner = Knowledge::AnalysisRunner.new(
           project: agent_run.project,
@@ -158,7 +168,7 @@ module Knowledge
           end
         end
 
-        log_all_providers_unavailable(knowledge_run, reason: "containerized_providers_failed") if providers.any?
+        log_all_providers_unavailable(knowledge_run, reason: "containerized_providers_failed")
         nil
       rescue Knowledge::AnalysisRunner::Error => e
         Rails.logger.warn(
@@ -283,10 +293,6 @@ module Knowledge
         providers.presence || [ DEFAULT_PROVIDER ]
       end
 
-      def supported_chat_providers
-        chat_providers.select { |provider| Knowledge::AnalysisRunner.supported_provider?(provider) }
-      end
-
       def model_for(provider)
         DEFAULT_MODEL if provider == DEFAULT_PROVIDER
       end
@@ -376,12 +382,12 @@ module Knowledge
         Rails.logger.warn(payload)
       end
 
-      def log_all_providers_unavailable(knowledge_run, reason:)
+      def log_all_providers_unavailable(knowledge_run, reason:, providers: nil)
         Rails.logger.warn(
           message: "knowledge.providers_unavailable",
           operation: "decision_drafting",
           reason: reason,
-          providers: knowledge_run.provider_attempts.map { |attempt| attempt["provider"] },
+          providers: providers || knowledge_run.provider_attempts.map { |attempt| attempt["provider"] },
           knowledge_run_id: knowledge_run.id,
           agent_run_id: agent_run.id
         )

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -107,7 +107,9 @@ module Knowledge
       end
 
       def send_to_llm_containerized(prompt)
+        success = false
         knowledge_run = create_knowledge_run!
+        providers = supported_chat_providers
 
         runner = Knowledge::AnalysisRunner.new(
           project: agent_run.project,
@@ -115,9 +117,8 @@ module Knowledge
         )
 
         runner.with_container do |r|
-          chat_providers.each do |provider|
-            next unless Knowledge::AnalysisRunner.supported_provider?(provider)
-
+          providers.each_with_index do |provider, index|
+            knowledge_run.record_provider_attempt(provider)
             output = r.call_llm(
               prompt,
               provider: provider,
@@ -126,18 +127,38 @@ module Knowledge
             )
 
             parsed = parse_text_output(output)
-            return parsed if parsed
+            if parsed
+              knowledge_run.update!(final_provider: provider)
+              success = true
+              return parsed
+            end
+
+            log_provider_switch(
+              from_provider: provider,
+              to_provider: providers[index + 1],
+              reason: "unparseable_response",
+              knowledge_run: knowledge_run
+            )
           rescue Knowledge::AnalysisRunner::Error => e
             Rails.logger.warn(
               message: "knowledge.decisions.draft_container_provider_failed",
               agent_run_id: agent_run.id,
+              knowledge_run_id: knowledge_run.id,
               provider: provider,
               error_class: e.class.name,
               error: e.message
             )
+            log_provider_switch(
+              from_provider: provider,
+              to_provider: providers[index + 1],
+              reason: "container_provider_failed",
+              knowledge_run: knowledge_run,
+              error: e
+            )
           end
         end
 
+        log_all_providers_unavailable(knowledge_run, reason: "containerized_providers_failed") if providers.any?
         nil
       rescue Knowledge::AnalysisRunner::Error => e
         Rails.logger.warn(
@@ -146,15 +167,18 @@ module Knowledge
           error_class: e.class.name,
           error: e.message
         )
-        send_to_llm_in_process(prompt)
+        fallback_result = send_to_llm_in_process(prompt)
+        success = fallback_result.present?
+        fallback_result
       ensure
-        finalize_knowledge_run!(knowledge_run)
+        finalize_knowledge_run!(knowledge_run, success: success)
       end
 
       def send_to_llm_in_process(prompt)
+        success = false
         setting = effective_user_setting
 
-        if setting
+        result = if setting
           create_knowledge_run! unless current_knowledge_run
 
           executor = Knowledge::ProviderExecutor.new(
@@ -176,36 +200,63 @@ module Knowledge
         else
           send_to_llm_in_process_without_executor(prompt)
         end
+
+        success = result.present?
+        result
       rescue Knowledge::ProviderExecutor::AllProvidersExhausted => e
         Rails.logger.warn(
           message: "knowledge.decisions.draft_all_providers_exhausted",
           agent_run_id: agent_run.id,
+          knowledge_run_id: current_knowledge_run&.id,
           error: e.message
         )
         nil
       ensure
-        finalize_knowledge_run!(current_knowledge_run) unless Knowledge::AnalysisRunner.available?
+        finalize_knowledge_run!(current_knowledge_run, success: success) unless Knowledge::AnalysisRunner.available?
       end
 
       def send_to_llm_in_process_without_executor(prompt)
-        chat_providers.each do |provider|
+        create_knowledge_run! unless current_knowledge_run
+        providers = chat_providers
+
+        providers.each_with_index do |provider, index|
+          current_knowledge_run.record_provider_attempt(provider)
           response = AgentHarness.send_message(
             prompt,
             **llm_request_options(provider)
           )
 
           parsed = parse_response(response)
-          return parsed if parsed
+          if parsed
+            current_knowledge_run.update!(final_provider: provider)
+            return parsed
+          end
+
+          log_provider_switch(
+            from_provider: provider,
+            to_provider: providers[index + 1],
+            reason: "invalid_response",
+            knowledge_run: current_knowledge_run
+          )
         rescue AgentHarness::Error => e
           Rails.logger.warn(
             message: "knowledge.decisions.draft_provider_failed",
             agent_run_id: agent_run.id,
+            knowledge_run_id: current_knowledge_run.id,
             provider: provider,
             error_class: e.class.name,
             error: e.message
           )
+          log_provider_switch(
+            from_provider: provider,
+            to_provider: providers[index + 1],
+            reason: "provider_failed",
+            knowledge_run: current_knowledge_run,
+            error: e
+          )
         end
 
+        log_all_providers_unavailable(current_knowledge_run, reason: "in_process_providers_failed")
         nil
       end
 
@@ -230,6 +281,10 @@ module Knowledge
         providers = setting ? Knowledge::ProviderSelector.for_chat(user_setting: setting) : []
 
         providers.presence || [ DEFAULT_PROVIDER ]
+      end
+
+      def supported_chat_providers
+        chat_providers.select { |provider| Knowledge::AnalysisRunner.supported_provider?(provider) }
       end
 
       def model_for(provider)
@@ -291,15 +346,44 @@ module Knowledge
         )
       end
 
-      def finalize_knowledge_run!(knowledge_run)
+      def finalize_knowledge_run!(knowledge_run, success:)
         return unless knowledge_run&.persisted?
 
-        knowledge_run.update!(status: "completed") if knowledge_run.active?
+        success ? knowledge_run.complete! : knowledge_run.fail!
       rescue ActiveRecord::RecordInvalid => e
         Rails.logger.warn(
           message: "knowledge.decisions.draft_knowledge_run_finalize_failed",
           knowledge_run_id: knowledge_run.id,
           error: e.message
+        )
+      end
+
+      def log_provider_switch(from_provider:, to_provider:, reason:, knowledge_run:, error: nil)
+        return if to_provider.blank?
+
+        payload = {
+          message: "knowledge.provider_switch",
+          operation: "decision_drafting",
+          from_provider: from_provider,
+          to_provider: to_provider,
+          reason: reason,
+          knowledge_run_id: knowledge_run.id,
+          agent_run_id: agent_run.id
+        }
+        payload[:error_class] = error.class.name if error
+        payload[:error] = error.message if error
+
+        Rails.logger.warn(payload)
+      end
+
+      def log_all_providers_unavailable(knowledge_run, reason:)
+        Rails.logger.warn(
+          message: "knowledge.providers_unavailable",
+          operation: "decision_drafting",
+          reason: reason,
+          providers: knowledge_run.provider_attempts.map { |attempt| attempt["provider"] },
+          knowledge_run_id: knowledge_run.id,
+          agent_run_id: agent_run.id
         )
       end
 

--- a/app/services/knowledge/provider_executor.rb
+++ b/app/services/knowledge/provider_executor.rb
@@ -18,11 +18,14 @@ module Knowledge
 
     def execute
       providers = available_providers
-      raise AllProvidersExhausted, "No available providers for #{@operation}" if providers.empty?
+      if providers.empty?
+        log_providers_unavailable("no_available_providers")
+        raise AllProvidersExhausted, "No available providers for #{@operation}"
+      end
 
       last_error = nil
 
-      providers.each do |provider|
+      providers.each_with_index do |provider, index|
         record_attempt(provider)
 
         begin
@@ -31,15 +34,20 @@ module Knowledge
           return result
         rescue AgentHarness::RateLimitError => e
           record_rate_limit(provider, e)
+          log_provider_failure(provider, "rate_limited", e)
+          log_provider_switch(provider, providers[index + 1], "rate_limited", e)
           last_error = e
           next
         rescue AgentHarness::Error => e
           record_failure(provider, e)
+          log_provider_failure(provider, "provider_error", e)
+          log_provider_switch(provider, providers[index + 1], "provider_error", e)
           last_error = e
           next
         end
       end
 
+      log_providers_unavailable("all_providers_exhausted", error: last_error)
       raise AllProvidersExhausted, "All providers exhausted for #{@operation}: #{last_error&.message}"
     end
 
@@ -84,6 +92,67 @@ module Knowledge
           s.circuit_state = "closed"
           s.failure_count = 0
         }
+    end
+
+    def log_provider_failure(provider, reason, error)
+      Rails.logger.warn(
+        message: "knowledge.provider_failure",
+        operation: @operation.to_s,
+        provider: provider,
+        reason: reason,
+        error_class: error.class.name,
+        error: error.message,
+        knowledge_run_id: @knowledge_run&.id,
+        user_setting_id: @user_setting.id
+      )
+    end
+
+    def log_provider_switch(from_provider, to_provider, reason, error)
+      return if to_provider.blank?
+
+      Rails.logger.warn(
+        message: "knowledge.provider_switch",
+        operation: @operation.to_s,
+        from_provider: from_provider,
+        to_provider: to_provider,
+        reason: reason,
+        error_class: error.class.name,
+        error: error.message,
+        knowledge_run_id: @knowledge_run&.id,
+        user_setting_id: @user_setting.id
+      )
+    end
+
+    def log_providers_unavailable(reason, error: nil)
+      payload = {
+        message: "knowledge.providers_unavailable",
+        operation: @operation.to_s,
+        reason: reason,
+        providers: available_providers_for_logging,
+        knowledge_run_id: @knowledge_run&.id,
+        user_setting_id: @user_setting.id
+      }
+      payload[:error_class] = error.class.name if error
+      payload[:error] = error.message if error
+
+      Rails.logger.warn(payload)
+    end
+
+    def available_providers_for_logging
+      case @operation.to_sym
+      when :embedding
+        configured_providers(:kb_embedding_provider, :kb_embedding_fallback_providers)
+      when :chat
+        configured_providers(:kb_chat_provider, :kb_chat_fallback_providers)
+      else
+        []
+      end
+    end
+
+    def configured_providers(primary_key, fallback_key)
+      [ @user_setting.public_send(primary_key), *Array(@user_setting.public_send(fallback_key)) ]
+        .filter_map { |provider| provider.to_s.strip.downcase.presence }
+        .uniq
     end
   end
 end

--- a/app/views/dashboard/_knowledge_widget.html.erb
+++ b/app/views/dashboard/_knowledge_widget.html.erb
@@ -56,9 +56,13 @@
         </span>
       </div>
 
-      <% if operational_status != "healthy" %>
+      <% if operational_status == "degraded" %>
         <p class="mt-3 text-sm text-amber-700">
-          Knowledge capabilities are degraded while one or more provider groups are unavailable.
+          Knowledge capabilities are degraded while one provider group remains available.
+        </p>
+      <% elsif operational_status == "unavailable" %>
+        <p class="mt-3 text-sm text-red-700">
+          Knowledge capabilities are unavailable because both provider groups are down.
         </p>
       <% end %>
 

--- a/app/views/dashboard/_knowledge_widget.html.erb
+++ b/app/views/dashboard/_knowledge_widget.html.erb
@@ -91,7 +91,7 @@
                       </div>
                       <div>
                         <dt class="font-medium text-gray-500">Rate Limit</dt>
-                        <dd><%= provider[:rate_limited_until] ? time_ago_in_words(provider[:rate_limited_until]) + " remaining" : "Clear" %></dd>
+                        <dd><%= provider[:rate_limited] ? time_ago_in_words(provider[:rate_limited_until]) + " remaining" : "Clear" %></dd>
                       </div>
                       <div>
                         <dt class="font-medium text-gray-500">Failures</dt>

--- a/app/views/dashboard/_knowledge_widget.html.erb
+++ b/app/views/dashboard/_knowledge_widget.html.erb
@@ -35,6 +35,77 @@
     </div>
   </div>
 
+  <% operational_status = knowledge_stats[:operational_status] %>
+  <% status_classes =
+    if operational_status == "healthy"
+      "bg-emerald-50 text-emerald-700 ring-emerald-600/20"
+    elsif operational_status == "degraded"
+      "bg-amber-50 text-amber-700 ring-amber-600/20"
+    else
+      "bg-red-50 text-red-700 ring-red-600/20"
+    end %>
+  <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+    <div class="px-4 py-5 sm:p-6">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-medium text-gray-500">Provider Health</h3>
+          <p class="mt-1 text-sm text-gray-700">Current availability for knowledge chat and embedding providers.</p>
+        </div>
+        <span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset <%= status_classes %>">
+          <%= operational_status.humanize %>
+        </span>
+      </div>
+
+      <% if operational_status != "healthy" %>
+        <p class="mt-3 text-sm text-amber-700">
+          Knowledge capabilities are degraded while one or more provider groups are unavailable.
+        </p>
+      <% end %>
+
+      <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <% { "Embedding" => knowledge_stats[:provider_health][:embedding], "Decision Drafting" => knowledge_stats[:provider_health][:chat] }.each do |label, providers| %>
+          <div class="rounded-lg border border-gray-200 p-4">
+            <div class="flex items-center justify-between gap-3">
+              <h4 class="text-sm font-semibold text-gray-900"><%= label %></h4>
+              <span class="text-xs text-gray-500"><%= pluralize(providers.size, "provider") %></span>
+            </div>
+
+            <% if providers.any? %>
+              <div class="mt-3 space-y-3">
+                <% providers.each do |provider| %>
+                  <div class="rounded-md bg-gray-50 px-3 py-2">
+                    <div class="flex items-center justify-between gap-3">
+                      <span class="font-medium text-gray-900"><%= provider[:provider] %></span>
+                      <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= provider[:available] ? "bg-emerald-100 text-emerald-700" : "bg-red-100 text-red-700" %>">
+                        <%= provider[:available] ? "Available" : "Unavailable" %>
+                      </span>
+                    </div>
+                    <dl class="mt-2 grid grid-cols-3 gap-2 text-xs text-gray-600">
+                      <div>
+                        <dt class="font-medium text-gray-500">Circuit</dt>
+                        <dd><%= provider[:circuit_state].humanize %></dd>
+                      </div>
+                      <div>
+                        <dt class="font-medium text-gray-500">Rate Limit</dt>
+                        <dd><%= provider[:rate_limited_until] ? time_ago_in_words(provider[:rate_limited_until]) + " remaining" : "Clear" %></dd>
+                      </div>
+                      <div>
+                        <dt class="font-medium text-gray-500">Failures</dt>
+                        <dd><%= provider[:recent_failures] %></dd>
+                      </div>
+                    </dl>
+                  </div>
+                <% end %>
+              </div>
+            <% else %>
+              <p class="mt-3 text-sm text-gray-500">No providers configured.</p>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
   <% if knowledge_stats[:artifacts_by_type].any? %>
     <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
       <div class="px-4 py-5 sm:p-6">
@@ -80,6 +151,68 @@
               <% end %>
             </tbody>
           </table>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <% if knowledge_stats[:pipeline_metrics].values.any? { |metric| metric[:total_runs].positive? } %>
+    <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+      <div class="px-4 py-5 sm:p-6">
+        <h3 class="text-sm font-medium text-gray-500">LLM Pipeline Metrics (Last 30 Days)</h3>
+        <div class="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-2">
+          <% knowledge_stats[:pipeline_metrics].each do |operation, metrics| %>
+            <div class="rounded-lg border border-gray-200 p-4">
+              <div class="flex items-center justify-between gap-3">
+                <h4 class="text-sm font-semibold text-gray-900"><%= operation.humanize %></h4>
+                <span class="text-xs text-gray-500"><%= pluralize(metrics[:total_runs], "run") %></span>
+              </div>
+
+              <div class="mt-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+                <div>
+                  <div class="text-xs font-medium uppercase tracking-wide text-gray-500">Success Rate</div>
+                  <div class="mt-1 font-semibold text-gray-900"><%= number_with_precision(metrics[:success_rate], precision: 1) %>%</div>
+                </div>
+                <div>
+                  <div class="text-xs font-medium uppercase tracking-wide text-gray-500">Completed</div>
+                  <div class="mt-1 font-semibold text-gray-900"><%= metrics[:successful_runs] %></div>
+                </div>
+                <div>
+                  <div class="text-xs font-medium uppercase tracking-wide text-gray-500">Failed</div>
+                  <div class="mt-1 font-semibold text-gray-900"><%= metrics[:failed_runs] %></div>
+                </div>
+                <div>
+                  <div class="text-xs font-medium uppercase tracking-wide text-gray-500">Avg Latency</div>
+                  <div class="mt-1 font-semibold text-gray-900"><%= number_with_precision(metrics[:avg_duration_seconds], precision: 2) %>s</div>
+                </div>
+              </div>
+
+              <% if metrics[:provider_distribution].any? %>
+                <table class="mt-4 min-w-full text-sm">
+                  <thead>
+                    <tr class="text-left text-gray-500">
+                      <th class="pr-4 font-medium">Provider</th>
+                      <th class="pr-4 font-medium text-right">Runs</th>
+                      <th class="pr-4 font-medium text-right">Success</th>
+                      <th class="font-medium text-right">Avg Latency</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% metrics[:provider_distribution].each do |provider| %>
+                      <tr>
+                        <td class="pr-4 py-1 text-gray-900"><%= provider[:provider] %></td>
+                        <td class="pr-4 py-1 text-right text-gray-700"><%= provider[:run_count] %></td>
+                        <td class="pr-4 py-1 text-right text-gray-700"><%= number_with_precision(provider[:success_rate], precision: 1) %>%</td>
+                        <td class="py-1 text-right text-gray-700"><%= number_with_precision(provider[:avg_duration_seconds], precision: 2) %>s</td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              <% else %>
+                <p class="mt-3 text-sm text-gray-500">No recent runs recorded for this operation.</p>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/spec/models/knowledge_run_spec.rb
+++ b/spec/models/knowledge_run_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe KnowledgeRun do
     end
   end
 
+  describe "#effective_provider" do
+    it "prefers final_provider when present" do
+      knowledge_run = build(:knowledge_run, final_provider: "openai", provider_attempts: [ { "provider" => "claude" } ])
+
+      expect(knowledge_run.effective_provider).to eq("openai")
+    end
+
+    it "falls back to the last attempted provider" do
+      knowledge_run = build(:knowledge_run, final_provider: nil, provider_attempts: [ { "provider" => "claude" }, { "provider" => "openai" } ])
+
+      expect(knowledge_run.effective_provider).to eq("openai")
+    end
+  end
+
   describe "#ensure_proxy_token!" do
     it "returns the existing token when present" do
       knowledge_run = create(:knowledge_run)
@@ -53,6 +67,24 @@ RSpec.describe KnowledgeRun do
 
       expect(token).to be_present
       expect(knowledge_run.reload.proxy_token).to eq(token)
+    end
+  end
+
+  describe "completion helpers" do
+    it "marks active runs as completed" do
+      knowledge_run = create(:knowledge_run, :running)
+
+      knowledge_run.complete!
+
+      expect(knowledge_run.reload.status).to eq("completed")
+    end
+
+    it "marks active runs as failed" do
+      knowledge_run = create(:knowledge_run, :running)
+
+      knowledge_run.fail!
+
+      expect(knowledge_run.reload.status).to eq("failed")
     end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -137,6 +137,16 @@ RSpec.describe "Dashboard" do
         expect(response.body).to include("Embedding")
       end
 
+      it "shows unavailable helper copy when both provider groups are down" do
+        create(:provider_state, :rate_limited, user: user, provider_name: user.settings.kb_embedding_provider)
+        create(:provider_state, :circuit_open, user: user, provider_name: user.settings.kb_chat_provider)
+
+        get dashboard_path
+
+        expect(response.body).to include("Knowledge capabilities are unavailable because both provider groups are down.")
+        expect(response.body).not_to include("Knowledge capabilities are degraded while one provider group remains available.")
+      end
+
       it "shows quality-paused projects on the dashboard" do
         project.update!(
           name: "Paused Project",

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -122,6 +122,21 @@ RSpec.describe "Dashboard" do
         expect(response.body).to include("42s")
       end
 
+      it "shows knowledge provider health and pipeline metrics" do
+        create(:provider_state, :rate_limited, user: user, provider_name: user.settings.kb_embedding_provider)
+        create(:provider_state, user: user, provider_name: user.settings.kb_chat_provider, failure_count: 2)
+        create(:knowledge_run, :completed, project: project, operation_type: "embedding", final_provider: "openai")
+        create(:knowledge_run, :failed, :decision_drafting, project: project, provider_attempts: [ { "provider" => "claude" } ])
+
+        get dashboard_path
+
+        expect(response.body).to include("Provider Health")
+        expect(response.body).to include("Unavailable")
+        expect(response.body).to include("LLM Pipeline Metrics (Last 30 Days)")
+        expect(response.body).to include("Decision Drafting")
+        expect(response.body).to include("Embedding")
+      end
+
       it "shows quality-paused projects on the dashboard" do
         project.update!(
           name: "Paused Project",

--- a/spec/services/knowledge/dashboard_stats_spec.rb
+++ b/spec/services/knowledge/dashboard_stats_spec.rb
@@ -55,6 +55,15 @@ RSpec.describe Knowledge::DashboardStats do
 
         expect(stats[:operational_status]).to eq("unavailable")
       end
+
+      it "checks circuit recovery once per configured provider state" do
+        dashboard = described_class.new(account: account)
+        allow(dashboard).to receive(:provider_status).and_call_original
+
+        dashboard.call
+
+        expect(dashboard).to have_received(:provider_status).twice
+      end
     end
 
     context "with knowledge artifacts" do
@@ -156,6 +165,22 @@ RSpec.describe Knowledge::DashboardStats do
         expect(drafting[:success_rate]).to eq(100.0)
         expect(drafting[:provider_distribution]).to contain_exactly(
           hash_including(provider: "claude", run_count: 1, success_rate: 100.0)
+        )
+      end
+
+      it "falls back to unknown when a run has no recorded provider" do
+        create(:knowledge_run, :failed,
+          project: project,
+          operation_type: "embedding",
+          final_provider: nil,
+          provider_attempts: [],
+          created_at: 6.minutes.ago,
+          updated_at: 3.minutes.ago)
+
+        distribution = stats[:pipeline_metrics]["embedding"][:provider_distribution]
+
+        expect(distribution).to include(
+          hash_including(provider: "unknown", run_count: 1, success_rate: 0.0)
         )
       end
     end

--- a/spec/services/knowledge/dashboard_stats_spec.rb
+++ b/spec/services/knowledge/dashboard_stats_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe Knowledge::DashboardStats do
 
         expect(dashboard).to have_received(:provider_status).twice
       end
+
+      it "does not report an expired rate limit as active" do
+        expired_time = 2.minutes.ago
+        owner.provider_states.find_by!(provider_name: owner.settings.kb_embedding_provider)
+          .update!(rate_limited_until: expired_time)
+
+        embedding = stats[:provider_health][:embedding].first
+
+        expect(embedding[:rate_limited]).to be(false)
+        expect(embedding[:rate_limited_until]).to be_within(1.second).of(expired_time)
+      end
     end
 
     context "with knowledge artifacts" do

--- a/spec/services/knowledge/dashboard_stats_spec.rb
+++ b/spec/services/knowledge/dashboard_stats_spec.rb
@@ -194,6 +194,49 @@ RSpec.describe Knowledge::DashboardStats do
           hash_including(provider: "unknown", run_count: 1, success_rate: 0.0)
         )
       end
+
+      context "when unfinished runs exist in the lookback window" do
+        before do
+          create(:knowledge_run, :running,
+            project: project,
+            operation_type: "embedding",
+            final_provider: "openai",
+            created_at: 5.minutes.ago,
+            updated_at: 1.minute.ago)
+          create(:knowledge_run,
+            project: project,
+            operation_type: "decision_drafting",
+            status: "pending",
+            final_provider: "claude",
+            created_at: 4.minutes.ago,
+            updated_at: 2.minutes.ago)
+        end
+
+        it "excludes unfinished runs from pipeline totals and rates" do
+          embedding = stats[:pipeline_metrics]["embedding"]
+          drafting = stats[:pipeline_metrics]["decision_drafting"]
+
+          expect(embedding[:total_runs]).to eq(2)
+          expect(embedding[:finished_runs]).to eq(2)
+          expect(embedding[:successful_runs]).to eq(1)
+          expect(embedding[:failed_runs]).to eq(1)
+          expect(embedding[:success_rate]).to eq(50.0)
+
+          expect(drafting[:total_runs]).to eq(1)
+          expect(drafting[:finished_runs]).to eq(1)
+          expect(drafting[:successful_runs]).to eq(1)
+          expect(drafting[:success_rate]).to eq(100.0)
+        end
+
+        it "excludes unfinished runs from provider distribution counts" do
+          distribution = stats[:pipeline_metrics]["embedding"][:provider_distribution]
+
+          expect(distribution).to contain_exactly(
+            hash_including(provider: "azure_openai", run_count: 1, success_rate: 0.0),
+            hash_including(provider: "openai", run_count: 1, success_rate: 100.0)
+          )
+        end
+      end
     end
 
     context "with no knowledge runs" do

--- a/spec/services/knowledge/dashboard_stats_spec.rb
+++ b/spec/services/knowledge/dashboard_stats_spec.rb
@@ -20,6 +20,40 @@ RSpec.describe Knowledge::DashboardStats do
         expect(stats[:stale_percent]).to eq(0)
         expect(stats[:artifacts_by_type]).to be_empty
         expect(stats[:last_collection_at]).to be_nil
+        expect(stats[:operational_status]).to eq("healthy")
+        expect(stats[:provider_health][:embedding_available]).to be true
+        expect(stats[:provider_health][:chat_available]).to be true
+      end
+    end
+
+    context "with unavailable provider states" do
+      let(:owner) { create(:user, account: account) }
+      let(:project) do
+        create(:project,
+          account: account,
+          created_by: owner,
+          github_token: create(:github_token, account: account, created_by: owner))
+      end
+
+      before do
+        project
+        create(:provider_state, :rate_limited, user: owner, provider_name: owner.settings.kb_embedding_provider)
+        create(:provider_state, :circuit_open, user: owner, provider_name: owner.settings.kb_chat_provider)
+      end
+
+      it "reports provider health and degraded operational status" do
+        embedding = stats[:provider_health][:embedding].first
+        chat = stats[:provider_health][:chat].first
+
+        expect(embedding[:provider]).to eq(owner.settings.kb_embedding_provider)
+        expect(embedding[:available]).to be false
+        expect(embedding[:rate_limited]).to be true
+
+        expect(chat[:provider]).to eq(owner.settings.kb_chat_provider)
+        expect(chat[:available]).to be false
+        expect(chat[:circuit_state]).to eq("open")
+
+        expect(stats[:operational_status]).to eq("unavailable")
       end
     end
 
@@ -83,9 +117,57 @@ RSpec.describe Knowledge::DashboardStats do
       end
     end
 
+    context "with pipeline metrics" do
+      before do
+        create(:knowledge_run, :completed,
+          project: project,
+          operation_type: "embedding",
+          final_provider: "openai",
+          created_at: 20.minutes.ago,
+          updated_at: 10.minutes.ago)
+        create(:knowledge_run, :failed,
+          project: project,
+          operation_type: "embedding",
+          provider_attempts: [ { "provider" => "azure_openai" } ],
+          created_at: 9.minutes.ago,
+          updated_at: 5.minutes.ago)
+        create(:knowledge_run, :completed, :decision_drafting,
+          project: project,
+          final_provider: "claude",
+          created_at: 7.minutes.ago,
+          updated_at: 4.minutes.ago)
+      end
+
+      it "summarizes success rate, latency, and provider distribution by operation" do
+        embedding = stats[:pipeline_metrics]["embedding"]
+        drafting = stats[:pipeline_metrics]["decision_drafting"]
+
+        expect(embedding[:total_runs]).to eq(2)
+        expect(embedding[:successful_runs]).to eq(1)
+        expect(embedding[:failed_runs]).to eq(1)
+        expect(embedding[:success_rate]).to eq(50.0)
+        expect(embedding[:avg_duration_seconds]).to eq(420.0)
+        expect(embedding[:provider_distribution]).to contain_exactly(
+          hash_including(provider: "azure_openai", run_count: 1, success_rate: 0.0, avg_duration_seconds: 240.0),
+          hash_including(provider: "openai", run_count: 1, success_rate: 100.0, avg_duration_seconds: 600.0)
+        )
+
+        expect(drafting[:total_runs]).to eq(1)
+        expect(drafting[:success_rate]).to eq(100.0)
+        expect(drafting[:provider_distribution]).to contain_exactly(
+          hash_including(provider: "claude", run_count: 1, success_rate: 100.0)
+        )
+      end
+    end
+
     context "with no knowledge runs" do
       it "returns empty token usage summary" do
         expect(stats[:token_usage_summary]).to be_empty
+      end
+
+      it "returns empty pipeline metrics" do
+        expect(stats[:pipeline_metrics]["embedding"]).to include(total_runs: 0, success_rate: 0.0)
+        expect(stats[:pipeline_metrics]["decision_drafting"]).to include(total_runs: 0, success_rate: 0.0)
       end
     end
 

--- a/spec/services/knowledge/decisions/draft_spec.rb
+++ b/spec/services/knowledge/decisions/draft_spec.rb
@@ -350,5 +350,34 @@ RSpec.describe Knowledge::Decisions::Draft do
       expect(kr.status).to eq("completed")
       expect(kr.operation_type).to eq("decision_drafting")
     end
+
+    it "marks the KnowledgeRun failed when all providers fail" do
+      allow(Knowledge::AnalysisRunner).to receive(:available?).and_return(false)
+      allow(AgentHarness).to receive(:send_message).and_raise(AgentHarness::Error, "timeout")
+
+      described_class.call(agent_run: agent_run)
+
+      expect(KnowledgeRun.last.status).to eq("failed")
+    end
+
+    it "logs provider switches for non-executor fallback paths" do
+      draft = described_class.new(agent_run: agent_run)
+
+      allow(Knowledge::AnalysisRunner).to receive(:available?).and_return(false)
+      allow(Rails.logger).to receive(:warn)
+      allow(draft).to receive_messages(effective_user_setting: nil, chat_providers: %w[cursor claude])
+      failed_response = instance_double(AgentHarness::Response, success?: false, error: "cursor unavailable")
+      allow(AgentHarness).to receive(:send_message).and_return(failed_response, llm_response)
+
+      draft.call
+
+      expect(Rails.logger).to have_received(:warn).with(hash_including(
+        message: "knowledge.provider_switch",
+        operation: "decision_drafting",
+        from_provider: "cursor",
+        to_provider: "claude",
+        knowledge_run_id: KnowledgeRun.last.id
+      ))
+    end
   end
 end

--- a/spec/services/knowledge/decisions/draft_spec.rb
+++ b/spec/services/knowledge/decisions/draft_spec.rb
@@ -327,6 +327,24 @@ RSpec.describe Knowledge::Decisions::Draft do
 
       expect(result).to be_nil
     end
+
+    it "logs unavailable providers when only non-container providers are configured" do
+      allow(Rails.logger).to receive(:warn)
+      allow(Knowledge::AnalysisRunner).to receive(:supported_provider?).with("cursor").and_return(false)
+      allow(Knowledge::AnalysisRunner).to receive(:supported_provider?).with("codex").and_return(false)
+      project.created_by.settings.update!(kb_chat_provider: "cursor", kb_chat_fallback_providers: [ "codex" ])
+
+      result = described_class.call(agent_run: agent_run)
+
+      expect(result).to be_nil
+      expect(Rails.logger).to have_received(:warn).with(hash_including(
+        message: "knowledge.providers_unavailable",
+        operation: "decision_drafting",
+        reason: "no_supported_container_providers",
+        providers: %w[cursor codex]
+      ))
+      expect(KnowledgeRun.last.status).to eq("failed")
+    end
   end
 
   describe "in-process fallback" do

--- a/spec/services/knowledge/provider_executor_spec.rb
+++ b/spec/services/knowledge/provider_executor_spec.rb
@@ -158,5 +158,48 @@ RSpec.describe Knowledge::ProviderExecutor do
         expect(state.failure_count).to eq(1)
       end
     end
+
+    context "with structured logging" do
+      it "logs provider switches when falling back" do
+        allow(Rails.logger).to receive(:warn)
+        executor = described_class.new(
+          user_setting: user_setting,
+          operation: :chat,
+          knowledge_run: knowledge_run
+        )
+
+        executor.execute do |provider|
+          raise AgentHarness::RateLimitError, "rate limited" if provider == "claude"
+          "ok"
+        end
+
+        expect(Rails.logger).to have_received(:warn).with(hash_including(
+          message: "knowledge.provider_switch",
+          from_provider: "claude",
+          to_provider: "openai",
+          operation: "chat",
+          knowledge_run_id: knowledge_run.id
+        ))
+      end
+
+      it "logs when all providers are unavailable before execution starts" do
+        allow(Rails.logger).to receive(:warn)
+        allow(Knowledge::ProviderSelector).to receive(:for_chat)
+          .with(user_setting: user_setting)
+          .and_return([])
+
+        executor = described_class.new(user_setting: user_setting, operation: :chat)
+
+        expect {
+          executor.execute { |_provider| "ok" }
+        }.to raise_error(Knowledge::ProviderExecutor::AllProvidersExhausted)
+
+        expect(Rails.logger).to have_received(:warn).with(hash_including(
+          message: "knowledge.providers_unavailable",
+          operation: "chat",
+          reason: "no_available_providers"
+        ))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implemented and committed as `7df8b74` with `feat(knowledge): monitor knowledge provider health`.

The change adds cached provider-health and operational-status reporting to `Knowledge::DashboardStats`, renders a provider health panel plus 30-day pipeline metrics in [app/views/dashboard/_knowledge_widget.html.erb](/workspace/app/views/dashboard/_knowledge_widget.html.erb), and tightens knowledge-run tracking so decision drafting records provider attempts/final provider, logs structured provider switches and unavailable states, and marks `KnowledgeRun` success/failure accurately.

Verification passed: `bundle exec rubocop` and full `bundle exec rspec` both succeeded (`10496 examples, 0 failures, 3 pending`). I also attempted `bin/rails db:prepare`, but in this environment that task resolved PostgreSQL via local socket and failed even though the test suite itself connected and ran successfully. The worktree is clean.

---

Closes #1047