### PR TITLE
perf(containers): PoolManager.metrics fires 5 separate COUNT queries

### DIFF
--- a/app/services/containers/pool_manager.rb
+++ b/app/services/containers/pool_manager.rb
@@ -29,13 +29,14 @@ module Containers
 
     def self.metrics(projects:)
       scope = ContainerPoolEntry.where(project_id: projects.select(:id))
+      counts = scope.group(:status).count
       active_projects = projects.active.count
 
       {
-        warm: scope.warm.count,
-        warming: scope.warming.count,
-        claimed: scope.claimed.count,
-        error: scope.errored.count,
+        warm: counts["warm"].to_i,
+        warming: counts["warming"].to_i,
+        claimed: counts["claimed"].to_i,
+        error: counts["error"].to_i,
         target: target_size * active_projects
       }
     end

--- a/spec/services/containers/pool_manager_spec.rb
+++ b/spec/services/containers/pool_manager_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe Containers::PoolManager do
       )
     end
 
+    it "uses two queries to load grouped counts and active project total" do
+      create(:container_pool_entry, project: project)
+      create(:container_pool_entry, :warming, project: project)
+
+      query_count = count_queries do
+        result = described_class.metrics(projects: Project.where(id: project.id))
+
+        expect(result).to eq(
+          warm: 1,
+          warming: 1,
+          claimed: 0,
+          error: 0,
+          target: described_class.target_size * 1
+        )
+      end
+
+      expect(query_count).to eq(2)
+    end
+
     it "returns zeros when no entries exist" do
       result = described_class.metrics(projects: Project.where(id: project.id))
 

--- a/spec/services/containers/pool_manager_spec.rb
+++ b/spec/services/containers/pool_manager_spec.rb
@@ -16,6 +16,41 @@ RSpec.describe Containers::PoolManager do
     end
   end
 
+  describe ".metrics" do
+    it "returns counts for each status and zero-defaults missing statuses" do
+      other_project = create(:project)
+      create(:container_pool_entry, project: project)
+      create(:container_pool_entry, project: project)
+      create(:container_pool_entry, :warming, project: project)
+      create(:container_pool_entry, :claimed, project: project)
+      create(:container_pool_entry, :errored, project: project)
+      # Entry for another project should not be counted
+      create(:container_pool_entry, project: other_project)
+
+      result = described_class.metrics(projects: Project.where(id: project.id))
+
+      expect(result).to eq(
+        warm: 2,
+        warming: 1,
+        claimed: 1,
+        error: 1,
+        target: described_class.target_size * 1
+      )
+    end
+
+    it "returns zeros when no entries exist" do
+      result = described_class.metrics(projects: Project.where(id: project.id))
+
+      expect(result).to eq(
+        warm: 0,
+        warming: 0,
+        claimed: 0,
+        error: 0,
+        target: described_class.target_size * 1
+      )
+    end
+  end
+
   describe "#acquire" do
     let(:agent_run) { create(:agent_run, project: project) }
     let(:service) { instance_double(Containers::Provision) }


### PR DESCRIPTION
## Summary

OK

Commit succeeded. The change replaces 4 separate `COUNT` queries (`warm`, `warming`, `claimed`, `errored`) with a single `GROUP BY :status` query, reducing database round-trips from 5 to 2 per dashboard load.

---

Closes #1698