### PR TITLE
feat(quality): Phase 3.4 — Quality Gates

### DIFF
--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -23,6 +23,7 @@ module QualityMetrics
         record_quality_metric
         update_experiment_variant_stats(automated_metric)
         update_prompt_version_stats if agent_run.prompt_version.present?
+        check_quality_pause
       end
 
       enqueue_quality_gate_check
@@ -66,6 +67,10 @@ module QualityMetrics
       return unless agent_run.project.quality_gates_enabled?
 
       QualityAlerts::CheckGateJob.perform_later(project_id: agent_run.project_id)
+    end
+
+    def check_quality_pause
+      QualityPause::Check.call(agent_run: agent_run)
     end
 
     # Builds scores for metrics relevant to the agent run's goal type.

--- a/app/services/quality_metrics/dashboard_stats.rb
+++ b/app/services/quality_metrics/dashboard_stats.rb
@@ -337,51 +337,72 @@ module QualityMetrics
     end
 
     def gate_status
-      thresholds = project.quality_gate_thresholds.enabled
+      thresholds = QualityThreshold.effective_for(project: project)
       return { thresholds: [], recent_events: [], active_breaches: 0 } if thresholds.empty?
 
-      recent_events = project.quality_gate_events
-        .includes(:quality_gate_threshold)
+      recent_events = project.quality_pause_events
         .order(created_at: :desc)
         .limit(20)
         .map do |e|
           {
-            event_type: e.event_type,
-            metric_key: e.quality_gate_threshold.metric_key,
-            severity: e.quality_gate_threshold.severity,
-            score_value: e.score_value.to_f,
-            threshold_value: e.threshold_value.to_f,
+            event_type: e.event_type == "paused" ? "trigger" : "recovery",
+            metric_key: e.metadata["metric_type"].presence || "composite_score",
+            goal_type: e.metadata["goal_type"],
+            severity: "critical",
+            score_value: e.composite_score&.to_f,
+            threshold_value: e.threshold&.to_f,
             created_at: e.created_at.iso8601
           }
         end
 
-      # Count active breaches: thresholds whose most recent event is a trigger.
-      # Uses DISTINCT ON to fetch the latest event per threshold in a single query.
-      threshold_ids = thresholds.pluck(:id)
-      active_breaches = QualityGateEvent
-        .where(quality_gate_threshold_id: threshold_ids)
-        .where(
-          "id IN (SELECT DISTINCT ON (quality_gate_threshold_id) id " \
-          "FROM quality_gate_events " \
-          "WHERE quality_gate_threshold_id IN (?) " \
-          "ORDER BY quality_gate_threshold_id, created_at DESC)",
-          threshold_ids
-        )
-        .where(event_type: "trigger")
-        .count
-
       {
         thresholds: thresholds.map do |t|
           {
-            metric_key: t.metric_key,
-            min_threshold: t.min_threshold&.to_f,
-            max_threshold: t.max_threshold&.to_f,
-            severity: t.severity
+            metric_key: t.metric_type,
+            goal_type: t.goal_type,
+            min_threshold: t.min_value&.to_f,
+            max_threshold: nil,
+            severity: t.enabled? ? "critical" : "info",
+            source_scope: t.source_scope
           }
         end,
         recent_events: recent_events,
-        active_breaches: active_breaches
+        active_breaches: active_threshold_breaches(thresholds)
       }
+    end
+
+    def active_threshold_breaches(thresholds)
+      thresholds.count do |threshold|
+        scores = recent_scores_for(threshold)
+        next false if scores.size < QualityThreshold::DEFAULT_MIN_SAMPLE_SIZE
+
+        average = scores.sum / scores.size
+        threshold.breached?(average)
+      end
+    end
+
+    def recent_scores_for(threshold)
+      metrics_for_threshold(threshold).limit(QualityThreshold::DEFAULT_WINDOW_SIZE).filter_map do |metric|
+        if threshold.metric_type == "composite_score"
+          metric.composite_score&.to_f
+        else
+          metric.scores&.dig(threshold.metric_type)&.to_f
+        end
+      end
+    end
+
+    def metrics_for_threshold(threshold)
+      scope = QualityMetric.by_project(project.id)
+        .joins(:agent_run)
+        .where(agent_runs: { goal: threshold.goal_type })
+        .where(AgentRun.quality_scoreable_sql)
+        .order(created_at: :desc)
+
+      if threshold.metric_type == "composite_score"
+        scope.where.not(composite_score: nil)
+      else
+        scope.where("jsonb_exists(quality_metrics.scores, ?)", threshold.metric_type)
+      end
     end
 
     def empty_human_feedback

--- a/app/services/quality_metrics/trend_analysis.rb
+++ b/app/services/quality_metrics/trend_analysis.rb
@@ -64,12 +64,14 @@ module QualityMetrics
     def thresholds
       return [] unless @project_id
 
-      enabled_threshold_rows.map do |metric_key, min_threshold, max_threshold, severity|
+      enabled_thresholds.map do |threshold|
         {
-          metric_key: metric_key,
-          min_threshold: min_threshold&.to_f,
-          max_threshold: max_threshold&.to_f,
-          severity: severity
+          metric_key: threshold.metric_type,
+          goal_type: threshold.goal_type,
+          min_threshold: threshold.min_value&.to_f,
+          max_threshold: nil,
+          severity: threshold.enabled? ? "critical" : "info",
+          source_scope: threshold.source_scope
         }
       end
     end
@@ -77,16 +79,16 @@ module QualityMetrics
     def gate_events
       return [] unless @project_id
 
-      QualityGateEvent.for_project(@project_id)
+      QualityPauseEvent.where(project_id: @project_id)
         .recent.limit(window_size)
-        .includes(:quality_gate_threshold)
         .map do |e|
           {
-            event_type: e.event_type,
-            score_value: e.score_value.to_f,
-            threshold_value: e.threshold_value.to_f,
-            metric_key: e.quality_gate_threshold.metric_key,
-            severity: e.quality_gate_threshold.severity,
+            event_type: e.event_type == "paused" ? "trigger" : "recovery",
+            score_value: e.composite_score&.to_f,
+            threshold_value: e.threshold&.to_f,
+            metric_key: e.metadata["metric_type"].presence || "composite_score",
+            goal_type: e.metadata["goal_type"],
+            severity: "critical",
             created_at: e.created_at.iso8601
           }
         end
@@ -134,9 +136,9 @@ module QualityMetrics
       return nil unless @project_id
       return nil if slope >= 0 # Score is stable or improving
 
-      min_thresholds = enabled_threshold_rows.filter_map do |metric_key, min_threshold, _max_threshold, _severity|
-        min_threshold if metric_key == "composite_score"
-      end
+      min_thresholds = enabled_thresholds
+        .select { |threshold| threshold.metric_type == "composite_score" }
+        .filter_map(&:min_value)
 
       return nil if min_thresholds.empty?
 
@@ -149,11 +151,8 @@ module QualityMetrics
       steps.positive? ? steps : nil
     end
 
-    def enabled_threshold_rows
-      @enabled_threshold_rows ||= QualityGateThreshold
-        .where(project_id: @project_id)
-        .enabled
-        .pluck(:metric_key, :min_threshold, :max_threshold, :severity)
+    def enabled_thresholds
+      @enabled_thresholds ||= QualityThreshold.effective_for(project: Project.find(@project_id))
     end
   end
 end

--- a/spec/jobs/human_feedback_collection_job_spec.rb
+++ b/spec/jobs/human_feedback_collection_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe HumanFeedbackCollectionJob do
           pull_request: { review_comments: 1 }
         )
 
-        expect(QualityPause::Check).to receive(:call).with(agent_run: agent_run)
+        expect(QualityPause::Check).to receive(:call).with(agent_run: agent_run).at_least(:once)
 
         described_class.new.perform(agent_run.id)
 

--- a/spec/requests/projects/quality_dashboards_spec.rb
+++ b/spec/requests/projects/quality_dashboards_spec.rb
@@ -53,13 +53,16 @@ RSpec.describe "Projects::QualityDashboards" do
       end
 
       it "shows gate status alert when thresholds are breached" do
-        threshold = create(:quality_gate_threshold, project: project, min_threshold: 0.6)
         run = create(:agent_run, project: project)
-        metric = create(:quality_metric, agent_run: run, composite_score: 0.4)
-        create(:quality_gate_event,
-          project: project, quality_gate_threshold: threshold,
-          quality_metric: metric, event_type: "trigger",
-          score_value: 0.4, threshold_value: 0.6)
+        create(:quality_threshold, :project_override,
+          project: project,
+          metric_type: "composite_score",
+          goal_type: "create_pr",
+          min_value: 0.6,
+          enabled: true)
+        create(:quality_metric, agent_run: run, composite_score: 0.4)
+        create(:quality_metric, agent_run: create(:agent_run, project: project), composite_score: 0.5)
+        create(:quality_metric, agent_run: create(:agent_run, project: project), composite_score: 0.4)
 
         get project_quality_dashboard_path(project)
 

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -6,8 +6,18 @@ RSpec.describe QualityMetrics::Collect do
   describe ".call" do
     let(:agent_run) { create(:agent_run, :completed, iterations: 3) }
 
+    before do
+      allow(QualityPause::Check).to receive(:call)
+    end
+
     it "creates a quality metric for the agent run" do
       expect { described_class.call(agent_run: agent_run) }.to change(QualityMetric, :count).by(1)
+    end
+
+    it "checks for quality pauses after recording an eligible metric" do
+      described_class.call(agent_run: agent_run)
+
+      expect(QualityPause::Check).to have_received(:call).with(agent_run: agent_run)
     end
 
     it "sets iteration score in scores hash" do
@@ -164,6 +174,7 @@ RSpec.describe QualityMetrics::Collect do
           expect(metric.composite_score).to be_nil
           expect(metric.scores).to eq({ "excluded_status" => excluded_status })
           expect(metric.metadata["exclusion_reason"]).to eq("operational_failure")
+          expect(QualityPause::Check).not_to have_received(:call).with(agent_run: run)
         end
       end
 

--- a/spec/services/quality_metrics/dashboard_stats_gate_integration_spec.rb
+++ b/spec/services/quality_metrics/dashboard_stats_gate_integration_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe QualityMetrics::DashboardStats do
 
   describe "#gate_status" do
     it "returns empty gate status when no thresholds configured" do
+      create(:quality_threshold, :project_override, :disabled,
+        project: project, metric_type: "composite_score", goal_type: "create_pr")
+
       result = described_class.call(project: project)
 
       expect(result[:gate_status][:thresholds]).to eq([])
@@ -35,8 +38,8 @@ RSpec.describe QualityMetrics::DashboardStats do
     end
 
     it "returns threshold configuration" do
-      create(:quality_gate_threshold, project: project,
-        metric_key: "composite_score", min_threshold: 0.5, severity: "warning")
+      create(:quality_threshold, :project_override, project: project,
+        metric_type: "composite_score", goal_type: "create_pr", min_value: 0.5, enabled: true)
 
       result = described_class.call(project: project)
 
@@ -45,13 +48,11 @@ RSpec.describe QualityMetrics::DashboardStats do
     end
 
     it "includes recent gate events" do
-      threshold = create(:quality_gate_threshold, project: project)
       run = create(:agent_run, project: project)
-      metric = create(:quality_metric, agent_run: run, composite_score: 0.4)
-      create(:quality_gate_event,
-        project: project, quality_gate_threshold: threshold,
-        quality_metric: metric, event_type: "trigger",
-        score_value: 0.4, threshold_value: 0.5)
+      create(:quality_pause_event, :paused,
+        project: project, agent_run: run,
+        composite_score: 0.4, threshold: 0.5,
+        metadata: { "metric_type" => "composite_score", "goal_type" => "create_pr" })
 
       result = described_class.call(project: project)
 
@@ -60,13 +61,12 @@ RSpec.describe QualityMetrics::DashboardStats do
     end
 
     it "counts active breaches" do
-      threshold = create(:quality_gate_threshold, project: project)
-      run = create(:agent_run, project: project)
-      metric = create(:quality_metric, agent_run: run, composite_score: 0.4)
-      create(:quality_gate_event,
-        project: project, quality_gate_threshold: threshold,
-        quality_metric: metric, event_type: "trigger",
-        score_value: 0.4, threshold_value: 0.5)
+      create(:quality_threshold, :project_override, project: project,
+        metric_type: "composite_score", goal_type: "create_pr", min_value: 0.5, enabled: true)
+      3.times do
+        run = create(:agent_run, project: project)
+        create(:quality_metric, agent_run: run, composite_score: 0.4)
+      end
 
       result = described_class.call(project: project)
       expect(result[:gate_status][:active_breaches]).to eq(1)

--- a/spec/services/quality_metrics/trend_analysis_spec.rb
+++ b/spec/services/quality_metrics/trend_analysis_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe QualityMetrics::TrendAnalysis do
     end
 
     it "includes thresholds when requested" do
-      create(:quality_gate_threshold, project: project,
-        metric_key: "composite_score", min_threshold: 0.5, severity: "warning")
+      create(:quality_threshold, :project_override, project: project,
+        metric_type: "composite_score", goal_type: "create_pr", min_value: 0.5, enabled: true)
 
       result = described_class.call(
         project_id: project.id,
@@ -99,13 +99,11 @@ RSpec.describe QualityMetrics::TrendAnalysis do
     let(:project) { create(:project) }
 
     it "includes gate events when requested" do
-      threshold = create(:quality_gate_threshold, project: project)
       run = create(:agent_run, project: project)
-      metric = create(:quality_metric, agent_run: run, composite_score: 0.4)
-      create(:quality_gate_event,
-        project: project, quality_gate_threshold: threshold,
-        quality_metric: metric, event_type: "trigger",
-        score_value: 0.4, threshold_value: 0.5)
+      create(:quality_pause_event, :paused,
+        project: project, agent_run: run,
+        composite_score: 0.4, threshold: 0.5,
+        metadata: { "metric_type" => "composite_score", "goal_type" => "create_pr" })
 
       result = described_class.call(
         project_id: project.id,
@@ -164,8 +162,8 @@ RSpec.describe QualityMetrics::TrendAnalysis do
     end
 
     it "estimates breach when scores are declining" do
-      create(:quality_gate_threshold, project: project,
-        metric_key: "composite_score", min_threshold: 0.5)
+      create(:quality_threshold, :project_override, project: project,
+        metric_type: "composite_score", goal_type: "create_pr", min_value: 0.5, enabled: true)
 
       scores = [ 0.9, 0.85, 0.8, 0.75, 0.7 ]
       scores.each_with_index do |score, i|


### PR DESCRIPTION
## Summary

The `/tmp` exhaustion turned out to be caused by the still-running full-suite process holding deleted temp files open. I’m killing that stale run so `/tmp` space is actually reclaimed, then I’ll rerun the full suite from the clean state.

---

Closes #737