### PR TITLE
feat(guardrails): Phase 3.2 — Agent Monitoring & Guardrails

### DIFF
--- a/app/services/anomalies/detect.rb
+++ b/app/services/anomalies/detect.rb
@@ -54,7 +54,7 @@ module Anomalies
       end
 
       log_anomalies(anomalies) if anomalies.any?
-      publish_notification(anomalies) if anomalies.any?
+      publish_notification(anomalies) if should_publish_notification?(anomalies)
       enforce_guardrail(anomalies)
 
       anomalies
@@ -188,6 +188,14 @@ module Anomalies
         action_url: project_agent_run_path(project, agent_run),
         nav_section: "agent_runs"
       )
+    end
+
+    def should_publish_notification?(anomalies)
+      anomalies.any? && !guardrail_will_fire?(anomalies)
+    end
+
+    def guardrail_will_fire?(anomalies)
+      agent_run.running? && anomalies.any? { |anomaly| anomaly.severity == "critical" }
     end
 
     def notification_severity(anomalies)

--- a/app/services/anomalies/detect.rb
+++ b/app/services/anomalies/detect.rb
@@ -2,6 +2,8 @@
 
 module Anomalies
   class Detect
+    include Rails.application.routes.url_helpers
+
     # Default z-score thresholds for anomaly severity.
     WARNING_THRESHOLD = 2.0
     CRITICAL_THRESHOLD = 3.0
@@ -52,6 +54,8 @@ module Anomalies
       end
 
       log_anomalies(anomalies) if anomalies.any?
+      publish_notification(anomalies) if anomalies.any?
+      enforce_guardrail(anomalies)
 
       anomalies
     end
@@ -158,6 +162,53 @@ module Anomalies
           deviation_factor: anomaly.deviation_factor
         )
       end
+    end
+
+    def publish_notification(anomalies)
+      Notifications::Publish.call(
+        account: project.account,
+        source: "agent_run_anomaly",
+        subject: agent_run,
+        severity: notification_severity(anomalies),
+        title: "Anomalous agent behavior detected for run ##{agent_run.id}",
+        description: anomalies.map(&:message).join("; "),
+        metadata: {
+          project_id: project.id,
+          anomaly_count: anomalies.size,
+          anomalies: anomalies.map { |anomaly|
+            {
+              metric_name: anomaly.metric_name,
+              severity: anomaly.severity,
+              anomaly_type: anomaly.anomaly_type,
+              metric_value: anomaly.metric_value,
+              deviation_factor: anomaly.deviation_factor
+            }
+          }
+        },
+        action_url: project_agent_run_path(project, agent_run),
+        nav_section: "agent_runs"
+      )
+    end
+
+    def notification_severity(anomalies)
+      anomalies.any? { |anomaly| anomaly.severity == "critical" } ? :error : :warning
+    end
+
+    def enforce_guardrail(anomalies)
+      return unless agent_run.running?
+
+      critical_anomalies = anomalies.select { |anomaly| anomaly.severity == "critical" }
+      return if critical_anomalies.empty?
+
+      Guardrails::ViolationHandler.call(
+        agent_run: agent_run,
+        violation_type: "anomaly",
+        details: critical_anomalies.map(&:message).join("; "),
+        metrics: {
+          anomaly_count: anomalies.size,
+          critical_metrics: critical_anomalies.map(&:metric_name)
+        }
+      )
     end
   end
 end

--- a/app/services/anomalies/detect.rb
+++ b/app/services/anomalies/detect.rb
@@ -202,11 +202,21 @@ module Anomalies
       anomalies.any? { |anomaly| anomaly.severity == "critical" } ? :error : :warning
     end
 
+    def resolve_prior_anomaly_notification
+      Notifications::Resolve.call(
+        account: project.account,
+        source: "agent_run_anomaly",
+        subject: agent_run
+      )
+    end
+
     def enforce_guardrail(anomalies)
       return unless agent_run.running?
 
       critical_anomalies = anomalies.select { |anomaly| anomaly.severity == "critical" }
       return if critical_anomalies.empty?
+
+      resolve_prior_anomaly_notification
 
       Guardrails::ViolationHandler.call(
         agent_run: agent_run,

--- a/app/services/guardrails/violation_handler.rb
+++ b/app/services/guardrails/violation_handler.rb
@@ -15,6 +15,8 @@ module Guardrails
   #   result.paused?       # => true
   #   result.violation_type # => "loop_detected"
   class ViolationHandler
+    include Rails.application.routes.url_helpers
+
     def self.call(...)
       new(...).call
     end
@@ -35,6 +37,7 @@ module Guardrails
       return already_handled_result(context) unless paused
 
       log_violation(context)
+      publish_notification(context)
       context = persist_execution_cleanup(context, stop_in_flight_execution)
 
       # Dashboard alert is handled by LiveDashboardBroadcastJob (triggered by
@@ -126,6 +129,36 @@ module Guardrails
       updated_context = context.merge(execution_cleanup: cleanup_result)
       agent_run.update!(guardrail_context: updated_context)
       updated_context
+    end
+
+    def publish_notification(context)
+      Notifications::Publish.call(
+        account: agent_run.project.account,
+        source: "guardrail_#{violation_type}",
+        subject: agent_run,
+        severity: notification_severity,
+        title: notification_title,
+        description: details,
+        metadata: {
+          violation_type: violation_type,
+          project_id: agent_run.project_id,
+          agent_type: agent_run.agent_type,
+          trigger_type: agent_run.trigger_type,
+          metrics: context[:metrics],
+          recommended_action: context[:recommended_action],
+          triggered_at: context[:triggered_at]
+        },
+        action_url: project_agent_run_path(agent_run.project, agent_run),
+        nav_section: "agent_runs"
+      )
+    end
+
+    def notification_severity
+      violation_type == "anomaly" ? :warning : :error
+    end
+
+    def notification_title
+      "Agent run ##{agent_run.id} paused by #{violation_type.tr("_", " ")} guardrail"
     end
 
     class Result

--- a/app/services/guardrails/violation_handler.rb
+++ b/app/services/guardrails/violation_handler.rb
@@ -154,7 +154,7 @@ module Guardrails
     end
 
     def notification_severity
-      violation_type == "anomaly" ? :warning : :error
+      :error
     end
 
     def notification_title

--- a/app/services/guardrails/violation_handler.rb
+++ b/app/services/guardrails/violation_handler.rb
@@ -37,8 +37,19 @@ module Guardrails
       return already_handled_result(context) unless paused
 
       log_violation(context)
-      publish_notification(context)
       context = persist_execution_cleanup(context, stop_in_flight_execution)
+
+      begin
+        publish_notification(context)
+      rescue => e
+        Rails.logger.error(
+          message: "guardrails.notification_failed",
+          agent_run_id: agent_run.id,
+          violation_type: violation_type,
+          error_class: e.class.name,
+          error_message: e.message
+        )
+      end
 
       # Dashboard alert is handled by LiveDashboardBroadcastJob (triggered by
       # the status change callback) to avoid duplicate notifications.

--- a/app/services/token_usage_tracker.rb
+++ b/app/services/token_usage_tracker.rb
@@ -64,7 +64,10 @@ class TokenUsageTracker
     # 1. Row locks from the usage write are already released
     # 2. External side-effects (Temporal cancel, container cleanup) don't
     #    run inside a transaction — a failure won't roll back recorded usage
-    enforce_hard_stop_budgets(tracked_run) if enforce_guardrails && update_aggregates && cost_cents.positive? && tracked_run.is_a?(AgentRun)
+    if enforce_guardrails && update_aggregates && tracked_run.is_a?(AgentRun)
+      enforce_token_limit(tracked_run, hard_limit: resolved_hard_limit)
+      enforce_hard_stop_budgets(tracked_run) if cost_cents.positive?
+    end
 
     Projects::StatsSummary.bust_cache!(tracked_run.project.id) if update_aggregates && tracked_run.project
   end
@@ -251,6 +254,33 @@ class TokenUsageTracker
     end
   end
   private_class_method :update_cost_budgets
+
+  def self.enforce_token_limit(agent_run, hard_limit:)
+    return unless hard_limit.to_i.positive?
+    return unless AgentRun.where(id: agent_run.id, status: "running").exists?
+
+    current_tokens = agent_run.total_tokens
+    return if current_tokens < hard_limit
+
+    Rails.logger.warn(
+      message: "agent_execution.token_limit_hard_stop_enforced",
+      agent_run_id: agent_run.id,
+      current_tokens: current_tokens,
+      hard_limit: hard_limit
+    )
+
+    Guardrails::ViolationHandler.call(
+      agent_run: agent_run,
+      violation_type: "token_limit",
+      details: "Token usage exceeded #{hard_limit} limit (#{current_tokens} used)",
+      metrics: {
+        current_tokens: current_tokens,
+        hard_limit: hard_limit,
+        usage_percent: (current_tokens * 100.0 / hard_limit).round(1)
+      }
+    )
+  end
+  private_class_method :enforce_token_limit
 
   # Checks hard_stop budgets after recording usage. If any budget is
   # exceeded, cancels the running agent to enforce the cost limit.

--- a/spec/services/anomalies/detect_spec.rb
+++ b/spec/services/anomalies/detect_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Anomalies::Detect do
   let(:project) { create(:project) }
 
   describe ".call" do
+    before do
+      allow(Notifications::Publish).to receive(:call)
+    end
+
     context "without enough historical data for baselines" do
       let(:agent_run) { create(:agent_run, :completed, :with_metrics, project: project) }
 
@@ -75,6 +79,19 @@ RSpec.describe Anomalies::Detect do
             hash_including(
               message: "anomaly_detection.anomaly_detected",
               metric_name: "tokens_total"
+            )
+          )
+        end
+
+        it "publishes an agent run notification" do
+          described_class.call(anomalous_run)
+
+          expect(Notifications::Publish).to have_received(:call).with(
+            hash_including(
+              account: project.account,
+              source: "agent_run_anomaly",
+              subject: anomalous_run,
+              nav_section: "agent_runs"
             )
           )
         end
@@ -367,6 +384,41 @@ RSpec.describe Anomalies::Detect do
           tokens_output: 5_000)
 
         expect(described_class.call(agent_run)).to be_empty
+      end
+    end
+
+    context "when a running run shows critical anomalies" do
+      before do
+        [ 10_000, 12_000, 14_000, 16_000, 18_000, 20_000 ].each do |tokens|
+          create(:agent_run, :completed,
+            project: project,
+            tokens_input: tokens,
+            tokens_output: tokens / 2,
+            duration_seconds: 600,
+            iterations: 5,
+            cost_cents: 150)
+        end
+      end
+
+      it "routes the anomaly through the guardrail handler" do
+        running_run = create(:agent_run, :running,
+          project: project,
+          tokens_input: 5_000_000,
+          tokens_output: 2_500_000,
+          duration_seconds: 600,
+          iterations: 5,
+          cost_cents: 150)
+
+        allow(Guardrails::ViolationHandler).to receive(:call)
+
+        described_class.call(running_run)
+
+        expect(Guardrails::ViolationHandler).to have_received(:call).with(
+          hash_including(
+            agent_run: running_run,
+            violation_type: "anomaly"
+          )
+        )
       end
     end
   end

--- a/spec/services/anomalies/detect_spec.rb
+++ b/spec/services/anomalies/detect_spec.rb
@@ -420,6 +420,63 @@ RSpec.describe Anomalies::Detect do
           )
         )
       end
+
+      it "does not publish a separate anomaly notification when the guardrail will fire" do
+        running_run = create(:agent_run, :running,
+          project: project,
+          tokens_input: 5_000_000,
+          tokens_output: 2_500_000,
+          duration_seconds: 600,
+          iterations: 5,
+          cost_cents: 150)
+
+        allow(Guardrails::ViolationHandler).to receive(:call)
+
+        described_class.call(running_run)
+
+        expect(Notifications::Publish).not_to have_received(:call).with(
+          hash_including(
+            source: "agent_run_anomaly",
+            subject: running_run
+          )
+        )
+      end
+    end
+
+    context "when a running run shows only warning anomalies" do
+      before do
+        [ 10_000, 12_000, 14_000, 16_000, 18_000, 20_000 ].each do |tokens|
+          create(:agent_run, :completed,
+            project: project,
+            tokens_input: tokens,
+            tokens_output: tokens / 2,
+            duration_seconds: 600,
+            iterations: 5,
+            cost_cents: 150)
+        end
+      end
+
+      it "publishes the anomaly notification without invoking the guardrail handler" do
+        running_run = create(:agent_run, :running,
+          project: project,
+          tokens_input: 24_000,
+          tokens_output: 12_000,
+          duration_seconds: 600,
+          iterations: 5,
+          cost_cents: 150)
+
+        allow(Guardrails::ViolationHandler).to receive(:call)
+
+        described_class.call(running_run)
+
+        expect(Notifications::Publish).to have_received(:call).with(
+          hash_including(
+            source: "agent_run_anomaly",
+            subject: running_run
+          )
+        )
+        expect(Guardrails::ViolationHandler).not_to have_received(:call)
+      end
     end
   end
 end

--- a/spec/services/anomalies/detect_spec.rb
+++ b/spec/services/anomalies/detect_spec.rb
@@ -421,6 +421,27 @@ RSpec.describe Anomalies::Detect do
         )
       end
 
+      it "resolves any prior warning-level anomaly notification when escalating to guardrail" do
+        running_run = create(:agent_run, :running,
+          project: project,
+          tokens_input: 5_000_000,
+          tokens_output: 2_500_000,
+          duration_seconds: 600,
+          iterations: 5,
+          cost_cents: 150)
+
+        allow(Guardrails::ViolationHandler).to receive(:call)
+        allow(Notifications::Resolve).to receive(:call)
+
+        described_class.call(running_run)
+
+        expect(Notifications::Resolve).to have_received(:call).with(
+          account: project.account,
+          source: "agent_run_anomaly",
+          subject: running_run
+        )
+      end
+
       it "does not publish a separate anomaly notification when the guardrail will fire" do
         running_run = create(:agent_run, :running,
           project: project,

--- a/spec/services/guardrails/violation_handler_spec.rb
+++ b/spec/services/guardrails/violation_handler_spec.rb
@@ -169,6 +169,21 @@ RSpec.describe Guardrails::ViolationHandler do
       )
     end
 
+    it "completes enforcement even when notification delivery fails" do
+      allow(Notifications::Publish).to receive(:call).and_raise(StandardError, "broadcast error")
+
+      result = described_class.call(
+        agent_run: agent_run,
+        violation_type: "token_limit",
+        details: "Token limit exceeded"
+      )
+
+      expect(result.paused?).to be true
+      expect(agent_run.reload.status).to eq("paused")
+      expect(agent_run.guardrail_context["execution_cleanup"]).to be_present
+      expect(AgentRuns::Cancel).to have_received(:call)
+    end
+
     it "does not pause a non-running agent run" do
       agent_run.update!(status: "completed", completed_at: Time.current)
 

--- a/spec/services/guardrails/violation_handler_spec.rb
+++ b/spec/services/guardrails/violation_handler_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Guardrails::ViolationHandler do
 
     before do
       allow(AgentRuns::Cancel).to receive(:call)
+      allow(Notifications::Publish).to receive(:call)
     end
 
     it "pauses the agent run on loop detection" do
@@ -23,6 +24,15 @@ RSpec.describe Guardrails::ViolationHandler do
       expect(agent_run.guardrail_violation_type).to eq("loop_detected")
       expect(agent_run.paused_at).to be_present
       expect(AgentRuns::Cancel).to have_received(:call).with(agent_run: agent_run, skip_status_update: true)
+      expect(Notifications::Publish).to have_received(:call).with(
+        hash_including(
+          account: agent_run.project.account,
+          source: "guardrail_loop_detected",
+          subject: agent_run,
+          severity: :error,
+          nav_section: "agent_runs"
+        )
+      )
     end
 
     it "pauses the agent run on token limit violation" do
@@ -175,6 +185,7 @@ RSpec.describe Guardrails::ViolationHandler do
       expect(result.paused?).to be true
       expect(result.violation_type).to eq("loop_detected")
       expect(agent_run.reload.guardrail_violation_type).to eq("loop_detected")
+      expect(Notifications::Publish).not_to have_received(:call)
     end
 
     it "raises on unknown violation type" do

--- a/spec/services/guardrails/violation_handler_spec.rb
+++ b/spec/services/guardrails/violation_handler_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe Guardrails::ViolationHandler do
 
       expect(result.paused?).to be true
       expect(agent_run.reload.guardrail_violation_type).to eq("anomaly")
+      expect(Notifications::Publish).to have_received(:call).with(
+        hash_including(
+          account: agent_run.project.account,
+          source: "guardrail_anomaly",
+          subject: agent_run,
+          severity: :error,
+          nav_section: "agent_runs"
+        )
+      )
     end
 
     it "stores violation context as structured data" do

--- a/spec/services/token_usage_tracker_spec.rb
+++ b/spec/services/token_usage_tracker_spec.rb
@@ -239,6 +239,8 @@ RSpec.describe TokenUsageTracker do
   describe "token limit checking" do
     before do
       project.update!(max_tokens_per_run: 10_000, token_limit_warning_threshold: 80)
+      allow(AgentRuns::Cancel).to receive(:call)
+      allow(Notifications::Publish).to receive(:call)
     end
 
     it "persists the agent run once when token_limit_status changes" do
@@ -265,8 +267,6 @@ RSpec.describe TokenUsageTracker do
     end
 
     it "pauses a running agent when the hard token limit is exceeded" do
-      allow(AgentRuns::Cancel).to receive(:call)
-
       described_class.track(tracked_run: agent_run, usage: { tokens_input: 7000, tokens_output: 4000 })
 
       agent_run.reload

--- a/spec/services/token_usage_tracker_spec.rb
+++ b/spec/services/token_usage_tracker_spec.rb
@@ -264,6 +264,17 @@ RSpec.describe TokenUsageTracker do
       expect(agent_run.reload.token_limit_status).to eq("exceeded")
     end
 
+    it "pauses a running agent when the hard token limit is exceeded" do
+      allow(AgentRuns::Cancel).to receive(:call)
+
+      described_class.track(tracked_run: agent_run, usage: { tokens_input: 7000, tokens_output: 4000 })
+
+      agent_run.reload
+      expect(agent_run.status).to eq("paused")
+      expect(agent_run.guardrail_violation_type).to eq("token_limit")
+      expect(AgentRuns::Cancel).to have_received(:call).with(agent_run: agent_run, skip_status_update: true)
+    end
+
     it "logs a warning when crossing the soft threshold" do
       described_class.track(tracked_run: agent_run, usage: { tokens_input: 5000, tokens_output: 3000 })
       log = agent_run.agent_run_logs.find_by(log_type: "system")
@@ -273,7 +284,7 @@ RSpec.describe TokenUsageTracker do
 
     it "logs an exceeded message when crossing the hard limit" do
       described_class.track(tracked_run: agent_run, usage: { tokens_input: 7000, tokens_output: 4000 })
-      log = agent_run.agent_run_logs.where(log_type: "system").last
+      log = agent_run.agent_run_logs.find_by(log_type: "system", metadata: { type: "token_limit_exceeded" })
       expect(log.content).to include("Token limit exceeded")
       expect(log.metadata).to eq({ "type" => "token_limit_exceeded" })
     end
@@ -294,6 +305,7 @@ RSpec.describe TokenUsageTracker do
         enforce_guardrails: false
       )
       expect(agent_run.reload.token_limit_status).to eq("exceeded")
+      expect(agent_run.reload.status).to eq("running")
     end
 
     it "transitions from warning to exceeded as usage grows" do


### PR DESCRIPTION
## Summary

Implemented Phase 3.2 guardrail wiring and committed it as `f8c8ffe` (`feat(guardrails): enforce token and anomaly guardrails`).

The change set does three things: token overruns now hard-stop active runs through `Guardrails::ViolationHandler` instead of only marking `token_limit_status`; guardrail pauses now publish agent-run notifications with actionable context; and anomaly detection now raises notifications and routes critical in-flight anomalies through the same guardrail path. The covered files are [app/services/token_usage_tracker.rb](/workspace/app/services/token_usage_tracker.rb), [app/services/guardrails/violation_handler.rb](/workspace/app/services/guardrails/violation_handler.rb), [app/services/anomalies/detect.rb](/workspace/app/services/anomalies/detect.rb), plus their specs.

Verification passed. I ran `bundle exec rubocop` cleanly and `bundle exec rspec` completed with `10588 examples, 0 failures, 3 pending` and `93.96%` coverage. The worktree is clean.

---

Closes #735