### PR TITLE
feat(evolution): Phase 3.3 — Prompt Evolution

### DIFF
--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -182,7 +182,7 @@ class TenantSetting < ApplicationRecord
   def self.read_worker_setting_from_db(key)
     return nil unless table_exists?
 
-    setting = (Current.account || Account.first)&.tenant_setting
+    setting = (Current.account || Account.order(:id).first)&.tenant_setting
     return nil unless setting
 
     value = setting.worker_settings&.dig(key.to_s)

--- a/app/services/prompt_evolution/select.rb
+++ b/app/services/prompt_evolution/select.rb
@@ -111,7 +111,7 @@ module PromptEvolution
     # PromptVersions that are active and have enough samples to score.
     def eligible_candidates
       @eligible_candidates ||= begin
-        candidates = prompt.prompt_versions.active.includes(:quality_metrics).to_a
+        candidates = prompt.prompt_versions.active.includes(agent_runs: :quality_metrics).to_a
         candidates.select { |v| sample_count(v) >= @min_samples }
       end
     end
@@ -121,10 +121,7 @@ module PromptEvolution
     end
 
     def fitness_samples(version)
-      version.agent_runs.filter_map do |run|
-        sample = fitness_sample_for(run)
-        sample if sample
-      end
+      version.agent_runs.filter_map { |run| fitness_sample_for(run) }
     end
 
     def fitness_sample_for(run)

--- a/app/services/prompt_evolution/select.rb
+++ b/app/services/prompt_evolution/select.rb
@@ -6,10 +6,10 @@ module PromptEvolution
   # rolls back to a previous generation if the current version's fitness has
   # regressed.
   #
-  # Fitness is the mean composite_score across the version's automated
-  # QualityMetrics that have a composite_score recorded. Tournament
-  # selection randomly samples k candidates per round and picks the
-  # fittest; the overall winner is the fittest version across all rounds.
+  # Fitness is the composite score returned by PromptEvolution::FitnessFunction
+  # using automated samples for each version. Tournament selection randomly
+  # samples k candidates per round and picks the fittest; the overall winner
+  # is the fittest version across all rounds.
   #
   # Generation depth is derived from the parent_version_id chain on
   # PromptVersion, which is already tracked when mutations are created.
@@ -117,21 +117,39 @@ module PromptEvolution
     end
 
     def sample_count(version)
-      scored_metrics(version).size
+      fitness_samples(version).size
     end
 
-    def scored_metrics(version)
-      version.quality_metrics.select do |metric|
+    def fitness_samples(version)
+      version.agent_runs.filter_map do |run|
+        sample = fitness_sample_for(run)
+        sample if sample
+      end
+    end
+
+    def fitness_sample_for(run)
+      metric = automated_metric_for(run)
+      return unless metric&.composite_score.present?
+
+      {
+        composite_score: metric.composite_score,
+        cost_cents: run.cost_cents,
+        duration_seconds: run.duration_seconds
+      }
+    end
+
+    def automated_metric_for(run)
+      run.quality_metrics.find do |metric|
         metric.metric_type == "automated" && metric.composite_score.present?
       end
     end
 
-    # Mean composite_score across automated metrics referencing this version.
+    # Composite fitness across automated samples for this version.
     def fitness_for(version)
-      scores = scored_metrics(version).map { |m| m.composite_score.to_f }
-      return nil if scores.empty?
+      samples = fitness_samples(version)
+      return nil if samples.empty?
 
-      (scores.sum / scores.size).round(6)
+      FitnessFunction.call(samples: samples, project: prompt.project).composite_fitness.round(6)
     end
 
     def build_fitness_map(candidates)

--- a/spec/services/prompt_evolution/select_spec.rb
+++ b/spec/services/prompt_evolution/select_spec.rb
@@ -37,6 +37,74 @@ RSpec.describe PromptEvolution::Select do
     ])
   end
 
+  def add_runs_with_metrics(version, runs:)
+    now = Time.current
+
+    Array(runs).each do |attrs|
+      run_id = insert_metric_runs(version, 1, now: now).first
+      AgentRun.find(run_id).update_columns(
+        cost_cents: attrs[:cost_cents],
+        duration_seconds: attrs[:duration_seconds]
+      )
+      QualityMetric.insert_all!([
+        metric_row(
+          run_id: run_id,
+          version: version,
+          score: attrs.fetch(:score),
+          metric_type: "automated",
+          now: now
+        )
+      ])
+    end
+  end
+
+  def fitness_samples_for(version)
+    version.agent_runs.includes(:quality_metrics).filter_map do |run|
+      metric = run.quality_metrics.find do |quality_metric|
+        quality_metric.metric_type == "automated" && quality_metric.composite_score.present?
+      end
+      next unless metric
+
+      {
+        composite_score: metric.composite_score,
+        cost_cents: run.cost_cents,
+        duration_seconds: run.duration_seconds
+      }
+    end
+  end
+
+  def repeated_runs(score:, cost_cents:, duration_seconds:)
+    Array.new(3) do
+      { score: score, cost_cents: cost_cents, duration_seconds: duration_seconds }
+    end
+  end
+
+  def build_project_scoped_prompt(project)
+    scoped_prompt = create(:prompt, :with_version, project: project, account: project.account)
+    control = scoped_prompt.current_version
+    variant = create(:prompt_version,
+      prompt: scoped_prompt,
+      version: control.version + 1,
+      parent_version: control,
+      template: "Variant #{control.version + 1} for {{title}} {{body}}"
+    )
+
+    [ scoped_prompt, control, variant ]
+  end
+
+  def stub_fitness_function_for_project(project, threshold:, control_score:, variant_score:)
+    control_result = instance_double(PromptEvolution::FitnessFunction::Result, composite_fitness: control_score)
+    variant_result = instance_double(PromptEvolution::FitnessFunction::Result, composite_fitness: variant_score)
+
+    allow(PromptEvolution::FitnessFunction).to receive(:call) do |samples:, **kwargs|
+      actual_project = kwargs.fetch(:project)
+      expect(actual_project).to eq(project)
+
+      average_quality = samples.sum { |sample| sample[:composite_score].to_f } / samples.size
+      average_quality >= threshold ? variant_result : control_result
+    end
+  end
+
   def insert_metric_runs(version, count, now:)
     return [] if count.zero?
 
@@ -138,7 +206,50 @@ RSpec.describe PromptEvolution::Select do
         random: Random.new(3)
       )
 
-      expect(result.fitness[v2.id]).to be_within(0.01).of(0.81)
+      expected = PromptEvolution::FitnessFunction.call(
+        samples: fitness_samples_for(v2),
+        project: prompt.project
+      ).composite_fitness
+
+      expect(result.fitness[v2.id]).to be_within(0.01).of(expected)
+    end
+
+    it "uses the composite fitness function so lower cost and faster runs can win ties" do
+      v2 = add_version(parent: v1)
+
+      add_runs_with_metrics(v1, runs: repeated_runs(score: 0.8, cost_cents: 400, duration_seconds: 1_200))
+      add_runs_with_metrics(v2, runs: repeated_runs(score: 0.8, cost_cents: 50, duration_seconds: 300))
+
+      result = described_class.call(
+        prompt: prompt,
+        tournament_size: 2,
+        rounds: 5,
+        retirement_threshold: 0.0,
+        random: Random.new(13)
+      )
+
+      expect(result.fitness[v2.id]).to be > result.fitness[v1.id]
+      expect(result.winner).to eq(v2)
+      expect(prompt.reload.current_version).to eq(v2)
+    end
+
+    it "passes the prompt project into the composite fitness function" do
+      scoped_prompt, control, variant = build_project_scoped_prompt(metric_project)
+      add_runs_with_metrics(control, runs: repeated_runs(score: 0.7, cost_cents: 20, duration_seconds: 60))
+      add_runs_with_metrics(variant, runs: repeated_runs(score: 0.9, cost_cents: 500, duration_seconds: 1_800))
+      stub_fitness_function_for_project(metric_project, threshold: 0.8, control_score: 0.4, variant_score: 0.9)
+
+      result = described_class.call(
+        prompt: scoped_prompt,
+        tournament_size: 2,
+        rounds: 5,
+        retirement_threshold: 0.0,
+        random: Random.new(17)
+      )
+
+      expect(result.fitness[variant.id]).to be > result.fitness[control.id]
+      expect(result.winner).to eq(variant)
+      expect(scoped_prompt.reload.current_version).to eq(variant)
     end
 
     it "retires underperformers below the retirement threshold" do


### PR DESCRIPTION
## Summary

Committed as `f4dedc1` with `fix(prompt-evolution): use composite fitness for selection`.

The change makes `PromptEvolution::Select` rank variants with `PromptEvolution::FitnessFunction` instead of raw average quality only, so selection now incorporates cost/speed tradeoffs and project-scoped fitness settings. I also fixed the Rails 8.1 boot regression in `TenantSetting` by ordering the fallback `Account` lookup, and expanded `select_spec` to cover composite-fitness tie-breaking plus project-aware fitness delegation.

Verification passed with `DB_HOST=paid-svc-a3-s1-postgres bin/rails db:prepare`, `DB_HOST=paid-svc-a3-s1-postgres bundle exec rubocop`, and `DB_HOST=paid-svc-a3-s1-postgres bundle exec rspec` (`10587 examples, 0 failures, 3 pending`).

---

Closes #736