### PR TITLE
feat(projects): make max_execution_seconds user-configurable and eventually deprecate

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -285,7 +285,7 @@ class ProjectsController < ApplicationController
 
   def project_params
     params.require(:project).permit(:github_token_id, :owner, :repo, :name, :active,
-      :poll_interval_seconds, :github_id, :default_branch,
+      :poll_interval_seconds, :max_execution_seconds, :github_id, :default_branch,
       :owner_reviewer_login, :merge_method, :max_draft_review_rounds, :auto_pick_enabled, :auto_merge_mode,
       :auto_fix_merge_conflicts, :auto_scan_security,
       :generated_label_name, :automation_label_name,

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -171,6 +171,14 @@
           </div>
 
           <div>
+            <%= form.label :max_execution_seconds, "Max Execution Time (seconds)", class: "block text-sm font-medium leading-6 text-gray-900" %>
+            <div class="mt-2">
+              <%= form.number_field :max_execution_seconds, min: 60, max: 86_400, step: 1, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+            </div>
+            <p class="mt-1 text-xs text-gray-500">Maximum wall-clock time for agent runs (60 to 86,400 seconds). Default: 3,600 seconds (1 hour).</p>
+          </div>
+
+          <div>
             <%= form.label :allowed_github_usernames, "Trusted GitHub Usernames", class: "block text-sm font-medium leading-6 text-gray-900" %>
             <div class="mt-2">
               <input type="text" name="project[allowed_github_usernames_csv]" id="project_allowed_github_usernames_csv"


### PR DESCRIPTION
## Summary

OK

Done. The commit succeeded with all checks passing. Here's what was done:

1. **`app/controllers/projects_controller.rb`** — Added `:max_execution_seconds` to the permitted params in `project_params`
2. **`app/views/projects/edit.html.erb`** — Added a number field for "Max Execution Time (seconds)" in the project settings form, with min/max matching the model validation (60–86,400 seconds)

The existing model validation (`validates :max_execution_seconds, numericality: { only_integer: true, greater_than_or_equal_to: 60, less_than_or_equal_to: 86_400 }`) already handles server-side validation. No migration needed since the column already exists with a default of 3600.

---

Closes #855