### PR TITLE
feat(screenshots): define .paid/screenshots.yml config schema and parser

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -74,6 +74,11 @@ class Project < ApplicationRecord
     "metric_thresholds" => {}
   }.freeze
 
+  DEFAULT_SCREENSHOT_SETTINGS = {
+    "enabled" => false,
+    "driver" => "playwright"
+  }.freeze
+
   AUTOMATION_SETTINGS = [
     { label: "Auto-Add Labels", attribute: :auto_add_labels_enabled,
      description: "Automatically add the generated label to PRs and issues created by Paid." }.freeze,
@@ -187,6 +192,7 @@ class Project < ApplicationRecord
   validate :created_by_belongs_to_same_account, if: -> { created_by.present? }
   validate :review_settings_valid
   validate :priority_labels_valid
+  validate :screenshot_settings_valid
 
   scope :active, -> { where(active: true) }
   scope :inactive, -> { where(active: false) }
@@ -525,6 +531,12 @@ class Project < ApplicationRecord
     effective_quality_gate_settings["enabled"] == true
   end
 
+  def effective_screenshot_settings
+    saved = screenshot_settings
+    saved = saved.is_a?(Hash) ? saved.deep_stringify_keys : {}
+    DEFAULT_SCREENSHOT_SETTINGS.deep_merge(saved)
+  end
+
   def review_settings=(value)
     @effective_review_settings = nil
     @automation_configuration = nil
@@ -846,6 +858,25 @@ class Project < ApplicationRecord
     end
 
     validate_review_methods_config(normalized)
+  end
+
+  def screenshot_settings_valid
+    return if screenshot_settings.nil? || screenshot_settings == {}
+
+    unless screenshot_settings.is_a?(Hash)
+      errors.add(:screenshot_settings, "must be a JSON object")
+      return
+    end
+
+    normalized = screenshot_settings.deep_stringify_keys
+
+    if normalized.key?("enabled") && ![ true, false ].include?(normalized["enabled"])
+      errors.add(:screenshot_settings, "enabled must be true or false")
+    end
+
+    if normalized.key?("driver") && !Screenshots::Configuration::VALID_DRIVERS.include?(normalized["driver"])
+      errors.add(:screenshot_settings, "driver must be one of: #{Screenshots::Configuration::VALID_DRIVERS.join(', ')}")
+    end
   end
 
   def validate_review_methods_config(normalized)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -877,6 +877,40 @@ class Project < ApplicationRecord
     if normalized.key?("driver") && !Screenshots::Configuration::VALID_DRIVERS.include?(normalized["driver"])
       errors.add(:screenshot_settings, "driver must be one of: #{Screenshots::Configuration::VALID_DRIVERS.join(', ')}")
     end
+
+    validate_screenshot_settings_shape(normalized)
+  end
+
+  def validate_screenshot_settings_shape(normalized)
+    allowed_keys = Screenshots::ConfigParser::VALID_TOP_LEVEL_KEYS
+    extra_keys = normalized.keys - allowed_keys
+    if extra_keys.any?
+      errors.add(:screenshot_settings, "contains unknown keys: #{extra_keys.join(', ')}")
+    end
+
+    if normalized.key?("base_url") && !(normalized["base_url"].is_a?(String) && normalized["base_url"].present?)
+      errors.add(:screenshot_settings, "base_url must be a non-blank string")
+    end
+
+    if normalized.key?("viewport") && !normalized["viewport"].is_a?(Hash)
+      errors.add(:screenshot_settings, "viewport must be a JSON object with width and height")
+    end
+
+    if normalized.key?("auth") && !normalized["auth"].is_a?(Hash)
+      errors.add(:screenshot_settings, "auth must be a JSON object")
+    end
+
+    if normalized.key?("seed") && !normalized["seed"].is_a?(Array)
+      errors.add(:screenshot_settings, "seed must be an array")
+    end
+
+    if normalized.key?("setup") && !normalized["setup"].is_a?(Array)
+      errors.add(:screenshot_settings, "setup must be an array")
+    end
+
+    if normalized.key?("services") && !normalized["services"].is_a?(Array)
+      errors.add(:screenshot_settings, "services must be an array")
+    end
   end
 
   def validate_review_methods_config(normalized)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -870,47 +870,9 @@ class Project < ApplicationRecord
 
     normalized = screenshot_settings.deep_stringify_keys
 
-    if normalized.key?("enabled") && ![ true, false ].include?(normalized["enabled"])
-      errors.add(:screenshot_settings, "enabled must be true or false")
-    end
-
-    if normalized.key?("driver") && !Screenshots::Configuration::VALID_DRIVERS.include?(normalized["driver"])
-      errors.add(:screenshot_settings, "driver must be one of: #{Screenshots::Configuration::VALID_DRIVERS.join(', ')}")
-    end
-
-    validate_screenshot_settings_shape(normalized)
-  end
-
-  def validate_screenshot_settings_shape(normalized)
-    allowed_keys = Screenshots::ConfigParser::VALID_TOP_LEVEL_KEYS
-    extra_keys = normalized.keys - allowed_keys
-    if extra_keys.any?
-      errors.add(:screenshot_settings, "contains unknown keys: #{extra_keys.join(', ')}")
-    end
-
-    if normalized.key?("base_url") && !(normalized["base_url"].is_a?(String) && normalized["base_url"].present?)
-      errors.add(:screenshot_settings, "base_url must be a non-blank string")
-    end
-
-    if normalized.key?("viewport") && !normalized["viewport"].is_a?(Hash)
-      errors.add(:screenshot_settings, "viewport must be a JSON object with width and height")
-    end
-
-    if normalized.key?("auth") && !normalized["auth"].is_a?(Hash)
-      errors.add(:screenshot_settings, "auth must be a JSON object")
-    end
-
-    if normalized.key?("seed") && !normalized["seed"].is_a?(Array)
-      errors.add(:screenshot_settings, "seed must be an array")
-    end
-
-    if normalized.key?("setup") && !normalized["setup"].is_a?(Array)
-      errors.add(:screenshot_settings, "setup must be an array")
-    end
-
-    if normalized.key?("services") && !normalized["services"].is_a?(Array)
-      errors.add(:screenshot_settings, "services must be an array")
-    end
+    Screenshots::ConfigParser.validate_partial!(normalized)
+  rescue Screenshots::ConfigError => e
+    errors.add(:screenshot_settings, e.message)
   end
 
   def validate_review_methods_config(normalized)

--- a/app/services/screenshots/config_error.rb
+++ b/app/services/screenshots/config_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Screenshots
+  class ConfigError < StandardError; end
+end

--- a/app/services/screenshots/config_parser.rb
+++ b/app/services/screenshots/config_parser.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require "base64"
+require "psych"
+
+module Screenshots
+  class ConfigParser
+    CONFIG_PATH = ".paid/screenshots.yml"
+    VALID_TOP_LEVEL_KEYS = %w[
+      driver
+      enabled
+      base_url
+      viewport
+      routes
+      auth
+      seed
+      setup
+      services
+      ui_patterns
+      ui_exclusions
+    ].freeze
+    VALID_ROUTE_KEYS = %w[path name requires_auth seed_key].freeze
+    VALID_AUTH_KEYS = %w[strategy login_path fields credentials].freeze
+    VALID_VIEWPORT_KEYS = %w[width height].freeze
+    VALID_SEED_KEYS = %w[model factory key].freeze
+
+    class << self
+      def call(project: nil, repo_path: nil, blob: nil, content: nil)
+        new(project:, repo_path:, blob:, content:).call
+      end
+
+      def from_repo_path(repo_path, project: nil)
+        call(project:, repo_path:)
+      end
+
+      def from_blob(blob, project: nil)
+        call(project:, blob:)
+      end
+    end
+
+    def initialize(project: nil, repo_path: nil, blob: nil, content: nil)
+      @project = project
+      @repo_path = repo_path
+      @blob = blob
+      @content = content
+    end
+
+    def call
+      file_settings = parse_content(raw_content)
+      validate_root!(file_settings)
+
+      Screenshots::Configuration.from_hash(merged_settings(file_settings)).freeze
+    end
+
+    private
+
+    attr_reader :project, :repo_path, :blob, :content
+
+    def raw_content
+      return content if content.present?
+      return decode_blob(blob) if blob.present?
+
+      path = config_path
+      raise ConfigError, "Missing #{CONFIG_PATH} in #{repo_path}" unless File.exist?(path)
+
+      File.read(path)
+    rescue Errno::ENOENT => e
+      raise ConfigError, "Unable to read #{CONFIG_PATH}: #{e.message}"
+    end
+
+    def config_path
+      Pathname(repo_path).join(CONFIG_PATH)
+    end
+
+    def decode_blob(value)
+      return value if value.is_a?(String)
+      return Base64.decode64(value.content.to_s) if value.respond_to?(:content)
+
+      raise ConfigError, "GitHub blob must be a YAML string or a blob object with content"
+    end
+
+    def parse_content(value)
+      parsed = Psych.safe_load(value, aliases: false)
+      return {} if parsed.nil?
+
+      unless parsed.is_a?(Hash)
+        raise ConfigError, "#{CONFIG_PATH} must contain a YAML mapping at the top level"
+      end
+
+      parsed.deep_stringify_keys
+    rescue Psych::SyntaxError => e
+      raise ConfigError, "Invalid YAML in #{CONFIG_PATH}: #{e.message}"
+    end
+
+    def merged_settings(file_settings)
+      db_settings = project&.effective_screenshot_settings || {}
+      explicit_db_settings = explicit_project_settings
+      merged = db_settings.deep_merge(file_settings)
+
+      %w[routes auth seed setup].each do |key|
+        merged[key] = file_settings[key] if file_settings.key?(key)
+      end
+
+      %w[enabled driver].each do |key|
+        merged[key] = explicit_db_settings[key] if explicit_db_settings.key?(key)
+      end
+
+      merged
+    end
+
+    def explicit_project_settings
+      settings = project&.screenshot_settings
+      return {} unless settings.is_a?(Hash)
+
+      settings.deep_stringify_keys
+    end
+
+    def validate_root!(settings)
+      validate_unknown_keys!("top-level", settings, VALID_TOP_LEVEL_KEYS)
+
+      validate_driver!(settings["driver"]) if settings.key?("driver")
+      validate_enabled!(settings["enabled"]) if settings.key?("enabled")
+      validate_base_url!(settings["base_url"]) if settings.key?("base_url")
+      validate_viewport!(settings["viewport"]) if settings.key?("viewport")
+      validate_routes!(settings["routes"])
+      validate_auth!(settings["auth"]) if settings.key?("auth")
+      validate_seed!(settings["seed"]) if settings.key?("seed")
+      validate_string_array!("setup", settings["setup"]) if settings.key?("setup")
+      validate_string_array!("services", settings["services"]) if settings.key?("services")
+      validate_globs!("ui_patterns", settings["ui_patterns"]) if settings.key?("ui_patterns")
+      validate_globs!("ui_exclusions", settings["ui_exclusions"]) if settings.key?("ui_exclusions")
+    end
+
+    def validate_unknown_keys!(context, hash, allowed_keys)
+      extras = hash.keys - allowed_keys
+      return if extras.empty?
+
+      raise ConfigError, "#{context} contains unknown keys: #{extras.join(', ')}"
+    end
+
+    def validate_driver!(value)
+      return if value.in?(Configuration::VALID_DRIVERS)
+
+      raise ConfigError, "driver must be one of: #{Configuration::VALID_DRIVERS.join(', ')}"
+    end
+
+    def validate_enabled!(value)
+      return if value == true || value == false
+
+      raise ConfigError, "enabled must be true or false"
+    end
+
+    def validate_base_url!(value)
+      return if value.is_a?(String) && value.present?
+
+      raise ConfigError, "base_url must be a non-blank string"
+    end
+
+    def validate_viewport!(value)
+      unless value.is_a?(Hash)
+        raise ConfigError, "viewport must be a mapping with width and height"
+      end
+
+      validate_unknown_keys!("viewport", value, VALID_VIEWPORT_KEYS)
+
+      %w[width height].each do |key|
+        viewport_value = value[key]
+        next if viewport_value.is_a?(Integer) && viewport_value.positive?
+
+        raise ConfigError, "viewport.#{key} must be a positive integer"
+      end
+    end
+
+    def validate_routes!(value)
+      unless value.is_a?(Array) && value.any?
+        raise ConfigError, "routes must be a non-empty array"
+      end
+
+      value.each_with_index do |route, index|
+        unless route.is_a?(Hash)
+          raise ConfigError, "routes[#{index}] must be a mapping"
+        end
+
+        validate_unknown_keys!("routes[#{index}]", route, VALID_ROUTE_KEYS)
+
+        %w[path name].each do |key|
+          next if route[key].is_a?(String) && route[key].present?
+
+          raise ConfigError, "routes[#{index}].#{key} is required"
+        end
+
+        if route.key?("requires_auth") && ![ true, false ].include?(route["requires_auth"])
+          raise ConfigError, "routes[#{index}].requires_auth must be true or false"
+        end
+
+        if route.key?("seed_key") && !(route["seed_key"].is_a?(String) && route["seed_key"].present?)
+          raise ConfigError, "routes[#{index}].seed_key must be a non-blank string"
+        end
+      end
+    end
+
+    def validate_auth!(value)
+      unless value.is_a?(Hash)
+        raise ConfigError, "auth must be a mapping"
+      end
+
+      validate_unknown_keys!("auth", value, VALID_AUTH_KEYS)
+
+      strategy = value.fetch("strategy", "none")
+      unless strategy.in?(Configuration::VALID_AUTH_STRATEGIES)
+        raise ConfigError, "auth.strategy must be one of: #{Configuration::VALID_AUTH_STRATEGIES.join(', ')}"
+      end
+
+      if value.key?("login_path") && !(value["login_path"].is_a?(String) && value["login_path"].present?)
+        raise ConfigError, "auth.login_path must be a non-blank string"
+      end
+
+      %w[fields credentials].each do |key|
+        next unless value.key?(key)
+        next if value[key].is_a?(Hash)
+
+        raise ConfigError, "auth.#{key} must be a mapping"
+      end
+
+      return unless strategy == "form"
+
+      fields = value["fields"]
+      unless fields.is_a?(Hash)
+        raise ConfigError, "auth.fields is required when auth.strategy is form"
+      end
+
+      %w[email password submit].each do |key|
+        next if fields[key].is_a?(String) && fields[key].present?
+
+        raise ConfigError, "auth.fields.#{key} is required when auth.strategy is form"
+      end
+    end
+
+    def validate_seed!(value)
+      unless value.is_a?(Array)
+        raise ConfigError, "seed must be an array"
+      end
+
+      value.each_with_index do |record, index|
+        unless record.is_a?(Hash)
+          raise ConfigError, "seed[#{index}] must be a mapping"
+        end
+
+        %w[model factory key].each do |key|
+          next if record[key].is_a?(String) && record[key].present?
+
+          raise ConfigError, "seed[#{index}].#{key} is required"
+        end
+      end
+    end
+
+    def validate_string_array!(name, value)
+      unless value.is_a?(Array)
+        raise ConfigError, "#{name} must be an array"
+      end
+
+      value.each_with_index do |item, index|
+        next if item.is_a?(String) && item.present?
+
+        raise ConfigError, "#{name}[#{index}] must be a non-blank string"
+      end
+    end
+
+    def validate_globs!(name, value)
+      validate_string_array!(name, value)
+
+      value.each_with_index do |pattern, index|
+        next if valid_glob_pattern?(pattern)
+
+        raise ConfigError, "#{name}[#{index}] must be a valid glob pattern"
+      end
+    end
+
+    def valid_glob_pattern?(pattern)
+      return false if pattern.include?("\0")
+
+      balanced_glob?(pattern, "{", "}") && balanced_glob?(pattern, "[", "]")
+    end
+
+    def balanced_glob?(pattern, open_char, close_char)
+      balance = 0
+
+      pattern.each_char do |char|
+        balance += 1 if char == open_char
+        balance -= 1 if char == close_char
+        return false if balance.negative?
+      end
+
+      balance.zero?
+    end
+  end
+end

--- a/app/services/screenshots/config_parser.rb
+++ b/app/services/screenshots/config_parser.rb
@@ -22,8 +22,6 @@ module Screenshots
     VALID_ROUTE_KEYS = %w[path name requires_auth seed_key].freeze
     VALID_AUTH_KEYS = %w[strategy login_path fields credentials].freeze
     VALID_VIEWPORT_KEYS = %w[width height].freeze
-    VALID_SEED_KEYS = %w[model factory key].freeze
-
     class << self
       def call(project: nil, repo_path: nil, blob: nil, content: nil)
         new(project:, repo_path:, blob:, content:).call

--- a/app/services/screenshots/config_parser.rb
+++ b/app/services/screenshots/config_parser.rb
@@ -34,6 +34,12 @@ module Screenshots
       def from_blob(blob, project: nil)
         call(project:, blob:)
       end
+
+      # Validates a partial settings hash (e.g. DB-stored project settings where
+      # routes are not required). Raises ConfigError on invalid nested values.
+      def validate_partial!(settings)
+        new.send(:validate_partial!, settings)
+      end
     end
 
     def initialize(project: nil, repo_path: nil, blob: nil, content: nil)
@@ -116,13 +122,18 @@ module Screenshots
     end
 
     def validate_root!(settings)
+      validate_partial!(settings)
+      validate_routes!(settings["routes"])
+    end
+
+    def validate_partial!(settings)
       validate_unknown_keys!("top-level", settings, VALID_TOP_LEVEL_KEYS)
 
       validate_driver!(settings["driver"]) if settings.key?("driver")
       validate_enabled!(settings["enabled"]) if settings.key?("enabled")
       validate_base_url!(settings["base_url"]) if settings.key?("base_url")
       validate_viewport!(settings["viewport"]) if settings.key?("viewport")
-      validate_routes!(settings["routes"])
+      validate_routes_shape!(settings["routes"]) if settings.key?("routes")
       validate_auth!(settings["auth"]) if settings.key?("auth")
       validate_seed!(settings["seed"]) if settings.key?("seed")
       validate_string_array!("setup", settings["setup"]) if settings.key?("setup")
@@ -175,6 +186,12 @@ module Screenshots
       unless value.is_a?(Array) && value.any?
         raise ConfigError, "routes must be a non-empty array"
       end
+
+      validate_routes_shape!(value)
+    end
+
+    def validate_routes_shape!(value)
+      return unless value.is_a?(Array)
 
       value.each_with_index do |route, index|
         unless route.is_a?(Hash)

--- a/app/services/screenshots/config_parser.rb
+++ b/app/services/screenshots/config_parser.rb
@@ -175,6 +175,8 @@ module Screenshots
       validate_unknown_keys!("viewport", value, VALID_VIEWPORT_KEYS)
 
       %w[width height].each do |key|
+        next unless value.key?(key)
+
         viewport_value = value[key]
         next if viewport_value.is_a?(Integer) && viewport_value.positive?
 

--- a/app/services/screenshots/config_parser.rb
+++ b/app/services/screenshots/config_parser.rb
@@ -88,6 +88,8 @@ module Screenshots
       end
 
       parsed.deep_stringify_keys
+    rescue Psych::DisallowedClass => e
+      raise ConfigError, "#{CONFIG_PATH} contains unsupported YAML types (e.g. symbols): #{e.message}"
     rescue Psych::SyntaxError => e
       raise ConfigError, "Invalid YAML in #{CONFIG_PATH}: #{e.message}"
     end

--- a/app/services/screenshots/configuration.rb
+++ b/app/services/screenshots/configuration.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Screenshots
+  class Configuration < ::Data.define(
+    :enabled,
+    :driver,
+    :base_url,
+    :viewport,
+    :routes,
+    :auth,
+    :seed,
+    :setup,
+    :services,
+    :ui_patterns,
+    :ui_exclusions
+  )
+    VALID_DRIVERS = %w[playwright cuprite].freeze
+    VALID_AUTH_STRATEGIES = %w[none form token custom].freeze
+    DEFAULT_BASE_URL = "http://localhost:3000"
+    DEFAULT_UI_PATTERNS = [
+      "app/views/**/*",
+      "app/javascript/**/*",
+      "app/assets/stylesheets/**/*",
+      "app/components/**/*"
+    ].freeze
+    DEFAULT_UI_EXCLUSIONS = [
+      "app/views/layouts/mailer/**/*",
+      "app/views/pwa/**/*"
+    ].freeze
+
+    Viewport = ::Data.define(:width, :height)
+    Route = ::Data.define(:path, :name, :requires_auth, :seed_key)
+    Auth = ::Data.define(:strategy, :login_path, :fields, :credentials)
+    SeedRecord = ::Data.define(:model, :factory, :key, :attributes)
+
+    class << self
+      def from_hash(hash)
+        hash ||= {}
+
+        new(
+          enabled: hash["enabled"] == true,
+          driver: hash.fetch("driver", "playwright"),
+          base_url: hash.fetch("base_url", DEFAULT_BASE_URL),
+          viewport: viewport_from_hash(hash["viewport"]),
+          routes: routes_from_array(hash["routes"]),
+          auth: auth_from_hash(hash["auth"]),
+          seed: seed_from_array(hash["seed"]),
+          setup: string_array(hash["setup"]).freeze,
+          services: string_array(hash["services"]).freeze,
+          ui_patterns: string_array(hash["ui_patterns"], default: DEFAULT_UI_PATTERNS).freeze,
+          ui_exclusions: string_array(hash["ui_exclusions"], default: DEFAULT_UI_EXCLUSIONS).freeze
+        )
+      end
+
+      private
+
+      def viewport_from_hash(hash)
+        normalized = hash || {}
+
+        Viewport.new(
+          width: normalized.fetch("width", 1280),
+          height: normalized.fetch("height", 900)
+        )
+      end
+
+      def routes_from_array(routes)
+        Array(routes).map do |route|
+          Route.new(
+            path: route["path"],
+            name: route["name"],
+            requires_auth: route["requires_auth"] == true,
+            seed_key: route["seed_key"]
+          )
+        end.freeze
+      end
+
+      def auth_from_hash(hash)
+        normalized = hash || {}
+
+        Auth.new(
+          strategy: normalized.fetch("strategy", "none"),
+          login_path: normalized["login_path"],
+          fields: stringify_hash(normalized["fields"]).freeze,
+          credentials: stringify_hash(normalized["credentials"]).freeze
+        )
+      end
+
+      def seed_from_array(seed)
+        Array(seed).map do |record|
+          SeedRecord.new(
+            model: record["model"],
+            factory: record["factory"],
+            key: record["key"],
+            attributes: record.except("model", "factory", "key").deep_stringify_keys.freeze
+          )
+        end.freeze
+      end
+
+      def string_array(value, default: [])
+        return default.map(&:dup) if value.nil?
+
+        Array(value).map(&:to_s)
+      end
+
+      def stringify_hash(value)
+        return {} unless value.is_a?(Hash)
+
+        value.deep_stringify_keys
+      end
+    end
+
+    def enabled? = enabled == true
+  end
+end

--- a/db/migrate/20260506174922_add_screenshot_settings_to_projects.rb
+++ b/db/migrate/20260506174922_add_screenshot_settings_to_projects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddScreenshotSettingsToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :screenshot_settings, :jsonb, default: {}, null: false,
+      comment: "Project-level defaults and overrides for repository screenshot capture config"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3317,7 +3317,8 @@ CREATE TABLE public.projects (
     scheduler_pause_reason character varying,
     knowledge_evolution_enabled boolean DEFAULT false NOT NULL,
     agent_runs_count integer DEFAULT 0 NOT NULL,
-    completed_agent_runs_count integer DEFAULT 0 NOT NULL
+    completed_agent_runs_count integer DEFAULT 0 NOT NULL,
+    screenshot_settings jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 ALTER TABLE ONLY public.projects FORCE ROW LEVEL SECURITY;
@@ -3335,6 +3336,13 @@ COMMENT ON COLUMN public.projects.agent_runs_count IS 'Counter cache for total a
 --
 
 COMMENT ON COLUMN public.projects.completed_agent_runs_count IS 'Counter cache for completed agent runs';
+
+
+--
+-- Name: COLUMN projects.screenshot_settings; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.projects.screenshot_settings IS 'Project-level defaults and overrides for repository screenshot capture config';
 
 
 --
@@ -11197,6 +11205,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260506174922'),
 ('20260506074459'),
 ('20260505220424'),
 ('20260504222628'),
@@ -11444,3 +11453,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260128004342'),
 ('20260128004305'),
 ('20260127154444');
+

--- a/docs/SCREENSHOTS_CONFIG.md
+++ b/docs/SCREENSHOTS_CONFIG.md
@@ -1,0 +1,83 @@
+# Screenshot Configuration
+
+Paid reads screenshot capture settings from `.paid/screenshots.yml` in the target repository.
+
+## Schema
+
+```yaml
+driver: playwright          # optional: playwright | cuprite
+base_url: http://localhost:3000
+viewport:
+  width: 1280
+  height: 900
+
+routes:                     # required, non-empty
+  - path: /
+    name: homepage
+  - path: /dashboard
+    name: dashboard
+    requires_auth: true
+  - path: /projects/:project_id
+    name: project_show
+    requires_auth: true
+    seed_key: project
+
+auth:                       # optional
+  strategy: form            # none | form | token | custom
+  login_path: /login
+  fields:
+    email: input[name="email"]
+    password: input[name="password"]
+    submit: button[type="submit"]
+  credentials:
+    email: admin@example.com
+    password: password123
+
+seed:                       # optional
+  - model: User
+    factory: admin
+    key: user
+  - model: Project
+    factory: project
+    key: project
+    owner: user
+
+setup:                      # optional
+  - bin/rails db:prepare
+  - bin/rails db:seed
+
+services:                   # optional
+  - postgres
+  - redis
+
+ui_patterns:                # optional
+  - app/views/**/*
+  - app/javascript/**/*
+  - app/assets/stylesheets/**/*
+  - app/components/**/*
+
+ui_exclusions:              # optional
+  - app/views/layouts/mailer/**/*
+  - app/views/pwa/**/*
+```
+
+## Defaults
+
+- `driver`: `playwright`
+- `base_url`: `http://localhost:3000`
+- `viewport.width`: `1280`
+- `viewport.height`: `900`
+- `auth.strategy`: `none`
+- `seed`, `setup`, `services`: empty arrays
+- `ui_patterns`: `app/views/**/*`, `app/javascript/**/*`, `app/assets/stylesheets/**/*`, `app/components/**/*`
+- `ui_exclusions`: `app/views/layouts/mailer/**/*`, `app/views/pwa/**/*`
+
+## Resolution Rules
+
+Paid resolves screenshot configuration in this order:
+
+1. Start with `Project.screenshot_settings` from the database.
+2. Overlay `.paid/screenshots.yml` from the repository.
+3. Re-apply database overrides for `enabled` and `driver`.
+
+Repository config takes precedence for `routes`, `auth`, `seed`, and `setup`.

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -927,6 +927,17 @@ RSpec.describe Project do
       end
     end
 
+    describe "#effective_screenshot_settings" do
+      it "merges screenshot defaults with stored settings" do
+        project = build(:project, screenshot_settings: { "enabled" => true })
+
+        expect(project.effective_screenshot_settings).to eq(
+          "enabled" => true,
+          "driver" => "playwright"
+        )
+      end
+    end
+
     describe "validation" do
       it "accepts empty review_settings" do
         project = build(:project, review_settings: {})
@@ -945,6 +956,29 @@ RSpec.describe Project do
           }
         })
         expect(project).to be_valid
+      end
+
+      it "accepts valid screenshot_settings" do
+        project = build(:project, screenshot_settings: {
+          "enabled" => true,
+          "driver" => "cuprite"
+        })
+
+        expect(project).to be_valid
+      end
+
+      it "rejects non-hash screenshot_settings" do
+        project = build(:project, screenshot_settings: "bad")
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("must be a JSON object")
+      end
+
+      it "rejects unknown screenshot drivers" do
+        project = build(:project, screenshot_settings: { "driver" => "selenium" })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("driver must be one of: playwright, cuprite")
       end
 
       it "rejects unknown review methods" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -981,6 +981,27 @@ RSpec.describe Project do
         expect(project.errors[:screenshot_settings].join).to include("driver must be one of: playwright, cuprite")
       end
 
+      it "rejects unknown screenshot_settings keys" do
+        project = build(:project, screenshot_settings: { "enabled" => true, "bogus" => 1 })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("unknown keys: bogus")
+      end
+
+      it "rejects invalid viewport in screenshot_settings" do
+        project = build(:project, screenshot_settings: { "viewport" => "bad" })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("viewport must be a JSON object")
+      end
+
+      it "rejects invalid base_url in screenshot_settings" do
+        project = build(:project, screenshot_settings: { "base_url" => 123 })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("base_url must be a non-blank string")
+      end
+
       it "rejects unknown review methods" do
         project = build(:project, review_settings: {
           "methods" => { "unknown_method" => { "enabled" => true } }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -992,7 +992,7 @@ RSpec.describe Project do
         project = build(:project, screenshot_settings: { "viewport" => "bad" })
 
         expect(project).not_to be_valid
-        expect(project.errors[:screenshot_settings].join).to include("viewport must be a JSON object")
+        expect(project.errors[:screenshot_settings].join).to include("viewport must be a mapping")
       end
 
       it "rejects invalid base_url in screenshot_settings" do
@@ -1000,6 +1000,41 @@ RSpec.describe Project do
 
         expect(project).not_to be_valid
         expect(project.errors[:screenshot_settings].join).to include("base_url must be a non-blank string")
+      end
+
+      it "rejects non-positive viewport dimensions" do
+        project = build(:project, screenshot_settings: { "viewport" => { "width" => -1, "height" => 900 } })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("viewport.width must be a positive integer")
+      end
+
+      it "rejects non-string items in ui_patterns" do
+        project = build(:project, screenshot_settings: { "ui_patterns" => [ 123 ] })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("ui_patterns[0] must be a non-blank string")
+      end
+
+      it "rejects invalid auth strategy" do
+        project = build(:project, screenshot_settings: { "auth" => { "strategy" => "bogus" } })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("auth.strategy must be one of")
+      end
+
+      it "rejects non-hash seed items" do
+        project = build(:project, screenshot_settings: { "seed" => [ 123 ] })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("seed[0] must be a mapping")
+      end
+
+      it "rejects non-string setup items" do
+        project = build(:project, screenshot_settings: { "setup" => [ 456 ] })
+
+        expect(project).not_to be_valid
+        expect(project.errors[:screenshot_settings].join).to include("setup[0] must be a non-blank string")
       end
 
       it "rejects unknown review methods" do

--- a/spec/services/screenshots/config_parser_spec.rb
+++ b/spec/services/screenshots/config_parser_spec.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require "base64"
+require "rails_helper"
+
+RSpec.describe Screenshots::ConfigParser do
+  def write_config(dir, content)
+    FileUtils.mkdir_p(File.join(dir, ".paid"))
+    File.write(File.join(dir, ".paid", "screenshots.yml"), content)
+  end
+
+  let(:repo_dir) { Dir.mktmpdir }
+  let(:project) { build(:project) }
+
+  after do
+    FileUtils.rm_rf(repo_dir)
+  end
+
+  describe ".from_repo_path" do
+    context "with a minimal config" do
+      subject(:config) { described_class.from_repo_path(repo_dir, project: project) }
+
+      before do
+        write_config(repo_dir, <<~YAML)
+          routes:
+            - path: /
+              name: homepage
+        YAML
+      end
+
+      it "returns a frozen configuration object" do
+        expect(config).to be_a(Screenshots::Configuration)
+        expect(config).to be_frozen
+      end
+
+      it "applies top-level defaults" do
+        expect(config.enabled?).to be false
+        expect(config.driver).to eq("playwright")
+        expect(config.base_url).to eq("http://localhost:3000")
+      end
+
+      it "applies viewport and auth defaults" do
+        expect(config.viewport.width).to eq(1280)
+        expect(config.viewport.height).to eq(900)
+        expect(config.auth.strategy).to eq("none")
+      end
+
+      it "keeps the declared route and default UI globs" do
+        expect(config.routes).to contain_exactly(
+          have_attributes(path: "/", name: "homepage", requires_auth: false, seed_key: nil)
+        )
+        expect(config.ui_patterns).to eq(Screenshots::Configuration::DEFAULT_UI_PATTERNS)
+        expect(config.ui_exclusions).to eq(Screenshots::Configuration::DEFAULT_UI_EXCLUSIONS)
+      end
+    end
+
+    context "with a full config" do
+      subject(:config) { described_class.from_repo_path(repo_dir, project: project) }
+
+      before do
+        write_config(repo_dir, <<~YAML)
+          driver: cuprite
+          base_url: http://localhost:4000
+          viewport:
+            width: 1440
+            height: 960
+          routes:
+            - path: /
+              name: homepage
+            - path: /projects/:project_id
+              name: project_show
+              requires_auth: true
+              seed_key: project
+          auth:
+            strategy: form
+            login_path: /login
+            fields:
+              email: input[name="email"]
+              password: input[name="password"]
+              submit: button[type="submit"]
+            credentials:
+              email: admin@example.com
+              password: password123
+          seed:
+            - model: User
+              factory: admin
+              key: user
+            - model: Project
+              factory: project
+              key: project
+              owner: user
+          setup:
+            - bin/rails db:prepare
+            - bin/rails db:seed
+          services:
+            - postgres
+            - redis
+          ui_patterns:
+            - app/views/**/*
+            - app/components/**/*
+          ui_exclusions:
+            - app/views/layouts/mailer/**/*
+        YAML
+      end
+
+      it "parses the driver, base url, and viewport" do
+        expect(config.driver).to eq("cuprite")
+        expect(config.base_url).to eq("http://localhost:4000")
+        expect(config.viewport).to have_attributes(width: 1440, height: 960)
+      end
+
+      it "parses routes and auth" do
+        expect(config.routes.last).to have_attributes(
+          path: "/projects/:project_id",
+          name: "project_show",
+          requires_auth: true,
+          seed_key: "project"
+        )
+        expect(config.auth).to have_attributes(strategy: "form", login_path: "/login")
+        expect(config.auth.fields).to include("email" => 'input[name="email"]')
+        expect(config.auth.credentials).to include("email" => "admin@example.com")
+      end
+
+      it "parses seed, setup, services, and UI globs" do
+        expect(config.seed.last).to have_attributes(model: "Project", factory: "project", key: "project")
+        expect(config.seed.last.attributes).to eq("owner" => "user")
+        expect(config.setup).to eq([ "bin/rails db:prepare", "bin/rails db:seed" ])
+        expect(config.services).to eq(%w[postgres redis])
+        expect(config.ui_patterns).to eq([ "app/views/**/*", "app/components/**/*" ])
+        expect(config.ui_exclusions).to eq([ "app/views/layouts/mailer/**/*" ])
+      end
+    end
+
+    context "with project-level overrides" do
+      subject(:config) { described_class.from_repo_path(repo_dir, project: project) }
+
+      before do
+        project.screenshot_settings = {
+          "enabled" => true,
+          "driver" => "cuprite",
+          "auth" => { "strategy" => "token", "credentials" => { "token" => "db-token" } },
+          "setup" => [ "bin/rails db:prepare" ]
+        }
+
+        write_config(repo_dir, <<~YAML)
+          driver: playwright
+          routes:
+            - path: /dashboard
+              name: dashboard
+              requires_auth: true
+          auth:
+            strategy: form
+            login_path: /login
+            fields:
+              email: input[name="email"]
+              password: input[name="password"]
+              submit: button[type="submit"]
+          setup:
+            - yarn build
+        YAML
+      end
+
+      it "keeps enabled and driver from the database" do
+        expect(config.enabled?).to be true
+        expect(config.driver).to eq("cuprite")
+      end
+
+      it "uses repo-defined auth, routes, and setup" do
+        expect(config.routes).to contain_exactly(have_attributes(name: "dashboard"))
+        expect(config.auth.strategy).to eq("form")
+        expect(config.auth.login_path).to eq("/login")
+        expect(config.setup).to eq([ "yarn build" ])
+      end
+    end
+
+    it "raises a helpful error for a missing config file" do
+      expect {
+        described_class.from_repo_path(repo_dir, project: project)
+      }.to raise_error(Screenshots::ConfigError, /Missing \.paid\/screenshots\.yml/)
+    end
+
+    it "rejects an invalid driver" do
+      write_config(repo_dir, <<~YAML)
+        driver: selenium
+        routes:
+          - path: /
+            name: homepage
+      YAML
+
+      expect {
+        described_class.from_repo_path(repo_dir, project: project)
+      }.to raise_error(Screenshots::ConfigError, /driver must be one of: playwright, cuprite/)
+    end
+
+    it "rejects empty routes" do
+      write_config(repo_dir, <<~YAML)
+        routes: []
+      YAML
+
+      expect {
+        described_class.from_repo_path(repo_dir, project: project)
+      }.to raise_error(Screenshots::ConfigError, /routes must be a non-empty array/)
+    end
+
+    it "requires auth.fields when auth.strategy is form" do
+      write_config(repo_dir, <<~YAML)
+        routes:
+          - path: /
+            name: homepage
+        auth:
+          strategy: form
+      YAML
+
+      expect {
+        described_class.from_repo_path(repo_dir, project: project)
+      }.to raise_error(Screenshots::ConfigError, /auth\.fields is required/)
+    end
+
+    it "rejects non-positive viewport values" do
+      write_config(repo_dir, <<~YAML)
+        viewport:
+          width: 0
+          height: 900
+        routes:
+          - path: /
+            name: homepage
+      YAML
+
+      expect {
+        described_class.from_repo_path(repo_dir, project: project)
+      }.to raise_error(Screenshots::ConfigError, /viewport\.width must be a positive integer/)
+    end
+
+    it "rejects malformed glob patterns" do
+      write_config(repo_dir, <<~YAML)
+        routes:
+          - path: /
+            name: homepage
+        ui_patterns:
+          - "app/views/[**/*"
+      YAML
+
+      expect {
+        described_class.from_repo_path(repo_dir, project: project)
+      }.to raise_error(Screenshots::ConfigError, /ui_patterns\[0\] must be a valid glob pattern/)
+    end
+  end
+
+  describe ".from_blob" do
+    it "reads config from a GitHub blob" do
+      blob = Struct.new(:content).new(Base64.strict_encode64(<<~YAML))
+        routes:
+          - path: /
+            name: homepage
+      YAML
+
+      config = described_class.from_blob(blob, project: project)
+
+      expect(config.routes.first).to have_attributes(path: "/", name: "homepage")
+    end
+  end
+end

--- a/spec/services/screenshots/config_parser_spec.rb
+++ b/spec/services/screenshots/config_parser_spec.rb
@@ -216,6 +216,34 @@ RSpec.describe Screenshots::ConfigParser do
       }.to raise_error(Screenshots::ConfigError, /auth\.fields is required/)
     end
 
+    it "accepts a partial viewport with only width" do
+      write_config(repo_dir, <<~YAML)
+        viewport:
+          width: 1440
+        routes:
+          - path: /
+            name: homepage
+      YAML
+
+      config = described_class.from_repo_path(repo_dir, project: project)
+
+      expect(config.viewport).to have_attributes(width: 1440, height: 900)
+    end
+
+    it "accepts a partial viewport with only height" do
+      write_config(repo_dir, <<~YAML)
+        viewport:
+          height: 1080
+        routes:
+          - path: /
+            name: homepage
+      YAML
+
+      config = described_class.from_repo_path(repo_dir, project: project)
+
+      expect(config.viewport).to have_attributes(width: 1280, height: 1080)
+    end
+
     it "rejects non-positive viewport values" do
       write_config(repo_dir, <<~YAML)
         viewport:

--- a/spec/services/screenshots/config_parser_spec.rb
+++ b/spec/services/screenshots/config_parser_spec.rb
@@ -231,6 +231,22 @@ RSpec.describe Screenshots::ConfigParser do
       }.to raise_error(Screenshots::ConfigError, /viewport\.width must be a positive integer/)
     end
 
+    it "wraps Psych::DisallowedClass in ConfigError for YAML symbols" do
+      write_config(repo_dir, <<~YAML)
+        routes:
+          - path: /
+            name: homepage
+        seed:
+          - model: User
+            factory: :admin
+            key: user
+      YAML
+
+      expect {
+        described_class.from_repo_path(repo_dir, project: project)
+      }.to raise_error(Screenshots::ConfigError, /unsupported YAML types/)
+    end
+
     it "rejects malformed glob patterns" do
       write_config(repo_dir, <<~YAML)
         routes:


### PR DESCRIPTION
## Summary

Added the screenshot config layer end to end. The branch now has `projects.screenshot_settings`, a typed `Screenshots::Configuration` value object, `Screenshots::ConfigParser` with repo-path and blob entry points, merge precedence that keeps explicit DB `enabled`/`driver` overrides while letting repo config control `routes`/`auth`/`seed`/`setup`, plus validation errors through `Screenshots::ConfigError`. I also documented `.paid/screenshots.yml` in [docs/SCREENSHOTS_CONFIG.md](/workspace/docs/SCREENSHOTS_CONFIG.md) and added parser/model specs.

Verification passed with `bundle exec rubocop` and full `RAILS_ENV=test bundle exec rspec` (`10738 examples, 0 failures, 3 pending`). Changes are committed as `feat(screenshots): add repository config parser` at `1ba712b`.

---

Closes #1648