### PR TITLE
fix(devcontainer): sync pinned tool installs and Redis fallback

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,8 +44,44 @@ RUN apt-get update -qq \
 RUN corepack enable && corepack prepare yarn@1.22.22 --activate
 
 # Install ast-grep for collector integration specs and local code analysis.
-COPY bin/install-ast-grep /tmp/install-ast-grep
-RUN chmod +x /tmp/install-ast-grep && /tmp/install-ast-grep && rm /tmp/install-ast-grep
+# Keep this inline instead of COPYing a repo script: the devcontainer image is
+# often rebuilt from a minimal or noisy workspace context, and BuildKit has
+# intermittently failed to resolve bin/install-ast-grep from that context.
+ARG AST_GREP_VERSION=0.42.1
+RUN set -eu; \
+  arch="$(dpkg --print-architecture)"; \
+  case "$arch" in \
+    amd64) rust_triple="x86_64-unknown-linux-gnu"; checksum="5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657" ;; \
+    arm64) rust_triple="aarch64-unknown-linux-gnu"; checksum="3ba383839044cf9817929435f5ce0027f91d06931e8efb32d942e58d73d92be5" ;; \
+    *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+  esac; \
+  zipfile="app-${rust_triple}.zip"; \
+  url="https://github.com/ast-grep/ast-grep/releases/download/${AST_GREP_VERSION}/${zipfile}"; \
+  tmpdir="$(mktemp -d)"; \
+  trap 'rm -rf "$tmpdir"' EXIT; \
+  curl -fsSL -o "$tmpdir/$zipfile" "$url"; \
+  echo "$checksum  $tmpdir/$zipfile" | sha256sum -c -; \
+  unzip -j -o "$tmpdir/$zipfile" ast-grep -d "$tmpdir"; \
+  install -m 0755 "$tmpdir/ast-grep" /usr/local/bin/ast-grep; \
+  ln -sf /usr/local/bin/ast-grep /usr/local/bin/sg
+
+# Install scc for collector integration specs and local code analysis.
+ARG SCC_VERSION=3.7.0
+RUN set -eu; \
+  arch="$(dpkg --print-architecture)"; \
+  case "$arch" in \
+    amd64) scc_arch="x86_64"; checksum="3d9d65b00ca874c2b29151abe7e1480736f5229edc3ce8e4b2791460cdfabf5a" ;; \
+    arm64) scc_arch="arm64"; checksum="dcb05c6e993bb2d8d2da4765ff018f2e752325dd205a41698929c55e4123575d" ;; \
+    *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+  esac; \
+  tarball="scc_Linux_${scc_arch}.tar.gz"; \
+  url="https://github.com/boyter/scc/releases/download/v${SCC_VERSION}/${tarball}"; \
+  tmpdir="$(mktemp -d)"; \
+  trap 'rm -rf "$tmpdir"' EXIT; \
+  curl -fsSL -o "$tmpdir/$tarball" "$url"; \
+  echo "$checksum  $tmpdir/$tarball" | sha256sum -c -; \
+  tar -xzf "$tmpdir/$tarball" -C /usr/local/bin scc; \
+  chmod +x /usr/local/bin/scc
 
 # Install overmind process manager (requires tmux, installed above)
 RUN gem install overmind

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
+/.overmind.sock
 !/log/.keep
 !/tmp/.keep
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ temporal operator namespace list
 bin/setup                    # Install deps, prepare DB, start server
 bin/setup --skip-server      # Setup without starting server
 bin/setup --reset            # Setup with database reset
-bin/update                   # Update Ruby, Yarn, and supported Dockerfile-pinned deps
+bin/update                   # Update supported pinned tool binaries (`--lockfiles` to also update Ruby/Yarn deps)
 
 # Development
 bin/dev                      # Start dev server with Overmind (Rails + JS + CSS + split Temporal poll/agent workers)

--- a/bin/install-ast-grep
+++ b/bin/install-ast-grep
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-AST_GREP_VERSION="${AST_GREP_VERSION:-0.42.0}"
+AST_GREP_VERSION="${AST_GREP_VERSION:-0.42.1}"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 case "$(uname -s)" in
@@ -16,7 +16,7 @@ case "$(dpkg --print-architecture)" in
   amd64)
     RUST_TRIPLE="x86_64-unknown-linux-gnu"
     case "${AST_GREP_VERSION}" in
-      0.42.0) EXPECTED_CHECKSUM="e825a05603f0bcc4cd9076c4cc8c9abd6d008b7cd07d9aa3cc323ba4b8606651" ;;
+      0.42.1) EXPECTED_CHECKSUM="5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657" ;;
       0.41.0) EXPECTED_CHECKSUM="e71afdcbb2e79f7710a56d2f89662bdd0a6e9d639c4abecd5d5f129d80a38bac" ;;
       *) echo "No checksum configured for ast-grep ${AST_GREP_VERSION} on amd64" >&2; exit 1 ;;
     esac
@@ -24,7 +24,7 @@ case "$(dpkg --print-architecture)" in
   arm64)
     RUST_TRIPLE="aarch64-unknown-linux-gnu"
     case "${AST_GREP_VERSION}" in
-      0.42.0) EXPECTED_CHECKSUM="5c830eae8456569e2f7212434ed9c238f58dca412d76045418ed6d394a755836" ;;
+      0.42.1) EXPECTED_CHECKSUM="3ba383839044cf9817929435f5ce0027f91d06931e8efb32d942e58d73d92be5" ;;
       0.41.0) EXPECTED_CHECKSUM="6f089d014d5fda8fed2e63e5095acf8ebec4c4cd2e721bd663f2284ace42b623" ;;
       *) echo "No checksum configured for ast-grep ${AST_GREP_VERSION} on arm64" >&2; exit 1 ;;
     esac
@@ -45,3 +45,4 @@ curl -fsSL -o "${TMPDIR}/${ZIPFILE}" "${URL}"
 echo "${EXPECTED_CHECKSUM}  ${TMPDIR}/${ZIPFILE}" | sha256sum -c -
 unzip -j -o "${TMPDIR}/${ZIPFILE}" ast-grep -d "${TMPDIR}"
 install -m 0755 "${TMPDIR}/ast-grep" "${INSTALL_DIR}/ast-grep"
+ln -sf "${INSTALL_DIR}/ast-grep" "${INSTALL_DIR}/sg"

--- a/bin/update
+++ b/bin/update
@@ -8,14 +8,27 @@ require "time"
 require "uri"
 
 APP_ROOT = Pathname(__dir__).join("..").expand_path
-DOCKERFILE_PATH = APP_ROOT.join("docker/agent/Dockerfile")
+AGENT_DOCKERFILE_PATH = APP_ROOT.join("docker/agent/Dockerfile")
+DEVCONTAINER_DOCKERFILE_PATH = APP_ROOT.join(".devcontainer/Dockerfile")
+INSTALL_AST_GREP_PATH = APP_ROOT.join("bin/install-ast-grep")
 PACKAGE_JSON_PATH = APP_ROOT.join("package.json")
 GEMFILE_LOCK_PATH = APP_ROOT.join("Gemfile.lock")
 YARN_LOCK_PATH = APP_ROOT.join("yarn.lock")
-# Codex CLI version is owned by agent-harness (installation_contract) and
-# injected at Docker build time — it is no longer pinned in the Dockerfile.
-DOCKERFILE_NPM_PACKAGES = {
-  "yarn" => /^(\s*&& corepack prepare yarn@)([^\s]+)( --activate\s*)$/
+
+YARN_PATTERNS = {
+  AGENT_DOCKERFILE_PATH => /^(\s*&& corepack prepare yarn@)([^\s]+)( --activate\s*)$/,
+  DEVCONTAINER_DOCKERFILE_PATH => /^(RUN corepack enable && corepack prepare yarn@)([^\s]+)( --activate\s*)$/
+}.freeze
+
+BINARY_RELEASES = {
+  "ast-grep" => {
+    repo: "ast-grep/ast-grep",
+    strip_leading_v: false
+  },
+  "scc" => {
+    repo: "boyter/scc",
+    strip_leading_v: true
+  }
 }.freeze
 
 # Minimum age (in hours) a package version must have been published before
@@ -28,41 +41,68 @@ def system!(*args)
   system(*args, exception: true)
 end
 
-# Fetch the full npm registry document for a package. Returns parsed JSON.
-# Cached per package name to avoid redundant requests.
+def fetch_json(uri_string, headers: {})
+  uri = URI(uri_string)
+  request = Net::HTTP::Get.new(uri)
+  headers.each { |key, value| request[key] = value }
+
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+    http.request(request)
+  end
+  raise "Failed to fetch #{uri}: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+  JSON.parse(response.body)
+end
+
 def fetch_npm_registry(package_name)
   @npm_registry_cache ||= {}
   @npm_registry_cache[package_name] ||= begin
     escaped = package_name.gsub("/", "%2F")
-    uri = URI("https://registry.npmjs.org/#{escaped}")
-    response = Net::HTTP.get_response(uri)
-    raise "Failed to fetch #{package_name}: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
-
-    JSON.parse(response.body)
+    fetch_json("https://registry.npmjs.org/#{escaped}")
   end
 end
 
-# Fetch the latest version and its publish timestamp from the npm registry.
-# Returns [version, published_at] where published_at is a Time object.
 def fetch_npm_version_info(package_name)
   data = fetch_npm_registry(package_name)
   latest = data.dig("dist-tags", "latest")
   published_at = Time.parse(data.dig("time", latest))
-  [latest, published_at]
+  [ latest, published_at ]
 end
 
-# Fetch the publish timestamp for a specific gem version from RubyGems.
-def fetch_gem_publish_time(gem_name, version)
-  uri = URI("https://rubygems.org/api/v2/rubygems/#{gem_name}/versions/#{version}.json")
-  response = Net::HTTP.get_response(uri)
-  return nil unless response.is_a?(Net::HTTPSuccess)
+def fetch_github_release(package_name)
+  @github_release_cache ||= {}
+  @github_release_cache[package_name] ||= begin
+    repo = BINARY_RELEASES.fetch(package_name).fetch(:repo)
+    fetch_json(
+      "https://api.github.com/repos/#{repo}/releases/latest",
+      headers: { "Accept" => "application/vnd.github+json" }
+    )
+  end
+end
 
-  Time.parse(JSON.parse(response.body).fetch("created_at"))
+def fetch_binary_version_info(package_name)
+  release = fetch_github_release(package_name)
+  version = release.fetch("tag_name")
+  version = version.delete_prefix("v") if BINARY_RELEASES.fetch(package_name).fetch(:strip_leading_v)
+  [ version, Time.parse(release.fetch("published_at")) ]
+end
+
+def fetch_release_asset_digest(package_name, asset_name)
+  release = fetch_github_release(package_name)
+  asset = release.fetch("assets").find { |item| item.fetch("name") == asset_name }
+  raise "Asset #{asset_name} not found in #{package_name} release" unless asset
+
+  digest = asset.fetch("digest")
+  digest.delete_prefix("sha256:")
+end
+
+def fetch_gem_publish_time(gem_name, version)
+  data = fetch_json("https://rubygems.org/api/v2/rubygems/#{gem_name}/versions/#{version}.json")
+  Time.parse(data.fetch("created_at"))
 rescue StandardError
   nil
 end
 
-# Fetch the publish timestamp for a specific npm package version.
 def fetch_npm_publish_time(package_name, version)
   data = fetch_npm_registry(package_name)
   time_str = data.dig("time", version)
@@ -76,44 +116,239 @@ def age_hours(published_at)
 end
 
 def replace_version(contents, pattern, new_version)
-  updated = false
+  matched = false
+  changed = false
 
   rewritten = contents.gsub(pattern) do
-    updated = true
+    matched = true
+    changed ||= Regexp.last_match(2) != new_version
     "#{Regexp.last_match(1)}#{new_version}#{Regexp.last_match(3)}"
   end
 
-  [rewritten, updated]
+  [ rewritten, matched, changed ]
+end
+
+def replace_in_file(path, replacements)
+  contents = path.read
+  applied = []
+
+  replacements.each do |replacement|
+    updated_contents, matched, changed = replace_version(
+      contents,
+      replacement.fetch(:pattern),
+      replacement.fetch(:value)
+    )
+    raise "Did not find #{replacement.fetch(:label)}" unless matched
+
+    contents = updated_contents
+    applied << replacement.fetch(:label) if changed
+  end
+
+  path.write(contents) unless applied.empty?
+  applied
 end
 
 def usage
-  puts "Usage: bin/update [--skip-age-check]"
-  puts "Updates Ruby gems, Yarn packages, and supported Dockerfile-pinned npm tools."
+  puts "Usage: bin/update [--lockfiles] [--skip-age-check]"
+  puts "Updates supported pinned tool binaries."
   puts ""
   puts "Options:"
+  puts "  --lockfiles       Also update Ruby gems and JavaScript lockfiles"
   puts "  --skip-age-check  Skip the package age quarantine check"
   puts ""
   puts "Environment:"
   puts "  MIN_PACKAGE_AGE_HOURS  Minimum hours since publish (default: 72)"
 end
 
-def update_dockerfile(versions_to_apply)
-  contents = DOCKERFILE_PATH.read
+def update_yarn(version)
+  update_package_manager(version)
+
   updates = []
   failures = []
 
-  DOCKERFILE_NPM_PACKAGES.each do |package_name, pattern|
-    next unless versions_to_apply.key?(package_name)
-
-    latest_version = versions_to_apply.fetch(package_name)
-    contents, updated = replace_version(contents, pattern, latest_version)
-    updates << "#{package_name} -> #{latest_version}" if updated
+  YARN_PATTERNS.each do |path, pattern|
+    updates.concat(
+      replace_in_file(
+        path,
+        [
+          {
+            pattern: pattern,
+            value: version,
+            label: "#{path.relative_path_from(APP_ROOT)} -> yarn@#{version}"
+          }
+        ]
+      )
+    )
   rescue StandardError => error
-    failures << "#{package_name} (#{error.message})"
+    failures << "yarn (#{path.relative_path_from(APP_ROOT)}: #{error.message})"
   end
 
-  DOCKERFILE_PATH.write(contents)
-  [updates, failures]
+  [ updates, failures ]
+end
+
+def update_ast_grep(version, amd64_checksum, arm64_checksum)
+  updates = []
+  failures = []
+
+  [
+    {
+      path: AGENT_DOCKERFILE_PATH,
+      replacements: [
+        {
+          pattern: /^(RUN AST_GREP_VERSION=)([^\s]+)( \\\s*)$/,
+          value: version,
+          label: "#{AGENT_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} AST_GREP_VERSION"
+        },
+        {
+          pattern: /^(\s*amd64\) RUST_TRIPLE="x86_64-unknown-linux-gnu"; EXPECTED_CHECKSUM=")([0-9a-f]+)(".*)$/,
+          value: amd64_checksum,
+          label: "#{AGENT_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} ast-grep amd64 checksum"
+        },
+        {
+          pattern: /^(\s*arm64\) RUST_TRIPLE="aarch64-unknown-linux-gnu"; EXPECTED_CHECKSUM=")([0-9a-f]+)(".*)$/,
+          value: arm64_checksum,
+          label: "#{AGENT_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} ast-grep arm64 checksum"
+        }
+      ]
+    },
+    {
+      path: DEVCONTAINER_DOCKERFILE_PATH,
+      replacements: [
+        {
+          pattern: /^(ARG AST_GREP_VERSION=)([^\s]+)(\s*)$/,
+          value: version,
+          label: "#{DEVCONTAINER_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} AST_GREP_VERSION"
+        },
+        {
+          pattern: /^(\s*amd64\) rust_triple="x86_64-unknown-linux-gnu"; checksum=")([0-9a-f]+)(".*)$/,
+          value: amd64_checksum,
+          label: "#{DEVCONTAINER_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} ast-grep amd64 checksum"
+        },
+        {
+          pattern: /^(\s*arm64\) rust_triple="aarch64-unknown-linux-gnu"; checksum=")([0-9a-f]+)(".*)$/,
+          value: arm64_checksum,
+          label: "#{DEVCONTAINER_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} ast-grep arm64 checksum"
+        }
+      ]
+    }
+  ].each do |entry|
+    updates.concat(replace_in_file(entry.fetch(:path), entry.fetch(:replacements)))
+  rescue StandardError => error
+    failures << "ast-grep (#{entry.fetch(:path).relative_path_from(APP_ROOT)}: #{error.message})"
+  end
+
+  updates.concat(update_install_ast_grep(version, amd64_checksum, arm64_checksum))
+  [ updates, failures ]
+rescue StandardError => error
+  [ updates, failures + [ "ast-grep (#{error.message})" ] ]
+end
+
+def update_install_ast_grep(version, amd64_checksum, arm64_checksum)
+  lines = INSTALL_AST_GREP_PATH.readlines
+  original = lines.join
+  current_version = lines
+    .find { |line| line.start_with?("AST_GREP_VERSION=") }
+    &.match(/AST_GREP_VERSION="\$\{AST_GREP_VERSION:-([^}]+)\}"/)
+    &.captures
+    &.first
+  raise "Could not determine current ast-grep default version" unless current_version
+
+  default_matched = false
+  amd64_matched = false
+  arm64_matched = false
+  current_arch = nil
+
+  rewritten = lines.map do |line|
+    current_arch = :amd64 if line.strip == "amd64)"
+    current_arch = :arm64 if line.strip == "arm64)"
+
+    if line.start_with?("AST_GREP_VERSION=")
+      default_matched = true
+      %(AST_GREP_VERSION="${AST_GREP_VERSION:-#{version}}"\n)
+    elsif line.match?(/^\s+#{Regexp.escape(current_version)}\) EXPECTED_CHECKSUM="/)
+      case current_arch
+      when :amd64
+        amd64_matched = true
+        line.sub(current_version, version).sub(/EXPECTED_CHECKSUM="[0-9a-f]+"/, %(EXPECTED_CHECKSUM="#{amd64_checksum}"))
+      when :arm64
+        arm64_matched = true
+        line.sub(current_version, version).sub(/EXPECTED_CHECKSUM="[0-9a-f]+"/, %(EXPECTED_CHECKSUM="#{arm64_checksum}"))
+      else
+        line
+      end
+    else
+      line
+    end
+  end
+
+  raise "Failed to update default version in #{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)}" unless default_matched
+  raise "Failed to update amd64 checksum in #{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)}" unless amd64_matched
+  raise "Failed to update arm64 checksum in #{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)}" unless arm64_matched
+
+  updated = rewritten.join
+  INSTALL_AST_GREP_PATH.write(updated) unless updated == original
+
+  return [] if updated == original
+
+  [
+    "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} AST_GREP_VERSION=#{version}",
+    "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} ast-grep amd64 checksum",
+    "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} ast-grep arm64 checksum"
+  ]
+end
+
+def update_scc(version, amd64_checksum, arm64_checksum)
+  updates = []
+  failures = []
+
+  [
+    {
+      path: AGENT_DOCKERFILE_PATH,
+      replacements: [
+        {
+          pattern: /^(RUN SCC_VERSION=)([^\s]+)( \\\s*)$/,
+          value: version,
+          label: "#{AGENT_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} SCC_VERSION"
+        },
+        {
+          pattern: /^(\s*amd64\) SCC_ARCH="x86_64"; EXPECTED_CHECKSUM=")([0-9a-f]+)(".*)$/,
+          value: amd64_checksum,
+          label: "#{AGENT_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} scc amd64 checksum"
+        },
+        {
+          pattern: /^(\s*arm64\) SCC_ARCH="arm64"; EXPECTED_CHECKSUM=")([0-9a-f]+)(".*)$/,
+          value: arm64_checksum,
+          label: "#{AGENT_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} scc arm64 checksum"
+        }
+      ]
+    },
+    {
+      path: DEVCONTAINER_DOCKERFILE_PATH,
+      replacements: [
+        {
+          pattern: /^(ARG SCC_VERSION=)([^\s]+)(\s*)$/,
+          value: version,
+          label: "#{DEVCONTAINER_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} SCC_VERSION"
+        },
+        {
+          pattern: /^(\s*amd64\) scc_arch="x86_64"; checksum=")([0-9a-f]+)(".*)$/,
+          value: amd64_checksum,
+          label: "#{DEVCONTAINER_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} scc amd64 checksum"
+        },
+        {
+          pattern: /^(\s*arm64\) scc_arch="arm64"; checksum=")([0-9a-f]+)(".*)$/,
+          value: arm64_checksum,
+          label: "#{DEVCONTAINER_DOCKERFILE_PATH.relative_path_from(APP_ROOT)} scc arm64 checksum"
+        }
+      ]
+    }
+  ].each do |entry|
+    updates.concat(replace_in_file(entry.fetch(:path), entry.fetch(:replacements)))
+  rescue StandardError => error
+    failures << "scc (#{entry.fetch(:path).relative_path_from(APP_ROOT)}: #{error.message})"
+  end
+
+  [ updates, failures ]
 end
 
 def update_package_manager(latest_yarn)
@@ -122,8 +357,6 @@ def update_package_manager(latest_yarn)
   PACKAGE_JSON_PATH.write(JSON.pretty_generate(package_json) << "\n")
 end
 
-# Parse yarn.lock to extract package name -> version mappings for direct dependencies.
-# Returns Hash of { "package-name" => "version" }.
 def parse_yarn_lock_versions
   content = YARN_LOCK_PATH.read
   versions = {}
@@ -141,8 +374,6 @@ def parse_yarn_lock_versions
   versions
 end
 
-# Parse Gemfile.lock to extract gem name -> version mappings.
-# Returns Hash of { "gem-name" => "version" }.
 def parse_gemfile_lock_versions
   content = GEMFILE_LOCK_PATH.read
   versions = {}
@@ -161,15 +392,12 @@ def parse_gemfile_lock_versions
   versions
 end
 
-# Check ages of updated packages in a lockfile diff. Takes the before/after
-# versions and a block that fetches the publish time for a given name+version.
-# Returns arrays of [quarantined, checked].
 def check_lockfile_ages(before_versions, after_versions, &fetch_time)
   quarantined = []
   checked = 0
 
   after_versions.each do |name, version|
-    next if before_versions[name] == version # unchanged
+    next if before_versions[name] == version
 
     checked += 1
     published_at = fetch_time.call(name, version)
@@ -181,7 +409,7 @@ def check_lockfile_ages(before_versions, after_versions, &fetch_time)
     end
   end
 
-  [quarantined, checked]
+  [ quarantined, checked ]
 end
 
 if ARGV.any? { |arg| %w[-h --help].include?(arg) }
@@ -190,79 +418,120 @@ if ARGV.any? { |arg| %w[-h --help].include?(arg) }
 end
 
 skip_age_check = ARGV.delete("--skip-age-check") || MIN_PACKAGE_AGE_HOURS.zero?
+update_lockfiles = ARGV.delete("--lockfiles")
+
+if ARGV.any?
+  warn "Unknown arguments: #{ARGV.join(" ")}"
+  usage
+  exit 1
+end
 
 Dir.chdir(APP_ROOT) do
-  # Snapshot lockfile versions before updating so we only age-check changed packages.
-  gem_versions_before = parse_gemfile_lock_versions
-  yarn_versions_before = parse_yarn_lock_versions
+  gem_versions_before = update_lockfiles ? parse_gemfile_lock_versions : {}
+  yarn_versions_before = update_lockfiles ? parse_yarn_lock_versions : {}
 
-  puts "== Updating Ruby gems =="
-  system! "bundle", "update"
+  if update_lockfiles
+    puts "== Updating Ruby gems =="
+    system! "bundle", "update"
 
-  puts "\n== Updating JavaScript packages =="
-  system! "yarn", "upgrade"
-  system! "bin/yarn-postinstall"
-
-  puts "\n== Updating Dockerfile-pinned npm tools =="
-  latest_versions = {}
-  skipped_too_new = []
-
-  DOCKERFILE_NPM_PACKAGES.each do |package_name, _pattern|
-    version, published_at = fetch_npm_version_info(package_name)
-    hours = age_hours(published_at)
-
-    if !skip_age_check && hours < MIN_PACKAGE_AGE_HOURS
-      skipped_too_new << "  #{package_name}@#{version} (#{hours}h old, minimum: #{MIN_PACKAGE_AGE_HOURS}h)"
-      latest_versions[package_name] = nil
-    else
-      latest_versions[package_name] = version
-    end
+    puts "\n== Updating JavaScript packages =="
+    system! "yarn", "upgrade"
+    system! "bin/yarn-postinstall"
+  else
+    puts "== Skipping lockfile updates =="
+    puts "Use --lockfiles to also run bundle/yarn updates."
   end
 
-  # Only update versions that passed the age check (or weren't checked).
-  # nil values mean the package was quarantined — keep the existing version.
-  applicable_versions = latest_versions.compact
-  update_package_manager(applicable_versions.fetch("yarn")) if applicable_versions.key?("yarn")
+  puts "\n== Updating pinned tool binaries =="
+  updates = []
+  failures = []
+  skipped_too_new = []
 
-  updates, failures = update_dockerfile(applicable_versions)
+  yarn_version, yarn_published_at = fetch_npm_version_info("yarn")
+  yarn_hours = age_hours(yarn_published_at)
+  if !skip_age_check && yarn_hours < MIN_PACKAGE_AGE_HOURS
+    skipped_too_new << "  yarn@#{yarn_version} (#{yarn_hours}h old, minimum: #{MIN_PACKAGE_AGE_HOURS}h)"
+  else
+    yarn_updates, yarn_failures = update_yarn(yarn_version)
+    updates.concat(yarn_updates)
+    failures.concat(yarn_failures)
+  end
+
+  BINARY_RELEASES.each_key do |package_name|
+    version, published_at = fetch_binary_version_info(package_name)
+    hours = age_hours(published_at)
+    if !skip_age_check && hours < MIN_PACKAGE_AGE_HOURS
+      skipped_too_new << "  #{package_name}@#{version} (#{hours}h old, minimum: #{MIN_PACKAGE_AGE_HOURS}h)"
+      next
+    end
+
+    binary_updates, binary_failures = case package_name
+    when "ast-grep"
+      update_ast_grep(
+        version,
+        fetch_release_asset_digest(package_name, "app-x86_64-unknown-linux-gnu.zip"),
+        fetch_release_asset_digest(package_name, "app-aarch64-unknown-linux-gnu.zip")
+      )
+    when "scc"
+      update_scc(
+        version,
+        fetch_release_asset_digest(package_name, "scc_Linux_x86_64.tar.gz"),
+        fetch_release_asset_digest(package_name, "scc_Linux_arm64.tar.gz")
+      )
+    else
+      [ [], [] ]
+    end
+
+    updates.concat(binary_updates)
+    failures.concat(binary_failures)
+  rescue StandardError => error
+    failures << "#{package_name} (#{error.message})"
+  end
+
   if updates.empty?
-    puts "No npm-pinned Dockerfile dependencies matched."
+    puts "No pinned tool versions changed."
   else
     updates.each { |update| puts "Updated #{update}" }
   end
 
   failures.each { |failure| warn "Skipped #{failure}" }
 
-  # Age-check updated lockfile packages
   unless skip_age_check
     puts "\n== Checking package ages (quarantine: #{MIN_PACKAGE_AGE_HOURS}h) =="
+    all_quarantined = skipped_too_new.dup
 
-    gem_quarantined, gem_checked = check_lockfile_ages(
-      gem_versions_before, parse_gemfile_lock_versions
-    ) { |name, version| fetch_gem_publish_time(name, version) }
-    puts "  Checked #{gem_checked} updated gem(s)"
+    if update_lockfiles
+      gem_quarantined, gem_checked = check_lockfile_ages(
+        gem_versions_before, parse_gemfile_lock_versions
+      ) { |name, version| fetch_gem_publish_time(name, version) }
+      puts "  Checked #{gem_checked} updated gem(s)"
 
-    yarn_quarantined, yarn_checked = check_lockfile_ages(
-      yarn_versions_before, parse_yarn_lock_versions
-    ) { |name, version| fetch_npm_publish_time(name, version) }
-    puts "  Checked #{yarn_checked} updated npm package(s)"
+      yarn_quarantined, yarn_checked = check_lockfile_ages(
+        yarn_versions_before, parse_yarn_lock_versions
+      ) { |name, version| fetch_npm_publish_time(name, version) }
+      puts "  Checked #{yarn_checked} updated npm package(s)"
 
-    all_quarantined = skipped_too_new + gem_quarantined + yarn_quarantined
+      all_quarantined.concat(gem_quarantined).concat(yarn_quarantined)
+    else
+      puts "  Checked pinned tool binaries only"
+    end
 
     if all_quarantined.any?
       warn "\n⚠ WARNING: #{all_quarantined.size} package(s) are newer than the " \
         "#{MIN_PACKAGE_AGE_HOURS}h quarantine period:"
-      all_quarantined.each { |q| warn q }
-      warn "\nDockerfile-pinned packages were NOT updated to quarantined versions."
-      warn "Lockfile packages (gems/npm) were updated by bundle/yarn — review the diff"
-      warn "carefully before committing, or revert with: git checkout Gemfile.lock yarn.lock"
+      all_quarantined.each { |entry| warn entry }
+      warn "\nPinned tool binaries were NOT updated to quarantined versions."
+      if update_lockfiles
+        warn "Lockfile packages (gems/npm) were updated by bundle/yarn — review the diff"
+        warn "carefully before committing, or revert with: git checkout Gemfile.lock yarn.lock"
+      end
     else
       puts "  All updated packages are older than #{MIN_PACKAGE_AGE_HOURS}h ✓"
     end
   end
 
-  puts "\n== Skipped checksum-pinned Dockerfile installs =="
-  puts "Skipped Node.js, Ruby, ast-grep, and scc because they require checksum-aware release updates."
+  puts "\n== Skipped pinned binary installs =="
+  puts "Skipped Node.js and Ruby because they still require manual checksum-aware release updates."
 
   puts "\n== Update complete =="
 end

--- a/bin/update
+++ b/bin/update
@@ -128,7 +128,7 @@ def replace_version(contents, pattern, new_version)
   [ rewritten, matched, changed ]
 end
 
-def replace_in_file(path, replacements)
+def plan_file_replacements(path, replacements)
   contents = path.read
   applied = []
 
@@ -144,8 +144,32 @@ def replace_in_file(path, replacements)
     applied << replacement.fetch(:label) if changed
   end
 
-  path.write(contents) unless applied.empty?
-  applied
+  {
+    path: path,
+    contents: contents,
+    updates: applied
+  }
+end
+
+def apply_planned_updates(planned_updates)
+  planned_updates.each do |entry|
+    next if entry.fetch(:updates).empty?
+
+    entry.fetch(:path).write(entry.fetch(:contents))
+  end
+end
+
+def plan_package_manager_update(latest_yarn)
+  package_json = JSON.parse(PACKAGE_JSON_PATH.read)
+  updated = "yarn@#{latest_yarn}"
+  current = package_json["packageManager"]
+  package_json["packageManager"] = updated
+
+  {
+    path: PACKAGE_JSON_PATH,
+    contents: JSON.pretty_generate(package_json) << "\n",
+    updates: current == updated ? [] : [ "package.json -> #{updated}" ]
+  }
 end
 
 def usage
@@ -161,36 +185,27 @@ def usage
 end
 
 def update_yarn(version)
-  update_package_manager(version)
-
-  updates = []
-  failures = []
+  planned_updates = [ plan_package_manager_update(version) ]
 
   YARN_PATTERNS.each do |path, pattern|
-    updates.concat(
-      replace_in_file(
-        path,
-        [
-          {
-            pattern: pattern,
-            value: version,
-            label: "#{path.relative_path_from(APP_ROOT)} -> yarn@#{version}"
-          }
-        ]
-      )
+    planned_updates << plan_file_replacements(
+      path,
+      [
+        {
+          pattern: pattern,
+          value: version,
+          label: "#{path.relative_path_from(APP_ROOT)} -> yarn@#{version}"
+        }
+      ]
     )
-  rescue StandardError => error
-    failures << "yarn (#{path.relative_path_from(APP_ROOT)}: #{error.message})"
   end
 
-  [ updates, failures ]
+  apply_planned_updates(planned_updates)
+  planned_updates.flat_map { |entry| entry.fetch(:updates) }
 end
 
 def update_ast_grep(version, amd64_checksum, arm64_checksum)
-  updates = []
-  failures = []
-
-  [
+  planned_updates = [
     {
       path: AGENT_DOCKERFILE_PATH,
       replacements: [
@@ -231,19 +246,14 @@ def update_ast_grep(version, amd64_checksum, arm64_checksum)
         }
       ]
     }
-  ].each do |entry|
-    updates.concat(replace_in_file(entry.fetch(:path), entry.fetch(:replacements)))
-  rescue StandardError => error
-    failures << "ast-grep (#{entry.fetch(:path).relative_path_from(APP_ROOT)}: #{error.message})"
-  end
+  ].map { |entry| plan_file_replacements(entry.fetch(:path), entry.fetch(:replacements)) }
 
-  updates.concat(update_install_ast_grep(version, amd64_checksum, arm64_checksum))
-  [ updates, failures ]
-rescue StandardError => error
-  [ updates, failures + [ "ast-grep (#{error.message})" ] ]
+  planned_updates << plan_install_ast_grep_update(version, amd64_checksum, arm64_checksum)
+  apply_planned_updates(planned_updates)
+  planned_updates.flat_map { |entry| entry.fetch(:updates) }
 end
 
-def update_install_ast_grep(version, amd64_checksum, arm64_checksum)
+def plan_install_ast_grep_update(version, amd64_checksum, arm64_checksum)
   lines = INSTALL_AST_GREP_PATH.readlines
   original = lines.join
   current_version = lines
@@ -286,22 +296,25 @@ def update_install_ast_grep(version, amd64_checksum, arm64_checksum)
   raise "Failed to update arm64 checksum in #{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)}" unless arm64_matched
 
   updated = rewritten.join
-  INSTALL_AST_GREP_PATH.write(updated) unless updated == original
+  updates = if updated == original
+    []
+  else
+    [
+      "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} AST_GREP_VERSION=#{version}",
+      "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} ast-grep amd64 checksum",
+      "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} ast-grep arm64 checksum"
+    ]
+  end
 
-  return [] if updated == original
-
-  [
-    "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} AST_GREP_VERSION=#{version}",
-    "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} ast-grep amd64 checksum",
-    "#{INSTALL_AST_GREP_PATH.relative_path_from(APP_ROOT)} ast-grep arm64 checksum"
-  ]
+  {
+    path: INSTALL_AST_GREP_PATH,
+    contents: updated,
+    updates: updates
+  }
 end
 
 def update_scc(version, amd64_checksum, arm64_checksum)
-  updates = []
-  failures = []
-
-  [
+  planned_updates = [
     {
       path: AGENT_DOCKERFILE_PATH,
       replacements: [
@@ -342,19 +355,10 @@ def update_scc(version, amd64_checksum, arm64_checksum)
         }
       ]
     }
-  ].each do |entry|
-    updates.concat(replace_in_file(entry.fetch(:path), entry.fetch(:replacements)))
-  rescue StandardError => error
-    failures << "scc (#{entry.fetch(:path).relative_path_from(APP_ROOT)}: #{error.message})"
-  end
+  ].map { |entry| plan_file_replacements(entry.fetch(:path), entry.fetch(:replacements)) }
 
-  [ updates, failures ]
-end
-
-def update_package_manager(latest_yarn)
-  package_json = JSON.parse(PACKAGE_JSON_PATH.read)
-  package_json["packageManager"] = "yarn@#{latest_yarn}"
-  PACKAGE_JSON_PATH.write(JSON.pretty_generate(package_json) << "\n")
+  apply_planned_updates(planned_updates)
+  planned_updates.flat_map { |entry| entry.fetch(:updates) }
 end
 
 def parse_yarn_lock_versions
@@ -444,7 +448,6 @@ Dir.chdir(APP_ROOT) do
 
   puts "\n== Updating pinned tool binaries =="
   updates = []
-  failures = []
   skipped_too_new = []
 
   yarn_version, yarn_published_at = fetch_npm_version_info("yarn")
@@ -452,9 +455,11 @@ Dir.chdir(APP_ROOT) do
   if !skip_age_check && yarn_hours < MIN_PACKAGE_AGE_HOURS
     skipped_too_new << "  yarn@#{yarn_version} (#{yarn_hours}h old, minimum: #{MIN_PACKAGE_AGE_HOURS}h)"
   else
-    yarn_updates, yarn_failures = update_yarn(yarn_version)
-    updates.concat(yarn_updates)
-    failures.concat(yarn_failures)
+    begin
+      updates.concat(update_yarn(yarn_version))
+    rescue StandardError => error
+      raise "Failed to update yarn: #{error.message}"
+    end
   end
 
   BINARY_RELEASES.each_key do |package_name|
@@ -465,7 +470,7 @@ Dir.chdir(APP_ROOT) do
       next
     end
 
-    binary_updates, binary_failures = case package_name
+    binary_updates = case package_name
     when "ast-grep"
       update_ast_grep(
         version,
@@ -479,13 +484,12 @@ Dir.chdir(APP_ROOT) do
         fetch_release_asset_digest(package_name, "scc_Linux_arm64.tar.gz")
       )
     else
-      [ [], [] ]
+      []
     end
 
     updates.concat(binary_updates)
-    failures.concat(binary_failures)
   rescue StandardError => error
-    failures << "#{package_name} (#{error.message})"
+    raise "Failed to update #{package_name}: #{error.message}"
   end
 
   if updates.empty?
@@ -493,8 +497,6 @@ Dir.chdir(APP_ROOT) do
   else
     updates.each { |update| puts "Updated #{update}" }
   end
-
-  failures.each { |failure| warn "Skipped #{failure}" }
 
   unless skip_age_check
     puts "\n== Checking package ages (quarantine: #{MIN_PACKAGE_AGE_HOURS}h) =="

--- a/config/initializers/rails_performance.rb
+++ b/config/initializers/rails_performance.rb
@@ -1,10 +1,26 @@
 # frozen_string_literal: true
 
 if defined?(RailsPerformance)
+  redis_url = ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/0")
+  redis_client = Redis.new(url: redis_url)
+  performance_enabled = true
+
+  begin
+    redis_client.ping
+  rescue Redis::CannotConnectError, RedisClient::CannotConnectError, SocketError => error
+    performance_enabled = false
+    Rails.logger.warn(
+      message: "rails_performance.disabled",
+      redis_url: redis_url,
+      error_class: error.class.name,
+      error_message: error.message
+    )
+  end
+
   RailsPerformance.setup do |config|
-    config.redis = Redis.new(url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/0"))
+    config.redis = redis_client
     config.duration = 4.hours
     config.ignored_paths = [ "/rails/performance" ]
-    config.enabled = true
+    config.enabled = performance_enabled
   end
 end

--- a/config/initializers/rails_performance.rb
+++ b/config/initializers/rails_performance.rb
@@ -9,9 +9,11 @@ if defined?(RailsPerformance)
     redis_client.ping
   rescue Redis::CannotConnectError, RedisClient::CannotConnectError, SocketError => error
     performance_enabled = false
+    parsed = URI.parse(redis_url)
     Rails.logger.warn(
       message: "rails_performance.disabled",
-      redis_url: redis_url,
+      redis_host: parsed.host,
+      redis_db: parsed.path,
       error_class: error.class.name,
       error_message: error.message
     )

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -111,11 +111,11 @@ RUN mkdir -p "$COREPACK_HOME" \
 
 # Install ast-grep (AST-based code search/lint)
 # https://github.com/ast-grep/ast-grep/releases
-RUN AST_GREP_VERSION=0.41.0 \
+RUN AST_GREP_VERSION=0.42.1 \
     && DEB_ARCH="$(dpkg --print-architecture)" \
     && case "$DEB_ARCH" in \
-        amd64) RUST_TRIPLE="x86_64-unknown-linux-gnu"; EXPECTED_CHECKSUM="e71afdcbb2e79f7710a56d2f89662bdd0a6e9d639c4abecd5d5f129d80a38bac" ;; \
-        arm64) RUST_TRIPLE="aarch64-unknown-linux-gnu"; EXPECTED_CHECKSUM="6f089d014d5fda8fed2e63e5095acf8ebec4c4cd2e721bd663f2284ace42b623" ;; \
+        amd64) RUST_TRIPLE="x86_64-unknown-linux-gnu"; EXPECTED_CHECKSUM="5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657" ;; \
+        arm64) RUST_TRIPLE="aarch64-unknown-linux-gnu"; EXPECTED_CHECKSUM="3ba383839044cf9817929435f5ce0027f91d06931e8efb32d942e58d73d92be5" ;; \
         *) echo "Unsupported architecture: $DEB_ARCH" >&2; exit 1 ;; \
     esac \
     && ZIPFILE="app-${RUST_TRIPLE}.zip" \
@@ -127,11 +127,11 @@ RUN AST_GREP_VERSION=0.41.0 \
 
 # Install scc (code line counter)
 # https://github.com/boyter/scc/releases
-RUN SCC_VERSION=3.6.0 \
+RUN SCC_VERSION=3.7.0 \
     && DEB_ARCH="$(dpkg --print-architecture)" \
     && case "$DEB_ARCH" in \
-        amd64) SCC_ARCH="x86_64"; EXPECTED_CHECKSUM="da923e0b94c5ce818088ba2e3d1667cdb064b3c684592e3c774c7f97b63194f6" ;; \
-        arm64) SCC_ARCH="arm64"; EXPECTED_CHECKSUM="87fd3f5d4c393c6b665d23bf9b601753b2f6f8a953e6f265d5ea1498195d082f" ;; \
+        amd64) SCC_ARCH="x86_64"; EXPECTED_CHECKSUM="3d9d65b00ca874c2b29151abe7e1480736f5229edc3ce8e4b2791460cdfabf5a" ;; \
+        arm64) SCC_ARCH="arm64"; EXPECTED_CHECKSUM="dcb05c6e993bb2d8d2da4765ff018f2e752325dd205a41698929c55e4123575d" ;; \
         *) echo "Unsupported architecture: $DEB_ARCH" >&2; exit 1 ;; \
     esac \
     && TARBALL="scc_Linux_${SCC_ARCH}.tar.gz" \

--- a/spec/config/rails_performance_initializer_spec.rb
+++ b/spec/config/rails_performance_initializer_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe RailsPerformanceInitializer, :no_db do
     expect(config).to have_received(:enabled=).with(false)
     expect(Rails.logger).to have_received(:warn).with(
       message: "rails_performance.disabled",
-      redis_url: "redis://127.0.0.1:6379/0",
+      redis_host: "127.0.0.1",
+      redis_db: "/0",
       error_class: "Redis::CannotConnectError",
       error_message: "Connection refused"
     )

--- a/spec/config/rails_performance_initializer_spec.rb
+++ b/spec/config/rails_performance_initializer_spec.rb
@@ -8,17 +8,25 @@ unless defined?(RailsPerformanceInitializerConfig)
     attr_writer :redis, :duration, :ignored_paths, :enabled
   end
 end
+unless defined?(RedisClientConnection)
+  RedisClientConnection = Class.new do
+    def ping
+    end
+  end
+end
 
 RSpec.describe RailsPerformanceInitializer, :no_db do
   let(:initializer_path) { Rails.root.join("config/initializers/rails_performance.rb") }
   let(:config) { instance_double(RailsPerformanceInitializerConfig) }
-  let(:redis_client) { Object.new }
+  let(:redis_client) { instance_double(RedisClientConnection) }
   let(:rails_performance_module) do
     Module.new do
       def self.setup
       end
     end
   end
+  let(:redis_error_class) { Class.new(StandardError) }
+  let(:redis_client_error_class) { Class.new(StandardError) }
   let(:redis_class) do
     Class.new do
       def self.new(*)
@@ -29,13 +37,18 @@ RSpec.describe RailsPerformanceInitializer, :no_db do
   before do
     stub_const("RailsPerformance", rails_performance_module)
     stub_const("Redis", redis_class)
+    stub_const("Redis::CannotConnectError", redis_error_class)
+    stub_const("RedisClient", Module.new)
+    stub_const("RedisClient::CannotConnectError", redis_client_error_class)
     allow(RailsPerformance).to receive(:setup).and_yield(config)
     allow(config).to receive(:redis=)
     allow(config).to receive(:duration=)
     allow(config).to receive(:ignored_paths=)
     allow(config).to receive(:enabled=)
     allow(Redis).to receive(:new).and_return(redis_client)
+    allow(redis_client).to receive(:ping).and_return("PONG")
     allow(ENV).to receive(:fetch).and_call_original
+    allow(Rails.logger).to receive(:warn)
   end
 
   it "defaults REDIS_URL for local development when the env var is absent" do
@@ -56,5 +69,21 @@ RSpec.describe RailsPerformanceInitializer, :no_db do
 
     expect(Redis).to have_received(:new).with(url: "redis://example.test:6379/5")
     expect(config).to have_received(:enabled=).with(true)
+  end
+
+  it "disables rails_performance when Redis is unavailable" do
+    allow(ENV).to receive(:fetch).with("REDIS_URL", "redis://127.0.0.1:6379/0").and_return("redis://127.0.0.1:6379/0")
+    allow(redis_client).to receive(:ping).and_raise(Redis::CannotConnectError.new("Connection refused"))
+
+    load initializer_path
+
+    expect(config).to have_received(:redis=).with(redis_client)
+    expect(config).to have_received(:enabled=).with(false)
+    expect(Rails.logger).to have_received(:warn).with(
+      message: "rails_performance.disabled",
+      redis_url: "redis://127.0.0.1:6379/0",
+      error_class: "Redis::CannotConnectError",
+      error_message: "Connection refused"
+    )
   end
 end


### PR DESCRIPTION
## Summary
- make `rails_performance` disable itself instead of crashing requests when Redis is unavailable
- fix the devcontainer rebuild path and keep pinned collector tools in sync across the devcontainer, agent image, and installer script
- tighten `bin/update` so pinned tool binary updates are the default, with lockfile updates as an explicit opt-in

## Testing
- `ruby -c bin/update`
- `sh -n bin/install-ast-grep`
- `shellcheck bin/install-ast-grep`
- `bin/rubocop bin/update config/initializers/rails_performance.rb spec/config/rails_performance_initializer_spec.rb`
- `COVERAGE=false bundle exec rspec spec/config/rails_performance_initializer_spec.rb`
- `bin/update --help`
- `MIN_PACKAGE_AGE_HOURS=0 bin/update`
