### PR TITLE
Fix #1535: Pin exact PostgreSQL client version across all environments to eliminate structure.sql drift

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN set -e; \
   && . /etc/os-release \
   && printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/pgdg.sources \
   && apt-get update -qq \
-  && apt-get install -y build-essential cmake shellcheck tmux libpq-dev postgresql-client-16 \
+  && apt-get install -y build-essential cmake shellcheck tmux libpq-dev postgresql-client-16=16.13-1.pgdg12+1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install chromium separately for better layer caching (updates more frequently)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,47 +51,57 @@ jobs:
 
       - name: Verify Postgres image pins are in sync
         # Keep the Postgres server image pin aligned across compose, devcontainer,
-        # and CI, and ensure installed client tools use the same major version.
+        # and CI, and ensure installed client tools use the exact matching pg_dump version.
         run: |
+          check_contains() {
+            local file="$1"
+            local expected="$2"
+            local message="$3"
+
+            if ! grep -Fq "$expected" "$file"; then
+              echo "::error file=$file::$message"
+              exit 1
+            fi
+          }
+
           dev=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .devcontainer/compose.yaml | head -1 | awk '{print $NF}')
           compose=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' docker-compose.yml | head -1 | awk '{print $NF}')
           ci=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/ci.yml | head -1 | awk '{print $NF}')
           systest=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/system_tests.yml | head -1 | awk '{print $NF}')
-          major=${compose#postgres:}
-          major=${major%%.*}
+          test_prof=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/test_prof.yml | head -1 | awk '{print $NF}')
+          screenshots=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/pr-screenshots.yml | head -1 | awk '{print $NF}')
+          version=${compose#postgres:}
+          major=${version%%.*}
+          bookworm_client="postgresql-client-${major}=${version}-1.pgdg12+1"
+          trixie_client="postgresql-client-${major}=${version}-1.pgdg13+1"
+          noble_client="postgresql-client-${major}=${version}-1.pgdg24.04+1"
+
           echo "devcontainer/compose.yaml:       ${dev:-<none>}"
           echo "docker-compose.yml:              ${compose:-<none>}"
           echo ".github/workflows/ci.yml:        ${ci:-<none>}"
           echo ".github/workflows/system_tests:  ${systest:-<none>}"
-          echo "expected client major:           ${major:-<none>}"
-          if [ -z "$dev" ] || [ -z "$compose" ] || [ -z "$ci" ] || [ -z "$systest" ]; then
+          echo ".github/workflows/test_prof.yml: ${test_prof:-<none>}"
+          echo ".github/workflows/pr-screenshots:${screenshots:-<none>}"
+          echo "expected Bookworm client:        ${bookworm_client}"
+          echo "expected Trixie client:          ${trixie_client}"
+          echo "expected Noble client:           ${noble_client}"
+          if [ -z "$dev" ] || [ -z "$compose" ] || [ -z "$ci" ] || [ -z "$systest" ] || [ -z "$test_prof" ] || [ -z "$screenshots" ]; then
             echo "::error::Postgres image pin missing in one or more files"
             exit 1
           fi
-          if [ "$dev" != "$compose" ] || [ "$compose" != "$ci" ] || [ "$ci" != "$systest" ]; then
-            echo "::error::Postgres image pins are out of sync. Update all four together."
+          if [ "$dev" != "$compose" ] || [ "$compose" != "$ci" ] || [ "$ci" != "$systest" ] || [ "$systest" != "$test_prof" ] || [ "$test_prof" != "$screenshots" ]; then
+            echo "::error::Postgres image pins are out of sync. Update all workflow and compose references together."
             exit 1
           fi
-          if ! grep -q "postgresql-client-${major}" .devcontainer/Dockerfile; then
-            echo "::error::.devcontainer/Dockerfile is not pinned to postgresql-client-${major}"
-            exit 1
-          fi
-          if ! grep -q "postgresql-client-${major}" Dockerfile; then
-            echo "::error::Dockerfile is not pinned to postgresql-client-${major}"
-            exit 1
-          fi
-          if ! grep -q "postgresql-client-${major}" docker/agent/Dockerfile; then
-            echo "::error::docker/agent/Dockerfile is not pinned to postgresql-client-${major}"
-            exit 1
-          fi
-          if ! grep -q "postgresql-client-${major}" .github/workflows/ci.yml; then
-            echo "::error::.github/workflows/ci.yml is not pinned to postgresql-client-${major}"
-            exit 1
-          fi
-          if ! grep -q "postgresql-client-${major}" .github/workflows/system_tests.yml; then
-            echo "::error::.github/workflows/system_tests.yml is not pinned to postgresql-client-${major}"
-            exit 1
-          fi
+          check_contains .devcontainer/Dockerfile "$bookworm_client" ".devcontainer/Dockerfile is not pinned to $bookworm_client"
+          check_contains Dockerfile "$trixie_client" "Dockerfile is not pinned to $trixie_client"
+          check_contains docker/agent/Dockerfile "$noble_client" "docker/agent/Dockerfile is not pinned to $noble_client"
+          check_contains docker/agent/Dockerfile "apt.postgresql.org/pub/repos/apt" "docker/agent/Dockerfile must install from PGDG"
+          check_contains Dockerfile "apt.postgresql.org/pub/repos/apt" "Dockerfile must install from PGDG"
+          check_contains .github/workflows/ci.yml "$noble_client" ".github/workflows/ci.yml is not pinned to $noble_client"
+          check_contains .github/workflows/system_tests.yml "$noble_client" ".github/workflows/system_tests.yml is not pinned to $noble_client"
+          check_contains .github/workflows/test_prof.yml "$noble_client" ".github/workflows/test_prof.yml is not pinned to $noble_client"
+          check_contains .github/workflows/pr-screenshots.yml "$noble_client" ".github/workflows/pr-screenshots.yml is not pinned to $noble_client"
 
   test:
     runs-on: ubuntu-latest
@@ -148,7 +158,13 @@ jobs:
         run: bin/install-ast-grep
 
       - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc >/dev/null
+          . /etc/os-release
+          printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/pgdg.sources >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-16=16.13-1.pgdg24.04+1
 
       - name: Build assets
         run: yarn build && yarn build:css
@@ -237,7 +253,13 @@ jobs:
         run: yarn install --frozen-lockfile && bin/yarn-postinstall
 
       - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc >/dev/null
+          . /etc/os-release
+          printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/pgdg.sources >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-16=16.13-1.pgdg24.04+1
 
       - name: Set up database
         run: bin/rails db:prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           check_contains .github/workflows/pr-screenshots.yml "$noble_client" ".github/workflows/pr-screenshots.yml is not pinned to $noble_client"
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
@@ -202,7 +202,7 @@ jobs:
         run: bundle exec fasterer
 
   performance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     services:
       postgres:

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -70,7 +70,7 @@ jobs:
   capture:
     needs: detect
     if: needs.detect.outputs.has_ui_changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -120,7 +120,13 @@ jobs:
         run: yarn install --frozen-lockfile && bin/yarn-postinstall
 
       - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc >/dev/null
+          . /etc/os-release
+          printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/pgdg.sources >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-16=16.13-1.pgdg24.04+1
 
       - name: Create application database role
         env:

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   system:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     services:

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -64,7 +64,13 @@ jobs:
         run: yarn install --frozen-lockfile && bin/yarn-postinstall
 
       - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc >/dev/null
+          . /etc/os-release
+          printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/pgdg.sources >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-16=16.13-1.pgdg24.04+1
 
       - name: Locate Chromium-family browser
         # Prefer a preinstalled browser when one exists, but don't fail the

--- a/.github/workflows/test_prof.yml
+++ b/.github/workflows/test_prof.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   profile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     services:

--- a/.github/workflows/test_prof.yml
+++ b/.github/workflows/test_prof.yml
@@ -70,7 +70,13 @@ jobs:
         run: yarn install --frozen-lockfile && bin/yarn-postinstall
 
       - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client-16
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc >/dev/null
+          . /etc/os-release
+          printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/pgdg.sources >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-16=16.13-1.pgdg24.04+1
 
       - name: Set up database
         run: bin/rails db:prepare

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,18 @@ FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 # Rails app lives here
 WORKDIR /rails
 
+ARG PGDG_POSTGRESQL_CLIENT_16_VERSION=16.13-1.pgdg13+1
+
 # Install base packages
-# Keep client tools on the same Postgres major as the pinned server image.
+# Keep client tools on the exact Postgres version shipped by the pinned server image.
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 postgresql-client-16 && \
+    apt-get install --no-install-recommends -y ca-certificates curl gnupg libjemalloc2 && \
+    install -d /usr/share/postgresql-common/pgdg && \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc && \
+    . /etc/os-release && \
+    printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/pgdg.sources && \
+    apt-get update -qq && \
+    apt-get install --no-install-recommends -y "postgresql-client-16=${PGDG_POSTGRESQL_CLIENT_16_VERSION}" && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 # Rails app lives here
 WORKDIR /rails
 
-ARG PGDG_POSTGRESQL_CLIENT_16_VERSION=16.13-1.pgdg13+1
+ARG PGDG_POSTGRESQL_CLIENT_16_PACKAGE=postgresql-client-16=16.13-1.pgdg13+1
 
 # Install base packages
 # Keep client tools on the exact Postgres version shipped by the pinned server image.
@@ -25,7 +25,7 @@ RUN apt-get update -qq && \
     . /etc/os-release && \
     printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/pgdg.sources && \
     apt-get update -qq && \
-    apt-get install --no-install-recommends -y "postgresql-client-16=${PGDG_POSTGRESQL_CLIENT_16_VERSION}" && \
+    apt-get install --no-install-recommends -y "${PGDG_POSTGRESQL_CLIENT_16_PACKAGE}" && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -38,8 +38,15 @@ RUN NODE_VERSION=22.13.0 \
     && tar -xzf "${TARBALL}" -C /usr/local --strip-components=1 \
     && rm "${TARBALL}"
 
+# Install the PGDG apt repository so Ubuntu Noble can install the same pg_dump
+# minor version as the pinned Postgres server image.
+RUN install -d /usr/share/postgresql-common/pgdg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+    && . /etc/os-release \
+    && printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/pgdg.sources
+
 # Install Ruby build dependencies, runtime deps, Python, PostgreSQL client libs, and ShellCheck
-# Keep client tools on the same Postgres major as the pinned server image.
+# Keep client tools on the exact Postgres version shipped by the pinned server image.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
     bison \
@@ -50,7 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libffi-dev \
     libgdbm-dev \
     libpq-dev \
-    postgresql-client-16 \
+    postgresql-client-16=16.13-1.pgdg24.04+1 \
     rustc \
     shellcheck \
     python3 \


### PR DESCRIPTION
## Summary

Pinned `postgresql-client-16` to exact PGDG package versions across the devcontainer, agent image, production image, and CI workflows, and tightened the CI sync check so it verifies exact client package strings plus PGDG usage rather than just Postgres major version. I also updated the other workflows that install the client (`test_prof` and `pr-screenshots`) so they don’t drift from the main CI path.

Validation passed: `bundle install`, `yarn install`, `bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec`. `db:prepare` needed the provided PostgreSQL service exported as `DB_HOST=paid-svc-a3-s1-postgres DB_PORT=5432 DB_USERNAME=agent DB_PASSWORD=agent` in this environment. The commit is `1de89a5` with message `fix(postgres): pin exact client version across environments`. The worktree is clean.

---

Closes #1535