### PR TITLE
fix(auto-pick): recover orphaned in_progress issues with no active run

### DIFF
--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -40,6 +40,12 @@ class StaleRunDetectorJob < ApplicationJob
   # PR scanning indefinitely if the pause is never acted on.
   PAUSED_TIMEOUT = AgentRun.stale_paused_timeout
 
+  # Issues with paid_state=in_progress are only eligible for recovery once
+  # they've been orphaned for at least this long. Avoids racing with run
+  # creation (create_agent_run_activity sets in_progress then enqueues the
+  # workflow, which may take a few seconds to produce a visible AgentRun).
+  ORPHANED_IN_PROGRESS_AGE = 15.minutes
+
   # Maximum times a stale claimed run can be automatically unclaimed before
   # being timed out. Prevents infinite retry loops when the underlying
   # issue is persistent (e.g. misconfigured project, missing credentials).
@@ -55,6 +61,7 @@ class StaleRunDetectorJob < ApplicationJob
     unclaimed = 0
     requeued = 0
     skipped = 0
+    recovered_orphans = 0
 
     stale_running_runs(running_threshold).find_each do |agent_run|
       resolved += 1 if resolve_stale_run(agent_run)
@@ -100,6 +107,8 @@ class StaleRunDetectorJob < ApplicationJob
       )
     end
 
+    recovered_orphans = recover_orphaned_in_progress_issues
+
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - job_started_at) * 1000).round
     Rails.logger.info(
       message: "stale_run_detector.completed",
@@ -107,15 +116,57 @@ class StaleRunDetectorJob < ApplicationJob
       unclaimed: unclaimed,
       requeued: requeued,
       skipped: skipped,
+      recovered_orphans: recovered_orphans,
       duration_ms: duration_ms
     )
 
-    ProcessRunQueueJob.perform_later if resolved > 0 || unclaimed > 0 || requeued > 0
+    ProcessRunQueueJob.perform_later if resolved > 0 || unclaimed > 0 || requeued > 0 || recovered_orphans > 0
   end
 
   private
 
-  # Uses the default timeout rather than per-user maximums. Individual run
+  # Finds issues stuck in paid_state=in_progress that have no active agent
+  # run. This can happen when a Temporal workflow crashes before reaching a
+  # terminal activity, or when an agent run is deleted without updating the
+  # associated issue. Without recovery these issues are invisible to auto-pick
+  # (which skips in_progress) and invisible to all other cleanup jobs (which
+  # operate top-down from AgentRun records).
+  def recover_orphaned_in_progress_issues
+    active_issue_ids = AgentRun.where(status: AgentRun::UNFINISHED_STATUSES)
+      .where.not(issue_id: nil)
+      .select(:issue_id)
+
+    orphans = Issue.where(paid_state: "in_progress")
+      .where.not(id: active_issue_ids)
+      .where("updated_at < ?", ORPHANED_IN_PROGRESS_AGE.ago)
+
+    count = 0
+    orphans.find_each do |issue|
+      issue.with_lock do
+        issue.reload
+        next unless issue.paid_state == "in_progress"
+        next if AgentRun.where(issue: issue, status: AgentRun::UNFINISHED_STATUSES).exists?
+
+        issue.update!(paid_state: "new")
+        count += 1
+        Rails.logger.info(
+          message: "stale_run_detector.recovered_orphaned_in_progress",
+          issue_id: issue.id,
+          issue_number: issue.github_number,
+          project_id: issue.project_id
+        )
+      end
+    rescue => e
+      Rails.logger.error(
+        message: "stale_run_detector.recover_orphan_failed",
+        issue_id: issue.id,
+        error: e.message
+      )
+    end
+    count
+  end
+
+  # Uses the default timeout rather than per-project maximums. Individual run
   # timeouts are enforced by the Temporal workflow; this job is a safety net
   # for orphaned runs where the workflow died. Using UserSetting.maximum
   # would let a single user's large timeout delay stale-run detection for

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -136,7 +136,7 @@ class StaleRunDetectorJob < ApplicationJob
       .where.not(issue_id: nil)
       .select(:issue_id)
 
-    orphans = Issue.where(paid_state: "in_progress")
+    orphans = Issue.where(paid_state: "in_progress", is_pull_request: false)
       .where.not(id: active_issue_ids)
       .where("updated_at < ?", ORPHANED_IN_PROGRESS_AGE.ago)
 

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -166,7 +166,7 @@ class StaleRunDetectorJob < ApplicationJob
     count
   end
 
-  # Uses the default timeout rather than per-project maximums. Individual run
+  # Uses the default timeout rather than per-user maximums. Individual run
   # timeouts are enforced by the Temporal workflow; this job is a safety net
   # for orphaned runs where the workflow died. Using UserSetting.maximum
   # would let a single user's large timeout delay stale-run detection for

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -144,8 +144,7 @@ class StaleRunDetectorJob < ApplicationJob
     orphans.find_each do |issue|
       issue.with_lock do
         issue.reload
-        next unless issue.paid_state == "in_progress"
-        next if AgentRun.where(issue: issue, status: AgentRun::UNFINISHED_STATUSES).exists?
+        next unless recoverable_orphaned_issue?(issue)
 
         issue.update!(paid_state: "new")
         count += 1
@@ -164,6 +163,32 @@ class StaleRunDetectorJob < ApplicationJob
       )
     end
     count
+  end
+
+  def recoverable_orphaned_issue?(issue)
+    return false unless issue.paid_state == "in_progress"
+    return false if AgentRun.where(issue: issue, status: AgentRun::UNFINISHED_STATUSES).exists?
+    return false if orphaned_enhance_issue_recheck?(issue)
+
+    true
+  end
+
+  # FetchIssuesActivity intentionally moves a needs_input issue to
+  # in_progress before QueueAgentRunActivity persists the follow-up
+  # enhance_issue run. If that workflow dies in between, the issue is
+  # orphaned but still semantically belongs to the enhance_issue path.
+  # Resetting it to "new" would let normal auto-pick queue create_pr
+  # instead of the intended enhancement rerun.
+  def orphaned_enhance_issue_recheck?(issue)
+    return false if issue.enhance_issue_rounds.zero?
+    return false if issue.has_label?(issue.project.enhance_issue_needs_input_label_name)
+    return false if issue.has_label?(issue.project.enhance_issue_enhanced_label_name)
+
+    latest_goal_for(issue) == "enhance_issue"
+  end
+
+  def latest_goal_for(issue)
+    issue.agent_runs.order(created_at: :desc, id: :desc).limit(1).pick(:goal)
   end
 
   # Uses the default timeout rather than per-user maximums. Individual run

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -528,6 +528,34 @@ RSpec.describe StaleRunDetectorJob do
         expect(issue.reload.paid_state).to eq("in_progress")
       end
 
+      it "does not reset an orphaned enhance_issue recheck before its run is queued" do
+        issue = create(:issue,
+          project: project,
+          paid_state: "in_progress",
+          enhance_issue_rounds: 1,
+          labels: [],
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+        create(:agent_run, :completed, :enhance_issue_goal, project: project, issue: issue, pull_request_number: nil)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "still resets a non-enhancement orphan with prior enhance_issue history" do
+        issue = create(:issue,
+          project: project,
+          paid_state: "in_progress",
+          enhance_issue_rounds: 1,
+          labels: [ project.enhance_issue_enhanced_label_name ],
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+        create(:agent_run, :completed, :enhance_issue_goal, project: project, issue: issue, pull_request_number: nil)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("new")
+      end
+
       it "does not reset an issue whose paid_state changed before lock acquisition" do
         issue = create(:issue, project: project, paid_state: "in_progress",
           updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -562,6 +562,15 @@ RSpec.describe StaleRunDetectorJob do
         expect(issue.reload.paid_state).to eq("in_progress")
       end
 
+      it "does not reset an in_progress pull request with no active run" do
+        pull_request = create(:issue, :pull_request, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        described_class.perform_now
+
+        expect(pull_request.reload.paid_state).to eq("in_progress")
+      end
+
       it "enqueues ProcessRunQueueJob after recovering orphans" do
         create(:issue, project: project, paid_state: "in_progress",
           updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -505,5 +505,71 @@ RSpec.describe StaleRunDetectorJob do
         expect(stale_run.stale_requeue_count).to eq(1)
       end
     end
+
+    context "with orphaned in_progress issues" do
+      let(:project) { create(:project) }
+
+      it "resets an orphaned in_progress issue to new when no active run exists" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("new")
+      end
+
+      it "does not reset an in_progress issue that has an active run" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+        create(:agent_run, :running, project: project, issue: issue)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "does not reset an issue whose paid_state changed before lock acquisition" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        issue.update_column(:paid_state, "completed")
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("completed")
+      end
+
+      it "does not reset an issue that gets a new run between query and lock" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        allow(AgentRun).to receive(:where).and_call_original
+        allow(AgentRun).to receive(:where).with(
+          hash_including(issue: issue)
+        ).and_return(double(exists?: true))
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "does not reset a recently updated in_progress issue" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: 1.minute.ago)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "enqueues ProcessRunQueueJob after recovering orphans" do
+        create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        expect(ProcessRunQueueJob).to receive(:perform_later).and_call_original
+
+        described_class.perform_now
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds `recover_orphaned_in_progress_issues` to `StaleRunDetectorJob` to auto-heal issues stuck at `paid_state=in_progress` with no active agent run
- Uses row-level lock + reload + re-check (consistent with `resolve_stale_run` / `requeue_stale_unfinished_run`) to prevent TOCTOU races
- 15-minute age threshold avoids racing with `CreateAgentRunActivity`'s `paid_state` transition
- Resets orphans to `new` and triggers `ProcessRunQueueJob` to immediately re-seed the queue

## Problem

Issues with `paid_state=in_progress` but no active agent run are invisible to auto-pick (which skips `in_progress`) and invisible to all cleanup jobs (which operate top-down from `AgentRun` records). This can happen when a Temporal workflow crashes before reaching a terminal activity, or when an agent run is deleted without updating the associated issue. These issues remain stuck permanently without manual intervention.

## Test plan

- 6 new specs covering: happy path recovery, active-run guard, age threshold, paid_state change guard, TOCTOU race guard, and ProcessRunQueueJob enqueue
- All 44 existing + new specs passing
- Lint clean