### PR TITLE
feat(scaling): Phase 3.6 — Auto-Scaling Preparation

### DIFF
--- a/app/services/scaling/orchestrators/docker_swarm_adapter.rb
+++ b/app/services/scaling/orchestrators/docker_swarm_adapter.rb
@@ -61,8 +61,10 @@ module Scaling
       end
 
       def healthy?
-        output = run_command("docker", "info", "--format", "{{json .Swarm.LocalNodeState}}")
-        JSON.parse(output) == "active"
+        output = run_command("docker", "info", "--format", "{{json .Swarm}}")
+        swarm = JSON.parse(output, symbolize_names: true)
+
+        swarm[:LocalNodeState] == "active" && swarm[:ControlAvailable] == true
       rescue StandardError
         false
       end

--- a/app/services/scaling/orchestrators/docker_swarm_adapter.rb
+++ b/app/services/scaling/orchestrators/docker_swarm_adapter.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module Scaling
+  module Orchestrators
+    # Docker Swarm adapter for the scaling orchestrator interface.
+    #
+    # Uses the Docker CLI against a Swarm manager to inspect, scale, and
+    # update services. This keeps the integration lightweight while matching
+    # the development-friendly command-based approach used by
+    # {DockerComposeAdapter}.
+    class DockerSwarmAdapter
+      include Scaling::Orchestrator
+
+      class CommandError < OrchestratorError; end
+
+      def current_status(service:)
+        payload = inspect_service(service)
+        desired = payload.dig(:Spec, :Mode, :Replicated, :Replicas) || 0
+        running = payload.dig(:ServiceStatus, :RunningTasks) || 0
+
+        Data::ServiceStatus.new(
+          service: service,
+          current_replicas: running,
+          desired_replicas: desired,
+          available_replicas: running,
+          cpu_usage: nil,
+          memory_usage: nil,
+          ready: desired.positive? && running >= desired
+        )
+      end
+
+      def scale(service:, desired_replicas:)
+        previous = current_status(service: service).desired_replicas
+        run_command("docker", "service", "scale", "#{service}=#{desired_replicas}")
+
+        Data::ScaleResult.new(
+          service: service,
+          previous_replicas: previous,
+          desired_replicas: desired_replicas,
+          accepted: true,
+          message: "Service #{service} scaled to #{desired_replicas} via docker swarm"
+        )
+      end
+
+      def set_resource_limits(service:, cpu_limit: nil, memory_limit: nil)
+        args = [ "docker", "service", "update" ]
+        args.push("--limit-cpu", cpu_limit) if cpu_limit
+        args.push("--limit-memory", memory_limit) if memory_limit
+        args.push(service)
+        run_command(*args)
+
+        Data::ResourceUpdateResult.new(
+          service: service,
+          cpu_limit: cpu_limit,
+          memory_limit: memory_limit,
+          accepted: true,
+          message: "Resource limits updated for #{service}"
+        )
+      end
+
+      def healthy?
+        output = run_command("docker", "info", "--format", "{{json .Swarm.LocalNodeState}}")
+        JSON.parse(output) == "active"
+      rescue StandardError
+        false
+      end
+
+      private
+
+      def inspect_service(service)
+        output = run_command("docker", "service", "inspect", service, "--format", "{{json .}}")
+        JSON.parse(output, symbolize_names: true)
+      rescue JSON::ParserError => e
+        raise CommandError, "Invalid docker service inspect output: #{e.message}"
+      end
+
+      def run_command(*cmd)
+        stdout, stderr, status = Open3.capture3(*cmd)
+        return stdout if status.success?
+
+        raise CommandError, "Command failed (exit #{status.exitstatus}): #{stderr.presence || stdout}"
+      end
+    end
+  end
+end

--- a/app/services/scaling/orchestrators/docker_swarm_adapter.rb
+++ b/app/services/scaling/orchestrators/docker_swarm_adapter.rb
@@ -46,8 +46,8 @@ module Scaling
 
       def set_resource_limits(service:, cpu_limit: nil, memory_limit: nil)
         args = [ "docker", "service", "update" ]
-        args.push("--limit-cpu", cpu_limit) if cpu_limit
-        args.push("--limit-memory", memory_limit) if memory_limit
+        args.push("--limit-cpu", normalize_cpu_limit(cpu_limit)) if cpu_limit
+        args.push("--limit-memory", normalize_memory_limit(memory_limit)) if memory_limit
         args.push(service)
         run_command(*args)
 
@@ -107,6 +107,44 @@ module Scaling
         return stdout if status.success?
 
         raise CommandError, "Command failed (exit #{status.exitstatus}): #{stderr.presence || stdout}"
+      end
+
+      def normalize_cpu_limit(value)
+        string = value.to_s.strip
+        raise CommandError, "Invalid docker swarm cpu_limit: #{value.inspect}" if string.blank?
+
+        return format_decimal(string.delete_suffix("m").to_f / 1000) if string.end_with?("m") && numeric?(string.delete_suffix("m"))
+        return format_decimal(string.to_f) if numeric?(string)
+
+        raise CommandError, "Invalid docker swarm cpu_limit: #{value.inspect}"
+      end
+
+      def normalize_memory_limit(value)
+        string = value.to_s.strip
+        raise CommandError, "Invalid docker swarm memory_limit: #{value.inspect}" if string.blank?
+
+        match = string.match(/\A(?<amount>\d+(?:\.\d+)?)(?<unit>ki|mi|gi|ti|k|m|g|t)?\z/i)
+        raise CommandError, "Invalid docker swarm memory_limit: #{value.inspect}" unless match
+
+        amount = format_decimal(match[:amount].to_f)
+        unit = case match[:unit]&.downcase
+        when "ki" then "k"
+        when "mi" then "m"
+        when "gi" then "g"
+        when "ti" then "t"
+        else
+          match[:unit].to_s.downcase
+        end
+
+        "#{amount}#{unit}"
+      end
+
+      def numeric?(value)
+        value.match?(/\A\d+(?:\.\d+)?\z/)
+      end
+
+      def format_decimal(value)
+        value.to_s.sub(/\.0+\z/, "").sub(/(\.\d*?)0+\z/, '\1')
       end
     end
   end

--- a/app/services/scaling/orchestrators/docker_swarm_adapter.rb
+++ b/app/services/scaling/orchestrators/docker_swarm_adapter.rb
@@ -65,6 +65,8 @@ module Scaling
         swarm = JSON.parse(output, symbolize_names: true)
 
         swarm[:LocalNodeState] == "active" && swarm[:ControlAvailable] == true
+      rescue JSON::ParserError
+        false
       rescue StandardError
         false
       end

--- a/app/services/scaling/orchestrators/docker_swarm_adapter.rb
+++ b/app/services/scaling/orchestrators/docker_swarm_adapter.rb
@@ -18,7 +18,7 @@ module Scaling
       def current_status(service:)
         payload = inspect_service(service)
         desired = payload.dig(:Spec, :Mode, :Replicated, :Replicas) || 0
-        running = payload.dig(:ServiceStatus, :RunningTasks) || 0
+        running = running_task_count(service)
 
         Data::ServiceStatus.new(
           service: service,
@@ -76,6 +76,28 @@ module Scaling
         JSON.parse(output, symbolize_names: true)
       rescue JSON::ParserError => e
         raise CommandError, "Invalid docker service inspect output: #{e.message}"
+      end
+
+      def running_task_count(service)
+        output = run_command(
+          "docker", "service", "ps", service,
+          "--filter", "desired-state=running",
+          "--format", "{{json .}}"
+        )
+
+        parse_service_tasks(output).count { |task| task[:CurrentState].to_s.start_with?("Running") }
+      end
+
+      def parse_service_tasks(output)
+        return [] if output.blank?
+
+        output.lines.filter_map do |line|
+          next if line.blank?
+
+          JSON.parse(line, symbolize_names: true)
+        rescue JSON::ParserError => e
+          raise CommandError, "Invalid docker service ps output: #{e.message}"
+        end
       end
 
       def run_command(*cmd)

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -237,10 +237,12 @@ module Scaling
           primary[:rolloutState].to_s.casecmp("COMPLETED").zero?
       end
 
+      # Converts shared-contract cpu_limit values to ECS CPU units.
+      # The contract defines "500m" as 500 millicores and "2" as 2 CPUs.
+      # ECS uses 1024 units per vCPU, so "2" becomes 2048.
       def ecs_cpu_units(value)
         string = value.to_s.strip
         return (string.delete_suffix("m").to_f / 1000 * 1024).round if string.end_with?("m")
-        return string.to_i if string.match?(/\A\d+\z/)
 
         (string.to_f * 1024).round
       end

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -69,6 +69,8 @@ module Scaling
         service_data = describe_service(service)
         task_definition = describe_task_definition(service_data.fetch(:taskDefinition))
         container_definitions = updated_container_definitions(service, task_definition[:containerDefinitions], cpu_limit, memory_limit)
+        return no_op_resource_update(service, cpu_limit, memory_limit) if container_definitions == task_definition[:containerDefinitions]
+
         registration = register_task_definition(task_definition, container_definitions)
 
         run_aws("ecs", "update-service",
@@ -154,6 +156,16 @@ module Scaling
         parse_json(
           run_aws("ecs", "register-task-definition",
             "--cli-input-json", JSON.generate(payload))
+        )
+      end
+
+      def no_op_resource_update(service, cpu_limit, memory_limit)
+        Data::ResourceUpdateResult.new(
+          service: service,
+          cpu_limit: cpu_limit,
+          memory_limit: memory_limit,
+          accepted: true,
+          message: "Resource limits already match the requested ECS service configuration"
         )
       end
 

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -267,6 +267,7 @@ module Scaling
         cmd = [ "aws" ]
         cmd.push("--region", region) if region.present?
         cmd.push("--profile", profile) if profile.present?
+        cmd.push("--output", "json")
         cmd.concat(args)
 
         stdout, stderr, status = Open3.capture3(*cmd)

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -221,7 +221,8 @@ module Scaling
         step = config.fetch(:step)
         minimum = [ required_memory, memory_range.begin ].max
 
-        memory_range.begin + (((minimum - memory_range.begin).to_f / step).ceil * step)
+        aligned = memory_range.begin + (((minimum - memory_range.begin).to_f / step).ceil * step)
+        [ aligned, memory_range.end ].min
       end
 
       def service_ready?(service)

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -14,6 +14,9 @@ module Scaling
 
       class ApiError < OrchestratorError; end
 
+      CPU_LIMIT_PATTERN = /\A\d+(?:\.\d+)?m?\z/.freeze
+      MEMORY_LIMIT_PATTERN = /\A\d+(?:\.\d+)?(?:mi|gi|m|g)?\z/i.freeze
+
       FARGATE_TASK_SIZES = {
         256 => { memory_range: 512..2048, step: 512 },
         512 => { memory_range: 1024..4096, step: 1024 },
@@ -242,6 +245,8 @@ module Scaling
       # ECS uses 1024 units per vCPU, so "2" becomes 2048.
       def ecs_cpu_units(value)
         string = value.to_s.strip
+        raise ApiError, "Invalid ECS cpu_limit: #{value.inspect}" if string.blank? || !string.match?(CPU_LIMIT_PATTERN)
+
         return (string.delete_suffix("m").to_f / 1000 * 1024).round if string.end_with?("m")
 
         (string.to_f * 1024).round
@@ -249,6 +254,8 @@ module Scaling
 
       def ecs_memory_mib(value)
         string = value.to_s.strip.downcase
+        raise ApiError, "Invalid ECS memory_limit: #{value.inspect}" if string.blank? || !string.match?(MEMORY_LIMIT_PATTERN)
+
         return string.delete_suffix("mi").to_i if string.end_with?("mi")
         return (string.delete_suffix("gi").to_f * 1024).round if string.end_with?("gi")
         return string.delete_suffix("m").to_i if string.end_with?("m")

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -183,8 +183,8 @@ module Scaling
       end
 
       def updated_task_resources(task_definition, container_definitions)
-        required_cpu = container_definitions.sum { |definition| definition[:cpu].to_i if definition[:cpu] }.to_i
-        required_memory = container_definitions.sum { |definition| definition[:memory].to_i if definition[:memory] }.to_i
+        required_cpu = container_definitions.sum { |definition| definition[:cpu].to_i }
+        required_memory = container_definitions.sum { |definition| definition[:memory].to_i }
         current_cpu = task_definition[:cpu].to_i
         current_memory = task_definition[:memory].to_i
 

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -70,11 +70,12 @@ module Scaling
 
       def set_resource_limits(service:, cpu_limit: nil, memory_limit: nil)
         service_data = describe_service(service)
-        task_definition = describe_task_definition(service_data.fetch(:taskDefinition))
+        task_definition_data = describe_task_definition(service_data.fetch(:taskDefinition))
+        task_definition = task_definition_data.fetch(:task_definition)
         container_definitions = updated_container_definitions(service, task_definition[:containerDefinitions], cpu_limit, memory_limit)
         return no_op_resource_update(service, cpu_limit, memory_limit) if container_definitions == task_definition[:containerDefinitions]
 
-        registration = register_task_definition(task_definition, container_definitions)
+        registration = register_task_definition(task_definition, container_definitions, task_definition_data[:tags])
 
         run_aws("ecs", "update-service",
           "--cluster", cluster,
@@ -116,10 +117,14 @@ module Scaling
       def describe_task_definition(task_definition_arn)
         response = parse_json(
           run_aws("ecs", "describe-task-definition",
-            "--task-definition", task_definition_arn)
+            "--task-definition", task_definition_arn,
+            "--include", "TAGS")
         )
 
-        response.fetch(:taskDefinition)
+        {
+          task_definition: response.fetch(:taskDefinition),
+          tags: response[:tags]
+        }
       end
 
       def updated_container_definitions(service, definitions, cpu_limit, memory_limit)
@@ -135,7 +140,7 @@ module Scaling
         end
       end
 
-      def register_task_definition(task_definition, container_definitions)
+      def register_task_definition(task_definition, container_definitions, tags)
         task_resources = updated_task_resources(task_definition, container_definitions)
         payload = {
           family: task_definition[:family],
@@ -153,7 +158,8 @@ module Scaling
           ipcMode: task_definition[:ipcMode],
           proxyConfiguration: task_definition[:proxyConfiguration],
           inferenceAccelerators: task_definition[:inferenceAccelerators],
-          ephemeralStorage: task_definition[:ephemeralStorage]
+          ephemeralStorage: task_definition[:ephemeralStorage],
+          tags: tags
         }.compact
 
         parse_json(

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -240,6 +240,7 @@ module Scaling
       def ecs_cpu_units(value)
         string = value.to_s.strip
         return (string.delete_suffix("m").to_f / 1000 * 1024).round if string.end_with?("m")
+        return string.to_i if string.match?(/\A\d+\z/)
 
         (string.to_f * 1024).round
       end

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -14,10 +14,21 @@ module Scaling
 
       class ApiError < OrchestratorError; end
 
-      attr_reader :cluster, :region, :profile
+      FARGATE_TASK_SIZES = {
+        256 => { memory_range: 512..2048, step: 512 },
+        512 => { memory_range: 1024..4096, step: 1024 },
+        1024 => { memory_range: 2048..8192, step: 1024 },
+        2048 => { memory_range: 4096..16384, step: 1024 },
+        4096 => { memory_range: 8192..30720, step: 1024 },
+        8192 => { memory_range: 16384..61440, step: 4096 },
+        16384 => { memory_range: 32768..122880, step: 8192 }
+      }.freeze
 
-      def initialize(cluster: "default", region: nil, profile: nil, **)
+      attr_reader :cluster, :container_name, :region, :profile
+
+      def initialize(cluster: "default", container_name: nil, region: nil, profile: nil, **)
         @cluster = cluster
+        @container_name = container_name
         @region = region
         @profile = profile
       end
@@ -107,8 +118,7 @@ module Scaling
       end
 
       def updated_container_definitions(service, definitions, cpu_limit, memory_limit)
-        target_name = definitions.any? { |definition| definition[:name] == service } ? service : definitions.first&.fetch(:name)
-        raise ApiError, "task definition has no container definitions" unless target_name
+        target_name = resolve_target_container_name(service, definitions)
 
         definitions.map do |definition|
           next definition unless definition[:name] == target_name
@@ -121,6 +131,7 @@ module Scaling
       end
 
       def register_task_definition(task_definition, container_definitions)
+        task_resources = updated_task_resources(task_definition, container_definitions)
         payload = {
           family: task_definition[:family],
           taskRoleArn: task_definition[:taskRoleArn],
@@ -130,8 +141,8 @@ module Scaling
           volumes: task_definition[:volumes],
           placementConstraints: task_definition[:placementConstraints],
           requiresCompatibilities: task_definition[:requiresCompatibilities],
-          cpu: task_definition[:cpu],
-          memory: task_definition[:memory],
+          cpu: task_resources[:cpu],
+          memory: task_resources[:memory],
           runtimePlatform: task_definition[:runtimePlatform],
           pidMode: task_definition[:pidMode],
           ipcMode: task_definition[:ipcMode],
@@ -144,6 +155,61 @@ module Scaling
           run_aws("ecs", "register-task-definition",
             "--cli-input-json", JSON.generate(payload))
         )
+      end
+
+      def resolve_target_container_name(service, definitions)
+        raise ApiError, "task definition has no container definitions" if definitions.blank?
+
+        target_name = container_name || service
+        return target_name if definitions.any? { |definition| definition[:name] == target_name }
+
+        raise ApiError,
+          "task definition does not contain container #{target_name.inspect}; configure container_name when the ECS service name differs"
+      end
+
+      def updated_task_resources(task_definition, container_definitions)
+        required_cpu = container_definitions.sum { |definition| definition[:cpu].to_i if definition[:cpu] }.to_i
+        required_memory = container_definitions.sum { |definition| definition[:memory].to_i if definition[:memory] }.to_i
+        current_cpu = task_definition[:cpu].to_i
+        current_memory = task_definition[:memory].to_i
+
+        required_cpu = [ required_cpu, current_cpu ].max
+        required_memory = [ required_memory, current_memory ].max
+
+        if Array(task_definition[:requiresCompatibilities]).include?("FARGATE")
+          fargate_task_resources(required_cpu, required_memory)
+        else
+          {
+            cpu: task_definition[:cpu].present? ? required_cpu.to_s : nil,
+            memory: task_definition[:memory].present? ? required_memory.to_s : nil
+          }
+        end
+      end
+
+      def fargate_task_resources(required_cpu, required_memory)
+        cpu, config = FARGATE_TASK_SIZES.find do |candidate_cpu, candidate_config|
+          next false if candidate_cpu < required_cpu
+
+          memory_range = candidate_config.fetch(:memory_range)
+          next false if required_memory > memory_range.end
+
+          aligned_fargate_memory(required_memory, candidate_config).between?(memory_range.begin, memory_range.end)
+        end
+
+        raise ApiError, "requested CPU/memory exceeds supported ECS Fargate task sizes" unless cpu && config
+
+        {
+          cpu: cpu.to_s,
+          memory: aligned_fargate_memory(required_memory, config).to_s
+        }
+      end
+
+      def aligned_fargate_memory(required_memory, config)
+        memory_range = config.fetch(:memory_range)
+        step = config.fetch(:step)
+        minimum = [ required_memory, memory_range.begin ].max
+
+        memory_range.begin + (((minimum - memory_range.begin).to_f / step).ceil * step)
       end
 
       def service_ready?(service)

--- a/app/services/scaling/orchestrators/ecs_adapter.rb
+++ b/app/services/scaling/orchestrators/ecs_adapter.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module Scaling
+  module Orchestrators
+    # Amazon ECS adapter for the scaling orchestrator interface.
+    #
+    # Integrates with ECS through the AWS CLI so operators can wire the
+    # scaling system into existing ECS deployments without adding another SDK
+    # dependency to the app.
+    class EcsAdapter
+      include Scaling::Orchestrator
+
+      class ApiError < OrchestratorError; end
+
+      attr_reader :cluster, :region, :profile
+
+      def initialize(cluster: "default", region: nil, profile: nil, **)
+        @cluster = cluster
+        @region = region
+        @profile = profile
+      end
+
+      def current_status(service:)
+        svc = describe_service(service)
+        desired = svc[:desiredCount] || 0
+        running = svc[:runningCount] || 0
+
+        Data::ServiceStatus.new(
+          service: service,
+          current_replicas: running,
+          desired_replicas: desired,
+          available_replicas: running,
+          cpu_usage: nil,
+          memory_usage: nil,
+          ready: service_ready?(svc)
+        )
+      end
+
+      def scale(service:, desired_replicas:)
+        previous = describe_service(service)[:desiredCount] || 0
+        run_aws("ecs", "update-service",
+          "--cluster", cluster,
+          "--service", service,
+          "--desired-count", desired_replicas.to_s)
+
+        Data::ScaleResult.new(
+          service: service,
+          previous_replicas: previous,
+          desired_replicas: desired_replicas,
+          accepted: true,
+          message: "ECS service #{service} updated to desired count #{desired_replicas}"
+        )
+      end
+
+      def set_resource_limits(service:, cpu_limit: nil, memory_limit: nil)
+        service_data = describe_service(service)
+        task_definition = describe_task_definition(service_data.fetch(:taskDefinition))
+        container_definitions = updated_container_definitions(service, task_definition[:containerDefinitions], cpu_limit, memory_limit)
+        registration = register_task_definition(task_definition, container_definitions)
+
+        run_aws("ecs", "update-service",
+          "--cluster", cluster,
+          "--service", service,
+          "--task-definition", registration.dig(:taskDefinition, :taskDefinitionArn),
+          "--force-new-deployment")
+
+        Data::ResourceUpdateResult.new(
+          service: service,
+          cpu_limit: cpu_limit,
+          memory_limit: memory_limit,
+          accepted: true,
+          message: "Resource limits updated for ECS service #{service}"
+        )
+      end
+
+      def healthy?
+        run_aws("ecs", "list-services", "--cluster", cluster, "--max-items", "1")
+        true
+      rescue StandardError
+        false
+      end
+
+      private
+
+      def describe_service(service)
+        response = parse_json(
+          run_aws("ecs", "describe-services",
+            "--cluster", cluster,
+            "--services", service)
+        )
+
+        failure = response.fetch(:failures, []).first
+        raise ApiError, failure[:reason] || "service #{service} not found" if failure
+
+        response.fetch(:services, []).first || raise(ApiError, "service #{service} not found")
+      end
+
+      def describe_task_definition(task_definition_arn)
+        response = parse_json(
+          run_aws("ecs", "describe-task-definition",
+            "--task-definition", task_definition_arn)
+        )
+
+        response.fetch(:taskDefinition)
+      end
+
+      def updated_container_definitions(service, definitions, cpu_limit, memory_limit)
+        target_name = definitions.any? { |definition| definition[:name] == service } ? service : definitions.first&.fetch(:name)
+        raise ApiError, "task definition has no container definitions" unless target_name
+
+        definitions.map do |definition|
+          next definition unless definition[:name] == target_name
+
+          definition.merge(
+            cpu: cpu_limit ? ecs_cpu_units(cpu_limit) : definition[:cpu],
+            memory: memory_limit ? ecs_memory_mib(memory_limit) : definition[:memory]
+          )
+        end
+      end
+
+      def register_task_definition(task_definition, container_definitions)
+        payload = {
+          family: task_definition[:family],
+          taskRoleArn: task_definition[:taskRoleArn],
+          executionRoleArn: task_definition[:executionRoleArn],
+          networkMode: task_definition[:networkMode],
+          containerDefinitions: container_definitions,
+          volumes: task_definition[:volumes],
+          placementConstraints: task_definition[:placementConstraints],
+          requiresCompatibilities: task_definition[:requiresCompatibilities],
+          cpu: task_definition[:cpu],
+          memory: task_definition[:memory],
+          runtimePlatform: task_definition[:runtimePlatform],
+          pidMode: task_definition[:pidMode],
+          ipcMode: task_definition[:ipcMode],
+          proxyConfiguration: task_definition[:proxyConfiguration],
+          inferenceAccelerators: task_definition[:inferenceAccelerators],
+          ephemeralStorage: task_definition[:ephemeralStorage]
+        }.compact
+
+        parse_json(
+          run_aws("ecs", "register-task-definition",
+            "--cli-input-json", JSON.generate(payload))
+        )
+      end
+
+      def service_ready?(service)
+        desired = service[:desiredCount] || 0
+        running = service[:runningCount] || 0
+        primary = Array(service[:deployments]).find { |deployment| deployment[:status] == "PRIMARY" }
+
+        desired.positive? &&
+          running >= desired &&
+          primary &&
+          primary[:runningCount].to_i >= desired &&
+          primary[:rolloutState].to_s.casecmp("COMPLETED").zero?
+      end
+
+      def ecs_cpu_units(value)
+        string = value.to_s.strip
+        return (string.delete_suffix("m").to_f / 1000 * 1024).round if string.end_with?("m")
+
+        (string.to_f * 1024).round
+      end
+
+      def ecs_memory_mib(value)
+        string = value.to_s.strip.downcase
+        return string.delete_suffix("mi").to_i if string.end_with?("mi")
+        return (string.delete_suffix("gi").to_f * 1024).round if string.end_with?("gi")
+        return string.delete_suffix("m").to_i if string.end_with?("m")
+        return (string.delete_suffix("g").to_f * 1024).round if string.end_with?("g")
+
+        string.to_i
+      end
+
+      def parse_json(payload)
+        JSON.parse(payload, symbolize_names: true)
+      rescue JSON::ParserError => e
+        raise ApiError, "Invalid AWS CLI JSON output: #{e.message}"
+      end
+
+      def run_aws(*args)
+        cmd = [ "aws" ]
+        cmd.push("--region", region) if region.present?
+        cmd.push("--profile", profile) if profile.present?
+        cmd.concat(args)
+
+        stdout, stderr, status = Open3.capture3(*cmd)
+        return stdout if status.success?
+
+        raise ApiError, stderr.presence || stdout.presence || "AWS CLI command failed"
+      end
+    end
+  end
+end

--- a/config/initializers/scaling_orchestrators.rb
+++ b/config/initializers/scaling_orchestrators.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  resolver = Scaling::Orchestrators::Resolver
+
+  {
+    kubernetes: Scaling::Orchestrators::KubernetesAdapter,
+    docker_compose: Scaling::Orchestrators::DockerComposeAdapter,
+    docker_swarm: Scaling::Orchestrators::DockerSwarmAdapter,
+    ecs: Scaling::Orchestrators::EcsAdapter
+  }.each do |type, adapter_class|
+    resolver.register(type, ->(config) { adapter_class.new(**config) })
+  end
+end

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -544,7 +544,7 @@ Deliverables:
 
 **Objective**: Lay groundwork for automatic worker scaling.
 
-**Status**: Complete — `Scaling::WorkerPoolAdvisor` implements hybrid reactive/predictive algorithm with cost caps and cooldown. `Scaling::QueueMonitor` + `QueueMonitorJob` track GoodJob, Temporal, and agent-run queues. `Scaling::Orchestrator` interface with `KubernetesAdapter` and `DockerComposeAdapter`. Scaling documentation in `docs/SCALING.md`, `docs/runbooks/scaling.md`, and `docs/rdrs/RDR-024`.
+**Status**: Complete — `Scaling::WorkerPoolAdvisor` implements hybrid reactive/predictive algorithm with cost caps and cooldown. `Scaling::QueueMonitor` + `QueueMonitorJob` track GoodJob, Temporal, and agent-run queues. `Scaling::Orchestrator` now exposes concrete adapters for Kubernetes, Docker Swarm, ECS, and Docker Compose. Scaling documentation in `docs/SCALING.md`, `docs/runbooks/scaling.md`, and `docs/rdrs/RDR-024`.
 
 Tasks:
 

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -6,6 +6,18 @@ operational procedures for running Paid in production at various scales.
 For worker-specific tuning details, see [WORKER_POOL_TUNING.md](WORKER_POOL_TUNING.md).
 For monitoring and alerting, see [OBSERVABILITY.md](OBSERVABILITY.md).
 
+## Orchestrator Integrations
+
+Paid's scaling decision layer is infrastructure-agnostic. `Scaling::Orchestrator`
+adapters translate those decisions into platform-specific actions:
+
+| Adapter | Primary target | Notes |
+|---------|----------------|-------|
+| `Scaling::Orchestrators::KubernetesAdapter` | Kubernetes Deployments | Direct replica scaling plus resource-limit patching |
+| `Scaling::Orchestrators::DockerSwarmAdapter` | Docker Swarm services | Uses `docker service` CLI commands against a Swarm manager |
+| `Scaling::Orchestrators::EcsAdapter` | Amazon ECS services | Uses the AWS CLI to scale services and roll task-definition revisions |
+| `Scaling::Orchestrators::DockerComposeAdapter` | Local/dev Docker Compose | Development and CI fallback, not a production auto-scaling target |
+
 ## Architecture Overview
 
 Paid has four independently scalable process types:

--- a/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb
@@ -55,12 +55,20 @@ RSpec.describe Scaling::Orchestrators::DockerSwarmAdapter do
   end
 
   describe "#healthy?" do
-    it "returns true when the node is an active swarm manager/worker" do
+    it "returns true when the node is an active swarm manager" do
       allow(adapter).to receive(:run_command)
-        .with("docker", "info", "--format", "{{json .Swarm.LocalNodeState}}")
-        .and_return('"active"' "\n")
+        .with("docker", "info", "--format", "{{json .Swarm}}")
+        .and_return({ LocalNodeState: "active", ControlAvailable: true }.to_json)
 
       expect(adapter.healthy?).to be true
+    end
+
+    it "returns false when the node is a swarm worker" do
+      allow(adapter).to receive(:run_command)
+        .with("docker", "info", "--format", "{{json .Swarm}}")
+        .and_return({ LocalNodeState: "active", ControlAvailable: false }.to_json)
+
+      expect(adapter.healthy?).to be false
     end
 
     it "returns false when docker info fails" do

--- a/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb
@@ -74,15 +74,21 @@ RSpec.describe Scaling::Orchestrators::DockerSwarmAdapter do
   end
 
   describe "#set_resource_limits" do
-    it "updates service limits" do
+    it "normalizes shared orchestrator resource strings for docker swarm" do
       expect(adapter).to receive(:run_command)
-        .with("docker", "service", "update", "--limit-cpu", "2", "--limit-memory", "1g", "agent-worker")
+        .with("docker", "service", "update", "--limit-cpu", "0.5", "--limit-memory", "512m", "agent-worker")
         .and_return("updated")
 
-      result = adapter.set_resource_limits(service: "agent-worker", cpu_limit: "2", memory_limit: "1g")
+      result = adapter.set_resource_limits(service: "agent-worker", cpu_limit: "500m", memory_limit: "512Mi")
 
       expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
       expect(result.accepted).to be true
+    end
+
+    it "raises a clear adapter error for invalid resource strings" do
+      expect do
+        adapter.set_resource_limits(service: "agent-worker", cpu_limit: "half", memory_limit: "512Mi")
+      end.to raise_error(described_class::CommandError, /cpu_limit/)
     end
   end
 

--- a/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb
@@ -6,13 +6,22 @@ RSpec.describe Scaling::Orchestrators::DockerSwarmAdapter do
   let(:adapter) { described_class.new }
 
   describe "#current_status" do
-    it "returns a ServiceStatus from docker service inspect output" do
+    it "returns a ServiceStatus from docker service inspect and task output" do
       inspect_output = {
-        Spec: { Mode: { Replicated: { Replicas: 3 } } },
-        ServiceStatus: { RunningTasks: 2 }
+        Spec: { Mode: { Replicated: { Replicas: 3 } } }
       }.to_json
+      tasks_output = <<~JSONL
+        {"ID":"1","CurrentState":"Running 2 minutes ago"}
+        {"ID":"2","CurrentState":"Running 30 seconds ago"}
+        {"ID":"3","CurrentState":"Pending 5 seconds ago"}
+      JSONL
 
-      allow(adapter).to receive(:run_command).and_return(inspect_output)
+      expect(adapter).to receive(:run_command)
+        .with("docker", "service", "inspect", "agent-worker", "--format", "{{json .}}")
+        .and_return(inspect_output)
+      expect(adapter).to receive(:run_command)
+        .with("docker", "service", "ps", "agent-worker", "--filter", "desired-state=running", "--format", "{{json .}}")
+        .and_return(tasks_output)
 
       status = adapter.current_status(service: "agent-worker")
 
@@ -20,6 +29,29 @@ RSpec.describe Scaling::Orchestrators::DockerSwarmAdapter do
       expect(status.current_replicas).to eq(2)
       expect(status.desired_replicas).to eq(3)
       expect(status.ready).to be false
+    end
+
+    it "does not rely on ServiceStatus being present in inspect output" do
+      inspect_output = {
+        Spec: { Mode: { Replicated: { Replicas: 2 } } }
+      }.to_json
+      tasks_output = <<~JSONL
+        {"ID":"1","CurrentState":"Running 2 minutes ago"}
+        {"ID":"2","CurrentState":"Running 30 seconds ago"}
+      JSONL
+
+      expect(adapter).to receive(:run_command)
+        .with("docker", "service", "inspect", "agent-worker", "--format", "{{json .}}")
+        .and_return(inspect_output)
+      expect(adapter).to receive(:run_command)
+        .with("docker", "service", "ps", "agent-worker", "--filter", "desired-state=running", "--format", "{{json .}}")
+        .and_return(tasks_output)
+
+      status = adapter.current_status(service: "agent-worker")
+
+      expect(status.current_replicas).to eq(2)
+      expect(status.desired_replicas).to eq(2)
+      expect(status.ready).to be true
     end
   end
 

--- a/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Scaling::Orchestrators::DockerSwarmAdapter do
+  let(:adapter) { described_class.new }
+
+  describe "#current_status" do
+    it "returns a ServiceStatus from docker service inspect output" do
+      inspect_output = {
+        Spec: { Mode: { Replicated: { Replicas: 3 } } },
+        ServiceStatus: { RunningTasks: 2 }
+      }.to_json
+
+      allow(adapter).to receive(:run_command).and_return(inspect_output)
+
+      status = adapter.current_status(service: "agent-worker")
+
+      expect(status).to be_a(Scaling::Orchestrators::Data::ServiceStatus)
+      expect(status.current_replicas).to eq(2)
+      expect(status.desired_replicas).to eq(3)
+      expect(status.ready).to be false
+    end
+  end
+
+  describe "#scale" do
+    it "calls docker service scale and returns a ScaleResult" do
+      allow(adapter).to receive(:current_status)
+        .with(service: "agent-worker")
+        .and_return(double(desired_replicas: 2))
+      expect(adapter).to receive(:run_command)
+        .with("docker", "service", "scale", "agent-worker=5")
+        .and_return("agent-worker scaled")
+
+      result = adapter.scale(service: "agent-worker", desired_replicas: 5)
+
+      expect(result).to be_a(Scaling::Orchestrators::Data::ScaleResult)
+      expect(result.previous_replicas).to eq(2)
+      expect(result.desired_replicas).to eq(5)
+      expect(result.accepted).to be true
+    end
+  end
+
+  describe "#set_resource_limits" do
+    it "updates service limits" do
+      expect(adapter).to receive(:run_command)
+        .with("docker", "service", "update", "--limit-cpu", "2", "--limit-memory", "1g", "agent-worker")
+        .and_return("updated")
+
+      result = adapter.set_resource_limits(service: "agent-worker", cpu_limit: "2", memory_limit: "1g")
+
+      expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
+      expect(result.accepted).to be true
+    end
+  end
+
+  describe "#healthy?" do
+    it "returns true when the node is an active swarm manager/worker" do
+      allow(adapter).to receive(:run_command)
+        .with("docker", "info", "--format", "{{json .Swarm.LocalNodeState}}")
+        .and_return('"active"' "\n")
+
+      expect(adapter.healthy?).to be true
+    end
+
+    it "returns false when docker info fails" do
+      allow(adapter).to receive(:run_command).and_raise(described_class::CommandError, "unavailable")
+
+      expect(adapter.healthy?).to be false
+    end
+  end
+end

--- a/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Scaling::Orchestrators::EcsAdapter do
+  let(:adapter) { described_class.new(cluster: "paid-prod", region: "us-east-1") }
+  let(:service_name) { "agent-worker" }
+
+  def expect_service_description(payload)
+    allow(adapter).to receive(:run_aws).with(
+      "ecs", "describe-services",
+      "--cluster", "paid-prod",
+      "--services", service_name
+    ).and_return(payload.to_json)
+  end
+
+  describe "#current_status" do
+    let(:ready_service_payload) do
+      {
+        services: [
+          {
+            desiredCount: 4,
+            runningCount: 4,
+            deployments: [
+              { status: "PRIMARY", runningCount: 4, rolloutState: "COMPLETED" }
+            ]
+          }
+        ],
+        failures: []
+      }
+    end
+
+    it "returns a ServiceStatus from ECS service data" do
+      expect_service_description(ready_service_payload)
+
+      status = adapter.current_status(service: service_name)
+
+      expect(status).to be_a(Scaling::Orchestrators::Data::ServiceStatus)
+      expect(status.current_replicas).to eq(4)
+      expect(status.desired_replicas).to eq(4)
+      expect(status.ready).to be true
+    end
+
+    it "raises ApiError when ECS reports a failure" do
+      expect_service_description(services: [], failures: [ { arn: "arn", reason: "MISSING" } ])
+
+      expect { adapter.current_status(service: service_name) }
+        .to raise_error(described_class::ApiError, /MISSING/)
+    end
+  end
+
+  describe "#scale" do
+    it "updates the ECS desired count" do
+      allow(adapter).to receive(:describe_service).with(service_name).and_return({ desiredCount: 2 })
+      expect(adapter).to receive(:run_aws).with(
+        "ecs", "update-service",
+        "--cluster", "paid-prod",
+        "--service", service_name,
+        "--desired-count", "6"
+      ).and_return({ service: { desiredCount: 6 } }.to_json)
+
+      result = adapter.scale(service: service_name, desired_replicas: 6)
+
+      expect(result).to be_a(Scaling::Orchestrators::Data::ScaleResult)
+      expect(result.previous_replicas).to eq(2)
+      expect(result.desired_replicas).to eq(6)
+      expect(result.accepted).to be true
+    end
+  end
+
+  describe "#set_resource_limits" do
+    let(:task_definition) do
+      {
+        family: service_name,
+        taskDefinitionArn: "arn:aws:ecs:task-definition/agent-worker:7",
+        networkMode: "awsvpc",
+        containerDefinitions: [
+          { name: service_name, cpu: 256, memory: 512, essential: true }
+        ],
+        requiresCompatibilities: [ "FARGATE" ],
+        cpu: "512",
+        memory: "1024"
+      }
+    end
+    let(:next_task_definition_arn) { "arn:aws:ecs:task-definition/agent-worker:8" }
+
+    def expect_task_definition_registration
+      expect(adapter).to receive(:run_aws).with(
+        "ecs", "register-task-definition",
+        "--cli-input-json", kind_of(String)
+      ) do |*args|
+        payload = JSON.parse(args.last, symbolize_names: true)
+        container = payload.fetch(:containerDefinitions).first
+        expect(container[:cpu]).to eq(512)
+        expect(container[:memory]).to eq(2048)
+
+        { taskDefinition: { taskDefinitionArn: next_task_definition_arn } }.to_json
+      end
+    end
+
+    it "registers a new task definition revision and forces a deployment" do
+      allow(adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
+      allow(adapter).to receive(:describe_task_definition)
+        .with(task_definition[:taskDefinitionArn])
+        .and_return(task_definition)
+      expect_task_definition_registration
+
+      expect(adapter).to receive(:run_aws).with(
+        "ecs", "update-service",
+        "--cluster", "paid-prod",
+        "--service", service_name,
+        "--task-definition", next_task_definition_arn,
+        "--force-new-deployment"
+      ).and_return({ service: { taskDefinition: next_task_definition_arn } }.to_json)
+
+      result = adapter.set_resource_limits(service: service_name, cpu_limit: "500m", memory_limit: "2Gi")
+
+      expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
+      expect(result.accepted).to be true
+    end
+  end
+
+  describe "#healthy?" do
+    it "returns true when the AWS CLI can list ECS services" do
+      allow(adapter).to receive(:run_aws).with(
+        "ecs", "list-services",
+        "--cluster", "paid-prod",
+        "--max-items", "1"
+      ).and_return({ serviceArns: [] }.to_json)
+
+      expect(adapter.healthy?).to be true
+    end
+
+    it "returns false when the AWS CLI call fails" do
+      allow(adapter).to receive(:run_aws).and_raise(described_class::ApiError, "auth failed")
+
+      expect(adapter.healthy?).to be false
+    end
+  end
+end

--- a/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
@@ -262,6 +262,36 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
       expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
       expect(result.accepted).to be true
     end
+
+    it "raises for invalid cpu_limit strings" do
+      allow(adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
+      allow(adapter).to receive(:describe_task_definition)
+        .with(task_definition[:taskDefinitionArn])
+        .and_return(task_definition)
+      expect(adapter).not_to receive(:register_task_definition)
+      expect(adapter).not_to receive(:run_aws).with("ecs", "update-service", any_args)
+
+      expect do
+        adapter.set_resource_limits(service: service_name, cpu_limit: "half", memory_limit: "2Gi")
+      end.to raise_error(described_class::ApiError, /cpu_limit/)
+    end
+
+    it "raises for invalid memory_limit strings" do
+      allow(adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
+      allow(adapter).to receive(:describe_task_definition)
+        .with(task_definition[:taskDefinitionArn])
+        .and_return(task_definition)
+      expect(adapter).not_to receive(:register_task_definition)
+      expect(adapter).not_to receive(:run_aws).with("ecs", "update-service", any_args)
+
+      expect do
+        adapter.set_resource_limits(service: service_name, cpu_limit: "500m", memory_limit: "bogus")
+      end.to raise_error(described_class::ApiError, /memory_limit/)
+    end
   end
 
   describe "#healthy?" do

--- a/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
     ).and_return(payload.to_json)
   end
 
+  def described_task_definition(task_definition, tags: nil)
+    { task_definition:, tags: }
+  end
+
   describe "#current_status" do
     let(:ready_service_payload) do
       {
@@ -85,7 +89,8 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
     let(:next_task_definition_arn) { "arn:aws:ecs:task-definition/agent-worker:8" }
 
     def expect_task_definition_registration(expected_cpu: "512", expected_memory: "2048",
-                                              expected_container_cpu: 512, expected_container_memory: 2048)
+                                              expected_container_cpu: 512, expected_container_memory: 2048,
+                                              expected_tags: nil)
       expect(adapter).to receive(:run_aws).with(
         "ecs", "register-task-definition",
         "--cli-input-json", kind_of(String)
@@ -96,6 +101,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         expect(container[:memory]).to eq(expected_container_memory)
         expect(payload[:cpu]).to eq(expected_cpu)
         expect(payload[:memory]).to eq(expected_memory)
+        expect(payload[:tags]).to eq(expected_tags) if expected_tags
 
         { taskDefinition: { taskDefinitionArn: next_task_definition_arn } }.to_json
       end
@@ -125,7 +131,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         .and_return({ taskDefinition: task_definition_arn })
       allow(named_adapter).to receive(:describe_task_definition)
         .with(task_definition_arn)
-        .and_return(task_definition)
+        .and_return(described_task_definition(task_definition))
     end
 
     def expect_named_adapter_service_update(named_adapter)
@@ -144,7 +150,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
       allow(adapter).to receive(:describe_task_definition)
         .with(task_definition[:taskDefinitionArn])
-        .and_return(task_definition)
+        .and_return(described_task_definition(task_definition))
       expect_task_definition_registration
 
       expect(adapter).to receive(:run_aws).with(
@@ -167,7 +173,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
       allow(adapter).to receive(:describe_task_definition)
         .with(task_definition[:taskDefinitionArn])
-        .and_return(task_definition)
+        .and_return(described_task_definition(task_definition))
       expect_task_definition_registration(expected_cpu: "2048", expected_memory: "4096",
                                           expected_container_cpu: 2048)
       expect(adapter).to receive(:run_aws).with(
@@ -190,7 +196,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
       allow(adapter).to receive(:describe_task_definition)
         .with(task_definition[:taskDefinitionArn])
-        .and_return(task_definition)
+        .and_return(described_task_definition(task_definition))
       expect_task_definition_registration(expected_cpu: "512")
 
       expect(adapter).to receive(:run_aws).with(
@@ -213,7 +219,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
       allow(adapter).to receive(:describe_task_definition)
         .with(task_definition[:taskDefinitionArn])
-        .and_return(task_definition)
+        .and_return(described_task_definition(task_definition))
       expect(adapter).not_to receive(:register_task_definition)
       expect(adapter).not_to receive(:run_aws)
 
@@ -237,7 +243,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
       allow(adapter).to receive(:describe_task_definition)
         .with(task_definition[:taskDefinitionArn])
-        .and_return(mismatched_task_definition)
+        .and_return(described_task_definition(mismatched_task_definition))
 
       expect do
         adapter.set_resource_limits(service: service_name, cpu_limit: "500m", memory_limit: "2Gi")
@@ -269,7 +275,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
       allow(adapter).to receive(:describe_task_definition)
         .with(task_definition[:taskDefinitionArn])
-        .and_return(task_definition)
+        .and_return(described_task_definition(task_definition))
       expect(adapter).not_to receive(:register_task_definition)
       expect(adapter).not_to receive(:run_aws).with("ecs", "update-service", any_args)
 
@@ -284,13 +290,39 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
       allow(adapter).to receive(:describe_task_definition)
         .with(task_definition[:taskDefinitionArn])
-        .and_return(task_definition)
+        .and_return(described_task_definition(task_definition))
       expect(adapter).not_to receive(:register_task_definition)
       expect(adapter).not_to receive(:run_aws).with("ecs", "update-service", any_args)
 
       expect do
         adapter.set_resource_limits(service: service_name, cpu_limit: "500m", memory_limit: "bogus")
       end.to raise_error(described_class::ApiError, /memory_limit/)
+    end
+
+    it "preserves task definition tags when registering a replacement revision" do
+      tags = [
+        { key: "owner", value: "platform" },
+        { key: "cost-center", value: "infra" }
+      ]
+
+      allow(adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
+      allow(adapter).to receive(:describe_task_definition)
+        .with(task_definition[:taskDefinitionArn])
+        .and_return(described_task_definition(task_definition, tags:))
+      expect_task_definition_registration(expected_tags: tags)
+      expect(adapter).to receive(:run_aws).with(
+        "ecs", "update-service",
+        "--cluster", "paid-prod",
+        "--service", service_name,
+        "--task-definition", next_task_definition_arn,
+        "--force-new-deployment"
+      ).and_return({ service: { taskDefinition: next_task_definition_arn } }.to_json)
+
+      result = adapter.set_resource_limits(service: service_name, cpu_limit: "500m", memory_limit: "2Gi")
+
+      expect(result.accepted).to be true
     end
   end
 
@@ -318,6 +350,26 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         "ecs", "list-services",
         "--cluster", "paid-prod",
         "--max-items", "1"
+      )
+    end
+
+    it "includes tags when describing task definitions" do
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture3).and_return([
+        { taskDefinition: { family: service_name }, tags: [] }.to_json,
+        "",
+        status
+      ])
+
+      adapter.send(:describe_task_definition, "arn:aws:ecs:task-definition/agent-worker:7")
+
+      expect(Open3).to have_received(:capture3).with(
+        "aws",
+        "--region", "us-east-1",
+        "--output", "json",
+        "ecs", "describe-task-definition",
+        "--task-definition", "arn:aws:ecs:task-definition/agent-worker:7",
+        "--include", "TAGS"
       )
     end
 

--- a/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
@@ -160,6 +160,23 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
       expect(result.accepted).to be true
     end
 
+    it "short-circuits when the requested limits already match the target container" do
+      allow(adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
+      allow(adapter).to receive(:describe_task_definition)
+        .with(task_definition[:taskDefinitionArn])
+        .and_return(task_definition)
+      expect(adapter).not_to receive(:register_task_definition)
+      expect(adapter).not_to receive(:run_aws)
+
+      result = adapter.set_resource_limits(service: service_name, cpu_limit: "250m", memory_limit: "512Mi")
+
+      expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
+      expect(result.accepted).to be true
+      expect(result.message).to match(/already match/)
+    end
+
     it "raises when the ECS service name does not match a container definition" do
       mismatched_task_definition = task_definition.merge(
         containerDefinitions: [

--- a/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
@@ -84,15 +84,16 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
     end
     let(:next_task_definition_arn) { "arn:aws:ecs:task-definition/agent-worker:8" }
 
-    def expect_task_definition_registration(expected_cpu: "512", expected_memory: "2048")
+    def expect_task_definition_registration(expected_cpu: "512", expected_memory: "2048",
+                                              expected_container_cpu: 512, expected_container_memory: 2048)
       expect(adapter).to receive(:run_aws).with(
         "ecs", "register-task-definition",
         "--cli-input-json", kind_of(String)
       ) do |*args|
         payload = JSON.parse(args.last, symbolize_names: true)
         container = payload.fetch(:containerDefinitions).first
-        expect(container[:cpu]).to eq(512)
-        expect(container[:memory]).to eq(2048)
+        expect(container[:cpu]).to eq(expected_container_cpu)
+        expect(container[:memory]).to eq(expected_container_memory)
         expect(payload[:cpu]).to eq(expected_cpu)
         expect(payload[:memory]).to eq(expected_memory)
 
@@ -160,15 +161,15 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
       expect(result.accepted).to be true
     end
 
-    it "preserves raw ECS CPU-unit inputs when updating container resources" do
+    it "treats bare integer cpu_limit as CPU cores per the shared contract" do
       allow(adapter).to receive(:describe_service)
         .with(service_name)
         .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
       allow(adapter).to receive(:describe_task_definition)
         .with(task_definition[:taskDefinitionArn])
         .and_return(task_definition)
-      expect_task_definition_registration(expected_cpu: "512")
-
+      expect_task_definition_registration(expected_cpu: "2048", expected_memory: "4096",
+                                          expected_container_cpu: 2048)
       expect(adapter).to receive(:run_aws).with(
         "ecs", "update-service",
         "--cluster", "paid-prod",
@@ -177,7 +178,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         "--force-new-deployment"
       ).and_return({ service: { taskDefinition: next_task_definition_arn } }.to_json)
 
-      result = adapter.set_resource_limits(service: service_name, cpu_limit: "512", memory_limit: "2Gi")
+      result = adapter.set_resource_limits(service: service_name, cpu_limit: "2", memory_limit: "2Gi")
 
       expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
       expect(result.accepted).to be true

--- a/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
@@ -275,6 +275,22 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
       expect(adapter.healthy?).to be true
     end
 
+    it "forces JSON output for CLI calls" do
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture3).and_return([ "{}", "", status ])
+
+      adapter.send(:run_aws, "ecs", "list-services", "--cluster", "paid-prod", "--max-items", "1")
+
+      expect(Open3).to have_received(:capture3).with(
+        "aws",
+        "--region", "us-east-1",
+        "--output", "json",
+        "ecs", "list-services",
+        "--cluster", "paid-prod",
+        "--max-items", "1"
+      )
+    end
+
     it "returns false when the AWS CLI call fails" do
       allow(adapter).to receive(:run_aws).and_raise(described_class::ApiError, "auth failed")
 

--- a/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
@@ -160,6 +160,52 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
       expect(result.accepted).to be true
     end
 
+    it "preserves raw ECS CPU-unit inputs when updating container resources" do
+      allow(adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
+      allow(adapter).to receive(:describe_task_definition)
+        .with(task_definition[:taskDefinitionArn])
+        .and_return(task_definition)
+      expect_task_definition_registration(expected_cpu: "512")
+
+      expect(adapter).to receive(:run_aws).with(
+        "ecs", "update-service",
+        "--cluster", "paid-prod",
+        "--service", service_name,
+        "--task-definition", next_task_definition_arn,
+        "--force-new-deployment"
+      ).and_return({ service: { taskDefinition: next_task_definition_arn } }.to_json)
+
+      result = adapter.set_resource_limits(service: service_name, cpu_limit: "512", memory_limit: "2Gi")
+
+      expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
+      expect(result.accepted).to be true
+    end
+
+    it "converts fractional vCPU inputs to ECS CPU units" do
+      allow(adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
+      allow(adapter).to receive(:describe_task_definition)
+        .with(task_definition[:taskDefinitionArn])
+        .and_return(task_definition)
+      expect_task_definition_registration(expected_cpu: "512")
+
+      expect(adapter).to receive(:run_aws).with(
+        "ecs", "update-service",
+        "--cluster", "paid-prod",
+        "--service", service_name,
+        "--task-definition", next_task_definition_arn,
+        "--force-new-deployment"
+      ).and_return({ service: { taskDefinition: next_task_definition_arn } }.to_json)
+
+      result = adapter.set_resource_limits(service: service_name, cpu_limit: "0.5", memory_limit: "2Gi")
+
+      expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
+      expect(result.accepted).to be true
+    end
+
     it "short-circuits when the requested limits already match the target container" do
       allow(adapter).to receive(:describe_service)
         .with(service_name)

--- a/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
+++ b/spec/services/scaling/orchestrators/ecs_adapter_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
     end
     let(:next_task_definition_arn) { "arn:aws:ecs:task-definition/agent-worker:8" }
 
-    def expect_task_definition_registration
+    def expect_task_definition_registration(expected_cpu: "512", expected_memory: "2048")
       expect(adapter).to receive(:run_aws).with(
         "ecs", "register-task-definition",
         "--cli-input-json", kind_of(String)
@@ -93,9 +93,48 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
         container = payload.fetch(:containerDefinitions).first
         expect(container[:cpu]).to eq(512)
         expect(container[:memory]).to eq(2048)
+        expect(payload[:cpu]).to eq(expected_cpu)
+        expect(payload[:memory]).to eq(expected_memory)
 
         { taskDefinition: { taskDefinitionArn: next_task_definition_arn } }.to_json
       end
+    end
+
+    def expect_named_task_definition_registration(named_adapter)
+      expect(named_adapter).to receive(:run_aws).with(
+        "ecs", "register-task-definition",
+        "--cli-input-json", kind_of(String)
+      ) do |*args|
+        payload = JSON.parse(args.last, symbolize_names: true)
+
+        expect(payload[:containerDefinitions]).to contain_exactly(
+          include(name: "web", cpu: 512, memory: 2048),
+          include(name: "sidecar", cpu: 128, memory: 256)
+        )
+        expect(payload[:cpu]).to eq("1024")
+        expect(payload[:memory]).to eq("3072")
+
+        { taskDefinition: { taskDefinitionArn: next_task_definition_arn } }.to_json
+      end
+    end
+
+    def stub_named_adapter_task_definition(named_adapter, task_definition_arn, task_definition)
+      allow(named_adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition_arn })
+      allow(named_adapter).to receive(:describe_task_definition)
+        .with(task_definition_arn)
+        .and_return(task_definition)
+    end
+
+    def expect_named_adapter_service_update(named_adapter)
+      expect(named_adapter).to receive(:run_aws).with(
+        "ecs", "update-service",
+        "--cluster", "paid-prod",
+        "--service", service_name,
+        "--task-definition", next_task_definition_arn,
+        "--force-new-deployment"
+      ).and_return({ service: { taskDefinition: next_task_definition_arn } }.to_json)
     end
 
     it "registers a new task definition revision and forces a deployment" do
@@ -116,6 +155,45 @@ RSpec.describe Scaling::Orchestrators::EcsAdapter do
       ).and_return({ service: { taskDefinition: next_task_definition_arn } }.to_json)
 
       result = adapter.set_resource_limits(service: service_name, cpu_limit: "500m", memory_limit: "2Gi")
+
+      expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
+      expect(result.accepted).to be true
+    end
+
+    it "raises when the ECS service name does not match a container definition" do
+      mismatched_task_definition = task_definition.merge(
+        containerDefinitions: [
+          { name: "web", cpu: 256, memory: 512, essential: true },
+          { name: "sidekiq", cpu: 256, memory: 512, essential: true }
+        ]
+      )
+
+      allow(adapter).to receive(:describe_service)
+        .with(service_name)
+        .and_return({ taskDefinition: task_definition[:taskDefinitionArn] })
+      allow(adapter).to receive(:describe_task_definition)
+        .with(task_definition[:taskDefinitionArn])
+        .and_return(mismatched_task_definition)
+
+      expect do
+        adapter.set_resource_limits(service: service_name, cpu_limit: "500m", memory_limit: "2Gi")
+      end.to raise_error(described_class::ApiError, /configure container_name/)
+    end
+
+    it "updates the configured target container when service and container names differ" do
+      named_adapter = described_class.new(cluster: "paid-prod", region: "us-east-1", container_name: "web")
+      mismatched_task_definition = task_definition.merge(
+        containerDefinitions: [
+          { name: "web", cpu: 256, memory: 512, essential: true },
+          { name: "sidecar", cpu: 128, memory: 256, essential: false }
+        ]
+      )
+
+      stub_named_adapter_task_definition(named_adapter, task_definition[:taskDefinitionArn], mismatched_task_definition)
+      expect_named_task_definition_registration(named_adapter)
+      expect_named_adapter_service_update(named_adapter)
+
+      result = named_adapter.set_resource_limits(service: service_name, cpu_limit: "500m", memory_limit: "2Gi")
 
       expect(result).to be_a(Scaling::Orchestrators::Data::ResourceUpdateResult)
       expect(result.accepted).to be true

--- a/spec/services/scaling/orchestrators/resolver_spec.rb
+++ b/spec/services/scaling/orchestrators/resolver_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe Scaling::Orchestrators::Resolver do
     end
   end
 
+  describe "default registrations" do
+    it "registers the built-in orchestrator adapters" do
+      expect(described_class.registered_types).to include(
+        :kubernetes,
+        :docker_compose,
+        :docker_swarm,
+        :ecs
+      )
+    end
+  end
+
   describe ".for" do
     before do
       described_class.reset!
@@ -50,10 +61,16 @@ RSpec.describe Scaling::Orchestrators::Resolver do
     it "clears a single orchestrator type when given one" do
       described_class.register(:kubernetes, factory)
       described_class.register(:docker_compose, factory)
+      described_class.register(:docker_swarm, factory)
+      described_class.register(:ecs, factory)
 
       described_class.reset!(:kubernetes)
 
-      expect(described_class.registered_types).to contain_exactly(:docker_compose)
+      expect(described_class.registered_types).to contain_exactly(
+        :docker_compose,
+        :docker_swarm,
+        :ecs
+      )
     end
 
     it "clears every registration when called without arguments" do


### PR DESCRIPTION
## Summary

Implemented the remaining Phase 3.6 orchestrator groundwork by adding explicit `DockerSwarmAdapter` and `EcsAdapter`, wiring built-in adapter registration in [config/initializers/scaling_orchestrators.rb](/workspace/config/initializers/scaling_orchestrators.rb), extending resolver coverage, and updating the scaling docs so they reflect Kubernetes, Swarm, ECS, and Docker Compose support. The new adapters live in [app/services/scaling/orchestrators/docker_swarm_adapter.rb](/workspace/app/services/scaling/orchestrators/docker_swarm_adapter.rb) and [app/services/scaling/orchestrators/ecs_adapter.rb](/workspace/app/services/scaling/orchestrators/ecs_adapter.rb), with specs in [spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb](/workspace/spec/services/scaling/orchestrators/docker_swarm_adapter_spec.rb) and [spec/services/scaling/orchestrators/ecs_adapter_spec.rb](/workspace/spec/services/scaling/orchestrators/ecs_adapter_spec.rb).

Validation passed: `bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec` completed successfully with `10763 examples, 0 failures, 3 pending`. The commit is `ee4428b` with message `feat(scaling): add swarm and ecs scaling adapters`. The worktree is clean.

---

Closes #739