### PR TITLE
feat(screenshots): framework auto-detection and config suggestion

### DIFF
--- a/app/controllers/projects/screenshot_configs_controller.rb
+++ b/app/controllers/projects/screenshot_configs_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Projects
+  class ScreenshotConfigsController < ApplicationController
+    before_action :set_project
+
+    def detect
+      authorize @project, :update?
+
+      result = Screenshots::DetectFramework.call(project: @project)
+
+      respond_to do |format|
+        format.html do
+          flash[:screenshot_config_suggestion_yaml] = result.suggested_yaml
+          flash[:screenshot_config_framework] = result.framework.to_s
+          flash[:screenshot_config_confidence] = result.confidence
+          redirect_to edit_project_path(@project),
+            notice: "Suggested screenshot config generated for #{result.framework.to_s.humanize}."
+        end
+
+        format.json do
+          render json: result.to_h.merge(suggested_yaml: result.suggested_yaml)
+        end
+      end
+    rescue GithubClient::Error => e
+      respond_to do |format|
+        format.html do
+          redirect_to edit_project_path(@project), alert: "Could not detect screenshot config: #{e.message}"
+        end
+
+        format.json do
+          render json: { error: "Could not detect screenshot config: #{e.message}" }, status: :unprocessable_content
+        end
+      end
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).includes(:github_token, :created_by).find(params[:project_id])
+    end
+  end
+end

--- a/app/controllers/projects/screenshot_configs_controller.rb
+++ b/app/controllers/projects/screenshot_configs_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require "securerandom"
+
 module Projects
   class ScreenshotConfigsController < ApplicationController
+    SUGGESTED_CONFIG_CACHE_TTL = 10.minutes
+
     before_action :set_project
 
     def detect
@@ -11,7 +15,7 @@ module Projects
 
       respond_to do |format|
         format.html do
-          flash[:screenshot_config_suggestion_yaml] = result.suggested_yaml
+          flash[:screenshot_config_suggestion_cache_key] = cache_suggested_yaml(result.suggested_yaml)
           flash[:screenshot_config_framework] = result.framework.to_s
           flash[:screenshot_config_confidence] = result.confidence
           redirect_to edit_project_path(@project),
@@ -38,6 +42,17 @@ module Projects
 
     def set_project
       @project = policy_scope(Project).includes(:github_token, :created_by).find(params[:project_id])
+    end
+
+    def cache_suggested_yaml(suggested_yaml)
+      cache_key = [
+        "projects",
+        @project.id,
+        "screenshot-config-suggestion",
+        SecureRandom.uuid
+      ].join("/")
+      Rails.cache.write(cache_key, suggested_yaml, expires_in: SUGGESTED_CONFIG_CACHE_TTL)
+      cache_key
     end
   end
 end

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -207,7 +207,8 @@ module Screenshots
       "projects/quality_thresholds_controller.rb" => [ :project_quality_dashboard ],
       "projects/service_containers_controller.rb" => [ :project_edit ],
       "projects/mcp_servers_controller.rb" => [ :project_edit ],
-      "projects/knowledge_recommendations_controller.rb" => [ :project_knowledge_recommendations ]
+      "projects/knowledge_recommendations_controller.rb" => [ :project_knowledge_recommendations ],
+      "projects/screenshot_configs_controller.rb" => [ :project_edit ]
     }.freeze
 
     def targets_for(path)

--- a/app/services/screenshots/detect_framework.rb
+++ b/app/services/screenshots/detect_framework.rb
@@ -1,0 +1,577 @@
+# frozen_string_literal: true
+
+require "find"
+require "json"
+require "open3"
+require "psych"
+require "set"
+require "yaml"
+
+module Screenshots
+  class DetectFramework
+    Result = ::Data.define(
+      :framework,
+      :confidence,
+      :suggested_config,
+      :detected_services,
+      :detected_routes
+    ) do
+      def to_h
+        {
+          framework: framework,
+          confidence: confidence,
+          suggested_config: suggested_config,
+          detected_services: detected_services,
+          detected_routes: detected_routes
+        }
+      end
+
+      def suggested_yaml
+        Psych.dump(suggested_config.deep_stringify_keys)
+      end
+    end
+
+    ROUTE_EXTENSIONS = %w[.js .jsx .ts .tsx .rb .py].freeze
+    NEXT_PAGE_EXTENSIONS = %w[.js .jsx .ts .tsx].freeze
+    JS_DEPENDENCY_KEYS = %w[dependencies devDependencies].freeze
+    DATABASE_ADAPTER_MAP = {
+      "postgresql" => "postgres",
+      "postgis" => "postgres",
+      "mysql2" => "mysql",
+      "trilogy" => "mysql",
+      "sqlite3" => "sqlite",
+      "redis" => "redis"
+    }.freeze
+    SERVICE_DEPENDENCY_MAP = {
+      "pg" => "postgres",
+      "postgres" => "postgres",
+      "postgresql" => "postgres",
+      "redis" => "redis",
+      "redis-rb" => "redis",
+      "ioredis" => "redis",
+      "sidekiq" => "redis",
+      "mysql2" => "mysql",
+      "mysql" => "mysql"
+    }.freeze
+
+    attr_reader :project, :repo_path
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project: nil, repo_path: nil)
+      @project = project
+      @repo_path = repo_path
+    end
+
+    def call
+      detection = detect_rails || detect_nextjs || detect_django || detect_generic
+      suggested_routes = detection.fetch(:routes).presence || default_routes_for(detection.fetch(:framework))
+      services = detect_services
+
+      Result.new(
+        framework: detection.fetch(:framework),
+        confidence: detection.fetch(:confidence),
+        suggested_config: build_suggested_config(
+          framework: detection.fetch(:framework),
+          driver: detection.fetch(:driver),
+          routes: suggested_routes,
+          services: services,
+          auth: detection[:auth]
+        ),
+        detected_services: services,
+        detected_routes: suggested_routes
+      )
+    end
+
+    private
+
+    def repo
+      @repo ||= begin
+        return LocalRepository.new(repo_path) if repo_path.present?
+        return GithubRepository.new(project) if project.present?
+
+        raise ArgumentError, "project or repo_path is required"
+      end
+    end
+
+    def detect_rails
+      score = 0.0
+      score += 0.55 if repo.file?("config/routes.rb")
+      score += 0.3 if gemfile_dependency?("rails")
+      score += 0.15 if repo.directory?("app/controllers")
+      return unless score >= 0.5
+
+      {
+        framework: :rails,
+        confidence: score.round(2),
+        driver: "cuprite",
+        auth: detect_rails_auth,
+        routes: discover_rails_routes
+      }
+    end
+
+    def detect_nextjs
+      score = 0.0
+      score += 0.55 if %w[next.config.js next.config.mjs next.config.ts].any? { |path| repo.file?(path) }
+      score += 0.3 if package_dependency?("next")
+      score += 0.15 if repo.directory?("app") || repo.directory?("pages")
+      return unless score >= 0.5
+
+      {
+        framework: :nextjs,
+        confidence: score.round(2),
+        driver: "playwright",
+        auth: detect_nextjs_auth,
+        routes: discover_nextjs_routes
+      }
+    end
+
+    def detect_django
+      score = 0.0
+      score += 0.55 if repo.file?("manage.py")
+      score += 0.25 if repo.glob("**/settings.py").any?
+      score += 0.2 if repo.glob("**/urls.py").any?
+      return unless score >= 0.5
+
+      {
+        framework: :django,
+        confidence: score.round(2),
+        driver: "playwright",
+        auth: detect_django_auth,
+        routes: discover_django_routes
+      }
+    end
+
+    def detect_generic
+      files = repo.paths
+      html = files.any? { |path| path.end_with?(".html", ".erb", ".haml", ".slim") }
+      css = files.any? { |path| path.end_with?(".css", ".scss", ".sass") }
+      js = files.any? { |path| path.end_with?(".js", ".jsx", ".ts", ".tsx") }
+
+      confidence = if html && (css || js)
+        0.45
+      elsif html || css || js
+        0.3
+      else
+        0.2
+      end
+
+      {
+        framework: :generic,
+        confidence: confidence,
+        driver: "playwright",
+        auth: { "strategy" => "none" },
+        routes: []
+      }
+    end
+
+    def build_suggested_config(framework:, driver:, routes:, services:, auth:)
+      config = {
+        "enabled" => true,
+        "driver" => driver,
+        "base_url" => base_url_for(framework),
+        "routes" => routes.map(&:deep_stringify_keys)
+      }
+      config["services"] = services if services.any?
+      config["auth"] = auth if auth.present?
+      config
+    end
+
+    def base_url_for(framework)
+      framework == :django ? "http://localhost:8000" : Screenshots::Configuration::DEFAULT_BASE_URL
+    end
+
+    def default_routes_for(framework)
+      return [] if framework == :generic
+
+      [ route_hash("/", "home") ]
+    end
+
+    def detect_services
+      services = Set.new
+
+      extract_database_adapters.each do |adapter|
+        mapped = DATABASE_ADAPTER_MAP[adapter]
+        services << mapped if mapped.present?
+      end
+
+      dependency_names.each do |dependency|
+        mapped = SERVICE_DEPENDENCY_MAP[dependency]
+        services << mapped if mapped.present?
+      end
+
+      services.to_a.sort
+    end
+
+    def dependency_names
+      @dependency_names ||= begin
+        names = Set.new
+        gemfile_dependencies.each { |name| names << name }
+        package_dependencies.each { |name| names << name }
+        names
+      end
+    end
+
+    def gemfile_dependencies
+      content = repo.read("Gemfile")
+      return [] if content.blank?
+
+      content.scan(/^\s*gem\s+["']([^"']+)["']/).flatten
+    end
+
+    def gemfile_dependency?(name)
+      gemfile_dependencies.include?(name)
+    end
+
+    def package_dependencies
+      content = repo.read("package.json")
+      return [] if content.blank?
+
+      data = JSON.parse(content)
+      JS_DEPENDENCY_KEYS.flat_map do |key|
+        deps = data[key]
+        deps.is_a?(Hash) ? deps.keys : []
+      end
+    rescue JSON::ParserError
+      []
+    end
+
+    def package_dependency?(name)
+      package_dependencies.include?(name)
+    end
+
+    def extract_database_adapters
+      content = repo.read("config/database.yml")
+      return [] if content.blank?
+
+      sanitized = content.gsub(/<%.*?%>/m, '""')
+      data = YAML.safe_load(sanitized, aliases: true)
+      adapters = []
+      collect_adapters(data, adapters)
+      adapters
+    rescue Psych::Exception
+      []
+    end
+
+    def collect_adapters(value, adapters)
+      return unless value.is_a?(Hash)
+
+      value.each_value do |child|
+        next unless child.is_a?(Hash)
+
+        if child["adapter"].present?
+          adapters << child["adapter"]
+        else
+          collect_adapters(child, adapters)
+        end
+      end
+    end
+
+    def detect_rails_auth
+      return devise_auth_config if gemfile_dependency?("devise")
+
+      routes = repo.read("config/routes.rb").to_s
+      return devise_auth_config if routes.include?("devise_for")
+
+      { "strategy" => "none" }
+    end
+
+    def devise_auth_config
+      {
+        "strategy" => "form",
+        "login_path" => "/users/sign_in",
+        "fields" => {
+          "email" => "user[email]",
+          "password" => "user[password]",
+          "submit" => "Log in"
+        }
+      }
+    end
+
+    def detect_nextjs_auth
+      auth_paths = repo.paths.select do |path|
+        path.match?(%r{(?:app|pages)/api/auth/.+nextauth}) || path.include?("next-auth") || path.include?("nextauth")
+      end
+
+      middleware = repo.read("middleware.ts").to_s + repo.read("middleware.js").to_s
+      nextauth_detected = package_dependency?("next-auth") || package_dependency?("@auth/core") || auth_paths.any? ||
+        middleware.match?(/nextauth|withAuth|auth\(/i)
+
+      return { "strategy" => "none" } unless nextauth_detected
+
+      {
+        "strategy" => "custom",
+        "login_path" => "/api/auth/signin"
+      }
+    end
+
+    def detect_django_auth
+      auth_file = repo.glob("**/urls.py").find do |path|
+        repo.read(path).to_s.match?(/django\.contrib\.auth|accounts\/login/)
+      end
+      return { "strategy" => "none" } unless auth_file
+
+      {
+        "strategy" => "form",
+        "login_path" => "/accounts/login/",
+        "fields" => {
+          "email" => "username",
+          "password" => "password",
+          "submit" => "Log in"
+        }
+      }
+    end
+
+    def discover_rails_routes
+      routes_from_command = discover_rails_routes_from_command
+      return routes_from_command if routes_from_command.any?
+
+      content = repo.read("config/routes.rb").to_s
+      return [] if content.blank?
+
+      prefixes = []
+      routes = []
+
+      content.each_line do |line|
+        stripped = line.strip
+        next if stripped.start_with?("#")
+
+        if (match = stripped.match(/^namespace\s+:([a-zA-Z_][\w]*)\s+do/))
+          prefixes << match[1]
+          next
+        end
+
+        if stripped == "end"
+          prefixes.pop if prefixes.any?
+          next
+        end
+
+        route = parse_rails_route_line(stripped, prefixes)
+        routes << route if route
+      end
+
+      unique_routes(routes)
+    end
+
+    def discover_rails_routes_from_command
+      return [] unless repo.respond_to?(:root_path)
+
+      root = repo.root_path
+      return [] unless File.exist?(File.join(root, "bin/rails"))
+
+      stdout, status = Open3.capture2e("bin/rails", "routes", chdir: root)
+      return [] unless status.success?
+
+      parse_rails_routes_output(stdout)
+    rescue StandardError
+      []
+    end
+
+    def parse_rails_routes_output(output)
+      output.each_line.filter_map do |line|
+        tokens = line.strip.split(/\s+/)
+        next if tokens.length < 2
+
+        verb_index = tokens.index { |token| token.match?(/\A(?:GET|POST|PATCH|PUT|DELETE)\z/) }
+        next unless verb_index
+        next if verb_index.zero?
+
+        route_hash(tokens[verb_index - 1], tokens[verb_index - 1], requires_auth: false)
+      end.then { |routes| unique_routes(routes) }
+    end
+
+    def parse_rails_route_line(line, prefixes)
+      return route_hash("/", "root") if line.match?(/^root\s+/)
+
+      if (match = line.match(/^(?:get|post|patch|put|delete)\s+["']([^"']+)["']/))
+        path = normalize_route_path(prefixes, match[1])
+        return route_hash(path, route_name_from_path(path))
+      end
+
+      if (match = line.match(/^resources\s+:([a-zA-Z_][\w]*)/))
+        path = normalize_route_path(prefixes, match[1])
+        return route_hash(path, match[1])
+      end
+
+      if (match = line.match(/^resource\s+:([a-zA-Z_][\w]*)/))
+        path = normalize_route_path(prefixes, match[1])
+        return route_hash(path, match[1])
+      end
+
+      nil
+    end
+
+    def discover_nextjs_routes
+      routes = []
+
+      repo.glob("app/**/page{#{NEXT_PAGE_EXTENSIONS.join(',')}}").each do |path|
+        route = next_app_route_for(path)
+        routes << route if route
+      end
+
+      repo.glob("pages/**/*{#{NEXT_PAGE_EXTENSIONS.join(',')}}").each do |path|
+        route = next_pages_route_for(path)
+        routes << route if route
+      end
+
+      unique_routes(routes)
+    end
+
+    def next_app_route_for(path)
+      relative = path.delete_prefix("app/").sub(%r{(?:^|/)page\.[^.]+$}, "")
+      return if relative.start_with?("api/")
+
+      segments = relative.split("/").reject { |segment| segment.blank? || segment.start_with?("(") }
+      route_path = "/" + segments.map { |segment| segment.gsub(/\[(.+?)\]/, ':\1') }.join("/")
+      route_path = "/" if route_path == "/"
+
+      route_hash(route_path, route_name_from_path(route_path))
+    end
+
+    def next_pages_route_for(path)
+      relative = path.delete_prefix("pages/")
+      return if relative.start_with?("api/")
+      return if relative.match?(%r{\A_(app|document|error)\.})
+
+      route_path = relative.sub(/\.[^.]+\z/, "")
+      route_path = route_path.delete_suffix("/index")
+      route_path = "/" if route_path.blank? || route_path == "index"
+      route_path = "/#{route_path}" unless route_path.start_with?("/")
+      route_path = route_path.gsub(/\[(.+?)\]/, ':\1')
+
+      route_hash(route_path, route_name_from_path(route_path))
+    end
+
+    def discover_django_routes
+      routes = repo.glob("**/urls.py").flat_map do |path|
+        parse_django_urls(repo.read(path).to_s)
+      end
+
+      unique_routes(routes)
+    end
+
+    def parse_django_urls(content)
+      content.each_line.filter_map do |line|
+        next unless (match = line.match(/(?:path|re_path)\(\s*["']([^"']*)["']/))
+
+        raw = match[1]
+        route_path = raw.start_with?("/") ? raw : "/#{raw}"
+        route_path = "/" if route_path == "/"
+        route_hash(route_path, route_name_from_path(route_path))
+      end
+    end
+
+    def normalize_route_path(prefixes, path)
+      full_path = ([ "", *prefixes, path ]).join("/")
+      "/" + full_path.gsub(%r{/+}, "/").delete_prefix("/")
+    end
+
+    def unique_routes(routes)
+      routes.compact.uniq { |route| route["path"] }.first(10)
+    end
+
+    def route_hash(path, name, requires_auth: false)
+      {
+        "path" => path,
+        "name" => name,
+        "requires_auth" => requires_auth
+      }
+    end
+
+    def route_name_from_path(path)
+      return "home" if path == "/"
+
+      path.delete_prefix("/").tr("/", "_").gsub(":", "").presence || "home"
+    end
+
+    class LocalRepository
+      attr_reader :root_path
+
+      def initialize(root_path)
+        @root_path = root_path
+      end
+
+      def file?(path)
+        File.file?(absolute(path))
+      end
+
+      def directory?(path)
+        Dir.exist?(absolute(path))
+      end
+
+      def read(path)
+        return unless file?(path)
+
+        File.read(absolute(path))
+      end
+
+      def glob(pattern)
+        Dir.glob(pattern, base: root_path).select { |path| file?(path) }.sort
+      end
+
+      def paths
+        @paths ||= begin
+          files = []
+          Find.find(root_path) do |path|
+            next unless File.file?(path)
+
+            files << path.delete_prefix("#{root_path}/")
+          end
+          files.sort
+        end
+      end
+
+      private
+
+      def absolute(path)
+        File.join(root_path, path)
+      end
+    end
+
+    class GithubRepository
+      attr_reader :project
+
+      def initialize(project)
+        @project = project
+      end
+
+      def file?(path)
+        path_set.include?(path)
+      end
+
+      def directory?(path)
+        prefix = "#{path}/"
+        path_set.any? { |entry| entry.start_with?(prefix) }
+      end
+
+      def read(path)
+        return unless file?(path)
+
+        project.github_token.client.file_content(project.full_name, path: path)&.force_encoding("UTF-8")&.scrub("")
+      rescue GithubClient::NotFoundError
+        nil
+      end
+
+      def glob(pattern)
+        matcher = File::FNM_PATHNAME | File::FNM_EXTGLOB
+        paths.select { |path| File.fnmatch?(pattern, path, matcher) }
+      end
+
+      def paths
+        @paths ||= Array(tree.tree).select { |item| item.type == "blob" }.map(&:path).sort
+      end
+
+      private
+
+      def path_set
+        @path_set ||= paths.to_set
+      end
+
+      def tree
+        @tree ||= project.github_token.client.tree(project.full_name, project.default_branch || "main", recursive: true)
+      end
+    end
+  end
+end

--- a/app/services/screenshots/detect_framework.rb
+++ b/app/services/screenshots/detect_framework.rb
@@ -338,25 +338,27 @@ module Screenshots
       content = rails_routes_content
       return [] if content.blank?
 
-      prefixes = []
+      block_stack = []
       routes = []
 
-      content.each_line do |line|
-        stripped = line.strip
+      content.each_line.flat_map { |line| line.split(";") }.each do |statement|
+        stripped = statement.strip
         next if stripped.start_with?("#")
 
         if (match = stripped.match(/^namespace\s+:([a-zA-Z_][\w]*)\s+do/))
-          prefixes << match[1]
+          block_stack << match[1]
           next
         end
 
         if stripped == "end"
-          prefixes.pop if prefixes.any?
+          block_stack.pop if block_stack.any?
           next
         end
 
-        route = parse_rails_route_line(stripped, prefixes)
+        route = parse_rails_route_line(stripped, current_rails_prefixes(block_stack))
         routes << route if route
+
+        block_stack << nil if opens_rails_block?(stripped)
       end
 
       unique_routes(routes)
@@ -416,6 +418,14 @@ module Screenshots
       nil
     end
 
+    def current_rails_prefixes(block_stack)
+      block_stack.compact
+    end
+
+    def opens_rails_block?(line)
+      line.end_with?(" do") || line.match?(/\sdo\s+\|[^|]*\|\s*\z/)
+    end
+
     def discover_nextjs_routes
       routes = []
 
@@ -458,22 +468,84 @@ module Screenshots
     end
 
     def discover_django_routes
-      routes = repo.glob("**/urls.py").flat_map do |path|
-        parse_django_urls(repo.read(path).to_s)
+      routes = django_root_url_files.flat_map do |path|
+        parse_django_urlconf(path, prefix: "", visited: Set.new)
       end
 
       unique_routes(routes)
     end
 
-    def parse_django_urls(content)
+    def django_root_url_files
+      roots = django_root_url_files_from_settings
+      return roots if roots.any?
+
+      url_files = repo.glob("**/urls.py")
+      included = url_files.flat_map do |path|
+        parse_django_include_targets(repo.read(path).to_s)
+      end.to_set
+      root_files = url_files.reject { |path| included.include?(path) }
+      root_files.presence || url_files
+    end
+
+    def django_root_url_files_from_settings
+      repo.glob("**/settings.py").filter_map do |path|
+        repo.read(path).to_s[/ROOT_URLCONF\s*=\s*["']([^"']+)["']/, 1]
+      end.filter_map do |module_name|
+        django_module_path(module_name)
+      end.uniq
+    end
+
+    def parse_django_urlconf(path, prefix:, visited:)
+      visit_key = [ path, prefix ]
+      return [] if visited.include?(visit_key)
+
+      visited << visit_key
+      parse_django_urls(repo.read(path).to_s, prefix:, visited:)
+    end
+
+    def parse_django_urls(content, prefix:, visited:)
       content.each_line.filter_map do |line|
+        if (include_match = line.match(/(?:path|re_path)\(\s*["']([^"']*)["']\s*,\s*include\((.+?)\)\s*[,\)]/))
+          include_prefix = join_django_route_segments(prefix, include_match[1])
+          include_module = django_include_module_name(include_match[2])
+          include_path = include_module.present? ? django_module_path(include_module) : nil
+
+          next parse_django_urlconf(include_path, prefix: include_prefix, visited:) if include_path.present?
+          next route_hash(include_prefix, route_name_from_path(include_prefix))
+        end
+
         next unless (match = line.match(/(?:path|re_path)\(\s*["']([^"']*)["']/))
 
-        raw = match[1]
-        route_path = raw.start_with?("/") ? raw : "/#{raw}"
-        route_path = "/" if route_path == "/"
+        route_path = join_django_route_segments(prefix, match[1])
         route_hash(route_path, route_name_from_path(route_path))
+      end.flatten
+    end
+
+    def parse_django_include_targets(content)
+      content.each_line.filter_map do |line|
+        include_match = line.match(/include\((.+?)\)/)
+        next unless include_match
+
+        include_module = django_include_module_name(include_match[1])
+        next unless include_module.present?
+
+        django_module_path(include_module)
       end
+    end
+
+    def django_include_module_name(arguments)
+      arguments[/["']([^"']+)["']/, 1]
+    end
+
+    def django_module_path(module_name)
+      path = "#{module_name.tr('.', '/')}.py"
+      repo.file?(path) ? path : nil
+    end
+
+    def join_django_route_segments(prefix, path)
+      joined = [ prefix, path ].compact.reject(&:blank?).join("/")
+      normalized = joined.gsub(%r{/+}, "/").delete_prefix("/")
+      normalized.present? ? "/#{normalized}" : "/"
     end
 
     def normalize_route_path(prefixes, path)

--- a/app/services/screenshots/detect_framework.rb
+++ b/app/services/screenshots/detect_framework.rb
@@ -280,7 +280,7 @@ module Screenshots
     def detect_rails_auth
       return devise_auth_config if gemfile_dependency?("devise")
 
-      routes = repo.read("config/routes.rb").to_s
+      routes = rails_routes_content
       return devise_auth_config if routes.include?("devise_for")
 
       { "strategy" => "none" }
@@ -336,7 +336,7 @@ module Screenshots
       routes_from_command = discover_rails_routes_from_command
       return routes_from_command if routes_from_command.any?
 
-      content = repo.read("config/routes.rb").to_s
+      content = rails_routes_content
       return [] if content.blank?
 
       prefixes = []
@@ -361,6 +361,10 @@ module Screenshots
       end
 
       unique_routes(routes)
+    end
+
+    def rails_routes_content
+      @rails_routes_content ||= repo.read("config/routes.rb").to_s
     end
 
     def discover_rails_routes_from_command

--- a/app/services/screenshots/detect_framework.rb
+++ b/app/services/screenshots/detect_framework.rb
@@ -372,13 +372,15 @@ module Screenshots
     def parse_rails_routes_output(output)
       output.each_line.filter_map do |line|
         tokens = line.strip.split(/\s+/)
-        next if tokens.length < 2
+        next if tokens.length < 3
 
         verb_index = tokens.index { |token| token.match?(/\A(?:GET|POST|PATCH|PUT|DELETE)\z/) }
         next unless verb_index
-        next if verb_index.zero?
+        next unless tokens[verb_index + 1]
 
-        route_hash(tokens[verb_index - 1], tokens[verb_index - 1], requires_auth: false)
+        path = tokens[verb_index + 1].sub(/\(.:format\)\z/, "")
+        name = verb_index > 0 ? tokens[verb_index - 1] : path
+        route_hash(path, name, requires_auth: false)
       end.then { |routes| unique_routes(routes) }
     end
 

--- a/app/services/screenshots/detect_framework.rb
+++ b/app/services/screenshots/detect_framework.rb
@@ -67,7 +67,8 @@ module Screenshots
 
     def call
       detection = detect_rails || detect_nextjs || detect_django || detect_generic
-      suggested_routes = detection.fetch(:routes).presence || default_routes_for(detection.fetch(:framework))
+      detected_routes = detection.fetch(:routes)
+      suggested_routes = detected_routes.presence || default_routes_for
       services = detect_services
 
       Result.new(
@@ -81,7 +82,7 @@ module Screenshots
           auth: detection[:auth]
         ),
         detected_services: services,
-        detected_routes: suggested_routes
+        detected_routes: detected_routes
       )
     end
 
@@ -183,9 +184,7 @@ module Screenshots
       framework == :django ? "http://localhost:8000" : Screenshots::Configuration::DEFAULT_BASE_URL
     end
 
-    def default_routes_for(framework)
-      return [] if framework == :generic
-
+    def default_routes_for
       [ route_hash("/", "home") ]
     end
 
@@ -563,7 +562,7 @@ module Screenshots
       def read(path)
         return unless file?(path)
 
-        project.github_token.client.file_content(project.full_name, path: path)&.force_encoding("UTF-8")&.scrub("")
+        project.github_token.client.file_content(project.full_name, path:, ref:)&.force_encoding("UTF-8")&.scrub("")
       rescue GithubClient::NotFoundError
         nil
       end
@@ -583,8 +582,12 @@ module Screenshots
         @path_set ||= paths.to_set
       end
 
+      def ref
+        @ref ||= project.default_branch || "main"
+      end
+
       def tree
-        @tree ||= project.github_token.client.tree(project.full_name, project.default_branch || "main", recursive: true)
+        @tree ||= project.github_token.client.tree(project.full_name, ref, recursive: true)
       end
     end
   end

--- a/app/services/screenshots/detect_framework.rb
+++ b/app/services/screenshots/detect_framework.rb
@@ -215,10 +215,14 @@ module Screenshots
     end
 
     def gemfile_dependencies
-      content = repo.read("Gemfile")
-      return [] if content.blank?
-
-      content.scan(/^\s*gem\s+["']([^"']+)["']/).flatten
+      @gemfile_dependencies ||= begin
+        content = repo.read("Gemfile")
+        if content.blank?
+          []
+        else
+          content.scan(/^\s*gem\s+["']([^"']+)["']/).flatten
+        end
+      end
     end
 
     def gemfile_dependency?(name)
@@ -226,16 +230,20 @@ module Screenshots
     end
 
     def package_dependencies
-      content = repo.read("package.json")
-      return [] if content.blank?
-
-      data = JSON.parse(content)
-      JS_DEPENDENCY_KEYS.flat_map do |key|
-        deps = data[key]
-        deps.is_a?(Hash) ? deps.keys : []
+      @package_dependencies ||= begin
+        content = repo.read("package.json")
+        if content.blank?
+          []
+        else
+          data = JSON.parse(content)
+          JS_DEPENDENCY_KEYS.flat_map do |key|
+            deps = data[key]
+            deps.is_a?(Hash) ? deps.keys : []
+          end
+        end
+      rescue JSON::ParserError
+        []
       end
-    rescue JSON::ParserError
-      []
     end
 
     def package_dependency?(name)

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -736,7 +736,8 @@
       <% end %>
     </div>
   </div>
-  <% suggested_screenshot_config_yaml = flash[:screenshot_config_suggestion_yaml] %>
+  <% suggested_screenshot_cache_key = flash[:screenshot_config_suggestion_cache_key] %>
+  <% suggested_screenshot_config_yaml = suggested_screenshot_cache_key.present? ? Rails.cache.read(suggested_screenshot_cache_key) : nil %>
   <% suggested_screenshot_framework = flash[:screenshot_config_framework] %>
   <% suggested_screenshot_confidence = flash[:screenshot_config_confidence] %>
   <div class="mt-6 bg-white shadow sm:rounded-lg">

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -736,6 +736,37 @@
       <% end %>
     </div>
   </div>
+  <% suggested_screenshot_config_yaml = flash[:screenshot_config_suggestion_yaml] %>
+  <% suggested_screenshot_framework = flash[:screenshot_config_framework] %>
+  <% suggested_screenshot_confidence = flash[:screenshot_config_confidence] %>
+  <div class="mt-6 bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-5 sm:p-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h2 class="text-lg font-semibold text-gray-900">Screenshot Config</h2>
+          <p class="mt-1 text-sm text-gray-500">
+            Detect the app framework and generate a starter <code class="rounded bg-gray-100 px-1 py-0.5 text-xs">.paid/screenshots.yml</code>.
+          </p>
+        </div>
+        <%= button_to "Detect & Suggest", detect_project_screenshot_config_path(@project), method: :post, class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
+      </div>
+
+      <% if suggested_screenshot_config_yaml.present? %>
+        <div class="mt-4 rounded-md border border-gray-200 bg-gray-50 p-4">
+          <p class="text-sm font-medium text-gray-900">
+            Suggested config for <%= suggested_screenshot_framework.to_s.humanize %>
+            <% if suggested_screenshot_confidence.present? %>
+              <span class="font-normal text-gray-500">(<%= number_to_percentage(suggested_screenshot_confidence.to_f * 100, precision: 0) %> confidence)</span>
+            <% end %>
+          </p>
+          <p class="mt-1 text-sm text-gray-500">
+            Review this YAML, then copy it into <code class="rounded bg-white px-1 py-0.5 text-xs">.paid/screenshots.yml</code> or adapt it for project settings.
+          </p>
+          <textarea readonly rows="18" class="mt-3 block w-full rounded-md border-0 px-3 py-2 font-mono text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600"><%= suggested_screenshot_config_yaml %></textarea>
+        </div>
+      <% end %>
+    </div>
+  </div>
   <%# Service Containers section %>
   <div class="mt-6 bg-white shadow sm:rounded-lg">
     <div class="px-4 py-5 sm:p-6">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,9 @@ Rails.application.routes.draw do
     resource :quality_thresholds, only: [ :update ], controller: "projects/quality_thresholds"
     resource :cost_snapshot, only: [ :show ], controller: "projects/cost_snapshots"
     resource :cost_dashboard, only: [ :show ], controller: "projects/cost_dashboards"
+    resource :screenshot_config, only: [], controller: "projects/screenshot_configs" do
+      post :detect
+    end
     resources :cost_budgets, only: [ :create, :update, :destroy ], controller: "projects/cost_budgets"
     resources :agent_runs, only: [ :index, :show, :new, :create ], controller: "projects/agent_runs" do
       post :cancel, on: :member

--- a/spec/fixtures/screenshots/django_repo/manage.py
+++ b/spec/fixtures/screenshots/django_repo/manage.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+print("manage")

--- a/spec/fixtures/screenshots/django_repo/project/settings.py
+++ b/spec/fixtures/screenshots/django_repo/project/settings.py
@@ -1,0 +1,3 @@
+INSTALLED_APPS = [
+    "django.contrib.auth",
+]

--- a/spec/fixtures/screenshots/django_repo/project/urls.py
+++ b/spec/fixtures/screenshots/django_repo/project/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+urlpatterns = [
+    path("", lambda request: None, name="home"),
+    path("admin/", lambda request: None, name="admin"),
+    path("accounts/login/", lambda request: None, name="login"),
+]

--- a/spec/fixtures/screenshots/generic_repo/assets/app.css
+++ b/spec/fixtures/screenshots/generic_repo/assets/app.css
@@ -1,0 +1,1 @@
+body { color: black; }

--- a/spec/fixtures/screenshots/generic_repo/assets/app.js
+++ b/spec/fixtures/screenshots/generic_repo/assets/app.js
@@ -1,0 +1,1 @@
+console.log("generic");

--- a/spec/fixtures/screenshots/generic_repo/public/index.html
+++ b/spec/fixtures/screenshots/generic_repo/public/index.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html>
+  <body>Hello</body>
+</html>

--- a/spec/fixtures/screenshots/next_repo/app/api/auth/[...nextauth]/route.ts
+++ b/spec/fixtures/screenshots/next_repo/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export const runtime = "nodejs"

--- a/spec/fixtures/screenshots/next_repo/app/blog/[slug]/page.tsx
+++ b/spec/fixtures/screenshots/next_repo/app/blog/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function BlogPage() {
+  return <main>Blog</main>
+}

--- a/spec/fixtures/screenshots/next_repo/app/dashboard/page.tsx
+++ b/spec/fixtures/screenshots/next_repo/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <main>Dashboard</main>
+}

--- a/spec/fixtures/screenshots/next_repo/app/page.tsx
+++ b/spec/fixtures/screenshots/next_repo/app/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <main>Home</main>
+}

--- a/spec/fixtures/screenshots/next_repo/middleware.ts
+++ b/spec/fixtures/screenshots/next_repo/middleware.ts
@@ -1,0 +1,3 @@
+export default function middleware() {
+  return Response.redirect(new URL("/api/auth/signin", "http://localhost"))
+}

--- a/spec/fixtures/screenshots/next_repo/next.config.js
+++ b/spec/fixtures/screenshots/next_repo/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/spec/fixtures/screenshots/next_repo/package.json
+++ b/spec/fixtures/screenshots/next_repo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "next-repo",
+  "dependencies": {
+    "next": "15.0.0",
+    "next-auth": "5.0.0-beta.1"
+  }
+}

--- a/spec/fixtures/screenshots/rails_repo/Gemfile
+++ b/spec/fixtures/screenshots/rails_repo/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rails"
+gem "devise"
+gem "pg"
+gem "redis"

--- a/spec/fixtures/screenshots/rails_repo/app/controllers/home_controller.rb
+++ b/spec/fixtures/screenshots/rails_repo/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class HomeController < ApplicationController
+end

--- a/spec/fixtures/screenshots/rails_repo/config/database.yml
+++ b/spec/fixtures/screenshots/rails_repo/config/database.yml
@@ -1,0 +1,6 @@
+default: &default
+  adapter: postgresql
+
+development:
+  <<: *default
+  database: screenshots_development

--- a/spec/fixtures/screenshots/rails_repo/config/routes.rb
+++ b/spec/fixtures/screenshots/rails_repo/config/routes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  devise_for :users
+  root "home#index"
+  get "dashboard", to: "dashboard#show"
+  resources :reports, only: [ :index ]
+end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1756,18 +1756,28 @@ RSpec.describe "Projects" do
           detected_routes: [ { "path" => "/", "name" => "home" } ]
         )
       end
+      let(:memory_cache) { ActiveSupport::Cache::MemoryStore.new }
+
+      around do |example|
+        original_cache = Rails.cache
+        Rails.cache = memory_cache
+        example.run
+      ensure
+        Rails.cache = original_cache
+      end
 
       before do
         sign_in user
         allow(Screenshots::DetectFramework).to receive(:call).and_return(result)
       end
 
-      it "redirects to the edit page and stores the suggested YAML in flash" do
+      it "redirects to the edit page and stores the suggested YAML in cache" do
         post detect_project_screenshot_config_path(project)
 
         expect(response).to redirect_to(edit_project_path(project))
         expect(flash[:notice]).to include("Suggested screenshot config generated")
-        expect(flash[:screenshot_config_suggestion_yaml]).to include("driver: cuprite")
+        expect(flash[:screenshot_config_suggestion_cache_key]).to be_present
+        expect(Rails.cache.read(flash[:screenshot_config_suggestion_cache_key])).to include("driver: cuprite")
       end
 
       it "returns JSON when requested" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1734,6 +1734,91 @@ RSpec.describe "Projects" do
     end
   end
 
+  describe "POST /projects/:project_id/screenshot_config/detect" do
+    context "when not authenticated" do
+      it "redirects to the sign in page" do
+        project = create(:project, account: account, github_token: github_token)
+
+        post detect_project_screenshot_config_path(project)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as owner" do
+      let(:project) { create(:project, account: account, github_token: github_token) }
+      let(:result) do
+        Screenshots::DetectFramework::Result.new(
+          framework: :rails,
+          confidence: 0.95,
+          suggested_config: { "enabled" => true, "driver" => "cuprite", "routes" => [ { "path" => "/", "name" => "home" } ] },
+          detected_services: [ "postgres" ],
+          detected_routes: [ { "path" => "/", "name" => "home" } ]
+        )
+      end
+
+      before do
+        sign_in user
+        allow(Screenshots::DetectFramework).to receive(:call).and_return(result)
+      end
+
+      it "redirects to the edit page and stores the suggested YAML in flash" do
+        post detect_project_screenshot_config_path(project)
+
+        expect(response).to redirect_to(edit_project_path(project))
+        expect(flash[:notice]).to include("Suggested screenshot config generated")
+        expect(flash[:screenshot_config_suggestion_yaml]).to include("driver: cuprite")
+      end
+
+      it "returns JSON when requested" do
+        post detect_project_screenshot_config_path(project), headers: { "ACCEPT" => "application/json" }
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["framework"]).to eq("rails")
+        expect(body["confidence"]).to eq(0.95)
+        expect(body["suggested_yaml"]).to include("driver: cuprite")
+        expect(body["detected_services"]).to eq([ "postgres" ])
+      end
+
+      context "when detection fails" do
+        before do
+          allow(Screenshots::DetectFramework).to receive(:call)
+            .and_raise(GithubClient::ApiError.new("boom"))
+        end
+
+        it "redirects with an alert for HTML requests" do
+          post detect_project_screenshot_config_path(project)
+
+          expect(response).to redirect_to(edit_project_path(project))
+          expect(flash[:alert]).to include("Could not detect screenshot config")
+        end
+
+        it "returns a JSON error for API requests" do
+          post detect_project_screenshot_config_path(project), headers: { "ACCEPT" => "application/json" }
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(JSON.parse(response.body)["error"]).to include("Could not detect screenshot config")
+        end
+      end
+    end
+
+    context "when authenticated as viewer" do
+      let(:viewer_user) { create(:user, :viewer, account: account) }
+
+      before { sign_in viewer_user }
+
+      it "rejects the request" do
+        project = create(:project, account: account, github_token: github_token)
+
+        post detect_project_screenshot_config_path(project)
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("not authorized")
+      end
+    end
+  end
+
   describe "DELETE /projects/:id" do
     context "when not authenticated" do
       it "redirects to the sign in page" do

--- a/spec/services/screenshots/detect_framework_spec.rb
+++ b/spec/services/screenshots/detect_framework_spec.rb
@@ -55,4 +55,37 @@ RSpec.describe Screenshots::DetectFramework do
       expect(result.confidence).to be < 0.5
     end
   end
+
+  describe "parse_rails_routes_output" do
+    it "extracts the URI path (after the verb) from rails routes output" do
+      output = <<~ROUTES
+                         Prefix Verb   URI Pattern                 Controller#Action
+                           root GET    /                           home#index
+                      dashboard GET    /dashboard(.:format)        dashboard#show
+                        reports GET    /reports(.:format)          reports#index
+                   edit_profile GET    /profile/edit(.:format)     profiles#edit
+      ROUTES
+
+      service = described_class.new(repo_path: fixture_path("rails_repo"))
+      routes = service.send(:parse_rails_routes_output, output)
+      paths = routes.map { |r| r["path"] }
+
+      expect(paths).to include("/", "/dashboard", "/reports", "/profile/edit")
+      expect(paths).not_to include("root", "dashboard", "reports", "edit_profile")
+    end
+
+    it "handles lines where the prefix column is blank" do
+      output = <<~ROUTES
+                         Prefix Verb   URI Pattern                 Controller#Action
+                                POST   /sessions(.:format)         sessions#create
+                        sign_in GET    /sign_in(.:format)          sessions#new
+      ROUTES
+
+      service = described_class.new(repo_path: fixture_path("rails_repo"))
+      routes = service.send(:parse_rails_routes_output, output)
+      paths = routes.map { |r| r["path"] }
+
+      expect(paths).to include("/sessions", "/sign_in")
+    end
+  end
 end

--- a/spec/services/screenshots/detect_framework_spec.rb
+++ b/spec/services/screenshots/detect_framework_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Screenshots::DetectFramework do
+  def fixture_path(name)
+    Rails.root.join("spec/fixtures/screenshots/#{name}").to_s
+  end
+
+  describe ".call" do
+    it "detects a Rails app and suggests a Cuprite config" do
+      result = described_class.call(repo_path: fixture_path("rails_repo"))
+
+      expect(result.framework).to eq(:rails)
+      expect(result.confidence).to eq(1.0)
+      expect(result.suggested_config["driver"]).to eq("cuprite")
+      expect(result.detected_services).to contain_exactly("postgres", "redis")
+      expect(result.suggested_config.dig("auth", "strategy")).to eq("form")
+      expect(result.detected_routes.map { |route| route["path"] }).to include("/", "/dashboard", "/reports")
+    end
+
+    it "detects a Next.js app and discovers app routes" do
+      result = described_class.call(repo_path: fixture_path("next_repo"))
+
+      expect(result.framework).to eq(:nextjs)
+      expect(result.confidence).to eq(1.0)
+      expect(result.suggested_config["driver"]).to eq("playwright")
+      expect(result.suggested_config.dig("auth", "strategy")).to eq("custom")
+      expect(result.detected_routes.map { |route| route["path"] }).to include("/", "/dashboard", "/blog/:slug")
+    end
+
+    it "detects a Django app and parses urls.py routes" do
+      result = described_class.call(repo_path: fixture_path("django_repo"))
+
+      expect(result.framework).to eq(:django)
+      expect(result.confidence).to eq(1.0)
+      expect(result.suggested_config["base_url"]).to eq("http://localhost:8000")
+      expect(result.detected_routes.map { |route| route["path"] }).to include("/", "/admin/", "/accounts/login/")
+      expect(result.suggested_config.dig("auth", "login_path")).to eq("/accounts/login/")
+    end
+
+    it "falls back to a generic app when no known framework is detected" do
+      result = described_class.call(repo_path: fixture_path("generic_repo"))
+
+      expect(result.framework).to eq(:generic)
+      expect(result.confidence).to eq(0.45)
+      expect(result.suggested_config["driver"]).to eq("playwright")
+      expect(result.detected_routes).to eq([])
+      expect(result.suggested_yaml).to include("routes: []")
+    end
+
+    it "uses lower confidence when only generic frontend assets are present" do
+      result = described_class.call(repo_path: fixture_path("generic_repo"))
+
+      expect(result.confidence).to be < 0.5
+    end
+  end
+end

--- a/spec/services/screenshots/detect_framework_spec.rb
+++ b/spec/services/screenshots/detect_framework_spec.rb
@@ -92,6 +92,74 @@ RSpec.describe Screenshots::DetectFramework do
     end
   end
 
+  describe "fallback Rails route parsing" do
+    it "keeps namespace prefixes across nested non-namespace blocks" do
+      routes = <<~RUBY
+        Rails.application.routes.draw do
+          namespace :admin do
+            resources :users do
+              get "audit"
+            end
+
+            get "dashboard"
+          end
+        end
+      RUBY
+
+      repo = instance_double(
+        described_class::LocalRepository,
+        respond_to?: false,
+        read: routes
+      )
+
+      service = described_class.new(repo_path: fixture_path("rails_repo"))
+      allow(service).to receive(:repo).and_return(repo)
+
+      parsed_routes = service.send(:discover_rails_routes)
+
+      expect(parsed_routes.map { |route| route["path"] }).to include("/admin/users", "/admin/dashboard")
+    end
+  end
+
+  describe "Django url parsing" do
+    def django_repo_with_included_urls
+      instance_double(
+        described_class::LocalRepository,
+        glob: [ "config/settings.py", "project/urls.py", "blog/urls.py" ]
+      ).tap do |repo|
+        allow(repo).to receive(:file?) do |path|
+          [ "project/urls.py", "blog/urls.py" ].include?(path)
+        end
+        allow(repo).to receive(:read).with("config/settings.py").and_return('ROOT_URLCONF = "project.urls"')
+        allow(repo).to receive(:read).with("project/urls.py").and_return(<<~PY)
+          from django.urls import include, path
+
+          urlpatterns = [
+            path("blog/", include("blog.urls")),
+          ]
+        PY
+        allow(repo).to receive(:read).with("blog/urls.py").and_return(<<~PY)
+          from django.urls import path
+
+          urlpatterns = [
+            path("posts/", views.posts),
+          ]
+        PY
+      end
+    end
+
+    it "carries include prefixes into child urlconfs" do
+      repo = django_repo_with_included_urls
+      service = described_class.new(repo_path: fixture_path("django_repo"))
+      allow(service).to receive(:repo).and_return(repo)
+
+      parsed_routes = service.send(:discover_django_routes)
+
+      expect(parsed_routes.map { |route| route["path"] }).to include("/blog/posts/")
+      expect(parsed_routes.map { |route| route["path"] }).not_to include("/posts/")
+    end
+  end
+
   describe "dependency memoization" do
     let(:repo) do
       instance_double(

--- a/spec/services/screenshots/detect_framework_spec.rb
+++ b/spec/services/screenshots/detect_framework_spec.rb
@@ -88,4 +88,39 @@ RSpec.describe Screenshots::DetectFramework do
       expect(paths).to include("/sessions", "/sign_in")
     end
   end
+
+  describe "dependency memoization" do
+    let(:repo) do
+      instance_double(
+        described_class::LocalRepository,
+        file?: false,
+        directory?: false,
+        glob: [],
+        paths: []
+      )
+    end
+
+    before do
+      allow(repo).to receive(:read).with("Gemfile").and_return("gem 'rails'\ngem 'devise'\n")
+      allow(repo).to receive(:read).with("package.json").and_return(JSON.dump({
+        "dependencies" => { "next" => "1.0.0", "next-auth" => "1.0.0", "redis" => "1.0.0" }
+      }))
+      allow(repo).to receive(:read).with("config/database.yml").and_return("")
+      allow(repo).to receive(:read).with("config/routes.rb").and_return("devise_for :users\n")
+      allow(repo).to receive(:read).with("middleware.ts").and_return("")
+      allow(repo).to receive(:read).with("middleware.js").and_return("")
+    end
+
+    it "reads Gemfile and package.json once even when multiple detectors query dependencies" do
+      service = described_class.new(repo_path: fixture_path("generic_repo"))
+      allow(service).to receive(:repo).and_return(repo)
+
+      service.send(:detect_rails)
+      service.send(:detect_nextjs)
+      service.send(:detect_services)
+
+      expect(repo).to have_received(:read).with("Gemfile").once
+      expect(repo).to have_received(:read).with("package.json").once
+    end
+  end
 end

--- a/spec/services/screenshots/detect_framework_spec.rb
+++ b/spec/services/screenshots/detect_framework_spec.rb
@@ -46,7 +46,10 @@ RSpec.describe Screenshots::DetectFramework do
       expect(result.confidence).to eq(0.45)
       expect(result.suggested_config["driver"]).to eq("playwright")
       expect(result.detected_routes).to eq([])
-      expect(result.suggested_yaml).to include("routes: []")
+      expect(result.suggested_config["routes"]).to eq([
+        { "path" => "/", "name" => "home", "requires_auth" => false }
+      ])
+      expect(result.suggested_yaml).to include('- path: "/"')
     end
 
     it "uses lower confidence when only generic frontend assets are present" do
@@ -121,6 +124,30 @@ RSpec.describe Screenshots::DetectFramework do
 
       expect(repo).to have_received(:read).with("Gemfile").once
       expect(repo).to have_received(:read).with("package.json").once
+    end
+  end
+
+  describe "GitHub repository reads" do
+    it "uses the project's configured default branch for both tree and file reads" do
+      client = instance_double(GithubClient)
+      github_token = instance_double(GithubToken, client:)
+      project = instance_double(
+        Project,
+        github_token:,
+        full_name: "acme/widgets",
+        default_branch: "develop"
+      )
+
+      tree_item = double(type: "blob", path: "README.md")
+      tree = double(tree: [ tree_item ])
+
+      allow(client).to receive(:tree).with("acme/widgets", "develop", recursive: true).and_return(tree)
+      allow(client).to receive(:file_content).with("acme/widgets", path: "README.md", ref: "develop").and_return(+"# Widgets")
+
+      repo = described_class::GithubRepository.new(project)
+
+      expect(repo.paths).to eq([ "README.md" ])
+      expect(repo.read("README.md")).to eq("# Widgets")
     end
   end
 end


### PR DESCRIPTION
## Summary

Implemented framework detection and screenshot config suggestion, including a project endpoint and edit-page UI entry point.

Added `Screenshots::DetectFramework` with local/GitHub repo scanning for Rails, Next.js, Django, and generic apps, plus suggested config generation, route discovery, auth hints, and service detection. Added `POST /projects/:project_id/screenshot_config/detect` via [app/controllers/projects/screenshot_configs_controller.rb](/workspace/app/controllers/projects/screenshot_configs_controller.rb:1), wired the button and YAML preview into [app/views/projects/edit.html.erb](/workspace/app/views/projects/edit.html.erb:1), and covered it with fixture-backed specs in [spec/services/screenshots/detect_framework_spec.rb](/workspace/spec/services/screenshots/detect_framework_spec.rb:1) and request specs in [spec/requests/projects_spec.rb](/workspace/spec/requests/projects_spec.rb:1734). I also updated [app/services/screenshots/capture_targets.rb](/workspace/app/services/screenshots/capture_targets.rb:1) so the new controller satisfies the existing UI screenshot mapping guard.

Verification passed with `bundle exec rubocop`, `RAILS_ENV=test bin/rails db:prepare`, and `bundle exec rspec` (`10768` examples, `0` failures, `3` pending). A plain `bin/rails db:prepare` in development still tried local Postgres sockets in this environment, so I used the test env explicitly. Commit: `25703ba` (`feat(screenshots): detect framework and suggest config`).

---

Closes #1652