### PR TITLE
fix(github-sync): self-heal stale issue state and orphaned in_progress issues

### DIFF
--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -40,6 +40,12 @@ class StaleRunDetectorJob < ApplicationJob
   # PR scanning indefinitely if the pause is never acted on.
   PAUSED_TIMEOUT = AgentRun.stale_paused_timeout
 
+  # Issues with paid_state=in_progress are only eligible for recovery once
+  # they've been orphaned for at least this long. Avoids racing with run
+  # creation (create_agent_run_activity sets in_progress then enqueues the
+  # workflow, which may take a few seconds to produce a visible AgentRun).
+  ORPHANED_IN_PROGRESS_AGE = 15.minutes
+
   # Maximum times a stale claimed run can be automatically unclaimed before
   # being timed out. Prevents infinite retry loops when the underlying
   # issue is persistent (e.g. misconfigured project, missing credentials).
@@ -55,6 +61,7 @@ class StaleRunDetectorJob < ApplicationJob
     unclaimed = 0
     requeued = 0
     skipped = 0
+    recovered_orphans = 0
 
     stale_running_runs(running_threshold).find_each do |agent_run|
       resolved += 1 if resolve_stale_run(agent_run)
@@ -100,6 +107,8 @@ class StaleRunDetectorJob < ApplicationJob
       )
     end
 
+    recovered_orphans = recover_orphaned_in_progress_issues
+
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - job_started_at) * 1000).round
     Rails.logger.info(
       message: "stale_run_detector.completed",
@@ -107,15 +116,57 @@ class StaleRunDetectorJob < ApplicationJob
       unclaimed: unclaimed,
       requeued: requeued,
       skipped: skipped,
+      recovered_orphans: recovered_orphans,
       duration_ms: duration_ms
     )
 
-    ProcessRunQueueJob.perform_later if resolved > 0 || unclaimed > 0 || requeued > 0
+    ProcessRunQueueJob.perform_later if resolved > 0 || unclaimed > 0 || requeued > 0 || recovered_orphans > 0
   end
 
   private
 
-  # Uses the default timeout rather than per-user maximums. Individual run
+  # Finds issues stuck in paid_state=in_progress that have no active agent
+  # run. This can happen when a Temporal workflow crashes before reaching a
+  # terminal activity, or when an agent run is deleted without updating the
+  # associated issue. Without recovery these issues are invisible to auto-pick
+  # (which skips in_progress) and invisible to all other cleanup jobs (which
+  # operate top-down from AgentRun records).
+  def recover_orphaned_in_progress_issues
+    active_issue_ids = AgentRun.where(status: AgentRun::UNFINISHED_STATUSES)
+      .where.not(issue_id: nil)
+      .select(:issue_id)
+
+    orphans = Issue.where(paid_state: "in_progress")
+      .where.not(id: active_issue_ids)
+      .where("updated_at < ?", ORPHANED_IN_PROGRESS_AGE.ago)
+
+    count = 0
+    orphans.find_each do |issue|
+      issue.with_lock do
+        issue.reload
+        next unless issue.paid_state == "in_progress"
+        next if AgentRun.where(issue: issue, status: AgentRun::UNFINISHED_STATUSES).exists?
+
+        issue.update!(paid_state: "new")
+        count += 1
+        Rails.logger.info(
+          message: "stale_run_detector.recovered_orphaned_in_progress",
+          issue_id: issue.id,
+          issue_number: issue.github_number,
+          project_id: issue.project_id
+        )
+      end
+    rescue => e
+      Rails.logger.error(
+        message: "stale_run_detector.recover_orphan_failed",
+        issue_id: issue.id,
+        error: e.message
+      )
+    end
+    count
+  end
+
+  # Uses the default timeout rather than per-project maximums. Individual run
   # timeouts are enforced by the Temporal workflow; this job is a safety net
   # for orphaned runs where the workflow died. Using UserSetting.maximum
   # would let a single user's large timeout delay stale-run detection for

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -136,7 +136,7 @@ class StaleRunDetectorJob < ApplicationJob
       .where.not(issue_id: nil)
       .select(:issue_id)
 
-    orphans = Issue.where(paid_state: "in_progress")
+    orphans = Issue.where(paid_state: "in_progress", is_pull_request: false)
       .where.not(id: active_issue_ids)
       .where("updated_at < ?", ORPHANED_IN_PROGRESS_AGE.ago)
 

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -166,7 +166,7 @@ class StaleRunDetectorJob < ApplicationJob
     count
   end
 
-  # Uses the default timeout rather than per-project maximums. Individual run
+  # Uses the default timeout rather than per-user maximums. Individual run
   # timeouts are enforced by the Temporal workflow; this job is a safety net
   # for orphaned runs where the workflow died. Using UserSetting.maximum
   # would let a single user's large timeout delay stale-run detection for

--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -144,8 +144,7 @@ class StaleRunDetectorJob < ApplicationJob
     orphans.find_each do |issue|
       issue.with_lock do
         issue.reload
-        next unless issue.paid_state == "in_progress"
-        next if AgentRun.where(issue: issue, status: AgentRun::UNFINISHED_STATUSES).exists?
+        next unless recoverable_orphaned_issue?(issue)
 
         issue.update!(paid_state: "new")
         count += 1
@@ -164,6 +163,32 @@ class StaleRunDetectorJob < ApplicationJob
       )
     end
     count
+  end
+
+  def recoverable_orphaned_issue?(issue)
+    return false unless issue.paid_state == "in_progress"
+    return false if AgentRun.where(issue: issue, status: AgentRun::UNFINISHED_STATUSES).exists?
+    return false if orphaned_enhance_issue_recheck?(issue)
+
+    true
+  end
+
+  # FetchIssuesActivity intentionally moves a needs_input issue to
+  # in_progress before QueueAgentRunActivity persists the follow-up
+  # enhance_issue run. If that workflow dies in between, the issue is
+  # orphaned but still semantically belongs to the enhance_issue path.
+  # Resetting it to "new" would let normal auto-pick queue create_pr
+  # instead of the intended enhancement rerun.
+  def orphaned_enhance_issue_recheck?(issue)
+    return false if issue.enhance_issue_rounds.zero?
+    return false if issue.has_label?(issue.project.enhance_issue_needs_input_label_name)
+    return false if issue.has_label?(issue.project.enhance_issue_enhanced_label_name)
+
+    latest_goal_for(issue) == "enhance_issue"
+  end
+
+  def latest_goal_for(issue)
+    issue.agent_runs.order(created_at: :desc, id: :desc).limit(1).pick(:goal)
   end
 
   # Uses the default timeout rather than per-user maximums. Individual run

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -10,6 +10,7 @@ module Activities
     DEFAULT_RELATIONSHIP_PARSE_ISSUE_LIMIT = 100
     DEFAULT_RELATIONSHIP_PARSE_BUDGET_SECONDS = 30
     DEFAULT_RELATIONSHIP_COMMENT_PAGES = 2
+    ISSUE_RECONCILIATION_INTERVAL = 1.hour
 
     def execute(input)
       project_id = input[:project_id]
@@ -36,6 +37,7 @@ module Activities
       enhance_issue_rechecks = detect_enhance_issue_rechecks(project, synced_issues)
       closed_count = close_stale_issues(project, github_issues, truncated: truncated, incremental: incremental)
       stale_pr_count = reconcile_open_pull_requests(project, client) if incremental && !truncated
+      stale_issue_count = reconcile_open_issues(project, client) if incremental && !truncated
 
       if truncated && incremental
         # Incremental fetches sort ascending (oldest-updated first), so a
@@ -119,6 +121,7 @@ module Activities
         issue_count: synced_issues.size,
         closed_count: closed_count,
         stale_pr_count: stale_pr_count || 0,
+        stale_issue_count: stale_issue_count || 0,
         incremental: incremental,
         enhance_issue_recheck_count: enhance_issue_rechecks.size,
         rescan_count: incremental ? open_issues.count { |si| si[:rescan] } : 0
@@ -658,6 +661,77 @@ module Activities
       )
 
       count
+    end
+
+    # Mirrors reconcile_open_pull_requests for issues. Fetches all open issue
+    # numbers from GitHub and closes locally-open issues not in that set.
+    # Gated by ISSUE_RECONCILIATION_INTERVAL (default 1 hour) to limit API
+    # cost, since issue counts can be much larger than PR counts.
+    def reconcile_open_issues(project, client)
+      return 0 unless issue_reconciliation_due?(project)
+
+      open_numbers, truncated = fetch_open_issue_numbers(client, project.full_name)
+
+      project.update_column(:last_issue_reconciliation_at, Time.current)
+
+      if truncated
+        logger.warn(
+          message: "github_sync.issue_reconciliation_skipped_truncated",
+          project_id: project.id
+        )
+        return 0
+      end
+
+      stale = project.issues
+        .where(github_state: "open", is_pull_request: false, source: Issue::GITHUB_SOURCE)
+      stale = stale.where.not(github_number: open_numbers) if open_numbers.any?
+
+      count = stale.count
+      if count > 0
+        stale.update_all(github_state: "closed", updated_at: Time.current)
+        project.broadcast_issues_update
+
+        logger.info(
+          message: "github_sync.reconciled_stale_issues",
+          project_id: project.id,
+          count: count
+        )
+      end
+
+      count
+    end
+
+    def issue_reconciliation_due?(project)
+      last = project.last_issue_reconciliation_at
+      last.nil? || last < ISSUE_RECONCILIATION_INTERVAL.ago
+    end
+
+    def fetch_open_issue_numbers(client, repo_full_name)
+      numbers = []
+      page = 1
+      truncated = false
+
+      loop do
+        page_issues = client.issues(repo_full_name, state: "open", per_page: DEFAULT_PER_PAGE, page: page)
+        break if page_issues.empty?
+
+        numbers.concat(page_issues.reject { |i| i.respond_to?(:pull_request) && i.pull_request }.filter_map(&:number))
+        break if page_issues.size < DEFAULT_PER_PAGE
+
+        page += 1
+        next unless page > DEFAULT_MAX_PAGES
+
+        truncated = client.issues(repo_full_name, state: "open", per_page: DEFAULT_PER_PAGE, page: page).any?
+        logger.warn(
+          message: "github_sync.fetch_issue_numbers_page_limit",
+          repo: repo_full_name,
+          fetched_count: numbers.size,
+          max_pages: DEFAULT_MAX_PAGES
+        ) if truncated
+        break
+      end
+
+      [ numbers.uniq, truncated ]
     end
 
     # Stamp relationships_parsed_at only if a concurrent trust-policy change

--- a/db/migrate/20260507011753_add_last_issue_reconciliation_at_to_projects.rb
+++ b/db/migrate/20260507011753_add_last_issue_reconciliation_at_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastIssueReconciliationAtToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :last_issue_reconciliation_at, :datetime, comment: "Timestamp of the last issue state reconciliation against GitHub"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3318,7 +3318,8 @@ CREATE TABLE public.projects (
     knowledge_evolution_enabled boolean DEFAULT false NOT NULL,
     agent_runs_count integer DEFAULT 0 NOT NULL,
     completed_agent_runs_count integer DEFAULT 0 NOT NULL,
-    screenshot_settings jsonb DEFAULT '{}'::jsonb NOT NULL
+    screenshot_settings jsonb DEFAULT '{}'::jsonb NOT NULL,
+    last_issue_reconciliation_at timestamp(6) without time zone
 );
 
 ALTER TABLE ONLY public.projects FORCE ROW LEVEL SECURITY;
@@ -3343,6 +3344,13 @@ COMMENT ON COLUMN public.projects.completed_agent_runs_count IS 'Counter cache f
 --
 
 COMMENT ON COLUMN public.projects.screenshot_settings IS 'Project-level defaults and overrides for repository screenshot capture config';
+
+
+--
+-- Name: COLUMN projects.last_issue_reconciliation_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.projects.last_issue_reconciliation_at IS 'Timestamp of the last issue state reconciliation against GitHub';
 
 
 --
@@ -11205,6 +11213,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507011753'),
 ('20260506174922'),
 ('20260506074459'),
 ('20260505220424'),
@@ -11453,3 +11462,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260128004342'),
 ('20260128004305'),
 ('20260127154444');
+

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -528,6 +528,34 @@ RSpec.describe StaleRunDetectorJob do
         expect(issue.reload.paid_state).to eq("in_progress")
       end
 
+      it "does not reset an orphaned enhance_issue recheck before its run is queued" do
+        issue = create(:issue,
+          project: project,
+          paid_state: "in_progress",
+          enhance_issue_rounds: 1,
+          labels: [],
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+        create(:agent_run, :completed, :enhance_issue_goal, project: project, issue: issue, pull_request_number: nil)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "still resets a non-enhancement orphan with prior enhance_issue history" do
+        issue = create(:issue,
+          project: project,
+          paid_state: "in_progress",
+          enhance_issue_rounds: 1,
+          labels: [ project.enhance_issue_enhanced_label_name ],
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+        create(:agent_run, :completed, :enhance_issue_goal, project: project, issue: issue, pull_request_number: nil)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("new")
+      end
+
       it "does not reset an issue whose paid_state changed before lock acquisition" do
         issue = create(:issue, project: project, paid_state: "in_progress",
           updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -562,6 +562,15 @@ RSpec.describe StaleRunDetectorJob do
         expect(issue.reload.paid_state).to eq("in_progress")
       end
 
+      it "does not reset an in_progress pull request with no active run" do
+        pull_request = create(:issue, :pull_request, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        described_class.perform_now
+
+        expect(pull_request.reload.paid_state).to eq("in_progress")
+      end
+
       it "enqueues ProcessRunQueueJob after recovering orphans" do
         create(:issue, project: project, paid_state: "in_progress",
           updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -505,5 +505,71 @@ RSpec.describe StaleRunDetectorJob do
         expect(stale_run.stale_requeue_count).to eq(1)
       end
     end
+
+    context "with orphaned in_progress issues" do
+      let(:project) { create(:project) }
+
+      it "resets an orphaned in_progress issue to new when no active run exists" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("new")
+      end
+
+      it "does not reset an in_progress issue that has an active run" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+        create(:agent_run, :running, project: project, issue: issue)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "does not reset an issue whose paid_state changed before lock acquisition" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        issue.update_column(:paid_state, "completed")
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("completed")
+      end
+
+      it "does not reset an issue that gets a new run between query and lock" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        allow(AgentRun).to receive(:where).and_call_original
+        allow(AgentRun).to receive(:where).with(
+          hash_including(issue: issue)
+        ).and_return(double(exists?: true))
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "does not reset a recently updated in_progress issue" do
+        issue = create(:issue, project: project, paid_state: "in_progress",
+          updated_at: 1.minute.ago)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "enqueues ProcessRunQueueJob after recovering orphans" do
+        create(:issue, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        expect(ProcessRunQueueJob).to receive(:perform_later).and_call_original
+
+        described_class.perform_now
+      end
+    end
   end
 end

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -1220,6 +1220,7 @@ RSpec.describe Activities::FetchIssuesActivity do
 
       before do
         allow(github_client).to receive(:issues).and_return([ updated_issue ])
+        project.update_column(:last_issue_reconciliation_at, Time.current)
       end
 
       it "passes since parameter, state: all, and direction: asc to the API" do
@@ -1435,6 +1436,118 @@ RSpec.describe Activities::FetchIssuesActivity do
 
           returned_ids = result[:issues].map { |i| i[:id] }
           expect(returned_ids).not_to include(rescannable.id)
+        end
+      end
+
+      context "when issue reconciliation is due" do
+        before do
+          project.update_column(:last_issue_reconciliation_at, 2.hours.ago)
+        end
+
+        it "closes locally-open issues not in GitHub's open set" do
+          stale = create(:issue, project: project, github_issue_id: 5000,
+                         github_number: 50, github_state: "open")
+          open_issue = create(:issue, project: project, github_issue_id: 5001,
+                              github_number: 51, github_state: "open")
+
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(
+            project.full_name,
+            hash_including(state: "open")
+          ).and_return([
+            OpenStruct.new(number: 51, pull_request: nil)
+          ])
+
+          activity.execute(project_id: project.id)
+
+          expect(stale.reload.github_state).to eq("closed")
+          expect(open_issue.reload.github_state).to eq("open")
+        end
+
+        it "updates last_issue_reconciliation_at after running" do
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(
+            project.full_name,
+            hash_including(state: "open")
+          ).and_return([])
+
+          freeze_time do
+            activity.execute(project_id: project.id)
+
+            expect(project.reload.last_issue_reconciliation_at).to be_within(0.1).of(Time.current)
+          end
+        end
+
+        it "skips reconciliation when truncated" do
+          stub_const("#{described_class}::DEFAULT_PER_PAGE", 2)
+          stub_const("#{described_class}::DEFAULT_MAX_PAGES", 1)
+
+          stale = create(:issue, project: project, github_issue_id: 5000,
+                         github_number: 50, github_state: "open")
+
+          allow(github_client).to receive(:issues) do |_repo, **opts|
+            if opts[:state] == "open" && !opts.key?(:since)
+              [ OpenStruct.new(number: 1), OpenStruct.new(number: 2), OpenStruct.new(number: 3) ]
+            else
+              [ updated_issue ]
+            end
+          end
+          allow(Rails.logger).to receive(:warn)
+
+          activity.execute(project_id: project.id)
+
+          expect(stale.reload.github_state).to eq("open")
+        end
+
+        it "updates last_issue_reconciliation_at even when truncated" do
+          stub_const("#{described_class}::DEFAULT_PER_PAGE", 2)
+          stub_const("#{described_class}::DEFAULT_MAX_PAGES", 1)
+
+          allow(github_client).to receive(:issues) do |_repo, **opts|
+            if opts[:state] == "open" && !opts.key?(:since)
+              [ OpenStruct.new(number: 1), OpenStruct.new(number: 2), OpenStruct.new(number: 3) ]
+            else
+              [ updated_issue ]
+            end
+          end
+          allow(Rails.logger).to receive(:warn)
+
+          freeze_time do
+            activity.execute(project_id: project.id)
+
+            expect(project.reload.last_issue_reconciliation_at).to be_within(0.1).of(Time.current)
+          end
+        end
+
+        it "does not close pull requests during issue reconciliation" do
+          stale_issue = create(:issue, project: project, github_issue_id: 5000,
+                               github_number: 50, github_state: "open")
+          stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5001,
+                            github_number: 51, github_state: "open")
+
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(
+            project.full_name,
+            hash_including(state: "open")
+          ).and_return([])
+          allow(github_client).to receive_messages(pull_requests: [
+            OpenStruct.new(number: 51)
+          ])
+
+          activity.execute(project_id: project.id)
+
+          expect(stale_issue.reload.github_state).to eq("closed")
+          expect(stale_pr.reload.github_state).to eq("open")
+        end
+
+        it "skips reconciliation when recently reconciled" do
+          project.update_column(:last_issue_reconciliation_at, 5.minutes.ago)
+          stale = create(:issue, project: project, github_issue_id: 5000,
+                         github_number: 50, github_state: "open")
+
+          activity.execute(project_id: project.id)
+
+          expect(stale.reload.github_state).to eq("open")
         end
       end
     end


### PR DESCRIPTION
## Summary

- Adds periodic issue state reconciliation to `FetchIssuesActivity`, mirroring the existing `reconcile_open_pull_requests` pattern for PRs. During incremental fetches, fetches all open issue numbers from GitHub hourly and closes locally-open issues not in that set.
- Adds orphaned `in_progress` issue recovery to `StaleRunDetectorJob` — issues stuck in `in_progress` with no active agent run (after 15 minutes) are reset to `new` with row-level locking to prevent TOCTOU races.

## Root Cause

Issues closed on GitHub could remain `open` locally indefinitely because:
1. `close_stale_issues` skips during incremental fetches (by design — it only works on the current page of results)
2. No webhook or event-driven mechanism exists for issue close events
3. The `github_state` column is only updated by `FetchIssuesActivity` polling

This stale `github_state` made issues invisible to auto-pick (which requires `github_state: "open"`) and showed incorrect status in the UI.

## Changes

### Issue State Reconciliation (new)
- `projects.last_issue_reconciliation_at` column (migration) tracks last reconciliation
- `FetchIssuesActivity#reconcile_open_issues` fetches all open issue numbers from GitHub, closes locally-open issues not in that set
- Gated by `ISSUE_RECONCILIATION_INTERVAL = 1.hour` to limit API cost
- Timestamp stamped before truncation check to prevent wasted API calls on repos with >1000 open issues
- Filters out PRs from GitHub's issues API response (which returns both issues and PRs)

### Orphaned in_progress Recovery
- `StaleRunDetectorJob#recover_orphaned_in_progress_issues` resets `paid_state` from `in_progress` to `new` for issues with no active agent run after 15 minutes
- Uses `with_lock` + reload + re-check to prevent TOCTOU races
- Triggers `ProcessRunQueueJob` after recovery so auto-pick can re-evaluate

## Test Coverage

- 6 new specs for issue reconciliation (stale closure, timestamp update, truncation skip, timestamp on truncation, PR exclusion, interval gating)
- 6 new specs for orphan recovery (happy path, active-run guard, age threshold, paid_state guard, TOCTOU race, queue enqueue)
- All 117 tests pass, lint clean