### PR TITLE
feat(orchestration): log agent selection decisions with context

### DIFF
--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -32,7 +32,7 @@ module Models
           selector_type: "meta_agent",
           tier: initial_tier,
           reasoning: "Single candidate in pool; LLM selection skipped",
-          candidates: [ { model_id: only.model_id, score: only.capability_score.to_f } ],
+          candidates: [ only ],
           complexity_score: initial_complexity
         }
       end
@@ -52,7 +52,7 @@ module Models
         # separately on the selection record.
         tier: initial_tier,
         reasoning: response[:reasoning],
-        candidates: candidates.map { |m| { model_id: m.model_id, score: m.capability_score.to_f } },
+        candidates: candidates,
         complexity_score: response[:complexity_score]
       }
     rescue AgentHarness::Error, JSON::ParserError => e

--- a/app/services/models/rules_based_selector.rb
+++ b/app/services/models/rules_based_selector.rb
@@ -27,7 +27,7 @@ module Models
         tier: tier,
         reasoning: "Rules-based selection: complexity=#{complexity.round(1)}, tier=#{tier || 'unknown'}, " \
                    "selected #{selected.display_name} (capability=#{selected.capability_score})",
-        candidates: candidates.map { |m| { model_id: m.model_id, score: m.capability_score.to_f } },
+        candidates: candidates,
         complexity_score: complexity
       }
     end

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -4,6 +4,8 @@ module Models
   class Select
     include ProviderTierLookup
 
+    DECISION_LOG_TYPE = "model_selection_decision"
+
     attr_reader :agent_run
 
     def self.call(...)
@@ -18,26 +20,43 @@ module Models
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       selected = select_model
-      return nil unless selected
-
       duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
+      unless selected
+        persist_decision_log(outcome: "no_selection", duration_ms: duration_ms)
+        return nil
+      end
 
       final_tier = selected[:tier] || tier_for(selected)
       escalation = detect_escalation(selected, final_tier)
+      candidates = normalized_candidates(selected, selected_model_id: selected[:model].model_id)
 
-      ModelSelection.find_or_create_by!(agent_run: agent_run) do |ms|
+      selection = ModelSelection.find_or_create_by!(agent_run: agent_run) do |ms|
         ms.llm_model = selected[:model]
         ms.selector_type = selected[:selector_type]
         ms.reasoning = selected[:reasoning]
-        ms.candidates = selected[:candidates]
+        ms.candidates = candidates
         ms.complexity_score = selected[:complexity_score]
         ms.tier = final_tier
         ms.selection_duration_ms = duration_ms
         ms.escalated_from_tier = escalation[:from_tier]
         ms.escalated_reason = escalation[:reason]
       end
+      persist_decision_log(
+        outcome: "selected",
+        duration_ms: duration_ms,
+        selected: selected,
+        final_tier: final_tier,
+        escalation: escalation,
+        selection: selection,
+        candidates: candidates
+      )
+      selection
     rescue ActiveRecord::RecordNotUnique
       ModelSelection.find_by!(agent_run: agent_run)
+    rescue => e
+      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
+      persist_decision_log(outcome: "failed", duration_ms: duration_ms, error: e)
+      raise
     end
 
     private
@@ -82,7 +101,7 @@ module Models
         model: model,
         selector_type: "quality_escalation",
         reasoning: "Quality-triggered escalation to #{tier} tier",
-        candidates: [ { model_id: model.model_id, score: model.capability_score.to_f } ],
+        candidates: [ model ],
         complexity_score: nil,
         tier: tier
       }
@@ -115,7 +134,7 @@ module Models
         model: model,
         selector_type: "override",
         reasoning: reason,
-        candidates: [ { model_id: model.model_id, score: model.capability_score.to_f } ],
+        candidates: [ model ],
         complexity_score: nil,
         # For override paths the tier follows the chosen model directly, since
         # no complexity-based routing was performed.
@@ -168,6 +187,172 @@ module Models
       elsif project.model_preferences&.dig("quality_recovery_min_tier").present?
         "quality_recovery_project"
       end
+    end
+
+    def normalized_candidates(selected, selected_model_id:)
+      Array(selected[:candidates]).filter_map.with_index(1) do |candidate, rank|
+        normalize_candidate(candidate, rank: rank, selected_model_id: selected_model_id)
+      end
+    end
+
+    def normalize_candidate(candidate, rank:, selected_model_id:)
+      if candidate.is_a?(LlmModel)
+        serialize_model_candidate(candidate, rank: rank, selected: candidate.model_id == selected_model_id)
+      elsif candidate.respond_to?(:deep_symbolize_keys)
+        data = candidate.deep_symbolize_keys
+        model = LlmModel.find_by(model_id: data[:model_id])
+        serialize_hash_candidate(data, model: model, rank: rank, selected_model_id: selected_model_id)
+      end
+    end
+
+    def serialize_hash_candidate(data, model:, rank:, selected_model_id:)
+      {
+        rank: rank,
+        selected: data.fetch(:selected, data[:model_id] == selected_model_id),
+        model_id: data[:model_id],
+        provider: data[:provider] || model&.provider,
+        tier: data[:tier] || model&.tier,
+        score: data[:score],
+        capability_score: data[:capability_score] || model&.capability_score&.to_f,
+        input_cost_per_million: data[:input_cost_per_million] || model&.input_cost_per_million&.to_f,
+        output_cost_per_million: data[:output_cost_per_million] || model&.output_cost_per_million&.to_f
+      }.compact
+    end
+
+    def serialize_model_candidate(model, rank:, selected:)
+      {
+        rank: rank,
+        selected: selected,
+        model_id: model.model_id,
+        provider: model.provider,
+        tier: model.tier,
+        score: model.capability_score&.to_f,
+        capability_score: model.capability_score&.to_f,
+        input_cost_per_million: model.input_cost_per_million&.to_f,
+        output_cost_per_million: model.output_cost_per_million&.to_f
+      }.compact
+    end
+
+    def persist_decision_log(outcome:, duration_ms:, selected: nil, final_tier: nil, escalation: nil, selection: nil, candidates: nil, error: nil)
+      agent_run.agent_run_logs.create!(
+        log_type: "system",
+        content: decision_log_content(outcome: outcome, selected: selected, error: error),
+        metadata: {
+          type: DECISION_LOG_TYPE,
+          outcome: outcome,
+          duration_ms: duration_ms,
+          selection: selection_payload(selected: selected, selection: selection, final_tier: final_tier, escalation: escalation, candidates: candidates),
+          inputs: selection_inputs,
+          error: error_payload(error)
+        }.compact
+      )
+    rescue => log_error
+      Rails.logger.warn(
+        message: "model_selection.decision_log_failed",
+        agent_run_id: agent_run.id,
+        error_class: log_error.class.name,
+        error: log_error.message
+      )
+    end
+
+    def decision_log_content(outcome:, selected:, error:)
+      case outcome
+      when "selected"
+        "Agent selection succeeded via #{selected[:selector_type]} for #{selected[:model].model_id}"
+      when "no_selection"
+        "Agent selection found no eligible models"
+      else
+        "Agent selection failed: #{error.class}: #{error.message}"
+      end
+    end
+
+    def selection_payload(selected:, selection:, final_tier:, escalation:, candidates:)
+      return nil unless selected || selection
+
+      {
+        model_selection_id: selection&.id,
+        agent_type: agent_run.agent_type,
+        provider_id: agent_run.provider_id,
+        provider_key: agent_run.provider&.provider_key || agent_run.effective_provider,
+        effective_provider: agent_run.effective_provider,
+        selector_type: selected&.dig(:selector_type) || selection&.selector_type,
+        reasoning: selected&.dig(:reasoning) || selection&.reasoning,
+        model_id: selected&.dig(:model)&.model_id || selection&.llm_model&.model_id,
+        model_provider: selected&.dig(:model)&.provider || selection&.llm_model&.provider,
+        model_tier: selected&.dig(:model)&.tier || selection&.llm_model&.tier,
+        final_tier: final_tier || selection&.tier,
+        complexity_score: selected&.dig(:complexity_score) || selection&.complexity_score&.to_f,
+        escalated_from_tier: escalation&.dig(:from_tier) || selection&.escalated_from_tier,
+        escalated_reason: escalation&.dig(:reason) || selection&.escalated_reason,
+        candidates: candidates || selection&.candidates
+      }.compact
+    end
+
+    def selection_inputs
+      project = agent_run.project
+      issue = agent_run.issue
+      preferences = project.model_preferences || {}
+      provider = agent_run.provider
+
+      {
+        task: {
+          goal: agent_run.goal,
+          trigger_type: agent_run.trigger_type,
+          issue_id: issue&.id,
+          issue_title: issue&.title,
+          issue_body_length: issue&.body.to_s.length,
+          custom_prompt_present: agent_run.custom_prompt.present?,
+          existing_pr: agent_run.existing_pr?,
+          priority_tier: agent_run.priority_tier
+        }.compact,
+        repository: {
+          project_id: project.id,
+          full_name: project.full_name,
+          max_tokens_per_run: project.max_tokens_per_run
+        }.compact,
+        provider_context: {
+          provider_id: provider&.id,
+          provider_key: provider&.provider_key || agent_run.effective_provider,
+          agent_type: agent_run.agent_type,
+          effective_provider: agent_run.effective_provider,
+          complexity_thresholds: Models::TierForComplexity.new(agent_run: agent_run, complexity: 1.0).effective_thresholds
+        }.compact,
+        policy_constraints: {
+          required_model_id: preferences["required_model_id"],
+          preferred_model_ids: preferences["preferred_model_ids"],
+          excluded_model_ids: preferences["excluded_model_ids"],
+          max_tier: preferences["max_tier"],
+          quality_recovery_min_tier: preferences["quality_recovery_min_tier"],
+          goal_min_tier: preferences.dig("goal_min_tiers", agent_run.goal),
+          preferred_agent_type: preferences["preferred_agent_type"]
+        }.compact,
+        budget_signals: {
+          active_budgets: active_budget_signals(project)
+        }
+      }
+    end
+
+    def active_budget_signals(project)
+      project.cost_budgets.filter_map do |budget|
+        next unless budget.limit_cents.to_i.positive?
+
+        {
+          budget_type: budget.budget_type,
+          enforcement_mode: budget.enforcement_mode,
+          limit_cents: budget.limit_cents,
+          remaining_cents: budget.remaining_cents,
+          hard_stop: budget.hard_stop?
+        }
+      end
+    end
+
+    def error_payload(error)
+      return nil unless error
+
+      {
+        class: error.class.name,
+        message: error.message
+      }
     end
   end
 end

--- a/spec/services/models/meta_agent_selector_spec.rb
+++ b/spec/services/models/meta_agent_selector_spec.rb
@@ -69,17 +69,14 @@ RSpec.describe Models::MetaAgentSelector do
       it "restricts candidates to the complexity-derived tier" do
         result = described_class.call(agent_run: agent_run)
 
-        expect(result[:candidates].map { |c| c[:model_id] }).to contain_exactly("tier-low-agent")
+        expect(result[:candidates].map(&:model_id)).to contain_exactly("tier-low-agent")
       end
     end
 
     it "includes all candidates in the result" do
       result = described_class.call(agent_run: agent_run)
 
-      expect(result[:candidates]).to contain_exactly(
-        { model_id: "claude-sonnet-4-6", score: 9.0 },
-        { model_id: "claude-haiku-4-5-20251001", score: 5.0 }
-      )
+      expect(result[:candidates]).to contain_exactly(capable_model, cheap_model)
     end
 
     it "sends a prompt to AgentHarness with the correct parameters" do
@@ -187,7 +184,7 @@ RSpec.describe Models::MetaAgentSelector do
       it "excludes those models from candidates" do
         result = described_class.call(agent_run: agent_run)
 
-        expect(result[:candidates]).to eq([ { model_id: "claude-sonnet-4-6", score: 9.0 } ])
+        expect(result[:candidates]).to eq([ capable_model ])
       end
     end
 

--- a/spec/services/models/select_spec.rb
+++ b/spec/services/models/select_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Models::Select do
 
     context "with project model override (required_model_id)" do
       let!(:llm_model) { create(:llm_model, model_id: "claude-sonnet-4-6", tier: "high") }
+      let(:decision_log) { agent_run.agent_run_logs.where(log_type: "system").order(:id).last }
 
       before do
         project.update!(model_preferences: { "required_model_id" => "claude-sonnet-4-6" })
@@ -36,6 +37,70 @@ RSpec.describe Models::Select do
       it "persists a ModelSelection record" do
         expect { described_class.call(agent_run: agent_run) }
           .to change(ModelSelection, :count).by(1)
+      end
+
+      it "logs the persisted selection outcome" do
+        create(:cost_budget, :hard_stop, :per_run, project: project, limit_cents: 1_200, current_usage_cents: 300)
+
+        selection = described_class.call(agent_run: agent_run)
+
+        expect(decision_log).to be_present
+        expect(decision_log.content).to include("Agent selection succeeded")
+        expect(decision_log.metadata).to include("type" => "model_selection_decision", "outcome" => "selected")
+        expect(decision_log.metadata.dig("selection", "model_selection_id")).to eq(selection.id)
+        expect(decision_log.metadata.dig("selection", "agent_type")).to eq(agent_run.agent_type)
+        expect(decision_log.metadata.dig("selection", "provider_key")).to eq("claude")
+        expect(decision_log.metadata.dig("selection", "model_id")).to eq("claude-sonnet-4-6")
+        expect(decision_log.metadata.dig("selection", "model_provider")).to eq(llm_model.provider)
+      end
+
+      it "logs ranked candidates for the selection" do
+        described_class.call(agent_run: agent_run)
+
+        expect(decision_log.metadata.dig("selection", "candidates")).to contain_exactly(
+          include(
+            "rank" => 1,
+            "selected" => true,
+            "model_id" => "claude-sonnet-4-6",
+            "provider" => llm_model.provider,
+            "tier" => "high"
+          )
+        )
+      end
+
+      it "logs task and repository selection inputs" do
+        create(:cost_budget, :hard_stop, :per_run, project: project, limit_cents: 1_200, current_usage_cents: 300)
+
+        described_class.call(agent_run: agent_run)
+
+        expect(decision_log.metadata.dig("inputs", "task")).to include(
+          "goal" => agent_run.goal,
+          "trigger_type" => agent_run.trigger_type,
+          "issue_id" => agent_run.issue_id
+        )
+        expect(decision_log.metadata.dig("inputs", "repository")).to include(
+          "project_id" => project.id,
+          "full_name" => project.full_name
+        )
+      end
+
+      it "logs policy constraints and budget signals" do
+        create(:cost_budget, :hard_stop, :per_run, project: project, limit_cents: 1_200, current_usage_cents: 300)
+
+        described_class.call(agent_run: agent_run)
+
+        expect(decision_log.metadata.dig("inputs", "policy_constraints")).to include(
+          "required_model_id" => "claude-sonnet-4-6"
+        )
+        expect(decision_log.metadata.dig("inputs", "budget_signals", "active_budgets")).to contain_exactly(
+          include(
+            "budget_type" => "per_run",
+            "enforcement_mode" => "hard_stop",
+            "limit_cents" => 1200,
+            "remaining_cents" => 900,
+            "hard_stop" => true
+          )
+        )
       end
 
       it "does not call meta-agent or rules-based selector" do
@@ -228,6 +293,18 @@ RSpec.describe Models::Select do
       it "returns nil" do
         expect(described_class.call(agent_run: agent_run)).to be_nil
       end
+
+      it "logs the no-selection outcome with inputs" do
+        described_class.call(agent_run: agent_run)
+
+        log = agent_run.agent_run_logs.where(log_type: "system").order(:id).last
+
+        expect(log).to be_present
+        expect(log.content).to include("no eligible models")
+        expect(log.metadata).to include("type" => "model_selection_decision", "outcome" => "no_selection")
+        expect(log.metadata["selection"]).to be_nil
+        expect(log.metadata.dig("inputs", "repository", "full_name")).to eq(project.full_name)
+      end
     end
 
     context "when override model does not exist" do
@@ -357,6 +434,26 @@ RSpec.describe Models::Select do
 
         expect(selection).to be_a(ModelSelection)
         expect(selection.tier).to be_in(%w[low mid])
+      end
+    end
+
+    context "when selection raises" do
+      before do
+        allow(Models::MetaAgentSelector).to receive(:call).and_raise(StandardError, "selector blew up")
+      end
+
+      it "logs the failure before re-raising" do
+        expect {
+          described_class.call(agent_run: agent_run)
+        }.to raise_error(StandardError, "selector blew up")
+
+        log = agent_run.agent_run_logs.where(log_type: "system").order(:id).last
+
+        expect(log).to be_present
+        expect(log.content).to include("Agent selection failed")
+        expect(log.metadata).to include("type" => "model_selection_decision", "outcome" => "failed")
+        expect(log.metadata.dig("error", "class")).to eq("StandardError")
+        expect(log.metadata.dig("error", "message")).to eq("selector blew up")
       end
     end
   end

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -344,6 +344,20 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(issue.reload.paid_state).to eq("in_progress")
     end
 
+    it "does not fail when model selection raises" do
+      allow(Models::Select).to receive(:call).and_raise(StandardError, "selection blew up")
+      result = nil
+
+      expect {
+        result = activity.execute(project_id: project.id, issue_id: issue.id)
+      }.not_to raise_error
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.status).to eq("queued")
+      expect(agent_run.model_selection).to be_nil
+      expect(issue.reload.paid_state).to eq("in_progress")
+    end
+
     it "records a failed phase when later side effects raise" do
       allow(Issue).to receive(:find).with(issue.id).and_return(issue)
       allow(issue).to receive(:update!).and_raise(StandardError, "issue update failed")


### PR DESCRIPTION
## Summary

Implemented and committed as `c1e5a1d` on `paid/1749-featorchestration-log-agent-selection-decisions-wi-b60693`.

The change adds structured agent-selection decision logging in [`app/services/models/select.rb`](/workspace/app/services/models/select.rb), enriches persisted ranked alternatives with provider/tier/rank metadata, and records `selected`, `no_selection`, and `failed` outcomes without blocking run creation. I also updated the selector specs and `CreateAgentRunActivity` coverage for the non-fatal fallback path.

Verification passed with explicit DB connection env:
`bin/rails db:prepare`
`RAILS_ENV=test bin/rails db:prepare`
`bundle exec rubocop`
`bundle exec rspec`

The full suite finished `10845 examples, 0 failures, 3 pending`. The worktree is clean.

---

Closes #1749