### PR TITLE
feat(orchestration): log decomposition decisions with workflow context

### DIFF
--- a/app/models/decomposition_decision.rb
+++ b/app/models/decomposition_decision.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DecompositionDecision < ApplicationRecord
+  DECISION_TYPES = %w[planning_outcome parallelization_outcome].freeze
+
+  belongs_to :project
+  belongs_to :issue
+
+  validates :decision_key, presence: true, uniqueness: true
+  validates :workflow_name, :workflow_id, :decision_type, :outcome, presence: true
+  validates :decision_type, inclusion: { in: DECISION_TYPES }
+
+  scope :for_workflow, ->(workflow_id) { where(workflow_id: workflow_id) }
+  scope :for_issue, ->(issue) { where(issue: issue) }
+end

--- a/app/services/orchestration/decomposition_decisions/log.rb
+++ b/app/services/orchestration/decomposition_decisions/log.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Orchestration
+  module DecompositionDecisions
+    class Log
+      def self.call(...)
+        new(...).call
+      end
+
+      def initialize(project_id:, issue_id:, decision_key:, workflow_name:, workflow_id:, decision_type:, outcome:,
+        input_context: {}, plan_data: {}, error_details: {}, metadata: {})
+        @project_id = project_id
+        @issue_id = issue_id
+        @decision_key = decision_key
+        @workflow_name = workflow_name
+        @workflow_id = workflow_id
+        @decision_type = decision_type
+        @outcome = outcome
+        @input_context = normalize_hash(input_context)
+        @plan_data = normalize_hash(plan_data)
+        @error_details = normalize_hash(error_details)
+        @metadata = normalize_hash(metadata)
+      end
+
+      def call
+        existing = DecompositionDecision.find_by(decision_key: decision_key)
+        return existing if existing
+
+        DecompositionDecision.create!(
+          project_id: project_id,
+          issue_id: issue_id,
+          decision_key: decision_key,
+          workflow_name: workflow_name,
+          workflow_id: workflow_id,
+          decision_type: decision_type,
+          outcome: outcome,
+          input_context: enriched_input_context,
+          plan_data: plan_data,
+          hints: derived_hints,
+          error_details: error_details,
+          metadata: metadata
+        )
+      rescue ActiveRecord::RecordNotUnique
+        DecompositionDecision.find_by!(decision_key: decision_key)
+      end
+
+      private
+
+      attr_reader :project_id, :issue_id, :decision_key, :workflow_name, :workflow_id,
+        :decision_type, :outcome, :input_context, :plan_data, :error_details, :metadata
+
+      def issue
+        @issue ||= Issue.find(issue_id)
+      end
+
+      def enriched_input_context
+        input_context.merge(
+          "issue" => {
+            "id" => issue.id,
+            "github_number" => issue.github_number,
+            "github_url" => issue.github_url,
+            "title" => issue.title,
+            "labels" => issue.labels
+          }
+        )
+      end
+
+      def derived_hints
+        tasks = Array(plan_data["tasks"])
+        created_issues = Array(plan_data["created_issues"])
+        dependency_map = tasks.to_h do |task|
+          [ task["index"], Array(task["dependencies"]) ]
+        end
+        parallel_groups = tasks.group_by { |task| task["parallel_group"] }
+
+        {
+          "task_count" => tasks.size,
+          "created_issue_count" => created_issues.size,
+          "created_issue_numbers" => created_issues.filter_map { |issue_data| issue_data["github_number"] },
+          "dependency_edges" => dependency_map.values.sum(&:size),
+          "tasks_with_dependencies" => dependency_map.count { |_task_index, dependencies| dependencies.any? },
+          "dependency_map" => dependency_map,
+          "parallel_groups" => parallel_groups.transform_values { |group| group.map { |task| task["index"] } },
+          "parallelizable_groups" => parallel_groups.select { |_group, tasks_in_group| tasks_in_group.size > 1 }
+            .transform_values { |group| group.map { |task| task["index"] } }
+        }
+      end
+
+      def normalize_hash(value)
+        case value
+        when Hash
+          value.deep_stringify_keys
+        else
+          {}
+        end
+      end
+    end
+  end
+end

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -21,22 +21,23 @@ module Activities
       project = Project.find(project_id)
       issue = project.issues.find(issue_id)
 
-      tasks = decompose(issue, knowledge_context)
+      prompt_data = render_prompt(issue, knowledge_context)
+      tasks = decompose(prompt_data[:prompt])
 
       logger.info(
         message: "planning.decomposition_complete",
         project_id: project_id,
         issue_id: issue_id,
-        task_count: tasks.size
+        task_count: tasks.size,
+        prompt_source: prompt_data[:prompt_source]
       )
 
-      { tasks: tasks }
+      { tasks: tasks, prompt_source: prompt_data[:prompt_source] }
     end
 
     private
 
-    def decompose(issue, context)
-      prompt = build_prompt(issue, context)
+    def decompose(prompt)
       response = AgentHarness.send_message(
         prompt,
         provider: :claude,
@@ -95,7 +96,7 @@ module Activities
       ]
     PROMPT
 
-    def build_prompt(issue, context)
+    def render_prompt(issue, context)
       vars = {
         title: issue.title,
         body: issue.body.to_s.truncate(8000),
@@ -103,12 +104,23 @@ module Activities
         max_tasks: MAX_TASKS
       }
 
-      Prompts::Render.call(
-        slug: PROMPT_SLUG,
-        project: issue.project,
-        variables: vars,
-        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
-      ).strip
+      prompt = Prompt.resolve(PROMPT_SLUG, project: issue.project)
+      version = prompt&.current_version
+
+      if version
+        { prompt: version.render(vars).strip, prompt_source: "active_prompt" }
+      else
+        logger.warn(
+          message: "planning.decomposition_prompt_fallback",
+          project_id: issue.project_id,
+          issue_id: issue.id,
+          prompt_slug: PROMPT_SLUG
+        )
+        {
+          prompt: Prompts::Render.interpolate(FALLBACK_PROMPT, vars).strip,
+          prompt_source: "fallback_prompt"
+        }
+      end
     end
 
     def build_knowledge_section(snippets)

--- a/app/temporal/activities/log_decomposition_decision_activity.rb
+++ b/app/temporal/activities/log_decomposition_decision_activity.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Activities
+  class LogDecompositionDecisionActivity < BaseActivity
+    activity_name "LogDecompositionDecision"
+
+    def execute(input)
+      decision = Orchestration::DecompositionDecisions::Log.call(**input.deep_symbolize_keys)
+
+      {
+        decomposition_decision_id: decision.id,
+        decision_key: decision.decision_key
+      }
+    end
+  end
+end

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -22,11 +22,13 @@ module Workflows
   #   aggregate_pr: (optional) Whether to create an aggregated PR
   class FeatureOrchestrationWorkflow < BaseWorkflow
     DEFAULT_TIMEOUT_SECONDS = 7200
+    NO_RETRY = Temporalio::RetryPolicy.new(max_attempts: 1)
 
     def execute(input)
       project_id = input[:project_id]
       issue_id = input[:issue_id]
       timeout_seconds = input.fetch(:timeout_seconds, DEFAULT_TIMEOUT_SECONDS)
+      workflow_id = Temporalio::Workflow.info.workflow_id
 
       Temporalio::Workflow.logger.info(
         message: "feature_orchestration.started",
@@ -34,13 +36,25 @@ module Workflows
         issue_id: issue_id
       )
 
+      tasks = []
+      created_issues = []
+      planning_context = {}
+      prompt_source = nil
+      decision_phase = "planning"
+      decision_step = "fetch_planning_context"
+      @decision_step = decision_step
+
       # Phase 1: Decompose the feature into sub-tasks
       planning_result = run_planning(project_id, issue_id)
 
       tasks = planning_result[:tasks] || []
       created_issues = planning_result[:created_issues]
+      planning_context = planning_result[:context] || {}
+      prompt_source = planning_result[:prompt_source]
 
       # Update labels/state immediately after planning completes (mirrors PlanningWorkflow step 4)
+      decision_step = "update_planning_labels"
+      @decision_step = decision_step
       run_activity(
         Activities::UpdatePlanningLabelsActivity,
         {
@@ -51,8 +65,54 @@ module Workflows
         timeout: 30
       )
 
+      safe_log_decomposition_decision(
+        project_id: project_id,
+        issue_id: issue_id,
+        decision_key: "#{workflow_id}:planning_outcome:final",
+        workflow_name: self.class.name,
+        workflow_id: workflow_id,
+        decision_type: "planning_outcome",
+        outcome: planning_outcome_for(tasks),
+        input_context: planning_context,
+        plan_data: {
+          tasks: tasks,
+          created_issues: created_issues
+        },
+        metadata: {
+          prompt_source: prompt_source,
+          failed_step: nil,
+          activity_boundaries: %w[
+            Activities::FetchPlanningContextActivity
+            Activities::DecomposeFeatureActivity
+            Activities::CreateSubIssuesActivity
+            Activities::UpdatePlanningLabelsActivity
+          ]
+        }
+      )
+
       # If planning produced 0-1 tasks, no parallel execution needed
+      decision_phase = "parallelization"
       unless tasks.size > 1
+        safe_log_decomposition_decision(
+          project_id: project_id,
+          issue_id: issue_id,
+          decision_key: "#{workflow_id}:parallelization_outcome:final",
+          workflow_name: self.class.name,
+          workflow_id: workflow_id,
+          decision_type: "parallelization_outcome",
+          outcome: parallelization_outcome_for(tasks),
+          input_context: planning_context,
+          plan_data: {
+            tasks: tasks,
+            created_issues: created_issues
+          },
+          metadata: {
+            prompt_source: prompt_source,
+            failed_step: nil,
+            activity_boundaries: [ "Workflows::ParallelAgentExecutionWorkflow" ]
+          }
+        )
+
         Temporalio::Workflow.logger.info(
           message: "feature_orchestration.single_task_skip",
           project_id: project_id,
@@ -69,8 +129,33 @@ module Workflows
       end
 
       # Phase 2: Launch parallel execution on all sub-tasks
+      decision_step = "build_sub_tasks"
+      @decision_step = decision_step
       sub_tasks = build_sub_tasks(tasks, created_issues)
 
+      safe_log_decomposition_decision(
+        project_id: project_id,
+        issue_id: issue_id,
+        decision_key: "#{workflow_id}:parallelization_outcome:final",
+        workflow_name: self.class.name,
+        workflow_id: workflow_id,
+        decision_type: "parallelization_outcome",
+        outcome: "parallel_execution_planned",
+        input_context: planning_context,
+        plan_data: {
+          tasks: tasks,
+          created_issues: created_issues,
+          sub_tasks: sub_tasks
+        },
+        metadata: {
+          prompt_source: prompt_source,
+          failed_step: nil,
+          activity_boundaries: [ "Workflows::ParallelAgentExecutionWorkflow" ]
+        }
+      )
+
+      decision_step = "run_parallel_execution"
+      @decision_step = decision_step
       parallel_result = run_parallel_execution(
         project_id: project_id,
         issue_id: issue_id,
@@ -99,6 +184,31 @@ module Workflows
         aggregated_pr: parallel_result[:aggregated_pr]
       }
     rescue => e
+      failed_step = @decision_step || decision_step
+
+      safe_log_decomposition_decision(
+        project_id: project_id,
+        issue_id: issue_id,
+        decision_key: "#{workflow_id}:#{decision_phase}_outcome:failure",
+        workflow_name: self.class.name,
+        workflow_id: workflow_id,
+        decision_type: decision_phase == "parallelization" ? "parallelization_outcome" : "planning_outcome",
+        outcome: decision_phase == "parallelization" ? parallelization_failure_outcome_for(failed_step) : planning_failure_outcome_for(failed_step),
+        input_context: planning_context,
+        plan_data: {
+          tasks: tasks,
+          created_issues: created_issues
+        },
+        error_details: {
+          error_class: e.class.to_s,
+          error_message: e.message
+        },
+        metadata: {
+          prompt_source: prompt_source,
+          failed_step: failed_step
+        }
+      )
+
       Temporalio::Workflow.logger.error(
         message: "feature_orchestration.failed",
         project_id: project_id,
@@ -117,6 +227,7 @@ module Workflows
     # summary, requiring re-fetching. Shared activities keep the actual logic deduplicated.
     def run_planning(project_id, issue_id)
       # Step 1: Fetch knowledge base context
+      @decision_step = "fetch_planning_context"
       context_result = run_activity(
         Activities::FetchPlanningContextActivity,
         { project_id: project_id, issue_id: issue_id },
@@ -124,6 +235,7 @@ module Workflows
       )
 
       # Step 2: Decompose into sub-tasks
+      @decision_step = "decompose_feature"
       decompose_result = run_activity(
         Activities::DecomposeFeatureActivity,
         {
@@ -135,10 +247,12 @@ module Workflows
       )
 
       tasks = decompose_result[:tasks]
+      prompt_source = decompose_result[:prompt_source]
       created_issues = []
 
       # Step 3: Create sub-issues if multiple tasks
       if tasks.present? && tasks.size > 1
+        @decision_step = "create_sub_issues"
         create_result = run_activity(
           Activities::CreateSubIssuesActivity,
           {
@@ -160,7 +274,7 @@ module Workflows
         created_issues = create_result[:created_issues]
       end
 
-      { tasks: tasks, created_issues: created_issues }
+      { tasks: tasks, created_issues: created_issues, context: context_result[:context], prompt_source: prompt_source }
     end
 
     def build_sub_tasks(tasks, created_issues)
@@ -214,6 +328,51 @@ module Workflows
         id: workflow_id,
         execution_timeout: timeout_seconds + 300,
         task_queue: Paid::AGENT_TASK_QUEUE
+      )
+    end
+
+    def planning_outcome_for(tasks)
+      return "empty_plan" if tasks.empty?
+      return "single_task_plan" if tasks.one?
+
+      "sub_issues_created"
+    end
+
+    def planning_failure_outcome_for(step)
+      case step
+      when "decompose_feature" then "decomposition_failed"
+      when "create_sub_issues" then "sub_issue_creation_failed"
+      else "planning_failed"
+      end
+    end
+
+    def parallelization_outcome_for(tasks)
+      return "parallel_execution_skipped_empty_plan" if tasks.empty?
+      return "parallel_execution_skipped_single_task" if tasks.one?
+
+      "parallel_execution_planned"
+    end
+
+    def parallelization_failure_outcome_for(step)
+      case step
+      when "build_sub_tasks" then "parallelization_planning_failed"
+      else "parallelization_failed"
+      end
+    end
+
+    def safe_log_decomposition_decision(payload)
+      run_activity(
+        Activities::LogDecompositionDecisionActivity,
+        payload,
+        timeout: 30,
+        retry_policy: NO_RETRY
+      )
+    rescue => log_error
+      Temporalio::Workflow.logger.warn(
+        message: "feature_orchestration.decomposition_decision_log_failed",
+        workflow_id: Temporalio::Workflow.info.workflow_id,
+        error_class: log_error.class.to_s,
+        error: log_error.message
       )
     end
   end

--- a/app/temporal/workflows/planning_workflow.rb
+++ b/app/temporal/workflows/planning_workflow.rb
@@ -22,10 +22,17 @@ module Workflows
     def execute(input)
       project_id = input[:project_id]
       issue_id = input[:issue_id]
+      workflow_id = Temporalio::Workflow.info.workflow_id
 
       Temporalio::Workflow.logger.info(
         "PlanningWorkflow started for project=#{project_id} issue=#{issue_id}"
       )
+
+      context_result = {}
+      tasks = []
+      created_issues = []
+      prompt_source = nil
+      decision_step = "fetch_planning_context"
 
       # Step 1: Fetch knowledge base context for informed decomposition
       context_result = run_activity(
@@ -35,6 +42,7 @@ module Workflows
       )
 
       # Step 2: Decompose the feature into sub-tasks using LLM
+      decision_step = "decompose_feature"
       decompose_result = run_activity(
         Activities::DecomposeFeatureActivity,
         {
@@ -45,12 +53,14 @@ module Workflows
         timeout: 120
       )
 
-      tasks = decompose_result[:tasks]
+      tasks = Array(decompose_result[:tasks])
+      prompt_source = decompose_result[:prompt_source]
 
       # Step 3: Create sub-issues from the plan (skip if single-task or empty)
       if tasks.present? && tasks.size > 1
         sub_tasks = tasks.map { |t| { title: t[:title], body: t[:description] } }
 
+        decision_step = "create_sub_issues"
         create_result = run_activity(
           Activities::CreateSubIssuesActivity,
           {
@@ -63,11 +73,10 @@ module Workflows
         )
 
         created_issues = create_result[:created_issues]
-      else
-        created_issues = []
       end
 
       # Step 4: Update labels on the parent issue
+      decision_step = "update_planning_labels"
       run_activity(
         Activities::UpdatePlanningLabelsActivity,
         {
@@ -76,6 +85,31 @@ module Workflows
           task_count: tasks.size
         },
         timeout: 30
+      )
+
+      safe_log_decomposition_decision(
+        project_id: project_id,
+        issue_id: issue_id,
+        decision_key: "#{workflow_id}:planning_outcome:final",
+        workflow_name: self.class.name,
+        workflow_id: workflow_id,
+        decision_type: "planning_outcome",
+        outcome: planning_outcome_for(tasks),
+        input_context: context_result[:context],
+        plan_data: {
+          tasks: tasks,
+          created_issues: created_issues
+        },
+        metadata: {
+          prompt_source: prompt_source,
+          failed_step: nil,
+          activity_boundaries: %w[
+            Activities::FetchPlanningContextActivity
+            Activities::DecomposeFeatureActivity
+            Activities::CreateSubIssuesActivity
+            Activities::UpdatePlanningLabelsActivity
+          ]
+        }
       )
 
       {
@@ -87,6 +121,35 @@ module Workflows
       }
 
     rescue => e
+      safe_log_decomposition_decision(
+        project_id: project_id,
+        issue_id: issue_id,
+        decision_key: "#{workflow_id}:planning_outcome:failure",
+        workflow_name: self.class.name,
+        workflow_id: workflow_id,
+        decision_type: "planning_outcome",
+        outcome: planning_failure_outcome_for(decision_step),
+        input_context: context_result[:context],
+        plan_data: {
+          tasks: tasks,
+          created_issues: created_issues
+        },
+        error_details: {
+          error_class: e.class.to_s,
+          error_message: e.message
+        },
+        metadata: {
+          prompt_source: prompt_source,
+          failed_step: decision_step,
+          activity_boundaries: %w[
+            Activities::FetchPlanningContextActivity
+            Activities::DecomposeFeatureActivity
+            Activities::CreateSubIssuesActivity
+            Activities::UpdatePlanningLabelsActivity
+          ]
+        }
+      )
+
       Temporalio::Workflow.logger.error(
         message: "PlanningWorkflow failed",
         project_id: project_id,
@@ -95,6 +158,39 @@ module Workflows
         error: e.message
       )
       raise
+    end
+
+    private
+
+    def planning_outcome_for(tasks)
+      return "empty_plan" if tasks.empty?
+      return "single_task_plan" if tasks.one?
+
+      "sub_issues_created"
+    end
+
+    def planning_failure_outcome_for(step)
+      case step
+      when "decompose_feature" then "decomposition_failed"
+      when "create_sub_issues" then "sub_issue_creation_failed"
+      else "planning_failed"
+      end
+    end
+
+    def safe_log_decomposition_decision(payload)
+      run_activity(
+        Activities::LogDecompositionDecisionActivity,
+        payload,
+        timeout: 30,
+        retry_policy: NO_RETRY
+      )
+    rescue => log_error
+      Temporalio::Workflow.logger.warn(
+        message: "planning.decomposition_decision_log_failed",
+        workflow_id: Temporalio::Workflow.info.workflow_id,
+        error_class: log_error.class.to_s,
+        error: log_error.message
+      )
     end
   end
 end

--- a/db/migrate/20260421162139_enable_tenant_row_level_security.rb
+++ b/db/migrate/20260421162139_enable_tenant_row_level_security.rb
@@ -33,6 +33,7 @@ class EnableTenantRowLevelSecurity < ActiveRecord::Migration[8.1]
     context_intake_sessions
     cost_budgets
     decision_records
+    decomposition_decisions
     issues
     knowledge_artifacts
     knowledge_audit_events

--- a/db/migrate/20260507125050_create_decomposition_decisions.rb
+++ b/db/migrate/20260507125050_create_decomposition_decisions.rb
@@ -23,5 +23,25 @@ class CreateDecompositionDecisions < ActiveRecord::Migration[8.1]
     add_index :decomposition_decisions, [ :project_id, :created_at ]
     add_index :decomposition_decisions, [ :issue_id, :created_at ]
     add_index :decomposition_decisions, [ :workflow_id, :decision_type ]
+
+    execute <<~SQL
+      ALTER TABLE decomposition_decisions ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE decomposition_decisions FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON decomposition_decisions
+        USING (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = decomposition_decisions.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        )
+        WITH CHECK (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = decomposition_decisions.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        );
+    SQL
   end
 end

--- a/db/migrate/20260507125050_create_decomposition_decisions.rb
+++ b/db/migrate/20260507125050_create_decomposition_decisions.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateDecompositionDecisions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :decomposition_decisions do |t|
+      t.references :project, null: false, foreign_key: { on_delete: :cascade }, comment: "Project whose issue decomposition flow produced this decision."
+      t.references :issue, null: false, foreign_key: { on_delete: :cascade }, comment: "Parent issue being decomposed or parallelized."
+      t.string :decision_key, null: false, comment: "Idempotency key for this workflow decision boundary."
+      t.string :workflow_name, null: false, comment: "Temporal workflow class that emitted the decision."
+      t.string :workflow_id, null: false, comment: "Temporal workflow identifier for correlation across activities."
+      t.string :decision_type, null: false, comment: "Decision boundary being recorded, such as planning_outcome or parallelization_outcome."
+      t.string :outcome, null: false, comment: "Observed outcome at the decision boundary."
+      t.jsonb :input_context, null: false, default: {}, comment: "Issue and planning inputs available when the decision was made."
+      t.jsonb :plan_data, null: false, default: {}, comment: "Generated tasks, created issues, and related plan artifacts."
+      t.jsonb :hints, null: false, default: {}, comment: "Derived dependency and parallelism hints for later analysis."
+      t.jsonb :error_details, null: false, default: {}, comment: "Failure details when the decision path ended exceptionally."
+      t.jsonb :metadata, null: false, default: {}, comment: "Additional workflow metadata such as prompt source and activity boundaries."
+
+      t.timestamps
+    end
+
+    add_index :decomposition_decisions, :decision_key, unique: true
+    add_index :decomposition_decisions, [ :project_id, :created_at ]
+    add_index :decomposition_decisions, [ :issue_id, :created_at ]
+    add_index :decomposition_decisions, [ :workflow_id, :decision_type ]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1696,6 +1696,8 @@ CREATE TABLE public.decomposition_decisions (
     updated_at timestamp(6) without time zone NOT NULL
 );
 
+ALTER TABLE ONLY public.decomposition_decisions FORCE ROW LEVEL SECURITY;
+
 
 --
 -- Name: COLUMN decomposition_decisions.project_id; Type: COMMENT; Schema: public; Owner: -
@@ -10029,6 +10031,12 @@ ALTER TABLE public.decision_record_links ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.decision_records ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: decomposition_decisions; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.decomposition_decisions ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: exception_incidents; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -10548,6 +10556,16 @@ CREATE POLICY tenant_isolation ON public.decision_records USING ((public.paid_te
   WHERE ((projects.id = decision_records.project_id) AND (projects.account_id = public.paid_current_account_id())))))) WITH CHECK ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
    FROM public.projects
   WHERE ((projects.id = decision_records.project_id) AND (projects.account_id = public.paid_current_account_id()))))));
+
+--
+-- Name: decomposition_decisions tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.decomposition_decisions USING ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.projects
+  WHERE ((projects.id = decomposition_decisions.project_id) AND (projects.account_id = public.paid_current_account_id())))))) WITH CHECK ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.projects
+  WHERE ((projects.id = decomposition_decisions.project_id) AND (projects.account_id = public.paid_current_account_id()))))));
 
 
 --
@@ -11671,4 +11689,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260128004342'),
 ('20260128004305'),
 ('20260127154444');
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1675,6 +1675,132 @@ ALTER SEQUENCE public.decision_records_id_seq OWNED BY public.decision_records.i
 
 
 --
+-- Name: decomposition_decisions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.decomposition_decisions (
+    id bigint NOT NULL,
+    project_id bigint NOT NULL,
+    issue_id bigint NOT NULL,
+    decision_key character varying NOT NULL,
+    workflow_name character varying NOT NULL,
+    workflow_id character varying NOT NULL,
+    decision_type character varying NOT NULL,
+    outcome character varying NOT NULL,
+    input_context jsonb DEFAULT '{}'::jsonb NOT NULL,
+    plan_data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    hints jsonb DEFAULT '{}'::jsonb NOT NULL,
+    error_details jsonb DEFAULT '{}'::jsonb NOT NULL,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN decomposition_decisions.project_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.project_id IS 'Project whose issue decomposition flow produced this decision.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.issue_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.issue_id IS 'Parent issue being decomposed or parallelized.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.decision_key; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.decision_key IS 'Idempotency key for this workflow decision boundary.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.workflow_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.workflow_name IS 'Temporal workflow class that emitted the decision.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.workflow_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.workflow_id IS 'Temporal workflow identifier for correlation across activities.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.decision_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.decision_type IS 'Decision boundary being recorded, such as planning_outcome or parallelization_outcome.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.outcome; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.outcome IS 'Observed outcome at the decision boundary.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.input_context; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.input_context IS 'Issue and planning inputs available when the decision was made.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.plan_data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.plan_data IS 'Generated tasks, created issues, and related plan artifacts.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.hints; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.hints IS 'Derived dependency and parallelism hints for later analysis.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.error_details; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.error_details IS 'Failure details when the decision path ended exceptionally.';
+
+
+--
+-- Name: COLUMN decomposition_decisions.metadata; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.decomposition_decisions.metadata IS 'Additional workflow metadata such as prompt source and activity boundaries.';
+
+
+--
+-- Name: decomposition_decisions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.decomposition_decisions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: decomposition_decisions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.decomposition_decisions_id_seq OWNED BY public.decomposition_decisions.id;
+
+
+--
 -- Name: exception_incidents; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4744,6 +4870,13 @@ ALTER TABLE ONLY public.decision_records ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: decomposition_decisions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.decomposition_decisions ALTER COLUMN id SET DEFAULT nextval('public.decomposition_decisions_id_seq'::regclass);
+
+
+--
 -- Name: exception_incidents id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5337,6 +5470,14 @@ ALTER TABLE ONLY public.decision_record_links
 
 ALTER TABLE ONLY public.decision_records
     ADD CONSTRAINT decision_records_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: decomposition_decisions decomposition_decisions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.decomposition_decisions
+    ADD CONSTRAINT decomposition_decisions_pkey PRIMARY KEY (id);
 
 
 --
@@ -6950,6 +7091,48 @@ CREATE INDEX index_decision_records_on_superseded_by_id ON public.decision_recor
 --
 
 CREATE INDEX index_decision_records_on_tags ON public.decision_records USING gin (tags);
+
+
+--
+-- Name: index_decomposition_decisions_on_decision_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_decomposition_decisions_on_decision_key ON public.decomposition_decisions USING btree (decision_key);
+
+
+--
+-- Name: index_decomposition_decisions_on_issue_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_decomposition_decisions_on_issue_id ON public.decomposition_decisions USING btree (issue_id);
+
+
+--
+-- Name: index_decomposition_decisions_on_issue_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_decomposition_decisions_on_issue_id_and_created_at ON public.decomposition_decisions USING btree (issue_id, created_at);
+
+
+--
+-- Name: index_decomposition_decisions_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_decomposition_decisions_on_project_id ON public.decomposition_decisions USING btree (project_id);
+
+
+--
+-- Name: index_decomposition_decisions_on_project_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_decomposition_decisions_on_project_id_and_created_at ON public.decomposition_decisions USING btree (project_id, created_at);
+
+
+--
+-- Name: index_decomposition_decisions_on_workflow_id_and_decision_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_decomposition_decisions_on_workflow_id_and_decision_type ON public.decomposition_decisions USING btree (workflow_id, decision_type);
 
 
 --
@@ -8856,6 +9039,14 @@ ALTER TABLE ONLY public.chat_messages
 
 
 --
+-- Name: decomposition_decisions fk_rails_4adcc53fc4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.decomposition_decisions
+    ADD CONSTRAINT fk_rails_4adcc53fc4 FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
 -- Name: github_tokens fk_rails_4d276bfe2f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8869,6 +9060,14 @@ ALTER TABLE ONLY public.github_tokens
 
 ALTER TABLE ONLY public.cost_budgets
     ADD CONSTRAINT fk_rails_4e6c4ff426 FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: decomposition_decisions fk_rails_53762b28b0; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.decomposition_decisions
+    ADD CONSTRAINT fk_rails_53762b28b0 FOREIGN KEY (issue_id) REFERENCES public.issues(id) ON DELETE CASCADE;
 
 
 --
@@ -11221,6 +11420,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507125050'),
 ('20260507011753'),
 ('20260506175107'),
 ('20260506174922'),

--- a/spec/factories/decomposition_decisions.rb
+++ b/spec/factories/decomposition_decisions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :decomposition_decision do
+    project
+    issue { association :issue, project: project }
+    sequence(:decision_key) { |n| "workflow-#{n}:planning_outcome:final" }
+    workflow_name { "Workflows::PlanningWorkflow" }
+    sequence(:workflow_id) { |n| "workflow-#{n}" }
+    decision_type { "planning_outcome" }
+    outcome { "sub_issues_created" }
+    input_context { { "knowledge_results_count" => 2 } }
+    plan_data { { "tasks" => [], "created_issues" => [] } }
+    hints { { "task_count" => 0 } }
+    error_details { {} }
+    metadata { { "prompt_source" => "active_prompt" } }
+  end
+end

--- a/spec/models/decomposition_decision_spec.rb
+++ b/spec/models/decomposition_decision_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DecompositionDecision do
+  subject(:decomposition_decision) { build(:decomposition_decision) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:project) }
+    it { is_expected.to belong_to(:issue) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:decision_key) }
+    it { is_expected.to validate_uniqueness_of(:decision_key) }
+    it { is_expected.to validate_presence_of(:workflow_name) }
+    it { is_expected.to validate_presence_of(:workflow_id) }
+    it { is_expected.to validate_presence_of(:decision_type) }
+    it { is_expected.to validate_presence_of(:outcome) }
+    it { is_expected.to validate_inclusion_of(:decision_type).in_array(described_class::DECISION_TYPES) }
+  end
+
+  describe "defaults" do
+    it "initializes json payload columns to hashes" do
+      decision = described_class.new
+
+      expect(decision.input_context).to eq({})
+      expect(decision.plan_data).to eq({})
+      expect(decision.hints).to eq({})
+      expect(decision.error_details).to eq({})
+      expect(decision.metadata).to eq({})
+    end
+  end
+end

--- a/spec/services/orchestration/decomposition_decisions/log_spec.rb
+++ b/spec/services/orchestration/decomposition_decisions/log_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orchestration::DecompositionDecisions::Log do
+  describe ".call" do
+    let(:project) { create(:project) }
+    let(:issue) { create(:issue, project: project, title: "Add OAuth") }
+    let(:payload) do
+      {
+        project_id: project.id,
+        issue_id: issue.id,
+        decision_key: "wf-123:planning_outcome:final",
+        workflow_name: "Workflows::PlanningWorkflow",
+        workflow_id: "wf-123",
+        decision_type: "planning_outcome",
+        outcome: "sub_issues_created",
+        input_context: {
+          knowledge_results_count: 2,
+          issue_body: "Implement OAuth 2.0"
+        },
+        plan_data: {
+          tasks: [
+            { index: 0, title: "Schema", dependencies: [], parallel_group: 0 },
+            { index: 1, title: "Model", dependencies: [ 0 ], parallel_group: 1 },
+            { index: 2, title: "Controller", dependencies: [], parallel_group: 0 }
+          ],
+          created_issues: [
+            { github_number: 101 },
+            { github_number: 102 }
+          ]
+        },
+        error_details: {},
+        metadata: {
+          prompt_source: "fallback_prompt",
+          activity_boundaries: [ "Activities::DecomposeFeatureActivity" ]
+        }
+      }
+    end
+
+    it "persists structured context, plan data, and derived hints" do
+      decision = described_class.call(**payload)
+
+      expect(decision).to be_persisted
+      expect(decision.input_context).to include(
+        "knowledge_results_count" => 2,
+        "issue" => include(
+          "id" => issue.id,
+          "github_number" => issue.github_number,
+          "title" => "Add OAuth"
+        )
+      )
+      expect(decision.plan_data["tasks"].size).to eq(3)
+      expect(decision.hints).to include(
+        "task_count" => 3,
+        "created_issue_count" => 2,
+        "dependency_edges" => 1,
+        "tasks_with_dependencies" => 1,
+        "created_issue_numbers" => [ 101, 102 ]
+      )
+      expect(decision.hints["parallelizable_groups"]).to eq({ "0" => [ 0, 2 ] })
+      expect(decision.metadata["prompt_source"]).to eq("fallback_prompt")
+    end
+
+    it "is idempotent on decision_key" do
+      first = described_class.call(**payload)
+      second = described_class.call(**payload)
+
+      expect(second.id).to eq(first.id)
+      expect(DecompositionDecision.where(decision_key: payload[:decision_key]).count).to eq(1)
+    end
+  end
+end

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Activities::DecomposeFeatureActivity do
       expect(tasks[0][:parallel_group]).to eq(0)
       expect(tasks[1][:dependencies]).to eq([ 0 ])
       expect(tasks[2][:dependencies]).to eq([ 1 ])
+      expect(result[:prompt_source]).to eq("fallback_prompt")
     end
 
     it "calls AgentHarness with the correct provider and model" do
@@ -101,6 +102,20 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         timeout: described_class::TIMEOUT,
         tools: :none
       )
+    end
+
+    it "returns active_prompt when a seeded prompt version is available" do
+      prompt_version = instance_double(PromptVersion, render: "[]")
+      prompt = instance_double(Prompt, current_version: prompt_version)
+      allow(Prompt).to receive(:resolve).and_return(prompt)
+
+      result = activity.execute(
+        project_id: project.id,
+        issue_id: issue.id,
+        knowledge_context: knowledge_context
+      )
+
+      expect(result[:prompt_source]).to eq("active_prompt")
     end
 
     context "when LLM returns a single task" do

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
     before do
       allow(AgentHarness).to receive(:send_message).and_return(llm_response)
+      allow(Prompt).to receive(:resolve).and_return(nil)
       # Default: preserve CLI transport so existing exact-match expectations
       # pass. Individual specs flip this on to prove text-mode routing.
       allow(Llm::TextMode).to receive(:options).and_return({})

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         expect(result[:failed]).to eq(0)
       end
 
-    it "calls planning activities before parallel execution" do
-      workflow.execute(input)
+      it "calls planning activities before parallel execution" do
+        workflow.execute(input)
 
         expect(workflow).to have_received(:run_activity)
           .with(Activities::FetchPlanningContextActivity, hash_including(project_id: 1, issue_id: 2), timeout: 60)

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -90,14 +90,19 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         expect(result[:failed]).to eq(0)
       end
 
-      it "calls planning activities before parallel execution" do
-        workflow.execute(input)
+    it "calls planning activities before parallel execution" do
+      workflow.execute(input)
 
         expect(workflow).to have_received(:run_activity)
           .with(Activities::FetchPlanningContextActivity, hash_including(project_id: 1, issue_id: 2), timeout: 60)
         expect(workflow).to have_received(:run_activity)
           .with(Activities::DecomposeFeatureActivity, hash_including(project_id: 1, issue_id: 2), timeout: 120)
         expect_orchestration_sub_issue_creation!
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(decision_type: "planning_outcome", outcome: "sub_issues_created"),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
 
       it "launches ParallelAgentExecutionWorkflow as child workflow" do
@@ -137,6 +142,15 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
 
         expect(workflow).to have_received(:run_activity)
           .with(Activities::UpdatePlanningLabelsActivity, hash_including(task_count: 3), timeout: 30)
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              decision_type: "parallelization_outcome",
+              outcome: "parallel_execution_planned",
+              plan_data: hash_including(sub_tasks: array_including(hash_including(issue_id: 10)))
+            ),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
 
       it "passes aggregate_pr option to child workflow when provided" do
@@ -187,6 +201,14 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
 
         expect(workflow).to have_received(:run_activity)
           .with(Activities::UpdatePlanningLabelsActivity, hash_including(task_count: 1), timeout: 30)
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              decision_type: "parallelization_outcome",
+              outcome: "parallel_execution_skipped_single_task"
+            ),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
     end
 
@@ -203,6 +225,11 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         expect(result[:parallel_execution]).to be false
         expect(result[:task_count]).to eq(0)
         expect(Temporalio::Workflow).not_to have_received(:execute_child_workflow)
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(outcome: "parallel_execution_skipped_empty_plan"),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
     end
 
@@ -293,6 +320,14 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
           Temporalio::Error::ApplicationError,
           /returned nil issue_id for task 1: Task B/
         )
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              decision_type: "parallelization_outcome",
+              outcome: "parallelization_planning_failed"
+            ),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
     end
 
@@ -313,12 +348,30 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
 
     context "when an activity raises an error" do
       before do
-        allow(workflow).to receive(:run_activity)
-          .and_raise(Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed"))
+        allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+          case activity_class.name
+          when "Activities::FetchPlanningContextActivity"
+            { context: {} }
+          when "Activities::DecomposeFeatureActivity"
+            raise Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed")
+          when "Activities::LogDecompositionDecisionActivity"
+            { decomposition_decision_id: 9 }
+          else
+            {}
+          end
+        end
       end
 
       it "re-raises the error" do
         expect { workflow.execute(input) }.to raise_error(Temporalio::Error::ApplicationError, "LLM failed")
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              decision_type: "planning_outcome",
+              outcome: "decomposition_failed"
+            ),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
     end
 
@@ -426,6 +479,8 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         { created_issues: created_issues }
       when "Activities::UpdatePlanningLabelsActivity"
         { success: true }
+      when "Activities::LogDecompositionDecisionActivity"
+        { decomposition_decision_id: 1 }
       else
         {}
       end

--- a/spec/temporal/workflows/planning_workflow_spec.rb
+++ b/spec/temporal/workflows/planning_workflow_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Workflows::PlanningWorkflow do
     let(:input) { { project_id: 1, issue_id: 2 } }
 
     before do
-      allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger)
+      workflow_info = Struct.new(:workflow_id).new("test-planning-wf")
+      allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger, info: workflow_info)
     end
 
     it "accepts a single input parameter" do
@@ -48,6 +49,8 @@ RSpec.describe Workflows::PlanningWorkflow do
             { created_issues: [ { issue_id: 10 }, { issue_id: 11 }, { issue_id: 12 } ] }
           when "Activities::UpdatePlanningLabelsActivity"
             { success: true }
+          when "Activities::LogDecompositionDecisionActivity"
+            { decomposition_decision_id: 1 }
           else
             {}
           end
@@ -62,7 +65,7 @@ RSpec.describe Workflows::PlanningWorkflow do
         expect(result[:created_issues]).to eq([ { issue_id: 10 }, { issue_id: 11 }, { issue_id: 12 } ])
       end
 
-      it "calls all four activities in sequence" do
+      it "calls the planning activities in sequence" do
         workflow.execute(input)
 
         expect(workflow).to have_received(:run_activity)
@@ -77,6 +80,21 @@ RSpec.describe Workflows::PlanningWorkflow do
         expect(workflow).to have_received(:run_activity)
           .with(Activities::UpdatePlanningLabelsActivity, hash_including(project_id: 1, issue_id: 2, task_count: 3), timeout: 30)
       end
+
+      it "logs the final planning decision" do
+        workflow.execute(input)
+
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              workflow_name: "Workflows::PlanningWorkflow",
+              decision_type: "planning_outcome",
+              outcome: "sub_issues_created",
+              plan_data: hash_including(tasks: tasks)
+            ),
+            timeout: 30,
+            retry_policy: Workflows::PlanningWorkflow::NO_RETRY)
+      end
     end
 
     context "when decomposition produces a single task" do
@@ -90,9 +108,11 @@ RSpec.describe Workflows::PlanningWorkflow do
           when "Activities::FetchPlanningContextActivity"
             { context: {} }
           when "Activities::DecomposeFeatureActivity"
-            { tasks: tasks }
+            { tasks: tasks, prompt_source: "fallback_prompt" }
           when "Activities::UpdatePlanningLabelsActivity"
             { success: true }
+          when "Activities::LogDecompositionDecisionActivity"
+            { decomposition_decision_id: 2 }
           else
             {}
           end
@@ -107,6 +127,14 @@ RSpec.describe Workflows::PlanningWorkflow do
         expect(result[:created_issues]).to eq([])
         expect(workflow).not_to have_received(:run_activity)
           .with(Activities::CreateSubIssuesActivity, anything, any_args)
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              outcome: "single_task_plan",
+              metadata: hash_including(prompt_source: "fallback_prompt")
+            ),
+            timeout: 30,
+            retry_policy: Workflows::PlanningWorkflow::NO_RETRY)
       end
     end
 
@@ -120,6 +148,8 @@ RSpec.describe Workflows::PlanningWorkflow do
             { tasks: [] }
           when "Activities::UpdatePlanningLabelsActivity"
             { success: true }
+          when "Activities::LogDecompositionDecisionActivity"
+            { decomposition_decision_id: 3 }
           else
             {}
           end
@@ -132,17 +162,41 @@ RSpec.describe Workflows::PlanningWorkflow do
         expect(result[:success]).to be true
         expect(result[:task_count]).to eq(0)
         expect(result[:created_issues]).to eq([])
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(outcome: "empty_plan"),
+            timeout: 30,
+            retry_policy: Workflows::PlanningWorkflow::NO_RETRY)
       end
     end
 
     context "when an activity raises an error" do
       before do
-        allow(workflow).to receive(:run_activity)
-          .and_raise(Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed"))
+        allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+          case activity_class.name
+          when "Activities::FetchPlanningContextActivity"
+            { context: {} }
+          when "Activities::DecomposeFeatureActivity"
+            raise Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed")
+          when "Activities::LogDecompositionDecisionActivity"
+            { decomposition_decision_id: 4 }
+          else
+            {}
+          end
+        end
       end
 
       it "re-raises the error" do
         expect { workflow.execute(input) }.to raise_error(Temporalio::Error::ApplicationError)
+        expect(workflow).to have_received(:run_activity)
+          .with(Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              decision_type: "planning_outcome",
+              outcome: "decomposition_failed",
+              error_details: hash_including(error_message: "LLM failed")
+            ),
+            timeout: 30,
+            retry_policy: Workflows::PlanningWorkflow::NO_RETRY)
       end
     end
   end


### PR DESCRIPTION
## Summary

Implemented and committed as `85caa8c` with message `feat(orchestration): log decomposition decisions with workflow context`.

The change adds a dedicated `DecompositionDecision` model plus logging service/activity, records planning and parallelization outcomes from `PlanningWorkflow` and `FeatureOrchestrationWorkflow`, carries issue context, task/plan data, dependency and parallelism hints, and captures exceptional/fallback paths including prompt fallback in `DecomposeFeatureActivity`.

Verification passed:
- `bundle exec rubocop`
- `bundle exec rspec` via the enforced commit hook: `10852 examples, 0 failures, 3 pending`

I also ran `db:prepare` against the provided Postgres service and updated `db/structure.sql`.

---

Closes #1748