### PR TITLE
feat(analytics): build orchestration decision analysis queries

### DIFF
--- a/app/services/analytics/orchestration_decisions/base_query.rb
+++ b/app/services/analytics/orchestration_decisions/base_query.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class BaseQuery
+      UNCATEGORIZED_DECISION_TYPE = "uncategorized"
+
+      def initialize(relation: DecisionRecord.all, filters: {})
+        @relation = relation
+        @filters = filters
+      end
+
+      private
+
+      attr_reader :relation, :filters
+
+      def filtered_scope
+        scope = relation
+        scope = scope.where(project_id: project_ids) if project_ids.any?
+        scope = scope.where("decision_records.created_at >= ?", filters[:from]) if filters[:from].present?
+        scope = scope.where("decision_records.created_at <= ?", filters[:to]) if filters[:to].present?
+        scope = apply_decision_type_filter(scope)
+        scope
+      end
+
+      def apply_decision_type_filter(scope)
+        return scope if decision_types.empty?
+
+        clauses = []
+        binds = []
+
+        if tagged_decision_types.any?
+          clauses << <<~SQL.squish
+            EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements_text(decision_records.tags) AS tag(value)
+              WHERE NULLIF(LOWER(BTRIM(tag.value)), '') IN (?)
+            )
+          SQL
+          binds << tagged_decision_types
+        end
+
+        if uncategorized_selected?
+          clauses << <<~SQL.squish
+            NOT EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements_text(decision_records.tags) AS tag(value)
+              WHERE NULLIF(LOWER(BTRIM(tag.value)), '') IS NOT NULL
+            )
+          SQL
+        end
+
+        scope.where([ clauses.join(" OR "), *binds ])
+      end
+
+      def project_ids
+        @project_ids ||= Array(filters[:project_ids]).filter_map(&:presence).uniq
+      end
+
+      def decision_types
+        @decision_types ||= Array(filters[:decision_types]).filter_map do |value|
+          normalize_decision_type(value)
+        end.uniq
+      end
+
+      def tagged_decision_types
+        decision_types - [ UNCATEGORIZED_DECISION_TYPE ]
+      end
+
+      def uncategorized_selected?
+        decision_types.include?(UNCATEGORIZED_DECISION_TYPE)
+      end
+
+      def normalize_decision_type(value)
+        value.to_s.strip.downcase.presence
+      end
+
+      def decision_types_join_sql
+        <<~SQL.squish
+          LEFT JOIN LATERAL (
+            SELECT DISTINCT NULLIF(LOWER(BTRIM(tag.value)), '') AS decision_type
+            FROM jsonb_array_elements_text(decision_records.tags) AS tag(value)
+            WHERE NULLIF(LOWER(BTRIM(tag.value)), '') IS NOT NULL
+          ) decision_types ON TRUE
+        SQL
+      end
+
+      def decision_type_sql
+        "COALESCE(decision_types.decision_type, '#{UNCATEGORIZED_DECISION_TYPE}')"
+      end
+    end
+  end
+end

--- a/app/services/analytics/orchestration_decisions/base_query.rb
+++ b/app/services/analytics/orchestration_decisions/base_query.rb
@@ -85,8 +85,47 @@ module Analytics
         SQL
       end
 
-      def decision_type_sql
-        "COALESCE(decision_types.decision_type, '#{UNCATEGORIZED_DECISION_TYPE}')"
+      def decision_records_table
+        DecisionRecord.arel_table
+      end
+
+      def projects_table
+        Project.arel_table
+      end
+
+      def agent_runs_table
+        AgentRun.arel_table
+      end
+
+      def decision_types_table
+        Arel::Table.new(:decision_types)
+      end
+
+      def decision_type_expression
+        Arel::Nodes::NamedFunction.new(
+          "COALESCE",
+          [ decision_types_table[:decision_type], Arel::Nodes.build_quoted(UNCATEGORIZED_DECISION_TYPE) ]
+        )
+      end
+
+      def distinct_count(expression)
+        Arel::Nodes::Count.new([ expression ], true)
+      end
+
+      def distinct_status_count(status)
+        distinct_count(
+          Arel::Nodes::Case.new
+            .when(decision_records_table[:status].eq(status))
+            .then(decision_records_table[:id])
+        )
+      end
+
+      def distinct_completed_run_count
+        distinct_count(
+          Arel::Nodes::Case.new
+            .when(agent_runs_table[:status].eq("completed"))
+            .then(decision_records_table[:id])
+        )
       end
     end
   end

--- a/app/services/analytics/orchestration_decisions/by_decision_type_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_decision_type_query.rb
@@ -4,20 +4,22 @@ module Analytics
   module OrchestrationDecisions
     class ByDecisionTypeQuery < BaseQuery
       def call
+        total_count = distinct_count(decision_records_table[:id])
+
         scope = filtered_scope
           .left_joins(:agent_run)
           .joins(decision_types_join_sql)
 
-        scope = scope.where([ "#{decision_type_sql} IN (?)", decision_types ]) if decision_types.any?
+        scope = scope.where(decision_type_expression.in(decision_types)) if decision_types.any?
 
-        rows = scope.group(Arel.sql(decision_type_sql))
-          .order(Arel.sql("COUNT(DISTINCT decision_records.id) DESC"), Arel.sql("#{decision_type_sql} ASC"))
+        rows = scope.group(decision_type_expression)
+          .order(total_count.desc, decision_type_expression.asc)
           .pluck(
-            Arel.sql(decision_type_sql),
-            Arel.sql("COUNT(DISTINCT decision_records.id)"),
-            Arel.sql("COUNT(DISTINCT decision_records.project_id)"),
-            Arel.sql("COUNT(DISTINCT CASE WHEN decision_records.status = 'active' THEN decision_records.id END)"),
-            Arel.sql("COUNT(DISTINCT CASE WHEN agent_runs.status = 'completed' THEN decision_records.id END)")
+            decision_type_expression,
+            total_count,
+            distinct_count(decision_records_table[:project_id]),
+            distinct_status_count("active"),
+            distinct_completed_run_count
           )
 
         rows.map do |decision_type, total_count, project_count, active_count, completed_run_count|

--- a/app/services/analytics/orchestration_decisions/by_decision_type_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_decision_type_query.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class ByDecisionTypeQuery < BaseQuery
+      def call
+        scope = filtered_scope
+          .left_joins(:agent_run)
+          .joins(decision_types_join_sql)
+
+        scope = scope.where([ "#{decision_type_sql} IN (?)", decision_types ]) if decision_types.any?
+
+        rows = scope.group(Arel.sql(decision_type_sql))
+          .order(Arel.sql("COUNT(DISTINCT decision_records.id) DESC"), Arel.sql("#{decision_type_sql} ASC"))
+          .pluck(
+            Arel.sql(decision_type_sql),
+            Arel.sql("COUNT(DISTINCT decision_records.id)"),
+            Arel.sql("COUNT(DISTINCT decision_records.project_id)"),
+            Arel.sql("COUNT(DISTINCT CASE WHEN decision_records.status = 'active' THEN decision_records.id END)"),
+            Arel.sql("COUNT(DISTINCT CASE WHEN agent_runs.status = 'completed' THEN decision_records.id END)")
+          )
+
+        rows.map do |decision_type, total_count, project_count, active_count, completed_run_count|
+          {
+            decision_type: decision_type,
+            total_count: total_count,
+            project_count: project_count,
+            active_count: active_count,
+            completed_run_count: completed_run_count
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/analytics/orchestration_decisions/by_project_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_project_query.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class ByProjectQuery < BaseQuery
+      def call
+        rows = filtered_scope
+          .joins(:project)
+          .joins(decision_types_join_sql)
+          .group("projects.id", "projects.name", "projects.owner", "projects.repo")
+          .order(Arel.sql("COUNT(DISTINCT decision_records.id) DESC"), "projects.name ASC")
+          .pluck(
+            "projects.id",
+            "projects.name",
+            "projects.owner",
+            "projects.repo",
+            Arel.sql("COUNT(DISTINCT decision_records.id)"),
+            Arel.sql("COUNT(DISTINCT #{decision_type_sql})"),
+            Arel.sql("COUNT(DISTINCT CASE WHEN decision_records.status = 'active' THEN decision_records.id END)"),
+            Arel.sql("COUNT(DISTINCT CASE WHEN decision_records.status = 'superseded' THEN decision_records.id END)"),
+            Arel.sql("COUNT(DISTINCT CASE WHEN decision_records.status = 'reverted' THEN decision_records.id END)")
+          )
+
+        rows.map do |project_id, name, owner, repo, total_count, decision_type_count, active_count, superseded_count, reverted_count|
+          {
+            project_id: project_id,
+            project_name: name,
+            project_full_name: "#{owner}/#{repo}",
+            total_count: total_count,
+            decision_type_count: decision_type_count,
+            active_count: active_count,
+            superseded_count: superseded_count,
+            reverted_count: reverted_count
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/analytics/orchestration_decisions/by_project_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_project_query.rb
@@ -4,21 +4,29 @@ module Analytics
   module OrchestrationDecisions
     class ByProjectQuery < BaseQuery
       def call
+        total_count = distinct_count(decision_records_table[:id])
+        decision_type_count = distinct_count(decision_type_expression)
+
         rows = filtered_scope
           .joins(:project)
           .joins(decision_types_join_sql)
-          .group("projects.id", "projects.name", "projects.owner", "projects.repo")
-          .order(Arel.sql("COUNT(DISTINCT decision_records.id) DESC"), "projects.name ASC")
+          .group(
+            projects_table[:id],
+            projects_table[:name],
+            projects_table[:owner],
+            projects_table[:repo]
+          )
+          .order(total_count.desc, projects_table[:name].asc)
           .pluck(
-            "projects.id",
-            "projects.name",
-            "projects.owner",
-            "projects.repo",
-            Arel.sql("COUNT(DISTINCT decision_records.id)"),
-            Arel.sql("COUNT(DISTINCT #{decision_type_sql})"),
-            Arel.sql("COUNT(DISTINCT CASE WHEN decision_records.status = 'active' THEN decision_records.id END)"),
-            Arel.sql("COUNT(DISTINCT CASE WHEN decision_records.status = 'superseded' THEN decision_records.id END)"),
-            Arel.sql("COUNT(DISTINCT CASE WHEN decision_records.status = 'reverted' THEN decision_records.id END)")
+            projects_table[:id],
+            projects_table[:name],
+            projects_table[:owner],
+            projects_table[:repo],
+            total_count,
+            decision_type_count,
+            distinct_status_count("active"),
+            distinct_status_count("superseded"),
+            distinct_status_count("reverted")
           )
 
         rows.map do |project_id, name, owner, repo, total_count, decision_type_count, active_count, superseded_count, reverted_count|

--- a/app/services/analytics/orchestration_decisions/by_project_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_project_query.rb
@@ -7,9 +7,13 @@ module Analytics
         total_count = distinct_count(decision_records_table[:id])
         decision_type_count = distinct_count(decision_type_expression)
 
-        rows = filtered_scope
+        scope = filtered_scope
           .joins(:project)
           .joins(decision_types_join_sql)
+
+        scope = scope.where(decision_type_expression.in(decision_types)) if decision_types.any?
+
+        rows = scope
           .group(
             projects_table[:id],
             projects_table[:name],

--- a/app/services/analytics/orchestration_decisions/daily_volume_query.rb
+++ b/app/services/analytics/orchestration_decisions/daily_volume_query.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class DailyVolumeQuery < BaseQuery
+      def call
+        rows = filtered_scope
+          .group(Arel.sql("DATE(decision_records.created_at)"))
+          .order(Arel.sql("DATE(decision_records.created_at) ASC"))
+          .pluck(
+            Arel.sql("DATE(decision_records.created_at)"),
+            Arel.sql("COUNT(*)"),
+            Arel.sql("COUNT(*) FILTER (WHERE decision_records.status = 'active')"),
+            Arel.sql("COUNT(*) FILTER (WHERE decision_records.status = 'superseded')"),
+            Arel.sql("COUNT(*) FILTER (WHERE decision_records.status = 'reverted')")
+          )
+
+        rows.map do |day, total_count, active_count, superseded_count, reverted_count|
+          {
+            day: day,
+            total_count: total_count,
+            active_count: active_count,
+            superseded_count: superseded_count,
+            reverted_count: reverted_count
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/analytics/orchestration_decisions/question_set.rb
+++ b/app/services/analytics/orchestration_decisions/question_set.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class QuestionSet
+      QUESTIONS = [
+        {
+          key: "decision_volume_over_time",
+          question: "How many orchestration decisions are being recorded over time?",
+          query: "Analytics::OrchestrationDecisions::DailyVolumeQuery"
+        },
+        {
+          key: "decision_mix_by_type",
+          question: "Which decision types appear most often, based on decision-record tags?",
+          query: "Analytics::OrchestrationDecisions::ByDecisionTypeQuery"
+        },
+        {
+          key: "project_level_decision_patterns",
+          question: "Which projects produce the most decisions and how broad is their decision mix?",
+          query: "Analytics::OrchestrationDecisions::ByProjectQuery"
+        },
+        {
+          key: "decision_outcomes",
+          question: "How often do decisions remain active versus becoming superseded or reverted?",
+          query: "Analytics::OrchestrationDecisions::SummaryQuery"
+        }
+      ].freeze
+
+      def self.all
+        QUESTIONS
+      end
+    end
+  end
+end

--- a/app/services/analytics/orchestration_decisions/report.rb
+++ b/app/services/analytics/orchestration_decisions/report.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class Report
+      def initialize(relation: DecisionRecord.all, filters: {})
+        @relation = relation
+        @filters = filters
+      end
+
+      def self.call(...)
+        new(...).call
+      end
+
+      def call
+        {
+          questions: QuestionSet.all,
+          filters: serialized_filters,
+          summary: SummaryQuery.new(relation: relation, filters: filters).call,
+          by_project: ByProjectQuery.new(relation: relation, filters: filters).call,
+          by_decision_type: ByDecisionTypeQuery.new(relation: relation, filters: filters).call,
+          daily_volume: DailyVolumeQuery.new(relation: relation, filters: filters).call
+        }
+      end
+
+      private
+
+      attr_reader :relation, :filters
+
+      def serialized_filters
+        {
+          from: filters[:from],
+          to: filters[:to],
+          project_ids: Array(filters[:project_ids]).compact,
+          decision_types: Array(filters[:decision_types]).filter_map(&:presence)
+        }
+      end
+    end
+  end
+end

--- a/app/services/analytics/orchestration_decisions/summary_query.rb
+++ b/app/services/analytics/orchestration_decisions/summary_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class SummaryQuery < BaseQuery
+      def call
+        row = filtered_scope
+          .left_joins(:agent_run)
+          .select(
+            "COUNT(*) AS total_count",
+            "COUNT(*) FILTER (WHERE decision_records.status = 'active') AS active_count",
+            "COUNT(*) FILTER (WHERE decision_records.status = 'superseded') AS superseded_count",
+            "COUNT(*) FILTER (WHERE decision_records.status = 'reverted') AS reverted_count",
+            "COUNT(*) FILTER (WHERE decision_records.agent_run_id IS NOT NULL) AS linked_agent_run_count",
+            "COUNT(*) FILTER (WHERE agent_runs.status = 'completed') AS completed_run_count",
+            "COUNT(*) FILTER (WHERE agent_runs.status IN ('failed', 'timeout', 'auth_expired', 'rate_limited', 'cancelled')) AS failed_run_count"
+          )
+          .take
+
+        {
+          total_count: row.total_count.to_i,
+          active_count: row.active_count.to_i,
+          superseded_count: row.superseded_count.to_i,
+          reverted_count: row.reverted_count.to_i,
+          linked_agent_run_count: row.linked_agent_run_count.to_i,
+          completed_run_count: row.completed_run_count.to_i,
+          failed_run_count: row.failed_run_count.to_i
+        }
+      end
+    end
+  end
+end

--- a/spec/services/analytics/orchestration_decisions/report_spec.rb
+++ b/spec/services/analytics/orchestration_decisions/report_spec.rb
@@ -160,6 +160,27 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
     ]
   end
 
+  def expected_auth_uncategorized_projects
+    [
+      expected_project(
+        project: project_b,
+        total_count: 2,
+        decision_type_count: 2,
+        active_count: 1,
+        superseded_count: 0,
+        reverted_count: 1
+      ),
+      expected_project(
+        project: project_a,
+        total_count: 1,
+        decision_type_count: 1,
+        active_count: 1,
+        superseded_count: 0,
+        reverted_count: 0
+      )
+    ]
+  end
+
   describe ".call" do
     it "returns the initial question set" do
       report = described_class.call
@@ -278,7 +299,7 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
     it "filters the type rollup by tag-derived decision type, including uncategorized records" do
       report = described_class.call(filters: { decision_types: [ "AUTH", "uncategorized" ] })
 
-      expect(report[:by_project].pluck(:project_name)).to eq(%w[Beta Alpha])
+      expect(report[:by_project]).to eq(expected_auth_uncategorized_projects)
       expect(report[:by_decision_type]).to eq([
         expected_decision_type(
           decision_type: "auth",

--- a/spec/services/analytics/orchestration_decisions/report_spec.rb
+++ b/spec/services/analytics/orchestration_decisions/report_spec.rb
@@ -1,0 +1,300 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::OrchestrationDecisions::Report do
+  around do |example|
+    travel_to(Time.zone.local(2026, 5, 7, 12, 0, 0)) { example.run }
+  end
+
+  let(:account) { create(:account) }
+  let(:project_a) { create(:project, account: account, name: "Alpha") }
+  let(:project_b) { create(:project, account: account, name: "Beta") }
+
+  before do
+    create_decision_record(
+      project: project_a,
+      agent_run: create(:agent_run, :completed, project: project_a),
+      status: "active",
+      tags: %w[Auth API],
+      created_at: 2.days.ago
+    )
+
+    create_decision_record(
+      project: project_a,
+      agent_run: create(:agent_run, :failed, project: project_a),
+      status: "superseded",
+      tags: %w[performance],
+      created_at: 1.day.ago
+    )
+
+    create_decision_record(
+      project: project_b,
+      agent_run: create(:agent_run, :timeout, project: project_b),
+      status: "reverted",
+      tags: [],
+      created_at: Time.current
+    )
+
+    create_decision_record(
+      project: project_b,
+      agent_run: create(:agent_run, :completed, project: project_b),
+      status: "active",
+      tags: %w[auth],
+      created_at: 14.days.ago
+    )
+  end
+
+  def create_decision_record(...)
+    create(:decision_record, ...)
+  end
+
+  def expected_summary(total_count:, active_count:, superseded_count:, reverted_count:, completed_run_count:, failed_run_count:)
+    {
+      total_count: total_count,
+      active_count: active_count,
+      superseded_count: superseded_count,
+      reverted_count: reverted_count,
+      linked_agent_run_count: total_count,
+      completed_run_count: completed_run_count,
+      failed_run_count: failed_run_count
+    }
+  end
+
+  def expected_project(project:, total_count:, decision_type_count:, active_count:, superseded_count:, reverted_count:)
+    {
+      project_id: project.id,
+      project_name: project.name,
+      project_full_name: project.full_name,
+      total_count: total_count,
+      decision_type_count: decision_type_count,
+      active_count: active_count,
+      superseded_count: superseded_count,
+      reverted_count: reverted_count
+    }
+  end
+
+  def expected_decision_type(decision_type:, total_count:, project_count:, active_count:, completed_run_count:)
+    {
+      decision_type: decision_type,
+      total_count: total_count,
+      project_count: project_count,
+      active_count: active_count,
+      completed_run_count: completed_run_count
+    }
+  end
+
+  def expected_daily_volume(day:, total_count:, active_count:, superseded_count:, reverted_count:)
+    {
+      day: day,
+      total_count: total_count,
+      active_count: active_count,
+      superseded_count: superseded_count,
+      reverted_count: reverted_count
+    }
+  end
+
+  def expected_default_decision_types
+    [
+      expected_decision_type(
+        decision_type: "auth",
+        total_count: 2,
+        project_count: 2,
+        active_count: 2,
+        completed_run_count: 2
+      ),
+      expected_decision_type(
+        decision_type: "api",
+        total_count: 1,
+        project_count: 1,
+        active_count: 1,
+        completed_run_count: 1
+      ),
+      expected_decision_type(
+        decision_type: "performance",
+        total_count: 1,
+        project_count: 1,
+        active_count: 0,
+        completed_run_count: 0
+      ),
+      expected_decision_type(
+        decision_type: "uncategorized",
+        total_count: 1,
+        project_count: 1,
+        active_count: 0,
+        completed_run_count: 0
+      )
+    ]
+  end
+
+  def expected_default_daily_volume
+    [
+      expected_daily_volume(
+        day: 14.days.ago.to_date,
+        total_count: 1,
+        active_count: 1,
+        superseded_count: 0,
+        reverted_count: 0
+      ),
+      expected_daily_volume(
+        day: 2.days.ago.to_date,
+        total_count: 1,
+        active_count: 1,
+        superseded_count: 0,
+        reverted_count: 0
+      ),
+      expected_daily_volume(
+        day: 1.day.ago.to_date,
+        total_count: 1,
+        active_count: 0,
+        superseded_count: 1,
+        reverted_count: 0
+      ),
+      expected_daily_volume(
+        day: Time.current.to_date,
+        total_count: 1,
+        active_count: 0,
+        superseded_count: 0,
+        reverted_count: 1
+      )
+    ]
+  end
+
+  describe ".call" do
+    it "returns the initial question set" do
+      report = described_class.call
+
+      expect(report[:questions].map { |question| question[:key] }).to eq(
+        %w[
+          decision_volume_over_time
+          decision_mix_by_type
+          project_level_decision_patterns
+          decision_outcomes
+        ]
+      )
+    end
+
+    it "builds the summary rollup" do
+      report = described_class.call
+
+      expect(report[:summary]).to eq(
+        expected_summary(
+          total_count: 4,
+          active_count: 2,
+          superseded_count: 1,
+          reverted_count: 1,
+          completed_run_count: 2,
+          failed_run_count: 2
+        )
+      )
+    end
+
+    it "builds the project rollup" do
+      report = described_class.call
+
+      expect(report[:by_project]).to eq([
+        expected_project(
+          project: project_a,
+          total_count: 2,
+          decision_type_count: 3,
+          active_count: 1,
+          superseded_count: 1,
+          reverted_count: 0
+        ),
+        expected_project(
+          project: project_b,
+          total_count: 2,
+          decision_type_count: 2,
+          active_count: 1,
+          superseded_count: 0,
+          reverted_count: 1
+        )
+      ])
+    end
+
+    it "builds the decision-type rollup" do
+      report = described_class.call
+
+      expect(report[:by_decision_type]).to eq(expected_default_decision_types)
+    end
+
+    it "builds the daily volume rollup" do
+      report = described_class.call
+
+      expect(report[:daily_volume]).to eq(expected_default_daily_volume)
+    end
+
+    it "filters by time window" do
+      report = described_class.call(filters: { from: 3.days.ago, to: Time.current })
+
+      expect(report[:summary]).to eq(
+        expected_summary(
+          total_count: 3,
+          active_count: 1,
+          superseded_count: 1,
+          reverted_count: 1,
+          completed_run_count: 1,
+          failed_run_count: 2
+        )
+      )
+      expect(report[:by_project].map { |row| row[:project_name] }).to eq(%w[Alpha Beta])
+      expect(report[:by_decision_type].map { |row| row[:decision_type] }).to eq(
+        %w[api auth performance uncategorized]
+      )
+    end
+
+    it "filters by project" do
+      report = described_class.call(filters: { project_ids: [ project_b.id ] })
+
+      expect(report[:summary]).to eq(
+        expected_summary(
+          total_count: 2,
+          active_count: 1,
+          superseded_count: 0,
+          reverted_count: 1,
+          completed_run_count: 1,
+          failed_run_count: 1
+        )
+      )
+      expect(report[:by_project].pluck(:project_name)).to eq([ "Beta" ])
+      expect(report[:by_decision_type].pluck(:decision_type)).to eq(%w[auth uncategorized])
+    end
+
+    it "filters the summary by tag-derived decision type, including uncategorized records" do
+      report = described_class.call(filters: { decision_types: [ "AUTH", "uncategorized" ] })
+
+      expect(report[:summary]).to eq(
+        expected_summary(
+          total_count: 3,
+          active_count: 2,
+          superseded_count: 0,
+          reverted_count: 1,
+          completed_run_count: 2,
+          failed_run_count: 1
+        )
+      )
+    end
+
+    it "filters the type rollup by tag-derived decision type, including uncategorized records" do
+      report = described_class.call(filters: { decision_types: [ "AUTH", "uncategorized" ] })
+
+      expect(report[:by_project].pluck(:project_name)).to eq(%w[Beta Alpha])
+      expect(report[:by_decision_type]).to eq([
+        expected_decision_type(
+          decision_type: "auth",
+          total_count: 2,
+          project_count: 2,
+          active_count: 2,
+          completed_run_count: 2
+        ),
+        expected_decision_type(
+          decision_type: "uncategorized",
+          total_count: 1,
+          project_count: 1,
+          active_count: 0,
+          completed_run_count: 0
+        )
+      ])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implemented a new `Analytics::OrchestrationDecisions` query/report layer over `DecisionRecord` data. It includes a shared filtered base query plus reusable rollups for summary, project breakdown, decision-type breakdown, and daily volume, along with an initial question set and a top-level report service. Decision-type filtering is tag-derived, with explicit handling for `uncategorized`.

Added representative specs in [spec/services/analytics/orchestration_decisions/report_spec.rb](/workspace/spec/services/analytics/orchestration_decisions/report_spec.rb) covering time-window, project, and decision-type filters plus rollup correctness.

Validation passed with `bundle exec rubocop`, `bundle exec rspec`, and the pre-commit hook’s staged lint/test run. I used `RAILS_ENV=test bin/rails db:prepare` against the provided `DATABASE_URL` because the default development prepare path tried a nonexistent local socket in this environment.

Committed on the issue branch as `feat(analytics): add orchestration decision analysis queries` at `da76248`.

---

Closes #1751