### PR TITLE
feat(screenshots): Cross-project PR screenshot support

### DIFF
--- a/app/services/screenshots/config_parser.rb
+++ b/app/services/screenshots/config_parser.rb
@@ -70,7 +70,7 @@ module Screenshots
     end
 
     def ui_detection_overrides
-      file_settings = if content.present? || blob.present? || (repo_path.present? && File.exist?(config_path))
+      file_settings = if content.present? || blob.present? || repo_config_file_present?
         parse_content(raw_content)
       else
         {}
@@ -118,7 +118,7 @@ module Screenshots
       return decode_blob(blob) if blob.present?
 
       path = config_path
-      raise ConfigError, "Missing #{config_path_label} in #{repo_path}" unless File.exist?(path)
+      ensure_config_file!(path)
 
       File.read(path)
     rescue Errno::ENOENT => e
@@ -135,6 +135,23 @@ module Screenshots
 
     def config_path_label
       explicit_project_settings["config_path"].presence || CONFIG_PATH
+    end
+
+    def repo_config_file_present?
+      return false unless repo_path.present?
+
+      path = config_path
+      return false unless File.exist?(path)
+
+      ensure_config_file!(path)
+      true
+    end
+
+    def ensure_config_file!(path)
+      return if File.file?(path)
+      raise ConfigError, "Missing #{config_path_label} in #{repo_path}" unless File.exist?(path)
+
+      raise ConfigError, "#{config_path_label} must be a file"
     end
 
     def decode_blob(value)

--- a/app/services/screenshots/config_parser.rb
+++ b/app/services/screenshots/config_parser.rb
@@ -126,7 +126,11 @@ module Screenshots
     end
 
     def config_path
-      Pathname(repo_path).join(config_path_label)
+      root = Pathname(repo_path).expand_path
+      full = root.join(config_path_label).expand_path
+      return full if full.to_s.start_with?("#{root}/") || full == root
+
+      raise ConfigError, "config_path escapes the repo directory"
     end
 
     def config_path_label

--- a/app/services/screenshots/config_parser.rb
+++ b/app/services/screenshots/config_parser.rb
@@ -118,15 +118,19 @@ module Screenshots
       return decode_blob(blob) if blob.present?
 
       path = config_path
-      raise ConfigError, "Missing #{CONFIG_PATH} in #{repo_path}" unless File.exist?(path)
+      raise ConfigError, "Missing #{config_path_label} in #{repo_path}" unless File.exist?(path)
 
       File.read(path)
     rescue Errno::ENOENT => e
-      raise ConfigError, "Unable to read #{CONFIG_PATH}: #{e.message}"
+      raise ConfigError, "Unable to read #{config_path_label}: #{e.message}"
     end
 
     def config_path
-      Pathname(repo_path).join(CONFIG_PATH)
+      Pathname(repo_path).join(config_path_label)
+    end
+
+    def config_path_label
+      explicit_project_settings["config_path"].presence || CONFIG_PATH
     end
 
     def decode_blob(value)
@@ -141,14 +145,14 @@ module Screenshots
       return {} if parsed.nil?
 
       unless parsed.is_a?(Hash)
-        raise ConfigError, "#{CONFIG_PATH} must contain a YAML mapping at the top level"
+        raise ConfigError, "#{config_path_label} must contain a YAML mapping at the top level"
       end
 
       parsed.deep_stringify_keys
     rescue Psych::DisallowedClass => e
-      raise ConfigError, "#{CONFIG_PATH} contains unsupported YAML types (e.g. symbols): #{e.message}"
+      raise ConfigError, "#{config_path_label} contains unsupported YAML types (e.g. symbols): #{e.message}"
     rescue Psych::SyntaxError => e
-      raise ConfigError, "Invalid YAML in #{CONFIG_PATH}: #{e.message}"
+      raise ConfigError, "Invalid YAML in #{config_path_label}: #{e.message}"
     end
 
     def merged_settings(file_settings)

--- a/spec/services/screenshots/config_parser_spec.rb
+++ b/spec/services/screenshots/config_parser_spec.rb
@@ -5,8 +5,13 @@ require "rails_helper"
 
 RSpec.describe Screenshots::ConfigParser do
   def write_config(dir, content)
-    FileUtils.mkdir_p(File.join(dir, ".paid"))
-    File.write(File.join(dir, ".paid", "screenshots.yml"), content)
+    write_config_at(dir, ".paid/screenshots.yml", content)
+  end
+
+  def write_config_at(dir, path, content)
+    full_path = File.join(dir, path)
+    FileUtils.mkdir_p(File.dirname(full_path))
+    File.write(full_path, content)
   end
 
   let(:repo_dir) { Dir.mktmpdir }
@@ -52,6 +57,21 @@ RSpec.describe Screenshots::ConfigParser do
 
       expect(described_class.ui_detection_overrides(project:, repo_path: repo_dir)).to eq(
         framework: :nextjs
+      )
+    end
+
+    it "reads UI overrides from the project-configured config path" do
+      project.screenshot_settings = { "config_path" => ".paid/custom-screenshots.yml" }
+      write_config_at(repo_dir, ".paid/custom-screenshots.yml", <<~YAML)
+        routes:
+          - path: /
+            name: homepage
+        ui_patterns:
+          - frontend/**/*
+      YAML
+
+      expect(described_class.ui_detection_overrides(project:, repo_path: repo_dir)).to eq(
+        patterns: [ "frontend/**/*" ]
       )
     end
 
@@ -101,6 +121,26 @@ RSpec.describe Screenshots::ConfigParser do
         )
         expect(config.ui_patterns).to eq(Screenshots::Configuration::DEFAULT_UI_PATTERNS)
         expect(config.ui_exclusions).to eq(Screenshots::Configuration::DEFAULT_UI_EXCLUSIONS)
+      end
+    end
+
+    context "with a custom project config path" do
+      subject(:config) { described_class.from_repo_path(repo_dir, project: project) }
+
+      before do
+        project.screenshot_settings = { "config_path" => ".paid/custom-screenshots.yml" }
+
+        write_config_at(repo_dir, ".paid/custom-screenshots.yml", <<~YAML)
+          routes:
+            - path: /dashboard
+              name: dashboard
+        YAML
+      end
+
+      it "reads the configured file instead of the default path" do
+        expect(config.routes).to contain_exactly(
+          have_attributes(path: "/dashboard", name: "dashboard", requires_auth: false, seed_key: nil)
+        )
       end
     end
 

--- a/spec/services/screenshots/config_parser_spec.rb
+++ b/spec/services/screenshots/config_parser_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe Screenshots::ConfigParser do
       )
     end
 
+    it "rejects UI override config paths that escape the repo" do
+      project.screenshot_settings = { "config_path" => "../custom-screenshots.yml" }
+
+      expect {
+        described_class.ui_detection_overrides(project:, repo_path: repo_dir)
+      }.to raise_error(Screenshots::ConfigError, "config_path escapes the repo directory")
+    end
+
     it "does not return default Rails UI patterns when the repo config omits them" do
       write_config(repo_dir, <<~YAML)
         routes:
@@ -140,6 +148,15 @@ RSpec.describe Screenshots::ConfigParser do
       it "reads the configured file instead of the default path" do
         expect(config.routes).to contain_exactly(
           have_attributes(path: "/dashboard", name: "dashboard", requires_auth: false, seed_key: nil)
+        )
+      end
+
+      it "rejects configured paths that escape the repo" do
+        project.screenshot_settings = { "config_path" => "../custom-screenshots.yml" }
+
+        expect { config }.to raise_error(
+          Screenshots::ConfigError,
+          "config_path escapes the repo directory"
         )
       end
     end

--- a/spec/services/screenshots/config_parser_spec.rb
+++ b/spec/services/screenshots/config_parser_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe Screenshots::ConfigParser do
       }.to raise_error(Screenshots::ConfigError, "config_path escapes the repo directory")
     end
 
+    it "rejects UI override config paths that point to a directory" do
+      project.screenshot_settings = { "config_path" => "." }
+
+      expect {
+        described_class.ui_detection_overrides(project:, repo_path: repo_dir)
+      }.to raise_error(Screenshots::ConfigError, ". must be a file")
+    end
+
     it "does not return default Rails UI patterns when the repo config omits them" do
       write_config(repo_dir, <<~YAML)
         routes:
@@ -157,6 +165,15 @@ RSpec.describe Screenshots::ConfigParser do
         expect { config }.to raise_error(
           Screenshots::ConfigError,
           "config_path escapes the repo directory"
+        )
+      end
+
+      it "rejects configured paths that point to a directory" do
+        project.screenshot_settings = { "config_path" => "." }
+
+        expect { config }.to raise_error(
+          Screenshots::ConfigError,
+          ". must be a file"
         )
       end
     end


### PR DESCRIPTION
## Summary

Fixed the cross-project screenshot config-path bug and committed it as `13c4826` with `fix(screenshots): honor project screenshot config path`.

`Screenshots::ConfigParser` now resolves the repo config file from the project’s configured `screenshot_settings["config_path"]` instead of always hardcoding `.paid/screenshots.yml`, and its error messages now report the effective path as well. The new coverage in [spec/services/screenshots/config_parser_spec.rb](/workspace/spec/services/screenshots/config_parser_spec.rb:6) verifies both `ui_detection_overrides` and `from_repo_path` against a custom config path. The parser change is in [app/services/screenshots/config_parser.rb](/workspace/app/services/screenshots/config_parser.rb:116).

Verification passed:
- `bundle exec rails db:prepare` with `DB_HOST`/`DB_USERNAME`/`DB_PASSWORD` derived from `DATABASE_URL`
- `bundle exec rubocop`
- `bundle exec rspec`
- commit hooks passed on `git commit`

The worktree is clean.

---

Closes #1645