### PR TITLE
feat(orchestration): create orchestration decision logging schema

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -101,6 +101,7 @@ class AgentRun < ApplicationRecord
   has_many :configuration_experiment_assignments, dependent: :destroy
   has_many :container_metrics, dependent: :delete_all
   has_many :quality_metrics, dependent: :destroy
+  has_many :orchestration_decisions, dependent: :nullify
   has_one :worktree, dependent: :nullify
   has_one :model_selection, dependent: :destroy
   has_one :decision_record, dependent: :nullify

--- a/app/models/orchestration_decision.rb
+++ b/app/models/orchestration_decision.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class OrchestrationDecision < ApplicationRecord
+  belongs_to :project
+  belongs_to :agent_run, optional: true
+
+  before_validation :assign_project_from_agent_run
+
+  validates :decision_type, presence: true, length: { maximum: 100 }
+  validates :actor, presence: true, length: { maximum: 100 }
+  validate :project_matches_agent_run
+  validate :context_is_object
+  validate :inputs_is_object
+  validate :outputs_is_object
+  validate :outcome_references_is_array
+
+  scope :for_project, ->(project) { where(project: project) }
+  scope :for_agent_run, ->(agent_run) { where(agent_run: agent_run) }
+  scope :by_decision_type, ->(decision_type) { where(decision_type: decision_type) }
+  scope :by_actor, ->(actor) { where(actor: actor) }
+  scope :recent, -> { order(created_at: :desc, id: :desc) }
+
+  private
+
+  def assign_project_from_agent_run
+    self.project ||= agent_run&.project
+  end
+
+  def project_matches_agent_run
+    return unless project && agent_run
+    return if project_id == agent_run.project_id
+
+    errors.add(:project, "must match the agent run's project")
+  end
+
+  def context_is_object
+    validate_json_object(:context)
+  end
+
+  def inputs_is_object
+    validate_json_object(:inputs)
+  end
+
+  def outputs_is_object
+    validate_json_object(:outputs)
+  end
+
+  def outcome_references_is_array
+    return if outcome_references.is_a?(Array)
+
+    errors.add(:outcome_references, "must be an array")
+  end
+
+  def validate_json_object(attribute)
+    return if public_send(attribute).is_a?(Hash)
+
+    errors.add(attribute, "must be an object")
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -151,6 +151,7 @@ class Project < ApplicationRecord
   has_many :project_service_containers, dependent: :destroy
   has_many :service_containers, through: :project_service_containers
   has_many :decision_records, dependent: :destroy
+  has_many :orchestration_decisions, dependent: :destroy
   has_many :llm_output_metrics, dependent: :destroy
   has_many :knowledge_runs, dependent: :destroy
   has_many :knowledge_usage_stats, dependent: :destroy

--- a/db/migrate/20260421162139_enable_tenant_row_level_security.rb
+++ b/db/migrate/20260421162139_enable_tenant_row_level_security.rb
@@ -594,6 +594,8 @@ class EnableTenantRowLevelSecurity < ActiveRecord::Migration[8.1]
       "project_service_containers",
       "service_container_metrics",
       "knowledge_usage_stats",
+      # Added by a later migration but depends on the same tenant helper functions.
+      "orchestration_decisions",
       "token_usages",
       "tracker_configurations",
       "exception_incidents"

--- a/db/migrate/20260507164917_create_orchestration_decisions.rb
+++ b/db/migrate/20260507164917_create_orchestration_decisions.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class CreateOrchestrationDecisions < ActiveRecord::Migration[8.1]
+  def up
+    create_table :orchestration_decisions,
+      comment: "Structured log of orchestration decisions for later workflow analysis and learning." do |t|
+      t.references :project,
+        null: false,
+        foreign_key: { on_delete: :cascade },
+        comment: "Owning project for tenant isolation and project-level analysis."
+      t.references :agent_run,
+        null: true,
+        foreign_key: { on_delete: :nullify },
+        comment: "Agent run whose workflow emitted the decision when a specific run exists."
+      t.string :decision_type,
+        null: false,
+        limit: 100,
+        comment: "Decision category such as decompose, select_agent, parallelize, retry, or escalate."
+      t.string :actor,
+        null: false,
+        limit: 100,
+        comment: "Component or role that made the decision, such as workflow, planner, scheduler, or human."
+      t.jsonb :context,
+        null: false,
+        default: {},
+        comment: "Context snapshot used to make the decision, typically issue, project, and workflow features."
+      t.jsonb :inputs,
+        null: false,
+        default: {},
+        comment: "Structured inputs or options considered before the decision."
+      t.jsonb :outputs,
+        null: false,
+        default: {},
+        comment: "Structured payload describing what the workflow decided."
+      t.jsonb :outcome_references,
+        null: false,
+        default: [],
+        comment: "References to later runs, metrics, or artifacts used to attribute outcomes back to this decision."
+      t.timestamps
+    end
+
+    add_index :orchestration_decisions,
+      [ :project_id, :decision_type, :created_at ],
+      name: "idx_orchestration_decisions_project_type_created"
+    add_index :orchestration_decisions,
+      [ :agent_run_id, :decision_type, :created_at ],
+      name: "idx_orchestration_decisions_run_type_created"
+    add_index :orchestration_decisions,
+      [ :project_id, :actor, :created_at ],
+      name: "idx_orchestration_decisions_project_actor_created"
+
+    execute <<~SQL
+      ALTER TABLE orchestration_decisions ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE orchestration_decisions FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON orchestration_decisions
+        USING (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = orchestration_decisions.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        )
+        WITH CHECK (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = orchestration_decisions.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        );
+    SQL
+  end
+
+  def down
+    execute "DROP POLICY IF EXISTS tenant_isolation ON orchestration_decisions"
+    execute "ALTER TABLE orchestration_decisions NO FORCE ROW LEVEL SECURITY"
+    execute "ALTER TABLE orchestration_decisions DISABLE ROW LEVEL SECURITY"
+
+    drop_table :orchestration_decisions
+  end
+end

--- a/db/migrate/20260507164917_create_orchestration_decisions.rb
+++ b/db/migrate/20260507164917_create_orchestration_decisions.rb
@@ -40,8 +40,14 @@ class CreateOrchestrationDecisions < ActiveRecord::Migration[8.1]
     end
 
     add_index :orchestration_decisions,
+      [ :project_id, :created_at, :id ],
+      name: "idx_orchestration_decisions_project_recent"
+    add_index :orchestration_decisions,
       [ :project_id, :decision_type, :created_at ],
       name: "idx_orchestration_decisions_project_type_created"
+    add_index :orchestration_decisions,
+      [ :agent_run_id, :created_at, :id ],
+      name: "idx_orchestration_decisions_run_recent"
     add_index :orchestration_decisions,
       [ :agent_run_id, :decision_type, :created_at ],
       name: "idx_orchestration_decisions_run_type_created"

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6161,10 +6161,24 @@ CREATE INDEX idx_orchestration_decisions_project_actor_created ON public.orchest
 
 
 --
+-- Name: idx_orchestration_decisions_project_recent; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_orchestration_decisions_project_recent ON public.orchestration_decisions USING btree (project_id, created_at, id);
+
+
+--
 -- Name: idx_orchestration_decisions_project_type_created; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_orchestration_decisions_project_type_created ON public.orchestration_decisions USING btree (project_id, decision_type, created_at);
+
+
+--
+-- Name: idx_orchestration_decisions_run_recent; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_orchestration_decisions_run_recent ON public.orchestration_decisions USING btree (agent_run_id, created_at, id);
 
 
 --
@@ -11658,4 +11672,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260128004342'),
 ('20260128004305'),
 ('20260127154444');
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11221,6 +11221,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507164917'),
 ('20260507011753'),
 ('20260506175107'),
 ('20260506174922'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2938,6 +2938,109 @@ ALTER SEQUENCE public.onboarding_steps_id_seq OWNED BY public.onboarding_steps.i
 
 
 --
+-- Name: orchestration_decisions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.orchestration_decisions (
+    id bigint NOT NULL,
+    project_id bigint NOT NULL,
+    agent_run_id bigint,
+    decision_type character varying(100) NOT NULL,
+    actor character varying(100) NOT NULL,
+    context jsonb DEFAULT '{}'::jsonb NOT NULL,
+    inputs jsonb DEFAULT '{}'::jsonb NOT NULL,
+    outputs jsonb DEFAULT '{}'::jsonb NOT NULL,
+    outcome_references jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+ALTER TABLE ONLY public.orchestration_decisions FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: TABLE orchestration_decisions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.orchestration_decisions IS 'Structured log of orchestration decisions for later workflow analysis and learning.';
+
+
+--
+-- Name: COLUMN orchestration_decisions.project_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_decisions.project_id IS 'Owning project for tenant isolation and project-level analysis.';
+
+
+--
+-- Name: COLUMN orchestration_decisions.agent_run_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_decisions.agent_run_id IS 'Agent run whose workflow emitted the decision when a specific run exists.';
+
+
+--
+-- Name: COLUMN orchestration_decisions.decision_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_decisions.decision_type IS 'Decision category such as decompose, select_agent, parallelize, retry, or escalate.';
+
+
+--
+-- Name: COLUMN orchestration_decisions.actor; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_decisions.actor IS 'Component or role that made the decision, such as workflow, planner, scheduler, or human.';
+
+
+--
+-- Name: COLUMN orchestration_decisions.context; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_decisions.context IS 'Context snapshot used to make the decision, typically issue, project, and workflow features.';
+
+
+--
+-- Name: COLUMN orchestration_decisions.inputs; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_decisions.inputs IS 'Structured inputs or options considered before the decision.';
+
+
+--
+-- Name: COLUMN orchestration_decisions.outputs; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_decisions.outputs IS 'Structured payload describing what the workflow decided.';
+
+
+--
+-- Name: COLUMN orchestration_decisions.outcome_references; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_decisions.outcome_references IS 'References to later runs, metrics, or artifacts used to attribute outcomes back to this decision.';
+
+
+--
+-- Name: orchestration_decisions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.orchestration_decisions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: orchestration_decisions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.orchestration_decisions_id_seq OWNED BY public.orchestration_decisions.id;
+
+
+--
 -- Name: pr_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4905,6 +5008,13 @@ ALTER TABLE ONLY public.onboarding_steps ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: orchestration_decisions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orchestration_decisions ALTER COLUMN id SET DEFAULT nextval('public.orchestration_decisions_id_seq'::regclass);
+
+
+--
 -- Name: pr_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5572,6 +5682,14 @@ ALTER TABLE ONLY public.onboarding_steps
 
 
 --
+-- Name: orchestration_decisions orchestration_decisions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orchestration_decisions
+    ADD CONSTRAINT orchestration_decisions_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: pr_templates pr_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6033,6 +6151,27 @@ CREATE INDEX idx_on_project_id_recommendation_type_333faaed2e ON public.knowledg
 --
 
 CREATE INDEX idx_on_project_id_status_warmed_at_d791387888 ON public.container_pool_entries USING btree (project_id, status, warmed_at);
+
+
+--
+-- Name: idx_orchestration_decisions_project_actor_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_orchestration_decisions_project_actor_created ON public.orchestration_decisions USING btree (project_id, actor, created_at);
+
+
+--
+-- Name: idx_orchestration_decisions_project_type_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_orchestration_decisions_project_type_created ON public.orchestration_decisions USING btree (project_id, decision_type, created_at);
+
+
+--
+-- Name: idx_orchestration_decisions_run_type_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_orchestration_decisions_run_type_created ON public.orchestration_decisions USING btree (agent_run_id, decision_type, created_at);
 
 
 --
@@ -7730,6 +7869,20 @@ CREATE UNIQUE INDEX index_onboarding_steps_on_account_id_and_step ON public.onbo
 
 
 --
+-- Name: index_orchestration_decisions_on_agent_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orchestration_decisions_on_agent_run_id ON public.orchestration_decisions USING btree (agent_run_id);
+
+
+--
+-- Name: index_orchestration_decisions_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orchestration_decisions_on_project_id ON public.orchestration_decisions USING btree (project_id);
+
+
+--
 -- Name: index_pr_templates_on_account_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8784,6 +8937,14 @@ ALTER TABLE ONLY public.knowledge_artifacts
 
 
 --
+-- Name: orchestration_decisions fk_rails_373dda1f87; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orchestration_decisions
+    ADD CONSTRAINT fk_rails_373dda1f87 FOREIGN KEY (agent_run_id) REFERENCES public.agent_runs(id) ON DELETE SET NULL;
+
+
+--
 -- Name: linear_tokens fk_rails_377d92966e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9285,6 +9446,14 @@ ALTER TABLE ONLY public.pre_commit_requirements
 
 ALTER TABLE ONLY public.notifications
     ADD CONSTRAINT fk_rails_b080fb4855 FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: orchestration_decisions fk_rails_b0ebd4e80f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orchestration_decisions
+    ADD CONSTRAINT fk_rails_b0ebd4e80f FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
 
 
 --
@@ -9950,6 +10119,12 @@ ALTER TABLE public.notifications ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.onboarding_steps ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: orchestration_decisions; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.orchestration_decisions ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: pr_templates; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -10573,6 +10748,17 @@ CREATE POLICY tenant_isolation ON public.notifications USING ((public.paid_tenan
 --
 
 CREATE POLICY tenant_isolation ON public.onboarding_steps USING ((public.paid_tenant_bypass() OR (account_id = public.paid_current_account_id()))) WITH CHECK ((public.paid_tenant_bypass() OR (account_id = public.paid_current_account_id())));
+
+
+--
+-- Name: orchestration_decisions tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.orchestration_decisions USING ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.projects
+  WHERE ((projects.id = orchestration_decisions.project_id) AND (projects.account_id = public.paid_current_account_id())))))) WITH CHECK ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.projects
+  WHERE ((projects.id = orchestration_decisions.project_id) AND (projects.account_id = public.paid_current_account_id()))))));
 
 
 --

--- a/spec/factories/orchestration_decisions.rb
+++ b/spec/factories/orchestration_decisions.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :orchestration_decision do
+    agent_run { association :agent_run, :completed }
+    project { agent_run&.project || association(:project) }
+    decision_type { "decompose" }
+    actor { "workflow" }
+    context do
+      {
+        issue: { complexity: "high", file_count: 12 },
+        project: { language: "ruby", repository_size: "medium" }
+      }
+    end
+    inputs do
+      {
+        strategies: %w[single parallel],
+        available_agents: %w[claude_code codex]
+      }
+    end
+    outputs do
+      {
+        selected_strategy: "parallel",
+        agent_count: 2
+      }
+    end
+    outcome_references do
+      [
+        { type: "agent_run", id: agent_run&.id },
+        { type: "quality_metric", metric: "review_score" }
+      ]
+    end
+
+    trait :without_agent_run do
+      agent_run { nil }
+      project { association :project }
+    end
+  end
+end

--- a/spec/migrations/create_orchestration_decisions_spec.rb
+++ b/spec/migrations/create_orchestration_decisions_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe CreateOrchestrationDecisions, :aggregate_failures do
     expect(index_names).to include(
       "index_orchestration_decisions_on_project_id",
       "index_orchestration_decisions_on_agent_run_id",
+      "idx_orchestration_decisions_project_recent",
       "idx_orchestration_decisions_project_type_created",
+      "idx_orchestration_decisions_run_recent",
       "idx_orchestration_decisions_run_type_created",
       "idx_orchestration_decisions_project_actor_created"
     )

--- a/spec/migrations/create_orchestration_decisions_spec.rb
+++ b/spec/migrations/create_orchestration_decisions_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260507164917_create_orchestration_decisions")
+
+RSpec.describe CreateOrchestrationDecisions, :aggregate_failures do
+  self.use_transactional_tests = false
+
+  let(:migration) { described_class.new }
+  let(:connection) { ActiveRecord::Base.connection }
+
+  around do |example|
+    table_existed = connection.table_exists?(:orchestration_decisions)
+    migration.down if table_existed
+
+    example.run
+  ensure
+    migration.down if connection.table_exists?(:orchestration_decisions)
+    migration.up if table_existed
+  end
+
+  it "creates the table with indexes, foreign keys, comments, and tenant RLS" do
+    migration.up
+
+    expect(connection.table_exists?(:orchestration_decisions)).to be(true)
+    expect_schema
+    expect_indexes
+    expect_comments
+    expect_rls
+  end
+
+  private
+
+  def expect_schema
+    columns = connection.columns(:orchestration_decisions).index_by(&:name)
+    expect(columns.fetch("project_id").null).to be(false)
+    expect(columns.fetch("agent_run_id").null).to be(true)
+    expect(columns.fetch("decision_type").limit).to eq(100)
+    expect(columns.fetch("actor").limit).to eq(100)
+    expect(default_expression_for("context")).to include("'{}'::jsonb")
+    expect(default_expression_for("inputs")).to include("'{}'::jsonb")
+    expect(default_expression_for("outputs")).to include("'{}'::jsonb")
+    expect(default_expression_for("outcome_references")).to include("'[]'::jsonb")
+    expect(connection.foreign_key_exists?(:orchestration_decisions, :projects)).to be(true)
+    expect(connection.foreign_key_exists?(:orchestration_decisions, :agent_runs)).to be(true)
+  end
+
+  def expect_indexes
+    index_names = connection.indexes(:orchestration_decisions).map(&:name)
+    expect(index_names).to include(
+      "index_orchestration_decisions_on_project_id",
+      "index_orchestration_decisions_on_agent_run_id",
+      "idx_orchestration_decisions_project_type_created",
+      "idx_orchestration_decisions_run_type_created",
+      "idx_orchestration_decisions_project_actor_created"
+    )
+  end
+
+  def expect_comments
+    expect(table_comment).to eq("Structured log of orchestration decisions for later workflow analysis and learning.")
+    expect(column_comment("outcome_references")).to eq(
+      "References to later runs, metrics, or artifacts used to attribute outcomes back to this decision."
+    )
+  end
+
+  def expect_rls
+    expect(tenant_policy_present?).to be(true)
+    expect(row_level_security_enabled?).to be(true)
+    expect(row_level_security_forced?).to be(true)
+  end
+
+  def table_comment
+    connection.select_value(<<~SQL.squish)
+      SELECT obj_description('public.orchestration_decisions'::regclass, 'pg_class')
+    SQL
+  end
+
+  def column_comment(column_name)
+    connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array([
+        <<~SQL.squish,
+          SELECT col_description('public.orchestration_decisions'::regclass, ordinal_position)
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = 'orchestration_decisions'
+            AND column_name = ?
+        SQL
+        column_name
+      ])
+    )
+  end
+
+  def default_expression_for(column_name)
+    connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array([
+        <<~SQL.squish,
+          SELECT pg_get_expr(d.adbin, d.adrelid)
+          FROM pg_attribute a
+          INNER JOIN pg_attrdef d
+            ON d.adrelid = a.attrelid
+           AND d.adnum = a.attnum
+          WHERE a.attrelid = 'public.orchestration_decisions'::regclass
+            AND a.attname = ?
+        SQL
+        column_name
+      ])
+    )
+  end
+
+  def row_level_security_enabled?
+    truthy?(connection.select_value(<<~SQL.squish))
+      SELECT relrowsecurity
+      FROM pg_class
+      WHERE oid = 'public.orchestration_decisions'::regclass
+    SQL
+  end
+
+  def row_level_security_forced?
+    truthy?(connection.select_value(<<~SQL.squish))
+      SELECT relforcerowsecurity
+      FROM pg_class
+      WHERE oid = 'public.orchestration_decisions'::regclass
+    SQL
+  end
+
+  def tenant_policy_present?
+    connection.select_value(<<~SQL.squish).to_i.positive?
+      SELECT COUNT(*)
+      FROM pg_policies
+      WHERE schemaname = 'public'
+        AND tablename = 'orchestration_decisions'
+        AND policyname = 'tenant_isolation'
+    SQL
+  end
+
+  def truthy?(value)
+    value == true || value == "t"
+  end
+end

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AgentRun do
     it { is_expected.to belong_to(:issue).optional }
     it { is_expected.to have_many(:agent_run_logs).dependent(:destroy) }
     it { is_expected.to have_many(:agent_run_phases).dependent(:destroy) }
+    it { is_expected.to have_many(:orchestration_decisions).dependent(:nullify) }
   end
 
   describe "validations" do

--- a/spec/models/orchestration_decision_spec.rb
+++ b/spec/models/orchestration_decision_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe OrchestrationDecision do
 
         expect(described_class.recent).to eq([ newer, older ])
       end
+
+      it "uses id as a deterministic tiebreaker for identical timestamps" do
+        timestamp = Time.current.change(usec: 0)
+        earlier = create(:orchestration_decision, created_at: timestamp)
+        later = create(:orchestration_decision, created_at: timestamp)
+
+        expect(described_class.recent).to eq([ later, earlier ])
+      end
     end
   end
 

--- a/spec/models/orchestration_decision_spec.rb
+++ b/spec/models/orchestration_decision_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrchestrationDecision do
+  subject(:orchestration_decision) { build(:orchestration_decision) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:project).without_validating_presence }
+    it { is_expected.to belong_to(:agent_run).optional }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:decision_type) }
+    it { is_expected.to validate_length_of(:decision_type).is_at_most(100) }
+    it { is_expected.to validate_presence_of(:actor) }
+    it { is_expected.to validate_length_of(:actor).is_at_most(100) }
+
+    it "derives the project from the agent run when omitted" do
+      agent_run = create(:agent_run, :completed)
+      decision = build(:orchestration_decision, agent_run: agent_run, project: nil)
+
+      expect(decision).to be_valid
+      expect(decision.project).to eq(agent_run.project)
+    end
+
+    it "rejects a project from a different agent run" do
+      agent_run = create(:agent_run, :completed)
+      other_project = create(:project)
+      decision = build(:orchestration_decision, agent_run: agent_run, project: other_project)
+
+      expect(decision).not_to be_valid
+      expect(decision.errors[:project]).to include("must match the agent run's project")
+    end
+
+    it "requires context to be an object" do
+      decision = build(:orchestration_decision, context: [])
+
+      expect(decision).not_to be_valid
+      expect(decision.errors[:context]).to include("must be an object")
+    end
+
+    it "requires inputs to be an object" do
+      decision = build(:orchestration_decision, inputs: "parallel")
+
+      expect(decision).not_to be_valid
+      expect(decision.errors[:inputs]).to include("must be an object")
+    end
+
+    it "requires outputs to be an object" do
+      decision = build(:orchestration_decision, outputs: nil)
+
+      expect(decision).not_to be_valid
+      expect(decision.errors[:outputs]).to include("must be an object")
+    end
+
+    it "requires outcome_references to be an array" do
+      decision = build(:orchestration_decision, outcome_references: {})
+
+      expect(decision).not_to be_valid
+      expect(decision.errors[:outcome_references]).to include("must be an array")
+    end
+  end
+
+  describe "scopes" do
+    let(:project) { create(:project) }
+    let(:agent_run) { create(:agent_run, :completed, project: project) }
+
+    describe ".for_project" do
+      it "returns decisions for the given project" do
+        decision = create(:orchestration_decision, project: project, agent_run: agent_run)
+        create(:orchestration_decision)
+
+        expect(described_class.for_project(project)).to eq([ decision ])
+      end
+    end
+
+    describe ".for_agent_run" do
+      it "returns decisions for the given agent run" do
+        decision = create(:orchestration_decision, project: project, agent_run: agent_run)
+        create(:orchestration_decision, :without_agent_run, project: project)
+
+        expect(described_class.for_agent_run(agent_run)).to eq([ decision ])
+      end
+    end
+
+    describe ".by_decision_type" do
+      it "filters by decision type" do
+        decision = create(:orchestration_decision, decision_type: "parallelize")
+        create(:orchestration_decision, decision_type: "retry")
+
+        expect(described_class.by_decision_type("parallelize")).to eq([ decision ])
+      end
+    end
+
+    describe ".by_actor" do
+      it "filters by actor" do
+        decision = create(:orchestration_decision, actor: "planner")
+        create(:orchestration_decision, actor: "workflow")
+
+        expect(described_class.by_actor("planner")).to eq([ decision ])
+      end
+    end
+
+    describe ".recent" do
+      it "orders newest first" do
+        older = create(:orchestration_decision, created_at: 1.hour.ago)
+        newer = create(:orchestration_decision, created_at: 1.minute.ago)
+
+        expect(described_class.recent).to eq([ newer, older ])
+      end
+    end
+  end
+
+  describe "JSONB storage" do
+    it "persists structured decision fields" do
+      decision = create(:orchestration_decision)
+      reloaded = described_class.find(decision.id)
+
+      expect(reloaded.context).to eq(decision.context.deep_stringify_keys)
+      expect(reloaded.inputs).to eq(decision.inputs.deep_stringify_keys)
+      expect(reloaded.outputs).to eq(decision.outputs.deep_stringify_keys)
+      expect(reloaded.outcome_references).to eq(decision.outcome_references.map(&:stringify_keys))
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Project do
     it { is_expected.to have_many(:members).through(:project_memberships).source(:user) }
     it { is_expected.to have_many(:issues).dependent(:destroy) }
     it { is_expected.to have_many(:agent_runs).dependent(:destroy) }
+    it { is_expected.to have_many(:orchestration_decisions).dependent(:destroy) }
     it { is_expected.to have_many(:workflow_states).dependent(:destroy) }
   end
 


### PR DESCRIPTION
## Summary

Implemented the orchestration decision logging schema in [db/migrate/20260507164917_create_orchestration_decisions.rb](/workspace/db/migrate/20260507164917_create_orchestration_decisions.rb), added the model/factory/specs in [app/models/orchestration_decision.rb](/workspace/app/models/orchestration_decision.rb), [spec/factories/orchestration_decisions.rb](/workspace/spec/factories/orchestration_decisions.rb), [spec/models/orchestration_decision_spec.rb](/workspace/spec/models/orchestration_decision_spec.rb), and [spec/migrations/create_orchestration_decisions_spec.rb](/workspace/spec/migrations/create_orchestration_decisions_spec.rb). I also wired associations in [app/models/agent_run.rb](/workspace/app/models/agent_run.rb), [app/models/project.rb](/workspace/app/models/project.rb), and their model specs, and updated [db/structure.sql](/workspace/db/structure.sql).

Verification:
- `bundle exec rubocop` passes.
- The change-specific examples pass under `RAILS_ENV=test` with `DATABASE_URL` unset and `DB_HOST/DB_USERNAME/DB_PASSWORD` set.
- Full `bundle exec rspec` does not pass in this environment; it hits broader repository-level failures outside this change set, so I did not create a commit.

---

Closes #1747