### PR TITLE
feat(screenshots): container-based screenshot execution via Temporal activity

### DIFF
--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -276,10 +276,12 @@ module Containers
     # @param pull_request_number [Integer, nil] PR number for fallback fetch
     # @return [void]
     # @raise [CloneError] when clone or checkout fails
-    def clone_and_checkout_branch(branch_name:, pull_request_number: nil)
+    def clone_and_checkout_branch(branch_name:, pull_request_number: nil, persist: true)
       clone_repo
       checkout_remote_branch(branch_name, pull_request_number: pull_request_number)
       base_sha = record_merge_base
+
+      return unless persist
 
       agent_run.update!(
         worktree_path: "/workspace",

--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -101,8 +101,8 @@ module Containers
     #   Defaults to NETWORK_NAME (paid_agent). Callers should pass the same
     #   network the agent container will use so services are reachable.
     # @return [Hash] Environment variables hash for the agent container
-    def provision(agent_run, network: NetworkPolicy::NETWORK_NAME)
-      service_containers = agent_run.project.service_containers.to_a
+    def provision(agent_run, network: NetworkPolicy::NETWORK_NAME, service_names: nil)
+      service_containers = selected_service_containers(agent_run.project, service_names)
       return {} if service_containers.empty?
 
       @network = network
@@ -179,6 +179,13 @@ module Containers
     end
 
     private
+
+    def selected_service_containers(project, service_names)
+      scope = project.service_containers
+      names = Array(service_names).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+      scope = scope.where(name: names) if names.any?
+      scope.to_a
+    end
 
     def ensure_running!(service_container)
       if service_container.running?

--- a/app/services/screenshots/container_capture.rb
+++ b/app/services/screenshots/container_capture.rb
@@ -46,6 +46,7 @@ module Screenshots
       @service_provisioner = nil
       @screenshot_container = nil
       @chrome_container = nil
+      @screenshot_service_container_ids = []
       @tmpdir = nil
       @config = nil
       @network = nil
@@ -107,11 +108,7 @@ module Screenshots
 
     private
 
-    attr_reader :agent_run, :project, :logger
-
-    def config
-      @config
-    end
+    attr_reader :agent_run, :project, :logger, :config
 
     def service_provisioner
       @service_provisioner ||= Containers::ServiceProvisioner.new
@@ -199,7 +196,15 @@ module Screenshots
       service_names = configured_service_dependencies
       return if service_names.empty?
 
+      # Save the original service_container_ids so we can restore them after
+      # provisioning. ServiceProvisioner#provision overwrites the field, which
+      # would orphan the main workflow's service containers during cleanup.
+      original_ids = agent_run.service_container_ids.dup
+
       service_provisioner.provision(agent_run, network: @network, service_names: service_names)
+
+      @screenshot_service_container_ids = agent_run.service_container_ids - original_ids
+      agent_run.update!(service_container_ids: original_ids)
     end
 
     def configured_service_dependencies
@@ -272,8 +277,8 @@ module Screenshots
     end
 
     def run_capture!(ui_files)
-      runner_path = write_capture_runner
-      command = "node #{Shellwords.escape(runner_path)}"
+      write_capture_runner
+      command = "node .paid-screenshots/capture_runner.mjs"
       env = capture_env.merge(
         "SCREENSHOT_CONFIG_JSON" => screenshot_config_json,
         "SCREENSHOT_OUTPUT_DIR" => OUTPUT_DIR,
@@ -514,16 +519,31 @@ module Screenshots
         logger.warn(message: "screenshots.chrome_cleanup_failed", agent_run_id: agent_run.id, error: e.message)
       end
 
-      begin
-        service_provisioner.cleanup(agent_run)
-      rescue StandardError => e
-        logger.warn(message: "screenshots.services_cleanup_failed", agent_run_id: agent_run.id, error: e.message)
-      end
+      cleanup_screenshot_services!
 
       begin
         @screenshot_container&.cleanup(force: true)
       rescue StandardError => e
         logger.warn(message: "screenshots.container_cleanup_failed", agent_run_id: agent_run.id, error: e.message)
+      end
+    end
+
+    def cleanup_screenshot_services!
+      return if @screenshot_service_container_ids.empty?
+
+      ServiceContainer.where(id: @screenshot_service_container_ids).find_each do |sc|
+        sc.with_lock do
+          next unless sc.capacity_inflight_agent_run_count.zero?
+
+          docker = Docker::Container.get(sc.docker_container_id)
+          docker.stop(timeout: 10)
+          docker.delete(force: true, v: true)
+          sc.update!(status: "stopped", docker_container_id: nil)
+        end
+      rescue Docker::Error::DockerError => e
+        logger.warn(message: "screenshots.services_cleanup_failed", agent_run_id: agent_run.id, service_container: sc.name, error: e.message)
+      rescue StandardError => e
+        logger.warn(message: "screenshots.services_cleanup_failed", agent_run_id: agent_run.id, error: e.message)
       end
     end
   end

--- a/app/services/screenshots/container_capture.rb
+++ b/app/services/screenshots/container_capture.rb
@@ -135,8 +135,6 @@ module Screenshots
     def with_workspace
       @tmpdir = Dir.mktmpdir("paid-screenshots-#{agent_run.id}-")
       yield(@tmpdir)
-    ensure
-      FileUtils.rm_rf(@tmpdir) if @tmpdir.present?
     end
 
     def provision_capture_container(repo_path)
@@ -585,6 +583,8 @@ module Screenshots
       rescue StandardError => e
         logger.warn(message: "screenshots.container_cleanup_failed", agent_run_id: agent_run.id, error: e.message)
       end
+
+      FileUtils.rm_rf(@tmpdir) if @tmpdir.present?
     end
 
     def cleanup_screenshot_services!

--- a/app/services/screenshots/container_capture.rb
+++ b/app/services/screenshots/container_capture.rb
@@ -233,9 +233,9 @@ module Screenshots
       @screenshot_service_env = agent_run.service_environment&.deep_dup || {}
     ensure
       current_ids = agent_run.service_container_ids
-      @screenshot_service_container_ids |= current_ids - original_ids
+      @screenshot_service_container_ids |= current_ids - (original_ids || current_ids)
 
-      needs_restore = current_ids != original_ids || agent_run.service_environment != original_env
+      needs_restore = original_ids && (current_ids != original_ids || agent_run.service_environment != original_env)
       if needs_restore
         agent_run.update!(
           service_container_ids: original_ids,

--- a/app/services/screenshots/container_capture.rb
+++ b/app/services/screenshots/container_capture.rb
@@ -95,11 +95,13 @@ module Screenshots
     rescue Containers::Provision::TimeoutError => e
       screenshot_paths = collected_screenshots
       log_skip("capture_timeout", e.message, screenshot_count: screenshot_paths.size)
+      refresh_pr_comment("capture_failed")
       update_status("capture_timeout", screenshot_count: screenshot_paths.size)
       Result.new(status: "capture_timeout", changed_files: [], ui_files: [], screenshot_paths: screenshot_paths, published: false, screenshots_url: nil, error: e.message)
     rescue StandardError => e
       screenshot_paths = collected_screenshots
       log_skip("capture_failed", e.message, error_class: e.class.name, screenshot_count: screenshot_paths.size)
+      refresh_pr_comment("capture_failed")
       update_status("capture_failed", screenshot_count: screenshot_paths.size)
       Result.new(status: "capture_failed", changed_files: [], ui_files: [], screenshot_paths: screenshot_paths, published: false, screenshots_url: nil, error: e.message)
     ensure
@@ -180,6 +182,7 @@ module Screenshots
 
     def finalize_skip(status, changed_files:, ui_files:)
       log_skip(status, "no UI-facing changes detected")
+      refresh_pr_comment(status)
       update_status(status)
       Result.new(
         status: status,
@@ -202,9 +205,10 @@ module Screenshots
       original_ids = agent_run.service_container_ids.dup
 
       service_provisioner.provision(agent_run, network: @network, service_names: service_names)
-
-      @screenshot_service_container_ids = agent_run.service_container_ids - original_ids
-      agent_run.update!(service_container_ids: original_ids)
+    ensure
+      current_ids = agent_run.service_container_ids
+      @screenshot_service_container_ids |= current_ids - original_ids
+      agent_run.update!(service_container_ids: original_ids) unless current_ids == original_ids
     end
 
     def configured_service_dependencies
@@ -491,6 +495,25 @@ module Screenshots
         message: "screenshots.capture_status_update_failed",
         project_id: project.id,
         agent_run_id: agent_run.id,
+        error: e.message
+      )
+    end
+
+    def refresh_pr_comment(status)
+      Screenshots::PrComment.call(
+        github_client: project.github_token.client,
+        repo: project.full_name,
+        pr_number: agent_run.pull_request_number,
+        commit_sha: agent_run.result_commit_sha || agent_run.base_commit_sha || agent_run.branch_name,
+        screenshots: [],
+        status: status
+      )
+    rescue StandardError => e
+      logger.warn(
+        message: "screenshots.pr_comment_refresh_failed",
+        project_id: project.id,
+        agent_run_id: agent_run.id,
+        status: status,
         error: e.message
       )
     end

--- a/app/services/screenshots/container_capture.rb
+++ b/app/services/screenshots/container_capture.rb
@@ -47,6 +47,7 @@ module Screenshots
       @screenshot_container = nil
       @chrome_container = nil
       @screenshot_service_container_ids = []
+      @screenshot_service_env = {}
       @tmpdir = nil
       @config = nil
       @network = nil
@@ -55,13 +56,22 @@ module Screenshots
 
     def call
       ensure_capture_eligible!
+
+      # Lightweight precheck: fetch changed files via GitHub API and detect
+      # UI-relevant changes *before* paying the Docker/clone/startup cost.
+      # The precheck runs without repo context (no custom config overrides),
+      # so it may be slightly conservative — that is acceptable.
+      changed_files = fetch_changed_files
+      precheck_ui_files = detect_ui_files(changed_files, nil)
+      return finalize_skip("no_ui_changes", changed_files:, ui_files: precheck_ui_files) if precheck_ui_files.empty?
+
       with_workspace do |repo_path|
         provision_capture_container(repo_path)
         checkout_branch!
         @config = Screenshots::ConfigParser.from_repo_path(repo_path, project: project)
         validate_supported_config!
 
-        changed_files = fetch_changed_files
+        # Re-detect with full repo context (custom patterns/exclusions from config)
         ui_files = detect_ui_files(changed_files, repo_path)
         return finalize_skip("no_ui_changes", changed_files:, ui_files:) if ui_files.empty?
 
@@ -155,7 +165,15 @@ module Screenshots
       git_ops.install_artifact_excludes
     end
 
+    SUPPORTED_DRIVERS = %w[playwright].freeze
+
     def validate_supported_config!
+      unless config.driver.in?(SUPPORTED_DRIVERS)
+        raise Screenshots::ConfigError,
+          "container screenshot capture only supports drivers: #{SUPPORTED_DRIVERS.join(', ')} " \
+          "(configured: #{config.driver})"
+      end
+
       if config.seed.any?
         raise Screenshots::ConfigError, "container screenshot capture does not yet support seed data"
       end
@@ -199,16 +217,31 @@ module Screenshots
       service_names = configured_service_dependencies
       return if service_names.empty?
 
-      # Save the original service_container_ids so we can restore them after
-      # provisioning. ServiceProvisioner#provision overwrites the field, which
-      # would orphan the main workflow's service containers during cleanup.
+      # Snapshot the original service_container_ids and service_environment so
+      # we can restore them after provisioning. ServiceProvisioner#provision
+      # overwrites both fields, which would orphan the main workflow's service
+      # containers and leave stale DATABASE_URL/REDIS_URL pointing at the
+      # screenshot network's (now torn-down) services during cleanup.
       original_ids = agent_run.service_container_ids.dup
+      original_env = agent_run.service_environment&.deep_dup
 
       service_provisioner.provision(agent_run, network: @network, service_names: service_names)
+
+      # Capture the screenshot-specific service env for use in capture_env,
+      # then restore the agent_run to its original state so the main workflow's
+      # service references are not corrupted.
+      @screenshot_service_env = agent_run.service_environment&.deep_dup || {}
     ensure
       current_ids = agent_run.service_container_ids
       @screenshot_service_container_ids |= current_ids - original_ids
-      agent_run.update!(service_container_ids: original_ids) unless current_ids == original_ids
+
+      needs_restore = current_ids != original_ids || agent_run.service_environment != original_env
+      if needs_restore
+        agent_run.update!(
+          service_container_ids: original_ids,
+          service_environment: original_env
+        )
+      end
     end
 
     def configured_service_dependencies
@@ -452,7 +485,7 @@ module Screenshots
     end
 
     def capture_env
-      agent_run.service_environment.deep_dup.merge(
+      @screenshot_service_env.merge(
         "CHROME_URL" => CHROME_URL,
         "CI" => "1"
       )

--- a/app/services/screenshots/container_capture.rb
+++ b/app/services/screenshots/container_capture.rb
@@ -1,0 +1,530 @@
+# frozen_string_literal: true
+
+require "docker-api"
+require "fileutils"
+require "json"
+require "securerandom"
+require "shellwords"
+require "tmpdir"
+require "uri"
+
+module Screenshots
+  class ContainerCapture
+    CHROME_IMAGE = "ghcr.io/browserless/chromium"
+    CHROME_ALIAS = "paid-screenshot-browser"
+    CHROME_URL = "ws://#{CHROME_ALIAS}:3000"
+    OUTPUT_DIR = "tmp/screenshots"
+    APP_LOG_PATH = "tmp/paid-screenshot-app.log"
+    CAPTURE_TIMEOUT_SECONDS = 300
+    STARTUP_TIMEOUT_SECONDS = 90
+    MEMORY_BYTES = 2 * 1024 * 1024 * 1024
+    CPU_QUOTA = 100_000
+    PIDS_LIMIT = 300
+
+    Result = Struct.new(
+      :status,
+      :changed_files,
+      :ui_files,
+      :screenshot_paths,
+      :published,
+      :screenshots_url,
+      :error,
+      keyword_init: true
+    ) do
+      def success? = status == "captured"
+      def skipped? = status != "captured"
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(agent_run:, logger: Rails.logger)
+      @agent_run = agent_run
+      @project = agent_run.project
+      @logger = logger
+      @service_provisioner = nil
+      @screenshot_container = nil
+      @chrome_container = nil
+      @tmpdir = nil
+      @config = nil
+      @network = nil
+      @published_url = nil
+    end
+
+    def call
+      ensure_capture_eligible!
+      with_workspace do |repo_path|
+        provision_capture_container(repo_path)
+        checkout_branch!
+        @config = Screenshots::ConfigParser.from_repo_path(repo_path, project: project)
+        validate_supported_config!
+
+        changed_files = fetch_changed_files
+        ui_files = detect_ui_files(changed_files, repo_path)
+        return finalize_skip("no_ui_changes", changed_files:, ui_files:) if ui_files.empty?
+
+        provision_service_dependencies!
+        start_chrome!
+        run_setup_commands!
+        start_application!
+        screenshot_paths = run_capture!(ui_files)
+        publish_result!(screenshot_paths)
+
+        update_status(
+          "captured",
+          screenshot_count: screenshot_paths.size,
+          screenshots_url: @published_url
+        )
+
+        Result.new(
+          status: "captured",
+          changed_files: changed_files,
+          ui_files: ui_files,
+          screenshot_paths: screenshot_paths,
+          published: @published_url.present?,
+          screenshots_url: @published_url,
+          error: nil
+        )
+      end
+    rescue Screenshots::ConfigError => e
+      log_skip("config_error", e.message)
+      update_status("config_error")
+      Result.new(status: "config_error", changed_files: [], ui_files: [], screenshot_paths: [], published: false, screenshots_url: nil, error: e.message)
+    rescue Containers::Provision::TimeoutError => e
+      screenshot_paths = collected_screenshots
+      log_skip("capture_timeout", e.message, screenshot_count: screenshot_paths.size)
+      update_status("capture_timeout", screenshot_count: screenshot_paths.size)
+      Result.new(status: "capture_timeout", changed_files: [], ui_files: [], screenshot_paths: screenshot_paths, published: false, screenshots_url: nil, error: e.message)
+    rescue StandardError => e
+      screenshot_paths = collected_screenshots
+      log_skip("capture_failed", e.message, error_class: e.class.name, screenshot_count: screenshot_paths.size)
+      update_status("capture_failed", screenshot_count: screenshot_paths.size)
+      Result.new(status: "capture_failed", changed_files: [], ui_files: [], screenshot_paths: screenshot_paths, published: false, screenshots_url: nil, error: e.message)
+    ensure
+      cleanup!
+    end
+
+    private
+
+    attr_reader :agent_run, :project, :logger
+
+    def config
+      @config
+    end
+
+    def service_provisioner
+      @service_provisioner ||= Containers::ServiceProvisioner.new
+    end
+
+    def ensure_capture_eligible!
+      raise Screenshots::ConfigError, "screenshots are disabled for this project" unless project.screenshots_enabled?
+      raise Screenshots::ConfigError, "pull request number is required for screenshot capture" if agent_run.pull_request_number.blank?
+      raise Screenshots::ConfigError, "branch name is required for screenshot capture" if agent_run.branch_name.blank?
+    end
+
+    def with_workspace
+      @tmpdir = Dir.mktmpdir("paid-screenshots-#{agent_run.id}-")
+      yield(@tmpdir)
+    ensure
+      FileUtils.rm_rf(@tmpdir) if @tmpdir.present?
+    end
+
+    def provision_capture_container(repo_path)
+      @screenshot_container = Containers::Provision.new(
+        project: project,
+        worktree_path: repo_path,
+        memory_bytes: MEMORY_BYTES,
+        cpu_quota: CPU_QUOTA,
+        pids_limit: PIDS_LIMIT,
+        timeout_seconds: CAPTURE_TIMEOUT_SECONDS
+      )
+      @screenshot_container.provision
+      @network = @screenshot_container.network_name
+    end
+
+    def checkout_branch!
+      git_ops = Containers::GitOperations.new(
+        container_service: @screenshot_container,
+        agent_run: agent_run
+      )
+      git_ops.clone_and_checkout_branch(
+        branch_name: agent_run.branch_name,
+        pull_request_number: agent_run.pull_request_number,
+        persist: false
+      )
+      git_ops.install_artifact_excludes
+    end
+
+    def validate_supported_config!
+      if config.seed.any?
+        raise Screenshots::ConfigError, "container screenshot capture does not yet support seed data"
+      end
+
+      dynamic_route = config.routes.find do |route|
+        route.path.to_s.match?(/:\w+|%\{[^}]+\}/) || route.seed_key.present?
+      end
+      return unless dynamic_route
+
+      raise Screenshots::ConfigError, "route #{dynamic_route.name} requires seed interpolation, which is not supported in container capture yet"
+    end
+
+    def fetch_changed_files
+      project.github_token.client.pull_request_files(project.full_name, agent_run.pull_request_number)
+    rescue GithubClient::Error => e
+      log_skip("fetch_files_failed", e.message)
+      []
+    end
+
+    def detect_ui_files(changed_files, repo_path)
+      overrides = Screenshots::ConfigParser.ui_detection_overrides(project: project, repo_path: repo_path)
+      Screenshots::DetectUiChanges.call(changed_files:, repo_path:, **overrides).fetch(:ui_files)
+    end
+
+    def finalize_skip(status, changed_files:, ui_files:)
+      log_skip(status, "no UI-facing changes detected")
+      update_status(status)
+      Result.new(
+        status: status,
+        changed_files: changed_files,
+        ui_files: ui_files,
+        screenshot_paths: [],
+        published: false,
+        screenshots_url: nil,
+        error: nil
+      )
+    end
+
+    def provision_service_dependencies!
+      service_names = configured_service_dependencies
+      return if service_names.empty?
+
+      service_provisioner.provision(agent_run, network: @network, service_names: service_names)
+    end
+
+    def configured_service_dependencies
+      db_services = Array(project.effective_screenshot_settings["service_dependencies"])
+      (db_services + Array(config.services)).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+    end
+
+    def start_chrome!
+      @chrome_container = Docker::Container.create(
+        "Image" => CHROME_IMAGE,
+        "name" => "paid-screenshot-chrome-#{agent_run.id}-#{SecureRandom.hex(4)}",
+        "HostConfig" => {
+          "NetworkMode" => @network,
+          "Memory" => 1 * 1024 * 1024 * 1024,
+          "MemorySwap" => 1 * 1024 * 1024 * 1024,
+          "CpuPeriod" => 100_000,
+          "CpuQuota" => 100_000,
+          "PidsLimit" => 200
+        },
+        "NetworkingConfig" => {
+          "EndpointsConfig" => {
+            @network => {
+              "Aliases" => [ CHROME_ALIAS ]
+            }
+          }
+        },
+        "Labels" => {
+          "paid.screenshot_capture" => "true",
+          "paid.agent_run_id" => agent_run.id.to_s
+        }
+      )
+      @chrome_container.start
+    rescue Docker::Error::DockerError => e
+      raise Screenshots::ConfigError, "unable to start Chrome service container: #{e.message}"
+    end
+
+    def run_setup_commands!
+      config.setup_commands.each do |command|
+        result = @screenshot_container.execute(command, timeout: CAPTURE_TIMEOUT_SECONDS, env: capture_env, stream: false)
+        next if result.success?
+
+        raise "setup command failed: #{command}\n#{result[:stderr].presence || result[:stdout]}"
+      end
+    end
+
+    def start_application!
+      command = application_start_command
+      raise Screenshots::ConfigError, "could not determine how to start the application for screenshots" if command.blank?
+
+      launch_command = <<~SH
+        set -e
+        mkdir -p tmp
+        (#{command}) > #{Shellwords.escape(APP_LOG_PATH)} 2>&1 &
+        echo $! > tmp/paid-screenshot-app.pid
+      SH
+      @screenshot_container.execute(launch_command, timeout: 30, env: capture_env, stream: false)
+
+      wait_command = readiness_probe_command
+      @screenshot_container.execute(
+        wait_command,
+        timeout: STARTUP_TIMEOUT_SECONDS,
+        startup_timeout: STARTUP_TIMEOUT_SECONDS,
+        idle_timeout: STARTUP_TIMEOUT_SECONDS,
+        env: capture_env,
+        stream: false
+      )
+    rescue Containers::Provision::ExecutionError => e
+      app_log = read_file(APP_LOG_PATH)
+      raise "application startup failed: #{e.message}\n#{app_log}".strip
+    end
+
+    def run_capture!(ui_files)
+      runner_path = write_capture_runner
+      command = "node #{Shellwords.escape(runner_path)}"
+      env = capture_env.merge(
+        "SCREENSHOT_CONFIG_JSON" => screenshot_config_json,
+        "SCREENSHOT_OUTPUT_DIR" => OUTPUT_DIR,
+        "CHANGED_FILES" => ui_files.join("\n")
+      )
+
+      @screenshot_container.execute(
+        command,
+        timeout: CAPTURE_TIMEOUT_SECONDS,
+        startup_timeout: 30,
+        idle_timeout: 60,
+        env: env,
+        stream: false
+      )
+
+      collected_screenshots
+    rescue Containers::Provision::ExecutionError => e
+      raise "screenshot capture failed: #{e.message}"
+    end
+
+    def publish_result!(screenshot_paths)
+      return if screenshot_paths.empty?
+      return unless Screenshots::Storage.configured?
+
+      storage = Screenshots::Storage.new
+      uploaded = screenshot_paths.map do |path|
+        route_name = File.basename(path, ".png")
+        {
+          route_name: route_name,
+          url: storage.upload(
+            file_path: path,
+            org: project.owner,
+            repo: project.repo,
+            pr_number: agent_run.pull_request_number,
+            commit_sha: agent_run.result_commit_sha || agent_run.base_commit_sha || agent_run.branch_name,
+            route_name: route_name
+          )
+        }
+      end
+
+      previous = storage.previous_screenshots(
+        org: project.owner,
+        repo: project.repo,
+        pr_number: agent_run.pull_request_number,
+        exclude_sha: agent_run.result_commit_sha || agent_run.base_commit_sha || agent_run.branch_name
+      )
+
+      Screenshots::PrComment.call(
+        github_client: project.github_token.client,
+        repo: project.full_name,
+        pr_number: agent_run.pull_request_number,
+        commit_sha: agent_run.result_commit_sha || agent_run.base_commit_sha || agent_run.branch_name,
+        screenshots: uploaded,
+        previous_screenshots: previous
+      )
+
+      @published_url = uploaded.first&.fetch(:url, nil)
+    end
+
+    def write_capture_runner
+      runner_dir = File.join(@tmpdir, ".paid-screenshots")
+      FileUtils.mkdir_p(runner_dir)
+      path = File.join(runner_dir, "capture_runner.mjs")
+      File.write(path, capture_runner_script)
+      path
+    end
+
+    def capture_runner_script
+      <<~JS
+        import fs from "fs/promises";
+
+        const playwright = await import("playwright").catch(async () => import("playwright-core"));
+        const config = JSON.parse(process.env.SCREENSHOT_CONFIG_JSON);
+        const outputDir = process.env.SCREENSHOT_OUTPUT_DIR;
+        const browser = await playwright.chromium.connectOverCDP(process.env.CHROME_URL);
+        const context = browser.contexts()[0] || await browser.newContext({
+          viewport: config.viewport,
+        });
+        const page = await context.newPage();
+
+        async function authenticate() {
+          if (!config.auth || config.auth.strategy === "none") return;
+          if (config.auth.strategy !== "form") {
+            throw new Error(`unsupported auth strategy: ${config.auth.strategy}`);
+          }
+
+          await page.goto(new URL(config.auth.login_path || "/", config.base_url).toString(), { waitUntil: "networkidle" });
+          for (const [field, selector] of Object.entries(config.auth.fields || {})) {
+            if (field === "submit") continue;
+            await page.fill(selector, config.auth.credentials[field] || "");
+          }
+          await Promise.all([
+            page.waitForLoadState("networkidle"),
+            page.click(config.auth.fields.submit),
+          ]);
+        }
+
+        await fs.mkdir(outputDir, { recursive: true });
+        await authenticate();
+
+        for (const route of config.routes) {
+          const target = new URL(route.path, config.base_url).toString();
+          await page.goto(target, { waitUntil: "networkidle" });
+          await page.screenshot({ path: `${outputDir}/${route.name}.png`, fullPage: true });
+        }
+
+        await browser.close();
+      JS
+    end
+
+    def screenshot_config_json
+      {
+        base_url: config.base_url,
+        viewport: { width: config.viewport.width, height: config.viewport.height },
+        routes: config.routes.map { |route| { path: route.path, name: route.name } },
+        auth: {
+          strategy: config.auth.strategy,
+          login_path: config.auth.login_path,
+          fields: config.auth.fields,
+          credentials: config.auth.credentials
+        }
+      }.to_json
+    end
+
+    def application_start_command
+      port = app_port
+
+      if File.exist?(File.join(@tmpdir, "bin/dev"))
+        "PORT=#{port} bin/dev"
+      elsif File.exist?(File.join(@tmpdir, "bin/rails"))
+        "bundle exec bin/rails server -b 0.0.0.0 -p #{port}"
+      elsif File.exist?(File.join(@tmpdir, "manage.py"))
+        "python3 manage.py runserver 0.0.0.0:#{port}"
+      elsif package_dependency?("next")
+        "yarn next dev --hostname 0.0.0.0 --port #{port}"
+      elsif package_dependency?("vite")
+        "yarn vite --host 0.0.0.0 --port #{port}"
+      elsif File.exist?(File.join(@tmpdir, "package.json"))
+        "yarn dev --host 0.0.0.0 --port #{port}"
+      end
+    end
+
+    def readiness_probe_command
+      uri = URI.parse(config.base_url)
+      host = uri.host.presence || "127.0.0.1"
+      path = uri.path.presence || "/"
+      port = uri.port || app_port
+
+      <<~SH.squish
+        ruby -rnet/http -ruri -e '
+          deadline = Time.now + #{STARTUP_TIMEOUT_SECONDS};
+          uri = URI("http://#{host}:#{port}#{path}");
+          loop do
+            begin
+              response = Net::HTTP.start(uri.host, uri.port, open_timeout: 2, read_timeout: 2) { |http| http.get(uri.request_uri) };
+              exit 0 if response.code.to_i < 500;
+            rescue StandardError
+            end
+            raise "timeout" if Time.now >= deadline;
+            sleep 2;
+          end
+        '
+      SH
+    end
+
+    def capture_env
+      agent_run.service_environment.deep_dup.merge(
+        "CHROME_URL" => CHROME_URL,
+        "CI" => "1"
+      )
+    end
+
+    def app_port
+      uri = URI.parse(config&.base_url || Screenshots::Configuration::DEFAULT_BASE_URL)
+      uri.port || 3000
+    end
+
+    def package_dependency?(name)
+      package_json_path = File.join(@tmpdir, "package.json")
+      return false unless File.exist?(package_json_path)
+
+      package_json = JSON.parse(File.read(package_json_path))
+      [ "dependencies", "devDependencies" ].any? do |key|
+        package_json.fetch(key, {}).key?(name)
+      end
+    rescue JSON::ParserError
+      false
+    end
+
+    def collected_screenshots
+      Dir.glob(File.join(@tmpdir.to_s, OUTPUT_DIR, "*.png")).sort
+    end
+
+    def read_file(relative_path)
+      path = File.join(@tmpdir.to_s, relative_path)
+      File.exist?(path) ? File.read(path) : ""
+    end
+
+    def update_status(status, screenshot_count: 0, screenshots_url: nil)
+      project.update!(
+        screenshot_status: project.effective_screenshot_status.merge(
+          "last_capture_at" => Time.current.iso8601,
+          "last_capture_status" => status,
+          "screenshot_count" => screenshot_count,
+          "screenshots_url" => screenshots_url
+        )
+      )
+    rescue StandardError => e
+      logger.warn(
+        message: "screenshots.capture_status_update_failed",
+        project_id: project.id,
+        agent_run_id: agent_run.id,
+        error: e.message
+      )
+    end
+
+    def log_skip(reason, message, **extra)
+      logger.warn(
+        {
+          message: "screenshots.capture_skipped",
+          reason: reason,
+          project_id: project.id,
+          agent_run_id: agent_run.id,
+          error: message
+        }.merge(extra)
+      )
+    end
+
+    def cleanup!
+      begin
+        @chrome_container&.stop(timeout: 0)
+      rescue Docker::Error::DockerError
+      end
+
+      begin
+        @chrome_container&.delete(force: true, v: true)
+      rescue Docker::Error::DockerError => e
+        logger.warn(message: "screenshots.chrome_cleanup_failed", agent_run_id: agent_run.id, error: e.message)
+      end
+
+      begin
+        service_provisioner.cleanup(agent_run)
+      rescue StandardError => e
+        logger.warn(message: "screenshots.services_cleanup_failed", agent_run_id: agent_run.id, error: e.message)
+      end
+
+      begin
+        @screenshot_container&.cleanup(force: true)
+      rescue StandardError => e
+        logger.warn(message: "screenshots.container_cleanup_failed", agent_run_id: agent_run.id, error: e.message)
+      end
+    end
+  end
+end

--- a/app/services/screenshots/container_capture.rb
+++ b/app/services/screenshots/container_capture.rb
@@ -432,9 +432,12 @@ module Screenshots
       port = uri.port || app_port
 
       <<~SH.squish
+        SCREENSHOT_APP_HOST=#{Shellwords.escape(host)}
+        SCREENSHOT_APP_PORT=#{Shellwords.escape(port.to_s)}
+        SCREENSHOT_APP_PATH=#{Shellwords.escape(path)}
         ruby -rnet/http -ruri -e '
           deadline = Time.now + #{STARTUP_TIMEOUT_SECONDS};
-          uri = URI("http://#{host}:#{port}#{path}");
+          uri = URI("http://\#{ENV.fetch("SCREENSHOT_APP_HOST")}:\#{ENV.fetch("SCREENSHOT_APP_PORT")}\#{ENV.fetch("SCREENSHOT_APP_PATH")}");
           loop do
             begin
               response = Net::HTTP.start(uri.host, uri.port, open_timeout: 2, read_timeout: 2) { |http| http.get(uri.request_uri) };

--- a/app/temporal/activities/capture_screenshots_activity.rb
+++ b/app/temporal/activities/capture_screenshots_activity.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Activities
+  class CaptureScreenshotsActivity < BaseActivity
+    activity_name "CaptureScreenshots"
+
+    def execute(input)
+      agent_run = AgentRun.find(input[:agent_run_id])
+
+      track_phase(
+        agent_run_id: agent_run.id,
+        phase_key: "capture_screenshots",
+        phase_group: "post",
+        agent_run: agent_run
+      ) do
+        result = Screenshots::ContainerCapture.call(agent_run: agent_run, logger: logger)
+
+        logger.info(
+          message: "screenshots.capture_activity_completed",
+          agent_run_id: agent_run.id,
+          status: result.status,
+          screenshot_count: result.screenshot_paths.size
+        )
+
+        {
+          agent_run_id: agent_run.id,
+          status: result.status,
+          screenshot_count: result.screenshot_paths.size,
+          screenshots_url: result.screenshots_url,
+          error: result.error
+        }
+      end
+    end
+  end
+end

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -323,7 +323,10 @@ module Workflows
               # Step 8: Request review-bot review on the new draft PR (best-effort)
               request_review_bot_review(project_id, pr_result[:pull_request_number])
 
-              # Step 9: Draft a decision record (best-effort)
+              # Step 9: Capture screenshots for UI PRs (best-effort)
+              capture_screenshots(agent_run_id)
+
+              # Step 10: Draft a decision record (best-effort)
               draft_decision_record(agent_run_id)
             end
           end
@@ -631,6 +634,20 @@ module Workflows
     rescue => e
       Temporalio::Workflow.logger.warn(
         message: "agent_execution.draft_decision_record_failed",
+        agent_run_id: agent_run_id,
+        error: e.message,
+        error_class: e.class.name
+      )
+    end
+
+    def capture_screenshots(agent_run_id)
+      run_activity(Activities::CaptureScreenshotsActivity,
+        { agent_run_id: agent_run_id }, timeout: 360, retry_policy: NO_RETRY)
+    rescue Temporalio::Error::CanceledError
+      raise
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "agent_execution.capture_screenshots_failed",
         agent_run_id: agent_run_id,
         error: e.message,
         error_class: e.class.name

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -642,7 +642,7 @@ module Workflows
 
     def capture_screenshots(agent_run_id)
       run_activity(Activities::CaptureScreenshotsActivity,
-        { agent_run_id: agent_run_id }, timeout: 360, retry_policy: NO_RETRY)
+        { agent_run_id: agent_run_id }, timeout: 900, retry_policy: NO_RETRY)
     rescue Temporalio::Error::CanceledError
       raise
     rescue => e

--- a/spec/services/screenshots/container_capture_spec.rb
+++ b/spec/services/screenshots/container_capture_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Screenshots::ContainerCapture do
+  let(:project) do
+    create(:project, screenshot_settings: {
+      "enabled" => true,
+      "service_dependencies" => [ "postgres" ]
+    })
+  end
+  let(:agent_run) do
+    create(:agent_run,
+      project: project,
+      branch_name: "paid/test-branch",
+      pull_request_number: 99,
+      result_commit_sha: "abcdef1234567890")
+  end
+  let(:service) { described_class.new(agent_run: agent_run) }
+  let(:config) do
+    Screenshots::Configuration.from_hash(
+      "base_url" => "http://localhost:3000",
+      "routes" => [ { "path" => "/", "name" => "home" } ],
+      "services" => [ "redis" ]
+    )
+  end
+
+  before do
+    allow(Screenshots::Storage).to receive(:configured?).and_return(false)
+    allow(service).to receive(:with_workspace).and_yield(Dir.mktmpdir("screenshots-spec"))
+    allow(service).to receive(:provision_capture_container) { service.instance_variable_set(:@network, "paid-test") }
+    allow(service).to receive(:checkout_branch!)
+    allow(Screenshots::ConfigParser).to receive_messages(from_repo_path: config, ui_detection_overrides: {})
+    allow(service).to receive_messages(
+      fetch_changed_files: [ "app/views/home/index.html.erb" ],
+      detect_ui_files: [ "app/views/home/index.html.erb" ],
+      run_capture!: []
+    )
+    allow(service).to receive(:start_chrome!)
+    allow(service).to receive(:run_setup_commands!)
+    allow(service).to receive(:start_application!)
+    allow(service).to receive(:publish_result!)
+    allow(service).to receive(:cleanup!)
+    allow(project).to receive(:update!).and_call_original
+  end
+
+  it "merges project and repo service dependencies for provisioning" do
+    provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
+    allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+    allow(provisioner).to receive(:provision)
+
+    service.call
+
+    expect(provisioner).to have_received(:provision)
+      .with(agent_run, network: "paid-test", service_names: contain_exactly("postgres", "redis"))
+  end
+
+  it "marks the project status when capture is skipped for non-UI changes" do
+    allow(service).to receive(:detect_ui_files).and_return([])
+    allow(Containers::ServiceProvisioner).to receive(:new).and_return(instance_double(Containers::ServiceProvisioner, cleanup: true))
+
+    result = service.call
+
+    expect(result.status).to eq("no_ui_changes")
+    expect(project.reload.effective_screenshot_status["last_capture_status"]).to eq("no_ui_changes")
+  end
+end

--- a/spec/services/screenshots/container_capture_spec.rb
+++ b/spec/services/screenshots/container_capture_spec.rb
@@ -111,4 +111,21 @@ RSpec.describe Screenshots::ContainerCapture do
     expect(agent_run.reload.service_container_ids).to eq([])
     expect(service.instance_variable_get(:@screenshot_service_container_ids)).to contain_exactly(101, 202)
   end
+
+  it "shell-escapes readiness probe url parts before building the probe command" do
+    allow(service).to receive(:config).and_return(
+      Screenshots::Configuration.from_hash(
+        "base_url" => "http://localhost:3000/it's-a-path",
+        "routes" => [ { "path" => "/", "name" => "home" } ]
+      )
+    )
+
+    command = service.send(:readiness_probe_command)
+
+    expect(command).to include("SCREENSHOT_APP_HOST=localhost")
+    expect(command).to include("SCREENSHOT_APP_PORT=3000")
+    expect(command).to include("SCREENSHOT_APP_PATH=/it\\'s-a-path")
+    expect(command).to include('ENV.fetch("SCREENSHOT_APP_PATH")')
+    expect(command).not_to include(%q(uri = URI("http://localhost:3000/it's-a-path")))
+  end
 end

--- a/spec/services/screenshots/container_capture_spec.rb
+++ b/spec/services/screenshots/container_capture_spec.rb
@@ -56,13 +56,13 @@ RSpec.describe Screenshots::ContainerCapture do
       .with(agent_run, network: "paid-test", service_names: contain_exactly("postgres", "redis"))
   end
 
-  it "marks the project status when capture is skipped for non-UI changes" do
+  it "skips before container provisioning when precheck detects no UI changes" do
     allow(service).to receive(:detect_ui_files).and_return([])
-    allow(Containers::ServiceProvisioner).to receive(:new).and_return(instance_double(Containers::ServiceProvisioner, cleanup: true))
 
     result = service.call
 
     expect(result.status).to eq("no_ui_changes")
+    expect(service).not_to have_received(:provision_capture_container)
     expect(project.reload.effective_screenshot_status["last_capture_status"]).to eq("no_ui_changes")
     expect(Screenshots::PrComment).to have_received(:call) do |**args|
       expect(args).to include(
@@ -97,19 +97,40 @@ RSpec.describe Screenshots::ContainerCapture do
     end
   end
 
-  it "restores the original service container ids when dependency provisioning fails" do
+  it "restores the original service container ids and environment when dependency provisioning fails" do
     provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
     allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
     allow(provisioner).to receive(:provision) do
-      agent_run.update!(service_container_ids: [ 101, 202 ])
+      agent_run.update!(
+        service_container_ids: [ 101, 202 ],
+        service_environment: { "DATABASE_URL" => "postgres://screenshot-host/db" }
+      )
       raise Containers::Provision::TimeoutError, "timed out"
     end
 
     result = service.call
 
     expect(result.status).to eq("capture_timeout")
-    expect(agent_run.reload.service_container_ids).to eq([])
+    agent_run.reload
+    expect(agent_run.service_container_ids).to eq([])
+    expect(agent_run.service_environment).to eq({})
     expect(service.instance_variable_get(:@screenshot_service_container_ids)).to contain_exactly(101, 202)
+  end
+
+  it "rejects unsupported screenshot drivers with a config error" do
+    cuprite_config = Screenshots::Configuration.from_hash(
+      "driver" => "cuprite",
+      "base_url" => "http://localhost:3000",
+      "routes" => [ { "path" => "/", "name" => "home" } ]
+    )
+    allow(Screenshots::ConfigParser).to receive(:from_repo_path).and_return(cuprite_config)
+    provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
+    allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+
+    result = service.call
+
+    expect(result.status).to eq("config_error")
+    expect(result.error).to include("cuprite")
   end
 
   it "shell-escapes readiness probe url parts before building the probe command" do

--- a/spec/services/screenshots/container_capture_spec.rb
+++ b/spec/services/screenshots/container_capture_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Screenshots::ContainerCapture do
     allow(service).to receive(:with_workspace).and_yield(Dir.mktmpdir("screenshots-spec"))
     allow(service).to receive(:provision_capture_container) { service.instance_variable_set(:@network, "paid-test") }
     allow(service).to receive(:checkout_branch!)
+    allow(Screenshots::PrComment).to receive(:call)
     allow(Screenshots::ConfigParser).to receive_messages(from_repo_path: config, ui_detection_overrides: {})
     allow(service).to receive_messages(
       fetch_changed_files: [ "app/views/home/index.html.erb" ],
@@ -63,5 +64,51 @@ RSpec.describe Screenshots::ContainerCapture do
 
     expect(result.status).to eq("no_ui_changes")
     expect(project.reload.effective_screenshot_status["last_capture_status"]).to eq("no_ui_changes")
+    expect(Screenshots::PrComment).to have_received(:call) do |**args|
+      expect(args).to include(
+        repo: project.full_name,
+        pr_number: agent_run.pull_request_number,
+        commit_sha: agent_run.result_commit_sha,
+        screenshots: [],
+        status: "no_ui_changes"
+      )
+      expect(args[:github_client]).to be_a(GithubClient)
+    end
+  end
+
+  it "refreshes the PR comment when capture fails" do
+    provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
+    allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+    allow(provisioner).to receive(:provision)
+    allow(service).to receive(:start_application!).and_raise("boom")
+
+    result = service.call
+
+    expect(result.status).to eq("capture_failed")
+    expect(Screenshots::PrComment).to have_received(:call) do |**args|
+      expect(args).to include(
+        repo: project.full_name,
+        pr_number: agent_run.pull_request_number,
+        commit_sha: agent_run.result_commit_sha,
+        screenshots: [],
+        status: "capture_failed"
+      )
+      expect(args[:github_client]).to be_a(GithubClient)
+    end
+  end
+
+  it "restores the original service container ids when dependency provisioning fails" do
+    provisioner = instance_double(Containers::ServiceProvisioner, cleanup: true)
+    allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+    allow(provisioner).to receive(:provision) do
+      agent_run.update!(service_container_ids: [ 101, 202 ])
+      raise Containers::Provision::TimeoutError, "timed out"
+    end
+
+    result = service.call
+
+    expect(result.status).to eq("capture_timeout")
+    expect(agent_run.reload.service_container_ids).to eq([])
+    expect(service.instance_variable_get(:@screenshot_service_container_ids)).to contain_exactly(101, 202)
   end
 end

--- a/spec/temporal/activities/capture_screenshots_activity_spec.rb
+++ b/spec/temporal/activities/capture_screenshots_activity_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::CaptureScreenshotsActivity do
+  let(:activity) { described_class.new }
+  let(:project) { create(:project) }
+  let(:agent_run) { create(:agent_run, project: project) }
+
+  describe "#execute" do
+    it "delegates screenshot capture to the container capture service" do
+      result = Screenshots::ContainerCapture::Result.new(
+        status: "captured",
+        changed_files: [ "app/views/projects/show.html.erb" ],
+        ui_files: [ "app/views/projects/show.html.erb" ],
+        screenshot_paths: [ "/tmp/screenshots/home.png" ],
+        published: false,
+        screenshots_url: nil,
+        error: nil
+      )
+
+      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+      allow(Screenshots::ContainerCapture).to receive(:call).with(agent_run: agent_run, logger: Rails.logger).and_return(result)
+
+      activity_result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(activity_result).to include(
+        agent_run_id: agent_run.id,
+        status: "captured",
+        screenshot_count: 1,
+        screenshots_url: nil,
+        error: nil
+      )
+    end
+  end
+end

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -1039,7 +1039,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       expect(workflow).to have_received(:run_activity)
         .with(Activities::CaptureScreenshotsActivity,
           { agent_run_id: 42 },
-          timeout: 360,
+          timeout: 900,
           retry_policy: described_class::NO_RETRY)
     end
 

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -983,6 +983,33 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
           { pull_request_url: "https://github.com/o/r/pull/99", pull_request_number: 99 }
         when "Activities::UpdateIssueWithPrActivity" then {}
         when "Activities::RequestReviewActivity" then {}
+        when "Activities::CaptureScreenshotsActivity" then { status: "captured", screenshot_count: 2 }
+        when "Activities::DraftDecisionRecordActivity" then {}
+        when "Activities::CleanupContainerActivity" then {}
+        when "Activities::CleanupServicesActivity" then {}
+        when "Activities::CleanupWorktreeActivity" then {}
+        when "Activities::EnqueueJanitorActivity" then {}
+        else {}
+        end
+      end
+    end
+
+    def stub_new_pr_creation_with_screenshot_failure
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, provider_attempt_count: 1 }
+        when "Activities::ProvisionServicesActivity" then {}
+        when "Activities::ProvisionContainerActivity" then {}
+        when "Activities::CheckProxyHealthActivity" then {}
+        when "Activities::CloneRepoActivity" then {}
+        when "Activities::RunAgentActivity" then { success: true, has_changes: true }
+        when "Activities::PushBranchActivity" then {}
+        when "Activities::CreatePullRequestActivity"
+          { pull_request_url: "https://github.com/o/r/pull/99", pull_request_number: 99 }
+        when "Activities::UpdateIssueWithPrActivity" then {}
+        when "Activities::RequestReviewActivity" then {}
+        when "Activities::CaptureScreenshotsActivity"
+          raise StandardError, "chrome unreachable"
         when "Activities::DraftDecisionRecordActivity" then {}
         when "Activities::CleanupContainerActivity" then {}
         when "Activities::CleanupServicesActivity" then {}
@@ -1002,6 +1029,31 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         .with(Activities::RequestReviewActivity,
           { project_id: 1, pr_number: 99 },
           timeout: 60)
+    end
+
+    it "captures screenshots after PR creation" do
+      stub_new_pr_creation
+
+      workflow.execute(input)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::CaptureScreenshotsActivity,
+          { agent_run_id: 42 },
+          timeout: 360,
+          retry_policy: described_class::NO_RETRY)
+    end
+
+    it "does not fail the workflow when screenshot capture fails" do
+      stub_new_pr_creation_with_screenshot_failure
+
+      result = workflow.execute(input)
+
+      expect(result[:success]).to be true
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::DraftDecisionRecordActivity,
+          { agent_run_id: 42 },
+          timeout: 60,
+          retry_policy: described_class::NO_RETRY)
     end
 
     it "emits the pre-patch activity input shape for new PR when the workflow patch is not set" do


### PR DESCRIPTION
## Summary

Implemented container-based screenshot capture as a best-effort Temporal post-PR step and committed it as `9039b2a` (`feat(screenshots): capture PR screenshots in temporal`).

The change adds `Activities::CaptureScreenshotsActivity`, wires it into `AgentExecutionWorkflow` after PR creation, and introduces `Screenshots::ContainerCapture` to provision a lightweight screenshot container, clone the PR branch, merge screenshot config, provision configured services plus a browserless Chromium sidecar, run setup/start/capture, publish when storage is configured, and always clean up. I also extended container helpers so screenshot runs can clone without mutating the main agent run state and can provision only the requested service dependencies.

Validation passed with `bundle exec rubocop` and the full `bundle exec rspec` suite via the commit hook (`10969 examples, 0 failures, 3 pending`). `bin/rails db:prepare` did not succeed from this shell because the provided `DATABASE_URL` pointed at an internal Docker hostname not reachable from the host process. The worktree is clean.

---

Closes #1655