### PR TITLE
feat(strategy): extract hardcoded workflows into database strategies

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -32,6 +32,7 @@ class Account < ApplicationRecord
   has_many :chat_sessions, dependent: :destroy
   has_many :quality_thresholds, dependent: :destroy
   has_many :exception_incidents, dependent: :destroy
+  has_many :orchestration_strategies, dependent: :destroy
 
   validates :name, presence: true
   validates :plan, presence: true, inclusion: { in: PLANS }

--- a/app/models/orchestration_strategy.rb
+++ b/app/models/orchestration_strategy.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class OrchestrationStrategy < ApplicationRecord
+  STRATEGY_TYPES = %w[
+    review_settings
+    quality_gate
+    execution_timeouts
+    retry_policies
+    agent_settings
+    feature_orchestration
+    provider_resolution
+  ].freeze
+
+  belongs_to :account, optional: true
+
+  validates :strategy_type, presence: true, inclusion: { in: STRATEGY_TYPES }
+  validates :name, presence: true
+  validates :version, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :configuration, presence: true
+  validate :configuration_is_object
+
+  scope :active, -> { where(active: true) }
+  scope :system_defaults, -> { where(account_id: nil) }
+  scope :for_account, ->(account) { where(account: account) }
+  scope :by_type, ->(type) { where(strategy_type: type) }
+
+  def self.active_for(strategy_type, account: nil)
+    if account
+      for_account(account).by_type(strategy_type).active.order(version: :desc).first ||
+        system_defaults.by_type(strategy_type).active.order(version: :desc).first
+    else
+      system_defaults.by_type(strategy_type).active.order(version: :desc).first
+    end
+  end
+
+  def config_value(*keys)
+    keys.reduce(configuration) do |hash, key|
+      return nil unless hash.is_a?(Hash)
+
+      hash[key.to_s]
+    end
+  end
+
+  private
+
+  def configuration_is_object
+    return if configuration.is_a?(Hash)
+
+    errors.add(:configuration, "must be a JSON object")
+  end
+end

--- a/app/services/orchestration_strategies/defaults.rb
+++ b/app/services/orchestration_strategies/defaults.rb
@@ -113,7 +113,7 @@ module OrchestrationStrategies
           "max_attempts" => 2,
           "initial_interval_seconds" => 5,
           "max_interval_seconds" => 5,
-          "backoff_coefficient" => 1.0
+          "backoff_coefficient" => 2.0
         },
         "cleanup" => {
           "max_attempts" => 5,
@@ -159,12 +159,14 @@ module OrchestrationStrategies
           sub_issues_created
           decomposition_failed
           sub_issue_creation_failed
+          planning_failed
         ],
         "parallelization_outcomes" => %w[
           parallel_execution_skipped_empty_plan
           parallel_execution_skipped_single_task
           parallel_execution_planned
           parallelization_planning_failed
+          parallelization_failed
         ],
         "known_failure_types" => %w[
           AllProvidersExhausted

--- a/app/services/orchestration_strategies/defaults.rb
+++ b/app/services/orchestration_strategies/defaults.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+module OrchestrationStrategies
+  # Central registry of hardcoded orchestration defaults extracted from
+  # their original locations across the codebase. Each method returns the
+  # configuration hash that would be persisted in an OrchestrationStrategy
+  # record, keeping runtime semantics identical.
+  module Defaults
+    module_function
+
+    def configuration_for(strategy_type)
+      case strategy_type.to_s
+      when "review_settings"      then review_settings
+      when "quality_gate"         then quality_gate
+      when "execution_timeouts"   then execution_timeouts
+      when "retry_policies"       then retry_policies
+      when "agent_settings"       then agent_settings
+      when "feature_orchestration" then feature_orchestration
+      when "provider_resolution"  then provider_resolution
+      end
+    end
+
+    # Extracted from Project::DEFAULT_REVIEW_SETTINGS (app/models/project.rb:32-86)
+    def review_settings
+      {
+        "enabled" => false,
+        "wait_for_reviews" => true,
+        "address_all_bot_reviews" => false,
+        "methods" => {
+          "copilot" => {
+            "enabled" => false,
+            "termination" => {
+              "max_review_rounds" => 15,
+              "stop_when_no_comments" => true,
+              "quality_threshold" => nil,
+              "timeout_minutes" => nil
+            }
+          },
+          "paid_agent" => {
+            "enabled" => false,
+            "termination" => {
+              "max_review_rounds" => 15,
+              "max_review_goal_retries" => 3,
+              "stop_when_no_comments" => true,
+              "quality_threshold" => nil,
+              "timeout_minutes" => 30
+            }
+          },
+          "codex" => {
+            "enabled" => false,
+            "termination" => {
+              "max_review_rounds" => 15,
+              "stop_when_no_comments" => true,
+              "quality_threshold" => nil,
+              "timeout_minutes" => 60
+            }
+          },
+          "ci_action" => {
+            "enabled" => false,
+            "action_name" => nil,
+            "termination" => {
+              "max_review_rounds" => nil,
+              "stop_when_no_comments" => true,
+              "quality_threshold" => nil,
+              "timeout_minutes" => nil
+            }
+          },
+          "manual" => {
+            "enabled" => false,
+            "reviewer_login" => nil,
+            "termination" => {
+              "max_review_rounds" => nil,
+              "stop_when_no_comments" => false,
+              "quality_threshold" => nil,
+              "timeout_minutes" => 1440
+            }
+          }
+        }
+      }
+    end
+
+    # Extracted from Project::DEFAULT_QUALITY_GATE_SETTINGS (app/models/project.rb:88-94)
+    def quality_gate
+      {
+        "enabled" => false,
+        "composite_score_threshold" => 0.5,
+        "min_recent_runs" => 3,
+        "lookback_window_hours" => 24,
+        "metric_thresholds" => {}
+      }
+    end
+
+    # Extracted from:
+    #   - AGENT_TIMEOUT_DEFAULT (config/initializers/agent_harness.rb:71)
+    #   - Activities::RunAgentActivity (app/temporal/activities/run_agent_activity.rb:77-83)
+    #   - Workflows::FeatureOrchestrationWorkflow::DEFAULT_TIMEOUT_SECONDS (line 24)
+    def execution_timeouts
+      {
+        "agent_timeout_default_seconds" => 3600,
+        "issue_goal_timeout_seconds" => 600,
+        "issue_goal_idle_timeout_seconds" => 120,
+        "review_goal_idle_timeout_seconds" => 300,
+        "create_pr_idle_timeout_seconds" => 300,
+        "preflight_timeout_seconds" => 10,
+        "feature_orchestration_timeout_seconds" => 7200
+      }
+    end
+
+    # Extracted from Workflows::AgentExecutionWorkflow (app/temporal/workflows/agent_execution_workflow.rb:18-49)
+    def retry_policies
+      {
+        "run_agent" => {
+          "max_attempts" => 2,
+          "initial_interval_seconds" => 5,
+          "max_interval_seconds" => 5,
+          "backoff_coefficient" => 1.0
+        },
+        "cleanup" => {
+          "max_attempts" => 5,
+          "initial_interval_seconds" => 2,
+          "max_interval_seconds" => 15,
+          "backoff_coefficient" => 2.0
+        },
+        "change_detection" => {
+          "max_attempts" => 3,
+          "retry_backoff_seconds" => 0.25
+        }
+      }
+    end
+
+    # Extracted from TenantSetting::DEFAULT_AGENT_SETTINGS (app/models/tenant_setting.rb:28-31)
+    # and TenantSetting::DEFAULT_GUARDRAILS (app/models/tenant_setting.rb:18-22)
+    def agent_settings
+      {
+        "default_goal" => "create_pr",
+        "auto_continue" => true,
+        "guardrails" => {
+          "max_concurrent_runs" => 10,
+          "max_tokens_per_run" => 10_000_000,
+          "max_monthly_cost_cents" => nil
+        }
+      }
+    end
+
+    # Extracted from Workflows::FeatureOrchestrationWorkflow (app/temporal/workflows/feature_orchestration_workflow.rb)
+    # and Workflows::AgentExecutionWorkflow known failure types (lines 55-72)
+    def feature_orchestration
+      {
+        "default_timeout_seconds" => 7200,
+        "planning_phases" => %w[
+          fetch_planning_context
+          decompose_feature
+          create_sub_issues
+          update_planning_labels
+        ],
+        "planning_outcomes" => %w[
+          empty_plan
+          single_task_plan
+          sub_issues_created
+          decomposition_failed
+          sub_issue_creation_failed
+        ],
+        "parallelization_outcomes" => %w[
+          parallel_execution_skipped_empty_plan
+          parallel_execution_skipped_single_task
+          parallel_execution_planned
+          parallelization_planning_failed
+        ],
+        "known_failure_types" => %w[
+          AllProvidersExhausted
+          AgentExecutionFailed
+          IssueDraftInvalid
+          McpProvisioningFailed
+          MissingPrompt
+          MissingUser
+          ContainerNotProvisioned
+          ProxyUnavailable
+          RateLimit
+        ],
+        "known_failure_classes" => %w[
+          GithubClient::RateLimitError
+          GithubClient::AuthenticationError
+        ]
+      }
+    end
+
+    # Extracted from:
+    #   - Automation::Configuration::ReviewMethod::NAMES (app/services/automation/configuration/review_method.rb:16)
+    #   - Automation::Configuration::AutoReview::BOT_REQUEST_PRIORITY (line 23)
+    #   - Automation::Configuration::AutoReview::BOT_REVIEWER_LOGINS (lines 29-32)
+    #   - AgentRun::GOALS (app/models/agent_run.rb:16)
+    #   - AgentRun::AGENT_TYPES (app/models/agent_run.rb:14)
+    def provider_resolution
+      {
+        "review_method_names" => %w[copilot paid_agent codex ci_action manual],
+        "bot_request_priority" => %w[copilot codex],
+        "bot_reviewer_logins" => {
+          "copilot" => "copilot",
+          "codex" => "chatgpt-codex-connector"
+        },
+        "agent_types" => %w[claude_code cursor codex copilot aider gemini opencode kilocode api],
+        "goals" => %w[create_pr create_issue review enhance_issue analyze_issue],
+        "non_container_goals" => %w[enhance_issue analyze_issue]
+      }
+    end
+
+    def all
+      OrchestrationStrategy::STRATEGY_TYPES.index_with do |type|
+        configuration_for(type)
+      end
+    end
+  end
+end

--- a/app/services/orchestration_strategies/resolve.rb
+++ b/app/services/orchestration_strategies/resolve.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module OrchestrationStrategies
+  # Resolves the effective strategy configuration for a given type, with
+  # account-level overrides falling back to system defaults, then to
+  # hardcoded constants if no database record exists yet.
+  #
+  # This keeps runtime behavior identical during the migration period:
+  # callers get the same configuration values whether they come from a
+  # persisted strategy record or the legacy constants.
+  class Resolve
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(strategy_type:, account: nil)
+      @strategy_type = strategy_type.to_s
+      @account = account
+    end
+
+    def call
+      OrchestrationStrategy.active_for(strategy_type, account: account) ||
+        build_fallback
+    end
+
+    private
+
+    attr_reader :strategy_type, :account
+
+    def build_fallback
+      config = Defaults.configuration_for(strategy_type)
+      return nil unless config
+
+      OrchestrationStrategy.new(
+        strategy_type: strategy_type,
+        name: "#{strategy_type.titleize} (hardcoded fallback)",
+        version: 0,
+        configuration: config,
+        active: true,
+        account: nil
+      )
+    end
+  end
+end

--- a/app/services/orchestration_strategies/resolve.rb
+++ b/app/services/orchestration_strategies/resolve.rb
@@ -34,7 +34,7 @@ module OrchestrationStrategies
       OrchestrationStrategy.new(
         strategy_type: strategy_type,
         name: "#{strategy_type.titleize} (hardcoded fallback)",
-        version: 0,
+        version: 1,
         configuration: config,
         active: true,
         account: nil

--- a/app/services/orchestration_strategies/seed.rb
+++ b/app/services/orchestration_strategies/seed.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module OrchestrationStrategies
+  # Idempotently creates system-default OrchestrationStrategy records from
+  # hardcoded defaults. Safe to run in migrations, seeds, or rake tasks.
+  #
+  # Existing active records are left untouched — only missing strategy
+  # types are inserted.
+  class Seed
+    def self.call
+      new.call
+    end
+
+    def call
+      created = []
+
+      OrchestrationStrategy::STRATEGY_TYPES.each do |strategy_type|
+        next if OrchestrationStrategy.system_defaults.by_type(strategy_type).active.exists?
+
+        config = Defaults.configuration_for(strategy_type)
+        next unless config
+
+        record = OrchestrationStrategy.create!(
+          account: nil,
+          strategy_type: strategy_type,
+          name: default_name_for(strategy_type),
+          version: 1,
+          configuration: config,
+          active: true
+        )
+        created << record
+      end
+
+      created
+    end
+
+    private
+
+    def default_name_for(strategy_type)
+      strategy_type.titleize
+    end
+  end
+end

--- a/db/migrate/20260507204357_create_orchestration_strategies.rb
+++ b/db/migrate/20260507204357_create_orchestration_strategies.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateOrchestrationStrategies < ActiveRecord::Migration[8.1]
+  def change
+    create_table :orchestration_strategies, comment: "Persisted orchestration workflow configurations extracted from hardcoded defaults" do |t|
+      t.references :account, null: true, foreign_key: true, comment: "NULL = system-wide default; set = account-level override"
+      t.string :strategy_type, null: false, comment: "Category: review_settings, quality_gate, execution_timeouts, retry_policies, agent_settings, feature_orchestration, provider_resolution"
+      t.string :name, null: false, comment: "Human-readable name for this strategy"
+      t.integer :version, null: false, default: 1, comment: "Monotonically increasing version for audit trail"
+      t.jsonb :configuration, null: false, default: {}, comment: "Strategy-specific configuration data"
+      t.boolean :active, null: false, default: true, comment: "Whether this strategy is currently in effect"
+      t.timestamps
+    end
+
+    add_index :orchestration_strategies, [ :strategy_type, :account_id ],
+      unique: true,
+      where: "active = true",
+      name: "idx_orchestration_strategies_active_type_account"
+    add_index :orchestration_strategies, :strategy_type
+    add_index :orchestration_strategies, :active
+  end
+end

--- a/db/migrate/20260507223302_fix_orchestration_strategies_unique_index.rb
+++ b/db/migrate/20260507223302_fix_orchestration_strategies_unique_index.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class FixOrchestrationStrategiesUniqueIndex < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :orchestration_strategies,
+      name: "idx_orchestration_strategies_active_type_account"
+
+    add_index :orchestration_strategies, [ :strategy_type, :account_id ],
+      unique: true,
+      nulls_not_distinct: true,
+      where: "active = true",
+      name: "idx_orchestration_strategies_active_type_account"
+  end
+end

--- a/db/migrate/20260507223324_backfill_orchestration_strategies.rb
+++ b/db/migrate/20260507223324_backfill_orchestration_strategies.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillOrchestrationStrategies < ActiveRecord::Migration[8.1]
+  def up
+    OrchestrationStrategies::Seed.call
+  end
+
+  def down
+    # Seeded system-default records (account_id IS NULL) are removed on rollback.
+    # Account-level overrides are left in place.
+    execute <<~SQL
+      DELETE FROM orchestration_strategies WHERE account_id IS NULL
+    SQL
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,4 +31,7 @@ TenantContext.with_system_access do
 
   # Seed default prompts
   load Rails.root.join("db/seeds/prompts.rb")
+
+  # Seed default orchestration strategies
+  OrchestrationStrategies::Seed.call
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3169,6 +3169,91 @@ ALTER SEQUENCE public.orchestration_decisions_id_seq OWNED BY public.orchestrati
 
 
 --
+-- Name: orchestration_strategies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.orchestration_strategies (
+    id bigint NOT NULL,
+    account_id bigint,
+    strategy_type character varying NOT NULL,
+    name character varying NOT NULL,
+    version integer DEFAULT 1 NOT NULL,
+    configuration jsonb DEFAULT '{}'::jsonb NOT NULL,
+    active boolean DEFAULT true NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE orchestration_strategies; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.orchestration_strategies IS 'Persisted orchestration workflow configurations extracted from hardcoded defaults';
+
+
+--
+-- Name: COLUMN orchestration_strategies.account_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_strategies.account_id IS 'NULL = system-wide default; set = account-level override';
+
+
+--
+-- Name: COLUMN orchestration_strategies.strategy_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_strategies.strategy_type IS 'Category: review_settings, quality_gate, execution_timeouts, retry_policies, agent_settings, feature_orchestration, provider_resolution';
+
+
+--
+-- Name: COLUMN orchestration_strategies.name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_strategies.name IS 'Human-readable name for this strategy';
+
+
+--
+-- Name: COLUMN orchestration_strategies.version; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_strategies.version IS 'Monotonically increasing version for audit trail';
+
+
+--
+-- Name: COLUMN orchestration_strategies.configuration; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_strategies.configuration IS 'Strategy-specific configuration data';
+
+
+--
+-- Name: COLUMN orchestration_strategies.active; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.orchestration_strategies.active IS 'Whether this strategy is currently in effect';
+
+
+--
+-- Name: orchestration_strategies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.orchestration_strategies_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: orchestration_strategies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.orchestration_strategies_id_seq OWNED BY public.orchestration_strategies.id;
+
+
+--
 -- Name: pr_templates; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5157,6 +5242,13 @@ ALTER TABLE ONLY public.orchestration_decisions ALTER COLUMN id SET DEFAULT next
 
 
 --
+-- Name: orchestration_strategies id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orchestration_strategies ALTER COLUMN id SET DEFAULT nextval('public.orchestration_strategies_id_seq'::regclass);
+
+
+--
 -- Name: pr_templates id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5840,6 +5932,14 @@ ALTER TABLE ONLY public.orchestration_decisions
 
 
 --
+-- Name: orchestration_strategies orchestration_strategies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orchestration_strategies
+    ADD CONSTRAINT orchestration_strategies_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: pr_templates pr_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6336,6 +6436,13 @@ CREATE INDEX idx_orchestration_decisions_run_recent ON public.orchestration_deci
 --
 
 CREATE INDEX idx_orchestration_decisions_run_type_created ON public.orchestration_decisions USING btree (agent_run_id, decision_type, created_at);
+
+
+--
+-- Name: idx_orchestration_strategies_active_type_account; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_orchestration_strategies_active_type_account ON public.orchestration_strategies USING btree (strategy_type, account_id) WHERE (active = true);
 
 
 --
@@ -8075,6 +8182,27 @@ CREATE UNIQUE INDEX index_onboarding_steps_on_account_id_and_step ON public.onbo
 
 
 --
+-- Name: index_orchestration_strategies_on_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orchestration_strategies_on_account_id ON public.orchestration_strategies USING btree (account_id);
+
+
+--
+-- Name: index_orchestration_strategies_on_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orchestration_strategies_on_active ON public.orchestration_strategies USING btree (active);
+
+
+--
+-- Name: index_orchestration_strategies_on_strategy_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orchestration_strategies_on_strategy_type ON public.orchestration_strategies USING btree (strategy_type);
+
+
+--
 -- Name: index_pr_templates_on_account_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9326,6 +9454,14 @@ ALTER TABLE ONLY public.decision_records
 
 ALTER TABLE ONLY public.quality_pause_events
     ADD CONSTRAINT fk_rails_65e6e9ab0a FOREIGN KEY (agent_run_id) REFERENCES public.agent_runs(id);
+
+
+--
+-- Name: orchestration_strategies fk_rails_68b1d7e980; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.orchestration_strategies
+    ADD CONSTRAINT fk_rails_68b1d7e980 FOREIGN KEY (account_id) REFERENCES public.accounts(id);
 
 
 --
@@ -11632,6 +11768,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507204357'),
 ('20260507164917'),
 ('20260507125050'),
 ('20260507011753'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6442,7 +6442,7 @@ CREATE INDEX idx_orchestration_decisions_run_type_created ON public.orchestratio
 -- Name: idx_orchestration_strategies_active_type_account; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_orchestration_strategies_active_type_account ON public.orchestration_strategies USING btree (strategy_type, account_id) WHERE (active = true);
+CREATE UNIQUE INDEX idx_orchestration_strategies_active_type_account ON public.orchestration_strategies USING btree (strategy_type, account_id) NULLS NOT DISTINCT WHERE (active = true);
 
 
 --
@@ -11768,6 +11768,8 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507223324'),
+('20260507223302'),
 ('20260507204357'),
 ('20260507164917'),
 ('20260507125050'),

--- a/spec/factories/orchestration_strategies.rb
+++ b/spec/factories/orchestration_strategies.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :orchestration_strategy do
+    strategy_type { "review_settings" }
+    name { "Review Settings" }
+    version { 1 }
+    configuration { OrchestrationStrategies::Defaults.review_settings }
+    active { true }
+    account { nil }
+
+    trait :with_account do
+      account
+    end
+
+    trait :inactive do
+      active { false }
+    end
+
+    OrchestrationStrategy::STRATEGY_TYPES.each do |type|
+      trait type.to_sym do
+        strategy_type { type }
+        name { type.titleize }
+        configuration { OrchestrationStrategies::Defaults.configuration_for(type) }
+      end
+    end
+  end
+end

--- a/spec/models/orchestration_strategy_spec.rb
+++ b/spec/models/orchestration_strategy_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe OrchestrationStrategy do
   subject(:strategy) { build(:orchestration_strategy) }
 
+  # The backfill migration seeds system defaults during db:prepare in CI.
+  # Clear them here so these examples can create their own fixture rows.
+  before { described_class.delete_all }
+
   describe "associations" do
     it { is_expected.to belong_to(:account).optional }
   end

--- a/spec/models/orchestration_strategy_spec.rb
+++ b/spec/models/orchestration_strategy_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrchestrationStrategy do
+  subject(:strategy) { build(:orchestration_strategy) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:account).optional }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:strategy_type) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:version) }
+
+    it "validates strategy_type inclusion" do
+      strategy.strategy_type = "invalid"
+      expect(strategy).not_to be_valid
+      expect(strategy.errors[:strategy_type]).to include("is not included in the list")
+    end
+
+    it "validates configuration is a hash" do
+      strategy.configuration = "not a hash"
+      expect(strategy).not_to be_valid
+      expect(strategy.errors[:configuration]).to include("must be a JSON object")
+    end
+
+    it "accepts a valid strategy" do
+      expect(strategy).to be_valid
+    end
+  end
+
+  describe "scopes" do
+    let!(:active_system) { create(:orchestration_strategy, :review_settings) }
+    let!(:inactive) { create(:orchestration_strategy, :quality_gate, :inactive) }
+    let(:account) { create(:account) }
+    let!(:account_strategy) { create(:orchestration_strategy, :execution_timeouts, account: account) }
+
+    describe ".active" do
+      it "returns only active strategies" do
+        expect(described_class.active).to include(active_system, account_strategy)
+        expect(described_class.active).not_to include(inactive)
+      end
+    end
+
+    describe ".system_defaults" do
+      it "returns only strategies without an account" do
+        expect(described_class.system_defaults).to include(active_system, inactive)
+        expect(described_class.system_defaults).not_to include(account_strategy)
+      end
+    end
+
+    describe ".for_account" do
+      it "returns strategies for a specific account" do
+        expect(described_class.for_account(account)).to contain_exactly(account_strategy)
+      end
+    end
+
+    describe ".by_type" do
+      it "filters by strategy type" do
+        expect(described_class.by_type("review_settings")).to contain_exactly(active_system)
+      end
+    end
+  end
+
+  describe ".active_for" do
+    let!(:system_strategy) { create(:orchestration_strategy, :review_settings) }
+    let(:account) { create(:account) }
+
+    it "returns the system default when no account override exists" do
+      result = described_class.active_for("review_settings", account: account)
+      expect(result).to eq(system_strategy)
+    end
+
+    it "prefers an account-level override when present" do
+      account_override = create(:orchestration_strategy, :review_settings, account: account)
+      result = described_class.active_for("review_settings", account: account)
+      expect(result).to eq(account_override)
+    end
+
+    it "returns the system default without an account argument" do
+      result = described_class.active_for("review_settings")
+      expect(result).to eq(system_strategy)
+    end
+
+    it "returns nil when no strategy exists" do
+      result = described_class.active_for("agent_settings")
+      expect(result).to be_nil
+    end
+  end
+
+  describe "#config_value" do
+    subject(:strategy) do
+      build(:orchestration_strategy, configuration: {
+        "enabled" => true,
+        "methods" => { "copilot" => { "timeout" => 30 } }
+      })
+    end
+
+    it "retrieves top-level values" do
+      expect(strategy.config_value("enabled")).to be true
+    end
+
+    it "retrieves nested values" do
+      expect(strategy.config_value("methods", "copilot", "timeout")).to eq(30)
+    end
+
+    it "returns nil for missing keys" do
+      expect(strategy.config_value("nonexistent")).to be_nil
+    end
+
+    it "returns nil for deep missing keys" do
+      expect(strategy.config_value("methods", "missing", "key")).to be_nil
+    end
+  end
+end

--- a/spec/services/orchestration_strategies/defaults_spec.rb
+++ b/spec/services/orchestration_strategies/defaults_spec.rb
@@ -90,6 +90,8 @@ RSpec.describe OrchestrationStrategies::Defaults do
   describe ".feature_orchestration" do
     subject(:config) { described_class.feature_orchestration }
 
+    let(:workflow) { Workflows::FeatureOrchestrationWorkflow.allocate }
+
     it "preserves known failure types" do
       expect(config["known_failure_types"]).to eq(
         Workflows::AgentExecutionWorkflow::KNOWN_FAILURE_TYPES
@@ -104,6 +106,46 @@ RSpec.describe OrchestrationStrategies::Defaults do
 
     it "includes planning phases" do
       expect(config["planning_phases"]).to include("fetch_planning_context", "decompose_feature")
+    end
+
+    it "preserves all planning outcomes returned by the workflow" do
+      outcomes = [
+        workflow.send(:planning_outcome_for, []),
+        workflow.send(:planning_outcome_for, [ { title: "One task" } ]),
+        workflow.send(:planning_outcome_for, [ { title: "Task one" }, { title: "Task two" } ]),
+        workflow.send(:planning_failure_outcome_for, "decompose_feature"),
+        workflow.send(:planning_failure_outcome_for, "create_sub_issues"),
+        workflow.send(:planning_failure_outcome_for, "update_planning_labels")
+      ]
+
+      expect(config["planning_outcomes"]).to match_array(outcomes.uniq)
+    end
+
+    it "preserves all parallelization outcomes returned by the workflow" do
+      outcomes = [
+        workflow.send(:parallelization_outcome_for, []),
+        workflow.send(:parallelization_outcome_for, [ { title: "One task" } ]),
+        workflow.send(:parallelization_outcome_for, [ { title: "Task one" }, { title: "Task two" } ]),
+        workflow.send(:parallelization_failure_outcome_for, "build_sub_tasks"),
+        workflow.send(:parallelization_failure_outcome_for, "run_parallel_execution")
+      ]
+
+      expect(config["parallelization_outcomes"]).to match_array(outcomes.uniq)
+    end
+  end
+
+  describe ".retry_policies" do
+    subject(:config) { described_class.retry_policies }
+
+    it "preserves the run_agent retry policy values" do
+      policy = Workflows::AgentExecutionWorkflow::RUN_AGENT_RETRY_POLICY
+
+      expect(config["run_agent"]).to eq(
+        "max_attempts" => policy.max_attempts,
+        "initial_interval_seconds" => policy.initial_interval,
+        "max_interval_seconds" => policy.max_interval,
+        "backoff_coefficient" => policy.backoff_coefficient
+      )
     end
   end
 

--- a/spec/services/orchestration_strategies/defaults_spec.rb
+++ b/spec/services/orchestration_strategies/defaults_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrchestrationStrategies::Defaults do
+  describe ".configuration_for" do
+    OrchestrationStrategy::STRATEGY_TYPES.each do |type|
+      it "returns a hash for #{type}" do
+        config = described_class.configuration_for(type)
+        expect(config).to be_a(Hash)
+        expect(config).not_to be_empty
+      end
+    end
+
+    it "returns nil for unknown types" do
+      expect(described_class.configuration_for("unknown")).to be_nil
+    end
+  end
+
+  describe ".review_settings" do
+    subject(:config) { described_class.review_settings }
+
+    it "matches Project::DEFAULT_REVIEW_SETTINGS" do
+      expect(config).to eq(Project::DEFAULT_REVIEW_SETTINGS)
+    end
+
+    it "contains all review methods" do
+      expect(config["methods"].keys).to contain_exactly(
+        "copilot", "paid_agent", "codex", "ci_action", "manual"
+      )
+    end
+  end
+
+  describe ".quality_gate" do
+    subject(:config) { described_class.quality_gate }
+
+    it "matches Project::DEFAULT_QUALITY_GATE_SETTINGS" do
+      expect(config).to eq(Project::DEFAULT_QUALITY_GATE_SETTINGS)
+    end
+  end
+
+  describe ".execution_timeouts" do
+    subject(:config) { described_class.execution_timeouts }
+
+    it "preserves the agent timeout default" do
+      expect(config["agent_timeout_default_seconds"]).to eq(3600)
+    end
+
+    it "preserves issue goal timeout" do
+      expect(config["issue_goal_timeout_seconds"]).to eq(
+        Activities::RunAgentActivity::DEFAULT_ISSUE_GOAL_TIMEOUT
+      )
+    end
+
+    it "preserves review goal idle timeout" do
+      expect(config["review_goal_idle_timeout_seconds"]).to eq(
+        Activities::RunAgentActivity::DEFAULT_REVIEW_GOAL_IDLE_TIMEOUT
+      )
+    end
+
+    it "preserves feature orchestration timeout" do
+      expect(config["feature_orchestration_timeout_seconds"]).to eq(
+        Workflows::FeatureOrchestrationWorkflow::DEFAULT_TIMEOUT_SECONDS
+      )
+    end
+  end
+
+  describe ".agent_settings" do
+    subject(:config) { described_class.agent_settings }
+
+    it "preserves the default goal from TenantSetting" do
+      expect(config["default_goal"]).to eq(
+        TenantSetting::DEFAULT_AGENT_SETTINGS["default_goal"]
+      )
+    end
+
+    it "preserves auto_continue setting" do
+      expect(config["auto_continue"]).to eq(
+        TenantSetting::DEFAULT_AGENT_SETTINGS["auto_continue"]
+      )
+    end
+
+    it "preserves guardrail values from TenantSetting" do
+      expect(config["guardrails"]["max_concurrent_runs"]).to eq(
+        TenantSetting::DEFAULT_GUARDRAILS["max_concurrent_runs"]
+      )
+    end
+  end
+
+  describe ".feature_orchestration" do
+    subject(:config) { described_class.feature_orchestration }
+
+    it "preserves known failure types" do
+      expect(config["known_failure_types"]).to eq(
+        Workflows::AgentExecutionWorkflow::KNOWN_FAILURE_TYPES
+      )
+    end
+
+    it "preserves known failure classes" do
+      expect(config["known_failure_classes"]).to eq(
+        Workflows::AgentExecutionWorkflow::KNOWN_FAILURE_CLASSES
+      )
+    end
+
+    it "includes planning phases" do
+      expect(config["planning_phases"]).to include("fetch_planning_context", "decompose_feature")
+    end
+  end
+
+  describe ".provider_resolution" do
+    subject(:config) { described_class.provider_resolution }
+
+    it "preserves agent types from AgentRun" do
+      expect(config["agent_types"]).to eq(AgentRun::AGENT_TYPES)
+    end
+
+    it "preserves goals from AgentRun" do
+      expect(config["goals"]).to eq(AgentRun::GOALS)
+    end
+
+    it "preserves review method names" do
+      expect(config["review_method_names"]).to eq(
+        Automation::Configuration::ReviewMethod::NAMES.map(&:to_s)
+      )
+    end
+  end
+
+  describe ".all" do
+    it "returns a hash of all strategy types to their configurations" do
+      all = described_class.all
+      expect(all.keys).to match_array(OrchestrationStrategy::STRATEGY_TYPES)
+      all.each_value { |config| expect(config).to be_a(Hash) }
+    end
+  end
+end

--- a/spec/services/orchestration_strategies/resolve_spec.rb
+++ b/spec/services/orchestration_strategies/resolve_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrchestrationStrategies::Resolve do
+  describe ".call" do
+    context "when a persisted system default exists" do
+      let!(:strategy) { create(:orchestration_strategy, :review_settings) }
+
+      it "returns the persisted strategy" do
+        result = described_class.call(strategy_type: "review_settings")
+        expect(result).to eq(strategy)
+      end
+    end
+
+    context "when an account override exists" do
+      let(:account) { create(:account) }
+      let!(:account_strategy) do
+        create(:orchestration_strategy, :review_settings, account: account)
+      end
+
+      before { create(:orchestration_strategy, :review_settings) }
+
+      it "returns the account-level strategy" do
+        result = described_class.call(strategy_type: "review_settings", account: account)
+        expect(result).to eq(account_strategy)
+      end
+    end
+
+    context "when no persisted strategy exists" do
+      it "returns a fallback strategy built from hardcoded defaults" do
+        result = described_class.call(strategy_type: "review_settings")
+
+        expect(result).to be_a(OrchestrationStrategy)
+        expect(result).not_to be_persisted
+        expect(result.version).to eq(0)
+        expect(result.configuration).to eq(OrchestrationStrategies::Defaults.review_settings)
+      end
+
+      it "returns nil for unknown strategy types" do
+        result = described_class.call(strategy_type: "nonexistent")
+        expect(result).to be_nil
+      end
+    end
+
+    context "when account has no override but system default exists" do
+      let!(:system_strategy) { create(:orchestration_strategy, :review_settings) }
+      let(:account) { create(:account) }
+
+      it "falls back to the system default" do
+        result = described_class.call(strategy_type: "review_settings", account: account)
+        expect(result).to eq(system_strategy)
+      end
+    end
+  end
+end

--- a/spec/services/orchestration_strategies/resolve_spec.rb
+++ b/spec/services/orchestration_strategies/resolve_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OrchestrationStrategies::Resolve do
 
         expect(result).to be_a(OrchestrationStrategy)
         expect(result).not_to be_persisted
-        expect(result.version).to eq(0)
+        expect(result.version).to eq(1)
         expect(result.configuration).to eq(OrchestrationStrategies::Defaults.review_settings)
       end
 

--- a/spec/services/orchestration_strategies/resolve_spec.rb
+++ b/spec/services/orchestration_strategies/resolve_spec.rb
@@ -4,6 +4,10 @@ require "rails_helper"
 
 RSpec.describe OrchestrationStrategies::Resolve do
   describe ".call" do
+    # The backfill migration seeds system defaults during db:prepare in CI.
+    # Clear them here so these examples can control the persisted state.
+    before { OrchestrationStrategy.delete_all }
+
     context "when a persisted system default exists" do
       let!(:strategy) { create(:orchestration_strategy, :review_settings) }
 

--- a/spec/services/orchestration_strategies/seed_spec.rb
+++ b/spec/services/orchestration_strategies/seed_spec.rb
@@ -4,6 +4,10 @@ require "rails_helper"
 
 RSpec.describe OrchestrationStrategies::Seed do
   describe ".call" do
+    # The backfill migration seeds system defaults during db:prepare in CI.
+    # Clear them here so these examples can verify initial seeding behavior.
+    before { OrchestrationStrategy.delete_all }
+
     it "creates one active strategy per type" do
       expect { described_class.call }.to change(OrchestrationStrategy, :count)
         .by(OrchestrationStrategy::STRATEGY_TYPES.size)

--- a/spec/services/orchestration_strategies/seed_spec.rb
+++ b/spec/services/orchestration_strategies/seed_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrchestrationStrategies::Seed do
+  describe ".call" do
+    it "creates one active strategy per type" do
+      expect { described_class.call }.to change(OrchestrationStrategy, :count)
+        .by(OrchestrationStrategy::STRATEGY_TYPES.size)
+
+      OrchestrationStrategy::STRATEGY_TYPES.each do |type|
+        strategy = OrchestrationStrategy.system_defaults.by_type(type).active.first
+        expect(strategy).to be_present, "Expected system default for #{type}"
+        expect(strategy.configuration).to eq(
+          OrchestrationStrategies::Defaults.configuration_for(type)
+        )
+      end
+    end
+
+    it "is idempotent — running twice does not duplicate records" do
+      described_class.call
+      expect { described_class.call }.not_to change(OrchestrationStrategy, :count)
+    end
+
+    it "returns only newly created records" do
+      first_run = described_class.call
+      expect(first_run.size).to eq(OrchestrationStrategy::STRATEGY_TYPES.size)
+
+      second_run = described_class.call
+      expect(second_run).to be_empty
+    end
+
+    it "fills in missing types when some already exist" do
+      create(:orchestration_strategy, :review_settings)
+
+      created = described_class.call
+      expect(created.map(&:strategy_type)).not_to include("review_settings")
+      expect(created.size).to eq(OrchestrationStrategy::STRATEGY_TYPES.size - 1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

OK

Commit succeeded. Here's a summary of what was done:

**New files created:**
- `db/migrate/20260507204357_create_orchestration_strategies.rb` — migration with `orchestration_strategies` table (account FK, strategy_type, name, version, jsonb configuration, active flag, unique partial index on active type+account)
- `app/models/orchestration_strategy.rb` — model with 7 strategy types, validations, scopes, `.active_for` lookup, and `#config_value` for nested access
- `app/services/orchestration_strategies/defaults.rb` — central registry extracting all hardcoded defaults from their original locations (review settings, quality gates, execution timeouts, retry policies, agent settings, feature orchestration, provider resolution)
- `app/services/orchestration_strategies/resolve.rb` — resolution service with account-override → system-default → hardcoded-fallback chain
- `app/services/orchestration_strategies/seed.rb` — idempotent seeder creating one record per strategy type

**Modified files:**
- `app/models/account.rb` — added `has_many :orchestration_strategies`
- `db/seeds.rb` — calls `OrchestrationStrategies::Seed.call`
- `db/structure.sql` — updated with new table

**Test files (53 examples, 0 failures):**
- `spec/models/orchestration_strategy_spec.rb` — model validations, scopes, lookup, config_value
- `spec/services/orchestration_strategies/defaults_spec.rb` — verifies each extracted config matches the original hardcoded constants
- `spec/services/orchestration_strategies/resolve_spec.rb` — fallback chain behavior
- `spec/services/orchestration_strategies/seed_spec.rb` — idempotency and completeness

---

Closes #1755