### PR TITLE
feat(strategy): A/B test evolved strategies against baseline

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -99,6 +99,7 @@ class AgentRun < ApplicationRecord
   has_many :token_usages, dependent: :destroy
   has_many :ab_test_assignments, dependent: :destroy
   has_many :configuration_experiment_assignments, dependent: :destroy
+  has_many :strategy_experiment_assignments, dependent: :destroy
   has_many :container_metrics, dependent: :delete_all
   has_many :quality_metrics, dependent: :destroy
   has_many :orchestration_decisions, dependent: :nullify

--- a/app/models/strategy_experiment.rb
+++ b/app/models/strategy_experiment.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "zlib"
+
+class StrategyExperiment < ApplicationRecord
+  STATUSES = %w[draft running completed cancelled].freeze
+  STRATEGY_NAMES = %w[auto_pick auto_continue auto_review auto_merge].freeze
+  MAX_VARIANTS = 3
+  ANALYSIS_INTERVAL = AbTest::ANALYSIS_INTERVAL
+
+  belongs_to :account
+  belongs_to :winner_variant, class_name: "StrategyExperimentVariant", optional: true
+
+  has_many :strategy_experiment_variants, dependent: :destroy
+  has_many :strategy_experiment_assignments, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :strategy_name, presence: true, inclusion: { in: STRATEGY_NAMES }
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :control_config, presence: true
+  validates :min_samples_per_variant, numericality: { only_integer: true, greater_than_or_equal_to: 2 }
+  validates :confidence_threshold, numericality: { greater_than: 0, less_than_or_equal_to: 1 }
+  validates :traffic_percentage, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
+  validate :variant_count_within_limit
+  validate :winner_variant_belongs_to_experiment
+
+  scope :draft, -> { where(status: "draft") }
+  scope :running, -> { where(status: "running") }
+  scope :completed, -> { where(status: "completed") }
+  scope :cancelled, -> { where(status: "cancelled") }
+
+  def self.active_for(strategy_name, account:, agent_run: nil)
+    experiment = running
+      .where(strategy_name: strategy_name, account: account)
+      .order(:id)
+      .first
+    return nil unless experiment
+    return nil unless experiment.includes_traffic?(agent_run: agent_run)
+
+    experiment
+  end
+
+  def running?
+    status == "running"
+  end
+
+  def draft?
+    status == "draft"
+  end
+
+  def start!
+    with_lock do
+      reload
+      raise_invalid_status!("start") unless draft?
+
+      update!(status: "running", started_at: Time.current)
+    end
+  rescue ActiveRecord::RecordNotUnique
+    errors.add(:base, "another strategy experiment is already running for this strategy")
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def complete!(winner: nil)
+    with_lock do
+      reload
+      raise_invalid_status!("complete") unless running?
+
+      update!(status: "completed", completed_at: Time.current, winner_variant: winner)
+    end
+  end
+
+  def cancel!
+    with_lock do
+      reload
+      unless %w[draft running].include?(status)
+        raise_invalid_status!("cancel")
+      end
+
+      update!(status: "cancelled", completed_at: Time.current)
+    end
+  end
+
+  def control_variant
+    strategy_experiment_variants.find_by(is_control: true)
+  end
+
+  def sufficient_samples?
+    strategy_experiment_variants.all? { |v| v.sample_count >= min_samples_per_variant }
+  end
+
+  def includes_traffic?(agent_run: nil)
+    return false if traffic_percentage.zero?
+    return true if traffic_percentage == 100
+
+    return false unless agent_run
+
+    Zlib.crc32("#{id}:#{agent_run.class.name}:#{agent_run.id}") % 100 < traffic_percentage
+  end
+
+  def cached_or_compute_analysis(persist: true)
+    current_key = samples_key
+    if cached_analysis.present?
+      return deserialize_analysis if analysis_samples_key == current_key
+      return deserialize_analysis unless persist
+    end
+
+    return nil unless persist
+
+    StrategyExperiments::Analyze.call(strategy_experiment: self).tap { |result| persist_analysis!(result, current_key) }
+  end
+
+  private
+
+  CACHE_BUCKET_SIZE = ANALYSIS_INTERVAL
+
+  def raise_invalid_status!(action)
+    errors.add(:base, "cannot #{action} an experiment that is #{status}")
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def samples_key
+    total_samples = strategy_experiment_variants.sum(&:sample_count)
+    total_bucket = (total_samples / CACHE_BUCKET_SIZE) * CACHE_BUCKET_SIZE
+
+    variant_buckets = strategy_experiment_variants
+      .sort_by(&:id)
+      .map { |v| "#{v.id}:#{(v.sample_count / CACHE_BUCKET_SIZE) * CACHE_BUCKET_SIZE}" }
+      .join(",")
+
+    "total:#{total_bucket}|#{variant_buckets}"
+  end
+
+  def persist_analysis!(result, key)
+    update_columns(
+      cached_analysis: {
+        status: result.status.to_s,
+        confidence: result.confidence&.to_f,
+        improvement: result.improvement&.to_f,
+        winner_id: result.winner&.id
+      },
+      analysis_samples_key: key
+    )
+  end
+
+  def deserialize_analysis
+    data = cached_analysis.symbolize_keys
+    winner = data[:winner_id] ? strategy_experiment_variants.find_by(id: data[:winner_id]) : nil
+    StrategyExperiments::Analyze::Result.new(
+      status: data[:status]&.to_sym,
+      winner: winner,
+      confidence: data[:confidence],
+      improvement: data[:improvement]
+    )
+  end
+
+  def variant_count_within_limit
+    return if strategy_experiment_variants.size <= MAX_VARIANTS + 1
+
+    errors.add(:strategy_experiment_variants, "cannot have more than #{MAX_VARIANTS} variants plus control")
+  end
+
+  def winner_variant_belongs_to_experiment
+    return if winner_variant.nil?
+    return if winner_variant.strategy_experiment_id == id
+
+    errors.add(:winner_variant, "must belong to this strategy experiment")
+  end
+end

--- a/app/models/strategy_experiment_assignment.rb
+++ b/app/models/strategy_experiment_assignment.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class StrategyExperimentAssignment < ApplicationRecord
+  belongs_to :strategy_experiment
+  belongs_to :strategy_experiment_variant
+  belongs_to :agent_run
+
+  validates :agent_run_id, uniqueness: { scope: :strategy_experiment_id }
+  validate :strategy_experiment_variant_matches_experiment
+
+  private
+
+  def strategy_experiment_variant_matches_experiment
+    return if strategy_experiment_variant.nil? || strategy_experiment.nil?
+    return if strategy_experiment_variant.strategy_experiment_id == strategy_experiment_id
+
+    errors.add(:strategy_experiment_variant, "must belong to the same strategy experiment")
+  end
+end

--- a/app/models/strategy_experiment_variant.rb
+++ b/app/models/strategy_experiment_variant.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class StrategyExperimentVariant < ApplicationRecord
+  belongs_to :strategy_experiment
+
+  has_many :strategy_experiment_assignments, dependent: :destroy
+
+  validates :strategy_config, presence: true
+  validates :sample_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validate :strategy_experiment_variant_count_within_limit, on: :create
+
+  def parsed_config
+    JSON.parse(strategy_config)
+  end
+
+  def record_quality_score!(score)
+    raise ArgumentError, "quality score must be a number between 0 and 1" unless valid_score?(score)
+
+    with_lock do
+      score_decimal = BigDecimal(score.to_s)
+
+      self.sample_count += 1
+      self.total_quality_score = BigDecimal("0") if total_quality_score.nil?
+      self.total_quality_score += score_decimal
+      self.avg_quality_score = total_quality_score / sample_count
+      save!
+    end
+  end
+
+  private
+
+  def valid_score?(score)
+    score.is_a?(Numeric) && score >= 0 && score <= 1
+  end
+
+  def strategy_experiment_variant_count_within_limit
+    return if strategy_experiment.nil?
+
+    max_allowed = StrategyExperiment::MAX_VARIANTS + 1
+    if strategy_experiment.strategy_experiment_variants.count >= max_allowed
+      errors.add(:base, "strategy experiment cannot have more than #{StrategyExperiment::MAX_VARIANTS} variants plus control")
+    end
+  end
+end

--- a/app/services/strategy_experiments/analyze.rb
+++ b/app/services/strategy_experiments/analyze.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module StrategyExperiments
+  class Analyze
+    Result = Struct.new(:status, :winner, :confidence, :improvement, :details, keyword_init: true)
+
+    attr_reader :strategy_experiment
+
+    def initialize(strategy_experiment:)
+      @strategy_experiment = strategy_experiment
+    end
+
+    def self.call(...)
+      new(...).analyze
+    end
+
+    def analyze
+      variants = strategy_experiment.strategy_experiment_variants.order(:id).to_a
+      control = variants.find(&:is_control)
+
+      return Result.new(status: :insufficient_data) unless control
+      return Result.new(status: :insufficient_data) unless all_have_minimum_samples?(variants)
+
+      control_scores = scores_for(control)
+      return Result.new(status: :insufficient_data) if control_scores.size < 2
+
+      results = variants.reject(&:is_control).filter_map do |variant|
+        result_for(control_scores, variant)
+      end
+
+      determine_outcome(results)
+    end
+
+    private
+
+    def all_have_minimum_samples?(variants)
+      variants.all? { |v| v.sample_count >= strategy_experiment.min_samples_per_variant }
+    end
+
+    def scores_for(variant)
+      variant.strategy_experiment_assignments
+        .where.not(quality_score: nil)
+        .pluck(:quality_score)
+        .map(&:to_f)
+    end
+
+    def result_for(control_scores, variant)
+      variant_scores = scores_for(variant)
+      return nil if variant_scores.size < 2
+
+      t_result = AbTests::Statistics.welch_t_test(control_scores, variant_scores)
+      {
+        variant: variant,
+        mean_diff: AbTests::Statistics.mean(variant_scores) - AbTests::Statistics.mean(control_scores),
+        p_value: t_result[:p_value],
+        significant: t_result[:p_value] < (1 - strategy_experiment.confidence_threshold)
+      }
+    end
+
+    def determine_outcome(results)
+      return Result.new(status: :insufficient_data) if results.empty?
+
+      significant_improvements = results.select { |r| r[:significant] && r[:mean_diff] > 0 }
+
+      if significant_improvements.any?
+        winner = significant_improvements.max_by { |r| r[:mean_diff] }
+        Result.new(
+          status: :winner_found,
+          winner: winner[:variant],
+          confidence: 1 - winner[:p_value],
+          improvement: winner[:mean_diff],
+          details: results
+        )
+      elsif results.all? { |r| r[:significant] && r[:mean_diff] < 0 }
+        Result.new(status: :control_wins, details: results)
+      else
+        Result.new(status: :no_significant_difference, details: results)
+      end
+    end
+  end
+end

--- a/app/services/strategy_experiments/assign.rb
+++ b/app/services/strategy_experiments/assign.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module StrategyExperiments
+  class Assign
+    attr_reader :strategy_experiment, :agent_run
+
+    def initialize(strategy_experiment:, agent_run:)
+      @strategy_experiment = strategy_experiment
+      @agent_run = agent_run
+    end
+
+    def self.call(...)
+      new(...).assign
+    end
+
+    def assign
+      raise ArgumentError, "strategy experiment is not running" unless strategy_experiment.running?
+
+      existing = StrategyExperimentAssignment.find_by(
+        strategy_experiment: strategy_experiment,
+        agent_run: agent_run
+      )
+      return existing if existing
+
+      variant = select_variant
+
+      begin
+        StrategyExperimentAssignment.create!(
+          strategy_experiment: strategy_experiment,
+          strategy_experiment_variant: variant,
+          agent_run: agent_run
+        )
+      rescue ActiveRecord::RecordNotUnique
+        StrategyExperimentAssignment.find_by!(
+          strategy_experiment: strategy_experiment,
+          agent_run: agent_run
+        )
+      end
+    end
+
+    private
+
+    def select_variant
+      variants = strategy_experiment.strategy_experiment_variants.order(:id).to_a
+      raise ArgumentError, "strategy experiment has no variants" if variants.empty?
+      return variants.first if variants.size == 1
+
+      assignment_counts = StrategyExperimentAssignment
+        .where(strategy_experiment: strategy_experiment, strategy_experiment_variant: variants)
+        .group(:strategy_experiment_variant_id)
+        .count
+      max_count = variants.map { |v| assignment_counts[v.id] || 0 }.max
+      weights = variants.map { |v| (max_count - (assignment_counts[v.id] || 0)) + 1 }
+      total = weights.sum.to_f
+
+      roll = rand
+      cumulative = 0.0
+
+      variants.zip(weights).each do |variant, weight|
+        cumulative += weight / total
+        return variant if roll < cumulative
+      end
+
+      variants.last
+    end
+  end
+end

--- a/app/services/strategy_experiments/create.rb
+++ b/app/services/strategy_experiments/create.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module StrategyExperiments
+  class Create
+    attr_reader :name, :strategy_name, :control_config, :variant_configs, :description, :account, :options
+
+    def initialize(name:, strategy_name:, control_config:, variant_configs:, account:, description: nil, **options)
+      @name = name
+      @strategy_name = strategy_name
+      @control_config = control_config
+      @variant_configs = variant_configs
+      @description = description
+      @account = account
+      @options = options
+    end
+
+    def self.call(...)
+      new(...).create
+    end
+
+    def create
+      validate!
+
+      ActiveRecord::Base.transaction do
+        experiment = StrategyExperiment.create!(
+          account: account,
+          name: name,
+          description: description,
+          strategy_name: strategy_name,
+          status: "draft",
+          control_config: encoded(control_config),
+          min_samples_per_variant: options.fetch(:min_samples_per_variant, 30),
+          confidence_threshold: options.fetch(:confidence_threshold, 0.95),
+          traffic_percentage: options.fetch(:traffic_percentage, 100)
+        )
+
+        experiment.strategy_experiment_variants.create!(
+          strategy_config: encoded(control_config),
+          is_control: true
+        )
+
+        variant_configs.each do |config|
+          experiment.strategy_experiment_variants.create!(
+            strategy_config: encoded(config),
+            is_control: false
+          )
+        end
+
+        experiment
+      end
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "at least one variant config is required" if variant_configs.empty?
+      raise ArgumentError, "maximum #{StrategyExperiment::MAX_VARIANTS} variants allowed" if variant_configs.size > StrategyExperiment::MAX_VARIANTS
+      raise ArgumentError, "variant configs must be unique" if variant_configs.map { |c| encoded(c) }.uniq.size != variant_configs.size
+      raise ArgumentError, "variant configs cannot include the control config" if variant_configs.map { |c| encoded(c) }.include?(encoded(control_config))
+      raise ArgumentError, "strategy already has a running experiment" if running_experiment_exists?
+    end
+
+    def running_experiment_exists?
+      StrategyExperiment.running.exists?(strategy_name: strategy_name, account: account)
+    end
+
+    def encoded(value)
+      JSON.generate(value)
+    end
+  end
+end

--- a/app/services/strategy_experiments/record_result.rb
+++ b/app/services/strategy_experiments/record_result.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module StrategyExperiments
+  class RecordResult
+    attr_reader :strategy_experiment, :agent_run, :quality_score, :update_existing
+
+    def initialize(strategy_experiment:, agent_run:, quality_score:, update_existing: false)
+      @strategy_experiment = strategy_experiment
+      @agent_run = agent_run
+      @quality_score = quality_score
+      @update_existing = update_existing
+    end
+
+    def self.call(...)
+      new(...).record
+    end
+
+    def record
+      validate_quality_score!
+
+      score_recorded = ActiveRecord::Base.transaction { record_assignment_score }
+
+      check_auto_completion(strategy_experiment) if score_recorded
+    end
+
+    private
+
+    ANALYSIS_INTERVAL = StrategyExperiment::ANALYSIS_INTERVAL
+
+    def record_assignment_score
+      assignment = StrategyExperimentAssignment.find_by!(
+        strategy_experiment: strategy_experiment,
+        agent_run: agent_run
+      )
+      variant = assignment.strategy_experiment_variant
+
+      variant.with_lock do
+        assignment.reload
+        old_score = assignment.quality_score
+        if old_score.present? && !update_existing
+          false
+        else
+          assignment.update!(quality_score: quality_score)
+          if old_score.present?
+            adjust_variant_aggregates(variant, old_score: old_score, new_score: quality_score)
+            clear_analysis_cache
+          else
+            add_variant_score(variant, quality_score)
+          end
+
+          true
+        end
+      end
+    end
+
+    def validate_quality_score!
+      unless quality_score.is_a?(Numeric) && quality_score >= 0 && quality_score <= 1
+        raise ArgumentError, "quality_score must be a number between 0 and 1"
+      end
+    end
+
+    def check_auto_completion(strategy_experiment)
+      strategy_experiment.reload
+      return unless strategy_experiment.running?
+      return unless strategy_experiment.sufficient_samples?
+      return unless should_analyze?(strategy_experiment)
+
+      result = strategy_experiment.cached_or_compute_analysis
+      return if result.status == :insufficient_data
+
+      if result.status == :winner_found
+        strategy_experiment.complete!(winner: result.winner)
+      elsif result.status == :control_wins
+        strategy_experiment.complete!
+      end
+    rescue ActiveRecord::RecordInvalid
+      nil
+    end
+
+    def add_variant_score(variant, score)
+      score_decimal = BigDecimal(score.to_s)
+      variant.sample_count += 1
+      variant.total_quality_score = (variant.total_quality_score || BigDecimal("0")) + score_decimal
+      variant.avg_quality_score = variant.total_quality_score / variant.sample_count
+      variant.save!
+    end
+
+    def adjust_variant_aggregates(variant, old_score:, new_score:)
+      old_decimal = BigDecimal(old_score.to_s)
+      new_decimal = BigDecimal(new_score.to_s)
+      variant.total_quality_score = (variant.total_quality_score || BigDecimal("0")) - old_decimal + new_decimal
+      variant.avg_quality_score = variant.sample_count.positive? ? variant.total_quality_score / variant.sample_count : nil
+      variant.save!
+    end
+
+    def clear_analysis_cache
+      strategy_experiment.update_columns(cached_analysis: nil, analysis_samples_key: nil)
+    end
+
+    def should_analyze?(strategy_experiment)
+      return true if update_existing
+
+      total_samples = strategy_experiment.strategy_experiment_variants.sum(:sample_count)
+      min_required = strategy_experiment.min_samples_per_variant * strategy_experiment.strategy_experiment_variants.count
+      total_samples == min_required || (total_samples % ANALYSIS_INTERVAL).zero?
+    end
+  end
+end

--- a/db/migrate/20260507204652_create_strategy_experiments.rb
+++ b/db/migrate/20260507204652_create_strategy_experiments.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class CreateStrategyExperiments < ActiveRecord::Migration[8.1]
+  def change
+    create_table :strategy_experiments, comment: "A/B tests comparing evolved automation strategy variants against a baseline" do |t|
+      t.references :account, null: false, foreign_key: { on_delete: :cascade }
+      t.string :name, null: false
+      t.text :description
+      t.string :strategy_name, limit: 100, null: false, comment: "Automation strategy being tested (e.g. auto_pick, auto_review)"
+      t.string :status, limit: 50, null: false, default: "draft"
+      t.text :control_config, null: false, comment: "JSON-encoded baseline configuration for the strategy"
+      t.integer :min_samples_per_variant, null: false, default: 30
+      t.decimal :confidence_threshold, precision: 5, scale: 4, null: false, default: 0.95
+      t.integer :traffic_percentage, null: false, default: 100
+      t.jsonb :cached_analysis
+      t.string :analysis_samples_key
+      t.datetime :started_at
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+
+    create_table :strategy_experiment_variants, comment: "Individual variant arms within a strategy A/B test" do |t|
+      t.references :strategy_experiment, null: false, foreign_key: { on_delete: :cascade }
+      t.text :strategy_config, null: false, comment: "JSON-encoded configuration for this variant"
+      t.boolean :is_control, null: false, default: false
+      t.integer :sample_count, null: false, default: 0
+      t.decimal :total_quality_score, precision: 10, scale: 4, null: false, default: 0
+      t.decimal :avg_quality_score, precision: 5, scale: 4
+
+      t.timestamps
+    end
+
+    create_table :strategy_experiment_assignments, comment: "Maps each agent run to the strategy variant it was assigned" do |t|
+      t.references :strategy_experiment, null: false, foreign_key: { on_delete: :cascade }
+      t.references :strategy_experiment_variant, null: false, foreign_key: { on_delete: :cascade }
+      t.references :agent_run, null: false, foreign_key: { on_delete: :cascade }
+      t.decimal :quality_score, precision: 5, scale: 4
+
+      t.timestamps
+    end
+
+    add_reference :strategy_experiments,
+      :winner_variant,
+      foreign_key: { to_table: :strategy_experiment_variants, on_delete: :nullify },
+      index: true
+
+    add_index :strategy_experiments, [ :account_id, :strategy_name, :status ],
+      name: "index_strategy_experiments_on_account_strategy_status"
+    add_index :strategy_experiments,
+      [ :account_id, :strategy_name ],
+      unique: true,
+      where: "status = 'running'",
+      name: "index_strategy_experiments_one_running_per_account_strategy"
+    add_index :strategy_experiment_variants,
+      [ :strategy_experiment_id, :is_control ],
+      name: "index_strategy_experiment_variants_on_experiment_control"
+    add_index :strategy_experiment_variants,
+      :strategy_experiment_id,
+      unique: true,
+      where: "is_control = true",
+      name: "index_strategy_experiment_variants_one_control"
+    add_index :strategy_experiment_assignments,
+      [ :strategy_experiment_id, :agent_run_id ],
+      unique: true,
+      name: "index_strategy_experiment_assignments_unique"
+  end
+end

--- a/db/migrate/20260507224416_enable_rls_on_strategy_experiment_tables.rb
+++ b/db/migrate/20260507224416_enable_rls_on_strategy_experiment_tables.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class EnableRlsOnStrategyExperimentTables < ActiveRecord::Migration[8.1]
+  def up
+    # strategy_experiments: direct account_id
+    execute <<~SQL
+      ALTER TABLE strategy_experiments ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE strategy_experiments FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON strategy_experiments
+        AS PERMISSIVE FOR ALL
+        USING (paid_tenant_bypass() OR (strategy_experiments.account_id = paid_current_account_id()))
+        WITH CHECK (paid_tenant_bypass() OR (strategy_experiments.account_id = paid_current_account_id()));
+    SQL
+
+    # strategy_experiment_variants: through strategy_experiment
+    execute <<~SQL
+      ALTER TABLE strategy_experiment_variants ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE strategy_experiment_variants FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON strategy_experiment_variants
+        AS PERMISSIVE FOR ALL
+        USING (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM strategy_experiments
+            WHERE strategy_experiments.id = strategy_experiment_variants.strategy_experiment_id
+              AND strategy_experiments.account_id = paid_current_account_id()
+          )
+        )
+        WITH CHECK (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM strategy_experiments
+            WHERE strategy_experiments.id = strategy_experiment_variants.strategy_experiment_id
+              AND strategy_experiments.account_id = paid_current_account_id()
+          )
+        );
+    SQL
+
+    # strategy_experiment_assignments: through strategy_experiment
+    execute <<~SQL
+      ALTER TABLE strategy_experiment_assignments ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE strategy_experiment_assignments FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON strategy_experiment_assignments
+        AS PERMISSIVE FOR ALL
+        USING (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM strategy_experiments
+            WHERE strategy_experiments.id = strategy_experiment_assignments.strategy_experiment_id
+              AND strategy_experiments.account_id = paid_current_account_id()
+          )
+        )
+        WITH CHECK (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM strategy_experiments
+            WHERE strategy_experiments.id = strategy_experiment_assignments.strategy_experiment_id
+              AND strategy_experiments.account_id = paid_current_account_id()
+          )
+        );
+    SQL
+  end
+
+  def down
+    %w[strategy_experiments strategy_experiment_variants strategy_experiment_assignments].each do |table|
+      execute "DROP POLICY IF EXISTS tenant_isolation ON #{table}"
+      execute "ALTER TABLE #{table} NO FORCE ROW LEVEL SECURITY"
+      execute "ALTER TABLE #{table} DISABLE ROW LEVEL SECURITY"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3572,13 +3572,6 @@ COMMENT ON COLUMN public.projects.completed_agent_runs_count IS 'Counter cache f
 
 
 --
--- Name: COLUMN projects.last_issue_reconciliation_at; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.projects.last_issue_reconciliation_at IS 'Timestamp of the last issue state reconciliation against GitHub';
-
-
---
 -- Name: COLUMN projects.screenshot_settings; Type: COMMENT; Schema: public; Owner: -
 --
 
@@ -4355,6 +4348,8 @@ CREATE TABLE public.strategy_experiment_assignments (
     updated_at timestamp(6) without time zone NOT NULL
 );
 
+ALTER TABLE ONLY public.strategy_experiment_assignments FORCE ROW LEVEL SECURITY;
+
 
 --
 -- Name: TABLE strategy_experiment_assignments; Type: COMMENT; Schema: public; Owner: -
@@ -4397,6 +4392,8 @@ CREATE TABLE public.strategy_experiment_variants (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
+
+ALTER TABLE ONLY public.strategy_experiment_variants FORCE ROW LEVEL SECURITY;
 
 
 --
@@ -4455,6 +4452,8 @@ CREATE TABLE public.strategy_experiments (
     updated_at timestamp(6) without time zone NOT NULL,
     winner_variant_id bigint
 );
+
+ALTER TABLE ONLY public.strategy_experiments FORCE ROW LEVEL SECURITY;
 
 
 --
@@ -10791,6 +10790,24 @@ ALTER TABLE public.service_container_metrics ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.service_containers ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: strategy_experiment_assignments; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.strategy_experiment_assignments ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: strategy_experiment_variants; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.strategy_experiment_variants ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: strategy_experiments; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.strategy_experiments ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: style_guides; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -11544,6 +11561,35 @@ CREATE POLICY tenant_isolation ON public.service_containers USING ((public.paid_
 
 
 --
+-- Name: strategy_experiment_assignments tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.strategy_experiment_assignments USING ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.strategy_experiments
+  WHERE ((strategy_experiments.id = strategy_experiment_assignments.strategy_experiment_id) AND (strategy_experiments.account_id = public.paid_current_account_id())))))) WITH CHECK ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.strategy_experiments
+  WHERE ((strategy_experiments.id = strategy_experiment_assignments.strategy_experiment_id) AND (strategy_experiments.account_id = public.paid_current_account_id()))))));
+
+
+--
+-- Name: strategy_experiment_variants tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.strategy_experiment_variants USING ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.strategy_experiments
+  WHERE ((strategy_experiments.id = strategy_experiment_variants.strategy_experiment_id) AND (strategy_experiments.account_id = public.paid_current_account_id())))))) WITH CHECK ((public.paid_tenant_bypass() OR (EXISTS ( SELECT 1
+   FROM public.strategy_experiments
+  WHERE ((strategy_experiments.id = strategy_experiment_variants.strategy_experiment_id) AND (strategy_experiments.account_id = public.paid_current_account_id()))))));
+
+
+--
+-- Name: strategy_experiments tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.strategy_experiments USING ((public.paid_tenant_bypass() OR (account_id = public.paid_current_account_id()))) WITH CHECK ((public.paid_tenant_bypass() OR (account_id = public.paid_current_account_id())));
+
+
+--
 -- Name: tenant_settings tenant_isolation; Type: POLICY; Schema: public; Owner: -
 --
 
@@ -11958,6 +12004,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507224416'),
 ('20260507204652'),
 ('20260507164917'),
 ('20260507125050'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4342,6 +4342,162 @@ ALTER SEQUENCE public.service_containers_id_seq OWNED BY public.service_containe
 
 
 --
+-- Name: strategy_experiment_assignments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.strategy_experiment_assignments (
+    id bigint NOT NULL,
+    strategy_experiment_id bigint NOT NULL,
+    strategy_experiment_variant_id bigint NOT NULL,
+    agent_run_id bigint NOT NULL,
+    quality_score numeric(5,4),
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE strategy_experiment_assignments; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.strategy_experiment_assignments IS 'Maps each agent run to the strategy variant it was assigned';
+
+
+--
+-- Name: strategy_experiment_assignments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.strategy_experiment_assignments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: strategy_experiment_assignments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.strategy_experiment_assignments_id_seq OWNED BY public.strategy_experiment_assignments.id;
+
+
+--
+-- Name: strategy_experiment_variants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.strategy_experiment_variants (
+    id bigint NOT NULL,
+    strategy_experiment_id bigint NOT NULL,
+    strategy_config text NOT NULL,
+    is_control boolean DEFAULT false NOT NULL,
+    sample_count integer DEFAULT 0 NOT NULL,
+    total_quality_score numeric(10,4) DEFAULT 0.0 NOT NULL,
+    avg_quality_score numeric(5,4),
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE strategy_experiment_variants; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.strategy_experiment_variants IS 'Individual variant arms within a strategy A/B test';
+
+
+--
+-- Name: COLUMN strategy_experiment_variants.strategy_config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.strategy_experiment_variants.strategy_config IS 'JSON-encoded configuration for this variant';
+
+
+--
+-- Name: strategy_experiment_variants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.strategy_experiment_variants_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: strategy_experiment_variants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.strategy_experiment_variants_id_seq OWNED BY public.strategy_experiment_variants.id;
+
+
+--
+-- Name: strategy_experiments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.strategy_experiments (
+    id bigint NOT NULL,
+    account_id bigint NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    strategy_name character varying(100) NOT NULL,
+    status character varying(50) DEFAULT 'draft'::character varying NOT NULL,
+    control_config text NOT NULL,
+    min_samples_per_variant integer DEFAULT 30 NOT NULL,
+    confidence_threshold numeric(5,4) DEFAULT 0.95 NOT NULL,
+    traffic_percentage integer DEFAULT 100 NOT NULL,
+    cached_analysis jsonb,
+    analysis_samples_key character varying,
+    started_at timestamp(6) without time zone,
+    completed_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    winner_variant_id bigint
+);
+
+
+--
+-- Name: TABLE strategy_experiments; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.strategy_experiments IS 'A/B tests comparing evolved automation strategy variants against a baseline';
+
+
+--
+-- Name: COLUMN strategy_experiments.strategy_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.strategy_experiments.strategy_name IS 'Automation strategy being tested (e.g. auto_pick, auto_review)';
+
+
+--
+-- Name: COLUMN strategy_experiments.control_config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.strategy_experiments.control_config IS 'JSON-encoded baseline configuration for the strategy';
+
+
+--
+-- Name: strategy_experiments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.strategy_experiments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: strategy_experiments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.strategy_experiments_id_seq OWNED BY public.strategy_experiments.id;
+
+
+--
 -- Name: style_guides; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5304,6 +5460,27 @@ ALTER TABLE ONLY public.service_containers ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
+-- Name: strategy_experiment_assignments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiment_assignments ALTER COLUMN id SET DEFAULT nextval('public.strategy_experiment_assignments_id_seq'::regclass);
+
+
+--
+-- Name: strategy_experiment_variants id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiment_variants ALTER COLUMN id SET DEFAULT nextval('public.strategy_experiment_variants_id_seq'::regclass);
+
+
+--
+-- Name: strategy_experiments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiments ALTER COLUMN id SET DEFAULT nextval('public.strategy_experiments_id_seq'::regclass);
+
+
+--
 -- Name: style_guides id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -6016,6 +6193,30 @@ ALTER TABLE ONLY public.service_containers
 
 
 --
+-- Name: strategy_experiment_assignments strategy_experiment_assignments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiment_assignments
+    ADD CONSTRAINT strategy_experiment_assignments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: strategy_experiment_variants strategy_experiment_variants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiment_variants
+    ADD CONSTRAINT strategy_experiment_variants_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: strategy_experiments strategy_experiments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiments
+    ADD CONSTRAINT strategy_experiments_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: style_guides style_guides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6301,6 +6502,20 @@ CREATE INDEX idx_on_project_id_recommendation_type_333faaed2e ON public.knowledg
 --
 
 CREATE INDEX idx_on_project_id_status_warmed_at_d791387888 ON public.container_pool_entries USING btree (project_id, status, warmed_at);
+
+
+--
+-- Name: idx_on_strategy_experiment_id_c7c524095e; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_strategy_experiment_id_c7c524095e ON public.strategy_experiment_assignments USING btree (strategy_experiment_id);
+
+
+--
+-- Name: idx_on_strategy_experiment_variant_id_95cba2d3c7; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_strategy_experiment_variant_id_95cba2d3c7 ON public.strategy_experiment_assignments USING btree (strategy_experiment_variant_id);
 
 
 --
@@ -8656,6 +8871,69 @@ CREATE UNIQUE INDEX index_service_containers_on_account_id_and_name ON public.se
 
 
 --
+-- Name: index_strategy_experiment_assignments_on_agent_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_strategy_experiment_assignments_on_agent_run_id ON public.strategy_experiment_assignments USING btree (agent_run_id);
+
+
+--
+-- Name: index_strategy_experiment_assignments_unique; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_strategy_experiment_assignments_unique ON public.strategy_experiment_assignments USING btree (strategy_experiment_id, agent_run_id);
+
+
+--
+-- Name: index_strategy_experiment_variants_on_experiment_control; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_strategy_experiment_variants_on_experiment_control ON public.strategy_experiment_variants USING btree (strategy_experiment_id, is_control);
+
+
+--
+-- Name: index_strategy_experiment_variants_on_strategy_experiment_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_strategy_experiment_variants_on_strategy_experiment_id ON public.strategy_experiment_variants USING btree (strategy_experiment_id);
+
+
+--
+-- Name: index_strategy_experiment_variants_one_control; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_strategy_experiment_variants_one_control ON public.strategy_experiment_variants USING btree (strategy_experiment_id) WHERE (is_control = true);
+
+
+--
+-- Name: index_strategy_experiments_on_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_strategy_experiments_on_account_id ON public.strategy_experiments USING btree (account_id);
+
+
+--
+-- Name: index_strategy_experiments_on_account_strategy_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_strategy_experiments_on_account_strategy_status ON public.strategy_experiments USING btree (account_id, strategy_name, status);
+
+
+--
+-- Name: index_strategy_experiments_on_winner_variant_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_strategy_experiments_on_winner_variant_id ON public.strategy_experiments USING btree (winner_variant_id);
+
+
+--
+-- Name: index_strategy_experiments_one_running_per_account_strategy; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_strategy_experiments_one_running_per_account_strategy ON public.strategy_experiments USING btree (account_id, strategy_name) WHERE ((status)::text = 'running'::text);
+
+
+--
 -- Name: index_style_guides_on_account_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9297,6 +9575,14 @@ ALTER TABLE ONLY public.project_mcp_servers
 
 
 --
+-- Name: strategy_experiment_variants fk_rails_63128adc9b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiment_variants
+    ADD CONSTRAINT fk_rails_63128adc9b FOREIGN KEY (strategy_experiment_id) REFERENCES public.strategy_experiments(id) ON DELETE CASCADE;
+
+
+--
 -- Name: knowledge_audit_events fk_rails_6402bd2a4b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9398,6 +9684,14 @@ ALTER TABLE ONLY public.provider_api_keys
 
 ALTER TABLE ONLY public.issues
     ADD CONSTRAINT fk_rails_81439a1ee9 FOREIGN KEY (parent_issue_id) REFERENCES public.issues(id);
+
+
+--
+-- Name: strategy_experiment_assignments fk_rails_836548eed9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiment_assignments
+    ADD CONSTRAINT fk_rails_836548eed9 FOREIGN KEY (agent_run_id) REFERENCES public.agent_runs(id) ON DELETE CASCADE;
 
 
 --
@@ -9729,6 +10023,14 @@ ALTER TABLE ONLY public.billing_invoices
 
 
 --
+-- Name: strategy_experiment_assignments fk_rails_c0e892d6a1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiment_assignments
+    ADD CONSTRAINT fk_rails_c0e892d6a1 FOREIGN KEY (strategy_experiment_variant_id) REFERENCES public.strategy_experiment_variants(id) ON DELETE CASCADE;
+
+
+--
 -- Name: notification_rule_states fk_rails_c198fcfeea; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9913,6 +10215,14 @@ ALTER TABLE ONLY public.model_selections
 
 
 --
+-- Name: strategy_experiment_assignments fk_rails_e3f0fb3b46; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiment_assignments
+    ADD CONSTRAINT fk_rails_e3f0fb3b46 FOREIGN KEY (strategy_experiment_id) REFERENCES public.strategy_experiments(id) ON DELETE CASCADE;
+
+
+--
 -- Name: onboarding_steps fk_rails_e648887d14; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9993,6 +10303,14 @@ ALTER TABLE ONLY public.llm_output_metrics
 
 
 --
+-- Name: strategy_experiments fk_rails_f2c1b39dfb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiments
+    ADD CONSTRAINT fk_rails_f2c1b39dfb FOREIGN KEY (winner_variant_id) REFERENCES public.strategy_experiment_variants(id) ON DELETE SET NULL;
+
+
+--
 -- Name: chat_sessions fk_rails_f3ce73dd5f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10046,6 +10364,14 @@ ALTER TABLE ONLY public.ab_test_assignments
 
 ALTER TABLE ONLY public.worktrees
     ADD CONSTRAINT fk_rails_fd82a63e04 FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: strategy_experiments fk_rails_ff1e651e8d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strategy_experiments
+    ADD CONSTRAINT fk_rails_ff1e651e8d FOREIGN KEY (account_id) REFERENCES public.accounts(id) ON DELETE CASCADE;
 
 
 --
@@ -11632,6 +11958,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507204652'),
 ('20260507164917'),
 ('20260507125050'),
 ('20260507011753'),

--- a/spec/factories/strategy_experiment_assignments.rb
+++ b/spec/factories/strategy_experiment_assignments.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :strategy_experiment_assignment do
+    strategy_experiment
+    strategy_experiment_variant do
+      association :strategy_experiment_variant, strategy_experiment: strategy_experiment, strategy: :create
+    end
+    agent_run { association :agent_run, strategy: :create }
+  end
+end

--- a/spec/factories/strategy_experiment_variants.rb
+++ b/spec/factories/strategy_experiment_variants.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :strategy_experiment_variant do
+    strategy_experiment
+    sequence(:strategy_config) { |n| JSON.generate("version" => "variant_#{n}") }
+    is_control { false }
+    sample_count { 0 }
+    total_quality_score { 0 }
+  end
+end

--- a/spec/factories/strategy_experiments.rb
+++ b/spec/factories/strategy_experiments.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :strategy_experiment do
+    account
+    sequence(:name) { |n| "Strategy Experiment #{n}" }
+    strategy_name { "auto_review" }
+    status { "draft" }
+    control_config { JSON.generate("version" => "baseline") }
+    min_samples_per_variant { 30 }
+    confidence_threshold { 0.95 }
+    traffic_percentage { 100 }
+  end
+end

--- a/spec/migrations/add_account_to_service_containers_spec.rb
+++ b/spec/migrations/add_account_to_service_containers_spec.rb
@@ -9,18 +9,13 @@ require Rails.root.join("db/migrate/20260426011810_enable_rls_on_llm_output_metr
 require Rails.root.join("db/migrate/20260426231639_enable_rls_on_chat_tables")
 require Rails.root.join("db/migrate/20260427225726_enable_rls_on_knowledge_recommendations")
 require Rails.root.join("db/migrate/20260503093418_enable_rls_on_issue_merge_subscriptions")
+require Rails.root.join("db/migrate/20260428140000_create_exception_incidents")
+require Rails.root.join("db/migrate/20260507125050_create_decomposition_decisions")
+require Rails.root.join("db/migrate/20260507164917_create_orchestration_decisions")
+require Rails.root.join("db/migrate/20260507224416_enable_rls_on_strategy_experiment_tables")
 
 RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
   self.use_transactional_tests = false
-
-  let(:migration) { described_class.new }
-  let(:rls_migration) { EnableTenantRowLevelSecurity.new }
-  let(:knowledge_rls_migration) { EnableRlsOnKnowledgeUsageStats.new }
-  let(:notification_rls_migration) { EnableRlsOnNotificationRuleStates.new }
-  let(:llm_output_metrics_rls_migration) { EnableRlsOnLlmOutputMetrics.new }
-  let(:chat_rls_migration) { EnableRlsOnChatTables.new }
-  let(:knowledge_recommendations_rls_migration) { EnableRlsOnKnowledgeRecommendations.new }
-  let(:issue_merge_subscriptions_rls_migration) { EnableRlsOnIssueMergeSubscriptions.new }
 
   include MigrationSpecHelpers
 
@@ -28,6 +23,10 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     truncate_migration_test_data
 
     if tenant_policy_count.positive?
+      strategy_experiments_rls_migration.down if strategy_experiment_tables_have_rls?
+      orchestration_decisions_migration.down if orchestration_decisions_have_rls?
+      disable_decomposition_decisions_rls if decomposition_decisions_have_rls?
+      exception_incidents_migration.down if exception_incidents_have_rls?
       issue_merge_subscriptions_rls_migration.down if issue_merge_subscriptions_have_rls?
       knowledge_recommendations_rls_migration.down if knowledge_recommendations_has_rls?
       chat_rls_migration.down if chat_tables_have_rls?
@@ -53,6 +52,9 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
       chat_rls_migration.up unless chat_tables_have_rls?
       knowledge_recommendations_rls_migration.up unless knowledge_recommendations_has_rls?
       issue_merge_subscriptions_rls_migration.up unless issue_merge_subscriptions_have_rls?
+      exception_incidents_migration.up unless exception_incidents_have_rls?
+      orchestration_decisions_migration.up unless orchestration_decisions_have_rls?
+      strategy_experiments_rls_migration.up unless strategy_experiment_tables_have_rls?
     end
     ServiceContainer.reset_column_information
   end
@@ -239,6 +241,39 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     ).to_i.positive?
   end
 
+  def strategy_experiment_tables_have_rls?
+    ActiveRecord::Base.connection.select_value(<<~SQL.squish).to_i == 3
+      SELECT COUNT(*)
+      FROM pg_policies
+      WHERE policyname = 'tenant_isolation'
+        AND tablename IN ('strategy_experiments', 'strategy_experiment_variants', 'strategy_experiment_assignments')
+    SQL
+  end
+
+  def exception_incidents_have_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'exception_incidents' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
+  end
+
+  def decomposition_decisions_have_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'decomposition_decisions' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
+  end
+
+  def disable_decomposition_decisions_rls
+    ActiveRecord::Base.connection.execute("DROP POLICY IF EXISTS tenant_isolation ON decomposition_decisions")
+    ActiveRecord::Base.connection.execute("ALTER TABLE decomposition_decisions NO FORCE ROW LEVEL SECURITY")
+    ActiveRecord::Base.connection.execute("ALTER TABLE decomposition_decisions DISABLE ROW LEVEL SECURITY")
+  end
+
+  def orchestration_decisions_have_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'orchestration_decisions' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
+  end
+
   def tenant_policy_count
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(*) FROM pg_policies WHERE policyname = 'tenant_isolation'"
@@ -256,5 +291,49 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     connection.remove_index(:service_containers, column: [ :account_id, :name ], if_exists: true)
     connection.remove_column(:service_containers, :account_id) if connection.column_exists?(:service_containers, :account_id)
     migration.up
+  end
+
+  def migration
+    @migration ||= described_class.new
+  end
+
+  def rls_migration
+    @rls_migration ||= EnableTenantRowLevelSecurity.new
+  end
+
+  def knowledge_rls_migration
+    @knowledge_rls_migration ||= EnableRlsOnKnowledgeUsageStats.new
+  end
+
+  def notification_rls_migration
+    @notification_rls_migration ||= EnableRlsOnNotificationRuleStates.new
+  end
+
+  def llm_output_metrics_rls_migration
+    @llm_output_metrics_rls_migration ||= EnableRlsOnLlmOutputMetrics.new
+  end
+
+  def chat_rls_migration
+    @chat_rls_migration ||= EnableRlsOnChatTables.new
+  end
+
+  def knowledge_recommendations_rls_migration
+    @knowledge_recommendations_rls_migration ||= EnableRlsOnKnowledgeRecommendations.new
+  end
+
+  def issue_merge_subscriptions_rls_migration
+    @issue_merge_subscriptions_rls_migration ||= EnableRlsOnIssueMergeSubscriptions.new
+  end
+
+  def exception_incidents_migration
+    @exception_incidents_migration ||= CreateExceptionIncidents.new
+  end
+
+  def orchestration_decisions_migration
+    @orchestration_decisions_migration ||= CreateOrchestrationDecisions.new
+  end
+
+  def strategy_experiments_rls_migration
+    @strategy_experiments_rls_migration ||= EnableRlsOnStrategyExperimentTables.new
   end
 end

--- a/spec/models/strategy_experiment_assignment_spec.rb
+++ b/spec/models/strategy_experiment_assignment_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyExperimentAssignment do
+  describe "associations" do
+    it { is_expected.to belong_to(:strategy_experiment) }
+    it { is_expected.to belong_to(:strategy_experiment_variant) }
+    it { is_expected.to belong_to(:agent_run) }
+  end
+
+  describe "validations" do
+    it "rejects a variant from a different experiment" do
+      experiment_a = create(:strategy_experiment)
+      experiment_b = create(:strategy_experiment)
+      variant_b = create(:strategy_experiment_variant, strategy_experiment: experiment_b)
+
+      assignment = build(:strategy_experiment_assignment,
+        strategy_experiment: experiment_a,
+        strategy_experiment_variant: variant_b)
+
+      expect(assignment).not_to be_valid
+      expect(assignment.errors[:strategy_experiment_variant]).to be_present
+    end
+  end
+end

--- a/spec/models/strategy_experiment_spec.rb
+++ b/spec/models/strategy_experiment_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyExperiment do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:strategy_name) }
+    it { is_expected.to validate_inclusion_of(:strategy_name).in_array(described_class::STRATEGY_NAMES) }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+    it { is_expected.to validate_presence_of(:control_config) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:winner_variant).class_name("StrategyExperimentVariant").optional }
+    it { is_expected.to have_many(:strategy_experiment_variants).dependent(:destroy) }
+    it { is_expected.to have_many(:strategy_experiment_assignments).dependent(:destroy) }
+  end
+
+  describe "#start!" do
+    it "transitions from draft to running" do
+      experiment = create(:strategy_experiment, status: "draft")
+
+      experiment.start!
+
+      expect(experiment.reload.status).to eq("running")
+      expect(experiment.started_at).to be_present
+    end
+
+    it "raises when not in draft status" do
+      experiment = create(:strategy_experiment, status: "running", started_at: Time.current)
+
+      expect { experiment.start! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe "#complete!" do
+    it "transitions from running to completed" do
+      experiment = create(:strategy_experiment, status: "running", started_at: Time.current)
+
+      experiment.complete!
+
+      expect(experiment.reload.status).to eq("completed")
+      expect(experiment.completed_at).to be_present
+    end
+
+    it "accepts a winner variant" do
+      experiment = create(:strategy_experiment, status: "running", started_at: Time.current)
+      variant = create(:strategy_experiment_variant, strategy_experiment: experiment)
+
+      experiment.complete!(winner: variant)
+
+      expect(experiment.reload.winner_variant).to eq(variant)
+    end
+  end
+
+  describe "#cancel!" do
+    it "transitions from running to cancelled" do
+      experiment = create(:strategy_experiment, status: "running", started_at: Time.current)
+
+      experiment.cancel!
+
+      expect(experiment.reload.status).to eq("cancelled")
+    end
+
+    it "transitions from draft to cancelled" do
+      experiment = create(:strategy_experiment, status: "draft")
+
+      experiment.cancel!
+
+      expect(experiment.reload.status).to eq("cancelled")
+    end
+  end
+
+  describe ".active_for" do
+    it "returns a running experiment for the given strategy and account" do
+      account = create(:account)
+      experiment = create(:strategy_experiment, account: account, strategy_name: "auto_review", status: "running", started_at: Time.current)
+
+      result = described_class.active_for("auto_review", account: account)
+
+      expect(result).to eq(experiment)
+    end
+
+    it "returns nil when no running experiment exists" do
+      account = create(:account)
+      create(:strategy_experiment, account: account, strategy_name: "auto_review", status: "draft")
+
+      result = described_class.active_for("auto_review", account: account)
+
+      expect(result).to be_nil
+    end
+  end
+
+  describe "#sufficient_samples?" do
+    it "returns true when all variants meet the minimum" do
+      experiment = create(:strategy_experiment, min_samples_per_variant: 2)
+      create(:strategy_experiment_variant, strategy_experiment: experiment, is_control: true, sample_count: 2)
+      create(:strategy_experiment_variant, strategy_experiment: experiment, sample_count: 3)
+
+      expect(experiment.sufficient_samples?).to be true
+    end
+
+    it "returns false when any variant is below the minimum" do
+      experiment = create(:strategy_experiment, min_samples_per_variant: 5)
+      create(:strategy_experiment_variant, strategy_experiment: experiment, is_control: true, sample_count: 5)
+      create(:strategy_experiment_variant, strategy_experiment: experiment, sample_count: 2)
+
+      expect(experiment.sufficient_samples?).to be false
+    end
+  end
+end

--- a/spec/models/strategy_experiment_variant_spec.rb
+++ b/spec/models/strategy_experiment_variant_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyExperimentVariant do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:strategy_config) }
+    it { is_expected.to belong_to(:strategy_experiment) }
+    it { is_expected.to have_many(:strategy_experiment_assignments).dependent(:destroy) }
+  end
+
+  describe "#parsed_config" do
+    it "returns the parsed JSON config" do
+      variant = build(:strategy_experiment_variant, strategy_config: JSON.generate("version" => "v2"))
+
+      expect(variant.parsed_config).to eq("version" => "v2")
+    end
+  end
+
+  describe "#record_quality_score!" do
+    it "atomically updates the aggregate scores" do
+      variant = create(:strategy_experiment_variant)
+
+      variant.record_quality_score!(0.8)
+
+      expect(variant.reload.sample_count).to eq(1)
+      expect(variant.avg_quality_score.to_f).to eq(0.8)
+    end
+
+    it "rejects scores outside 0..1" do
+      variant = create(:strategy_experiment_variant)
+
+      expect { variant.record_quality_score!(1.5) }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/security/tenant_context_spec.rb
+++ b/spec/security/tenant_context_spec.rb
@@ -8,6 +8,10 @@ require Rails.root.join("db/migrate/20260426011810_enable_rls_on_llm_output_metr
 require Rails.root.join("db/migrate/20260426231639_enable_rls_on_chat_tables")
 require Rails.root.join("db/migrate/20260427225726_enable_rls_on_knowledge_recommendations")
 require Rails.root.join("db/migrate/20260503093418_enable_rls_on_issue_merge_subscriptions")
+require Rails.root.join("db/migrate/20260428140000_create_exception_incidents")
+require Rails.root.join("db/migrate/20260507125050_create_decomposition_decisions")
+require Rails.root.join("db/migrate/20260507164917_create_orchestration_decisions")
+require Rails.root.join("db/migrate/20260507224416_enable_rls_on_strategy_experiment_tables")
 
 RSpec.describe TenantContext, :tenant_isolation do
   around do |example|
@@ -168,6 +172,10 @@ RSpec.describe TenantContext, :tenant_isolation do
 
   def install_tenant_policies
     ActiveRecord::Migration.suppress_messages do
+      EnableRlsOnStrategyExperimentTables.new.down if strategy_experiment_tables_have_rls?
+      CreateOrchestrationDecisions.new.down if orchestration_decisions_have_rls?
+      disable_decomposition_decisions_rls if decomposition_decisions_have_rls?
+      CreateExceptionIncidents.new.down if exception_incidents_have_rls?
       EnableRlsOnKnowledgeRecommendations.new.down if knowledge_recommendations_has_rls?
       EnableRlsOnChatTables.new.down if chat_tables_have_rls?
       EnableRlsOnLlmOutputMetrics.new.down if llm_output_metrics_has_rls?
@@ -182,6 +190,9 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnChatTables.new.up unless chat_tables_have_rls?
       EnableRlsOnKnowledgeRecommendations.new.up unless knowledge_recommendations_has_rls?
       EnableRlsOnIssueMergeSubscriptions.new.up unless issue_merge_subscriptions_has_rls?
+      CreateExceptionIncidents.new.up unless exception_incidents_have_rls?
+      CreateOrchestrationDecisions.new.up unless orchestration_decisions_have_rls?
+      EnableRlsOnStrategyExperimentTables.new.up unless strategy_experiment_tables_have_rls?
     end
     ActiveRecord::Base.connection.execute("RESET ROLE")
     cleanup_restricted_role
@@ -196,6 +207,10 @@ RSpec.describe TenantContext, :tenant_isolation do
     ActiveRecord::Base.connection.execute("RESET ROLE")
     cleanup_restricted_role
     ActiveRecord::Migration.suppress_messages do
+      EnableRlsOnStrategyExperimentTables.new.down if strategy_experiment_tables_have_rls?
+      CreateOrchestrationDecisions.new.down if orchestration_decisions_have_rls?
+      disable_decomposition_decisions_rls if decomposition_decisions_have_rls?
+      CreateExceptionIncidents.new.down if exception_incidents_have_rls?
       EnableRlsOnKnowledgeRecommendations.new.down if knowledge_recommendations_has_rls?
       EnableRlsOnChatTables.new.down if chat_tables_have_rls?
       EnableRlsOnLlmOutputMetrics.new.down if llm_output_metrics_has_rls?
@@ -234,6 +249,39 @@ RSpec.describe TenantContext, :tenant_isolation do
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'issue_merge_subscriptions' AND policyname = 'tenant_isolation'"
     ).to_i.positive?
+  end
+
+  def exception_incidents_have_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'exception_incidents' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
+  end
+
+  def decomposition_decisions_have_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'decomposition_decisions' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
+  end
+
+  def disable_decomposition_decisions_rls
+    ActiveRecord::Base.connection.execute("DROP POLICY IF EXISTS tenant_isolation ON decomposition_decisions")
+    ActiveRecord::Base.connection.execute("ALTER TABLE decomposition_decisions NO FORCE ROW LEVEL SECURITY")
+    ActiveRecord::Base.connection.execute("ALTER TABLE decomposition_decisions DISABLE ROW LEVEL SECURITY")
+  end
+
+  def orchestration_decisions_have_rls?
+    ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'orchestration_decisions' AND policyname = 'tenant_isolation'"
+    ).to_i.positive?
+  end
+
+  def strategy_experiment_tables_have_rls?
+    ActiveRecord::Base.connection.select_value(<<~SQL.squish).to_i == 3
+      SELECT COUNT(*)
+      FROM pg_policies
+      WHERE policyname = 'tenant_isolation'
+        AND tablename IN ('strategy_experiments', 'strategy_experiment_variants', 'strategy_experiment_assignments')
+    SQL
   end
 
   def cleanup_restricted_role

--- a/spec/services/strategy_experiments/analyze_spec.rb
+++ b/spec/services/strategy_experiments/analyze_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyExperiments::Analyze do
+  let(:strategy_experiment) { create(:strategy_experiment, status: "running", min_samples_per_variant: 5) }
+  let!(:control) do
+    create(:strategy_experiment_variant,
+      strategy_experiment: strategy_experiment,
+      strategy_config: strategy_experiment.control_config,
+      is_control: true)
+  end
+  let!(:variant) { create(:strategy_experiment_variant, strategy_experiment: strategy_experiment, strategy_config: JSON.generate("version" => "evolved")) }
+  let(:project) { create(:project) }
+
+  def add_scores(test_variant, scores)
+    timestamp = Time.current
+    agent_run_rows = scores.map do
+      {
+        project_id: project.id,
+        agent_type: "claude_code",
+        status: "pending",
+        goal: "create_pr",
+        trigger_type: "automatic",
+        custom_prompt: "strategy experiment sample",
+        proxy_token: SecureRandom.hex(32),
+        created_at: timestamp,
+        updated_at: timestamp
+      }
+    end
+
+    inserted_runs = AgentRun.insert_all!(agent_run_rows, returning: %w[id])
+    assignment_rows = scores.zip(inserted_runs.rows.flatten).map do |score, agent_run_id|
+      {
+        strategy_experiment_id: strategy_experiment.id,
+        strategy_experiment_variant_id: test_variant.id,
+        agent_run_id: agent_run_id,
+        quality_score: score,
+        created_at: timestamp,
+        updated_at: timestamp
+      }
+    end
+
+    StrategyExperimentAssignment.insert_all!(assignment_rows)
+    test_variant.update!(sample_count: scores.size)
+  end
+
+  it "detects a significantly better variant" do
+    add_scores(control, [ 0.3, 0.35, 0.25, 0.3, 0.28, 0.32, 0.27, 0.31, 0.29, 0.33 ])
+    add_scores(variant, [ 0.8, 0.85, 0.9, 0.82, 0.88, 0.84, 0.86, 0.83, 0.87, 0.81 ])
+
+    result = described_class.call(strategy_experiment: strategy_experiment)
+
+    expect(result.status).to eq(:winner_found)
+    expect(result.winner).to eq(variant)
+    expect(result.confidence).to be > 0.95
+    expect(result.improvement).to be > 0.4
+  end
+
+  it "returns insufficient data below the minimum sample count" do
+    add_scores(control, [ 0.5, 0.6 ])
+    add_scores(variant, [ 0.7, 0.8 ])
+
+    result = described_class.call(strategy_experiment: strategy_experiment)
+
+    expect(result.status).to eq(:insufficient_data)
+  end
+
+  it "detects when control wins" do
+    add_scores(control, [ 0.8, 0.85, 0.9, 0.82, 0.88, 0.84, 0.86, 0.83, 0.87, 0.81 ])
+    add_scores(variant, [ 0.3, 0.35, 0.25, 0.3, 0.28, 0.32, 0.27, 0.31, 0.29, 0.33 ])
+
+    result = described_class.call(strategy_experiment: strategy_experiment)
+
+    expect(result.status).to eq(:control_wins)
+  end
+
+  it "returns no significant difference for similar scores" do
+    add_scores(control, [ 0.5, 0.51, 0.49, 0.52, 0.48, 0.5, 0.51, 0.49, 0.5, 0.51 ])
+    add_scores(variant, [ 0.51, 0.5, 0.52, 0.49, 0.51, 0.5, 0.49, 0.52, 0.5, 0.51 ])
+
+    result = described_class.call(strategy_experiment: strategy_experiment)
+
+    expect(result.status).to eq(:no_significant_difference)
+  end
+end

--- a/spec/services/strategy_experiments/assign_spec.rb
+++ b/spec/services/strategy_experiments/assign_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyExperiments::Assign do
+  let(:strategy_experiment) { create(:strategy_experiment, status: "running", started_at: Time.current) }
+  let!(:control) do
+    create(:strategy_experiment_variant,
+      strategy_experiment: strategy_experiment,
+      strategy_config: strategy_experiment.control_config,
+      is_control: true)
+  end
+  let!(:variant) { create(:strategy_experiment_variant, strategy_experiment: strategy_experiment, strategy_config: JSON.generate("version" => "evolved")) }
+
+  describe ".call" do
+    it "creates an assignment for the agent run" do
+      agent_run = create(:agent_run)
+
+      assignment = described_class.call(strategy_experiment: strategy_experiment, agent_run: agent_run)
+
+      expect(assignment).to be_persisted
+      expect(assignment.strategy_experiment).to eq(strategy_experiment)
+      expect(assignment.agent_run).to eq(agent_run)
+      expect([ control, variant ]).to include(assignment.strategy_experiment_variant)
+    end
+
+    it "returns an existing assignment for duplicate agent runs" do
+      agent_run = create(:agent_run)
+
+      first = described_class.call(strategy_experiment: strategy_experiment, agent_run: agent_run)
+      second = described_class.call(strategy_experiment: strategy_experiment, agent_run: agent_run)
+
+      expect(second).to eq(first)
+    end
+
+    it "raises when the experiment is not running" do
+      draft = create(:strategy_experiment, status: "draft")
+      create(:strategy_experiment_variant, strategy_experiment: draft, strategy_config: draft.control_config, is_control: true)
+
+      expect {
+        described_class.call(strategy_experiment: draft, agent_run: create(:agent_run))
+      }.to raise_error(ArgumentError, /not running/)
+    end
+  end
+end

--- a/spec/services/strategy_experiments/create_spec.rb
+++ b/spec/services/strategy_experiments/create_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyExperiments::Create do
+  describe ".call" do
+    let(:account) { create(:account) }
+
+    it "creates a draft experiment with control and variant configs" do
+      experiment = described_class.call(
+        account: account,
+        name: "Auto-review evolved v2",
+        strategy_name: "auto_review",
+        control_config: { "version" => "baseline" },
+        variant_configs: [ { "version" => "evolved_v2" } ]
+      )
+
+      expect(experiment).to be_persisted
+      expect(experiment.account).to eq(account)
+      expect(experiment.status).to eq("draft")
+      expect(experiment.strategy_name).to eq("auto_review")
+      expect(experiment.strategy_experiment_variants.size).to eq(2)
+      expect(experiment.control_variant.parsed_config).to eq("version" => "baseline")
+    end
+
+    it "rejects duplicate variant configs" do
+      expect {
+        described_class.call(
+          account: account,
+          name: "Dup test",
+          strategy_name: "auto_pick",
+          control_config: { "v" => 1 },
+          variant_configs: [ { "v" => 2 }, { "v" => 2 } ]
+        )
+      }.to raise_error(ArgumentError, /unique/)
+    end
+
+    it "rejects variant configs matching the control" do
+      expect {
+        described_class.call(
+          account: account,
+          name: "Same as control",
+          strategy_name: "auto_pick",
+          control_config: { "v" => 1 },
+          variant_configs: [ { "v" => 1 } ]
+        )
+      }.to raise_error(ArgumentError, /control/)
+    end
+
+    it "rejects empty variant configs" do
+      expect {
+        described_class.call(
+          account: account,
+          name: "No variants",
+          strategy_name: "auto_pick",
+          control_config: { "v" => 1 },
+          variant_configs: []
+        )
+      }.to raise_error(ArgumentError, /at least one/)
+    end
+  end
+
+  describe "full lifecycle: create, assign, record, auto-complete" do
+    let(:account) { create(:account) }
+    let(:project) { create(:project, account: account) }
+
+    it "auto-completes with the evolved variant as winner" do
+      experiment = described_class.call(
+        account: account,
+        name: "Auto-review evolved v2 test",
+        strategy_name: "auto_review",
+        control_config: { "version" => "baseline" },
+        variant_configs: [ { "version" => "evolved_v2" } ],
+        min_samples_per_variant: 5,
+        confidence_threshold: 0.95
+      )
+
+      control = experiment.control_variant
+      variant = experiment.strategy_experiment_variants.find_by(is_control: false)
+      experiment.start!
+
+      record_scores(experiment, control, project, [ 0.3, 0.35, 0.25, 0.3, 0.28 ])
+      record_scores(experiment, variant, project, [ 0.8, 0.85, 0.9, 0.82, 0.88 ])
+
+      experiment.reload
+      expect(experiment.status).to eq("completed")
+      expect(experiment.winner_variant).to eq(variant)
+    end
+
+    it "distributes assignments across variants" do
+      experiment = described_class.call(
+        account: account,
+        name: "Balanced test",
+        strategy_name: "auto_pick",
+        control_config: { "v" => 1 },
+        variant_configs: [ { "v" => 2 } ],
+        min_samples_per_variant: 5
+      )
+      experiment.start!
+
+      counts = 10.times
+        .map { StrategyExperiments::Assign.call(strategy_experiment: experiment, agent_run: create(:agent_run, project: project)) }
+        .map(&:strategy_experiment_variant_id)
+        .tally
+
+      expect(counts.keys.size).to eq(2)
+      counts.each_value { |c| expect(c).to be >= 2 }
+    end
+
+    private
+
+    def record_scores(experiment, variant, project, scores)
+      scores.each do |score|
+        run = create(:agent_run, project: project)
+        StrategyExperimentAssignment.create!(
+          strategy_experiment: experiment,
+          strategy_experiment_variant: variant,
+          agent_run: run
+        )
+        StrategyExperiments::RecordResult.call(
+          strategy_experiment: experiment,
+          agent_run: run,
+          quality_score: score
+        )
+      end
+    end
+  end
+end

--- a/spec/services/strategy_experiments/record_result_spec.rb
+++ b/spec/services/strategy_experiments/record_result_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyExperiments::RecordResult do
+  let(:strategy_experiment) { create(:strategy_experiment, status: "running", started_at: Time.current) }
+  let(:variant) { create(:strategy_experiment_variant, strategy_experiment: strategy_experiment) }
+  let(:agent_run) { create(:agent_run) }
+  let!(:assignment) do
+    create(:strategy_experiment_assignment,
+      strategy_experiment: strategy_experiment,
+      strategy_experiment_variant: variant,
+      agent_run: agent_run)
+  end
+
+  it "records a quality score and updates variant aggregates" do
+    described_class.call(strategy_experiment: strategy_experiment, agent_run: agent_run, quality_score: 0.85)
+
+    expect(assignment.reload.quality_score.to_f).to eq(0.85)
+    expect(variant.reload.sample_count).to eq(1)
+    expect(variant.avg_quality_score.to_f).to eq(0.85)
+  end
+
+  it "does not double-count repeated recording" do
+    described_class.call(strategy_experiment: strategy_experiment, agent_run: agent_run, quality_score: 0.8)
+    described_class.call(strategy_experiment: strategy_experiment, agent_run: agent_run, quality_score: 0.9)
+
+    expect(variant.reload.sample_count).to eq(1)
+    expect(variant.avg_quality_score.to_f).to eq(0.8)
+  end
+
+  it "updates an existing score when update_existing is true" do
+    described_class.call(strategy_experiment: strategy_experiment, agent_run: agent_run, quality_score: 0.8)
+    described_class.call(
+      strategy_experiment: strategy_experiment,
+      agent_run: agent_run,
+      quality_score: 0.6,
+      update_existing: true
+    )
+
+    expect(assignment.reload.quality_score.to_f).to eq(0.6)
+    expect(variant.reload.sample_count).to eq(1)
+    expect(variant.avg_quality_score.to_f).to eq(0.6)
+  end
+
+  it "rejects scores outside 0..1" do
+    expect {
+      described_class.call(strategy_experiment: strategy_experiment, agent_run: agent_run, quality_score: 1.5)
+    }.to raise_error(ArgumentError, /between 0 and 1/)
+  end
+end


### PR DESCRIPTION
## Summary

OK

Commit succeeded. Here's a summary of what was implemented:

**Migration** (`db/migrate/20260507204652_create_strategy_experiments.rb`):
- `strategy_experiments` - main experiment table with strategy_name, status lifecycle, traffic percentage, confidence threshold, cached analysis
- `strategy_experiment_variants` - arms with JSON strategy config, control flag, aggregate quality scores
- `strategy_experiment_assignments` - links agent runs to variants with per-run quality scores
- Unique index enforcing one running experiment per account+strategy

**Models**:
- `StrategyExperiment` - lifecycle management (draft→running→completed/cancelled), `active_for` lookup, traffic routing via CRC32 hash, cached analysis with bucketed invalidation
- `StrategyExperimentVariant` - atomic `record_quality_score!`, `parsed_config` for JSON deserialization
- `StrategyExperimentAssignment` - validates variant belongs to experiment, unique per experiment+run

**Services**:
- `StrategyExperiments::Create` - creates experiment with control + variant configs, validates uniqueness
- `StrategyExperiments::Assign` - weighted random selection balancing assignments across variants, idempotent
- `StrategyExperiments::RecordResult` - records quality scores, auto-completes when min samples reached via statistical analysis
- `StrategyExperiments::Analyze` - Welch's t-test via `AbTests::Statistics`, determines winner/control_wins/no_significant_difference

**Specs** (46 examples, 0 failures):
- Model validations, associations, and lifecycle transitions
- Service unit tests for each operation
- End-to-end lifecycle test proving create→start→assign→record→auto-complete with winner detection
- Balanced assignment distribution test

---

Closes #1758