### PR TITLE
feat(strategy): add human review gate for strategy changes

### DIFF
--- a/app/controllers/ab_tests_controller.rb
+++ b/app/controllers/ab_tests_controller.rb
@@ -82,9 +82,10 @@ class AbTestsController < ApplicationController
 
   def promote
     authorize @ab_test, :update?
-    AbTests::PromoteWinner.call(ab_test: @ab_test)
+    promoter = AbTests::PromoteWinner.new(ab_test: @ab_test)
+    promoter.promote
     redirect_to prompt_ab_test_path(@prompt, @ab_test),
-                notice: "Winner promoted! v#{@ab_test.winner_variant.prompt_version.version} is now the current version."
+                notice: promotion_notice(promoter)
   rescue ArgumentError, ActiveRecord::RecordInvalid => e
     message = e.is_a?(ActiveRecord::RecordInvalid) ? e.record.errors.full_messages.join(", ") : e.message
     redirect_to prompt_ab_test_path(@prompt, @ab_test), alert: message
@@ -135,5 +136,14 @@ class AbTestsController < ApplicationController
     end
 
     analysis
+  end
+
+  def promotion_notice(promoter)
+    winning_version = @ab_test.winner_variant.prompt_version
+    if promoter.gated?
+      "Winner queued for review. v#{winning_version.version} must be approved before it can become active."
+    else
+      "Winner promoted! v#{winning_version.version} is now the current version."
+    end
   end
 end

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -23,6 +23,7 @@ class Prompt < ApplicationRecord
   validates :category, presence: true, inclusion: { in: CATEGORIES }
   validates :account, presence: true, if: :project_level?
   validate :project_belongs_to_account, if: -> { project.present? && account.present? }
+  validate :current_version_must_be_activatable
 
   scope :active, -> { where(active: true) }
   scope :inactive, -> { where(active: false) }
@@ -121,5 +122,12 @@ class Prompt < ApplicationRecord
     return if project.account_id == account_id
 
     errors.add(:project, "must belong to the same account")
+  end
+
+  def current_version_must_be_activatable
+    return unless current_version
+    return if current_version.activatable?
+
+    errors.add(:current_version, "must be approved before it can become active")
   end
 end

--- a/app/models/prompt_version.rb
+++ b/app/models/prompt_version.rb
@@ -25,6 +25,7 @@ class PromptVersion < ApplicationRecord
 
   scope :active, -> { where(retired_at: nil) }
   scope :retired, -> { where.not(retired_at: nil) }
+  scope :activatable, -> { where(review_status: nil).or(where(review_status: "approved")) }
   scope :pending_review, -> { where(review_status: "pending") }
   scope :approved, -> { where(review_status: "approved") }
   scope :rejected, -> { where(review_status: "rejected") }
@@ -64,6 +65,10 @@ class PromptVersion < ApplicationRecord
   # while the prompt's review gate was enabled), regardless of outcome.
   def under_review?
     review_status.present?
+  end
+
+  def activatable?
+    !under_review? || approved?
   end
 
   private

--- a/app/services/prompt_evolution/select.rb
+++ b/app/services/prompt_evolution/select.rb
@@ -111,7 +111,7 @@ module PromptEvolution
     # PromptVersions that are active and have enough samples to score.
     def eligible_candidates
       @eligible_candidates ||= begin
-        candidates = prompt.prompt_versions.active.includes(agent_runs: :quality_metrics).to_a
+        candidates = prompt.prompt_versions.active.activatable.includes(agent_runs: :quality_metrics).to_a
         candidates.select { |v| sample_count(v) >= @min_samples }
       end
     end

--- a/app/views/ab_tests/show.html.erb
+++ b/app/views/ab_tests/show.html.erb
@@ -30,7 +30,15 @@
               <%= button_to "Cancel Test", cancel_prompt_ab_test_path(@prompt, @ab_test), method: :post, class: "inline-flex items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500", form: { data: { turbo_confirm: "Cancel this A/B test? This action cannot be undone." } } %>
             <% end %>
             <% if @ab_test.completed? && @ab_test.winner_variant.present? %>
-              <%= button_to "Promote Winner", promote_prompt_ab_test_path(@prompt, @ab_test), method: :post, class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500", form: { data: { turbo_confirm: "Promote the winning variant as the current prompt version? This will change the active prompt template." } } %>
+              <% winner = @ab_test.winner_variant.prompt_version %>
+              <% gated_winner = @prompt.requires_review? && !winner.approved? %>
+              <% button_label = gated_winner ? "Queue Winner for Review" : "Promote Winner" %>
+              <% confirm_message = if gated_winner
+                "Queue the winning variant for human review? It will stay inactive until explicitly approved."
+              else
+                "Promote the winning variant as the current prompt version? This will change the active prompt template."
+              end %>
+              <%= button_to button_label, promote_prompt_ab_test_path(@prompt, @ab_test), method: :post, class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500", form: { data: { turbo_confirm: confirm_message } } %>
             <% end %>
           <% end %>
         </div>
@@ -76,6 +84,18 @@
               <span class="inline-flex items-center rounded-md bg-green-100 px-2 py-1 text-sm font-medium text-green-700">
                 v<%= @ab_test.winner_variant.prompt_version.version %>
               </span>
+              <% if @prompt.requires_review? %>
+                <% winner = @ab_test.winner_variant.prompt_version %>
+                <% if winner.pending_review? %>
+                  <span class="ml-2 inline-flex items-center rounded-md bg-yellow-100 px-2 py-1 text-sm font-medium text-yellow-800">
+                    pending review
+                  </span>
+                <% elsif winner.approved? %>
+                  <span class="ml-2 inline-flex items-center rounded-md bg-blue-100 px-2 py-1 text-sm font-medium text-blue-700">
+                    approved
+                  </span>
+                <% end %>
+              <% end %>
             </dd>
           </div>
         <% end %>

--- a/spec/models/prompt_spec.rb
+++ b/spec/models/prompt_spec.rb
@@ -61,6 +61,25 @@ RSpec.describe Prompt do
       expect(prompt).not_to be_valid
       expect(prompt.errors[:project]).to include("must belong to the same account")
     end
+
+    it "rejects a pending review version as current_version" do
+      prompt = create(:prompt, :global, :with_version)
+      pending = prompt.create_pending_version!(template: "Pending")
+
+      prompt.current_version = pending
+
+      expect(prompt).not_to be_valid
+      expect(prompt.errors[:current_version]).to include("must be approved before it can become active")
+    end
+
+    it "allows an approved review version as current_version" do
+      prompt = create(:prompt, :global, :with_version)
+      approved = prompt.create_pending_version!(template: "Approved", review_status: "approved")
+
+      prompt.current_version = approved
+
+      expect(prompt).to be_valid
+    end
   end
 
   describe "scopes" do

--- a/spec/models/prompt_version_spec.rb
+++ b/spec/models/prompt_version_spec.rb
@@ -124,13 +124,14 @@ RSpec.describe PromptVersion do
     end
 
     it "scopes activatable versions to unreviewed and approved records" do
-      pending = create(:prompt_version, :pending_review, prompt: prompt, version: 1)
+      pending_v = create(:prompt_version, :pending_review, prompt: prompt, version: 1)
       approved = create(:prompt_version, :approved, prompt: prompt, version: 2)
       rejected = create(:prompt_version, :rejected, prompt: prompt, version: 3)
       unreviewed = create(:prompt_version, prompt: prompt, version: 4)
 
-      expect(described_class.activatable).to contain_exactly(approved, unreviewed)
-      expect(described_class.activatable).not_to include(pending, rejected)
+      activatable = prompt.prompt_versions.activatable
+      expect(activatable).to contain_exactly(approved, unreviewed)
+      expect(activatable).not_to include(pending_v, rejected)
     end
 
     it "allows review fields to be updated after creation" do

--- a/spec/models/prompt_version_spec.rb
+++ b/spec/models/prompt_version_spec.rb
@@ -123,6 +123,16 @@ RSpec.describe PromptVersion do
       expect(described_class.rejected).to contain_exactly(rejected)
     end
 
+    it "scopes activatable versions to unreviewed and approved records" do
+      pending = create(:prompt_version, :pending_review, prompt: prompt, version: 1)
+      approved = create(:prompt_version, :approved, prompt: prompt, version: 2)
+      rejected = create(:prompt_version, :rejected, prompt: prompt, version: 3)
+      unreviewed = create(:prompt_version, prompt: prompt, version: 4)
+
+      expect(described_class.activatable).to contain_exactly(approved, unreviewed)
+      expect(described_class.activatable).not_to include(pending, rejected)
+    end
+
     it "allows review fields to be updated after creation" do
       version = create(:prompt_version, :pending_review, prompt: prompt, version: 1)
       user = create(:user)
@@ -132,6 +142,18 @@ RSpec.describe PromptVersion do
       version.review_notes = "Good enough"
       version.review_status = "approved"
       expect(version).to be_valid
+    end
+
+    it "treats only approved or unreviewed versions as activatable" do
+      pending = create(:prompt_version, :pending_review, prompt: prompt, version: 1)
+      approved = create(:prompt_version, :approved, prompt: prompt, version: 2)
+      rejected = create(:prompt_version, :rejected, prompt: prompt, version: 3)
+      unreviewed = create(:prompt_version, prompt: prompt, version: 4)
+
+      expect(pending).not_to be_activatable
+      expect(rejected).not_to be_activatable
+      expect(approved).to be_activatable
+      expect(unreviewed).to be_activatable
     end
   end
 

--- a/spec/requests/ab_tests_spec.rb
+++ b/spec/requests/ab_tests_spec.rb
@@ -123,6 +123,19 @@ RSpec.describe "AbTests" do
         get prompt_ab_test_path(prompt, ab_test)
         expect(response.body).to include("Promote Winner")
       end
+
+      it "shows review queue action for gated winners awaiting approval" do
+        prompt.update!(requires_review: true)
+        ab_test = create(:ab_test, prompt: prompt, status: "completed", completed_at: Time.current)
+        version = prompt.create_pending_version!(template: "Candidate {{title}}")
+        variant = create(:ab_test_variant, ab_test: ab_test, prompt_version: version)
+        ab_test.update!(winner_variant: variant)
+
+        get prompt_ab_test_path(prompt, ab_test)
+
+        expect(response.body).to include("Queue Winner for Review")
+        expect(response.body).to include("pending review")
+      end
     end
   end
 
@@ -315,6 +328,22 @@ RSpec.describe "AbTests" do
         post promote_prompt_ab_test_path(prompt, ab_test)
         expect(response).to redirect_to(prompt_ab_test_path(prompt, ab_test))
         expect(flash[:alert]).to be_present
+      end
+
+      it "queues the winner for review instead of promoting when the prompt requires review" do
+        prompt.update!(requires_review: true)
+        ab_test = create(:ab_test, prompt: prompt, status: "completed", completed_at: Time.current)
+        version = prompt.create_pending_version!(template: "Candidate {{title}}")
+        variant = create(:ab_test_variant, ab_test: ab_test, prompt_version: version)
+        ab_test.update!(winner_variant: variant)
+        original_version = prompt.current_version
+
+        post promote_prompt_ab_test_path(prompt, ab_test)
+
+        expect(prompt.reload.current_version).to eq(original_version)
+        expect(version.reload).to be_pending_review
+        expect(response).to redirect_to(prompt_ab_test_path(prompt, ab_test))
+        expect(flash[:notice]).to include("queued for review")
       end
     end
 

--- a/spec/services/prompt_evolution/select_spec.rb
+++ b/spec/services/prompt_evolution/select_spec.rb
@@ -377,6 +377,20 @@ RSpec.describe PromptEvolution::Select do
       expect(result.fitness.keys).to contain_exactly(v2.id)
     end
 
+    it "excludes pending review versions from selection and promotion" do
+      v2 = add_version(parent: v1)
+      v2.update!(review_status: "pending")
+
+      add_metrics(v1, scores: [ 0.5, 0.52, 0.48 ])
+      add_metrics(v2, scores: [ 0.95, 0.94, 0.96 ])
+
+      result = described_class.call(prompt: prompt, retirement_threshold: 0.0)
+
+      expect(result.winner).to eq(v1)
+      expect(result.fitness.keys).to contain_exactly(v1.id)
+      expect(prompt.reload.current_version).to eq(v1)
+    end
+
     it "builds a generation map from the parent_version chain" do
       v2 = add_version(parent: v1)
       v3 = add_version(parent: v2)


### PR DESCRIPTION
## Summary

Implemented the review gate enforcement and committed it as `6c83efc` with `feat(strategy): enforce human review before activating evolved winners`.

The change adds an activation guard so `Prompt.current_version` cannot point at pending or rejected review candidates, updates prompt evolution selection to ignore non-activatable versions, and fixes the A/B winner flow/UI so gated winners are queued for review instead of being described as promoted. Coverage was added for the blocked promotion path plus the approve/reject/supersede lifecycle.

Verified with `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent bin/rails db:prepare`, `bundle exec rubocop`, and `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent bundle exec rspec`. The repo is clean with no uncommitted changes.

---

Closes #1759