### PR TITLE
feat(optimization): create configuration bundle schema

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -32,6 +32,7 @@ class Account < ApplicationRecord
   has_many :chat_sessions, dependent: :destroy
   has_many :quality_thresholds, dependent: :destroy
   has_many :exception_incidents, dependent: :destroy
+  has_many :configuration_bundles, dependent: :destroy
 
   validates :name, presence: true
   validates :plan, presence: true, inclusion: { in: PLANS }

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -99,6 +99,7 @@ class AgentRun < ApplicationRecord
   has_many :token_usages, dependent: :destroy
   has_many :ab_test_assignments, dependent: :destroy
   has_many :configuration_experiment_assignments, dependent: :destroy
+  has_many :bundle_outcomes, dependent: :destroy
   has_many :container_metrics, dependent: :delete_all
   has_many :quality_metrics, dependent: :destroy
   has_many :orchestration_decisions, dependent: :nullify

--- a/app/models/bundle_outcome.rb
+++ b/app/models/bundle_outcome.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BundleOutcome < ApplicationRecord
+  belongs_to :configuration_bundle
+  belongs_to :agent_run
+
+  validates :agent_run_id, uniqueness: { scope: :configuration_bundle_id }
+  validates :quality_score, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }, allow_nil: true
+  validates :duration_seconds, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :cost_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :tokens_used, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+end

--- a/app/models/bundle_outcome.rb
+++ b/app/models/bundle_outcome.rb
@@ -9,4 +9,14 @@ class BundleOutcome < ApplicationRecord
   validates :duration_seconds, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :cost_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :tokens_used, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :agent_run_matches_bundle_scope, if: -> { configuration_bundle.present? && agent_run.present? }
+
+  private
+
+  def agent_run_matches_bundle_scope
+    return if agent_run.project.account_id == configuration_bundle.account_id &&
+      (configuration_bundle.project_id.nil? || agent_run.project_id == configuration_bundle.project_id)
+
+    errors.add(:agent_run, "must belong to the same account and project scope as the configuration bundle")
+  end
 end

--- a/app/models/configuration_bundle.rb
+++ b/app/models/configuration_bundle.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class ConfigurationBundle < ApplicationRecord
+  STATUSES = %w[draft active retired].freeze
+
+  belongs_to :account
+  belongs_to :project, optional: true
+  belongs_to :prompt_version, optional: true
+  belongs_to :llm_model, optional: true
+
+  has_many :bundle_outcomes, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :version, presence: true,
+    numericality: { only_integer: true, greater_than: 0 },
+    uniqueness: { scope: [ :account_id, :project_id ] }
+  validates :strategy, length: { maximum: 100 }, allow_nil: true
+  validates :fingerprint, length: { maximum: 64 }, uniqueness: true, allow_nil: true
+  validate :project_belongs_to_account, if: -> { project.present? && account.present? }
+
+  scope :draft, -> { where(status: "draft") }
+  scope :active, -> { where(status: "active") }
+  scope :retired, -> { where(status: "retired") }
+
+  def activate!
+    with_lock do
+      reload
+      raise_invalid_transition!("activate", "draft") unless draft?
+
+      update!(status: "active", activated_at: Time.current)
+    end
+  end
+
+  def retire!
+    with_lock do
+      reload
+      raise_invalid_transition!("retire", "active") unless active?
+
+      update!(status: "retired", retired_at: Time.current)
+    end
+  end
+
+  def draft?
+    status == "draft"
+  end
+
+  def active?
+    status == "active"
+  end
+
+  def retired?
+    status == "retired"
+  end
+
+  def avg_quality_score
+    bundle_outcomes.average(:quality_score)
+  end
+
+  def success_rate
+    total = bundle_outcomes.count
+    return nil if total.zero?
+
+    bundle_outcomes.where(success: true).count.to_f / total
+  end
+
+  private
+
+  def raise_invalid_transition!(action, required_status)
+    errors.add(:base, "cannot #{action} a bundle that is #{status} (must be #{required_status})")
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def project_belongs_to_account
+    return if project.account_id == account_id
+
+    errors.add(:project, "must belong to the same account")
+  end
+end

--- a/app/models/configuration_bundle.rb
+++ b/app/models/configuration_bundle.rb
@@ -18,6 +18,7 @@ class ConfigurationBundle < ApplicationRecord
   validates :strategy, length: { maximum: 100 }, allow_nil: true
   validates :fingerprint, length: { maximum: 64 }, uniqueness: { scope: :account_id }, allow_nil: true
   validate :project_belongs_to_account, if: -> { project.present? && account.present? }
+  validate :prompt_version_matches_scope, if: -> { prompt_version.present? }
 
   scope :draft, -> { where(status: "draft") }
   scope :active, -> { where(status: "active") }
@@ -85,5 +86,14 @@ class ConfigurationBundle < ApplicationRecord
     return if project.account_id == account_id
 
     errors.add(:project, "must belong to the same account")
+  end
+
+  def prompt_version_matches_scope
+    prompt = prompt_version.prompt
+    return if prompt.global?
+    return if prompt.account_level? && prompt.account_id == account_id
+    return if prompt.project_level? && prompt.account_id == account_id && prompt.project_id == project_id
+
+    errors.add(:prompt_version, "must match the bundle account/project scope")
   end
 end

--- a/app/models/configuration_bundle.rb
+++ b/app/models/configuration_bundle.rb
@@ -13,8 +13,8 @@ class ConfigurationBundle < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :version, presence: true,
-    numericality: { only_integer: true, greater_than: 0 },
-    uniqueness: { scope: [ :account_id, :project_id ] }
+    numericality: { only_integer: true, greater_than: 0 }
+  validate :version_unique_for_scope
   validates :strategy, length: { maximum: 100 }, allow_nil: true
   validates :fingerprint, length: { maximum: 64 }, uniqueness: true, allow_nil: true
   validate :project_belongs_to_account, if: -> { project.present? && account.present? }
@@ -58,10 +58,10 @@ class ConfigurationBundle < ApplicationRecord
   end
 
   def success_rate
-    total = bundle_outcomes.count
-    return nil if total.zero?
+    total, successful = bundle_outcomes.pick(Arel.sql("COUNT(*), COUNT(*) FILTER (WHERE success)"))
+    return nil if total.nil? || total.zero?
 
-    bundle_outcomes.where(success: true).count.to_f / total
+    successful.to_f / total
   end
 
   private
@@ -69,6 +69,16 @@ class ConfigurationBundle < ApplicationRecord
   def raise_invalid_transition!(action, required_status)
     errors.add(:base, "cannot #{action} a bundle that is #{status} (must be #{required_status})")
     raise ActiveRecord::RecordInvalid, self
+  end
+
+  def version_unique_for_scope
+    return if version.blank? || account_id.blank?
+
+    scope = self.class.where(account_id: account_id, version: version)
+    scope = project_id.nil? ? scope.where(project_id: nil) : scope.where(project_id: project_id)
+    scope = scope.where.not(id: id) if persisted?
+
+    errors.add(:version, :taken) if scope.exists?
   end
 
   def project_belongs_to_account

--- a/app/models/configuration_bundle.rb
+++ b/app/models/configuration_bundle.rb
@@ -16,7 +16,7 @@ class ConfigurationBundle < ApplicationRecord
     numericality: { only_integer: true, greater_than: 0 }
   validate :version_unique_for_scope
   validates :strategy, length: { maximum: 100 }, allow_nil: true
-  validates :fingerprint, length: { maximum: 64 }, uniqueness: true, allow_nil: true
+  validates :fingerprint, length: { maximum: 64 }, uniqueness: { scope: :account_id }, allow_nil: true
   validate :project_belongs_to_account, if: -> { project.present? && account.present? }
 
   scope :draft, -> { where(status: "draft") }

--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -6,6 +6,7 @@ class LlmModel < ApplicationRecord
   TIERS = %w[low mid high].freeze
 
   has_many :model_selections, dependent: :restrict_with_error
+  has_many :configuration_bundles, dependent: :nullify
 
   validates :model_id, presence: true, uniqueness: true
   validates :display_name, presence: true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -169,6 +169,7 @@ class Project < ApplicationRecord
   has_many :quality_pause_events, dependent: :destroy
   has_many :knowledge_recommendations, dependent: :destroy
   has_many :exception_incidents, dependent: :nullify
+  has_many :configuration_bundles, dependent: :destroy
 
   encrypts :webhook_secret
 

--- a/app/models/prompt_version.rb
+++ b/app/models/prompt_version.rb
@@ -14,6 +14,7 @@ class PromptVersion < ApplicationRecord
   has_many :ab_test_variants, dependent: :restrict_with_error
   has_many :quality_metrics, dependent: :nullify
   has_many :llm_output_metrics, dependent: :nullify
+  has_many :configuration_bundles, dependent: :nullify
 
   validates :version, presence: true,
     numericality: { only_integer: true, greater_than: 0 },

--- a/db/migrate/20260421162139_enable_tenant_row_level_security.rb
+++ b/db/migrate/20260421162139_enable_tenant_row_level_security.rb
@@ -596,6 +596,9 @@ class EnableTenantRowLevelSecurity < ActiveRecord::Migration[8.1]
       "service_container_metrics",
       "knowledge_usage_stats",
       # Added by a later migration but depends on the same tenant helper functions.
+      "configuration_bundles",
+      "bundle_outcomes",
+      # Added by later migrations but depend on the same tenant helper functions.
       "orchestration_decisions",
       "token_usages",
       "tracker_configurations",

--- a/db/migrate/20260508014445_create_configuration_bundles.rb
+++ b/db/migrate/20260508014445_create_configuration_bundles.rb
@@ -49,9 +49,14 @@ class CreateConfigurationBundles < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
+    add_index :configuration_bundles, [ :account_id, :version ],
+      unique: true,
+      where: "project_id IS NULL",
+      name: "index_config_bundles_unique_version_account"
     add_index :configuration_bundles, [ :account_id, :project_id, :version ],
       unique: true,
-      name: "index_config_bundles_unique_version"
+      where: "project_id IS NOT NULL",
+      name: "index_config_bundles_unique_version_project"
     add_index :configuration_bundles, [ :account_id, :status ],
       name: "index_config_bundles_on_account_status"
     add_index :configuration_bundles, [ :project_id, :status ],
@@ -67,5 +72,44 @@ class CreateConfigurationBundles < ActiveRecord::Migration[8.1]
       name: "index_bundle_outcomes_unique_run"
     add_index :bundle_outcomes, :quality_score
     add_index :bundle_outcomes, :success
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          ALTER TABLE configuration_bundles ENABLE ROW LEVEL SECURITY;
+          ALTER TABLE configuration_bundles FORCE ROW LEVEL SECURITY;
+          CREATE POLICY tenant_isolation ON configuration_bundles
+            USING (paid_tenant_bypass() OR (configuration_bundles.account_id = paid_current_account_id()))
+            WITH CHECK (paid_tenant_bypass() OR (configuration_bundles.account_id = paid_current_account_id()));
+
+          ALTER TABLE bundle_outcomes ENABLE ROW LEVEL SECURITY;
+          ALTER TABLE bundle_outcomes FORCE ROW LEVEL SECURITY;
+          CREATE POLICY tenant_isolation ON bundle_outcomes
+            USING (
+              paid_tenant_bypass() OR EXISTS (
+                SELECT 1 FROM configuration_bundles
+                WHERE configuration_bundles.id = bundle_outcomes.configuration_bundle_id
+                  AND configuration_bundles.account_id = paid_current_account_id()
+              )
+            )
+            WITH CHECK (
+              paid_tenant_bypass() OR EXISTS (
+                SELECT 1 FROM configuration_bundles
+                WHERE configuration_bundles.id = bundle_outcomes.configuration_bundle_id
+                  AND configuration_bundles.account_id = paid_current_account_id()
+              )
+            );
+        SQL
+      end
+
+      dir.down do
+        execute "DROP POLICY IF EXISTS tenant_isolation ON bundle_outcomes"
+        execute "ALTER TABLE bundle_outcomes NO FORCE ROW LEVEL SECURITY"
+        execute "ALTER TABLE bundle_outcomes DISABLE ROW LEVEL SECURITY"
+        execute "DROP POLICY IF EXISTS tenant_isolation ON configuration_bundles"
+        execute "ALTER TABLE configuration_bundles NO FORCE ROW LEVEL SECURITY"
+        execute "ALTER TABLE configuration_bundles DISABLE ROW LEVEL SECURITY"
+      end
+    end
   end
 end

--- a/db/migrate/20260508014445_create_configuration_bundles.rb
+++ b/db/migrate/20260508014445_create_configuration_bundles.rb
@@ -61,7 +61,7 @@ class CreateConfigurationBundles < ActiveRecord::Migration[8.1]
       name: "index_config_bundles_on_account_status"
     add_index :configuration_bundles, [ :project_id, :status ],
       name: "index_config_bundles_on_project_status"
-    add_index :configuration_bundles, :fingerprint,
+    add_index :configuration_bundles, [ :account_id, :fingerprint ],
       unique: true,
       where: "fingerprint IS NOT NULL",
       name: "index_config_bundles_unique_fingerprint"

--- a/db/migrate/20260508014445_create_configuration_bundles.rb
+++ b/db/migrate/20260508014445_create_configuration_bundles.rb
@@ -90,6 +90,11 @@ class CreateConfigurationBundles < ActiveRecord::Migration[8.1]
                 SELECT 1 FROM configuration_bundles
                 WHERE configuration_bundles.id = bundle_outcomes.configuration_bundle_id
                   AND configuration_bundles.account_id = paid_current_account_id()
+              ) AND EXISTS (
+                SELECT 1 FROM agent_runs
+                INNER JOIN projects ON projects.id = agent_runs.project_id
+                WHERE agent_runs.id = bundle_outcomes.agent_run_id
+                  AND projects.account_id = paid_current_account_id()
               )
             )
             WITH CHECK (
@@ -97,6 +102,11 @@ class CreateConfigurationBundles < ActiveRecord::Migration[8.1]
                 SELECT 1 FROM configuration_bundles
                 WHERE configuration_bundles.id = bundle_outcomes.configuration_bundle_id
                   AND configuration_bundles.account_id = paid_current_account_id()
+              ) AND EXISTS (
+                SELECT 1 FROM agent_runs
+                INNER JOIN projects ON projects.id = agent_runs.project_id
+                WHERE agent_runs.id = bundle_outcomes.agent_run_id
+                  AND projects.account_id = paid_current_account_id()
               )
             );
         SQL

--- a/db/migrate/20260508014445_create_configuration_bundles.rb
+++ b/db/migrate/20260508014445_create_configuration_bundles.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class CreateConfigurationBundles < ActiveRecord::Migration[8.1]
+  def change
+    create_table :configuration_bundles, comment: "Versioned snapshots of configuration components used for agent runs" do |t|
+      t.references :account, null: false, foreign_key: { on_delete: :cascade }
+      t.references :project, foreign_key: { on_delete: :cascade },
+        comment: "Optional project scope; NULL means account-wide bundle"
+      t.references :prompt_version, foreign_key: { on_delete: :nullify },
+        comment: "The prompt template version included in this bundle"
+      t.references :llm_model, foreign_key: { on_delete: :nullify },
+        comment: "The LLM model included in this bundle"
+      t.integer :version, null: false, default: 1,
+        comment: "Monotonic version number within the account/project scope"
+      t.string :name, null: false, limit: 255
+      t.text :description
+      t.string :status, null: false, default: "draft", limit: 50,
+        comment: "Lifecycle state: draft, active, retired"
+      t.string :strategy, limit: 100,
+        comment: "Orchestration strategy identifier (e.g. single_agent, multi_agent)"
+      t.jsonb :strategy_params, null: false, default: {},
+        comment: "Strategy-specific parameters (concurrency, escalation thresholds, etc.)"
+      t.jsonb :context, null: false, default: {},
+        comment: "Additional context such as guardrails, token budgets, or feature flags"
+      t.string :fingerprint, limit: 64,
+        comment: "Content-addressable hash for deduplication"
+      t.datetime :activated_at, comment: "When the bundle was promoted to active"
+      t.datetime :retired_at, comment: "When the bundle was retired"
+
+      t.timestamps
+    end
+
+    create_table :bundle_outcomes, comment: "Measured results from using a configuration bundle on an agent run" do |t|
+      t.references :configuration_bundle, null: false, foreign_key: { on_delete: :cascade }
+      t.references :agent_run, null: false, foreign_key: { on_delete: :cascade }
+      t.decimal :quality_score, precision: 5, scale: 4,
+        comment: "Overall quality score (0.0-1.0)"
+      t.integer :duration_seconds,
+        comment: "Wall-clock time for the agent run"
+      t.integer :cost_cents,
+        comment: "Total cost of the agent run in cents"
+      t.integer :tokens_used,
+        comment: "Total tokens (input + output) consumed"
+      t.boolean :success, null: false, default: false,
+        comment: "Whether the agent run completed successfully"
+      t.jsonb :metrics, null: false, default: {},
+        comment: "Additional outcome metrics (lines changed, test pass rate, etc.)"
+
+      t.timestamps
+    end
+
+    add_index :configuration_bundles, [ :account_id, :project_id, :version ],
+      unique: true,
+      name: "index_config_bundles_unique_version"
+    add_index :configuration_bundles, [ :account_id, :status ],
+      name: "index_config_bundles_on_account_status"
+    add_index :configuration_bundles, [ :project_id, :status ],
+      name: "index_config_bundles_on_project_status"
+    add_index :configuration_bundles, :fingerprint,
+      unique: true,
+      where: "fingerprint IS NOT NULL",
+      name: "index_config_bundles_unique_fingerprint"
+    add_index :configuration_bundles, :status
+
+    add_index :bundle_outcomes, [ :configuration_bundle_id, :agent_run_id ],
+      unique: true,
+      name: "index_bundle_outcomes_unique_run"
+    add_index :bundle_outcomes, :quality_score
+    add_index :bundle_outcomes, :success
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7557,7 +7557,7 @@ CREATE INDEX index_config_bundles_on_project_status ON public.configuration_bund
 -- Name: index_config_bundles_unique_fingerprint; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_config_bundles_unique_fingerprint ON public.configuration_bundles USING btree (fingerprint) WHERE (fingerprint IS NOT NULL);
+CREATE UNIQUE INDEX index_config_bundles_unique_fingerprint ON public.configuration_bundles USING btree (account_id, fingerprint) WHERE (fingerprint IS NOT NULL);
 
 
 --
@@ -12657,4 +12657,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260128004342'),
 ('20260128004305'),
 ('20260127154444');
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -822,6 +822,8 @@ CREATE TABLE public.bundle_outcomes (
     updated_at timestamp(6) without time zone NOT NULL
 );
 
+ALTER TABLE ONLY public.bundle_outcomes FORCE ROW LEVEL SECURITY;
+
 
 --
 -- Name: TABLE bundle_outcomes; Type: COMMENT; Schema: public; Owner: -
@@ -1082,6 +1084,8 @@ CREATE TABLE public.configuration_bundles (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
+
+ALTER TABLE ONLY public.configuration_bundles FORCE ROW LEVEL SECURITY;
 
 
 --
@@ -11000,6 +11004,12 @@ ALTER TABLE public.billing_periods ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.billing_plans ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: bundle_outcomes; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.bundle_outcomes ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: chat_messages; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -11022,6 +11032,12 @@ ALTER TABLE public.chat_sessions ENABLE ROW LEVEL SECURITY;
 --
 
 ALTER TABLE public.collector_runs ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: configuration_bundles; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.configuration_bundles ENABLE ROW LEVEL SECURITY;
 
 --
 -- Name: container_metrics; Type: ROW SECURITY; Schema: public; Owner: -
@@ -11473,6 +11489,23 @@ CREATE POLICY tenant_isolation ON public.billing_plans USING ((public.paid_tenan
 
 
 --
+-- Name: bundle_outcomes tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.bundle_outcomes USING ((public.paid_tenant_bypass() OR ((EXISTS ( SELECT 1
+   FROM public.configuration_bundles
+  WHERE ((configuration_bundles.id = bundle_outcomes.configuration_bundle_id) AND (configuration_bundles.account_id = public.paid_current_account_id())))) AND (EXISTS ( SELECT 1
+   FROM (public.agent_runs
+     JOIN public.projects ON ((projects.id = agent_runs.project_id)))
+  WHERE ((agent_runs.id = bundle_outcomes.agent_run_id) AND (projects.account_id = public.paid_current_account_id()))))))) WITH CHECK ((public.paid_tenant_bypass() OR ((EXISTS ( SELECT 1
+   FROM public.configuration_bundles
+  WHERE ((configuration_bundles.id = bundle_outcomes.configuration_bundle_id) AND (configuration_bundles.account_id = public.paid_current_account_id())))) AND (EXISTS ( SELECT 1
+   FROM (public.agent_runs
+     JOIN public.projects ON ((projects.id = agent_runs.project_id)))
+  WHERE ((agent_runs.id = bundle_outcomes.agent_run_id) AND (projects.account_id = public.paid_current_account_id())))))));
+
+
+--
 -- Name: chat_messages tenant_isolation; Type: POLICY; Schema: public; Owner: -
 --
 
@@ -11532,6 +11565,13 @@ CREATE POLICY tenant_isolation ON public.collector_runs USING ((public.paid_tena
    FROM (public.project_versions
      JOIN public.projects ON ((projects.id = project_versions.project_id)))
   WHERE ((project_versions.id = collector_runs.project_version_id) AND (projects.account_id = public.paid_current_account_id()))))));
+
+
+--
+-- Name: configuration_bundles tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation ON public.configuration_bundles USING ((public.paid_tenant_bypass() OR (account_id = public.paid_current_account_id()))) WITH CHECK ((public.paid_tenant_bypass() OR (account_id = public.paid_current_account_id())));
 
 
 --
@@ -12796,3 +12836,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260128004342'),
 ('20260128004305'),
 ('20260127154444');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -805,6 +805,93 @@ ALTER SEQUENCE public.billing_plans_id_seq OWNED BY public.billing_plans.id;
 
 
 --
+-- Name: bundle_outcomes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.bundle_outcomes (
+    id bigint NOT NULL,
+    configuration_bundle_id bigint NOT NULL,
+    agent_run_id bigint NOT NULL,
+    quality_score numeric(5,4),
+    duration_seconds integer,
+    cost_cents integer,
+    tokens_used integer,
+    success boolean DEFAULT false NOT NULL,
+    metrics jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE bundle_outcomes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.bundle_outcomes IS 'Measured results from using a configuration bundle on an agent run';
+
+
+--
+-- Name: COLUMN bundle_outcomes.quality_score; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.bundle_outcomes.quality_score IS 'Overall quality score (0.0-1.0)';
+
+
+--
+-- Name: COLUMN bundle_outcomes.duration_seconds; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.bundle_outcomes.duration_seconds IS 'Wall-clock time for the agent run';
+
+
+--
+-- Name: COLUMN bundle_outcomes.cost_cents; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.bundle_outcomes.cost_cents IS 'Total cost of the agent run in cents';
+
+
+--
+-- Name: COLUMN bundle_outcomes.tokens_used; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.bundle_outcomes.tokens_used IS 'Total tokens (input + output) consumed';
+
+
+--
+-- Name: COLUMN bundle_outcomes.success; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.bundle_outcomes.success IS 'Whether the agent run completed successfully';
+
+
+--
+-- Name: COLUMN bundle_outcomes.metrics; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.bundle_outcomes.metrics IS 'Additional outcome metrics (lines changed, test pass rate, etc.)';
+
+
+--
+-- Name: bundle_outcomes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.bundle_outcomes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: bundle_outcomes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.bundle_outcomes_id_seq OWNED BY public.bundle_outcomes.id;
+
+
+--
 -- Name: chat_messages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -970,6 +1057,134 @@ CREATE SEQUENCE public.collector_runs_id_seq
 --
 
 ALTER SEQUENCE public.collector_runs_id_seq OWNED BY public.collector_runs.id;
+
+
+--
+-- Name: configuration_bundles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.configuration_bundles (
+    id bigint NOT NULL,
+    account_id bigint NOT NULL,
+    project_id bigint,
+    prompt_version_id bigint,
+    llm_model_id bigint,
+    version integer DEFAULT 1 NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    status character varying(50) DEFAULT 'draft'::character varying NOT NULL,
+    strategy character varying(100),
+    strategy_params jsonb DEFAULT '{}'::jsonb NOT NULL,
+    context jsonb DEFAULT '{}'::jsonb NOT NULL,
+    fingerprint character varying(64),
+    activated_at timestamp(6) without time zone,
+    retired_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE configuration_bundles; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.configuration_bundles IS 'Versioned snapshots of configuration components used for agent runs';
+
+
+--
+-- Name: COLUMN configuration_bundles.project_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.project_id IS 'Optional project scope; NULL means account-wide bundle';
+
+
+--
+-- Name: COLUMN configuration_bundles.prompt_version_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.prompt_version_id IS 'The prompt template version included in this bundle';
+
+
+--
+-- Name: COLUMN configuration_bundles.llm_model_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.llm_model_id IS 'The LLM model included in this bundle';
+
+
+--
+-- Name: COLUMN configuration_bundles.version; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.version IS 'Monotonic version number within the account/project scope';
+
+
+--
+-- Name: COLUMN configuration_bundles.status; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.status IS 'Lifecycle state: draft, active, retired';
+
+
+--
+-- Name: COLUMN configuration_bundles.strategy; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.strategy IS 'Orchestration strategy identifier (e.g. single_agent, multi_agent)';
+
+
+--
+-- Name: COLUMN configuration_bundles.strategy_params; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.strategy_params IS 'Strategy-specific parameters (concurrency, escalation thresholds, etc.)';
+
+
+--
+-- Name: COLUMN configuration_bundles.context; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.context IS 'Additional context such as guardrails, token budgets, or feature flags';
+
+
+--
+-- Name: COLUMN configuration_bundles.fingerprint; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.fingerprint IS 'Content-addressable hash for deduplication';
+
+
+--
+-- Name: COLUMN configuration_bundles.activated_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.activated_at IS 'When the bundle was promoted to active';
+
+
+--
+-- Name: COLUMN configuration_bundles.retired_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.configuration_bundles.retired_at IS 'When the bundle was retired';
+
+
+--
+-- Name: configuration_bundles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.configuration_bundles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: configuration_bundles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.configuration_bundles_id_seq OWNED BY public.configuration_bundles.id;
 
 
 --
@@ -3572,13 +3787,6 @@ COMMENT ON COLUMN public.projects.completed_agent_runs_count IS 'Counter cache f
 
 
 --
--- Name: COLUMN projects.last_issue_reconciliation_at; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.projects.last_issue_reconciliation_at IS 'Timestamp of the last issue state reconciliation against GitHub';
-
-
---
 -- Name: COLUMN projects.screenshot_settings; Type: COMMENT; Schema: public; Owner: -
 --
 
@@ -4884,6 +5092,13 @@ ALTER TABLE ONLY public.billing_plans ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: bundle_outcomes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bundle_outcomes ALTER COLUMN id SET DEFAULT nextval('public.bundle_outcomes_id_seq'::regclass);
+
+
+--
 -- Name: chat_messages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4909,6 +5124,13 @@ ALTER TABLE ONLY public.chat_sessions ALTER COLUMN id SET DEFAULT nextval('publi
 --
 
 ALTER TABLE ONLY public.collector_runs ALTER COLUMN id SET DEFAULT nextval('public.collector_runs_id_seq'::regclass);
+
+
+--
+-- Name: configuration_bundles id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.configuration_bundles ALTER COLUMN id SET DEFAULT nextval('public.configuration_bundles_id_seq'::regclass);
 
 
 --
@@ -5480,6 +5702,14 @@ ALTER TABLE ONLY public.billing_plans
 
 
 --
+-- Name: bundle_outcomes bundle_outcomes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bundle_outcomes
+    ADD CONSTRAINT bundle_outcomes_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: chat_messages chat_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5509,6 +5739,14 @@ ALTER TABLE ONLY public.chat_sessions
 
 ALTER TABLE ONLY public.collector_runs
     ADD CONSTRAINT collector_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: configuration_bundles configuration_bundles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.configuration_bundles
+    ADD CONSTRAINT configuration_bundles_pkey PRIMARY KEY (id);
 
 
 --
@@ -6920,6 +7158,41 @@ CREATE INDEX index_billing_plans_on_account_id_and_active ON public.billing_plan
 
 
 --
+-- Name: index_bundle_outcomes_on_agent_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bundle_outcomes_on_agent_run_id ON public.bundle_outcomes USING btree (agent_run_id);
+
+
+--
+-- Name: index_bundle_outcomes_on_configuration_bundle_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bundle_outcomes_on_configuration_bundle_id ON public.bundle_outcomes USING btree (configuration_bundle_id);
+
+
+--
+-- Name: index_bundle_outcomes_on_quality_score; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bundle_outcomes_on_quality_score ON public.bundle_outcomes USING btree (quality_score);
+
+
+--
+-- Name: index_bundle_outcomes_on_success; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bundle_outcomes_on_success ON public.bundle_outcomes USING btree (success);
+
+
+--
+-- Name: index_bundle_outcomes_unique_run; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_bundle_outcomes_unique_run ON public.bundle_outcomes USING btree (configuration_bundle_id, agent_run_id);
+
+
+--
 -- Name: index_chat_messages_on_chat_session_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7046,6 +7319,34 @@ CREATE INDEX index_collector_runs_on_status ON public.collector_runs USING btree
 
 
 --
+-- Name: index_config_bundles_on_account_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_config_bundles_on_account_status ON public.configuration_bundles USING btree (account_id, status);
+
+
+--
+-- Name: index_config_bundles_on_project_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_config_bundles_on_project_status ON public.configuration_bundles USING btree (project_id, status);
+
+
+--
+-- Name: index_config_bundles_unique_fingerprint; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_config_bundles_unique_fingerprint ON public.configuration_bundles USING btree (fingerprint) WHERE (fingerprint IS NOT NULL);
+
+
+--
+-- Name: index_config_bundles_unique_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_config_bundles_unique_version ON public.configuration_bundles USING btree (account_id, project_id, version);
+
+
+--
 -- Name: index_config_experiment_assignments_unique; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7071,6 +7372,41 @@ CREATE UNIQUE INDEX index_config_experiment_variants_one_control ON public.confi
 --
 
 CREATE UNIQUE INDEX index_config_experiments_one_running_per_account_key ON public.configuration_experiments USING btree (account_id, config_key) WHERE (((status)::text = 'running'::text) AND (account_id IS NOT NULL));
+
+
+--
+-- Name: index_configuration_bundles_on_account_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_configuration_bundles_on_account_id ON public.configuration_bundles USING btree (account_id);
+
+
+--
+-- Name: index_configuration_bundles_on_llm_model_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_configuration_bundles_on_llm_model_id ON public.configuration_bundles USING btree (llm_model_id);
+
+
+--
+-- Name: index_configuration_bundles_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_configuration_bundles_on_project_id ON public.configuration_bundles USING btree (project_id);
+
+
+--
+-- Name: index_configuration_bundles_on_prompt_version_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_configuration_bundles_on_prompt_version_id ON public.configuration_bundles USING btree (prompt_version_id);
+
+
+--
+-- Name: index_configuration_bundles_on_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_configuration_bundles_on_status ON public.configuration_bundles USING btree (status);
 
 
 --
@@ -8937,6 +9273,14 @@ ALTER TABLE ONLY public.agent_runs
 
 
 --
+-- Name: bundle_outcomes fk_rails_0b74105583; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bundle_outcomes
+    ADD CONSTRAINT fk_rails_0b74105583 FOREIGN KEY (agent_run_id) REFERENCES public.agent_runs(id) ON DELETE CASCADE;
+
+
+--
 -- Name: agent_coordination_signals fk_rails_0e200247b7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9094,6 +9438,14 @@ ALTER TABLE ONLY public.configuration_experiments
 
 ALTER TABLE ONLY public.token_usages
     ADD CONSTRAINT fk_rails_2e5496eeab FOREIGN KEY (knowledge_run_id) REFERENCES public.knowledge_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: configuration_bundles fk_rails_305af63fff; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.configuration_bundles
+    ADD CONSTRAINT fk_rails_305af63fff FOREIGN KEY (prompt_version_id) REFERENCES public.prompt_versions(id) ON DELETE SET NULL;
 
 
 --
@@ -9369,6 +9721,14 @@ ALTER TABLE ONLY public.provider_states
 
 
 --
+-- Name: bundle_outcomes fk_rails_77962f38a2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bundle_outcomes
+    ADD CONSTRAINT fk_rails_77962f38a2 FOREIGN KEY (configuration_bundle_id) REFERENCES public.configuration_bundles(id) ON DELETE CASCADE;
+
+
+--
 -- Name: pr_templates fk_rails_7ac0951baa; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9521,6 +9881,14 @@ ALTER TABLE ONLY public.prompts
 
 
 --
+-- Name: configuration_bundles fk_rails_9ae9fd1826; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.configuration_bundles
+    ADD CONSTRAINT fk_rails_9ae9fd1826 FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
 -- Name: chat_sessions fk_rails_9b5b542892; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9537,6 +9905,14 @@ ALTER TABLE ONLY public.quality_thresholds
 
 
 --
+-- Name: configuration_bundles fk_rails_9c1905c6a8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.configuration_bundles
+    ADD CONSTRAINT fk_rails_9c1905c6a8 FOREIGN KEY (account_id) REFERENCES public.accounts(id) ON DELETE CASCADE;
+
+
+--
 -- Name: prompt_versions fk_rails_9e0a501722; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9550,6 +9926,14 @@ ALTER TABLE ONLY public.prompt_versions
 
 ALTER TABLE ONLY public.ab_test_variants
     ADD CONSTRAINT fk_rails_9fad431770 FOREIGN KEY (ab_test_id) REFERENCES public.ab_tests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: configuration_bundles fk_rails_a150076ed9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.configuration_bundles
+    ADD CONSTRAINT fk_rails_a150076ed9 FOREIGN KEY (llm_model_id) REFERENCES public.llm_models(id) ON DELETE SET NULL;
 
 
 --
@@ -11632,6 +12016,7 @@ ALTER TABLE public.worktrees ENABLE ROW LEVEL SECURITY;
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260508014445'),
 ('20260507164917'),
 ('20260507125050'),
 ('20260507011753'),

--- a/spec/factories/bundle_outcomes.rb
+++ b/spec/factories/bundle_outcomes.rb
@@ -3,7 +3,12 @@
 FactoryBot.define do
   factory :bundle_outcome do
     configuration_bundle
-    agent_run
+    agent_run do
+      scoped_project = configuration_bundle.project || association(:project, account: configuration_bundle.account)
+      association :agent_run,
+        project: scoped_project,
+        issue: association(:issue, project: scoped_project)
+    end
     quality_score { 0.85 }
     duration_seconds { 120 }
     cost_cents { 50 }

--- a/spec/factories/bundle_outcomes.rb
+++ b/spec/factories/bundle_outcomes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bundle_outcome do
+    configuration_bundle
+    agent_run
+    quality_score { 0.85 }
+    duration_seconds { 120 }
+    cost_cents { 50 }
+    tokens_used { 5000 }
+    success { true }
+    metrics { {} }
+  end
+end

--- a/spec/factories/configuration_bundles.rb
+++ b/spec/factories/configuration_bundles.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :configuration_bundle do
+    account
+    sequence(:name) { |n| "Configuration Bundle #{n}" }
+    version { 1 }
+    status { "draft" }
+    strategy { "single_agent" }
+    strategy_params { {} }
+    context { {} }
+  end
+end

--- a/spec/migrations/add_account_to_service_containers_spec.rb
+++ b/spec/migrations/add_account_to_service_containers_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
 
     if tenant_policy_count.positive?
       strategy_experiments_rls_migration.down if strategy_experiment_tables_have_rls?
-      orchestration_decisions_migration.down if orchestration_decisions_have_rls?
+      orchestration_decisions_migration.down if orchestration_decisions_table_exists?
       disable_decomposition_decisions_rls if decomposition_decisions_have_rls?
-      exception_incidents_migration.down if exception_incidents_have_rls?
+      exception_incidents_migration.down if exception_incidents_table_exists?
       issue_merge_subscriptions_rls_migration.down if issue_merge_subscriptions_have_rls?
       knowledge_recommendations_rls_migration.down if knowledge_recommendations_has_rls?
       chat_rls_migration.down if chat_tables_have_rls?
@@ -52,8 +52,8 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
       chat_rls_migration.up unless chat_tables_have_rls?
       knowledge_recommendations_rls_migration.up unless knowledge_recommendations_has_rls?
       issue_merge_subscriptions_rls_migration.up unless issue_merge_subscriptions_have_rls?
-      exception_incidents_migration.up unless exception_incidents_have_rls?
-      orchestration_decisions_migration.up unless orchestration_decisions_have_rls?
+      exception_incidents_migration.up unless exception_incidents_table_exists?
+      orchestration_decisions_migration.up unless orchestration_decisions_table_exists?
       strategy_experiments_rls_migration.up unless strategy_experiment_tables_have_rls?
     end
     ServiceContainer.reset_column_information
@@ -256,6 +256,10 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     ).to_i.positive?
   end
 
+  def exception_incidents_table_exists?
+    ActiveRecord::Base.connection.table_exists?(:exception_incidents)
+  end
+
   def decomposition_decisions_have_rls?
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'decomposition_decisions' AND policyname = 'tenant_isolation'"
@@ -272,6 +276,10 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'orchestration_decisions' AND policyname = 'tenant_isolation'"
     ).to_i.positive?
+  end
+
+  def orchestration_decisions_table_exists?
+    ActiveRecord::Base.connection.table_exists?(:orchestration_decisions)
   end
 
   def tenant_policy_count

--- a/spec/models/bundle_outcome_spec.rb
+++ b/spec/models/bundle_outcome_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BundleOutcome do
+  describe "associations" do
+    it { is_expected.to belong_to(:configuration_bundle) }
+    it { is_expected.to belong_to(:agent_run) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_numericality_of(:quality_score).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(1).allow_nil }
+    it { is_expected.to validate_numericality_of(:duration_seconds).only_integer.is_greater_than_or_equal_to(0).allow_nil }
+    it { is_expected.to validate_numericality_of(:cost_cents).only_integer.is_greater_than_or_equal_to(0).allow_nil }
+    it { is_expected.to validate_numericality_of(:tokens_used).only_integer.is_greater_than_or_equal_to(0).allow_nil }
+
+    it "enforces uniqueness of agent_run scoped to configuration_bundle" do
+      outcome = create(:bundle_outcome)
+      duplicate = build(:bundle_outcome,
+        configuration_bundle: outcome.configuration_bundle,
+        agent_run: outcome.agent_run)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:agent_run_id]).to be_present
+    end
+  end
+end

--- a/spec/models/bundle_outcome_spec.rb
+++ b/spec/models/bundle_outcome_spec.rb
@@ -23,5 +23,26 @@ RSpec.describe BundleOutcome do
       expect(duplicate).not_to be_valid
       expect(duplicate.errors[:agent_run_id]).to be_present
     end
+
+    it "requires the agent run to stay within the bundle account" do
+      outcome = build(:bundle_outcome)
+      other_project = create(:project)
+      outcome.agent_run = build(:agent_run, project: other_project, issue: build(:issue, project: other_project))
+
+      expect(outcome).not_to be_valid
+      expect(outcome.errors[:agent_run]).to include("must belong to the same account and project scope as the configuration bundle")
+    end
+
+    it "requires project-scoped bundles to use runs from the same project" do
+      project = create(:project)
+      bundle = build(:configuration_bundle, account: project.account, project: project)
+      other_project = create(:project, account: project.account)
+      outcome = build(:bundle_outcome,
+        configuration_bundle: bundle,
+        agent_run: build(:agent_run, project: other_project, issue: build(:issue, project: other_project)))
+
+      expect(outcome).not_to be_valid
+      expect(outcome.errors[:agent_run]).to include("must belong to the same account and project scope as the configuration bundle")
+    end
   end
 end

--- a/spec/models/configuration_bundle_spec.rb
+++ b/spec/models/configuration_bundle_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConfigurationBundle do
+  describe "associations" do
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:project).optional }
+    it { is_expected.to belong_to(:prompt_version).optional }
+    it { is_expected.to belong_to(:llm_model).optional }
+    it { is_expected.to have_many(:bundle_outcomes).dependent(:destroy) }
+  end
+
+  describe "validations" do
+    subject { build(:configuration_bundle) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(255) }
+    it { is_expected.to validate_presence_of(:status) }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+    it { is_expected.to validate_presence_of(:version) }
+    it { is_expected.to validate_numericality_of(:version).only_integer.is_greater_than(0) }
+    it { is_expected.to validate_length_of(:strategy).is_at_most(100) }
+
+    it "validates version uniqueness scoped to account and project" do
+      bundle = create(:configuration_bundle)
+      duplicate = build(:configuration_bundle, account: bundle.account, project: bundle.project, version: bundle.version)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:version]).to be_present
+    end
+
+    it "allows same version for different projects" do
+      account = create(:account)
+      project_a = create(:project, account: account)
+      project_b = create(:project, account: account)
+      create(:configuration_bundle, account: account, project: project_a, version: 1)
+
+      bundle = build(:configuration_bundle, account: account, project: project_b, version: 1)
+      expect(bundle).to be_valid
+    end
+
+    it "validates project belongs to account" do
+      other_account = create(:account)
+      project = create(:project, account: other_account)
+      bundle = build(:configuration_bundle, project: project)
+
+      expect(bundle).not_to be_valid
+      expect(bundle.errors[:project]).to include("must belong to the same account")
+    end
+  end
+
+  describe "scopes" do
+    it "filters by status" do
+      draft = create(:configuration_bundle, status: "draft")
+      active = create(:configuration_bundle, status: "active", activated_at: Time.current)
+      retired = create(:configuration_bundle, status: "retired", retired_at: Time.current)
+
+      expect(described_class.draft).to contain_exactly(draft)
+      expect(described_class.active).to contain_exactly(active)
+      expect(described_class.retired).to contain_exactly(retired)
+    end
+  end
+
+  describe "#activate!" do
+    it "transitions a draft bundle to active" do
+      bundle = create(:configuration_bundle, status: "draft")
+
+      bundle.activate!
+
+      expect(bundle.status).to eq("active")
+      expect(bundle.activated_at).to be_present
+    end
+
+    it "raises when not in draft status" do
+      bundle = create(:configuration_bundle, status: "active", activated_at: Time.current)
+
+      expect { bundle.activate! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe "#retire!" do
+    it "transitions an active bundle to retired" do
+      bundle = create(:configuration_bundle, status: "active", activated_at: Time.current)
+
+      bundle.retire!
+
+      expect(bundle.status).to eq("retired")
+      expect(bundle.retired_at).to be_present
+    end
+
+    it "raises when not in active status" do
+      bundle = create(:configuration_bundle, status: "draft")
+
+      expect { bundle.retire! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe "#avg_quality_score" do
+    it "returns the average quality score of outcomes" do
+      bundle = create(:configuration_bundle)
+      create(:bundle_outcome, configuration_bundle: bundle, quality_score: 0.8)
+      create(:bundle_outcome, configuration_bundle: bundle, quality_score: 0.6)
+
+      expect(bundle.avg_quality_score).to eq(0.7)
+    end
+
+    it "returns nil when no outcomes exist" do
+      bundle = create(:configuration_bundle)
+
+      expect(bundle.avg_quality_score).to be_nil
+    end
+  end
+
+  describe "#success_rate" do
+    it "returns the ratio of successful outcomes" do
+      bundle = create(:configuration_bundle)
+      create(:bundle_outcome, configuration_bundle: bundle, success: true)
+      create(:bundle_outcome, configuration_bundle: bundle, success: true)
+      create(:bundle_outcome, configuration_bundle: bundle, success: false)
+
+      expect(bundle.success_rate).to be_within(0.001).of(0.667)
+    end
+
+    it "returns nil when no outcomes exist" do
+      bundle = create(:configuration_bundle)
+
+      expect(bundle.success_rate).to be_nil
+    end
+  end
+end

--- a/spec/models/configuration_bundle_spec.rb
+++ b/spec/models/configuration_bundle_spec.rb
@@ -67,6 +67,34 @@ RSpec.describe ConfigurationBundle do
       expect(bundle).not_to be_valid
       expect(bundle.errors[:project]).to include("must belong to the same account")
     end
+
+    it "allows a global prompt version for any bundle scope" do
+      prompt = create(:prompt, :global)
+      prompt_version = create(:prompt_version, prompt: prompt)
+      project = create(:project)
+
+      expect(build(:configuration_bundle, prompt_version: prompt_version)).to be_valid
+      expect(build(:configuration_bundle, account: project.account, project: project, prompt_version: prompt_version)).to be_valid
+    end
+
+    it "requires account-scoped prompt versions to match the bundle account" do
+      prompt = create(:prompt, :for_account)
+      prompt_version = create(:prompt_version, prompt: prompt)
+      bundle = build(:configuration_bundle, prompt_version: prompt_version)
+
+      expect(bundle).not_to be_valid
+      expect(bundle.errors[:prompt_version]).to include("must match the bundle account/project scope")
+    end
+
+    it "requires project-scoped prompt versions to match the bundle project" do
+      bundle_project = create(:project)
+      prompt = create(:prompt, project: create(:project, account: bundle_project.account), account: bundle_project.account)
+      prompt_version = create(:prompt_version, prompt: prompt)
+      bundle = build(:configuration_bundle, account: bundle_project.account, project: bundle_project, prompt_version: prompt_version)
+
+      expect(bundle).not_to be_valid
+      expect(bundle.errors[:prompt_version]).to include("must match the bundle account/project scope")
+    end
   end
 
   describe "scopes" do

--- a/spec/models/configuration_bundle_spec.rb
+++ b/spec/models/configuration_bundle_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe ConfigurationBundle do
       expect(duplicate.errors[:version]).to be_present
     end
 
+    it "prevents duplicate versions for account-level bundles (nil project)" do
+      account = create(:account)
+      create(:configuration_bundle, account: account, project: nil, version: 1)
+
+      duplicate = build(:configuration_bundle, account: account, project: nil, version: 1)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:version]).to be_present
+    end
+
     it "allows same version for different projects" do
       account = create(:account)
       project_a = create(:project, account: account)

--- a/spec/models/configuration_bundle_spec.rb
+++ b/spec/models/configuration_bundle_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe ConfigurationBundle do
     it { is_expected.to validate_numericality_of(:version).only_integer.is_greater_than(0) }
     it { is_expected.to validate_length_of(:strategy).is_at_most(100) }
 
+    it "validates fingerprint uniqueness within an account" do
+      bundle = create(:configuration_bundle, fingerprint: "shared-fingerprint")
+      duplicate = build(:configuration_bundle, account: bundle.account, fingerprint: bundle.fingerprint)
+      other_account_bundle = build(:configuration_bundle, fingerprint: bundle.fingerprint)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:fingerprint]).to be_present
+      expect(other_account_bundle).to be_valid
+    end
+
     it "validates version uniqueness scoped to account and project" do
       bundle = create(:configuration_bundle)
       duplicate = build(:configuration_bundle, account: bundle.account, project: bundle.project, version: bundle.version)

--- a/spec/security/tenant_context_spec.rb
+++ b/spec/security/tenant_context_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe TenantContext, :tenant_isolation do
   def install_tenant_policies
     ActiveRecord::Migration.suppress_messages do
       EnableRlsOnStrategyExperimentTables.new.down if strategy_experiment_tables_have_rls?
-      CreateOrchestrationDecisions.new.down if orchestration_decisions_have_rls?
+      CreateOrchestrationDecisions.new.down if orchestration_decisions_table_exists?
       disable_decomposition_decisions_rls if decomposition_decisions_have_rls?
       CreateExceptionIncidents.new.down if exception_incidents_have_rls?
       EnableRlsOnKnowledgeRecommendations.new.down if knowledge_recommendations_has_rls?
@@ -190,8 +190,8 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnChatTables.new.up unless chat_tables_have_rls?
       EnableRlsOnKnowledgeRecommendations.new.up unless knowledge_recommendations_has_rls?
       EnableRlsOnIssueMergeSubscriptions.new.up unless issue_merge_subscriptions_has_rls?
-      CreateExceptionIncidents.new.up unless exception_incidents_have_rls?
-      CreateOrchestrationDecisions.new.up unless orchestration_decisions_have_rls?
+      CreateExceptionIncidents.new.up unless exception_incidents_table_exists?
+      CreateOrchestrationDecisions.new.up unless orchestration_decisions_table_exists?
       EnableRlsOnStrategyExperimentTables.new.up unless strategy_experiment_tables_have_rls?
     end
     ActiveRecord::Base.connection.execute("RESET ROLE")
@@ -208,7 +208,7 @@ RSpec.describe TenantContext, :tenant_isolation do
     cleanup_restricted_role
     ActiveRecord::Migration.suppress_messages do
       EnableRlsOnStrategyExperimentTables.new.down if strategy_experiment_tables_have_rls?
-      CreateOrchestrationDecisions.new.down if orchestration_decisions_have_rls?
+      CreateOrchestrationDecisions.new.down if orchestration_decisions_table_exists?
       disable_decomposition_decisions_rls if decomposition_decisions_have_rls?
       CreateExceptionIncidents.new.down if exception_incidents_have_rls?
       EnableRlsOnKnowledgeRecommendations.new.down if knowledge_recommendations_has_rls?
@@ -257,6 +257,10 @@ RSpec.describe TenantContext, :tenant_isolation do
     ).to_i.positive?
   end
 
+  def exception_incidents_table_exists?
+    ActiveRecord::Base.connection.table_exists?(:exception_incidents)
+  end
+
   def decomposition_decisions_have_rls?
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'decomposition_decisions' AND policyname = 'tenant_isolation'"
@@ -273,6 +277,10 @@ RSpec.describe TenantContext, :tenant_isolation do
     ActiveRecord::Base.connection.select_value(
       "SELECT COUNT(*) FROM pg_policies WHERE tablename = 'orchestration_decisions' AND policyname = 'tenant_isolation'"
     ).to_i.positive?
+  end
+
+  def orchestration_decisions_table_exists?
+    ActiveRecord::Base.connection.table_exists?(:orchestration_decisions)
   end
 
   def strategy_experiment_tables_have_rls?


### PR DESCRIPTION
## Summary

OK

Commit succeeded. Here's what was done:

**Migration** (`db/migrate/20260508014445_create_configuration_bundles.rb`):
- `configuration_bundles` table with references to `accounts`, `projects`, `prompt_versions`, and `llm_models`, plus fields for version, name, status, strategy, strategy_params (JSONB), context (JSONB), and fingerprint
- `bundle_outcomes` table linking bundles to agent runs with quality_score, duration, cost, tokens, success flag, and metrics (JSONB)
- Indexes for version uniqueness (scoped to account+project), status filtering, fingerprint deduplication, and outcome uniqueness per bundle+run

**Models**:
- `ConfigurationBundle` with status lifecycle (draft → active → retired), scopes, and aggregate methods (`avg_quality_score`, `success_rate`)
- `BundleOutcome` with validations on all numeric fields

**Associations** added to existing models:
- `Account`, `Project` → `has_many :configuration_bundles`
- `AgentRun` → `has_many :bundle_outcomes`
- `PromptVersion`, `LlmModel` → `has_many :configuration_bundles`

**Specs**: 31 examples, 0 failures — covering associations, validations, scopes, state transitions, and aggregate calculations.

---

Closes #1761