### PR TITLE
feat(strategy): implement context-aware strategy selection

### DIFF
--- a/app/services/automation/pull_request_evaluator.rb
+++ b/app/services/automation/pull_request_evaluator.rb
@@ -39,7 +39,10 @@ module Automation
       metadata[:lifecycle] = lifecycle if lifecycle
 
       context = Context.build(record: record, project: project, metadata: metadata)
-      Strategies::AutoContinue.new.evaluate(context)
+      Strategies::Select.call(
+        strategy_type: :auto_continue,
+        project: project
+      ).evaluate(context)
     end
   end
 end

--- a/app/services/automation/strategies/auto_continue.rb
+++ b/app/services/automation/strategies/auto_continue.rb
@@ -63,7 +63,7 @@ module Automation
         return noop_result if signals.scan.nil?
 
         review_context = context.with_metadata(scan: signals.scan)
-        Strategies::AutoReview.new.evaluate(review_context)
+        auto_review_strategy(context).evaluate(review_context)
       end
 
       private
@@ -137,7 +137,14 @@ module Automation
       end
 
       def delegate_to_auto_review(context)
-        Strategies::AutoReview.new.evaluate(context)
+        auto_review_strategy(context).evaluate(context)
+      end
+
+      def auto_review_strategy(context)
+        Strategies::Select.call(
+          strategy_type: :auto_review,
+          project: context.project
+        )
       end
     end
   end

--- a/app/services/automation/strategies/null_strategy.rb
+++ b/app/services/automation/strategies/null_strategy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Automation
+  module Strategies
+    # Safe fallback strategy that always returns a noop result.
+    #
+    # Used by {Select} when no registration matches the requested
+    # strategy type at any scope and no built-in default exists.
+    # Ensures callers never receive +nil+ from the selection service.
+    class NullStrategy
+      include Automation::Strategy
+
+      def evaluate(_context)
+        noop_result
+      end
+    end
+  end
+end

--- a/app/services/automation/strategies/registry.rb
+++ b/app/services/automation/strategies/registry.rb
@@ -102,9 +102,10 @@ module Automation
       end
 
       def find_account(ctx)
-        return nil unless ctx.account
+        account_id = ctx.account_id || ctx.account&.id
+        return nil unless account_id
 
-        @account[[ ctx.strategy_type, ctx.account.id ]]
+        @account[[ ctx.strategy_type, account_id ]]
       end
 
       def find_global(ctx)

--- a/app/services/automation/strategies/registry.rb
+++ b/app/services/automation/strategies/registry.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Automation
+  module Strategies
+    # Thread-safe registry of strategy classes keyed by scope.
+    #
+    # Strategies can be registered at four scope levels, checked in
+    # descending precedence during lookup:
+    #
+    #   1. +:task+    — keyed by (strategy_type, task_type)
+    #   2. +:project+ — keyed by (strategy_type, project_id)
+    #   3. +:account+ — keyed by (strategy_type, account_id)
+    #   4. +:global+  — keyed by (strategy_type)
+    #
+    # Each registration stores the strategy class and an optional hash of
+    # constructor keyword arguments, so the caller gets a ready-to-use
+    # strategy instance from {#resolve}.
+    class Registry
+      Registration = Data.define(:strategy_class, :constructor_args)
+
+      def initialize
+        @mutex = Mutex.new
+        @global = {}
+        @account = {}
+        @project = {}
+        @task = {}
+      end
+
+      # Register a strategy at the global scope (lowest precedence).
+      def register_global(strategy_type, strategy_class, **constructor_args)
+        @mutex.synchronize do
+          @global[strategy_type.to_s] = Registration.new(
+            strategy_class: strategy_class,
+            constructor_args: constructor_args
+          )
+        end
+      end
+
+      # Register a strategy scoped to a specific account.
+      def register_account(strategy_type, account_id, strategy_class, **constructor_args)
+        @mutex.synchronize do
+          @account[[ strategy_type.to_s, account_id ]] = Registration.new(
+            strategy_class: strategy_class,
+            constructor_args: constructor_args
+          )
+        end
+      end
+
+      # Register a strategy scoped to a specific project.
+      def register_project(strategy_type, project_id, strategy_class, **constructor_args)
+        @mutex.synchronize do
+          @project[[ strategy_type.to_s, project_id ]] = Registration.new(
+            strategy_class: strategy_class,
+            constructor_args: constructor_args
+          )
+        end
+      end
+
+      # Register a strategy scoped to a specific task type.
+      def register_task(strategy_type, task_type, strategy_class, **constructor_args)
+        @mutex.synchronize do
+          @task[[ strategy_type.to_s, task_type.to_s ]] = Registration.new(
+            strategy_class: strategy_class,
+            constructor_args: constructor_args
+          )
+        end
+      end
+
+      # Look up the highest-precedence registration for the given
+      # {SelectionContext}. Returns +nil+ when nothing matches.
+      def resolve(selection_context)
+        @mutex.synchronize do
+          find_task(selection_context) ||
+            find_project(selection_context) ||
+            find_account(selection_context) ||
+            find_global(selection_context)
+        end
+      end
+
+      # Remove all registrations. Primarily useful in tests.
+      def clear!
+        @mutex.synchronize do
+          @global.clear
+          @account.clear
+          @project.clear
+          @task.clear
+        end
+      end
+
+      private
+
+      def find_task(ctx)
+        return nil unless ctx.task_type
+
+        @task[[ ctx.strategy_type, ctx.task_type ]]
+      end
+
+      def find_project(ctx)
+        return nil unless ctx.project
+
+        @project[[ ctx.strategy_type, ctx.project.id ]]
+      end
+
+      def find_account(ctx)
+        return nil unless ctx.account
+
+        @account[[ ctx.strategy_type, ctx.account.id ]]
+      end
+
+      def find_global(ctx)
+        @global[ctx.strategy_type]
+      end
+    end
+  end
+end

--- a/app/services/automation/strategies/select.rb
+++ b/app/services/automation/strategies/select.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Automation
+  module Strategies
+    # Selects a strategy instance based on project, task, and runtime
+    # context. Implements a four-tier precedence lookup (task → project →
+    # account → global) with a safe fallback to built-in defaults when
+    # no specialized registration matches.
+    #
+    # == Usage
+    #
+    #   strategy = Automation::Strategies::Select.call(
+    #     strategy_type: :auto_pick,
+    #     project: project
+    #   )
+    #   result = strategy.evaluate(context)
+    #
+    # == Fallback behavior
+    #
+    # When the registry has no registration for the requested
+    # +strategy_type+ at any scope, the service falls back to the
+    # built-in default strategies. If no default exists either, it
+    # returns a +NullStrategy+ that always produces a noop result,
+    # ensuring callers never receive +nil+.
+    class Select
+      DEFAULTS = {
+        "auto_pick" => AutoPick,
+        "auto_continue" => AutoContinue,
+        "auto_review" => AutoReview,
+        "auto_merge" => AutoMerge
+      }.freeze
+
+      attr_reader :strategy_type, :project, :account, :task_type, :metadata
+
+      def initialize(strategy_type:, project: nil, account: nil, task_type: nil, metadata: nil, registry: nil)
+        @strategy_type = strategy_type.to_s
+        @project = project
+        @account = account
+        @task_type = task_type
+        @metadata = metadata
+        @registry = registry
+      end
+
+      def self.call(**args)
+        new(**args).call
+      end
+
+      # Returns a strategy instance ready for +#evaluate(context)+.
+      def call
+        selection_context = SelectionContext.build(
+          strategy_type: strategy_type,
+          project: project,
+          account: account,
+          task_type: task_type,
+          metadata: metadata
+        )
+
+        registration = resolve_registration(selection_context)
+        instantiate(registration)
+      end
+
+      private
+
+      def resolve_registration(selection_context)
+        registry.resolve(selection_context)
+      end
+
+      def registry
+        @registry || self.class.default_registry
+      end
+
+      def instantiate(registration)
+        if registration
+          registration.strategy_class.new(**registration.constructor_args)
+        else
+          fallback_instance
+        end
+      end
+
+      def fallback_instance
+        klass = DEFAULTS[strategy_type]
+        return NullStrategy.new unless klass
+
+        klass.new
+      end
+
+      class << self
+        def default_registry
+          @default_registry ||= build_default_registry
+        end
+
+        # Replace the default registry. Returns the previous registry
+        # so callers can restore it (useful in tests).
+        def default_registry=(registry)
+          @default_registry = registry
+        end
+
+        # Reset to built-in defaults. Primarily useful in tests.
+        def reset_default_registry!
+          @default_registry = build_default_registry
+        end
+
+        private
+
+        def build_default_registry
+          Registry.new.tap do |r|
+            DEFAULTS.each do |type, klass|
+              r.register_global(type, klass)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/automation/strategies/select.rb
+++ b/app/services/automation/strategies/select.rb
@@ -89,10 +89,12 @@ module Automation
           @default_registry ||= build_default_registry
         end
 
-        # Replace the default registry. Returns the previous registry
+        # Replace the default registry and return the previous one
         # so callers can restore it (useful in tests).
-        def default_registry=(registry)
+        def swap_default_registry(registry)
+          previous_registry = default_registry
           @default_registry = registry
+          previous_registry
         end
 
         # Reset to built-in defaults. Primarily useful in tests.

--- a/app/services/automation/strategies/selection_context.rb
+++ b/app/services/automation/strategies/selection_context.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Automation
+  module Strategies
+    # Encodes the inputs used to select a strategy version.
+    #
+    # Selection precedence (highest to lowest):
+    #   1. Task-specific  — matches on +strategy_type+ and +task_type+
+    #   2. Project-specific — matches on +strategy_type+ and +project+
+    #   3. Account-specific — matches on +strategy_type+ and +account+
+    #   4. Global default  — matches on +strategy_type+ only
+    #
+    # +metadata+ carries optional runtime signals (e.g. issue complexity,
+    # language, test coverage) that registrations can use for finer-grained
+    # matching in future iterations.
+    class SelectionContext < Data.define(:strategy_type, :project, :account, :task_type, :metadata)
+      EMPTY_METADATA = {}.freeze
+
+      def self.build(strategy_type:, project: nil, account: nil, task_type: nil, metadata: nil)
+        account ||= project&.respond_to?(:account) ? project.account : nil
+
+        new(
+          strategy_type: strategy_type.to_s,
+          project: project,
+          account: account,
+          task_type: task_type&.to_s,
+          metadata: (metadata || EMPTY_METADATA).freeze
+        )
+      end
+    end
+  end
+end

--- a/app/services/automation/strategies/selection_context.rb
+++ b/app/services/automation/strategies/selection_context.rb
@@ -13,19 +13,36 @@ module Automation
     # +metadata+ carries optional runtime signals (e.g. issue complexity,
     # language, test coverage) that registrations can use for finer-grained
     # matching in future iterations.
-    class SelectionContext < Data.define(:strategy_type, :project, :account, :task_type, :metadata)
+    class SelectionContext < Data.define(:strategy_type, :project, :account, :account_id, :task_type, :metadata)
       EMPTY_METADATA = {}.freeze
 
       def self.build(strategy_type:, project: nil, account: nil, task_type: nil, metadata: nil)
-        account ||= project&.respond_to?(:account) ? project.account : nil
+        account_id = account&.id || account_id_from(project)
+        account ||= loaded_project_account(project)
 
         new(
           strategy_type: strategy_type.to_s,
           project: project,
           account: account,
+          account_id: account_id,
           task_type: task_type&.to_s,
           metadata: (metadata || EMPTY_METADATA).freeze
         )
+      end
+
+      def self.account_id_from(project)
+        return unless project&.respond_to?(:account_id)
+
+        project.account_id
+      end
+
+      def self.loaded_project_account(project)
+        return unless project&.respond_to?(:association)
+
+        association = project.association(:account)
+        return unless association.loaded?
+
+        project.account
       end
     end
   end

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -109,7 +109,10 @@ module Issues
     private
 
     def strategy
-      @strategy ||= Automation::Strategies::AutoPick.new
+      @strategy ||= Automation::Strategies::Select.call(
+        strategy_type: :auto_pick,
+        project: @project
+      )
     end
 
     def should_sync_blocking_parent_reviews?

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -2387,7 +2387,10 @@ module Activities
         project: project,
         metadata: { Automation::Strategies::AutoMerge::SIGNALS_KEY => signals }
       )
-      result = Automation::Strategies::AutoMerge.new.evaluate(context)
+      result = Automation::Strategies::Select.call(
+        strategy_type: :auto_merge,
+        project: project
+      ).evaluate(context)
       result.decisions.any? { |d| d.type == "merge" }
     end
 

--- a/spec/services/automation/pull_request_evaluator_spec.rb
+++ b/spec/services/automation/pull_request_evaluator_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe Automation::PullRequestEvaluator do
       expect(result.to_h).to eq(decisions: [ { type: "noop" } ])
     end
 
+    it "selects auto-continue through Automation::Strategies::Select for explicit PR decisions" do
+      selected_strategy = instance_double(Automation::Strategies::AutoContinue)
+      result = Automation::Result.noop
+
+      allow(Automation::Strategies::Select).to receive(:call)
+        .with(strategy_type: :auto_continue, project: project)
+        .and_return(selected_strategy)
+      allow(selected_strategy).to receive(:evaluate).and_return(result)
+
+      described_class.new(record: pull_request, explicit_pr_decisions: true).call(
+        scan: { issue_id: pull_request.id, pr_number: 42, phase: "ready", triggers: [] }
+      )
+
+      expect(Automation::Strategies::Select).to have_received(:call)
+        .with(strategy_type: :auto_continue, project: project)
+      expect(selected_strategy).to have_received(:evaluate).with(
+        have_attributes(project: project, record: pull_request)
+      )
+    end
+
     it "maps paid_agent review signals to an explicit review decision" do
       result = described_class.new(record: pull_request, explicit_pr_decisions: true).call(scan: {
         issue_id: pull_request.id,

--- a/spec/services/automation/strategies/auto_continue_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_spec.rb
@@ -26,18 +26,44 @@ RSpec.describe Automation::Strategies::AutoContinue do
     result.to_h[:decisions].map { |d| d[:type] }
   end
 
+  def ready_scan_payload
+    {
+      issue_id: pull_request.id,
+      pr_number: 42,
+      phase: "ready",
+      triggers: []
+    }
+  end
+
   it "is an Automation::Strategy" do
     expect(described_class.ancestors).to include(Automation::Strategy)
   end
 
   describe "backwards compatibility" do
+    it "selects auto-review through Automation::Strategies::Select when lifecycle signals are absent" do
+      selected_strategy = instance_double(Automation::Strategies::AutoReview)
+      context = Automation::Context.build(
+        record: pull_request,
+        project: project,
+        metadata: { scan: ready_scan_payload }
+      )
+
+      allow(Automation::Strategies::Select).to receive(:call)
+        .with(strategy_type: :auto_review, project: project)
+        .and_return(selected_strategy)
+      allow(selected_strategy).to receive(:evaluate).and_return(Automation::Result.noop)
+
+      strategy.evaluate(context)
+
+      expect(Automation::Strategies::Select).to have_received(:call)
+        .with(strategy_type: :auto_review, project: project)
+      expect(selected_strategy).to have_received(:evaluate).with(
+        have_attributes(project: project, record: pull_request)
+      )
+    end
+
     it "delegates to AutoReview when no lifecycle signals are present" do
-      result = evaluate(scan: {
-        issue_id: pull_request.id,
-        pr_number: 42,
-        phase: "ready",
-        triggers: [ { type: "owner_approved" } ]
-      })
+      result = evaluate(scan: ready_scan_payload.merge(triggers: [ { type: "owner_approved" } ]))
 
       expect(result.to_h[:decisions].first).to include(type: "merge")
     end

--- a/spec/services/automation/strategies/null_strategy_spec.rb
+++ b/spec/services/automation/strategies/null_strategy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Strategies::NullStrategy do
+  subject(:strategy) { described_class.new }
+
+  let(:project) { build_stubbed(:project) }
+
+  describe "#evaluate" do
+    it "returns a noop result for any context" do
+      context = Automation::Context.build(record: nil, project: project, metadata: {})
+
+      result = strategy.evaluate(context)
+
+      expect(result).to be_a(Automation::Result)
+      expect(result.decisions.size).to eq(1)
+      expect(result.decisions.first.type).to eq("noop")
+    end
+  end
+end

--- a/spec/services/automation/strategies/registry_spec.rb
+++ b/spec/services/automation/strategies/registry_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Strategies::Registry do
+  subject(:registry) { described_class.new }
+
+  let(:account) { build_stubbed(:account) }
+  let(:project) { build_stubbed(:project, account: account) }
+
+  let(:global_strategy) { Automation::Strategies::AutoPick }
+  let(:account_strategy) { Automation::Strategies::AutoContinue }
+  let(:project_strategy) { Automation::Strategies::AutoReview }
+  let(:task_strategy) { Automation::Strategies::AutoMerge }
+
+  def build_ctx(strategy_type: "auto_pick", proj: nil, acct: nil, task_type: nil)
+    Automation::Strategies::SelectionContext.build(
+      strategy_type: strategy_type,
+      project: proj,
+      account: acct,
+      task_type: task_type
+    )
+  end
+
+  describe "#resolve" do
+    it "returns nil when nothing is registered" do
+      ctx = build_ctx
+
+      expect(registry.resolve(ctx)).to be_nil
+    end
+
+    it "resolves a global registration" do
+      registry.register_global("auto_pick", global_strategy)
+      ctx = build_ctx
+
+      reg = registry.resolve(ctx)
+
+      expect(reg.strategy_class).to eq(global_strategy)
+    end
+
+    it "resolves an account registration over global" do
+      registry.register_global("auto_pick", global_strategy)
+      registry.register_account("auto_pick", account.id, account_strategy)
+      ctx = build_ctx(acct: account)
+
+      reg = registry.resolve(ctx)
+
+      expect(reg.strategy_class).to eq(account_strategy)
+    end
+
+    it "resolves a project registration over account and global" do
+      registry.register_global("auto_pick", global_strategy)
+      registry.register_account("auto_pick", account.id, account_strategy)
+      registry.register_project("auto_pick", project.id, project_strategy)
+      ctx = build_ctx(proj: project, acct: account)
+
+      reg = registry.resolve(ctx)
+
+      expect(reg.strategy_class).to eq(project_strategy)
+    end
+
+    it "resolves a task registration over all other scopes" do
+      registry.register_global("auto_pick", global_strategy)
+      registry.register_account("auto_pick", account.id, account_strategy)
+      registry.register_project("auto_pick", project.id, project_strategy)
+      registry.register_task("auto_pick", "bug_fix", task_strategy)
+      ctx = build_ctx(proj: project, acct: account, task_type: "bug_fix")
+
+      reg = registry.resolve(ctx)
+
+      expect(reg.strategy_class).to eq(task_strategy)
+    end
+
+    it "falls back to account when project has no registration" do
+      registry.register_global("auto_pick", global_strategy)
+      registry.register_account("auto_pick", account.id, account_strategy)
+      ctx = build_ctx(proj: project, acct: account)
+
+      reg = registry.resolve(ctx)
+
+      expect(reg.strategy_class).to eq(account_strategy)
+    end
+
+    it "falls back to global when no scoped registration matches" do
+      registry.register_global("auto_pick", global_strategy)
+      ctx = build_ctx(proj: project, acct: account, task_type: "feature")
+
+      reg = registry.resolve(ctx)
+
+      expect(reg.strategy_class).to eq(global_strategy)
+    end
+
+    it "preserves constructor args in the registration" do
+      registry.register_global("auto_pick", global_strategy, candidate_source: :custom)
+      ctx = build_ctx
+
+      reg = registry.resolve(ctx)
+
+      expect(reg.constructor_args).to eq({ candidate_source: :custom })
+    end
+
+    it "does not match a different strategy type" do
+      registry.register_global("auto_merge", task_strategy)
+      ctx = build_ctx(strategy_type: "auto_pick")
+
+      expect(registry.resolve(ctx)).to be_nil
+    end
+  end
+
+  describe "#clear!" do
+    it "removes all registrations" do
+      registry.register_global("auto_pick", global_strategy)
+      registry.register_account("auto_pick", account.id, account_strategy)
+      registry.register_project("auto_pick", project.id, project_strategy)
+      registry.register_task("auto_pick", "bug_fix", task_strategy)
+
+      registry.clear!
+
+      ctx = build_ctx(proj: project, acct: account, task_type: "bug_fix")
+      expect(registry.resolve(ctx)).to be_nil
+    end
+  end
+end

--- a/spec/services/automation/strategies/registry_spec.rb
+++ b/spec/services/automation/strategies/registry_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe Automation::Strategies::Registry do
       expect(reg.strategy_class).to eq(global_strategy)
     end
 
+    it "resolves an account registration from project.account_id without an account object" do
+      registry.register_account("auto_pick", account.id, account_strategy)
+      project_without_account = Struct.new(:id, :account_id).new(project.id, account.id)
+      ctx = build_ctx(proj: project_without_account)
+
+      reg = registry.resolve(ctx)
+
+      expect(reg.strategy_class).to eq(account_strategy)
+    end
+
     it "preserves constructor args in the registration" do
       registry.register_global("auto_pick", global_strategy, candidate_source: :custom)
       ctx = build_ctx

--- a/spec/services/automation/strategies/select_spec.rb
+++ b/spec/services/automation/strategies/select_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Strategies::Select do
+  let(:registry) { Automation::Strategies::Registry.new }
+  let(:account) { build_stubbed(:account) }
+  let(:project) { build_stubbed(:project, account: account) }
+
+  def select(**args)
+    described_class.call(registry: registry, **args)
+  end
+
+  describe ".call" do
+    context "with global defaults" do
+      before do
+        registry.register_global("auto_pick", Automation::Strategies::AutoPick)
+        registry.register_global("auto_continue", Automation::Strategies::AutoContinue)
+        registry.register_global("auto_review", Automation::Strategies::AutoReview)
+        registry.register_global("auto_merge", Automation::Strategies::AutoMerge)
+      end
+
+      it "returns the global default for auto_pick" do
+        strategy = select(strategy_type: :auto_pick)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoPick)
+      end
+
+      it "returns the global default for auto_continue" do
+        strategy = select(strategy_type: :auto_continue)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoContinue)
+      end
+
+      it "returns the global default for auto_review" do
+        strategy = select(strategy_type: :auto_review)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoReview)
+      end
+
+      it "returns the global default for auto_merge" do
+        strategy = select(strategy_type: :auto_merge)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoMerge)
+      end
+    end
+
+    context "with account-scoped registration" do
+      it "returns the account-scoped strategy when project belongs to the account" do
+        registry.register_global("auto_pick", Automation::Strategies::AutoPick)
+        registry.register_account("auto_pick", account.id, Automation::Strategies::AutoContinue)
+
+        strategy = select(strategy_type: :auto_pick, project: project)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoContinue)
+      end
+
+      it "falls back to global when the account has no registration" do
+        other_account = build_stubbed(:account)
+        registry.register_global("auto_pick", Automation::Strategies::AutoPick)
+        registry.register_account("auto_pick", other_account.id, Automation::Strategies::AutoContinue)
+
+        strategy = select(strategy_type: :auto_pick, project: project)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoPick)
+      end
+    end
+
+    context "with project-scoped registration" do
+      it "returns the project-scoped strategy" do
+        registry.register_global("auto_pick", Automation::Strategies::AutoPick)
+        registry.register_project("auto_pick", project.id, Automation::Strategies::AutoReview)
+
+        strategy = select(strategy_type: :auto_pick, project: project)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoReview)
+      end
+
+      it "takes precedence over account-scoped registration" do
+        registry.register_account("auto_pick", account.id, Automation::Strategies::AutoContinue)
+        registry.register_project("auto_pick", project.id, Automation::Strategies::AutoReview)
+
+        strategy = select(strategy_type: :auto_pick, project: project)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoReview)
+      end
+    end
+
+    context "with task-scoped registration" do
+      it "returns the task-scoped strategy" do
+        registry.register_global("auto_pick", Automation::Strategies::AutoPick)
+        registry.register_task("auto_pick", "bug_fix", Automation::Strategies::AutoMerge)
+
+        strategy = select(strategy_type: :auto_pick, task_type: :bug_fix)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoMerge)
+      end
+
+      it "takes precedence over project-scoped registration" do
+        registry.register_project("auto_pick", project.id, Automation::Strategies::AutoReview)
+        registry.register_task("auto_pick", "bug_fix", Automation::Strategies::AutoMerge)
+
+        strategy = select(strategy_type: :auto_pick, project: project, task_type: :bug_fix)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoMerge)
+      end
+    end
+
+    context "with constructor args" do
+      it "passes constructor args to the strategy" do
+        source = instance_double(Automation::Strategies::AutoPick::DefaultCandidateSource)
+        registry.register_global("auto_pick", Automation::Strategies::AutoPick, candidate_source: source)
+
+        strategy = select(strategy_type: :auto_pick)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoPick)
+      end
+    end
+
+    context "with no matching registration" do
+      it "falls back to the built-in default when the registry has no match" do
+        strategy = select(strategy_type: :auto_pick)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoPick)
+      end
+
+      it "returns a NullStrategy for an unknown strategy type" do
+        strategy = select(strategy_type: :unknown_strategy)
+
+        expect(strategy).to be_a(Automation::Strategies::NullStrategy)
+      end
+
+      it "NullStrategy returns a noop result" do
+        strategy = select(strategy_type: :unknown_strategy)
+        context = Automation::Context.build(
+          record: nil,
+          project: project,
+          metadata: {}
+        )
+
+        result = strategy.evaluate(context)
+
+        expect(result.decisions.size).to eq(1)
+        expect(result.decisions.first.type).to eq("noop")
+      end
+    end
+  end
+end

--- a/spec/services/automation/strategies/select_spec.rb
+++ b/spec/services/automation/strategies/select_spec.rb
@@ -145,4 +145,20 @@ RSpec.describe Automation::Strategies::Select do
       end
     end
   end
+
+  describe ".swap_default_registry" do
+    after do
+      described_class.reset_default_registry!
+    end
+
+    it "returns the previous registry and installs the new one" do
+      previous_registry = described_class.default_registry
+      replacement_registry = Automation::Strategies::Registry.new
+
+      returned_registry = described_class.swap_default_registry(replacement_registry)
+
+      expect(returned_registry).to be(previous_registry)
+      expect(described_class.default_registry).to be(replacement_registry)
+    end
+  end
 end

--- a/spec/services/automation/strategies/select_spec.rb
+++ b/spec/services/automation/strategies/select_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe Automation::Strategies::Select do
 
         expect(strategy).to be_a(Automation::Strategies::AutoPick)
       end
+
+      it "uses project.account_id without touching project.account" do
+        registry.register_global("auto_pick", Automation::Strategies::AutoPick)
+        registry.register_account("auto_pick", account.id, Automation::Strategies::AutoContinue)
+        project_without_account = Struct.new(:id, :account_id).new(project.id, account.id)
+
+        strategy = select(strategy_type: :auto_pick, project: project_without_account)
+
+        expect(strategy).to be_a(Automation::Strategies::AutoContinue)
+      end
     end
 
     context "with project-scoped registration" do

--- a/spec/services/automation/strategies/selection_context_spec.rb
+++ b/spec/services/automation/strategies/selection_context_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Automation::Strategies::SelectionContext do
       ctx = described_class.build(strategy_type: "auto_pick", project: project)
 
       expect(ctx.account).to eq(account)
+      expect(ctx.account_id).to eq(account.id)
     end
 
     it "uses the explicit account when provided" do
@@ -50,12 +51,23 @@ RSpec.describe Automation::Strategies::SelectionContext do
       )
 
       expect(ctx.account).to eq(account)
+      expect(ctx.account_id).to eq(account.id)
     end
 
     it "leaves account nil when neither project nor account is given" do
       ctx = described_class.build(strategy_type: "auto_pick")
 
       expect(ctx.account).to be_nil
+      expect(ctx.account_id).to be_nil
+    end
+
+    it "derives account_id from project without loading account" do
+      project = Struct.new(:id, :account_id).new(123, 456)
+
+      ctx = described_class.build(strategy_type: "auto_pick", project: project)
+
+      expect(ctx.account).to be_nil
+      expect(ctx.account_id).to eq(456)
     end
   end
 end

--- a/spec/services/automation/strategies/selection_context_spec.rb
+++ b/spec/services/automation/strategies/selection_context_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Automation::Strategies::SelectionContext do
+  describe ".build" do
+    it "normalizes strategy_type to a string" do
+      ctx = described_class.build(strategy_type: :auto_pick)
+
+      expect(ctx.strategy_type).to eq("auto_pick")
+    end
+
+    it "normalizes task_type to a string" do
+      ctx = described_class.build(strategy_type: "auto_pick", task_type: :bug_fix)
+
+      expect(ctx.task_type).to eq("bug_fix")
+    end
+
+    it "freezes metadata" do
+      ctx = described_class.build(strategy_type: "auto_pick", metadata: { lang: "ruby" })
+
+      expect(ctx.metadata).to be_frozen
+    end
+
+    it "defaults metadata to an empty frozen hash" do
+      ctx = described_class.build(strategy_type: "auto_pick")
+
+      expect(ctx.metadata).to eq({})
+      expect(ctx.metadata).to be_frozen
+    end
+
+    it "infers account from project when not explicitly given" do
+      account = build_stubbed(:account)
+      project = build_stubbed(:project, account: account)
+
+      ctx = described_class.build(strategy_type: "auto_pick", project: project)
+
+      expect(ctx.account).to eq(account)
+    end
+
+    it "uses the explicit account when provided" do
+      account = build_stubbed(:account)
+      other_account = build_stubbed(:account)
+      project = build_stubbed(:project, account: other_account)
+
+      ctx = described_class.build(
+        strategy_type: "auto_pick",
+        project: project,
+        account: account
+      )
+
+      expect(ctx.account).to eq(account)
+    end
+
+    it "leaves account nil when neither project nor account is given" do
+      ctx = described_class.build(strategy_type: "auto_pick")
+
+      expect(ctx.account).to be_nil
+    end
+  end
+end

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe Issues::AutoPick do
   let(:project) { create(:project, auto_pick_enabled: true) }
 
   describe "#call" do
+    it "selects the auto-pick strategy through Automation::Strategies::Select" do
+      selected_strategy = instance_double(Automation::Strategies::AutoPick)
+      issue = create(:issue, project: project, github_state: "open")
+      result = Automation::Result.new(decisions: [ Automation::Decision.queue_create_pr_run(issue_id: issue.id) ])
+
+      allow(Automation::Strategies::Select).to receive(:call)
+        .with(strategy_type: :auto_pick, project: project)
+        .and_return(selected_strategy)
+      allow(selected_strategy).to receive(:evaluate).and_return(result)
+
+      described_class.new(project).call
+
+      expect(Automation::Strategies::Select).to have_received(:call)
+        .with(strategy_type: :auto_pick, project: project)
+      expect(selected_strategy).to have_received(:evaluate).with(
+        have_attributes(project: project)
+      )
+    end
+
     it "selects the next unblocked open issue and creates a queued agent run" do
       issue = create(:issue, project: project, github_state: "open")
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -60,6 +60,39 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     allow(Github::ReviewBotInstallationToken).to receive(:configured?).and_return(true)
   end
 
+  describe "#evaluate_auto_merge" do
+    let(:selected_strategy) { instance_double(Automation::Strategies::AutoMerge) }
+    let(:signals) do
+      Automation::Strategies::AutoMerge::Signals.build(
+        issue_id: 123,
+        pr_number: 42,
+        bot_authored: true,
+        dependabot_eligible: true,
+        checks_green: true,
+        mergeable: true
+      )
+    end
+    let(:merge_result) do
+      Automation::Result.new(decisions: [ Automation::Decision.merge(issue_id: 123, pr_number: 42) ])
+    end
+
+    it "selects the auto-merge strategy through Automation::Strategies::Select" do
+      allow(Automation::Strategies::Select).to receive(:call)
+        .with(strategy_type: :auto_merge, project: project)
+        .and_return(selected_strategy)
+      allow(selected_strategy).to receive(:evaluate).and_return(merge_result)
+
+      result = activity.send(:evaluate_auto_merge, project, signals)
+
+      expect(result).to be(true)
+      expect(Automation::Strategies::Select).to have_received(:call)
+        .with(strategy_type: :auto_merge, project: project)
+      expect(selected_strategy).to have_received(:evaluate).with(
+        have_attributes(project: project)
+      )
+    end
+  end
+
   describe "#execute" do
     context "when project is missing" do
       it "returns empty result with project_missing flag" do


### PR DESCRIPTION
## Summary

OK

Commit succeeded. Here's a summary of what was implemented:

**4 new files in `app/services/automation/strategies/`:**

- **`selection_context.rb`** — `Data.define` value object encoding selection inputs (strategy_type, project, account, task_type, metadata) with auto-inference of account from project
- **`registry.rb`** — Thread-safe registry with four scope tiers: task → project → account → global. Stores `Registration` structs (strategy class + constructor args) and resolves by descending precedence
- **`select.rb`** — Service (`Select.call(strategy_type:, project:, ...)`) that builds a `SelectionContext`, queries the registry, and returns a ready-to-use strategy instance. Falls back to built-in defaults (AutoPick/AutoContinue/AutoReview/AutoMerge) or a `NullStrategy`
- **`null_strategy.rb`** — Safe fallback that always returns a noop result, ensuring callers never get `nil`

**4 spec files with 32 examples covering:**
- SelectionContext construction and normalization
- Registry precedence (global < account < project < task)
- Select service end-to-end with all scope levels
- Fallback behavior for unknown strategy types
- Constructor args pass-through

---

Closes #1756