### PR TITLE
feat(orchestration): Phase 4.1 — Orchestration Decision Logging

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -52,7 +52,7 @@ class DashboardController < ApplicationController
   def decision_metrics
     @time_range = valid_time_range
     @decision_metrics = Analytics::OrchestrationDecisions::Report.call(
-      relation: decision_records_scope,
+      relation: orchestration_decisions_scope,
       filters: decision_metrics_filters
     )
     render partial: "dashboard/orchestration_decisions",
@@ -98,8 +98,8 @@ class DashboardController < ApplicationController
     Dashboard::Stats::VALID_GOALS.include?(goal) ? goal : "all"
   end
 
-  def decision_records_scope
-    DecisionRecord.joins(:project).where(projects: { account_id: current_account.id })
+  def orchestration_decisions_scope
+    OrchestrationDecision.joins(:project).where(projects: { account_id: current_account.id })
   end
 
   def decision_metrics_filters

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -82,9 +82,9 @@ module DashboardHelper
   }.freeze
 
   DECISION_STATUS_BADGE_CLASSES = {
-    "active" => "bg-emerald-100 text-emerald-700",
-    "superseded" => "bg-amber-100 text-amber-700",
-    "reverted" => "bg-rose-100 text-rose-700"
+    "applied" => "bg-emerald-100 text-emerald-700",
+    "noop" => "bg-amber-100 text-amber-700",
+    "failed" => "bg-rose-100 text-rose-700"
   }.freeze
 
   def time_range_label(range)

--- a/app/services/analytics/orchestration_decisions/base_query.rb
+++ b/app/services/analytics/orchestration_decisions/base_query.rb
@@ -3,9 +3,9 @@
 module Analytics
   module OrchestrationDecisions
     class BaseQuery
-      UNCATEGORIZED_DECISION_TYPE = "uncategorized"
+      DEFAULT_DECISION_STATUS = "applied"
 
-      def initialize(relation: DecisionRecord.all, filters: {})
+      def initialize(relation: OrchestrationDecision.all, filters: {})
         @relation = relation
         @filters = filters
       end
@@ -17,40 +17,10 @@ module Analytics
       def filtered_scope
         scope = relation
         scope = scope.where(project_id: project_ids) if project_ids.any?
-        scope = scope.where("decision_records.created_at >= ?", filters[:from]) if filters[:from].present?
-        scope = scope.where("decision_records.created_at <= ?", filters[:to]) if filters[:to].present?
-        scope = apply_decision_type_filter(scope)
+        scope = scope.where("orchestration_decisions.created_at >= ?", filters[:from]) if filters[:from].present?
+        scope = scope.where("orchestration_decisions.created_at <= ?", filters[:to]) if filters[:to].present?
+        scope = scope.where(decision_type: decision_types) if decision_types.any?
         scope
-      end
-
-      def apply_decision_type_filter(scope)
-        return scope if decision_types.empty?
-
-        clauses = []
-        binds = []
-
-        if tagged_decision_types.any?
-          clauses << <<~SQL.squish
-            EXISTS (
-              SELECT 1
-              FROM jsonb_array_elements_text(decision_records.tags) AS tag(value)
-              WHERE NULLIF(LOWER(BTRIM(tag.value)), '') IN (?)
-            )
-          SQL
-          binds << tagged_decision_types
-        end
-
-        if uncategorized_selected?
-          clauses << <<~SQL.squish
-            NOT EXISTS (
-              SELECT 1
-              FROM jsonb_array_elements_text(decision_records.tags) AS tag(value)
-              WHERE NULLIF(LOWER(BTRIM(tag.value)), '') IS NOT NULL
-            )
-          SQL
-        end
-
-        scope.where([ clauses.join(" OR "), *binds ])
       end
 
       def project_ids
@@ -63,30 +33,12 @@ module Analytics
         end.uniq
       end
 
-      def tagged_decision_types
-        decision_types - [ UNCATEGORIZED_DECISION_TYPE ]
-      end
-
-      def uncategorized_selected?
-        decision_types.include?(UNCATEGORIZED_DECISION_TYPE)
-      end
-
       def normalize_decision_type(value)
         value.to_s.strip.downcase.presence
       end
 
-      def decision_types_join_sql
-        <<~SQL.squish
-          LEFT JOIN LATERAL (
-            SELECT DISTINCT NULLIF(LOWER(BTRIM(tag.value)), '') AS decision_type
-            FROM jsonb_array_elements_text(decision_records.tags) AS tag(value)
-            WHERE NULLIF(LOWER(BTRIM(tag.value)), '') IS NOT NULL
-          ) decision_types ON TRUE
-        SQL
-      end
-
-      def decision_records_table
-        DecisionRecord.arel_table
+      def orchestration_decisions_table
+        OrchestrationDecision.arel_table
       end
 
       def projects_table
@@ -97,34 +49,23 @@ module Analytics
         AgentRun.arel_table
       end
 
-      def decision_types_table
-        Arel::Table.new(:decision_types)
-      end
-
-      def decision_type_expression
-        Arel::Nodes::NamedFunction.new(
-          "COALESCE",
-          [ decision_types_table[:decision_type], Arel::Nodes.build_quoted(UNCATEGORIZED_DECISION_TYPE) ]
-        )
-      end
-
       def distinct_count(expression)
         Arel::Nodes::Count.new([ expression ], true)
       end
 
       def distinct_status_count(status)
-        distinct_count(
-          Arel::Nodes::Case.new
-            .when(decision_records_table[:status].eq(status))
-            .then(decision_records_table[:id])
+        quoted_status = ActiveRecord::Base.connection.quote(status)
+        Arel.sql(
+          "COUNT(DISTINCT CASE " \
+          "WHEN COALESCE(orchestration_decisions.context ->> 'decision_status', '#{DEFAULT_DECISION_STATUS}') = #{quoted_status} " \
+          "THEN orchestration_decisions.id END)"
         )
       end
 
       def distinct_completed_run_count
-        distinct_count(
-          Arel::Nodes::Case.new
-            .when(agent_runs_table[:status].eq("completed"))
-            .then(decision_records_table[:id])
+        Arel.sql(
+          "COUNT(DISTINCT CASE " \
+          "WHEN agent_runs.status = 'completed' THEN orchestration_decisions.id END)"
         )
       end
     end

--- a/app/services/analytics/orchestration_decisions/base_query.rb
+++ b/app/services/analytics/orchestration_decisions/base_query.rb
@@ -65,7 +65,7 @@ module Analytics
       def distinct_completed_run_count
         Arel.sql(
           "COUNT(DISTINCT CASE " \
-          "WHEN agent_runs.status = 'completed' THEN orchestration_decisions.id END)"
+          "WHEN agent_runs.status = 'completed' THEN agent_runs.id END)"
         )
       end
     end

--- a/app/services/analytics/orchestration_decisions/by_decision_type_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_decision_type_query.rb
@@ -4,30 +4,29 @@ module Analytics
   module OrchestrationDecisions
     class ByDecisionTypeQuery < BaseQuery
       def call
-        total_count = distinct_count(decision_records_table[:id])
+        total_count = distinct_count(orchestration_decisions_table[:id])
 
         scope = filtered_scope
           .left_joins(:agent_run)
-          .joins(decision_types_join_sql)
 
-        scope = scope.where(decision_type_expression.in(decision_types)) if decision_types.any?
-
-        rows = scope.group(decision_type_expression)
-          .order(total_count.desc, decision_type_expression.asc)
+        rows = scope.group(orchestration_decisions_table[:decision_type])
+          .order(total_count.desc, orchestration_decisions_table[:decision_type].asc)
           .pluck(
-            decision_type_expression,
+            orchestration_decisions_table[:decision_type],
             total_count,
-            distinct_count(decision_records_table[:project_id]),
-            distinct_status_count("active"),
+            distinct_count(orchestration_decisions_table[:project_id]),
+            distinct_count(orchestration_decisions_table[:actor]),
+            distinct_status_count("failed"),
             distinct_completed_run_count
           )
 
-        rows.map do |decision_type, total_count, project_count, active_count, completed_run_count|
+        rows.map do |decision_type, total_count, project_count, actor_count, failed_count, completed_run_count|
           {
             decision_type: decision_type,
             total_count: total_count,
             project_count: project_count,
-            active_count: active_count,
+            actor_count: actor_count,
+            failed_count: failed_count,
             completed_run_count: completed_run_count
           }
         end

--- a/app/services/analytics/orchestration_decisions/by_project_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_project_query.rb
@@ -4,14 +4,12 @@ module Analytics
   module OrchestrationDecisions
     class ByProjectQuery < BaseQuery
       def call
-        total_count = distinct_count(decision_records_table[:id])
-        decision_type_count = distinct_count(decision_type_expression)
+        total_count = distinct_count(orchestration_decisions_table[:id])
+        decision_type_count = distinct_count(orchestration_decisions_table[:decision_type])
+        actor_count = distinct_count(orchestration_decisions_table[:actor])
 
         scope = filtered_scope
           .joins(:project)
-          .joins(decision_types_join_sql)
-
-        scope = scope.where(decision_type_expression.in(decision_types)) if decision_types.any?
 
         rows = scope
           .group(
@@ -28,21 +26,23 @@ module Analytics
             projects_table[:repo],
             total_count,
             decision_type_count,
-            distinct_status_count("active"),
-            distinct_status_count("superseded"),
-            distinct_status_count("reverted")
+            actor_count,
+            distinct_status_count("applied"),
+            distinct_status_count("noop"),
+            distinct_status_count("failed")
           )
 
-        rows.map do |project_id, name, owner, repo, total_count, decision_type_count, active_count, superseded_count, reverted_count|
+        rows.map do |project_id, name, owner, repo, total_count, decision_type_count, actor_count, applied_count, noop_count, failed_count|
           {
             project_id: project_id,
             project_name: name,
             project_full_name: "#{owner}/#{repo}",
             total_count: total_count,
             decision_type_count: decision_type_count,
-            active_count: active_count,
-            superseded_count: superseded_count,
-            reverted_count: reverted_count
+            actor_count: actor_count,
+            applied_count: applied_count,
+            noop_count: noop_count,
+            failed_count: failed_count
           }
         end
       end

--- a/app/services/analytics/orchestration_decisions/daily_volume_query.rb
+++ b/app/services/analytics/orchestration_decisions/daily_volume_query.rb
@@ -5,23 +5,23 @@ module Analytics
     class DailyVolumeQuery < BaseQuery
       def call
         rows = filtered_scope
-          .group(Arel.sql("DATE(decision_records.created_at)"))
-          .order(Arel.sql("DATE(decision_records.created_at) ASC"))
+          .group(Arel.sql("DATE(orchestration_decisions.created_at)"))
+          .order(Arel.sql("DATE(orchestration_decisions.created_at) ASC"))
           .pluck(
-            Arel.sql("DATE(decision_records.created_at)"),
+            Arel.sql("DATE(orchestration_decisions.created_at)"),
             Arel.sql("COUNT(*)"),
-            Arel.sql("COUNT(*) FILTER (WHERE decision_records.status = 'active')"),
-            Arel.sql("COUNT(*) FILTER (WHERE decision_records.status = 'superseded')"),
-            Arel.sql("COUNT(*) FILTER (WHERE decision_records.status = 'reverted')")
+            Arel.sql("COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'applied')"),
+            Arel.sql("COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'noop')"),
+            Arel.sql("COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'failed')")
           )
 
-        rows.map do |day, total_count, active_count, superseded_count, reverted_count|
+        rows.map do |day, total_count, applied_count, noop_count, failed_count|
           {
             day: day,
             total_count: total_count,
-            active_count: active_count,
-            superseded_count: superseded_count,
-            reverted_count: reverted_count
+            applied_count: applied_count,
+            noop_count: noop_count,
+            failed_count: failed_count
           }
         end
       end

--- a/app/services/analytics/orchestration_decisions/question_set.rb
+++ b/app/services/analytics/orchestration_decisions/question_set.rb
@@ -11,7 +11,7 @@ module Analytics
         },
         {
           key: "decision_mix_by_type",
-          question: "Which decision types appear most often, based on decision-record tags?",
+          question: "Which orchestration decision types appear most often across workflows, retries, and selection paths?",
           query: "Analytics::OrchestrationDecisions::ByDecisionTypeQuery"
         },
         {
@@ -21,7 +21,7 @@ module Analytics
         },
         {
           key: "decision_outcomes",
-          question: "How often do decisions remain active versus becoming superseded or reverted?",
+          question: "How often are orchestration decisions applied, skipped as no-ops, or recorded as failures?",
           query: "Analytics::OrchestrationDecisions::SummaryQuery"
         }
       ].freeze

--- a/app/services/analytics/orchestration_decisions/report.rb
+++ b/app/services/analytics/orchestration_decisions/report.rb
@@ -3,7 +3,7 @@
 module Analytics
   module OrchestrationDecisions
     class Report
-      def initialize(relation: DecisionRecord.all, filters: {})
+      def initialize(relation: OrchestrationDecision.all, filters: {})
         @relation = relation
         @filters = filters
       end

--- a/app/services/analytics/orchestration_decisions/summary_query.rb
+++ b/app/services/analytics/orchestration_decisions/summary_query.rb
@@ -11,9 +11,9 @@ module Analytics
             "COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'applied') AS applied_count",
             "COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'noop') AS noop_count",
             "COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'failed') AS failed_count",
-            "COUNT(*) FILTER (WHERE orchestration_decisions.agent_run_id IS NOT NULL) AS linked_agent_run_count",
-            "COUNT(*) FILTER (WHERE agent_runs.status = 'completed') AS completed_run_count",
-            "COUNT(*) FILTER (WHERE agent_runs.status IN ('failed', 'timeout', 'auth_expired', 'rate_limited', 'cancelled')) AS failed_run_count",
+            "COUNT(DISTINCT orchestration_decisions.agent_run_id) AS linked_agent_run_count",
+            "COUNT(DISTINCT agent_runs.id) FILTER (WHERE agent_runs.status = 'completed') AS completed_run_count",
+            "COUNT(DISTINCT agent_runs.id) FILTER (WHERE agent_runs.status IN ('failed', 'timeout', 'auth_expired', 'rate_limited', 'cancelled')) AS failed_run_count",
             "COUNT(DISTINCT orchestration_decisions.project_id) AS project_count",
             "COUNT(DISTINCT orchestration_decisions.actor) AS actor_count"
           )

--- a/app/services/analytics/orchestration_decisions/summary_query.rb
+++ b/app/services/analytics/orchestration_decisions/summary_query.rb
@@ -8,23 +8,27 @@ module Analytics
           .left_joins(:agent_run)
           .select(
             "COUNT(*) AS total_count",
-            "COUNT(*) FILTER (WHERE decision_records.status = 'active') AS active_count",
-            "COUNT(*) FILTER (WHERE decision_records.status = 'superseded') AS superseded_count",
-            "COUNT(*) FILTER (WHERE decision_records.status = 'reverted') AS reverted_count",
-            "COUNT(*) FILTER (WHERE decision_records.agent_run_id IS NOT NULL) AS linked_agent_run_count",
+            "COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'applied') AS applied_count",
+            "COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'noop') AS noop_count",
+            "COUNT(*) FILTER (WHERE COALESCE(orchestration_decisions.context ->> 'decision_status', 'applied') = 'failed') AS failed_count",
+            "COUNT(*) FILTER (WHERE orchestration_decisions.agent_run_id IS NOT NULL) AS linked_agent_run_count",
             "COUNT(*) FILTER (WHERE agent_runs.status = 'completed') AS completed_run_count",
-            "COUNT(*) FILTER (WHERE agent_runs.status IN ('failed', 'timeout', 'auth_expired', 'rate_limited', 'cancelled')) AS failed_run_count"
+            "COUNT(*) FILTER (WHERE agent_runs.status IN ('failed', 'timeout', 'auth_expired', 'rate_limited', 'cancelled')) AS failed_run_count",
+            "COUNT(DISTINCT orchestration_decisions.project_id) AS project_count",
+            "COUNT(DISTINCT orchestration_decisions.actor) AS actor_count"
           )
           .take
 
         {
           total_count: row.total_count.to_i,
-          active_count: row.active_count.to_i,
-          superseded_count: row.superseded_count.to_i,
-          reverted_count: row.reverted_count.to_i,
+          applied_count: row.applied_count.to_i,
+          noop_count: row.noop_count.to_i,
+          failed_count: row.failed_count.to_i,
           linked_agent_run_count: row.linked_agent_run_count.to_i,
           completed_run_count: row.completed_run_count.to_i,
-          failed_run_count: row.failed_run_count.to_i
+          failed_run_count: row.failed_run_count.to_i,
+          project_count: row.project_count.to_i,
+          actor_count: row.actor_count.to_i
         }
       end
     end

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -243,6 +243,25 @@ module Models
       )
       inputs_payload = selection_inputs
 
+      persist_orchestration_decision_safely(
+        outcome: outcome,
+        duration_ms: duration_ms,
+        selected: selected,
+        selection_payload: selection_payload,
+        inputs_payload: inputs_payload,
+        error: error
+      )
+      persist_agent_run_decision_log(
+        outcome: outcome,
+        duration_ms: duration_ms,
+        selected: selected,
+        selection_payload: selection_payload,
+        inputs_payload: inputs_payload,
+        error: error
+      )
+    end
+
+    def persist_agent_run_decision_log(outcome:, duration_ms:, selected:, selection_payload:, inputs_payload:, error:)
       agent_run.agent_run_logs.create!(
         log_type: "system",
         content: decision_log_content(outcome: outcome, selected: selected, error: error),
@@ -255,6 +274,16 @@ module Models
           error: error_payload(error)
         }.compact
       )
+    rescue => log_error
+      Rails.logger.warn(
+        message: "model_selection.decision_log_failed",
+        agent_run_id: agent_run.id,
+        error_class: log_error.class.name,
+        error: log_error.message
+      )
+    end
+
+    def persist_orchestration_decision_safely(outcome:, duration_ms:, selected:, selection_payload:, inputs_payload:, error:)
       persist_orchestration_decision(
         outcome: outcome,
         duration_ms: duration_ms,
@@ -265,7 +294,7 @@ module Models
       )
     rescue => log_error
       Rails.logger.warn(
-        message: "model_selection.decision_log_failed",
+        message: "model_selection.orchestration_decision_failed",
         agent_run_id: agent_run.id,
         error_class: log_error.class.name,
         error: log_error.message

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -234,6 +234,15 @@ module Models
     end
 
     def persist_decision_log(outcome:, duration_ms:, selected: nil, final_tier: nil, escalation: nil, selection: nil, candidates: nil, error: nil)
+      selection_payload = selection_payload(
+        selected: selected,
+        selection: selection,
+        final_tier: final_tier,
+        escalation: escalation,
+        candidates: candidates
+      )
+      inputs_payload = selection_inputs
+
       agent_run.agent_run_logs.create!(
         log_type: "system",
         content: decision_log_content(outcome: outcome, selected: selected, error: error),
@@ -241,10 +250,18 @@ module Models
           type: DECISION_LOG_TYPE,
           outcome: outcome,
           duration_ms: duration_ms,
-          selection: selection_payload(selected: selected, selection: selection, final_tier: final_tier, escalation: escalation, candidates: candidates),
-          inputs: selection_inputs,
+          selection: selection_payload,
+          inputs: inputs_payload,
           error: error_payload(error)
         }.compact
+      )
+      persist_orchestration_decision(
+        outcome: outcome,
+        duration_ms: duration_ms,
+        selected: selected,
+        selection_payload: selection_payload,
+        inputs_payload: inputs_payload,
+        error: error
       )
     rescue => log_error
       Rails.logger.warn(
@@ -353,6 +370,36 @@ module Models
         class: error.class.name,
         message: error.message
       }
+    end
+
+    def persist_orchestration_decision(outcome:, duration_ms:, selected:, selection_payload:, inputs_payload:, error:)
+      OrchestrationDecision.record(
+        project: agent_run.project,
+        issue: agent_run.issue,
+        agent_run: agent_run,
+        action: "select_agent",
+        decision_point: selected&.dig(:selector_type) || "model_selection",
+        status: orchestration_status_for(outcome),
+        signals: inputs_payload.merge(
+          "duration_ms" => duration_ms
+        ),
+        result: {
+          "outcome" => outcome,
+          "selection" => selection_payload,
+          "error" => error_payload(error)
+        }.compact
+      )
+    end
+
+    def orchestration_status_for(outcome)
+      case outcome
+      when "selected"
+        "applied"
+      when "no_selection"
+        "noop"
+      else
+        "failed"
+      end
     end
   end
 end

--- a/app/services/orchestration/decomposition_decisions/log.rb
+++ b/app/services/orchestration/decomposition_decisions/log.rb
@@ -3,6 +3,13 @@
 module Orchestration
   module DecompositionDecisions
     class Log
+      NOOP_OUTCOMES = %w[
+        empty_plan
+        single_task_plan
+        parallel_execution_skipped_empty_plan
+        parallel_execution_skipped_single_task
+      ].freeze
+
       def self.call(...)
         new(...).call
       end
@@ -123,7 +130,7 @@ module Orchestration
             workflow_id: workflow_id,
             workflow_name: workflow_name,
             issue_id: issue_id,
-            decision_status: error_details.present? ? "failed" : "applied"
+            decision_status: orchestration_status
           },
           inputs: enriched_input_context,
           outputs: {
@@ -135,6 +142,13 @@ module Orchestration
           },
           outcome_references: []
         )
+      end
+
+      def orchestration_status
+        return "failed" if error_details.present?
+        return "noop" if NOOP_OUTCOMES.include?(outcome)
+
+        "applied"
       end
     end
   end

--- a/app/services/orchestration/decomposition_decisions/log.rb
+++ b/app/services/orchestration/decomposition_decisions/log.rb
@@ -24,9 +24,9 @@ module Orchestration
 
       def call
         existing = DecompositionDecision.find_by(decision_key: decision_key)
-        return existing if existing
+        return existing.tap { ensure_orchestration_decision! } if existing
 
-        DecompositionDecision.create!(
+        decision = DecompositionDecision.create!(
           project_id: project_id,
           issue_id: issue_id,
           decision_key: decision_key,
@@ -40,8 +40,10 @@ module Orchestration
           error_details: error_details,
           metadata: metadata
         )
+        ensure_orchestration_decision!
+        decision
       rescue ActiveRecord::RecordNotUnique
-        DecompositionDecision.find_by!(decision_key: decision_key)
+        DecompositionDecision.find_by!(decision_key: decision_key).tap { ensure_orchestration_decision! }
       end
 
       private
@@ -93,6 +95,46 @@ module Orchestration
         else
           {}
         end
+      end
+
+      def ensure_orchestration_decision!
+        existing = OrchestrationDecision.find_by(
+          [
+            <<~SQL.squish,
+              project_id = ?
+              AND decision_type = ?
+              AND actor = ?
+              AND context ->> 'decision_key' = ?
+            SQL
+            project_id,
+            decision_type,
+            workflow_name,
+            decision_key
+          ]
+        )
+        return existing if existing
+
+        OrchestrationDecision.create!(
+          project_id: project_id,
+          decision_type: decision_type,
+          actor: workflow_name,
+          context: {
+            decision_key: decision_key,
+            workflow_id: workflow_id,
+            workflow_name: workflow_name,
+            issue_id: issue_id,
+            decision_status: error_details.present? ? "failed" : "applied"
+          },
+          inputs: enriched_input_context,
+          outputs: {
+            outcome: outcome,
+            plan_data: plan_data,
+            hints: derived_hints,
+            error_details: error_details,
+            metadata: metadata
+          },
+          outcome_references: []
+        )
       end
     end
   end

--- a/app/services/orchestration/decomposition_decisions/log.rb
+++ b/app/services/orchestration/decomposition_decisions/log.rb
@@ -142,6 +142,15 @@ module Orchestration
           },
           outcome_references: []
         )
+      rescue StandardError => e
+        Rails.logger.warn(
+          message: "decomposition.orchestration_decision_failed",
+          project_id: project_id,
+          decision_key: decision_key,
+          error_class: e.class.name,
+          error: e.message
+        )
+        nil
       end
 
       def orchestration_status

--- a/app/views/dashboard/_orchestration_decisions.html.erb
+++ b/app/views/dashboard/_orchestration_decisions.html.erb
@@ -1,11 +1,10 @@
 <%= turbo_frame_tag "dashboard-decision-metrics" do %>
   <% summary = report[:summary] %>
   <% total_count = summary[:total_count].to_i %>
-  <% active_count = summary[:active_count].to_i %>
-  <% superseded_count = summary[:superseded_count].to_i %>
-  <% reverted_count = summary[:reverted_count].to_i %>
-  <% changed_count = superseded_count + reverted_count %>
-  <% project_count = report[:by_project].size %>
+  <% applied_count = summary[:applied_count].to_i %>
+  <% noop_count = summary[:noop_count].to_i %>
+  <% failed_count = summary[:failed_count].to_i %>
+  <% project_count = summary[:project_count].to_i %>
   <% daily_volume = report[:daily_volume] %>
   <% low_data = total_count.positive? && (total_count < 5 || project_count < 2 || daily_volume.size < 3) %>
 
@@ -13,7 +12,7 @@
     <div class="flex items-start justify-between gap-4">
       <div>
         <h2 class="text-lg font-semibold text-gray-900">Orchestration Decision Metrics</h2>
-        <p class="mt-1 text-sm text-gray-500">See which orchestration decisions stay active, which are later changed, and where those patterns cluster by type and project context.</p>
+        <p class="mt-1 text-sm text-gray-500">See which orchestration decisions are being captured, which paths apply versus noop or fail, and where those patterns cluster by type and project context.</p>
       </div>
       <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
         <%= time_range_label(time_range) %>
@@ -21,14 +20,14 @@
     </div>
 
     <% if total_count.zero? %>
-      <div class="mt-4 rounded-lg border border-dashed border-gray-300 bg-white px-6 py-10 text-center shadow-sm">
-        <h3 class="text-sm font-semibold text-gray-900">No orchestration decisions yet</h3>
-        <p class="mt-2 text-sm text-gray-500">Decision metrics will appear after agent runs publish decision records.</p>
-      </div>
+        <div class="mt-4 rounded-lg border border-dashed border-gray-300 bg-white px-6 py-10 text-center shadow-sm">
+          <h3 class="text-sm font-semibold text-gray-900">No orchestration decisions yet</h3>
+          <p class="mt-2 text-sm text-gray-500">Decision metrics will appear after workflows, retries, and agent selection paths emit orchestration events.</p>
+        </div>
     <% else %>
       <% if low_data %>
         <div class="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
-          Only <%= number_with_delimiter(total_count) %> decision <%= "record".pluralize(total_count) %> across <%= number_with_delimiter(project_count) %> <%= "project".pluralize(project_count) %> match this window. Treat trend and context comparisons as directional until more data arrives.
+          Only <%= number_with_delimiter(total_count) %> orchestration <%= "decision".pluralize(total_count) %> across <%= number_with_delimiter(project_count) %> <%= "project".pluralize(project_count) %> match this window. Treat trend and context comparisons as directional until more data arrives.
         </div>
       <% end %>
 
@@ -38,13 +37,18 @@
           <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= number_with_delimiter(total_count) %></dd>
         </div>
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-          <dt class="truncate text-sm font-medium text-gray-500">Still Active</dt>
-          <dd class="mt-1 text-3xl font-semibold tracking-tight text-emerald-600"><%= number_with_delimiter(active_count) %></dd>
+          <dt class="truncate text-sm font-medium text-gray-500">Applied</dt>
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-emerald-600"><%= number_with_delimiter(applied_count) %></dd>
         </div>
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-          <dt class="truncate text-sm font-medium text-gray-500">Changed Later</dt>
-          <dd class="mt-1 text-3xl font-semibold tracking-tight text-amber-600"><%= number_with_delimiter(changed_count) %></dd>
-          <p class="mt-2 text-xs text-gray-500"><%= number_with_delimiter(superseded_count) %> superseded, <%= number_with_delimiter(reverted_count) %> reverted</p>
+          <dt class="truncate text-sm font-medium text-gray-500">No-op</dt>
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-amber-600"><%= number_with_delimiter(noop_count) %></dd>
+          <p class="mt-2 text-xs text-gray-500">Recorded but intentionally skipped or unchanged.</p>
+        </div>
+        <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+          <dt class="truncate text-sm font-medium text-gray-500">Failed Decisions</dt>
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-rose-600"><%= number_with_delimiter(failed_count) %></dd>
+          <p class="mt-2 text-xs text-gray-500">Errors or blocked orchestration paths.</p>
         </div>
         <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
           <dt class="truncate text-sm font-medium text-gray-500">Linked Run Outcomes</dt>
@@ -57,12 +61,12 @@
         <div class="overflow-hidden rounded-lg bg-white shadow xl:col-span-2">
           <div class="px-4 py-5 sm:p-6">
             <h3 class="text-sm font-semibold text-gray-900">Outcome Mix</h3>
-            <p class="mt-1 text-sm text-gray-500">How often decisions remain active versus being revised or rolled back.</p>
+            <p class="mt-1 text-sm text-gray-500">How often orchestration paths apply, skip work, or fail.</p>
             <div class="mt-4 space-y-4">
               <% [
-                [ "active", active_count ],
-                [ "superseded", superseded_count ],
-                [ "reverted", reverted_count ]
+                [ "applied", applied_count ],
+                [ "noop", noop_count ],
+                [ "failed", failed_count ]
               ].each do |status, count| %>
                 <% share = total_count.zero? ? 0 : ((count.to_f / total_count) * 100).round %>
                 <div>
@@ -84,7 +88,7 @@
         <div class="overflow-hidden rounded-lg bg-white shadow xl:col-span-3">
           <div class="px-4 py-5 sm:p-6">
             <h3 class="text-sm font-semibold text-gray-900">Decision Types by Context</h3>
-            <p class="mt-1 text-sm text-gray-500">Most common tagged decision categories, with how broadly they appear and how often they land on completed runs.</p>
+            <p class="mt-1 text-sm text-gray-500">Most common decision categories, with how broadly they appear and how often they land on failed or completed runs.</p>
           </div>
           <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200">
@@ -93,6 +97,8 @@
                   <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Type</th>
                   <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Decisions</th>
                   <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Projects</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Actors</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Failed</th>
                   <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Completed Runs</th>
                 </tr>
               </thead>
@@ -102,6 +108,8 @@
                     <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= decision_type_label(row[:decision_type]) %></td>
                     <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:total_count]) %></td>
                     <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:project_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:actor_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:failed_count]) %></td>
                     <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:completed_run_count]) %></td>
                   </tr>
                 <% end %>
@@ -112,10 +120,10 @@
       </div>
 
       <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
-        <div class="px-4 py-5 sm:p-6">
-          <h3 class="text-sm font-semibold text-gray-900">Project Context</h3>
-          <p class="mt-1 text-sm text-gray-500">Projects producing the most decision activity, plus how varied and stable those decisions are.</p>
-        </div>
+          <div class="px-4 py-5 sm:p-6">
+            <h3 class="text-sm font-semibold text-gray-900">Project Context</h3>
+            <p class="mt-1 text-sm text-gray-500">Projects producing the most decision activity, plus how varied those decision types and actors are.</p>
+          </div>
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
@@ -123,8 +131,9 @@
                 <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Project</th>
                 <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Decisions</th>
                 <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Types</th>
-                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Active</th>
-                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Changed</th>
+                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Actors</th>
+                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Applied</th>
+                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Failed</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 bg-white">
@@ -136,8 +145,9 @@
                   </td>
                   <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:total_count]) %></td>
                   <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:decision_type_count]) %></td>
-                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:active_count]) %></td>
-                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:superseded_count].to_i + row[:reverted_count].to_i) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:actor_count]) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:applied_count]) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:failed_count]) %></td>
                 </tr>
               <% end %>
             </tbody>
@@ -149,20 +159,20 @@
         <div class="px-4 py-5 sm:p-6">
           <h3 class="text-sm font-semibold text-gray-900">Decision Volume Over Time</h3>
           <% if daily_volume.size >= 2 %>
-            <p class="mt-1 text-sm text-gray-500">Daily decision counts split by active, superseded, and reverted outcomes.</p>
+            <p class="mt-1 text-sm text-gray-500">Daily decision counts split by applied, no-op, and failed outcomes.</p>
             <div class="mt-4">
               <%= column_chart [
                 {
-                  name: "Active",
-                  data: daily_volume.to_h { |row| [row[:day], row[:active_count]] }
+                  name: "Applied",
+                  data: daily_volume.to_h { |row| [row[:day], row[:applied_count]] }
                 },
                 {
-                  name: "Superseded",
-                  data: daily_volume.to_h { |row| [row[:day], row[:superseded_count]] }
+                  name: "No-op",
+                  data: daily_volume.to_h { |row| [row[:day], row[:noop_count]] }
                 },
                 {
-                  name: "Reverted",
-                  data: daily_volume.to_h { |row| [row[:day], row[:reverted_count]] }
+                  name: "Failed",
+                  data: daily_volume.to_h { |row| [row[:day], row[:failed_count]] }
                 }
               ],
                   id: "decision-volume-chart",

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -389,12 +389,13 @@ RSpec.describe "Dashboard" do
 
     before { sign_in user }
 
-    def create_decision_metric(project:, created_at:, status: "active", tags: %w[routing], agent_run_traits: [ :completed ])
-      create(:decision_record,
+    def create_decision_metric(project:, created_at:, decision_status: "applied", decision_type: "retry", actor: "timeout_auto_retry", agent_run_traits: [ :completed ])
+      create(:orchestration_decision,
         project: project,
         agent_run: create(:agent_run, *agent_run_traits, project: project),
-        status: status,
-        tags: tags,
+        decision_type: decision_type,
+        actor: actor,
+        context: { decision_status: decision_status },
         created_at: created_at)
     end
 
@@ -409,11 +410,11 @@ RSpec.describe "Dashboard" do
       expect(response.body).to include("Decision Types by Context")
     end
 
-    it "shows an empty state when no decision records exist" do
+    it "shows an empty state when no orchestration decisions exist" do
       get dashboard_decision_metrics_path(time_range: "cumulative")
 
       expect(response.body).to include("No orchestration decisions yet")
-      expect(response.body).to include("Decision metrics will appear after agent runs publish decision records.")
+      expect(response.body).to include("Decision metrics will appear after workflows, retries, and agent selection paths emit orchestration events.")
     end
 
     it "shows a low-data message when the sample is too small for stable comparisons" do
@@ -422,26 +423,33 @@ RSpec.describe "Dashboard" do
       get dashboard_decision_metrics_path(time_range: "7d")
 
       expect(response.body).to include("Treat trend and context comparisons as directional until more data arrives.")
-      expect(response.body).to include("Only 1 decision record across 1 project match this window.")
+      expect(response.body).to include("Only 1 orchestration decision across 1 project match this window.")
       expect(response.body).to include("Not enough daily history yet for a useful trend view.")
     end
 
     it "scopes decision metrics to the current account and time window" do
       create_decision_metric(project: project, created_at: 2.days.ago)
-      create_decision_metric(project: project, created_at: 1.day.ago, status: "superseded", agent_run_traits: [ :failed ])
-      create(:decision_record,
+      create_decision_metric(project: project, created_at: 1.day.ago, decision_status: "failed", agent_run_traits: [ :failed ])
+      create(:orchestration_decision, :without_agent_run,
         project: create(:project, name: "Ignored", owner: "ignored", repo: "ignored"),
-        tags: %w[routing],
+        decision_type: "retry",
+        actor: "timeout_auto_retry",
+        context: { decision_status: "applied" },
         created_at: 1.day.ago)
-      create_decision_metric(project: project, created_at: 45.days.ago, tags: %w[planning])
+      create_decision_metric(
+        project: project,
+        created_at: 45.days.ago,
+        decision_type: "planning_outcome",
+        actor: "Workflows::PlanningWorkflow"
+      )
 
       get dashboard_decision_metrics_path(time_range: "7d")
 
       expect(response.body).to include("Total Decisions")
-      expect(response.body).to include("Routing")
+      expect(response.body).to include("Retry")
       expect(response.body).to include("Alpha")
       expect(response.body).not_to include("Ignored")
-      expect(response.body).not_to include("Planning")
+      expect(response.body).not_to include("Planning Outcome")
     end
   end
 

--- a/spec/services/analytics/orchestration_decisions/report_spec.rb
+++ b/spec/services/analytics/orchestration_decisions/report_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
   let(:account) { create(:account) }
   let(:project_a) { create(:project, account: account, name: "Alpha") }
   let(:project_b) { create(:project, account: account, name: "Beta") }
+  let(:completed_select_agent_run) { create(:agent_run, :completed, project: project_b) }
 
   before do
     create_decision(
@@ -41,11 +42,20 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
 
     create_decision(
       project: project_b,
-      agent_run: create(:agent_run, :completed, project: project_b),
+      agent_run: completed_select_agent_run,
       decision_type: "select_agent",
       actor: "rules",
       context: { decision_status: "applied" },
       created_at: 14.days.ago
+    )
+
+    create_decision(
+      project: project_b,
+      agent_run: completed_select_agent_run,
+      decision_type: "select_agent",
+      actor: "fallback_rules",
+      context: { decision_status: "applied" },
+      created_at: 13.days.ago
     )
   end
 
@@ -53,13 +63,13 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
     create(:orchestration_decision, ...)
   end
 
-  def expected_summary(total_count:, applied_count:, noop_count:, failed_count:, completed_run_count:, failed_run_count:, project_count:, actor_count:)
+  def expected_summary(total_count:, applied_count:, noop_count:, failed_count:, linked_agent_run_count:, completed_run_count:, failed_run_count:, project_count:, actor_count:)
     {
       total_count: total_count,
       applied_count: applied_count,
       noop_count: noop_count,
       failed_count: failed_count,
-      linked_agent_run_count: total_count,
+      linked_agent_run_count: linked_agent_run_count,
       completed_run_count: completed_run_count,
       failed_run_count: failed_run_count,
       project_count: project_count,
@@ -105,6 +115,15 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
   def expected_project_rollup
     [
       expected_project(
+        project: project_b,
+        total_count: 3,
+        decision_type_count: 1,
+        actor_count: 3,
+        applied_count: 2,
+        noop_count: 1,
+        failed_count: 0
+      ),
+      expected_project(
         project: project_a,
         total_count: 2,
         decision_type_count: 2,
@@ -112,15 +131,6 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
         applied_count: 1,
         noop_count: 0,
         failed_count: 1
-      ),
-      expected_project(
-        project: project_b,
-        total_count: 2,
-        decision_type_count: 1,
-        actor_count: 2,
-        applied_count: 1,
-        noop_count: 1,
-        failed_count: 0
       )
     ]
   end
@@ -129,9 +139,9 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
     [
       expected_decision_type(
         decision_type: "select_agent",
-        total_count: 2,
+        total_count: 3,
         project_count: 1,
-        actor_count: 2,
+        actor_count: 3,
         failed_count: 0,
         completed_run_count: 1
       ),
@@ -164,6 +174,13 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
         failed_count: 0
       ),
       expected_daily_volume(
+        day: 13.days.ago.to_date,
+        total_count: 1,
+        applied_count: 1,
+        noop_count: 0,
+        failed_count: 0
+      ),
+      expected_daily_volume(
         day: 2.days.ago.to_date,
         total_count: 1,
         applied_count: 1,
@@ -189,14 +206,15 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
 
   def expected_select_agent_summary
     expected_summary(
-      total_count: 2,
-      applied_count: 1,
+      total_count: 3,
+      applied_count: 2,
       noop_count: 1,
       failed_count: 0,
+      linked_agent_run_count: 2,
       completed_run_count: 1,
       failed_run_count: 1,
       project_count: 1,
-      actor_count: 2
+      actor_count: 3
     )
   end
 
@@ -219,14 +237,15 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
 
       expect(report[:summary]).to eq(
         expected_summary(
-          total_count: 4,
-          applied_count: 2,
+          total_count: 5,
+          applied_count: 3,
           noop_count: 1,
           failed_count: 1,
+          linked_agent_run_count: 4,
           completed_run_count: 2,
           failed_run_count: 2,
           project_count: 2,
-          actor_count: 4
+          actor_count: 5
         )
       )
     end
@@ -252,6 +271,7 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
           applied_count: 1,
           noop_count: 1,
           failed_count: 1,
+          linked_agent_run_count: 3,
           completed_run_count: 1,
           failed_run_count: 2,
           project_count: 2,
@@ -269,14 +289,15 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
 
       expect(report[:summary]).to eq(
         expected_summary(
-          total_count: 2,
-          applied_count: 1,
+          total_count: 3,
+          applied_count: 2,
           noop_count: 1,
           failed_count: 0,
+          linked_agent_run_count: 2,
           completed_run_count: 1,
           failed_run_count: 1,
           project_count: 1,
-          actor_count: 2
+          actor_count: 3
         )
       )
       expect(report[:by_project].pluck(:project_name)).to eq([ "Beta" ])

--- a/spec/services/analytics/orchestration_decisions/report_spec.rb
+++ b/spec/services/analytics/orchestration_decisions/report_spec.rb
@@ -12,173 +12,192 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
   let(:project_b) { create(:project, account: account, name: "Beta") }
 
   before do
-    create_decision_record(
+    create_decision(
       project: project_a,
       agent_run: create(:agent_run, :completed, project: project_a),
-      status: "active",
-      tags: %w[Auth API],
+      decision_type: "planning_outcome",
+      actor: "Workflows::PlanningWorkflow",
+      context: { decision_status: "applied" },
       created_at: 2.days.ago
     )
 
-    create_decision_record(
+    create_decision(
       project: project_a,
       agent_run: create(:agent_run, :failed, project: project_a),
-      status: "superseded",
-      tags: %w[performance],
+      decision_type: "retry",
+      actor: "timeout_auto_retry",
+      context: { decision_status: "failed" },
       created_at: 1.day.ago
     )
 
-    create_decision_record(
+    create_decision(
       project: project_b,
       agent_run: create(:agent_run, :timeout, project: project_b),
-      status: "reverted",
-      tags: [],
+      decision_type: "select_agent",
+      actor: "model_selection",
+      context: { decision_status: "noop" },
       created_at: Time.current
     )
 
-    create_decision_record(
+    create_decision(
       project: project_b,
       agent_run: create(:agent_run, :completed, project: project_b),
-      status: "active",
-      tags: %w[auth],
+      decision_type: "select_agent",
+      actor: "rules",
+      context: { decision_status: "applied" },
       created_at: 14.days.ago
     )
   end
 
-  def create_decision_record(...)
-    create(:decision_record, ...)
+  def create_decision(...)
+    create(:orchestration_decision, ...)
   end
 
-  def expected_summary(total_count:, active_count:, superseded_count:, reverted_count:, completed_run_count:, failed_run_count:)
+  def expected_summary(total_count:, applied_count:, noop_count:, failed_count:, completed_run_count:, failed_run_count:, project_count:, actor_count:)
     {
       total_count: total_count,
-      active_count: active_count,
-      superseded_count: superseded_count,
-      reverted_count: reverted_count,
+      applied_count: applied_count,
+      noop_count: noop_count,
+      failed_count: failed_count,
       linked_agent_run_count: total_count,
       completed_run_count: completed_run_count,
-      failed_run_count: failed_run_count
+      failed_run_count: failed_run_count,
+      project_count: project_count,
+      actor_count: actor_count
     }
   end
 
-  def expected_project(project:, total_count:, decision_type_count:, active_count:, superseded_count:, reverted_count:)
+  def expected_project(project:, total_count:, decision_type_count:, actor_count:, applied_count:, noop_count:, failed_count:)
     {
       project_id: project.id,
       project_name: project.name,
       project_full_name: project.full_name,
       total_count: total_count,
       decision_type_count: decision_type_count,
-      active_count: active_count,
-      superseded_count: superseded_count,
-      reverted_count: reverted_count
+      actor_count: actor_count,
+      applied_count: applied_count,
+      noop_count: noop_count,
+      failed_count: failed_count
     }
   end
 
-  def expected_decision_type(decision_type:, total_count:, project_count:, active_count:, completed_run_count:)
+  def expected_decision_type(decision_type:, total_count:, project_count:, actor_count:, failed_count:, completed_run_count:)
     {
       decision_type: decision_type,
       total_count: total_count,
       project_count: project_count,
-      active_count: active_count,
+      actor_count: actor_count,
+      failed_count: failed_count,
       completed_run_count: completed_run_count
     }
   end
 
-  def expected_daily_volume(day:, total_count:, active_count:, superseded_count:, reverted_count:)
+  def expected_daily_volume(day:, total_count:, applied_count:, noop_count:, failed_count:)
     {
       day: day,
       total_count: total_count,
-      active_count: active_count,
-      superseded_count: superseded_count,
-      reverted_count: reverted_count
+      applied_count: applied_count,
+      noop_count: noop_count,
+      failed_count: failed_count
     }
   end
 
-  def expected_default_decision_types
+  def expected_project_rollup
+    [
+      expected_project(
+        project: project_a,
+        total_count: 2,
+        decision_type_count: 2,
+        actor_count: 2,
+        applied_count: 1,
+        noop_count: 0,
+        failed_count: 1
+      ),
+      expected_project(
+        project: project_b,
+        total_count: 2,
+        decision_type_count: 1,
+        actor_count: 2,
+        applied_count: 1,
+        noop_count: 1,
+        failed_count: 0
+      )
+    ]
+  end
+
+  def expected_decision_type_rollup
     [
       expected_decision_type(
-        decision_type: "auth",
+        decision_type: "select_agent",
         total_count: 2,
-        project_count: 2,
-        active_count: 2,
-        completed_run_count: 2
-      ),
-      expected_decision_type(
-        decision_type: "api",
-        total_count: 1,
         project_count: 1,
-        active_count: 1,
+        actor_count: 2,
+        failed_count: 0,
         completed_run_count: 1
       ),
       expected_decision_type(
-        decision_type: "performance",
+        decision_type: "planning_outcome",
         total_count: 1,
         project_count: 1,
-        active_count: 0,
-        completed_run_count: 0
+        actor_count: 1,
+        failed_count: 0,
+        completed_run_count: 1
       ),
       expected_decision_type(
-        decision_type: "uncategorized",
+        decision_type: "retry",
         total_count: 1,
         project_count: 1,
-        active_count: 0,
+        actor_count: 1,
+        failed_count: 1,
         completed_run_count: 0
       )
     ]
   end
 
-  def expected_default_daily_volume
+  def expected_daily_volume_rollup
     [
       expected_daily_volume(
         day: 14.days.ago.to_date,
         total_count: 1,
-        active_count: 1,
-        superseded_count: 0,
-        reverted_count: 0
+        applied_count: 1,
+        noop_count: 0,
+        failed_count: 0
       ),
       expected_daily_volume(
         day: 2.days.ago.to_date,
         total_count: 1,
-        active_count: 1,
-        superseded_count: 0,
-        reverted_count: 0
+        applied_count: 1,
+        noop_count: 0,
+        failed_count: 0
       ),
       expected_daily_volume(
         day: 1.day.ago.to_date,
         total_count: 1,
-        active_count: 0,
-        superseded_count: 1,
-        reverted_count: 0
+        applied_count: 0,
+        noop_count: 0,
+        failed_count: 1
       ),
       expected_daily_volume(
         day: Time.current.to_date,
         total_count: 1,
-        active_count: 0,
-        superseded_count: 0,
-        reverted_count: 1
+        applied_count: 0,
+        noop_count: 1,
+        failed_count: 0
       )
     ]
   end
 
-  def expected_auth_uncategorized_projects
-    [
-      expected_project(
-        project: project_b,
-        total_count: 2,
-        decision_type_count: 2,
-        active_count: 1,
-        superseded_count: 0,
-        reverted_count: 1
-      ),
-      expected_project(
-        project: project_a,
-        total_count: 1,
-        decision_type_count: 1,
-        active_count: 1,
-        superseded_count: 0,
-        reverted_count: 0
-      )
-    ]
+  def expected_select_agent_summary
+    expected_summary(
+      total_count: 2,
+      applied_count: 1,
+      noop_count: 1,
+      failed_count: 0,
+      completed_run_count: 1,
+      failed_run_count: 1,
+      project_count: 1,
+      actor_count: 2
+    )
   end
 
   describe ".call" do
@@ -201,48 +220,27 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
       expect(report[:summary]).to eq(
         expected_summary(
           total_count: 4,
-          active_count: 2,
-          superseded_count: 1,
-          reverted_count: 1,
+          applied_count: 2,
+          noop_count: 1,
+          failed_count: 1,
           completed_run_count: 2,
-          failed_run_count: 2
+          failed_run_count: 2,
+          project_count: 2,
+          actor_count: 4
         )
       )
     end
 
     it "builds the project rollup" do
-      report = described_class.call
-
-      expect(report[:by_project]).to eq([
-        expected_project(
-          project: project_a,
-          total_count: 2,
-          decision_type_count: 3,
-          active_count: 1,
-          superseded_count: 1,
-          reverted_count: 0
-        ),
-        expected_project(
-          project: project_b,
-          total_count: 2,
-          decision_type_count: 2,
-          active_count: 1,
-          superseded_count: 0,
-          reverted_count: 1
-        )
-      ])
+      expect(described_class.call[:by_project]).to eq(expected_project_rollup)
     end
 
     it "builds the decision-type rollup" do
-      report = described_class.call
-
-      expect(report[:by_decision_type]).to eq(expected_default_decision_types)
+      expect(described_class.call[:by_decision_type]).to eq(expected_decision_type_rollup)
     end
 
     it "builds the daily volume rollup" do
-      report = described_class.call
-
-      expect(report[:daily_volume]).to eq(expected_default_daily_volume)
+      expect(described_class.call[:daily_volume]).to eq(expected_daily_volume_rollup)
     end
 
     it "filters by time window" do
@@ -251,16 +249,18 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
       expect(report[:summary]).to eq(
         expected_summary(
           total_count: 3,
-          active_count: 1,
-          superseded_count: 1,
-          reverted_count: 1,
+          applied_count: 1,
+          noop_count: 1,
+          failed_count: 1,
           completed_run_count: 1,
-          failed_run_count: 2
+          failed_run_count: 2,
+          project_count: 2,
+          actor_count: 3
         )
       )
       expect(report[:by_project].map { |row| row[:project_name] }).to eq(%w[Alpha Beta])
       expect(report[:by_decision_type].map { |row| row[:decision_type] }).to eq(
-        %w[api auth performance uncategorized]
+        %w[planning_outcome retry select_agent]
       )
     end
 
@@ -270,52 +270,25 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
       expect(report[:summary]).to eq(
         expected_summary(
           total_count: 2,
-          active_count: 1,
-          superseded_count: 0,
-          reverted_count: 1,
+          applied_count: 1,
+          noop_count: 1,
+          failed_count: 0,
           completed_run_count: 1,
-          failed_run_count: 1
+          failed_run_count: 1,
+          project_count: 1,
+          actor_count: 2
         )
       )
       expect(report[:by_project].pluck(:project_name)).to eq([ "Beta" ])
-      expect(report[:by_decision_type].pluck(:decision_type)).to eq(%w[auth uncategorized])
+      expect(report[:by_decision_type].pluck(:decision_type)).to eq([ "select_agent" ])
     end
 
-    it "filters the summary by tag-derived decision type, including uncategorized records" do
-      report = described_class.call(filters: { decision_types: [ "AUTH", "uncategorized" ] })
+    it "filters by decision type" do
+      report = described_class.call(filters: { decision_types: [ "SELECT_AGENT" ] })
 
-      expect(report[:summary]).to eq(
-        expected_summary(
-          total_count: 3,
-          active_count: 2,
-          superseded_count: 0,
-          reverted_count: 1,
-          completed_run_count: 2,
-          failed_run_count: 1
-        )
-      )
-    end
-
-    it "filters the type rollup by tag-derived decision type, including uncategorized records" do
-      report = described_class.call(filters: { decision_types: [ "AUTH", "uncategorized" ] })
-
-      expect(report[:by_project]).to eq(expected_auth_uncategorized_projects)
-      expect(report[:by_decision_type]).to eq([
-        expected_decision_type(
-          decision_type: "auth",
-          total_count: 2,
-          project_count: 2,
-          active_count: 2,
-          completed_run_count: 2
-        ),
-        expected_decision_type(
-          decision_type: "uncategorized",
-          total_count: 1,
-          project_count: 1,
-          active_count: 0,
-          completed_run_count: 0
-        )
-      ])
+      expect(report[:summary]).to eq(expected_select_agent_summary)
+      expect(report[:by_project].pluck(:project_name)).to eq([ "Beta" ])
+      expect(report[:by_decision_type]).to eq([ expected_decision_type_rollup.first ])
     end
   end
 end

--- a/spec/services/models/select_spec.rb
+++ b/spec/services/models/select_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Models::Select do
     context "with project model override (required_model_id)" do
       let!(:llm_model) { create(:llm_model, model_id: "claude-sonnet-4-6", tier: "high") }
       let(:decision_log) { agent_run.agent_run_logs.where(log_type: "system").order(:id).last }
+      let(:orchestration_decision) { agent_run.orchestration_decisions.order(:id).last }
 
       before do
         project.update!(model_preferences: { "required_model_id" => "claude-sonnet-4-6" })
@@ -52,6 +53,25 @@ RSpec.describe Models::Select do
         expect(decision_log.metadata.dig("selection", "provider_key")).to eq("claude")
         expect(decision_log.metadata.dig("selection", "model_id")).to eq("claude-sonnet-4-6")
         expect(decision_log.metadata.dig("selection", "model_provider")).to eq(llm_model.provider)
+      end
+
+      it "records an orchestration decision with selection context" do
+        selection = described_class.call(agent_run: agent_run)
+
+        expect(orchestration_decision).to be_present
+        expect(orchestration_decision.decision_type).to eq("select_agent")
+        expect(orchestration_decision.actor).to eq("override")
+        expect(orchestration_decision.context).to include(
+          "decision_status" => "applied",
+          "issue_id" => agent_run.issue_id
+        )
+        expect(orchestration_decision.outputs).to include(
+          "outcome" => "selected",
+          "selection" => include(
+            "model_selection_id" => selection.id,
+            "model_id" => "claude-sonnet-4-6"
+          )
+        )
       end
 
       it "logs ranked candidates for the selection" do
@@ -305,6 +325,17 @@ RSpec.describe Models::Select do
         expect(log.metadata["selection"]).to be_nil
         expect(log.metadata.dig("inputs", "repository", "full_name")).to eq(project.full_name)
       end
+
+      it "records a noop orchestration decision" do
+        described_class.call(agent_run: agent_run)
+
+        decision = agent_run.orchestration_decisions.order(:id).last
+
+        expect(decision.decision_type).to eq("select_agent")
+        expect(decision.actor).to eq("model_selection")
+        expect(decision.context["decision_status"]).to eq("noop")
+        expect(decision.outputs["outcome"]).to eq("no_selection")
+      end
     end
 
     context "when override model does not exist" do
@@ -454,6 +485,22 @@ RSpec.describe Models::Select do
         expect(log.metadata).to include("type" => "model_selection_decision", "outcome" => "failed")
         expect(log.metadata.dig("error", "class")).to eq("StandardError")
         expect(log.metadata.dig("error", "message")).to eq("selector blew up")
+      end
+
+      it "records a failed orchestration decision before re-raising" do
+        expect {
+          described_class.call(agent_run: agent_run)
+        }.to raise_error(StandardError, "selector blew up")
+
+        decision = agent_run.orchestration_decisions.order(:id).last
+
+        expect(decision.decision_type).to eq("select_agent")
+        expect(decision.actor).to eq("model_selection")
+        expect(decision.context["decision_status"]).to eq("failed")
+        expect(decision.outputs["error"]).to include(
+          "class" => "StandardError",
+          "message" => "selector blew up"
+        )
       end
     end
   end

--- a/spec/services/models/select_spec.rb
+++ b/spec/services/models/select_spec.rb
@@ -503,5 +503,28 @@ RSpec.describe Models::Select do
         )
       end
     end
+
+    context "when the legacy system log write fails" do
+      before do
+        create(:llm_model, model_id: "claude-sonnet-4-6", tier: "high")
+        project.update!(model_preferences: { "required_model_id" => "claude-sonnet-4-6" })
+        allow(agent_run.agent_run_logs).to receive(:create!).and_raise(ActiveRecord::ActiveRecordError, "log write failed")
+      end
+
+      it "still records the orchestration decision" do
+        selection = described_class.call(agent_run: agent_run)
+
+        expect(selection).to be_present
+        decision = agent_run.orchestration_decisions.order(:id).last
+
+        expect(decision).to be_present
+        expect(decision.decision_type).to eq("select_agent")
+        expect(decision.context["decision_status"]).to eq("applied")
+        expect(decision.outputs).to include(
+          "outcome" => "selected",
+          "selection" => include("model_id" => "claude-sonnet-4-6")
+        )
+      end
+    end
   end
 end

--- a/spec/services/orchestration/decomposition_decisions/log_spec.rb
+++ b/spec/services/orchestration/decomposition_decisions/log_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe Orchestration::DecompositionDecisions::Log do
       }
     end
 
+    def orchestration_decision_for(decision_key)
+      OrchestrationDecision.find_by!(
+        [
+          <<~SQL.squish,
+            project_id = ?
+            AND decision_type = ?
+            AND actor = ?
+            AND context ->> 'decision_key' = ?
+          SQL
+          project.id,
+          "planning_outcome",
+          "Workflows::PlanningWorkflow",
+          decision_key
+        ]
+      )
+    end
+
     it "persists structured context, plan data, and derived hints" do
       decision = described_class.call(**payload)
 
@@ -85,6 +102,32 @@ RSpec.describe Orchestration::DecompositionDecisions::Log do
         "outcome" => "sub_issues_created",
         "hints" => include("task_count" => 3)
       )
+    end
+
+    it "marks skipped decomposition outcomes as noop" do
+      decision_key = "wf-123:planning_outcome:single-task"
+      described_class.call(**payload.merge(
+        decision_key: decision_key,
+        outcome: "single_task_plan",
+        plan_data: { tasks: [ { index: 0, title: "Only task", dependencies: [], parallel_group: 0 } ] }
+      ))
+      orchestration_decision = orchestration_decision_for(decision_key)
+
+      expect(orchestration_decision.context["decision_status"]).to eq("noop")
+      expect(orchestration_decision.outputs["outcome"]).to eq("single_task_plan")
+    end
+
+    it "marks failed decomposition outcomes as failed" do
+      decision_key = "wf-123:planning_outcome:failed"
+      described_class.call(**payload.merge(
+        decision_key: decision_key,
+        outcome: "decomposition_failed",
+        error_details: { error_message: "LLM failed" }
+      ))
+      orchestration_decision = orchestration_decision_for(decision_key)
+
+      expect(orchestration_decision.context["decision_status"]).to eq("failed")
+      expect(orchestration_decision.outputs["error_details"]).to include("error_message" => "LLM failed")
     end
 
     it "is idempotent on decision_key" do

--- a/spec/services/orchestration/decomposition_decisions/log_spec.rb
+++ b/spec/services/orchestration/decomposition_decisions/log_spec.rb
@@ -144,5 +144,25 @@ RSpec.describe Orchestration::DecompositionDecisions::Log do
         ).count
       ).to eq(1)
     end
+
+    it "does not mask the decomposition decision when orchestration mirroring fails" do
+      allow(OrchestrationDecision).to receive(:create!).and_raise(ActiveRecord::StatementInvalid, "boom")
+      allow(Rails.logger).to receive(:warn)
+
+      decision = described_class.call(**payload)
+
+      expect(decision).to be_persisted
+      expect(decision.decision_key).to eq(payload[:decision_key])
+      expect(DecompositionDecision.find_by(decision_key: payload[:decision_key])).to eq(decision)
+      expect(Rails.logger).to have_received(:warn).with(
+        hash_including(
+          message: "decomposition.orchestration_decision_failed",
+          project_id: project.id,
+          decision_key: payload[:decision_key],
+          error_class: "ActiveRecord::StatementInvalid",
+          error: "boom"
+        )
+      )
+    end
   end
 end

--- a/spec/services/orchestration/decomposition_decisions/log_spec.rb
+++ b/spec/services/orchestration/decomposition_decisions/log_spec.rb
@@ -62,12 +62,44 @@ RSpec.describe Orchestration::DecompositionDecisions::Log do
       expect(decision.metadata["prompt_source"]).to eq("fallback_prompt")
     end
 
+    it "mirrors the decomposition record into orchestration decisions" do
+      described_class.call(**payload)
+
+      orchestration_decision = OrchestrationDecision.find_by(
+        project: project,
+        decision_type: "planning_outcome",
+        actor: "Workflows::PlanningWorkflow"
+      )
+
+      expect(orchestration_decision).to be_present
+      expect(orchestration_decision.context).to include(
+        "decision_key" => payload[:decision_key],
+        "workflow_id" => payload[:workflow_id],
+        "decision_status" => "applied"
+      )
+      expect(orchestration_decision.inputs).to include(
+        "knowledge_results_count" => 2,
+        "issue" => include("id" => issue.id, "title" => "Add OAuth")
+      )
+      expect(orchestration_decision.outputs).to include(
+        "outcome" => "sub_issues_created",
+        "hints" => include("task_count" => 3)
+      )
+    end
+
     it "is idempotent on decision_key" do
       first = described_class.call(**payload)
       second = described_class.call(**payload)
 
       expect(second.id).to eq(first.id)
       expect(DecompositionDecision.where(decision_key: payload[:decision_key]).count).to eq(1)
+      expect(
+        OrchestrationDecision.where(
+          project: project,
+          decision_type: "planning_outcome",
+          actor: "Workflows::PlanningWorkflow"
+        ).count
+      ).to eq(1)
     end
   end
 end


### PR DESCRIPTION
## Summary

Implemented Phase 4.1 integration and committed it as `54ce64d` with `feat(orchestration): log and analyze orchestration decisions`.

The main changes were:
- model-selection decisions now write `OrchestrationDecision` records for `selected`, `no_selection`, and `failed` outcomes
- decomposition decisions are mirrored into `OrchestrationDecision` so the orchestration event stream includes planning/parallelization paths too
- the dashboard analytics/reporting stack now reads `OrchestrationDecision` instead of `DecisionRecord`, with applied/no-op/failed summaries, type/project rollups, and updated dashboard copy/UI
- request/service specs were updated to cover the new logging and analytics behavior

Verification:
- `bundle exec rubocop` passed
- `bundle exec rspec` passed: `11054 examples, 0 failures, 3 pending`
- `bin/rails db:prepare` passed once run with the provided Postgres host env
- `git status` is clean

The three pending specs are existing environment-dependent cases: two Qdrant live specs and one real-browser system spec.

---

Closes #1753