### PR TITLE
feat(strategy): build strategy evolution workflow

### DIFF
--- a/app/services/strategy_evolution/create_candidates.rb
+++ b/app/services/strategy_evolution/create_candidates.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module StrategyEvolution
+  class CreateCandidates
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(strategy_snapshot:, account:, mutations:)
+      @strategy_snapshot = strategy_snapshot.deep_symbolize_keys
+      @account = account
+      @mutations = Array(mutations)
+    end
+
+    def call
+      return [] if mutations.empty?
+
+      next_version = next_version_number
+
+      ActiveRecord::Base.transaction do
+        mutations.map do |mutation|
+          candidate = OrchestrationStrategy.create!(
+            account: account,
+            strategy_type: strategy_type,
+            name: strategy_name,
+            version: next_version,
+            configuration: candidate_configuration(mutation),
+            active: false
+          )
+          next_version += 1
+          candidate
+        end
+      end
+    end
+
+    private
+
+    attr_reader :strategy_snapshot, :account, :mutations
+
+    def strategy_type
+      strategy_snapshot.fetch(:strategy_type)
+    end
+
+    def strategy_name
+      strategy_snapshot.fetch(:name)
+    end
+
+    def next_version_number
+      current_max = OrchestrationStrategy.where(account:, strategy_type:).maximum(:version).to_i
+      [ current_max + 1, 1 ].max
+    end
+
+    def candidate_configuration(mutation)
+      mutation.configuration.deep_stringify_keys.merge(
+        "_evolution" => {
+          "source_strategy_id" => strategy_snapshot[:id],
+          "source_version" => strategy_snapshot[:version],
+          "generated_at" => Time.current.iso8601,
+          "mutation_strategy" => mutation.strategy,
+          "reasoning" => mutation.reasoning,
+          "expected_improvement" => mutation.expected_improvement,
+          "diff" => mutation.diff,
+          "provenance" => mutation.provenance
+        }
+      )
+    end
+  end
+end

--- a/app/services/strategy_evolution/create_candidates.rb
+++ b/app/services/strategy_evolution/create_candidates.rb
@@ -15,20 +15,22 @@ module StrategyEvolution
     def call
       return [] if mutations.empty?
 
-      next_version = next_version_number
-
       ActiveRecord::Base.transaction do
-        mutations.map do |mutation|
-          candidate = OrchestrationStrategy.create!(
-            account: account,
-            strategy_type: strategy_type,
-            name: strategy_name,
-            version: next_version,
-            configuration: candidate_configuration(mutation),
-            active: false
-          )
-          next_version += 1
-          candidate
+        account.with_lock do
+          next_version = next_version_number
+
+          mutations.map do |mutation|
+            candidate = OrchestrationStrategy.create!(
+              account: account,
+              strategy_type: strategy_type,
+              name: strategy_name,
+              version: next_version,
+              configuration: candidate_configuration(mutation),
+              active: false
+            )
+            next_version += 1
+            candidate
+          end
         end
       end
     end

--- a/app/services/strategy_evolution/mutate.rb
+++ b/app/services/strategy_evolution/mutate.rb
@@ -226,7 +226,11 @@ module StrategyEvolution
 
         current_value.all? { |key, value| valid_schema?(value, candidate_value[key]) }
       when Array
-        candidate_value.is_a?(Array)
+        return false unless candidate_value.is_a?(Array)
+        return true if current_value.empty?
+
+        element_exemplar = current_value.first
+        candidate_value.all? { |element| valid_schema?(element_exemplar, element) }
       when Numeric
         candidate_value.is_a?(Numeric)
       when TrueClass, FalseClass

--- a/app/services/strategy_evolution/mutate.rb
+++ b/app/services/strategy_evolution/mutate.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+module StrategyEvolution
+  class Mutate
+    include Llm::OutputNormalizer
+
+    DEFAULT_MODEL = "claude-sonnet-4-6"
+    TIMEOUT = 60
+    MAX_MUTATION_COUNT = 5
+    MIN_MUTATION_COUNT = 1
+    MAX_ERROR_OUTPUT = 500
+    MUTATION_STRATEGIES = %w[refinement risk_reduction throughput observability].freeze
+
+    Mutation = Struct.new(
+      :configuration,
+      :strategy,
+      :reasoning,
+      :expected_improvement,
+      :diff,
+      :provenance,
+      keyword_init: true
+    )
+
+    def self.call(strategy:, analysis:, options: {})
+      new(strategy:, analysis:, options:).call
+    end
+
+    def initialize(strategy:, analysis:, options: {})
+      @strategy = strategy.deep_symbolize_keys
+      @analysis = analysis.deep_symbolize_keys
+      raw_count = options.fetch(:mutation_count, options.fetch("mutation_count", 2))
+      @mutation_count = Integer(raw_count).clamp(MIN_MUTATION_COUNT, MAX_MUTATION_COUNT)
+      raw_strategies = options.fetch(:strategies, options.fetch("strategies", MUTATION_STRATEGIES))
+      @mutation_strategies = Array(raw_strategies).map(&:to_s) & MUTATION_STRATEGIES
+      validate!
+    end
+
+    def call
+      response = request_mutations
+      return [] if response.nil?
+
+      parse_mutations(response)
+    end
+
+    private
+
+    attr_reader :strategy, :analysis, :mutation_count, :mutation_strategies
+
+    PROMPT_SLUG = "evolution.mutate_strategy"
+
+    FALLBACK_PROMPT = <<~PROMPT
+      You are evolving an orchestration strategy from historical execution outcomes.
+
+      ## Current Strategy
+      ```json
+      {{current_strategy_json}}
+      ```
+
+      ## Prior Versions
+      ```json
+      {{prior_versions_json}}
+      ```
+
+      ## Historical Outcome Summary
+      ```json
+      {{performance_json}}
+      ```
+
+      ## Successful Samples
+      ```json
+      {{success_samples_json}}
+      ```
+
+      ## Failure Samples
+      ```json
+      {{failure_samples_json}}
+      ```
+
+      ## Mutation Strategies
+      {{mutation_strategies_section}}
+
+      ## Instructions
+      Generate exactly {{mutation_count}} candidate strategy variants.
+      Each candidate must:
+      - Return a full strategy configuration object, not a patch
+      - Keep the same top-level schema as the current strategy
+      - Use one of the allowed mutation strategies: {{strategies_csv}}
+      - Target an observed failure mode or guardrail issue
+
+      Respond with ONLY valid JSON:
+      {"mutations":[{"configuration":{},"strategy":"one of {{strategies_pipe}}","reasoning":"why this change should help","expected_improvement":"what should improve"}]}
+    PROMPT
+
+    def validate!
+      raise ArgumentError, "strategy configuration is required" if current_configuration.blank?
+      raise ArgumentError, "mutation strategies must not be empty" if mutation_strategies.empty?
+    end
+
+    def request_mutations
+      response = AgentHarness.send_message(
+        build_prompt,
+        provider: :claude,
+        model: DEFAULT_MODEL,
+        timeout: TIMEOUT,
+        tools: :none,
+        **Llm::TextMode.options
+      )
+      unless response.success?
+        Rails.logger.warn(
+          message: "strategy_evolution.mutate_unsuccessful_response",
+          strategy_type: strategy[:strategy_type],
+          account_id: strategy[:account_id],
+          exit_code: response.exit_code,
+          error_detail: truncated_error(response)
+        )
+        return nil
+      end
+
+      response.output
+    rescue AgentHarness::Error => e
+      Rails.logger.warn(
+        message: "strategy_evolution.mutate_failed",
+        strategy_type: strategy[:strategy_type],
+        account_id: strategy[:account_id],
+        error_class: e.class.name,
+        error: e.message
+      )
+      nil
+    end
+
+    def truncated_error(response)
+      raw = response.error.to_s
+      return nil if raw.blank?
+
+      Knowledge::Redaction::Redactor.call(text: raw).clean_text.truncate(MAX_ERROR_OUTPUT, omission: " [truncated]")
+    end
+
+    def build_prompt
+      vars = {
+        current_strategy_json: JSON.pretty_generate(current_configuration),
+        prior_versions_json: JSON.pretty_generate(Array(analysis[:prior_versions])),
+        performance_json: JSON.pretty_generate(analysis.fetch(:performance, {})),
+        success_samples_json: JSON.pretty_generate(Array(analysis[:sample_successes])),
+        failure_samples_json: JSON.pretty_generate(Array(analysis[:sample_failures])),
+        mutation_count: mutation_count,
+        mutation_strategies_section: mutation_strategies.map { |name| "- #{name.humanize}" }.join("\n"),
+        strategies_csv: mutation_strategies.join(", "),
+        strategies_pipe: mutation_strategies.join("/")
+      }
+
+      Prompts::Render.call(
+        slug: PROMPT_SLUG,
+        variables: vars,
+        fallback: -> { Prompts::Render.interpolate(FALLBACK_PROMPT, vars) }
+      )
+    end
+
+    def parse_mutations(raw_output)
+      cleaned = clean_output(raw_output)
+      parsed = JSON.parse(cleaned)
+      mutations = parsed.fetch("mutations") { return [] }
+      return [] unless mutations.is_a?(Array)
+
+      mutations.filter_map { |mutation| build_mutation(mutation) }.first(mutation_count)
+    rescue JSON::ParserError => e
+      Rails.logger.warn(
+        message: "strategy_evolution.mutate_parse_failed",
+        strategy_type: strategy[:strategy_type],
+        account_id: strategy[:account_id],
+        error: e.message
+      )
+      []
+    end
+
+    def clean_output(text)
+      cleaned = text.to_s.strip
+      loop do
+        previous = cleaned
+        cleaned = strip_markdown_fence(cleaned)
+        cleaned = strip_surrounding_quotes(cleaned)
+        break if cleaned == previous
+      end
+      cleaned
+    end
+
+    def build_mutation(data)
+      return nil unless data.is_a?(Hash)
+
+      configuration = data["configuration"]
+      strategy_name = data["strategy"].to_s.strip
+      reasoning = data["reasoning"].to_s.strip
+      expected_improvement = data["expected_improvement"].to_s.strip
+      return nil unless configuration.is_a?(Hash)
+      return nil unless mutation_strategies.include?(strategy_name)
+
+      normalized = configuration.deep_stringify_keys
+      return nil unless valid_schema?(current_configuration, normalized)
+
+      diff = diff_entries(current_configuration, normalized)
+      return nil if diff.empty?
+
+      Mutation.new(
+        configuration: normalized,
+        strategy: strategy_name,
+        reasoning: reasoning,
+        expected_improvement: expected_improvement,
+        diff: diff,
+        provenance: {
+          "source_strategy_id" => strategy[:id],
+          "source_version" => strategy[:version],
+          "decision_summary" => analysis.fetch(:performance, {}).slice(:decision_count, :success_rate, :guardrail_violation_types)
+        }
+      )
+    end
+
+    def current_configuration
+      @current_configuration ||= strategy.fetch(:configuration).deep_stringify_keys
+    end
+
+    def valid_schema?(current_value, candidate_value)
+      case current_value
+      when Hash
+        return false unless candidate_value.is_a?(Hash)
+        return true if current_value.empty?
+        return false unless current_value.keys.sort == candidate_value.keys.sort
+
+        current_value.all? { |key, value| valid_schema?(value, candidate_value[key]) }
+      when Array
+        candidate_value.is_a?(Array)
+      when Numeric
+        candidate_value.is_a?(Numeric)
+      when TrueClass, FalseClass
+        candidate_value == true || candidate_value == false
+      when String
+        candidate_value.is_a?(String)
+      when NilClass
+        true
+      else
+        candidate_value.class == current_value.class
+      end
+    end
+
+    def diff_entries(current_value, candidate_value, path = nil)
+      if current_value.is_a?(Hash) && candidate_value.is_a?(Hash)
+        current_value.keys.sort.flat_map do |key|
+          next_path = [ path, key ].compact.join("/")
+          diff_entries(current_value[key], candidate_value[key], next_path)
+        end
+      else
+        current_value == candidate_value ? [] : [ diff_entry(path, current_value, candidate_value) ]
+      end
+    end
+
+    def diff_entry(path, current_value, candidate_value)
+      {
+        "path" => "/#{path}",
+        "from" => current_value,
+        "to" => candidate_value
+      }
+    end
+  end
+end

--- a/app/services/strategy_evolution/prepare_inputs.rb
+++ b/app/services/strategy_evolution/prepare_inputs.rb
@@ -25,8 +25,8 @@ module StrategyEvolution
         strategy: serialize_strategy(current_strategy),
         prior_versions: prior_versions.map { |strategy| serialize_strategy(strategy) },
         performance: performance_summary,
-        sample_successes: sampled_decisions(successes),
-        sample_failures: sampled_decisions(failures)
+        sample_successes: serialize_decisions(sample_successes),
+        sample_failures: serialize_decisions(sample_failures)
       }
     end
 
@@ -46,50 +46,84 @@ module StrategyEvolution
         .limit(5)
     end
 
-    def decisions
-      @decisions ||= OrchestrationDecision
-        .includes(:agent_run)
+    def scoped_decisions
+      OrchestrationDecision
         .joins(:project)
         .where(projects: { account_id: account.id })
         .where(created_at: lookback_days.days.ago..Time.current)
-        .order(created_at: :desc, id: :desc)
-        .to_a
+    end
+
+    def aggregates
+      @aggregates ||= scoped_decisions
+        .left_joins(:agent_run)
+        .pick(
+          Arel.sql("COUNT(*)"),
+          Arel.sql("COUNT(agent_runs.id)"),
+          Arel.sql("COUNT(*) FILTER (WHERE agent_runs.status IN ('completed','no_output'))"),
+          Arel.sql("COUNT(*) FILTER (WHERE agent_runs.guardrail_violation_type IS NOT NULL " \
+                   "OR (agent_runs.id IS NOT NULL AND agent_runs.status NOT IN ('completed','no_output')))")
+        )
+    end
+
+    def decision_count
+      aggregates[0]
+    end
+
+    def run_backed_count
+      aggregates[1]
+    end
+
+    def success_count
+      aggregates[2]
+    end
+
+    def failure_count
+      aggregates[3]
+    end
+
+    def tallies
+      @tallies ||= begin
+        base = scoped_decisions.left_joins(:agent_run)
+        {
+          decision_types: tally_column(base, "orchestration_decisions.decision_type"),
+          actors: tally_column(base, "orchestration_decisions.actor"),
+          run_statuses: tally_column(base, "agent_runs.status"),
+          guardrail_violation_types: tally_column(base, "agent_runs.guardrail_violation_type")
+        }
+      end
     end
 
     def performance_summary
-      run_backed = decisions.count { |decision| decision.agent_run.present? }
-      successful = successes.count
-      failed = failures.count
-
       {
-        decision_count: decisions.size,
+        decision_count: decision_count,
         min_decisions: min_decisions,
-        run_backed_decision_count: run_backed,
-        success_count: successful,
-        failure_count: failed,
-        success_rate: success_rate(run_backed, successful),
-        decision_types: tally(decisions.map(&:decision_type)),
-        actors: tally(decisions.map(&:actor)),
-        run_statuses: tally(decisions.filter_map { |decision| decision.agent_run&.status }),
-        guardrail_violation_types: tally(decisions.filter_map { |decision| decision.agent_run&.guardrail_violation_type })
+        run_backed_decision_count: run_backed_count,
+        success_count: success_count,
+        failure_count: failure_count,
+        success_rate: success_rate(run_backed_count, success_count),
+        **tallies
       }
     end
 
-    def successes
-      decisions.select { |decision| successful_run?(decision) }
+    def sample_successes
+      @sample_successes ||= scoped_decisions
+        .includes(:agent_run)
+        .joins(:agent_run)
+        .where(agent_runs: { status: SUCCESSFUL_RUN_STATUSES })
+        .order(created_at: :desc, id: :desc)
+        .limit(sample_limit)
     end
 
-    def failures
-      decisions.select { |decision| failed_run?(decision) }
-    end
-
-    def successful_run?(decision)
-      SUCCESSFUL_RUN_STATUSES.include?(decision.agent_run&.status)
-    end
-
-    def failed_run?(decision)
-      decision.agent_run&.guardrail_violation_type.present? ||
-        (decision.agent_run.present? && !successful_run?(decision))
+    def sample_failures
+      @sample_failures ||= scoped_decisions
+        .includes(:agent_run)
+        .joins(:agent_run)
+        .where(
+          "agent_runs.guardrail_violation_type IS NOT NULL " \
+          "OR agent_runs.status NOT IN (?)", SUCCESSFUL_RUN_STATUSES
+        )
+        .order(created_at: :desc, id: :desc)
+        .limit(sample_limit)
     end
 
     def success_rate(run_backed, successful)
@@ -98,8 +132,8 @@ module StrategyEvolution
       (successful.to_f / run_backed).round(4)
     end
 
-    def sampled_decisions(rows)
-      rows.first(sample_limit).map do |decision|
+    def serialize_decisions(rows)
+      rows.map do |decision|
         {
           id: decision.id,
           decision_type: decision.decision_type,
@@ -128,8 +162,11 @@ module StrategyEvolution
       }
     end
 
-    def tally(values)
-      values.reject(&:blank?).tally
+    def tally_column(relation, column)
+      relation
+        .where.not(column => [ nil, "" ])
+        .group(column)
+        .count
     end
   end
 end

--- a/app/services/strategy_evolution/prepare_inputs.rb
+++ b/app/services/strategy_evolution/prepare_inputs.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module StrategyEvolution
+  class PrepareInputs
+    DEFAULT_LOOKBACK_DAYS = 60
+    DEFAULT_MIN_DECISIONS = 10
+    DEFAULT_SAMPLE_LIMIT = 5
+    SUCCESSFUL_RUN_STATUSES = %w[completed no_output].freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(strategy_type:, account:, lookback_days: DEFAULT_LOOKBACK_DAYS,
+      min_decisions: DEFAULT_MIN_DECISIONS, sample_limit: DEFAULT_SAMPLE_LIMIT)
+      @strategy_type = strategy_type.to_s
+      @account = account
+      @lookback_days = lookback_days
+      @min_decisions = min_decisions
+      @sample_limit = sample_limit
+    end
+
+    def call
+      {
+        strategy: serialize_strategy(current_strategy),
+        prior_versions: prior_versions.map { |strategy| serialize_strategy(strategy) },
+        performance: performance_summary,
+        sample_successes: sampled_decisions(successes),
+        sample_failures: sampled_decisions(failures)
+      }
+    end
+
+    private
+
+    attr_reader :strategy_type, :account, :lookback_days, :min_decisions, :sample_limit
+
+    def current_strategy
+      @current_strategy ||= OrchestrationStrategy.active_for(strategy_type, account: account) ||
+        OrchestrationStrategies::Resolve.call(strategy_type:, account:)
+    end
+
+    def prior_versions
+      @prior_versions ||= OrchestrationStrategy
+        .where(account:, strategy_type:)
+        .order(version: :desc, id: :desc)
+        .limit(5)
+    end
+
+    def decisions
+      @decisions ||= OrchestrationDecision
+        .includes(:agent_run)
+        .joins(:project)
+        .where(projects: { account_id: account.id })
+        .where(created_at: lookback_days.days.ago..Time.current)
+        .order(created_at: :desc, id: :desc)
+        .to_a
+    end
+
+    def performance_summary
+      run_backed = decisions.count { |decision| decision.agent_run.present? }
+      successful = successes.count
+      failed = failures.count
+
+      {
+        decision_count: decisions.size,
+        min_decisions: min_decisions,
+        run_backed_decision_count: run_backed,
+        success_count: successful,
+        failure_count: failed,
+        success_rate: success_rate(run_backed, successful),
+        decision_types: tally(decisions.map(&:decision_type)),
+        actors: tally(decisions.map(&:actor)),
+        run_statuses: tally(decisions.filter_map { |decision| decision.agent_run&.status }),
+        guardrail_violation_types: tally(decisions.filter_map { |decision| decision.agent_run&.guardrail_violation_type })
+      }
+    end
+
+    def successes
+      decisions.select { |decision| successful_run?(decision) }
+    end
+
+    def failures
+      decisions.select { |decision| failed_run?(decision) }
+    end
+
+    def successful_run?(decision)
+      SUCCESSFUL_RUN_STATUSES.include?(decision.agent_run&.status)
+    end
+
+    def failed_run?(decision)
+      decision.agent_run&.guardrail_violation_type.present? ||
+        (decision.agent_run.present? && !successful_run?(decision))
+    end
+
+    def success_rate(run_backed, successful)
+      return nil if run_backed.zero?
+
+      (successful.to_f / run_backed).round(4)
+    end
+
+    def sampled_decisions(rows)
+      rows.first(sample_limit).map do |decision|
+        {
+          id: decision.id,
+          decision_type: decision.decision_type,
+          actor: decision.actor,
+          created_at: decision.created_at.iso8601,
+          run_status: decision.agent_run&.status,
+          guardrail_violation_type: decision.agent_run&.guardrail_violation_type,
+          context: decision.context,
+          inputs: decision.inputs,
+          outputs: decision.outputs
+        }
+      end
+    end
+
+    def serialize_strategy(strategy)
+      return nil unless strategy
+
+      {
+        id: strategy.id,
+        strategy_type: strategy.strategy_type,
+        name: strategy.name,
+        version: strategy.version,
+        active: strategy.active,
+        account_id: strategy.account_id,
+        configuration: strategy.configuration
+      }
+    end
+
+    def tally(values)
+      values.reject(&:blank?).tally
+    end
+  end
+end

--- a/app/temporal/activities/generate_strategy_mutations_activity.rb
+++ b/app/temporal/activities/generate_strategy_mutations_activity.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Activities
+  class GenerateStrategyMutationsActivity < BaseActivity
+    activity_name "GenerateStrategyMutations"
+
+    def execute(input)
+      mutations = StrategyEvolution::Mutate.call(
+        strategy: input.fetch(:strategy),
+        analysis: input.slice(:performance, :sample_successes, :sample_failures, :prior_versions),
+        options: {
+          mutation_count: input.fetch(:mutation_count, 2),
+          strategies: input[:strategies]
+        }.compact
+      )
+
+      {
+        strategy_type: input.fetch(:strategy).fetch(:strategy_type),
+        mutations: mutations.map do |mutation|
+          {
+            configuration: mutation.configuration,
+            strategy: mutation.strategy,
+            reasoning: mutation.reasoning,
+            expected_improvement: mutation.expected_improvement,
+            diff: mutation.diff,
+            provenance: mutation.provenance
+          }
+        end
+      }
+    end
+  end
+end

--- a/app/temporal/activities/persist_strategy_candidates_activity.rb
+++ b/app/temporal/activities/persist_strategy_candidates_activity.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Activities
+  class PersistStrategyCandidatesActivity < BaseActivity
+    activity_name "PersistStrategyCandidates"
+
+    Mutation = Struct.new(
+      :configuration,
+      :strategy,
+      :reasoning,
+      :expected_improvement,
+      :diff,
+      :provenance,
+      keyword_init: true
+    )
+
+    def execute(input)
+      account = Account.find(input.fetch(:account_id))
+      mutations = Array(input.fetch(:mutations, [])).map do |mutation|
+        Mutation.new(**mutation.slice(
+          :configuration,
+          :strategy,
+          :reasoning,
+          :expected_improvement,
+          :diff,
+          :provenance
+        ))
+      end
+
+      candidates = StrategyEvolution::CreateCandidates.call(
+        strategy_snapshot: input.fetch(:strategy),
+        account: account,
+        mutations: mutations
+      )
+
+      {
+        strategy_type: input.fetch(:strategy).fetch(:strategy_type),
+        candidate_ids: candidates.map(&:id),
+        candidate_count: candidates.size
+      }
+    end
+  end
+end

--- a/app/temporal/activities/persist_strategy_candidates_activity.rb
+++ b/app/temporal/activities/persist_strategy_candidates_activity.rb
@@ -4,15 +4,7 @@ module Activities
   class PersistStrategyCandidatesActivity < BaseActivity
     activity_name "PersistStrategyCandidates"
 
-    Mutation = Struct.new(
-      :configuration,
-      :strategy,
-      :reasoning,
-      :expected_improvement,
-      :diff,
-      :provenance,
-      keyword_init: true
-    )
+    Mutation = StrategyEvolution::Mutate::Mutation
 
     def execute(input)
       account = Account.find(input.fetch(:account_id))

--- a/app/temporal/activities/prepare_strategy_evolution_inputs_activity.rb
+++ b/app/temporal/activities/prepare_strategy_evolution_inputs_activity.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Activities
+  class PrepareStrategyEvolutionInputsActivity < BaseActivity
+    activity_name "PrepareStrategyEvolutionInputs"
+
+    def execute(input)
+      account = Account.find(input.fetch(:account_id))
+      strategy_type = input.fetch(:strategy_type)
+
+      result = StrategyEvolution::PrepareInputs.call(
+        strategy_type: strategy_type,
+        account: account,
+        lookback_days: input.fetch(:lookback_days, StrategyEvolution::PrepareInputs::DEFAULT_LOOKBACK_DAYS),
+        min_decisions: input.fetch(:min_decisions, StrategyEvolution::PrepareInputs::DEFAULT_MIN_DECISIONS),
+        sample_limit: input.fetch(:sample_limit, StrategyEvolution::PrepareInputs::DEFAULT_SAMPLE_LIMIT)
+      )
+
+      result.merge(account_id: account.id, strategy_type: strategy_type)
+    end
+  end
+end

--- a/app/temporal/workflows/strategy_evolution_workflow.rb
+++ b/app/temporal/workflows/strategy_evolution_workflow.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Workflows
+  class StrategyEvolutionWorkflow < BaseWorkflow
+    MUTATION_TIMEOUT = 120
+
+    def execute(input)
+      account_id = input.fetch(:account_id)
+      strategy_type = input.fetch(:strategy_type)
+
+      inputs_result = run_activity(
+        Activities::PrepareStrategyEvolutionInputsActivity,
+        {
+          account_id: account_id,
+          strategy_type: strategy_type,
+          lookback_days: input.fetch(:lookback_days, StrategyEvolution::PrepareInputs::DEFAULT_LOOKBACK_DAYS),
+          min_decisions: input.fetch(:min_decisions, StrategyEvolution::PrepareInputs::DEFAULT_MIN_DECISIONS),
+          sample_limit: input.fetch(:sample_limit, StrategyEvolution::PrepareInputs::DEFAULT_SAMPLE_LIMIT)
+        },
+        timeout: 30
+      )
+
+      performance = inputs_result.fetch(:performance, {})
+      decision_count = performance.fetch(:decision_count, 0)
+      min_decisions = performance.fetch(:min_decisions, StrategyEvolution::PrepareInputs::DEFAULT_MIN_DECISIONS)
+
+      if decision_count < min_decisions
+        return {
+          status: :insufficient_history,
+          account_id: account_id,
+          strategy_type: strategy_type,
+          decision_count: decision_count,
+          min_decisions: min_decisions
+        }
+      end
+
+      mutation_result = run_activity(
+        Activities::GenerateStrategyMutationsActivity,
+        inputs_result.merge(
+          mutation_count: input.fetch(:mutation_count, 2),
+          strategies: input[:strategies]
+        ),
+        timeout: MUTATION_TIMEOUT
+      )
+
+      mutations = mutation_result.fetch(:mutations, [])
+      if mutations.blank?
+        return {
+          status: :no_mutations,
+          account_id: account_id,
+          strategy_type: strategy_type
+        }
+      end
+
+      persist_result = run_activity(
+        Activities::PersistStrategyCandidatesActivity,
+        {
+          account_id: account_id,
+          strategy: inputs_result.fetch(:strategy),
+          mutations: mutations
+        },
+        timeout: 30
+      )
+
+      candidate_ids = persist_result.fetch(:candidate_ids, [])
+      if candidate_ids.blank?
+        return {
+          status: :no_candidates_created,
+          account_id: account_id,
+          strategy_type: strategy_type
+        }
+      end
+
+      {
+        status: :candidates_created,
+        account_id: account_id,
+        strategy_type: strategy_type,
+        candidate_ids: candidate_ids,
+        candidate_count: persist_result.fetch(:candidate_count, candidate_ids.size)
+      }
+    end
+  end
+end

--- a/spec/services/strategy_evolution/create_candidates_spec.rb
+++ b/spec/services/strategy_evolution/create_candidates_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyEvolution::CreateCandidates do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:strategy) { create(:orchestration_strategy, :review_settings, account: account, version: 3) }
+    let(:mutation) do
+      StrategyEvolution::Mutate::Mutation.new(
+        configuration: strategy.configuration.deep_dup.tap do |config|
+          config["methods"]["paid_agent"]["termination"]["timeout_minutes"] = 20
+        end,
+        strategy: "risk_reduction",
+        reasoning: "Shorter timeout after repeated loops",
+        expected_improvement: "Less guardrail thrash",
+        diff: [ { "path" => "/methods/paid_agent/termination/timeout_minutes", "from" => 30, "to" => 20 } ],
+        provenance: { "decision_summary" => { "decision_count" => 15, "success_rate" => 0.4 } }
+      )
+    end
+    let(:strategy_snapshot) do
+      {
+        id: strategy.id,
+        strategy_type: strategy.strategy_type,
+        name: strategy.name,
+        version: strategy.version,
+        configuration: strategy.configuration
+      }
+    end
+
+    it "persists inactive candidate versions with provenance metadata" do
+      candidates = described_class.call(strategy_snapshot: strategy_snapshot, account: account, mutations: [ mutation ])
+
+      expect(candidates.size).to eq(1)
+      expect(candidates.first).not_to be_active
+      expect(candidates.first.version).to eq(4)
+      expect(candidates.first.configuration.dig("_evolution", "mutation_strategy")).to eq("risk_reduction")
+      expect(candidates.first.configuration.dig("_evolution", "diff")).to include(
+        include("path" => "/methods/paid_agent/termination/timeout_minutes")
+      )
+      expect(OrchestrationStrategy.active_for("review_settings", account: account)).to eq(strategy)
+    end
+
+    it "returns an empty array when no mutations are provided" do
+      expect(described_class.call(strategy_snapshot: strategy_snapshot, account: account, mutations: [])).to eq([])
+    end
+  end
+end

--- a/spec/services/strategy_evolution/create_candidates_spec.rb
+++ b/spec/services/strategy_evolution/create_candidates_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe StrategyEvolution::CreateCandidates do
       expect(OrchestrationStrategy.active_for("review_settings", account: account)).to eq(strategy)
     end
 
+    it "allocates candidate versions while holding the account lock" do
+      allow(account).to receive(:with_lock).and_wrap_original do |method, *args, &block|
+        method.call(*args, &block)
+      end
+
+      described_class.call(strategy_snapshot: strategy_snapshot, account: account, mutations: [ mutation ])
+
+      expect(account).to have_received(:with_lock)
+    end
+
     it "returns an empty array when no mutations are provided" do
       expect(described_class.call(strategy_snapshot: strategy_snapshot, account: account, mutations: [])).to eq([])
     end

--- a/spec/services/strategy_evolution/mutate_spec.rb
+++ b/spec/services/strategy_evolution/mutate_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyEvolution::Mutate do
+  let(:strategy) do
+    {
+      id: 12,
+      strategy_type: "review_settings",
+      name: "Review Settings",
+      version: 3,
+      account_id: 7,
+      configuration: OrchestrationStrategies::Defaults.review_settings
+    }
+  end
+  let(:analysis) do
+    {
+      prior_versions: [ strategy.except(:configuration).merge(configuration: strategy[:configuration]) ],
+      performance: { decision_count: 12, success_rate: 0.42, guardrail_violation_types: { "loop_detected" => 2 } },
+      sample_successes: [ { id: 1, run_status: "completed" } ],
+      sample_failures: [ { id: 2, run_status: "paused", guardrail_violation_type: "loop_detected" } ]
+    }
+  end
+  let(:candidate_config) do
+    strategy[:configuration].deep_dup.tap do |config|
+      config["methods"]["paid_agent"]["termination"]["timeout_minutes"] = 20
+    end
+  end
+  let(:valid_response) do
+    JSON.generate(
+      "mutations" => [
+        {
+          "configuration" => candidate_config,
+          "strategy" => "risk_reduction",
+          "reasoning" => "Shorten review retries when loops appear",
+          "expected_improvement" => "Fewer paused review runs"
+        }
+      ]
+    )
+  end
+  let(:response) { instance_double(AgentHarness::Response, success?: true, output: valid_response) }
+
+  before do
+    allow(AgentHarness).to receive(:send_message).and_return(response)
+    allow(Llm::TextMode).to receive(:options).and_return({})
+  end
+
+  it "returns structured mutations with provenance and diffs" do
+    mutations = described_class.call(strategy: strategy, analysis: analysis, options: { mutation_count: 1 })
+
+    expect(mutations.size).to eq(1)
+    expect(mutations.first.strategy).to eq("risk_reduction")
+    expect(mutations.first.configuration.dig("methods", "paid_agent", "termination", "timeout_minutes")).to eq(20)
+    expect(mutations.first.diff).to contain_exactly(
+      include("path" => "/methods/paid_agent/termination/timeout_minutes", "from" => 30, "to" => 20)
+    )
+    expect(mutations.first.provenance).to include(
+      "source_strategy_id" => 12,
+      "source_version" => 3
+    )
+  end
+
+  it "passes historical analysis into the LLM prompt" do
+    described_class.call(strategy: strategy, analysis: analysis)
+
+    expect(AgentHarness).to have_received(:send_message).with(
+      a_string_including("\"decision_count\": 12", "\"loop_detected\": 2"),
+      hash_including(provider: :claude, model: "claude-sonnet-4-6", timeout: 60, tools: :none)
+    )
+  end
+
+  it "drops candidates that violate the current strategy schema guardrail" do
+    invalid_response = JSON.generate(
+      "mutations" => [
+        {
+          "configuration" => candidate_config.merge("unexpected" => true),
+          "strategy" => "risk_reduction",
+          "reasoning" => "invalid",
+          "expected_improvement" => "invalid"
+        }
+      ]
+    )
+    allow(response).to receive(:output).and_return(invalid_response)
+
+    expect(described_class.call(strategy: strategy, analysis: analysis)).to eq([])
+  end
+end

--- a/spec/services/strategy_evolution/mutate_spec.rb
+++ b/spec/services/strategy_evolution/mutate_spec.rb
@@ -84,4 +84,47 @@ RSpec.describe StrategyEvolution::Mutate do
 
     expect(described_class.call(strategy: strategy, analysis: analysis)).to eq([])
   end
+
+  context "with array-bearing strategy types" do
+    let(:strategy) do
+      {
+        id: 20,
+        strategy_type: "feature_orchestration",
+        name: "Feature Orchestration",
+        version: 1,
+        account_id: 7,
+        configuration: OrchestrationStrategies::Defaults.feature_orchestration
+      }
+    end
+    let(:candidate_config) do
+      strategy[:configuration].deep_dup.tap do |config|
+        config["planning_phases"] = %w[fetch_planning_context decompose_feature]
+      end
+    end
+
+    it "accepts candidates whose arrays contain valid element types" do
+      mutations = described_class.call(strategy: strategy, analysis: analysis, options: { mutation_count: 1 })
+
+      expect(mutations.size).to eq(1)
+    end
+
+    it "rejects candidates whose arrays contain invalid element types" do
+      bad_config = strategy[:configuration].deep_dup.tap do |config|
+        config["planning_phases"] = [ 1, { "oops" => true } ]
+      end
+      bad_response = JSON.generate(
+        "mutations" => [
+          {
+            "configuration" => bad_config,
+            "strategy" => "risk_reduction",
+            "reasoning" => "invalid array elements",
+            "expected_improvement" => "nothing"
+          }
+        ]
+      )
+      allow(response).to receive(:output).and_return(bad_response)
+
+      expect(described_class.call(strategy: strategy, analysis: analysis)).to eq([])
+    end
+  end
 end

--- a/spec/services/strategy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/strategy_evolution/prepare_inputs_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyEvolution::PrepareInputs do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:project) { create(:project, account: account) }
+    let!(:strategy) { create(:orchestration_strategy, :review_settings, account: account, version: 2) }
+    let!(:older_version) { create(:orchestration_strategy, :review_settings, account: account, version: 1, active: false) }
+
+    before do
+      create(
+        :orchestration_decision,
+        project: project,
+        agent_run: create(:agent_run, :completed, project: project),
+        decision_type: "queue_review_run",
+        actor: "auto_review"
+      )
+      create(
+        :orchestration_decision,
+        project: project,
+        agent_run: create(:agent_run, :paused, project: project),
+        decision_type: "escalate",
+        actor: "auto_review"
+      )
+      other_project = create(:project)
+      create(:orchestration_decision, project: other_project, agent_run: create(:agent_run, :failed, project: other_project))
+    end
+
+    it "collects the current strategy, recent versions, and account-scoped outcomes" do
+      result = described_class.call(strategy_type: "review_settings", account: account, min_decisions: 2)
+
+      expect(result[:strategy]).to include(id: strategy.id, version: 2, strategy_type: "review_settings")
+      expect(result[:prior_versions].map { |row| row[:id] }).to include(strategy.id, older_version.id)
+      expect(result.dig(:performance, :decision_count)).to eq(2)
+      expect(result.dig(:performance, :success_count)).to eq(1)
+      expect(result.dig(:performance, :failure_count)).to eq(1)
+      expect(result.dig(:performance, :guardrail_violation_types)).to include("loop_detected" => 1)
+      expect(result[:sample_successes].size).to eq(1)
+      expect(result[:sample_failures].size).to eq(1)
+    end
+  end
+end

--- a/spec/temporal/activities/generate_strategy_mutations_activity_spec.rb
+++ b/spec/temporal/activities/generate_strategy_mutations_activity_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::GenerateStrategyMutationsActivity do
+  let(:activity) { described_class.new }
+  let(:strategy) do
+    {
+      id: 3,
+      strategy_type: "review_settings",
+      name: "Review Settings",
+      version: 2,
+      account_id: 9,
+      configuration: OrchestrationStrategies::Defaults.review_settings
+    }
+  end
+  let(:mutation) do
+    StrategyEvolution::Mutate::Mutation.new(
+      configuration: strategy[:configuration],
+      strategy: "refinement",
+      reasoning: "Tune review flow",
+      expected_improvement: "Higher success rate",
+      diff: [ { "path" => "/enabled", "from" => false, "to" => true } ],
+      provenance: { "source_version" => 2 }
+    )
+  end
+
+  it "serializes generated mutations" do
+    allow(StrategyEvolution::Mutate).to receive(:call).and_return([ mutation ])
+
+    result = activity.execute(
+      strategy: strategy,
+      performance: { decision_count: 12 },
+      sample_successes: [],
+      sample_failures: [],
+      mutation_count: 1
+    )
+
+    expect(result[:mutations]).to contain_exactly(
+      include(strategy: "refinement", expected_improvement: "Higher success rate")
+    )
+  end
+end

--- a/spec/temporal/activities/persist_strategy_candidates_activity_spec.rb
+++ b/spec/temporal/activities/persist_strategy_candidates_activity_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe Activities::PersistStrategyCandidatesActivity do
     input[:mutations][0][:diff] = [ { "path" => "/enabled", "from" => false, "to" => true } ]
   end
 
+  it "rehydrates mutations with the canonical mutation type" do
+    allow(StrategyEvolution::CreateCandidates).to receive(:call).and_return([])
+
+    activity.execute(input)
+
+    expect(StrategyEvolution::CreateCandidates).to have_received(:call) do |kwargs|
+      expect(kwargs[:mutations]).to all(be_a(StrategyEvolution::Mutate::Mutation))
+    end
+  end
+
   it "persists inactive candidates and returns their ids" do
     result = activity.execute(input)
 

--- a/spec/temporal/activities/persist_strategy_candidates_activity_spec.rb
+++ b/spec/temporal/activities/persist_strategy_candidates_activity_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::PersistStrategyCandidatesActivity do
+  let(:activity) { described_class.new }
+  let(:account) { create(:account) }
+  let(:strategy) { create(:orchestration_strategy, :review_settings, account: account, version: 2) }
+  let(:input) do
+    {
+      account_id: account.id,
+      strategy: {
+        id: strategy.id,
+        strategy_type: strategy.strategy_type,
+        name: strategy.name,
+        version: strategy.version,
+        configuration: strategy.configuration
+      },
+      mutations: [
+        {
+          configuration: strategy.configuration.deep_dup,
+          strategy: "observability",
+          reasoning: "Record more context",
+          expected_improvement: "Faster diagnosis",
+          diff: [ { "path" => "/enabled", "from" => false, "to" => false } ],
+          provenance: { "source_version" => strategy.version }
+        }
+      ]
+    }
+  end
+
+  before do
+    input[:mutations][0][:configuration]["enabled"] = true
+    input[:mutations][0][:diff] = [ { "path" => "/enabled", "from" => false, "to" => true } ]
+  end
+
+  it "persists inactive candidates and returns their ids" do
+    result = activity.execute(input)
+
+    expect(result[:candidate_count]).to eq(1)
+    expect(result[:candidate_ids]).not_to be_empty
+    expect(OrchestrationStrategy.find(result[:candidate_ids].first)).not_to be_active
+  end
+end

--- a/spec/temporal/workflows/strategy_evolution_workflow_spec.rb
+++ b/spec/temporal/workflows/strategy_evolution_workflow_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Workflows::StrategyEvolutionWorkflow do
+  let(:workflow) { described_class.new }
+  let(:input) { { account_id: 9, strategy_type: "review_settings" } }
+  let(:prepared_inputs) do
+    {
+      account_id: 9,
+      strategy_type: "review_settings",
+      strategy: {
+        id: 3,
+        strategy_type: "review_settings",
+        name: "Review Settings",
+        version: 2,
+        configuration: OrchestrationStrategies::Defaults.review_settings
+      },
+      prior_versions: [],
+      performance: { decision_count: 12, min_decisions: 10 },
+      sample_successes: [],
+      sample_failures: []
+    }
+  end
+
+  before do
+    allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger)
+  end
+
+  it "stops early when history is insufficient" do
+    allow(workflow).to receive(:run_activity).and_return(prepared_inputs.deep_merge(performance: { decision_count: 4, min_decisions: 10 }))
+
+    result = workflow.execute(input)
+
+    expect(result).to include(status: :insufficient_history, decision_count: 4, min_decisions: 10)
+    expect(workflow).to have_received(:run_activity).once
+  end
+
+  it "returns no_mutations when guardrails filter every candidate" do
+    allow(workflow).to receive(:run_activity) do |activity_class, *_args|
+      case activity_class.name
+      when "Activities::PrepareStrategyEvolutionInputsActivity"
+        prepared_inputs
+      when "Activities::GenerateStrategyMutationsActivity"
+        { strategy_type: "review_settings", mutations: [] }
+      end
+    end
+
+    result = workflow.execute(input)
+
+    expect(result).to include(status: :no_mutations, account_id: 9, strategy_type: "review_settings")
+  end
+
+  it "persists generated candidates without auto-promoting them" do
+    mutation = {
+      configuration: OrchestrationStrategies::Defaults.review_settings.deep_dup,
+      strategy: "risk_reduction",
+      reasoning: "Safer timeout",
+      expected_improvement: "Fewer loops",
+      diff: [ { path: "/methods/paid_agent/termination/timeout_minutes", from: 30, to: 20 } ],
+      provenance: { source_version: 2 }
+    }
+
+    allow(workflow).to receive(:run_activity) do |activity_class, *_args|
+      case activity_class.name
+      when "Activities::PrepareStrategyEvolutionInputsActivity"
+        prepared_inputs
+      when "Activities::GenerateStrategyMutationsActivity"
+        { strategy_type: "review_settings", mutations: [ mutation ] }
+      when "Activities::PersistStrategyCandidatesActivity"
+        { strategy_type: "review_settings", candidate_ids: [ 101 ], candidate_count: 1 }
+      end
+    end
+
+    result = workflow.execute(input)
+
+    expect(result).to include(status: :candidates_created, candidate_ids: [ 101 ], candidate_count: 1)
+  end
+end


### PR DESCRIPTION
## Summary

Implemented the strategy evolution workflow and committed it on a feature branch.

The change adds a new `StrategyEvolution` pipeline that prepares historical inputs, asks the LLM for candidate mutations with provenance and structured diffs, and persists those candidates as inactive `OrchestrationStrategy` versions without promoting them. It also adds Temporal activities plus `Workflows::StrategyEvolutionWorkflow` to handle insufficient-history, no-mutation, and no-candidate guardrails.

Verification is complete: `bundle exec rubocop` passed, `bundle exec rspec` passed (`11267 examples, 0 failures, 3 pending`), and the commit succeeded with hooks enabled. Commit: `9e9a2f6` (`feat(strategy): add strategy evolution workflow`).

---

Closes #1757