### PR TITLE
fix(dashboard): serialize deferred frame loading

### DIFF
--- a/app/javascript/controllers/dashboard_frames_controller.js
+++ b/app/javascript/controllers/dashboard_frames_controller.js
@@ -1,0 +1,64 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Staggers dashboard turbo-frame loads so the page does not burst several
+// concurrent widget requests at once. This keeps the initial dashboard shell
+// responsive in constrained environments where Puma only has a few threads.
+export default class extends Controller {
+  static targets = ["frame"]
+  static values = {
+    frameDelay: { type: Number, default: 350 },
+    initialDelay: { type: Number, default: 0 }
+  }
+
+  connect() {
+    this.pendingFrames = this.frameTargets.filter((frame) => !frame.getAttribute("src"))
+    this.loadNextFrame = this.loadNextFrame.bind(this)
+    this.onFrameSettled = this.onFrameSettled.bind(this)
+
+    this.frameTargets.forEach((frame) => {
+      frame.addEventListener("turbo:frame-load", this.onFrameSettled)
+      frame.addEventListener("turbo:fetch-request-error", this.onFrameSettled)
+    })
+
+    this.scheduleNextFrame(this.initialDelayValue)
+  }
+
+  disconnect() {
+    if (this.timer) {
+      window.clearTimeout(this.timer)
+      this.timer = null
+    }
+
+    this.frameTargets.forEach((frame) => {
+      frame.removeEventListener("turbo:frame-load", this.onFrameSettled)
+      frame.removeEventListener("turbo:fetch-request-error", this.onFrameSettled)
+    })
+  }
+
+  scheduleNextFrame(delay = this.frameDelayValue) {
+    if (this.pendingFrames.length === 0 || this.currentFrame) return
+
+    this.timer = window.setTimeout(this.loadNextFrame, delay)
+  }
+
+  loadNextFrame() {
+    this.timer = null
+    const frame = this.pendingFrames.shift()
+    if (!frame) return
+
+    const src = frame.dataset.dashboardFramesSrc
+    if (src) {
+      this.currentFrame = frame
+      frame.setAttribute("src", src)
+    } else {
+      this.scheduleNextFrame()
+    }
+  }
+
+  onFrameSettled(event) {
+    if (event.target !== this.currentFrame) return
+
+    this.currentFrame = null
+    this.scheduleNextFrame()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -31,6 +31,9 @@ application.register("chat-stream", ChatStreamController)
 import ConfirmDeleteController from "./confirm_delete_controller"
 application.register("confirm-delete", ConfirmDeleteController)
 
+import DashboardFramesController from "./dashboard_frames_controller"
+application.register("dashboard-frames", DashboardFramesController)
+
 import DropdownController from "./dropdown_controller"
 application.register("dropdown", DropdownController)
 

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -49,7 +49,6 @@
       <turbo-frame id="dashboard-queue-health"
         data-dashboard-frames-target="frame"
         data-dashboard-frames-src="<%= dashboard_queue_health_path %>"
-        loading="lazy"
         class="mt-6 block">
         <div class="animate-pulse rounded-lg bg-gray-100 h-24"></div>
       </turbo-frame>
@@ -70,8 +69,7 @@
     <div class="mt-4">
       <turbo-frame id="dashboard-metrics"
         data-dashboard-frames-target="frame"
-        data-dashboard-frames-src="<%= dashboard_metrics_path(time_range: @time_range) %>"
-        loading="lazy">
+        data-dashboard-frames-src="<%= dashboard_metrics_path(time_range: @time_range) %>">
         <div class="animate-pulse space-y-4">
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div class="rounded-lg bg-gray-100 h-24"></div>
@@ -83,14 +81,12 @@
       </turbo-frame>
       <turbo-frame id="dashboard-knowledge-stats"
         data-dashboard-frames-target="frame"
-        data-dashboard-frames-src="<%= dashboard_knowledge_stats_path %>"
-        loading="lazy">
+        data-dashboard-frames-src="<%= dashboard_knowledge_stats_path %>">
         <div class="animate-pulse mt-8 rounded-lg bg-gray-100 h-24"></div>
       </turbo-frame>
       <turbo-frame id="dashboard-decision-metrics"
         data-dashboard-frames-target="frame"
         data-dashboard-frames-src="<%= dashboard_decision_metrics_path(time_range: @time_range) %>"
-        loading="lazy"
         class="mt-8 block">
         <div class="animate-pulse space-y-4">
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -113,8 +109,7 @@
     <div class="mt-4">
       <turbo-frame id="dashboard-performance"
         data-dashboard-frames-target="frame"
-        data-dashboard-frames-src="<%= dashboard_performance_path(time_range: @time_range, status: @status_filter, goal: @goal_filter) %>"
-        loading="lazy">
+        data-dashboard-frames-src="<%= dashboard_performance_path(time_range: @time_range, status: @status_filter, goal: @goal_filter) %>">
         <div class="animate-pulse space-y-4">
           <div class="rounded-lg bg-gray-100 h-48"></div>
           <div class="rounded-lg bg-gray-100 h-48"></div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream_from current_account, :dashboard_updates %>
 <%= turbo_stream_from current_account, :live_dashboard %>
 
-<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10" data-controller="live-dashboard">
+<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10" data-controller="live-dashboard dashboard-frames">
   <div class="sm:flex sm:items-center sm:justify-between">
     <div class="sm:flex-auto">
       <h1 class="text-2xl font-semibold leading-6 text-gray-900">Dashboard</h1>
@@ -46,7 +46,11 @@
         <%= render "dashboard/queue_preview", queue_preview: @queue_preview %>
       </div>
 
-      <turbo-frame id="dashboard-queue-health" src="<%= dashboard_queue_health_path %>" loading="lazy" class="mt-6 block">
+      <turbo-frame id="dashboard-queue-health"
+        data-dashboard-frames-target="frame"
+        data-dashboard-frames-src="<%= dashboard_queue_health_path %>"
+        loading="lazy"
+        class="mt-6 block">
         <div class="animate-pulse rounded-lg bg-gray-100 h-24"></div>
       </turbo-frame>
 
@@ -64,7 +68,10 @@
       Cumulative / Periodic Metrics
     </summary>
     <div class="mt-4">
-      <turbo-frame id="dashboard-metrics" src="<%= dashboard_metrics_path(time_range: @time_range) %>" loading="lazy">
+      <turbo-frame id="dashboard-metrics"
+        data-dashboard-frames-target="frame"
+        data-dashboard-frames-src="<%= dashboard_metrics_path(time_range: @time_range) %>"
+        loading="lazy">
         <div class="animate-pulse space-y-4">
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div class="rounded-lg bg-gray-100 h-24"></div>
@@ -74,10 +81,17 @@
           </div>
         </div>
       </turbo-frame>
-      <turbo-frame id="dashboard-knowledge-stats" src="<%= dashboard_knowledge_stats_path %>" loading="lazy">
+      <turbo-frame id="dashboard-knowledge-stats"
+        data-dashboard-frames-target="frame"
+        data-dashboard-frames-src="<%= dashboard_knowledge_stats_path %>"
+        loading="lazy">
         <div class="animate-pulse mt-8 rounded-lg bg-gray-100 h-24"></div>
       </turbo-frame>
-      <turbo-frame id="dashboard-decision-metrics" src="<%= dashboard_decision_metrics_path(time_range: @time_range) %>" loading="lazy" class="mt-8 block">
+      <turbo-frame id="dashboard-decision-metrics"
+        data-dashboard-frames-target="frame"
+        data-dashboard-frames-src="<%= dashboard_decision_metrics_path(time_range: @time_range) %>"
+        loading="lazy"
+        class="mt-8 block">
         <div class="animate-pulse space-y-4">
           <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div class="rounded-lg bg-gray-100 h-24"></div>
@@ -97,7 +111,10 @@
       Performance
     </summary>
     <div class="mt-4">
-      <turbo-frame id="dashboard-performance" src="<%= dashboard_performance_path(time_range: @time_range, status: @status_filter, goal: @goal_filter) %>" loading="lazy">
+      <turbo-frame id="dashboard-performance"
+        data-dashboard-frames-target="frame"
+        data-dashboard-frames-src="<%= dashboard_performance_path(time_range: @time_range, status: @status_filter, goal: @goal_filter) %>"
+        loading="lazy">
         <div class="animate-pulse space-y-4">
           <div class="rounded-lg bg-gray-100 h-48"></div>
           <div class="rounded-lg bg-gray-100 h-48"></div>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -74,6 +74,20 @@ RSpec.describe "Dashboard" do
         expect(doc.at_css("turbo-frame#dashboard-decision-metrics[loading='lazy']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[loading='lazy']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-queue-health[loading='lazy']")).to be_present
+        expect(doc.at_css("[data-controller~='dashboard-frames']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-metrics[data-dashboard-frames-src='#{dashboard_metrics_path(time_range: "cumulative")}']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-performance[data-dashboard-frames-src='#{dashboard_performance_path(time_range: "cumulative", status: "all", goal: "all")}']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-decision-metrics[data-dashboard-frames-src='#{dashboard_decision_metrics_path(time_range: "cumulative")}']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[data-dashboard-frames-src='#{dashboard_knowledge_stats_path}']")).to be_present
+      end
+
+      it "wires queue health and frame serialization on the dashboard shell" do
+        get dashboard_path
+
+        doc = Nokogiri::HTML(response.body)
+        expect(doc.at_css("[data-controller~='dashboard-frames']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-queue-health[loading='lazy']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-queue-health[data-dashboard-frames-src='#{dashboard_queue_health_path}']")).to be_present
       end
 
       it "shows live metrics section with active runs" do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -65,20 +65,25 @@ RSpec.describe "Dashboard" do
         expect(chart).to be_present
       end
 
-      it "renders lazy turbo frames for metrics, performance, knowledge, and queue health" do
+      it "renders deferred turbo frame wiring for metrics, performance, knowledge, and queue health", :aggregate_failures do
         get dashboard_path
 
         doc = Nokogiri::HTML(response.body)
-        expect(doc.at_css("turbo-frame#dashboard-metrics[loading='lazy']")).to be_present
-        expect(doc.at_css("turbo-frame#dashboard-performance[loading='lazy']")).to be_present
-        expect(doc.at_css("turbo-frame#dashboard-decision-metrics[loading='lazy']")).to be_present
-        expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[loading='lazy']")).to be_present
-        expect(doc.at_css("turbo-frame#dashboard-queue-health[loading='lazy']")).to be_present
         expect(doc.at_css("[data-controller~='dashboard-frames']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-metrics[data-dashboard-frames-src='#{dashboard_metrics_path(time_range: "cumulative")}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-performance[data-dashboard-frames-src='#{dashboard_performance_path(time_range: "cumulative", status: "all", goal: "all")}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-decision-metrics[data-dashboard-frames-src='#{dashboard_decision_metrics_path(time_range: "cumulative")}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[data-dashboard-frames-src='#{dashboard_knowledge_stats_path}']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-metrics[loading]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-performance[loading]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-decision-metrics[loading]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[loading]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-queue-health[loading]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-metrics[src]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-performance[src]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-decision-metrics[src]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[src]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-queue-health[src]")).not_to be_present
       end
 
       it "wires queue health and frame serialization on the dashboard shell" do
@@ -86,8 +91,8 @@ RSpec.describe "Dashboard" do
 
         doc = Nokogiri::HTML(response.body)
         expect(doc.at_css("[data-controller~='dashboard-frames']")).to be_present
-        expect(doc.at_css("turbo-frame#dashboard-queue-health[loading='lazy']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-queue-health[data-dashboard-frames-src='#{dashboard_queue_health_path}']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-queue-health[src]")).not_to be_present
       end
 
       it "shows live metrics section with active runs" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1430,8 +1430,8 @@ RSpec.describe Containers::Provision do
         )
       end
 
-      it "sets COPILOT_GITHUB_TOKEN from gh auth when config.json lacks oauth_token" do
-        allow(service).to receive(:gh_cli_token).and_return("gho_test_token_from_gh")
+      it "sets COPILOT_GITHUB_TOKEN when config.json lacks oauth_token and token resolution succeeds" do
+        allow(service).to receive(:resolve_copilot_github_token).and_return("gho_test_token_from_gh")
 
         expect(Docker::Container).to receive(:create) do |config|
           expect(config["Env"]).to include("COPILOT_GITHUB_TOKEN=gho_test_token_from_gh")

--- a/spec/system/dashboard_orchestration_decision_metrics_spec.rb
+++ b/spec/system/dashboard_orchestration_decision_metrics_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Dashboard orchestration decision metrics", type: :system do
     create(:user, :owner, account: account, email: "owner@example.com", password: "password123")
   end
 
-  it "shows the lazy-loaded decision metrics frame on the dashboard" do
+  it "renders deferred decision metrics frame wiring on the dashboard shell" do
     visit new_user_session_path
 
     fill_in "Email", with: user.email
@@ -18,7 +18,8 @@ RSpec.describe "Dashboard orchestration decision metrics", type: :system do
     frame = page.find("turbo-frame#dashboard-decision-metrics", visible: false)
 
     expect(page).to have_content("Cumulative / Periodic Metrics")
-    expect(frame["src"]).to eq(dashboard_decision_metrics_path(time_range: "cumulative"))
-    expect(frame["loading"]).to eq("lazy")
+    expect(frame["data-dashboard-frames-src"]).to eq(dashboard_decision_metrics_path(time_range: "cumulative"))
+    expect(frame["src"]).to be_nil
+    expect(page.find("[data-controller~='dashboard-frames']", visible: false)).to be_present
   end
 end


### PR DESCRIPTION
## Summary
- serialize dashboard Turbo frame loading instead of firing all widget requests at once
- keep dashboard frame placeholders in the shell and defer frame `src` assignment through a Stimulus controller
- cover the deferred dashboard frame wiring in request specs

## Testing
- `COVERAGE=false bin/rspec spec/requests/dashboard_spec.rb`
- `yarn build` (passed in the original workspace; unavailable in the clean worktree because `esbuild` was not installed there)
