### PR TITLE
feat(scaling): add scaling observation instrumentation

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -153,6 +153,7 @@ class Project < ApplicationRecord
   has_many :service_containers, through: :project_service_containers
   has_many :decision_records, dependent: :destroy
   has_many :orchestration_decisions, dependent: :destroy
+  has_many :scaling_observations, dependent: :destroy
   has_many :llm_output_metrics, dependent: :destroy
   has_many :knowledge_runs, dependent: :destroy
   has_many :knowledge_usage_stats, dependent: :destroy

--- a/app/models/scaling_observation.rb
+++ b/app/models/scaling_observation.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class ScalingObservation < ApplicationRecord
+  belongs_to :project
+  belongs_to :issue, optional: true
+
+  before_validation :assign_project_from_issue
+
+  validates :workflow_id, presence: true, length: { maximum: 255 }, uniqueness: { scope: :project_id }
+  validates :workflow_name, presence: true, length: { maximum: 255 }
+  validates :observation_type, presence: true, length: { maximum: 100 }
+  validates :status, presence: true, length: { maximum: 100 }
+  validates :success, inclusion: { in: [ true, false ] }
+  validates :parallel_execution, inclusion: { in: [ true, false ] }
+  validate :project_matches_issue
+  validate :metadata_is_object
+
+  NUMERIC_FIELDS = %i[
+    task_count
+    dependency_edge_count
+    parallelizable_group_count
+    agent_count_planned
+    agent_count_launched
+    agent_count_succeeded
+    agent_count_failed
+    agent_count_blocked
+    total_iterations
+    max_iterations
+    parallelism_planned
+    parallelism_observed
+    batch_count
+    duration_seconds
+    total_cost_cents
+    total_input_tokens
+    total_output_tokens
+  ].freeze
+
+  NUMERIC_FIELDS.each do |field|
+    validates field, numericality: { greater_than_or_equal_to: 0 }, allow_nil: field == :duration_seconds
+  end
+
+  scope :recent, -> { order(created_at: :desc, id: :desc) }
+  scope :for_project, ->(project) { where(project: project) }
+  scope :for_issue, ->(issue) { where(issue: issue) }
+  scope :for_workflow, ->(workflow_id) { where(workflow_id: workflow_id) }
+  scope :by_observation_type, ->(observation_type) { where(observation_type: observation_type) }
+  scope :by_status, ->(status) { where(status: status) }
+
+  private
+
+  def assign_project_from_issue
+    self.project ||= issue&.project
+  end
+
+  def project_matches_issue
+    return unless project && issue
+    return if project_id == issue.project_id
+
+    errors.add(:project, "must match the issue's project")
+  end
+
+  def metadata_is_object
+    return if metadata.is_a?(Hash)
+
+    errors.add(:metadata, "must be an object")
+  end
+end

--- a/app/services/scaling_observations/record.rb
+++ b/app/services/scaling_observations/record.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+module ScalingObservations
+  class Record
+    NON_LAUNCHED_ERRORS = %w[dependencies_failed unresolvable_dependencies].freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project_id:, workflow_id:, workflow_name:, issue_id: nil, tasks: [], parallel_result: nil,
+      started_at: nil, error_details: {}, metadata: {})
+      @project_id = project_id
+      @workflow_id = workflow_id
+      @workflow_name = workflow_name
+      @issue_id = issue_id
+      @tasks = Array(tasks).map(&:deep_symbolize_keys)
+      @parallel_result = (parallel_result || {}).deep_symbolize_keys
+      @started_at = started_at
+      @error_details = normalize_hash(error_details)
+      @metadata = normalize_hash(metadata)
+    end
+
+    def call
+      observation = ScalingObservation.find_or_initialize_by(project_id: project_id, workflow_id: workflow_id)
+
+      observation.assign_attributes(
+        issue_id: issue_id,
+        workflow_name: workflow_name,
+        observation_type: "feature_orchestration",
+        status: observation_status,
+        success: observation_success?,
+        parallel_execution: parallel_execution?,
+        task_count: tasks.size,
+        dependency_edge_count: dependency_edge_count,
+        parallelizable_group_count: parallelizable_group_count,
+        agent_count_planned: tasks.size,
+        agent_count_launched: launched_count,
+        agent_count_succeeded: succeeded_count,
+        agent_count_failed: failed_count,
+        agent_count_blocked: blocked_count,
+        total_iterations: child_runs.sum { |run| run.iterations.to_i },
+        max_iterations: child_runs.map { |run| run.iterations.to_i }.max.to_i,
+        parallelism_planned: parallelism_planned,
+        parallelism_observed: parallelism_observed,
+        batch_count: batch_count,
+        duration_seconds: duration_seconds,
+        total_cost_cents: child_runs.sum { |run| run.cost_cents.to_i },
+        total_input_tokens: child_runs.sum { |run| run.tokens_input.to_i },
+        total_output_tokens: child_runs.sum { |run| run.tokens_output.to_i },
+        metadata: observation_metadata
+      )
+
+      observation.save!
+      observation
+    end
+
+    private
+
+    attr_reader :project_id, :workflow_id, :workflow_name, :issue_id, :tasks, :parallel_result, :started_at,
+      :error_details, :metadata
+
+    def project
+      @project ||= Project.find(project_id)
+    end
+
+    def child_runs
+      @child_runs ||= AgentRun.where(project: project, parent_workflow_id: workflow_id).to_a
+    end
+
+    def execution_summary
+      @execution_summary ||= normalize_hash(parallel_result[:execution_summary]).deep_symbolize_keys
+    end
+
+    def result_rows
+      @result_rows ||= Array(parallel_result[:results]).map do |result|
+        result.is_a?(Hash) ? result.deep_symbolize_keys : {}
+      end
+    end
+
+    def dependency_edge_count
+      tasks.sum { |task| Array(task[:dependencies]).size }
+    end
+
+    def parallelizable_group_count
+      tasks.group_by { |task| task[:parallel_group] }.count { |_group, grouped_tasks| grouped_tasks.size > 1 }
+    end
+
+    def parallelism_planned
+      tasks.group_by { |task| task[:parallel_group] }.values.map(&:size).max.to_i
+    end
+
+    def parallelism_observed
+      execution_summary[:max_parallelism_observed].to_i
+    end
+
+    def batch_count
+      execution_summary[:batch_count].to_i
+    end
+
+    def launched_count
+      return launched_results.size if result_rows.any?
+
+      child_runs.size
+    end
+
+    def succeeded_count
+      return successful_results.size if result_rows.any?
+
+      child_runs.count { |run| run.status == "completed" }
+    end
+
+    def failed_count
+      return launched_failed_results.size if result_rows.any?
+
+      child_runs.count { |run| run.status != "completed" }
+    end
+
+    def blocked_count
+      return blocked_results.size if result_rows.any?
+      return tasks.size if parallel_result[:error].present? && parallel_execution?
+
+      0
+    end
+
+    def launched_results
+      result_rows.reject do |result|
+        result[:queued] == true || result.key?(:blocked_by) || NON_LAUNCHED_ERRORS.include?(result[:error].to_s)
+      end
+    end
+
+    def successful_results
+      result_rows.select { |result| result[:success] }
+    end
+
+    def terminal_failed_results
+      result_rows.select { |result| result[:success] == false }
+    end
+
+    def launched_failed_results
+      terminal_failed_results - blocked_results
+    end
+
+    def blocked_results
+      result_rows.select do |result|
+        result[:queued] == true || result.key?(:blocked_by) || NON_LAUNCHED_ERRORS.include?(result[:error].to_s)
+      end
+    end
+
+    def duration_seconds
+      return unless started_at
+
+      [ Time.current - started_at, 0 ].max.to_i
+    end
+
+    def observation_status
+      return "failed" if error_details.present?
+      return "skipped" unless parallel_execution?
+      return parallel_result[:error].to_s if parallel_result[:error].present?
+      return "completed" if parallel_result[:success]
+      return "partial_failure" if succeeded_count.positive? && failed_count.positive?
+
+      "failed"
+    end
+
+    def observation_success?
+      return false if error_details.present?
+      return true unless parallel_execution?
+
+      parallel_result[:success] == true
+    end
+
+    def parallel_execution?
+      tasks.size > 1
+    end
+
+    def observation_metadata
+      metadata.merge(
+        "batch_sizes" => Array(execution_summary[:batch_sizes]),
+        "error_tally" => result_rows.filter_map { |result| result[:error].presence }.tally,
+        "child_agent_run_ids" => child_runs.map(&:id),
+        "parallel_result" => {
+          "completed" => parallel_result[:completed],
+          "failed" => parallel_result[:failed],
+          "total" => parallel_result[:total],
+          "error" => parallel_result[:error]
+        }.compact,
+        "conflicts" => normalize_hash(parallel_result[:conflicts]),
+        "error_details" => error_details
+      )
+    end
+
+    def normalize_hash(value)
+      value.is_a?(Hash) ? value.deep_stringify_keys : {}
+    end
+  end
+end

--- a/app/services/scaling_observations/record.rb
+++ b/app/services/scaling_observations/record.rb
@@ -108,20 +108,25 @@ module ScalingObservations
     def succeeded_count
       return successful_results.size if result_rows.any?
 
-      child_runs.count { |run| run.status == "completed" }
+      child_run_status_counts.fetch("completed", 0)
     end
 
     def failed_count
       return launched_failed_results.size if result_rows.any?
 
-      child_runs.count { |run| run.status != "completed" }
+      AgentRun::FAILURE_STATUSES.sum { |status| child_run_status_counts.fetch(status, 0) }
     end
 
     def blocked_count
       return blocked_results.size if result_rows.any?
-      return tasks.size if parallel_result[:error].present? && parallel_execution?
 
-      0
+      return 0 unless parallel_execution?
+
+      [ tasks.size - launched_count, 0 ].max
+    end
+
+    def child_run_status_counts
+      @child_run_status_counts ||= child_runs.group_by(&:status).transform_values(&:size)
     end
 
     def launched_results

--- a/app/temporal/activities/record_scaling_observation_activity.rb
+++ b/app/temporal/activities/record_scaling_observation_activity.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Activities
+  class RecordScalingObservationActivity < BaseActivity
+    activity_name "RecordScalingObservation"
+
+    def execute(input)
+      observation = ScalingObservations::Record.call(**input.deep_symbolize_keys)
+
+      {
+        scaling_observation_id: observation.id,
+        workflow_id: observation.workflow_id
+      }
+    end
+  end
+end

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -29,6 +29,7 @@ module Workflows
       issue_id = input[:issue_id]
       timeout_seconds = input.fetch(:timeout_seconds, DEFAULT_TIMEOUT_SECONDS)
       workflow_id = Temporalio::Workflow.info.workflow_id
+      workflow_started_at = Temporalio::Workflow.now
 
       Temporalio::Workflow.logger.info(
         message: "feature_orchestration.started",
@@ -38,6 +39,7 @@ module Workflows
 
       tasks = []
       created_issues = []
+      parallel_result = nil
       planning_context = {}
       prompt_source = nil
       decision_phase = "planning"
@@ -119,6 +121,18 @@ module Workflows
           issue_id: issue_id,
           task_count: tasks.size
         )
+        safe_record_scaling_observation(
+          project_id: project_id,
+          issue_id: issue_id,
+          workflow_id: workflow_id,
+          workflow_name: self.class.name,
+          tasks: tasks,
+          started_at: workflow_started_at,
+          metadata: {
+            prompt_source: prompt_source,
+            created_issues: created_issues
+          }
+        )
         return {
           success: true,
           project_id: project_id,
@@ -172,6 +186,20 @@ module Workflows
         failed: parallel_result[:failed]
       )
 
+      safe_record_scaling_observation(
+        project_id: project_id,
+        issue_id: issue_id,
+        workflow_id: workflow_id,
+        workflow_name: self.class.name,
+        tasks: tasks,
+        parallel_result: parallel_result,
+        started_at: workflow_started_at,
+        metadata: {
+          prompt_source: prompt_source,
+          created_issues: created_issues
+        }
+      )
+
       {
         success: parallel_result[:success],
         project_id: project_id,
@@ -206,6 +234,25 @@ module Workflows
         metadata: {
           prompt_source: prompt_source,
           failed_step: failed_step
+        }
+      )
+
+      safe_record_scaling_observation(
+        project_id: project_id,
+        issue_id: issue_id,
+        workflow_id: workflow_id,
+        workflow_name: self.class.name,
+        tasks: tasks,
+        parallel_result: parallel_result,
+        started_at: workflow_started_at,
+        error_details: {
+          error_class: e.class.to_s,
+          error_message: e.message,
+          failed_step: failed_step
+        },
+        metadata: {
+          prompt_source: prompt_source,
+          created_issues: created_issues
         }
       )
 
@@ -373,6 +420,22 @@ module Workflows
         workflow_id: Temporalio::Workflow.info.workflow_id,
         error_class: log_error.class.to_s,
         error: log_error.message
+      )
+    end
+
+    def safe_record_scaling_observation(payload)
+      run_activity(
+        Activities::RecordScalingObservationActivity,
+        payload,
+        timeout: 30,
+        retry_policy: NO_RETRY
+      )
+    rescue => record_error
+      Temporalio::Workflow.logger.warn(
+        message: "feature_orchestration.scaling_observation_record_failed",
+        workflow_id: Temporalio::Workflow.info.workflow_id,
+        error_class: record_error.class.to_s,
+        error: record_error.message
       )
     end
   end

--- a/app/temporal/workflows/parallel_agent_execution_workflow.rb
+++ b/app/temporal/workflows/parallel_agent_execution_workflow.rb
@@ -64,7 +64,7 @@ module Workflows
 
       # Step 2: Launch child workflows with concurrency control
       max_concurrent = capacity[:available_slots]
-      results = launch_and_monitor_children(
+      results, execution_summary = launch_and_monitor_children(
         project_id: project_id,
         sub_tasks: sub_tasks,
         max_concurrent: max_concurrent,
@@ -119,7 +119,8 @@ module Workflows
         completed: completed,
         failed: failed,
         results: results,
-        conflicts: conflict_result
+        conflicts: conflict_result,
+        execution_summary: execution_summary
       }
       output[:aggregated_pr] = aggregated_pr if aggregated_pr
       output
@@ -220,6 +221,7 @@ module Workflows
       all_results = []
       batch_index = 0
       current_slots = max_concurrent
+      batch_sizes = []
 
       while remaining_tasks.any?
         ready_tasks, blocked_tasks = partition_ready_tasks(remaining_tasks, all_results)
@@ -291,6 +293,7 @@ module Workflows
         batch_size = [ current_slots, ready_tasks.size ].min
         batch = ready_tasks.first(batch_size)
         remaining_tasks -= batch
+        batch_sizes << batch.size
 
         batch_results = execute_batch(
           project_id: project_id,
@@ -304,7 +307,14 @@ module Workflows
         batch_index += 1
       end
 
-      all_results
+      [
+        all_results,
+        {
+          batch_count: batch_sizes.size,
+          batch_sizes: batch_sizes,
+          max_parallelism_observed: batch_sizes.max.to_i
+        }
+      ]
     end
 
     def partition_ready_tasks(remaining_tasks, all_results)

--- a/db/migrate/20260508212202_create_scaling_observations.rb
+++ b/db/migrate/20260508212202_create_scaling_observations.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+class CreateScalingObservations < ActiveRecord::Migration[8.1]
+  def up
+    create_table :scaling_observations,
+      comment: "Run-level observations for studying orchestration scaling behavior across agent count, iterations, and parallelism." do |t|
+      t.references :project,
+        null: false,
+        index: false,
+        foreign_key: { on_delete: :cascade },
+        comment: "Owning project for tenant isolation and experiment segmentation."
+      t.references :issue,
+        null: true,
+        index: false,
+        foreign_key: { on_delete: :nullify },
+        comment: "Parent feature issue whose orchestration emitted the observation."
+      t.string :workflow_id,
+        null: false,
+        limit: 255,
+        comment: "Temporal workflow ID for the orchestration run."
+      t.string :workflow_name,
+        null: false,
+        limit: 255,
+        comment: "Workflow class that emitted the observation."
+      t.string :observation_type,
+        null: false,
+        limit: 100,
+        default: "feature_orchestration",
+        comment: "Observation category used to group comparable orchestration runs."
+      t.string :status,
+        null: false,
+        limit: 100,
+        default: "completed",
+        comment: "Terminal orchestration outcome such as completed, skipped, no_capacity, partial_failure, or failed."
+      t.boolean :success,
+        null: false,
+        default: false,
+        comment: "Whether the orchestration run achieved its intended terminal outcome."
+      t.boolean :parallel_execution,
+        null: false,
+        default: false,
+        comment: "Whether the workflow attempted parallel child execution."
+      t.integer :task_count,
+        null: false,
+        default: 0,
+        comment: "Number of planned sub-tasks in the decomposition."
+      t.integer :dependency_edge_count,
+        null: false,
+        default: 0,
+        comment: "Total dependency edges across planned sub-tasks."
+      t.integer :parallelizable_group_count,
+        null: false,
+        default: 0,
+        comment: "Count of planned parallel groups containing more than one task."
+      t.integer :agent_count_planned,
+        null: false,
+        default: 0,
+        comment: "Number of agents the orchestration planned to use."
+      t.integer :agent_count_launched,
+        null: false,
+        default: 0,
+        comment: "Number of child agent runs actually launched."
+      t.integer :agent_count_succeeded,
+        null: false,
+        default: 0,
+        comment: "Number of launched child agent runs that completed successfully."
+      t.integer :agent_count_failed,
+        null: false,
+        default: 0,
+        comment: "Number of launched child agent runs that completed unsuccessfully."
+      t.integer :agent_count_blocked,
+        null: false,
+        default: 0,
+        comment: "Number of planned tasks that never launched because of dependencies, deadlines, or capacity."
+      t.integer :total_iterations,
+        null: false,
+        default: 0,
+        comment: "Sum of iterations across launched child agent runs."
+      t.integer :max_iterations,
+        null: false,
+        default: 0,
+        comment: "Maximum iterations observed on any launched child agent run."
+      t.integer :parallelism_planned,
+        null: false,
+        default: 0,
+        comment: "Maximum planned same-wave task count from decomposition parallel groups."
+      t.integer :parallelism_observed,
+        null: false,
+        default: 0,
+        comment: "Maximum child workflow batch size actually launched concurrently."
+      t.integer :batch_count,
+        null: false,
+        default: 0,
+        comment: "Number of execution batches used by the parallel workflow."
+      t.integer :duration_seconds,
+        comment: "Elapsed wall-clock seconds for the orchestration workflow."
+      t.integer :total_cost_cents,
+        null: false,
+        default: 0,
+        comment: "Sum of cost_cents across launched child agent runs."
+      t.integer :total_input_tokens,
+        null: false,
+        default: 0,
+        comment: "Sum of input tokens across launched child agent runs."
+      t.integer :total_output_tokens,
+        null: false,
+        default: 0,
+        comment: "Sum of output tokens across launched child agent runs."
+      t.jsonb :metadata,
+        null: false,
+        default: {},
+        comment: "Structured detail for experiments, including batch sizes, errors, and linked child runs."
+      t.timestamps
+    end
+
+    add_index :scaling_observations,
+      [ :project_id, :workflow_id ],
+      unique: true,
+      name: "idx_scaling_observations_project_workflow"
+    add_index :scaling_observations,
+      [ :project_id, :created_at, :id ],
+      name: "idx_scaling_observations_project_recent"
+    add_index :scaling_observations,
+      [ :project_id, :observation_type, :created_at ],
+      name: "idx_scaling_observations_project_type_created"
+    add_index :scaling_observations,
+      [ :project_id, :status, :created_at ],
+      name: "idx_scaling_observations_project_status_created"
+    add_index :scaling_observations,
+      [ :issue_id, :created_at ],
+      name: "idx_scaling_observations_issue_created"
+
+    execute <<~SQL
+      ALTER TABLE scaling_observations ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE scaling_observations FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON scaling_observations
+        USING (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scaling_observations.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        )
+        WITH CHECK (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scaling_observations.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        );
+    SQL
+  end
+
+  def down
+    execute "DROP POLICY IF EXISTS tenant_isolation ON scaling_observations"
+    execute "ALTER TABLE scaling_observations NO FORCE ROW LEVEL SECURITY"
+    execute "ALTER TABLE scaling_observations DISABLE ROW LEVEL SECURITY"
+
+    drop_table :scaling_observations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_180905) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_212202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1628,6 +1628,42 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_180905) do
     t.index ["project_id"], name: "index_quality_thresholds_on_project_id"
   end
 
+  create_table "scaling_observations", comment: "Run-level observations for studying orchestration scaling behavior across agent count, iterations, and parallelism.", force: :cascade do |t|
+    t.integer "agent_count_blocked", default: 0, null: false, comment: "Number of planned tasks that never launched because of dependencies, deadlines, or capacity."
+    t.integer "agent_count_failed", default: 0, null: false, comment: "Number of launched child agent runs that completed unsuccessfully."
+    t.integer "agent_count_launched", default: 0, null: false, comment: "Number of child agent runs actually launched."
+    t.integer "agent_count_planned", default: 0, null: false, comment: "Number of agents the orchestration planned to use."
+    t.integer "agent_count_succeeded", default: 0, null: false, comment: "Number of launched child agent runs that completed successfully."
+    t.integer "batch_count", default: 0, null: false, comment: "Number of execution batches used by the parallel workflow."
+    t.datetime "created_at", null: false
+    t.integer "dependency_edge_count", default: 0, null: false, comment: "Total dependency edges across planned sub-tasks."
+    t.integer "duration_seconds", comment: "Elapsed wall-clock seconds for the orchestration workflow."
+    t.bigint "issue_id", comment: "Parent feature issue whose orchestration emitted the observation."
+    t.integer "max_iterations", default: 0, null: false, comment: "Maximum iterations observed on any launched child agent run."
+    t.jsonb "metadata", default: {}, null: false, comment: "Structured detail for experiments, including batch sizes, errors, and linked child runs."
+    t.string "observation_type", limit: 100, default: "feature_orchestration", null: false, comment: "Observation category used to group comparable orchestration runs."
+    t.boolean "parallel_execution", default: false, null: false, comment: "Whether the workflow attempted parallel child execution."
+    t.integer "parallelism_observed", default: 0, null: false, comment: "Maximum child workflow batch size actually launched concurrently."
+    t.integer "parallelism_planned", default: 0, null: false, comment: "Maximum planned same-wave task count from decomposition parallel groups."
+    t.integer "parallelizable_group_count", default: 0, null: false, comment: "Count of planned parallel groups containing more than one task."
+    t.bigint "project_id", null: false, comment: "Owning project for tenant isolation and experiment segmentation."
+    t.string "status", limit: 100, default: "completed", null: false, comment: "Terminal orchestration outcome such as completed, skipped, no_capacity, partial_failure, or failed."
+    t.boolean "success", default: false, null: false, comment: "Whether the orchestration run achieved its intended terminal outcome."
+    t.integer "task_count", default: 0, null: false, comment: "Number of planned sub-tasks in the decomposition."
+    t.integer "total_cost_cents", default: 0, null: false, comment: "Sum of cost_cents across launched child agent runs."
+    t.integer "total_input_tokens", default: 0, null: false, comment: "Sum of input tokens across launched child agent runs."
+    t.integer "total_iterations", default: 0, null: false, comment: "Sum of iterations across launched child agent runs."
+    t.integer "total_output_tokens", default: 0, null: false, comment: "Sum of output tokens across launched child agent runs."
+    t.datetime "updated_at", null: false
+    t.string "workflow_id", limit: 255, null: false, comment: "Temporal workflow ID for the orchestration run."
+    t.string "workflow_name", limit: 255, null: false, comment: "Workflow class that emitted the observation."
+    t.index ["issue_id", "created_at"], name: "idx_scaling_observations_issue_created"
+    t.index ["project_id", "created_at", "id"], name: "idx_scaling_observations_project_recent"
+    t.index ["project_id", "observation_type", "created_at"], name: "idx_scaling_observations_project_type_created"
+    t.index ["project_id", "status", "created_at"], name: "idx_scaling_observations_project_status_created"
+    t.index ["project_id", "workflow_id"], name: "idx_scaling_observations_project_workflow", unique: true
+  end
+
   create_table "service_container_metrics", force: :cascade do |t|
     t.string "container_id", limit: 128, null: false
     t.float "cpu_percent", default: 0.0, null: false
@@ -2045,6 +2081,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_180905) do
   add_foreign_key "quality_recovery_actions", "prompt_versions", on_delete: :nullify
   add_foreign_key "quality_thresholds", "accounts"
   add_foreign_key "quality_thresholds", "projects"
+  add_foreign_key "scaling_observations", "issues", on_delete: :nullify
+  add_foreign_key "scaling_observations", "projects", on_delete: :cascade
   add_foreign_key "service_container_metrics", "service_containers", on_delete: :cascade
   add_foreign_key "service_containers", "accounts"
   add_foreign_key "strategy_experiment_assignments", "agent_runs", on_delete: :cascade

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Project do
     it { is_expected.to have_many(:issues).dependent(:destroy) }
     it { is_expected.to have_many(:agent_runs).dependent(:destroy) }
     it { is_expected.to have_many(:orchestration_decisions).dependent(:destroy) }
+    it { is_expected.to have_many(:scaling_observations).dependent(:destroy) }
     it { is_expected.to have_many(:workflow_states).dependent(:destroy) }
   end
 

--- a/spec/services/scaling_observations/record_spec.rb
+++ b/spec/services/scaling_observations/record_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScalingObservations::Record do
+  describe ".call" do
+    let(:project) { create(:project) }
+    let(:issue) { create(:issue, project: project) }
+    let(:workflow_id) { "feature-wf-123" }
+
+    it "persists scaling metrics for a completed parallel orchestration" do
+      child_runs = create_parallel_child_runs
+
+      expect_completed_parallel_observation(
+        build_completed_parallel_observation(child_runs: child_runs),
+        project: project,
+        issue: issue,
+        workflow_id: workflow_id,
+        child_run_ids: child_runs.map(&:id)
+      )
+    end
+
+    it "persists a skipped observation for single-task orchestration" do
+      observation = described_class.call(
+        project_id: project.id,
+        issue_id: issue.id,
+        workflow_id: workflow_id,
+        workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+        tasks: [ { index: 0, parallel_group: 0, dependencies: [] } ]
+      )
+
+      expect(observation).to have_attributes(
+        status: "skipped",
+        success: true,
+        parallel_execution: false,
+        task_count: 1,
+        agent_count_planned: 1,
+        agent_count_launched: 0,
+        agent_count_succeeded: 0,
+        agent_count_failed: 0,
+        agent_count_blocked: 0,
+        parallelism_planned: 1,
+        parallelism_observed: 0
+      )
+    end
+  end
+
+  def create_parallel_child_runs
+    [
+      create(:agent_run, :completed, project: project, issue: issue,
+        parent_workflow_id: workflow_id, iterations: 3, cost_cents: 120, tokens_input: 400, tokens_output: 150),
+      create(:agent_run, :completed, project: project, issue: issue,
+        parent_workflow_id: workflow_id, iterations: 1, cost_cents: 80, tokens_input: 300, tokens_output: 125),
+      create(:agent_run, :failed, project: project, issue: issue,
+        parent_workflow_id: workflow_id, iterations: 2, cost_cents: 60, tokens_input: 200, tokens_output: 50)
+    ]
+  end
+
+  def build_completed_parallel_observation(child_runs:)
+    travel_to(Time.zone.parse("2026-05-08 22:00:10 UTC")) do
+      described_class.call(
+        project_id: project.id,
+        issue_id: issue.id,
+        workflow_id: workflow_id,
+        workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+        started_at: Time.zone.parse("2026-05-08 22:00:00 UTC"),
+        tasks: [
+          { index: 0, parallel_group: 0, dependencies: [] },
+          { index: 1, parallel_group: 0, dependencies: [] },
+          { index: 2, parallel_group: 1, dependencies: [ 0 ] }
+        ],
+        parallel_result: completed_parallel_result(child_runs),
+        metadata: {
+          created_issues: [ { issue_id: 10 }, { issue_id: 11 }, { issue_id: 12 } ]
+        }
+      )
+    end
+  end
+
+  def completed_parallel_result(child_runs)
+    {
+      success: false,
+      total: 3,
+      completed: 2,
+      failed: 1,
+      results: [
+        { issue_id: 10, task_index: 0, success: true, agent_run_id: child_runs[0].id },
+        { issue_id: 11, task_index: 1, success: true, agent_run_id: child_runs[1].id },
+        { issue_id: 12, task_index: 2, success: false, agent_run_id: child_runs[2].id, error: "Agent execution failed" }
+      ],
+      execution_summary: {
+        batch_count: 2,
+        batch_sizes: [ 2, 1 ],
+        max_parallelism_observed: 2
+      }
+    }
+  end
+
+  def expect_completed_parallel_observation(observation, project:, issue:, workflow_id:, child_run_ids:)
+    expect(observation).to have_attributes(
+      project: project,
+      issue: issue,
+      workflow_id: workflow_id,
+      workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+      observation_type: "feature_orchestration",
+      status: "partial_failure",
+      success: false,
+      parallel_execution: true,
+      task_count: 3,
+      dependency_edge_count: 1,
+      parallelizable_group_count: 1,
+      agent_count_planned: 3,
+      agent_count_launched: 3,
+      agent_count_succeeded: 2,
+      agent_count_failed: 1,
+      agent_count_blocked: 0,
+      total_iterations: 6,
+      max_iterations: 3,
+      parallelism_planned: 2,
+      parallelism_observed: 2,
+      batch_count: 2,
+      duration_seconds: 10,
+      total_cost_cents: 260,
+      total_input_tokens: 900,
+      total_output_tokens: 325
+    )
+    expect(observation.metadata).to include(
+      "batch_sizes" => [ 2, 1 ],
+      "child_agent_run_ids" => match_array(child_run_ids),
+      "error_tally" => { "Agent execution failed" => 1 }
+    )
+  end
+end

--- a/spec/services/scaling_observations/record_spec.rb
+++ b/spec/services/scaling_observations/record_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe ScalingObservations::Record do
         agent_count_blocked: 1
       )
     end
+
+    it "derives fallback counts from child run status buckets when result rows are missing" do
+      create_mixed_status_child_runs
+
+      observation = build_fallback_status_observation
+
+      expect(observation).to have_attributes(
+        status: "partial_failure",
+        success: false,
+        agent_count_launched: 5,
+        agent_count_succeeded: 1,
+        agent_count_failed: 1,
+        agent_count_blocked: 1
+      )
+    end
   end
 
   def create_parallel_child_runs
@@ -73,6 +88,34 @@ RSpec.describe ScalingObservations::Record do
         parent_workflow_id: workflow_id, iterations: 1, cost_cents: 80, tokens_input: 300, tokens_output: 125),
       create(:agent_run, :failed, project: project, issue: issue,
         parent_workflow_id: workflow_id, iterations: 2, cost_cents: 60, tokens_input: 200, tokens_output: 50)
+    ]
+  end
+
+  def create_mixed_status_child_runs
+    %i[completed failed running cancelled retried].each do |status|
+      create(:agent_run, status, project: project, issue: issue, parent_workflow_id: workflow_id)
+    end
+  end
+
+  def build_fallback_status_observation
+    described_class.call(
+      project_id: project.id,
+      issue_id: issue.id,
+      workflow_id: workflow_id,
+      workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+      tasks: fallback_status_tasks,
+      parallel_result: { success: false }
+    )
+  end
+
+  def fallback_status_tasks
+    [
+      { index: 0, parallel_group: 0, dependencies: [] },
+      { index: 1, parallel_group: 0, dependencies: [] },
+      { index: 2, parallel_group: 0, dependencies: [] },
+      { index: 3, parallel_group: 0, dependencies: [] },
+      { index: 4, parallel_group: 0, dependencies: [] },
+      { index: 5, parallel_group: 1, dependencies: [ 4 ] }
     ]
   end
 

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -153,6 +153,28 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
 
+      it "records a scaling observation after parallel execution" do
+        workflow.execute(input)
+
+        expect(workflow).to have_received(:run_activity)
+          .with(
+            Activities::RecordScalingObservationActivity,
+            hash_including(
+              project_id: 1,
+              issue_id: 2,
+              workflow_id: "test-orchestration-wf",
+              workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+              tasks: tasks,
+              parallel_result: hash_including(
+                success: true,
+                execution_summary: hash_including(max_parallelism_observed: 1)
+              )
+            ),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
+          )
+      end
+
       it "passes aggregate_pr option to child workflow when provided" do
         result = workflow.execute(input.merge(aggregate_pr: true))
 
@@ -209,6 +231,23 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             ),
             timeout: 30,
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
+      end
+
+      it "records a skipped scaling observation" do
+        workflow.execute(input)
+
+        expect(workflow).to have_received(:run_activity)
+          .with(
+            Activities::RecordScalingObservationActivity,
+            hash_including(
+              project_id: 1,
+              issue_id: 2,
+              workflow_id: "test-orchestration-wf",
+              tasks: tasks
+            ),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
+          )
       end
     end
 
@@ -372,6 +411,7 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             ),
             timeout: 30,
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
+        expect_failed_scaling_observation_recorded!
       end
     end
 
@@ -481,6 +521,8 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         { success: true }
       when "Activities::LogDecompositionDecisionActivity"
         { decomposition_decision_id: 1 }
+      when "Activities::RecordScalingObservationActivity"
+        { scaling_observation_id: 1 }
       else
         {}
       end
@@ -490,10 +532,29 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
   def stub_parallel_execution(result)
     allow(Temporalio::Workflow).to receive(:execute_child_workflow)
       .with(Workflows::ParallelAgentExecutionWorkflow, anything, anything)
-      .and_return(result)
+      .and_return(result.deep_merge(execution_summary: { batch_count: result[:total], batch_sizes: Array.new(result[:total], 1), max_parallelism_observed: 1 }))
   end
 
   def stub_update_labels
     # Already handled by stub_planning_activities
+  end
+
+  def expect_failed_scaling_observation_recorded!
+    expect(workflow).to have_received(:run_activity)
+      .with(
+        Activities::RecordScalingObservationActivity,
+        hash_including(
+          project_id: 1,
+          issue_id: 2,
+          workflow_id: "test-orchestration-wf",
+          error_details: hash_including(
+            error_class: "Temporalio::Error::ApplicationError",
+            error_message: "LLM failed",
+            failed_step: "decompose_feature"
+          )
+        ),
+        timeout: 30,
+        retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
+      )
   end
 end

--- a/spec/temporal/workflows/parallel_agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/parallel_agent_execution_workflow_spec.rb
@@ -150,6 +150,11 @@ RSpec.describe Workflows::ParallelAgentExecutionWorkflow do
       expect(result[:success]).to be true
       expect(result[:total]).to eq(2)
       expect(result[:completed]).to eq(2)
+      expect(result[:execution_summary]).to eq(
+        batch_count: 1,
+        batch_sizes: [ 2 ],
+        max_parallelism_observed: 2
+      )
     end
 
     it "reports failures from child workflows" do
@@ -188,6 +193,11 @@ RSpec.describe Workflows::ParallelAgentExecutionWorkflow do
 
       expect(capacity_call_count.call).to eq(3)
       expect(result[:total]).to eq(3)
+      expect(result[:execution_summary]).to eq(
+        batch_count: 3,
+        batch_sizes: [ 1, 1, 1 ],
+        max_parallelism_observed: 1
+      )
     end
 
     it "marks remaining tasks as no_capacity when capacity runs out" do


### PR DESCRIPTION
## Summary

Implemented scaling observation instrumentation and committed it as `c46c86c` (`feat(scaling): record orchestration scaling observations`).

The change adds a new `scaling_observations` table/model plus a recording service and activity, then wires `FeatureOrchestrationWorkflow` to persist one observation per orchestrated run. It captures planned vs observed agent count, total/max iterations, planned vs observed parallelism, batch counts, duration, token/cost totals, and structured metadata. `ParallelAgentExecutionWorkflow` now returns execution batch summaries so the parent workflow can record actual concurrency, and the new specs cover completed, skipped, and failure paths.

Verification passed with `bundle exec rubocop` and full `bundle exec rspec` (`11328 examples, 0 failures, 3 pending`). `bundle install` succeeded after switching Bundler to a repo-local path; `yarn install` hit an `ENOSPC` disk-space error in this environment, but it wasn’t needed for this Ruby-only task. Rails DB commands also needed explicit `DB_HOST`/`DB_USERNAME`/`DB_PASSWORD` plus the runtime-role-guard bypass for local maintenance because of this container’s PostgreSQL setup. The worktree is clean.

---

Closes #1775