### PR TITLE
feat(coordination): A/B test evolved coordination policies

### DIFF
--- a/app/models/coordination_experiment.rb
+++ b/app/models/coordination_experiment.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "zlib"
+
+class CoordinationExperiment < ApplicationRecord
+  STATUSES = %w[draft running completed cancelled].freeze
+  POLICY_NAME = "feature_orchestration"
+
+  belongs_to :account
+  belongs_to :winner_variant, class_name: "CoordinationExperimentVariant", optional: true
+
+  has_many :coordination_experiment_variants, dependent: :destroy
+  has_many :coordination_experiment_assignments, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :policy_name, presence: true, inclusion: { in: [ POLICY_NAME ] }
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :control_policy, presence: true
+  validates :min_samples_per_variant, numericality: { only_integer: true, greater_than_or_equal_to: 2 }
+  validates :traffic_percentage, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
+  validate :winner_variant_belongs_to_experiment
+
+  scope :running, -> { where(status: "running") }
+
+  def self.active_for(account:, workflow_id:)
+    experiment = running.where(account:, policy_name: POLICY_NAME).order(:id).first
+    return nil unless experiment
+    return nil unless experiment.includes_traffic?(workflow_id:)
+
+    experiment
+  end
+
+  def running?
+    status == "running"
+  end
+
+  def control_variant
+    coordination_experiment_variants.find_by(is_control: true)
+  end
+
+  def includes_traffic?(workflow_id:)
+    return false if traffic_percentage.zero?
+    return true if traffic_percentage == 100
+
+    Zlib.crc32("#{id}:#{workflow_id}") % 100 < traffic_percentage
+  end
+
+  private
+
+  def winner_variant_belongs_to_experiment
+    return if winner_variant.nil?
+    return if winner_variant.coordination_experiment_id == id
+
+    errors.add(:winner_variant, "must belong to this experiment")
+  end
+end

--- a/app/models/coordination_experiment_assignment.rb
+++ b/app/models/coordination_experiment_assignment.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CoordinationExperimentAssignment < ApplicationRecord
+  OUTCOME_STATUSES = %w[assigned recorded].freeze
+
+  belongs_to :coordination_experiment
+  belongs_to :coordination_experiment_variant
+  belongs_to :project
+  belongs_to :issue, optional: true
+
+  validates :workflow_id, presence: true, length: { maximum: 255 }, uniqueness: { scope: :coordination_experiment_id }
+  validates :outcome_status, inclusion: { in: OUTCOME_STATUSES }
+  validate :variant_matches_experiment
+
+  scope :recorded, -> { where(outcome_status: "recorded") }
+
+  private
+
+  def variant_matches_experiment
+    return if coordination_experiment_variant.nil? || coordination_experiment.nil?
+    return if coordination_experiment_variant.coordination_experiment_id == coordination_experiment_id
+
+    errors.add(:coordination_experiment_variant, "must belong to the same experiment")
+  end
+end

--- a/app/models/coordination_experiment_variant.rb
+++ b/app/models/coordination_experiment_variant.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CoordinationExperimentVariant < ApplicationRecord
+  belongs_to :coordination_experiment
+
+  has_many :coordination_experiment_assignments, dependent: :destroy
+
+  validates :policy_config, presence: true
+  validates :sample_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  def parsed_policy
+    policy_config.deep_dup
+  end
+end

--- a/app/services/coordination/decomposition_service.rb
+++ b/app/services/coordination/decomposition_service.rb
@@ -35,11 +35,12 @@ module Coordination
       new(...).call
     end
 
-    def initialize(title:, description:, sub_components:, account: nil)
+    def initialize(title:, description:, sub_components:, account: nil, policy_override: nil)
       @title = title.to_s
       @description = description.to_s
       @sub_components = Array(sub_components)
       @account = account
+      @policy_override = policy_override
     end
 
     def call
@@ -76,9 +77,16 @@ module Coordination
 
     private
 
-    attr_reader :title, :description, :sub_components, :account
+    attr_reader :title, :description, :sub_components, :account, :policy_override
 
     def resolve_policy
+      if policy_override.present?
+        return normalize_policy(
+          DEFAULT_POLICY.merge(extract_decomposition_config_from_hash(policy_override))
+            .merge("source" => "experiment")
+        )
+      end
+
       strategy = OrchestrationStrategies::Resolve.call(
         strategy_type: STRATEGY_TYPE,
         account: account
@@ -99,18 +107,23 @@ module Coordination
 
     def extract_decomposition_config(strategy)
       return {} unless strategy
+      extract_decomposition_config_from_hash(strategy.configuration)
+    end
 
-      config = strategy.configuration
+    def extract_decomposition_config_from_hash(config)
       return {} unless config.is_a?(Hash)
 
-      # Extract decomposition-relevant keys from the feature_orchestration config.
-      # Strategy may contain a nested "decomposition" key with overrides, or
-      # top-level keys that map to decomposition parameters.
-      decomposition = config.fetch("decomposition", {})
-      return decomposition if decomposition.is_a?(Hash) && decomposition.any?
-
-      # Fall back to inferring from top-level feature_orchestration config
       {}.tap do |result|
+        decomposition = config.fetch("decomposition", {})
+        if decomposition.is_a?(Hash)
+          result["max_tasks"] = decomposition["max_tasks"] if decomposition.key?("max_tasks") && decomposition["max_tasks"] != DEFAULT_POLICY["max_tasks"]
+          result["min_components_to_decompose"] = decomposition["min_components_to_decompose"] if decomposition.key?("min_components_to_decompose") && decomposition["min_components_to_decompose"] != DEFAULT_POLICY["min_components_to_decompose"]
+          result["enabled"] = decomposition["enabled"] if decomposition.key?("enabled") && decomposition["enabled"] != DEFAULT_POLICY["enabled"]
+          if decomposition.key?("layer_order") && Array(decomposition["layer_order"]) != DEFAULT_POLICY["layer_order"]
+            result["layer_order"] = decomposition["layer_order"]
+          end
+        end
+
         result["max_tasks"] = config["max_tasks"] if config.key?("max_tasks")
         result["min_components_to_decompose"] = config["min_components_to_decompose"] if config.key?("min_components_to_decompose")
         result["enabled"] = config["decomposition_enabled"] if config.key?("decomposition_enabled")

--- a/app/services/coordination_experiments/assign.rb
+++ b/app/services/coordination_experiments/assign.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "zlib"
+
+module CoordinationExperiments
+  class Assign
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(coordination_experiment:, project:, workflow_id:, issue: nil)
+      @coordination_experiment = coordination_experiment
+      @project = project
+      @workflow_id = workflow_id
+      @issue = issue
+    end
+
+    def call
+      raise ArgumentError, "coordination experiment is not running" unless coordination_experiment.running?
+
+      existing = CoordinationExperimentAssignment.find_by(
+        coordination_experiment: coordination_experiment,
+        workflow_id: workflow_id
+      )
+      return existing if existing
+
+      CoordinationExperimentAssignment.create!(
+        coordination_experiment: coordination_experiment,
+        coordination_experiment_variant: select_variant,
+        project: project,
+        issue: issue,
+        workflow_id: workflow_id
+      )
+    rescue ActiveRecord::RecordNotUnique
+      CoordinationExperimentAssignment.find_by!(
+        coordination_experiment: coordination_experiment,
+        workflow_id: workflow_id
+      )
+    end
+
+    private
+
+    attr_reader :coordination_experiment, :project, :workflow_id, :issue
+
+    def select_variant
+      variants = coordination_experiment.coordination_experiment_variants.order(:id).to_a
+      raise ArgumentError, "coordination experiment has no variants" if variants.empty?
+
+      counts = CoordinationExperimentAssignment
+        .where(coordination_experiment:, coordination_experiment_variant: variants)
+        .group(:coordination_experiment_variant_id)
+        .count
+      min_count = variants.map { |variant| counts.fetch(variant.id, 0) }.min
+      candidates = variants.select { |variant| counts.fetch(variant.id, 0) == min_count }
+      candidates[Zlib.crc32("#{coordination_experiment.id}:#{workflow_id}") % candidates.size]
+    end
+  end
+end

--- a/app/services/coordination_experiments/outcome_metrics.rb
+++ b/app/services/coordination_experiments/outcome_metrics.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module CoordinationExperiments
+  class OutcomeMetrics
+    Result = Struct.new(:metrics, :coordination_score, keyword_init: true)
+
+    CONFLICT_PENALTY = 0.15
+    MANUAL_REVIEW_PENALTY = 0.15
+    DEPENDENCY_FAILURE_WEIGHT = 0.2
+    FAILED_TASK_WEIGHT = 0.35
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(task_count:, parallel_execution:, result:)
+      @task_count = task_count.to_i
+      @parallel_execution = parallel_execution
+      @result = (result || {}).deep_symbolize_keys
+    end
+
+    def call
+      metrics = base_metrics.merge(run_metrics)
+      Result.new(metrics:, coordination_score: coordination_score_for(metrics))
+    end
+
+    private
+
+    attr_reader :task_count, :parallel_execution, :result
+
+    def base_metrics
+      {
+        "task_count" => task_count,
+        "parallel_execution" => parallel_execution,
+        "completed_tasks" => result.fetch(:completed, 0).to_i,
+        "failed_tasks" => result.fetch(:failed, 0).to_i,
+        "success" => !!result[:success],
+        "queued_tasks" => child_results.count { |child| child[:queued] },
+        "dependency_failed_tasks" => child_results.count { |child| child[:error] == "dependencies_failed" },
+        "policy_cancelled_tasks" => child_results.count { |child| child[:error] == "cancelled_by_policy" },
+        "conflict_detected" => !!result.dig(:conflicts, :has_conflicts),
+        "manual_review_required" => !!result.dig(:conflicts, :requires_manual_review),
+        "aggregated_pr_created" => result[:aggregated_pr].present?
+      }
+    end
+
+    def run_metrics
+      runs = AgentRun.where(id: successful_run_ids)
+      {
+        "successful_run_count" => successful_run_ids.size,
+        "total_cost_cents" => runs.sum(:cost_cents).to_i,
+        "total_duration_seconds" => runs.sum(:duration_seconds).to_i,
+        "avg_iterations" => runs.average(:iterations).to_f.round(4)
+      }
+    end
+
+    def coordination_score_for(metrics)
+      total = [ metrics["task_count"], 1 ].max.to_f
+      success_ratio = metrics["completed_tasks"].to_f / total
+      failure_ratio = metrics["failed_tasks"].to_f / total
+      dependency_ratio = metrics["dependency_failed_tasks"].to_f / total
+
+      score = success_ratio
+      score -= failure_ratio * FAILED_TASK_WEIGHT
+      score -= dependency_ratio * DEPENDENCY_FAILURE_WEIGHT
+      score -= CONFLICT_PENALTY if metrics["conflict_detected"]
+      score -= MANUAL_REVIEW_PENALTY if metrics["manual_review_required"]
+
+      score.clamp(0.0, 1.0).round(4)
+    end
+
+    def child_results
+      Array(result[:results]).map(&:deep_symbolize_keys)
+    end
+
+    def successful_run_ids
+      child_results.filter_map do |child|
+        child[:agent_run_id] if child[:success]
+      end
+    end
+  end
+end

--- a/app/services/coordination_experiments/promotion_readiness.rb
+++ b/app/services/coordination_experiments/promotion_readiness.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module CoordinationExperiments
+  class PromotionReadiness
+    Result = Struct.new(:status, :candidate, :control_summary, :candidate_summary, :reasons, keyword_init: true)
+
+    MAX_COST_INCREASE_RATIO = 1.1
+    MAX_CONFLICT_RATE_INCREASE = 0.1
+    MAX_MANUAL_REVIEW_RATE_INCREASE = 0.1
+    MIN_SUCCESS_RATE_DELTA = -0.05
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(coordination_experiment:)
+      @coordination_experiment = coordination_experiment
+    end
+
+    def call
+      return Result.new(status: :more_data_needed, reasons: [ "insufficient_samples" ]) unless enough_samples?
+
+      candidate = variants.reject(&:is_control).max_by(&:avg_coordination_score)
+      return Result.new(status: :no_candidate, reasons: [ "no_variant_candidate" ]) unless candidate
+
+      control_summary = summarize(control_variant)
+      candidate_summary = summarize(candidate)
+      reasons = guardrail_failures(control_summary:, candidate_summary:)
+
+      status = reasons.empty? ? :ready : :guardrail_failed
+      Result.new(status:, candidate:, control_summary:, candidate_summary:, reasons:)
+    end
+
+    private
+
+    attr_reader :coordination_experiment
+
+    def variants
+      @variants ||= coordination_experiment.coordination_experiment_variants.order(:id).to_a
+    end
+
+    def control_variant
+      @control_variant ||= variants.find(&:is_control)
+    end
+
+    def enough_samples?
+      variants.present? && variants.all? { |variant| variant.sample_count >= coordination_experiment.min_samples_per_variant }
+    end
+
+    def summarize(variant)
+      assignments = variant.coordination_experiment_assignments.recorded.to_a
+      metrics = assignments.map(&:outcome_metrics)
+      {
+        sample_count: assignments.size,
+        avg_coordination_score: variant.avg_coordination_score.to_f,
+        success_rate: rate(metrics) { |metric| metric["success"] },
+        conflict_rate: rate(metrics) { |metric| metric["conflict_detected"] },
+        manual_review_rate: rate(metrics) { |metric| metric["manual_review_required"] },
+        avg_cost_cents: average(metrics) { |metric| metric["total_cost_cents"].to_f }
+      }
+    end
+
+    def guardrail_failures(control_summary:, candidate_summary:)
+      failures = []
+
+      if candidate_summary[:success_rate] < control_summary[:success_rate] + MIN_SUCCESS_RATE_DELTA
+        failures << "success_rate_regressed"
+      end
+
+      if candidate_summary[:conflict_rate] > control_summary[:conflict_rate] + MAX_CONFLICT_RATE_INCREASE
+        failures << "conflict_rate_too_high"
+      end
+
+      if candidate_summary[:manual_review_rate] > control_summary[:manual_review_rate] + MAX_MANUAL_REVIEW_RATE_INCREASE
+        failures << "manual_review_rate_too_high"
+      end
+
+      control_cost = control_summary[:avg_cost_cents]
+      if control_cost.positive? && candidate_summary[:avg_cost_cents] > (control_cost * MAX_COST_INCREASE_RATIO)
+        failures << "cost_increase_too_high"
+      end
+
+      failures
+    end
+
+    def rate(metrics)
+      return 0.0 if metrics.empty?
+
+      metrics.count { |metric| yield(metric) }.to_f / metrics.size
+    end
+
+    def average(metrics)
+      return 0.0 if metrics.empty?
+
+      metrics.sum { |metric| yield(metric) } / metrics.size
+    end
+  end
+end

--- a/app/services/coordination_experiments/record_outcome.rb
+++ b/app/services/coordination_experiments/record_outcome.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module CoordinationExperiments
+  class RecordOutcome
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(assignment:, task_count:, parallel_execution:, result:)
+      @assignment = assignment
+      @task_count = task_count
+      @parallel_execution = parallel_execution
+      @result = result
+    end
+
+    def call
+      computed = OutcomeMetrics.call(
+        task_count: task_count,
+        parallel_execution: parallel_execution,
+        result: result
+      )
+      variant = assignment.coordination_experiment_variant
+
+      variant.with_lock do
+        assignment.reload
+        old_score = assignment.coordination_score
+
+        assignment.update!(
+          coordination_score: computed.coordination_score,
+          outcome_metrics: computed.metrics,
+          outcome_status: "recorded"
+        )
+
+        if old_score.present?
+          adjust_variant_aggregates(variant, old_score:, new_score: computed.coordination_score)
+        else
+          add_variant_score(variant, computed.coordination_score)
+        end
+      end
+
+      computed
+    end
+
+    private
+
+    attr_reader :assignment, :task_count, :parallel_execution, :result
+
+    def add_variant_score(variant, score)
+      score_decimal = BigDecimal(score.to_s)
+      variant.sample_count += 1
+      variant.total_coordination_score = (variant.total_coordination_score || BigDecimal("0")) + score_decimal
+      variant.avg_coordination_score = variant.total_coordination_score / variant.sample_count
+      variant.save!
+    end
+
+    def adjust_variant_aggregates(variant, old_score:, new_score:)
+      old_decimal = BigDecimal(old_score.to_s)
+      new_decimal = BigDecimal(new_score.to_s)
+      variant.total_coordination_score = (variant.total_coordination_score || BigDecimal("0")) - old_decimal + new_decimal
+      variant.avg_coordination_score = variant.sample_count.positive? ? variant.total_coordination_score / variant.sample_count : nil
+      variant.save!
+    end
+  end
+end

--- a/app/services/orchestration_strategies/defaults.rb
+++ b/app/services/orchestration_strategies/defaults.rb
@@ -147,6 +147,16 @@ module OrchestrationStrategies
     def feature_orchestration
       {
         "default_timeout_seconds" => 7200,
+        "decomposition" => {
+          "enabled" => true,
+          "max_tasks" => 20,
+          "min_components_to_decompose" => 2,
+          "layer_order" => %w[model service controller view]
+        },
+        "parallel_execution" => {
+          "max_batch_size" => nil,
+          "cancel_remaining_on_failure" => false
+        },
         "planning_phases" => %w[
           fetch_planning_context
           decompose_feature

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -22,7 +22,11 @@ module Activities
       project = Project.find(project_id)
       issue = project.issues.find(issue_id)
 
-      policy_result = decompose_with_policy_service(project: project, issue: issue)
+      policy_result = decompose_with_policy_service(
+        project: project,
+        issue: issue,
+        coordination_policy: input[:coordination_policy]
+      )
       return policy_result if policy_result
 
       prompt_data = render_prompt(issue, knowledge_context)
@@ -41,13 +45,14 @@ module Activities
 
     private
 
-    def decompose_with_policy_service(project:, issue:)
+    def decompose_with_policy_service(project:, issue:, coordination_policy:)
       scope_result = ScopeAnalysis::Analyze.call(text: issue.body)
       decomposition_result = Coordination::DecompositionService.call(
         title: issue.title,
         description: issue.body,
         sub_components: scope_result.sub_components,
-        account: project.account
+        account: project.account,
+        policy_override: coordination_policy
       )
 
       return unless use_policy_service_result?(decomposition_result)

--- a/app/temporal/activities/record_coordination_experiment_outcome_activity.rb
+++ b/app/temporal/activities/record_coordination_experiment_outcome_activity.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Activities
+  class RecordCoordinationExperimentOutcomeActivity < BaseActivity
+    activity_name "RecordCoordinationExperimentOutcome"
+
+    def execute(input)
+      assignment = CoordinationExperimentAssignment.find(input[:assignment_id])
+
+      outcome = CoordinationExperiments::RecordOutcome.call(
+        assignment: assignment,
+        task_count: input[:task_count],
+        parallel_execution: input[:parallel_execution],
+        result: input[:result]
+      )
+
+      {
+        assignment_id: assignment.id,
+        coordination_score: outcome.coordination_score,
+        outcome_status: assignment.reload.outcome_status
+      }
+    end
+  end
+end

--- a/app/temporal/activities/resolve_coordination_experiment_activity.rb
+++ b/app/temporal/activities/resolve_coordination_experiment_activity.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Activities
+  class ResolveCoordinationExperimentActivity < BaseActivity
+    activity_name "ResolveCoordinationExperiment"
+
+    def execute(input)
+      project = Project.find(input[:project_id])
+      workflow_id = input[:workflow_id].to_s
+      issue = input[:issue_id] ? project.issues.find(input[:issue_id]) : nil
+
+      experiment = CoordinationExperiment.active_for(account: project.account, workflow_id:)
+      return { assignment_id: nil, coordination_policy: nil } unless experiment
+
+      assignment = CoordinationExperiments::Assign.call(
+        coordination_experiment: experiment,
+        project: project,
+        issue: issue,
+        workflow_id:
+      )
+
+      {
+        assignment_id: assignment.id,
+        experiment_id: experiment.id,
+        variant_id: assignment.coordination_experiment_variant_id,
+        coordination_policy: assignment.coordination_experiment_variant.parsed_policy
+      }
+    end
+  end
+end

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -40,12 +40,22 @@ module Workflows
       created_issues = []
       planning_context = {}
       prompt_source = nil
+      coordination_policy = nil
+      coordination_assignment_id = nil
       decision_phase = "planning"
       decision_step = "fetch_planning_context"
       @decision_step = decision_step
 
+      experiment_context = safely_resolve_coordination_experiment(
+        project_id: project_id,
+        issue_id: issue_id,
+        workflow_id: workflow_id
+      )
+      coordination_policy = experiment_context[:coordination_policy]
+      coordination_assignment_id = experiment_context[:assignment_id]
+
       # Phase 1: Decompose the feature into sub-tasks
-      planning_result = run_planning(project_id, issue_id)
+      planning_result = run_planning(project_id, issue_id, coordination_policy:)
 
       tasks = planning_result[:tasks] || []
       created_issues = planning_result[:created_issues]
@@ -119,13 +129,20 @@ module Workflows
           issue_id: issue_id,
           task_count: tasks.size
         )
-        return {
+        result = {
           success: true,
           project_id: project_id,
           issue_id: issue_id,
           task_count: tasks.size,
           parallel_execution: false
         }
+        safely_record_coordination_outcome(
+          assignment_id: coordination_assignment_id,
+          task_count: tasks.size,
+          parallel_execution: false,
+          result: result
+        )
+        return result
       end
 
       # Phase 2: Launch parallel execution on all sub-tasks
@@ -161,7 +178,15 @@ module Workflows
         issue_id: issue_id,
         sub_tasks: sub_tasks,
         timeout_seconds: timeout_seconds,
-        aggregate_pr: input[:aggregate_pr]
+        aggregate_pr: input[:aggregate_pr],
+        coordination_policy:
+      )
+
+      safely_record_coordination_outcome(
+        assignment_id: coordination_assignment_id,
+        task_count: tasks.size,
+        parallel_execution: true,
+        result: parallel_result
       )
 
       Temporalio::Workflow.logger.info(
@@ -216,6 +241,19 @@ module Workflows
         error_class: e.class.to_s,
         error: e.message
       )
+      safely_record_coordination_outcome(
+        assignment_id: coordination_assignment_id,
+        task_count: tasks.size,
+        parallel_execution: tasks.size > 1,
+        result: {
+          success: false,
+          completed: 0,
+          failed: tasks.size,
+          results: [],
+          conflicts: { has_conflicts: false, requires_manual_review: false },
+          error: e.message
+        }
+      )
       raise
     end
 
@@ -225,7 +263,7 @@ module Workflows
     # workflow because orchestration needs direct access to the decomposed tasks and created
     # issues to build sub_tasks for parallel execution. A child workflow would only return a
     # summary, requiring re-fetching. Shared activities keep the actual logic deduplicated.
-    def run_planning(project_id, issue_id)
+    def run_planning(project_id, issue_id, coordination_policy:)
       # Step 1: Fetch knowledge base context
       @decision_step = "fetch_planning_context"
       context_result = run_activity(
@@ -241,7 +279,8 @@ module Workflows
         {
           project_id: project_id,
           issue_id: issue_id,
-          knowledge_context: context_result[:context]
+          knowledge_context: context_result[:context],
+          coordination_policy: coordination_policy
         },
         timeout: 120
       )
@@ -308,7 +347,7 @@ module Workflows
       end
     end
 
-    def run_parallel_execution(project_id:, issue_id:, sub_tasks:, timeout_seconds:, aggregate_pr:)
+    def run_parallel_execution(project_id:, issue_id:, sub_tasks:, timeout_seconds:, aggregate_pr:, coordination_policy:)
       parent_wf_id = Temporalio::Workflow.info.workflow_id
 
       child_input = {
@@ -319,6 +358,7 @@ module Workflows
         timeout_seconds: timeout_seconds
       }
       child_input[:aggregate_pr] = aggregate_pr unless aggregate_pr.nil?
+      child_input[:coordination_policy] = coordination_policy if coordination_policy.present?
 
       workflow_id = "parallel-#{parent_wf_id}-#{Temporalio::Workflow.now.to_i}"
 
@@ -373,6 +413,47 @@ module Workflows
         workflow_id: Temporalio::Workflow.info.workflow_id,
         error_class: log_error.class.to_s,
         error: log_error.message
+      )
+    end
+
+    def safely_resolve_coordination_experiment(project_id:, issue_id:, workflow_id:)
+      run_activity(
+        Activities::ResolveCoordinationExperimentActivity,
+        { project_id:, issue_id:, workflow_id: },
+        timeout: 30,
+        retry_policy: NO_RETRY
+      )
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "feature_orchestration.coordination_experiment_resolution_failed",
+        workflow_id: Temporalio::Workflow.info.workflow_id,
+        error_class: e.class.to_s,
+        error: e.message
+      )
+      { assignment_id: nil, coordination_policy: nil }
+    end
+
+    def safely_record_coordination_outcome(assignment_id:, task_count:, parallel_execution:, result:)
+      return unless assignment_id
+
+      run_activity(
+        Activities::RecordCoordinationExperimentOutcomeActivity,
+        {
+          assignment_id: assignment_id,
+          task_count: task_count,
+          parallel_execution: parallel_execution,
+          result: result
+        },
+        timeout: 30,
+        retry_policy: NO_RETRY
+      )
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "feature_orchestration.coordination_experiment_record_failed",
+        workflow_id: Temporalio::Workflow.info.workflow_id,
+        assignment_id: assignment_id,
+        error_class: e.class.to_s,
+        error: e.message
       )
     end
   end

--- a/app/temporal/workflows/parallel_agent_execution_workflow.rb
+++ b/app/temporal/workflows/parallel_agent_execution_workflow.rb
@@ -30,6 +30,7 @@ module Workflows
       sub_tasks = normalize_sub_tasks(input.fetch(:sub_tasks, []))
       parent_wf_id = input[:parent_workflow_id] || Temporalio::Workflow.info.workflow_id
       timeout_seconds = input.fetch(:timeout_seconds, DEFAULT_TIMEOUT_SECONDS)
+      coordination_policy = normalize_coordination_policy(input[:coordination_policy])
 
       Temporalio::Workflow.logger.info(
         message: "parallel_execution.started",
@@ -69,7 +70,8 @@ module Workflows
         sub_tasks: sub_tasks,
         max_concurrent: max_concurrent,
         parent_wf_id: parent_wf_id,
-        timeout_seconds: timeout_seconds
+        timeout_seconds: timeout_seconds,
+        coordination_policy: coordination_policy
       )
 
       # Step 3: Detect and resolve conflicts between successful runs.
@@ -214,7 +216,7 @@ module Workflows
     # then waits for all to complete. Recomputes batch size from the latest
     # capacity check before each batch, and enforces an overall deadline
     # derived from timeout_seconds.
-    def launch_and_monitor_children(project_id:, sub_tasks:, max_concurrent:, parent_wf_id:, timeout_seconds:)
+    def launch_and_monitor_children(project_id:, sub_tasks:, max_concurrent:, parent_wf_id:, timeout_seconds:, coordination_policy:)
       deadline = Temporalio::Workflow.now + timeout_seconds
       remaining_tasks = sub_tasks.dup
       all_results = []
@@ -288,7 +290,11 @@ module Workflows
           break
         end
 
-        batch_size = [ current_slots, ready_tasks.size ].min
+        batch_size = [
+          current_slots,
+          ready_tasks.size,
+          max_batch_size_for(coordination_policy)
+        ].compact.min
         batch = ready_tasks.first(batch_size)
         remaining_tasks -= batch
 
@@ -301,6 +307,18 @@ module Workflows
         )
 
         all_results.concat(batch_results)
+        if cancel_remaining_on_failure?(coordination_policy) && batch_results.any? { |batch_result| batch_result[:success] == false }
+          all_results.concat(
+            build_terminal_results_for_remaining(
+              all_results: all_results,
+              remaining_tasks: remaining_tasks,
+              ready_tasks: remaining_tasks,
+              blocked_tasks: [],
+              ready_error: "cancelled_by_policy"
+            )
+          )
+          break
+        end
         batch_index += 1
       end
 
@@ -507,6 +525,20 @@ module Workflows
         resolution: nil,
         error: nil
       }
+    end
+
+    def normalize_coordination_policy(policy)
+      (policy || {}).deep_symbolize_keys
+    end
+
+    def max_batch_size_for(policy)
+      Integer(policy.dig(:parallel_execution, :max_batch_size))
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    def cancel_remaining_on_failure?(policy)
+      policy.dig(:parallel_execution, :cancel_remaining_on_failure) == true
     end
 
     # Launches a batch of child workflows in parallel and waits for all to complete.

--- a/db/migrate/20260508120000_create_coordination_experiments.rb
+++ b/db/migrate/20260508120000_create_coordination_experiments.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class CreateCoordinationExperiments < ActiveRecord::Migration[8.1]
+  def change
+    create_table :coordination_experiments, comment: "Workflow-scoped A/B tests for feature orchestration coordination policies" do |t|
+      t.references :account, null: false, foreign_key: { on_delete: :cascade }
+      t.string :name, null: false
+      t.text :description
+      t.string :policy_name, null: false, default: "feature_orchestration", comment: "Coordination policy family under test"
+      t.string :status, null: false, default: "draft"
+      t.jsonb :control_policy, null: false, default: {}, comment: "Baseline coordination policy configuration"
+      t.integer :min_samples_per_variant, null: false, default: 10
+      t.integer :traffic_percentage, null: false, default: 100
+      t.datetime :started_at
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+
+    create_table :coordination_experiment_variants, comment: "Individual policy arms within a coordination experiment" do |t|
+      t.references :coordination_experiment, null: false, foreign_key: { on_delete: :cascade }
+      t.jsonb :policy_config, null: false, default: {}, comment: "Effective policy config for this variant"
+      t.boolean :is_control, null: false, default: false
+      t.integer :sample_count, null: false, default: 0
+      t.decimal :total_coordination_score, precision: 10, scale: 4, null: false, default: 0
+      t.decimal :avg_coordination_score, precision: 5, scale: 4
+
+      t.timestamps
+    end
+
+    create_table :coordination_experiment_assignments, comment: "Assignment and outcome for one feature orchestration workflow sample" do |t|
+      t.references :coordination_experiment, null: false, foreign_key: { on_delete: :cascade }
+      t.references :coordination_experiment_variant, null: false, foreign_key: { on_delete: :cascade }
+      t.references :project, null: false, foreign_key: { on_delete: :cascade }
+      t.references :issue, foreign_key: { on_delete: :nullify }
+      t.string :workflow_id, null: false, comment: "Temporal workflow ID for the orchestrated feature sample"
+      t.string :outcome_status, null: false, default: "assigned"
+      t.decimal :coordination_score, precision: 5, scale: 4
+      t.jsonb :outcome_metrics, null: false, default: {}, comment: "Aggregated coordination quality and cost metrics"
+
+      t.timestamps
+    end
+
+    add_reference :coordination_experiments,
+      :winner_variant,
+      foreign_key: { to_table: :coordination_experiment_variants, on_delete: :nullify },
+      index: true
+
+    add_index :coordination_experiments, [ :account_id, :policy_name, :status ],
+      name: "idx_coordination_experiments_account_policy_status"
+    add_index :coordination_experiments, [ :account_id, :policy_name ],
+      unique: true,
+      where: "status = 'running'",
+      name: "idx_coordination_experiments_one_running_policy"
+    add_index :coordination_experiment_variants, [ :coordination_experiment_id, :is_control ],
+      unique: true,
+      where: "is_control = true",
+      name: "idx_coordination_experiment_variants_one_control"
+    add_index :coordination_experiment_assignments, [ :coordination_experiment_id, :workflow_id ],
+      unique: true,
+      name: "idx_coordination_experiment_assignments_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -578,6 +578,57 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_180905) do
     t.index ["started_by_id"], name: "index_context_intake_sessions_on_started_by_id"
   end
 
+  create_table "coordination_experiment_assignments", comment: "Assignment and outcome for one feature orchestration workflow sample", force: :cascade do |t|
+    t.bigint "coordination_experiment_id", null: false
+    t.bigint "coordination_experiment_variant_id", null: false
+    t.decimal "coordination_score", precision: 5, scale: 4
+    t.datetime "created_at", null: false
+    t.bigint "issue_id"
+    t.jsonb "outcome_metrics", default: {}, null: false, comment: "Aggregated coordination quality and cost metrics"
+    t.string "outcome_status", default: "assigned", null: false
+    t.bigint "project_id", null: false
+    t.datetime "updated_at", null: false
+    t.string "workflow_id", null: false, comment: "Temporal workflow ID for the orchestrated feature sample"
+    t.index ["coordination_experiment_id", "workflow_id"], name: "idx_coordination_experiment_assignments_unique", unique: true
+    t.index ["coordination_experiment_id"], name: "idx_on_coordination_experiment_id_73eaaefa30"
+    t.index ["coordination_experiment_variant_id"], name: "idx_on_coordination_experiment_variant_id_d60101236e"
+    t.index ["issue_id"], name: "index_coordination_experiment_assignments_on_issue_id"
+    t.index ["project_id"], name: "index_coordination_experiment_assignments_on_project_id"
+  end
+
+  create_table "coordination_experiment_variants", comment: "Individual policy arms within a coordination experiment", force: :cascade do |t|
+    t.decimal "avg_coordination_score", precision: 5, scale: 4
+    t.bigint "coordination_experiment_id", null: false
+    t.datetime "created_at", null: false
+    t.boolean "is_control", default: false, null: false
+    t.jsonb "policy_config", default: {}, null: false, comment: "Effective policy config for this variant"
+    t.integer "sample_count", default: 0, null: false
+    t.decimal "total_coordination_score", precision: 10, scale: 4, default: "0.0", null: false
+    t.datetime "updated_at", null: false
+    t.index ["coordination_experiment_id", "is_control"], name: "idx_coordination_experiment_variants_one_control", unique: true, where: "(is_control = true)"
+    t.index ["coordination_experiment_id"], name: "idx_on_coordination_experiment_id_3f1ff8497b"
+  end
+
+  create_table "coordination_experiments", comment: "Workflow-scoped A/B tests for feature orchestration coordination policies", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.datetime "completed_at"
+    t.jsonb "control_policy", default: {}, null: false, comment: "Baseline coordination policy configuration"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.integer "min_samples_per_variant", default: 10, null: false
+    t.string "name", null: false
+    t.string "policy_name", default: "feature_orchestration", null: false, comment: "Coordination policy family under test"
+    t.datetime "started_at"
+    t.string "status", default: "draft", null: false
+    t.integer "traffic_percentage", default: 100, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "winner_variant_id"
+    t.index ["account_id", "policy_name", "status"], name: "idx_coordination_experiments_account_policy_status"
+    t.index ["account_id", "policy_name"], name: "idx_coordination_experiments_one_running_policy", unique: true, where: "((status)::text = 'running'::text)"
+    t.index ["account_id"], name: "index_coordination_experiments_on_account_id"
+    t.index ["winner_variant_id"], name: "index_coordination_experiments_on_winner_variant_id"
+  end
+
   create_table "cost_budgets", force: :cascade do |t|
     t.datetime "alert_sent_at"
     t.integer "alert_threshold_percent", default: 80, null: false
@@ -1958,6 +2009,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_180905) do
   add_foreign_key "context_intake_responses", "context_intake_sessions"
   add_foreign_key "context_intake_sessions", "projects"
   add_foreign_key "context_intake_sessions", "users", column: "started_by_id"
+  add_foreign_key "coordination_experiment_assignments", "coordination_experiment_variants", on_delete: :cascade
+  add_foreign_key "coordination_experiment_assignments", "coordination_experiments", on_delete: :cascade
+  add_foreign_key "coordination_experiment_assignments", "issues", on_delete: :nullify
+  add_foreign_key "coordination_experiment_assignments", "projects", on_delete: :cascade
+  add_foreign_key "coordination_experiment_variants", "coordination_experiments", on_delete: :cascade
+  add_foreign_key "coordination_experiments", "accounts", on_delete: :cascade
+  add_foreign_key "coordination_experiments", "coordination_experiment_variants", column: "winner_variant_id", on_delete: :nullify
   add_foreign_key "cost_budgets", "projects", on_delete: :cascade
   add_foreign_key "decision_record_links", "decision_records", on_delete: :cascade
   add_foreign_key "decision_records", "agent_runs", on_delete: :nullify

--- a/spec/factories/coordination_experiment_assignments.rb
+++ b/spec/factories/coordination_experiment_assignments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :coordination_experiment_assignment do
+    coordination_experiment
+    coordination_experiment_variant do
+      association :coordination_experiment_variant, coordination_experiment: coordination_experiment, strategy: :create
+    end
+    project
+    issue { nil }
+    sequence(:workflow_id) { |n| "coordination-workflow-#{n}" }
+    outcome_status { "assigned" }
+    outcome_metrics { {} }
+  end
+end

--- a/spec/factories/coordination_experiment_variants.rb
+++ b/spec/factories/coordination_experiment_variants.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :coordination_experiment_variant do
+    coordination_experiment
+    policy_config { OrchestrationStrategies::Defaults.feature_orchestration.deep_dup }
+    is_control { false }
+    sample_count { 0 }
+    total_coordination_score { 0 }
+  end
+end

--- a/spec/factories/coordination_experiments.rb
+++ b/spec/factories/coordination_experiments.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :coordination_experiment do
+    account
+    sequence(:name) { |n| "Coordination Experiment #{n}" }
+    policy_name { CoordinationExperiment::POLICY_NAME }
+    status { "running" }
+    control_policy { OrchestrationStrategies::Defaults.feature_orchestration.deep_dup }
+    min_samples_per_variant { 2 }
+    traffic_percentage { 100 }
+  end
+end

--- a/spec/models/coordination_experiment_spec.rb
+++ b/spec/models/coordination_experiment_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CoordinationExperiment do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:policy_name) }
+    it { is_expected.to validate_inclusion_of(:policy_name).in_array([ described_class::POLICY_NAME ]) }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+  end
+
+  describe ".active_for" do
+    let(:account) { create(:account) }
+
+    it "returns the running experiment when workflow traffic is included" do
+      experiment = create(:coordination_experiment, account: account, traffic_percentage: 100)
+
+      expect(described_class.active_for(account:, workflow_id: "wf-1")).to eq(experiment)
+    end
+
+    it "returns nil when the traffic gate excludes the workflow" do
+      create(:coordination_experiment, account: account, traffic_percentage: 0)
+
+      expect(described_class.active_for(account:, workflow_id: "wf-1")).to be_nil
+    end
+  end
+end

--- a/spec/services/coordination_experiments/assign_spec.rb
+++ b/spec/services/coordination_experiments/assign_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CoordinationExperiments::Assign do
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account) }
+  let(:issue) { create(:issue, project: project) }
+  let(:experiment) { create(:coordination_experiment, account: account, status: "running") }
+  let!(:control) do
+    create(:coordination_experiment_variant,
+      coordination_experiment: experiment,
+      policy_config: experiment.control_policy,
+      is_control: true)
+  end
+  let!(:variant) do
+    create(:coordination_experiment_variant,
+      coordination_experiment: experiment,
+      policy_config: experiment.control_policy.merge("parallel_execution" => { "max_batch_size" => 1 }))
+  end
+
+  it "creates a workflow-scoped assignment" do
+    assignment = described_class.call(
+      coordination_experiment: experiment,
+      project: project,
+      issue: issue,
+      workflow_id: "wf-123"
+    )
+
+    expect(assignment.project).to eq(project)
+    expect(assignment.issue).to eq(issue)
+    expect(assignment.workflow_id).to eq("wf-123")
+    expect([ control, variant ]).to include(assignment.coordination_experiment_variant)
+  end
+
+  it "reuses the existing assignment for the same workflow" do
+    first = described_class.call(coordination_experiment: experiment, project: project, workflow_id: "wf-123")
+    second = described_class.call(coordination_experiment: experiment, project: project, workflow_id: "wf-123")
+
+    expect(second.id).to eq(first.id)
+  end
+
+  it "balances across variants" do
+    assignments = 6.times.map do |index|
+      described_class.call(
+        coordination_experiment: experiment,
+        project: project,
+        workflow_id: "wf-#{index}"
+      )
+    end
+
+    counts = assignments.map(&:coordination_experiment_variant_id).tally
+
+    expect(counts.keys.size).to eq(2)
+    counts.each_value { |count| expect(count).to be_between(2, 4) }
+  end
+end

--- a/spec/services/coordination_experiments/promotion_readiness_spec.rb
+++ b/spec/services/coordination_experiments/promotion_readiness_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CoordinationExperiments::PromotionReadiness do
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account) }
+  let(:issue) { create(:issue, project: project) }
+  let(:experiment) { create(:coordination_experiment, account: account, min_samples_per_variant: 2) }
+  let!(:control) do
+    create(:coordination_experiment_variant,
+      coordination_experiment: experiment,
+      policy_config: experiment.control_policy,
+      is_control: true,
+      sample_count: 2,
+      avg_coordination_score: 0.6,
+      total_coordination_score: 1.2)
+  end
+  let!(:variant) do
+    create(:coordination_experiment_variant,
+      coordination_experiment: experiment,
+      policy_config: experiment.control_policy.merge("parallel_execution" => { "max_batch_size" => 1 }),
+      sample_count: 2,
+      avg_coordination_score: 0.8,
+      total_coordination_score: 1.6)
+  end
+
+  before do
+    [ true, true ].each_with_index do |success, index|
+      create(:coordination_experiment_assignment,
+        coordination_experiment: experiment,
+        coordination_experiment_variant: control,
+        project: project,
+        issue: issue,
+        workflow_id: "control-#{index}",
+        outcome_status: "recorded",
+        coordination_score: 0.6,
+        outcome_metrics: {
+          "success" => success,
+          "conflict_detected" => false,
+          "manual_review_required" => false,
+          "total_cost_cents" => 100
+        })
+      create(:coordination_experiment_assignment,
+        coordination_experiment: experiment,
+        coordination_experiment_variant: variant,
+        project: project,
+        issue: issue,
+        workflow_id: "variant-#{index}",
+        outcome_status: "recorded",
+        coordination_score: 0.8,
+        outcome_metrics: {
+          "success" => success,
+          "conflict_detected" => false,
+          "manual_review_required" => false,
+          "total_cost_cents" => 105
+        })
+    end
+  end
+
+  it "marks the evolved variant ready when quality improves within guardrails" do
+    result = described_class.call(coordination_experiment: experiment)
+
+    expect(result.status).to eq(:ready)
+    expect(result.candidate).to eq(variant)
+    expect(result.reasons).to eq([])
+  end
+
+  it "fails readiness when cost guardrails regress too far" do
+    variant.coordination_experiment_assignments.recorded.update_all(
+      outcome_metrics: {
+        "success" => true,
+        "conflict_detected" => false,
+        "manual_review_required" => false,
+        "total_cost_cents" => 200
+      }
+    )
+
+    result = described_class.call(coordination_experiment: experiment)
+
+    expect(result.status).to eq(:guardrail_failed)
+    expect(result.reasons).to include("cost_increase_too_high")
+  end
+end

--- a/spec/services/coordination_experiments/record_outcome_spec.rb
+++ b/spec/services/coordination_experiments/record_outcome_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CoordinationExperiments::RecordOutcome do
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account) }
+  let(:issue) { create(:issue, project: project) }
+  let(:experiment) { create(:coordination_experiment, account: account, status: "running") }
+  let(:variant) { create(:coordination_experiment_variant, coordination_experiment: experiment) }
+  let(:assignment) do
+    create(:coordination_experiment_assignment,
+      coordination_experiment: experiment,
+      coordination_experiment_variant: variant,
+      project: project,
+      issue: issue)
+  end
+  let!(:run) do
+    create(:agent_run,
+      :completed,
+      project: project,
+      issue: issue,
+      cost_cents: 250,
+      duration_seconds: 120,
+      iterations: 2)
+  end
+  let(:result_payload) do
+    {
+      success: true,
+      completed: 2,
+      failed: 0,
+      results: [ { success: true, agent_run_id: run.id }, { success: true } ],
+      conflicts: { has_conflicts: false, requires_manual_review: false }
+    }
+  end
+
+  it "records workflow metrics and updates variant aggregates" do
+    described_class.call(
+      assignment: assignment,
+      task_count: 2,
+      parallel_execution: true,
+      result: result_payload
+    )
+
+    assignment.reload
+    variant.reload
+
+    expect(assignment.outcome_status).to eq("recorded")
+    expect(assignment.outcome_metrics).to include(
+      "task_count" => 2,
+      "parallel_execution" => true,
+      "total_cost_cents" => 250,
+      "total_duration_seconds" => 120
+    )
+    expect(assignment.coordination_score).to eq(1.0)
+    expect(variant.sample_count).to eq(1)
+    expect(variant.avg_coordination_score.to_f).to eq(1.0)
+  end
+end

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -114,9 +114,26 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             hash_including(
               project_id: 1,
               parent_issue_id: 2,
+              coordination_policy: hash_including("parallel_execution" => anything),
               sub_tasks: array_including(hash_including(:custom_prompt))
             ),
             hash_including(task_queue: Paid::AGENT_TASK_QUEUE)
+          )
+      end
+
+      it "records coordination experiment outcomes after parallel execution" do
+        workflow.execute(input)
+
+        expect(workflow).to have_received(:run_activity)
+          .with(
+            Activities::RecordCoordinationExperimentOutcomeActivity,
+            hash_including(
+              assignment_id: 77,
+              task_count: 3,
+              parallel_execution: true
+            ),
+            timeout: 30,
+            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
           )
       end
 
@@ -350,10 +367,14 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
       before do
         allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
           case activity_class.name
+          when "Activities::ResolveCoordinationExperimentActivity"
+            { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
           when "Activities::FetchPlanningContextActivity"
             { context: {} }
           when "Activities::DecomposeFeatureActivity"
             raise Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed")
+          when "Activities::RecordCoordinationExperimentOutcomeActivity"
+            { assignment_id: 77, outcome_status: "recorded" }
           when "Activities::LogDecompositionDecisionActivity"
             { decomposition_decision_id: 9 }
           else
@@ -471,6 +492,8 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
   def stub_planning_activities(tasks:, created_issues:)
     allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
       case activity_class.name
+      when "Activities::ResolveCoordinationExperimentActivity"
+        { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
       when "Activities::FetchPlanningContextActivity"
         { context: { issue_title: "Feature", knowledge_snippets: [] } }
       when "Activities::DecomposeFeatureActivity"
@@ -479,6 +502,8 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         { created_issues: created_issues }
       when "Activities::UpdatePlanningLabelsActivity"
         { success: true }
+      when "Activities::RecordCoordinationExperimentOutcomeActivity"
+        { assignment_id: 77, outcome_status: "recorded" }
       when "Activities::LogDecompositionDecisionActivity"
         { decomposition_decision_id: 1 }
       else

--- a/spec/temporal/workflows/parallel_agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/parallel_agent_execution_workflow_spec.rb
@@ -232,6 +232,22 @@ RSpec.describe Workflows::ParallelAgentExecutionWorkflow do
       expect(result[:completed]).to eq(3)
     end
 
+    it "caps batch size when coordination policy sets max_batch_size" do
+      stub_full_capacity
+      stub_successful_futures(count: 3)
+      stub_no_conflicts
+
+      workflow.execute(
+        three_task_input.merge(
+          coordination_policy: {
+            "parallel_execution" => { "max_batch_size" => 1 }
+          }
+        )
+      )
+
+      expect(Temporalio::Workflow::Future).to have_received(:try_all_of).exactly(3).times
+    end
+
     it "waits to launch dependent tasks until prerequisites complete" do
       stub_full_capacity
       stub_successful_futures(count: 3)
@@ -266,6 +282,25 @@ RSpec.describe Workflows::ParallelAgentExecutionWorkflow do
       expect(result[:failed]).to eq(2)
       expect(result[:results]).to include(
         include(issue_id: 20, task_index: 1, success: false, error: "dependencies_failed", blocked_by: [ 0 ])
+      )
+    end
+
+    it "cancels remaining ready tasks when policy forbids continuing after a failure" do
+      stub_incremental_capacity
+      stub_dependency_failure_sequence
+      stub_no_conflicts
+
+      result = workflow.execute(
+        three_task_input.merge(
+          coordination_policy: {
+            "parallel_execution" => { "cancel_remaining_on_failure" => true }
+          }
+        )
+      )
+
+      expect(result[:results]).to include(
+        include(issue_id: 20, success: false, error: "cancelled_by_policy", queued: true),
+        include(issue_id: 30, success: false, error: "cancelled_by_policy", queued: true)
       )
     end
 


### PR DESCRIPTION
## Summary

Implemented coordination policy experiments for feature orchestration and committed it as `497590b` with message `feat(coordination): add orchestration policy experiments`.

The change adds workflow-scoped coordination experiment models/services, safe assignment and outcome recording activities, policy override wiring through decomposition and parallel execution, richer coordination/cost metrics, and promotion-readiness checks. It also extends `feature_orchestration` defaults with explicit decomposition and parallel-execution policy knobs and adds specs for assignment, aggregation, workflow integration, and promotion gating.

Verification passed:
- `bundle exec rubocop`
- `bundle exec rspec`
- Commit hook `bin/lint --staged` and repo hook `bundle exec rspec`

`git status` is clean.

---

Closes #1773