### PR TITLE
Fix #1843: Add end-to-end system coverage for full business context questionnaire completion and KB persistence

### DIFF
--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -10,7 +10,7 @@ module Knowledge
     def show
       authorize @project, :show?
       @session ||= latest_session
-      load_wizard_state if @session&.in_progress?
+      load_wizard_state(active_section_key: params[:section]) if @session&.in_progress?
     end
 
     def create
@@ -35,7 +35,7 @@ module Knowledge
         skipped: skipped
       )
 
-      load_wizard_state
+      load_wizard_state(active_section_key: preferred_section_after_update(question_key))
       render :show
     rescue ArgumentError => e
       redirect_to project_context_intake_path(@project), alert: e.message
@@ -74,10 +74,40 @@ module Knowledge
       @project.context_intake_sessions.latest_first.first
     end
 
-    def load_wizard_state
+    def load_wizard_state(active_section_key: nil)
       @sections = ContextIntake::QuestionnaireSchema.sections
       @responses = @session.context_intake_responses.ordered.index_by(&:question_key)
       @progress = @session.progress
+      @active_section_key = resolve_active_section_key(active_section_key)
+    end
+
+    def resolve_active_section_key(active_section_key)
+      valid_section_keys = @sections.map { |section| section[:key] }
+      requested_section = active_section_key.presence_in(valid_section_keys)
+
+      requested_section || next_incomplete_section_key || @sections.first&.fetch(:key, nil)
+    end
+
+    def next_incomplete_section_key
+      @sections.find do |section|
+        section[:questions].any? { |question| !@responses[question[:key]]&.answered? }
+      end&.fetch(:key, nil)
+    end
+
+    def preferred_section_after_update(question_key)
+      section_key = ContextIntake::QuestionnaireSchema.find_question(question_key)&.dig(:section, :key)
+      return unless section_key
+
+      section_has_unanswered_questions?(section_key) ? section_key : nil
+    end
+
+    def section_has_unanswered_questions?(section_key)
+      section = ContextIntake::QuestionnaireSchema.sections.find { |entry| entry[:key] == section_key }
+      return false unless section
+
+      section[:questions].any? do |question|
+        !@session.context_intake_responses.find_by(question_key: question[:key])&.answered?
+      end
     end
 
     def abort_if_in_progress!

--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -98,7 +98,9 @@ module Knowledge
       section_key = ContextIntake::QuestionnaireSchema.find_question(question_key)&.dig(:section, :key)
       return unless section_key
 
-      section_has_unanswered_questions?(section_key) ? section_key : nil
+      return section_key if section_has_unanswered_questions?(section_key)
+
+      next_incomplete_section_key_for_session || section_key
     end
 
     def section_has_unanswered_questions?(section_key)
@@ -108,6 +110,14 @@ module Knowledge
       section[:questions].any? do |question|
         !@session.context_intake_responses.find_by(question_key: question[:key])&.answered?
       end
+    end
+
+    def next_incomplete_section_key_for_session
+      ContextIntake::QuestionnaireSchema.sections.find do |section|
+        section[:questions].any? do |question|
+          !@session.context_intake_responses.find_by(question_key: question[:key])&.answered?
+        end
+      end&.fetch(:key, nil)
     end
 
     def abort_if_in_progress!

--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -98,24 +98,26 @@ module Knowledge
       section_key = ContextIntake::QuestionnaireSchema.find_question(question_key)&.dig(:section, :key)
       return unless section_key
 
-      return section_key if section_has_unanswered_questions?(section_key)
+      responses = @session.context_intake_responses.index_by(&:question_key)
 
-      next_incomplete_section_key_for_session || section_key
+      return section_key if section_has_unanswered_questions?(section_key, responses)
+
+      next_incomplete_section_key_for_session(responses) || section_key
     end
 
-    def section_has_unanswered_questions?(section_key)
+    def section_has_unanswered_questions?(section_key, responses)
       section = ContextIntake::QuestionnaireSchema.sections.find { |entry| entry[:key] == section_key }
       return false unless section
 
       section[:questions].any? do |question|
-        !@session.context_intake_responses.find_by(question_key: question[:key])&.answered?
+        !responses[question[:key]]&.answered?
       end
     end
 
-    def next_incomplete_section_key_for_session
+    def next_incomplete_section_key_for_session(responses)
       ContextIntake::QuestionnaireSchema.sections.find do |section|
         section[:questions].any? do |question|
-          !@session.context_intake_responses.find_by(question_key: question[:key])&.answered?
+          !responses[question[:key]]&.answered?
         end
       end&.fetch(:key, nil)
     end

--- a/app/views/knowledge/context_intake/_wizard.html.erb
+++ b/app/views/knowledge/context_intake/_wizard.html.erb
@@ -1,9 +1,4 @@
-<%
-  # Helper to determine which section is currently active based on progress
-  current_section_index = @sections.index { |s| s[:questions].any? { |q| !@responses[q[:key]]&.answered? } } || 0
-%>
-<div class="mt-6" data-controller="context-intake">
-  <%# Progress bar %>
+<div class="mt-6">
   <div class="overflow-hidden rounded-lg bg-white shadow">
     <div class="px-4 py-4 sm:px-6">
       <div class="flex items-center justify-between">
@@ -21,15 +16,11 @@
   <%# Section navigation %>
   <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
     <nav class="flex overflow-x-auto px-4 py-3 sm:px-6" aria-label="Sections">
-      <% @sections.each_with_index do |section, idx| %>
-        <button type="button"
-                class="mr-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors
-                       <%= idx == (@session.current_step > 0 ? current_section_index : 0) ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100' %>"
-                data-context-intake-target="sectionTab"
-                data-action="click->context-intake#switchSection"
-                data-section="<%= section[:key] %>">
+      <% @sections.each do |section| %>
+        <%= link_to project_context_intake_path(@project, section: section[:key]),
+              class: "mr-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors #{section[:key] == @active_section_key ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'}" do %>
           <%= section[:title] %>
-        </button>
+        <% end %>
       <% end %>
     </nav>
   </div>
@@ -37,9 +28,8 @@
   <%# Questions per section %>
   <% @sections.each do |section| %>
     <div class="mt-4 overflow-hidden rounded-lg bg-white shadow"
-         data-context-intake-target="sectionPanel"
          data-section="<%= section[:key] %>"
-         style="<%= section[:key] == @sections.first[:key] ? '' : 'display: none;' %>">
+         style="<%= section[:key] == @active_section_key ? '' : 'display: none;' %>">
       <div class="px-4 py-5 sm:p-6">
         <h3 class="text-lg font-medium text-gray-900 mb-4"><%= section[:title] %></h3>
 

--- a/spec/system/knowledge/context_intake_spec.rb
+++ b/spec/system/knowledge/context_intake_spec.rb
@@ -31,13 +31,22 @@ RSpec.describe "Business context questionnaire", system_driver: :rack_test, type
   end
 
   def complete_questionnaire(answers)
-    Knowledge::ContextIntake::QuestionnaireSchema.sections.each do |section|
-      click_link section[:title]
+    sections = Knowledge::ContextIntake::QuestionnaireSchema.sections
 
-      within_section_panel(section[:key]) do
-        section[:questions].each do |question|
-          answer_question(question[:key], answers.fetch(question[:key]))
+    sections.each_with_index do |section, section_index|
+      expect_active_section(section[:key], section[:title])
+
+      section[:questions].each_with_index do |question, question_index|
+        answer_question(question[:key], answers.fetch(question[:key]))
+
+        next_section_key = if question_index < section[:questions].length - 1
+          section[:key]
+        else
+          sections[section_index + 1]&.fetch(:key, section[:key]) || section[:key]
         end
+
+        next_section_title = sections.find { |entry| entry[:key] == next_section_key }[:title]
+        expect_active_section(next_section_key, next_section_title)
       end
     end
 
@@ -75,6 +84,14 @@ RSpec.describe "Business context questionnaire", system_driver: :rack_test, type
   def within_section_panel(section_key, &)
     within(find(%([data-section="#{section_key}"]), visible: true)) do
       yield
+    end
+  end
+
+  def expect_active_section(section_key, section_title)
+    expect(page).to have_css("[data-section]", visible: true, count: 1)
+
+    within_section_panel(section_key) do
+      expect(page).to have_css("h3", text: section_title)
     end
   end
 

--- a/spec/system/knowledge/context_intake_spec.rb
+++ b/spec/system/knowledge/context_intake_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Business context questionnaire", system_driver: :rack_test, type: :system do
+  let!(:account) { create(:account) }
+  let!(:user) do
+    create(:user, :owner, account: account, email: "owner@example.com", password: "password123")
+  end
+  let!(:project) { create(:project, account: account, created_by: user) }
+
+  it "completes the questionnaire, persists business context, and reuses it for later prompts" do
+    answers = questionnaire_answers
+
+    sign_in_and_start_questionnaire
+    complete_questionnaire(answers)
+    expect_persisted_business_context(answers)
+    expect_later_prompt_to_include_business_context(answers)
+  end
+
+  def sign_in_and_start_questionnaire
+    visit new_user_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    click_button "Sign in"
+
+    visit project_context_intake_path(project)
+    click_button "Start Business Context Questionnaire"
+
+    expect(page).to have_content("Business context questionnaire started.")
+  end
+
+  def complete_questionnaire(answers)
+    Knowledge::ContextIntake::QuestionnaireSchema.sections.each do |section|
+      click_link section[:title]
+
+      within_section_panel(section[:key]) do
+        section[:questions].each do |question|
+          answer_question(question[:key], answers.fetch(question[:key]))
+        end
+      end
+    end
+
+    click_button "Complete & Save Business Context"
+
+    expect(page).to have_content("Business context saved and synthesized into project knowledge.")
+    expect(page).to have_content("Business context captured")
+  end
+
+  def expect_persisted_business_context(answers)
+    artifacts = KnowledgeArtifact.for_project(project).active.by_type("business_context").includes(:knowledge_chunks)
+
+    expect(artifacts.count).to eq(Knowledge::ContextIntake::QuestionnaireSchema.sections.count)
+    expect(artifacts.map(&:identifier)).to include("business_context:product_purpose", "business_context:terminology")
+    expect(artifacts.find_by(identifier: "business_context:product_purpose")&.content)
+      .to include(answers.fetch("product_description"))
+    expect(artifacts.flat_map { |artifact| artifact.knowledge_chunks.active.pluck(:content) })
+      .to include(a_string_including(answers.fetch("domain_terms")))
+  end
+
+  def expect_later_prompt_to_include_business_context(answers)
+    issue = create(:issue,
+      project: project,
+      title: "Clarify enterprise billing workflows",
+      body: "Need to update billing behavior for enterprise customers.",
+      github_creator_login: project.allowed_github_usernames.first)
+
+    prompt = Prompts::BuildForIssue.call(issue: issue, project: project)
+
+    expect(prompt).to include("Business Context (maintainer-provided)")
+    expect(prompt).to include(answers.fetch("product_description"))
+    expect(prompt).to include(answers.fetch("domain_terms"))
+  end
+
+  def within_section_panel(section_key, &)
+    within(find(%([data-section="#{section_key}"]), visible: true)) do
+      yield
+    end
+  end
+
+  def answer_question(question_key, answer_text)
+    within(:xpath, %(.//form[input[@name='question_key' and @value='#{question_key}']])) do
+      fill_in "answer_text", with: answer_text
+      click_button "Save"
+    end
+  end
+
+  def questionnaire_answers
+    {
+      "product_description" => "Paid coordinates AI agents to turn trusted GitHub issues into reviewed pull requests.",
+      "business_model" => "Teams pay for orchestrated agent runs that automate software delivery work.",
+      "primary_users" => "Engineering leaders and platform teams are the primary users.",
+      "non_users" => "We do not optimize this product for consumer end users.",
+      "critical_journeys" => "A maintainer labels an issue, the agent opens a PR, and reviewers merge it safely.",
+      "failure_modes" => "Agents must avoid opening duplicate PRs or missing dependency blockers.",
+      "key_features" => "Issue orchestration, guarded execution, and automated reviews are the core features.",
+      "good_bad_examples" => "Good behavior respects project rules and dependencies; bad behavior bypasses safeguards.",
+      "external_resources" => "Customer onboarding docs and internal runbooks live outside the repository.",
+      "api_contracts" => "GitHub webhook handling and provider quota limits constrain execution behavior.",
+      "deployment_model" => "The product is delivered as a hosted SaaS control plane.",
+      "environments" => "Changes move from staging to production after validation and operator approval.",
+      "compliance" => "SOC 2 controls and audit trails are important for enterprise customers.",
+      "slas_commitments" => "Customers expect reliable automation and careful backwards compatibility.",
+      "migration_constraints" => "Ongoing multi-tenant rollout work limits risky schema changes.",
+      "domain_terms" => "A Paid run is an orchestrated agent execution with project-specific guardrails.",
+      "naming_conventions" => "Use project language that distinguishes issues, runs, reviews, and knowledge artifacts."
+    }
+  end
+end


### PR DESCRIPTION
## Summary

Implemented the questionnaire flow fix and added end-to-end coverage.

The fix makes section navigation server-rendered instead of relying on missing JS behavior, preserves the active questionnaire section, and advances to the next incomplete section after each save. The new system spec walks the full business-context questionnaire, asserts `business_context` artifacts and chunks are written to the knowledge base, and verifies a later `Prompts::BuildForIssue` call includes the saved context.

Validation passed with `bundle exec rubocop` and `bundle exec rspec` (`11324 examples, 0 failures, 3 pending`). I also completed the requested commit: `082765e` (`fix(context-intake): cover full questionnaire completion and KB reuse`).

One environment note: `bin/rails db:prepare` / development `db:migrate` was blocked by the repo’s runtime-role guard because `DATABASE_URL` points at the unsafe `agent` Postgres role here, but the test database was migrated and the full suite ran successfully.

---

Closes #1843