### PR TITLE
fix(sync): add issue backfill to catch issues missed by incremental sync

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -682,6 +682,8 @@ module Activities
         return 0
       end
 
+      backfill_open_issues(project, client, open_numbers)
+
       stale = project.issues
         .where(github_state: "open", is_pull_request: false, source: Issue::GITHUB_SOURCE)
       stale = stale.where.not(github_number: open_numbers) if open_numbers.any?
@@ -699,6 +701,20 @@ module Activities
       end
 
       count
+    end
+
+    def backfill_open_issues(project, client, open_issue_numbers)
+      return if open_issue_numbers.empty?
+
+      existing_open_numbers = project.issues
+        .where(github_state: "open", is_pull_request: false, github_number: open_issue_numbers)
+        .pluck(:github_number)
+        .to_set
+
+      (open_issue_numbers - existing_open_numbers.to_a).each do |number|
+        github_issue = client.issue(project.full_name, number)
+        sync_issue(project, github_issue)
+      end
     end
 
     def issue_reconciliation_due?(project)

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe Activities::FetchIssuesActivity do
     )
   end
 
+  def github_issue(number, id: 6000 + number, title: "Open issue", labels: [ "paid-build" ])
+    OpenStruct.new(
+      id: id,
+      number: number,
+      title: title,
+      body: "Body",
+      state: "open",
+      labels: labels.map { |label| OpenStruct.new(name: label) },
+      pull_request: nil,
+      user: OpenStruct.new(login: "viamin"),
+      created_at: 2.days.ago,
+      updated_at: 5.minutes.ago
+    )
+  end
+
   def create_parsed_issue_with_external_dependency(project, issue_number:, depends_on_number:)
     issue = create(:issue,
       project: project,
@@ -1476,6 +1491,42 @@ RSpec.describe Activities::FetchIssuesActivity do
 
             expect(project.reload.last_issue_reconciliation_at).to be_within(0.1).of(Time.current)
           end
+        end
+
+        it "backfills open issues missing from the local cache" do
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(
+            project.full_name,
+            hash_including(state: "open")
+          ).and_return([
+            OpenStruct.new(number: 52, pull_request: nil)
+          ])
+          allow(github_client).to receive(:issue).with(project.full_name, 52).and_return(
+            github_issue(52, id: 6002, title: "Recovered issue")
+          )
+
+          activity.execute(project_id: project.id)
+
+          issue = project.issues.find_by!(github_issue_id: 6002)
+          expect(issue.github_number).to eq(52)
+          expect(issue.github_state).to eq("open")
+          expect(issue.is_pull_request).to be false
+        end
+
+        it "does not backfill pull requests from the open issue reconciliation set" do
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(
+            project.full_name,
+            hash_including(state: "open")
+          ).and_return([
+            OpenStruct.new(number: 52, pull_request: OpenStruct.new(html_url: "https://github.com/owner/repo/pull/52"))
+          ])
+          allow(github_client).to receive(:issue)
+
+          activity.execute(project_id: project.id)
+
+          expect(github_client).not_to have_received(:issue).with(project.full_name, 52)
+          expect(project.issues.find_by(github_number: 52)).to be_nil
         end
 
         it "skips reconciliation when truncated" do


### PR DESCRIPTION
## Summary

Implemented the issue backfill in `reconcile_open_issues` by adding `backfill_open_issues` in [app/temporal/activities/fetch_issues_activity.rb](/workspace/app/temporal/activities/fetch_issues_activity.rb). It now diffs GitHub’s current open issue numbers against locally open non-PR issues and fetches any missing records via `client.issue(...)` before stale-closure runs, matching the existing PR safety net.

Added execute-level coverage in [spec/temporal/activities/fetch_issues_activity_spec.rb](/workspace/spec/temporal/activities/fetch_issues_activity_spec.rb) for both behaviors: missing open issues are recreated, and PRs surfaced in the open-issues listing are still excluded from issue backfill.

Verification passed with `bundle exec rubocop`, `bundle exec rspec`, and the pre-commit hook during commit. Commit: `755b394` (`fix(sync): backfill open issues during reconciliation`).

---

Closes #1858