### PR TITLE
fix(notifications): remove blocking-parent review notifications

### DIFF
--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -93,11 +93,6 @@ module Automation
             scope
           end
 
-          def review_required_parent_scope(project)
-            with_open_non_pr_subissues(parent_review_scope(project))
-              .where(id: blocking_parent_issue_ids(project))
-          end
-
           def next_candidate(project)
             eligible_scope(project)
               .order(
@@ -200,11 +195,6 @@ module Automation
             end
           end
 
-          def parent_review_scope(project)
-            Issue.where(project: project, github_state: "open", is_pull_request: false)
-              .where(source: [ Issue::GITHUB_SOURCE, Issue::SYNTHETIC_CODE_SCANNING_SOURCE ])
-          end
-
           def without_open_non_pr_subissues(scope)
             scope.where(<<~SQL.squish)
               NOT EXISTS (
@@ -216,27 +206,6 @@ module Automation
                   AND sub_issues.github_state = 'open'
               )
             SQL
-          end
-
-          def with_open_non_pr_subissues(scope)
-            scope.where(<<~SQL.squish)
-              EXISTS (
-                SELECT 1
-                FROM issues sub_issues
-                WHERE sub_issues.parent_issue_id = issues.id
-                  AND sub_issues.project_id = issues.project_id
-                  AND sub_issues.is_pull_request = FALSE
-                  AND sub_issues.github_state = 'open'
-              )
-            SQL
-          end
-
-          def blocking_parent_issue_ids(project)
-            IssueDependency.joins(:issue)
-              .where(issues: { project_id: project.id, github_state: "open", is_pull_request: false })
-              .where.not(depends_on_issue_id: nil)
-              .distinct
-              .select(:depends_on_issue_id)
           end
 
           # Returns a CASE expression that maps each issue to a numeric

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -25,7 +25,6 @@ module Issues
     NoRunnableProviderError = Class.new(StandardError)
 
     PAID_READY_LABEL = "paid-ready"
-    BLOCKING_PARENT_REVIEW_SOURCE = "blocking_parent_issue_review"
 
     # Returns the Set of issue IDs from +displayed_issues+ that are
     # currently eligible for auto-picking (per-issue criteria only;
@@ -42,8 +41,6 @@ module Issues
     end
 
     def call
-      sync_blocking_parent_review_notifications if should_sync_blocking_parent_reviews?
-
       result = strategy.evaluate(build_context)
       decision = result.decisions.first
       return nil if decision.nil? || decision.type == "noop"
@@ -113,74 +110,6 @@ module Issues
         strategy_type: :auto_pick,
         project: @project
       )
-    end
-
-    def should_sync_blocking_parent_reviews?
-      @project.auto_pick_enabled? && !@project.quality_paused?
-    end
-
-    def sync_blocking_parent_review_notifications
-      review_issues = Automation::Strategies::AutoPick::DefaultCandidateSource
-        .review_required_parent_scope(@project)
-        .includes(:sub_issues)
-        .to_a
-
-      review_issues.each { |issue| publish_blocking_parent_review_notification(issue) }
-
-      unresolved_blocking_parent_notifications(review_issues.map(&:id)).find_each do |notification|
-        Notifications::Resolve.call(
-          account: notification.account,
-          user: notification.user,
-          source: BLOCKING_PARENT_REVIEW_SOURCE,
-          subject: notification.subject
-        )
-      end
-    end
-
-    def publish_blocking_parent_review_notification(issue)
-      open_child_numbers = issue.sub_issues
-        .select { |sub_issue| !sub_issue.is_pull_request? && sub_issue.github_state == "open" }
-        .map(&:github_number)
-        .sort
-
-      blocking_issue_count = IssueDependency.joins(:issue)
-        .where(depends_on_issue: issue)
-        .where(issues: { project_id: @project.id, github_state: "open", is_pull_request: false })
-        .distinct
-        .count(:issue_id)
-
-      Notifications::Publish.call(
-        account: @project.account,
-        user: @project.effective_owner,
-        source: BLOCKING_PARENT_REVIEW_SOURCE,
-        subject: issue,
-        severity: :warning,
-        title: "Parent issue ##{issue.github_number} is blocking auto-pick",
-        description: "Open child issues: #{open_child_numbers.map { |n| "##{n}" }.join(", ")}. " \
-          "Review close-out work so #{blocking_issue_count} blocked issue#{'s' unless blocking_issue_count == 1} can move forward.",
-        nav_section: "dashboard",
-        action_url: "/projects/#{@project.id}",
-        metadata: {
-          issue_number: issue.github_number,
-          open_child_issue_numbers: open_child_numbers,
-          blocking_issue_count: blocking_issue_count
-        }
-      )
-    end
-
-    def unresolved_blocking_parent_notifications(active_issue_ids)
-      scope = Notification.where(
-        account: @project.account,
-        user: @project.effective_owner,
-        source: BLOCKING_PARENT_REVIEW_SOURCE,
-        subject_type: "Issue",
-        subject_id: @project.issues.select(:id),
-        resolved_at: nil
-      )
-
-      return scope if active_issue_ids.empty?
-
-      scope.where.not(subject_id: active_issue_ids)
     end
 
     def build_context

--- a/db/migrate/20260509025902_resolve_orphaned_blocking_parent_review_notifications.rb
+++ b/db/migrate/20260509025902_resolve_orphaned_blocking_parent_review_notifications.rb
@@ -7,9 +7,10 @@ class ResolveOrphanedBlockingParentReviewNotifications < ActiveRecord::Migration
   end
 
   def down
-    Notification.where(source: "blocking_parent_issue_review")
-      .where.not(resolved_at: nil)
-      .where("resolved_at >= ?", Time.utc(2026, 5, 9))
-      .update_all(resolved_at: nil)
+    # This migration is irreversible because we cannot distinguish between
+    # notifications resolved by this migration vs. those resolved for other reasons.
+    # Reopening all notifications from this source could resurrect notifications
+    # that were legitimately resolved elsewhere.
+    raise ActiveRecord::IrreversibleMigration, "Cannot reverse notification cleanup - would resurrect legitimately resolved notifications"
   end
 end

--- a/db/migrate/20260509025902_resolve_orphaned_blocking_parent_review_notifications.rb
+++ b/db/migrate/20260509025902_resolve_orphaned_blocking_parent_review_notifications.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ResolveOrphanedBlockingParentReviewNotifications < ActiveRecord::Migration[8.1]
+  def up
+    Notification.where(source: "blocking_parent_issue_review", resolved_at: nil)
+      .update_all(resolved_at: Time.current)
+  end
+
+  def down
+    Notification.where(source: "blocking_parent_issue_review")
+      .where.not(resolved_at: nil)
+      .where("resolved_at >= ?", Time.utc(2026, 5, 9))
+      .update_all(resolved_at: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_180905) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_025902) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -2933,7 +2933,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_180905) do
   SQL
 
   create_trigger :logidze_on_projects, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_projects BEFORE INSERT OR UPDATE ON public.projects FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{last_polled_at,last_agent_run_at,last_github_activity_at,last_issue_sync_at,total_cost_cents,total_tokens_used}')
+      CREATE TRIGGER logidze_on_projects BEFORE INSERT OR UPDATE ON public.projects FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_tenant_settings, sql_definition: <<-SQL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -3019,7 +3019,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_045503) do
   SQL
 
   create_trigger :logidze_on_projects, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_projects BEFORE INSERT OR UPDATE ON public.projects FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+      CREATE TRIGGER logidze_on_projects BEFORE INSERT OR UPDATE ON public.projects FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{last_polled_at,last_agent_run_at,last_github_activity_at,last_issue_sync_at,total_cost_cents,total_tokens_used}')
   SQL
 
   create_trigger :logidze_on_tenant_settings, sql_definition: <<-SQL

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -131,52 +131,6 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
     end
   end
 
-  describe ".review_required_parent_scope" do
-    it "returns blocking parent issues that still have open sub-issues" do
-      parent = create(:issue, project: project, github_number: 1)
-      child = create(:issue, project: project, github_number: 2, parent_issue: parent)
-      blocked = create(:issue, project: project, github_number: 3)
-      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
-
-      scope = described_class.review_required_parent_scope(project)
-
-      expect(scope.pluck(:id)).to contain_exactly(parent.id)
-      expect(child).to be_present
-    end
-
-    it "returns blocking parent issues even when auto-pick label exclusions make them ineligible" do
-      parent = create(:issue, project: project, github_number: 1, labels: [ "tracking" ])
-      create(:issue, project: project, github_number: 2, parent_issue: parent)
-      blocked = create(:issue, project: project, github_number: 3)
-      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
-
-      scope = described_class.review_required_parent_scope(project)
-
-      expect(scope.pluck(:id)).to contain_exactly(parent.id)
-    end
-
-    it "returns blocking parent issues even when trusted-user auto-pick filters exclude them" do
-      project.update!(allowed_github_usernames: [ "trusted-user" ])
-      parent = create(:issue, project: project, github_number: 1, github_creator_login: "external-user")
-      create(:issue, project: project, github_number: 2, parent_issue: parent)
-      blocked = create(:issue, project: project, github_number: 3)
-      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
-
-      scope = described_class.review_required_parent_scope(project)
-
-      expect(scope.pluck(:id)).to contain_exactly(parent.id)
-    end
-
-    it "does not return parents that are not blocking downstream issues" do
-      parent = create(:issue, project: project, github_number: 1)
-      create(:issue, project: project, github_number: 2, parent_issue: parent)
-
-      scope = described_class.review_required_parent_scope(project)
-
-      expect(scope).to be_empty
-    end
-  end
-
   describe ".eligible_issue_ids" do
     it "returns the subset of displayed issues that are eligible" do
       eligible = create(:issue, project: project)

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -394,66 +394,6 @@ RSpec.describe Issues::AutoPick do
       expect(result.issue).to eq(standalone)
     end
 
-    it "publishes a review notification for a blocking parent with open sub-issues" do
-      parent = create(:issue, project: project, github_number: 1)
-      create(:issue, project: project, github_number: 2, parent_issue: parent)
-      blocked = create(:issue, project: project, github_number: 3)
-      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
-
-      described_class.new(project).call
-
-      notification = Notification.find_by!(
-        account: project.account,
-        user: project.effective_owner,
-        source: "blocking_parent_issue_review",
-        subject: parent
-      )
-
-      expect(notification.severity).to eq("warning")
-      expect(notification.title).to eq("Parent issue ##{parent.github_number} is blocking auto-pick")
-      expect(notification.metadata).to include(
-        "open_child_issue_numbers" => [ 2 ],
-        "blocking_issue_count" => 1
-      )
-    end
-
-    it "publishes a review notification for a blocking parent even when auto-pick excludes it by label" do
-      parent = create(:issue, project: project, github_number: 1, labels: [ "epic" ])
-      create(:issue, project: project, github_number: 2, parent_issue: parent)
-      blocked = create(:issue, project: project, github_number: 3)
-      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
-
-      described_class.new(project).call
-
-      expect(Notification.find_by(
-        account: project.account,
-        user: project.effective_owner,
-        source: "blocking_parent_issue_review",
-        subject: parent
-      )).to be_present
-    end
-
-    it "resolves a blocking-parent review notification once the parent is no longer blocking" do
-      parent = create(:issue, project: project, github_number: 1)
-      child = create(:issue, project: project, github_number: 2, parent_issue: parent)
-      blocked = create(:issue, project: project, github_number: 3)
-      create(:issue_dependency, issue: blocked, depends_on_issue: parent)
-
-      described_class.new(project).call
-
-      child.update!(github_state: "closed")
-      described_class.new(project).call
-
-      notification = Notification.find_by!(
-        account: project.account,
-        user: project.effective_owner,
-        source: "blocking_parent_issue_review",
-        subject: parent
-      )
-
-      expect(notification.resolved_at).to be_present
-    end
-
     it "picks the oldest issue regardless of unblock count" do
       # leaf_b is older (lower number) but unblocks fewer issues
       leaf_b = create(:issue, project: project, github_number: 5)


### PR DESCRIPTION
## Summary

- Removes the `blocking_parent_issue_review` notification pipeline that surfaced warnings whenever a parent issue with open children was blocking downstream auto-pick candidates
- Normal parent-child dependency blocking is intentional and expected — not worth alerting on (circular dependencies would be, but that's a separate feature)
- The notification text was also unclear about what was blocked vs blocking, making it unactionable
- Adds a migration to resolve any existing orphaned notifications of this source in the DB

## Changes

- **`app/services/issues/auto_pick.rb`** — removed `BLOCKING_PARENT_REVIEW_SOURCE`, the sync call in `#call`, and four private methods (`should_sync_blocking_parent_reviews?`, `sync_blocking_parent_review_notifications`, `publish_blocking_parent_review_notification`, `unresolved_blocking_parent_notifications`)
- **`app/services/automation/strategies/auto_pick/default_candidate_source.rb`** — removed `review_required_parent_scope`, `parent_review_scope`, `with_open_non_pr_subissues`, and `blocking_parent_issue_ids` (kept `without_open_non_pr_subissues`, still used by `eligible_scope`)
- **`db/migrate/20260509025902_...`** — resolves existing orphaned `blocking_parent_issue_review` notifications
- Removed 7 corresponding test cases across both spec files

## Test plan

- [x] All 116 specs in `auto_pick_spec.rb` and `default_candidate_source_spec.rb` pass
- [x] `bin/lint --changed` clean
- [x] Verified no dangling references to removed code