### PR TITLE
feat(scaling): run agent-count scaling experiment

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -154,6 +154,8 @@ class Project < ApplicationRecord
   has_many :decision_records, dependent: :destroy
   has_many :orchestration_decisions, dependent: :destroy
   has_many :scaling_observations, dependent: :destroy
+  has_many :scaling_experiments, dependent: :destroy
+  has_many :scaling_experiment_assignments, dependent: :destroy
   has_many :llm_output_metrics, dependent: :destroy
   has_many :knowledge_runs, dependent: :destroy
   has_many :knowledge_usage_stats, dependent: :destroy

--- a/app/models/scaling_experiment.rb
+++ b/app/models/scaling_experiment.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "zlib"
+
+class ScalingExperiment < ApplicationRecord
+  STATUSES = %w[draft running completed cancelled].freeze
+  DIMENSIONS = %w[agent_count].freeze
+
+  belongs_to :project
+
+  has_many :scaling_experiment_assignments, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :hypothesis, presence: true
+  validates :dimension, presence: true, inclusion: { in: DIMENSIONS }
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :control_value, numericality: { only_integer: true, greater_than: 0 }
+  validates :min_samples_per_value, numericality: { only_integer: true, greater_than_or_equal_to: 2 }
+  validates :traffic_percentage, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
+  validate :values_tested_are_positive_integers
+  validate :control_value_in_values_tested
+  validate :context_filter_is_object
+
+  scope :draft, -> { where(status: "draft") }
+  scope :running, -> { where(status: "running") }
+  scope :completed, -> { where(status: "completed") }
+  scope :cancelled, -> { where(status: "cancelled") }
+
+  def self.active_for(project:, dimension:, workflow_id:, task_count:)
+    experiment = running.where(project:, dimension:).order(:id).first
+    return nil unless experiment
+    return nil unless experiment.includes_traffic?(workflow_id:)
+    return nil unless experiment.matches_context?(task_count:)
+
+    experiment
+  end
+
+  def running?
+    status == "running"
+  end
+
+  def draft?
+    status == "draft"
+  end
+
+  def start!
+    with_lock do
+      reload
+      raise_invalid_status!("start") unless draft?
+
+      update!(status: "running", started_at: Time.current)
+    end
+  rescue ActiveRecord::RecordNotUnique
+    errors.add(:base, "another scaling experiment is already running for this dimension")
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def complete!
+    with_lock do
+      reload
+      raise_invalid_status!("complete") unless running?
+
+      update!(status: "completed", completed_at: Time.current)
+    end
+  end
+
+  def cancel!
+    with_lock do
+      reload
+      raise_invalid_status!("cancel") unless %w[draft running].include?(status)
+
+      update!(status: "cancelled", completed_at: Time.current)
+    end
+  end
+
+  def includes_traffic?(workflow_id:)
+    return false if traffic_percentage.zero?
+    return true if traffic_percentage == 100
+
+    Zlib.crc32("#{id}:#{workflow_id}") % 100 < traffic_percentage
+  end
+
+  def matches_context?(task_count:)
+    return false if task_count.to_i < min_task_count
+    return false if max_task_count && task_count.to_i > max_task_count
+
+    true
+  end
+
+  def eligible_values(task_count:)
+    normalized_values_tested.select { |value| value <= task_count.to_i }
+  end
+
+  def sufficient_samples?
+    sample_counts = recorded_sample_counts
+    normalized_values_tested.all? { |value| sample_counts.fetch(value, 0) >= min_samples_per_value }
+  end
+
+  def samples_key
+    recorded_counts = recorded_sample_counts
+
+    normalized_values_tested
+      .map { |value| "#{value}:#{recorded_counts.fetch(value, 0)}" }
+      .join(",")
+  end
+
+  def cached_or_compute_summary(persist: true)
+    current_key = samples_key
+    if cached_summary.present?
+      return cached_summary if summary_samples_key == current_key
+      return cached_summary unless persist
+    end
+
+    summary = ScalingExperiments::SummarizeResults.call(scaling_experiment: self)
+    return summary unless persist
+
+    update_columns(cached_summary: summary, summary_samples_key: current_key)
+    summary
+  end
+
+  private
+
+  def normalized_values_tested
+    @normalized_values_tested ||= Array(values_tested).map { |value| Integer(value) }.uniq.sort
+  rescue ArgumentError, TypeError
+    []
+  end
+
+  def recorded_sample_counts
+    scaling_experiment_assignments
+      .recorded
+      .group(:assigned_value)
+      .count
+      .transform_keys(&:to_i)
+  end
+
+  def min_task_count
+    context_filter.fetch("min_task_count", 2).to_i
+  end
+
+  def max_task_count
+    raw = context_filter["max_task_count"]
+    return nil if raw.blank?
+
+    raw.to_i
+  end
+
+  def raise_invalid_status!(action)
+    errors.add(:base, "cannot #{action} an experiment that is #{status}")
+    raise ActiveRecord::RecordInvalid, self
+  end
+
+  def values_tested_are_positive_integers
+    values = Array(values_tested)
+    if values.blank?
+      errors.add(:values_tested, "must include at least one value")
+      return
+    end
+
+    normalized = values.filter_map do |value|
+      Integer(value)
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    if normalized.size != values.size || normalized.any?(&:zero?) || normalized.any?(&:negative?)
+      errors.add(:values_tested, "must contain unique positive integers")
+      return
+    end
+
+    return if normalized.uniq.size == normalized.size
+
+    errors.add(:values_tested, "must contain unique positive integers")
+  end
+
+  def control_value_in_values_tested
+    return if values_tested.blank?
+    return if normalized_values_tested.include?(control_value.to_i)
+
+    errors.add(:control_value, "must be included in values_tested")
+  end
+
+  def context_filter_is_object
+    return if context_filter.is_a?(Hash)
+
+    errors.add(:context_filter, "must be an object")
+  end
+end

--- a/app/models/scaling_experiment_assignment.rb
+++ b/app/models/scaling_experiment_assignment.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ScalingExperimentAssignment < ApplicationRecord
+  OUTCOME_STATUSES = %w[assigned recorded skipped].freeze
+
+  belongs_to :scaling_experiment
+  belongs_to :project
+  belongs_to :issue, optional: true
+  belongs_to :scaling_observation, optional: true
+
+  before_validation :assign_project_from_experiment
+
+  validates :workflow_id, presence: true, length: { maximum: 255 }, uniqueness: { scope: :scaling_experiment_id }
+  validates :assigned_value, numericality: { only_integer: true, greater_than: 0 }
+  validates :outcome_status, inclusion: { in: OUTCOME_STATUSES }
+  validate :project_matches_experiment
+  validate :project_matches_observation
+  validate :execution_plan_is_object
+  validate :outcome_summary_is_object
+
+  scope :recorded, -> { where(outcome_status: "recorded") }
+
+  private
+
+  def assign_project_from_experiment
+    self.project ||= scaling_experiment&.project
+  end
+
+  def project_matches_experiment
+    return unless scaling_experiment && project
+    return if scaling_experiment.project_id == project_id
+
+    errors.add(:project, "must match the experiment project")
+  end
+
+  def project_matches_observation
+    return unless scaling_observation && project
+    return if scaling_observation.project_id == project_id
+
+    errors.add(:scaling_observation, "must belong to the same project")
+  end
+
+  def execution_plan_is_object
+    return if execution_plan.is_a?(Hash)
+
+    errors.add(:execution_plan, "must be an object")
+  end
+
+  def outcome_summary_is_object
+    return if outcome_summary.is_a?(Hash)
+
+    errors.add(:outcome_summary, "must be an object")
+  end
+end

--- a/app/services/scaling_experiments/assign.rb
+++ b/app/services/scaling_experiments/assign.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "zlib"
+
+module ScalingExperiments
+  class Assign
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(scaling_experiment:, workflow_id:, task_count:, project:, issue: nil)
+      @scaling_experiment = scaling_experiment
+      @workflow_id = workflow_id
+      @task_count = task_count.to_i
+      @project = project
+      @issue = issue
+    end
+
+    def call
+      raise ArgumentError, "scaling experiment is not running" unless scaling_experiment.running?
+      return unless scaling_experiment.matches_context?(task_count:)
+
+      existing = ScalingExperimentAssignment.find_by(
+        scaling_experiment: scaling_experiment,
+        workflow_id: workflow_id
+      )
+      return existing if existing
+
+      value = select_value
+      return unless value
+
+      ScalingExperimentAssignment.create!(
+        scaling_experiment: scaling_experiment,
+        project: project,
+        issue: issue,
+        workflow_id: workflow_id,
+        assigned_value: value,
+        execution_plan: build_execution_plan(value)
+      )
+    rescue ActiveRecord::RecordNotUnique
+      ScalingExperimentAssignment.find_by!(
+        scaling_experiment: scaling_experiment,
+        workflow_id: workflow_id
+      )
+    end
+
+    private
+
+    attr_reader :scaling_experiment, :workflow_id, :task_count, :project, :issue
+
+    def select_value
+      values = scaling_experiment.eligible_values(task_count:)
+      return if values.empty?
+
+      counts = ScalingExperimentAssignment
+        .where(scaling_experiment:, assigned_value: values)
+        .group(:assigned_value)
+        .count
+      min_count = values.map { |value| counts.fetch(value, 0) }.min
+      candidates = values.select { |value| counts.fetch(value, 0) == min_count }
+      candidates[Zlib.crc32("#{scaling_experiment.id}:#{workflow_id}") % candidates.size]
+    end
+
+    def build_execution_plan(value)
+      {
+        "dimension" => scaling_experiment.dimension,
+        "requested_agent_count" => value,
+        "max_batch_size" => value,
+        "task_count" => task_count,
+        "eligible_values" => scaling_experiment.eligible_values(task_count:),
+        "safety_limits" => {
+          "task_count_cap" => task_count,
+          "project_capacity_checked_during_execution" => true,
+          "dependency_order_respected" => true
+        }
+      }
+    end
+  end
+end

--- a/app/services/scaling_experiments/create.rb
+++ b/app/services/scaling_experiments/create.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ScalingExperiments
+  class Create
+    DEFAULT_CONTEXT_FILTER = {
+      "min_task_count" => 2
+    }.freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, name:, hypothesis:, values_tested:, control_value:, min_samples_per_value: 2,
+      traffic_percentage: 100, context_filter: {}, dimension: "agent_count")
+      @project = project
+      @name = name
+      @hypothesis = hypothesis
+      @values_tested = values_tested
+      @control_value = control_value
+      @min_samples_per_value = min_samples_per_value
+      @traffic_percentage = traffic_percentage
+      @context_filter = context_filter
+      @dimension = dimension
+    end
+
+    def call
+      ScalingExperiment.create!(
+        project: project,
+        name: name,
+        hypothesis: hypothesis,
+        dimension: dimension,
+        values_tested: Array(values_tested).map { |value| Integer(value) }.uniq.sort,
+        control_value: Integer(control_value),
+        min_samples_per_value: min_samples_per_value,
+        traffic_percentage: traffic_percentage,
+        context_filter: normalized_context_filter
+      )
+    end
+
+    private
+
+    attr_reader :project, :name, :hypothesis, :values_tested, :control_value, :min_samples_per_value,
+      :traffic_percentage, :context_filter, :dimension
+
+    def normalized_context_filter
+      DEFAULT_CONTEXT_FILTER.merge((context_filter || {}).deep_stringify_keys)
+    end
+  end
+end

--- a/app/services/scaling_experiments/record_result.rb
+++ b/app/services/scaling_experiments/record_result.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ScalingExperiments
+  class RecordResult
+    Result = Struct.new(:assignment, :summary, keyword_init: true)
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(assignment:, scaling_observation:)
+      @assignment = assignment
+      @scaling_observation = scaling_observation
+    end
+
+    def call
+      assignment.with_lock do
+        assignment.reload
+        assignment.update!(
+          scaling_observation: scaling_observation,
+          outcome_status: outcome_status,
+          outcome_summary: build_outcome_summary
+        )
+      end
+
+      summary = ScalingExperiments::SummarizeResults.call(scaling_experiment: scaling_experiment)
+      scaling_experiment.update_columns(cached_summary: summary, summary_samples_key: scaling_experiment.samples_key)
+      scaling_experiment.complete! if scaling_experiment.running? && scaling_experiment.sufficient_samples?
+
+      Result.new(assignment:, summary:)
+    end
+
+    private
+
+    attr_reader :assignment, :scaling_observation
+
+    def scaling_experiment
+      assignment.scaling_experiment
+    end
+
+    def outcome_status
+      scaling_observation.parallel_execution? ? "recorded" : "skipped"
+    end
+
+    def build_outcome_summary
+      {
+        "observation_id" => scaling_observation.id,
+        "status" => scaling_observation.status,
+        "success" => scaling_observation.success,
+        "parallel_execution" => scaling_observation.parallel_execution,
+        "agent_count_planned" => scaling_observation.agent_count_planned,
+        "agent_count_launched" => scaling_observation.agent_count_launched,
+        "agent_count_succeeded" => scaling_observation.agent_count_succeeded,
+        "agent_count_failed" => scaling_observation.agent_count_failed,
+        "agent_count_blocked" => scaling_observation.agent_count_blocked,
+        "parallelism_observed" => scaling_observation.parallelism_observed,
+        "duration_seconds" => scaling_observation.duration_seconds,
+        "total_cost_cents" => scaling_observation.total_cost_cents,
+        "total_input_tokens" => scaling_observation.total_input_tokens,
+        "total_output_tokens" => scaling_observation.total_output_tokens
+      }
+    end
+  end
+end

--- a/app/services/scaling_experiments/summarize_results.rb
+++ b/app/services/scaling_experiments/summarize_results.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module ScalingExperiments
+  class SummarizeResults
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(scaling_experiment:)
+      @scaling_experiment = scaling_experiment
+    end
+
+    def call
+      summaries = value_summaries
+      control = summaries.find { |summary| summary["assigned_value"] == scaling_experiment.control_value }
+      leader = summaries.max_by do |summary|
+        [
+          summary["success_rate"],
+          summary["sample_count"],
+          -summary["avg_duration_seconds"]
+        ]
+      end
+
+      {
+        "status" => scaling_experiment.sufficient_samples? ? "ready_for_analysis" : "collecting",
+        "dimension" => scaling_experiment.dimension,
+        "control_value" => scaling_experiment.control_value,
+        "sample_count" => summaries.sum { |summary| summary["sample_count"] },
+        "values" => summaries,
+        "leading_value" => leader&.fetch("assigned_value", nil),
+        "improvement_over_control" => improvement_over_control(control:, leader:)
+      }.compact
+    end
+
+    private
+
+    attr_reader :scaling_experiment
+
+    def value_summaries
+      assignments_by_value = scaling_experiment.scaling_experiment_assignments
+        .recorded
+        .includes(:scaling_observation)
+        .group_by(&:assigned_value)
+
+      scaling_experiment.values_tested.map(&:to_i).uniq.sort.map do |value|
+        assignments = assignments_by_value.fetch(value, [])
+        observations = assignments.filter_map(&:scaling_observation)
+        {
+          "assigned_value" => value,
+          "sample_count" => observations.size,
+          "success_rate" => rate(observations, &:success),
+          "avg_duration_seconds" => average(observations, &:duration_seconds),
+          "avg_cost_cents" => average(observations, &:total_cost_cents),
+          "avg_parallelism_observed" => average(observations, &:parallelism_observed),
+          "avg_agent_count_launched" => average(observations, &:agent_count_launched),
+          "status_tally" => observations.map(&:status).tally
+        }
+      end
+    end
+
+    def improvement_over_control(control:, leader:)
+      return unless control && leader
+
+      {
+        "success_rate_delta" => (leader["success_rate"] - control["success_rate"]).round(4),
+        "duration_seconds_delta" => (leader["avg_duration_seconds"] - control["avg_duration_seconds"]).round(4),
+        "cost_cents_delta" => (leader["avg_cost_cents"] - control["avg_cost_cents"]).round(4)
+      }
+    end
+
+    def rate(observations)
+      return 0.0 if observations.empty?
+
+      (observations.count { |observation| yield(observation) }.to_f / observations.size).round(4)
+    end
+
+    def average(observations)
+      return 0.0 if observations.empty?
+
+      (observations.sum { |observation| yield(observation).to_f } / observations.size).round(4)
+    end
+  end
+end

--- a/app/temporal/activities/record_scaling_experiment_result_activity.rb
+++ b/app/temporal/activities/record_scaling_experiment_result_activity.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Activities
+  class RecordScalingExperimentResultActivity < BaseActivity
+    activity_name "RecordScalingExperimentResult"
+
+    def execute(input)
+      assignment = ScalingExperimentAssignment.find(input[:assignment_id])
+      scaling_observation = ScalingObservation.find(input[:scaling_observation_id])
+
+      result = ScalingExperiments::RecordResult.call(
+        assignment: assignment,
+        scaling_observation: scaling_observation
+      )
+
+      {
+        assignment_id: assignment.id,
+        outcome_status: assignment.reload.outcome_status,
+        summary_status: result.summary["status"]
+      }
+    end
+  end
+end

--- a/app/temporal/activities/resolve_scaling_experiment_activity.rb
+++ b/app/temporal/activities/resolve_scaling_experiment_activity.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Activities
+  class ResolveScalingExperimentActivity < BaseActivity
+    activity_name "ResolveScalingExperiment"
+
+    def execute(input)
+      project = Project.find(input[:project_id])
+      workflow_id = input[:workflow_id].to_s
+      task_count = input[:task_count].to_i
+      issue = input[:issue_id] ? project.issues.find(input[:issue_id]) : nil
+
+      experiment = ScalingExperiment.active_for(
+        project: project,
+        dimension: "agent_count",
+        workflow_id: workflow_id,
+        task_count: task_count
+      )
+      return { assignment_id: nil, execution_plan: nil } unless experiment
+
+      assignment = ScalingExperiments::Assign.call(
+        scaling_experiment: experiment,
+        project: project,
+        issue: issue,
+        workflow_id: workflow_id,
+        task_count: task_count
+      )
+      return { assignment_id: nil, execution_plan: nil } unless assignment
+
+      {
+        assignment_id: assignment.id,
+        scaling_experiment_id: experiment.id,
+        assigned_value: assignment.assigned_value,
+        execution_plan: assignment.execution_plan
+      }
+    end
+  end
+end

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -44,6 +44,8 @@ module Workflows
       prompt_source = nil
       coordination_policy = nil
       coordination_assignment_id = nil
+      scaling_execution_plan = nil
+      scaling_assignment_id = nil
       decision_phase = "planning"
       decision_step = "fetch_planning_context"
       @decision_step = decision_step
@@ -63,6 +65,16 @@ module Workflows
       created_issues = planning_result[:created_issues]
       planning_context = planning_result[:context] || {}
       prompt_source = planning_result[:prompt_source]
+
+      scaling_experiment_context = safely_resolve_scaling_experiment(
+        project_id: project_id,
+        issue_id: issue_id,
+        workflow_id: workflow_id,
+        task_count: tasks.size
+      )
+      scaling_execution_plan = scaling_experiment_context[:execution_plan]
+      scaling_assignment_id = scaling_experiment_context[:assignment_id]
+      coordination_policy = apply_scaling_execution_plan(coordination_policy, scaling_execution_plan)
 
       # Update labels/state immediately after planning completes (mirrors PlanningWorkflow step 4)
       decision_step = "update_planning_labels"
@@ -138,7 +150,7 @@ module Workflows
           task_count: tasks.size,
           parallel_execution: false
         }
-        safe_record_scaling_observation(
+        scaling_observation = safe_record_scaling_observation(
           project_id: project_id,
           issue_id: issue_id,
           workflow_id: workflow_id,
@@ -147,8 +159,13 @@ module Workflows
           started_at: workflow_started_at,
           metadata: {
             prompt_source: prompt_source,
-            created_issues: created_issues
+            created_issues: created_issues,
+            scaling_experiment: scaling_metadata(scaling_execution_plan, scaling_assignment_id)
           }
+        )
+        safely_record_scaling_experiment_result(
+          assignment_id: scaling_assignment_id,
+          scaling_observation_id: scaling_observation&.dig(:scaling_observation_id)
         )
         safely_record_coordination_outcome(
           assignment_id: coordination_assignment_id,
@@ -211,7 +228,7 @@ module Workflows
         failed: parallel_result[:failed]
       )
 
-      safe_record_scaling_observation(
+      scaling_observation = safe_record_scaling_observation(
         project_id: project_id,
         issue_id: issue_id,
         workflow_id: workflow_id,
@@ -221,8 +238,13 @@ module Workflows
         started_at: workflow_started_at,
         metadata: {
           prompt_source: prompt_source,
-          created_issues: created_issues
+          created_issues: created_issues,
+          scaling_experiment: scaling_metadata(scaling_execution_plan, scaling_assignment_id)
         }
+      )
+      safely_record_scaling_experiment_result(
+        assignment_id: scaling_assignment_id,
+        scaling_observation_id: scaling_observation&.dig(:scaling_observation_id)
       )
 
       {
@@ -262,7 +284,7 @@ module Workflows
         }
       )
 
-      safe_record_scaling_observation(
+      scaling_observation = safe_record_scaling_observation(
         project_id: project_id,
         issue_id: issue_id,
         workflow_id: workflow_id,
@@ -277,8 +299,13 @@ module Workflows
         },
         metadata: {
           prompt_source: prompt_source,
-          created_issues: created_issues
+          created_issues: created_issues,
+          scaling_experiment: scaling_metadata(scaling_execution_plan, scaling_assignment_id)
         }
+      )
+      safely_record_scaling_experiment_result(
+        assignment_id: scaling_assignment_id,
+        scaling_observation_id: scaling_observation&.dig(:scaling_observation_id)
       )
 
       Temporalio::Workflow.logger.error(
@@ -479,6 +506,23 @@ module Workflows
       )
     end
 
+    def safely_resolve_scaling_experiment(project_id:, issue_id:, workflow_id:, task_count:)
+      run_activity(
+        Activities::ResolveScalingExperimentActivity,
+        { project_id:, issue_id:, workflow_id:, task_count: },
+        timeout: 30,
+        retry_policy: NO_RETRY
+      )
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "feature_orchestration.scaling_experiment_resolution_failed",
+        workflow_id: Temporalio::Workflow.info.workflow_id,
+        error_class: e.class.to_s,
+        error: e.message
+      )
+      { assignment_id: nil, execution_plan: nil }
+    end
+
     def safely_resolve_coordination_experiment(project_id:, issue_id:, workflow_id:)
       run_activity(
         Activities::ResolveCoordinationExperimentActivity,
@@ -518,6 +562,51 @@ module Workflows
         error_class: e.class.to_s,
         error: e.message
       )
+    end
+
+    def safely_record_scaling_experiment_result(assignment_id:, scaling_observation_id:)
+      return unless assignment_id && scaling_observation_id
+
+      run_activity(
+        Activities::RecordScalingExperimentResultActivity,
+        {
+          assignment_id: assignment_id,
+          scaling_observation_id: scaling_observation_id
+        },
+        timeout: 30,
+        retry_policy: NO_RETRY
+      )
+    rescue => e
+      Temporalio::Workflow.logger.warn(
+        message: "feature_orchestration.scaling_experiment_record_failed",
+        workflow_id: Temporalio::Workflow.info.workflow_id,
+        assignment_id: assignment_id,
+        scaling_observation_id: scaling_observation_id,
+        error_class: e.class.to_s,
+        error: e.message
+      )
+    end
+
+    def apply_scaling_execution_plan(policy, execution_plan)
+      return policy unless execution_plan.present?
+
+      requested_agent_count = execution_plan[:max_batch_size] || execution_plan["max_batch_size"]
+      return policy unless requested_agent_count
+
+      normalized_policy = (policy || {}).deep_dup
+      normalized_policy["parallel_execution"] ||= {}
+      normalized_policy["parallel_execution"]["max_batch_size"] = requested_agent_count
+      normalized_policy
+    end
+
+    def scaling_metadata(execution_plan, assignment_id)
+      return unless assignment_id && execution_plan.present?
+
+      {
+        assignment_id: assignment_id,
+        requested_agent_count: execution_plan[:requested_agent_count] || execution_plan["requested_agent_count"],
+        max_batch_size: execution_plan[:max_batch_size] || execution_plan["max_batch_size"]
+      }.compact
     end
   end
 end

--- a/db/migrate/20260509034206_create_scaling_experiments.rb
+++ b/db/migrate/20260509034206_create_scaling_experiments.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+class CreateScalingExperiments < ActiveRecord::Migration[8.1]
+  def up
+    create_table :scaling_experiments,
+      comment: "Controlled orchestration experiments for measuring how feature outcomes change as the agent count changes." do |t|
+      t.references :project,
+        null: false,
+        index: false,
+        foreign_key: { on_delete: :cascade },
+        comment: "Owning project for tenant isolation and experiment segmentation."
+      t.string :name,
+        null: false,
+        limit: 255,
+        comment: "Human-readable experiment name displayed in dashboards and logs."
+      t.text :hypothesis,
+        null: false,
+        comment: "Expected scaling behavior being tested, such as diminishing returns after a certain agent count."
+      t.string :dimension,
+        null: false,
+        limit: 50,
+        default: "agent_count",
+        comment: "Scaling dimension under test. Agent count is the initial supported dimension."
+      t.jsonb :values_tested,
+        null: false,
+        default: [],
+        comment: "Ordered list of experiment arms, such as [1, 2, 4], for the tested dimension."
+      t.integer :control_value,
+        null: false,
+        comment: "Baseline arm used as the control when comparing experiment results."
+      t.jsonb :context_filter,
+        null: false,
+        default: {},
+        comment: "Eligibility filter for safely including only comparable workflows in the experiment."
+      t.string :status,
+        null: false,
+        limit: 50,
+        default: "draft",
+        comment: "Lifecycle state for the experiment: draft, running, completed, or cancelled."
+      t.integer :min_samples_per_value,
+        null: false,
+        default: 2,
+        comment: "Minimum number of recorded workflows required for each tested value before the experiment can complete."
+      t.integer :traffic_percentage,
+        null: false,
+        default: 100,
+        comment: "Percent of eligible workflows allowed into the experiment."
+      t.jsonb :cached_summary,
+        null: false,
+        default: {},
+        comment: "Persisted descriptive summary for later analysis services and polling UIs."
+      t.string :summary_samples_key,
+        comment: "Cache key derived from per-arm sample counts so summaries can be reused until data changes."
+      t.datetime :started_at,
+        comment: "Timestamp when the experiment started assigning workflows."
+      t.datetime :completed_at,
+        comment: "Timestamp when the experiment stopped collecting data."
+      t.timestamps
+    end
+
+    add_index :scaling_experiments,
+      [ :project_id, :dimension, :status ],
+      name: "idx_scaling_experiments_project_dimension_status"
+    add_index :scaling_experiments,
+      [ :project_id, :dimension ],
+      unique: true,
+      where: "((status)::text = 'running'::text)",
+      name: "idx_scaling_experiments_one_running_dimension"
+
+    create_table :scaling_experiment_assignments,
+      comment: "Workflow-scoped assignments and result snapshots for scaling experiments." do |t|
+      t.references :scaling_experiment,
+        null: false,
+        index: false,
+        foreign_key: { on_delete: :cascade },
+        comment: "Parent scaling experiment for this assignment."
+      t.references :project,
+        null: false,
+        index: false,
+        foreign_key: { on_delete: :cascade },
+        comment: "Owning project copied onto the assignment to simplify isolation and queries."
+      t.references :issue,
+        null: true,
+        index: false,
+        foreign_key: { on_delete: :nullify },
+        comment: "Parent feature issue whose orchestration workflow was assigned."
+      t.references :scaling_observation,
+        null: true,
+        index: false,
+        foreign_key: { on_delete: :nullify },
+        comment: "Captured observation recorded for this assigned workflow once execution completes."
+      t.string :workflow_id,
+        null: false,
+        limit: 255,
+        comment: "Temporal workflow ID used as the stable experiment sample identifier."
+      t.integer :assigned_value,
+        null: false,
+        comment: "Experiment arm chosen for the workflow, such as the requested agent count cap."
+      t.string :outcome_status,
+        null: false,
+        limit: 50,
+        default: "assigned",
+        comment: "Capture state for the assignment: assigned, recorded, or skipped."
+      t.jsonb :execution_plan,
+        null: false,
+        default: {},
+        comment: "Structured execution plan describing how the assigned arm should be applied safely."
+      t.jsonb :outcome_summary,
+        null: false,
+        default: {},
+        comment: "Normalized snapshot of the resulting observation for downstream analysis services."
+      t.timestamps
+    end
+
+    add_index :scaling_experiment_assignments,
+      [ :scaling_experiment_id, :workflow_id ],
+      unique: true,
+      name: "idx_scaling_experiment_assignments_unique"
+    add_index :scaling_experiment_assignments,
+      :scaling_observation_id,
+      unique: true,
+      where: "(scaling_observation_id IS NOT NULL)",
+      name: "idx_scaling_experiment_assignments_observation_unique"
+    add_index :scaling_experiment_assignments,
+      [ :project_id, :outcome_status, :created_at ],
+      name: "idx_scaling_experiment_assignments_project_status"
+    add_index :scaling_experiment_assignments,
+      [ :project_id, :created_at ],
+      name: "idx_scaling_experiment_assignments_project_recent"
+
+    execute <<~SQL
+      ALTER TABLE scaling_experiments ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE scaling_experiments FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON scaling_experiments
+        USING (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scaling_experiments.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        )
+        WITH CHECK (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scaling_experiments.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        );
+    SQL
+
+    execute <<~SQL
+      ALTER TABLE scaling_experiment_assignments ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE scaling_experiment_assignments FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON scaling_experiment_assignments
+        USING (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scaling_experiment_assignments.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        )
+        WITH CHECK (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scaling_experiment_assignments.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        );
+    SQL
+  end
+
+  def down
+    execute "DROP POLICY IF EXISTS tenant_isolation ON scaling_experiment_assignments"
+    execute "ALTER TABLE scaling_experiment_assignments NO FORCE ROW LEVEL SECURITY"
+    execute "ALTER TABLE scaling_experiment_assignments DISABLE ROW LEVEL SECURITY"
+
+    execute "DROP POLICY IF EXISTS tenant_isolation ON scaling_experiments"
+    execute "ALTER TABLE scaling_experiments NO FORCE ROW LEVEL SECURITY"
+    execute "ALTER TABLE scaling_experiments DISABLE ROW LEVEL SECURITY"
+
+    drop_table :scaling_experiment_assignments
+    drop_table :scaling_experiments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_212202) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1705,6 +1705,45 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_212202) do
     t.index ["project_id"], name: "index_quality_thresholds_on_project_id"
   end
 
+  create_table "scaling_experiment_assignments", comment: "Workflow-scoped assignments and result snapshots for scaling experiments.", force: :cascade do |t|
+    t.integer "assigned_value", null: false, comment: "Experiment arm chosen for the workflow, such as the requested agent count cap."
+    t.datetime "created_at", null: false
+    t.jsonb "execution_plan", default: {}, null: false, comment: "Structured execution plan describing how the assigned arm should be applied safely."
+    t.bigint "issue_id", comment: "Parent feature issue whose orchestration workflow was assigned."
+    t.string "outcome_status", limit: 50, default: "assigned", null: false, comment: "Capture state for the assignment: assigned, recorded, or skipped."
+    t.jsonb "outcome_summary", default: {}, null: false, comment: "Normalized snapshot of the resulting observation for downstream analysis services."
+    t.bigint "project_id", null: false, comment: "Owning project copied onto the assignment to simplify isolation and queries."
+    t.bigint "scaling_experiment_id", null: false, comment: "Parent scaling experiment for this assignment."
+    t.bigint "scaling_observation_id", comment: "Captured observation recorded for this assigned workflow once execution completes."
+    t.datetime "updated_at", null: false
+    t.string "workflow_id", limit: 255, null: false, comment: "Temporal workflow ID used as the stable experiment sample identifier."
+    t.index ["project_id", "created_at"], name: "idx_scaling_experiment_assignments_project_recent"
+    t.index ["project_id", "outcome_status", "created_at"], name: "idx_scaling_experiment_assignments_project_status"
+    t.index ["scaling_experiment_id", "workflow_id"], name: "idx_scaling_experiment_assignments_unique", unique: true
+    t.index ["scaling_observation_id"], name: "idx_scaling_experiment_assignments_observation_unique", unique: true, where: "(scaling_observation_id IS NOT NULL)"
+  end
+
+  create_table "scaling_experiments", comment: "Controlled orchestration experiments for measuring how feature outcomes change as the agent count changes.", force: :cascade do |t|
+    t.jsonb "cached_summary", default: {}, null: false, comment: "Persisted descriptive summary for later analysis services and polling UIs."
+    t.datetime "completed_at", comment: "Timestamp when the experiment stopped collecting data."
+    t.jsonb "context_filter", default: {}, null: false, comment: "Eligibility filter for safely including only comparable workflows in the experiment."
+    t.integer "control_value", null: false, comment: "Baseline arm used as the control when comparing experiment results."
+    t.datetime "created_at", null: false
+    t.string "dimension", limit: 50, default: "agent_count", null: false, comment: "Scaling dimension under test. Agent count is the initial supported dimension."
+    t.text "hypothesis", null: false, comment: "Expected scaling behavior being tested, such as diminishing returns after a certain agent count."
+    t.integer "min_samples_per_value", default: 2, null: false, comment: "Minimum number of recorded workflows required for each tested value before the experiment can complete."
+    t.string "name", limit: 255, null: false, comment: "Human-readable experiment name displayed in dashboards and logs."
+    t.bigint "project_id", null: false, comment: "Owning project for tenant isolation and experiment segmentation."
+    t.datetime "started_at", comment: "Timestamp when the experiment started assigning workflows."
+    t.string "status", limit: 50, default: "draft", null: false, comment: "Lifecycle state for the experiment: draft, running, completed, or cancelled."
+    t.string "summary_samples_key", comment: "Cache key derived from per-arm sample counts so summaries can be reused until data changes."
+    t.integer "traffic_percentage", default: 100, null: false, comment: "Percent of eligible workflows allowed into the experiment."
+    t.datetime "updated_at", null: false
+    t.jsonb "values_tested", default: [], null: false, comment: "Ordered list of experiment arms, such as [1, 2, 4], for the tested dimension."
+    t.index ["project_id", "dimension", "status"], name: "idx_scaling_experiments_project_dimension_status"
+    t.index ["project_id", "dimension"], name: "idx_scaling_experiments_one_running_dimension", unique: true, where: "((status)::text = 'running'::text)"
+  end
+
   create_table "scaling_observations", comment: "Run-level observations for studying orchestration scaling behavior across agent count, iterations, and parallelism.", force: :cascade do |t|
     t.integer "agent_count_blocked", default: 0, null: false, comment: "Number of planned tasks that never launched because of dependencies, deadlines, or capacity."
     t.integer "agent_count_failed", default: 0, null: false, comment: "Number of launched child agent runs that completed unsuccessfully."
@@ -2167,6 +2206,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_212202) do
   add_foreign_key "quality_recovery_actions", "prompt_versions", on_delete: :nullify
   add_foreign_key "quality_thresholds", "accounts"
   add_foreign_key "quality_thresholds", "projects"
+  add_foreign_key "scaling_experiment_assignments", "issues", on_delete: :nullify
+  add_foreign_key "scaling_experiment_assignments", "projects", on_delete: :cascade
+  add_foreign_key "scaling_experiment_assignments", "scaling_experiments", on_delete: :cascade
+  add_foreign_key "scaling_experiment_assignments", "scaling_observations", on_delete: :nullify
+  add_foreign_key "scaling_experiments", "projects", on_delete: :cascade
   add_foreign_key "scaling_observations", "issues", on_delete: :nullify
   add_foreign_key "scaling_observations", "projects", on_delete: :cascade
   add_foreign_key "service_container_metrics", "service_containers", on_delete: :cascade
@@ -2190,26 +2234,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_212202) do
   add_foreign_key "workflow_states", "projects"
   add_foreign_key "worktrees", "agent_runs", on_delete: :nullify
   add_foreign_key "worktrees", "projects", on_delete: :cascade
-
-  create_function :paid_current_account_id, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
-       RETURNS bigint
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
-      $function$
-  SQL
-
-  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
-       RETURNS boolean
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
-      $function$
-  SQL
 
   create_function :logidze_capture_exception, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.logidze_capture_exception(error_data jsonb)
@@ -2943,6 +2967,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_212202) do
           END IF;
           RETURN buf;
         END;
+      $function$
+  SQL
+
+  create_function :paid_current_account_id, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
+       RETURNS bigint
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
+      $function$
+  SQL
+
+  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
+       RETURNS boolean
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
       $function$
   SQL
 

--- a/spec/factories/scaling_experiment_assignments.rb
+++ b/spec/factories/scaling_experiment_assignments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :scaling_experiment_assignment do
+    scaling_experiment
+    project { scaling_experiment.project }
+    issue { nil }
+    scaling_observation { nil }
+    sequence(:workflow_id) { |n| "scaling-workflow-#{n}" }
+    assigned_value { 1 }
+    outcome_status { "assigned" }
+    execution_plan { { "max_batch_size" => assigned_value, "requested_agent_count" => assigned_value } }
+    outcome_summary { {} }
+  end
+end

--- a/spec/factories/scaling_experiments.rb
+++ b/spec/factories/scaling_experiments.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :scaling_experiment do
+    project
+    sequence(:name) { |n| "Scaling Experiment #{n}" }
+    hypothesis { "Success improves as agent count increases before diminishing returns appear." }
+    dimension { "agent_count" }
+    values_tested { [ 1, 2, 4 ] }
+    control_value { 1 }
+    context_filter { { "min_task_count" => 2 } }
+    status { "running" }
+    min_samples_per_value { 2 }
+    traffic_percentage { 100 }
+  end
+end

--- a/spec/factories/scaling_observations.rb
+++ b/spec/factories/scaling_observations.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :scaling_observation do
+    project
+    issue { nil }
+    sequence(:workflow_id) { |n| "feature-wf-#{n}" }
+    workflow_name { "Workflows::FeatureOrchestrationWorkflow" }
+    observation_type { "feature_orchestration" }
+    status { "completed" }
+    success { true }
+    parallel_execution { true }
+    task_count { 3 }
+    dependency_edge_count { 1 }
+    parallelizable_group_count { 1 }
+    agent_count_planned { 2 }
+    agent_count_launched { 2 }
+    agent_count_succeeded { 2 }
+    agent_count_failed { 0 }
+    agent_count_blocked { 0 }
+    total_iterations { 4 }
+    max_iterations { 2 }
+    parallelism_planned { 2 }
+    parallelism_observed { 2 }
+    batch_count { 2 }
+    duration_seconds { 120 }
+    total_cost_cents { 300 }
+    total_input_tokens { 700 }
+    total_output_tokens { 250 }
+    metadata { {} }
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Project do
     it { is_expected.to have_many(:agent_runs).dependent(:destroy) }
     it { is_expected.to have_many(:orchestration_decisions).dependent(:destroy) }
     it { is_expected.to have_many(:scaling_observations).dependent(:destroy) }
+    it { is_expected.to have_many(:scaling_experiments).dependent(:destroy) }
+    it { is_expected.to have_many(:scaling_experiment_assignments).dependent(:destroy) }
     it { is_expected.to have_many(:workflow_states).dependent(:destroy) }
   end
 

--- a/spec/models/scaling_experiment_spec.rb
+++ b/spec/models/scaling_experiment_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScalingExperiment do
+  describe "validations" do
+    subject(:scaling_experiment) { build(:scaling_experiment) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:hypothesis) }
+    it { is_expected.to validate_inclusion_of(:dimension).in_array(described_class::DIMENSIONS) }
+    it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+  end
+
+  describe ".active_for" do
+    let(:project) { create(:project) }
+
+    it "returns the running experiment when traffic and context match" do
+      experiment = create(:scaling_experiment, project: project, traffic_percentage: 100)
+
+      expect(
+        described_class.active_for(project: project, dimension: "agent_count", workflow_id: "wf-1", task_count: 3)
+      ).to eq(experiment)
+    end
+
+    it "returns nil when the workflow is excluded by task count" do
+      create(:scaling_experiment, project: project, context_filter: { "min_task_count" => 4 })
+
+      expect(
+        described_class.active_for(project: project, dimension: "agent_count", workflow_id: "wf-1", task_count: 3)
+      ).to be_nil
+    end
+  end
+end

--- a/spec/services/scaling_experiments/assign_spec.rb
+++ b/spec/services/scaling_experiments/assign_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScalingExperiments::Assign do
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project) }
+  let(:experiment) { create(:scaling_experiment, project: project, values_tested: [ 1, 2, 4 ]) }
+
+  it "creates a workflow-scoped assignment with a safe execution plan" do
+    assignment = described_class.call(
+      scaling_experiment: experiment,
+      project: project,
+      issue: issue,
+      workflow_id: "wf-123",
+      task_count: 4
+    )
+
+    expect(assignment.project).to eq(project)
+    expect(assignment.issue).to eq(issue)
+    expect(assignment.workflow_id).to eq("wf-123")
+    expect(assignment.execution_plan).to include(
+      "dimension" => "agent_count",
+      "task_count" => 4
+    )
+  end
+
+  it "reuses the existing assignment for the same workflow" do
+    first = described_class.call(
+      scaling_experiment: experiment,
+      project: project,
+      workflow_id: "wf-123",
+      task_count: 4
+    )
+    second = described_class.call(
+      scaling_experiment: experiment,
+      project: project,
+      workflow_id: "wf-123",
+      task_count: 4
+    )
+
+    expect(second.id).to eq(first.id)
+  end
+
+  it "balances across only the values that are eligible for the task count" do
+    assignments = 6.times.map do |index|
+      described_class.call(
+        scaling_experiment: experiment,
+        project: project,
+        workflow_id: "wf-#{index}",
+        task_count: 2
+      )
+    end
+
+    counts = assignments.map(&:assigned_value).tally
+
+    expect(counts.keys).to contain_exactly(1, 2)
+    counts.each_value { |count| expect(count).to be_between(2, 4) }
+  end
+
+  it "skips assignments when the task count does not satisfy the context filter" do
+    experiment.update!(context_filter: { "min_task_count" => 5 })
+
+    assignment = described_class.call(
+      scaling_experiment: experiment,
+      project: project,
+      workflow_id: "wf-123",
+      task_count: 4
+    )
+
+    expect(assignment).to be_nil
+  end
+end

--- a/spec/services/scaling_experiments/create_spec.rb
+++ b/spec/services/scaling_experiments/create_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScalingExperiments::Create do
+  describe ".call" do
+    let(:project) { create(:project) }
+
+    it "creates a draft experiment with safe defaults" do
+      experiment = described_class.call(
+        project: project,
+        name: "Agent Count Scaling",
+        hypothesis: "More agents improve success until returns flatten.",
+        values_tested: [ 4, 1, 2, 2 ],
+        control_value: 1
+      )
+
+      expect(experiment).to be_persisted
+      expect(experiment.project).to eq(project)
+      expect(experiment.status).to eq("draft")
+      expect(experiment.values_tested).to eq([ 1, 2, 4 ])
+      expect(experiment.context_filter).to include("min_task_count" => 2)
+    end
+  end
+end

--- a/spec/services/scaling_experiments/record_result_spec.rb
+++ b/spec/services/scaling_experiments/record_result_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScalingExperiments::RecordResult do
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project) }
+  let(:experiment) do
+    create(:scaling_experiment,
+      project: project,
+      values_tested: [ 1, 2 ],
+      min_samples_per_value: 2,
+      cached_summary: {})
+  end
+
+  def create_observation!(workflow_id:, assigned_value:, success:, cost_cents:, duration_seconds:)
+    observation = create(:scaling_observation,
+      project: project,
+      issue: issue,
+      workflow_id: workflow_id,
+      success: success,
+      status: success ? "completed" : "partial_failure",
+      agent_count_planned: assigned_value,
+      agent_count_launched: assigned_value,
+      parallelism_observed: assigned_value,
+      total_cost_cents: cost_cents,
+      duration_seconds: duration_seconds)
+
+    assignment = create(:scaling_experiment_assignment,
+      scaling_experiment: experiment,
+      project: project,
+      issue: issue,
+      workflow_id: workflow_id,
+      assigned_value: assigned_value,
+      execution_plan: { "max_batch_size" => assigned_value, "requested_agent_count" => assigned_value })
+
+    described_class.call(assignment: assignment, scaling_observation: observation)
+  end
+
+  it "captures a normalized outcome snapshot and refreshes the experiment summary" do
+    result = create_observation!(
+      workflow_id: "wf-1",
+      assigned_value: 2,
+      success: true,
+      cost_cents: 350,
+      duration_seconds: 180
+    )
+
+    assignment = result.assignment.reload
+    experiment.reload
+
+    expect(assignment.outcome_status).to eq("recorded")
+    expect(assignment.outcome_summary).to include(
+      "status" => "completed",
+      "success" => true,
+      "total_cost_cents" => 350
+    )
+    expect(experiment.cached_summary).to include(
+      "status" => "collecting",
+      "sample_count" => 1,
+      "values" => array_including(hash_including("assigned_value" => 2, "sample_count" => 1))
+    )
+  end
+
+  it "completes the experiment once every value reaches the minimum sample count" do
+    create_observation!(workflow_id: "wf-1", assigned_value: 1, success: true, cost_cents: 100, duration_seconds: 100)
+    create_observation!(workflow_id: "wf-2", assigned_value: 1, success: true, cost_cents: 120, duration_seconds: 120)
+    create_observation!(workflow_id: "wf-3", assigned_value: 2, success: false, cost_cents: 200, duration_seconds: 200)
+    create_observation!(workflow_id: "wf-4", assigned_value: 2, success: true, cost_cents: 220, duration_seconds: 150)
+
+    experiment.reload
+
+    expect(experiment.status).to eq("completed")
+    expect(experiment.cached_summary).to include("status" => "ready_for_analysis", "leading_value" => 1)
+  end
+end

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             hash_including(
               project_id: 1,
               parent_issue_id: 2,
-              coordination_policy: hash_including("parallel_execution" => anything),
+              coordination_policy: hash_including("parallel_execution" => hash_including("max_batch_size" => 2)),
               sub_tasks: array_including(hash_including(:custom_prompt))
             ),
             hash_including(task_queue: Paid::AGENT_TASK_QUEUE)
@@ -173,19 +173,18 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
       it "records a scaling observation after parallel execution" do
         workflow.execute(input)
 
+        expect_scaling_observation_recorded!(tasks: tasks)
+      end
+
+      it "records the experiment result against the captured scaling observation" do
+        workflow.execute(input)
+
         expect(workflow).to have_received(:run_activity)
           .with(
-            Activities::RecordScalingObservationActivity,
+            Activities::RecordScalingExperimentResultActivity,
             hash_including(
-              project_id: 1,
-              issue_id: 2,
-              workflow_id: "test-orchestration-wf",
-              workflow_name: "Workflows::FeatureOrchestrationWorkflow",
-              tasks: tasks,
-              parallel_result: hash_including(
-                success: true,
-                execution_summary: hash_including(max_parallelism_observed: 1)
-              )
+              assignment_id: 88,
+              scaling_observation_id: 1
             ),
             timeout: 30,
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
@@ -408,12 +407,22 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
           case activity_class.name
           when "Activities::ResolveCoordinationExperimentActivity"
             { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
+          when "Activities::ResolveScalingExperimentActivity"
+            {
+              assignment_id: 88,
+              execution_plan: {
+                "requested_agent_count" => 2,
+                "max_batch_size" => 2
+              }
+            }
           when "Activities::FetchPlanningContextActivity"
             { context: {} }
           when "Activities::DecomposeFeatureActivity"
             raise Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed")
           when "Activities::RecordCoordinationExperimentOutcomeActivity"
             { assignment_id: 77, outcome_status: "recorded" }
+          when "Activities::RecordScalingExperimentResultActivity"
+            { assignment_id: 88, outcome_status: "recorded" }
           when "Activities::LogDecompositionDecisionActivity"
             { decomposition_decision_id: 9 }
           else
@@ -534,6 +543,14 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
       case activity_class.name
       when "Activities::ResolveCoordinationExperimentActivity"
         { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
+      when "Activities::ResolveScalingExperimentActivity"
+        {
+          assignment_id: 88,
+          execution_plan: {
+            "requested_agent_count" => 2,
+            "max_batch_size" => 2
+          }
+        }
       when "Activities::FetchPlanningContextActivity"
         { context: { issue_title: "Feature", knowledge_snippets: [] } }
       when "Activities::DecomposeFeatureActivity"
@@ -544,6 +561,8 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         { success: true }
       when "Activities::RecordCoordinationExperimentOutcomeActivity"
         { assignment_id: 77, outcome_status: "recorded" }
+      when "Activities::RecordScalingExperimentResultActivity"
+        { assignment_id: 88, outcome_status: "recorded" }
       when "Activities::LogDecompositionDecisionActivity"
         { decomposition_decision_id: 1 }
       when "Activities::RecordScalingObservationActivity"
@@ -576,6 +595,33 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             error_class: "Temporalio::Error::ApplicationError",
             error_message: "LLM failed",
             failed_step: "decompose_feature"
+          )
+        ),
+        timeout: 30,
+        retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
+      )
+  end
+
+  def expect_scaling_observation_recorded!(tasks:)
+    expect(workflow).to have_received(:run_activity)
+      .with(
+        Activities::RecordScalingObservationActivity,
+        hash_including(
+          project_id: 1,
+          issue_id: 2,
+          workflow_id: "test-orchestration-wf",
+          workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+          tasks: tasks,
+          parallel_result: hash_including(
+            success: true,
+            execution_summary: hash_including(max_parallelism_observed: 1)
+          ),
+          metadata: hash_including(
+            scaling_experiment: hash_including(
+              assignment_id: 88,
+              requested_agent_count: 2,
+              max_batch_size: 2
+            )
           )
         ),
         timeout: 30,


### PR DESCRIPTION
## Summary

Implemented the agent-count scaling experiment flow and committed it as `feat(scaling): add agent-count experiment flow` (`fb8d244`).

The change adds a new `scaling_experiments`/`scaling_experiment_assignments` layer on top of existing `scaling_observations`, plus services and Temporal activities to assign eligible feature-orchestration workflows to an agent-count arm, apply that arm safely via `parallel_execution.max_batch_size`, persist normalized outcome snapshots, and maintain a cached initial summary for later analysis. Coverage was added for experiment creation, assignment, result capture, and workflow integration.

Verification passed with `bundle exec rubocop --cache false` and a clean full `bundle exec rspec` run using `DATABASE_URL` unset so Rails used the proper `paid_test` database. The suite finished with `11412 examples, 0 failures, 3 pending` where the pending cases are the existing Qdrant/browser-dependent specs.

---

Closes #1777