### PR TITLE
feat(scaling): run iteration-count scaling experiment

### DIFF
--- a/app/models/scaling_experiment.rb
+++ b/app/models/scaling_experiment.rb
@@ -4,7 +4,7 @@ require "zlib"
 
 class ScalingExperiment < ApplicationRecord
   STATUSES = %w[draft running completed cancelled].freeze
-  DIMENSIONS = %w[agent_count].freeze
+  DIMENSIONS = %w[agent_count iteration_count].freeze
 
   belongs_to :project
 
@@ -88,7 +88,14 @@ class ScalingExperiment < ApplicationRecord
   end
 
   def eligible_values(task_count:)
-    normalized_values_tested.select { |value| value <= task_count.to_i }
+    case dimension
+    when "agent_count"
+      normalized_values_tested.select { |value| value <= task_count.to_i }
+    when "iteration_count"
+      normalized_values_tested
+    else
+      []
+    end
   end
 
   def sufficient_samples?

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -26,6 +26,7 @@ module QualityMetrics
         check_quality_pause
       end
       record_bundle_outcome
+      refresh_scaling_experiment_results
 
       enqueue_quality_gate_check
       automated_metric
@@ -256,6 +257,23 @@ module QualityMetrics
       variant.total_quality_score = (variant.total_quality_score || BigDecimal(0)) - old_decimal + new_decimal
       variant.avg_quality_score = variant.sample_count.positive? ? variant.total_quality_score / variant.sample_count : nil
       variant.save!
+    end
+
+    def refresh_scaling_experiment_results
+      return if agent_run.parent_workflow_id.blank?
+
+      observation = ScalingObservation.find_by(
+        project_id: agent_run.project_id,
+        workflow_id: agent_run.parent_workflow_id
+      )
+      return unless observation
+
+      ScalingExperimentAssignment.where(scaling_observation: observation).find_each do |assignment|
+        ScalingExperiments::RecordResult.call(
+          assignment: assignment,
+          scaling_observation: observation
+        )
+      end
     end
 
     def update_prompt_version_stats

--- a/app/services/scaling_experiments/assign.rb
+++ b/app/services/scaling_experiments/assign.rb
@@ -62,18 +62,44 @@ module ScalingExperiments
     end
 
     def build_execution_plan(value)
-      {
-        "dimension" => scaling_experiment.dimension,
-        "requested_agent_count" => value,
-        "max_batch_size" => value,
-        "task_count" => task_count,
-        "eligible_values" => scaling_experiment.eligible_values(task_count:),
-        "safety_limits" => {
-          "task_count_cap" => task_count,
-          "project_capacity_checked_during_execution" => true,
-          "dependency_order_respected" => true
+      case scaling_experiment.dimension
+      when "agent_count"
+        {
+          "dimension" => scaling_experiment.dimension,
+          "requested_agent_count" => value,
+          "max_batch_size" => value,
+          "task_count" => task_count,
+          "eligible_values" => scaling_experiment.eligible_values(task_count:),
+          "safety_limits" => {
+            "task_count_cap" => task_count,
+            "project_capacity_checked_during_execution" => true,
+            "dependency_order_respected" => true
+          }
         }
-      }
+      when "iteration_count"
+        {
+          "dimension" => scaling_experiment.dimension,
+          "requested_iteration_count" => value,
+          "task_count" => task_count,
+          "eligible_values" => scaling_experiment.eligible_values(task_count:),
+          "application_mode" => "task_prompt_budget",
+          "prompt_suffix" => iteration_budget_prompt(value),
+          "safety_limits" => {
+            "minimum_iteration_count" => 1,
+            "dependency_order_respected" => true,
+            "parallel_batch_size_unchanged" => true
+          }
+        }
+      else
+        {}
+      end
+    end
+
+    def iteration_budget_prompt(value)
+      <<~PROMPT.strip
+        Iteration budget: aim to complete this task within #{value} agent iterations.
+        If you cannot finish safely within that budget, stop and report the blocker instead of continuing indefinitely.
+      PROMPT
     end
   end
 end

--- a/app/services/scaling_experiments/record_result.rb
+++ b/app/services/scaling_experiments/record_result.rb
@@ -57,8 +57,30 @@ module ScalingExperiments
         "duration_seconds" => scaling_observation.duration_seconds,
         "total_cost_cents" => scaling_observation.total_cost_cents,
         "total_input_tokens" => scaling_observation.total_input_tokens,
-        "total_output_tokens" => scaling_observation.total_output_tokens
+        "total_output_tokens" => scaling_observation.total_output_tokens,
+        "quality_metric_sample_count" => quality_scores.size,
+        "avg_quality_score" => average_quality_score
       }
+    end
+
+    def child_runs
+      @child_runs ||= AgentRun
+        .includes(:quality_metrics)
+        .where(project_id: scaling_observation.project_id, parent_workflow_id: scaling_observation.workflow_id)
+    end
+
+    def quality_scores
+      @quality_scores ||= child_runs.filter_map do |run|
+        run.quality_metrics.find do |metric|
+          metric.metric_type == "automated" && metric.composite_score.present?
+        end&.composite_score&.to_f
+      end
+    end
+
+    def average_quality_score
+      return nil if quality_scores.empty?
+
+      (quality_scores.sum / quality_scores.size).round(4)
     end
   end
 end

--- a/app/services/scaling_experiments/summarize_results.rb
+++ b/app/services/scaling_experiments/summarize_results.rb
@@ -13,13 +13,7 @@ module ScalingExperiments
     def call
       summaries = value_summaries
       control = summaries.find { |summary| summary["assigned_value"] == scaling_experiment.control_value }
-      leader = summaries.max_by do |summary|
-        [
-          summary["success_rate"],
-          summary["sample_count"],
-          -summary["avg_duration_seconds"]
-        ]
-      end
+      leader = summaries.max_by { |summary| leader_sort_key(summary) }
 
       {
         "status" => scaling_experiment.sufficient_samples? ? "ready_for_analysis" : "collecting",
@@ -51,6 +45,8 @@ module ScalingExperiments
           "success_rate" => rate(observations, &:success),
           "avg_duration_seconds" => average(observations, &:duration_seconds),
           "avg_cost_cents" => average(observations, &:total_cost_cents),
+          "avg_quality_score" => average_quality_score(assignments),
+          "quality_metric_sample_count" => quality_metric_sample_count(assignments),
           "avg_parallelism_observed" => average(observations, &:parallelism_observed),
           "avg_agent_count_launched" => average(observations, &:agent_count_launched),
           "status_tally" => observations.map(&:status).tally
@@ -62,10 +58,39 @@ module ScalingExperiments
       return unless control && leader
 
       {
+        "quality_score_delta" => delta(leader["avg_quality_score"], control["avg_quality_score"]),
         "success_rate_delta" => (leader["success_rate"] - control["success_rate"]).round(4),
         "duration_seconds_delta" => (leader["avg_duration_seconds"] - control["avg_duration_seconds"]).round(4),
         "cost_cents_delta" => (leader["avg_cost_cents"] - control["avg_cost_cents"]).round(4)
       }
+    end
+
+    def leader_sort_key(summary)
+      [
+        summary["quality_metric_sample_count"].to_i.positive? ? 1 : 0,
+        summary["avg_quality_score"].to_f,
+        summary["success_rate"],
+        summary["sample_count"],
+        -summary["avg_duration_seconds"],
+        -summary["avg_cost_cents"]
+      ]
+    end
+
+    def average_quality_score(assignments)
+      quality_scores = assignments.filter_map { |assignment| assignment.outcome_summary["avg_quality_score"]&.to_f }
+      return nil if quality_scores.empty?
+
+      (quality_scores.sum / quality_scores.size).round(4)
+    end
+
+    def quality_metric_sample_count(assignments)
+      assignments.sum { |assignment| assignment.outcome_summary["quality_metric_sample_count"].to_i }
+    end
+
+    def delta(value, control)
+      return unless value && control
+
+      (value - control).round(4)
     end
 
     def rate(observations)

--- a/app/services/scaling_experiments/summarize_results.rb
+++ b/app/services/scaling_experiments/summarize_results.rb
@@ -59,9 +59,9 @@ module ScalingExperiments
 
       {
         "quality_score_delta" => delta(leader["avg_quality_score"], control["avg_quality_score"]),
-        "success_rate_delta" => (leader["success_rate"] - control["success_rate"]).round(4),
-        "duration_seconds_delta" => (leader["avg_duration_seconds"] - control["avg_duration_seconds"]).round(4),
-        "cost_cents_delta" => (leader["avg_cost_cents"] - control["avg_cost_cents"]).round(4)
+        "success_rate_delta" => delta(leader["success_rate"], control["success_rate"]),
+        "duration_seconds_delta" => delta(leader["avg_duration_seconds"], control["avg_duration_seconds"]),
+        "cost_cents_delta" => delta(leader["avg_cost_cents"], control["avg_cost_cents"])
       }
     end
 

--- a/app/services/scaling_observations/record.rb
+++ b/app/services/scaling_observations/record.rb
@@ -66,7 +66,7 @@ module ScalingObservations
     end
 
     def child_runs
-      @child_runs ||= AgentRun.where(project: project, parent_workflow_id: workflow_id).to_a
+      @child_runs ||= AgentRun.includes(:quality_metrics).where(project: project, parent_workflow_id: workflow_id).to_a
     end
 
     def execution_summary
@@ -192,6 +192,7 @@ module ScalingObservations
         "batch_sizes" => Array(execution_summary[:batch_sizes]),
         "error_tally" => result_rows.filter_map { |result| result[:error].presence }.tally,
         "child_agent_run_ids" => child_runs.map(&:id),
+        "quality_summary" => quality_summary,
         "parallel_result" => {
           "completed" => parallel_result[:completed],
           "failed" => parallel_result[:failed],
@@ -205,6 +206,25 @@ module ScalingObservations
 
     def normalize_hash(value)
       value.is_a?(Hash) ? value.deep_stringify_keys : {}
+    end
+
+    def quality_summary
+      quality_scores = child_runs.filter_map do |run|
+        run.quality_metrics.find do |metric|
+          metric.metric_type == "automated" && metric.composite_score.present?
+        end&.composite_score&.to_f
+      end
+
+      {
+        "avg_quality_score" => average(quality_scores),
+        "quality_metric_sample_count" => quality_scores.size
+      }.compact
+    end
+
+    def average(values)
+      return if values.empty?
+
+      (values.sum / values.size).round(4)
     end
   end
 end

--- a/app/temporal/activities/resolve_scaling_experiment_activity.rb
+++ b/app/temporal/activities/resolve_scaling_experiment_activity.rb
@@ -10,28 +10,34 @@ module Activities
       task_count = input[:task_count].to_i
       issue = input[:issue_id] ? project.issues.find(input[:issue_id]) : nil
 
-      experiment = ScalingExperiment.active_for(
-        project: project,
-        dimension: "agent_count",
-        workflow_id: workflow_id,
-        task_count: task_count
-      )
-      return { assignment_id: nil, execution_plan: nil } unless experiment
+      assignments = ScalingExperiment.running
+        .where(project: project)
+        .order(:id)
+        .filter_map do |experiment|
+        next unless experiment.includes_traffic?(workflow_id:)
+        next unless experiment.matches_context?(task_count:)
 
-      assignment = ScalingExperiments::Assign.call(
-        scaling_experiment: experiment,
-        project: project,
-        issue: issue,
-        workflow_id: workflow_id,
-        task_count: task_count
-      )
-      return { assignment_id: nil, execution_plan: nil } unless assignment
+        assignment = ScalingExperiments::Assign.call(
+          scaling_experiment: experiment,
+          project: project,
+          issue: issue,
+          workflow_id: workflow_id,
+          task_count: task_count
+        )
+        next unless assignment
+
+        {
+          assignment_id: assignment.id,
+          scaling_experiment_id: experiment.id,
+          dimension: experiment.dimension,
+          assigned_value: assignment.assigned_value,
+          execution_plan: assignment.execution_plan
+        }
+      end
 
       {
-        assignment_id: assignment.id,
-        scaling_experiment_id: experiment.id,
-        assigned_value: assignment.assigned_value,
-        execution_plan: assignment.execution_plan
+        assignment_ids: assignments.map { |assignment| assignment[:assignment_id] },
+        assignments: assignments
       }
     end
   end

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -44,8 +44,7 @@ module Workflows
       prompt_source = nil
       coordination_policy = nil
       coordination_assignment_id = nil
-      scaling_execution_plan = nil
-      scaling_assignment_id = nil
+      scaling_assignments = []
       decision_phase = "planning"
       decision_step = "fetch_planning_context"
       @decision_step = decision_step
@@ -72,9 +71,8 @@ module Workflows
         workflow_id: workflow_id,
         task_count: tasks.size
       )
-      scaling_execution_plan = scaling_experiment_context[:execution_plan]
-      scaling_assignment_id = scaling_experiment_context[:assignment_id]
-      coordination_policy = apply_scaling_execution_plan(coordination_policy, scaling_execution_plan)
+      scaling_assignments = Array(scaling_experiment_context[:assignments])
+      coordination_policy = apply_scaling_execution_plans(coordination_policy, scaling_assignments)
 
       # Update labels/state immediately after planning completes (mirrors PlanningWorkflow step 4)
       decision_step = "update_planning_labels"
@@ -160,11 +158,11 @@ module Workflows
           metadata: {
             prompt_source: prompt_source,
             created_issues: created_issues,
-            scaling_experiment: scaling_metadata(scaling_execution_plan, scaling_assignment_id)
+            scaling_experiments: scaling_metadata(scaling_assignments)
           }
         )
-        safely_record_scaling_experiment_result(
-          assignment_id: scaling_assignment_id,
+        safely_record_scaling_experiment_results(
+          assignment_ids: scaling_assignments.map { |assignment| assignment[:assignment_id] || assignment["assignment_id"] },
           scaling_observation_id: scaling_observation&.dig(:scaling_observation_id)
         )
         safely_record_coordination_outcome(
@@ -179,7 +177,7 @@ module Workflows
       # Phase 2: Launch parallel execution on all sub-tasks
       decision_step = "build_sub_tasks"
       @decision_step = decision_step
-      sub_tasks = build_sub_tasks(tasks, created_issues)
+      sub_tasks = build_sub_tasks(tasks, created_issues, scaling_assignments: scaling_assignments)
 
       safe_log_decomposition_decision(
         project_id: project_id,
@@ -239,11 +237,11 @@ module Workflows
         metadata: {
           prompt_source: prompt_source,
           created_issues: created_issues,
-          scaling_experiment: scaling_metadata(scaling_execution_plan, scaling_assignment_id)
+          scaling_experiments: scaling_metadata(scaling_assignments)
         }
       )
-      safely_record_scaling_experiment_result(
-        assignment_id: scaling_assignment_id,
+      safely_record_scaling_experiment_results(
+        assignment_ids: scaling_assignments.map { |assignment| assignment[:assignment_id] || assignment["assignment_id"] },
         scaling_observation_id: scaling_observation&.dig(:scaling_observation_id)
       )
 
@@ -300,11 +298,11 @@ module Workflows
         metadata: {
           prompt_source: prompt_source,
           created_issues: created_issues,
-          scaling_experiment: scaling_metadata(scaling_execution_plan, scaling_assignment_id)
+          scaling_experiments: scaling_metadata(scaling_assignments)
         }
       )
-      safely_record_scaling_experiment_result(
-        assignment_id: scaling_assignment_id,
+      safely_record_scaling_experiment_results(
+        assignment_ids: scaling_assignments.map { |assignment| assignment[:assignment_id] || assignment["assignment_id"] },
         scaling_observation_id: scaling_observation&.dig(:scaling_observation_id)
       )
 
@@ -390,14 +388,15 @@ module Workflows
       { tasks: tasks, created_issues: created_issues, context: context_result[:context], prompt_source: prompt_source }
     end
 
-    def build_sub_tasks(tasks, created_issues)
+    def build_sub_tasks(tasks, created_issues, scaling_assignments:)
+      iteration_prompt_suffix = iteration_prompt_suffix_for(scaling_assignments)
       created_issues_by_index = created_issues.each_with_index.each_with_object({}) do |(issue, fallback_index), memo|
         memo[issue.fetch(:index, fallback_index)] = issue
       end
 
       tasks.each_with_index.map do |task, index|
         sub_task = {
-          custom_prompt: task[:description],
+          custom_prompt: append_scaling_prompt(task[:description], iteration_prompt_suffix),
           task_index: task.fetch(:index, index),
           dependencies: Array(task[:dependencies]),
           parallel_group: task[:parallel_group]
@@ -520,7 +519,7 @@ module Workflows
         error_class: e.class.to_s,
         error: e.message
       )
-      { assignment_id: nil, execution_plan: nil }
+      { assignment_ids: [], assignments: [] }
     end
 
     def safely_resolve_coordination_experiment(project_id:, issue_id:, workflow_id:)
@@ -564,49 +563,83 @@ module Workflows
       )
     end
 
-    def safely_record_scaling_experiment_result(assignment_id:, scaling_observation_id:)
-      return unless assignment_id && scaling_observation_id
+    def safely_record_scaling_experiment_results(assignment_ids:, scaling_observation_id:)
+      return if assignment_ids.blank? || scaling_observation_id.blank?
 
-      run_activity(
-        Activities::RecordScalingExperimentResultActivity,
+      Array(assignment_ids).each do |assignment_id|
+        run_activity(
+          Activities::RecordScalingExperimentResultActivity,
+          {
+            assignment_id: assignment_id,
+            scaling_observation_id: scaling_observation_id
+          },
+          timeout: 30,
+          retry_policy: NO_RETRY
+        )
+      rescue => e
+        Temporalio::Workflow.logger.warn(
+          message: "feature_orchestration.scaling_experiment_record_failed",
+          workflow_id: Temporalio::Workflow.info.workflow_id,
+          assignment_id: assignment_id,
+          scaling_observation_id: scaling_observation_id,
+          error_class: e.class.to_s,
+          error: e.message
+        )
+      end
+    end
+
+    def apply_scaling_execution_plans(policy, scaling_assignments)
+      normalized_policy = (policy || {}).deep_dup
+
+      Array(scaling_assignments).each do |assignment|
+        execution_plan = assignment[:execution_plan] || assignment["execution_plan"] || {}
+        dimension = execution_plan[:dimension] || execution_plan["dimension"]
+        next unless dimension == "agent_count"
+
+        requested_agent_count = execution_plan[:max_batch_size] || execution_plan["max_batch_size"]
+        next unless requested_agent_count
+
+        normalized_policy["parallel_execution"] ||= {}
+        normalized_policy["parallel_execution"]["max_batch_size"] = requested_agent_count
+      end
+
+      normalized_policy.presence || policy
+    end
+
+    def scaling_metadata(scaling_assignments)
+      Array(scaling_assignments).filter_map do |assignment|
+        execution_plan = assignment[:execution_plan] || assignment["execution_plan"] || {}
+        assignment_id = assignment[:assignment_id] || assignment["assignment_id"]
+        dimension = assignment[:dimension] || assignment["dimension"] || execution_plan[:dimension] || execution_plan["dimension"]
+        next unless assignment_id && dimension
+
         {
           assignment_id: assignment_id,
-          scaling_observation_id: scaling_observation_id
-        },
-        timeout: 30,
-        retry_policy: NO_RETRY
-      )
-    rescue => e
-      Temporalio::Workflow.logger.warn(
-        message: "feature_orchestration.scaling_experiment_record_failed",
-        workflow_id: Temporalio::Workflow.info.workflow_id,
-        assignment_id: assignment_id,
-        scaling_observation_id: scaling_observation_id,
-        error_class: e.class.to_s,
-        error: e.message
-      )
+          dimension: dimension,
+          requested_agent_count: execution_plan[:requested_agent_count] || execution_plan["requested_agent_count"],
+          max_batch_size: execution_plan[:max_batch_size] || execution_plan["max_batch_size"],
+          requested_iteration_count: execution_plan[:requested_iteration_count] || execution_plan["requested_iteration_count"],
+          application_mode: execution_plan[:application_mode] || execution_plan["application_mode"]
+        }.compact
+      end
     end
 
-    def apply_scaling_execution_plan(policy, execution_plan)
-      return policy unless execution_plan.present?
+    def iteration_prompt_suffix_for(scaling_assignments)
+      iteration_assignment = Array(scaling_assignments).find do |assignment|
+        execution_plan = assignment[:execution_plan] || assignment["execution_plan"] || {}
+        dimension = assignment[:dimension] || assignment["dimension"] || execution_plan[:dimension] || execution_plan["dimension"]
+        dimension == "iteration_count"
+      end
+      return unless iteration_assignment
 
-      requested_agent_count = execution_plan[:max_batch_size] || execution_plan["max_batch_size"]
-      return policy unless requested_agent_count
-
-      normalized_policy = (policy || {}).deep_dup
-      normalized_policy["parallel_execution"] ||= {}
-      normalized_policy["parallel_execution"]["max_batch_size"] = requested_agent_count
-      normalized_policy
+      execution_plan = iteration_assignment[:execution_plan] || iteration_assignment["execution_plan"] || {}
+      execution_plan[:prompt_suffix] || execution_plan["prompt_suffix"]
     end
 
-    def scaling_metadata(execution_plan, assignment_id)
-      return unless assignment_id && execution_plan.present?
+    def append_scaling_prompt(prompt, prompt_suffix)
+      return prompt if prompt_suffix.blank?
 
-      {
-        assignment_id: assignment_id,
-        requested_agent_count: execution_plan[:requested_agent_count] || execution_plan["requested_agent_count"],
-        max_batch_size: execution_plan[:max_batch_size] || execution_plan["max_batch_size"]
-      }.compact
+      [ prompt, prompt_suffix ].compact.join("\n\n")
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_044911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -580,6 +580,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
     t.index ["started_by_id"], name: "index_context_intake_sessions_on_started_by_id"
   end
 
+  create_table "coordination_decisions", comment: "Execution-time coordination decisions pinned to the exact policy version used so outcomes can be attributed later.", force: :cascade do |t|
+    t.bigint "agent_run_id", comment: "Optional agent run whose workflow emitted the coordination decision."
+    t.jsonb "alternatives", default: {}, null: false, comment: "Alternative actions or scores considered before the final decision."
+    t.jsonb "context_snapshot", default: {}, null: false, comment: "Context snapshot used as policy input when the decision was made."
+    t.bigint "coordination_policy_id", null: false, comment: "Stable coordination policy selected when the decision was made."
+    t.bigint "coordination_policy_version_id", null: false, comment: "Exact immutable coordination policy version evaluated for this decision."
+    t.datetime "created_at", null: false
+    t.jsonb "decision_made", default: {}, null: false, comment: "Structured payload describing the selected action, plan, or classification."
+    t.string "decision_type", limit: 100, null: false, comment: "Decision boundary, such as should_decompose, decomposition_plan, recovery_action, or should_escalate."
+    t.decimal "outcome_contribution", precision: 5, scale: 4, comment: "Attributed contribution score from later outcomes, typically normalized to the 0.0-1.0 range."
+    t.bigint "project_id", null: false, comment: "Owning project for tenant isolation and workflow-level analysis."
+    t.string "workflow_id", limit: 255, comment: "Temporal or orchestration workflow identifier used to correlate related decisions."
+    t.index ["agent_run_id", "created_at", "id"], name: "idx_coordination_decisions_run_recent"
+    t.index ["coordination_policy_id", "decision_type", "created_at"], name: "idx_coordination_decisions_policy_type_created"
+    t.index ["coordination_policy_version_id", "created_at", "id"], name: "idx_coordination_decisions_version_recent"
+    t.index ["project_id", "created_at", "id"], name: "idx_coordination_decisions_project_recent"
+    t.index ["workflow_id"], name: "idx_coordination_decisions_workflow_id"
+  end
+
   create_table "coordination_experiment_assignments", comment: "Assignment and outcome for one feature orchestration workflow sample", force: :cascade do |t|
     t.bigint "coordination_experiment_id", null: false
     t.bigint "coordination_experiment_variant_id", null: false
@@ -629,6 +648,37 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
     t.index ["account_id", "policy_name"], name: "idx_coordination_experiments_one_running_policy", unique: true, where: "((status)::text = 'running'::text)"
     t.index ["account_id"], name: "index_coordination_experiments_on_account_id"
     t.index ["winner_variant_id"], name: "index_coordination_experiments_on_winner_variant_id"
+  end
+
+  create_table "coordination_policies", comment: "Account-scoped coordination policies that select rules for decomposition, recovery, escalation, and lifecycle handling.", force: :cascade do |t|
+    t.bigint "account_id", null: false, comment: "Owning tenant for policy isolation and account-level overrides."
+    t.datetime "activated_at", comment: "When the policy first became active for execution."
+    t.jsonb "context_selector", default: {}, null: false, comment: "Structured applicability filter used to match this policy to a workflow or project context."
+    t.datetime "created_at", null: false
+    t.bigint "current_version_id", comment: "Promoted immutable policy version currently used for execution."
+    t.text "description", comment: "Optional operator-facing description of the coordination policy intent."
+    t.string "lifecycle_state", limit: 50, default: "draft", null: false, comment: "Lifecycle state for the policy record: draft, active, or retired."
+    t.string "name", limit: 255, null: false, comment: "Human-readable identifier for this policy within its account and policy family."
+    t.string "policy_type", limit: 50, null: false, comment: "Coordination policy family such as decomposition, recovery, escalation, or lifecycle."
+    t.datetime "retired_at", comment: "When the policy was retired from active use."
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "policy_type", "lifecycle_state"], name: "idx_coordination_policies_account_type_state"
+    t.index ["account_id", "policy_type", "name"], name: "idx_coordination_policies_account_type_name", unique: true
+    t.index ["account_id"], name: "index_coordination_policies_on_account_id"
+    t.index ["context_selector"], name: "idx_coordination_policies_context_selector", using: :gin
+    t.index ["current_version_id"], name: "index_coordination_policies_on_current_version_id"
+  end
+
+  create_table "coordination_policy_versions", comment: "Immutable rule snapshots for coordination policies, allowing evolution and decision attribution by exact version.", force: :cascade do |t|
+    t.bigint "coordination_policy_id", null: false, comment: "Stable policy record that owns this immutable version."
+    t.datetime "created_at", null: false
+    t.text "llm_prompt", comment: "Optional prompt template used when the policy delegates part of the decision to an LLM."
+    t.jsonb "parameters", default: {}, null: false, comment: "Tunable thresholds, weights, and other policy parameters separated from rule structure."
+    t.text "reasoning", comment: "Why this version was created or promoted, including evolution rationale."
+    t.jsonb "rules", default: {}, null: false, comment: "Structured decision rules, mappings, and heuristics executed by coordination services."
+    t.integer "version", null: false, comment: "Monotonic version number within a coordination policy."
+    t.index ["coordination_policy_id", "version"], name: "idx_coordination_policy_versions_policy_version", unique: true
+    t.index ["coordination_policy_id"], name: "index_coordination_policy_versions_on_coordination_policy_id"
   end
 
   create_table "cost_budgets", force: :cascade do |t|
@@ -2110,6 +2160,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
   add_foreign_key "context_intake_responses", "context_intake_sessions"
   add_foreign_key "context_intake_sessions", "projects"
   add_foreign_key "context_intake_sessions", "users", column: "started_by_id"
+  add_foreign_key "coordination_decisions", "agent_runs", on_delete: :nullify
+  add_foreign_key "coordination_decisions", "coordination_policies"
+  add_foreign_key "coordination_decisions", "coordination_policy_versions"
+  add_foreign_key "coordination_decisions", "projects", on_delete: :cascade
   add_foreign_key "coordination_experiment_assignments", "coordination_experiment_variants", on_delete: :cascade
   add_foreign_key "coordination_experiment_assignments", "coordination_experiments", on_delete: :cascade
   add_foreign_key "coordination_experiment_assignments", "issues", on_delete: :nullify
@@ -2117,6 +2171,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
   add_foreign_key "coordination_experiment_variants", "coordination_experiments", on_delete: :cascade
   add_foreign_key "coordination_experiments", "accounts", on_delete: :cascade
   add_foreign_key "coordination_experiments", "coordination_experiment_variants", column: "winner_variant_id", on_delete: :nullify
+  add_foreign_key "coordination_policies", "accounts", on_delete: :cascade
+  add_foreign_key "coordination_policies", "coordination_policy_versions", column: "current_version_id", on_delete: :nullify
+  add_foreign_key "coordination_policy_versions", "coordination_policies", on_delete: :cascade
   add_foreign_key "cost_budgets", "projects", on_delete: :cascade
   add_foreign_key "decision_record_links", "decision_records", on_delete: :cascade
   add_foreign_key "decision_records", "agent_runs", on_delete: :nullify
@@ -2234,6 +2291,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
   add_foreign_key "workflow_states", "projects"
   add_foreign_key "worktrees", "agent_runs", on_delete: :nullify
   add_foreign_key "worktrees", "projects", on_delete: :cascade
+
+  create_function :paid_current_account_id, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
+       RETURNS bigint
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
+      $function$
+  SQL
+
+  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
+       RETURNS boolean
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
+      $function$
+  SQL
 
   create_function :logidze_capture_exception, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.logidze_capture_exception(error_data jsonb)
@@ -2967,26 +3044,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
           END IF;
           RETURN buf;
         END;
-      $function$
-  SQL
-
-  create_function :paid_current_account_id, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
-       RETURNS bigint
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
-      $function$
-  SQL
-
-  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
-       RETURNS boolean
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
       $function$
   SQL
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_044911) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -580,25 +580,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_044911) do
     t.index ["started_by_id"], name: "index_context_intake_sessions_on_started_by_id"
   end
 
-  create_table "coordination_decisions", comment: "Execution-time coordination decisions pinned to the exact policy version used so outcomes can be attributed later.", force: :cascade do |t|
-    t.bigint "agent_run_id", comment: "Optional agent run whose workflow emitted the coordination decision."
-    t.jsonb "alternatives", default: {}, null: false, comment: "Alternative actions or scores considered before the final decision."
-    t.jsonb "context_snapshot", default: {}, null: false, comment: "Context snapshot used as policy input when the decision was made."
-    t.bigint "coordination_policy_id", null: false, comment: "Stable coordination policy selected when the decision was made."
-    t.bigint "coordination_policy_version_id", null: false, comment: "Exact immutable coordination policy version evaluated for this decision."
-    t.datetime "created_at", null: false
-    t.jsonb "decision_made", default: {}, null: false, comment: "Structured payload describing the selected action, plan, or classification."
-    t.string "decision_type", limit: 100, null: false, comment: "Decision boundary, such as should_decompose, decomposition_plan, recovery_action, or should_escalate."
-    t.decimal "outcome_contribution", precision: 5, scale: 4, comment: "Attributed contribution score from later outcomes, typically normalized to the 0.0-1.0 range."
-    t.bigint "project_id", null: false, comment: "Owning project for tenant isolation and workflow-level analysis."
-    t.string "workflow_id", limit: 255, comment: "Temporal or orchestration workflow identifier used to correlate related decisions."
-    t.index ["agent_run_id", "created_at", "id"], name: "idx_coordination_decisions_run_recent"
-    t.index ["coordination_policy_id", "decision_type", "created_at"], name: "idx_coordination_decisions_policy_type_created"
-    t.index ["coordination_policy_version_id", "created_at", "id"], name: "idx_coordination_decisions_version_recent"
-    t.index ["project_id", "created_at", "id"], name: "idx_coordination_decisions_project_recent"
-    t.index ["workflow_id"], name: "idx_coordination_decisions_workflow_id"
-  end
-
   create_table "coordination_experiment_assignments", comment: "Assignment and outcome for one feature orchestration workflow sample", force: :cascade do |t|
     t.bigint "coordination_experiment_id", null: false
     t.bigint "coordination_experiment_variant_id", null: false
@@ -648,37 +629,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_044911) do
     t.index ["account_id", "policy_name"], name: "idx_coordination_experiments_one_running_policy", unique: true, where: "((status)::text = 'running'::text)"
     t.index ["account_id"], name: "index_coordination_experiments_on_account_id"
     t.index ["winner_variant_id"], name: "index_coordination_experiments_on_winner_variant_id"
-  end
-
-  create_table "coordination_policies", comment: "Account-scoped coordination policies that select rules for decomposition, recovery, escalation, and lifecycle handling.", force: :cascade do |t|
-    t.bigint "account_id", null: false, comment: "Owning tenant for policy isolation and account-level overrides."
-    t.datetime "activated_at", comment: "When the policy first became active for execution."
-    t.jsonb "context_selector", default: {}, null: false, comment: "Structured applicability filter used to match this policy to a workflow or project context."
-    t.datetime "created_at", null: false
-    t.bigint "current_version_id", comment: "Promoted immutable policy version currently used for execution."
-    t.text "description", comment: "Optional operator-facing description of the coordination policy intent."
-    t.string "lifecycle_state", limit: 50, default: "draft", null: false, comment: "Lifecycle state for the policy record: draft, active, or retired."
-    t.string "name", limit: 255, null: false, comment: "Human-readable identifier for this policy within its account and policy family."
-    t.string "policy_type", limit: 50, null: false, comment: "Coordination policy family such as decomposition, recovery, escalation, or lifecycle."
-    t.datetime "retired_at", comment: "When the policy was retired from active use."
-    t.datetime "updated_at", null: false
-    t.index ["account_id", "policy_type", "lifecycle_state"], name: "idx_coordination_policies_account_type_state"
-    t.index ["account_id", "policy_type", "name"], name: "idx_coordination_policies_account_type_name", unique: true
-    t.index ["account_id"], name: "index_coordination_policies_on_account_id"
-    t.index ["context_selector"], name: "idx_coordination_policies_context_selector", using: :gin
-    t.index ["current_version_id"], name: "index_coordination_policies_on_current_version_id"
-  end
-
-  create_table "coordination_policy_versions", comment: "Immutable rule snapshots for coordination policies, allowing evolution and decision attribution by exact version.", force: :cascade do |t|
-    t.bigint "coordination_policy_id", null: false, comment: "Stable policy record that owns this immutable version."
-    t.datetime "created_at", null: false
-    t.text "llm_prompt", comment: "Optional prompt template used when the policy delegates part of the decision to an LLM."
-    t.jsonb "parameters", default: {}, null: false, comment: "Tunable thresholds, weights, and other policy parameters separated from rule structure."
-    t.text "reasoning", comment: "Why this version was created or promoted, including evolution rationale."
-    t.jsonb "rules", default: {}, null: false, comment: "Structured decision rules, mappings, and heuristics executed by coordination services."
-    t.integer "version", null: false, comment: "Monotonic version number within a coordination policy."
-    t.index ["coordination_policy_id", "version"], name: "idx_coordination_policy_versions_policy_version", unique: true
-    t.index ["coordination_policy_id"], name: "index_coordination_policy_versions_on_coordination_policy_id"
   end
 
   create_table "cost_budgets", force: :cascade do |t|
@@ -2160,10 +2110,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_044911) do
   add_foreign_key "context_intake_responses", "context_intake_sessions"
   add_foreign_key "context_intake_sessions", "projects"
   add_foreign_key "context_intake_sessions", "users", column: "started_by_id"
-  add_foreign_key "coordination_decisions", "agent_runs", on_delete: :nullify
-  add_foreign_key "coordination_decisions", "coordination_policies"
-  add_foreign_key "coordination_decisions", "coordination_policy_versions"
-  add_foreign_key "coordination_decisions", "projects", on_delete: :cascade
   add_foreign_key "coordination_experiment_assignments", "coordination_experiment_variants", on_delete: :cascade
   add_foreign_key "coordination_experiment_assignments", "coordination_experiments", on_delete: :cascade
   add_foreign_key "coordination_experiment_assignments", "issues", on_delete: :nullify
@@ -2171,9 +2117,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_044911) do
   add_foreign_key "coordination_experiment_variants", "coordination_experiments", on_delete: :cascade
   add_foreign_key "coordination_experiments", "accounts", on_delete: :cascade
   add_foreign_key "coordination_experiments", "coordination_experiment_variants", column: "winner_variant_id", on_delete: :nullify
-  add_foreign_key "coordination_policies", "accounts", on_delete: :cascade
-  add_foreign_key "coordination_policies", "coordination_policy_versions", column: "current_version_id", on_delete: :nullify
-  add_foreign_key "coordination_policy_versions", "coordination_policies", on_delete: :cascade
   add_foreign_key "cost_budgets", "projects", on_delete: :cascade
   add_foreign_key "decision_record_links", "decision_records", on_delete: :cascade
   add_foreign_key "decision_records", "agent_runs", on_delete: :nullify
@@ -2291,26 +2234,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_044911) do
   add_foreign_key "workflow_states", "projects"
   add_foreign_key "worktrees", "agent_runs", on_delete: :nullify
   add_foreign_key "worktrees", "projects", on_delete: :cascade
-
-  create_function :paid_current_account_id, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
-       RETURNS bigint
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
-      $function$
-  SQL
-
-  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
-       RETURNS boolean
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
-      $function$
-  SQL
 
   create_function :logidze_capture_exception, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.logidze_capture_exception(error_data jsonb)
@@ -3044,6 +2967,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_044911) do
           END IF;
           RETURN buf;
         END;
+      $function$
+  SQL
+
+  create_function :paid_current_account_id, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
+       RETURNS bigint
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
+      $function$
+  SQL
+
+  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
+       RETURNS boolean
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
       $function$
   SQL
 

--- a/spec/models/scaling_experiment_spec.rb
+++ b/spec/models/scaling_experiment_spec.rb
@@ -31,4 +31,18 @@ RSpec.describe ScalingExperiment do
       ).to be_nil
     end
   end
+
+  describe "#eligible_values" do
+    it "caps agent_count values by task count" do
+      experiment = build(:scaling_experiment, dimension: "agent_count", values_tested: [ 1, 2, 4 ])
+
+      expect(experiment.eligible_values(task_count: 2)).to eq([ 1, 2 ])
+    end
+
+    it "keeps iteration_count values independent of task count" do
+      experiment = build(:scaling_experiment, dimension: "iteration_count", values_tested: [ 1, 2, 4 ])
+
+      expect(experiment.eligible_values(task_count: 2)).to eq([ 1, 2, 4 ])
+    end
+  end
 end

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -38,6 +38,27 @@ RSpec.describe QualityMetrics::Collect do
       expect { described_class.call(agent_run: agent_run) }.not_to change(QualityMetric, :count)
     end
 
+    it "refreshes linked scaling experiment results for orchestration child runs" do
+      parent_workflow_id = "feature-wf-123"
+      agent_run.update!(parent_workflow_id: parent_workflow_id)
+      observation = create(:scaling_observation, project: agent_run.project, issue: agent_run.issue, workflow_id: parent_workflow_id)
+      experiment = create(:scaling_experiment, project: agent_run.project)
+      assignment = create(:scaling_experiment_assignment,
+        scaling_experiment: experiment,
+        project: agent_run.project,
+        issue: agent_run.issue,
+        scaling_observation: observation)
+
+      allow(ScalingExperiments::RecordResult).to receive(:call)
+
+      described_class.call(agent_run: agent_run)
+
+      expect(ScalingExperiments::RecordResult).to have_received(:call).with(
+        assignment: assignment,
+        scaling_observation: observation
+      )
+    end
+
     context "with create_pr goal" do
       it "includes agent_rerun_count but omits review_comment_count until collected" do
         metric = described_class.call(agent_run: agent_run)

--- a/spec/services/scaling_experiments/assign_spec.rb
+++ b/spec/services/scaling_experiments/assign_spec.rb
@@ -70,4 +70,27 @@ RSpec.describe ScalingExperiments::Assign do
 
     expect(assignment).to be_nil
   end
+
+  it "builds an iteration-budget execution plan for iteration_count experiments" do
+    iteration_experiment = create(:scaling_experiment,
+      project: project,
+      dimension: "iteration_count",
+      values_tested: [ 1, 2, 4 ])
+
+    assignment = described_class.call(
+      scaling_experiment: iteration_experiment,
+      project: project,
+      issue: issue,
+      workflow_id: "wf-iterations",
+      task_count: 2
+    )
+
+    expect(assignment.execution_plan).to include(
+      "dimension" => "iteration_count",
+      "requested_iteration_count" => assignment.assigned_value,
+      "application_mode" => "task_prompt_budget"
+    )
+    expect(assignment.execution_plan["eligible_values"]).to eq([ 1, 2, 4 ])
+    expect(assignment.execution_plan["prompt_suffix"]).to include("Iteration budget")
+  end
 end

--- a/spec/services/scaling_experiments/record_result_spec.rb
+++ b/spec/services/scaling_experiments/record_result_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ScalingExperiments::RecordResult do
       cached_summary: {})
   end
 
-  def create_observation!(workflow_id:, assigned_value:, success:, cost_cents:, duration_seconds:)
+  def create_observation!(workflow_id:, assigned_value:, success:, cost_cents:, duration_seconds:, quality_scores: [])
     observation = create(:scaling_observation,
       project: project,
       issue: issue,
@@ -34,6 +34,11 @@ RSpec.describe ScalingExperiments::RecordResult do
       assigned_value: assigned_value,
       execution_plan: { "max_batch_size" => assigned_value, "requested_agent_count" => assigned_value })
 
+    quality_scores.each do |score|
+      run = create(:agent_run, :completed, project: project, issue: issue, parent_workflow_id: workflow_id)
+      create(:quality_metric, agent_run: run, metric_type: "automated", composite_score: score)
+    end
+
     described_class.call(assignment: assignment, scaling_observation: observation)
   end
 
@@ -43,23 +48,15 @@ RSpec.describe ScalingExperiments::RecordResult do
       assigned_value: 2,
       success: true,
       cost_cents: 350,
-      duration_seconds: 180
+      duration_seconds: 180,
+      quality_scores: [ 0.7, 0.9 ]
     )
 
     assignment = result.assignment.reload
     experiment.reload
 
-    expect(assignment.outcome_status).to eq("recorded")
-    expect(assignment.outcome_summary).to include(
-      "status" => "completed",
-      "success" => true,
-      "total_cost_cents" => 350
-    )
-    expect(experiment.cached_summary).to include(
-      "status" => "collecting",
-      "sample_count" => 1,
-      "values" => array_including(hash_including("assigned_value" => 2, "sample_count" => 1))
-    )
+    expect_recorded_assignment_summary(assignment)
+    expect_cached_experiment_summary(experiment)
   end
 
   it "completes the experiment once every value reaches the minimum sample count" do
@@ -72,5 +69,24 @@ RSpec.describe ScalingExperiments::RecordResult do
 
     expect(experiment.status).to eq("completed")
     expect(experiment.cached_summary).to include("status" => "ready_for_analysis", "leading_value" => 1)
+  end
+
+  def expect_recorded_assignment_summary(assignment)
+    expect(assignment.outcome_status).to eq("recorded")
+    expect(assignment.outcome_summary).to include(
+      "status" => "completed",
+      "success" => true,
+      "total_cost_cents" => 350,
+      "quality_metric_sample_count" => 2,
+      "avg_quality_score" => 0.8
+    )
+  end
+
+  def expect_cached_experiment_summary(experiment)
+    expect(experiment.cached_summary).to include(
+      "status" => "collecting",
+      "sample_count" => 1,
+      "values" => array_including(hash_including("assigned_value" => 2, "sample_count" => 1, "avg_quality_score" => 0.8))
+    )
   end
 end

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -145,9 +145,9 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             Workflows::ParallelAgentExecutionWorkflow,
             hash_including(
               sub_tasks: [
-                { custom_prompt: "Create users table", issue_id: 10, task_index: 0, dependencies: [], parallel_group: 0 },
-                { custom_prompt: "Create User model", issue_id: 11, task_index: 1, dependencies: [ 0 ], parallel_group: 1 },
-                { custom_prompt: "Create UsersController", issue_id: 12, task_index: 2, dependencies: [ 1 ], parallel_group: 2 }
+                { custom_prompt: include("Create users table"), issue_id: 10, task_index: 0, dependencies: [], parallel_group: 0 },
+                { custom_prompt: include("Create User model"), issue_id: 11, task_index: 1, dependencies: [ 0 ], parallel_group: 1 },
+                { custom_prompt: include("Create UsersController"), issue_id: 12, task_index: 2, dependencies: [ 1 ], parallel_group: 2 }
               ]
             ),
             anything
@@ -179,16 +179,8 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
       it "records the experiment result against the captured scaling observation" do
         workflow.execute(input)
 
-        expect(workflow).to have_received(:run_activity)
-          .with(
-            Activities::RecordScalingExperimentResultActivity,
-            hash_including(
-              assignment_id: 88,
-              scaling_observation_id: 1
-            ),
-            timeout: 30,
-            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
-          )
+        expect_scaling_result_recorded!(88)
+        expect_scaling_result_recorded!(99)
       end
 
       it "passes aggregate_pr option to child workflow when provided" do
@@ -409,11 +401,27 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
           when "Activities::ResolveScalingExperimentActivity"
             {
-              assignment_id: 88,
-              execution_plan: {
-                "requested_agent_count" => 2,
-                "max_batch_size" => 2
-              }
+              assignments: [
+                {
+                  assignment_id: 88,
+                  dimension: "agent_count",
+                  execution_plan: {
+                    "dimension" => "agent_count",
+                    "requested_agent_count" => 2,
+                    "max_batch_size" => 2
+                  }
+                },
+                {
+                  assignment_id: 99,
+                  dimension: "iteration_count",
+                  execution_plan: {
+                    "dimension" => "iteration_count",
+                    "requested_iteration_count" => 3,
+                    "application_mode" => "task_prompt_budget",
+                    "prompt_suffix" => "Iteration budget: aim to complete this task within 3 agent iterations."
+                  }
+                }
+              ]
             }
           when "Activities::FetchPlanningContextActivity"
             { context: {} }
@@ -545,11 +553,27 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
       when "Activities::ResolveScalingExperimentActivity"
         {
-          assignment_id: 88,
-          execution_plan: {
-            "requested_agent_count" => 2,
-            "max_batch_size" => 2
-          }
+          assignments: [
+            {
+              assignment_id: 88,
+              dimension: "agent_count",
+              execution_plan: {
+                "dimension" => "agent_count",
+                "requested_agent_count" => 2,
+                "max_batch_size" => 2
+              }
+            },
+            {
+              assignment_id: 99,
+              dimension: "iteration_count",
+              execution_plan: {
+                "dimension" => "iteration_count",
+                "requested_iteration_count" => 3,
+                "application_mode" => "task_prompt_budget",
+                "prompt_suffix" => "Iteration budget: aim to complete this task within 3 agent iterations."
+              }
+            }
+          ]
         }
       when "Activities::FetchPlanningContextActivity"
         { context: { issue_title: "Feature", knowledge_snippets: [] } }
@@ -617,12 +641,34 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             execution_summary: hash_including(max_parallelism_observed: 1)
           ),
           metadata: hash_including(
-            scaling_experiment: hash_including(
-              assignment_id: 88,
-              requested_agent_count: 2,
-              max_batch_size: 2
+            scaling_experiments: array_including(
+              hash_including(
+                assignment_id: 88,
+                dimension: "agent_count",
+                requested_agent_count: 2,
+                max_batch_size: 2
+              ),
+              hash_including(
+                assignment_id: 99,
+                dimension: "iteration_count",
+                requested_iteration_count: 3,
+                application_mode: "task_prompt_budget"
+              )
             )
           )
+        ),
+        timeout: 30,
+        retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
+      )
+  end
+
+  def expect_scaling_result_recorded!(assignment_id)
+    expect(workflow).to have_received(:run_activity)
+      .with(
+        Activities::RecordScalingExperimentResultActivity,
+        hash_including(
+          assignment_id: assignment_id,
+          scaling_observation_id: 1
         ),
         timeout: 30,
         retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY


### PR DESCRIPTION
## Summary

Implemented the iteration-count scaling flow and committed it as `0bd87ab` (`feat(scaling): add iteration-count experiment flow`).

The change extends `scaling_experiments` beyond `agent_count` to support `iteration_count`, resolves multiple scaling assignments per orchestration, applies iteration experiments as prompt-level iteration budgets on sub-tasks, and records richer downstream summaries including quality, cost, and latency signals. I also added refresh logic so scaling experiment summaries get updated when child-run quality metrics arrive, and expanded specs around assignment planning, result capture, and workflow integration.

Validation passed with `bundle exec rubocop` and the full `bundle exec rspec` suite: `11439 examples, 0 failures, 3 pending`. `bin/rails db:prepare` also passed once I ran Rails commands with `DATABASE_URL` unset and `DB_HOST`/`DB_USERNAME`/`DB_PASSWORD` set from the provided Postgres service, because the raw `DATABASE_URL` was overriding Rails’ multi-environment database names. `gh` was not installed in this environment, so I could not read the GitHub issue comments directly.

---

Closes #1778