### PR TITLE
feat(optimization): Phase 4.3 — End-to-End Outcome Optimization

### DIFF
--- a/app/services/configuration_bundles/objective_score.rb
+++ b/app/services/configuration_bundles/objective_score.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module ConfigurationBundles
+  class ObjectiveScore
+    MIN_COST_DOLLARS = 0.01
+
+    Result = Struct.new(
+      :objective_score,
+      :quality_score,
+      :cost_score,
+      :speed_score,
+      :quality_per_dollar,
+      keyword_init: true
+    )
+
+    attr_reader :project, :quality_score, :cost_cents, :duration_seconds
+
+    def initialize(project:, quality_score:, cost_cents:, duration_seconds:)
+      @project = project
+      @quality_score = quality_score
+      @cost_cents = cost_cents
+      @duration_seconds = duration_seconds
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      fitness = PromptEvolution::FitnessFunction.call(
+        samples: [ sample ],
+        weights: objective_weights,
+        reference_cost_cents: project_optimizer_setting("reference_cost_cents"),
+        reference_duration_seconds: project_optimizer_setting("reference_duration_seconds")
+      )
+
+      Result.new(
+        objective_score: fitness.composite_fitness,
+        quality_score: fitness.quality_score,
+        cost_score: fitness.cost_score,
+        speed_score: fitness.speed_score,
+        quality_per_dollar: quality_per_dollar
+      )
+    end
+
+    private
+
+    def sample
+      {
+        composite_score: quality_score,
+        cost_cents: cost_cents,
+        duration_seconds: duration_seconds
+      }
+    end
+
+    def objective_weights
+      project_optimizer_setting("weights") || PromptEvolution::FitnessFunction::DEFAULT_WEIGHTS
+    end
+
+    def quality_per_dollar
+      return nil if quality_score.nil? || cost_cents.nil?
+
+      quality_score.to_f / [ cost_cents.to_f / 100.0, MIN_COST_DOLLARS ].max
+    end
+
+    def project_optimizer_setting(*path)
+      settings = project.fitness_settings
+      return unless settings.is_a?(Hash)
+
+      settings.deep_stringify_keys.dig("configuration_bundle_optimizer", *path)
+    end
+  end
+end

--- a/app/services/configuration_bundles/optimizer.rb
+++ b/app/services/configuration_bundles/optimizer.rb
@@ -26,6 +26,7 @@ module ConfigurationBundles
     )
 
     ScoreInputs = Struct.new(
+      :predicted_objective_score,
       :predicted_quality_score,
       :uncertainty,
       :sample_count,
@@ -77,13 +78,14 @@ module ConfigurationBundles
       definition = bundle_definition(variant_by_experiment_id)
       fingerprint = Digest::SHA256.hexdigest(JSON.generate(definition))
       prediction = surrogate_model.predict(bundle_definition: definition, fingerprint: fingerprint)
-      acquisition_score = prediction.mean_quality_score + (EXPLORATION_WEIGHT * prediction.uncertainty)
+      acquisition_score = prediction.mean_objective_score + (EXPLORATION_WEIGHT * prediction.uncertainty)
 
       Selection.new(
         definition: definition,
         fingerprint: fingerprint,
         variant_by_experiment_id: variant_by_experiment_id,
         score_inputs: ScoreInputs.new(
+          predicted_objective_score: prediction.mean_objective_score,
           predicted_quality_score: prediction.mean_quality_score,
           uncertainty: prediction.uncertainty,
           sample_count: prediction.sample_count,
@@ -113,6 +115,7 @@ module ConfigurationBundles
     def exploitative_selection(selections)
       selections.max_by do |selection|
         [
+          selection.score_inputs.predicted_objective_score,
           selection.score_inputs.predicted_quality_score,
           selection.score_inputs.acquisition_score
         ]
@@ -123,6 +126,7 @@ module ConfigurationBundles
       selections.max_by do |selection|
         [
           selection.score_inputs.acquisition_score,
+          selection.score_inputs.predicted_objective_score,
           selection.score_inputs.predicted_quality_score
         ]
       end

--- a/app/services/configuration_bundles/record_outcome.rb
+++ b/app/services/configuration_bundles/record_outcome.rb
@@ -16,6 +16,13 @@ module ConfigurationBundles
     def call
       return unless agent_run.configuration_bundle
 
+      objective_result = ConfigurationBundles::ObjectiveScore.call(
+        project: agent_run.project,
+        quality_score: quality_metric.composite_score,
+        cost_cents: agent_run.cost_cents,
+        duration_seconds: agent_run.duration_seconds
+      )
+
       outcome = BundleOutcome.find_or_initialize_by(
         configuration_bundle: agent_run.configuration_bundle,
         agent_run: agent_run
@@ -29,6 +36,10 @@ module ConfigurationBundles
         metrics: {
           "component_scores" => quality_metric.scores || {},
           "completed_at" => agent_run.completed_at&.iso8601,
+          "cost_score" => objective_result.cost_score,
+          "objective_score" => objective_result.objective_score,
+          "quality_per_dollar" => objective_result.quality_per_dollar,
+          "speed_score" => objective_result.speed_score,
           "status" => agent_run.status
         }
       )

--- a/app/services/configuration_bundles/surrogate_model.rb
+++ b/app/services/configuration_bundles/surrogate_model.rb
@@ -31,7 +31,7 @@ module ConfigurationBundles
       raise ArgumentError, "project is required when scope is not provided" unless project
 
       BundleOutcome
-        .includes(:configuration_bundle, :agent_run)
+        .includes(:configuration_bundle, agent_run: :project)
         .joins(agent_run: :project)
         .where(agent_runs: { project_id: project.id })
         .where.not(quality_score: nil)

--- a/app/services/configuration_bundles/surrogate_model.rb
+++ b/app/services/configuration_bundles/surrogate_model.rb
@@ -5,6 +5,7 @@ module ConfigurationBundles
     include Canonicalization
 
     Prediction = Struct.new(
+      :mean_objective_score,
       :mean_quality_score,
       :uncertainty,
       :sample_count,
@@ -46,10 +47,13 @@ module ConfigurationBundles
       return empty_prediction if matches.empty?
 
       total_weight = matches.sum { |match| match[:weight] }
+      weighted_objective_sum = matches.sum { |match| match[:weight] * match[:objective_score] }
       weighted_sum = matches.sum { |match| match[:weight] * match[:quality_score] }
+      weighted_objective = ((PRIOR_MEAN * PRIOR_WEIGHT) + weighted_objective_sum) / (PRIOR_WEIGHT + total_weight)
       weighted_mean = ((PRIOR_MEAN * PRIOR_WEIGHT) + weighted_sum) / (PRIOR_WEIGHT + total_weight)
 
       Prediction.new(
+        mean_objective_score: weighted_objective,
         mean_quality_score: weighted_mean,
         uncertainty: 1.0 / Math.sqrt(PRIOR_WEIGHT + total_weight),
         sample_count: total_weight.round(4),
@@ -69,7 +73,7 @@ module ConfigurationBundles
         similarity = similarity(bundle_features, outcome_row[:features])
         next if similarity.zero?
 
-        match_row(outcome_row[:quality_score], similarity)
+        match_row(outcome_row[:objective_score], outcome_row[:quality_score], similarity)
       end
     end
 
@@ -79,7 +83,7 @@ module ConfigurationBundles
       outcome_rows_by_fingerprint.fetch(fingerprint, []).filter_map do |outcome_row|
         next unless same_scoring_context?(scoring_context, outcome_row[:scoring_context])
 
-        match_row(outcome_row[:quality_score], 1.0)
+        match_row(outcome_row[:objective_score], outcome_row[:quality_score], 1.0)
       end
     end
 
@@ -94,6 +98,7 @@ module ConfigurationBundles
           rows << {
             fingerprint: outcome.configuration_bundle.fingerprint,
             features: feature_map(definition),
+            objective_score: outcome_objective_score(outcome),
             quality_score: outcome.quality_score.to_f,
             scoring_context: scoring_context_for(outcome)
           }
@@ -107,8 +112,9 @@ module ConfigurationBundles
       @outcome_rows_by_fingerprint ||= outcome_rows.group_by { |outcome_row| outcome_row[:fingerprint] }
     end
 
-    def match_row(quality_score, weight)
+    def match_row(objective_score, quality_score, weight)
       {
+        objective_score: objective_score,
         weight: weight,
         quality_score: quality_score
       }
@@ -116,6 +122,7 @@ module ConfigurationBundles
 
     def empty_prediction
       Prediction.new(
+        mean_objective_score: PRIOR_MEAN,
         mean_quality_score: PRIOR_MEAN,
         uncertainty: 1.0,
         sample_count: 0.0,
@@ -168,6 +175,18 @@ module ConfigurationBundles
       Array(definition["mcp_servers"])
         .map { |snapshot| canonicalize(snapshot) }
         .sort_by { |snapshot| JSON.generate(snapshot) }
+    end
+
+    def outcome_objective_score(outcome)
+      objective_score = outcome.metrics&.fetch("objective_score", nil)
+      return objective_score.to_f if objective_score.present?
+
+      ConfigurationBundles::ObjectiveScore.call(
+        project: outcome.agent_run.project,
+        quality_score: outcome.quality_score,
+        cost_cents: outcome.cost_cents,
+        duration_seconds: outcome.duration_seconds
+      ).objective_score
     end
 
     def similarity(lhs, rhs)

--- a/app/services/projects/bundle_performance_dashboard_stats.rb
+++ b/app/services/projects/bundle_performance_dashboard_stats.rb
@@ -368,7 +368,7 @@ module Projects
         AVG(
           COALESCE(
             NULLIF(bundle_outcomes.metrics ->> 'objective_score', '')::double precision,
-            bundle_outcomes.quality_score
+            #{objective_score_fallback_sql}
           )
         )
       SQL
@@ -386,6 +386,63 @@ module Projects
           )
         )
       SQL
+    end
+
+    def objective_score_fallback_sql
+      <<~SQL.squish
+        ROUND(
+          (
+            (#{optimizer_weights[:quality]} * COALESCE(LEAST(GREATEST(bundle_outcomes.quality_score, 0.0), 1.0), 0.0)) +
+            (#{optimizer_weights[:cost]} * #{normalized_inverse_sql("bundle_outcomes.cost_cents", optimizer_reference_cost_cents)}) +
+            (#{optimizer_weights[:speed]} * #{normalized_inverse_sql("bundle_outcomes.duration_seconds", optimizer_reference_duration_seconds)})
+          )::numeric,
+          4
+        )::double precision
+      SQL
+    end
+
+    def normalized_inverse_sql(column_name, reference)
+      <<~SQL.squish
+        CASE
+          WHEN #{column_name} IS NULL THEN 0.0
+          ELSE #{reference} / (GREATEST(#{column_name}, 0.0) + #{reference})
+        END
+      SQL
+    end
+
+    def optimizer_weights
+      @optimizer_weights ||= begin
+        configured = project_optimizer_setting("weights")
+        PromptEvolution::FitnessFunction.new(samples: [], weights: configured)
+          .score
+          .weights
+      end
+    end
+
+    def optimizer_reference_cost_cents
+      @optimizer_reference_cost_cents ||= positive_optimizer_setting(
+        project_optimizer_setting("reference_cost_cents"),
+        PromptEvolution::FitnessFunction::DEFAULT_REFERENCE_COST_CENTS
+      )
+    end
+
+    def optimizer_reference_duration_seconds
+      @optimizer_reference_duration_seconds ||= positive_optimizer_setting(
+        project_optimizer_setting("reference_duration_seconds"),
+        PromptEvolution::FitnessFunction::DEFAULT_REFERENCE_DURATION_SECONDS
+      )
+    end
+
+    def project_optimizer_setting(*path)
+      settings = project.fitness_settings
+      return unless settings.is_a?(Hash)
+
+      settings.deep_stringify_keys.dig("configuration_bundle_optimizer", *path)
+    end
+
+    def positive_optimizer_setting(value, fallback)
+      numeric = Float(value, exception: false)
+      numeric&.positive? ? numeric : fallback.to_f
     end
   end
 end

--- a/app/services/projects/bundle_performance_dashboard_stats.rb
+++ b/app/services/projects/bundle_performance_dashboard_stats.rb
@@ -65,13 +65,15 @@ module Projects
         rows = bundle_outcomes_scope
           .joins(:configuration_bundle)
           .group("configuration_bundles.id")
-          .order(Arel.sql("AVG(bundle_outcomes.quality_score) DESC NULLS LAST, COUNT(bundle_outcomes.id) DESC"))
+          .order(Arel.sql("#{average_objective_score_sql} DESC NULLS LAST, AVG(bundle_outcomes.quality_score) DESC NULLS LAST, COUNT(bundle_outcomes.id) DESC"))
           .limit(MAX_BUNDLE_ROWS)
           .pluck(
             Arel.sql("configuration_bundles.id"),
             Arel.sql("COUNT(bundle_outcomes.id)"),
             Arel.sql("COUNT(bundle_outcomes.quality_score)"),
+            Arel.sql(average_objective_score_sql),
             Arel.sql("AVG(bundle_outcomes.quality_score)"),
+            Arel.sql(average_quality_per_dollar_sql),
             Arel.sql("COUNT(*) FILTER (WHERE bundle_outcomes.success)"),
             Arel.sql("AVG(bundle_outcomes.cost_cents)"),
             Arel.sql("AVG(bundle_outcomes.duration_seconds)"),
@@ -84,7 +86,7 @@ module Projects
           .where(id: rows.map(&:first))
           .index_by(&:id)
 
-        rows.filter_map do |bundle_id, outcome_count, quality_count, avg_quality, success_count, avg_cost, avg_duration, avg_tokens, last_seen_at|
+        rows.filter_map do |bundle_id, outcome_count, quality_count, avg_objective, avg_quality, avg_quality_per_dollar, success_count, avg_cost, avg_duration, avg_tokens, last_seen_at|
           bundle = bundles_by_id[bundle_id]
           next unless bundle
 
@@ -95,7 +97,9 @@ module Projects
             bundle: bundle,
             outcome_count: outcome_count,
             quality_sample_count: quality_count,
+            avg_objective_score: avg_objective&.to_f,
             avg_quality_score: avg_quality&.to_f,
+            avg_quality_per_dollar: avg_quality_per_dollar&.to_f,
             success_rate: outcome_count.zero? ? nil : success_count.to_f / outcome_count,
             avg_cost_cents: avg_cost&.to_f&.round,
             avg_duration_seconds: avg_duration&.to_f&.round,
@@ -157,23 +161,23 @@ module Projects
     end
 
     def tradeoff_frontier
-      candidates = all_bundle_quality_cost.select { |b| b[:avg_quality_score].present? && b[:avg_cost_cents].present? }
+      candidates = all_bundle_quality_cost.select { |b| b[:avg_objective_score].present? && b[:avg_cost_cents].present? }
       return [] if candidates.empty?
 
       pareto_bundles = candidates.reject do |bundle|
         candidates.any? do |other|
           next if other.equal?(bundle)
 
-          other[:avg_quality_score] >= bundle[:avg_quality_score] &&
+          other[:avg_objective_score] >= bundle[:avg_objective_score] &&
             other[:avg_cost_cents] <= bundle[:avg_cost_cents] &&
             (
-              other[:avg_quality_score] > bundle[:avg_quality_score] ||
+              other[:avg_objective_score] > bundle[:avg_objective_score] ||
               other[:avg_cost_cents] < bundle[:avg_cost_cents]
             )
         end
       end
 
-      pareto_bundles.sort_by { |bundle| [ -bundle[:avg_quality_score], bundle[:avg_cost_cents] ] }
+      pareto_bundles.sort_by { |bundle| [ -bundle[:avg_objective_score], bundle[:avg_cost_cents] ] }
     end
 
     def all_bundle_quality_cost
@@ -183,6 +187,7 @@ module Projects
           .group("configuration_bundles.id")
           .pluck(
             Arel.sql("configuration_bundles.id"),
+            Arel.sql(average_objective_score_sql),
             Arel.sql("AVG(bundle_outcomes.quality_score)"),
             Arel.sql("AVG(bundle_outcomes.cost_cents)"),
             Arel.sql("AVG(bundle_outcomes.tokens_used)")
@@ -192,12 +197,13 @@ module Projects
           .where(id: rows.map(&:first))
           .index_by(&:id)
 
-        rows.filter_map do |bundle_id, avg_quality, avg_cost, avg_tokens|
+        rows.filter_map do |bundle_id, avg_objective, avg_quality, avg_cost, avg_tokens|
           bundle = bundles_by_id[bundle_id]
           next unless bundle
 
           {
             bundle: bundle,
+            avg_objective_score: avg_objective&.to_f,
             avg_quality_score: avg_quality&.to_f,
             avg_cost_cents: avg_cost&.to_f&.round,
             avg_tokens_used: avg_tokens&.to_f&.round
@@ -324,6 +330,7 @@ module Projects
 
       {
         acquisition_score: selection.score_inputs.acquisition_score.to_f,
+        predicted_objective_score: selection.score_inputs.predicted_objective_score.to_f,
         predicted_quality_score: selection.score_inputs.predicted_quality_score.to_f,
         uncertainty: uncertainty,
         confidence_proxy: 1.0 - uncertainty.clamp(0.0, 1.0),
@@ -354,6 +361,31 @@ module Projects
       "#{prefix}: #{parsed_value.inspect}"
     rescue JSON::ParserError
       "#{variant.is_control ? 'Control' : 'Variant'}: invalid JSON"
+    end
+
+    def average_objective_score_sql
+      <<~SQL.squish
+        AVG(
+          COALESCE(
+            NULLIF(bundle_outcomes.metrics ->> 'objective_score', '')::double precision,
+            bundle_outcomes.quality_score
+          )
+        )
+      SQL
+    end
+
+    def average_quality_per_dollar_sql
+      <<~SQL.squish
+        AVG(
+          COALESCE(
+            NULLIF(bundle_outcomes.metrics ->> 'quality_per_dollar', '')::double precision,
+            CASE
+              WHEN bundle_outcomes.quality_score IS NULL OR bundle_outcomes.cost_cents IS NULL THEN NULL
+              ELSE bundle_outcomes.quality_score / GREATEST(bundle_outcomes.cost_cents / 100.0, 0.01)
+            END
+          )
+        )
+      SQL
     end
   end
 end

--- a/app/views/projects/bundle_performance_dashboards/show.html.erb
+++ b/app/views/projects/bundle_performance_dashboards/show.html.erb
@@ -46,7 +46,7 @@
 
     <div class="mt-8">
       <h2 class="text-lg font-semibold text-gray-900">Bundle Performance</h2>
-      <p class="mt-1 text-sm text-gray-500">Top bundles ranked by observed quality, with sparse evidence called out directly.</p>
+      <p class="mt-1 text-sm text-gray-500">Top bundles ranked by the observed outcome-cost objective, with raw quality and efficiency shown alongside sparse evidence warnings.</p>
       <% if @stats[:bundle_rankings].any? %>
         <div class="mt-4 overflow-hidden overflow-x-auto rounded-lg bg-white shadow">
           <table class="min-w-full divide-y divide-gray-200">
@@ -54,7 +54,9 @@
               <tr>
                 <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Bundle</th>
                 <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Samples</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Objective</th>
                 <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Quality</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Quality / $</th>
                 <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Success</th>
                 <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Cost</th>
                 <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Duration</th>
@@ -79,7 +81,9 @@
                     <% end %>
                   </td>
                   <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= row[:quality_sample_count] %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-right text-sm <%= quality_score_color(row[:avg_objective_score]) %>"><%= format_quality_score(row[:avg_objective_score]) %></td>
                   <td class="whitespace-nowrap px-4 py-3 text-right text-sm <%= quality_score_color(row[:avg_quality_score]) %>"><%= format_quality_score(row[:avg_quality_score]) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= row[:avg_quality_per_dollar] ? number_with_precision(row[:avg_quality_per_dollar], precision: 2, strip_insignificant_zeros: true) : "--" %></td>
                   <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= number_to_percentage((row[:success_rate] || 0) * 100, precision: 0) %></td>
                   <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= row[:avg_cost_cents] ? format_cost_cents(row[:avg_cost_cents]) : "--" %></td>
                   <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= format_duration(row[:avg_duration_seconds]) %></td>
@@ -167,13 +171,14 @@
 
     <div class="mt-8">
       <h2 class="text-lg font-semibold text-gray-900">Outcome-Cost Tradeoffs</h2>
-      <p class="mt-1 text-sm text-gray-500">Pareto-efficient bundles keep quality high without paying more than a clearly better alternative.</p>
+      <p class="mt-1 text-sm text-gray-500">Pareto-efficient bundles keep the cost-aware objective high without paying more than a clearly better alternative.</p>
       <% if @stats[:tradeoff_frontier].any? %>
         <div class="mt-4 overflow-hidden overflow-x-auto rounded-lg bg-white shadow">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
               <tr>
                 <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Bundle</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Objective</th>
                 <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Quality</th>
                 <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Cost</th>
                 <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Tokens</th>
@@ -183,6 +188,7 @@
               <% @stats[:tradeoff_frontier].each do |bundle| %>
                 <tr>
                   <td class="px-4 py-3 text-sm font-medium text-gray-900"><%= bundle[:bundle].name %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-right text-sm <%= quality_score_color(bundle[:avg_objective_score]) %>"><%= format_quality_score(bundle[:avg_objective_score]) %></td>
                   <td class="whitespace-nowrap px-4 py-3 text-right text-sm <%= quality_score_color(bundle[:avg_quality_score]) %>"><%= format_quality_score(bundle[:avg_quality_score]) %></td>
                   <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= format_cost_cents(bundle[:avg_cost_cents]) %></td>
                   <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= number_with_delimiter(bundle[:avg_tokens_used]) %></td>
@@ -225,6 +231,7 @@
                     <thead class="bg-gray-50">
                       <tr>
                         <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Candidate</th>
+                        <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Predicted Objective</th>
                         <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Predicted Quality</th>
                         <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Confidence Proxy</th>
                         <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Weighted Samples</th>
@@ -235,6 +242,7 @@
                       <% insight[:candidates].each do |candidate| %>
                         <tr>
                           <td class="px-4 py-3 text-sm text-gray-900"><%= candidate[:experiment_values].presence&.join(", ") || "Baseline configuration" %></td>
+                          <td class="whitespace-nowrap px-4 py-3 text-right text-sm <%= quality_score_color(candidate[:predicted_objective_score]) %>"><%= format_quality_score(candidate[:predicted_objective_score]) %></td>
                           <td class="whitespace-nowrap px-4 py-3 text-right text-sm <%= quality_score_color(candidate[:predicted_quality_score]) %>"><%= format_quality_score(candidate[:predicted_quality_score]) %></td>
                           <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= number_to_percentage(candidate[:confidence_proxy] * 100, precision: 0) %></td>
                           <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-500"><%= number_with_precision(candidate[:sample_count], precision: 2, strip_insignificant_zeros: true) %></td>

--- a/spec/services/configuration_bundles/objective_score_spec.rb
+++ b/spec/services/configuration_bundles/objective_score_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConfigurationBundles::ObjectiveScore do
+  it "returns a cost-aware objective and a measurable quality-per-dollar ratio" do
+    project = create(:project)
+
+    result = described_class.call(
+      project: project,
+      quality_score: 0.8,
+      cost_cents: 50,
+      duration_seconds: 600
+    )
+
+    expect(result.objective_score).to be_within(0.001).of(0.7133)
+    expect(result.cost_score).to be_within(0.001).of(0.6667)
+    expect(result.speed_score).to be_within(0.001).of(0.5)
+    expect(result.quality_per_dollar).to be_within(0.001).of(1.6)
+  end
+
+  it "respects optimizer-specific weights and references from project settings" do
+    project = create(:project)
+    project.update!(fitness_settings: {
+      "configuration_bundle_optimizer" => {
+        "weights" => { "quality" => 1.0, "cost" => 0.0, "speed" => 0.0 },
+        "reference_cost_cents" => 500,
+        "reference_duration_seconds" => 1200
+      }
+    })
+
+    result = described_class.call(
+      project: project,
+      quality_score: 0.8,
+      cost_cents: 500,
+      duration_seconds: 1200
+    )
+
+    expect(result.objective_score).to eq(0.8)
+    expect(result.cost_score).to be_within(0.001).of(0.5)
+    expect(result.speed_score).to be_within(0.001).of(0.5)
+  end
+end

--- a/spec/services/configuration_bundles/optimizer_spec.rb
+++ b/spec/services/configuration_bundles/optimizer_spec.rb
@@ -30,21 +30,22 @@ RSpec.describe ConfigurationBundles::Optimizer do
       create_bundle_history(
         experiment: experiment,
         variant: control,
-        quality_scores: [ 0.72, 0.74, 0.76, 0.78 ]
+        quality_scores: [ 0.62, 0.64, 0.66, 0.68 ]
       )
       create_bundle_history(
         experiment: experiment,
         variant: challenger,
-        quality_scores: [ 0.9 ]
+        quality_scores: [ 0.98 ]
       )
 
       selection = described_class.call(agent_run: agent_run)
 
       expect(selection.variant_by_experiment_id).to eq(experiment.id => challenger)
+      expect(selection.score_inputs.predicted_objective_score).to be > 0
       expect(selection.score_inputs.predicted_quality_score).to be > 0
       expect(selection.score_inputs.uncertainty).to be > 0
       expect(selection.score_inputs.acquisition_score).to be >
-        selection.score_inputs.predicted_quality_score
+        selection.score_inputs.predicted_objective_score
     end
 
     it "routes no-issue runs through the project exploration budget" do
@@ -137,6 +138,26 @@ RSpec.describe ConfigurationBundles::Optimizer do
       experiment.update!(status: "completed", completed_at: Time.current)
 
       expect(described_class.call(agent_run: agent_run)).to be_nil
+    end
+
+    it "prefers the cheaper bundle when quality is matched" do
+      create_bundle_history(
+        experiment: experiment,
+        variant: control,
+        quality_scores: [ 0.8, 0.8 ],
+        cost_cents: 25
+      )
+      create_bundle_history(
+        experiment: experiment,
+        variant: challenger,
+        quality_scores: [ 0.8, 0.8 ],
+        cost_cents: 200
+      )
+
+      selection = described_class.call(agent_run: agent_run)
+
+      expect(selection.variant_by_experiment_id).to eq(experiment.id => control)
+      expect(selection.score_inputs.predicted_objective_score).to be <= selection.score_inputs.predicted_quality_score
     end
 
     it "skips malformed variants while still scoring valid candidates" do
@@ -260,6 +281,7 @@ RSpec.describe ConfigurationBundles::Optimizer do
   def prediction_for(mode)
     if mode == :exploitative
       ConfigurationBundles::SurrogateModel::Prediction.new(
+        mean_objective_score: 0.82,
         mean_quality_score: 0.82,
         uncertainty: 0.01,
         sample_count: 4,
@@ -267,6 +289,7 @@ RSpec.describe ConfigurationBundles::Optimizer do
       )
     else
       ConfigurationBundles::SurrogateModel::Prediction.new(
+        mean_objective_score: 0.72,
         mean_quality_score: 0.72,
         uncertainty: 0.35,
         sample_count: 1,
@@ -284,7 +307,7 @@ RSpec.describe ConfigurationBundles::Optimizer do
     end
   end
 
-  def create_bundle_history(experiment:, variant:, quality_scores:)
+  def create_bundle_history(experiment:, variant:, quality_scores:, cost_cents: 40)
     definition = {
       "schema_version" => 1,
       "goal" => agent_run.goal,
@@ -302,11 +325,17 @@ RSpec.describe ConfigurationBundles::Optimizer do
     bundle = create(:configuration_bundle, account: project.account, definition: definition)
 
     quality_scores.each do |quality_score|
-      run = create(:agent_run, :completed, configuration_bundle: bundle, project: project, issue: create(:issue, project: project))
+      run = create(:agent_run,
+        :completed,
+        configuration_bundle: bundle,
+        project: project,
+        issue: create(:issue, project: project),
+        cost_cents: cost_cents)
       create(:bundle_outcome,
         configuration_bundle: bundle,
         agent_run: run,
-        quality_score: quality_score)
+        quality_score: quality_score,
+        cost_cents: cost_cents)
     end
   end
 end

--- a/spec/services/configuration_bundles/record_outcome_spec.rb
+++ b/spec/services/configuration_bundles/record_outcome_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe ConfigurationBundles::RecordOutcome do
     expect(outcome.tokens_used).to eq(agent_run.tokens_input + agent_run.tokens_output)
     expect(outcome.metrics).to include(
       "component_scores" => { "pr_created" => 1.0 },
+      "objective_score" => be_within(0.001).of(0.684),
+      "quality_per_dollar" => be_within(0.001).of(0.56),
       "status" => "completed"
     )
   end

--- a/spec/services/configuration_bundles/surrogate_model_spec.rb
+++ b/spec/services/configuration_bundles/surrogate_model_spec.rb
@@ -30,16 +30,20 @@ RSpec.describe ConfigurationBundles::SurrogateModel do
       create(:bundle_outcome, configuration_bundle: review_bundle, agent_run: review_run, quality_score: 0.95)
     end
 
-    it "materializes outcome history once across predictions" do
+    def build_materialized_history_model
       scope = instance_double(ActiveRecord::Relation)
       ordered_scope = instance_double(ActiveRecord::Relation)
       limited_scope = instance_double(ActiveRecord::Relation)
-      outcome_agent_run = instance_double(AgentRun, goal: "create_pr")
+      outcome_project = instance_double(Project, fitness_settings: nil)
+      outcome_agent_run = instance_double(AgentRun, goal: "create_pr", project: outcome_project)
       bundle = instance_double(ConfigurationBundle,
         definition: { "schema_version" => 1, "goal" => "create_pr", "agent_type" => "claude_code" },
         fingerprint: "known-fingerprint")
       outcome = instance_double(BundleOutcome,
         configuration_bundle: bundle,
+        metrics: nil,
+        cost_cents: nil,
+        duration_seconds: nil,
         quality_score: 0.8,
         agent_run: outcome_agent_run)
       model = described_class.new(scope: scope)
@@ -47,6 +51,33 @@ RSpec.describe ConfigurationBundles::SurrogateModel do
       allow(scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
       allow(ordered_scope).to receive(:limit).with(described_class::MAX_OUTCOME_ROWS).and_return(limited_scope)
       expect(limited_scope).to receive(:each).once.and_yield(outcome)
+
+      [ model, bundle ]
+    end
+
+    def create_priced_outcome(project:, token_budget:, cost_cents:)
+      bundle = create(:configuration_bundle,
+        account: project.account,
+        definition: bundle_definition(goal: "create_pr", token_budget: token_budget))
+      run = create(:agent_run,
+        :completed,
+        project: project,
+        issue: create(:issue, project: project),
+        goal: "create_pr",
+        configuration_bundle: bundle,
+        cost_cents: cost_cents)
+
+      create(:bundle_outcome,
+        configuration_bundle: bundle,
+        agent_run: run,
+        quality_score: 0.8,
+        cost_cents: cost_cents)
+
+      bundle
+    end
+
+    it "materializes outcome history once across predictions" do
+      model, bundle = build_materialized_history_model
 
       2.times do
         prediction = model.predict(bundle_definition: bundle.definition, fingerprint: bundle.fingerprint)
@@ -65,6 +96,24 @@ RSpec.describe ConfigurationBundles::SurrogateModel do
 
       expect(prediction.mean_quality_score).to eq(described_class::PRIOR_MEAN)
       expect(prediction.matched_outcomes).to eq(0)
+    end
+
+    it "penalizes expensive outcomes in the objective prediction even when quality matches" do
+      project = create(:project)
+      cheap_bundle = create_priced_outcome(project:, token_budget: 4000, cost_cents: 20)
+      expensive_bundle = create_priced_outcome(project:, token_budget: 8000, cost_cents: 200)
+
+      cheap_prediction = described_class.call(
+        project: project,
+        bundle_definition: cheap_bundle.definition
+      )
+      expensive_prediction = described_class.call(
+        project: project,
+        bundle_definition: expensive_bundle.definition
+      )
+
+      expect(cheap_prediction.mean_quality_score).to eq(expensive_prediction.mean_quality_score)
+      expect(cheap_prediction.mean_objective_score).to be > expensive_prediction.mean_objective_score
     end
   end
 end

--- a/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
+++ b/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
@@ -141,6 +141,8 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
 
       expect(stats[:sparse]).to be(false)
       expect(stats[:summary][:bundle_count]).to eq(1)
+      expect(stats[:bundle_rankings].first[:avg_objective_score]).to be < stats[:bundle_rankings].first[:avg_quality_score]
+      expect(stats[:bundle_rankings].first[:avg_quality_per_dollar]).to be > 1
       expect(stats[:bundle_rankings].first[:avg_quality_score]).to be_within(0.001).of(0.85)
       expect(stats[:experiment_confidence].first[:variants].size).to eq(2)
       expect(stats[:tradeoff_frontier].first[:bundle]).to eq(bundle)
@@ -221,16 +223,29 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
       configuration_bundle: bundle,
       cost_cents: cost_cents)
 
+    objective = ConfigurationBundles::ObjectiveScore.call(
+      project: project,
+      quality_score: quality_score,
+      cost_cents: cost_cents,
+      duration_seconds: run.duration_seconds
+    )
+
     create(:bundle_outcome,
       configuration_bundle: bundle,
       agent_run: run,
       quality_score: quality_score,
       cost_cents: cost_cents,
+      duration_seconds: run.duration_seconds,
+      metrics: {
+        "objective_score" => objective.objective_score,
+        "quality_per_dollar" => objective.quality_per_dollar
+      },
       success: true)
   end
 
   def mock_optimizer_selection
     score_inputs = ConfigurationBundles::Optimizer::ScoreInputs.new(
+      predicted_objective_score: 0.76,
       predicted_quality_score: 0.8,
       uncertainty: 0.1,
       sample_count: 5,

--- a/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
+++ b/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
@@ -58,6 +58,31 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
       expect(frontier_bundles).to include(pareto_bundle)
     end
 
+    it "recomputes objective scores for historical outcomes missing persisted metrics" do
+      expensive_bundle = create_simple_bundle(project:)
+      create_bundle_outcome(
+        project: project,
+        bundle: expensive_bundle,
+        quality_score: 0.8,
+        cost_cents: 10_000,
+        metrics: {}
+      )
+
+      efficient_bundle = create_simple_bundle(project:)
+      create_bundle_outcome(
+        project: project,
+        bundle: efficient_bundle,
+        quality_score: 0.79,
+        cost_cents: 10
+      )
+
+      stats = described_class.call(project: project)
+
+      expect(stats[:bundle_rankings].first[:bundle]).to eq(efficient_bundle)
+      expect(stats[:bundle_rankings].find { |row| row[:bundle] == expensive_bundle }[:avg_objective_score]).to be < 0.8
+      expect(stats[:tradeoff_frontier].first[:bundle]).to eq(efficient_bundle)
+    end
+
     it "is not sparse when optimizer insights have candidates despite no outcomes or experiments" do
       run = create(:agent_run, project: project, issue: create(:issue, project: project), goal: "create_pr")
 
@@ -172,6 +197,12 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
     [ experiment, control, variant ]
   end
 
+  def create_simple_bundle(project:)
+    create(:configuration_bundle, account: project.account, definition: {
+      "schema_version" => 1, "goal" => "create_pr", "agent_type" => "claude_code", "experiments" => {}
+    })
+  end
+
   def create_bundle(project:, experiment:, variant:)
     create(:configuration_bundle,
       account: project.account,
@@ -214,7 +245,7 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
     end
   end
 
-  def create_bundle_outcome(project:, bundle:, quality_score:, cost_cents:)
+  def create_bundle_outcome(project:, bundle:, quality_score:, cost_cents:, metrics: nil)
     run = create(:agent_run,
       :completed,
       project: project,
@@ -236,7 +267,7 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
       quality_score: quality_score,
       cost_cents: cost_cents,
       duration_seconds: run.duration_seconds,
-      metrics: {
+      metrics: metrics || {
         "objective_score" => objective.objective_score,
         "quality_per_dollar" => objective.quality_per_dollar
       },


### PR DESCRIPTION
## Summary

Implemented Phase 4.3’s missing optimization target by making bundle selection cost-aware instead of quality-only. The new `ConfigurationBundles::ObjectiveScore` service computes a bundle outcome objective plus `quality_per_dollar`, `RecordOutcome` persists those metrics, `SurrogateModel` predicts objective and quality, `Optimizer` now ranks on predicted objective, and the bundle performance dashboard shows objective/efficiency alongside the existing quality signals.

Validation completed with workspace-local Bundler/Yarn installs, `db:prepare`, `bundle exec rubocop`, and a full `bundle exec rspec` pass. The app needed `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent` because `config/database.yml` only reads the explicit DB env keys for dev/test. The only non-green items were the existing 3 pending specs already present in the suite. Commit created: `ef63c4f` (`feat(optimization): optimize bundles for outcome-cost efficiency`).

---

Closes #1767