### PR TITLE
feat(scaling): design controlled orchestration scaling experiments

### DIFF
--- a/app/models/scaling_experiment.rb
+++ b/app/models/scaling_experiment.rb
@@ -4,7 +4,15 @@ require "zlib"
 
 class ScalingExperiment < ApplicationRecord
   STATUSES = %w[draft running completed cancelled].freeze
-  DIMENSIONS = %w[agent_count].freeze
+  DIMENSIONS = %w[agent_count max_iterations parallelism].freeze
+  OUTCOME_METRIC_KEYS = %w[
+    success_rate
+    duration_seconds
+    total_cost_cents
+    agent_launch_success_rate
+    blocked_task_rate
+    parallelism_observed
+  ].freeze
 
   belongs_to :project
 
@@ -20,6 +28,13 @@ class ScalingExperiment < ApplicationRecord
   validate :values_tested_are_positive_integers
   validate :control_value_in_values_tested
   validate :context_filter_is_object
+  validate :independent_variables_is_array
+  validate :outcome_metrics_is_array
+  validate :control_definition_is_object
+  validate :cohort_settings_is_object
+  validate :primary_dimension_variable_matches_plan
+  validate :outcome_metrics_are_supported
+  validate :primary_outcome_metric_present
 
   scope :draft, -> { where(status: "draft") }
   scope :running, -> { where(status: "running") }
@@ -91,6 +106,15 @@ class ScalingExperiment < ApplicationRecord
     normalized_values_tested.select { |value| value <= task_count.to_i }
   end
 
+  def cohort_label(task_count:, assigned_value:)
+    format(
+      cohort_label_template,
+      dimension: dimension,
+      value: assigned_value,
+      task_bucket: cohort_task_bucket(task_count:)
+    )
+  end
+
   def sufficient_samples?
     sample_counts = recorded_sample_counts
     normalized_values_tested.all? { |value| sample_counts.fetch(value, 0) >= min_samples_per_value }
@@ -121,7 +145,7 @@ class ScalingExperiment < ApplicationRecord
   private
 
   def normalized_values_tested
-    @normalized_values_tested ||= Array(values_tested).map { |value| Integer(value) }.uniq.sort
+    Array(values_tested).map { |value| Integer(value) }.uniq.sort
   rescue ArgumentError, TypeError
     []
   end
@@ -143,6 +167,21 @@ class ScalingExperiment < ApplicationRecord
     return nil if raw.blank?
 
     raw.to_i
+  end
+
+  def cohort_label_template
+    cohort_settings.fetch("label_template", "%<dimension>s-%<value>s__%<task_bucket>s")
+  end
+
+  def cohort_task_bucket(task_count:)
+    bucket = Array(cohort_settings["task_count_buckets"]).find do |candidate|
+      minimum = candidate["min"].to_i
+      maximum = candidate["max"]
+
+      task_count.to_i >= minimum && (maximum.blank? || task_count.to_i <= maximum.to_i)
+    end
+
+    bucket&.fetch("label", nil) || "tasks-unspecified"
   end
 
   def raise_invalid_status!(action)
@@ -184,5 +223,65 @@ class ScalingExperiment < ApplicationRecord
     return if context_filter.is_a?(Hash)
 
     errors.add(:context_filter, "must be an object")
+  end
+
+  def independent_variables_is_array
+    return if independent_variables.is_a?(Array)
+
+    errors.add(:independent_variables, "must be an array")
+  end
+
+  def outcome_metrics_is_array
+    return if outcome_metrics.is_a?(Array)
+
+    errors.add(:outcome_metrics, "must be an array")
+  end
+
+  def control_definition_is_object
+    return if control_definition.is_a?(Hash)
+
+    errors.add(:control_definition, "must be an object")
+  end
+
+  def cohort_settings_is_object
+    return if cohort_settings.is_a?(Hash)
+
+    errors.add(:cohort_settings, "must be an object")
+  end
+
+  def primary_dimension_variable_matches_plan
+    return unless independent_variables.is_a?(Array)
+
+    primary_variable = independent_variables.find { |variable| variable.is_a?(Hash) && variable["key"] == dimension }
+    if primary_variable.blank?
+      errors.add(:independent_variables, "must include the tested dimension")
+      return
+    end
+
+    variable_values = Array(primary_variable["values"]).map(&:to_i).uniq.sort
+    return if variable_values == normalized_values_tested && primary_variable["control_value"].to_i == control_value
+
+    errors.add(:independent_variables, "must match values_tested and control_value for the tested dimension")
+  end
+
+  def outcome_metrics_are_supported
+    return unless outcome_metrics.is_a?(Array)
+
+    invalid_keys = outcome_metrics.filter_map do |metric|
+      next unless metric.is_a?(Hash)
+
+      key = metric["key"].to_s
+      key unless OUTCOME_METRIC_KEYS.include?(key)
+    end
+    return if invalid_keys.empty?
+
+    errors.add(:outcome_metrics, "contains unsupported keys: #{invalid_keys.sort.join(', ')}")
+  end
+
+  def primary_outcome_metric_present
+    return unless outcome_metrics.is_a?(Array)
+    return if outcome_metrics.any? { |metric| metric.is_a?(Hash) && metric["primary"] == true }
+
+    errors.add(:outcome_metrics, "must include one primary metric")
   end
 end

--- a/app/services/scaling_experiments/assign.rb
+++ b/app/services/scaling_experiments/assign.rb
@@ -62,11 +62,12 @@ module ScalingExperiments
     end
 
     def build_execution_plan(value)
-      {
+      plan = {
         "dimension" => scaling_experiment.dimension,
-        "requested_agent_count" => value,
-        "max_batch_size" => value,
+        "dimension_value" => value,
         "task_count" => task_count,
+        "cohort_label" => scaling_experiment.cohort_label(task_count:, assigned_value: value),
+        "cohort_schedule" => scaling_experiment.cohort_settings.slice("assignment_strategy", "cadence", "assignment_unit"),
         "eligible_values" => scaling_experiment.eligible_values(task_count:),
         "safety_limits" => {
           "task_count_cap" => task_count,
@@ -74,6 +75,20 @@ module ScalingExperiments
           "dependency_order_respected" => true
         }
       }
+
+      case scaling_experiment.dimension
+      when "agent_count"
+        plan.merge!(
+          "requested_agent_count" => value,
+          "max_batch_size" => value
+        )
+      when "max_iterations"
+        plan["max_iterations_per_agent"] = value
+      when "parallelism"
+        plan["max_batch_size"] = value
+      end
+
+      plan
     end
   end
 end

--- a/app/services/scaling_experiments/create.rb
+++ b/app/services/scaling_experiments/create.rb
@@ -5,13 +5,19 @@ module ScalingExperiments
     DEFAULT_CONTEXT_FILTER = {
       "min_task_count" => 2
     }.freeze
+    DEFAULT_TASK_COUNT_BUCKETS = [
+      { "label" => "tasks-2-3", "min" => 2, "max" => 3 },
+      { "label" => "tasks-4-6", "min" => 4, "max" => 6 },
+      { "label" => "tasks-7-plus", "min" => 7 }
+    ].freeze
 
     def self.call(...)
       new(...).call
     end
 
     def initialize(project:, name:, hypothesis:, values_tested:, control_value:, min_samples_per_value: 2,
-      traffic_percentage: 100, context_filter: {}, dimension: "agent_count")
+      traffic_percentage: 100, context_filter: {}, dimension: "agent_count",
+      independent_variables: nil, outcome_metrics: nil, control_definition: nil, cohort_settings: nil)
       @project = project
       @name = name
       @hypothesis = hypothesis
@@ -21,29 +27,138 @@ module ScalingExperiments
       @traffic_percentage = traffic_percentage
       @context_filter = context_filter
       @dimension = dimension
+      @independent_variables = independent_variables
+      @outcome_metrics = outcome_metrics
+      @control_definition = control_definition
+      @cohort_settings = cohort_settings
     end
 
     def call
+      normalized_values = Array(values_tested).map { |value| Integer(value) }.uniq.sort
+      normalized_control_value = Integer(control_value)
+
       ScalingExperiment.create!(
         project: project,
         name: name,
         hypothesis: hypothesis,
         dimension: dimension,
-        values_tested: Array(values_tested).map { |value| Integer(value) }.uniq.sort,
-        control_value: Integer(control_value),
+        values_tested: normalized_values,
+        control_value: normalized_control_value,
         min_samples_per_value: min_samples_per_value,
         traffic_percentage: traffic_percentage,
-        context_filter: normalized_context_filter
+        context_filter: normalized_context_filter,
+        independent_variables: normalized_independent_variables(normalized_values:, normalized_control_value:),
+        outcome_metrics: normalized_outcome_metrics,
+        control_definition: normalized_control_definition,
+        cohort_settings: normalized_cohort_settings
       )
     end
 
     private
 
     attr_reader :project, :name, :hypothesis, :values_tested, :control_value, :min_samples_per_value,
-      :traffic_percentage, :context_filter, :dimension
+      :traffic_percentage, :context_filter, :dimension, :independent_variables, :outcome_metrics,
+      :control_definition, :cohort_settings
 
     def normalized_context_filter
       DEFAULT_CONTEXT_FILTER.merge((context_filter || {}).deep_stringify_keys)
+    end
+
+    def normalized_independent_variables(normalized_values:, normalized_control_value:)
+      if independent_variables.present?
+        return Array(independent_variables).map { |variable| (variable || {}).deep_stringify_keys }
+      end
+
+      [
+        {
+          "key" => dimension,
+          "role" => "primary",
+          "values" => normalized_values,
+          "control_value" => normalized_control_value,
+          "source" => "execution_plan"
+        },
+        {
+          "key" => "task_count",
+          "role" => "stratification",
+          "source" => "scaling_observations.task_count"
+        },
+        {
+          "key" => "dependency_edge_count",
+          "role" => "context",
+          "source" => "scaling_observations.dependency_edge_count"
+        }
+      ]
+    end
+
+    def normalized_outcome_metrics
+      if outcome_metrics.present?
+        return Array(outcome_metrics).map { |metric| (metric || {}).deep_stringify_keys }
+      end
+
+      [
+        {
+          "key" => "success_rate",
+          "primary" => true,
+          "objective" => "maximize",
+          "source" => "scaling_observations.success"
+        },
+        {
+          "key" => "duration_seconds",
+          "primary" => false,
+          "objective" => "minimize",
+          "source" => "scaling_observations.duration_seconds"
+        },
+        {
+          "key" => "total_cost_cents",
+          "primary" => false,
+          "objective" => "minimize",
+          "source" => "scaling_observations.total_cost_cents"
+        },
+        {
+          "key" => "agent_launch_success_rate",
+          "primary" => false,
+          "objective" => "maximize",
+          "source" => "scaling_observations.agent_count_succeeded / agent_count_launched"
+        },
+        {
+          "key" => "blocked_task_rate",
+          "primary" => false,
+          "objective" => "minimize",
+          "source" => "scaling_observations.agent_count_blocked / task_count"
+        }
+      ]
+    end
+
+    def normalized_control_definition
+      return control_definition.deep_stringify_keys if control_definition.present?
+
+      {
+        "baseline_label" => "#{dimension}=#{Integer(control_value)}",
+        "comparison_method" => "within_task_count_bucket",
+        "fairness_conditions" => [
+          "same_project",
+          "same_workflow_name",
+          "same_observation_type",
+          "same_task_count_bucket"
+        ],
+        "guardrails" => [
+          "respect_dependency_order",
+          "respect_project_capacity",
+          "skip_non_parallel_runs"
+        ]
+      }
+    end
+
+    def normalized_cohort_settings
+      return cohort_settings.deep_stringify_keys if cohort_settings.present?
+
+      {
+        "assignment_strategy" => "balanced_underfilled",
+        "cadence" => "continuous",
+        "assignment_unit" => "workflow_id",
+        "label_template" => "%<dimension>s-%<value>s__%<task_bucket>s",
+        "task_count_buckets" => DEFAULT_TASK_COUNT_BUCKETS
+      }
     end
   end
 end

--- a/app/services/scaling_experiments/record_result.rb
+++ b/app/services/scaling_experiments/record_result.rb
@@ -45,6 +45,7 @@ module ScalingExperiments
     def build_outcome_summary
       {
         "observation_id" => scaling_observation.id,
+        "cohort_label" => assignment.execution_plan["cohort_label"],
         "status" => scaling_observation.status,
         "success" => scaling_observation.success,
         "parallel_execution" => scaling_observation.parallel_execution,

--- a/app/services/scaling_experiments/summarize_results.rb
+++ b/app/services/scaling_experiments/summarize_results.rb
@@ -25,6 +25,8 @@ module ScalingExperiments
         "status" => scaling_experiment.sufficient_samples? ? "ready_for_analysis" : "collecting",
         "dimension" => scaling_experiment.dimension,
         "control_value" => scaling_experiment.control_value,
+        "primary_metric" => primary_metric,
+        "cohort_strategy" => scaling_experiment.cohort_settings.slice("assignment_strategy", "cadence", "label_template"),
         "sample_count" => summaries.sum { |summary| summary["sample_count"] },
         "values" => summaries,
         "leading_value" => leader&.fetch("assigned_value", nil),
@@ -35,6 +37,11 @@ module ScalingExperiments
     private
 
     attr_reader :scaling_experiment
+
+    def primary_metric
+      metric = scaling_experiment.outcome_metrics.find { |candidate| candidate["primary"] == true }
+      metric&.fetch("key", nil)
+    end
 
     def value_summaries
       assignments_by_value = scaling_experiment.scaling_experiment_assignments

--- a/db/migrate/20260509045503_add_experiment_plan_fields_to_scaling_experiments.rb
+++ b/db/migrate/20260509045503_add_experiment_plan_fields_to_scaling_experiments.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AddExperimentPlanFieldsToScalingExperiments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :scaling_experiments,
+      :independent_variables,
+      :jsonb,
+      null: false,
+      default: [],
+      comment: "Declared primary and contextual variables for the controlled scaling plan, including the tested arm values."
+    add_column :scaling_experiments,
+      :outcome_metrics,
+      :jsonb,
+      null: false,
+      default: [],
+      comment: "Outcome metrics tracked for the experiment plan, including optimization direction and primary-vs-guardrail roles."
+    add_column :scaling_experiments,
+      :control_definition,
+      :jsonb,
+      null: false,
+      default: {},
+      comment: "Control conditions and fairness guardrails that must hold for cohort-to-cohort comparisons."
+    add_column :scaling_experiments,
+      :cohort_settings,
+      :jsonb,
+      null: false,
+      default: {},
+      comment: "Scheduling and labeling rules for experiment cohorts, such as task buckets and label templates."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_045503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1725,14 +1725,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_034206) do
 
   create_table "scaling_experiments", comment: "Controlled orchestration experiments for measuring how feature outcomes change as the agent count changes.", force: :cascade do |t|
     t.jsonb "cached_summary", default: {}, null: false, comment: "Persisted descriptive summary for later analysis services and polling UIs."
+    t.jsonb "cohort_settings", default: {}, null: false, comment: "Scheduling and labeling rules for experiment cohorts, such as task buckets and label templates."
     t.datetime "completed_at", comment: "Timestamp when the experiment stopped collecting data."
     t.jsonb "context_filter", default: {}, null: false, comment: "Eligibility filter for safely including only comparable workflows in the experiment."
+    t.jsonb "control_definition", default: {}, null: false, comment: "Control conditions and fairness guardrails that must hold for cohort-to-cohort comparisons."
     t.integer "control_value", null: false, comment: "Baseline arm used as the control when comparing experiment results."
     t.datetime "created_at", null: false
     t.string "dimension", limit: 50, default: "agent_count", null: false, comment: "Scaling dimension under test. Agent count is the initial supported dimension."
     t.text "hypothesis", null: false, comment: "Expected scaling behavior being tested, such as diminishing returns after a certain agent count."
+    t.jsonb "independent_variables", default: [], null: false, comment: "Declared primary and contextual variables for the controlled scaling plan, including the tested arm values."
     t.integer "min_samples_per_value", default: 2, null: false, comment: "Minimum number of recorded workflows required for each tested value before the experiment can complete."
     t.string "name", limit: 255, null: false, comment: "Human-readable experiment name displayed in dashboards and logs."
+    t.jsonb "outcome_metrics", default: [], null: false, comment: "Outcome metrics tracked for the experiment plan, including optimization direction and primary-vs-guardrail roles."
     t.bigint "project_id", null: false, comment: "Owning project for tenant isolation and experiment segmentation."
     t.datetime "started_at", comment: "Timestamp when the experiment started assigning workflows."
     t.string "status", limit: 50, default: "draft", null: false, comment: "Lifecycle state for the experiment: draft, running, completed, or cancelled."

--- a/docs/experiments/orchestration_scaling.md
+++ b/docs/experiments/orchestration_scaling.md
@@ -1,0 +1,47 @@
+# Orchestration Scaling Experiment Plan
+
+Issue [#1776](https://github.com/viamin/paid/issues/1776) defines the controlled experiment design for measuring orchestration scaling behavior with fair cohort comparisons.
+
+## Core Independent Variables
+
+- `agent_count`: Primary scaling arm for the first rollout because Paid already records planned and launched agent counts and can safely cap batches through execution plans.
+- `max_iterations`: Follow-on arm for testing refinement depth without changing decomposition shape.
+- `parallelism`: Follow-on arm for testing concurrency limits independently from total task volume.
+- `task_count` and `dependency_edge_count`: Required stratification variables. They are not tuned directly, but they are used to keep comparisons inside comparable workflow cohorts.
+
+Each `ScalingExperiment` stores these variables in `independent_variables`. The experiment `dimension` marks the primary variable under test for that run, while the remaining entries describe context that must stay comparable.
+
+## Outcome Metrics
+
+- `success_rate`: Primary outcome metric. Optimize upward.
+- `duration_seconds`: Efficiency metric. Optimize downward.
+- `total_cost_cents`: Spend metric. Optimize downward.
+- `agent_launch_success_rate`: Reliability metric for child-run execution. Optimize upward.
+- `blocked_task_rate`: Guardrail metric for capacity or dependency starvation. Optimize downward.
+
+These are stored in `outcome_metrics` with `primary` and `objective` metadata so summaries and later analysis can distinguish optimization targets from guardrails.
+
+## Controls And Guardrails
+
+Fair comparisons require the following control conditions:
+
+- Compare only workflows from the same project and orchestration workflow class.
+- Compare only within the same task-count bucket.
+- Preserve dependency order and existing project-capacity checks.
+- Exclude non-parallel runs from recorded experiment outcomes when the orchestration never actually exercised the scaling treatment.
+
+These rules are stored in `control_definition` so the plan travels with the experiment record instead of living only in prose.
+
+## Cohorts
+
+Cohorts are assigned continuously at workflow start with a balanced-underfilled strategy:
+
+- Assignment unit: `workflow_id`
+- Cadence: continuous rollout while the experiment is `running`
+- Labels: `%{dimension}-%{value}__%{task_bucket}`
+- Default task buckets:
+  - `tasks-2-3`
+  - `tasks-4-6`
+  - `tasks-7-plus`
+
+The schedule and label template live in `cohort_settings`, and each assignment copies its resolved cohort label into `execution_plan["cohort_label"]`.

--- a/spec/factories/scaling_experiment_assignments.rb
+++ b/spec/factories/scaling_experiment_assignments.rb
@@ -9,7 +9,15 @@ FactoryBot.define do
     sequence(:workflow_id) { |n| "scaling-workflow-#{n}" }
     assigned_value { 1 }
     outcome_status { "assigned" }
-    execution_plan { { "max_batch_size" => assigned_value, "requested_agent_count" => assigned_value } }
+    execution_plan do
+      {
+        "dimension" => scaling_experiment.dimension,
+        "dimension_value" => assigned_value,
+        "requested_agent_count" => assigned_value,
+        "max_batch_size" => assigned_value,
+        "cohort_label" => "agent_count-#{assigned_value}__tasks-2-3"
+      }
+    end
     outcome_summary { {} }
   end
 end

--- a/spec/factories/scaling_experiments.rb
+++ b/spec/factories/scaling_experiments.rb
@@ -9,6 +9,58 @@ FactoryBot.define do
     values_tested { [ 1, 2, 4 ] }
     control_value { 1 }
     context_filter { { "min_task_count" => 2 } }
+    independent_variables do
+      [
+        {
+          "key" => dimension,
+          "role" => "primary",
+          "values" => values_tested,
+          "control_value" => control_value,
+          "source" => "execution_plan"
+        },
+        {
+          "key" => "task_count",
+          "role" => "stratification",
+          "source" => "scaling_observations.task_count"
+        }
+      ]
+    end
+    outcome_metrics do
+      [
+        {
+          "key" => "success_rate",
+          "primary" => true,
+          "objective" => "maximize",
+          "source" => "scaling_observations.success"
+        },
+        {
+          "key" => "duration_seconds",
+          "primary" => false,
+          "objective" => "minimize",
+          "source" => "scaling_observations.duration_seconds"
+        }
+      ]
+    end
+    control_definition do
+      {
+        "comparison_method" => "within_task_count_bucket",
+        "fairness_conditions" => [ "same_project", "same_task_count_bucket" ],
+        "guardrails" => [ "respect_dependency_order", "skip_non_parallel_runs" ]
+      }
+    end
+    cohort_settings do
+      {
+        "assignment_strategy" => "balanced_underfilled",
+        "cadence" => "continuous",
+        "assignment_unit" => "workflow_id",
+        "label_template" => "%<dimension>s-%<value>s__%<task_bucket>s",
+        "task_count_buckets" => [
+          { "label" => "tasks-2-3", "min" => 2, "max" => 3 },
+          { "label" => "tasks-4-6", "min" => 4, "max" => 6 },
+          { "label" => "tasks-7-plus", "min" => 7 }
+        ]
+      }
+    end
     status { "running" }
     min_samples_per_value { 2 }
     traffic_percentage { 100 }

--- a/spec/models/scaling_experiment_spec.rb
+++ b/spec/models/scaling_experiment_spec.rb
@@ -10,6 +10,28 @@ RSpec.describe ScalingExperiment do
     it { is_expected.to validate_presence_of(:hypothesis) }
     it { is_expected.to validate_inclusion_of(:dimension).in_array(described_class::DIMENSIONS) }
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+
+    it "requires one primary outcome metric" do
+      scaling_experiment.outcome_metrics = [ { "key" => "success_rate", "primary" => false } ]
+
+      expect(scaling_experiment).not_to be_valid
+      expect(scaling_experiment.errors[:outcome_metrics]).to include("must include one primary metric")
+    end
+
+    it "requires the tested dimension to match the plan values" do
+      scaling_experiment.independent_variables = [
+        {
+          "key" => "agent_count",
+          "role" => "primary",
+          "values" => [ 1, 2 ],
+          "control_value" => 1
+        }
+      ]
+
+      expect(scaling_experiment).not_to be_valid
+      expect(scaling_experiment.errors[:independent_variables])
+        .to include("must match values_tested and control_value for the tested dimension")
+    end
   end
 
   describe ".active_for" do
@@ -29,6 +51,14 @@ RSpec.describe ScalingExperiment do
       expect(
         described_class.active_for(project: project, dimension: "agent_count", workflow_id: "wf-1", task_count: 3)
       ).to be_nil
+    end
+  end
+
+  describe "#cohort_label" do
+    it "formats the configured task bucket into a stable cohort label" do
+      experiment = build(:scaling_experiment)
+
+      expect(experiment.cohort_label(task_count: 5, assigned_value: 2)).to eq("agent_count-2__tasks-4-6")
     end
   end
 end

--- a/spec/services/scaling_experiments/assign_spec.rb
+++ b/spec/services/scaling_experiments/assign_spec.rb
@@ -7,6 +7,28 @@ RSpec.describe ScalingExperiments::Assign do
   let(:issue) { create(:issue, project: project) }
   let(:experiment) { create(:scaling_experiment, project: project, values_tested: [ 1, 2, 4 ]) }
 
+  def configure_iteration_experiment!
+    experiment.update!(
+      dimension: "max_iterations",
+      values_tested: [ 1, 3, 5 ],
+      control_value: 1,
+      independent_variables: [
+        {
+          "key" => "max_iterations",
+          "role" => "primary",
+          "values" => [ 1, 3, 5 ],
+          "control_value" => 1,
+          "source" => "execution_plan"
+        },
+        {
+          "key" => "task_count",
+          "role" => "stratification",
+          "source" => "scaling_observations.task_count"
+        }
+      ]
+    )
+  end
+
   it "creates a workflow-scoped assignment with a safe execution plan" do
     assignment = described_class.call(
       scaling_experiment: experiment,
@@ -21,8 +43,10 @@ RSpec.describe ScalingExperiments::Assign do
     expect(assignment.workflow_id).to eq("wf-123")
     expect(assignment.execution_plan).to include(
       "dimension" => "agent_count",
+      "dimension_value" => assignment.assigned_value,
       "task_count" => 4
     )
+    expect(assignment.execution_plan["cohort_label"]).to eq("agent_count-#{assignment.assigned_value}__tasks-4-6")
   end
 
   it "reuses the existing assignment for the same workflow" do
@@ -69,5 +93,22 @@ RSpec.describe ScalingExperiments::Assign do
     )
 
     expect(assignment).to be_nil
+  end
+
+  it "builds a dimension-specific execution plan for iteration experiments" do
+    configure_iteration_experiment!
+
+    assignment = described_class.call(
+      scaling_experiment: experiment,
+      project: project,
+      workflow_id: "wf-iteration",
+      task_count: 4
+    )
+
+    expect(assignment.execution_plan).to include(
+      "dimension" => "max_iterations",
+      "dimension_value" => assignment.assigned_value,
+      "max_iterations_per_agent" => assignment.assigned_value
+    )
   end
 end

--- a/spec/services/scaling_experiments/create_spec.rb
+++ b/spec/services/scaling_experiments/create_spec.rb
@@ -5,21 +5,39 @@ require "rails_helper"
 RSpec.describe ScalingExperiments::Create do
   describe ".call" do
     let(:project) { create(:project) }
-
-    it "creates a draft experiment with safe defaults" do
-      experiment = described_class.call(
+    let(:experiment) do
+      described_class.call(
         project: project,
         name: "Agent Count Scaling",
         hypothesis: "More agents improve success until returns flatten.",
         values_tested: [ 4, 1, 2, 2 ],
         control_value: 1
       )
+    end
 
+    it "creates a draft experiment with normalized values and context defaults" do
       expect(experiment).to be_persisted
       expect(experiment.project).to eq(project)
       expect(experiment.status).to eq("draft")
       expect(experiment.values_tested).to eq([ 1, 2, 4 ])
       expect(experiment.context_filter).to include("min_task_count" => 2)
+    end
+
+    it "stores the experiment plan defaults for analysis and cohort scheduling" do
+      expect(experiment.independent_variables).to include(
+        hash_including("key" => "agent_count", "values" => [ 1, 2, 4 ], "control_value" => 1)
+      )
+      expect(experiment.outcome_metrics).to include(
+        hash_including("key" => "success_rate", "primary" => true, "objective" => "maximize")
+      )
+      expect(experiment.control_definition).to include(
+        "comparison_method" => "within_task_count_bucket",
+        "guardrails" => array_including("respect_dependency_order")
+      )
+      expect(experiment.cohort_settings).to include(
+        "assignment_strategy" => "balanced_underfilled",
+        "label_template" => "%<dimension>s-%<value>s__%<task_bucket>s"
+      )
     end
   end
 end

--- a/spec/services/scaling_experiments/record_result_spec.rb
+++ b/spec/services/scaling_experiments/record_result_spec.rb
@@ -32,9 +32,22 @@ RSpec.describe ScalingExperiments::RecordResult do
       issue: issue,
       workflow_id: workflow_id,
       assigned_value: assigned_value,
-      execution_plan: { "max_batch_size" => assigned_value, "requested_agent_count" => assigned_value })
+      execution_plan: {
+        "max_batch_size" => assigned_value,
+        "requested_agent_count" => assigned_value,
+        "cohort_label" => experiment.cohort_label(task_count: assigned_value, assigned_value: assigned_value)
+      })
 
     described_class.call(assignment: assignment, scaling_observation: observation)
+  end
+
+  def expect_recorded_summary(assignment)
+    expect(assignment.outcome_summary).to include(
+      "cohort_label" => "agent_count-2__tasks-2-3",
+      "status" => "completed",
+      "success" => true,
+      "total_cost_cents" => 350
+    )
   end
 
   it "captures a normalized outcome snapshot and refreshes the experiment summary" do
@@ -50,13 +63,10 @@ RSpec.describe ScalingExperiments::RecordResult do
     experiment.reload
 
     expect(assignment.outcome_status).to eq("recorded")
-    expect(assignment.outcome_summary).to include(
-      "status" => "completed",
-      "success" => true,
-      "total_cost_cents" => 350
-    )
+    expect_recorded_summary(assignment)
     expect(experiment.cached_summary).to include(
       "status" => "collecting",
+      "primary_metric" => "success_rate",
       "sample_count" => 1,
       "values" => array_including(hash_including("assigned_value" => 2, "sample_count" => 1))
     )


### PR DESCRIPTION
## Summary

Implemented the scaling experiment plan and committed it as `db0ce7b` (`feat(scaling): define orchestration experiment plans`).

The change extends `ScalingExperiment` to store structured experiment-plan data for independent variables, outcome metrics, control conditions, and cohort scheduling/labels; propagates cohort labels into assignment/execution metadata; and adds [docs/experiments/orchestration_scaling.md](/workspace/docs/experiments/orchestration_scaling.md:1) to document the controlled experiment design for `#1776`. It also adds the supporting migration and updates specs/factories around the new plan schema.

Verification passed with `bundle exec rubocop` and `bundle exec rspec`. The full suite finished with `11440 examples, 0 failures, 3 pending` (the pending cases are the existing Qdrant/browser-dependent ones). The worktree is clean.

---

Closes #1776