### PR TITLE
feat(scaling): implement scaling-based resource allocator

### DIFF
--- a/app/services/scaling/allocation_inputs.rb
+++ b/app/services/scaling/allocation_inputs.rb
@@ -3,7 +3,7 @@
 module Scaling
   class AllocationInputs
     attr_reader :task_count, :budget_cents, :max_agent_count, :max_duration_seconds,
-                :dependency_edge_count, :parallelizable_group_count
+                :dependency_edge_count, :parallelizable_group_count, :max_parallelism
 
     def initialize(
       task_count:,
@@ -11,7 +11,8 @@ module Scaling
       max_agent_count: 8,
       max_duration_seconds: 0,
       dependency_edge_count: 0,
-      parallelizable_group_count: 0
+      parallelizable_group_count: 0,
+      max_parallelism: nil
     )
       @task_count = Integer(task_count)
       @budget_cents = Integer(budget_cents)
@@ -19,6 +20,7 @@ module Scaling
       @max_duration_seconds = Integer(max_duration_seconds)
       @dependency_edge_count = Integer(dependency_edge_count)
       @parallelizable_group_count = Integer(parallelizable_group_count)
+      @max_parallelism = max_parallelism.nil? ? nil : Integer(max_parallelism)
 
       validate!
       freeze
@@ -45,6 +47,11 @@ module Scaling
       parallelism_potential * 0.4 + edge_density * 0.3 + (1.0 / task_count) * 0.3
     end
 
+    def parallelism_limit
+      configured_limit = max_parallelism if max_parallelism&.positive?
+      [ configured_limit || task_count, task_count ].min
+    end
+
     private
 
     def validate!
@@ -54,6 +61,7 @@ module Scaling
       raise ArgumentError, "max_duration_seconds must be non-negative" if max_duration_seconds.negative?
       raise ArgumentError, "dependency_edge_count must be non-negative" if dependency_edge_count.negative?
       raise ArgumentError, "parallelizable_group_count must be non-negative" if parallelizable_group_count.negative?
+      raise ArgumentError, "max_parallelism must be non-negative" if max_parallelism&.negative?
     end
   end
 end

--- a/app/services/scaling/allocation_inputs.rb
+++ b/app/services/scaling/allocation_inputs.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Scaling
+  class AllocationInputs
+    STALE_THRESHOLD_SECONDS = 7.days.to_i
+
+    attr_reader :task_count, :budget_cents, :max_agent_count, :max_duration_seconds,
+                :dependency_edge_count, :parallelizable_group_count
+
+    def initialize(
+      task_count:,
+      budget_cents: 0,
+      max_agent_count: 8,
+      max_duration_seconds: 0,
+      dependency_edge_count: 0,
+      parallelizable_group_count: 0
+    )
+      @task_count = Integer(task_count)
+      @budget_cents = Integer(budget_cents)
+      @max_agent_count = Integer(max_agent_count)
+      @max_duration_seconds = Integer(max_duration_seconds)
+      @dependency_edge_count = Integer(dependency_edge_count)
+      @parallelizable_group_count = Integer(parallelizable_group_count)
+
+      validate!
+      freeze
+    end
+
+    def budget_constrained?
+      budget_cents.positive?
+    end
+
+    def time_constrained?
+      max_duration_seconds.positive?
+    end
+
+    def parallelism_potential
+      return 0.0 if task_count.zero?
+
+      parallelizable_group_count.to_f / task_count
+    end
+
+    def complexity_score
+      return 0.0 if task_count.zero?
+
+      edge_density = dependency_edge_count.to_f / task_count
+      parallelism_potential * 0.4 + edge_density * 0.3 + (1.0 / task_count) * 0.3
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "task_count must be positive" unless task_count.positive?
+      raise ArgumentError, "budget_cents must be non-negative" if budget_cents.negative?
+      raise ArgumentError, "max_agent_count must be positive" unless max_agent_count.positive?
+      raise ArgumentError, "max_duration_seconds must be non-negative" if max_duration_seconds.negative?
+      raise ArgumentError, "dependency_edge_count must be non-negative" if dependency_edge_count.negative?
+      raise ArgumentError, "parallelizable_group_count must be non-negative" if parallelizable_group_count.negative?
+    end
+  end
+end

--- a/app/services/scaling/allocation_inputs.rb
+++ b/app/services/scaling/allocation_inputs.rb
@@ -2,8 +2,6 @@
 
 module Scaling
   class AllocationInputs
-    STALE_THRESHOLD_SECONDS = 7.days.to_i
-
     attr_reader :task_count, :budget_cents, :max_agent_count, :max_duration_seconds,
                 :dependency_edge_count, :parallelizable_group_count
 

--- a/app/services/scaling/allocation_inputs.rb
+++ b/app/services/scaling/allocation_inputs.rb
@@ -61,7 +61,7 @@ module Scaling
       raise ArgumentError, "max_duration_seconds must be non-negative" if max_duration_seconds.negative?
       raise ArgumentError, "dependency_edge_count must be non-negative" if dependency_edge_count.negative?
       raise ArgumentError, "parallelizable_group_count must be non-negative" if parallelizable_group_count.negative?
-      raise ArgumentError, "max_parallelism must be non-negative" if max_parallelism&.negative?
+      raise ArgumentError, "max_parallelism must be positive" if max_parallelism && !max_parallelism.positive?
     end
   end
 end

--- a/app/services/scaling/allocation_inputs.rb
+++ b/app/services/scaling/allocation_inputs.rb
@@ -61,6 +61,7 @@ module Scaling
       raise ArgumentError, "max_duration_seconds must be non-negative" if max_duration_seconds.negative?
       raise ArgumentError, "dependency_edge_count must be non-negative" if dependency_edge_count.negative?
       raise ArgumentError, "parallelizable_group_count must be non-negative" if parallelizable_group_count.negative?
+      raise ArgumentError, "parallelizable_group_count must not exceed task_count" if parallelizable_group_count > task_count
       raise ArgumentError, "max_parallelism must be positive" if max_parallelism && !max_parallelism.positive?
     end
   end

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -273,7 +273,8 @@ module Scaling
     end
 
     def summary_value(summary, key, default: nil)
-      summary[key] || summary[key.to_s] || default
+      val = summary.fetch(key) { summary.fetch(key.to_s, default) }
+      val.nil? ? default : val
     end
 
     def parallelism_cap(agent_count)

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -42,7 +42,6 @@ module Scaling
     private
 
     def allocate_from_observations
-      grouped = group_by_agent_count
       return allocate_fallback if grouped.empty?
 
       best_value = find_optimal_agent_count(grouped)

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -58,23 +58,24 @@ module Scaling
     end
 
     def allocate_from_experiments
-      best_summary = experiment_summaries.max_by do |summary|
+      best_summary = usable_experiment_summaries.max_by do |summary|
         [
-          summary[:success_rate] || 0.0,
-          -(summary[:avg_duration_seconds] || Float::INFINITY)
+          summary_value(summary, :success_rate, default: 0.0),
+          -summary_value(summary, :avg_duration_seconds, default: Float::INFINITY)
         ]
       end
       return allocate_fallback unless best_summary
 
-      value = best_summary[:assigned_value] || best_summary[:value]
+      value = summary_value(best_summary, :assigned_value) || summary_value(best_summary, :value)
       return allocate_fallback unless value
 
+      agent_count = clamp_agents(value)
       build_allocation(
-        agent_count: clamp_agents(value),
+        agent_count: agent_count,
         max_iterations: 3,
-        parallelism_level: [ value, inputs.parallelizable_group_count ].min,
+        parallelism_level: [ agent_count, inputs.parallelizable_group_count ].min,
         source: :experiment,
-        reason: "experiment leading value=#{value} success_rate=#{format_rate(best_summary[:success_rate])}"
+        reason: "experiment leading value=#{value} success_rate=#{format_rate(summary_value(best_summary, :success_rate, default: 0.0))}"
       )
     end
 
@@ -99,12 +100,7 @@ module Scaling
     end
 
     def experiment_summaries_usable?
-      return false if experiment_summaries.empty?
-
-      experiment_summaries.any? do |summary|
-        (summary[:sample_count] || 0) >= MIN_OBSERVATIONS_FOR_CONFIDENCE &&
-          (summary[:success_rate] || 0.0) > MIN_SUCCESS_RATE_FOR_LEARNING
-      end
+      usable_experiment_summaries.any?
     end
 
     def group_by_agent_count
@@ -217,7 +213,7 @@ module Scaling
                              observations_with_cost.sum { |obs| obs.agent_count_launched.to_i }
         if avg_cost_per_agent.positive?
           max_affordable = (inputs.budget_cents / avg_cost_per_agent).floor
-          return [ agent_count, max_affordable ].min
+          return [ agent_count, [ max_affordable, 1 ].max ].min
         end
       end
 
@@ -232,6 +228,17 @@ module Scaling
 
     def grouped
       @grouped ||= group_by_agent_count
+    end
+
+    def usable_experiment_summaries
+      @usable_experiment_summaries ||= experiment_summaries.select do |summary|
+        summary_value(summary, :sample_count, default: 0) >= MIN_OBSERVATIONS_FOR_CONFIDENCE &&
+          summary_value(summary, :success_rate, default: 0.0) > MIN_SUCCESS_RATE_FOR_LEARNING
+      end
+    end
+
+    def summary_value(summary, key, default: nil)
+      summary[key] || summary[key.to_s] || default
     end
 
     def fallback_reason

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+module Scaling
+  class ResourceAllocator
+    Allocation = Struct.new(
+      :agent_count,
+      :max_iterations,
+      :parallelism_level,
+      :source,
+      :reason,
+      :metrics,
+      keyword_init: true
+    )
+
+    MIN_OBSERVATIONS_FOR_CONFIDENCE = 5
+    STALE_THRESHOLD = 7.days
+    MIN_SUCCESS_RATE_FOR_LEARNING = 0.3
+    DIMINISHING_RETURNS_THRESHOLD = 0.05
+
+    attr_reader :inputs, :observations, :experiment_summaries
+
+    def initialize(inputs:, observations: [], experiment_summaries: [])
+      @inputs = inputs
+      @observations = observations
+      @experiment_summaries = experiment_summaries
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      if observations_fresh_and_sufficient?
+        allocate_from_observations
+      elsif experiment_summaries_usable?
+        allocate_from_experiments
+      else
+        allocate_fallback
+      end
+    end
+
+    private
+
+    def allocate_from_observations
+      grouped = group_by_agent_count
+      return allocate_fallback if grouped.empty?
+
+      best_value = find_optimal_agent_count(grouped)
+      iterations = recommend_iterations(grouped, best_value)
+      parallelism = recommend_parallelism(grouped, best_value)
+
+      build_allocation(
+        agent_count: clamp_agents(best_value),
+        max_iterations: iterations,
+        parallelism_level: parallelism,
+        source: :observations,
+        reason: observation_reason(grouped, best_value)
+      )
+    end
+
+    def allocate_from_experiments
+      best_summary = experiment_summaries.max_by do |summary|
+        [
+          summary[:success_rate] || 0.0,
+          -(summary[:avg_duration_seconds] || Float::INFINITY)
+        ]
+      end
+      return allocate_fallback unless best_summary
+
+      value = best_summary[:assigned_value] || best_summary[:value]
+      return allocate_fallback unless value
+
+      build_allocation(
+        agent_count: clamp_agents(value),
+        max_iterations: 3,
+        parallelism_level: [ value, inputs.parallelizable_group_count ].min,
+        source: :experiment,
+        reason: "experiment leading value=#{value} success_rate=#{format_rate(best_summary[:success_rate])}"
+      )
+    end
+
+    def allocate_fallback
+      conservative_agents = conservative_agent_count
+      build_allocation(
+        agent_count: conservative_agents,
+        max_iterations: 3,
+        parallelism_level: [ conservative_agents, inputs.parallelizable_group_count ].min,
+        source: :fallback,
+        reason: fallback_reason
+      )
+    end
+
+    def observations_fresh_and_sufficient?
+      return false if observations.size < MIN_OBSERVATIONS_FOR_CONFIDENCE
+
+      latest = observations.max_by(&:created_at)
+      return false unless latest
+
+      latest.created_at > STALE_THRESHOLD.ago
+    end
+
+    def experiment_summaries_usable?
+      return false if experiment_summaries.empty?
+
+      experiment_summaries.any? do |summary|
+        (summary[:sample_count] || 0) >= MIN_OBSERVATIONS_FOR_CONFIDENCE &&
+          (summary[:success_rate] || 0.0) > MIN_SUCCESS_RATE_FOR_LEARNING
+      end
+    end
+
+    def group_by_agent_count
+      observations
+        .select { |obs| obs.agent_count_launched.to_i.positive? }
+        .group_by { |obs| obs.agent_count_launched.to_i }
+        .transform_values { |group| compute_group_stats(group) }
+        .select { |_value, stats| stats[:count] >= 2 }
+    end
+
+    def compute_group_stats(group)
+      success_rate = group.count(&:success).to_f / group.size
+      avg_duration = group.sum(&:duration_seconds).to_f / group.size
+      avg_cost = group.sum(&:total_cost_cents).to_f / group.size
+      avg_iterations = group.sum { |obs| obs.total_iterations.to_i }.to_f / group.size
+
+      {
+        count: group.size,
+        success_rate: success_rate,
+        avg_duration_seconds: avg_duration,
+        avg_cost_cents: avg_cost,
+        avg_iterations: avg_iterations,
+        observations: group
+      }
+    end
+
+    def find_optimal_agent_count(grouped)
+      sorted_values = grouped.keys.sort
+      return sorted_values.first if sorted_values.size == 1
+
+      scored = sorted_values.map do |value|
+        stats = grouped[value]
+        score = compute_allocation_score(stats, value, sorted_values)
+        { value: value, score: score }
+      end
+
+      best = scored.max_by { |entry| entry[:score] }
+      best[:value]
+    end
+
+    def compute_allocation_score(stats, value, sorted_values)
+      success_weight = 0.5
+      cost_weight = 0.3
+      duration_weight = 0.2
+
+      max_cost = sorted_values.map { |v| grouped[v][:avg_cost_cents] }.max.to_f
+      max_duration = sorted_values.map { |v| grouped[v][:avg_duration_seconds] }.max.to_f
+
+      cost_efficiency = max_cost.positive? ? 1.0 - (stats[:avg_cost_cents] / max_cost) : 0.5
+      duration_efficiency = max_duration.positive? ? 1.0 - (stats[:avg_duration_seconds] / max_duration) : 0.5
+
+      diminishing_penalty = compute_diminishing_penalty(value, sorted_values)
+
+      raw_score = (stats[:success_rate] * success_weight) +
+                  (cost_efficiency * cost_weight) +
+                  (duration_efficiency * duration_weight) -
+                  diminishing_penalty
+
+      [ raw_score, 0.0 ].max
+    end
+
+    def compute_diminishing_penalty(value, sorted_values)
+      return 0.0 if sorted_values.size < 2
+      return 0.0 unless sorted_values.include?(value)
+
+      idx = sorted_values.index(value)
+      return 0.0 if idx.zero?
+
+      prev_value = sorted_values[idx - 1]
+      prev_stats = grouped[prev_value]
+      curr_stats = grouped[value]
+      return 0.0 unless prev_stats && curr_stats
+
+      marginal_improvement = curr_stats[:success_rate] - prev_stats[:success_rate]
+      return 0.0 unless marginal_improvement < DIMINISHING_RETURNS_THRESHOLD
+
+      marginal_improvement.abs * 2.0
+    end
+
+    def recommend_iterations(grouped, best_value)
+      stats = grouped[best_value]
+      return 3 unless stats
+
+      observed = stats[:avg_iterations].round
+      [ [ observed, 1 ].max, 10 ].min
+    end
+
+    def recommend_parallelism(grouped, best_value)
+      stats = grouped[best_value]
+      observed = stats&.dig(:observations)&.map { |obs| obs.parallelism_observed.to_i } || []
+
+      return [ best_value, inputs.parallelizable_group_count ].min if observed.empty?
+
+      avg_parallelism = (observed.sum.to_f / observed.size).round
+      [ avg_parallelism, best_value, inputs.parallelizable_group_count ].min
+    end
+
+    def conservative_agent_count
+      base = [ inputs.task_count, 2 ].min
+      base = [ base, inputs.max_agent_count ].min
+      apply_budget_cap(base)
+    end
+
+    def apply_budget_cap(agent_count)
+      return agent_count unless inputs.budget_constrained?
+
+      observations_with_cost = observations.select { |obs| obs.total_cost_cents.to_i.positive? }
+      if observations_with_cost.any?
+        avg_cost_per_agent = observations_with_cost.sum(&:total_cost_cents).to_f /
+                             observations_with_cost.sum { |obs| obs.agent_count_launched.to_i }
+        if avg_cost_per_agent.positive?
+          max_affordable = (inputs.budget_cents / avg_cost_per_agent).floor
+          return [ agent_count, max_affordable ].min
+        end
+      end
+
+      agent_count
+    end
+
+    def clamp_agents(value)
+      clamped = value.clamp(1, inputs.max_agent_count)
+      clamped = [ clamped, inputs.task_count ].min
+      apply_budget_cap(clamped)
+    end
+
+    def grouped
+      @grouped ||= group_by_agent_count
+    end
+
+    def fallback_reason
+      reasons = []
+      reasons << "insufficient observations (#{observations.size}/#{MIN_OBSERVATIONS_FOR_CONFIDENCE})"
+      reasons << "no usable experiment data" unless experiment_summaries_usable?
+      reasons.join("; ")
+    end
+
+    def observation_reason(grouped, best_value)
+      stats = grouped[best_value]
+      "best observed agent_count=#{best_value} " \
+        "success_rate=#{format_rate(stats[:success_rate])} " \
+        "n=#{stats[:count]}"
+    end
+
+    def build_allocation(agent_count:, max_iterations:, parallelism_level:, source:, reason:)
+      Allocation.new(
+        agent_count: agent_count,
+        max_iterations: max_iterations,
+        parallelism_level: parallelism_level,
+        source: source,
+        reason: reason,
+        metrics: {
+          observation_count: observations.size,
+          experiment_summary_count: experiment_summaries.size,
+          task_count: inputs.task_count,
+          complexity_score: inputs.complexity_score.round(4),
+          parallelism_potential: inputs.parallelism_potential.round(4)
+        }
+      )
+    end
+
+    def format_rate(value)
+      format("%.2f%%", (value || 0.0) * 100)
+    end
+  end
+end

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -92,12 +92,11 @@ module Scaling
     end
 
     def observations_fresh_and_sufficient?
-      return false if observations.size < MIN_OBSERVATIONS_FOR_CONFIDENCE
+      fresh_observations.size >= MIN_OBSERVATIONS_FOR_CONFIDENCE
+    end
 
-      latest = observations.max_by(&:created_at)
-      return false unless latest
-
-      latest.created_at > STALE_THRESHOLD.ago
+    def fresh_observations
+      @fresh_observations ||= observations.select { |obs| obs.created_at > STALE_THRESHOLD.ago }
     end
 
     def experiment_summaries_usable?
@@ -105,7 +104,7 @@ module Scaling
     end
 
     def group_by_agent_count
-      observations
+      fresh_observations
         .select { |obs| obs.agent_count_launched.to_i.positive? }
         .group_by { |obs| obs.agent_count_launched.to_i }
         .transform_values { |group| compute_group_stats(group) }
@@ -208,17 +207,37 @@ module Scaling
     def apply_budget_cap(agent_count)
       return agent_count unless inputs.budget_constrained?
 
-      observations_with_cost = observations.select { |obs| obs.total_cost_cents.to_i.positive? }
-      if observations_with_cost.any?
-        avg_cost_per_agent = observations_with_cost.sum(&:total_cost_cents).to_f /
-                             observations_with_cost.sum { |obs| obs.agent_count_launched.to_i }
-        if avg_cost_per_agent.positive?
-          max_affordable = (inputs.budget_cents / avg_cost_per_agent).floor
-          return [ agent_count, [ max_affordable, 1 ].max ].min
-        end
+      avg_cost_per_agent = avg_cost_per_agent_from_observations
+      avg_cost_per_agent ||= avg_cost_per_agent_from_experiments
+
+      if avg_cost_per_agent&.positive?
+        max_affordable = (inputs.budget_cents / avg_cost_per_agent).floor
+        return [ agent_count, [ max_affordable, 1 ].max ].min
       end
 
       agent_count
+    end
+
+    def avg_cost_per_agent_from_observations
+      observations_with_cost = observations.select { |obs| obs.total_cost_cents.to_i.positive? }
+      return nil unless observations_with_cost.any?
+
+      total_cost = observations_with_cost.sum(&:total_cost_cents).to_f
+      total_agents = observations_with_cost.sum { |obs| obs.agent_count_launched.to_i }
+      return nil unless total_agents.positive?
+
+      total_cost / total_agents
+    end
+
+    def avg_cost_per_agent_from_experiments
+      values_with_cost = normalized_experiment_values.select do |v|
+        cost = summary_value(v, :avg_cost_cents, default: 0)
+        cost.to_f.positive?
+      end
+      return nil unless values_with_cost.any?
+
+      total_cost = values_with_cost.sum { |v| summary_value(v, :avg_cost_cents, default: 0).to_f }
+      total_cost / values_with_cost.size
     end
 
     def clamp_agents(value)
@@ -232,9 +251,24 @@ module Scaling
     end
 
     def usable_experiment_summaries
-      @usable_experiment_summaries ||= experiment_summaries.select do |summary|
+      @usable_experiment_summaries ||= normalized_experiment_values.select do |summary|
         summary_value(summary, :sample_count, default: 0) >= MIN_OBSERVATIONS_FOR_CONFIDENCE &&
           summary_value(summary, :success_rate, default: 0.0) > MIN_SUCCESS_RATE_FOR_LEARNING
+      end
+    end
+
+    # Normalizes experiment summaries to a flat per-value format.
+    # Accepts both flat value hashes (already per-value) and the nested
+    # cached_summary shape produced by ScalingExperiments::SummarizeResults,
+    # which wraps per-value data in a top-level hash with a "values" array.
+    def normalized_experiment_values
+      @normalized_experiment_values ||= experiment_summaries.flat_map do |summary|
+        values = summary_value(summary, :values)
+        if values.is_a?(Array)
+          values
+        else
+          [ summary ]
+        end
       end
     end
 

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -47,11 +47,12 @@ module Scaling
       best_value = find_optimal_agent_count(grouped)
       iterations = recommend_iterations(grouped, best_value)
       parallelism = recommend_parallelism(grouped, best_value)
+      agent_count = clamp_agents(best_value)
 
       build_allocation(
-        agent_count: clamp_agents(best_value),
+        agent_count: agent_count,
         max_iterations: iterations,
-        parallelism_level: parallelism,
+        parallelism_level: [ parallelism, agent_count ].min,
         source: :observations,
         reason: observation_reason(grouped, best_value)
       )
@@ -263,7 +264,7 @@ module Scaling
       Allocation.new(
         agent_count: agent_count,
         max_iterations: max_iterations,
-        parallelism_level: parallelism_level,
+        parallelism_level: [ parallelism_level, agent_count ].min,
         source: source,
         reason: reason,
         metrics: {

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -73,7 +73,7 @@ module Scaling
       build_allocation(
         agent_count: agent_count,
         max_iterations: 3,
-        parallelism_level: [ agent_count, inputs.parallelizable_group_count ].min,
+        parallelism_level: parallelism_cap(agent_count),
         source: :experiment,
         reason: "experiment leading value=#{value} success_rate=#{format_rate(summary_value(best_summary, :success_rate, default: 0.0))}"
       )
@@ -84,7 +84,7 @@ module Scaling
       build_allocation(
         agent_count: conservative_agents,
         max_iterations: 3,
-        parallelism_level: [ conservative_agents, inputs.parallelizable_group_count ].min,
+        parallelism_level: parallelism_cap(conservative_agents),
         source: :fallback,
         reason: fallback_reason
       )
@@ -113,7 +113,7 @@ module Scaling
 
     def compute_group_stats(group)
       success_rate = group.count(&:success).to_f / group.size
-      avg_duration = group.sum(&:duration_seconds).to_f / group.size
+      avg_duration = group.sum { |obs| obs.duration_seconds.to_i }.to_f / group.size
       avg_cost = group.sum(&:total_cost_cents).to_f / group.size
       avg_iterations = group.sum { |obs| obs.total_iterations.to_i }.to_f / group.size
 
@@ -192,10 +192,10 @@ module Scaling
       stats = grouped[best_value]
       observed = stats&.dig(:observations)&.map { |obs| obs.parallelism_observed.to_i } || []
 
-      return [ best_value, inputs.parallelizable_group_count ].min if observed.empty?
+      return parallelism_cap(best_value) if observed.empty?
 
       avg_parallelism = (observed.sum.to_f / observed.size).round
-      [ avg_parallelism, best_value, inputs.parallelizable_group_count ].min
+      parallelism_cap([ avg_parallelism, best_value ].min)
     end
 
     def conservative_agent_count
@@ -239,6 +239,10 @@ module Scaling
 
     def summary_value(summary, key, default: nil)
       summary[key] || summary[key.to_s] || default
+    end
+
+    def parallelism_cap(agent_count)
+      [ agent_count, inputs.parallelism_limit ].min
     end
 
     def fallback_reason

--- a/spec/services/scaling/allocation_inputs_spec.rb
+++ b/spec/services/scaling/allocation_inputs_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe Scaling::AllocationInputs do
       expect { described_class.new(task_count: 3, dependency_edge_count: -1) }.to raise_error(ArgumentError, /dependency_edge_count must be non-negative/)
     end
 
+    it "raises when parallelizable groups exceed task count" do
+      expect do
+        described_class.new(task_count: 3, parallelizable_group_count: 4)
+      end.to raise_error(ArgumentError, /parallelizable_group_count must not exceed task_count/)
+    end
+
     it "raises on zero max_parallelism" do
       expect { described_class.new(task_count: 3, max_parallelism: 0) }.to raise_error(ArgumentError, /max_parallelism must be positive/)
     end

--- a/spec/services/scaling/allocation_inputs_spec.rb
+++ b/spec/services/scaling/allocation_inputs_spec.rb
@@ -51,8 +51,12 @@ RSpec.describe Scaling::AllocationInputs do
       expect { described_class.new(task_count: 3, dependency_edge_count: -1) }.to raise_error(ArgumentError, /dependency_edge_count must be non-negative/)
     end
 
+    it "raises on zero max_parallelism" do
+      expect { described_class.new(task_count: 3, max_parallelism: 0) }.to raise_error(ArgumentError, /max_parallelism must be positive/)
+    end
+
     it "raises on negative max_parallelism" do
-      expect { described_class.new(task_count: 3, max_parallelism: -1) }.to raise_error(ArgumentError, /max_parallelism must be non-negative/)
+      expect { described_class.new(task_count: 3, max_parallelism: -1) }.to raise_error(ArgumentError, /max_parallelism must be positive/)
     end
 
     it "is frozen" do

--- a/spec/services/scaling/allocation_inputs_spec.rb
+++ b/spec/services/scaling/allocation_inputs_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Scaling::AllocationInputs do
+  describe ".new" do
+    it "creates inputs with valid parameters" do
+      inputs = described_class.new(
+        task_count: 5,
+        budget_cents: 1000,
+        max_agent_count: 4,
+        max_duration_seconds: 300,
+        dependency_edge_count: 3,
+        parallelizable_group_count: 2
+      )
+
+      expect(inputs.task_count).to eq(5)
+      expect(inputs.budget_cents).to eq(1000)
+      expect(inputs.max_agent_count).to eq(4)
+      expect(inputs.max_duration_seconds).to eq(300)
+      expect(inputs.dependency_edge_count).to eq(3)
+      expect(inputs.parallelizable_group_count).to eq(2)
+    end
+
+    it "applies defaults for optional parameters" do
+      inputs = described_class.new(task_count: 3)
+
+      expect(inputs.budget_cents).to eq(0)
+      expect(inputs.max_agent_count).to eq(8)
+      expect(inputs.max_duration_seconds).to eq(0)
+      expect(inputs.dependency_edge_count).to eq(0)
+      expect(inputs.parallelizable_group_count).to eq(0)
+    end
+
+    it "raises on zero task_count" do
+      expect { described_class.new(task_count: 0) }.to raise_error(ArgumentError, /task_count must be positive/)
+    end
+
+    it "raises on negative budget_cents" do
+      expect { described_class.new(task_count: 3, budget_cents: -1) }.to raise_error(ArgumentError, /budget_cents must be non-negative/)
+    end
+
+    it "raises on zero max_agent_count" do
+      expect { described_class.new(task_count: 3, max_agent_count: 0) }.to raise_error(ArgumentError, /max_agent_count must be positive/)
+    end
+
+    it "raises on negative dependency_edge_count" do
+      expect { described_class.new(task_count: 3, dependency_edge_count: -1) }.to raise_error(ArgumentError, /dependency_edge_count must be non-negative/)
+    end
+
+    it "is frozen" do
+      inputs = described_class.new(task_count: 3)
+      expect(inputs).to be_frozen
+    end
+  end
+
+  describe "#budget_constrained?" do
+    it "returns true when budget is positive" do
+      inputs = described_class.new(task_count: 3, budget_cents: 500)
+      expect(inputs).to be_budget_constrained
+    end
+
+    it "returns false when budget is zero" do
+      inputs = described_class.new(task_count: 3)
+      expect(inputs).not_to be_budget_constrained
+    end
+  end
+
+  describe "#time_constrained?" do
+    it "returns true when duration is positive" do
+      inputs = described_class.new(task_count: 3, max_duration_seconds: 600)
+      expect(inputs).to be_time_constrained
+    end
+
+    it "returns false when duration is zero" do
+      inputs = described_class.new(task_count: 3)
+      expect(inputs).not_to be_time_constrained
+    end
+  end
+
+  describe "#parallelism_potential" do
+    it "returns ratio of parallelizable groups to tasks" do
+      inputs = described_class.new(task_count: 4, parallelizable_group_count: 2)
+      expect(inputs.parallelism_potential).to eq(0.5)
+    end
+
+    it "returns 0 when no parallelizable groups" do
+      inputs = described_class.new(task_count: 4)
+      expect(inputs.parallelism_potential).to eq(0.0)
+    end
+
+    it "returns 1.0 when all tasks are parallelizable" do
+      inputs = described_class.new(task_count: 4, parallelizable_group_count: 4)
+      expect(inputs.parallelism_potential).to eq(1.0)
+    end
+  end
+
+  describe "#complexity_score" do
+    it "returns a float between 0 and 1" do
+      inputs = described_class.new(
+        task_count: 4,
+        dependency_edge_count: 2,
+        parallelizable_group_count: 2
+      )
+      expect(inputs.complexity_score).to be_between(0.0, 1.0)
+    end
+
+    it "returns 0 for a single task with no edges or parallelism" do
+      inputs = described_class.new(task_count: 1)
+      expect(inputs.complexity_score).to eq(0.3)
+    end
+  end
+end

--- a/spec/services/scaling/allocation_inputs_spec.rb
+++ b/spec/services/scaling/allocation_inputs_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Scaling::AllocationInputs do
         max_agent_count: 4,
         max_duration_seconds: 300,
         dependency_edge_count: 3,
-        parallelizable_group_count: 2
+        parallelizable_group_count: 2,
+        max_parallelism: 4
       )
 
       expect(inputs.task_count).to eq(5)
@@ -20,6 +21,7 @@ RSpec.describe Scaling::AllocationInputs do
       expect(inputs.max_duration_seconds).to eq(300)
       expect(inputs.dependency_edge_count).to eq(3)
       expect(inputs.parallelizable_group_count).to eq(2)
+      expect(inputs.max_parallelism).to eq(4)
     end
 
     it "applies defaults for optional parameters" do
@@ -30,6 +32,7 @@ RSpec.describe Scaling::AllocationInputs do
       expect(inputs.max_duration_seconds).to eq(0)
       expect(inputs.dependency_edge_count).to eq(0)
       expect(inputs.parallelizable_group_count).to eq(0)
+      expect(inputs.max_parallelism).to be_nil
     end
 
     it "raises on zero task_count" do
@@ -46,6 +49,10 @@ RSpec.describe Scaling::AllocationInputs do
 
     it "raises on negative dependency_edge_count" do
       expect { described_class.new(task_count: 3, dependency_edge_count: -1) }.to raise_error(ArgumentError, /dependency_edge_count must be non-negative/)
+    end
+
+    it "raises on negative max_parallelism" do
+      expect { described_class.new(task_count: 3, max_parallelism: -1) }.to raise_error(ArgumentError, /max_parallelism must be non-negative/)
     end
 
     it "is frozen" do
@@ -108,6 +115,23 @@ RSpec.describe Scaling::AllocationInputs do
     it "returns 0 for a single task with no edges or parallelism" do
       inputs = described_class.new(task_count: 1)
       expect(inputs.complexity_score).to eq(0.3)
+    end
+  end
+
+  describe "#parallelism_limit" do
+    it "uses the configured max parallelism when present" do
+      inputs = described_class.new(task_count: 6, max_parallelism: 4)
+      expect(inputs.parallelism_limit).to eq(4)
+    end
+
+    it "falls back to task_count when max parallelism is unspecified" do
+      inputs = described_class.new(task_count: 6)
+      expect(inputs.parallelism_limit).to eq(6)
+    end
+
+    it "never exceeds task_count" do
+      inputs = described_class.new(task_count: 3, max_parallelism: 8)
+      expect(inputs.parallelism_limit).to eq(3)
     end
   end
 end

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -141,6 +141,31 @@ RSpec.describe Scaling::ResourceAllocator do
         expect(result.reason).to include("experiment leading value=2")
       end
 
+      it "supports string-keyed experiment summaries" do
+        summaries = [
+          { "assigned_value" => 1, "success_rate" => 0.4, "avg_duration_seconds" => 300, "sample_count" => 10 },
+          { "assigned_value" => 2, "success_rate" => 0.8, "avg_duration_seconds" => 150, "sample_count" => 10 }
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(2)
+      end
+
+      it "ignores unusable experiment cohorts when selecting the leader" do
+        summaries = [
+          { assigned_value: 1, success_rate: 0.31, avg_duration_seconds: 300, sample_count: 10 },
+          { assigned_value: 2, success_rate: 1.0, avg_duration_seconds: 100, sample_count: 1 },
+          { assigned_value: 3, success_rate: 0.9, avg_duration_seconds: 90, sample_count: 2 }
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(1)
+      end
+
       it "falls back when experiment sample counts are too low" do
         summaries = [
           { assigned_value: 2, success_rate: 0.9, avg_duration_seconds: 100, sample_count: 2 }
@@ -203,7 +228,19 @@ RSpec.describe Scaling::ResourceAllocator do
 
         result = described_class.call(inputs: inputs, observations: observations)
 
-        expect(result.agent_count).to be <= 4
+        expect(result.agent_count).to eq(1)
+      end
+
+      it "never returns zero agents when the budget is below observed per-agent cost" do
+        inputs = Scaling::AllocationInputs.new(task_count: 8, max_agent_count: 8, budget_cents: 10)
+        observations = [
+          *4.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120) },
+          *4.times.map { build_observation(agent_count: 4, success: true, total_cost_cents: 200, duration_seconds: 80) }
+        ]
+
+        result = described_class.call(inputs: inputs, observations: observations)
+
+        expect(result.agent_count).to eq(1)
       end
     end
 

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe Scaling::ResourceAllocator do
       it "allocates based on the best-performing agent count" do
         observations = [
           *3.times.map { build_observation(agent_count: 1, success: false, total_cost_cents: 50, duration_seconds: 200) },
-          *3.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120) },
-          *3.times.map { build_observation(agent_count: 4, success: true, total_cost_cents: 250, duration_seconds: 80) }
+          *3.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 200, duration_seconds: 200) },
+          *3.times.map { build_observation(agent_count: 4, success: true, total_cost_cents: 150, duration_seconds: 80) }
         ]
 
         result = described_class.call(inputs: default_inputs, observations: observations)
@@ -164,7 +164,7 @@ RSpec.describe Scaling::ResourceAllocator do
       end
     end
 
-    context "preferring observations over experiments" do
+    context "when both observations and experiments are available" do
       it "uses observations when both sources are available and sufficient" do
         observations = 6.times.map do
           build_observation(agent_count: 3, success: true, total_cost_cents: 150, duration_seconds: 100)
@@ -221,7 +221,7 @@ RSpec.describe Scaling::ResourceAllocator do
       end
     end
 
-    context "allocation struct" do
+    context "with allocation struct" do
       it "includes metrics about the decision context" do
         result = described_class.call(inputs: default_inputs)
 
@@ -235,7 +235,7 @@ RSpec.describe Scaling::ResourceAllocator do
       end
     end
 
-    context "iteration recommendation" do
+    context "with iteration recommendation" do
       it "recommends iterations based on observed average" do
         observations = 6.times.map do
           build_observation(agent_count: 2, success: true, total_iterations: 5, duration_seconds: 120)
@@ -267,7 +267,7 @@ RSpec.describe Scaling::ResourceAllocator do
       end
     end
 
-    context "parallelism recommendation" do
+    context "with parallelism recommendation" do
       it "limits parallelism to parallelizable group count" do
         inputs = Scaling::AllocationInputs.new(
           task_count: 6,
@@ -344,7 +344,7 @@ RSpec.describe Scaling::ResourceAllocator do
       end
     end
 
-    context "edge case: all observations fail" do
+    context "when all observations fail" do
       it "still allocates based on cost/duration efficiency" do
         observations = [
           *3.times.map { build_observation(agent_count: 1, success: false, total_cost_cents: 50, duration_seconds: 100) },
@@ -358,14 +358,15 @@ RSpec.describe Scaling::ResourceAllocator do
       end
     end
 
-    context "edge case: observations with only one agent count group"
-    it "picks the single available value" do
-      observations = Array.new(6) do
-        build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120)
-      end
+    context "with only one agent count group in observations" do
+      it "picks the single available value" do
+        observations = Array.new(6) do
+          build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120)
+        end
 
-      result = described_class.call(inputs: default_inputs, observations: observations)
-      expect(result.agent_count).to eq(2)
+        result = described_class.call(inputs: default_inputs, observations: observations)
+        expect(result.agent_count).to eq(2)
+      end
     end
   end
 end

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -91,6 +91,20 @@ RSpec.describe Scaling::ResourceAllocator do
         result = described_class.call(inputs: default_inputs, observations: observations)
         expect(result.source).to eq(:fallback)
       end
+
+      it "excludes stale observations from scoring even when fresh ones exist" do
+        stale_high_count = 4.times.map do
+          build_observation(agent_count: 4, success: true, total_cost_cents: 100, duration_seconds: 80, created_at: 10.days.ago)
+        end
+        fresh_low_count = 6.times.map do
+          build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120)
+        end
+
+        result = described_class.call(inputs: default_inputs, observations: stale_high_count + fresh_low_count)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to eq(2)
+      end
     end
 
     context "with fresh sufficient observations showing clear winner" do
@@ -203,6 +217,41 @@ RSpec.describe Scaling::ResourceAllocator do
         result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
 
         expect(result.source).to eq(:fallback)
+      end
+    end
+
+    context "with nested cached_summary format from SummarizeResults" do
+      it "extracts per-value data from the values array" do
+        summaries = [
+          {
+            "status" => "ready_for_analysis",
+            "dimension" => "agent_count",
+            "sample_count" => 20,
+            "values" => [
+              { "assigned_value" => 1, "success_rate" => 0.4, "avg_duration_seconds" => 300, "sample_count" => 10, "avg_cost_cents" => 50.0 },
+              { "assigned_value" => 2, "success_rate" => 0.8, "avg_duration_seconds" => 150, "sample_count" => 10, "avg_cost_cents" => 100.0 }
+            ]
+          }
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(2)
+      end
+    end
+
+    context "with experiment-based budget constraint" do
+      it "caps agent count using experiment avg_cost_cents when no observations exist" do
+        inputs = Scaling::AllocationInputs.new(task_count: 8, max_agent_count: 8, budget_cents: 150)
+        summaries = [
+          { assigned_value: 4, success_rate: 0.8, avg_duration_seconds: 100, sample_count: 10, avg_cost_cents: 100.0 }
+        ]
+
+        result = described_class.call(inputs: inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(1)
       end
     end
 

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -1,0 +1,371 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Scaling::ResourceAllocator do
+  let(:default_inputs) { Scaling::AllocationInputs.new(task_count: 4, max_agent_count: 8) }
+
+  def build_observation(agent_count:, success:, created_at: Time.current, **overrides)
+    ScalingObservation.new(
+      project: build(:project),
+      workflow_id: SecureRandom.uuid,
+      workflow_name: "TestWorkflow",
+      observation_type: "feature_orchestration",
+      status: "completed",
+      success: success,
+      parallel_execution: true,
+      task_count: 4,
+      agent_count_planned: agent_count,
+      agent_count_launched: agent_count,
+      agent_count_succeeded: success ? agent_count : 0,
+      agent_count_failed: success ? 0 : agent_count,
+      agent_count_blocked: 0,
+      total_iterations: overrides.fetch(:total_iterations, 3),
+      max_iterations: 2,
+      parallelism_planned: agent_count,
+      parallelism_observed: overrides.fetch(:parallelism_observed, agent_count),
+      batch_count: agent_count,
+      duration_seconds: overrides.fetch(:duration_seconds, 120),
+      total_cost_cents: overrides.fetch(:total_cost_cents, 100 * agent_count),
+      total_input_tokens: 500,
+      total_output_tokens: 200,
+      metadata: {}
+    ) do |obs|
+      obs.created_at = created_at
+    end
+  end
+
+  describe ".call" do
+    context "with no observations or experiments" do
+      it "returns a fallback allocation" do
+        result = described_class.call(inputs: default_inputs)
+
+        expect(result.source).to eq(:fallback)
+        expect(result.agent_count).to be_positive
+        expect(result.max_iterations).to be_positive
+        expect(result.reason).to include("insufficient observations")
+      end
+
+      it "clamps agent count to task_count as a safe default" do
+        inputs = Scaling::AllocationInputs.new(task_count: 3, max_agent_count: 8)
+        result = described_class.call(inputs: inputs)
+
+        expect(result.agent_count).to be <= 3
+      end
+    end
+
+    context "with too few observations" do
+      it "returns fallback when below minimum observation threshold" do
+        observations = 4.times.map do
+          build_observation(agent_count: 2, success: true)
+        end
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+        expect(result.source).to eq(:fallback)
+      end
+    end
+
+    context "with stale observations" do
+      it "returns fallback when all observations are older than threshold" do
+        observations = 6.times.map do
+          build_observation(
+            agent_count: 2,
+            success: true,
+            created_at: 10.days.ago
+          )
+        end
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+        expect(result.source).to eq(:fallback)
+      end
+    end
+
+    context "with fresh sufficient observations showing clear winner" do
+      it "allocates based on the best-performing agent count" do
+        observations = [
+          *3.times.map { build_observation(agent_count: 1, success: false, total_cost_cents: 50, duration_seconds: 200) },
+          *3.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120) },
+          *3.times.map { build_observation(agent_count: 4, success: true, total_cost_cents: 250, duration_seconds: 80) }
+        ]
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to eq(4)
+        expect(result.reason).to include("agent_count=4")
+      end
+    end
+
+    context "with observations showing diminishing returns" do
+      it "penalizes agent counts beyond diminishing returns threshold" do
+        observations = [
+          *3.times.map { build_observation(agent_count: 1, success: false, total_cost_cents: 50, duration_seconds: 300) },
+          *3.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 150) },
+          *3.times.map { build_observation(agent_count: 4, success: true, total_cost_cents: 400, duration_seconds: 140) },
+          *3.times.map { build_observation(agent_count: 8, success: true, total_cost_cents: 800, duration_seconds: 130) }
+        ]
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to be <= 4
+      end
+    end
+
+    context "with observations where higher agent counts fail" do
+      it "prefers lower agent counts when they succeed more" do
+        observations = [
+          *4.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120) },
+          *4.times.map { build_observation(agent_count: 4, success: false, total_cost_cents: 300, duration_seconds: 180) }
+        ]
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to eq(2)
+      end
+    end
+
+    context "with experiment summaries but no observations" do
+      it "allocates based on the experiment's leading value" do
+        summaries = [
+          { assigned_value: 1, success_rate: 0.4, avg_duration_seconds: 300, sample_count: 10 },
+          { assigned_value: 2, success_rate: 0.8, avg_duration_seconds: 150, sample_count: 10 },
+          { assigned_value: 4, success_rate: 0.6, avg_duration_seconds: 120, sample_count: 10 }
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(2)
+        expect(result.reason).to include("experiment leading value=2")
+      end
+
+      it "falls back when experiment sample counts are too low" do
+        summaries = [
+          { assigned_value: 2, success_rate: 0.9, avg_duration_seconds: 100, sample_count: 2 }
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:fallback)
+      end
+    end
+
+    context "with experiment summaries where success rate is very low" do
+      it "falls back when no experiment summary meets minimum success rate" do
+        summaries = [
+          { assigned_value: 2, success_rate: 0.1, avg_duration_seconds: 300, sample_count: 10 }
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:fallback)
+      end
+    end
+
+    context "preferring observations over experiments" do
+      it "uses observations when both sources are available and sufficient" do
+        observations = 6.times.map do
+          build_observation(agent_count: 3, success: true, total_cost_cents: 150, duration_seconds: 100)
+        end
+        summaries = [
+          { assigned_value: 1, success_rate: 0.9, avg_duration_seconds: 80, sample_count: 20 }
+        ]
+
+        result = described_class.call(inputs: default_inputs, observations: observations, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:observations)
+      end
+    end
+
+    context "with budget constraint" do
+      it "caps agent count to what the budget allows based on observed costs" do
+        inputs = Scaling::AllocationInputs.new(task_count: 8, max_agent_count: 8, budget_cents: 300)
+        observations = [
+          *4.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120) },
+          *4.times.map { build_observation(agent_count: 4, success: true, total_cost_cents: 500, duration_seconds: 80) }
+        ]
+
+        result = described_class.call(inputs: inputs, observations: observations)
+
+        avg_cost_per_agent = observations.sum(&:total_cost_cents).to_f /
+                             observations.sum { |obs| obs.agent_count_launched.to_i }
+        max_affordable = (300 / avg_cost_per_agent).floor
+        expect(result.agent_count).to be <= [ max_affordable, 4 ].min
+      end
+
+      it "applies budget cap to fallback allocation" do
+        inputs = Scaling::AllocationInputs.new(task_count: 4, max_agent_count: 8, budget_cents: 50)
+        observations = 6.times.map do
+          build_observation(agent_count: 2, success: true, total_cost_cents: 200, duration_seconds: 120)
+        end
+
+        result = described_class.call(inputs: inputs, observations: observations)
+
+        expect(result.agent_count).to be <= 4
+      end
+    end
+
+    context "with max_agent_count constraint" do
+      it "never exceeds max_agent_count even if observations suggest higher" do
+        inputs = Scaling::AllocationInputs.new(task_count: 8, max_agent_count: 2)
+        observations = [
+          *4.times.map { build_observation(agent_count: 1, success: false, total_cost_cents: 50, duration_seconds: 300) },
+          *4.times.map { build_observation(agent_count: 4, success: true, total_cost_cents: 200, duration_seconds: 80) }
+        ]
+
+        result = described_class.call(inputs: inputs, observations: observations)
+
+        expect(result.agent_count).to be <= 2
+      end
+    end
+
+    context "allocation struct" do
+      it "includes metrics about the decision context" do
+        result = described_class.call(inputs: default_inputs)
+
+        expect(result.metrics).to include(
+          observation_count: be_a(Integer),
+          experiment_summary_count: be_a(Integer),
+          task_count: 4,
+          complexity_score: be_a(Float),
+          parallelism_potential: be_a(Float)
+        )
+      end
+    end
+
+    context "iteration recommendation" do
+      it "recommends iterations based on observed average" do
+        observations = 6.times.map do
+          build_observation(agent_count: 2, success: true, total_iterations: 5, duration_seconds: 120)
+        end
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.max_iterations).to eq(5)
+      end
+
+      it "clamps iterations to minimum of 1" do
+        observations = 6.times.map do
+          build_observation(agent_count: 2, success: true, total_iterations: 0, duration_seconds: 120)
+        end
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.max_iterations).to be >= 1
+      end
+
+      it "clamps iterations to maximum of 10" do
+        observations = 6.times.map do
+          build_observation(agent_count: 2, success: true, total_iterations: 50, duration_seconds: 120)
+        end
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.max_iterations).to be <= 10
+      end
+    end
+
+    context "parallelism recommendation" do
+      it "limits parallelism to parallelizable group count" do
+        inputs = Scaling::AllocationInputs.new(
+          task_count: 6,
+          max_agent_count: 8,
+          parallelizable_group_count: 2
+        )
+        observations = 6.times.map do
+          build_observation(
+            agent_count: 4,
+            success: true,
+            parallelism_observed: 4,
+            duration_seconds: 120
+          )
+        end
+
+        result = described_class.call(inputs: inputs, observations: observations)
+
+        expect(result.parallelism_level).to be <= 2
+      end
+
+      it "limits parallelism to agent count" do
+        inputs = Scaling::AllocationInputs.new(
+          task_count: 4,
+          max_agent_count: 2,
+          parallelizable_group_count: 4
+        )
+        observations = 6.times.map do
+          build_observation(agent_count: 2, success: true, parallelism_observed: 2, duration_seconds: 120)
+        end
+
+        result = described_class.call(inputs: inputs, observations: observations)
+
+        expect(result.parallelism_level).to be <= 2
+      end
+    end
+
+    context "with mixed success rates across agent counts" do
+      it "selects the agent count with the best composite score" do
+        observations = [
+          *3.times.map { build_observation(agent_count: 1, success: true, total_cost_cents: 50, duration_seconds: 200) },
+          *3.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120) },
+          *3.times.map { build_observation(agent_count: 3, success: true, total_cost_cents: 150, duration_seconds: 110) }
+        ]
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to be_between(1, 4)
+      end
+    end
+
+    context "with single observation group" do
+      it "picks the only available agent count" do
+        observations = 6.times.map do
+          build_observation(agent_count: 3, success: true, total_cost_cents: 150, duration_seconds: 100)
+        end
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.agent_count).to eq(3)
+      end
+    end
+
+    context "with observations having zero cost" do
+      it "still produces a valid allocation" do
+        observations = 6.times.map do
+          build_observation(agent_count: 2, success: true, total_cost_cents: 0, duration_seconds: 100)
+        end
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to be_positive
+      end
+    end
+
+    context "edge case: all observations fail" do
+      it "still allocates based on cost/duration efficiency" do
+        observations = [
+          *3.times.map { build_observation(agent_count: 1, success: false, total_cost_cents: 50, duration_seconds: 100) },
+          *3.times.map { build_observation(agent_count: 4, success: false, total_cost_cents: 400, duration_seconds: 300) }
+        ]
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to eq(1)
+      end
+    end
+
+    context "edge case: observations with only one agent count group"
+    it "picks the single available value" do
+      observations = Array.new(6) do
+        build_observation(agent_count: 2, success: true, total_cost_cents: 100, duration_seconds: 120)
+      end
+
+      result = described_class.call(inputs: default_inputs, observations: observations)
+      expect(result.agent_count).to eq(2)
+    end
+  end
+end

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe Scaling::ResourceAllocator do
 
         expect(result.agent_count).to be <= 3
       end
+
+      it "caps fallback parallelism by max parallelism width" do
+        inputs = Scaling::AllocationInputs.new(
+          task_count: 4,
+          max_agent_count: 8,
+          parallelizable_group_count: 1,
+          max_parallelism: 4
+        )
+
+        result = described_class.call(inputs: inputs)
+
+        expect(result.parallelism_level).to eq(2)
+      end
     end
 
     context "with too few observations" do
@@ -151,6 +164,22 @@ RSpec.describe Scaling::ResourceAllocator do
 
         expect(result.source).to eq(:experiment)
         expect(result.agent_count).to eq(2)
+      end
+
+      it "caps experiment parallelism by max parallelism width" do
+        inputs = Scaling::AllocationInputs.new(
+          task_count: 4,
+          max_agent_count: 8,
+          parallelizable_group_count: 1,
+          max_parallelism: 4
+        )
+        summaries = [
+          { assigned_value: 4, success_rate: 0.8, avg_duration_seconds: 150, sample_count: 10 }
+        ]
+
+        result = described_class.call(inputs: inputs, experiment_summaries: summaries)
+
+        expect(result.parallelism_level).to eq(4)
       end
 
       it "ignores unusable experiment cohorts when selecting the leader" do
@@ -305,11 +334,12 @@ RSpec.describe Scaling::ResourceAllocator do
     end
 
     context "with parallelism recommendation" do
-      it "limits parallelism to parallelizable group count" do
+      it "limits parallelism to configured max parallelism width" do
         inputs = Scaling::AllocationInputs.new(
           task_count: 6,
           max_agent_count: 8,
-          parallelizable_group_count: 2
+          parallelizable_group_count: 2,
+          max_parallelism: 2
         )
         observations = 6.times.map do
           build_observation(
@@ -329,7 +359,7 @@ RSpec.describe Scaling::ResourceAllocator do
         inputs = Scaling::AllocationInputs.new(
           task_count: 4,
           max_agent_count: 2,
-          parallelizable_group_count: 4
+          max_parallelism: 4
         )
         observations = 6.times.map do
           build_observation(agent_count: 2, success: true, parallelism_observed: 2, duration_seconds: 120)
@@ -338,6 +368,31 @@ RSpec.describe Scaling::ResourceAllocator do
         result = described_class.call(inputs: inputs, observations: observations)
 
         expect(result.parallelism_level).to be <= 2
+      end
+
+      it "uses max parallelism width instead of parallel group count" do
+        inputs = Scaling::AllocationInputs.new(
+          task_count: 4,
+          max_agent_count: 8,
+          parallelizable_group_count: 1,
+          max_parallelism: 4
+        )
+        observations = 6.times.map do
+          build_observation(agent_count: 4, success: true, parallelism_observed: 4, duration_seconds: 120)
+        end
+
+        result = described_class.call(inputs: inputs, observations: observations)
+
+        expect(result.parallelism_level).to eq(4)
+      end
+
+      it "treats nil durations as zero when averaging observation cohorts" do
+        observations = [
+          *3.times.map { build_observation(agent_count: 2, success: true, duration_seconds: nil) },
+          *3.times.map { build_observation(agent_count: 2, success: true, duration_seconds: 120) }
+        ]
+
+        expect { described_class.call(inputs: default_inputs, observations: observations) }.not_to raise_error
       end
     end
 

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -180,6 +180,18 @@ RSpec.describe Scaling::ResourceAllocator do
         expect(result.agent_count).to eq(2)
       end
 
+      it "preserves explicit zero durations when ranking experiment leaders" do
+        summaries = [
+          { assigned_value: 1, success_rate: 0.8, avg_duration_seconds: 10, sample_count: 10 },
+          { assigned_value: 2, success_rate: 0.8, avg_duration_seconds: 0, sample_count: 10 }
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(2)
+      end
+
       it "caps experiment parallelism by max parallelism width" do
         inputs = Scaling::AllocationInputs.new(
           task_count: 4,

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -370,6 +370,23 @@ RSpec.describe Scaling::ResourceAllocator do
         expect(result.parallelism_level).to be <= 2
       end
 
+      it "caps observed parallelism after clamping the chosen agent count" do
+        inputs = Scaling::AllocationInputs.new(
+          task_count: 8,
+          max_agent_count: 2,
+          max_parallelism: 8
+        )
+        observations = [
+          *4.times.map { build_observation(agent_count: 1, success: false, total_cost_cents: 50, duration_seconds: 300) },
+          *4.times.map { build_observation(agent_count: 4, success: true, parallelism_observed: 4, total_cost_cents: 200, duration_seconds: 80) }
+        ]
+
+        result = described_class.call(inputs: inputs, observations: observations)
+
+        expect(result.agent_count).to eq(2)
+        expect(result.parallelism_level).to eq(2)
+      end
+
       it "uses max parallelism width instead of parallel group count" do
         inputs = Scaling::AllocationInputs.new(
           task_count: 4,


### PR DESCRIPTION
## Summary

OK.

Now let me read the key files to understand the patterns and design the allocator.

Now let me read the existing patterns for value objects and specs.

Let me also check the existing factories and service directory structure.

Now I have a complete understanding of the codebase. Let me implement the scaling-based resource allocator. I'll create:

1. `Scaling::AllocationInputs` - value object for allocator inputs
2. `Scaling::ResourceAllocator` - the main allocator service
3. Comprehensive specs

Now let me write the specs:

Now let me run the tests:

The gem installation is going one at a time. Let me try a different approach - install all failing gems at once:

The issue is a permission problem with the cache directory. Let me fix this:

---

Closes #1780