### PR TITLE
feat(scaling): analyze orchestration parallelism effects

### DIFF
--- a/app/services/scaling_experiments/summarize_results.rb
+++ b/app/services/scaling_experiments/summarize_results.rb
@@ -12,6 +12,7 @@ module ScalingExperiments
 
     def call
       summaries = value_summaries
+      analysis = parallelism_analysis
       control = summaries.find { |summary| summary["assigned_value"] == scaling_experiment.control_value }
       leader = summaries.max_by do |summary|
         [
@@ -27,6 +28,8 @@ module ScalingExperiments
         "control_value" => scaling_experiment.control_value,
         "sample_count" => summaries.sum { |summary| summary["sample_count"] },
         "values" => summaries,
+        "parallelism_analysis" => analysis,
+        "allocator_decision" => analysis["allocator_decision"],
         "leading_value" => leader&.fetch("assigned_value", nil),
         "improvement_over_control" => improvement_over_control(control:, leader:)
       }.compact
@@ -35,6 +38,13 @@ module ScalingExperiments
     private
 
     attr_reader :scaling_experiment
+
+    def recorded_observations
+      @recorded_observations ||= scaling_experiment.scaling_experiment_assignments
+        .recorded
+        .includes(:scaling_observation)
+        .filter_map(&:scaling_observation)
+    end
 
     def value_summaries
       assignments_by_value = scaling_experiment.scaling_experiment_assignments
@@ -56,6 +66,10 @@ module ScalingExperiments
           "status_tally" => observations.map(&:status).tally
         }
       end
+    end
+
+    def parallelism_analysis
+      ScalingObservations::AnalyzeParallelism.call(observations: recorded_observations).to_h
     end
 
     def improvement_over_control(control:, leader:)

--- a/app/services/scaling_observations/analyze_parallelism.rb
+++ b/app/services/scaling_observations/analyze_parallelism.rb
@@ -69,7 +69,7 @@ module ScalingObservations
           rows = grouped.fetch(agent_count)
           previous = summaries.last
 
-          summaries << build_value_summary(agent_count:, observations: rows, previous:)
+          summaries << build_value_summary(agent_count:, rows:, previous:)
         end
 
         summaries
@@ -99,7 +99,9 @@ module ScalingObservations
     end
 
     def recommendation
-      @recommendation ||= begin
+      return @recommendation if defined?(@recommendation)
+
+      @recommendation = begin
         candidate = recommendable_values.max_by do |value|
           [
             value["success_rate"],
@@ -140,19 +142,19 @@ module ScalingObservations
       candidate.fetch("sample_count", 0) >= (min_samples * 2) ? "high" : "medium"
     end
 
-    def build_value_summary(agent_count:, observations:, previous:)
-      sample_count = observations.size
-      success_rate = rate(observations, &:success)
-      avg_duration_seconds = average(observations, &:duration_seconds)
-      avg_cost_cents = average(observations, &:total_cost_cents)
-      avg_parallelism_observed = average(observations, &:parallelism_observed)
+    def build_value_summary(agent_count:, rows:, previous:)
+      sample_count = rows.size
+      success_rate = rate(rows, &:success)
+      avg_duration_seconds = average(rows, &:duration_seconds)
+      avg_cost_cents = average(rows, &:total_cost_cents)
+      avg_parallelism_observed = average(rows, &:parallelism_observed)
       launch_rate = ratio(
-        observations.sum(&:agent_count_launched),
-        observations.sum(&:agent_count_planned)
+        rows.sum(&:agent_count_launched),
+        rows.sum(&:agent_count_planned)
       )
       blocked_rate = ratio(
-        observations.sum(&:agent_count_blocked),
-        observations.sum(&:agent_count_planned)
+        rows.sum(&:agent_count_blocked),
+        rows.sum(&:agent_count_planned)
       )
 
       marginal_duration_improvement_ratio = duration_improvement_ratio(previous, avg_duration_seconds)

--- a/app/services/scaling_observations/analyze_parallelism.rb
+++ b/app/services/scaling_observations/analyze_parallelism.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+module ScalingObservations
+  class AnalyzeParallelism
+    Result = Struct.new(
+      :status,
+      :sample_count,
+      :recommended_agent_count,
+      :recommended_max_batch_size,
+      :diminishing_returns_at,
+      :threshold_signal_at,
+      :allocator_decision,
+      :values,
+      keyword_init: true
+    ) do
+      def to_h
+        {
+          "status" => status,
+          "sample_count" => sample_count,
+          "recommended_agent_count" => recommended_agent_count,
+          "recommended_max_batch_size" => recommended_max_batch_size,
+          "diminishing_returns_at" => diminishing_returns_at,
+          "threshold_signal_at" => threshold_signal_at,
+          "allocator_decision" => allocator_decision,
+          "values" => values
+        }.compact
+      end
+    end
+
+    MIN_DURATION_IMPROVEMENT_RATIO = 0.10
+    SUCCESS_RATE_DROP_THRESHOLD = 0.15
+    BLOCKED_RATE_THRESHOLD = 0.20
+    LAUNCH_RATE_THRESHOLD = 0.85
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(observations:, min_samples: 2)
+      @observations = Array(observations).select(&:parallel_execution)
+      @min_samples = min_samples.to_i
+    end
+
+    def call
+      return Result.new(status: "insufficient_data", sample_count: 0, values: []) if grouped_values.empty?
+
+      Result.new(
+        status: analysis_status,
+        sample_count: grouped_values.sum { |value| value["sample_count"] },
+        recommended_agent_count: recommendation&.fetch("requested_agent_count", nil),
+        recommended_max_batch_size: recommendation&.fetch("max_batch_size", nil),
+        diminishing_returns_at: diminishing_returns_at,
+        threshold_signal_at: threshold_signal_at,
+        allocator_decision: recommendation,
+        values: grouped_values
+      )
+    end
+
+    private
+
+    attr_reader :observations, :min_samples
+
+    def grouped_values
+      @grouped_values ||= begin
+        grouped = observations.group_by { |observation| observation.agent_count_planned.to_i }
+        summaries = []
+
+        grouped.keys.sort.each do |agent_count|
+          rows = grouped.fetch(agent_count)
+          previous = summaries.last
+
+          summaries << build_value_summary(agent_count:, observations: rows, previous:)
+        end
+
+        summaries
+      end
+    end
+
+    def analysis_status
+      return "insufficient_data" if viable_values.empty?
+      return "ready" if recommendation.present?
+
+      "collecting"
+    end
+
+    def viable_values
+      @viable_values ||= grouped_values.select { |value| value["sample_count"] >= min_samples }
+    end
+
+    def diminishing_returns_at
+      grouped_values.find { |value| value["signals"].include?("diminishing_returns") }
+        &.fetch("agent_count", nil)
+    end
+
+    def threshold_signal_at
+      grouped_values.find do |value|
+        value["signals"].any? { |signal| signal != "diminishing_returns" }
+      end&.fetch("agent_count", nil)
+    end
+
+    def recommendation
+      @recommendation ||= begin
+        candidate = recommendable_values.max_by do |value|
+          [
+            value["success_rate"],
+            -value["avg_duration_seconds"],
+            -value["avg_cost_cents"],
+            -value["avg_parallelism_observed"],
+            -value["agent_count"]
+          ]
+        end
+        if candidate
+          {
+            "requested_agent_count" => candidate["agent_count"],
+            "max_batch_size" => candidate["agent_count"],
+            "reason" => recommendation_reason(candidate),
+            "confidence" => confidence_for(candidate)
+          }
+        end
+      end
+    end
+
+    def recommendable_values
+      @recommendable_values ||= viable_values.reject do |value|
+        value["signals"].any? { |signal| signal != "diminishing_returns" }
+      end.reject do |value|
+        value["signals"].include?("diminishing_returns")
+      end.presence || viable_values.reject { |value| value["signals"].any? { |signal| signal != "diminishing_returns" } }
+    end
+
+    def recommendation_reason(candidate)
+      if candidate["signals"].empty?
+        "best_success_rate_before_threshold"
+      else
+        "lowest_risk_viable_parallelism"
+      end
+    end
+
+    def confidence_for(candidate)
+      candidate.fetch("sample_count", 0) >= (min_samples * 2) ? "high" : "medium"
+    end
+
+    def build_value_summary(agent_count:, observations:, previous:)
+      sample_count = observations.size
+      success_rate = rate(observations, &:success)
+      avg_duration_seconds = average(observations, &:duration_seconds)
+      avg_cost_cents = average(observations, &:total_cost_cents)
+      avg_parallelism_observed = average(observations, &:parallelism_observed)
+      launch_rate = ratio(
+        observations.sum(&:agent_count_launched),
+        observations.sum(&:agent_count_planned)
+      )
+      blocked_rate = ratio(
+        observations.sum(&:agent_count_blocked),
+        observations.sum(&:agent_count_planned)
+      )
+
+      marginal_duration_improvement_ratio = duration_improvement_ratio(previous, avg_duration_seconds)
+      signals = build_signals(
+        previous: previous,
+        success_rate: success_rate,
+        blocked_rate: blocked_rate,
+        launch_rate: launch_rate,
+        marginal_duration_improvement_ratio: marginal_duration_improvement_ratio
+      )
+
+      {
+        "agent_count" => agent_count,
+        "sample_count" => sample_count,
+        "success_rate" => success_rate,
+        "avg_duration_seconds" => avg_duration_seconds,
+        "avg_cost_cents" => avg_cost_cents,
+        "avg_parallelism_observed" => avg_parallelism_observed,
+        "launch_rate" => launch_rate,
+        "blocked_rate" => blocked_rate,
+        "marginal_duration_improvement_ratio" => marginal_duration_improvement_ratio,
+        "signals" => signals
+      }
+    end
+
+    def build_signals(previous:, success_rate:, blocked_rate:, launch_rate:, marginal_duration_improvement_ratio:)
+      [].tap do |signals|
+        if previous && marginal_duration_improvement_ratio && marginal_duration_improvement_ratio <= MIN_DURATION_IMPROVEMENT_RATIO
+          signals << "diminishing_returns"
+        end
+        if previous && success_rate <= previous["success_rate"] - SUCCESS_RATE_DROP_THRESHOLD
+          signals << "success_rate_regression"
+        end
+        signals << "blocked_capacity" if blocked_rate >= BLOCKED_RATE_THRESHOLD
+        signals << "launch_shortfall" if launch_rate < LAUNCH_RATE_THRESHOLD
+      end
+    end
+
+    def duration_improvement_ratio(previous, avg_duration_seconds)
+      return unless previous
+      return 0.0 if previous["avg_duration_seconds"].zero?
+
+      ((previous["avg_duration_seconds"] - avg_duration_seconds) / previous["avg_duration_seconds"]).round(4)
+    end
+
+    def rate(observations)
+      return 0.0 if observations.empty?
+
+      (observations.count { |observation| yield(observation) }.to_f / observations.size).round(4)
+    end
+
+    def average(observations)
+      return 0.0 if observations.empty?
+
+      (observations.sum { |observation| yield(observation).to_f } / observations.size).round(4)
+    end
+
+    def ratio(numerator, denominator)
+      return 0.0 if denominator.to_i <= 0
+
+      (numerator.to_f / denominator).round(4)
+    end
+  end
+end

--- a/spec/services/scaling_experiments/record_result_spec.rb
+++ b/spec/services/scaling_experiments/record_result_spec.rb
@@ -49,17 +49,8 @@ RSpec.describe ScalingExperiments::RecordResult do
     assignment = result.assignment.reload
     experiment.reload
 
-    expect(assignment.outcome_status).to eq("recorded")
-    expect(assignment.outcome_summary).to include(
-      "status" => "completed",
-      "success" => true,
-      "total_cost_cents" => 350
-    )
-    expect(experiment.cached_summary).to include(
-      "status" => "collecting",
-      "sample_count" => 1,
-      "values" => array_including(hash_including("assigned_value" => 2, "sample_count" => 1))
-    )
+    expect_assignment_snapshot(assignment)
+    expect_collecting_summary(experiment)
   end
 
   it "completes the experiment once every value reaches the minimum sample count" do
@@ -71,6 +62,36 @@ RSpec.describe ScalingExperiments::RecordResult do
     experiment.reload
 
     expect(experiment.status).to eq("completed")
-    expect(experiment.cached_summary).to include("status" => "ready_for_analysis", "leading_value" => 1)
+    expect(experiment.cached_summary).to include(
+      "status" => "ready_for_analysis",
+      "leading_value" => 1,
+      "parallelism_analysis" => hash_including(
+        "status" => "ready",
+        "recommended_agent_count" => 1
+      ),
+      "allocator_decision" => hash_including(
+        "requested_agent_count" => 1,
+        "max_batch_size" => 1
+      )
+    )
+  end
+
+  def expect_assignment_snapshot(assignment)
+    expect(assignment.outcome_status).to eq("recorded")
+    expect(assignment.outcome_summary).to include(
+      "status" => "completed",
+      "success" => true,
+      "total_cost_cents" => 350
+    )
+  end
+
+  def expect_collecting_summary(experiment)
+    expect(experiment.cached_summary).to include(
+      "status" => "collecting",
+      "sample_count" => 1,
+      "values" => array_including(hash_including("assigned_value" => 2, "sample_count" => 1)),
+      "parallelism_analysis" => hash_including("status" => "insufficient_data")
+    )
+    expect(experiment.cached_summary).not_to have_key("allocator_decision")
   end
 end

--- a/spec/services/scaling_observations/analyze_parallelism_spec.rb
+++ b/spec/services/scaling_observations/analyze_parallelism_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScalingObservations::AnalyzeParallelism do
+  describe ".call" do
+    let(:project) { create(:project) }
+
+    it "detects diminishing returns and capacity thresholds, then recommends the best safe count" do
+      seed_recommendation_dataset(project)
+
+      result = described_class.call(observations: ScalingObservation.where(project: project))
+
+      expect_recommendation_result(result)
+    end
+
+    it "returns insufficient_data until enough samples exist for at least one value" do
+      seed_observations(project, 2, durations: [ 220 ], costs: [ 180 ], observed_parallelism: 2)
+
+      result = described_class.call(observations: ScalingObservation.where(project: project), min_samples: 2)
+
+      expect(result.status).to eq("insufficient_data")
+      expect(result.recommended_agent_count).to be_nil
+      expect(result.allocator_decision).to be_nil
+      expect(result.values).to contain_exactly(
+        hash_including(
+          "agent_count" => 2,
+          "sample_count" => 1,
+          "success_rate" => 1.0
+        )
+      )
+    end
+  end
+
+  def seed_recommendation_dataset(project)
+    seed_observations(project, 1, durations: [ 300, 290, 310 ], costs: [ 100, 95, 105 ])
+    seed_observations(project, 2, durations: [ 200, 190, 210 ], costs: [ 180, 175, 185 ], observed_parallelism: 2)
+    seed_observations(project, 3, durations: [ 180, 178, 182 ], costs: [ 255, 250, 260 ], observed_parallelism: 3)
+    seed_observations(project, 4,
+      durations: [ 175, 178, 182 ],
+      costs: [ 340, 335, 345 ],
+      successes: [ true, false, false ],
+      launched: [ 3, 3, 3 ],
+      blocked: [ 1, 1, 1 ],
+      observed_parallelism: 3)
+  end
+
+  def expect_recommendation_result(result)
+    expect(result.status).to eq("ready")
+    expect(result.sample_count).to eq(12)
+    expect(result.diminishing_returns_at).to eq(3)
+    expect(result.threshold_signal_at).to eq(4)
+    expect(result.recommended_agent_count).to eq(2)
+    expect(result.recommended_max_batch_size).to eq(2)
+    expect(result.allocator_decision).to include(
+      "requested_agent_count" => 2,
+      "max_batch_size" => 2,
+      "reason" => "best_success_rate_before_threshold"
+    )
+    expect(result.values).to include(
+      hash_including(
+        "agent_count" => 3,
+        "signals" => include("diminishing_returns")
+      ),
+      hash_including(
+        "agent_count" => 4,
+        "signals" => include("success_rate_regression", "blocked_capacity", "launch_shortfall")
+      )
+    )
+  end
+
+  def seed_observations(project, agent_count, durations:, costs:, successes: nil, launched: nil, blocked: nil, observed_parallelism: nil)
+    durations.each_with_index do |duration, index|
+      success = value_at(successes, index, true)
+      launched_count = value_at(launched, index, agent_count)
+      blocked_count = value_at(blocked, index, 0)
+
+      create(:scaling_observation,
+        project: project,
+        workflow_id: "wf-#{agent_count}-#{index}",
+        agent_count_planned: agent_count,
+        agent_count_launched: launched_count,
+        agent_count_succeeded: success ? launched_count : 0,
+        agent_count_failed: success ? 0 : launched_count,
+        agent_count_blocked: blocked_count,
+        parallelism_planned: agent_count,
+        parallelism_observed: observed_parallelism || agent_count,
+        success: success,
+        duration_seconds: duration,
+        total_cost_cents: costs.fetch(index))
+    end
+  end
+
+  def value_at(values, index, default)
+    return default unless values
+
+    values.fetch(index, default)
+  end
+end

--- a/spec/services/scaling_observations/analyze_parallelism_spec.rb
+++ b/spec/services/scaling_observations/analyze_parallelism_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe ScalingObservations::AnalyzeParallelism do
         )
       )
     end
+
+    it "memoizes an empty recommendation across repeated calls" do
+      seed_observations(project, 4,
+        durations: [ 205, 200 ],
+        costs: [ 340, 335 ],
+        launched: [ 3, 3 ],
+        blocked: [ 1, 1 ],
+        observed_parallelism: 3)
+
+      analyzer = described_class.new(observations: ScalingObservation.where(project: project), min_samples: 2)
+
+      expect(analyzer.send(:recommendation)).to be_nil
+      expect(analyzer.send(:recommendation)).to be_nil
+      expect(analyzer.call.status).to eq("collecting")
+      expect(analyzer.call.allocator_decision).to be_nil
+    end
   end
 
   def seed_recommendation_dataset(project)


### PR DESCRIPTION
## Summary

Implemented the orchestration parallelism analysis layer and committed it as `975ba9c` with `feat(scaling): analyze orchestration parallelism outcomes`.

The main change is a new `ScalingObservations::AnalyzeParallelism` service at [app/services/scaling_observations/analyze_parallelism.rb](/workspace/app/services/scaling_observations/analyze_parallelism.rb) that groups observations by planned agent count, computes success/duration/cost/launch metrics, flags diminishing returns and threshold signals, and emits an allocator-friendly recommendation payload. I also wired that into [app/services/scaling_experiments/summarize_results.rb](/workspace/app/services/scaling_experiments/summarize_results.rb) so cached experiment summaries now include `parallelism_analysis` and `allocator_decision`.

Specs were added in [spec/services/scaling_observations/analyze_parallelism_spec.rb](/workspace/spec/services/scaling_observations/analyze_parallelism_spec.rb) and extended in [spec/services/scaling_experiments/record_result_spec.rb](/workspace/spec/services/scaling_experiments/record_result_spec.rb) to cover seeded datasets, diminishing-return detection, threshold detection, and summary caching.

Verification passed:
- `DATABASE_URL="$DATABASE_URL" RAILS_ENV=test bundle exec rails db:prepare`
- `bundle exec rubocop`
- `bundle exec rspec`
- pre-commit hook commit gate also passed

`git status` is clean.

---

Closes #1779