### PR TITLE
Fix #1865: Remove redundant sections from live dashboard

### DIFF
--- a/app/services/dashboard/live_stats.rb
+++ b/app/services/dashboard/live_stats.rb
@@ -22,30 +22,18 @@ module Dashboard
 
     def build_stats
       today = Time.current.beginning_of_day
-      base = agent_runs
-      pool_metrics = Containers::PoolManager.metrics(projects: account.projects)
-      run_counts = base.pick(
+      run_counts = agent_runs.pick(
         Arel.sql("COUNT(*) FILTER (WHERE status = 'running')"),
         Arel.sql("COUNT(*) FILTER (WHERE status = 'queued' AND temporal_workflow_id IS NULL)"),
         Arel.sql(completed_today_sql(today)),
-        Arel.sql(failed_today_sql(today)),
-        Arel.sql("COUNT(DISTINCT container_id) FILTER (WHERE status = 'running' AND container_id IS NOT NULL)")
-      )
-      project_counts = account.projects.pick(
-        Arel.sql("COUNT(*)"),
-        Arel.sql("COUNT(*) FILTER (WHERE active)")
+        Arel.sql(failed_today_sql(today))
       )
 
       {
         active_runs: run_counts[0].to_i,
         queued_runs: run_counts[1].to_i,
         completed_today: run_counts[2].to_i,
-        failed_today: run_counts[3].to_i,
-        active_containers: run_counts[4].to_i,
-        warm_containers: pool_metrics[:warm],
-        pool_target: pool_metrics[:target],
-        total_projects: project_counts[0].to_i,
-        active_projects: project_counts[1].to_i
+        failed_today: run_counts[3].to_i
       }
     end
 

--- a/app/views/dashboard/_live_stats.html.erb
+++ b/app/views/dashboard/_live_stats.html.erb
@@ -16,22 +16,3 @@
     <dd class="mt-1 text-3xl font-semibold tracking-tight <%= stats[:failed_today].positive? ? 'text-red-600' : 'text-gray-900' %>"><%= stats[:failed_today] %></dd>
   </div>
 </dl>
-
-<dl class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-  <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-    <dt class="truncate text-sm font-medium text-gray-500">Active Containers</dt>
-    <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= stats[:active_containers] %></dd>
-  </div>
-  <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-    <dt class="truncate text-sm font-medium text-gray-500">Warm Containers</dt>
-    <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= stats[:warm_containers] %>/<%= stats[:pool_target] %></dd>
-  </div>
-  <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-    <dt class="truncate text-sm font-medium text-gray-500">Total Projects</dt>
-    <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= stats[:total_projects] %></dd>
-  </div>
-  <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-    <dt class="truncate text-sm font-medium text-gray-500">Active Projects</dt>
-    <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= stats[:active_projects] %></dd>
-  </div>
-</dl>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe "Dashboard" do
 
         expect(response.body).to include("Live Metrics")
         expect(response.body).to include("Active Runs")
+        expect(response.body).not_to include("Active Containers")
+        expect(response.body).not_to include("Warm Containers")
+        expect(response.body).not_to include("Total Projects")
+        expect(response.body).not_to include("Active Projects")
         expect(response.body).to include("Recent Activity")
       end
 

--- a/spec/services/dashboard/live_stats_spec.rb
+++ b/spec/services/dashboard/live_stats_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Dashboard::LiveStats do
       create(:agent_run, project: project, status: "queued", temporal_workflow_id: "wf-123")
       create(:agent_run, project: project, status: "completed", completed_at: 2.hours.ago)
       create(:agent_run, project: project, status: "failed", completed_at: 1.hour.ago)
-      create(:container_pool_entry, project: project)
 
       stats = described_class.call(account: account)
 
@@ -34,12 +33,7 @@ RSpec.describe Dashboard::LiveStats do
         active_runs: 2,
         queued_runs: 1,
         completed_today: 1,
-        failed_today: 1,
-        active_containers: 1,
-        warm_containers: 1,
-        pool_target: 0,
-        total_projects: 1,
-        active_projects: 1
+        failed_today: 1
       )
     end
 


### PR DESCRIPTION
## Summary

Removed the redundant live dashboard cards for `Active Containers`, `Warm Containers`, `Total Projects`, and `Active Projects` by trimming [app/views/dashboard/_live_stats.html.erb](/workspace/app/views/dashboard/_live_stats.html.erb). I also cleaned up [app/services/dashboard/live_stats.rb](/workspace/app/services/dashboard/live_stats.rb) so it no longer computes those unused counters, and updated the request/service specs in [spec/requests/dashboard_spec.rb](/workspace/spec/requests/dashboard_spec.rb) and [spec/services/dashboard/live_stats_spec.rb](/workspace/spec/services/dashboard/live_stats_spec.rb).

Validation passed: `bundle install`, `yarn install`, `db:prepare`, `bundle exec rubocop`, full `bundle exec rspec`, and the git pre-commit hook’s lint/test rerun. `db:prepare` needed explicit DB host credentials because the provided `DATABASE_URL` user is guarded outside test boot paths. Commit: `facc486` with message `fix(dashboard): remove redundant live stats cards`.

---

Closes #1865