### PR TITLE
Fix #1842: Fix provider filter names in agent runs index and add soft-delete for filter-backed records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem "devise"
 # Authorization [https://github.com/varvet/pundit]
 gem "pundit"
 
+# Soft-delete for low-volume reference records
+gem "discard"
+
 # CSV parsing (bundled gem since Ruby 3.4)
 gem "csv"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
+    discard (1.4.0)
+      activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
     docker-api (2.4.0)
       excon (>= 0.64.0)
@@ -580,6 +582,7 @@ DEPENDENCIES
   cuprite
   debug
   devise
+  discard
   docker-api
   factory_bot_rails
   faker
@@ -668,6 +671,7 @@ CHECKSUMS
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   devise (5.0.4) sha256=d605f2b85854e74e56ee789e2d398702bc2d06e6bcd894717a670a3199c74cc1
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  discard (1.4.0) sha256=6efcd2a53ddf96781f81b825d398f1c88ab88c0faa84e131bea6e16ef95d65d0
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   docker-api (2.4.0) sha256=824be734f4cc8718189be9c8e795b6414acbbf7e8b082a06f959a27dd8dd63e6
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d

--- a/app/controllers/agent_runs_controller.rb
+++ b/app/controllers/agent_runs_controller.rb
@@ -20,7 +20,7 @@ class AgentRunsController < ApplicationController
     AgentRun.preload_final_provider_records(@agent_runs)
     AgentRun.preload_source_pull_requests(@agent_runs)
     cache_key = AgentRun.provider_options_cache_key_for(account_id: current_account.id)
-    @provider_options = base_scope.distinct_effective_providers(cache_key: cache_key)
+    @provider_options = base_scope.distinct_effective_provider_options(account_id: current_account.id, cache_key: cache_key)
   end
 
   def pause_scheduler

--- a/app/controllers/chat_sessions_controller.rb
+++ b/app/controllers/chat_sessions_controller.rb
@@ -272,7 +272,7 @@ class ChatSessionsController < ApplicationController
     @sidebar_next_frame_id = sidebar[:next_frame_id]
     @sidebar_next_params = sidebar[:next_params]
     @new_chat_session = ChatSession.new(mode: "api")
-    @available_providers = current_user.providers.ordered
+    @available_providers = current_user.providers.kept_only.ordered
     @available_projects = current_account.projects.order(:name)
     @available_models = LlmModel.active.order(:provider, :display_name)
   end

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -854,8 +854,8 @@ module Projects
             end
           end
 
-          providers_by_id = owner.providers.where(id: routing_ids).index_by(&:id)
-          providers_by_key = owner.providers.where(provider_key: plain_keys).ordered
+          providers_by_id = owner.providers.kept_only.where(id: routing_ids).index_by(&:id)
+          providers_by_key = owner.providers.kept_only.where(provider_key: plain_keys).ordered
             .group_by(&:provider_key)
 
           identifiers.filter_map do |identifier|

--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -18,7 +18,7 @@ module Projects
       AgentRun.preload_final_provider_records(@agent_runs)
       AgentRun.preload_source_pull_requests(@agent_runs)
       cache_key = AgentRun.provider_options_cache_key_for(account_id: @project.account_id, project_id: @project.id)
-      @provider_options = base_scope.distinct_effective_providers(cache_key: cache_key)
+      @provider_options = base_scope.distinct_effective_provider_options(account_id: @project.account_id, cache_key: cache_key)
     end
 
     def show

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -80,7 +80,7 @@ class ProvidersController < ApplicationController
   def destroy
     authorize @provider
 
-    if @provider.destroy
+    if @provider.discard
       if reconcile_settings!
         redirect_to providers_path, notice: "Provider deleted successfully."
       else

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -204,7 +204,7 @@ class ProvidersController < ApplicationController
 
   def load_provider_options
     addable_keys = Provider.addable_provider_keys
-    existing_subscription_keys = current_user.providers.subscription.pluck(:provider_key)
+    existing_subscription_keys = current_user.providers.kept_only.subscription.pluck(:provider_key)
 
     # Subscription providers: only show keys not yet added
     @subscription_provider_options = if @provider&.persisted?
@@ -316,7 +316,7 @@ class ProvidersController < ApplicationController
     default_key = Provider.default_provider_key
     return [] unless default_key
 
-    default = current_user.providers.find_or_initialize_by(provider_key: default_key, auth_type: "subscription")
+    default = current_user.providers.kept_only.find_or_initialize_by(provider_key: default_key, auth_type: "subscription")
     default.enabled_for_agent_runs = true
     default.enabled_for_fallback = true if default.new_record?
 
@@ -448,7 +448,7 @@ class ProvidersController < ApplicationController
     invalid = false
     Provider.transaction do
       weights.each do |provider_id, weight_value|
-        provider = current_user.providers.find_by(id: provider_id)
+        provider = current_user.providers.kept_only.find_by(id: provider_id)
         next unless provider
 
         coerced = Integer(weight_value, exception: false)
@@ -494,7 +494,7 @@ class ProvidersController < ApplicationController
 
   def enabled_agent_provider_identifiers
     executable_keys = ProviderSupport.container_executable_provider_keys
-    providers = current_user.providers.for_agent_runs
+    providers = current_user.providers.kept_only.for_agent_runs
       .where(provider_key: executable_keys)
       .ordered
     UserSetting.provider_identifiers_for(providers, identifiers: true)
@@ -507,13 +507,13 @@ class ProvidersController < ApplicationController
     return [] if identifiers.blank?
 
     ids = identifiers.filter_map { |identifier| Provider.id_from_routing_key(identifier) }
-    providers_by_id = current_user.providers.where(id: ids).index_by(&:id)
+    providers_by_id = current_user.providers.kept_only.where(id: ids).index_by(&:id)
     ids.filter_map { |id| providers_by_id[id] }
   end
 
   def fallback_candidate_provider_identifiers
     executable_keys = ProviderSupport.container_executable_provider_keys
-    providers = current_user.providers.for_fallback
+    providers = current_user.providers.kept_only.for_fallback
       .where(provider_key: executable_keys)
       .ordered
     UserSetting.provider_identifiers_for(providers, identifiers: true)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -521,7 +521,7 @@ module ApplicationHelper
     end
     return {} if provider_ids_by_owner_id.empty?
 
-    Provider.where(user_id: provider_ids_by_owner_id.keys, id: provider_ids_by_owner_id.values.flatten.uniq)
+    Provider.with_discarded.where(user_id: provider_ids_by_owner_id.keys, id: provider_ids_by_owner_id.values.flatten.uniq)
       .index_by { |provider| [ provider.user_id, provider.id ] }
   end
 
@@ -536,7 +536,7 @@ module ApplicationHelper
     end
     return {} if owner_ids_by_provider_key.empty?
 
-    Provider.where(
+    Provider.with_discarded.where(
       user_id: owner_ids_by_provider_key.values.flatten.uniq,
       provider_key: owner_ids_by_provider_key.keys
     ).ordered.group_by { |provider| [ provider.user_id, provider.provider_key ] }

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -330,13 +330,44 @@ class AgentRun < ApplicationRecord
   end
 
   def self.compute_distinct_effective_provider_options(account_id:)
-    pluck(Arel.sql("DISTINCT #{effective_provider_sql}"))
-      .compact
-      .filter_map { |identifier| Provider.filter_option_for_identifier(identifier, account_id: account_id) }
+    identifiers = pluck(Arel.sql("DISTINCT #{effective_provider_sql}")).compact
+    routed_options = routed_provider_filter_options_by_identifier(identifiers, account_id:)
+
+    identifiers
+      .filter_map do |identifier|
+        if Provider.routing_key?(identifier)
+          routed_options[identifier]
+        else
+          Provider.filter_option_for_identifier(identifier, account_id: account_id)
+        end
+      end
       .uniq
       .sort_by { |option| [ option[:label], option[:value] ] }
   end
   private_class_method :compute_distinct_effective_provider_options
+
+  def self.routed_provider_filter_options_by_identifier(identifiers, account_id:)
+    provider_ids_by_identifier = identifiers.each_with_object({}) do |identifier, memo|
+      provider_id = Provider.id_from_routing_key(identifier)
+      memo[identifier] = provider_id if provider_id
+    end
+    return {} if provider_ids_by_identifier.empty?
+
+    providers_by_id = Provider.with_discarded.joins(:user)
+      .where(id: provider_ids_by_identifier.values.uniq, users: { account_id: account_id })
+      .index_by(&:id)
+
+    provider_ids_by_identifier.each_with_object({}) do |(identifier, provider_id), memo|
+      provider = providers_by_id[provider_id]
+      next unless provider
+
+      memo[identifier] = {
+        label: provider.display_name,
+        value: identifier
+      }
+    end
+  end
+  private_class_method :routed_provider_filter_options_by_identifier
 
   def self.final_provider_records_by_lookup(runs, fallback_owner_ids)
     lookup_pairs = runs.filter_map do |run|

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -91,7 +91,7 @@ class AgentRun < ApplicationRecord
   belongs_to :project, counter_cache: true
   belongs_to :issue, optional: true
   belongs_to :prompt_version, optional: true
-  belongs_to :provider, optional: true
+  belongs_to :provider, -> { with_discarded }, optional: true
   belongs_to :configuration_bundle, optional: true
 
   has_many :agent_run_logs, dependent: :destroy
@@ -279,13 +279,13 @@ class AgentRun < ApplicationRecord
 
   PROVIDER_OPTIONS_CACHE_TTL = 5.minutes
 
-  def self.distinct_effective_providers(cache_key: nil)
+  def self.distinct_effective_provider_options(account_id:, cache_key: nil)
     if cache_key
       Rails.cache.fetch(cache_key, expires_in: PROVIDER_OPTIONS_CACHE_TTL) do
-        compute_distinct_effective_providers
+        compute_distinct_effective_provider_options(account_id: account_id)
       end
     else
-      compute_distinct_effective_providers
+      compute_distinct_effective_provider_options(account_id: account_id)
     end
   end
 
@@ -329,12 +329,14 @@ class AgentRun < ApplicationRecord
     runs
   end
 
-  def self.compute_distinct_effective_providers
+  def self.compute_distinct_effective_provider_options(account_id:)
     pluck(Arel.sql("DISTINCT #{effective_provider_sql}"))
       .compact
-      .sort
+      .filter_map { |identifier| Provider.filter_option_for_identifier(identifier, account_id: account_id) }
+      .uniq
+      .sort_by { |option| [ option[:label], option[:value] ] }
   end
-  private_class_method :compute_distinct_effective_providers
+  private_class_method :compute_distinct_effective_provider_options
 
   def self.final_provider_records_by_lookup(runs, fallback_owner_ids)
     lookup_pairs = runs.filter_map do |run|
@@ -351,7 +353,7 @@ class AgentRun < ApplicationRecord
     provider_ids = lookup_pairs.map { |(_, identifier)| Provider.id_from_routing_key(identifier) }.uniq
     owner_ids = lookup_pairs.map(&:first).uniq
 
-    Provider.where(id: provider_ids, user_id: owner_ids).index_by { |provider| [ provider.user_id, provider.routing_key ] }
+    Provider.with_discarded.where(id: provider_ids, user_id: owner_ids).index_by { |provider| [ provider.user_id, provider.routing_key ] }
   end
   private_class_method :final_provider_records_by_lookup
 
@@ -1471,13 +1473,15 @@ class AgentRun < ApplicationRecord
   end
 
   def final_provider_record
+    return preloaded_final_provider_record if preloaded_final_provider_record_loaded
+
     owner = project&.effective_owner
     return unless owner
 
     return unless final_provider.present?
 
     provider_id = Provider.id_from_routing_key(final_provider)
-    owner.providers.find_by(id: provider_id) if provider_id
+    owner.providers.with_discarded.find_by(id: provider_id) if provider_id
   end
 
   # Returns the Provider record that reflects which provider actually ran the
@@ -1486,7 +1490,9 @@ class AgentRun < ApplicationRecord
   # provider-key forms of final_provider via Provider.for_identifier. Returns
   # nil if neither can be resolved.
   def effective_provider_record
-    Provider.for_identifier(project&.effective_owner, final_provider) || provider
+    Provider.for_identifier(project&.effective_owner, final_provider, include_discarded: true) ||
+      provider ||
+      Provider.with_discarded.find_by(id: provider_id)
   end
 
   def attempted_providers_by_routing_key
@@ -1498,7 +1504,7 @@ class AgentRun < ApplicationRecord
     end
     return {} if routing_ids.empty?
 
-    owner.providers.where(id: routing_ids).index_by(&:routing_key)
+    owner.providers.with_discarded.where(id: routing_ids).index_by(&:routing_key)
   end
 
   # Records a provider attempt in the providers_attempted array.

--- a/app/models/chat_session.rb
+++ b/app/models/chat_session.rb
@@ -14,7 +14,7 @@ class ChatSession < ApplicationRecord
   after_destroy_commit :broadcast_sidebar_remove
 
   belongs_to :project, optional: true
-  belongs_to :provider, optional: true
+  belongs_to :provider, -> { with_discarded }, optional: true
   belongs_to :created_by, class_name: "User", optional: true
 
   has_many :messages, class_name: "ChatMessage", dependent: :destroy

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -60,13 +60,12 @@ class Provider < ApplicationRecord
     "glm-4.5-air" => "low"
   }.freeze
 
-  default_scope -> { kept }
-
   belongs_to :user
   belongs_to :provider_api_key, optional: true
 
   has_many :chat_sessions, dependent: :nullify
 
+  scope :kept_only, -> { kept }
   scope :for_agent_runs, -> { where(enabled_for_agent_runs: true) }
   scope :for_fallback, -> { where(enabled_for_fallback: true) }
   scope :ordered, -> { order(:provider_key, :auth_type, :name, :id) }
@@ -395,16 +394,16 @@ class Provider < ApplicationRecord
     key = default_provider_key
     return unless key
 
-    user.providers.find_or_create_by!(provider_key: key, auth_type: "subscription")
+    user.providers.kept_only.find_or_create_by!(provider_key: key, auth_type: "subscription")
   rescue ActiveRecord::RecordNotUnique
-    user.providers.find_by!(provider_key: key, auth_type: "subscription")
+    user.providers.kept_only.find_by!(provider_key: key, auth_type: "subscription")
   end
 
   def self.first_enabled_for_owner(owner)
     return unless owner
 
     executable_keys = ProviderSupport.container_executable_provider_keys
-    owner.providers.for_agent_runs.where(provider_key: executable_keys).ordered.first
+    owner.providers.kept_only.for_agent_runs.where(provider_key: executable_keys).ordered.first
   end
 
   def self.display_name_for(provider_key)
@@ -476,14 +475,14 @@ class Provider < ApplicationRecord
     return nil if identifier.blank?
 
     if routing_key?(identifier)
-      relation = include_discarded ? with_discarded : all
+      relation = include_discarded ? with_discarded : kept_only
       relation.where(user: user).find_by(id: id_from_routing_key(identifier))
     else
       if include_discarded
-        preferred_identifier_match(all.where(user: user, provider_key: identifier).ordered) ||
+        preferred_identifier_match(kept_only.where(user: user, provider_key: identifier).ordered) ||
           preferred_identifier_match(with_discarded.where(user: user, provider_key: identifier).discarded.ordered)
       else
-        preferred_identifier_match(all.where(user: user, provider_key: identifier).ordered)
+        preferred_identifier_match(kept_only.where(user: user, provider_key: identifier).ordered)
       end
     end
   end
@@ -515,8 +514,8 @@ class Provider < ApplicationRecord
   # Updates the enabled_for_fallback flag on each of the user's providers
   # based on the given set of enabled provider identifiers.
   def self.update_fallback_flags(user, enabled_keys)
-    user.providers.transaction do
-      user.providers.find_each do |provider|
+    user.providers.kept_only.transaction do
+      user.providers.kept_only.find_each do |provider|
         new_value = enabled_keys.any? { |identifier| provider.matches_identifier?(identifier) }
         next if provider.enabled_for_fallback? == new_value
 
@@ -574,7 +573,7 @@ class Provider < ApplicationRecord
   def must_keep_at_least_one_agent_run_provider
     return unless user
     return unless will_save_change_to_enabled_for_agent_runs?(from: true, to: false)
-    return if user.providers.where.not(id: id).for_agent_runs.exists?
+    return if user.providers.kept_only.where.not(id: id).for_agent_runs.exists?
 
     errors.add(:enabled_for_agent_runs, "must keep at least one provider enabled for agent runs")
   end
@@ -582,7 +581,7 @@ class Provider < ApplicationRecord
   def prevent_destroying_last_agent_run_provider
     return if destroyed_by_association.present?
     return unless enabled_for_agent_runs?
-    return if user.providers.where.not(id: id).for_agent_runs.exists?
+    return if user.providers.kept_only.where.not(id: id).for_agent_runs.exists?
 
     errors.add(:base, "Cannot delete the last provider enabled for agent runs")
     throw(:abort)
@@ -708,7 +707,7 @@ class Provider < ApplicationRecord
     return unless user
 
     normalized_name = name.to_s
-    duplicate = user.providers.api_key.where(
+    duplicate = user.providers.kept_only.api_key.where(
       provider_key: provider_key,
       provider_api_key_id: provider_api_key_id
     ).where.not(id: id).where("COALESCE(name, '') = ?", normalized_name).exists?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -77,6 +77,7 @@ class Provider < ApplicationRecord
   before_validation :normalize_agent_co_author_trailer
   before_validation :clear_stale_direct_outbound_tier_models
   before_save :sync_direct_outbound_tier_models
+  before_discard :clear_provider_api_key_reference
   before_discard :prevent_destroying_last_agent_run_provider
   before_discard :prevent_destroying_default_provider
   after_commit :invalidate_agent_run_provider_option_caches
@@ -608,6 +609,10 @@ class Provider < ApplicationRecord
     Project.where(account_id: account_id).pluck(:id).each do |project_id|
       AgentRun.invalidate_provider_options_cache(account_id: account_id, project_id: project_id)
     end
+  end
+
+  def clear_provider_api_key_reference
+    self.provider_api_key = nil if provider_api_key_id.present?
   end
 
   def api_key_auth_requires_provider_api_key

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -80,7 +80,7 @@ class Provider < ApplicationRecord
   before_discard :clear_provider_api_key_reference
   before_discard :prevent_destroying_last_agent_run_provider
   before_discard :prevent_destroying_default_provider
-  after_commit :invalidate_agent_run_provider_option_caches
+  after_commit :invalidate_agent_run_provider_option_caches, if: :agent_run_provider_option_cache_invalidation_needed?
 
   validates :weight, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_WEIGHT }
   validates :provider_key, presence: true, length: { maximum: 50 }
@@ -90,7 +90,11 @@ class Provider < ApplicationRecord
   validates :fallback_role, presence: true, inclusion: { in: FALLBACK_ROLES }
   validates :name, length: { maximum: 100 }
   validates :provider_key,
-    uniqueness: { scope: [ :user_id, :auth_type ], message: "already has a subscription entry" },
+    uniqueness: {
+      scope: [ :user_id, :auth_type ],
+      conditions: -> { kept },
+      message: "already has a subscription entry"
+    },
     if: -> { subscription? }
 
   validate :must_keep_at_least_one_agent_run_provider
@@ -471,13 +475,16 @@ class Provider < ApplicationRecord
     return nil unless user
     return nil if identifier.blank?
 
-    relation = include_discarded ? with_discarded : all
-
     if routing_key?(identifier)
+      relation = include_discarded ? with_discarded : all
       relation.where(user: user).find_by(id: id_from_routing_key(identifier))
     else
-      matching_providers = relation.where(user: user, provider_key: identifier).ordered
-      matching_providers.subscription.first || matching_providers.first
+      if include_discarded
+        preferred_identifier_match(all.where(user: user, provider_key: identifier).ordered) ||
+          preferred_identifier_match(with_discarded.where(user: user, provider_key: identifier).discarded.ordered)
+      else
+        preferred_identifier_match(all.where(user: user, provider_key: identifier).ordered)
+      end
     end
   end
 
@@ -614,6 +621,40 @@ class Provider < ApplicationRecord
   def clear_provider_api_key_reference
     self.provider_api_key = nil if provider_api_key_id.present?
   end
+
+  def agent_run_provider_option_cache_invalidation_needed?
+    previous_changes.key?("id") ||
+      previous_changes.key?("discarded_at") ||
+      previous_changes.key?("name") ||
+      previous_changes.key?("provider_key") ||
+      previous_changes.key?("auth_type") ||
+      display_name_config_changed?
+  end
+
+  def display_name_config_changed?
+    previous_config, current_config = previous_changes["config"]
+    return false unless previous_changes.key?("config")
+
+    display_name_config_value(previous_config) != display_name_config_value(current_config)
+  end
+
+  def display_name_config_value(config_value)
+    config = config_value.is_a?(Hash) ? config_value : {}
+
+    case provider_key
+    when "opencode"
+      config.dig("opencode", "model")
+    when "kilocode"
+      config.dig("kilocode", "model")
+    when "aider"
+      config.dig("aider", "model")
+    end
+  end
+
+  def self.preferred_identifier_match(matching_providers)
+    matching_providers.subscription.first || matching_providers.first
+  end
+  private_class_method :preferred_identifier_match
 
   def api_key_auth_requires_provider_api_key
     return unless api_key?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -76,9 +76,9 @@ class Provider < ApplicationRecord
   before_validation :normalize_agent_co_author_trailer
   before_validation :clear_stale_direct_outbound_tier_models
   before_save :sync_direct_outbound_tier_models
-  before_discard :clear_provider_api_key_reference
   before_discard :prevent_destroying_last_agent_run_provider
   before_discard :prevent_destroying_default_provider
+  before_discard :clear_provider_api_key_reference
   after_commit :invalidate_agent_run_provider_option_caches, if: :agent_run_provider_option_cache_invalidation_needed?
 
   validates :weight, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_WEIGHT }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,8 @@ require "set"
 require "shellwords"
 
 class Provider < ApplicationRecord
+  include Discard::Model
+
   AUTH_TYPES = %w[subscription api_key].freeze
   FALLBACK_ROLES = %w[standard rate_limit_fallback].freeze
   ROUTING_KEY_PREFIX = "provider:".freeze
@@ -58,6 +60,8 @@ class Provider < ApplicationRecord
     "glm-4.5-air" => "low"
   }.freeze
 
+  default_scope -> { kept }
+
   belongs_to :user
   belongs_to :provider_api_key, optional: true
 
@@ -73,6 +77,9 @@ class Provider < ApplicationRecord
   before_validation :normalize_agent_co_author_trailer
   before_validation :clear_stale_direct_outbound_tier_models
   before_save :sync_direct_outbound_tier_models
+  before_discard :prevent_destroying_last_agent_run_provider
+  before_discard :prevent_destroying_default_provider
+  after_commit :invalidate_agent_run_provider_option_caches
 
   validates :weight, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_WEIGHT }
   validates :provider_key, presence: true, length: { maximum: 50 }
@@ -459,16 +466,42 @@ class Provider < ApplicationRecord
     id
   end
 
-  def self.for_identifier(user, identifier)
+  def self.for_identifier(user, identifier, include_discarded: false)
     return nil unless user
     return nil if identifier.blank?
 
+    relation = include_discarded ? with_discarded : all
+
     if routing_key?(identifier)
-      user.providers.find_by(id: id_from_routing_key(identifier))
+      relation.where(user: user).find_by(id: id_from_routing_key(identifier))
     else
-      matching_providers = user.providers.where(provider_key: identifier).ordered
+      matching_providers = relation.where(user: user, provider_key: identifier).ordered
       matching_providers.subscription.first || matching_providers.first
     end
+  end
+
+  def self.filter_option_for_identifier(identifier, account_id:)
+    return if identifier.blank?
+
+    if routing_key?(identifier)
+      provider_id = id_from_routing_key(identifier)
+      return unless provider_id
+
+      provider = with_discarded.joins(:user).find_by(id: provider_id, users: { account_id: account_id })
+      return unless provider
+
+      return {
+        label: provider.display_name,
+        value: identifier
+      }
+    end
+
+    normalized_identifier = ProviderSupport.provider_key_for_agent_type(identifier)
+
+    {
+      label: display_name_for(normalized_identifier),
+      value: normalized_identifier
+    }
   end
 
   # Updates the enabled_for_fallback flag on each of the user's providers
@@ -565,6 +598,16 @@ class Provider < ApplicationRecord
 
     errors.add(:base, "Cannot delete the #{Provider.display_name(default_key)} provider")
     throw(:abort)
+  end
+
+  def invalidate_agent_run_provider_option_caches
+    return unless user
+
+    account_id = user.account_id
+    AgentRun.invalidate_provider_options_cache(account_id: account_id)
+    Project.where(account_id: account_id).pluck(:id).each do |project_id|
+      AgentRun.invalidate_provider_options_cache(account_id: account_id, project_id: project_id)
+    end
   end
 
   def api_key_auth_requires_provider_api_key

--- a/app/models/provider_api_key.rb
+++ b/app/models/provider_api_key.rb
@@ -4,7 +4,7 @@ require "set"
 
 class ProviderApiKey < ApplicationRecord
   belongs_to :user
-  has_many :providers, dependent: :restrict_with_error
+  has_many :providers, -> { kept }, dependent: :restrict_with_error
 
   encrypts :api_key
 

--- a/app/models/provider_api_key.rb
+++ b/app/models/provider_api_key.rb
@@ -4,7 +4,7 @@ require "set"
 
 class ProviderApiKey < ApplicationRecord
   belongs_to :user
-  has_many :providers, dependent: :restrict_with_error
+  has_many :providers, -> { with_discarded }, dependent: :restrict_with_error
 
   encrypts :api_key
 

--- a/app/models/provider_api_key.rb
+++ b/app/models/provider_api_key.rb
@@ -4,7 +4,7 @@ require "set"
 
 class ProviderApiKey < ApplicationRecord
   belongs_to :user
-  has_many :providers, -> { with_discarded }, dependent: :restrict_with_error
+  has_many :providers, dependent: :restrict_with_error
 
   encrypts :api_key
 

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -155,7 +155,7 @@ class UserSetting < ApplicationRecord
     return executable_keys if user.new_record?
 
     provider_identifiers_for(
-      user.providers.for_agent_runs.where(provider_key: executable_keys).ordered,
+      user.providers.kept_only.for_agent_runs.where(provider_key: executable_keys).ordered,
       identifiers: identifiers
     )
   end
@@ -169,7 +169,7 @@ class UserSetting < ApplicationRecord
     return executable_keys if user.new_record?
 
     provider_identifiers_for(
-      user.providers.for_fallback.where(provider_key: executable_keys).ordered,
+      user.providers.kept_only.for_fallback.where(provider_key: executable_keys).ordered,
       identifiers: identifiers
     )
   end
@@ -182,7 +182,7 @@ class UserSetting < ApplicationRecord
     return [] if user.new_record?
 
     executable_keys = ProviderSupport.container_executable_provider_keys
-    user.providers.api_key.rate_limit_fallback.for_agent_runs.for_fallback
+    user.providers.kept_only.api_key.rate_limit_fallback.for_agent_runs.for_fallback
       .where(provider_key: executable_keys)
       .distinct
       .pluck(:provider_key)
@@ -434,7 +434,7 @@ class UserSetting < ApplicationRecord
     routing_ids = candidates.filter_map { |identifier| Provider.id_from_routing_key(identifier) }
     return {} if routing_ids.empty?
 
-    user.providers.where(id: routing_ids).pluck(:id, :weight).to_h do |id, weight|
+    user.providers.kept_only.where(id: routing_ids).pluck(:id, :weight).to_h do |id, weight|
       [ "#{Provider::ROUTING_KEY_PREFIX}#{id}", weight || Provider::DEFAULT_WEIGHT ]
     end
   end
@@ -568,7 +568,7 @@ class UserSetting < ApplicationRecord
 
     executable_keys = ProviderSupport.container_executable_provider_keys
     self.class.provider_identifiers_for(
-      user.providers.for_agent_runs.where(provider_key: executable_keys).ordered,
+      user.providers.kept_only.for_agent_runs.where(provider_key: executable_keys).ordered,
       identifiers: true
     )
   end
@@ -579,7 +579,7 @@ class UserSetting < ApplicationRecord
 
     executable_keys = ProviderSupport.container_executable_provider_keys
     self.class.provider_identifiers_for(
-      user.providers.for_fallback.where(provider_key: executable_keys).ordered,
+      user.providers.kept_only.for_fallback.where(provider_key: executable_keys).ordered,
       identifiers: true
     )
   end
@@ -604,7 +604,7 @@ class UserSetting < ApplicationRecord
     end
     return [] if routing_ids.empty?
 
-    matching_providers = user.providers.where(id: routing_ids, provider_key: token).ordered.to_a
+    matching_providers = user.providers.kept_only.where(id: routing_ids, provider_key: token).ordered.to_a
     return [] if matching_providers.empty?
 
     preferred_provider = matching_providers.min_by do |provider|

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -38,7 +38,7 @@ class ProviderPolicy < ApplicationPolicy
     def resolve
       raise Pundit::NotAuthorizedError, "must be logged in" unless user
 
-      scope.where(user: user)
+      scope.kept_only.where(user: user)
     end
 
     private

--- a/app/services/agent_runs/create_followup.rb
+++ b/app/services/agent_runs/create_followup.rb
@@ -56,7 +56,7 @@ module AgentRuns
       end
 
       provider_id, agent_type = AgentRuns::ProviderResolver.call(project: agent_run.project, goal: goal)
-      provider = Provider.find_by(id: provider_id) if provider_id
+      provider = Provider.kept_only.find_by(id: provider_id) if provider_id
       agent_type ||= provider ? Provider.agent_type_for(provider.provider_key) : fallback_agent_type
 
       [ provider, agent_type ]

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -9,7 +9,7 @@ module AgentRuns
     def self.selected_provider(project:, provider_id:)
       return if provider_id.blank?
 
-      project.effective_owner&.providers&.find_by(id: provider_id)
+      project.effective_owner&.providers&.kept_only&.find_by(id: provider_id)
     end
 
     def initialize(project:, goal:, requested_agent_type: nil, requested_provider_id: nil, respect_requested: true, logger: nil)
@@ -55,7 +55,7 @@ module AgentRuns
       owner = project.effective_owner
       return [ nil, agent_type ] unless owner
 
-      provider = owner.providers.find_by(provider_key: provider_key)
+      provider = owner.providers.kept_only.find_by(provider_key: provider_key)
       provider ? [ provider.id, agent_type ] : [ nil, agent_type ]
     end
 
@@ -106,13 +106,13 @@ module AgentRuns
       return unless api_key
       return unless api_key.compatible_with?(base_provider.provider_key)
 
-      owner.providers.find_or_create_by!(
+      owner.providers.kept_only.find_or_create_by!(
         provider_key: base_provider.provider_key,
         auth_type: "api_key",
         provider_api_key: api_key
       )
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
-      owner.providers.find_by(
+      owner.providers.kept_only.find_by(
         provider_key: base_provider.provider_key,
         auth_type: "api_key",
         provider_api_key: api_key

--- a/app/services/agent_runs/provider_selection_logger.rb
+++ b/app/services/agent_runs/provider_selection_logger.rb
@@ -136,7 +136,7 @@ module AgentRuns
       owner = project.effective_owner
       return [] unless owner
 
-      owner.providers.ordered.select do |provider|
+      owner.providers.kept_only.ordered.select do |provider|
         provider.enabled_for_agent_runs? &&
           ProviderSupport.container_executable_provider_key?(provider.provider_key)
       end

--- a/app/services/chat_sessions/create.rb
+++ b/app/services/chat_sessions/create.rb
@@ -83,7 +83,7 @@ module ChatSessions
 
     def resolved_provider
       @resolved_provider ||= if provider_id.present?
-        Provider.find(provider_id).tap do |provider|
+        Provider.kept_only.find(provider_id).tap do |provider|
           unless provider.user&.account_id == account.id
             raise ArgumentError, "provider must belong to the same account"
           end

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -178,7 +178,7 @@ module Issues
 
     def resolve_provider(goal)
       provider_id, = AgentRuns::ProviderResolver.call(project: @project, goal: goal)
-      Provider.find_by(id: provider_id) if provider_id
+      Provider.kept_only.find_by(id: provider_id) if provider_id
     end
   end
 end

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -382,7 +382,7 @@ module Activities
       return false if agent_run.provider_id == provider_id && agent_run.agent_type == agent_type
 
       agent_run.update!(
-        provider: Provider.find_by(id: provider_id),
+        provider: Provider.kept_only.find_by(id: provider_id),
         agent_type: agent_type
       )
       true

--- a/app/views/agent_runs/_filters.html.erb
+++ b/app/views/agent_runs/_filters.html.erb
@@ -33,7 +33,7 @@
       <div>
         <%= f.label :effective_provider_eq, "Provider", class: "block text-sm font-medium text-gray-700" %>
         <%= f.select :effective_provider_eq,
-          options_for_select(provider_options.map { |p| [Provider.display_name_for(p), p] }, params.dig(:q, :effective_provider_eq)),
+          options_for_select(provider_options.map { |option| [option[:label], option[:value]] }, params.dig(:q, :effective_provider_eq)),
           { include_blank: "All Providers" },
           class: "mt-1 block rounded-md border-gray-300 py-2 pl-3 pr-10 text-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500" %>
       </div>

--- a/db/migrate/20260509100259_add_discarded_at_to_providers.rb
+++ b/db/migrate/20260509100259_add_discarded_at_to_providers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddDiscardedAtToProviders < ActiveRecord::Migration[8.1]
+  def change
+    add_column :providers, :discarded_at, :datetime, comment: "Soft-delete timestamp so historical provider names remain available for filters and run history."
+    add_index :providers, :discarded_at
+
+    remove_index :providers, name: "idx_providers_unique_api_key"
+    remove_index :providers, name: "idx_providers_unique_subscription"
+
+    add_index :providers, [ :user_id, :provider_key, :provider_api_key_id, :name ],
+      unique: true,
+      where: "((auth_type)::text = 'api_key'::text) AND (discarded_at IS NULL)",
+      name: "idx_providers_unique_api_key"
+    add_index :providers, [ :user_id, :provider_key ],
+      unique: true,
+      where: "((auth_type)::text = 'subscription'::text) AND (discarded_at IS NULL)",
+      name: "idx_providers_unique_subscription"
+  end
+end

--- a/db/migrate/20260509121018_relax_provider_api_key_constraint_for_discarded_providers.rb
+++ b/db/migrate/20260509121018_relax_provider_api_key_constraint_for_discarded_providers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RelaxProviderApiKeyConstraintForDiscardedProviders < ActiveRecord::Migration[8.1]
+  def change
+    remove_check_constraint :providers, name: "providers_api_key_requires_key"
+    add_check_constraint :providers,
+      "(auth_type != 'api_key') OR provider_api_key_id IS NOT NULL OR discarded_at IS NOT NULL",
+      name: "providers_api_key_requires_key"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_045503) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_100259) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1582,6 +1582,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_045503) do
     t.jsonb "complexity_thresholds", default: {"low_max" => 3, "mid_max" => 7}, null: false
     t.jsonb "config", default: {}, null: false
     t.datetime "created_at", null: false
+    t.datetime "discarded_at", comment: "Soft-delete timestamp so historical provider names remain available for filters and run history."
     t.boolean "enabled_for_agent_runs", default: true, null: false
     t.boolean "enabled_for_fallback", default: true, null: false
     t.string "fallback_role", limit: 30, default: "standard", null: false
@@ -1593,10 +1594,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_045503) do
     t.bigint "user_id", null: false
     t.integer "weight", default: 1, null: false
     t.index ["auth_type"], name: "index_providers_on_auth_type"
+    t.index ["discarded_at"], name: "index_providers_on_discarded_at"
     t.index ["provider_api_key_id"], name: "index_providers_on_provider_api_key_id"
     t.index ["tier_model_ids"], name: "index_providers_on_tier_model_ids", using: :gin
-    t.index ["user_id", "provider_key", "provider_api_key_id", "name"], name: "idx_providers_unique_api_key", unique: true, where: "((auth_type)::text = 'api_key'::text)"
-    t.index ["user_id", "provider_key"], name: "idx_providers_unique_subscription", unique: true, where: "((auth_type)::text = 'subscription'::text)"
+    t.index ["user_id", "provider_key", "provider_api_key_id", "name"], name: "idx_providers_unique_api_key", unique: true, where: "(((auth_type)::text = 'api_key'::text) AND (discarded_at IS NULL))"
+    t.index ["user_id", "provider_key"], name: "idx_providers_unique_subscription", unique: true, where: "(((auth_type)::text = 'subscription'::text) AND (discarded_at IS NULL))"
     t.index ["user_id"], name: "index_providers_on_user_id"
     t.check_constraint "auth_type::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL", name: "providers_api_key_requires_key"
     t.check_constraint "auth_type::text <> 'subscription'::text OR provider_api_key_id IS NULL AND fallback_role::text = 'standard'::text", name: "providers_subscription_invariants"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_100259) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_121018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1600,7 +1600,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_100259) do
     t.index ["user_id", "provider_key", "provider_api_key_id", "name"], name: "idx_providers_unique_api_key", unique: true, where: "(((auth_type)::text = 'api_key'::text) AND (discarded_at IS NULL))"
     t.index ["user_id", "provider_key"], name: "idx_providers_unique_subscription", unique: true, where: "(((auth_type)::text = 'subscription'::text) AND (discarded_at IS NULL))"
     t.index ["user_id"], name: "index_providers_on_user_id"
-    t.check_constraint "auth_type::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL", name: "providers_api_key_requires_key"
+    t.check_constraint "auth_type::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL OR discarded_at IS NOT NULL", name: "providers_api_key_requires_key"
     t.check_constraint "auth_type::text <> 'subscription'::text OR provider_api_key_id IS NULL AND fallback_role::text = 'standard'::text", name: "providers_subscription_invariants"
     t.check_constraint "weight >= 1", name: "providers_weight_positive"
   end

--- a/docs/soft_delete_filter_backed_records.md
+++ b/docs/soft_delete_filter_backed_records.md
@@ -1,0 +1,24 @@
+# Soft Delete For Filter-Backed Records
+
+`Provider` now uses `discard` because provider names surface in agent-run history and filter labels, and hard deletion caused routed filter values like `provider:123` to lose their display name.
+
+Use `discard` for low-volume reference/configuration tables only when both of these are true:
+
+- The record's human-readable name appears in a UI filter or historical detail view.
+- Recreating the record later should not erase the historical label attached to old rows.
+
+Near-term candidates if they gain the same historical filter problem:
+
+- `ConfigurationBundle`
+- `Prompt`
+- `ServiceContainer`
+- `StyleGuide`
+
+Do not apply soft delete to high-volume operational tables. The storage and query cost is not justified there.
+
+- `AgentRun`
+- `AgentRunLog`
+- `AgentRunPhase`
+- `ChatMessage`
+- `CollectorRun`
+- `TokenUsage`

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2505,6 +2505,64 @@ RSpec.describe AgentRun do
         expect(Rails.cache.read(account_key)).to be_nil
       end
 
+      it "does not invalidate provider option caches for non-label provider changes" do
+        project = create(:project)
+        provider = create(:provider, user: project.effective_owner, provider_key: "opencode", name: "Kimi K2.5")
+        create(:agent_run, project: project, final_provider: provider.routing_key)
+        account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
+
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
+        expect(Rails.cache.read(account_key)).not_to be_nil
+
+        provider.update!(weight: provider.weight + 1)
+
+        expect(Rails.cache.read(account_key)).not_to be_nil
+      end
+
+      it "does not invalidate provider option caches for unrelated config changes" do
+        project = create(:project)
+        provider = create(
+          :provider,
+          user: project.effective_owner,
+          provider_key: "opencode",
+          name: "",
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2-0905" } }
+        )
+        create(:agent_run, project: project, final_provider: provider.routing_key)
+        account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
+
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
+        expect(Rails.cache.read(account_key)).not_to be_nil
+
+        provider.update!(
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2-0905" }, "extra" => "value" }
+        )
+
+        expect(Rails.cache.read(account_key)).not_to be_nil
+      end
+
+      it "invalidates provider option caches when model-driven display names change" do
+        project = create(:project)
+        provider = create(
+          :provider,
+          user: project.effective_owner,
+          provider_key: "opencode",
+          name: "",
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2-0905" } }
+        )
+        create(:agent_run, project: project, final_provider: provider.routing_key)
+        account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
+
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
+        expect(Rails.cache.read(account_key)).not_to be_nil
+
+        provider.update!(
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2-0906" } }
+        )
+
+        expect(Rails.cache.read(account_key)).to be_nil
+      end
+
       it "invalidates provider option caches when a provider is discarded" do
         project = create(:project)
         provider = create(:provider, user: project.effective_owner, provider_key: "opencode", name: "Kimi K2.5")

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2342,7 +2342,7 @@ RSpec.describe AgentRun do
     end
   end
 
-  describe ".distinct_effective_providers caching" do
+  describe ".distinct_effective_provider_options caching" do
     around do |example|
       original_cache = Rails.cache
       Rails.cache = ActiveSupport::Cache::MemoryStore.new
@@ -2358,10 +2358,10 @@ RSpec.describe AgentRun do
       account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
       scope = described_class.where(project_id: project.id)
 
-      first_call = scope.distinct_effective_providers(cache_key: account_key)
-      expect(first_call).to include("claude")
+      first_call = scope.distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
+      expect(first_call).to include({ label: Provider.display_name_for("claude"), value: "claude" })
 
-      second_call = scope.distinct_effective_providers(cache_key: account_key)
+      second_call = scope.distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
       expect(second_call).to eq(first_call)
     end
 
@@ -2371,13 +2371,13 @@ RSpec.describe AgentRun do
 
       scope = described_class.where(project_id: project.id)
 
-      first = scope.distinct_effective_providers
-      expect(first).to include("claude")
+      first = scope.distinct_effective_provider_options(account_id: project.account_id)
+      expect(first).to include({ label: Provider.display_name_for("claude"), value: "claude" })
 
       create(:agent_run, :completed, project: project, agent_type: "cursor")
 
-      second = scope.distinct_effective_providers
-      expect(second).to include("cursor")
+      second = scope.distinct_effective_provider_options(account_id: project.account_id)
+      expect(second).to include({ label: Provider.display_name_for("cursor"), value: "cursor" })
     end
 
     it "uses separate cache keys for account and project scope" do
@@ -2387,11 +2387,31 @@ RSpec.describe AgentRun do
       account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
       project_key = described_class.provider_options_cache_key_for(account_id: project.account_id, project_id: project.id)
 
-      described_class.where(project_id: project.id).distinct_effective_providers(cache_key: account_key)
-      described_class.where(project_id: project.id).distinct_effective_providers(cache_key: project_key)
+      described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
+      described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: project_key)
 
       expect(Rails.cache.read(account_key)).not_to be_nil
       expect(Rails.cache.read(project_key)).not_to be_nil
+    end
+
+    it "keeps discarded provider names available for routed filter options" do
+      project = create(:project)
+      provider = create(:provider, user: project.effective_owner, provider_key: "opencode", name: "Kimi K2.5")
+      create(:agent_run, :completed, project: project, final_provider: provider.routing_key)
+      provider.discard!
+
+      options = described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id)
+
+      expect(options).to include({ label: "Kimi K2.5", value: provider.routing_key })
+    end
+
+    it "omits unresolved routed provider ids from filter options" do
+      project = create(:project)
+      create(:agent_run, :completed, project: project, final_provider: "provider:999999")
+
+      options = described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id)
+
+      expect(options).to be_empty
     end
 
     it "includes account_id in project-scoped cache key" do
@@ -2405,7 +2425,7 @@ RSpec.describe AgentRun do
         project = create(:project)
         account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
 
-        described_class.where(project_id: project.id).distinct_effective_providers(cache_key: account_key)
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
         expect(Rails.cache.read(account_key)).not_to be_nil
 
         create(:agent_run, project: project, agent_type: "cursor")
@@ -2418,7 +2438,7 @@ RSpec.describe AgentRun do
         agent_run = create(:agent_run, :running, project: project, agent_type: "claude_code")
         account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
 
-        described_class.where(project_id: project.id).distinct_effective_providers(cache_key: account_key)
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
         expect(Rails.cache.read(account_key)).not_to be_nil
 
         agent_run.update!(final_provider: "cursor")
@@ -2431,7 +2451,7 @@ RSpec.describe AgentRun do
         agent_run = create(:agent_run, :queued, project: project, agent_type: "claude_code")
         account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
 
-        described_class.where(project_id: project.id).distinct_effective_providers(cache_key: account_key)
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
         expect(Rails.cache.read(account_key)).not_to be_nil
 
         agent_run.update!(status: "running", started_at: Time.current)
@@ -2451,6 +2471,34 @@ RSpec.describe AgentRun do
 
         expect(Rails.cache.read(account_key)).to be_nil
         expect(Rails.cache.read(project_key)).to be_nil
+      end
+
+      it "invalidates provider option caches when a routed provider is renamed" do
+        project = create(:project)
+        provider = create(:provider, user: project.effective_owner, provider_key: "opencode", name: "Kimi K2.5")
+        create(:agent_run, project: project, final_provider: provider.routing_key)
+        account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
+
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
+        expect(Rails.cache.read(account_key)).not_to be_nil
+
+        provider.update!(name: "Kimi K2.6")
+
+        expect(Rails.cache.read(account_key)).to be_nil
+      end
+
+      it "invalidates provider option caches when a provider is discarded" do
+        project = create(:project)
+        provider = create(:provider, user: project.effective_owner, provider_key: "opencode", name: "Kimi K2.5")
+        create(:agent_run, project: project, final_provider: provider.routing_key)
+        account_key = described_class.provider_options_cache_key_for(account_id: project.account_id)
+
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id, cache_key: account_key)
+        expect(Rails.cache.read(account_key)).not_to be_nil
+
+        provider.discard!
+
+        expect(Rails.cache.read(account_key)).to be_nil
       end
     end
   end

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2405,6 +2405,24 @@ RSpec.describe AgentRun do
       expect(options).to include({ label: "Kimi K2.5", value: provider.routing_key })
     end
 
+    it "bulk-loads routed provider filter options without N+1 queries" do
+      project = create(:project)
+      providers = %w[opencode cursor gemini].map.with_index do |provider_key, index|
+        create(:provider, user: project.effective_owner, provider_key:, name: "Routed Provider #{index}")
+      end
+      providers.each do |provider|
+        create(:agent_run, :completed, project: project, final_provider: provider.routing_key)
+      end
+
+      queries = capture_queries do
+        described_class.where(project_id: project.id).distinct_effective_provider_options(account_id: project.account_id)
+      end
+
+      provider_queries = queries.grep(/FROM "providers"/)
+
+      expect(provider_queries.size).to eq(1)
+    end
+
     it "omits unresolved routed provider ids from filter options" do
       project = create(:project)
       create(:agent_run, :completed, project: project, final_provider: "provider:999999")

--- a/spec/models/provider_api_key_spec.rb
+++ b/spec/models/provider_api_key_spec.rb
@@ -92,6 +92,15 @@ RSpec.describe ProviderApiKey do
 
       expect(api_key.destroy).to be_truthy
     end
+
+    it "allows deletion after the referencing provider has been discarded" do
+      api_key = create(:provider_api_key, api_service_type: "anthropic")
+      provider = create(:provider, :api_key, user: api_key.user, provider_key: "cursor", provider_api_key: api_key)
+      provider.discard!
+
+      expect(api_key.providers).to be_empty
+      expect(api_key.destroy).to be_truthy
+    end
   end
 
   describe ".for_api_service_type" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -953,4 +953,18 @@ RSpec.describe Provider do
       expect { duplicate.save!(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
+
+  describe "soft delete lifecycle" do
+    it "clears the API key reference when discarding an api-key provider" do
+      user = create(:user)
+      api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
+      provider = create(:provider, :api_key, user: user, provider_key: "cursor", provider_api_key: api_key)
+
+      expect(provider.discard).to be(true)
+
+      discarded_provider = described_class.with_discarded.find(provider.id)
+      expect(discarded_provider).to be_discarded
+      expect(discarded_provider.provider_api_key_id).to be_nil
+    end
+  end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -974,5 +974,21 @@ RSpec.describe Provider do
       expect(discarded_provider).to be_discarded
       expect(discarded_provider.provider_api_key_id).to be_nil
     end
+
+    it "does not clear the API key reference when discard is aborted by a guard" do
+      user = create(:user)
+      api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
+      provider = create(:provider, :api_key, user: user, provider_key: "cursor", provider_api_key: api_key)
+      user.providers.kept_only.where.not(id: provider.id).update_all(enabled_for_agent_runs: false, enabled_for_fallback: false)
+
+      expect(provider.discard).to be(false)
+
+      expect(provider.provider_api_key_id).to eq(api_key.id)
+      expect(provider.errors[:base]).to include("Cannot delete the last provider enabled for agent runs")
+
+      persisted_provider = described_class.find(provider.id)
+      expect(persisted_provider).to be_kept
+      expect(persisted_provider.provider_api_key_id).to eq(api_key.id)
+    end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -494,6 +494,14 @@ RSpec.describe Provider do
 
       expect(described_class.for_identifier(user, "claude")).to eq(subscription)
     end
+
+    it "prefers kept rows before discarded rows when including discarded matches" do
+      discarded_subscription = create(:provider, user: user, provider_key: "opencode", name: "Legacy Name")
+      discarded_subscription.update_column(:discarded_at, Time.current)
+      kept_subscription = create(:provider, user: user, provider_key: "opencode", name: "Current Name")
+
+      expect(described_class.for_identifier(user, "opencode", include_discarded: true)).to eq(kept_subscription)
+    end
   end
 
   describe "#display_name" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -212,4 +212,16 @@ RSpec.describe User do
       end
     end
   end
+
+  describe "provider cleanup" do
+    it "destroys discarded providers when the user is destroyed" do
+      user = create(:user)
+      provider = create(:provider, user: user, provider_key: "cursor")
+      provider.discard!
+
+      expect { user.destroy! }
+        .to change { Provider.with_discarded.where(id: provider.id).count }
+        .from(1).to(0)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,6 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "fixture_kit/rspec"
 require "rspec/rails"
 require "test_prof/recipes/rspec/factory_default"
-require "docker-api"
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "fixture_kit/rspec"
 require "rspec/rails"
 require "test_prof/recipes/rspec/factory_default"
+require "docker-api"
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -258,6 +258,20 @@ RSpec.describe "AgentRuns" do
         expect(response.body).not_to include(project_agent_run_path(project, issue_run))
       end
 
+      it "shows named provider filter labels and omits unresolved routed ids" do
+        kept_provider = create(:provider, user: project.effective_owner, provider_key: "opencode", name: "Kimi K2.5")
+        create(:agent_run, project: project, final_provider: kept_provider.routing_key)
+        create(:agent_run, project: project, final_provider: "provider:999999")
+        kept_provider.discard!
+
+        get agent_runs_path
+
+        option_text = parsed_html.css('select[name="q[effective_provider_eq]"] option').map { |option| option.text.squish }
+
+        expect(option_text).to include("Kimi K2.5")
+        expect(option_text).not_to include("provider:999999")
+      end
+
       it "shows the goal filter dropdown" do
         get agent_runs_path
 

--- a/spec/requests/provider_api_keys_spec.rb
+++ b/spec/requests/provider_api_keys_spec.rb
@@ -291,6 +291,18 @@ RSpec.describe "ProviderApiKeys" do
         expect(response).to redirect_to(provider_api_key_path(api_key))
         expect(flash[:alert]).to include("Cannot delete")
       end
+
+      it "allows deletion after the referencing provider has been soft deleted" do
+        api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
+        provider = create(:provider, :api_key, user: user, provider_key: "cursor", provider_api_key: api_key)
+        provider.discard!
+
+        expect {
+          delete provider_api_key_path(api_key)
+        }.to change(ProviderApiKey, :count).by(-1)
+
+        expect(response).to redirect_to(provider_api_keys_path)
+      end
     end
   end
 end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -765,7 +765,7 @@ RSpec.describe "Providers" do
       delete provider_path(provider)
 
       expect(response).to redirect_to(providers_path)
-      expect(Provider.find_by(id: provider.id)).to be_nil
+      expect(Provider.kept_only.find_by(id: provider.id)).to be_nil
       expect(Provider.with_discarded.find(provider.id)).to be_discarded
     end
   end

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -758,5 +758,15 @@ RSpec.describe "Providers" do
       expect(response).to redirect_to(providers_path)
       expect(flash[:alert]).to include("Cannot delete the last provider")
     end
+
+    it "soft deletes providers instead of removing the row" do
+      provider = create(:provider, user: user, provider_key: "cursor", name: "Cursor Stable")
+
+      delete provider_path(provider)
+
+      expect(response).to redirect_to(providers_path)
+      expect(Provider.find_by(id: provider.id)).to be_nil
+      expect(Provider.with_discarded.find(provider.id)).to be_discarded
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implemented the fix and the soft-delete follow-up in the working tree.

Provider filter options now come from resolved `{label, value}` entries instead of raw identifiers, so the agent runs index no longer renders `provider:<number>` as a visible option. Routed providers with a surviving record, including discarded ones, keep their historical display names; unresolved routed IDs are omitted from the filter list. I also added `discard` soft-delete support for `Provider`, switched provider deletion to `discard`, updated historical provider lookups to use `with_discarded`, and documented the broader low-volume/high-volume soft-delete direction in [docs/soft_delete_filter_backed_records.md](/workspace/docs/soft_delete_filter_backed_records.md:1).

Verification completed manually:
- `bundle exec rubocop` passed.
- `bundle exec rspec spec/models/agent_run_spec.rb spec/requests/agent_runs_spec.rb spec/requests/providers_spec.rb` passed.
- `bundle exec rspec` passed with `11444 examples, 0 failures, 3 pending`.

The remaining step is mechanical: the `git commit -m "fix(agent-runs): preserve provider filter names with soft delete"` command is still running its hook-driven full test pass in the attached session, so I can’t honestly claim the commit has finished yet.

---

Closes #1842