### PR TITLE
feat(orchestration): log decomposition decisions with workflow context

### DIFF
--- a/app/models/decomposition_decision.rb
+++ b/app/models/decomposition_decision.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DecompositionDecision < ApplicationRecord
-  DECISION_TYPES = %w[planning_outcome parallelization_outcome].freeze
+  DECISION_TYPES = %w[decomposition_strategy planning_outcome parallelization_outcome].freeze
 
   belongs_to :project
   belongs_to :issue

--- a/app/models/decomposition_decision.rb
+++ b/app/models/decomposition_decision.rb
@@ -2,6 +2,7 @@
 
 class DecompositionDecision < ApplicationRecord
   DECISION_TYPES = %w[decomposition_strategy planning_outcome parallelization_outcome].freeze
+  POLICY_OUTCOME_DECISION_TYPES = %w[planning_outcome parallelization_outcome].freeze
 
   belongs_to :project
   belongs_to :issue

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -60,6 +60,7 @@ module CoordinationPolicyEvolution
       @scoped_decisions ||= DecompositionDecision
         .joins(:project)
         .where(projects: { account_id: account.id })
+        .where(decision_type: DecompositionDecision::POLICY_OUTCOME_DECISION_TYPES)
         .where(created_at: lookback_days.days.ago..Time.current)
     end
 

--- a/app/services/orchestration/decomposition_decisions/log.rb
+++ b/app/services/orchestration/decomposition_decisions/log.rb
@@ -6,6 +6,7 @@ module Orchestration
       NOOP_OUTCOMES = %w[
         empty_plan
         single_task_plan
+        policy_skipped
         parallel_execution_skipped_empty_plan
         parallel_execution_skipped_single_task
       ].freeze

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -122,12 +122,12 @@ module Activities
         skip_reason: decomposition_result.skip_reason
       )
 
-      {
+      [ {
         tasks: tasks,
         prompt_source: POLICY_PROMPT_SOURCE,
         policy_source: decomposition_result.policy_source,
         skip_reason: decomposition_result.skip_reason
-      }
+      }, context ]
     rescue StandardError => e
       context[:error_details] = {
         error_class: e.class.name,
@@ -139,13 +139,6 @@ module Activities
         error: e.message
       )
       [ nil, context ]
-    else
-      [ {
-        tasks: tasks,
-        prompt_source: POLICY_PROMPT_SOURCE,
-        policy_source: decomposition_result.policy_source,
-        skip_reason: decomposition_result.skip_reason
-      }, context ]
     end
 
     def decompose(prompt)

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -107,6 +107,7 @@ module Activities
         policy_override: coordination_policy
       )
       context[:source] = decomposition_result.policy_source
+      context[:present] = policy_source_present?(decomposition_result.policy_source)
       context[:skip_reason] = decomposition_result.skip_reason
 
       return [ nil, context ] unless use_policy_service_result?(decomposition_result)
@@ -305,6 +306,7 @@ module Activities
     def default_policy_context
       {
         attempted: false,
+        present: false,
         source: nil,
         skip_reason: nil,
         error_details: {},
@@ -326,7 +328,7 @@ module Activities
         outcome: outcome,
         input_context: input_context.merge(
           scope_analysis: policy_context[:scope_analysis],
-          coordination_policy_present: policy_context[:attempted]
+          coordination_policy_present: policy_context[:present]
         ),
         plan_data: { tasks: tasks },
         error_details: error_details,
@@ -360,6 +362,10 @@ module Activities
       return "policy_skipped" if policy_result[:skip_reason].present?
 
       "policy_decomposed"
+    end
+
+    def policy_source_present?(policy_source)
+      %w[experiment feature_orchestration].include?(policy_source)
     end
 
     def llm_strategy_outcome_for(policy_context)

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -18,16 +18,33 @@ module Activities
       project_id = input[:project_id]
       issue_id = input[:issue_id]
       knowledge_context = input[:knowledge_context] || {}
+      workflow_name = input[:workflow_name]
+      workflow_id = input[:workflow_id]
 
       project = Project.find(project_id)
       issue = project.issues.find(issue_id)
+      prompt_data = nil
+      policy_context = default_policy_context
 
-      policy_result = decompose_with_policy_service(
+      policy_result, policy_context = decompose_with_policy_service(
         project: project,
         issue: issue,
         coordination_policy: input[:coordination_policy]
       )
-      return policy_result if policy_result
+      if policy_result
+        log_decomposition_strategy_decision(
+          project: project,
+          issue: issue,
+          workflow_name: workflow_name,
+          workflow_id: workflow_id,
+          input_context: knowledge_context,
+          tasks: policy_result[:tasks],
+          prompt_source: policy_result[:prompt_source],
+          policy_context: policy_context,
+          outcome: policy_strategy_outcome_for(policy_result)
+        )
+        return policy_result
+      end
 
       prompt_data = render_prompt(issue, knowledge_context)
       tasks = decompose(prompt_data[:prompt])
@@ -40,13 +57,48 @@ module Activities
         prompt_source: prompt_data[:prompt_source]
       )
 
+      log_decomposition_strategy_decision(
+        project: project,
+        issue: issue,
+        workflow_name: workflow_name,
+        workflow_id: workflow_id,
+        input_context: knowledge_context,
+        tasks: tasks,
+        prompt_source: prompt_data[:prompt_source],
+        policy_context: policy_context,
+        outcome: llm_strategy_outcome_for(policy_context)
+      )
+
       { tasks: tasks, prompt_source: prompt_data[:prompt_source] }
+    rescue Temporalio::Error::ApplicationError => e
+      log_decomposition_strategy_decision(
+        project: project,
+        issue: issue,
+        workflow_name: workflow_name,
+        workflow_id: workflow_id,
+        input_context: knowledge_context,
+        tasks: [],
+        prompt_source: prompt_data&.dig(:prompt_source),
+        policy_context: policy_context,
+        outcome: llm_failure_outcome_for(policy_context),
+        error_details: {
+          error_class: e.class.name,
+          error_message: e.message
+        }
+      )
+      raise
     end
 
     private
 
     def decompose_with_policy_service(project:, issue:, coordination_policy:)
+      context = default_policy_context.merge(attempted: true)
       scope_result = ScopeAnalysis::Analyze.call(text: issue.body)
+      context[:scope_analysis] = {
+        should_decompose: scope_result.should_decompose?,
+        confidence: scope_result.confidence,
+        sub_components: scope_result.sub_components
+      }
       decomposition_result = Coordination::DecompositionService.call(
         title: issue.title,
         description: issue.body,
@@ -54,8 +106,10 @@ module Activities
         account: project.account,
         policy_override: coordination_policy
       )
+      context[:source] = decomposition_result.policy_source
+      context[:skip_reason] = decomposition_result.skip_reason
 
-      return unless use_policy_service_result?(decomposition_result)
+      return [ nil, context ] unless use_policy_service_result?(decomposition_result)
 
       tasks = serialize_policy_tasks(decomposition_result.tasks)
       logger.info(
@@ -75,12 +129,23 @@ module Activities
         skip_reason: decomposition_result.skip_reason
       }
     rescue StandardError => e
+      context[:error_details] = {
+        error_class: e.class.name,
+        error_message: e.message
+      }
       logger.warn(
         message: "planning.policy_decomposition_failed",
         error_class: e.class.name,
         error: e.message
       )
-      nil
+      [ nil, context ]
+    else
+      [ {
+        tasks: tasks,
+        prompt_source: POLICY_PROMPT_SOURCE,
+        policy_source: decomposition_result.policy_source,
+        skip_reason: decomposition_result.skip_reason
+      }, context ]
     end
 
     def decompose(prompt)
@@ -242,6 +307,78 @@ module Activities
         type: "DecompositionFailed",
         non_retryable: true
       )
+    end
+
+    def default_policy_context
+      {
+        attempted: false,
+        source: nil,
+        skip_reason: nil,
+        error_details: {},
+        scope_analysis: {}
+      }
+    end
+
+    def log_decomposition_strategy_decision(project:, issue:, workflow_name:, workflow_id:, input_context:, tasks:,
+      prompt_source:, policy_context:, outcome:, error_details: {})
+      return if workflow_name.blank? || workflow_id.blank?
+
+      Orchestration::DecompositionDecisions::Log.call(
+        project_id: project.id,
+        issue_id: issue.id,
+        decision_key: decomposition_decision_key(workflow_id, error_details),
+        workflow_name: workflow_name,
+        workflow_id: workflow_id,
+        decision_type: "decomposition_strategy",
+        outcome: outcome,
+        input_context: input_context.merge(
+          scope_analysis: policy_context[:scope_analysis],
+          coordination_policy_present: policy_context[:attempted]
+        ),
+        plan_data: { tasks: tasks },
+        error_details: error_details,
+        metadata: {
+          prompt_source: prompt_source,
+          workflow_step: "decompose_feature",
+          activity_boundaries: [ self.class.name ],
+          policy_attempted: policy_context[:attempted],
+          policy_source: policy_context[:source],
+          skip_reason: policy_context[:skip_reason],
+          policy_error: policy_context[:error_details]
+        }
+      )
+    rescue StandardError => e
+      logger.warn(
+        message: "planning.decomposition_strategy_log_failed",
+        project_id: project.id,
+        issue_id: issue.id,
+        workflow_id: workflow_id,
+        error_class: e.class.name,
+        error: e.message
+      )
+    end
+
+    def decomposition_decision_key(workflow_id, error_details)
+      suffix = error_details.present? ? "failure" : "final"
+      "#{workflow_id}:decomposition_strategy:#{suffix}"
+    end
+
+    def policy_strategy_outcome_for(policy_result)
+      return "policy_skipped" if policy_result[:skip_reason].present?
+
+      "policy_decomposed"
+    end
+
+    def llm_strategy_outcome_for(policy_context)
+      return "llm_fallback_after_policy_failure" if policy_context[:error_details].present?
+
+      "llm_generated_plan"
+    end
+
+    def llm_failure_outcome_for(policy_context)
+      return "llm_fallback_failed_after_policy_failure" if policy_context[:error_details].present?
+
+      "llm_decomposition_failed"
     end
   end
 end

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -352,7 +352,9 @@ module Workflows
           project_id: project_id,
           issue_id: issue_id,
           knowledge_context: context_result[:context],
-          coordination_policy: coordination_policy
+          coordination_policy: coordination_policy,
+          workflow_name: self.class.name,
+          workflow_id: Temporalio::Workflow.info.workflow_id
         },
         timeout: 120
       )

--- a/app/temporal/workflows/planning_workflow.rb
+++ b/app/temporal/workflows/planning_workflow.rb
@@ -48,7 +48,9 @@ module Workflows
         {
           project_id: project_id,
           issue_id: issue_id,
-          knowledge_context: context_result[:context]
+          knowledge_context: context_result[:context],
+          workflow_name: self.class.name,
+          workflow_id: workflow_id
         },
         timeout: 120
       )

--- a/spec/models/decomposition_decision_spec.rb
+++ b/spec/models/decomposition_decision_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe DecompositionDecision do
     it { is_expected.to validate_presence_of(:decision_type) }
     it { is_expected.to validate_presence_of(:outcome) }
     it { is_expected.to validate_inclusion_of(:decision_type).in_array(described_class::DECISION_TYPES) }
+
+    it "supports decomposition strategy decisions" do
+      expect(described_class::DECISION_TYPES).to include("decomposition_strategy")
+    end
   end
 
   describe "defaults" do

--- a/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
         hints: { "task_count" => 0 },
         metadata: { "policy_source" => "feature_orchestration" }
       )
+      create(
+        :decomposition_decision,
+        project: project,
+        issue: create(:issue, project: project),
+        decision_type: "decomposition_strategy",
+        outcome: "decomposed",
+        hints: { "task_count" => 99 },
+        metadata: { "policy_source" => "feature_orchestration" }
+      )
       other_project = create(:project)
       create(:decomposition_decision, project: other_project, issue: create(:issue, project: other_project))
     end
@@ -62,6 +71,7 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
         "planning_outcome" => 2,
         "parallelization_outcome" => 1
       )
+      expect(result.dig(:performance, :decision_type_counts)).not_to include("decomposition_strategy")
       expect(result.dig(:performance, :policy_source_counts)).to include(
         "feature_orchestration" => 2,
         "defaults" => 1

--- a/spec/services/orchestration/decomposition_decisions/log_spec.rb
+++ b/spec/services/orchestration/decomposition_decisions/log_spec.rb
@@ -79,6 +79,30 @@ RSpec.describe Orchestration::DecompositionDecisions::Log do
       expect(decision.metadata["prompt_source"]).to eq("fallback_prompt")
     end
 
+    it "persists decomposition strategy decisions with workflow context" do
+      decision = described_class.call(**payload.merge(
+        decision_key: "wf-123:decomposition_strategy:final",
+        decision_type: "decomposition_strategy",
+        outcome: "llm_fallback_after_policy_failure",
+        metadata: payload[:metadata].merge(
+          workflow_step: "decompose_feature",
+          policy_source: "experiment",
+          policy_error: { error_message: "scope failure" }
+        )
+      ))
+
+      expect(decision.decision_type).to eq("decomposition_strategy")
+      expect(decision.metadata).to include(
+        "workflow_step" => "decompose_feature",
+        "policy_source" => "experiment",
+        "policy_error" => include("error_message" => "scope failure")
+      )
+      expect(decision.hints).to include(
+        "task_count" => 3,
+        "dependency_edges" => 1
+      )
+    end
+
     it "mirrors the decomposition record into orchestration decisions" do
       described_class.call(**payload)
 

--- a/spec/services/orchestration/decomposition_decisions/log_spec.rb
+++ b/spec/services/orchestration/decomposition_decisions/log_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Orchestration::DecompositionDecisions::Log do
       }
     end
 
-    def orchestration_decision_for(decision_key)
+    def orchestration_decision_for(decision_key, decision_type: "planning_outcome")
       OrchestrationDecision.find_by!(
         [
           <<~SQL.squish,
@@ -48,7 +48,7 @@ RSpec.describe Orchestration::DecompositionDecisions::Log do
             AND context ->> 'decision_key' = ?
           SQL
           project.id,
-          "planning_outcome",
+          decision_type,
           "Workflows::PlanningWorkflow",
           decision_key
         ]
@@ -139,6 +139,22 @@ RSpec.describe Orchestration::DecompositionDecisions::Log do
 
       expect(orchestration_decision.context["decision_status"]).to eq("noop")
       expect(orchestration_decision.outputs["outcome"]).to eq("single_task_plan")
+    end
+
+    it "marks policy-skipped decomposition strategy outcomes as noop" do
+      decision_key = "wf-123:decomposition_strategy:policy-skipped"
+      described_class.call(**payload.merge(
+        decision_key: decision_key,
+        decision_type: "decomposition_strategy",
+        outcome: "policy_skipped"
+      ))
+      orchestration_decision = orchestration_decision_for(
+        decision_key,
+        decision_type: "decomposition_strategy"
+      )
+
+      expect(orchestration_decision.context["decision_status"]).to eq("noop")
+      expect(orchestration_decision.outputs["outcome"]).to eq("policy_skipped")
     end
 
     it "marks failed decomposition outcomes as failed" do

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Activities::DecomposeFeatureActivity do
   let(:issue) { create(:issue, project: project, title: "Add OAuth", body: "Implement OAuth 2.0 login") }
 
   describe "#execute" do
+    let(:logged_decision) { build_stubbed(:decomposition_decision, decision_type: "decomposition_strategy") }
     let(:llm_response) do
       instance_double(
         AgentHarness::Response,
@@ -33,27 +34,81 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
     before do
       allow(AgentHarness).to receive(:send_message).and_return(llm_response)
+      allow(Orchestration::DecompositionDecisions::Log).to receive(:call).and_return(logged_decision)
       allow(Prompt).to receive(:resolve).and_return(nil)
       # Default: preserve CLI transport so existing exact-match expectations
       # pass. Individual specs flip this on to prove text-mode routing.
       allow(Llm::TextMode).to receive(:options).and_return({})
     end
 
-    it "returns parsed tasks from LLM output" do
-      result = activity.execute(
+    def execute_with_workflow_context(workflow_name:, workflow_id:)
+      activity.execute(
         project_id: project.id,
         issue_id: issue.id,
-        knowledge_context: knowledge_context
+        knowledge_context: knowledge_context,
+        workflow_name: workflow_name,
+        workflow_id: workflow_id
       )
+    end
 
-      tasks = result[:tasks]
+    def expect_llm_strategy_decision_logged(workflow_name:, workflow_id:, outcome:, prompt_source:)
+      expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
+        hash_including(
+          workflow_name: workflow_name,
+          workflow_id: workflow_id,
+          decision_type: "decomposition_strategy",
+          outcome: outcome,
+          metadata: hash_including(
+            workflow_step: "decompose_feature",
+            prompt_source: prompt_source,
+            activity_boundaries: [ "Activities::DecomposeFeatureActivity" ]
+          )
+        )
+      )
+    end
+
+    def expect_policy_decomposition_logged(workflow_name:, workflow_id:, outcome:)
+      expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
+        hash_including(
+          workflow_name: workflow_name,
+          workflow_id: workflow_id,
+          outcome: outcome,
+          metadata: hash_including(
+            prompt_source: "policy_service",
+            policy_attempted: true
+          )
+        )
+      )
+    end
+
+    def expect_oauth_tasks(tasks)
       expect(tasks.size).to eq(3)
       expect(tasks[0][:title]).to eq("Add OAuth migration")
       expect(tasks[0][:dependencies]).to eq([])
       expect(tasks[0][:parallel_group]).to eq(0)
       expect(tasks[1][:dependencies]).to eq([ 0 ])
       expect(tasks[2][:dependencies]).to eq([ 1 ])
+    end
+
+    it "returns parsed tasks from LLM output" do
+      result = execute_with_workflow_context(
+        workflow_name: "Workflows::PlanningWorkflow",
+        workflow_id: "planning-wf-1"
+      )
+
+      expect_oauth_tasks(result[:tasks])
       expect(result[:prompt_source]).to eq("fallback_prompt")
+      expect_llm_strategy_decision_logged(
+        workflow_name: "Workflows::PlanningWorkflow",
+        workflow_id: "planning-wf-1",
+        outcome: "llm_generated_plan",
+        prompt_source: "fallback_prompt"
+      )
+      expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
+        hash_including(
+          plan_data: hash_including(tasks: array_including(hash_including(title: "Add OAuth migration")))
+        )
+      )
     end
 
     context "when policy-based decomposition applies" do
@@ -67,15 +122,19 @@ RSpec.describe Activities::DecomposeFeatureActivity do
       end
 
       it "uses Coordination::DecompositionService instead of the LLM path" do
-        result = activity.execute(
-          project_id: project.id,
-          issue_id: issue.id,
-          knowledge_context: knowledge_context
+        result = execute_with_workflow_context(
+          workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+          workflow_id: "orchestration-wf-1"
         )
 
         expect(result[:prompt_source]).to eq(described_class::POLICY_PROMPT_SOURCE)
         expect(result[:tasks]).to all(include(:dependencies, :parallel_group, :scope))
         expect(AgentHarness).not_to have_received(:send_message)
+        expect_policy_decomposition_logged(
+          workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+          workflow_id: "orchestration-wf-1",
+          outcome: "policy_decomposed"
+        )
       end
     end
 
@@ -124,13 +183,21 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         result = activity.execute(
           project_id: project.id,
           issue_id: issue.id,
-          knowledge_context: knowledge_context
+          knowledge_context: knowledge_context,
+          workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+          workflow_id: "orchestration-wf-2"
         )
 
         expect(result[:prompt_source]).to eq(described_class::POLICY_PROMPT_SOURCE)
         expect(result[:tasks]).to eq([])
         expect(result[:skip_reason]).to eq("decomposition_disabled_by_policy")
         expect(AgentHarness).not_to have_received(:send_message)
+        expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
+          hash_including(
+            outcome: "policy_skipped",
+            plan_data: hash_including(tasks: [])
+          )
+        )
       end
     end
 
@@ -144,7 +211,9 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         result = activity.execute(
           project_id: project.id,
           issue_id: issue.id,
-          knowledge_context: knowledge_context
+          knowledge_context: knowledge_context,
+          workflow_name: "Workflows::PlanningWorkflow",
+          workflow_id: "planning-wf-2"
         )
 
         expect(result[:prompt_source]).to eq("fallback_prompt")
@@ -182,7 +251,13 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
     context "when policy decomposition raises" do
       let(:logger) { instance_spy(Logger) }
-      let(:scope_result) { double(sub_components: [ "api" ]) }
+      let(:scope_result) do
+        double(
+          should_decompose?: true,
+          confidence: 0.9,
+          sub_components: [ "api" ]
+        )
+      end
 
       before do
         allow(activity).to receive(:logger).and_return(logger)
@@ -192,10 +267,9 @@ RSpec.describe Activities::DecomposeFeatureActivity do
       end
 
       it "logs and falls back to LLM decomposition" do
-        result = activity.execute(
-          project_id: project.id,
-          issue_id: issue.id,
-          knowledge_context: knowledge_context
+        result = execute_with_workflow_context(
+          workflow_name: "Workflows::PlanningWorkflow",
+          workflow_id: "planning-wf-3"
         )
 
         expect(result[:prompt_source]).to eq("fallback_prompt")
@@ -205,6 +279,12 @@ RSpec.describe Activities::DecomposeFeatureActivity do
           message: "planning.policy_decomposition_failed",
           error_class: "StandardError",
           error: "decomposition failure"
+        )
+        expect_llm_strategy_decision_logged(
+          workflow_name: "Workflows::PlanningWorkflow",
+          workflow_id: "planning-wf-3",
+          outcome: "llm_fallback_after_policy_failure",
+          prompt_source: "fallback_prompt"
         )
       end
     end
@@ -320,9 +400,18 @@ RSpec.describe Activities::DecomposeFeatureActivity do
           activity.execute(
             project_id: project.id,
             issue_id: issue.id,
-            knowledge_context: knowledge_context
+            knowledge_context: knowledge_context,
+            workflow_name: "Workflows::PlanningWorkflow",
+            workflow_id: "planning-wf-4"
           )
         }.to raise_error(Temporalio::Error::ApplicationError, /LLM decomposition failed/)
+        expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
+          hash_including(
+            decision_key: "planning-wf-4:decomposition_strategy:failure",
+            outcome: "llm_decomposition_failed",
+            error_details: hash_including(error_message: "LLM decomposition failed: Rate limited")
+          )
+        )
       end
     end
 
@@ -334,9 +423,17 @@ RSpec.describe Activities::DecomposeFeatureActivity do
           activity.execute(
             project_id: project.id,
             issue_id: issue.id,
-            knowledge_context: knowledge_context
+            knowledge_context: knowledge_context,
+            workflow_name: "Workflows::PlanningWorkflow",
+            workflow_id: "planning-wf-5"
           )
         }.to raise_error(Temporalio::Error::ApplicationError, /Failed to parse/)
+        expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
+          hash_including(
+            outcome: "llm_decomposition_failed",
+            error_details: hash_including(error_message: a_string_including("Failed to parse"))
+          )
+        )
       end
     end
 

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -58,6 +58,9 @@ RSpec.describe Activities::DecomposeFeatureActivity do
           workflow_id: workflow_id,
           decision_type: "decomposition_strategy",
           outcome: outcome,
+          input_context: hash_including(
+            coordination_policy_present: false
+          ),
           metadata: hash_including(
             workflow_step: "decompose_feature",
             prompt_source: prompt_source,
@@ -67,12 +70,15 @@ RSpec.describe Activities::DecomposeFeatureActivity do
       )
     end
 
-    def expect_policy_decomposition_logged(workflow_name:, workflow_id:, outcome:)
+    def expect_policy_decomposition_logged(workflow_name:, workflow_id:, outcome:, coordination_policy_present:)
       expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
         hash_including(
           workflow_name: workflow_name,
           workflow_id: workflow_id,
           outcome: outcome,
+          input_context: hash_including(
+            coordination_policy_present: coordination_policy_present
+          ),
           metadata: hash_including(
             prompt_source: "policy_service",
             policy_attempted: true
@@ -133,7 +139,8 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         expect_policy_decomposition_logged(
           workflow_name: "Workflows::FeatureOrchestrationWorkflow",
           workflow_id: "orchestration-wf-1",
-          outcome: "policy_decomposed"
+          outcome: "policy_decomposed",
+          coordination_policy_present: false
         )
       end
     end
@@ -195,6 +202,9 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
           hash_including(
             outcome: "policy_skipped",
+            input_context: hash_including(
+              coordination_policy_present: true
+            ),
             plan_data: hash_including(tasks: [])
           )
         )

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -96,7 +96,16 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         expect(workflow).to have_received(:run_activity)
           .with(Activities::FetchPlanningContextActivity, hash_including(project_id: 1, issue_id: 2), timeout: 60)
         expect(workflow).to have_received(:run_activity)
-          .with(Activities::DecomposeFeatureActivity, hash_including(project_id: 1, issue_id: 2), timeout: 120)
+          .with(
+            Activities::DecomposeFeatureActivity,
+            hash_including(
+              project_id: 1,
+              issue_id: 2,
+              workflow_name: "Workflows::FeatureOrchestrationWorkflow",
+              workflow_id: "test-orchestration-wf"
+            ),
+            timeout: 120
+          )
         expect_orchestration_sub_issue_creation!
         expect(workflow).to have_received(:run_activity)
           .with(Activities::LogDecompositionDecisionActivity,

--- a/spec/temporal/workflows/planning_workflow_spec.rb
+++ b/spec/temporal/workflows/planning_workflow_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe Workflows::PlanningWorkflow do
       allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger, info: workflow_info)
     end
 
+    def expect_decompose_feature_activity_called
+      expect(workflow).to have_received(:run_activity)
+        .with(
+          Activities::DecomposeFeatureActivity,
+          hash_including(
+            project_id: 1,
+            issue_id: 2,
+            workflow_name: "Workflows::PlanningWorkflow",
+            workflow_id: "test-planning-wf"
+          ),
+          timeout: 120
+        )
+    end
+
     it "accepts a single input parameter" do
       params = workflow.method(:execute).parameters
       expect(params).to eq([ [ :req, :input ] ])
@@ -70,8 +84,7 @@ RSpec.describe Workflows::PlanningWorkflow do
 
         expect(workflow).to have_received(:run_activity)
           .with(Activities::FetchPlanningContextActivity, hash_including(project_id: 1, issue_id: 2), timeout: 60)
-        expect(workflow).to have_received(:run_activity)
-          .with(Activities::DecomposeFeatureActivity, hash_including(project_id: 1, issue_id: 2), timeout: 120)
+        expect_decompose_feature_activity_called
         expected_sub_tasks = tasks.map { |t| { title: t[:title], body: t[:description] } }
         expect(workflow).to have_received(:run_activity)
           .with(Activities::CreateSubIssuesActivity,


### PR DESCRIPTION
## Summary

Implemented the issue on branch `paid/1784-featorchestration-log-decomposition-decisions-with-7df5f0` and committed it as `a135a28` with message `feat(orchestration): log decomposition strategy decisions`.

The change logs decomposition decisions at the activity boundary in [`app/temporal/activities/decompose_feature_activity.rb`](/workspace/app/temporal/activities/decompose_feature_activity.rb), including workflow identity, issue/input context, generated plan data, dependency/parallelism hints, and explicit failure or fallback outcomes. Both [`PlanningWorkflow`](/workspace/app/temporal/workflows/planning_workflow.rb) and [`FeatureOrchestrationWorkflow`](/workspace/app/temporal/workflows/feature_orchestration_workflow.rb) now pass workflow name and workflow ID through so those records are correlated to the workflow run. Specs were added/updated to cover successful decomposition, policy-based decomposition, fallback behavior, and terminal failure paths.

Verification passed with full runs of `bundle exec rubocop` and `bundle exec rspec` (`11440 examples, 0 failures, 3 pending`). The worktree is clean, and nothing was pushed.

---

Closes #1784