### PR TITLE
feat(orchestration): log agent selection decisions with context

### DIFF
--- a/app/services/agent_runs/provider_selection_logger.rb
+++ b/app/services/agent_runs/provider_selection_logger.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+module AgentRuns
+  class ProviderSelectionLogger
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, goal:, resolved_agent_type:, resolved_provider_id:, issue: nil, agent_run: nil,
+      requested_agent_type: nil, requested_provider_id: nil, respect_requested: false, outcome: "selected", error: nil)
+      @project = project
+      @goal = goal
+      @resolved_agent_type = resolved_agent_type
+      @resolved_provider_id = resolved_provider_id
+      @issue = issue
+      @agent_run = agent_run
+      @requested_agent_type = requested_agent_type
+      @requested_provider_id = requested_provider_id
+      @respect_requested = respect_requested
+      @outcome = outcome
+      @error = error
+    end
+
+    def call
+      OrchestrationDecision.record(
+        project: project,
+        issue: issue,
+        agent_run: agent_run,
+        action: "select_agent",
+        decision_point: selection_source,
+        status: decision_status,
+        signals: inputs_payload,
+        result: outputs_payload
+      )
+    end
+
+    private
+
+    attr_reader :project, :goal, :resolved_agent_type, :resolved_provider_id, :issue, :agent_run,
+      :requested_agent_type, :requested_provider_id, :respect_requested, :outcome, :error
+
+    def inputs_payload
+      {
+        "task" => {
+          "goal" => goal,
+          "issue_id" => issue&.id,
+          "issue_title" => issue&.title,
+          "custom_prompt_present" => agent_run&.custom_prompt.present?,
+          "trigger_type" => agent_run&.trigger_type,
+          "priority_tier" => agent_run&.priority_tier
+        }.compact,
+        "repository" => {
+          "project_id" => project.id,
+          "full_name" => project.full_name,
+          "max_tokens_per_run" => project.max_tokens_per_run
+        }.compact,
+        "requested_selection" => {
+          "provider_id" => requested_provider_id,
+          "agent_type" => requested_agent_type,
+          "respect_requested" => respect_requested
+        }.compact,
+        "policy_constraints" => {
+          "preferred_agent_type" => preferences["preferred_agent_type"],
+          "default_agent_provider" => settings&.default_agent_provider,
+          "goal_default_agent_provider" => settings&.default_agent_providers_by_goal&.[](goal.to_s),
+          "provider_selection_mode" => settings&.provider_selection_mode
+        }.compact,
+        "budget_signals" => {
+          "active_budgets" => active_budget_signals
+        }
+      }
+    end
+
+    def outputs_payload
+      {
+        "outcome" => outcome,
+        "selection" => selection_payload,
+        "error" => error_payload
+      }.compact
+    end
+
+    def selection_payload
+      return if resolved_agent_type.blank? && resolved_provider_id.blank?
+
+      provider = selected_provider
+      {
+        "provider_id" => resolved_provider_id,
+        "provider_key" => provider&.provider_key || Provider.provider_key_for_agent_type(resolved_agent_type),
+        "auth_type" => provider&.auth_type,
+        "agent_type" => resolved_agent_type,
+        "effective_provider" => provider&.provider_key || Provider.provider_key_for_agent_type(resolved_agent_type),
+        "candidates" => ranked_candidates
+      }.compact
+    end
+
+    def ranked_candidates
+      candidates = []
+      provider = selected_provider
+
+      if resolved_agent_type.present? || provider.present?
+        candidates << candidate_payload(
+          provider: provider,
+          agent_type: resolved_agent_type.presence || Provider.agent_type_for(provider&.provider_key),
+          selected: true
+        )
+      end
+
+      runnable_provider_candidates.each do |candidate_provider|
+        next if provider && candidate_provider.id == provider.id
+
+        candidates << candidate_payload(
+          provider: candidate_provider,
+          agent_type: Provider.agent_type_for(candidate_provider.provider_key),
+          selected: false
+        )
+      end
+
+      candidates.compact.each_with_index.map do |candidate, index|
+        candidate.merge("rank" => index + 1)
+      end
+    end
+
+    def candidate_payload(provider:, agent_type:, selected:)
+      return if provider.nil? && agent_type.blank?
+
+      {
+        "selected" => selected,
+        "provider_id" => provider&.id,
+        "provider_key" => provider&.provider_key || Provider.provider_key_for_agent_type(agent_type),
+        "auth_type" => provider&.auth_type,
+        "agent_type" => agent_type
+      }.compact
+    end
+
+    def runnable_provider_candidates
+      owner = project.effective_owner
+      return [] unless owner
+
+      owner.providers.ordered.select do |provider|
+        provider.enabled_for_agent_runs? &&
+          ProviderSupport.container_executable_provider_key?(provider.provider_key)
+      end
+    end
+
+    def active_budget_signals
+      project.cost_budgets.filter_map do |budget|
+        next unless budget.limit_cents.to_i.positive?
+
+        {
+          "budget_type" => budget.budget_type,
+          "enforcement_mode" => budget.enforcement_mode,
+          "limit_cents" => budget.limit_cents,
+          "remaining_cents" => budget.remaining_cents,
+          "hard_stop" => budget.hard_stop?
+        }
+      end
+    end
+
+    def selected_provider
+      @selected_provider ||= ProviderResolver.selected_provider(project: project, provider_id: resolved_provider_id)
+    end
+
+    def preferences
+      @preferences ||= project.model_preferences || {}
+    end
+
+    def settings
+      @settings ||= UserSettingsResolver.call(project: project, strict: false)
+    end
+
+    def selection_source
+      preferred_agent_type = preferences["preferred_agent_type"]
+      return "requested_provider" if requested_provider_selected?
+      return "requested_agent_type" if requested_agent_type_selected?
+      return "project_preferred_agent_type" if preferred_agent_type.present? && preferred_agent_type == resolved_agent_type
+
+      "provider_selection"
+    end
+
+    def requested_provider_selected?
+      requested_provider_id.present? && requested_provider_id.to_s == resolved_provider_id.to_s
+    end
+
+    def requested_agent_type_selected?
+      requested_provider_id.blank? &&
+        requested_agent_type.present? &&
+        requested_agent_type == resolved_agent_type
+    end
+
+    def decision_status
+      outcome == "selected" ? "applied" : "failed"
+    end
+
+    def error_payload
+      return unless error
+
+      {
+        "class" => error.class.name,
+        "message" => error.message
+      }
+    end
+  end
+end

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -26,20 +26,15 @@ module Activities
       goal ||= project.account.tenant_setting&.default_goal || "create_pr"
       issue = issue_id ? Issue.find(issue_id) : nil
       user_settings = resolve_user_settings(project)
-      provider_id, agent_type = resolve_provider_selection(
+      provider_selection_options = {
         project: project,
-        requested_agent_type: input[:agent_type],
-        requested_provider_id: provider_id,
+        issue: issue,
         goal: goal,
-        respect_requested: input.key?(:agent_type) || input.key?(:provider_id)
-      )
-      validate_requested_provider_resolution!(
-        project: project,
+        requested_agent_type: input[:agent_type],
         requested_provider_id: input[:provider_id],
-        resolved_provider_id: provider_id
-      )
-
-      validate_runnable_provider!(project: project, provider_id: provider_id, agent_type: agent_type, goal: goal)
+        respect_requested: input.key?(:agent_type) || input.key?(:provider_id)
+      }
+      provider_id, agent_type = resolve_and_validate_provider_selection!(**provider_selection_options)
 
       # Resolve and render prompt version if no custom prompt is provided.
       # Skip for untrusted issues to match the safety behavior in AgentRun#prompt_for_issue.
@@ -93,6 +88,7 @@ module Activities
       attrs[:parent_workflow_id] = input[:parent_workflow_id] if input[:parent_workflow_id]
 
       agent_run = AgentRun.create!(**attrs)
+      log_provider_selection(agent_run: agent_run, **provider_selection_options, resolved_provider_id: provider_id, resolved_agent_type: agent_type)
 
       track_phase(
         agent_run_id: agent_run.id,
@@ -150,6 +146,41 @@ module Activities
         respect_requested: respect_requested,
         logger: logger
       )
+    end
+
+    def resolve_and_validate_provider_selection!(project:, issue:, requested_agent_type:, requested_provider_id:, goal:, respect_requested:)
+      provider_id = nil
+      agent_type = nil
+      provider_id, agent_type = resolve_provider_selection(
+        project: project,
+        requested_agent_type: requested_agent_type,
+        requested_provider_id: requested_provider_id,
+        goal: goal,
+        respect_requested: respect_requested
+      )
+
+      validate_requested_provider_resolution!(
+        project: project,
+        requested_provider_id: requested_provider_id,
+        resolved_provider_id: provider_id
+      )
+
+      validate_runnable_provider!(project: project, provider_id: provider_id, agent_type: agent_type, goal: goal)
+      [ provider_id, agent_type ]
+    rescue Temporalio::Error::ApplicationError => error
+      log_provider_selection(
+        project: project,
+        issue: issue,
+        goal: goal,
+        requested_agent_type: requested_agent_type,
+        requested_provider_id: requested_provider_id,
+        respect_requested: respect_requested,
+        resolved_provider_id: provider_id,
+        resolved_agent_type: agent_type,
+        outcome: "failed",
+        error: error
+      )
+      raise
     end
 
     def refresh_automatic_run_provider!(agent_run)
@@ -236,6 +267,23 @@ module Activities
 
     def resolve_user_settings(project)
       AgentRuns::UserSettingsResolver.call(project: project, strict: false)
+    end
+
+    def log_provider_selection(project:, goal:, resolved_agent_type:, resolved_provider_id:, issue: nil, agent_run: nil,
+      requested_agent_type: nil, requested_provider_id: nil, respect_requested: false, outcome: "selected", error: nil)
+      AgentRuns::ProviderSelectionLogger.call(
+        project: project,
+        issue: issue,
+        agent_run: agent_run,
+        goal: goal,
+        requested_agent_type: requested_agent_type,
+        requested_provider_id: requested_provider_id,
+        respect_requested: respect_requested,
+        resolved_provider_id: resolved_provider_id,
+        resolved_agent_type: resolved_agent_type,
+        outcome: outcome,
+        error: error
+      )
     end
 
     def provider_attempt_count_for(agent_run, user_settings)

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -18,6 +18,7 @@ module Activities
       project = Project.find(project_id)
       goal ||= project.account.tenant_setting&.default_goal || "create_pr"
       issue = issue_id ? Issue.find(issue_id) : nil
+      respect_requested = input.key?(:agent_type) || input.key?(:provider_id)
       provider_id, agent_type = resolve_provider_selection(
         project: project,
         requested_agent_type: requested_agent_type,
@@ -78,6 +79,18 @@ module Activities
         )
         return { agent_run_id: agent_run.id, queued: false, duplicate: true }
       end
+
+      AgentRuns::ProviderSelectionLogger.call(
+        project: project,
+        issue: issue,
+        agent_run: agent_run,
+        goal: goal,
+        requested_agent_type: requested_agent_type,
+        requested_provider_id: input[:provider_id],
+        respect_requested: respect_requested,
+        resolved_provider_id: provider_id,
+        resolved_agent_type: agent_type
+      )
 
       logger.info(
         message: "concurrency.agent_run_queued",

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -79,6 +79,22 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(agent_run.agent_type).to eq("cursor")
     end
 
+    it "records the provider selection decision with requested and ranked alternatives" do
+      provider = create(:provider, user: project.created_by, provider_key: "cursor")
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id, provider_id: provider.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      decision = agent_run.orchestration_decisions.where(decision_type: "select_agent").find_by(actor: "requested_provider")
+
+      expect_requested_provider_decision(
+        decision: decision,
+        provider_id: provider.id,
+        provider_key: "cursor",
+        agent_type: "cursor"
+      )
+    end
+
     it "falls back to the runnable default when a requested provider_id is not container executable" do
       provider = create(:provider, user: project.created_by, provider_key: "copilot")
       allow(ProviderSupport).to receive(:container_executable_provider_key?).and_call_original
@@ -141,6 +157,10 @@ RSpec.describe Activities::CreateAgentRunActivity do
         expect(error.type).to eq("NoRunnableProvider")
         expect(error.non_retryable).to be(true)
       }
+
+      decision = project.orchestration_decisions.order(:id).last
+
+      expect_failed_provider_decision(decision: decision, provider_id: missing_provider_id)
     end
 
     it "uses the goal-specific provider for fresh review runs" do
@@ -707,5 +727,37 @@ RSpec.describe Activities::CreateAgentRunActivity do
         expect(queued_run.agent_type).to eq("claude_code")
       end
     end
+  end
+
+  def expect_requested_provider_decision(decision:, provider_id:, provider_key:, agent_type:)
+    expect(decision).to be_present
+    expect(decision.context).to include(
+      "decision_status" => "applied",
+      "issue_id" => issue.id
+    )
+    expect(decision.inputs.dig("requested_selection", "provider_id")).to eq(provider_id)
+    expect(decision.inputs.dig("repository", "full_name")).to eq(project.full_name)
+    expect(decision.outputs).to include(
+      "outcome" => "selected",
+      "selection" => include(
+        "provider_id" => provider_id,
+        "provider_key" => provider_key,
+        "agent_type" => agent_type,
+        "candidates" => include(
+          include("rank" => 1, "selected" => true, "provider_id" => provider_id, "provider_key" => provider_key)
+        )
+      )
+    )
+  end
+
+  def expect_failed_provider_decision(decision:, provider_id:)
+    expect(decision.agent_run_id).to be_nil
+    expect(decision.decision_type).to eq("select_agent")
+    expect(decision.context["decision_status"]).to eq("failed")
+    expect(decision.inputs.dig("requested_selection", "provider_id")).to eq(provider_id)
+    expect(decision.outputs["error"]).to include(
+      "class" => "Temporalio::Error::ApplicationError",
+      "message" => include("provider_id=#{provider_id}")
+    )
   end
 end

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -97,6 +97,28 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.agent_type).to eq("codex")
     end
 
+    it "records a provider selection decision for queued runs" do
+      codex_provider = user.providers.find_or_create_by!(provider_key: "codex", auth_type: "subscription")
+      user.settings.update!(default_agent_provider: codex_provider.routing_key)
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      decision = agent_run.orchestration_decisions.where(decision_type: "select_agent").find_by(actor: "provider_selection")
+
+      expect(decision).to be_present
+      expect(decision.context["decision_status"]).to eq("applied")
+      expect(decision.outputs).to include(
+        "outcome" => "selected",
+        "selection" => include(
+          "provider_id" => codex_provider.id,
+          "provider_key" => "codex",
+          "agent_type" => "codex"
+        )
+      )
+      expect(decision.inputs.dig("policy_constraints", "default_agent_provider")).to eq(codex_provider.routing_key)
+    end
+
     it "uses the tenant API key provider for the default provider" do
       api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
       create(:tenant_setting, account: user.account,


### PR DESCRIPTION
## Summary

Implemented and committed on `paid/1785-featorchestration-log-agent-selection-decisions-wi-fc5851` as `460af7c` (`feat(orchestration): log provider selection context`).

The change adds `AgentRuns::ProviderSelectionLogger` and wires it into both `CreateAgentRunActivity` and `QueueAgentRunActivity` so provider/agent selection decisions are persisted as `OrchestrationDecision` records with task, repository, policy, and budget context. Successful selections now record the chosen provider/agent plus ranked provider alternatives, and pre-run provider-resolution failures are logged safely before the activity raises.

Verification passed:
- `bin/rails db:prepare`
- `bundle exec rubocop`
- `bundle exec rspec`

The full suite finished with `11443 examples, 0 failures, 3 pending`.

---

Closes #1785