### PR TITLE
chore: add Prosopite N+1 detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,10 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"
 
+  # N+1 query detection for Rails requests and specs.
+  gem "pg_query", require: false
+  gem "prosopite"
+
   # Audits gems for known security defects (use config/bundler-audit.yml to ignore issues)
   gem "bundler-audit", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,8 @@ GEM
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
+    pg_query (6.2.2)
+      google-protobuf (>= 3.25.3)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -332,6 +334,7 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
+    prosopite (2.2.0)
     psych (5.3.1)
       date
       stringio
@@ -596,7 +599,9 @@ DEPENDENCIES
   octokit
   pagy (~> 43.5)
   pg (~> 1.1)
+  pg_query
   propshaft
+  prosopite
   puma (>= 5.0)
   pundit
   qdrant-ruby
@@ -747,10 +752,12 @@ CHECKSUMS
   pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
+  pg_query (6.2.2) sha256=316c194160ccfac8af9a7aff55cdc5b2d13bdd8bd8734976c6bddc477e779b6f
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
+  prosopite (2.2.0) sha256=14affaa3ff0ff15abe8f6ae2951de0984dc6da5df1c42333692d2c0789d08b91
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   puma (8.0.1) sha256=7b94e50c07655718c1fb8ae41a11fc06c7d61293208b3aa608ff71a46d3ad37c

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,4 +58,11 @@ Rails.application.configure do
   config.active_record.encryption.primary_key = "test0primary0key0for0encryption0"
   config.active_record.encryption.deterministic_key = "test0deterministic0key0for0encr"
   config.active_record.encryption.key_derivation_salt = "test0key0derivation0salt0value0"
+
+  config.after_initialize do
+    next unless ENV["PROSOPITE"] == "true"
+
+    Prosopite.raise = ENV["PROSOPITE_RAISE"] == "true"
+    Prosopite.stderr_logger = true unless Prosopite.raise?
+  end
 end

--- a/config/initializers/prosopite.rb
+++ b/config/initializers/prosopite.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+return unless Rails.env.development?
+
+require "prosopite/middleware/rack"
+
+Rails.application.config.after_initialize do
+  Prosopite.rails_logger = true
+end
+
+Rails.application.config.middleware.use(Prosopite::Middleware::Rack)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -99,10 +99,18 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    if database_available && !example.metadata[:tenant_isolation]
-      TenantContext.with_system_access { example.run }
+    run_example = proc do
+      if database_available && !example.metadata[:tenant_isolation]
+        TenantContext.with_system_access { example.run }
+      else
+        example.run
+      end
+    end
+
+    if ENV["PROSOPITE"] == "true"
+      Prosopite.scan { run_example.call }
     else
-      example.run
+      run_example.call
     end
   ensure
     next unless database_available


### PR DESCRIPTION
## Summary
Adds `prosopite` for N+1 query detection in this Rails app.

## Changes
- add `prosopite` and `pg_query` to the app bundle
- enable request-level Prosopite middleware in development
- add opt-in Prosopite scanning for RSpec examples via `PROSOPITE=true`
- support optional test failure mode via `PROSOPITE_RAISE=true`
- keep test behavior unchanged by default so the suite does not start failing unexpectedly

## Verification
- booted Rails and confirmed `Prosopite::Middleware::Rack` is mounted in development
- verified test env toggles for warn mode and raise mode
- ran `COVERAGE=false PROSOPITE=true bin/rspec spec/services/llm/text_mode_spec.rb`

## Notes
This keeps developer UX conservative by default while making it easy to run targeted N+1 checks locally or in CI.