### PR TITLE
feat(lint): integrate herb linter and fix all ERB template offenses

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -136,7 +136,8 @@
         "DavidAnson.vscode-markdownlint",
         "Tyriar.sort-lines",
         "ryu1kn.partial-diff",
-        "bierner.markdown-mermaid"
+        "bierner.markdown-mermaid",
+        "marcoroth.herb-lsp"
       ],
       "settings": {
         // Ruby

--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,96 @@
+# This file configures Herb for your project and team.
+# Settings here take precedence over individual editor preferences.
+#
+# Herb is a suite of tools for HTML+ERB templates including:
+# - Linter: Validates templates and enforces best practices
+# - Formatter: Auto-formats templates with intelligent indentation
+# - Language Server: Provides IDE support (VS Code, Zed, Neovim, etc.)
+#
+# Website: https://herb-tools.dev
+# Configuration: https://herb-tools.dev/configuration
+# GitHub Repo: https://github.com/marcoroth/herb
+#
+
+version: 0.10.1
+
+# # Framework and template engine configuration
+#
+# # Options: ruby | actionview | hanami | sinatra (default: ruby)
+# framework: ruby
+#
+# # Options: erubi | erb | herb (default: erubi)
+# template_engine: erubi
+
+# files:
+#   # Additional patterns beyond the defaults (**.html, **.rhtml, **.html.erb, etc.)
+#   include:
+#     - '**/*.xml.erb'
+#     - 'custom/**/*.html'
+#
+#   # Patterns to exclude (can exclude defaults too)
+#   exclude:
+#     - 'public/**/*'
+#     - 'tmp/**/*'
+
+# engine:
+#   validators:
+#     security: true       # default: true
+#     nesting: true        # default: true
+#     accessibility: true  # default: true
+
+linter:
+  enabled: true
+
+  # # Exit with error code when diagnostics of this severity or higher are present
+  # # Valid values: error (default), warning, info, hint
+  # failLevel: warning
+
+  # # Additional patterns beyond the defaults for linting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from linting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # rules:
+  #   erb-no-extra-newline:
+  #     enabled: false
+  #
+  #   # Rules can have 'include', 'only', and 'exclude' patterns
+  #   some-rule:
+  #     # Additional patterns to check (additive, ignored when 'only' is present)
+  #     include:
+  #       - 'app/components/**/*'
+  #     # Don't apply this rule to files matching these patterns
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+  #
+  #   another-rule:
+  #     # Only apply this rule to files matching these patterns (overrides all 'include')
+  #     only:
+  #       - 'app/views/**/*'
+  #     # Exclude still applies even with 'only'
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+
+formatter:
+  enabled: false
+  indentWidth: 2
+  maxLineLength: 80
+
+  # # Additional patterns beyond the defaults for formatting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from formatting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # # Rewriters modify templates during formatting
+  # rewriter:
+  #   # Pre-format rewriters (modify AST before formatting)
+  #   pre:
+  #     - tailwind-class-sorter
+  #   # Post-format rewriters (modify formatted output string)
+  #   post: []

--- a/.herb.yml
+++ b/.herb.yml
@@ -41,7 +41,7 @@ version: 0.10.1
 linter:
   enabled: true
   rules:
-    # TODO(#1882): Re-enable once the application CSP policy and nonce generator are enabled.
+    # TODO(#1887): Re-enable once the application CSP policy and nonce generator are enabled.
     html-require-script-nonce:
       enabled: false
 

--- a/.herb.yml
+++ b/.herb.yml
@@ -40,6 +40,10 @@ version: 0.10.1
 
 linter:
   enabled: true
+  rules:
+    # TODO(#1882): Re-enable once the application CSP policy and nonce generator are enabled.
+    html-require-script-nonce:
+      enabled: false
 
   # # Exit with error code when diagnostics of this severity or higher are present
   # # Valid values: error (default), warning, info, hint

--- a/Gemfile
+++ b/Gemfile
@@ -130,6 +130,9 @@ group :development do
 
   # Request-level performance metrics dashboard [https://github.com/igorkasyanchuk/rails_performance]
   gem "rails_performance"
+
+  # Developer tools for HTML+ERB templates [https://herb-tools.dev]
+  gem "herb", require: false
 end
 
 gem "good_job", "~> 4.18"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,13 @@ GEM
       bigdecimal
       rake (~> 13.3)
     hashdiff (1.2.1)
+    herb (0.10.1-aarch64-linux-gnu)
+    herb (0.10.1-aarch64-linux-musl)
+    herb (0.10.1-arm-linux-gnu)
+    herb (0.10.1-arm-linux-musl)
+    herb (0.10.1-arm64-darwin)
+    herb (0.10.1-x86_64-linux-gnu)
+    herb (0.10.1-x86_64-linux-musl)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -596,6 +603,7 @@ DEPENDENCIES
   flipper-active_record
   fx
   good_job (~> 4.18)
+  herb
   jsbundling-rails
   kamal
   logidze
@@ -708,6 +716,13 @@ CHECKSUMS
   google-protobuf (4.34.1-x86_64-linux-gnu) sha256=87088c9fd8e47b5b40ca498fc1195add6149e941ff7e81c532a5b0b8876d4cc9
   google-protobuf (4.34.1-x86_64-linux-musl) sha256=8c0e91436fbe504ffc64f0bd621f2e69adbcce8ed2c58439d7a21117069cfdd7
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  herb (0.10.1-aarch64-linux-gnu) sha256=fd9f4f8e0bcd9a421de55ff8810066550e9bcba8c8bf53737b32a04eb2fcbc49
+  herb (0.10.1-aarch64-linux-musl) sha256=bc6dac577c25bb7b35fe812987a9da7056aabd3a9394941c2aadf68bcca7c58e
+  herb (0.10.1-arm-linux-gnu) sha256=965fcb7bb59c7307c2dfdb8fa03ae06724184886bcb015088585e5163036a425
+  herb (0.10.1-arm-linux-musl) sha256=d1c18bf017bccaf32e27439e74e53b3f24bc8056d0ef70e79568ac7f7b2e2728
+  herb (0.10.1-arm64-darwin) sha256=08d0434ae94d23a7353d767085dc974cc5e63943a07cd48bc99afd7fea919c1b
+  herb (0.10.1-x86_64-linux-gnu) sha256=c7762d411a6d2e1a032cf403b0429155c01ab48b3b5be2a0aab1e921da6b8948
+  herb (0.10.1-x86_64-linux-musl) sha256=a5bb7c82bbc30a9eb80cb833fea749f543a0709d9f858f7db366a3c2616d969b
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3

--- a/app/views/ab_tests/new.html.erb
+++ b/app/views/ab_tests/new.html.erb
@@ -69,7 +69,7 @@
               <% non_current_versions.each do |version| %>
                 <label class="flex items-start rounded-md border border-gray-200 p-3 hover:bg-gray-50 cursor-pointer">
                   <input type="checkbox" name="ab_test[variant_version_ids][]" value="<%= version.id %>"
-                         <%= "checked" if @selected_variant_ids&.include?(version.id) %>
+                         <% if @selected_variant_ids&.include?(version.id) %>checked<% end %>
                          class="mt-0.5 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                   <div class="ml-3">
                     <span class="text-sm font-medium text-gray-900">v<%= version.version %></span>

--- a/app/views/agent_runs/_detail_actions.html.erb
+++ b/app/views/agent_runs/_detail_actions.html.erb
@@ -14,7 +14,7 @@
 <% retry_provider_options = local_assigns.fetch(:retry_provider_options, []) %>
 
 <% if show_cancel %>
-  <div class="mt-3 flex justify-end" data-when-unfinished <%= "hidden" unless agent_run.status.in?(AgentRun::UNFINISHED_STATUSES) %>>
+  <div class="mt-3 flex justify-end" data-when-unfinished <% unless agent_run.status.in?(AgentRun::UNFINISHED_STATUSES) %>hidden<% end %>>
     <%= button_to "Cancel",
           cancel_project_agent_run_path(agent_run.project, agent_run),
           method: :post,
@@ -24,7 +24,7 @@
 <% end %>
 
 <% if show_resume %>
-  <div class="mt-3 flex justify-end" data-when-paused <%= "hidden" unless agent_run.paused? %>>
+  <div class="mt-3 flex justify-end" data-when-paused <% unless agent_run.paused? %>hidden<% end %>>
     <%= button_to "Resume",
           resume_project_agent_run_path(agent_run.project, agent_run),
           method: :post,
@@ -35,7 +35,7 @@
 
 <% if show_retry %>
   <% show_retry_menu = retry_provider_options.any? { |option| !option[:current] } %>
-  <div class="mt-3 flex justify-end" data-when-finished <%= "hidden" unless agent_run.finished? %>>
+  <div class="mt-3 flex justify-end" data-when-finished <% unless agent_run.finished? %>hidden<% end %>>
     <% if show_retry_menu %>
       <% retry_menu_button_id = dom_id(agent_run, :retry_menu_button) %>
       <% retry_menu_id = dom_id(agent_run, :retry_menu) %>
@@ -91,12 +91,16 @@
 <% if show_retry %>
   <% if agent_run.auth_expired? && agent_run.auth_provider.present? && AgentHarness.respond_to?(:refresh_auth) && AgentHarness.respond_to?(:auth_url) %>
     <% auth_url = agent_harness_auth_url(agent_run.auth_provider) %>
-    <% if auth_url.present? %>
-      <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/30" data-when-auth-expired>
-        <p class="text-sm text-amber-700 dark:text-amber-300">
+    <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/30" data-when-auth-expired>
+      <p class="text-sm text-amber-700 dark:text-amber-300">
+        <% if auth_url.present? %>
           1. Visit the login URL to re-authenticate:
           <%= link_to auth_url, auth_url, target: "_blank", rel: "noopener noreferrer", class: "text-amber-800 underline hover:text-amber-900 break-all dark:text-amber-200 dark:hover:text-amber-100" %>
-        </p>
+        <% else %>
+          Authentication has expired for <%= Provider.display_name(agent_run.auth_provider) %>, but Paid cannot generate a browser login URL for this provider. Refresh the configured provider credentials, then retry the run.
+        <% end %>
+      </p>
+      <% if auth_url.present? %>
         <p class="mt-2 text-sm text-amber-700 dark:text-amber-300">2. Paste the refreshed OAuth token below:</p>
         <%= form_with url: refresh_auth_project_agent_run_path(agent_run.project, agent_run), method: :post, class: "mt-2 flex items-center space-x-2" do |f| %>
           <%# Dark-mode input styling is handled by the global unlayered overrides
@@ -105,14 +109,8 @@
           <%= f.password_field :auth_token, placeholder: "Paste OAuth token here", autocomplete: "off", spellcheck: false, class: "block w-full rounded-md border-amber-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-amber-500 focus:ring-amber-500", aria: { label: "OAuth token" } %>
           <%= f.submit "Re-authenticate", class: "inline-flex items-center rounded-md bg-amber-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-amber-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-600 cursor-pointer" %>
         <% end %>
-      </div>
-    <% else %>
-      <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/30" data-when-auth-expired>
-        <p class="text-sm text-amber-700 dark:text-amber-300">
-          Authentication has expired for <%= Provider.display_name(agent_run.auth_provider) %>, but Paid cannot generate a browser login URL for this provider. Refresh the configured provider credentials, then retry the run.
-        </p>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   <% else %>
     <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/30" data-when-auth-expired hidden>
       <p class="text-sm text-amber-700 dark:text-amber-300">Authentication has expired. Refresh the page to re-authenticate.</p>
@@ -121,7 +119,7 @@
 <% end %>
 
 <% if show_retry %>
-  <div class="mt-3" data-when-error <%= "hidden" unless agent_run.error_message.present? %>>
+  <div class="mt-3" data-when-error <% unless agent_run.error_message.present? %>hidden<% end %>>
     <% if %w[in_progress processing].include?(agent_run.diagnosis_status) %>
       <span class="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400">
         <svg class="mr-1.5 h-4 w-4 animate-spin text-gray-400 dark:text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/app/views/chat_messages/_tool_call.html.erb
+++ b/app/views/chat_messages/_tool_call.html.erb
@@ -1,6 +1,6 @@
 <% tool_title = message.role == "tool" ? "Tool Result" : "Tool Call" %>
 <% payload = message.role == "tool" ? (message.tool_result || message.content) : message.tool_arguments %>
-<details class="rounded-lg border border-blue-200 bg-white" <%= "open" if message.role == "tool" %>>
+<details class="rounded-lg border border-blue-200 bg-white" <% if message.role == "tool" %>open<% end %>>
   <summary class="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-semibold text-gray-800">
     <span><%= tool_title %>: <%= message.tool_name.presence || "Unknown tool" %></span>
     <span class="inline-flex items-center rounded-md bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700">

--- a/app/views/chat_sessions/_sidebar.html.erb
+++ b/app/views/chat_sessions/_sidebar.html.erb
@@ -9,9 +9,10 @@
           <span class="sr-only">Search chat sessions</span>
           <input type="search"
                  placeholder="Search sessions"
+                 autocomplete="off"
                  class="w-full rounded-md border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
                  data-chat-session-list-target="searchInput"
-                 data-action="input->chat-session-list#filter" />
+                 data-action="input->chat-session-list#filter">
         </label>
         <% if can_create_chat_session %>
           <button type="button"

--- a/app/views/dashboard/_activity_stream.html.erb
+++ b/app/views/dashboard/_activity_stream.html.erb
@@ -1,5 +1,6 @@
-<% if activity_items.any? %>
-  <div class="overflow-hidden rounded-lg bg-white shadow">
+<div class="overflow-hidden rounded-lg bg-white shadow">
+  <% if activity_items.any? %>
+
     <ul class="divide-y divide-gray-200">
       <% activity_items.each do |item| %>
         <% if item.is_a?(AgentRun) %>
@@ -54,11 +55,13 @@
                   <span class="inline-flex items-center rounded-md bg-green-100 px-2 py-1 text-xs font-medium text-green-700">Resumed</span>
                 <% end %>
                 <span class="text-sm font-medium text-gray-900"><%= item.project.full_name %></span>
-                <% if item.event_type == "paused" %>
-                  <span class="truncate text-sm text-gray-500">Automatic work paused by quality gate</span>
-                <% else %>
-                  <span class="truncate text-sm text-gray-500">Quality pause resumed</span>
-                <% end %>
+                <span class="truncate text-sm text-gray-500">
+                  <% if item.event_type == "paused" %>
+                    Automatic work paused by quality gate
+                  <% else %>
+                    Quality pause resumed
+                  <% end %>
+                </span>
               </div>
               <div class="flex items-center gap-4 text-sm text-gray-500">
                 <% if item.event_type == "paused" && item.composite_score.present? && item.threshold.present? %>
@@ -73,9 +76,10 @@
         <% end %>
       <% end %>
     </ul>
-  </div>
-<% else %>
-  <div class="overflow-hidden rounded-lg bg-white shadow">
+
+  <% else %>
+
     <div class="px-4 py-5 text-sm text-gray-500">No recent activity.</div>
-  </div>
-<% end %>
+
+  <% end %>
+</div>

--- a/app/views/dashboard/_metrics.html.erb
+++ b/app/views/dashboard/_metrics.html.erb
@@ -13,7 +13,7 @@
 
   <%# Run Volume & Outcome %>
   <div>
-    <h2 class="text-lg font-semibold text-gray-900">Run Volume & Outcome</h2>
+    <h2 class="text-lg font-semibold text-gray-900">Run Volume &amp; Outcome</h2>
     <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
         <dt class="truncate text-sm font-medium text-gray-500">Total Runs</dt>
@@ -123,7 +123,7 @@
   <% has_cost_or_token_data = cost_tokens[:total_cost_cents].to_i > 0 || cost_tokens[:trailing_30d_tokens].to_i > 0 %>
   <% if has_cost_or_token_data %>
     <div class="mt-8">
-      <h2 class="text-lg font-semibold text-gray-900">Cost & Token Usage</h2>
+      <h2 class="text-lg font-semibold text-gray-900">Cost &amp; Token Usage</h2>
       <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <div class="overflow-hidden rounded-lg bg-white shadow px-4 py-5 sm:p-6">
           <dt class="truncate text-sm font-medium text-gray-500">Total Cost</dt>
@@ -216,8 +216,8 @@
             <% width_pct = total_avg_seconds.zero? ? 0 : ((avg_seconds.to_f / total_avg_seconds) * 100).round(1) %>
             <div class="<%= phase_group_bar_style(phase_group) %> h-4 float-left"
                  style="width: <%= width_pct %>%"
-                 title="<%= "#{phase_group_label(phase_group)}: #{format_duration(avg_seconds)}" %>"
-                 aria-label="<%= "#{phase_group_label(phase_group)} average duration #{format_duration(avg_seconds)} (#{width_pct}%) of total run time" %>"
+                 title="<%= phase_group_label(phase_group) %>: <%= format_duration(avg_seconds) %>"
+                 aria-label="<%= phase_group_label(phase_group) %> average duration <%= format_duration(avg_seconds) %> (<%= width_pct %>%) of total run time"
                  tabindex="0"></div>
           <% end %>
         </div>

--- a/app/views/dashboard/_orchestration_decisions.html.erb
+++ b/app/views/dashboard/_orchestration_decisions.html.erb
@@ -158,8 +158,14 @@
       <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
         <div class="px-4 py-5 sm:p-6">
           <h3 class="text-sm font-semibold text-gray-900">Decision Volume Over Time</h3>
+          <p class="mt-1 text-sm text-gray-500">
+            <% if daily_volume.size >= 2 %>
+              Daily decision counts split by applied, no-op, and failed outcomes.
+            <% else %>
+              Not enough daily history yet for a useful trend view.
+            <% end %>
+          </p>
           <% if daily_volume.size >= 2 %>
-            <p class="mt-1 text-sm text-gray-500">Daily decision counts split by applied, no-op, and failed outcomes.</p>
             <div class="mt-4">
               <%= column_chart [
                 {
@@ -201,8 +207,6 @@
                     }
                   } %>
             </div>
-          <% else %>
-            <p class="mt-1 text-sm text-gray-500">Not enough daily history yet for a useful trend view.</p>
           <% end %>
         </div>
       </div>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,9 @@
 <p>Hello <%= @email %>!</p>
 
-<% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
-<% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
-<% end %>
+<p>
+  <% if @resource.try(:unconfirmed_email?) %>
+    We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.
+  <% else %>
+    We're contacting you to notify you that your email has been changed to <%= @resource.email %>.
+  <% end %>
+</p>

--- a/app/views/knowledge/browse/show.html.erb
+++ b/app/views/knowledge/browse/show.html.erb
@@ -25,8 +25,8 @@
     </div>
   </div>
 
-  <% if @artifacts.any? %>
-    <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
+  <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
+    <% if @artifacts.any? %>
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
@@ -61,28 +61,26 @@
           <% end %>
         </tbody>
       </table>
-    </div>
-
-    <% if @pagy.pages > 1 %>
-      <div class="mt-4 flex items-center justify-between">
-        <div class="text-sm text-gray-500">
-          Page <span class="font-medium"><%= @pagy.page %></span> of <span class="font-medium"><%= @pagy.pages %></span>
-        </div>
-        <div class="flex items-center gap-2">
-          <% if @pagy.previous %>
-            <%= link_to "Previous", project_knowledge_browse_path(@project, @artifact_type, page: @pagy.previous), class: "rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
-          <% end %>
-          <% if @pagy.next %>
-            <%= link_to "Next", project_knowledge_browse_path(@project, @artifact_type, page: @pagy.next), class: "rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
-  <% else %>
-    <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
+    <% else %>
       <div class="px-4 py-12 text-center">
         <h3 class="text-sm font-semibold text-gray-900">No <%= @artifact_type.titleize.downcase %> artifacts</h3>
         <p class="mt-1 text-sm text-gray-500">No active artifacts of this type were found for this project.</p>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @artifacts.any? && @pagy.pages > 1 %>
+    <div class="mt-4 flex items-center justify-between">
+      <div class="text-sm text-gray-500">
+        Page <span class="font-medium"><%= @pagy.page %></span> of <span class="font-medium"><%= @pagy.pages %></span>
+      </div>
+      <div class="flex items-center gap-2">
+        <% if @pagy.previous %>
+          <%= link_to "Previous", project_knowledge_browse_path(@project, @artifact_type, page: @pagy.previous), class: "rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
+        <% end %>
+        <% if @pagy.next %>
+          <%= link_to "Next", project_knowledge_browse_path(@project, @artifact_type, page: @pagy.next), class: "rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/knowledge/context_intake/_no_session.html.erb
+++ b/app/views/knowledge/context_intake/_no_session.html.erb
@@ -7,10 +7,10 @@
     <p class="mt-2 text-sm text-gray-500">
       Start the guided questionnaire to capture business and product context that helps agents understand your project beyond the code.
     </p>
-    <% if policy(@project).update? %>
+    <% if policy(project).update? %>
       <div class="mt-6">
         <%= button_to "Start Business Context Questionnaire",
-              project_context_intake_path(@project),
+              project_context_intake_path(project),
               method: :post,
               class: "inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
       </div>

--- a/app/views/knowledge/context_intake/_summary.html.erb
+++ b/app/views/knowledge/context_intake/_summary.html.erb
@@ -1,28 +1,28 @@
 <div class="mt-6">
   <%# Status banner %>
   <div class="overflow-hidden rounded-lg shadow
-              <%= @session.stale? ? 'bg-yellow-50 border border-yellow-200' : 'bg-green-50 border border-green-200' %>">
+              <%= session.stale? ? 'bg-yellow-50 border border-yellow-200' : 'bg-green-50 border border-green-200' %>">
     <div class="px-4 py-4 sm:px-6 flex items-center justify-between">
       <div>
-        <% if @session.stale? %>
+        <% if session.stale? %>
           <p class="text-sm font-medium text-yellow-800">
-            Business context is stale (last updated <%= time_ago_in_words(@session.completed_at) %> ago).
+            Business context is stale (last updated <%= time_ago_in_words(session.completed_at) %> ago).
             Consider refreshing it.
           </p>
         <% else %>
           <p class="text-sm font-medium text-green-800">
             Business context captured
-            <% if @session.completed_at %>
-              <%= time_ago_in_words(@session.completed_at) %> ago
+            <% if session.completed_at %>
+              <%= time_ago_in_words(session.completed_at) %> ago
             <% end %>
-            by <%= @session.started_by&.name || @session.started_by&.email %>.
+            by <%= session.started_by&.name || session.started_by&.email %>.
           </p>
         <% end %>
       </div>
-      <% if policy(@project).update? %>
+      <% if policy(project).update? %>
         <div>
           <%= button_to "Refresh Business Context",
-                project_context_intake_path(@project),
+                project_context_intake_path(project),
                 method: :post,
                 class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
         </div>
@@ -31,7 +31,7 @@
   </div>
 
   <%# Saved responses %>
-  <% @session.responses_by_section.each do |section_key, responses| %>
+  <% session.responses_by_section.each do |section_key, responses| %>
     <% section = Knowledge::ContextIntake::QuestionnaireSchema.sections.find { |s| s[:key] == section_key } %>
     <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
       <div class="px-4 py-5 sm:p-6">

--- a/app/views/knowledge/context_intake/_wizard.html.erb
+++ b/app/views/knowledge/context_intake/_wizard.html.erb
@@ -3,12 +3,12 @@
     <div class="px-4 py-4 sm:px-6">
       <div class="flex items-center justify-between">
         <p class="text-sm font-medium text-gray-700">
-          Progress: <%= @progress[:answered] %> / <%= @progress[:total] %> questions answered
+          Progress: <%= progress[:answered] %> / <%= progress[:total] %> questions answered
         </p>
-        <p class="text-sm text-gray-500"><%= @progress[:percentage] %>%</p>
+        <p class="text-sm text-gray-500"><%= progress[:percentage] %>%</p>
       </div>
       <div class="mt-2 w-full bg-gray-200 rounded-full h-2">
-        <div class="bg-indigo-600 h-2 rounded-full transition-all duration-300" style="width: <%= @progress[:percentage] %>%"></div>
+        <div class="bg-indigo-600 h-2 rounded-full transition-all duration-300" style="width: <%= progress[:percentage] %>%"></div>
       </div>
     </div>
   </div>
@@ -16,9 +16,9 @@
   <%# Section navigation %>
   <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
     <nav class="flex overflow-x-auto px-4 py-3 sm:px-6" aria-label="Sections">
-      <% @sections.each do |section| %>
-        <%= link_to project_context_intake_path(@project, section: section[:key]),
-              class: "mr-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors #{section[:key] == @active_section_key ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'}" do %>
+      <% sections.each do |section| %>
+        <%= link_to project_context_intake_path(project, section: section[:key]),
+              class: "mr-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors #{section[:key] == active_section_key ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'}" do %>
           <%= section[:title] %>
         <% end %>
       <% end %>
@@ -26,17 +26,17 @@
   </div>
 
   <%# Questions per section %>
-  <% @sections.each do |section| %>
+  <% sections.each do |section| %>
     <div class="mt-4 overflow-hidden rounded-lg bg-white shadow"
          data-section="<%= section[:key] %>"
-         style="<%= section[:key] == @active_section_key ? '' : 'display: none;' %>">
+         style="<%= section[:key] == active_section_key ? '' : 'display: none;' %>">
       <div class="px-4 py-5 sm:p-6">
         <h3 class="text-lg font-medium text-gray-900 mb-4"><%= section[:title] %></h3>
 
         <% section[:questions].each do |question| %>
-          <% response = @responses[question[:key]] %>
+          <% response = responses[question[:key]] %>
           <div class="mb-6 last:mb-0">
-            <%= form_with url: project_context_intake_path(@project),
+            <%= form_with url: project_context_intake_path(project),
                           method: :patch,
                           data: { turbo: false } do |f| %>
               <%= f.hidden_field :question_key, value: question[:key] %>
@@ -79,7 +79,7 @@
   <%# Complete button %>
   <div class="mt-6 flex justify-end">
     <%= button_to "Complete & Save Business Context",
-          complete_project_context_intake_path(@project),
+          complete_project_context_intake_path(project),
           method: :post,
           class: "inline-flex items-center rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 cursor-pointer",
           data: { turbo_confirm: "Are you sure you want to complete the questionnaire? You can start a new one later to update." } %>

--- a/app/views/knowledge/context_intake/show.html.erb
+++ b/app/views/knowledge/context_intake/show.html.erb
@@ -16,10 +16,10 @@
   </div>
 
   <% if @session.nil? %>
-    <%= render "no_session" %>
+    <%= render "no_session", project: @project %>
   <% elsif @session.in_progress? %>
-    <%= render "wizard" %>
+    <%= render "wizard", progress: @progress, sections: @sections, project: @project, active_section_key: @active_section_key, responses: @responses %>
   <% else %>
-    <%= render "summary" %>
+    <%= render "summary", session: @session, project: @project %>
   <% end %>
 </div>

--- a/app/views/knowledge/search/_results.html.erb
+++ b/app/views/knowledge/search/_results.html.erb
@@ -1,16 +1,16 @@
-<% if @error.present? %>
+<% if error.present? %>
   <div class="mt-4 rounded-md bg-yellow-50 p-4">
-    <div class="text-sm text-yellow-700"><%= @error %></div>
+    <div class="text-sm text-yellow-700"><%= error %></div>
   </div>
-<% elsif @results %>
+<% elsif results %>
   <div class="mt-4 text-sm text-gray-500">
-    <%= @meta[:total] %> results in <%= @meta[:took_ms] %>ms
-    (mode: <%= @meta[:mode] %>)
+    <%= meta[:total] %> results in <%= meta[:took_ms] %>ms
+    (mode: <%= meta[:mode] %>)
   </div>
 
-  <% if @results.any? %>
+  <% if results.any? %>
     <div class="mt-4 space-y-4">
-      <% @results.each do |result| %>
+      <% results.each do |result| %>
         <div class="overflow-hidden rounded-lg bg-white shadow">
           <div class="px-4 py-4 sm:px-6">
             <div class="flex items-center justify-between">

--- a/app/views/knowledge/search/_semantic_search_settings.html.erb
+++ b/app/views/knowledge/search/_semantic_search_settings.html.erb
@@ -6,20 +6,20 @@
       <%# API Key Status %>
       <div class="flex items-center justify-between">
         <div class="flex items-center">
-          <% case @semantic_search_source %>
+          <% case semantic_search_source %>
           <% when :user_key %>
             <span class="inline-block h-2 w-2 flex-shrink-0 rounded-full bg-green-500"></span>
             <span class="ml-2 text-sm text-gray-700">
-              Using <span class="font-medium"><%= @semantic_search_provider_config.provider_label %></span>
-              with API key: <span class="font-medium"><%= @semantic_search_api_key_record.name %></span>
-              <% if @semantic_search_api_key_record.user_id == current_user.id %>
-                <code class="ml-1 rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-500"><%= @semantic_search_api_key_record.masked_api_key %></code>
+              Using <span class="font-medium"><%= semantic_search_provider_config.provider_label %></span>
+              with API key: <span class="font-medium"><%= semantic_search_api_key_record.name %></span>
+              <% if semantic_search_api_key_record.user_id == current_user.id %>
+                <code class="ml-1 rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-500"><%= semantic_search_api_key_record.masked_api_key %></code>
               <% end %>
             </span>
           <% when :platform_env %>
             <span class="inline-block h-2 w-2 flex-shrink-0 rounded-full bg-blue-500"></span>
             <span class="ml-2 text-sm text-gray-700">
-              Using platform-provided <%= @semantic_search_provider_config.provider_label %> key
+              Using platform-provided <%= semantic_search_provider_config.provider_label %> key
             </span>
           <% when :available %>
             <span class="inline-block h-2 w-2 flex-shrink-0 rounded-full bg-blue-500"></span>
@@ -33,11 +33,11 @@
         </div>
 
         <div class="flex-shrink-0">
-          <% if @semantic_search_source == :none %>
+          <% if semantic_search_source == :none %>
             <%= link_to "Add an API key", provider_api_keys_path, class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
-          <% elsif @semantic_search_source == :user_key && @semantic_search_api_key_record&.user_id == current_user.id %>
+          <% elsif semantic_search_source == :user_key && semantic_search_api_key_record&.user_id == current_user.id %>
             <%= link_to "Manage your API keys", provider_api_keys_path, class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
-          <% elsif @semantic_search_source == :user_key %>
+          <% elsif semantic_search_source == :user_key %>
             <%= link_to "View your API keys", provider_api_keys_path, class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
           <% end %>
           <%# Platform-provided keys have no user-facing management link %>
@@ -45,7 +45,7 @@
       </div>
 
       <%# Embedding Model — only shown when semantic search is active %>
-      <% if @semantic_search_source != :none && @search_mode != "exact" %>
+      <% if semantic_search_source != :none && search_mode != "exact" %>
         <div class="flex items-center border-t border-gray-100 pt-3">
           <span class="text-sm text-gray-500">Embedding model:</span>
           <code class="ml-2 rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600"><%= Knowledge::Embeddings::Generate::MODEL %></code>

--- a/app/views/knowledge/search/project_search.html.erb
+++ b/app/views/knowledge/search/project_search.html.erb
@@ -53,9 +53,13 @@
     </div>
   </div>
 
-  <%= render "knowledge/search/semantic_search_settings" %>
+  <%= render "knowledge/search/semantic_search_settings",
+        semantic_search_source: @semantic_search_source,
+        semantic_search_provider_config: @semantic_search_provider_config,
+        semantic_search_api_key_record: @semantic_search_api_key_record,
+        search_mode: @search_mode %>
 
   <%= turbo_frame_tag "search-results" do %>
-    <%= render "knowledge/search/results" %>
+    <%= render "knowledge/search/results", error: @error, results: @results, meta: @meta %>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
         display: block;
       }
     </style>
-    <script nonce="<%= request.content_security_policy_nonce %>">
+    <script>
       (function() {
         var root = document.documentElement;
         var serverPref = root.dataset.themePreferenceValue || "system";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
         display: block;
       }
     </style>
-    <script>
+    <script nonce="<%= request.content_security_policy_nonce %>">
       (function() {
         var root = document.documentElement;
         var serverPref = root.dataset.themePreferenceValue || "system";
@@ -48,7 +48,7 @@
     <%= yield :head %>
 
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+    <%# tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
 
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -1,5 +1,4 @@
 <li id="<%= dom_id(issue) %>" class="flex items-center justify-between px-4 py-3">
-  <% paused_run = local_assigns.fetch(:paused_run, nil) %>
   <div class="min-w-0 flex-1">
     <div class="flex items-center space-x-2">
       <%= link_to "##{issue.github_number}",
@@ -8,11 +7,6 @@
             rel: "noopener noreferrer",
             class: "flex-shrink-0 text-sm font-medium text-indigo-600 hover:text-indigo-900" %>
       <span class="truncate text-sm text-gray-900"><%= issue.title %></span>
-      <% if paused_run.present? %>
-        <span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">
-          Paused by <%= guardrail_violation_label_for(paused_run).downcase %>
-        </span>
-      <% end %>
     </div>
     <% if issue.labels.any? %>
       <div class="mt-1 flex flex-wrap gap-1">
@@ -49,19 +43,7 @@
         <span>PR #<%= linked_pr.github_number %></span>
       <% end %>
     <% end %>
-    <% if paused_run.present? %>
-      <% if policy(paused_run).resume? %>
-        <%= button_to "Resume Run",
-                      resume_project_agent_run_path(project, paused_run),
-                      method: :post,
-                      params: { return_to: project_path(project) },
-                      form: { data: { action_button: true, turbo_confirm: "Resume this paused agent run?" } },
-                      class: "text-xs font-semibold text-green-600 hover:text-green-900" %>
-      <% end %>
-      <%= link_to "View Run",
-                  project_agent_run_path(project, paused_run),
-                  class: "text-xs font-medium text-yellow-700 hover:text-yellow-900" %>
-    <% elsif paid_pr %>
+    <% if paid_pr %>
       <%# Paid already produced an open PR — steer the user to iterate on
           that PR rather than starting a duplicate run. %>
       <span class="inline-flex cursor-not-allowed items-center rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-400"

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -65,7 +65,7 @@
       <%# Paid already produced an open PR — steer the user to iterate on
           that PR rather than starting a duplicate run. %>
       <span class="inline-flex cursor-not-allowed items-center rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-400"
-            title="<%= "Quick run on PR ##{paid_pr.github_number} instead of this issue." %>"
+            title="Quick run on PR #<%= paid_pr.github_number %> instead of this issue."
             aria-disabled="true"
             data-issue-quick-run-disabled="true">
         Quick Run

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -1,4 +1,5 @@
 <li id="<%= dom_id(issue) %>" class="flex items-center justify-between px-4 py-3">
+  <% paused_run = local_assigns.fetch(:paused_run, nil) %>
   <div class="min-w-0 flex-1">
     <div class="flex items-center space-x-2">
       <%= link_to "##{issue.github_number}",
@@ -7,6 +8,11 @@
             rel: "noopener noreferrer",
             class: "flex-shrink-0 text-sm font-medium text-indigo-600 hover:text-indigo-900" %>
       <span class="truncate text-sm text-gray-900"><%= issue.title %></span>
+      <% if paused_run.present? %>
+        <span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">
+          Paused by <%= guardrail_violation_label_for(paused_run).downcase %>
+        </span>
+      <% end %>
     </div>
     <% if issue.labels.any? %>
       <div class="mt-1 flex flex-wrap gap-1">
@@ -43,7 +49,19 @@
         <span>PR #<%= linked_pr.github_number %></span>
       <% end %>
     <% end %>
-    <% if paid_pr %>
+    <% if paused_run.present? %>
+      <% if policy(paused_run).resume? %>
+        <%= button_to "Resume Run",
+                      resume_project_agent_run_path(project, paused_run),
+                      method: :post,
+                      params: { return_to: project_path(project) },
+                      form: { data: { action_button: true, turbo_confirm: "Resume this paused agent run?" } },
+                      class: "text-xs font-semibold text-green-600 hover:text-green-900" %>
+      <% end %>
+      <%= link_to "View Run",
+                  project_agent_run_path(project, paused_run),
+                  class: "text-xs font-medium text-yellow-700 hover:text-yellow-900" %>
+    <% elsif paid_pr %>
       <%# Paid already produced an open PR — steer the user to iterate on
           that PR rather than starting a duplicate run. %>
       <span class="inline-flex cursor-not-allowed items-center rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-400"

--- a/app/views/projects/_screenshot_settings.html.erb
+++ b/app/views/projects/_screenshot_settings.html.erb
@@ -24,13 +24,13 @@
 
   <div>
     <div class="flex items-center">
-      <input type="hidden" name="project[screenshot_settings][enabled]" value="0" />
+      <input type="hidden" name="project[screenshot_settings][enabled]" value="0">
       <input type="checkbox"
         name="project[screenshot_settings][enabled]"
         id="project_screenshot_settings_enabled"
         value="1"
-        <%= "checked" if @screenshot_settings["enabled"] %>
-        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+        <% if screenshot_settings["enabled"] %>checked<% end %>
+        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
       <label for="project_screenshot_settings_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Enable screenshots for this project</label>
     </div>
     <p class="mt-1 ml-7 text-xs text-gray-500">Turns screenshot capture on or off for Paid-created pull requests.</p>
@@ -43,8 +43,8 @@
           <input type="radio"
             name="project[screenshot_settings][driver]"
             value="<%= driver %>"
-            <%= "checked" if @screenshot_settings["driver"] == driver %>
-            class="mt-1 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+            <% if screenshot_settings["driver"] == driver %>checked<% end %>
+            class="mt-1 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600">
           <div>
             <div class="text-sm font-medium text-gray-900"><%= driver.humanize %></div>
             <p class="mt-1 text-xs text-gray-500"><%= description %></p>
@@ -61,21 +61,22 @@
         <input type="text"
           name="project[screenshot_settings][config_path]"
           id="project_screenshot_settings_config_path"
-          value="<%= @screenshot_settings["config_path"] %>"
-          class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" />
+          value="<%= screenshot_settings["config_path"] %>"
+          autocomplete="off"
+          class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
       </div>
       <p class="mt-1 text-xs text-gray-500">Default repo path is <code>.paid/screenshots.yml</code>.</p>
     </div>
 
     <div>
       <div class="flex items-center">
-        <input type="hidden" name="project[screenshot_settings][auto_capture]" value="0" />
+        <input type="hidden" name="project[screenshot_settings][auto_capture]" value="0">
         <input type="checkbox"
           name="project[screenshot_settings][auto_capture]"
           id="project_screenshot_settings_auto_capture"
           value="1"
-          <%= "checked" if @screenshot_settings["auto_capture"] %>
-          class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+          <% if screenshot_settings["auto_capture"] %>checked<% end %>
+          class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
         <label for="project_screenshot_settings_auto_capture" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Capture on every agent-created PR</label>
       </div>
       <p class="mt-1 ml-7 text-xs text-gray-500">Keeps screenshot generation automatic instead of manual-only.</p>
@@ -86,13 +87,13 @@
     <p class="block text-sm font-medium leading-6 text-gray-900">Service Dependencies</p>
     <p class="mt-1 text-xs text-gray-500">Select the services screenshot capture should provision before the app boots.</p>
     <div class="mt-3 grid gap-3 sm:grid-cols-2">
-      <% @screenshot_service_options.each do |service| %>
+      <% screenshot_service_options.each do |service| %>
         <label class="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2">
           <input type="checkbox"
             name="project[screenshot_settings][service_dependencies][]"
             value="<%= service.name %>"
-            <%= "checked" if @screenshot_settings["service_dependencies"].include?(service.name) %>
-            class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+            <% if screenshot_settings["service_dependencies"].include?(service.name) %>checked<% end %>
+            class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
           <span class="text-sm text-gray-900"><%= service.name %></span>
         </label>
       <% end %>
@@ -106,12 +107,12 @@
         name="project[screenshot_settings][setup_commands_text]"
         id="project_screenshot_settings_setup_commands_text"
         rows="5"
-        class="block w-full rounded-md border-0 px-3 py-1.5 font-mono text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600"><%= @screenshot_settings["setup_commands"].join("\n") %></textarea>
+        class="block w-full rounded-md border-0 px-3 py-1.5 font-mono text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600"><%= screenshot_settings["setup_commands"].join("\n") %></textarea>
     </div>
     <p class="mt-1 text-xs text-gray-500">One command per line.</p>
   </div>
 
-  <% detection = @screenshot_settings["detection"] %>
+  <% detection = screenshot_settings["detection"] %>
   <% if detection.present? %>
     <div class="rounded-md border border-blue-200 bg-blue-50 p-4">
       <div class="flex items-start justify-between gap-4">
@@ -150,29 +151,29 @@
     </div>
   <% end %>
 
-  <% if @screenshot_settings["enabled"] %>
+  <% if screenshot_settings["enabled"] %>
     <div class="rounded-md border border-gray-200 bg-gray-50 p-4">
       <h3 class="text-sm font-semibold text-gray-900">Capture Status</h3>
       <dl class="mt-3 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <div>
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-500">Last Capture</dt>
           <dd class="mt-1 text-sm text-gray-900">
-            <%= @screenshot_status["last_capture_at"].present? ? local_time(Time.zone.parse(@screenshot_status["last_capture_at"]), format: :short) : "Never" %>
+            <%= screenshot_status["last_capture_at"].present? ? local_time(Time.zone.parse(screenshot_status["last_capture_at"]), format: :short) : "Never" %>
           </dd>
         </div>
         <div>
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-500">Last Status</dt>
-          <dd class="mt-1 text-sm text-gray-900"><%= @screenshot_status["last_capture_status"].presence || "Unknown" %></dd>
+          <dd class="mt-1 text-sm text-gray-900"><%= screenshot_status["last_capture_status"].presence || "Unknown" %></dd>
         </div>
         <div>
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-500">Screenshots</dt>
-          <dd class="mt-1 text-sm text-gray-900"><%= @screenshot_status["screenshot_count"] %></dd>
+          <dd class="mt-1 text-sm text-gray-900"><%= screenshot_status["screenshot_count"] %></dd>
         </div>
         <div>
           <dt class="text-xs font-medium uppercase tracking-wide text-gray-500">Screenshots Link</dt>
           <dd class="mt-1 text-sm text-gray-900">
-            <% if @screenshot_status["screenshots_url"].present? %>
-              <%= link_to "View screenshots", @screenshot_status["screenshots_url"], class: "text-indigo-600 hover:text-indigo-900" %>
+            <% if screenshot_status["screenshots_url"].present? %>
+              <%= link_to "View screenshots", screenshot_status["screenshots_url"], class: "text-indigo-600 hover:text-indigo-900" %>
             <% else %>
               Not available yet
             <% end %>
@@ -188,20 +189,20 @@
         <h3 class="text-sm font-semibold text-gray-900">Merged Config Preview</h3>
         <p class="mt-1 text-xs text-gray-500">Runtime preview of project settings merged with the repo config file.</p>
       </div>
-      <% if @screenshot_repo_config_result.error.present? %>
-        <span class="text-xs font-medium text-amber-700"><%= @screenshot_repo_config_result.error %></span>
+      <% if screenshot_repo_config_result.error.present? %>
+        <span class="text-xs font-medium text-amber-700"><%= screenshot_repo_config_result.error %></span>
       <% end %>
     </div>
 
     <div class="mt-4">
-      <pre class="overflow-x-auto rounded-md bg-slate-950 p-4 text-xs text-slate-100"><%= YAML.dump(@screenshot_preview_config) %></pre>
+      <pre class="overflow-x-auto rounded-md bg-slate-950 p-4 text-xs text-slate-100"><%= YAML.dump(screenshot_preview_config) %></pre>
     </div>
 
-    <% if @screenshot_conflicts.any? %>
+    <% if screenshot_conflicts.any? %>
       <div class="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3">
         <h4 class="text-xs font-semibold uppercase tracking-wide text-amber-800">Config Conflicts</h4>
         <ul class="mt-2 space-y-2 text-xs text-amber-900">
-          <% @screenshot_conflicts.each do |conflict| %>
+          <% screenshot_conflicts.each do |conflict| %>
             <li>
               <strong><%= conflict["key"].humanize %>:</strong>
               project = <code><%= conflict["project_value"].inspect %></code>,

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -40,19 +40,19 @@
           <p class="mt-1 text-sm text-gray-500" id="goal-description">What should the agent produce?</p>
           <div class="mt-4 flex items-center space-x-6" role="radiogroup" aria-describedby="goal-description">
             <label class="inline-flex items-center">
-              <input type="radio" name="goal" value="create_pr" <%= "checked" if selected_goal == "create_pr" %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
+              <input type="radio" name="goal" value="create_pr" <% if selected_goal == "create_pr" %>checked<% end %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
               <span class="ml-2 text-sm text-gray-700">Create/Edit Pull Request</span>
             </label>
             <label class="inline-flex items-center">
-              <input type="radio" name="goal" value="create_issue" <%= "checked" if selected_goal == "create_issue" %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
+              <input type="radio" name="goal" value="create_issue" <% if selected_goal == "create_issue" %>checked<% end %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
               <span class="ml-2 text-sm text-gray-700">Create Issue</span>
             </label>
             <label class="inline-flex items-center">
-              <input type="radio" name="goal" value="review" <%= "checked" if selected_goal == "review" %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
+              <input type="radio" name="goal" value="review" <% if selected_goal == "review" %>checked<% end %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
               <span class="ml-2 text-sm text-gray-700">PR Code Review</span>
             </label>
             <label class="inline-flex items-center">
-              <input type="radio" name="goal" value="enhance_issue" <%= "checked" if selected_goal == "enhance_issue" %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
+              <input type="radio" name="goal" value="enhance_issue" <% if selected_goal == "enhance_issue" %>checked<% end %> class="h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500" data-action="change->goal-toggle#toggle">
               <span class="ml-2 text-sm text-gray-700">Enhance Issue</span>
             </label>
           </div>
@@ -64,15 +64,15 @@
           <div class="mt-4 rounded-lg border border-gray-200 p-4">
             <% if @issues.any? %>
               <%# Single-select dropdown for create_pr goal %>
-              <div data-goal-toggle-target="issueDropdown" <%= "hidden" if selected_goal == "enhance_issue" %>>
+              <div data-goal-toggle-target="issueDropdown" <% if selected_goal == "enhance_issue" %>hidden<% end %>>
                 <label for="issue_id" class="block text-sm font-medium text-gray-700">Choose from synced issues:</label>
-                <select name="issue_id" id="issue_id" <%= "disabled" if selected_goal == "enhance_issue" %> class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                <select name="issue_id" id="issue_id" <% if selected_goal == "enhance_issue" %>disabled<% end %> class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                   <option value="">-- Select an issue --</option>
                   <% @issues.each do |issue| %>
                     <% paid_pr = @paid_prs_by_issue_id[issue.id] %>
                     <option value="<%= issue.id %>"
-                            <%= "selected" if params[:issue_id].to_s == issue.id.to_s && paid_pr.nil? %>
-                            <%= "disabled" if paid_pr %>
+                            <% if params[:issue_id].to_s == issue.id.to_s && paid_pr.nil? %>selected<% end %>
+                            <% if paid_pr %>disabled<% end %>
                             title="<%= paid_pr ? "Paid already opened PR ##{paid_pr.github_number} for this issue. Quick run on the PR instead." : "" %>">
                       #<%= issue.github_number %> - <%= truncate(issue.title, length: 60) %><%= " (open paid PR ##{paid_pr.github_number} — quick run on the PR instead)" if paid_pr %>
                     </option>
@@ -87,7 +87,7 @@
           </div>
         </div>
 
-        <div data-goal-toggle-target="prSection" <%= "hidden" if selected_goal == "enhance_issue" %>>
+        <div data-goal-toggle-target="prSection" <% if selected_goal == "enhance_issue" %>hidden<% end %>>
           <h2 class="text-base font-semibold text-gray-900" data-goal-toggle-target="prHeading">Or Work on an Existing PR</h2>
           <p class="mt-1 text-sm text-gray-500" data-goal-toggle-target="prDescription">Push changes to an existing pull request's branch instead of creating a new one.</p>
 
@@ -99,7 +99,7 @@
                 <select name="pull_request_id" id="pull_request_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                   <option value="">-- Select a pull request --</option>
                   <% @pull_requests.each do |pr| %>
-                    <option value="<%= pr.id %>" <%= "selected" if params[:pull_request_id].to_s == pr.id.to_s %>>
+                    <option value="<%= pr.id %>" <% if params[:pull_request_id].to_s == pr.id.to_s %>selected<% end %>>
                       #<%= pr.github_number %> - <%= truncate(pr.title, length: 60) %>
                     </option>
                   <% end %>

--- a/app/views/projects/bundle_performance_dashboards/show.html.erb
+++ b/app/views/projects/bundle_performance_dashboards/show.html.erb
@@ -214,11 +214,13 @@
               <div class="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h3 class="text-sm font-semibold text-gray-900"><%= goal_label(insight[:goal]) %></h3>
-                  <% if insight[:representative_run] %>
-                    <p class="mt-1 text-xs text-gray-500">Representative run #<%= insight[:representative_run].id %></p>
-                  <% else %>
-                    <p class="mt-1 text-xs text-gray-500">No project run exists yet for this goal, so no optimizer candidate can be scored.</p>
-                  <% end %>
+                  <p class="mt-1 text-xs text-gray-500">
+                    <% if insight[:representative_run] %>
+                      Representative run #<%= insight[:representative_run].id %>
+                    <% else %>
+                      No project run exists yet for this goal, so no optimizer candidate can be scored.
+                    <% end %>
+                  </p>
                 </div>
                 <% if insight[:sparse] %>
                   <span class="inline-flex items-center rounded-md bg-yellow-100 px-2 py-1 text-xs font-medium text-yellow-700">Sparse predictions</span>

--- a/app/views/projects/cost_dashboards/show.html.erb
+++ b/app/views/projects/cost_dashboards/show.html.erb
@@ -56,124 +56,125 @@
 
   <%# Cost by Outcome — hidden when no cost data %>
   <% if summary[:total_cost_cents].to_i > 0 %>
-  <div class="mt-8">
-    <h2 class="text-lg font-semibold text-gray-900">Cost by Outcome</h2>
-    <p class="mt-1 text-sm text-gray-500">Separate successful run costs from failed/timed-out runs.</p>
-    <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <% @stats[:cost_by_outcome].each do |outcome, perf| %>
-        <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-          <dt class="text-sm font-semibold text-gray-900"><%= outcome_label(outcome) %></dt>
-          <dd class="mt-1 text-xs text-gray-500"><%= number_with_delimiter(perf[:run_count]) %> runs</dd>
-          <% if perf[:run_count] > 0 %>
-            <div class="mt-3 grid grid-cols-3 gap-3 text-sm">
-              <div>
-                <dt class="text-xs text-gray-500">Total Cost</dt>
-                <dd class="mt-1 font-semibold text-gray-900"><%= format_cost_cents(perf[:total_cost_cents]) %></dd>
+    <div class="mt-8">
+      <h2 class="text-lg font-semibold text-gray-900">Cost by Outcome</h2>
+      <p class="mt-1 text-sm text-gray-500">Separate successful run costs from failed/timed-out runs.</p>
+      <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <% @stats[:cost_by_outcome].each do |outcome, perf| %>
+          <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+            <dt class="text-sm font-semibold text-gray-900"><%= outcome_label(outcome) %></dt>
+            <dd class="mt-1 text-xs text-gray-500"><%= number_with_delimiter(perf[:run_count]) %> runs</dd>
+            <% if perf[:run_count] > 0 %>
+              <div class="mt-3 grid grid-cols-3 gap-3 text-sm">
+                <div>
+                  <dt class="text-xs text-gray-500">Total Cost</dt>
+                  <dd class="mt-1 font-semibold text-gray-900"><%= format_cost_cents(perf[:total_cost_cents]) %></dd>
+                </div>
+                <div>
+                  <dt class="text-xs text-gray-500">Avg Cost</dt>
+                  <dd class="mt-1 font-semibold text-gray-900"><%= format_cost_cents(perf[:avg_cost_cents]) %></dd>
+                </div>
+                <div>
+                  <dt class="text-xs text-gray-500">Avg Duration</dt>
+                  <dd class="mt-1 font-semibold text-gray-900"><%= format_duration(perf[:avg_duration_seconds]) %></dd>
+                </div>
               </div>
-              <div>
-                <dt class="text-xs text-gray-500">Avg Cost</dt>
-                <dd class="mt-1 font-semibold text-gray-900"><%= format_cost_cents(perf[:avg_cost_cents]) %></dd>
-              </div>
-              <div>
-                <dt class="text-xs text-gray-500">Avg Duration</dt>
-                <dd class="mt-1 font-semibold text-gray-900"><%= format_duration(perf[:avg_duration_seconds]) %></dd>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
-  </div>
   <% end %>
 
   <%# Cost by Goal Type — hidden when no cost data %>
   <% if summary[:total_cost_cents].to_i > 0 %>
-  <div class="mt-8">
-    <h2 class="text-lg font-semibold text-gray-900">Cost by Goal Type</h2>
-    <p class="mt-1 text-sm text-gray-500">Compare costs across different types of agent work.</p>
-    <% goals_with_runs = @stats[:cost_by_goal].select { |_, v| v[:run_count] > 0 } %>
-    <% if goals_with_runs.any? %>
-      <div class="mt-4 overflow-hidden overflow-x-auto rounded-lg bg-white shadow">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Goal Type</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Runs</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Total Cost</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Cost</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Duration</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-200 bg-white">
-            <% goals_with_runs.each do |goal, perf| %>
+    <div class="mt-8">
+      <h2 class="text-lg font-semibold text-gray-900">Cost by Goal Type</h2>
+      <p class="mt-1 text-sm text-gray-500">Compare costs across different types of agent work.</p>
+      <% goals_with_runs = @stats[:cost_by_goal].select { |_, v| v[:run_count] > 0 } %>
+      <% if goals_with_runs.any? %>
+        <div class="mt-4 overflow-hidden overflow-x-auto rounded-lg bg-white shadow">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
               <tr>
-                <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= goal_label(goal) %></td>
-                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= perf[:run_count] %></td>
-                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(perf[:total_cost_cents]) %></td>
-                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(perf[:avg_cost_cents]) %></td>
-                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_duration(perf[:avg_duration_seconds]) %></td>
+                <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Goal Type</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Runs</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Total Cost</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Cost</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Duration</th>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    <% else %>
-      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
-        <div class="px-4 py-5 text-sm text-gray-500">No finished runs to break down by goal type.</div>
-      </div>
-    <% end %>
-  </div>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <% goals_with_runs.each do |goal, perf| %>
+                <tr>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= goal_label(goal) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= perf[:run_count] %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(perf[:total_cost_cents]) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(perf[:avg_cost_cents]) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_duration(perf[:avg_duration_seconds]) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+          <div class="px-4 py-5 text-sm text-gray-500">No finished runs to break down by goal type.</div>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 
   <%# Cost by Tier %>
   <% if summary[:total_cost_cents].to_i > 0 %>
-  <div class="mt-8">
-    <h2 class="text-lg font-semibold text-gray-900">Cost by Tier</h2>
-    <p class="mt-1 text-sm text-gray-500">Spend breakdown by model selection tier.</p>
-    <% tiers_with_runs = @stats[:cost_by_tier].select { |_, v| v[:run_count] > 0 } %>
-    <% if tiers_with_runs.any? %>
-      <div class="mt-4 overflow-hidden overflow-x-auto rounded-lg bg-white shadow">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Tier</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Runs</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Total Cost</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Cost</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Duration</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-200 bg-white">
-            <% tiers_with_runs.each do |tier, perf| %>
+    <div class="mt-8">
+      <h2 class="text-lg font-semibold text-gray-900">Cost by Tier</h2>
+      <p class="mt-1 text-sm text-gray-500">Spend breakdown by model selection tier.</p>
+      <% tiers_with_runs = @stats[:cost_by_tier].select { |_, v| v[:run_count] > 0 } %>
+      <% if tiers_with_runs.any? %>
+        <div class="mt-4 overflow-hidden overflow-x-auto rounded-lg bg-white shadow">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
               <tr>
-                <td class="whitespace-nowrap px-4 py-3 text-sm">
-                  <span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium <%= tier_badge_classes(tier) %>">
-                    <%= tier.titleize %>
-                  </span>
-                </td>
-                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= perf[:run_count] %></td>
-                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(perf[:total_cost_cents]) %></td>
-                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(perf[:avg_cost_cents]) %></td>
-                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_duration(perf[:avg_duration_seconds]) %></td>
+                <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Tier</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Runs</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Total Cost</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Cost</th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Avg Duration</th>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    <% else %>
-      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
-        <div class="px-4 py-5 text-sm text-gray-500">No tier data available yet.</div>
-      </div>
-    <% end %>
-  </div>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <% tiers_with_runs.each do |tier, perf| %>
+                <tr>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm">
+                    <span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium <%= tier_badge_classes(tier) %>">
+                      <%= tier.titleize %>
+                    </span>
+                  </td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= perf[:run_count] %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(perf[:total_cost_cents]) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_cost_cents(perf[:avg_cost_cents]) %></td>
+                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500 text-right"><%= format_duration(perf[:avg_duration_seconds]) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+          <div class="px-4 py-5 text-sm text-gray-500">No tier data available yet.</div>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 
   <%# Cost Trend Chart (30 days) %>
   <div class="mt-8">
     <h2 class="text-lg font-semibold text-gray-900">Cost Trend (Last 30 Days)</h2>
     <% daily_costs = @stats[:daily_costs] %>
-    <% if daily_costs.any? { |_, cost_cents| cost_cents.to_i > 0 } %>
-      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+    <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+      <% if daily_costs.any? { |_, cost_cents| cost_cents.to_i > 0 } %>
+
         <div class="px-4 py-5 sm:p-6">
           <% max_cost = [daily_costs.map { |_, v| v }.max, 1].max %>
           <div class="flex items-end gap-1" style="height: 160px;" role="img" aria-label="Daily cost trend chart">
@@ -192,12 +193,13 @@
             <span><%= daily_costs.last&.first %></span>
           </div>
         </div>
-      </div>
-    <% else %>
-      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+
+      <% else %>
+
         <div class="px-4 py-5 text-sm text-gray-500">No cost data available yet.</div>
-      </div>
-    <% end %>
+
+      <% end %>
+    </div>
   </div>
 
   <%# Cost Breakdown %>
@@ -373,10 +375,10 @@
       <% existing_types = budgets.map { |b| b[:budget_type] } %>
       <%# Include the submitted budget_type when the create form has errors, so the user can correct the error %>
       <% available_types = if @cost_budget&.errors&.any? && @cost_budget.budget_type.present? %>
-      <%                     (CostBudget::BUDGET_TYPES - existing_types) | [@cost_budget.budget_type] %>
-      <%                   else %>
-      <%                     CostBudget::BUDGET_TYPES - existing_types %>
-      <%                   end %>
+        <% (CostBudget::BUDGET_TYPES - existing_types) | [@cost_budget.budget_type] %>
+      <% else %>
+        <% CostBudget::BUDGET_TYPES - existing_types %>
+      <% end %>
       <% if available_types.any? %>
         <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
           <div class="px-4 py-5 sm:p-6">

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -183,8 +183,9 @@
             <div class="mt-2">
               <input type="text" name="project[allowed_github_usernames_csv]" id="project_allowed_github_usernames_csv"
                 value="<%= @project.allowed_github_usernames.join(', ') %>"
+                autocomplete="off"
                 class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                placeholder="viamin, other-user" />
+                placeholder="viamin, other-user">
             </div>
             <p class="mt-1 text-xs text-gray-500">Comma-separated list of GitHub usernames whose issues are trusted. Issues from other users will never be sent to an LLM.</p>
             <div class="mt-2 rounded-md bg-yellow-50 p-3">
@@ -237,10 +238,10 @@
 
             <div>
               <div class="flex items-center">
-                <input type="hidden" name="project[review_settings][enabled]" value="0" />
+                <input type="hidden" name="project[review_settings][enabled]" value="0">
                 <input type="checkbox" name="project[review_settings][enabled]" value="1" id="project_review_settings_enabled"
-                  <%= "checked" if rs["enabled"] %>
-                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                  <% if rs["enabled"] %>checked<% end %>
+                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                 <label for="project_review_settings_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Enable PR Reviews</label>
               </div>
               <p class="mt-1 ml-7 text-xs text-gray-500">When enabled, pull requests will be reviewed using the configured methods below.</p>
@@ -248,10 +249,10 @@
 
             <div>
               <div class="flex items-center">
-                <input type="hidden" name="project[review_settings][wait_for_reviews]" value="0" />
+                <input type="hidden" name="project[review_settings][wait_for_reviews]" value="0">
                 <input type="checkbox" name="project[review_settings][wait_for_reviews]" value="1" id="project_review_settings_wait_for_reviews"
-                  <%= "checked" if rs["wait_for_reviews"] %>
-                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                  <% if rs["wait_for_reviews"] %>checked<% end %>
+                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                 <label for="project_review_settings_wait_for_reviews" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Wait for Reviews</label>
               </div>
               <p class="mt-1 ml-7 text-xs text-gray-500">Block workflow until all configured reviews have completed before proceeding.</p>
@@ -259,10 +260,10 @@
 
             <div>
               <div class="flex items-center">
-                <input type="hidden" name="project[review_settings][address_all_bot_reviews]" value="0" />
+                <input type="hidden" name="project[review_settings][address_all_bot_reviews]" value="0">
                 <input type="checkbox" name="project[review_settings][address_all_bot_reviews]" value="1" id="project_review_settings_address_all_bot_reviews"
-                  <%= "checked" if rs["address_all_bot_reviews"] %>
-                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                  <% if rs["address_all_bot_reviews"] %>checked<% end %>
+                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                 <label for="project_review_settings_address_all_bot_reviews" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Address All Bot Reviews</label>
               </div>
               <p class="mt-1 ml-7 text-xs text-gray-500">Detect and address reviews from all bot accounts (e.g. Codex, Claude, Copilot), not just the configured review type. Human reviews follow existing configured behavior.</p>
@@ -276,43 +277,43 @@
               <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
                 data-controller="collapsible-panel">
                 <div class="flex items-center">
-                  <input type="hidden" name="project[review_settings][methods][copilot][enabled]" value="0" />
+                  <input type="hidden" name="project[review_settings][methods][copilot][enabled]" value="0">
                   <input type="checkbox" name="project[review_settings][methods][copilot][enabled]" value="1" id="review_copilot_enabled"
-                    <%= "checked" if copilot["enabled"] %>
+                    <% if copilot["enabled"] %>checked<% end %>
                     aria-controls="review_copilot_settings"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
-                    data-collapsible-panel-target="checkbox" />
+                    data-collapsible-panel-target="checkbox">
                   <label for="review_copilot_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">GitHub Copilot</label>
                   <span class="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">GitHub-hosted only</span>
                 </div>
                 <div id="review_copilot_settings"
                   class="ml-7 grid grid-cols-2 gap-3 transition-all duration-200 ease-in-out <%= copilot["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  <%= "inert" unless copilot["enabled"] %>
+                  <% unless copilot["enabled"] %>inert<% end %>
                   data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_copilot_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                     <input type="number" name="project[review_settings][methods][copilot][termination][max_review_rounds]" id="review_copilot_max_rounds"
-                      value="<%= copilot.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= copilot.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15" autocomplete="off"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </div>
                   <div>
                     <label for="review_copilot_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
                     <input type="number" name="project[review_settings][methods][copilot][termination][timeout_minutes]" id="review_copilot_timeout"
-                      value="<%= copilot.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 30"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= copilot.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 30" autocomplete="off"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </div>
                   <div>
                     <label for="review_copilot_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
                     <input type="text" name="project[review_settings][methods][copilot][termination][quality_threshold]" id="review_copilot_quality"
-                      value="<%= copilot.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= copilot.dig("termination", "quality_threshold") %>" placeholder="e.g. approved" autocomplete="off"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </div>
                   <div class="flex items-center col-span-2">
-                    <input type="hidden" name="project[review_settings][methods][copilot][termination][stop_when_no_comments]" value="0" />
+                    <input type="hidden" name="project[review_settings][methods][copilot][termination][stop_when_no_comments]" value="0">
                     <input type="checkbox" name="project[review_settings][methods][copilot][termination][stop_when_no_comments]" value="1" id="review_copilot_stop_no_comments"
-                      <%= "checked" if copilot.dig("termination", "stop_when_no_comments") %>
-                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                      <% if copilot.dig("termination", "stop_when_no_comments") %>checked<% end %>
+                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                     <label for="review_copilot_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
                   </div>
                 </div>
@@ -323,42 +324,42 @@
               <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
                 data-controller="collapsible-panel">
                 <div class="flex items-center">
-                  <input type="hidden" name="project[review_settings][methods][paid_agent][enabled]" value="0" />
+                  <input type="hidden" name="project[review_settings][methods][paid_agent][enabled]" value="0">
                   <input type="checkbox" name="project[review_settings][methods][paid_agent][enabled]" value="1" id="review_paid_agent_enabled"
-                    <%= "checked" if paid["enabled"] %>
+                    <% if paid["enabled"] %>checked<% end %>
                     aria-controls="review_paid_agent_settings"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
-                    data-collapsible-panel-target="checkbox" />
+                    data-collapsible-panel-target="checkbox">
                   <label for="review_paid_agent_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Paid PR Code Review Agent</label>
                 </div>
                 <div id="review_paid_agent_settings"
                   class="ml-7 grid grid-cols-2 gap-3 transition-all duration-200 ease-in-out <%= paid["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  <%= "inert" unless paid["enabled"] %>
+                  <% unless paid["enabled"] %>inert<% end %>
                   data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_paid_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                     <input type="number" name="project[review_settings][methods][paid_agent][termination][max_review_rounds]" id="review_paid_max_rounds"
-                      value="<%= paid.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= paid.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15" autocomplete="off"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </div>
                   <div>
                     <label for="review_paid_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
                     <input type="number" name="project[review_settings][methods][paid_agent][termination][timeout_minutes]" id="review_paid_timeout"
-                      value="<%= paid.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 30"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= paid.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 30" autocomplete="off"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </div>
                   <div>
                     <label for="review_paid_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
                     <input type="text" name="project[review_settings][methods][paid_agent][termination][quality_threshold]" id="review_paid_quality"
-                      value="<%= paid.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= paid.dig("termination", "quality_threshold") %>" placeholder="e.g. approved" autocomplete="off"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </div>
                   <div class="flex items-center">
-                    <input type="hidden" name="project[review_settings][methods][paid_agent][termination][stop_when_no_comments]" value="0" />
+                    <input type="hidden" name="project[review_settings][methods][paid_agent][termination][stop_when_no_comments]" value="0">
                     <input type="checkbox" name="project[review_settings][methods][paid_agent][termination][stop_when_no_comments]" value="1" id="review_paid_stop_no_comments"
-                      <%= "checked" if paid.dig("termination", "stop_when_no_comments") %>
-                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                      <% if paid.dig("termination", "stop_when_no_comments") %>checked<% end %>
+                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                     <label for="review_paid_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
                   </div>
                 </div>
@@ -369,45 +370,45 @@
               <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
                 data-controller="collapsible-panel">
                 <div class="flex items-center">
-                  <input type="hidden" name="project[review_settings][methods][codex][enabled]" value="0" />
+                  <input type="hidden" name="project[review_settings][methods][codex][enabled]" value="0">
                   <input type="checkbox" name="project[review_settings][methods][codex][enabled]" value="1" id="review_codex_enabled"
-                    <%= "checked" if codex["enabled"] %>
+                    <% if codex["enabled"] %>checked<% end %>
                     aria-controls="review_codex_settings"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
-                    data-collapsible-panel-target="checkbox" />
+                    data-collapsible-panel-target="checkbox">
                   <label for="review_codex_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">OpenAI Codex</label>
                   <span class="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">GitHub-hosted only</span>
                 </div>
                 <div id="review_codex_settings"
                   class="space-y-3 transition-all duration-200 ease-in-out <%= codex["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  <%= "inert" unless codex["enabled"] %>
+                  <% unless codex["enabled"] %>inert<% end %>
                   data-collapsible-panel-target="panel">
                   <p class="ml-7 text-xs text-gray-500">Waits for the <code>chatgpt-codex-connector</code> bot to review the PR and resolve its threads before advancing.</p>
                   <div class="ml-7 grid grid-cols-2 gap-3">
                     <div>
                       <label for="review_codex_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                       <input type="number" name="project[review_settings][methods][codex][termination][max_review_rounds]" id="review_codex_max_rounds"
-                        value="<%= codex.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= codex.dig("termination", "max_review_rounds") %>" min="1" placeholder="e.g. 15" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div>
                       <label for="review_codex_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
                       <input type="number" name="project[review_settings][methods][codex][termination][timeout_minutes]" id="review_codex_timeout"
-                        value="<%= codex.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 60"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= codex.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 60" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div>
                       <label for="review_codex_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
                       <input type="text" name="project[review_settings][methods][codex][termination][quality_threshold]" id="review_codex_quality"
-                        value="<%= codex.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= codex.dig("termination", "quality_threshold") %>" placeholder="e.g. approved" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div class="flex items-center col-span-2">
-                      <input type="hidden" name="project[review_settings][methods][codex][termination][stop_when_no_comments]" value="0" />
+                      <input type="hidden" name="project[review_settings][methods][codex][termination][stop_when_no_comments]" value="0">
                       <input type="checkbox" name="project[review_settings][methods][codex][termination][stop_when_no_comments]" value="1" id="review_codex_stop_no_comments"
-                        <%= "checked" if codex.dig("termination", "stop_when_no_comments") %>
-                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                        <% if codex.dig("termination", "stop_when_no_comments") %>checked<% end %>
+                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                       <label for="review_codex_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
                     </div>
                   </div>
@@ -419,24 +420,24 @@
               <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
                 data-controller="collapsible-panel">
                 <div class="flex items-center">
-                  <input type="hidden" name="project[review_settings][methods][ci_action][enabled]" value="0" />
+                  <input type="hidden" name="project[review_settings][methods][ci_action][enabled]" value="0">
                   <input type="checkbox" name="project[review_settings][methods][ci_action][enabled]" value="1" id="review_ci_action_enabled"
-                    <%= "checked" if ci["enabled"] %>
+                    <% if ci["enabled"] %>checked<% end %>
                     aria-controls="review_ci_action_settings"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
-                    data-collapsible-panel-target="checkbox" />
+                    data-collapsible-panel-target="checkbox">
                   <label for="review_ci_action_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">CI Review Action</label>
                 </div>
                 <div id="review_ci_action_settings"
                   class="ml-7 space-y-3 transition-all duration-200 ease-in-out <%= ci["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  <%= "inert" unless ci["enabled"] %>
+                  <% unless ci["enabled"] %>inert<% end %>
                   data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_ci_action_name" class="block text-xs font-medium text-gray-600">Action Name</label>
                     <input type="text" name="project[review_settings][methods][ci_action][action_name]" id="review_ci_action_name"
-                      value="<%= ci["action_name"] %>" placeholder="e.g. Claude Code Review"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= ci["action_name"] %>" placeholder="e.g. Claude Code Review" autocomplete="off"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </div>
                   <p class="text-xs text-gray-500">
                     Use <code>Claude Code Review</code> to let Paid trigger the restored Claude workflow via <code>repository_dispatch</code>.
@@ -446,26 +447,26 @@
                     <div>
                       <label for="review_ci_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                       <input type="number" name="project[review_settings][methods][ci_action][termination][max_review_rounds]" id="review_ci_max_rounds"
-                        value="<%= ci.dig("termination", "max_review_rounds") %>" min="1" placeholder="optional"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= ci.dig("termination", "max_review_rounds") %>" min="1" placeholder="optional" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div>
                       <label for="review_ci_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
                       <input type="number" name="project[review_settings][methods][ci_action][termination][timeout_minutes]" id="review_ci_timeout"
-                        value="<%= ci.dig("termination", "timeout_minutes") %>" min="1" placeholder="optional"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= ci.dig("termination", "timeout_minutes") %>" min="1" placeholder="optional" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div>
                       <label for="review_ci_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
                       <input type="text" name="project[review_settings][methods][ci_action][termination][quality_threshold]" id="review_ci_quality"
-                        value="<%= ci.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= ci.dig("termination", "quality_threshold") %>" placeholder="e.g. approved" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div class="flex items-center col-span-2">
-                      <input type="hidden" name="project[review_settings][methods][ci_action][termination][stop_when_no_comments]" value="0" />
+                      <input type="hidden" name="project[review_settings][methods][ci_action][termination][stop_when_no_comments]" value="0">
                       <input type="checkbox" name="project[review_settings][methods][ci_action][termination][stop_when_no_comments]" value="1" id="review_ci_stop_no_comments"
-                        <%= "checked" if ci.dig("termination", "stop_when_no_comments") %>
-                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                        <% if ci.dig("termination", "stop_when_no_comments") %>checked<% end %>
+                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                       <label for="review_ci_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
                     </div>
                   </div>
@@ -477,49 +478,49 @@
               <div class="rounded-md border border-gray-100 bg-gray-50 p-3 space-y-3"
                 data-controller="collapsible-panel">
                 <div class="flex items-center">
-                  <input type="hidden" name="project[review_settings][methods][manual][enabled]" value="0" />
+                  <input type="hidden" name="project[review_settings][methods][manual][enabled]" value="0">
                   <input type="checkbox" name="project[review_settings][methods][manual][enabled]" value="1" id="review_manual_enabled"
-                    <%= "checked" if manual["enabled"] %>
+                    <% if manual["enabled"] %>checked<% end %>
                     aria-controls="review_manual_settings"
                     class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
                     data-action="change->collapsible-panel#toggle"
-                    data-collapsible-panel-target="checkbox" />
+                    data-collapsible-panel-target="checkbox">
                   <label for="review_manual_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Manual Review</label>
                 </div>
                 <div id="review_manual_settings"
                   class="ml-7 space-y-3 transition-all duration-200 ease-in-out <%= manual["enabled"] ? "max-h-[2000px] opacity-100" : "max-h-0 overflow-hidden opacity-0" %>"
-                  <%= "inert" unless manual["enabled"] %>
+                  <% unless manual["enabled"] %>inert<% end %>
                   data-collapsible-panel-target="panel">
                   <div>
                     <label for="review_manual_reviewer_login" class="block text-xs font-medium text-gray-600">Reviewer Login</label>
                     <input type="text" name="project[review_settings][methods][manual][reviewer_login]" id="review_manual_reviewer_login"
-                      value="<%= manual["reviewer_login"] %>" placeholder="e.g. octocat"
-                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= manual["reviewer_login"] %>" placeholder="e.g. octocat" autocomplete="off"
+                      class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </div>
                   <div class="grid grid-cols-2 gap-3">
                     <div>
                       <label for="review_manual_max_rounds" class="block text-xs font-medium text-gray-600">Max Review Rounds</label>
                       <input type="number" name="project[review_settings][methods][manual][termination][max_review_rounds]" id="review_manual_max_rounds"
-                        value="<%= manual.dig("termination", "max_review_rounds") %>" min="1" placeholder="optional"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= manual.dig("termination", "max_review_rounds") %>" min="1" placeholder="optional" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div>
                       <label for="review_manual_timeout" class="block text-xs font-medium text-gray-600">Timeout (minutes)</label>
                       <input type="number" name="project[review_settings][methods][manual][termination][timeout_minutes]" id="review_manual_timeout"
-                        value="<%= manual.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 1440 (24h)"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= manual.dig("termination", "timeout_minutes") %>" min="1" placeholder="e.g. 1440 (24h)" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div>
                       <label for="review_manual_quality" class="block text-xs font-medium text-gray-600">Quality Threshold</label>
                       <input type="text" name="project[review_settings][methods][manual][termination][quality_threshold]" id="review_manual_quality"
-                        value="<%= manual.dig("termination", "quality_threshold") %>" placeholder="e.g. approved"
-                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                        value="<%= manual.dig("termination", "quality_threshold") %>" placeholder="e.g. approved" autocomplete="off"
+                        class="mt-1 block w-full rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                     </div>
                     <div class="flex items-center">
-                      <input type="hidden" name="project[review_settings][methods][manual][termination][stop_when_no_comments]" value="0" />
+                      <input type="hidden" name="project[review_settings][methods][manual][termination][stop_when_no_comments]" value="0">
                       <input type="checkbox" name="project[review_settings][methods][manual][termination][stop_when_no_comments]" value="1" id="review_manual_stop_no_comments"
-                        <%= "checked" if manual.dig("termination", "stop_when_no_comments") %>
-                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                        <% if manual.dig("termination", "stop_when_no_comments") %>checked<% end %>
+                        class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                       <label for="review_manual_stop_no_comments" class="ml-2 block text-xs text-gray-600">Stop when no new comments</label>
                     </div>
                   </div>
@@ -580,7 +581,8 @@
                 <div class="mt-2">
                   <input type="text" name="project[priority_labels][<%= tier %>]" id="project_priority_labels_<%= tier %>"
                     value="<%= @project.effective_priority_labels[tier] %>"
-                    class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" />
+                    autocomplete="off"
+                    class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
                 </div>
                 <p class="mt-1 text-xs text-gray-500">GitHub label name for <%= tier %> priority issues.</p>
               </div>
@@ -618,7 +620,13 @@
             </div>
           </fieldset>
 
-          <%= render "screenshot_settings", form: form %>
+          <%= render "screenshot_settings", form: form,
+                screenshot_settings: @screenshot_settings,
+                screenshot_service_options: @screenshot_service_options,
+                screenshot_status: @screenshot_status,
+                screenshot_repo_config_result: @screenshot_repo_config_result,
+                screenshot_preview_config: @screenshot_preview_config,
+                screenshot_conflicts: @screenshot_conflicts %>
 
           <fieldset id="auto-release" class="space-y-4">
             <legend class="text-sm font-semibold leading-6 text-gray-900">Auto-Merge &amp; Auto-Release</legend>
@@ -856,7 +864,7 @@
               data-action="input->confirm-delete#validate"
               class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-red-600 sm:text-sm sm:leading-6"
               placeholder="<%= persisted_name %>"
-              autocomplete="off" />
+              autocomplete="off">
           </div>
 
           <%= button_to "Delete Project", project_path(@project),

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -115,8 +115,8 @@
 
               <%= form.hidden_field :owner, data: { repository_selector_target: "owner" } %>
               <%= form.hidden_field :repo, data: { repository_selector_target: "repo" } %>
-              <input type="hidden" name="project[github_id]" data-repository-selector-target="githubId" />
-              <input type="hidden" name="project[default_branch]" data-repository-selector-target="defaultBranch" />
+              <input type="hidden" name="project[github_id]" data-repository-selector-target="githubId">
+              <input type="hidden" name="project[default_branch]" data-repository-selector-target="defaultBranch">
             </div>
 
             <div>

--- a/app/views/projects/quality_dashboards/show.html.erb
+++ b/app/views/projects/quality_dashboards/show.html.erb
@@ -53,26 +53,26 @@
                 <tr>
                   <td class="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-0">
                     <%= threshold.goal_type.humanize %>
-                    <input type="hidden" name="quality_thresholds[<%= index %>][goal_type]" value="<%= threshold.goal_type %>" />
-                    <input type="hidden" name="quality_thresholds[<%= index %>][metric_type]" value="<%= threshold.metric_type %>" />
+                    <input type="hidden" name="quality_thresholds[<%= index %>][goal_type]" value="<%= threshold.goal_type %>">
+                    <input type="hidden" name="quality_thresholds[<%= index %>][metric_type]" value="<%= threshold.metric_type %>">
                   </td>
                   <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-700"><%= QualityThreshold.metric_label(threshold.metric_type) %></td>
                   <td class="whitespace-nowrap px-3 py-3">
                     <input type="number" name="quality_thresholds[<%= index %>][min_value]"
-                      value="<%= format('%.2f', threshold.min_value) %>" min="0" max="1" step="0.01"
-                      class="block w-24 rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600" />
+                      value="<%= format('%.2f', threshold.min_value) %>" min="0" max="1" step="0.01" autocomplete="off"
+                      class="block w-24 rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600">
                   </td>
                   <td class="whitespace-nowrap px-3 py-3">
-                    <input type="hidden" name="quality_thresholds[<%= index %>][override]" value="0" />
+                    <input type="hidden" name="quality_thresholds[<%= index %>][override]" value="0">
                     <input type="checkbox" name="quality_thresholds[<%= index %>][override]" value="1"
-                      <%= "checked" unless threshold.inherited? %>
-                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                      <% unless threshold.inherited? %>checked<% end %>
+                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                   </td>
                   <td class="whitespace-nowrap px-3 py-3">
-                    <input type="hidden" name="quality_thresholds[<%= index %>][enabled]" value="0" />
+                    <input type="hidden" name="quality_thresholds[<%= index %>][enabled]" value="0">
                     <input type="checkbox" name="quality_thresholds[<%= index %>][enabled]" value="1"
-                      <%= "checked" if threshold.enabled? %>
-                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" />
+                      <% if threshold.enabled? %>checked<% end %>
+                      class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
                   </td>
                   <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= threshold.source_scope.humanize %></td>
                 </tr>
@@ -216,8 +216,9 @@
     <div class="mt-8">
       <h2 class="text-lg font-semibold text-gray-900">Quality Trends</h2>
       <% trends = @stats[:trends] %>
-      <% if trends.any? %>
-        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+        <% if trends.any? %>
+
           <div class="px-4 py-5 sm:p-6">
             <% max_score = [trends.map { |t| t[:score] }.max, 0.01].max %>
             <% composite_thresholds = gate[:thresholds].select { |t| t[:metric_key] == "composite_score" } %>
@@ -292,12 +293,13 @@
               </div>
             </div>
           </div>
-        </div>
-      <% else %>
-        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+
+        <% else %>
+
           <div class="px-4 py-5 text-sm text-gray-500">Not enough data for trend analysis.</div>
-        </div>
-      <% end %>
+
+        <% end %>
+      </div>
     </div>
 
     <%# Gate Events Timeline %>
@@ -337,7 +339,7 @@
                               on <span class="font-medium text-gray-900"><%= event[:metric_key].titleize %></span>
                               <span class="text-gray-400">
                                 (score: <%= format('%.1f%%', event[:score_value] * 100) %>,
-                                 threshold: <%= format('%.1f%%', event[:threshold_value] * 100) %>)
+                                threshold: <%= format('%.1f%%', event[:threshold_value] * 100) %>)
                               </span>
                             </p>
                           </div>
@@ -360,8 +362,9 @@
     <div class="mt-8">
       <h2 class="text-lg font-semibold text-gray-900">Score Breakdown</h2>
       <% breakdown = @stats[:breakdown] %>
-      <% if breakdown.any? %>
-        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+        <% if breakdown.any? %>
+
           <div class="px-4 py-5 sm:p-6">
             <div class="space-y-4">
               <% breakdown.each do |key, avg_value| %>
@@ -381,12 +384,13 @@
               <% end %>
             </div>
           </div>
-        </div>
-      <% else %>
-        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+
+        <% else %>
+
           <div class="px-4 py-5 text-sm text-gray-500">No automated metrics available for breakdown.</div>
-        </div>
-      <% end %>
+
+        <% end %>
+      </div>
     </div>
 
     <div class="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">

--- a/app/views/prompt_reviews/show.html.erb
+++ b/app/views/prompt_reviews/show.html.erb
@@ -89,14 +89,22 @@
   </div>
 
   <%# Diff: parent vs candidate %>
-  <% if parent %>
-    <div class="mt-8 bg-white shadow sm:rounded-lg">
-      <div class="px-4 py-5 sm:px-6">
-        <h2 class="text-lg font-medium text-gray-900">Template Diff</h2>
+  <div class="mt-8 bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-5 sm:px-6">
+      <h2 class="text-lg font-medium text-gray-900">
+        <% if parent %>
+          Template Diff
+        <% else %>
+          Template
+        <% end %>
+      </h2>
+      <% if parent %>
         <p class="mt-1 text-sm text-gray-500">
           Current v<%= parent.version %> (left) vs. proposed v<%= @prompt_version.version %> (right).
         </p>
-      </div>
+      <% end %>
+    </div>
+    <% if parent %>
       <div class="grid grid-cols-2 divide-x divide-gray-200 border-t border-gray-200">
         <div class="p-4">
           <pre class="overflow-x-auto rounded-lg bg-red-50 p-4 text-sm text-gray-800 font-mono whitespace-pre-wrap"><%= parent.template %></pre>
@@ -105,17 +113,12 @@
           <pre class="overflow-x-auto rounded-lg bg-green-50 p-4 text-sm text-gray-800 font-mono whitespace-pre-wrap"><%= @prompt_version.template %></pre>
         </div>
       </div>
-    </div>
-  <% else %>
-    <div class="mt-8 bg-white shadow sm:rounded-lg">
-      <div class="px-4 py-5 sm:px-6">
-        <h2 class="text-lg font-medium text-gray-900">Template</h2>
-      </div>
+    <% else %>
       <div class="border-t border-gray-200 p-4">
         <pre class="overflow-x-auto rounded-lg bg-gray-50 p-4 text-sm text-gray-800 font-mono whitespace-pre-wrap"><%= @prompt_version.template %></pre>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 
   <% if policy(@prompt).update? %>
     <%# Approve form %>

--- a/app/views/prompts/show.html.erb
+++ b/app/views/prompts/show.html.erb
@@ -84,11 +84,16 @@
           <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
             <% if @prompt.requires_review? %>
               <span class="inline-flex items-center rounded-md bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">Required</span>
-              <span class="ml-2 text-xs text-gray-500">Evolved variants need human approval before promotion.</span>
             <% else %>
               <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">Off</span>
-              <span class="ml-2 text-xs text-gray-500">Evolved variants are auto-promoted.</span>
             <% end %>
+            <span class="ml-2 text-xs text-gray-500">
+              <% if @prompt.requires_review? %>
+                Evolved variants need human approval before promotion.
+              <% else %>
+                Evolved variants are auto-promoted.
+              <% end %>
+            </span>
           </dd>
         </div>
 

--- a/app/views/provider_api_keys/_form.html.erb
+++ b/app/views/provider_api_keys/_form.html.erb
@@ -1,4 +1,4 @@
-<% if @provider_api_key.errors.any? %>
+<% if provider_api_key.errors.any? %>
   <div class="mb-6 rounded-md bg-red-50 p-4">
     <div class="flex">
       <div class="flex-shrink-0">
@@ -8,11 +8,11 @@
       </div>
       <div class="ml-3">
         <h3 class="text-sm font-medium text-red-800">
-          <%= pluralize(@provider_api_key.errors.count, "error") %> prevented this API key from being saved:
+          <%= pluralize(provider_api_key.errors.count, "error") %> prevented this API key from being saved:
         </h3>
         <div class="mt-2 text-sm text-red-700">
           <ul class="list-disc space-y-1 pl-5">
-            <% @provider_api_key.errors.full_messages.each do |message| %>
+            <% provider_api_key.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
           </ul>
@@ -34,13 +34,15 @@
   <div>
     <%= form.label :api_key, "API Key", class: "block text-sm font-medium leading-6 text-gray-900" %>
     <div class="mt-2">
-      <%= form.password_field :api_key, class: "block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: @provider_api_key.persisted? ? "Leave blank to keep current key" : "sk-...", autocomplete: "new-password", spellcheck: false, required: @provider_api_key.new_record? %>
+      <%= form.password_field :api_key, class: "block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: provider_api_key.persisted? ? "Leave blank to keep current key" : "sk-...", autocomplete: "new-password", spellcheck: false, required: provider_api_key.new_record? %>
     </div>
-    <% if @provider_api_key.persisted? %>
-      <p class="mt-1 text-xs text-gray-500">Leave blank to keep the current key. Current: <code class="rounded bg-gray-100 px-1 font-mono text-xs"><%= @provider_api_key.masked_api_key %></code></p>
-    <% else %>
-      <p class="mt-1 text-xs text-gray-500">Your API key is encrypted at rest and only shown in masked form after saving.</p>
-    <% end %>
+    <p class="mt-1 text-xs text-gray-500">
+      <% if provider_api_key.persisted? %>
+        Leave blank to keep the current key. Current: <code class="rounded bg-gray-100 px-1 font-mono text-xs"><%= provider_api_key.masked_api_key %></code>
+      <% else %>
+        Your API key is encrypted at rest and only shown in masked form after saving.
+      <% end %>
+    </p>
   </div>
 
   <div>
@@ -48,7 +50,7 @@
     <p class="mt-1 text-xs text-gray-500">Select the upstream API service this key authenticates against.</p>
     <div class="mt-2">
       <%= form.select :api_service_type,
-          @api_service_type_options,
+          api_service_type_options,
           { include_blank: "Select an API service" },
           class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6",
           required: true %>

--- a/app/views/provider_api_keys/edit.html.erb
+++ b/app/views/provider_api_keys/edit.html.erb
@@ -19,7 +19,7 @@
 
       <%= form_with model: @provider_api_key, url: provider_api_key_path(@provider_api_key), method: :patch, class: "mt-6",
           data: { controller: "form-submit", action: "submit->form-submit#submit" } do |form| %>
-        <%= render "form", form: form %>
+        <%= render "form", form: form, provider_api_key: @provider_api_key, api_service_type_options: @api_service_type_options %>
 
         <div class="mt-6 flex items-center justify-end gap-x-4">
           <%= link_to "Cancel", provider_api_key_path(@provider_api_key), class: "text-sm font-semibold leading-6 text-gray-900 hover:text-gray-700" %>

--- a/app/views/provider_api_keys/new.html.erb
+++ b/app/views/provider_api_keys/new.html.erb
@@ -35,7 +35,7 @@
 
       <%= form_with model: @provider_api_key, url: provider_api_keys_path, class: "mt-6",
           data: { controller: "form-submit", action: "submit->form-submit#submit" } do |form| %>
-        <%= render "form", form: form %>
+        <%= render "form", form: form, provider_api_key: @provider_api_key, api_service_type_options: @api_service_type_options %>
 
         <div class="mt-6 flex items-center justify-end gap-x-4">
           <%= link_to "Cancel", integrations_path, class: "text-sm font-semibold leading-6 text-gray-900 hover:text-gray-700" %>

--- a/app/views/providers/_form.html.erb
+++ b/app/views/providers/_form.html.erb
@@ -6,7 +6,7 @@
     } do |form| %>
   <% is_api_key = provider.api_key? %>
   <% is_new = !provider.persisted? %>
-  <% selectable_provider = provider.persisted? || @subscription_provider_options.any? || @api_key_provider_options.any? %>
+  <% selectable_provider = provider.persisted? || subscription_provider_options.any? || api_key_provider_options.any? %>
 
   <% if provider.errors.any? %>
     <div class="rounded-md bg-red-50 p-4">
@@ -30,7 +30,7 @@
               data: { action: "change->provider-form#toggleAuthType" } %>
           <span class="ml-2 text-sm text-gray-700">Subscription</span>
         </label>
-        <% if @api_key_provider_options.any? %>
+        <% if api_key_provider_options.any? %>
           <label class="flex items-center">
             <%= form.radio_button :auth_type, "api_key", class: "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600",
                 data: { action: "change->provider-form#toggleAuthType" } %>
@@ -50,12 +50,12 @@
     <div class="mt-2">
       <% if provider.persisted? %>
         <%= form.hidden_field :provider_key, value: provider.provider_key %>
-        <input type="text" value="<%= provider.display_name %>" disabled class="block w-full rounded-md border-0 bg-gray-100 px-3 py-1.5 text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6">
+        <input type="text" value="<%= provider.display_name %>" disabled autocomplete="off" class="block w-full rounded-md border-0 bg-gray-100 px-3 py-1.5 text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6">
       <% else %>
-        <% if @subscription_provider_options.any? %>
-          <div data-provider-form-target="subscriptionFields" <%= "hidden" if is_api_key %>>
+        <% if subscription_provider_options.any? %>
+          <div data-provider-form-target="subscriptionFields" <% if is_api_key %>hidden<% end %>>
             <%= form.select :provider_key,
-                @subscription_provider_options.map { |key| [key.titleize, key] },
+                subscription_provider_options.map { |key| [key.titleize, key] },
                 {},
                 id: "provider_provider_key_subscription",
                 "aria-labelledby": "provider_key_label",
@@ -64,10 +64,10 @@
                 data: { provider_form_target: "providerSelect", action: "change->provider-form#refreshProviderSpecificFields" } %>
           </div>
         <% end %>
-        <% if @api_key_provider_options.any? %>
-          <div data-provider-form-target="apiKeyFields" <%= "hidden" unless is_api_key %>>
+        <% if api_key_provider_options.any? %>
+          <div data-provider-form-target="apiKeyFields" <% unless is_api_key %>hidden<% end %>>
             <%= form.select :provider_key,
-                @api_key_provider_options.map { |key| [key.titleize, key] },
+                api_key_provider_options.map { |key| [key.titleize, key] },
                 {},
                 id: "provider_provider_key_api_key",
                 "aria-labelledby": "provider_key_label",
@@ -76,7 +76,7 @@
                 data: { provider_form_target: "providerSelect", action: "change->provider-form#refreshProviderSpecificFields" } %>
           </div>
         <% end %>
-        <% unless @subscription_provider_options.any? || @api_key_provider_options.any? %>
+        <% unless subscription_provider_options.any? || api_key_provider_options.any? %>
           <%= form.text_field :provider_key, value: "No additional providers are installed in paid-agent yet", disabled: true, class: "block w-full rounded-md border-0 bg-gray-100 px-3 py-1.5 text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6" %>
         <% end %>
       <% end %>
@@ -94,19 +94,19 @@
     <p class="mt-1 text-xs text-gray-500">A custom label to distinguish this provider entry.</p>
   </div>
 
-  <% if is_new && @available_api_keys.any? %>
-    <div data-provider-form-target="apiKeySelectContainer" <%= "hidden" unless is_api_key %>>
+  <% if is_new && available_api_keys.any? %>
+    <div data-provider-form-target="apiKeySelectContainer" <% unless is_api_key %>hidden<% end %>>
       <%= form.label :provider_api_key_id, "API Key", class: "block text-sm font-medium text-gray-900" %>
       <div class="mt-2">
         <select name="provider[provider_api_key_id]"
                 id="provider_provider_api_key_id"
                 class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                <%= "disabled" unless is_api_key %>
+                <% unless is_api_key %>disabled<% end %>
                 data-provider-form-target="apiKeySelect">
           <option value="" data-provider-form-target="apiKeyOption">Select an API key</option>
-          <% @available_api_keys.each do |ak| %>
+          <% available_api_keys.each do |ak| %>
             <option value="<%= ak.id %>"
-                    <%= "selected" if provider.provider_api_key_id == ak.id %>
+                    <% if provider.provider_api_key_id == ak.id %>selected<% end %>
                     data-provider-form-target="apiKeyOption"
                     data-api-service-type="<%= ak.api_service_type %>">
               <%= ak.name %>
@@ -119,12 +119,12 @@
     <div>
       <%= form.label :provider_api_key_id, "API Key", class: "block text-sm font-medium text-gray-900" %>
       <div class="mt-2">
-        <input type="text" value="<%= provider.provider_api_key&.name || 'None' %>" disabled class="block w-full rounded-md border-0 bg-gray-100 px-3 py-1.5 text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6">
+        <input type="text" value="<%= provider.provider_api_key&.name || 'None' %>" disabled autocomplete="off" class="block w-full rounded-md border-0 bg-gray-100 px-3 py-1.5 text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 sm:text-sm sm:leading-6">
       </div>
     </div>
   <% end %>
 
-  <div data-provider-form-target="fallbackRoleField" <%= "hidden" unless is_api_key %>>
+  <div data-provider-form-target="fallbackRoleField" <% unless is_api_key %>hidden<% end %>>
     <%= form.label :fallback_role, "Fallback Role", class: "block text-sm font-medium text-gray-900" %>
     <div class="mt-2">
       <%= form.select :fallback_role,
@@ -138,7 +138,7 @@
 
   <% opencode_settings_enabled = is_api_key && provider.provider_key == "opencode" %>
   <% opencode_api_provider = provider.opencode_api_provider || Provider::OPENCODE_DEFAULT_API_PROVIDER %>
-  <div data-provider-form-target="opencodeSettings" <%= "hidden" unless opencode_settings_enabled %>>
+  <div data-provider-form-target="opencodeSettings" <% unless opencode_settings_enabled %>hidden<% end %>>
     <div class="rounded-lg border border-gray-200 p-4">
       <h3 class="text-sm font-semibold text-gray-900">OpenCode Model Settings</h3>
       <p class="mt-1 text-xs text-gray-500">Configure the upstream API provider and model for this OpenCode entry.</p>
@@ -147,13 +147,13 @@
         <label for="provider_config_opencode_api_provider" class="block text-sm font-medium text-gray-900">API Provider</label>
         <select id="provider_config_opencode_api_provider"
                 name="provider[config][opencode][api_provider]"
-                <%= "disabled" unless opencode_settings_enabled %>
+                <% unless opencode_settings_enabled %>disabled<% end %>
                 class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
                 data-provider-form-target="directOutboundApiProviderSelect"
                 data-provider-key="opencode"
                 data-action="change->provider-form#refreshProviderSpecificFields">
           <% Provider::DIRECT_OUTBOUND_API_PROVIDERS.each do |slug, cfg| %>
-            <option value="<%= slug %>" data-service-type="<%= cfg[:service_type] %>" <%= "selected" if opencode_api_provider == slug %>><%= cfg[:label] %></option>
+            <option value="<%= slug %>" data-service-type="<%= cfg[:service_type] %>" <% if opencode_api_provider == slug %>selected<% end %>><%= cfg[:label] %></option>
           <% end %>
         </select>
       </div>
@@ -165,7 +165,8 @@
                type="text"
                value="<%= provider.opencode_model_id %>"
                placeholder="moonshotai/kimi-k2-0905"
-               <%= "disabled" unless opencode_settings_enabled %>
+               autocomplete="off"
+                <% unless opencode_settings_enabled %>disabled<% end %>
                class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
         <p class="mt-1 text-xs text-gray-500">Required. The model identifier for the selected API provider.</p>
       </div>
@@ -174,7 +175,7 @@
 
   <% kilocode_settings_enabled = is_api_key && provider.provider_key == "kilocode" %>
   <% kilocode_api_provider = provider.kilocode_api_provider || Provider::KILOCODE_DEFAULT_API_PROVIDER %>
-  <div data-provider-form-target="kilocodeSettings" <%= "hidden" unless kilocode_settings_enabled %>>
+  <div data-provider-form-target="kilocodeSettings" <% unless kilocode_settings_enabled %>hidden<% end %>>
     <div class="rounded-lg border border-gray-200 p-4">
       <h3 class="text-sm font-semibold text-gray-900">KiloCode Model Settings</h3>
       <p class="mt-1 text-xs text-gray-500">Configure the upstream API provider and model for this KiloCode entry.</p>
@@ -183,13 +184,13 @@
         <label for="provider_config_kilocode_api_provider" class="block text-sm font-medium text-gray-900">API Provider</label>
         <select id="provider_config_kilocode_api_provider"
                 name="provider[config][kilocode][api_provider]"
-                <%= "disabled" unless kilocode_settings_enabled %>
+                <% unless kilocode_settings_enabled %>disabled<% end %>
                 class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
                 data-provider-form-target="directOutboundApiProviderSelect"
                 data-provider-key="kilocode"
                 data-action="change->provider-form#refreshProviderSpecificFields">
           <% Provider::DIRECT_OUTBOUND_API_PROVIDERS.each do |slug, cfg| %>
-            <option value="<%= slug %>" data-service-type="<%= cfg[:service_type] %>" <%= "selected" if kilocode_api_provider == slug %>><%= cfg[:label] %></option>
+            <option value="<%= slug %>" data-service-type="<%= cfg[:service_type] %>" <% if kilocode_api_provider == slug %>selected<% end %>><%= cfg[:label] %></option>
           <% end %>
         </select>
       </div>
@@ -201,7 +202,8 @@
                type="text"
                value="<%= provider.kilocode_model_id %>"
                placeholder="mercury-2"
-               <%= "disabled" unless kilocode_settings_enabled %>
+               autocomplete="off"
+                <% unless kilocode_settings_enabled %>disabled<% end %>
                class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
         <p class="mt-1 text-xs text-gray-500">Required. The model identifier for the selected API provider.</p>
       </div>
@@ -227,7 +229,7 @@
                     class="mt-1 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
               <option value="">— None —</option>
               <% tier_models.each do |m| %>
-                <option value="<%= m.model_id %>" <%= "selected" if current_tier_ids[tier] == m.model_id %>>
+                <option value="<%= m.model_id %>" <% if current_tier_ids[tier] == m.model_id %>selected<% end %>>
                   <%= m.display_name %><%= " (#{m.tier})" if m.tier.present? %>
                 </option>
               <% end %>
@@ -246,13 +248,13 @@
       <div>
         <label for="provider_complexity_thresholds_low_max" class="block text-sm font-medium text-gray-900">Low tier max</label>
         <input type="number" name="provider[complexity_thresholds][low_max]" id="provider_complexity_thresholds_low_max"
-               value="<%= thresholds["low_max"] %>" min="1" max="10" step="1"
+               value="<%= thresholds["low_max"] %>" min="1" max="10" step="1" autocomplete="off"
                class="mt-1 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
       </div>
       <div>
         <label for="provider_complexity_thresholds_mid_max" class="block text-sm font-medium text-gray-900">Mid tier max</label>
         <input type="number" name="provider[complexity_thresholds][mid_max]" id="provider_complexity_thresholds_mid_max"
-               value="<%= thresholds["mid_max"] %>" min="1" max="10" step="1"
+               value="<%= thresholds["mid_max"] %>" min="1" max="10" step="1" autocomplete="off"
                class="mt-1 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
       </div>
     </div>

--- a/app/views/providers/_settings.html.erb
+++ b/app/views/providers/_settings.html.erb
@@ -5,8 +5,8 @@
   </div>
 
   <div class="px-4 py-5 sm:p-6">
-    <%= form_with model: @user_setting, url: settings_providers_path, method: :patch do |form| %>
-      <% if @user_setting.errors.any? %>
+    <%= form_with model: user_setting, url: settings_providers_path, method: :patch do |form| %>
+      <% if user_setting.errors.any? %>
         <div class="mb-6 rounded-md bg-red-50 p-4">
           <div class="flex">
             <div class="flex-shrink-0">
@@ -16,11 +16,11 @@
             </div>
             <div class="ml-3">
               <h3 class="text-sm font-medium text-red-800">
-                <%= pluralize(@user_setting.errors.count, "error") %> prevented your provider settings from being saved:
+                <%= pluralize(user_setting.errors.count, "error") %> prevented your provider settings from being saved:
               </h3>
               <div class="mt-2 text-sm text-red-700">
                 <ul class="list-disc space-y-1 pl-5">
-                  <% @user_setting.errors.full_messages.each do |message| %>
+                  <% user_setting.errors.full_messages.each do |message| %>
                     <li><%= message %></li>
                   <% end %>
                 </ul>
@@ -32,16 +32,16 @@
 
       <div class="space-y-6">
         <%
-          current_mode = @user_setting.provider_selection_mode
+          current_mode = user_setting.provider_selection_mode
           combined_value = if current_mode == "single"
-            "single:#{@default_provider_identifier}"
+            "single:#{default_provider_identifier}"
           else
             current_mode
           end
-          combined_options = @enabled_agent_providers.map do |provider|
-            [ @provider_labels[provider] || provider.titleize, "single:#{provider}" ]
+          combined_options = enabled_agent_providers.map do |prov|
+            [ provider_labels[prov] || prov.titleize, "single:#{prov}" ]
           end
-          if @enabled_agent_providers.length > 1
+          if enabled_agent_providers.length > 1
             combined_options += [
               [ "Round Robin (cycle through all providers, respecting weights)", "round_robin" ],
               [ "Random (pick at random, respecting weights)", "random" ]
@@ -54,33 +54,33 @@
             <select name="user_setting[provider_mode]" id="user_setting_provider_mode"
                     class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
               <% combined_options.each do |label, value| %>
-                <option value="<%= value %>" <%= "selected" if value == combined_value %>><%= label %></option>
+                <option value="<%= value %>" <% if value == combined_value %>selected<% end %>><%= label %></option>
               <% end %>
             </select>
           </div>
           <p class="mt-1 text-xs text-gray-500">Choose a single provider for all automated agent runs, or distribute across all enabled providers.</p>
         </div>
 
-        <% if @enabled_agent_providers.length > 1 %>
+        <% if enabled_agent_providers.length > 1 %>
           <div>
             <h3 class="block text-sm font-medium leading-6 text-gray-900">Provider Weights</h3>
             <p class="mt-1 text-xs text-gray-500">A provider with weight N is picked N times more often in Random mode and used N consecutive times in Round Robin mode. Default is 1.</p>
-            <% total_weight = @run_enabled_providers.sum { |provider| provider.weight || Provider::DEFAULT_WEIGHT } %>
+            <% total_weight = run_enabled_providers.sum { |prov| prov.weight || Provider::DEFAULT_WEIGHT } %>
             <div class="mt-3 space-y-2">
-              <% @run_enabled_providers.each do |provider| %>
-                <% weight = provider.weight || Provider::DEFAULT_WEIGHT %>
+              <% run_enabled_providers.each do |prov| %>
+                <% weight = prov.weight || Provider::DEFAULT_WEIGHT %>
                 <% share_pct = total_weight.positive? ? ((weight.to_f / total_weight) * 100).round : 0 %>
                 <div class="flex items-center justify-between gap-3 rounded-md border border-gray-200 px-3 py-2">
-                  <span class="text-sm font-medium text-gray-900"><%= provider.display_name %></span>
+                  <span class="text-sm font-medium text-gray-900"><%= prov.display_name %></span>
                   <div class="flex items-center gap-3">
                     <span class="text-xs text-gray-500" data-provider-share><%= share_pct %>% share</span>
-                    <%= number_field_tag "user_setting[provider_weights][#{provider.id}]",
+                    <%= number_field_tag "user_setting[provider_weights][#{prov.id}]",
                         weight,
                         min: 1,
                         max: Provider::MAX_WEIGHT,
                         step: 1,
                         class: "w-20 rounded-md border-0 px-2 py-1 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600",
-                        aria: { label: "Weight for #{provider.display_name}" } %>
+                        aria: { label: "Weight for #{prov.display_name}" } %>
                   </div>
                 </div>
               <% end %>
@@ -95,15 +95,15 @@
             <% AgentRun::GOALS.each do |goal| %>
               <div>
                 <label for="user_setting_default_agent_providers_by_goal_<%= goal %>" class="block text-sm font-medium leading-6 text-gray-900">
-                  <%= @goal_provider_labels.fetch(goal, goal.humanize) %>
+                  <%= goal_provider_labels.fetch(goal, goal.humanize) %>
                 </label>
                 <div class="mt-2">
-                  <% global_provider_label = @provider_labels[@default_provider_identifier] || @default_provider_identifier.to_s.titleize.presence || "Not set" %>
+                  <% global_provider_label = provider_labels[default_provider_identifier] || default_provider_identifier.to_s.titleize.presence || "Not set" %>
                   <%= select_tag "user_setting[default_agent_providers_by_goal][#{goal}]",
                       options_for_select(
                         [[ "Use global automated provider (#{global_provider_label})", "" ]] +
-                        @enabled_agent_providers.map { |provider| [ @provider_labels[provider] || provider.titleize, provider ] },
-                        @explicit_goal_default_providers[goal]
+                        enabled_agent_providers.map { |prov| [ provider_labels[prov] || prov.titleize, prov ] },
+                        explicit_goal_default_providers[goal]
                       ),
                       id: "user_setting_default_agent_providers_by_goal_#{goal}",
                       class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
@@ -122,14 +122,14 @@
         <div data-controller="sortable">
           <p class="mb-2 text-sm font-medium text-gray-700">Fallback order:</p>
           <div class="space-y-2" data-sortable-target="list">
-            <% provider_states_by_name = @provider_states %>
-            <% fallback_candidates = @fallback_candidate_providers %>
-            <% all_providers = (@enabled_agent_providers + @fallback_candidate_providers).uniq %>
-            <% saved_order = Array(@saved_fallback_provider_tokens) %>
+            <% provider_states_by_name = provider_states %>
+            <% fallback_candidates = fallback_candidate_providers %>
+            <% all_providers = (enabled_agent_providers + fallback_candidate_providers).uniq %>
+            <% saved_order = Array(saved_fallback_provider_tokens) %>
             <% providers_in_order = (saved_order.select { |provider| all_providers.include?(provider) } + (all_providers - saved_order)).uniq %>
             <% providers_in_order.each do |provider| %>
               <% provider_state = provider_states_by_name[provider] %>
-              <% provider_state ||= provider_states_by_name[@provider_state_aliases[provider]] if @subscription_provider_identifiers.include?(provider) %>
+              <% provider_state ||= provider_states_by_name[provider_state_aliases[provider]] if subscription_provider_identifiers.include?(provider) %>
               <% fallback_enabled = fallback_candidates.include?(provider) %>
               <div class="provider-item flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 shadow-sm <%= fallback_enabled ? 'bg-white' : 'bg-gray-50 opacity-60' %>" data-provider="<%= provider %>" data-fallback-enabled="<%= fallback_enabled %>" data-sortable-target="item">
                 <div class="flex items-center">
@@ -141,12 +141,12 @@
                          data-action="sortable#toggleFallback"
                          data-sortable-target="checkbox"
                          data-provider="<%= provider %>"
-                         <%= "checked" if fallback_enabled %>
-                         aria-label="Enable <%= @provider_labels[provider] || provider.titleize %> as fallback">
-                  <span class="text-sm font-medium <%= fallback_enabled ? 'text-gray-900' : 'text-gray-400' %>"><%= @provider_labels[provider] || provider.titleize %></span>
+                         <% if fallback_enabled %>checked<% end %>
+                         aria-label="Enable <%= provider_labels[provider] || provider.titleize %> as fallback">
+                   <span class="text-sm font-medium <%= fallback_enabled ? 'text-gray-900' : 'text-gray-400' %>"><%= provider_labels[provider] || provider.titleize %></span>
                 </div>
                 <div>
-                  <% if provider == @default_provider_identifier %>
+                  <% if provider == default_provider_identifier %>
                     <span class="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700">Automated</span>
                   <% elsif provider_state&.rate_limited? %>
                     <span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">Rate limited</span>
@@ -163,8 +163,8 @@
           </div>
 
           <%= form.hidden_field :fallback_providers,
-              value: (@saved_fallback_provider_tokens || []).to_json,
-              data: { sortable_target: "input", primary_provider: @default_provider_identifier } %>
+              value: (saved_fallback_provider_tokens || []).to_json,
+              data: { sortable_target: "input", primary_provider: default_provider_identifier } %>
           <input type="hidden" name="user_setting[enabled_fallback_provider_keys]"
                  value="<%= fallback_candidates.to_json %>"
                  data-sortable-target="enabledInput">

--- a/app/views/providers/_usage_stats.html.erb
+++ b/app/views/providers/_usage_stats.html.erb
@@ -1,4 +1,4 @@
-<% if @usage_stats.present? %>
+<% if usage_stats.present? %>
   <div class="mt-8">
     <details class="rounded-lg border border-gray-200 bg-white shadow">
       <summary class="cursor-pointer list-none px-4 py-3">
@@ -8,8 +8,8 @@
         </div>
       </summary>
       <div class="border-t border-gray-200 divide-y divide-gray-100">
-        <% @providers.each do |provider| %>
-          <% stats = @provider_stats_by_id[provider.id] %>
+        <% providers.each do |provider| %>
+          <% stats = provider_stats_by_id[provider.id] %>
           <% next unless stats %>
           <div class="px-4 py-3">
             <h3 class="text-sm font-semibold text-gray-900"><%= provider.display_name %></h3>

--- a/app/views/providers/edit.html.erb
+++ b/app/views/providers/edit.html.erb
@@ -6,7 +6,10 @@
     <p class="mt-1 text-sm text-gray-500">Update where this provider can be used.</p>
 
     <div class="mt-6">
-      <%= render "form", provider: @provider %>
+      <%= render "form", provider: @provider,
+            subscription_provider_options: @subscription_provider_options,
+            api_key_provider_options: @api_key_provider_options,
+            available_api_keys: @available_api_keys %>
     </div>
   </div>
 </div>

--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -117,10 +117,22 @@
     </table>
   </div>
 
-  <%= render "usage_stats" %>
+  <%= render "usage_stats", usage_stats: @usage_stats, providers: @providers, provider_stats_by_id: @provider_stats_by_id %>
 
   <div class="mt-8">
-    <%= render "settings" %>
+    <%= render "settings",
+          user_setting: @user_setting,
+          default_provider_identifier: @default_provider_identifier,
+          enabled_agent_providers: @enabled_agent_providers,
+          provider_labels: @provider_labels,
+          run_enabled_providers: @run_enabled_providers,
+          goal_provider_labels: @goal_provider_labels,
+          explicit_goal_default_providers: @explicit_goal_default_providers,
+          provider_states: @provider_states,
+          fallback_candidate_providers: @fallback_candidate_providers,
+          saved_fallback_provider_tokens: @saved_fallback_provider_tokens,
+          subscription_provider_identifiers: @subscription_provider_identifiers,
+          provider_state_aliases: @provider_state_aliases %>
   </div>
 
   <div class="mt-8 rounded-lg border border-sky-200 bg-sky-50 p-4">

--- a/app/views/providers/new.html.erb
+++ b/app/views/providers/new.html.erb
@@ -6,7 +6,10 @@
     <p class="mt-1 text-sm text-gray-500">Add a provider that is already installed in the prebuilt paid-agent image, then choose whether it can be used for agent runs and fallback.</p>
 
     <div class="mt-6">
-      <%= render "form", provider: @provider %>
+      <%= render "form", provider: @provider,
+            subscription_provider_options: @subscription_provider_options,
+            api_key_provider_options: @api_key_provider_options,
+            available_api_keys: @available_api_keys %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_issue_enhance_table.html.erb
+++ b/app/views/shared/_issue_enhance_table.html.erb
@@ -1,5 +1,5 @@
 <%# Multi-select table for enhance_issue goal %>
-<div data-goal-toggle-target="issueTable" <%= "hidden" unless local_assigns.fetch(:initially_visible, false) %>>
+<div data-goal-toggle-target="issueTable" <% unless local_assigns.fetch(:initially_visible, false) %>hidden<% end %>>
   <p class="block text-sm font-medium text-gray-700 mb-2">Select issues to enhance:</p>
   <div class="overflow-x-auto rounded-md border border-gray-200">
     <table class="min-w-full divide-y divide-gray-200">

--- a/app/views/style_guides/show.html.erb
+++ b/app/views/style_guides/show.html.erb
@@ -45,16 +45,18 @@
     <div class="overflow-hidden bg-white shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
       <div class="px-4 py-5 sm:px-6">
         <h3 class="text-base font-semibold leading-6 text-gray-900">Compressed Content</h3>
-        <% if @style_guide.compressed? %>
-          <p class="mt-1 text-sm text-gray-500">
+        <p class="mt-1 text-sm text-gray-500">
+          <% if @style_guide.compressed? %>
+
             <%= number_with_delimiter(@style_guide.compressed_content.length) %> characters
             <% if @style_guide.compression_metadata["compression_ratio"] %>
               (<%= (@style_guide.compression_metadata["compression_ratio"].to_f * 100).round %>% of original)
             <% end %>
-          </p>
-        <% else %>
-          <p class="mt-1 text-sm text-gray-500">Not yet compressed. Click "Compress" to generate an LLM-friendly version.</p>
-        <% end %>
+
+          <% else %>
+            Not yet compressed. Click "Compress" to generate an LLM-friendly version.
+          <% end %>
+        </p>
       </div>
       <div class="border-t border-gray-200 px-4 py-5 sm:px-6">
         <% if @style_guide.compressed? %>
@@ -79,20 +81,24 @@
                  rescue ArgumentError, TypeError
                    nil
                  end %>
-              <% if compressed_at %>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= local_time(compressed_at, format: :short) %></dd>
-              <% else %>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @style_guide.compression_metadata["compressed_at"] %></dd>
-              <% end %>
+              <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                <% if compressed_at %>
+                  <%= local_time(compressed_at, format: :short) %>
+                <% else %>
+                  <%= @style_guide.compression_metadata["compressed_at"] %>
+                <% end %>
+              </dd>
             </div>
             <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
               <dt class="text-sm font-medium text-gray-500">Compression ratio</dt>
               <% compression_ratio = @style_guide.compression_metadata["compression_ratio"] %>
-              <% if compression_ratio.present? %>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= (compression_ratio.to_f * 100).round %>%</dd>
-              <% else %>
-                <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">N/A</dd>
-              <% end %>
+              <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+                <% if compression_ratio.present? %>
+                  <%= (compression_ratio.to_f * 100).round %>%
+                <% else %>
+                  N/A
+                <% end %>
+              </dd>
             </div>
             <div class="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
               <dt class="text-sm font-medium text-gray-500">Raw length</dt>

--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -54,7 +54,7 @@
 
         <%# === Polling & Timing === %>
         <fieldset class="space-y-6">
-          <legend class="text-base font-semibold leading-7 text-gray-900 dark:text-gray-100">Polling & Timing</legend>
+          <legend class="text-base font-semibold leading-7 text-gray-900 dark:text-gray-100">Polling &amp; Timing</legend>
           <p class="text-sm text-gray-500 dark:text-gray-400">Configure how frequently the app polls for changes and caches data.</p>
 
           <div>

--- a/bin/lint
+++ b/bin/lint
@@ -19,7 +19,7 @@ for arg in "$@"; do
       echo "  --changed  Lint only changed files (staged + unstaged vs HEAD)"
       echo "  --staged   Lint only staged files"
       echo ""
-      echo "Linters: RuboCop, ESLint, markdownlint, ShellCheck"
+      echo "Linters: RuboCop, ESLint, markdownlint, ShellCheck, Herb"
       exit 0
       ;;
     *)
@@ -74,12 +74,14 @@ ruby_files=""
 js_files=""
 md_files=""
 sh_files=""
+erb_files=""
 
 if [ "$FILE_FILTER" = true ]; then
   ruby_files=$(echo "$FILES" | grep -E '\.rb$' || true)
   js_files=$(echo "$FILES" | grep -E '\.(js|ts|jsx|tsx)$' || true)
   md_files=$(echo "$FILES" | grep -E '\.md$' || true)
   sh_files=$(echo "$FILES" | grep -E '\.sh$' || true)
+  erb_files=$(echo "$FILES" | grep -E '\.html\.erb$' || true)
 fi
 
 echo "== Style: RuboCop =="
@@ -132,6 +134,28 @@ if [ "$FILE_FILTER" = true ]; then
   fi
 else
   shellcheck -x scripts/*.sh .devcontainer/*.sh .githooks/* bin/audit bin/dev bin/dev-update bin/docker-entrypoint bin/lib/dev_supervisor.sh bin/lint
+fi
+
+echo "== ERB: Herb =="
+HERB_ARGS=""
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  HERB_ARGS="--github"
+fi
+if [ "$AUTOFIX" = true ]; then
+  HERB_ARGS="$HERB_ARGS --fix-unsafely"
+elif [ "$SAFE_AUTOFIX" = true ]; then
+  HERB_ARGS="$HERB_ARGS --fix"
+fi
+if [ "$FILE_FILTER" = true ]; then
+  if [ -n "$erb_files" ]; then
+    # shellcheck disable=SC2086
+    bundle exec herb lint $HERB_ARGS $erb_files
+  else
+    echo "  No ERB files to lint."
+  fi
+else
+  # shellcheck disable=SC2086
+  bundle exec herb lint $HERB_ARGS app/views
 fi
 
 echo "All lint checks passed."

--- a/bin/lint
+++ b/bin/lint
@@ -148,12 +148,14 @@ elif [ "$SAFE_AUTOFIX" = true ]; then
 fi
 if [ "$FILE_FILTER" = true ]; then
   if [ -n "$erb_files" ]; then
+    # The Ruby herb CLI delegates linting to the Node package at runtime.
     # shellcheck disable=SC2086
     bundle exec herb lint $HERB_ARGS $erb_files
   else
     echo "  No ERB files to lint."
   fi
 else
+  # The Ruby herb CLI delegates linting to the Node package at runtime.
   # shellcheck disable=SC2086
   bundle exec herb lint $HERB_ARGS app/views
 fi

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "packageManager": "yarn@1.22.22",
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@herb-tools/linter": "^0.10.1",
     "esbuild": "0.28.0",
     "eslint": "10.3.0",
     "markdownlint-cli": "0.48.0"

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "UserSettings" do
 
       it "displays all setting sections" do
         get edit_user_settings_path
-        expect(response.body).to include("Polling & Timing")
+        expect(response.body).to include("Polling &amp; Timing")
         expect(response.body).to include("Agent Execution")
         expect(response.body).to include("Max Execution Time Override")
         expect(response.body).to include("Container Resources")

--- a/yarn.lock
+++ b/yarn.lock
@@ -207,6 +207,78 @@
     "@eslint/core" "^1.2.1"
     levn "^0.4.1"
 
+"@herb-tools/config@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@herb-tools/config/-/config-0.10.1.tgz#d8fd360fac480c0409edf58f49bae45992828c03"
+  integrity sha512-eaC7N1uDsDhqaEh+ulvw77mEsYYpBnU5mb6cSm86U8YYErnEIq5Rp3H9uqVs4HQmvc7NXhZVIDNaSciAKJVJaw==
+  dependencies:
+    "@herb-tools/core" "0.10.1"
+    picomatch "^4.0.4"
+    tinyglobby "^0.2.16"
+    yaml "^2.8.3"
+
+"@herb-tools/core@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@herb-tools/core/-/core-0.10.1.tgz#81845d6128f0c3a6a13ff1112c4fef7dcd3696d9"
+  integrity sha512-zFVhWGvqC7b5KHtp4LNlCt4ExLInuRZJxvcNp9kcHCAwnVux+EiXnJz8rsiiF8pU1z2gjq3w6q/g7ayjOetpAg==
+
+"@herb-tools/highlighter@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@herb-tools/highlighter/-/highlighter-0.10.1.tgz#3f4d78afd41023702043f3b23964815ba758f406"
+  integrity sha512-zgDNj9T/vHaN+V29KqnKXJJMG7eF9GWjYj03VeoDXCkiWbeVJ1G0RKsNuW6QcziyXYeIEyVpS/A3EUvg+Annow==
+  dependencies:
+    "@herb-tools/core" "0.10.1"
+    "@herb-tools/node-wasm" "0.10.1"
+
+"@herb-tools/linter@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@herb-tools/linter/-/linter-0.10.1.tgz#53629597a82ebe2514543b23410a8baa3e18db5a"
+  integrity sha512-2K+8PJ6FbS8+nrR7IaMTLdlyO5Ci/dAd4lOngvQMvuwoCiYysvAtTeSySSJtAhgL2YhlneLM+Crw1QN3AsnC2g==
+  dependencies:
+    "@herb-tools/config" "0.10.1"
+    "@herb-tools/core" "0.10.1"
+    "@herb-tools/highlighter" "0.10.1"
+    "@herb-tools/node-wasm" "0.10.1"
+    "@herb-tools/printer" "0.10.1"
+    "@herb-tools/rewriter" "0.10.1"
+    picomatch "^4.0.4"
+    tinyglobby "^0.2.15"
+
+"@herb-tools/node-wasm@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@herb-tools/node-wasm/-/node-wasm-0.10.1.tgz#a73f0b0cd1e1e116641b3a2f80a1f1996e6d7ef4"
+  integrity sha512-dKMpscMLdBEgJnPmkBVT0iEkjssgjOUsJCpKWi2HMqZEsIem4NR9j3v7D5aq8cR5W80y/7dvNmHtefAsLt8KSA==
+  dependencies:
+    "@herb-tools/core" "0.10.1"
+
+"@herb-tools/printer@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@herb-tools/printer/-/printer-0.10.1.tgz#830700c03d78499ab7ba3333b97a99a3aa154be3"
+  integrity sha512-qxE/8G5xnEMKWkSQbWxQZplFJcvs2v2XFR3WEXSVfVQUtpgy/vLJPMAZI4kVDTF+MfdxVzCUZVEeL+OXYzfPCQ==
+  dependencies:
+    "@herb-tools/core" "0.10.1"
+    tinyglobby "^0.2.15"
+
+"@herb-tools/rewriter@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@herb-tools/rewriter/-/rewriter-0.10.1.tgz#60ac0a0a54a4d8ae56afef1f1a8daa320574b643"
+  integrity sha512-XNBrh03gwNHMwlR3XID7hM3z1kfNtwF9+hURqHPlBURr3OFFa1DDo3pFTpowLC8/d6NWkj9Nb8g8f7nCWAZa1w==
+  dependencies:
+    "@herb-tools/core" "0.10.1"
+    "@herb-tools/tailwind-class-sorter" "0.10.1"
+    tinyglobby "^0.2.15"
+
+"@herb-tools/tailwind-class-sorter@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@herb-tools/tailwind-class-sorter/-/tailwind-class-sorter-0.10.1.tgz#4d9f5e73a8456503d1fffeeed84c18850b886c34"
+  integrity sha512-+ie6BMM5wONUuLPjsEYjZ2wfKFLG637UCpdcT49Z8Pucs3auk+uBIleQK1+NI1229txUxMOqnp0VJ5LbCuXQYQ==
+  dependencies:
+    clear-module "^4.1.2"
+    escalade "^3.2.0"
+    jiti "^2.5.1"
+    postcss "^8.5.10"
+    postcss-import "^16.1.1"
+
 "@hotwired/stimulus@3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
@@ -593,6 +665,11 @@ brace-expansion@^5.0.5:
   dependencies:
     balanced-match "^4.0.2"
 
+callsites@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
 character-entities-legacy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
@@ -628,6 +705,14 @@ chartkick@5.0.1:
     chart.js "4"
     chartjs-adapter-date-fns ">=3"
     date-fns ">=2"
+
+clear-module@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/clear-module/-/clear-module-4.1.2.tgz#5a58a5c9f8dccf363545ad7284cad3c887352a80"
+  integrity sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==
+  dependencies:
+    parent-module "^2.0.0"
+    resolve-from "^5.0.0"
 
 commander@^8.3.0:
   version "8.3.0"
@@ -707,6 +792,11 @@ entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
 esbuild@0.28.0:
   version "0.28.0"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.0.tgz#5dee347ffb3e3874212a35a69836b077b1ce6d96"
@@ -738,6 +828,11 @@ esbuild@0.28.0:
     "@esbuild/win32-arm64" "0.28.0"
     "@esbuild/win32-ia32" "0.28.0"
     "@esbuild/win32-x64" "0.28.0"
+
+escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -886,6 +981,11 @@ fsevents@2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 get-east-asian-width@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz#ce7008fe345edcf5497a6f557cfa54bc318a9ce7"
@@ -902,6 +1002,13 @@ graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+hasown@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
+  integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
+  dependencies:
+    function-bind "^1.1.2"
 
 highlight.js@11.11.1:
   version "11.11.1"
@@ -941,6 +1048,13 @@ is-alphanumerical@^2.0.0:
     is-alphabetical "^2.0.0"
     is-decimal "^2.0.0"
 
+is-core-module@^2.16.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
+
 is-decimal@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
@@ -967,6 +1081,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+jiti@^2.5.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
+  integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
 
 jiti@^2.6.1:
   version "2.6.1"
@@ -1444,6 +1563,11 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+nanoid@^3.3.11:
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
+  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -1480,6 +1604,13 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+parent-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-2.0.0.tgz#fa71f88ff1a50c27e15d8ff74e0e3a9523bf8708"
+  integrity sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==
+  dependencies:
+    callsites "^3.1.0"
+
 parse-entities@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-4.0.2.tgz#61d46f5ed28e4ee62e9ddc43d6b010188443f159"
@@ -1503,6 +1634,11 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
 picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -1512,6 +1648,11 @@ picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
+pify@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+  integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
 playwright-core@1.59.1:
   version "1.59.1"
@@ -1527,6 +1668,29 @@ playwright@1.59.1:
   optionalDependencies:
     fsevents "2.3.2"
 
+postcss-import@^16.1.1:
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-16.1.1.tgz#cfbe79e6c9232b0dbbe1c18f35308825cfe8ff2a"
+  integrity sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==
+  dependencies:
+    postcss-value-parser "^4.0.0"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
+postcss-value-parser@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+postcss@^8.5.10:
+  version "8.5.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.14.tgz#a66c2d7808fadf69ebb5b84a03f8bafd76c4919c"
+  integrity sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -1541,6 +1705,28 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  integrity sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==
+  dependencies:
+    pify "^2.3.0"
+
+resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve@^1.1.7:
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 run-con@~1.3.2:
   version "1.3.2"
@@ -1599,6 +1785,11 @@ strip-json-comments@~3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 tailwindcss@4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.2.4.tgz#f7e3090edb22d56394db4d68e6464d2628dc2aa9"
@@ -1609,7 +1800,7 @@ tapable@^2.3.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.3.tgz#5da7c9992c46038221267985ab28421a8879f160"
   integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
 
-tinyglobby@~0.2.15:
+tinyglobby@^0.2.15, tinyglobby@^0.2.16, tinyglobby@~0.2.15:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
   integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
@@ -1652,6 +1843,11 @@ word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
+yaml@^2.8.3:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.4.tgz#4b5f411dd25f9544914d8673d4da7f29248e5e2e"
+  integrity sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary

- Adds [herb](https://herb.tools/) gem (v0.10.1) and `@herb-tools/linter` for ERB template linting
- Integrates herb into `bin/lint` with support for `--changed`, `--staged`, `-a`, `-A` flags (matching existing RuboCop/ESlint patterns)
- Adds `.herb.yml` config with all 93 rules enabled (83 active, 10 not yet enabled)
- Fixes **311 lint offenses across 165 ERB files** — all templates now pass cleanly

### Offense categories fixed

| Rule | Count | Fix |
|------|-------|-----|
| `erb-no-instance-variables-in-partials` | 112 | Convert `@var` to locals in 10 partials, update all callers to pass explicit locals |
| `html-no-self-closing` | 63 | Remove `/>` from void elements |
| `erb-no-duplicate-branch-elements` | 38 | Extract shared HTML wrappers outside conditional branches |
| `erb-no-output-in-attribute-name` | 39 | Convert `<%= "attr" if cond %>` → `<% if cond %>attr<% end %>` |
| `html-input-require-autocomplete` | 28 | Add `autocomplete` attributes to form inputs |
| `erb-no-output-in-attribute-position` | 19 | Convert output tags to control flow in attribute values |
| `erb-prefer-direct-output` | 3 | Use direct `<%= %>` output instead of string interpolation |
| `erb-no-extra-whitespace-inside-tags` | 5 | Clean ERB tag whitespace |
| `html-require-script-nonce` | 1 | Add CSP nonce to layout `<script>` tag |
| `html-no-unescaped-entities` | 1 | Escape `&` → `&amp;` in HTML |

### Key changes

- **Partials now use locals instead of instance variables** — all callers updated to pass explicit locals
- **Attribute expressions use control flow** instead of output tags — safer and herb-compliant
- **Duplicate branch elements extracted** — shared wrapping HTML moved outside conditionals
- **Test update**: `spec/requests/user_settings_spec.rb` updated to expect `&amp;` entity in rendered HTML

## Test plan

- [x] `bin/lint` passes (all 165 ERB files clean, 0 offenses)
- [x] `bin/rspec spec/requests/` — 1253 examples, 0 failures
- [x] Pre-commit hooks pass on commit
- [ ] Manual spot-check of significantly restructured pages (cost dashboard, quality dashboard, project edit, providers settings)