### PR TITLE
feat(dashboard): add provider health section above queue health in live dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -64,6 +64,11 @@ class DashboardController < ApplicationController
     render partial: "dashboard/knowledge_widget", locals: { knowledge_stats: @knowledge_stats }
   end
 
+  def provider_health
+    @provider_health = Dashboard::ProviderHealth.call(account: current_account)
+    render partial: "dashboard/provider_health", locals: @provider_health
+  end
+
   def queue_health
     @queue_health = Scaling::QueueMonitor.cached_for_account(current_account)
     render partial: "dashboard/queue_health", locals: { queue_depths: @queue_health.queue_depths, healthy: @queue_health.healthy? }

--- a/app/services/dashboard/provider_health.rb
+++ b/app/services/dashboard/provider_health.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Dashboard
+  class ProviderHealth
+    CACHE_TTL = 20.seconds
+
+    ProviderStatus = Struct.new(
+      :provider,
+      :owner_name,
+      :owner_email,
+      :auth_type,
+      :status,
+      :status_label,
+      :available,
+      :failure_count,
+      :rate_limited_until,
+      keyword_init: true
+    )
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:)
+      @account = account
+    end
+
+    def call
+      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { build_payload }
+    end
+
+    private
+
+    attr_reader :account
+
+    def build_payload
+      providers = provider_rows
+
+      {
+        providers: providers,
+        total: providers.size,
+        available: providers.count(&:available),
+        rate_limited: providers.count { |provider| provider.status == :rate_limited },
+        circuit_open: providers.count { |provider| provider.status == :circuit_open },
+        recovering: providers.count { |provider| provider.status == :recovering },
+        healthy: providers.any? && providers.all?(&:available)
+      }
+    end
+
+    def provider_rows
+      state_by_provider = provider_states.index_by(&:provider_name)
+
+      configured_providers.map do |provider|
+        build_provider_status(provider, state_by_provider[provider.state_key])
+      end.sort_by { |provider| [ status_priority(provider.status), provider.provider.downcase, provider.owner_email.downcase ] }
+    end
+
+    def configured_providers
+      @configured_providers ||= Provider
+        .joins(:user)
+        .where(users: { account_id: account.id })
+        .for_agent_runs
+        .includes(:user)
+        .ordered
+    end
+
+    def provider_states
+      @provider_states ||= ProviderState
+        .joins(:user)
+        .where(users: { account_id: account.id }, provider_name: configured_providers.map(&:state_key))
+        .includes(:user)
+    end
+
+    def build_provider_status(provider, state)
+      state&.check_circuit_recovery!
+
+      status =
+        if state&.rate_limited?
+          :rate_limited
+        elsif state&.circuit_open?
+          :circuit_open
+        elsif state&.circuit_half_open?
+          :recovering
+        else
+          :available
+        end
+
+      ProviderStatus.new(
+        provider: provider.display_name,
+        owner_name: provider.user.name.presence || provider.user.email,
+        owner_email: provider.user.email,
+        auth_type: provider.api_key? ? "API Key" : "Subscription",
+        status: status,
+        status_label: status.to_s.humanize,
+        available: status == :available,
+        failure_count: state&.failure_count || 0,
+        rate_limited_until: state&.rate_limited_until
+      )
+    end
+
+    def status_priority(status)
+      case status
+      when :rate_limited then 0
+      when :circuit_open then 1
+      when :recovering then 2
+      else 3
+      end
+    end
+
+    def cache_key
+      "dashboard/provider_health/#{account.id}"
+    end
+  end
+end

--- a/app/services/dashboard/provider_health.rb
+++ b/app/services/dashboard/provider_health.rb
@@ -3,6 +3,7 @@
 module Dashboard
   class ProviderHealth
     CACHE_TTL = 20.seconds
+    DEFAULT_CIRCUIT_BREAKER_TIMEOUT = UserSetting.column_defaults["circuit_breaker_timeout_seconds"]
 
     ProviderStatus = Struct.new(
       :provider,
@@ -60,7 +61,7 @@ module Dashboard
         .joins(:user)
         .where(users: { account_id: account.id })
         .for_agent_runs
-        .includes(:user)
+        .includes(user: :user_setting)
         .ordered
     end
 
@@ -72,7 +73,7 @@ module Dashboard
     end
 
     def build_provider_status(provider, state)
-      state&.check_circuit_recovery!
+      state&.check_circuit_recovery!(timeout: circuit_breaker_timeout_for(provider))
 
       status =
         if state&.rate_limited?
@@ -96,6 +97,10 @@ module Dashboard
         failure_count: state&.failure_count || 0,
         rate_limited_until: state&.rate_limited_until
       )
+    end
+
+    def circuit_breaker_timeout_for(provider)
+      provider.user.user_setting&.circuit_breaker_timeout_seconds || DEFAULT_CIRCUIT_BREAKER_TIMEOUT
     end
 
     def status_priority(status)

--- a/app/views/dashboard/_provider_health.html.erb
+++ b/app/views/dashboard/_provider_health.html.erb
@@ -33,7 +33,7 @@
 
       <% if recovering.positive? %>
         <p class="mt-3 text-sm text-gray-600">
-          <%= pluralize(recovering, "provider") %> is recovering in half-open mode.
+          <%= pluralize(recovering, "provider") %> <%= recovering == 1 ? "is" : "are" %> recovering in half-open mode.
         </p>
       <% end %>
 

--- a/app/views/dashboard/_provider_health.html.erb
+++ b/app/views/dashboard/_provider_health.html.erb
@@ -1,0 +1,90 @@
+<%= turbo_frame_tag "dashboard-provider-health" do %>
+<div class="overflow-hidden rounded-lg bg-white shadow">
+  <div class="px-4 py-5 sm:p-6">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h3 class="text-base font-semibold text-gray-900">Provider Health</h3>
+        <p class="mt-1 text-sm text-gray-500">Live status for agent-run providers configured across this account.</p>
+      </div>
+      <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium <%= healthy ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800' %>">
+        <%= healthy ? "Healthy" : "Degraded" %>
+      </span>
+    </div>
+
+    <% if providers.any? %>
+      <dl class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div class="rounded-lg bg-gray-50 px-3 py-3">
+          <dt class="text-xs font-medium uppercase tracking-wide text-gray-500">Configured</dt>
+          <dd class="mt-1 text-2xl font-semibold text-gray-900"><%= total %></dd>
+        </div>
+        <div class="rounded-lg bg-gray-50 px-3 py-3">
+          <dt class="text-xs font-medium uppercase tracking-wide text-gray-500">Available</dt>
+          <dd class="mt-1 text-2xl font-semibold text-emerald-600"><%= available %></dd>
+        </div>
+        <div class="rounded-lg bg-gray-50 px-3 py-3">
+          <dt class="text-xs font-medium uppercase tracking-wide text-gray-500">Rate Limited</dt>
+          <dd class="mt-1 text-2xl font-semibold text-amber-600"><%= rate_limited %></dd>
+        </div>
+        <div class="rounded-lg bg-gray-50 px-3 py-3">
+          <dt class="text-xs font-medium uppercase tracking-wide text-gray-500">Circuit Open</dt>
+          <dd class="mt-1 text-2xl font-semibold text-red-600"><%= circuit_open %></dd>
+        </div>
+      </dl>
+
+      <% if recovering.positive? %>
+        <p class="mt-3 text-sm text-gray-600">
+          <%= pluralize(recovering, "provider") %> is recovering in half-open mode.
+        </p>
+      <% end %>
+
+      <div class="mt-4 flow-root">
+        <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+            <table class="min-w-full divide-y divide-gray-300">
+              <thead>
+                <tr>
+                  <th scope="col" class="py-2 pl-4 pr-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500 sm:pl-0">Provider</th>
+                  <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Owner</th>
+                  <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Auth</th>
+                  <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Status</th>
+                  <th scope="col" class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500">Failures</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200">
+                <% providers.each do |provider| %>
+                  <tr>
+                    <td class="whitespace-nowrap py-2 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-0"><%= provider.provider %></td>
+                    <td class="whitespace-nowrap px-3 py-2 text-sm text-gray-500"><%= provider.owner_name %></td>
+                    <td class="whitespace-nowrap px-3 py-2 text-sm text-gray-500"><%= provider.auth_type %></td>
+                    <td class="whitespace-nowrap px-3 py-2 text-sm text-gray-900">
+                      <% badge_classes = case provider.status
+                      when :rate_limited
+                        "bg-amber-100 text-amber-700"
+                      when :circuit_open
+                        "bg-red-100 text-red-700"
+                      when :recovering
+                        "bg-sky-100 text-sky-700"
+                      else
+                        "bg-green-100 text-green-700"
+                      end %>
+                      <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= badge_classes %>">
+                        <%= provider.status_label %>
+                      </span>
+                      <% if provider.status == :rate_limited && provider.rate_limited_until.present? %>
+                        <p class="mt-1 text-xs text-gray-500">Resets <%= local_time(provider.rate_limited_until, format: :relative) %></p>
+                      <% end %>
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-2 text-right text-sm text-gray-900"><%= provider.failure_count %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <p class="mt-4 text-sm text-gray-500">No agent-run providers are enabled for this account yet.</p>
+    <% end %>
+  </div>
+</div>
+<% end %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -46,6 +46,13 @@
         <%= render "dashboard/queue_preview", queue_preview: @queue_preview %>
       </div>
 
+      <turbo-frame id="dashboard-provider-health"
+        data-dashboard-frames-target="frame"
+        data-dashboard-frames-src="<%= dashboard_provider_health_path %>"
+        class="mt-6 block">
+        <div class="animate-pulse rounded-lg bg-gray-100 h-32"></div>
+      </turbo-frame>
+
       <turbo-frame id="dashboard-queue-health"
         data-dashboard-frames-target="frame"
         data-dashboard-frames-src="<%= dashboard_queue_health_path %>"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   get "dashboard/performance", to: "dashboard#performance", as: :dashboard_performance
   get "dashboard/decision_metrics", to: "dashboard#decision_metrics", as: :dashboard_decision_metrics
   get "dashboard/knowledge_stats", to: "dashboard#knowledge_stats", as: :dashboard_knowledge_stats
+  get "dashboard/provider_health", to: "dashboard#provider_health", as: :dashboard_provider_health
   get "dashboard/queue_health", to: "dashboard#queue_health", as: :dashboard_queue_health
   post "dashboard/cancel_run/:id", to: "dashboard#cancel_run", as: :dashboard_cancel_run
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -540,6 +540,27 @@ RSpec.describe "Dashboard" do
       expect(response.body).to include("Rate limited")
       expect(response.body).to include("Configured")
     end
+
+    it "uses plural grammar for multiple recovering providers" do
+      create(:user_setting, user: user, circuit_breaker_timeout_seconds: 30)
+      first_provider = user.providers.find_by!(provider_key: Provider.default_provider_key, auth_type: "subscription")
+      second_provider_key = (ProviderSupport.container_executable_provider_keys - [ first_provider.provider_key ]).first || "cursor"
+      second_provider = create(:provider, user: user, provider_key: second_provider_key, auth_type: "subscription")
+
+      [ first_provider, second_provider ].each do |provider|
+        create(
+          :provider_state,
+          :circuit_open,
+          user: user,
+          provider_name: provider.state_key,
+          circuit_opened_at: 31.seconds.ago
+        )
+      end
+
+      get dashboard_provider_health_path
+
+      expect(response.body).to include("2 providers are recovering in half-open mode.")
+    end
   end
 
   describe "GET /dashboard/live" do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Dashboard" do
         expect(chart).to be_present
       end
 
-      it "renders deferred turbo frame wiring for metrics, performance, knowledge, and queue health", :aggregate_failures do
+      it "renders deferred turbo frame wiring for metrics, performance, knowledge, provider health, and queue health", :aggregate_failures do
         get dashboard_path
 
         doc = Nokogiri::HTML(response.body)
@@ -74,16 +74,34 @@ RSpec.describe "Dashboard" do
         expect(doc.at_css("turbo-frame#dashboard-performance[data-dashboard-frames-src='#{dashboard_performance_path(time_range: "cumulative", status: "all", goal: "all")}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-decision-metrics[data-dashboard-frames-src='#{dashboard_decision_metrics_path(time_range: "cumulative")}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[data-dashboard-frames-src='#{dashboard_knowledge_stats_path}']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-provider-health[data-dashboard-frames-src='#{dashboard_provider_health_path}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-metrics[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-performance[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-decision-metrics[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[loading]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-provider-health[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-queue-health[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-metrics[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-performance[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-decision-metrics[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[src]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-provider-health[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-queue-health[src]")).not_to be_present
+      end
+
+      it "renders provider health above queue health in the dashboard shell" do
+        get dashboard_path
+
+        doc = Nokogiri::HTML(response.body)
+        expect(doc.at_css("[data-controller~='dashboard-frames']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-provider-health[data-dashboard-frames-src='#{dashboard_provider_health_path}']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-queue-health[data-dashboard-frames-src='#{dashboard_queue_health_path}']")).to be_present
+        provider_frame = doc.at_css("turbo-frame#dashboard-provider-health")
+        queue_frame = doc.at_css("turbo-frame#dashboard-queue-health")
+
+        expect(provider_frame).to be_present
+        expect(queue_frame).to be_present
+        expect(provider_frame.path).to be < queue_frame.path
       end
 
       it "wires queue health and frame serialization on the dashboard shell" do
@@ -91,7 +109,6 @@ RSpec.describe "Dashboard" do
 
         doc = Nokogiri::HTML(response.body)
         expect(doc.at_css("[data-controller~='dashboard-frames']")).to be_present
-        expect(doc.at_css("turbo-frame#dashboard-queue-health[data-dashboard-frames-src='#{dashboard_queue_health_path}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-queue-health[src]")).not_to be_present
       end
 
@@ -501,6 +518,27 @@ RSpec.describe "Dashboard" do
       get dashboard_queue_health_path
 
       expect(Scaling::QueueMonitor).to have_received(:cached_for_account).with(account)
+    end
+  end
+
+  describe "GET /dashboard/provider_health" do
+    let(:account) { create(:account) }
+    let(:user) { create(:user, account: account) }
+
+    before { sign_in user }
+
+    it "returns provider health partial within a turbo frame" do
+      provider = user.providers.find_by!(provider_key: Provider.default_provider_key, auth_type: "subscription")
+      create(:provider_state, :rate_limited, user: user, provider_name: provider.state_key)
+
+      get dashboard_provider_health_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("dashboard-provider-health")
+      expect(response.body).to include("Provider Health")
+      expect(response.body).to include(provider.display_name)
+      expect(response.body).to include("Rate limited")
+      expect(response.body).to include("Configured")
     end
   end
 

--- a/spec/services/dashboard/provider_health_spec.rb
+++ b/spec/services/dashboard/provider_health_spec.rb
@@ -47,5 +47,23 @@ RSpec.describe Dashboard::ProviderHealth do
       expect(stats[:total]).to eq(1)
       expect(stats[:providers].map(&:owner_email)).to eq([ user.email ])
     end
+
+    it "uses each provider owner's configured circuit breaker timeout when checking recovery" do
+      provider = default_provider
+      create(:user_setting, user: user, circuit_breaker_timeout_seconds: 30)
+      create(
+        :provider_state,
+        :circuit_open,
+        user: user,
+        provider_name: provider.state_key,
+        circuit_opened_at: 31.seconds.ago
+      )
+
+      stats = described_class.call(account: account)
+
+      expect(stats[:circuit_open]).to eq(0)
+      expect(stats[:recovering]).to eq(1)
+      expect(stats[:providers].map(&:status)).to eq([ :recovering ])
+    end
   end
 end

--- a/spec/services/dashboard/provider_health_spec.rb
+++ b/spec/services/dashboard/provider_health_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Dashboard::ProviderHealth do
+  around do |example|
+    original_store = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+  ensure
+    Rails.cache = original_store
+  end
+
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:user) { create(:user, account: account, name: "Operator One", email: "operator@example.com") }
+    let(:default_provider) { user.providers.find_by!(provider_key: Provider.default_provider_key, auth_type: "subscription") }
+    let(:secondary_provider_key) { (ProviderSupport.container_executable_provider_keys - [ default_provider.provider_key ]).first || "cursor" }
+
+    it "returns configured provider health for the account" do
+      available_provider = default_provider
+      rate_limited_provider = create(:provider, user: user, provider_key: secondary_provider_key, auth_type: "subscription")
+      create(:provider_state, user: user, provider_name: rate_limited_provider.state_key, rate_limited_until: 10.minutes.from_now)
+
+      stats = described_class.call(account: account)
+
+      expect(stats).to include(
+        total: 2,
+        available: 1,
+        rate_limited: 1,
+        circuit_open: 0,
+        recovering: 0,
+        healthy: false
+      )
+      expect(stats[:providers].map(&:provider)).to eq([ rate_limited_provider.display_name, available_provider.display_name ])
+      expect(stats[:providers].map(&:status)).to eq([ :rate_limited, :available ])
+    end
+
+    it "filters providers to the current account" do
+      default_provider
+
+      other_user = create(:user)
+      create(:provider, user: other_user, provider_key: secondary_provider_key)
+
+      stats = described_class.call(account: account)
+
+      expect(stats[:total]).to eq(1)
+      expect(stats[:providers].map(&:owner_email)).to eq([ user.email ])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Added a live `Provider Health` section above `Queue Health` on the dashboard. It now lazy-loads through its own turbo frame, summarizes configured agent-run providers across the account, and shows real status data per provider row including availability, rate limiting, circuit-open/recovering state, owner, auth type, and failure count.

Coverage was added for the new service and for dashboard rendering/order, including verifying that `Provider Health` appears before `Queue Health`. Full validation passed: `bundle exec rubocop` and `bundle exec rspec` both succeeded. The change is committed as `82d0cb2` with message `feat(dashboard): add provider health to live dashboard`.

---

Closes #1875