### PR TITLE
feat(strategy): Phase 4.2 — Learned Orchestration Strategies

### DIFF
--- a/app/services/orchestration_strategy_selector.rb
+++ b/app/services/orchestration_strategy_selector.rb
@@ -82,7 +82,7 @@ class OrchestrationStrategySelector
         "account_id" => effective_account_id
       }.compact
 
-      derived.merge(context)
+      context.merge(derived)
     end
   end
 

--- a/app/services/orchestration_strategy_selector.rb
+++ b/app/services/orchestration_strategy_selector.rb
@@ -118,7 +118,7 @@ class OrchestrationStrategySelector
     when Hash
       value.sum { |_key, nested| count_rules(nested) }
     when Array
-      value.size
+      1
     else
       1
     end

--- a/app/services/orchestration_strategy_selector.rb
+++ b/app/services/orchestration_strategy_selector.rb
@@ -118,7 +118,7 @@ class OrchestrationStrategySelector
     when Hash
       value.sum { |_key, nested| count_rules(nested) }
     when Array
-      1
+      0
     else
       1
     end

--- a/app/services/orchestration_strategy_selector.rb
+++ b/app/services/orchestration_strategy_selector.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+class OrchestrationStrategySelector
+  Result = Data.define(:strategy, :strategy_version, :scope, :matched_rule_count) do
+    delegate :content, :promotion_state, :version, to: :strategy_version
+    delegate :decision_type, :name, :selection_rules, :slug, to: :strategy
+  end
+
+  SCOPE_PRIORITIES = {
+    project: 3,
+    account: 2,
+    global: 1
+  }.freeze
+
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(decision_type:, context: {}, project: nil, account: nil)
+    @decision_type = decision_type.to_s
+    @context = normalize_hash(context)
+    @project = project
+    @account = account
+  end
+
+  def call
+    candidates
+      .filter_map { |strategy| build_result(strategy) }
+      .max_by { |result| [ SCOPE_PRIORITIES.fetch(result.scope), result.matched_rule_count, result.version, result.strategy.id ] }
+  end
+
+  private
+
+  attr_reader :decision_type, :context, :project, :account
+
+  def candidates
+    @candidates ||= Strategy
+      .active
+      .by_decision_type(decision_type)
+      .includes(:current_version)
+      .select { |strategy| visible_in_scope?(strategy) }
+  end
+
+  def visible_in_scope?(strategy)
+    case scope_for(strategy)
+    when :project
+      project.present? && strategy.project_id == project.id
+    when :account
+      effective_account_id.present? && strategy.account_id == effective_account_id && strategy.project_id.nil?
+    when :global
+      strategy.global?
+    else
+      false
+    end
+  end
+
+  def build_result(strategy)
+    version = strategy.current_version
+    return nil unless version&.active?
+    return nil unless rules_match?(strategy.selection_rules, selection_context)
+
+    Result.new(
+      strategy: strategy,
+      strategy_version: version,
+      scope: scope_for(strategy),
+      matched_rule_count: count_rules(strategy.selection_rules)
+    )
+  end
+
+  def scope_for(strategy)
+    return :project if strategy.project_id.present?
+    return :account if strategy.account_id.present?
+
+    :global
+  end
+
+  def selection_context
+    @selection_context ||= begin
+      derived = {
+        "decision_type" => decision_type,
+        "project_id" => project&.id,
+        "account_id" => effective_account_id
+      }.compact
+
+      derived.merge(context)
+    end
+  end
+
+  def effective_account_id
+    @effective_account_id ||= account&.id || project&.account_id
+  end
+
+  def rules_match?(rules, subject)
+    normalized_rules = normalize_hash(rules)
+    return true if normalized_rules.empty?
+
+    normalized_rules.all? do |key, expected|
+      actual = subject[key]
+      value_matches?(expected, actual)
+    end
+  end
+
+  def value_matches?(expected, actual)
+    case expected
+    when Hash
+      actual.is_a?(Hash) && rules_match?(expected, actual)
+    when Array
+      expected.include?("any") || expected.any? { |value| value_matches?(value, actual) }
+    when nil, "any"
+      true
+    else
+      actual.to_s == expected.to_s
+    end
+  end
+
+  def count_rules(value)
+    case value
+    when Hash
+      value.sum { |_key, nested| count_rules(nested) }
+    when Array
+      value.size
+    else
+      1
+    end
+  end
+
+  def normalize_hash(value)
+    return {} unless value.is_a?(Hash)
+
+    value.deep_stringify_keys
+  end
+end

--- a/db/migrate/20260508064240_tighten_orchestration_decisions_strategy_version_tenant_check.rb
+++ b/db/migrate/20260508064240_tighten_orchestration_decisions_strategy_version_tenant_check.rb
@@ -2,6 +2,8 @@
 
 class TightenOrchestrationDecisionsStrategyVersionTenantCheck < ActiveRecord::Migration[8.1]
   def up
+    execute 'DROP TRIGGER IF EXISTS "validate_strategy_version_scope" ON "orchestration_decisions"'
+    execute "DROP FUNCTION IF EXISTS validate_orchestration_decision_strategy_version_scope()"
     create_function :validate_orchestration_decision_strategy_version_scope, version: 1
     execute 'DROP TRIGGER IF EXISTS "validate_strategy_version_scope" ON "orchestration_decisions"'
     create_trigger :validate_strategy_version_scope, on: :orchestration_decisions

--- a/spec/services/orchestration_strategy_selector_spec.rb
+++ b/spec/services/orchestration_strategy_selector_spec.rb
@@ -138,9 +138,11 @@ RSpec.describe OrchestrationStrategySelector do
       strategy = specific_language_account_strategy
 
       result = selector_result(account: account, context: { language: "ruby" })
+      broad_result = selector_result(account: account, context: { language: "python" })
 
       expect(result.strategy).to eq(strategy)
       expect(result.matched_rule_count).to eq(1)
+      expect(broad_result.matched_rule_count).to eq(0)
     end
 
     it "ignores strategies whose current version is not active" do

--- a/spec/services/orchestration_strategy_selector_spec.rb
+++ b/spec/services/orchestration_strategy_selector_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe OrchestrationStrategySelector do
         }
       )
     end
+    let(:scope_key_strategy) do
+      create_strategy_with_version(
+        :for_project,
+        project: project,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: {
+          "decision_type" => "issue_execution",
+          "project_id" => project.id.to_s,
+          "account_id" => account.id.to_s
+        }
+      )
+    end
 
     def create_strategy_with_version(*traits, **attributes)
       strategy = create(:strategy, *traits, **attributes)
@@ -144,6 +157,22 @@ RSpec.describe OrchestrationStrategySelector do
 
       expect(result.strategy).to eq(strategy)
       expect(result.scope).to eq(:account)
+    end
+
+    it "does not let caller context override derived scope keys" do
+      strategy = scope_key_strategy
+
+      result = selector_result(
+        project: project,
+        context: {
+          decision_type: "wrong_decision",
+          project_id: SecureRandom.uuid,
+          account_id: SecureRandom.uuid
+        }
+      )
+
+      expect(result.strategy).to eq(strategy)
+      expect(result.scope).to eq(:project)
     end
   end
 end

--- a/spec/services/orchestration_strategy_selector_spec.rb
+++ b/spec/services/orchestration_strategy_selector_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrchestrationStrategySelector do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:project) { create(:project, account: account) }
+    let(:global_bug_fix_strategy) do
+      create_strategy_with_version(
+        :global,
+        decision_type: "issue_execution",
+        selection_rules: { "task_type" => "bug_fix" }
+      )
+    end
+    let(:account_bug_fix_strategy) do
+      create_strategy_with_version(
+        :for_account,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: { "task_type" => "bug_fix" }
+      )
+    end
+    let(:project_bug_fix_strategy) do
+      create_strategy_with_version(
+        :for_project,
+        project: project,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: { "task_type" => "bug_fix" }
+      )
+    end
+    let(:broad_account_strategy) do
+      create_strategy_with_version(
+        :for_account,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: { "task_type" => "bug_fix" }
+      )
+    end
+    let(:specific_account_strategy) do
+      create_strategy_with_version(
+        :for_account,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: {
+          "task_type" => "bug_fix",
+          "metadata" => {
+            "repository_size" => "large"
+          }
+        }
+      )
+    end
+
+    def create_strategy_with_version(*traits, **attributes)
+      strategy = create(:strategy, *traits, **attributes)
+      version = create(:strategy_version, :active, strategy: strategy)
+      strategy.update!(current_version: version)
+      strategy
+    end
+
+    def selector_result(**args)
+      described_class.call(decision_type: "issue_execution", **args)
+    end
+
+    it "returns the global active version when no scoped override matches" do
+      strategy = create_strategy_with_version(
+        :global,
+        decision_type: "issue_execution",
+        selection_rules: { "task_type" => "any" }
+      )
+
+      result = selector_result(context: { task_type: "bug_fix" })
+
+      expect(result.strategy).to eq(strategy)
+      expect(result.strategy_version).to eq(strategy.current_version)
+      expect(result.scope).to eq(:global)
+    end
+
+    it "prefers a project-scoped strategy over account and global matches" do
+      global_bug_fix_strategy
+      account_bug_fix_strategy
+      strategy = project_bug_fix_strategy
+
+      result = selector_result(project: project, context: { task_type: "bug_fix" })
+
+      expect(result.strategy).to eq(strategy)
+      expect(result.scope).to eq(:project)
+    end
+
+    it "prefers the most specific rule set within the same scope" do
+      broad_account_strategy
+      strategy = specific_account_strategy
+
+      result = selector_result(
+        account: account,
+        context: {
+          task_type: "bug_fix",
+          metadata: { repository_size: "large" }
+        }
+      )
+
+      expect(result.strategy).to eq(strategy)
+      expect(result.matched_rule_count).to eq(2)
+    end
+
+    it "ignores strategies whose current version is not active" do
+      strategy = create(:strategy, :for_account, account: account, decision_type: "issue_execution")
+      draft_version = create(:strategy_version, strategy: strategy, promotion_state: "draft")
+      strategy.update_column(:current_version_id, draft_version.id)
+
+      result = described_class.call(
+        decision_type: "issue_execution",
+        account: account,
+        context: { task_type: "bug_fix" }
+      )
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil when no strategy matches the provided context" do
+      create_strategy_with_version(
+        :for_account,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: { "task_type" => "feature" }
+      )
+
+      result = selector_result(account: account, context: { task_type: "bug_fix" })
+
+      expect(result).to be_nil
+    end
+
+    it "uses the project account_id without loading project.account" do
+      strategy = create_strategy_with_version(
+        :for_account,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: { "task_type" => "bug_fix" }
+      )
+      lightweight_project = Struct.new(:id, :account_id).new(project.id, account.id)
+
+      result = selector_result(project: lightweight_project, context: { task_type: "bug_fix" })
+
+      expect(result.strategy).to eq(strategy)
+      expect(result.scope).to eq(:account)
+    end
+  end
+end

--- a/spec/services/orchestration_strategy_selector_spec.rb
+++ b/spec/services/orchestration_strategy_selector_spec.rb
@@ -64,6 +64,22 @@ RSpec.describe OrchestrationStrategySelector do
         }
       )
     end
+    let(:broad_language_account_strategy) do
+      create_strategy_with_version(
+        :for_account,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: { "language" => [ "ruby", "python" ] }
+      )
+    end
+    let(:specific_language_account_strategy) do
+      create_strategy_with_version(
+        :for_account,
+        account: account,
+        decision_type: "issue_execution",
+        selection_rules: { "language" => "ruby" }
+      )
+    end
 
     def create_strategy_with_version(*traits, **attributes)
       strategy = create(:strategy, *traits, **attributes)
@@ -115,6 +131,16 @@ RSpec.describe OrchestrationStrategySelector do
 
       expect(result.strategy).to eq(strategy)
       expect(result.matched_rule_count).to eq(2)
+    end
+
+    it "treats array alternatives as broader than an exact match" do
+      broad_language_account_strategy
+      strategy = specific_language_account_strategy
+
+      result = selector_result(account: account, context: { language: "ruby" })
+
+      expect(result.strategy).to eq(strategy)
+      expect(result.matched_rule_count).to eq(1)
     end
 
     it "ignores strategies whose current version is not active" do


### PR DESCRIPTION
## Summary

Implemented a data-backed `OrchestrationStrategySelector` in [app/services/orchestration_strategy_selector.rb](/workspace/app/services/orchestration_strategy_selector.rb), plus coverage in [spec/services/orchestration_strategy_selector_spec.rb](/workspace/spec/services/orchestration_strategy_selector_spec.rb). The selector resolves active `Strategy`/`StrategyVersion` records by decision type, scope precedence (`project` > `account` > `global`), and rule specificity, and only returns currently active versions.

I also hardened [db/migrate/20260508064240_tighten_orchestration_decisions_strategy_version_tenant_check.rb](/workspace/db/migrate/20260508064240_tighten_orchestration_decisions_strategy_version_tenant_check.rb) so rerunning `up` replaces the trigger/function cleanly. That fixed the migration-spec failure in `AddAccountToServiceContainers`.

Verification: `bundle exec rubocop` passed, and the commit hook ran `bundle exec rspec` successfully: 11,570 examples, 0 failures, 3 pending. Commit: `d85c838` (`feat(strategy): add orchestration strategy selector`).

---

Closes #1760