### PR TITLE
feat(analytics): build orchestration decision analysis queries

### DIFF
--- a/app/services/analytics/orchestration_decisions/base_query.rb
+++ b/app/services/analytics/orchestration_decisions/base_query.rb
@@ -62,6 +62,22 @@ module Analytics
         )
       end
 
+      def total_count
+        distinct_count(orchestration_decisions_table[:id])
+      end
+
+      def project_count
+        distinct_count(orchestration_decisions_table[:project_id])
+      end
+
+      def actor_count
+        distinct_count(orchestration_decisions_table[:actor])
+      end
+
+      def decision_type_count
+        distinct_count(orchestration_decisions_table[:decision_type])
+      end
+
       def distinct_completed_run_count
         Arel.sql(
           "COUNT(DISTINCT CASE " \

--- a/app/services/analytics/orchestration_decisions/by_actor_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_actor_query.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class ByActorQuery < BaseQuery
+      def call
+        rows = filtered_scope
+          .group(orchestration_decisions_table[:actor])
+          .order(total_count.desc, Arel.sql("LOWER(orchestration_decisions.actor) ASC"))
+          .pluck(
+            orchestration_decisions_table[:actor],
+            total_count,
+            project_count,
+            decision_type_count,
+            distinct_status_count("applied"),
+            distinct_status_count("noop"),
+            distinct_status_count("failed")
+          )
+
+        rows.map do |actor, total_count, project_count, decision_type_count, applied_count, noop_count, failed_count|
+          {
+            actor: actor,
+            total_count: total_count,
+            project_count: project_count,
+            decision_type_count: decision_type_count,
+            applied_count: applied_count,
+            noop_count: noop_count,
+            failed_count: failed_count
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/analytics/orchestration_decisions/by_decision_type_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_decision_type_query.rb
@@ -4,8 +4,6 @@ module Analytics
   module OrchestrationDecisions
     class ByDecisionTypeQuery < BaseQuery
       def call
-        total_count = distinct_count(orchestration_decisions_table[:id])
-
         scope = filtered_scope
           .left_joins(:agent_run)
 
@@ -14,8 +12,8 @@ module Analytics
           .pluck(
             orchestration_decisions_table[:decision_type],
             total_count,
-            distinct_count(orchestration_decisions_table[:project_id]),
-            distinct_count(orchestration_decisions_table[:actor]),
+            project_count,
+            actor_count,
             distinct_status_count("failed"),
             distinct_completed_run_count
           )

--- a/app/services/analytics/orchestration_decisions/by_project_query.rb
+++ b/app/services/analytics/orchestration_decisions/by_project_query.rb
@@ -4,10 +4,6 @@ module Analytics
   module OrchestrationDecisions
     class ByProjectQuery < BaseQuery
       def call
-        total_count = distinct_count(orchestration_decisions_table[:id])
-        decision_type_count = distinct_count(orchestration_decisions_table[:decision_type])
-        actor_count = distinct_count(orchestration_decisions_table[:actor])
-
         scope = filtered_scope
           .joins(:project)
 

--- a/app/services/analytics/orchestration_decisions/outcome_by_decision_type_query.rb
+++ b/app/services/analytics/orchestration_decisions/outcome_by_decision_type_query.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Analytics
+  module OrchestrationDecisions
+    class OutcomeByDecisionTypeQuery < BaseQuery
+      def call
+        rows = filtered_scope
+          .group(orchestration_decisions_table[:decision_type])
+          .order(total_count.desc, orchestration_decisions_table[:decision_type].asc)
+          .pluck(
+            orchestration_decisions_table[:decision_type],
+            total_count,
+            distinct_status_count("applied"),
+            distinct_status_count("noop"),
+            distinct_status_count("failed")
+          )
+
+        rows.map do |decision_type, total_count, applied_count, noop_count, failed_count|
+          {
+            decision_type: decision_type,
+            total_count: total_count,
+            applied_count: applied_count,
+            noop_count: noop_count,
+            failed_count: failed_count
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/analytics/orchestration_decisions/question_set.rb
+++ b/app/services/analytics/orchestration_decisions/question_set.rb
@@ -15,6 +15,16 @@ module Analytics
           query: "Analytics::OrchestrationDecisions::ByDecisionTypeQuery"
         },
         {
+          key: "decision_outcomes_by_type",
+          question: "Which decision types are usually applied, skipped as no-ops, or recorded as failures?",
+          query: "Analytics::OrchestrationDecisions::OutcomeByDecisionTypeQuery"
+        },
+        {
+          key: "decision_activity_by_actor",
+          question: "Which actors drive the most orchestration decisions, and how broad is each actor's decision mix?",
+          query: "Analytics::OrchestrationDecisions::ByActorQuery"
+        },
+        {
           key: "project_level_decision_patterns",
           question: "Which projects produce the most decisions and how broad is their decision mix?",
           query: "Analytics::OrchestrationDecisions::ByProjectQuery"

--- a/app/services/analytics/orchestration_decisions/report.rb
+++ b/app/services/analytics/orchestration_decisions/report.rb
@@ -19,6 +19,8 @@ module Analytics
           summary: SummaryQuery.new(relation: relation, filters: filters).call,
           by_project: ByProjectQuery.new(relation: relation, filters: filters).call,
           by_decision_type: ByDecisionTypeQuery.new(relation: relation, filters: filters).call,
+          outcome_by_decision_type: OutcomeByDecisionTypeQuery.new(relation: relation, filters: filters).call,
+          by_actor: ByActorQuery.new(relation: relation, filters: filters).call,
           daily_volume: DailyVolumeQuery.new(relation: relation, filters: filters).call
         }
       end

--- a/spec/services/analytics/orchestration_decisions/report_spec.rb
+++ b/spec/services/analytics/orchestration_decisions/report_spec.rb
@@ -102,6 +102,28 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
     }
   end
 
+  def expected_outcome_by_decision_type(decision_type:, total_count:, applied_count:, noop_count:, failed_count:)
+    {
+      decision_type: decision_type,
+      total_count: total_count,
+      applied_count: applied_count,
+      noop_count: noop_count,
+      failed_count: failed_count
+    }
+  end
+
+  def expected_actor(actor:, total_count:, project_count:, decision_type_count:, applied_count:, noop_count:, failed_count:)
+    {
+      actor: actor,
+      total_count: total_count,
+      project_count: project_count,
+      decision_type_count: decision_type_count,
+      applied_count: applied_count,
+      noop_count: noop_count,
+      failed_count: failed_count
+    }
+  end
+
   def expected_daily_volume(day:, total_count:, applied_count:, noop_count:, failed_count:)
     {
       day: day,
@@ -218,6 +240,146 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
     )
   end
 
+  def expected_outcome_by_decision_type_rollup
+    [
+      expected_outcome_by_decision_type(
+        decision_type: "select_agent",
+        total_count: 3,
+        applied_count: 2,
+        noop_count: 1,
+        failed_count: 0
+      ),
+      expected_outcome_by_decision_type(
+        decision_type: "planning_outcome",
+        total_count: 1,
+        applied_count: 1,
+        noop_count: 0,
+        failed_count: 0
+      ),
+      expected_outcome_by_decision_type(
+        decision_type: "retry",
+        total_count: 1,
+        applied_count: 0,
+        noop_count: 0,
+        failed_count: 1
+      )
+    ]
+  end
+
+  def expected_actor_rollup
+    [
+      expected_actor(
+        actor: "fallback_rules",
+        total_count: 1,
+        project_count: 1,
+        decision_type_count: 1,
+        applied_count: 1,
+        noop_count: 0,
+        failed_count: 0
+      ),
+      expected_actor(
+        actor: "model_selection",
+        total_count: 1,
+        project_count: 1,
+        decision_type_count: 1,
+        applied_count: 0,
+        noop_count: 1,
+        failed_count: 0
+      ),
+      expected_actor(
+        actor: "rules",
+        total_count: 1,
+        project_count: 1,
+        decision_type_count: 1,
+        applied_count: 1,
+        noop_count: 0,
+        failed_count: 0
+      ),
+      expected_actor(
+        actor: "timeout_auto_retry",
+        total_count: 1,
+        project_count: 1,
+        decision_type_count: 1,
+        applied_count: 0,
+        noop_count: 0,
+        failed_count: 1
+      ),
+      expected_actor(
+        actor: "Workflows::PlanningWorkflow",
+        total_count: 1,
+        project_count: 1,
+        decision_type_count: 1,
+        applied_count: 1,
+        noop_count: 0,
+        failed_count: 0
+      )
+    ]
+  end
+
+  def expect_time_window_rollups(report)
+    expect(report[:summary]).to eq(
+      expected_summary(
+        total_count: 3,
+        applied_count: 1,
+        noop_count: 1,
+        failed_count: 1,
+        linked_agent_run_count: 3,
+        completed_run_count: 1,
+        failed_run_count: 2,
+        project_count: 2,
+        actor_count: 3
+      )
+    )
+    expect(report[:by_project].map { |row| row[:project_name] }).to eq(%w[Alpha Beta])
+    expect(report[:by_decision_type].map { |row| row[:decision_type] }).to eq(
+      %w[planning_outcome retry select_agent]
+    )
+    expect(report[:outcome_by_decision_type].map { |row| row[:decision_type] }).to eq(
+      %w[planning_outcome retry select_agent]
+    )
+    expect(report[:by_actor].map { |row| row[:actor] }).to eq(
+      %w[model_selection timeout_auto_retry Workflows::PlanningWorkflow]
+    )
+  end
+
+  def expect_select_agent_rollups(report)
+    expect(report[:summary]).to eq(expected_select_agent_summary)
+    expect(report[:by_project].pluck(:project_name)).to eq([ "Beta" ])
+    expect(report[:by_decision_type]).to eq([ expected_decision_type_rollup.first ])
+    expect(report[:outcome_by_decision_type]).to eq([ expected_outcome_by_decision_type_rollup.first ])
+    expect(report[:by_actor]).to eq(
+      [
+        expected_actor(
+          actor: "fallback_rules",
+          total_count: 1,
+          project_count: 1,
+          decision_type_count: 1,
+          applied_count: 1,
+          noop_count: 0,
+          failed_count: 0
+        ),
+        expected_actor(
+          actor: "model_selection",
+          total_count: 1,
+          project_count: 1,
+          decision_type_count: 1,
+          applied_count: 0,
+          noop_count: 1,
+          failed_count: 0
+        ),
+        expected_actor(
+          actor: "rules",
+          total_count: 1,
+          project_count: 1,
+          decision_type_count: 1,
+          applied_count: 1,
+          noop_count: 0,
+          failed_count: 0
+        )
+      ]
+    )
+  end
+
   describe ".call" do
     it "returns the initial question set" do
       report = described_class.call
@@ -226,6 +388,8 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
         %w[
           decision_volume_over_time
           decision_mix_by_type
+          decision_outcomes_by_type
+          decision_activity_by_actor
           project_level_decision_patterns
           decision_outcomes
         ]
@@ -258,6 +422,14 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
       expect(described_class.call[:by_decision_type]).to eq(expected_decision_type_rollup)
     end
 
+    it "builds the outcome-by-decision-type rollup" do
+      expect(described_class.call[:outcome_by_decision_type]).to eq(expected_outcome_by_decision_type_rollup)
+    end
+
+    it "builds the actor rollup" do
+      expect(described_class.call[:by_actor]).to eq(expected_actor_rollup)
+    end
+
     it "builds the daily volume rollup" do
       expect(described_class.call[:daily_volume]).to eq(expected_daily_volume_rollup)
     end
@@ -265,23 +437,7 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
     it "filters by time window" do
       report = described_class.call(filters: { from: 3.days.ago, to: Time.current })
 
-      expect(report[:summary]).to eq(
-        expected_summary(
-          total_count: 3,
-          applied_count: 1,
-          noop_count: 1,
-          failed_count: 1,
-          linked_agent_run_count: 3,
-          completed_run_count: 1,
-          failed_run_count: 2,
-          project_count: 2,
-          actor_count: 3
-        )
-      )
-      expect(report[:by_project].map { |row| row[:project_name] }).to eq(%w[Alpha Beta])
-      expect(report[:by_decision_type].map { |row| row[:decision_type] }).to eq(
-        %w[planning_outcome retry select_agent]
-      )
+      expect_time_window_rollups(report)
     end
 
     it "filters by project" do
@@ -302,14 +458,14 @@ RSpec.describe Analytics::OrchestrationDecisions::Report do
       )
       expect(report[:by_project].pluck(:project_name)).to eq([ "Beta" ])
       expect(report[:by_decision_type].pluck(:decision_type)).to eq([ "select_agent" ])
+      expect(report[:outcome_by_decision_type]).to eq([ expected_outcome_by_decision_type_rollup.first ])
+      expect(report[:by_actor].pluck(:actor)).to eq(%w[fallback_rules model_selection rules])
     end
 
     it "filters by decision type" do
       report = described_class.call(filters: { decision_types: [ "SELECT_AGENT" ] })
 
-      expect(report[:summary]).to eq(expected_select_agent_summary)
-      expect(report[:by_project].pluck(:project_name)).to eq([ "Beta" ])
-      expect(report[:by_decision_type]).to eq([ expected_decision_type_rollup.first ])
+      expect_select_agent_rollups(report)
     end
   end
 end


### PR DESCRIPTION
## Summary

Implemented the orchestration decision analysis expansion and committed it as `8e29c80` with `feat(analytics): expand orchestration decision analysis queries`.

The report now exposes two additional reusable slices: actor-level rollups and outcome-by-decision-type rollups. I also widened the initial question set and refactored the shared base query helpers so project, time-window, and decision-type filters apply consistently across all rollups. Specs were expanded with representative fixture coverage for the new queries and filter behavior.

Verification: `bundle exec rubocop` passed. `bundle exec rspec` had `0 failures, 3 pending` when run with `COVERAGE=false`; the default uncovered run in this repo still trips the existing global SimpleCov 80% threshold even when the examples themselves pass. The worktree is clean.

---

Closes #1787