### PR TITLE
feat(strategy): build strategy evolution workflow

### DIFF
--- a/app/services/strategy_evolution/create_candidates.rb
+++ b/app/services/strategy_evolution/create_candidates.rb
@@ -2,6 +2,12 @@
 
 module StrategyEvolution
   class CreateCandidates
+    APPROVAL_STATE = {
+      "required" => true,
+      "status" => "pending_review",
+      "auto_promote" => false
+    }.freeze
+
     def self.call(...)
       new(...).call
     end
@@ -62,7 +68,8 @@ module StrategyEvolution
           "reasoning" => mutation.reasoning,
           "expected_improvement" => mutation.expected_improvement,
           "diff" => mutation.diff,
-          "provenance" => mutation.provenance
+          "provenance" => mutation.provenance,
+          "approval" => APPROVAL_STATE
         }
       )
     end

--- a/app/services/strategy_evolution/generate_candidates.rb
+++ b/app/services/strategy_evolution/generate_candidates.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module StrategyEvolution
+  class GenerateCandidates
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(strategy:, analysis:, options: {})
+      @strategy = strategy.deep_symbolize_keys
+      @analysis = analysis.deep_symbolize_keys
+      @options = options.deep_symbolize_keys
+    end
+
+    def call
+      mutations.map { |mutation| stamp_provenance(mutation) }
+    end
+
+    private
+
+    attr_reader :strategy, :analysis, :options
+
+    def mutations
+      @mutations ||= StrategyEvolution::Mutate.call(
+        strategy: strategy,
+        analysis: analysis,
+        options: options
+      )
+    end
+
+    def stamp_provenance(mutation)
+      StrategyEvolution::Mutate::Mutation.new(
+        configuration: mutation.configuration,
+        strategy: mutation.strategy,
+        reasoning: mutation.reasoning,
+        expected_improvement: mutation.expected_improvement,
+        diff: mutation.diff,
+        provenance: mutation.provenance.to_h.merge(
+          "generated_by" => self.class.name,
+          "sampled_decision_ids" => sampled_decision_ids,
+          "prior_versions" => prior_version_summary,
+          "measured_outcomes" => measured_outcomes
+        )
+      )
+    end
+
+    def sampled_decision_ids
+      @sampled_decision_ids ||= [ *analysis.fetch(:sample_successes, []), *analysis.fetch(:sample_failures, []) ]
+        .filter_map { |row| row[:id] || row["id"] }
+        .uniq
+    end
+
+    def prior_version_summary
+      Array(analysis[:prior_versions]).map do |version|
+        row = version.respond_to?(:deep_symbolize_keys) ? version.deep_symbolize_keys : version
+        {
+          id: row[:id],
+          version: row[:version],
+          active: row[:active]
+        }.compact
+      end
+    end
+
+    def measured_outcomes
+      analysis.fetch(:performance, {}).slice(
+        :decision_count,
+        :min_decisions,
+        :run_backed_decision_count,
+        :success_count,
+        :failure_count,
+        :success_rate,
+        :lookback_days,
+        :decision_types,
+        :actors,
+        :run_statuses,
+        :guardrail_violation_types
+      )
+    end
+  end
+end

--- a/app/services/strategy_evolution/prepare_inputs.rb
+++ b/app/services/strategy_evolution/prepare_inputs.rb
@@ -101,6 +101,7 @@ module StrategyEvolution
         success_count: success_count,
         failure_count: failure_count,
         success_rate: success_rate(run_backed_count, success_count),
+        lookback_days: lookback_days,
         **tallies
       }
     end

--- a/app/temporal/activities/generate_strategy_mutations_activity.rb
+++ b/app/temporal/activities/generate_strategy_mutations_activity.rb
@@ -5,7 +5,7 @@ module Activities
     activity_name "GenerateStrategyMutations"
 
     def execute(input)
-      mutations = StrategyEvolution::Mutate.call(
+      mutations = StrategyEvolution::GenerateCandidates.call(
         strategy: input.fetch(:strategy),
         analysis: input.slice(:performance, :sample_successes, :sample_failures, :prior_versions),
         options: {

--- a/spec/services/strategy_evolution/create_candidates_spec.rb
+++ b/spec/services/strategy_evolution/create_candidates_spec.rb
@@ -34,9 +34,18 @@ RSpec.describe StrategyEvolution::CreateCandidates do
       expect(candidates.size).to eq(1)
       expect(candidates.first).not_to be_active
       expect(candidates.first.version).to eq(4)
+      expect(candidates.first.configuration.dig("_evolution", "approval")).to eq(
+        "required" => true,
+        "status" => "pending_review",
+        "auto_promote" => false
+      )
       expect(candidates.first.configuration.dig("_evolution", "mutation_strategy")).to eq("risk_reduction")
       expect(candidates.first.configuration.dig("_evolution", "diff")).to include(
         include("path" => "/methods/paid_agent/termination/timeout_minutes")
+      )
+      expect(candidates.first.configuration.dig("_evolution", "provenance", "decision_summary")).to include(
+        "decision_count" => 15,
+        "success_rate" => 0.4
       )
       expect(OrchestrationStrategy.active_for("review_settings", account: account)).to eq(strategy)
     end

--- a/spec/services/strategy_evolution/generate_candidates_spec.rb
+++ b/spec/services/strategy_evolution/generate_candidates_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StrategyEvolution::GenerateCandidates do
+  describe ".call" do
+    let(:strategy) do
+      {
+        id: 12,
+        strategy_type: "review_settings",
+        version: 3,
+        account_id: 7,
+        configuration: OrchestrationStrategies::Defaults.review_settings
+      }
+    end
+    let(:analysis) do
+      {
+        prior_versions: [
+          { id: 12, version: 3, active: true },
+          { id: 9, version: 2, active: false }
+        ],
+        performance: {
+          decision_count: 12,
+          min_decisions: 10,
+          run_backed_decision_count: 9,
+          success_count: 5,
+          failure_count: 4,
+          success_rate: 0.5556,
+          lookback_days: 45,
+          decision_types: { "queue_review_run" => 7 },
+          actors: { "auto_review" => 9 },
+          run_statuses: { "completed" => 5, "paused" => 4 },
+          guardrail_violation_types: { "loop_detected" => 2 }
+        },
+        sample_successes: [ { id: 101 } ],
+        sample_failures: [ { id: 202 } ]
+      }
+    end
+    let(:mutation) do
+      StrategyEvolution::Mutate::Mutation.new(
+        configuration: strategy[:configuration].deep_dup,
+        strategy: "risk_reduction",
+        reasoning: "Reduce loop-prone retries",
+        expected_improvement: "Fewer paused review runs",
+        diff: [ { "path" => "/methods/paid_agent/termination/timeout_minutes", "from" => 30, "to" => 20 } ],
+        provenance: { "source_version" => 3 }
+      )
+    end
+
+    before do
+      allow(StrategyEvolution::Mutate).to receive(:call).and_return([ mutation ])
+    end
+
+    it "adds reviewable provenance from the sampled history" do
+      result = described_class.call(strategy: strategy, analysis: analysis, options: { mutation_count: 1 })
+
+      expect(result.size).to eq(1)
+      expect(result.first.provenance).to include(
+        "generated_by" => "StrategyEvolution::GenerateCandidates",
+        "sampled_decision_ids" => [ 101, 202 ]
+      )
+      expect(result.first.provenance.fetch("prior_versions")).to include(
+        include(id: 12, version: 3, active: true)
+      )
+      expect(result.first.provenance.fetch("measured_outcomes")).to include(
+        decision_count: 12,
+        run_backed_decision_count: 9,
+        failure_count: 4,
+        success_rate: 0.5556,
+        lookback_days: 45
+      )
+    end
+  end
+end

--- a/spec/services/strategy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/strategy_evolution/prepare_inputs_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe StrategyEvolution::PrepareInputs do
       expect(result.dig(:performance, :decision_count)).to eq(2)
       expect(result.dig(:performance, :success_count)).to eq(1)
       expect(result.dig(:performance, :failure_count)).to eq(1)
+      expect(result.dig(:performance, :lookback_days)).to eq(60)
       expect(result.dig(:performance, :guardrail_violation_types)).to include("loop_detected" => 1)
       expect(result[:sample_successes].size).to eq(1)
       expect(result[:sample_failures].size).to eq(1)

--- a/spec/temporal/activities/generate_strategy_mutations_activity_spec.rb
+++ b/spec/temporal/activities/generate_strategy_mutations_activity_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Activities::GenerateStrategyMutationsActivity do
   end
 
   it "serializes generated mutations" do
-    allow(StrategyEvolution::Mutate).to receive(:call).and_return([ mutation ])
+    allow(StrategyEvolution::GenerateCandidates).to receive(:call).and_return([ mutation ])
 
     result = activity.execute(
       strategy: strategy,


### PR DESCRIPTION
## Summary

Implemented the strategy evolution workflow updates and committed them as `d003d76` with `feat(strategy): preserve reviewable evolution candidates`.

The change adds a dedicated `StrategyEvolution::GenerateCandidates` service that wraps mutation generation with richer historical provenance, routes the mutation activity through that service, includes `lookback_days` in prepared performance inputs, and persists candidates with explicit pending-review metadata so they are never auto-promoted. Specs were added/updated for generation provenance, persistence metadata, and the activity path.

Verification passed with `bundle exec rubocop` and `bundle exec rspec` using the provided Postgres service settings. The full suite finished green with `11604 examples, 0 failures, 3 pending`.

---

Closes #1793