### PR TITLE
feat(strategy): create strategy and strategy version schema

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -37,6 +37,7 @@ class Account < ApplicationRecord
   has_many :exception_incidents, dependent: :destroy
   has_many :configuration_bundles, dependent: :destroy
   has_many :orchestration_strategies, dependent: :destroy
+  has_many :strategy_experiments, dependent: :destroy
 
   validates :name, presence: true
   validates :plan, presence: true, inclusion: { in: PLANS }

--- a/app/models/strategy_version.rb
+++ b/app/models/strategy_version.rb
@@ -29,6 +29,7 @@ class StrategyVersion < ApplicationRecord
   validates :promotion_state, inclusion: { in: PROMOTION_STATES }
   validate :content_is_object
   validate :provenance_is_object
+  validate :single_active_version_per_strategy
   validate :immutable_content_after_creation, on: :update
   validate :parent_version_belongs_to_strategy
 
@@ -71,5 +72,19 @@ class StrategyVersion < ApplicationRecord
     return if parent_version.strategy_id == strategy_id
 
     errors.add(:parent_version, "must belong to the same strategy")
+  end
+
+  def single_active_version_per_strategy
+    return unless promotion_state == "active" && retired_at.nil?
+    return unless strategy_id
+
+    existing_active_versions = self.class
+      .where(promotion_state: "active", retired_at: nil)
+      .where(strategy_id: strategy_id)
+      .where.not(id: id)
+
+    return unless existing_active_versions.exists?
+
+    errors.add(:promotion_state, "allows only one active version per strategy")
   end
 end

--- a/spec/migrations/create_strategies_and_strategy_versions_spec.rb
+++ b/spec/migrations/create_strategies_and_strategy_versions_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260507195716_create_strategies_and_strategy_versions")
+
+RSpec.describe CreateStrategiesAndStrategyVersions, :aggregate_failures do
+  self.use_transactional_tests = false
+
+  let(:migration) { described_class.new }
+  let(:connection) { ActiveRecord::Base.connection }
+
+  around do |example|
+    strategies_table_existed = connection.table_exists?(:strategies)
+    strategy_versions_table_existed = connection.table_exists?(:strategy_versions)
+
+    migration.down if strategy_versions_table_existed || strategies_table_existed
+    Strategy.reset_column_information
+    StrategyVersion.reset_column_information
+
+    example.run
+  ensure
+    migration.down if connection.table_exists?(:strategy_versions) || connection.table_exists?(:strategies)
+
+    if strategies_table_existed || strategy_versions_table_existed
+      migration.up
+    end
+
+    Strategy.reset_column_information
+    StrategyVersion.reset_column_information
+  end
+
+  it "creates strategy tables with scoped uniqueness, promotion safety, and foreign keys" do
+    migration.up
+
+    expect(connection.table_exists?(:strategies)).to be(true)
+    expect(connection.table_exists?(:strategy_versions)).to be(true)
+
+    expect_strategy_schema
+    expect_strategy_indexes
+    expect_strategy_comments
+    expect_strategy_version_schema
+    expect_strategy_version_indexes
+    expect_strategy_version_comments
+  end
+
+  private
+
+  def expect_strategy_schema
+    columns = connection.columns(:strategies).index_by(&:name)
+
+    expect(columns.fetch("slug").null).to be(false)
+    expect(columns.fetch("slug").limit).to eq(100)
+    expect(columns.fetch("decision_type").null).to be(false)
+    expect(columns.fetch("decision_type").limit).to eq(100)
+    expect(columns.fetch("status").null).to be(false)
+    expect(columns.fetch("status").default).to eq("active")
+    expect(default_expression_for(:strategies, "selection_rules")).to include("'{}'::jsonb")
+    expect(connection.foreign_key_exists?(:strategies, :accounts)).to be(true)
+    expect(connection.foreign_key_exists?(:strategies, :projects)).to be(true)
+    expect(connection.foreign_key_exists?(:strategies, :strategy_versions, column: :current_version_id)).to be(true)
+  end
+
+  def expect_strategy_indexes
+    expect(index_names(:strategies)).to include(
+      "index_strategies_on_current_version_id",
+      "index_strategies_on_decision_type",
+      "index_strategies_on_status",
+      "index_strategies_on_decision_type_and_status",
+      "index_strategies_on_slug_global",
+      "index_strategies_on_slug_account",
+      "index_strategies_on_slug_project"
+    )
+
+    expect(check_constraint_exists?(:strategies, "chk_strategies_scope_consistency")).to be(true)
+  end
+
+  def expect_strategy_comments
+    expect(table_comment(:strategies)).to eq("Scoped orchestration strategies selected for workflow decisions.")
+    expect(column_comment(:strategies, "selection_rules")).to eq(
+      "Structured scope and context rules used to select the strategy."
+    )
+  end
+
+  def expect_strategy_version_schema
+    columns = connection.columns(:strategy_versions).index_by(&:name)
+
+    expect(columns.fetch("strategy_id").null).to be(false)
+    expect(columns.fetch("version").null).to be(false)
+    expect(columns.fetch("promotion_state").null).to be(false)
+    expect(columns.fetch("promotion_state").default).to eq("draft")
+    expect(default_expression_for(:strategy_versions, "content")).to include("'{}'::jsonb")
+    expect(default_expression_for(:strategy_versions, "provenance")).to include("'{}'::jsonb")
+    expect(connection.foreign_key_exists?(:strategy_versions, :strategies)).to be(true)
+    expect(connection.foreign_key_exists?(:strategy_versions, :users, column: :created_by_user_id)).to be(true)
+    expect(connection.foreign_key_exists?(:strategy_versions, :strategy_versions, column: :parent_version_id)).to be(true)
+    expect(connection.foreign_key_exists?(:strategy_versions, :users, column: :promoted_by_user_id)).to be(true)
+  end
+
+  def expect_strategy_version_indexes
+    expect(index_names(:strategy_versions)).to include(
+      "index_strategy_versions_on_strategy_id_and_version",
+      "index_strategy_versions_on_strategy_and_promotion_state",
+      "index_strategy_versions_on_retired_at",
+      "index_strategy_versions_one_active_per_strategy"
+    )
+  end
+
+  def expect_strategy_version_comments
+    expect(table_comment(:strategy_versions)).to eq("Versioned orchestration strategy payloads and promotion history.")
+    expect(column_comment(:strategy_versions, "content")).to eq(
+      "Structured orchestration behavior moved out of hardcoded workflow logic."
+    )
+  end
+
+  def index_names(table_name)
+    connection.indexes(table_name).map(&:name)
+  end
+
+  def table_comment(table_name)
+    connection.select_value(<<~SQL.squish)
+      SELECT obj_description('public.#{table_name}'::regclass, 'pg_class')
+    SQL
+  end
+
+  def column_comment(table_name, column_name)
+    connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array([
+        <<~SQL.squish,
+          SELECT col_description('public.#{table_name}'::regclass, ordinal_position)
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = ?
+            AND column_name = ?
+        SQL
+        table_name.to_s,
+        column_name
+      ])
+    )
+  end
+
+  def default_expression_for(table_name, column_name)
+    connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array([
+        <<~SQL.squish,
+          SELECT pg_get_expr(d.adbin, d.adrelid)
+          FROM pg_attribute a
+          INNER JOIN pg_attrdef d
+            ON d.adrelid = a.attrelid
+           AND d.adnum = a.attnum
+          WHERE a.attrelid = ?::regclass
+            AND a.attname = ?
+        SQL
+        "public.#{table_name}",
+        column_name
+      ])
+    )
+  end
+
+  def check_constraint_exists?(table_name, constraint_name)
+    connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array([
+        <<~SQL.squish,
+          SELECT COUNT(*)
+          FROM pg_constraint
+          WHERE conrelid = ?::regclass
+            AND conname = ?
+        SQL
+        "public.#{table_name}",
+        constraint_name
+      ])
+    ).to_i.positive?
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Account do
     it { is_expected.to have_many(:billing_invoices).dependent(:destroy) }
     it { is_expected.to have_many(:billing_periods).dependent(:destroy) }
     it { is_expected.to have_many(:billing_plans).dependent(:destroy) }
+    it { is_expected.to have_many(:strategy_experiments).dependent(:destroy) }
   end
 
   describe "validations" do

--- a/spec/models/strategy_version_spec.rb
+++ b/spec/models/strategy_version_spec.rb
@@ -56,6 +56,25 @@ RSpec.describe StrategyVersion do
       expect(version).not_to be_valid
       expect(version.errors[:parent_version]).to include("must belong to the same strategy")
     end
+
+    it "allows only one active version per strategy" do
+      strategy = create(:strategy, :global)
+      create(:strategy_version, :active, strategy: strategy)
+
+      duplicate_active = build(:strategy_version, :active, strategy: strategy)
+
+      expect(duplicate_active).not_to be_valid
+      expect(duplicate_active.errors[:promotion_state]).to include("allows only one active version per strategy")
+    end
+
+    it "allows a new active version after the previous one is retired" do
+      strategy = create(:strategy, :global)
+      create(:strategy_version, :retired, strategy: strategy, version: 1)
+
+      replacement = build(:strategy_version, :active, strategy: strategy, version: 2)
+
+      expect(replacement).to be_valid
+    end
   end
 
   describe "immutability" do


### PR DESCRIPTION
## Summary

Added app-level safety and coverage around the existing strategy schema. `StrategyVersion` now validates that each strategy has at most one non-retired active version, `Account` now exposes `has_many :strategy_experiments`, and the model specs cover those cases. I also added a migration spec for `CreateStrategiesAndStrategyVersions` so the table shape, partial indexes, comments, foreign keys, and scope constraint are exercised directly.

Verification passed with `bundle exec rubocop` and `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent bundle exec rspec` after `bin/rails db:prepare` using the same DB env because the repo’s multi-DB config otherwise defaulted to a local socket. The hook-backed commit succeeded as `dd60097` with message `feat(strategy): harden strategy version schema coverage`.

---

Closes #1790