### PR TITLE
feat(coordination): implement escalation service with human-value prediction

### DIFF
--- a/app/services/coordination/escalation_policy.rb
+++ b/app/services/coordination/escalation_policy.rb
@@ -59,10 +59,9 @@ module Coordination
         .active
         .by_type(POLICY_TYPE)
         .where(account: project.account, policy_key: POLICY_KEY)
+        .where(project_id: [ nil, project.id ])
         .includes(:current_version)
-        .order(project_id: :desc, id: :desc)
-        .select { |candidate| candidate.project_id.nil? || candidate.project_id == project.id }
-        .sort_by { |candidate| candidate.project_id == project.id ? 0 : 1 }
+        .order(Arel.sql("CASE WHEN project_id IS NOT NULL THEN 0 ELSE 1 END"), id: :desc)
     end
 
     def fallback_policy(source)

--- a/app/services/coordination/escalation_policy.rb
+++ b/app/services/coordination/escalation_policy.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Coordination
+  class EscalationPolicy
+    POLICY_TYPE = "escalation"
+    POLICY_KEY = "human_intervention"
+
+    DEFAULT_POLICY = OrchestrationStrategies::Defaults
+      .feature_orchestration
+      .fetch("escalation")
+      .freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:)
+      @project = project
+    end
+
+    def call
+      return fallback_policy("defaults") unless policy
+      return fallback_policy("defaults") unless current_version
+
+      DEFAULT_POLICY
+        .deep_merge(current_version.rules)
+        .deep_merge(current_version.parameters)
+        .merge(
+          "source" => "coordination_policy",
+          "policy_key" => policy.policy_key,
+          "coordination_policy_id" => policy.id,
+          "coordination_policy_version_id" => current_version.id,
+          "coordination_policy_version" => current_version.version
+        )
+    rescue StandardError => e
+      Rails.logger.warn(
+        message: "coordination.escalation_policy_resolution_failed",
+        project_id: project.id,
+        error_class: e.class.name,
+        error_message: e.message
+      )
+      fallback_policy("fallback")
+    end
+
+    private
+
+    attr_reader :project
+
+    def policy
+      @policy ||= candidates.find { |candidate| candidate.current_version.present? }
+    end
+
+    def current_version
+      policy&.current_version
+    end
+
+    def candidates
+      @candidates ||= CoordinationPolicy
+        .active
+        .by_type(POLICY_TYPE)
+        .where(account: project.account, policy_key: POLICY_KEY)
+        .includes(:current_version)
+        .order(project_id: :desc, id: :desc)
+        .select { |candidate| candidate.project_id.nil? || candidate.project_id == project.id }
+        .sort_by { |candidate| candidate.project_id == project.id ? 0 : 1 }
+    end
+
+    def fallback_policy(source)
+      DEFAULT_POLICY.merge(
+        "source" => source,
+        "policy_key" => POLICY_KEY,
+        "coordination_policy_id" => nil,
+        "coordination_policy_version_id" => nil,
+        "coordination_policy_version" => nil
+      )
+    end
+  end
+end

--- a/app/services/coordination/escalation_service.rb
+++ b/app/services/coordination/escalation_service.rb
@@ -2,12 +2,7 @@
 
 module Coordination
   class EscalationService
-    STRATEGY_TYPE = "feature_orchestration"
-
-    DEFAULT_POLICY = OrchestrationStrategies::Defaults
-      .feature_orchestration
-      .fetch("escalation")
-      .freeze
+    DEFAULT_POLICY = Coordination::EscalationPolicy::DEFAULT_POLICY
 
     Result = Data.define(
       :action,
@@ -70,7 +65,8 @@ module Coordination
         )
       end
 
-      value = predict_human_value(policy)
+      signal_vector = prediction_signals
+      value = predict_human_value(policy, signal_vector)
       cost = interruption_cost(policy)
 
       if value - cost >= policy["human_value_threshold"]
@@ -121,25 +117,7 @@ module Coordination
     end
 
     def resolve_policy
-      strategy = OrchestrationStrategies::Resolve.call(
-        strategy_type: STRATEGY_TYPE,
-        account: project.account
-      )
-
-      config = strategy&.configuration
-      escalation = config.is_a?(Hash) ? config.fetch("escalation", {}) : {}
-      source = escalation.is_a?(Hash) && escalation.any? ? STRATEGY_TYPE : "defaults"
-
-      normalize_policy(DEFAULT_POLICY.merge(escalation).merge("source" => source))
-    rescue StandardError => e
-      Rails.logger.warn(
-        message: "coordination.escalation_policy_resolution_failed",
-        project_id: project.id,
-        issue_id: issue.id,
-        error_class: e.class.name,
-        error_message: e.message
-      )
-      normalize_policy(DEFAULT_POLICY.merge("source" => "fallback"))
+      normalize_policy(Coordination::EscalationPolicy.call(project: project))
     end
 
     def normalize_policy(policy)
@@ -151,10 +129,14 @@ module Coordination
         "interruption_cost" => DEFAULT_POLICY["interruption_cost"]
           .merge(policy["interruption_cost"] || {})
           .transform_values { |value| Float(value) },
-        "source" => policy["source"]
+        "source" => policy["source"],
+        "policy_key" => policy["policy_key"],
+        "coordination_policy_id" => policy["coordination_policy_id"],
+        "coordination_policy_version_id" => policy["coordination_policy_version_id"],
+        "coordination_policy_version" => policy["coordination_policy_version"]
       }
     rescue ArgumentError, TypeError
-      DEFAULT_POLICY.merge("source" => "fallback")
+      fallback_policy
     end
 
     def explicit_trigger(policy)
@@ -177,19 +159,31 @@ module Coordination
       "followup_limit_reached"
     end
 
-    def predict_human_value(policy)
+    def predict_human_value(policy, prediction_signals)
       weights = policy["weights"]
 
       value = 0.0
-      value += weights["operational_failure_breaker"] if signals["operational_failure_breaker"] == true
-      value += weights["review_goal_retry_pressure"] * normalized_retry_pressure
-      value += weights["draft_review_pressure"] * normalized_draft_pressure
-      value += weights["followup_pressure"] * normalized_followup_pressure
-      value += weights["blocking_triggers"] * normalized_blocking_trigger_pressure
-      value += weights["owner_reviewer_present"] if signals["owner_reviewer_login"].present?
-      value += weights["escalated_phase"] if signals["phase"] == "escalated"
+      value += weights["operational_failure_breaker"] if prediction_signals["operational_failure_breaker"]
+      value += weights["review_goal_retry_pressure"] * prediction_signals["review_goal_retry_pressure"]
+      value += weights["draft_review_pressure"] * prediction_signals["draft_review_pressure"]
+      value += weights["followup_pressure"] * prediction_signals["followup_pressure"]
+      value += weights["blocking_triggers"] * prediction_signals["blocking_trigger_pressure"]
+      value += weights["owner_reviewer_present"] if prediction_signals["owner_reviewer_present"]
+      value += weights["escalated_phase"] if prediction_signals["escalated_phase"]
 
       value.clamp(0.0, 1.0)
+    end
+
+    def prediction_signals
+      {
+        "operational_failure_breaker" => signals["operational_failure_breaker"] == true,
+        "review_goal_retry_pressure" => normalized_retry_pressure,
+        "draft_review_pressure" => normalized_draft_pressure,
+        "followup_pressure" => normalized_followup_pressure,
+        "blocking_trigger_pressure" => normalized_blocking_trigger_pressure,
+        "owner_reviewer_present" => signals["owner_reviewer_login"].present?,
+        "escalated_phase" => signals["phase"] == "escalated"
+      }
     end
 
     def interruption_cost(policy)
@@ -236,7 +230,24 @@ module Coordination
       hash.deep_stringify_keys
     end
 
+    def fallback_policy
+      {
+        "human_value_threshold" => DEFAULT_POLICY["human_value_threshold"],
+        "explicit_triggers" => Array(DEFAULT_POLICY["explicit_triggers"]).map(&:to_s),
+        "auto_resolve_trigger_types" => Array(DEFAULT_POLICY["auto_resolve_trigger_types"]).map(&:to_s),
+        "weights" => DEFAULT_POLICY["weights"].transform_values { |value| Float(value) },
+        "interruption_cost" => DEFAULT_POLICY["interruption_cost"].transform_values { |value| Float(value) },
+        "source" => "fallback",
+        "policy_key" => Coordination::EscalationPolicy::POLICY_KEY,
+        "coordination_policy_id" => nil,
+        "coordination_policy_version_id" => nil,
+        "coordination_policy_version" => nil
+      }
+    end
+
     def persist_decision(result, policy)
+      prediction_inputs = prediction_signals
+
       OrchestrationDecision.record(
         project: project,
         issue: issue,
@@ -244,8 +255,13 @@ module Coordination
         decision_point: "coordination_escalation_service",
         status: orchestration_status_for(result),
         signals: signals.merge(
+          "prediction_signals" => prediction_inputs,
           "trigger_types" => trigger_types,
-          "policy_source" => policy["source"]
+          "policy_source" => policy["source"],
+          "policy_key" => policy["policy_key"],
+          "coordination_policy_id" => policy["coordination_policy_id"],
+          "coordination_policy_version_id" => policy["coordination_policy_version_id"],
+          "coordination_policy_version" => policy["coordination_policy_version"]
         ),
         result: {
           "decision" => result.action,
@@ -254,7 +270,8 @@ module Coordination
           "interruption_cost" => result.interruption_cost,
           "net_value" => result.net_value,
           "threshold" => result.threshold,
-          "explicit_trigger" => result.explicit_trigger
+          "explicit_trigger" => result.explicit_trigger,
+          "policy_source" => result.policy_source
         }.compact
       )
     end

--- a/spec/services/coordination/escalation_service_spec.rb
+++ b/spec/services/coordination/escalation_service_spec.rb
@@ -62,6 +62,60 @@ RSpec.describe Coordination::EscalationService do
       end
     end
 
+    def persisted_prediction_signals
+      {
+        "operational_failure_breaker" => true,
+        "review_goal_retry_pressure" => 0.0,
+        "draft_review_pressure" => 0.0,
+        "followup_pressure" => 0.0,
+        "blocking_trigger_pressure" => 0.0,
+        "owner_reviewer_present" => true,
+        "escalated_phase" => false
+      }
+    end
+
+    def create_escalation_policy!(scope: :account, rules: {}, parameters: {})
+      traits = [ :active ]
+      traits << :project_scoped if scope == :project
+
+      create(:coordination_policy, *traits,
+        account: project.account,
+        project: scope == :project ? project : nil,
+        policy_type: "escalation",
+        policy_key: Coordination::EscalationPolicy::POLICY_KEY).tap do |policy|
+        policy.current_version.update!(rules:, parameters:)
+      end
+    end
+
+    def explicit_trigger_decision_inputs
+      {
+        "operational_failure_breaker" => true,
+        "prediction_signals" => persisted_prediction_signals,
+        "trigger_types" => [],
+        "policy_source" => "defaults",
+        "policy_key" => "human_intervention"
+      }
+    end
+
+    def coordination_policy_version_inputs(policy)
+      {
+        "policy_source" => "coordination_policy",
+        "coordination_policy_id" => policy.id,
+        "coordination_policy_version_id" => policy.current_version.id,
+        "coordination_policy_version" => policy.current_version.version
+      }
+    end
+
+    def low_threshold_parameters
+      {
+        "human_value_threshold" => 0.15,
+        "weights" => {
+          "review_goal_retry_pressure" => 0.7,
+          "blocking_triggers" => 0.4
+        }
+      }
+    end
+
     it "escalates on an explicit trigger and records the prediction inputs and outcome" do
       result = call_service(
         operational_failure_breaker: true,
@@ -73,15 +127,12 @@ RSpec.describe Coordination::EscalationService do
       expect_logged_decision(
         OrchestrationDecision.last,
         status: "applied",
-        inputs: {
-          "operational_failure_breaker" => true,
-          "trigger_types" => [],
-          "policy_source" => "feature_orchestration"
-        },
+        inputs: explicit_trigger_decision_inputs,
         outputs: {
           "decision" => "escalate",
           "reason" => "Consecutive operational failures (3 runs)",
-          "explicit_trigger" => "operational_failure_breaker"
+          "explicit_trigger" => "operational_failure_breaker",
+          "policy_source" => "defaults"
         }
       )
     end
@@ -93,7 +144,8 @@ RSpec.describe Coordination::EscalationService do
       expect(result.reason).to eq("followup_limit_reached")
       expect(OrchestrationDecision.last.outputs).to include(
         "decision" => "defer",
-        "reason" => "followup_limit_reached"
+        "reason" => "followup_limit_reached",
+        "policy_source" => "defaults"
       )
     end
 
@@ -104,23 +156,15 @@ RSpec.describe Coordination::EscalationService do
       expect(result.reason).to eq("automation_already_resolved")
       expect(OrchestrationDecision.last.outputs).to include(
         "decision" => "auto_resolve",
-        "reason" => "automation_already_resolved"
+        "reason" => "automation_already_resolved",
+        "policy_source" => "defaults"
       )
     end
 
-    it "uses account policy overrides when present" do
-      create(:orchestration_strategy, :feature_orchestration, :with_account,
-        account: project.account,
-        configuration: OrchestrationStrategies::Defaults.feature_orchestration.merge(
-          "escalation" => {
-            "explicit_triggers" => [],
-            "human_value_threshold" => 0.15,
-            "weights" => {
-              "review_goal_retry_pressure" => 0.7,
-              "blocking_triggers" => 0.4
-            }
-          }
-        ))
+    it "uses the active coordination policy when present" do
+      policy = create_escalation_policy!(
+        rules: { "explicit_triggers" => [] },
+        parameters: low_threshold_parameters)
 
       result = call_service(
         review_goal_retry_count: 3,
@@ -128,8 +172,27 @@ RSpec.describe Coordination::EscalationService do
       )
 
       expect(result).to be_escalate
-      expect(result.policy_source).to eq("feature_orchestration")
+      expect(result.policy_source).to eq("coordination_policy")
       expect(result.explicit_trigger).to be_nil
+      expect(OrchestrationDecision.last.inputs).to include(coordination_policy_version_inputs(policy))
+    end
+
+    it "prefers a project-scoped coordination policy over an account-wide policy" do
+      create_escalation_policy!(
+        rules: { "explicit_triggers" => [] },
+        parameters: { "human_value_threshold" => 0.05 }
+      )
+      scoped_policy = create_escalation_policy!(scope: :project,
+        rules: { "explicit_triggers" => [] },
+        parameters: { "human_value_threshold" => 0.9 })
+
+      result = call_service(review_goal_retry_count: 3)
+
+      expect(result).to be_auto_resolve
+      expect(OrchestrationDecision.last.inputs).to include(
+        "coordination_policy_id" => scoped_policy.id,
+        "coordination_policy_version_id" => scoped_policy.current_version.id
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

Implemented the escalation policy boundary in [app/services/coordination/escalation_policy.rb](/workspace/app/services/coordination/escalation_policy.rb), and refactored [app/services/coordination/escalation_service.rb](/workspace/app/services/coordination/escalation_service.rb) to resolve escalation behavior from active `CoordinationPolicy` records instead of `OrchestrationStrategy`. The service now makes the human-value signal vector explicit and persists both policy metadata and prediction inputs/outcomes in `OrchestrationDecision` for later evaluation. I updated [spec/services/coordination/escalation_service_spec.rb](/workspace/spec/services/coordination/escalation_service_spec.rb) to cover `escalate`, `defer`, `auto_resolve`, active coordination-policy overrides, and project-over-account precedence.

Verification passed with:
`yarn install`
`bundle exec rubocop`
`bundle exec rspec`

Commit: `421ac48` (`feat(coordination): add escalation policy resolver`)

One environment note: `gh` was not installed in this container, so I could not read the GitHub issue comments directly. The worktree is clean.

---

Closes #1807