### PR TITLE
feat(scaling): design controlled orchestration scaling experiments

### DIFF
--- a/app/models/scaling_experiment.rb
+++ b/app/models/scaling_experiment.rb
@@ -5,6 +5,11 @@ require "zlib"
 class ScalingExperiment < ApplicationRecord
   STATUSES = %w[draft running completed cancelled].freeze
   DIMENSIONS = %w[agent_count iteration_count max_iterations parallelism].freeze
+  INDEPENDENT_VARIABLE_KEYS = (DIMENSIONS + %w[task_count dependency_edge_count]).freeze
+  CONTROL_COMPARISON_METHODS = %w[within_task_count_bucket].freeze
+  COHORT_ASSIGNMENT_STRATEGIES = %w[balanced_underfilled].freeze
+  COHORT_CADENCES = %w[continuous].freeze
+  COHORT_ASSIGNMENT_UNITS = %w[workflow_id].freeze
   OUTCOME_METRIC_KEYS = %w[
     success_rate
     duration_seconds
@@ -33,8 +38,12 @@ class ScalingExperiment < ApplicationRecord
   validate :control_definition_is_object
   validate :cohort_settings_is_object
   validate :primary_dimension_variable_matches_plan
+  validate :independent_variables_are_supported
   validate :outcome_metrics_are_supported
+  validate :outcome_metrics_are_unique
   validate :primary_outcome_metric_present
+  validate :control_definition_is_supported
+  validate :cohort_settings_are_supported
 
   scope :draft, -> { where(status: "draft") }
   scope :running, -> { where(status: "running") }
@@ -116,8 +125,31 @@ class ScalingExperiment < ApplicationRecord
       cohort_label_template,
       dimension: dimension,
       value: assigned_value,
-      task_bucket: cohort_task_bucket(task_count:)
+      task_bucket: cohort_task_bucket_label(task_count:)
     )
+  end
+
+  def control_cohort_label(task_count:)
+    cohort_label(task_count:, assigned_value: control_value)
+  end
+
+  def cohort_schedule
+    cohort_settings.slice("assignment_strategy", "cadence", "assignment_unit", "label_template")
+  end
+
+  def cohort_task_bucket_label(task_count:)
+    cohort_task_bucket(task_count:)&.fetch("label", nil) || "tasks-unspecified"
+  end
+
+  def cohort_task_bucket(task_count:)
+    bucket = Array(cohort_settings["task_count_buckets"]).find do |candidate|
+      minimum = candidate["min"].to_i
+      maximum = candidate["max"]
+
+      task_count.to_i >= minimum && (maximum.blank? || task_count.to_i <= maximum.to_i)
+    end
+
+    bucket
   end
 
   def sufficient_samples?
@@ -176,17 +208,6 @@ class ScalingExperiment < ApplicationRecord
 
   def cohort_label_template
     cohort_settings.fetch("label_template", "%<dimension>s-%<value>s__%<task_bucket>s")
-  end
-
-  def cohort_task_bucket(task_count:)
-    bucket = Array(cohort_settings["task_count_buckets"]).find do |candidate|
-      minimum = candidate["min"].to_i
-      maximum = candidate["max"]
-
-      task_count.to_i >= minimum && (maximum.blank? || task_count.to_i <= maximum.to_i)
-    end
-
-    bucket&.fetch("label", nil) || "tasks-unspecified"
   end
 
   def raise_invalid_status!(action)
@@ -283,10 +304,80 @@ class ScalingExperiment < ApplicationRecord
     errors.add(:outcome_metrics, "contains unsupported keys: #{invalid_keys.sort.join(', ')}")
   end
 
+  def independent_variables_are_supported
+    return unless independent_variables.is_a?(Array)
+
+    invalid_keys = independent_variables.filter_map do |variable|
+      next unless variable.is_a?(Hash)
+
+      key = variable["key"].to_s
+      key unless INDEPENDENT_VARIABLE_KEYS.include?(key)
+    end
+    return if invalid_keys.empty?
+
+    errors.add(:independent_variables, "contains unsupported keys: #{invalid_keys.sort.join(', ')}")
+  end
+
+  def outcome_metrics_are_unique
+    return unless outcome_metrics.is_a?(Array)
+
+    metric_keys = outcome_metrics.filter_map { |metric| metric.is_a?(Hash) ? metric["key"].to_s.presence : nil }
+    return if metric_keys.uniq.size == metric_keys.size
+
+    errors.add(:outcome_metrics, "must contain unique keys")
+  end
+
   def primary_outcome_metric_present
     return unless outcome_metrics.is_a?(Array)
     return if outcome_metrics.any? { |metric| metric.is_a?(Hash) && metric["primary"] == true }
 
     errors.add(:outcome_metrics, "must include one primary metric")
+  end
+
+  def control_definition_is_supported
+    return unless control_definition.is_a?(Hash)
+
+    comparison_method = control_definition["comparison_method"].to_s
+    if comparison_method.blank? || !CONTROL_COMPARISON_METHODS.include?(comparison_method)
+      errors.add(:control_definition, "must include a supported comparison_method")
+    end
+
+    %w[fairness_conditions guardrails].each do |key|
+      values = control_definition[key]
+      next if values.is_a?(Array) && values.any?
+
+      errors.add(:control_definition, "must include #{key} as a non-empty array")
+    end
+  end
+
+  def cohort_settings_are_supported
+    return unless cohort_settings.is_a?(Hash)
+
+    if !COHORT_ASSIGNMENT_STRATEGIES.include?(cohort_settings["assignment_strategy"].to_s)
+      errors.add(:cohort_settings, "must include a supported assignment_strategy")
+    end
+
+    if !COHORT_CADENCES.include?(cohort_settings["cadence"].to_s)
+      errors.add(:cohort_settings, "must include a supported cadence")
+    end
+
+    if !COHORT_ASSIGNMENT_UNITS.include?(cohort_settings["assignment_unit"].to_s)
+      errors.add(:cohort_settings, "must include a supported assignment_unit")
+    end
+
+    errors.add(:cohort_settings, "must include label_template") if cohort_settings["label_template"].blank?
+
+    task_count_buckets = Array(cohort_settings["task_count_buckets"])
+    if task_count_buckets.empty?
+      errors.add(:cohort_settings, "must include at least one task_count_bucket")
+      return
+    end
+
+    task_count_buckets.each do |bucket|
+      unless bucket.is_a?(Hash) && bucket["label"].present? && bucket["min"].to_i.positive?
+        errors.add(:cohort_settings, "task_count_buckets must include label and positive min")
+        break
+      end
+    end
   end
 end

--- a/app/services/scaling_experiments/assign.rb
+++ b/app/services/scaling_experiments/assign.rb
@@ -62,12 +62,21 @@ module ScalingExperiments
     end
 
     def build_execution_plan(value)
+      task_bucket = scaling_experiment.cohort_task_bucket_label(task_count:)
+
       plan = {
         "dimension" => scaling_experiment.dimension,
         "dimension_value" => value,
         "task_count" => task_count,
+        "task_bucket" => task_bucket,
         "cohort_label" => scaling_experiment.cohort_label(task_count:, assigned_value: value),
-        "cohort_schedule" => scaling_experiment.cohort_settings.slice("assignment_strategy", "cadence", "assignment_unit"),
+        "control" => {
+          "dimension_value" => scaling_experiment.control_value,
+          "cohort_label" => scaling_experiment.control_cohort_label(task_count:),
+          "comparison_method" => scaling_experiment.control_definition["comparison_method"]
+        },
+        "cohort_schedule" => scaling_experiment.cohort_schedule,
+        "fairness_guardrails" => scaling_experiment.control_definition.slice("fairness_conditions", "guardrails"),
         "eligible_values" => scaling_experiment.eligible_values(task_count:),
         "safety_limits" => {
           "task_count_cap" => task_count,

--- a/docs/experiments/orchestration_scaling.md
+++ b/docs/experiments/orchestration_scaling.md
@@ -1,6 +1,6 @@
 # Orchestration Scaling Experiment Plan
 
-Issue [#1776](https://github.com/viamin/paid/issues/1776) defines the controlled experiment design for measuring orchestration scaling behavior with fair cohort comparisons.
+Issue [#1812](https://github.com/viamin/paid/issues/1812) defines the controlled experiment design for measuring orchestration scaling behavior with fair cohort comparisons.
 
 ## Core Independent Variables
 
@@ -19,7 +19,7 @@ Each `ScalingExperiment` stores these variables in `independent_variables`. The 
 - `agent_launch_success_rate`: Reliability metric for child-run execution. Optimize upward.
 - `blocked_task_rate`: Guardrail metric for capacity or dependency starvation. Optimize downward.
 
-These are stored in `outcome_metrics` with `primary` and `objective` metadata so summaries and later analysis can distinguish optimization targets from guardrails.
+These are stored in `outcome_metrics` with `primary` and `objective` metadata so summaries and later analysis can distinguish optimization targets from guardrails. The model validation also rejects unsupported or duplicate metric keys.
 
 ## Controls And Guardrails
 
@@ -30,7 +30,7 @@ Fair comparisons require the following control conditions:
 - Preserve dependency order and existing project-capacity checks.
 - Exclude non-parallel runs from recorded experiment outcomes when the orchestration never actually exercised the scaling treatment.
 
-These rules are stored in `control_definition` so the plan travels with the experiment record instead of living only in prose.
+These rules are stored in `control_definition` so the plan travels with the experiment record instead of living only in prose. Each assignment also copies the normalized control arm label and comparison method into `execution_plan["control"]` so downstream analysis can compare a treatment cohort to its proper control bucket without reconstructing the plan.
 
 ## Cohorts
 
@@ -44,4 +44,4 @@ Cohorts are assigned continuously at workflow start with a balanced-underfilled 
   - `tasks-4-6`
   - `tasks-7-plus`
 
-The schedule and label template live in `cohort_settings`, and each assignment copies its resolved cohort label into `execution_plan["cohort_label"]`.
+The schedule and label template live in `cohort_settings`, and each assignment copies its resolved task bucket, cohort label, control cohort label, and fairness guardrails into `execution_plan`. This keeps runtime assignment, result recording, and later analysis aligned on the same normalized experiment-plan metadata.

--- a/spec/models/scaling_experiment_spec.rb
+++ b/spec/models/scaling_experiment_spec.rb
@@ -32,6 +32,41 @@ RSpec.describe ScalingExperiment do
       expect(scaling_experiment.errors[:independent_variables])
         .to include("must match values_tested and control_value for the tested dimension")
     end
+
+    it "rejects unsupported independent variables" do
+      scaling_experiment.independent_variables = [
+        {
+          "key" => "repo_size",
+          "role" => "context",
+          "source" => "project.metadata"
+        },
+        {
+          "key" => "agent_count",
+          "role" => "primary",
+          "values" => [ 1, 2, 4 ],
+          "control_value" => 1
+        }
+      ]
+
+      expect(scaling_experiment).not_to be_valid
+      expect(scaling_experiment.errors[:independent_variables])
+        .to include("contains unsupported keys: repo_size")
+    end
+
+    it "requires supported control-definition fields and cohort settings" do
+      scaling_experiment.control_definition = { "comparison_method" => "cross_project" }
+      scaling_experiment.cohort_settings = { "assignment_strategy" => "random" }
+
+      expect(scaling_experiment).not_to be_valid
+      expect(scaling_experiment.errors[:control_definition])
+        .to include("must include a supported comparison_method")
+      expect(scaling_experiment.errors[:control_definition])
+        .to include("must include fairness_conditions as a non-empty array")
+      expect(scaling_experiment.errors[:cohort_settings])
+        .to include("must include a supported assignment_strategy")
+      expect(scaling_experiment.errors[:cohort_settings])
+        .to include("must include at least one task_count_bucket")
+    end
   end
 
   describe ".active_for" do
@@ -73,6 +108,14 @@ RSpec.describe ScalingExperiment do
       experiment = build(:scaling_experiment)
 
       expect(experiment.cohort_label(task_count: 5, assigned_value: 2)).to eq("agent_count-2__tasks-4-6")
+    end
+  end
+
+  describe "#control_cohort_label" do
+    it "formats the control arm label for the same task bucket" do
+      experiment = build(:scaling_experiment)
+
+      expect(experiment.control_cohort_label(task_count: 5)).to eq("agent_count-1__tasks-4-6")
     end
   end
 end

--- a/spec/services/scaling_experiments/assign_spec.rb
+++ b/spec/services/scaling_experiments/assign_spec.rb
@@ -29,6 +29,25 @@ RSpec.describe ScalingExperiments::Assign do
     )
   end
 
+  def expect_agent_count_assignment_plan(assignment)
+    expect(assignment.execution_plan).to include(
+      "dimension" => "agent_count",
+      "dimension_value" => assignment.assigned_value,
+      "task_count" => 4,
+      "task_bucket" => "tasks-4-6"
+    )
+    expect(assignment.execution_plan["cohort_label"]).to eq("agent_count-#{assignment.assigned_value}__tasks-4-6")
+    expect(assignment.execution_plan["control"]).to include(
+      "dimension_value" => 1,
+      "cohort_label" => "agent_count-1__tasks-4-6",
+      "comparison_method" => "within_task_count_bucket"
+    )
+    expect(assignment.execution_plan["fairness_guardrails"]).to include(
+      "fairness_conditions" => array_including("same_project"),
+      "guardrails" => array_including("respect_dependency_order")
+    )
+  end
+
   it "creates a workflow-scoped assignment with a safe execution plan" do
     assignment = described_class.call(
       scaling_experiment: experiment,
@@ -41,12 +60,7 @@ RSpec.describe ScalingExperiments::Assign do
     expect(assignment.project).to eq(project)
     expect(assignment.issue).to eq(issue)
     expect(assignment.workflow_id).to eq("wf-123")
-    expect(assignment.execution_plan).to include(
-      "dimension" => "agent_count",
-      "dimension_value" => assignment.assigned_value,
-      "task_count" => 4
-    )
-    expect(assignment.execution_plan["cohort_label"]).to eq("agent_count-#{assignment.assigned_value}__tasks-4-6")
+    expect_agent_count_assignment_plan(assignment)
   end
 
   it "reuses the existing assignment for the same workflow" do


### PR DESCRIPTION
## Summary

Implemented the scaling experiment-plan work and committed it as `feat(scaling): formalize orchestration experiment plans` (`6e83d67`).

The change tightens `ScalingExperiment` plan validation so the new JSON fields are structurally meaningful, not just present: supported independent-variable keys, unique/supported outcome metrics, required control-definition guardrails, and required cohort scheduling metadata. It also enriches scaling assignment execution plans with normalized `task_bucket`, control cohort metadata, and copied fairness guardrails so scheduling, recording, and later analysis use the same plan data. The doc at [docs/experiments/orchestration_scaling.md](/workspace/docs/experiments/orchestration_scaling.md:1) was updated to match issue `#1812` and the runtime metadata now being stored.

Validation completed with `bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec` passing. The full suite finished with `11641 examples, 0 failures, 3 pending`. The worktree is clean.

---

Closes #1812