### PR TITLE
fix(providers): show user-friendly message when Copilot test produces only MCP session events

### DIFF
--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -105,8 +105,11 @@ module Providers
       /validationLink:/i,
       /validationDescription:/i,
       /learnMoreUrl:/i,
-      /userHandled:/i
+      /userHandled:/i,
+      /"type"\s*:\s*"session\.(?:mcp_server_status_changed|shutdown)"/i
     ].freeze
+
+    MCP_SESSION_EVENT_PATTERN = /"type"\s*:\s*"session\./
 
     # Maps agent-harness error_category symbols to app-level error_type symbols.
     HARNESS_ERROR_CATEGORY_MAP = {
@@ -439,7 +442,16 @@ module Providers
         .reject { |line| line.match?(/\A[^\p{Alnum}]+\z/) }
         .reject { |line| noisy_error_line?(line) }
 
-      cleaned_lines.first || message.lines.first.to_s.strip
+      cleaned_lines.first || fallback_message_from(message)
+    end
+
+    def fallback_message_from(raw_message)
+      lines = raw_message.lines.map(&:strip).reject(&:empty?)
+      if lines.any? && lines.all? { |line| line.match?(MCP_SESSION_EVENT_PATTERN) }
+        "Agent started but did not produce a response. Verify the provider credentials and connectivity."
+      else
+        lines.first.to_s.strip
+      end
     end
 
     def matches_any_pattern?(message, patterns)

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -549,6 +549,45 @@ RSpec.describe Providers::TestAgent do
       end
     end
 
+    context "when copilot outputs only MCP session events without a response" do
+      let(:provider_record) { create(:provider, user: user, provider_key: "copilot", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+
+      let(:mcp_event) do
+        '{"type":"session.mcp_server_status_changed","data":{"serverName":"github-mcp-server","status":"connected"},"id":"853d58f1-3fe9-4407-9c7d-1807e033877e","timestamp":"2026-05-10T19:15:23.221Z","parentId":"3ef4d1aa-ac74-4058-854a-ac70cfd40c09","ephemeral":true}'
+      end
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "github_copilot")
+        stub_container_smoke_test(
+          name: :github_copilot, status: "error",
+          message: mcp_event,
+          latency_ms: 2000, error_category: nil, check: :smoke_test
+        )
+      end
+
+      it "returns a user-friendly message instead of raw MCP JSON" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:unexpected)
+        expect(result.message).to eq("Agent started but did not produce a response. Verify the provider credentials and connectivity.")
+      end
+
+      it "handles multiple MCP session events" do
+        shutdown_event = '{"type":"session.shutdown","data":{},"id":"abc123"}'
+        multi_mcp = "#{mcp_event}\n#{shutdown_event}"
+        allow(AgentHarness).to receive(:check_provider).and_return(
+          { name: :github_copilot, status: "error", message: multi_mcp, latency_ms: 3000, error_category: nil, check: :smoke_test }
+        )
+
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.message).to eq("Agent started but did not produce a response. Verify the provider credentials and connectivity.")
+      end
+    end
+
     context "when opencode smoke test succeeds via container" do
       let(:provider_record) { create(:provider, user: user, provider_key: "opencode", enabled_for_agent_runs: false, enabled_for_fallback: false) }
 


### PR DESCRIPTION
## Summary

- When the GitHub Copilot CLI smoke test fails after emitting MCP session lifecycle events (e.g. `session.mcp_server_status_changed`) but before producing a response, the raw JSON event was displayed as the error message
- Adds MCP session events (`mcp_server_status_changed`, `shutdown`) to the noisy-line filter in `Providers::TestAgent`
- Adds a `fallback_message_from` method that returns a user-friendly message when all output lines are MCP session events, instead of falling back to the raw JSON

## Test plan

- [x] New test: single MCP `session.mcp_server_status_changed` event returns friendly message
- [x] New test: multiple MCP session events (status change + shutdown) return friendly message
- [x] All 58 existing `test_agent_spec.rb` tests pass
- [x] `bin/lint --changed` passes