### PR TITLE
feat(strategy): implement context-aware strategy selection

### DIFF
--- a/app/services/strategies/select.rb
+++ b/app/services/strategies/select.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module Strategies
+  # Public API for context-aware strategy selection from database-backed
+  # OrchestrationStrategy records. Wraps OrchestrationStrategySelector with
+  # enriched context (task_type injection) and a structured Result that
+  # includes fallback semantics.
+  #
+  # Not yet wired into orchestration flows — Automation::Strategies::Select
+  # (registry-based class selection) remains the active path. A follow-up
+  # PR will integrate this service into the orchestration decision points
+  # (issue execution, auto-continue, auto-merge) so that database-backed
+  # strategy configuration takes effect at runtime.
   class Select
     Result = Data.define(:strategy, :strategy_version, :scope, :fallback, :matched_rule_count) do
       def content

--- a/app/services/strategies/select.rb
+++ b/app/services/strategies/select.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Strategies
+  class Select
+    Result = Data.define(:strategy, :strategy_version, :scope, :fallback, :matched_rule_count) do
+      def content
+        strategy_version&.content || {}
+      end
+
+      def found?
+        !fallback
+      end
+
+      def to_s
+        if found?
+          "#{strategy.name} (#{scope}, v#{strategy_version.version})"
+        else
+          "fallback"
+        end
+      end
+    end
+
+    FALLBACK_CONTENT = {
+      "decomposition_approach" => "single",
+      "max_parallel_agents" => 1,
+      "retry_policy" => { "type" => "exponential", "attempts" => 2 }
+    }.freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(decision_type:, context: {}, project: nil, account: nil, task_type: nil)
+      @decision_type = decision_type.to_s
+      @context = context
+      @project = project
+      @account = account
+      @task_type = task_type
+    end
+
+    def call
+      selector_result = OrchestrationStrategySelector.call(
+        decision_type: decision_type,
+        context: enriched_context,
+        project: project,
+        account: account
+      )
+
+      if selector_result
+        build_matched_result(selector_result)
+      else
+        build_fallback_result
+      end
+    end
+
+    private
+
+    attr_reader :decision_type, :context, :project, :account, :task_type
+
+    def enriched_context
+      base = normalize_hash(context)
+      base["task_type"] = task_type.to_s if task_type.present?
+      base
+    end
+
+    def build_matched_result(selector_result)
+      Result.new(
+        strategy: selector_result.strategy,
+        strategy_version: selector_result.strategy_version,
+        scope: selector_result.scope,
+        fallback: false,
+        matched_rule_count: selector_result.matched_rule_count
+      )
+    end
+
+    def build_fallback_result
+      Result.new(
+        strategy: nil,
+        strategy_version: nil,
+        scope: :fallback,
+        fallback: true,
+        matched_rule_count: 0
+      )
+    end
+
+    def normalize_hash(value)
+      return {} unless value.is_a?(Hash)
+
+      value.deep_stringify_keys
+    end
+  end
+end

--- a/app/services/strategies/select.rb
+++ b/app/services/strategies/select.rb
@@ -20,12 +20,6 @@ module Strategies
       end
     end
 
-    FALLBACK_CONTENT = {
-      "decomposition_approach" => "single",
-      "max_parallel_agents" => 1,
-      "retry_policy" => { "type" => "exponential", "attempts" => 2 }
-    }.freeze
-
     def self.call(...)
       new(...).call
     end
@@ -59,7 +53,7 @@ module Strategies
 
     def enriched_context
       base = normalize_hash(context)
-      base["task_type"] = task_type.to_s if task_type.present?
+      base["task_type"] ||= task_type.to_s if task_type.present?
       base
     end
 

--- a/spec/services/strategies/select_spec.rb
+++ b/spec/services/strategies/select_spec.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strategies::Select do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:project) { create(:project, account: account) }
+
+    def create_strategy_with_version(*traits, **attributes)
+      strategy = create(:strategy, *traits, **attributes)
+      version = create(:strategy_version, :active, strategy: strategy)
+      strategy.update!(current_version: version)
+      strategy
+    end
+
+    def select_result(**args)
+      described_class.call(decision_type: "issue_execution", **args)
+    end
+
+    describe "global strategy selection" do
+      it "returns a global strategy when no scoped override matches" do
+        strategy = create_strategy_with_version(
+          :global,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "any" }
+        )
+
+        result = select_result(context: { task_type: "bug_fix" })
+
+        expect(result).to be_found
+        expect(result.strategy).to eq(strategy)
+        expect(result.strategy_version).to eq(strategy.current_version)
+        expect(result.scope).to eq(:global)
+      end
+
+      it "returns a global strategy with empty selection rules as catch-all" do
+        strategy = create_strategy_with_version(
+          :global,
+          decision_type: "issue_execution",
+          selection_rules: {}
+        )
+
+        result = select_result
+
+        expect(result).to be_found
+        expect(result.strategy).to eq(strategy)
+        expect(result.scope).to eq(:global)
+      end
+
+      it "does not return a global strategy that does not match context" do
+        create_strategy_with_version(
+          :global,
+          decision_type: "issue_execution",
+          selection_rules: { "language" => "python" }
+        )
+
+        result = select_result(context: { language: "ruby" })
+
+        expect(result).not_to be_found
+      end
+    end
+
+    describe "account-scoped selection" do
+      it "prefers an account strategy over a global match" do
+        create_strategy_with_version(
+          :global,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "any" }
+        )
+        strategy = create_strategy_with_version(
+          :for_account,
+          account: account,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "any" }
+        )
+
+        result = select_result(account: account, context: { task_type: "any" })
+
+        expect(result.strategy).to eq(strategy)
+        expect(result.scope).to eq(:account)
+      end
+
+      it "does not match an account strategy for a different account" do
+        other_account = create(:account)
+        create_strategy_with_version(
+          :for_account,
+          account: other_account,
+          decision_type: "issue_execution",
+          selection_rules: {}
+        )
+
+        result = select_result(account: account)
+
+        expect(result).not_to be_found
+      end
+
+      it "resolves account from project when account is not given" do
+        strategy = create_strategy_with_version(
+          :for_account,
+          account: account,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "any" }
+        )
+
+        result = select_result(project: project, context: { task_type: "any" })
+
+        expect(result.strategy).to eq(strategy)
+        expect(result.scope).to eq(:account)
+      end
+    end
+
+    describe "project-scoped selection" do
+      it "prefers a project strategy over account and global matches" do
+        create_strategy_with_version(:global, decision_type: "issue_execution", selection_rules: { "task_type" => "any" })
+        create_strategy_with_version(:for_account, account: account, decision_type: "issue_execution", selection_rules: { "task_type" => "any" })
+        strategy = create_strategy_with_version(:for_project, project: project, account: account, decision_type: "issue_execution", selection_rules: { "task_type" => "any" })
+
+        result = select_result(project: project, account: account, context: { task_type: "any" })
+
+        expect(result.strategy).to eq(strategy)
+        expect(result.scope).to eq(:project)
+      end
+
+      it "does not match a project strategy for a different project" do
+        other_project = create(:project, account: account)
+        create_strategy_with_version(
+          :for_project,
+          project: other_project,
+          account: account,
+          decision_type: "issue_execution",
+          selection_rules: {}
+        )
+
+        result = select_result(project: project)
+
+        expect(result).not_to be_found
+      end
+    end
+
+    describe "task-specific selection" do
+      it "enriches context with task_type for rule matching" do
+        strategy = create_strategy_with_version(
+          :for_account,
+          account: account,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "bug_fix" }
+        )
+
+        result = select_result(account: account, task_type: "bug_fix")
+
+        expect(result).to be_found
+        expect(result.strategy).to eq(strategy)
+      end
+
+      it "prefers a task-specific strategy over a broader strategy at the same scope" do
+        create_strategy_with_version(
+          :for_account,
+          account: account,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "any" }
+        )
+        strategy = create_strategy_with_version(
+          :for_account,
+          account: account,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "bug_fix" }
+        )
+
+        result = select_result(account: account, task_type: "bug_fix")
+
+        expect(result.strategy).to eq(strategy)
+        expect(result.matched_rule_count).to eq(1)
+      end
+
+      it "does not match when task_type differs from selection rules" do
+        create_strategy_with_version(
+          :for_account,
+          account: account,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "feature" }
+        )
+
+        result = select_result(account: account, task_type: "bug_fix")
+
+        expect(result).not_to be_found
+      end
+
+      it "allows context to override task_type when explicitly provided" do
+        create_strategy_with_version(
+          :for_account,
+          account: account,
+          decision_type: "issue_execution",
+          selection_rules: { "task_type" => "refactor" }
+        )
+
+        result = select_result(account: account, task_type: "bug_fix", context: { "task_type" => "refactor" })
+
+        expect(result).to be_found
+      end
+    end
+
+    describe "rule specificity" do
+      it "prefers the strategy with more matched rules at the same scope" do
+        create_strategy_with_version(:for_account, account: account, decision_type: "issue_execution", selection_rules: { "task_type" => "bug_fix" })
+        strategy = create_strategy_with_version(:for_account, account: account, decision_type: "issue_execution", selection_rules: { "task_type" => "bug_fix", "language" => "ruby" })
+
+        result = select_result(account: account, task_type: "bug_fix", context: { language: "ruby" })
+
+        expect(result.strategy).to eq(strategy)
+        expect(result.matched_rule_count).to eq(2)
+      end
+    end
+
+    describe "fallback behavior" do
+      it "returns a fallback result when no strategy matches" do
+        result = select_result
+
+        expect(result).not_to be_found
+        expect(result.strategy).to be_nil
+        expect(result.strategy_version).to be_nil
+        expect(result.scope).to eq(:fallback)
+        expect(result.matched_rule_count).to eq(0)
+      end
+
+      it "provides empty content for fallback results" do
+        result = select_result
+
+        expect(result.content).to eq({})
+      end
+
+      it "does not return a draft strategy as fallback" do
+        strategy = create(:strategy, :global, :draft, decision_type: "issue_execution")
+        create(:strategy_version, strategy: strategy, promotion_state: "draft")
+        strategy.update_column(:current_version_id, strategy.strategy_versions.first.id)
+
+        result = select_result
+
+        expect(result).not_to be_found
+      end
+
+      it "does not return an archived strategy as fallback" do
+        create_strategy_with_version(
+          :global,
+          decision_type: "issue_execution",
+          selection_rules: {}
+        ).tap { |s| s.update!(status: "archived") }
+
+        result = select_result
+
+        expect(result).not_to be_found
+      end
+    end
+
+    describe "Result" do
+      it "delegates content from the strategy version" do
+        strategy = create_strategy_with_version(
+          :global,
+          decision_type: "issue_execution",
+          selection_rules: {}
+        )
+
+        result = select_result
+
+        expect(result.content).to eq(strategy.current_version.content)
+      end
+
+      it "has a human-readable to_s for matched results" do
+        strategy = create_strategy_with_version(
+          :global,
+          decision_type: "issue_execution",
+          selection_rules: {}
+        )
+
+        result = select_result
+
+        expect(result.to_s).to eq("#{strategy.name} (global, v#{strategy.current_version.version})")
+      end
+
+      it "has a human-readable to_s for fallback results" do
+        result = select_result
+
+        expect(result.to_s).to eq("fallback")
+      end
+    end
+
+    describe "decision type isolation" do
+      it "does not match strategies from a different decision type" do
+        create_strategy_with_version(
+          :global,
+          decision_type: "retry",
+          selection_rules: {}
+        )
+
+        result = select_result
+
+        expect(result).not_to be_found
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implement context-aware strategy selection so orchestration flows can dynamically resolve the best strategy version based on project, account, task type, and runtime context, with safe fallback behavior when no specialized strategy matches.

## Changes

**Services**
- Add `Strategies::Select` service (Servo pattern) that accepts selection inputs (`decision_type`, `context`, `project`, `account`, `task_type`) and returns a structured `Result` with the matched strategy, version, scope, and fallback status
- Delegate core selection logic to `OrchestrationStrategySelector` with enriched context (task_type injection)
- Implement four-tier precedence: project > account > global > fallback
- Return a safe fallback result (`fallback: true`, empty content) when no specialized strategy matches

**Tests**
- Add 21 specs covering global, account-scoped, project-scoped, and task-specific selection
- Cover rule specificity (more matched rules win at same scope), draft/archived exclusion, decision type isolation
- Verify `Result` interface (`content`, `to_s`, `found?`)

## Design Decisions

- **Four-tier precedence (project > account > global > fallback)**: Mirrors typical multi-tenant configuration patterns — the most specific scope always wins, with a safe default at the bottom. This avoids surprising behavior where a broad global rule overrides a project-specific one.
- **Delegation to `OrchestrationStrategySelector`**: Reuses the existing selection infrastructure rather than reimplementing matching logic, keeping the new service as a thin orchestration layer over proven internals.
- **Structured `Result` object**: Exposes `scope`, `fallback`, and `matched_rule_count` so callers can make informed decisions (e.g., logging when falling back, adjusting behavior based on match confidence).

---

Closes #1792