### PR TITLE
feat(optimization): create configuration bundle schema

### DIFF
--- a/app/models/bundle_outcome.rb
+++ b/app/models/bundle_outcome.rb
@@ -9,9 +9,16 @@ class BundleOutcome < ApplicationRecord
   validates :duration_seconds, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :cost_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :tokens_used, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :metrics_is_object
   validate :agent_run_matches_bundle_scope, if: -> { configuration_bundle.present? && agent_run.present? }
 
   private
+
+  def metrics_is_object
+    return if metrics.is_a?(Hash)
+
+    errors.add(:metrics, "must be an object")
+  end
 
   def agent_run_matches_bundle_scope
     return if agent_run.project.account_id == configuration_bundle.account_id &&

--- a/app/models/configuration_bundle.rb
+++ b/app/models/configuration_bundle.rb
@@ -21,6 +21,9 @@ class ConfigurationBundle < ApplicationRecord
   validates :strategy, length: { maximum: 100 }, allow_nil: true
   validates :fingerprint, length: { maximum: 64 }, uniqueness: { scope: :account_id }, allow_nil: true
   validates :definition, presence: true
+  validate :definition_is_object
+  validate :context_is_object
+  validate :strategy_params_is_object
   validate :project_belongs_to_account, if: -> { project.present? && account.present? }
   validate :prompt_version_matches_scope, if: -> { prompt_version.present? }
 
@@ -103,5 +106,23 @@ class ConfigurationBundle < ApplicationRecord
     return if prompt.project_level? && prompt.account_id == account_id && prompt.project_id == project_id
 
     errors.add(:prompt_version, "must match the bundle account/project scope")
+  end
+
+  def definition_is_object
+    validate_json_object(:definition)
+  end
+
+  def context_is_object
+    validate_json_object(:context)
+  end
+
+  def strategy_params_is_object
+    validate_json_object(:strategy_params)
+  end
+
+  def validate_json_object(attribute)
+    return if public_send(attribute).is_a?(Hash)
+
+    errors.add(attribute, "must be an object")
   end
 end

--- a/app/models/configuration_bundle.rb
+++ b/app/models/configuration_bundle.rb
@@ -109,6 +109,8 @@ class ConfigurationBundle < ApplicationRecord
   end
 
   def definition_is_object
+    return if definition.nil?
+
     validate_json_object(:definition)
   end
 

--- a/spec/migrations/create_configuration_bundles_spec.rb
+++ b/spec/migrations/create_configuration_bundles_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260508014445_create_configuration_bundles")
+require Rails.root.join("db/migrate/20260508020000_add_runtime_fields_to_configuration_bundles")
+
+RSpec.describe CreateConfigurationBundles, :aggregate_failures do
+  self.use_transactional_tests = false
+
+  let(:migration) { described_class.new }
+  let(:runtime_fields_migration) { AddRuntimeFieldsToConfigurationBundles.new }
+  let(:connection) { ActiveRecord::Base.connection }
+
+  around do |example|
+    configuration_bundles_table_existed = connection.table_exists?(:configuration_bundles)
+    bundle_outcomes_table_existed = connection.table_exists?(:bundle_outcomes)
+    configuration_bundle_id_existed = connection.column_exists?(:agent_runs, :configuration_bundle_id)
+
+    teardown_optimizer_schema
+    ConfigurationBundle.reset_column_information
+    BundleOutcome.reset_column_information
+    AgentRun.reset_column_information
+
+    example.run
+  ensure
+    teardown_optimizer_schema
+
+    migration.up if configuration_bundles_table_existed || bundle_outcomes_table_existed
+    runtime_fields_migration.up if configuration_bundle_id_existed
+
+    ConfigurationBundle.reset_column_information
+    BundleOutcome.reset_column_information
+    AgentRun.reset_column_information
+  end
+
+  it "creates configuration bundle and outcome tables for optimization lookups" do
+    migration.up
+    runtime_fields_migration.up
+
+    expect(connection.table_exists?(:configuration_bundles)).to be(true)
+    expect(connection.table_exists?(:bundle_outcomes)).to be(true)
+    expect(connection.column_exists?(:agent_runs, :configuration_bundle_id)).to be(true)
+
+    expect_configuration_bundle_schema
+    expect_configuration_bundle_indexes
+    expect_configuration_bundle_comments
+    expect_bundle_outcome_schema
+    expect_bundle_outcome_indexes
+    expect_bundle_outcome_comments
+    expect_agent_run_bundle_reference
+  end
+
+  private
+
+  def teardown_optimizer_schema
+    runtime_fields_migration.down if connection.column_exists?(:agent_runs, :configuration_bundle_id)
+    migration.down if connection.table_exists?(:bundle_outcomes) || connection.table_exists?(:configuration_bundles)
+  end
+
+  def expect_configuration_bundle_schema
+    columns = connection.columns(:configuration_bundles).index_by(&:name)
+
+    expect(columns.fetch("account_id").null).to be(false)
+    expect(columns.fetch("version").null).to be(false)
+    expect(default_expression_for(:configuration_bundles, "version")).to include("1")
+    expect(columns.fetch("name").null).to be(false)
+    expect(columns.fetch("name").limit).to eq(255)
+    expect(columns.fetch("status").null).to be(false)
+    expect(columns.fetch("status").default).to eq("draft")
+    expect(columns.fetch("status").limit).to eq(50)
+    expect(columns.fetch("strategy").limit).to eq(100)
+    expect(columns.fetch("fingerprint").limit).to eq(64)
+    expect(default_expression_for(:configuration_bundles, "strategy_params")).to include("'{}'::jsonb")
+    expect(default_expression_for(:configuration_bundles, "context")).to include("'{}'::jsonb")
+    expect(default_expression_for(:configuration_bundles, "definition")).to include("'{}'::jsonb")
+    expect(connection.foreign_key_exists?(:configuration_bundles, :accounts)).to be(true)
+    expect(connection.foreign_key_exists?(:configuration_bundles, :projects)).to be(true)
+    expect(connection.foreign_key_exists?(:configuration_bundles, :prompt_versions)).to be(true)
+    expect(connection.foreign_key_exists?(:configuration_bundles, :llm_models)).to be(true)
+  end
+
+  def expect_configuration_bundle_indexes
+    expect(index_names(:configuration_bundles)).to include(
+      "index_config_bundles_unique_version_account",
+      "index_config_bundles_unique_version_project",
+      "index_config_bundles_on_account_status",
+      "index_config_bundles_on_project_status",
+      "index_config_bundles_unique_fingerprint",
+      "index_configuration_bundles_on_account_id",
+      "index_configuration_bundles_on_project_id",
+      "index_configuration_bundles_on_prompt_version_id",
+      "index_configuration_bundles_on_llm_model_id",
+      "index_configuration_bundles_on_status"
+    )
+  end
+
+  def expect_configuration_bundle_comments
+    expect(table_comment(:configuration_bundles)).to eq(
+      "Versioned snapshots of configuration components used for agent runs"
+    )
+    expect(column_comment(:configuration_bundles, "context")).to eq(
+      "Additional context such as guardrails, token budgets, or feature flags"
+    )
+    expect(column_comment(:configuration_bundles, "definition")).to eq(
+      "Canonical runtime configuration snapshot used for optimization and fingerprinting"
+    )
+  end
+
+  def expect_bundle_outcome_schema
+    columns = connection.columns(:bundle_outcomes).index_by(&:name)
+
+    expect(columns.fetch("configuration_bundle_id").null).to be(false)
+    expect(columns.fetch("agent_run_id").null).to be(false)
+    expect(columns.fetch("success").null).to be(false)
+    expect(columns.fetch("success").default).to be(false)
+    expect(default_expression_for(:bundle_outcomes, "metrics")).to include("'{}'::jsonb")
+    expect(connection.foreign_key_exists?(:bundle_outcomes, :configuration_bundles)).to be(true)
+    expect(connection.foreign_key_exists?(:bundle_outcomes, :agent_runs)).to be(true)
+  end
+
+  def expect_bundle_outcome_indexes
+    expect(index_names(:bundle_outcomes)).to include(
+      "index_bundle_outcomes_unique_run",
+      "index_bundle_outcomes_on_agent_run_id",
+      "index_bundle_outcomes_on_quality_score",
+      "index_bundle_outcomes_on_success"
+    )
+  end
+
+  def expect_bundle_outcome_comments
+    expect(table_comment(:bundle_outcomes)).to eq(
+      "Measured results from using a configuration bundle on an agent run"
+    )
+    expect(column_comment(:bundle_outcomes, "metrics")).to eq(
+      "Additional outcome metrics (lines changed, test pass rate, etc.)"
+    )
+  end
+
+  def expect_agent_run_bundle_reference
+    expect(connection.foreign_key_exists?(:agent_runs, :configuration_bundles)).to be(true)
+    expect(index_names(:agent_runs)).to include("index_agent_runs_on_configuration_bundle_id")
+    expect(column_comment(:agent_runs, "configuration_bundle_id")).to eq(
+      "Configuration bundle assigned to the run before execution."
+    )
+  end
+
+  def index_names(table_name)
+    connection.indexes(table_name).map(&:name)
+  end
+
+  def table_comment(table_name)
+    connection.select_value(<<~SQL.squish)
+      SELECT obj_description('public.#{table_name}'::regclass, 'pg_class')
+    SQL
+  end
+
+  def column_comment(table_name, column_name)
+    connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array([
+        <<~SQL.squish,
+          SELECT col_description('public.#{table_name}'::regclass, ordinal_position)
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND table_name = ?
+            AND column_name = ?
+        SQL
+        table_name.to_s,
+        column_name
+      ])
+    )
+  end
+
+  def default_expression_for(table_name, column_name)
+    connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array([
+        <<~SQL.squish,
+          SELECT pg_get_expr(d.adbin, d.adrelid)
+          FROM pg_attribute a
+          INNER JOIN pg_attrdef d
+            ON d.adrelid = a.attrelid
+           AND d.adnum = a.attnum
+          WHERE a.attrelid = ?::regclass
+            AND a.attname = ?
+        SQL
+        "public.#{table_name}",
+        column_name
+      ])
+    )
+  end
+end

--- a/spec/models/bundle_outcome_spec.rb
+++ b/spec/models/bundle_outcome_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe BundleOutcome do
     it { is_expected.to validate_numericality_of(:cost_cents).only_integer.is_greater_than_or_equal_to(0).allow_nil }
     it { is_expected.to validate_numericality_of(:tokens_used).only_integer.is_greater_than_or_equal_to(0).allow_nil }
 
+    it "requires metrics to be a JSON object" do
+      outcome = build(:bundle_outcome, metrics: [])
+
+      expect(outcome).not_to be_valid
+      expect(outcome.errors[:metrics]).to include("must be an object")
+    end
+
     it "enforces uniqueness of agent_run scoped to configuration_bundle" do
       outcome = create(:bundle_outcome)
       duplicate = build(:bundle_outcome,

--- a/spec/models/configuration_bundle_spec.rb
+++ b/spec/models/configuration_bundle_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe ConfigurationBundle do
       expect(bundle.errors[:definition]).to include("must be an object")
     end
 
+    it "does not add a duplicate object error when definition is missing" do
+      bundle = build(:configuration_bundle, definition: nil)
+
+      expect(bundle).not_to be_valid
+      expect(bundle.errors[:definition]).to eq([ "can't be blank" ])
+    end
+
     it "requires context to be a JSON object" do
       bundle = build(:configuration_bundle, context: [])
 

--- a/spec/models/configuration_bundle_spec.rb
+++ b/spec/models/configuration_bundle_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ConfigurationBundle do
     it { is_expected.to belong_to(:project).optional }
     it { is_expected.to belong_to(:prompt_version).optional }
     it { is_expected.to belong_to(:llm_model).optional }
+    it { is_expected.to have_many(:agent_runs).dependent(:nullify) }
     it { is_expected.to have_many(:bundle_outcomes).dependent(:destroy) }
   end
 
@@ -21,6 +22,27 @@ RSpec.describe ConfigurationBundle do
     it { is_expected.to validate_presence_of(:version) }
     it { is_expected.to validate_numericality_of(:version).only_integer.is_greater_than(0) }
     it { is_expected.to validate_length_of(:strategy).is_at_most(100) }
+
+    it "requires definition to be a JSON object" do
+      bundle = build(:configuration_bundle, definition: [])
+
+      expect(bundle).not_to be_valid
+      expect(bundle.errors[:definition]).to include("must be an object")
+    end
+
+    it "requires context to be a JSON object" do
+      bundle = build(:configuration_bundle, context: [])
+
+      expect(bundle).not_to be_valid
+      expect(bundle.errors[:context]).to include("must be an object")
+    end
+
+    it "requires strategy_params to be a JSON object" do
+      bundle = build(:configuration_bundle, strategy_params: [])
+
+      expect(bundle).not_to be_valid
+      expect(bundle.errors[:strategy_params]).to include("must be an object")
+    end
 
     it "validates fingerprint uniqueness within an account" do
       bundle = create(:configuration_bundle, fingerprint: "shared-fingerprint")


### PR DESCRIPTION
## Summary

This change tightens the configuration bundle data model so optimization runs store structurally valid bundle definitions and measured outcomes, reducing the risk of malformed records and making bundle-backed analysis more reliable. It also fills in missing association and schema coverage around `agent_runs.configuration_bundle_id` so the versioned bundle schema introduced for `#1797` is fully enforced and documented.

## Changes

- **Schema and database**
  - Adds coverage for the configuration bundle schema with a dedicated migration spec that verifies the `configuration_bundles` and `bundle_outcomes` tables, their indexes, and schema comments.
  - Verifies the `agent_runs.configuration_bundle_id` reference so the bundle-to-run linkage is explicitly covered at the schema level.

- **Models and validations**
  - Hardens `ConfigurationBundle` by requiring `definition`, `context`, and `strategy_params` to be JSON objects rather than arbitrary JSON values.
  - Hardens `BundleOutcome` by requiring `metrics` to be a JSON object for consistent result storage and downstream querying.
  - Adds missing association coverage for `ConfigurationBundle -> agent_runs`.

- **Test coverage**
  - Adds model/spec coverage for the stricter JSON shape requirements and bundle/run associations.
  - Adds migration-level assertions for the new optimization schema so future changes catch drift in tables, references, indexes, and comments.

- **Code quality**
  - `bundle exec rubocop` passes.

## Design Decisions

- JSON fields are constrained to objects, not just valid JSON, because bundle definitions, execution context, strategy parameters, and measured metrics all need predictable key/value structure for validation and analysis.
- The schema is validated in a dedicated migration spec in addition to model specs so reviewers can rely on coverage for database-level shape, documentation, and query-path indexes, not just application behavior.
- The change extends the existing bundle schema rather than reshaping it, which keeps the `#1797` follow-up narrowly focused on correctness and coverage instead of introducing a broader migration redesign.

## Operational Concerns

- No additional deployment steps are expected beyond normal migration rollout.
- `bundle exec rspec` could not be executed in this container because PostgreSQL was unavailable (`ActiveRecord::ConnectionNotEstablished` against `/var/run/postgresql/.s.PGSQL.5432`), so full spec validation should run in an environment with the app database available.

---

Closes #1797