### PR TITLE
feat(dashboard): add orchestration decision metrics dashboard

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -87,6 +87,12 @@ module DashboardHelper
     "failed" => "bg-rose-100 text-rose-700"
   }.freeze
 
+  DECISION_STATUS_BAR_CLASSES = {
+    "applied" => "bg-emerald-500",
+    "noop" => "bg-amber-500",
+    "failed" => "bg-rose-500"
+  }.freeze
+
   def time_range_label(range)
     TIME_RANGE_LABELS.fetch(range, range.to_s.titleize)
   end
@@ -99,6 +105,10 @@ module DashboardHelper
 
   def decision_status_badge_classes(status)
     DECISION_STATUS_BADGE_CLASSES.fetch(status.to_s, "bg-slate-100 text-slate-700")
+  end
+
+  def decision_status_bar_classes(status)
+    DECISION_STATUS_BAR_CLASSES.fetch(status.to_s, "bg-slate-400")
   end
 
   # Dark-mode colors for these badges are handled by the global unlayered

--- a/app/views/dashboard/_orchestration_decisions.html.erb
+++ b/app/views/dashboard/_orchestration_decisions.html.erb
@@ -5,6 +5,7 @@
   <% noop_count = summary[:noop_count].to_i %>
   <% failed_count = summary[:failed_count].to_i %>
   <% project_count = summary[:project_count].to_i %>
+  <% actor_count = summary[:actor_count].to_i %>
   <% daily_volume = report[:daily_volume] %>
   <% low_data = total_count.positive? && (total_count < 5 || project_count < 2 || daily_volume.size < 3) %>
 
@@ -55,9 +56,14 @@
           <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= number_with_delimiter(summary[:linked_agent_run_count]) %></dd>
           <p class="mt-2 text-xs text-gray-500"><%= number_with_delimiter(summary[:completed_run_count]) %> completed, <%= number_with_delimiter(summary[:failed_run_count]) %> failed</p>
         </div>
+        <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+          <dt class="truncate text-sm font-medium text-gray-500">Decision Actors</dt>
+          <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= number_with_delimiter(actor_count) %></dd>
+          <p class="mt-2 text-xs text-gray-500"><%= number_with_delimiter(project_count) %> projects contributing context</p>
+        </div>
       </div>
 
-      <div class="mt-6 grid grid-cols-1 gap-6 xl:grid-cols-5">
+      <div class="mt-6 grid grid-cols-1 gap-6 xl:grid-cols-6">
         <div class="overflow-hidden rounded-lg bg-white shadow xl:col-span-2">
           <div class="px-4 py-5 sm:p-6">
             <h3 class="text-sm font-semibold text-gray-900">Outcome Mix</h3>
@@ -77,7 +83,7 @@
                     <span class="text-sm font-medium text-gray-900"><%= number_with_delimiter(count) %> · <%= number_to_percentage(share, precision: 0) %></span>
                   </div>
                   <div class="mt-2 h-2 rounded-full bg-gray-100">
-                    <div class="h-2 rounded-full <%= decision_status_badge_classes(status).split.first %>" style="width: <%= share %>%"></div>
+                    <div class="h-2 rounded-full <%= decision_status_bar_classes(status) %>" style="width: <%= share %>%"></div>
                   </div>
                 </div>
               <% end %>
@@ -85,7 +91,7 @@
           </div>
         </div>
 
-        <div class="overflow-hidden rounded-lg bg-white shadow xl:col-span-3">
+        <div class="overflow-hidden rounded-lg bg-white shadow xl:col-span-4">
           <div class="px-4 py-5 sm:p-6">
             <h3 class="text-sm font-semibold text-gray-900">Decision Types by Context</h3>
             <p class="mt-1 text-sm text-gray-500">Most common decision categories, with how broadly they appear and how often they land on failed or completed runs.</p>
@@ -119,11 +125,77 @@
         </div>
       </div>
 
-      <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
+      <div class="mt-6 grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <div class="overflow-hidden rounded-lg bg-white shadow">
           <div class="px-4 py-5 sm:p-6">
-            <h3 class="text-sm font-semibold text-gray-900">Project Context</h3>
-            <p class="mt-1 text-sm text-gray-500">Projects producing the most decision activity, plus how varied those decision types and actors are.</p>
+            <h3 class="text-sm font-semibold text-gray-900">Outcomes by Decision Type</h3>
+            <p class="mt-1 text-sm text-gray-500">Where each decision category is landing across applied, no-op, and failed outcomes.</p>
           </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Type</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Applied</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">No-op</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Failed</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Total</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 bg-white">
+                <% report[:outcome_by_decision_type].first(5).each do |row| %>
+                  <tr>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= decision_type_label(row[:decision_type]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:applied_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:noop_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:failed_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:total_count]) %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="overflow-hidden rounded-lg bg-white shadow">
+          <div class="px-4 py-5 sm:p-6">
+            <h3 class="text-sm font-semibold text-gray-900">Decision Actors</h3>
+            <p class="mt-1 text-sm text-gray-500">Actors generating the most decisions, plus the breadth of project and decision-type coverage they touch.</p>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Actor</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Decisions</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Projects</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Types</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Applied</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Failed</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 bg-white">
+                <% report[:by_actor].first(5).each do |row| %>
+                  <tr>
+                    <td class="px-4 py-3 text-sm text-gray-900"><%= row[:actor] %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:total_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:project_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:decision_type_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:applied_count]) %></td>
+                    <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600"><%= number_with_delimiter(row[:failed_count]) %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
+        <div class="px-4 py-5 sm:p-6">
+          <h3 class="text-sm font-semibold text-gray-900">Project Context</h3>
+          <p class="mt-1 text-sm text-gray-500">Projects producing the most decision activity, plus how varied those decision types and actors are.</p>
+        </div>
         <div class="overflow-x-auto">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -457,6 +457,24 @@ RSpec.describe "Dashboard" do
         created_at: created_at)
     end
 
+    def create_external_decision_metric(created_at:)
+      create(:orchestration_decision, :without_agent_run,
+        project: create(:project, name: "Ignored", owner: "ignored", repo: "ignored"),
+        decision_type: "retry",
+        actor: "timeout_auto_retry",
+        context: { decision_status: "applied" },
+        created_at: created_at)
+    end
+
+    def create_out_of_window_decision_metric(project:, created_at:)
+      create_decision_metric(
+        project: project,
+        created_at: created_at,
+        decision_type: "planning_outcome",
+        actor: "Workflows::PlanningWorkflow"
+      )
+    end
+
     it "returns the orchestration decision metrics partial within a turbo frame" do
       create_decision_metric(project: project, created_at: Time.current)
 
@@ -466,6 +484,8 @@ RSpec.describe "Dashboard" do
       expect(response.body).to include("dashboard-decision-metrics")
       expect(response.body).to include("Orchestration Decision Metrics")
       expect(response.body).to include("Decision Types by Context")
+      expect(response.body).to include("Outcomes by Decision Type")
+      expect(response.body).to include("Decision Actors")
     end
 
     it "shows an empty state when no orchestration decisions exist" do
@@ -488,24 +508,21 @@ RSpec.describe "Dashboard" do
     it "scopes decision metrics to the current account and time window" do
       create_decision_metric(project: project, created_at: 2.days.ago)
       create_decision_metric(project: project, created_at: 1.day.ago, decision_status: "failed", agent_run_traits: [ :failed ])
-      create(:orchestration_decision, :without_agent_run,
-        project: create(:project, name: "Ignored", owner: "ignored", repo: "ignored"),
-        decision_type: "retry",
-        actor: "timeout_auto_retry",
-        context: { decision_status: "applied" },
-        created_at: 1.day.ago)
-      create_decision_metric(
-        project: project,
-        created_at: 45.days.ago,
-        decision_type: "planning_outcome",
-        actor: "Workflows::PlanningWorkflow"
-      )
+      create_external_decision_metric(created_at: 1.day.ago)
+      create_out_of_window_decision_metric(project: project, created_at: 45.days.ago)
 
       get dashboard_decision_metrics_path(time_range: "7d")
+
+      document = Nokogiri::HTML(response.body)
+      actor_headers = document.css("table thead th").map { |header| header.text.squish }
 
       expect(response.body).to include("Total Decisions")
       expect(response.body).to include("Retry")
       expect(response.body).to include("Alpha")
+      expect(response.body).to include("timeout_auto_retry")
+      expect(actor_headers).to include("Actor")
+      expect(actor_headers).to include("Applied")
+      expect(actor_headers).to include("Failed")
       expect(response.body).not_to include("Ignored")
       expect(response.body).not_to include("Planning Outcome")
     end

--- a/spec/system/dashboard_orchestration_decision_metrics_spec.rb
+++ b/spec/system/dashboard_orchestration_decision_metrics_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Dashboard orchestration decision metrics", type: :system do
   let!(:user) do
     create(:user, :owner, account: account, email: "owner@example.com", password: "password123")
   end
+  let!(:project) { create(:project, account: account, name: "Alpha", owner: "acme", repo: "alpha") }
 
   it "renders deferred decision metrics frame wiring on the dashboard shell" do
     visit new_user_session_path
@@ -21,5 +22,29 @@ RSpec.describe "Dashboard orchestration decision metrics", type: :system do
     expect(frame["data-dashboard-frames-src"]).to eq(dashboard_decision_metrics_path(time_range: "cumulative"))
     expect(frame["src"]).to be_nil
     expect(page.find("[data-controller~='dashboard-frames']", visible: false)).to be_present
+  end
+
+  it "renders decision metrics sections and actor context in the frame endpoint" do
+    create(:orchestration_decision,
+      project: project,
+      agent_run: create(:agent_run, :completed, project: project),
+      decision_type: "retry",
+      actor: "timeout_auto_retry",
+      context: { decision_status: "applied" },
+      created_at: Time.current)
+
+    visit new_user_session_path
+
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "password123"
+    click_button "Sign in"
+
+    visit dashboard_decision_metrics_path(time_range: "cumulative")
+
+    expect(page).to have_content("Orchestration Decision Metrics")
+    expect(page).to have_content("Outcomes by Decision Type")
+    expect(page).to have_content("Decision Actors")
+    expect(page).to have_content("timeout_auto_retry")
+    expect(page).to have_content("Project Context")
   end
 end


### PR DESCRIPTION
## Summary

This change makes orchestration decision patterns visible inside the product so reviewers and operators can spot decision trends and outcomes without leaving the dashboard. It completes the dashboard surface on top of the existing reporting layer by exposing the remaining decision analytics, improving readability for low-data scenarios, and extending coverage around the new sections.

## Changes

- `UI / Dashboard`
  - Added the remaining orchestration decision metrics to the dashboard, including outcomes by decision type and actor-context rollups.
  - Expanded the actor summary card so the dashboard gives a clearer at-a-glance view of who is making decisions and in what context.
  - Corrected outcome-mix bar styling so bar fills use explicit chart colors rather than badge background classes, improving visual clarity and consistency.

- `Reporting integration`
  - Wired the dashboard to analytics already available in the report layer instead of introducing a parallel aggregation path.
  - Surfaced context-based decision outcomes in the existing metrics view so users can compare behavior across actor and decision dimensions from one screen.

- `Test coverage`
  - Extended request specs to assert the new dashboard sections and decision context data.
  - Extended system coverage to verify the expanded dashboard presentation, including the new actor-context analytics.

## Design Decisions

- Reused the existing report-layer analytics rather than adding dashboard-specific calculations to keep the dashboard as a presentation layer and avoid duplicating metric logic.
- Kept the finish-pass focused on exposing metrics already supported by the backend, which reduced risk and preserved consistency with existing decision logging behavior.
- Switched the outcome bars to explicit bar colors because badge utility classes were leaking presentation semantics into chart rendering and producing incorrect fills.

## Operational Notes

- No new deployment steps or infrastructure changes are required.
- `bundle exec rubocop` passed.
- `bundle exec rspec` could not run in this container because PostgreSQL was unavailable during test boot (`ActiveRecord::ConnectionNotEstablished` / `PG::ConnectionBad` while preparing the test database).

---

Closes #1788