### PR TITLE
feat(optimization): track configuration bundles per agent run

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -228,6 +228,8 @@ class ProcessRunQueueJob < ApplicationJob
   end
 
   def start_claimed_run(agent_run)
+    ConfigurationBundles::AssignToRun.call(agent_run: agent_run) if agent_run.configuration_bundle.blank?
+
     budget_result = CostBudgets::Check.call(agent_run.project)
     unless budget_result[:allowed]
       agent_run.fail!(error: "Budget enforcement: #{budget_result[:reason]}")

--- a/app/services/configuration_bundles/assign_to_run.rb
+++ b/app/services/configuration_bundles/assign_to_run.rb
@@ -22,7 +22,9 @@ module ConfigurationBundles
     def call
       selection = optimizer_selection
       definition = bundle_definition(selection&.variant_by_experiment_id)
-      fingerprint = selection&.fingerprint || bundle_fingerprint(definition)
+      fingerprint = bundle_fingerprint(definition)
+
+      log_selection_fingerprint_mismatch(selection:, fingerprint:) if selection
 
       bundle = find_or_create_bundle(fingerprint:, definition:)
       agent_run.update!(
@@ -140,6 +142,17 @@ module ConfigurationBundles
         error: e.message
       )
       nil
+    end
+
+    def log_selection_fingerprint_mismatch(selection:, fingerprint:)
+      return if selection.fingerprint.blank? || selection.fingerprint == fingerprint
+
+      Rails.logger.warn(
+        message: "configuration_bundles.selection_fingerprint_mismatch",
+        agent_run_id: agent_run.id,
+        optimizer_fingerprint: selection.fingerprint,
+        resolved_fingerprint: fingerprint
+      )
     end
   end
 end

--- a/app/services/configuration_bundles/assign_to_run.rb
+++ b/app/services/configuration_bundles/assign_to_run.rb
@@ -22,7 +22,7 @@ module ConfigurationBundles
     def call
       selection = optimizer_selection
       definition = bundle_definition(selection&.variant_by_experiment_id)
-      fingerprint = Digest::SHA256.hexdigest(JSON.generate(definition))
+      fingerprint = selection&.fingerprint || bundle_fingerprint(definition)
 
       bundle = find_or_create_bundle(fingerprint:, definition:)
       agent_run.update!(
@@ -57,7 +57,7 @@ module ConfigurationBundles
         status: "active",
         strategy: "runtime_snapshot",
         strategy_params: {},
-        context: {},
+        context: { "identity" => bundle_identity_metadata(definition) },
         fingerprint: fingerprint,
         definition: definition
       )

--- a/app/services/configuration_bundles/bundle_fingerprinting.rb
+++ b/app/services/configuration_bundles/bundle_fingerprinting.rb
@@ -6,7 +6,22 @@ module ConfigurationBundles
   module BundleFingerprinting
     include Canonicalization
 
+    BUNDLE_IDENTITY_SCHEMA_VERSION = 1
+    BUNDLE_FINGERPRINT_ALGORITHM = "sha256"
+
     private
+
+    def bundle_fingerprint(definition)
+      Digest::SHA256.hexdigest(JSON.generate(canonicalize(definition)))
+    end
+
+    def bundle_identity_metadata(definition)
+      {
+        "fingerprint" => bundle_fingerprint(definition),
+        "fingerprint_algorithm" => BUNDLE_FINGERPRINT_ALGORITHM,
+        "schema_version" => BUNDLE_IDENTITY_SCHEMA_VERSION
+      }
+    end
 
     def custom_prompt_sha256
       return if agent_run.custom_prompt.blank?

--- a/app/services/configuration_bundles/optimizer.rb
+++ b/app/services/configuration_bundles/optimizer.rb
@@ -76,7 +76,7 @@ module ConfigurationBundles
 
     def score_candidate(variant_by_experiment_id)
       definition = bundle_definition(variant_by_experiment_id)
-      fingerprint = Digest::SHA256.hexdigest(JSON.generate(definition))
+      fingerprint = bundle_fingerprint(definition)
       prediction = surrogate_model.predict(bundle_definition: definition, fingerprint: fingerprint)
       acquisition_score = prediction.mean_objective_score + (EXPLORATION_WEIGHT * prediction.uncertainty)
 

--- a/app/services/configuration_bundles/record_outcome.rb
+++ b/app/services/configuration_bundles/record_outcome.rb
@@ -16,6 +16,10 @@ module ConfigurationBundles
     def call
       return unless agent_run.configuration_bundle
 
+      tokens_input = agent_run.tokens_input.to_i
+      tokens_output = agent_run.tokens_output.to_i
+      queue_duration_seconds = duration_between(agent_run.created_at, agent_run.started_at)
+      total_duration_seconds = duration_between(agent_run.created_at, agent_run.completed_at)
       objective_result = ConfigurationBundles::ObjectiveScore.call(
         project: agent_run.project,
         quality_score: quality_metric.composite_score,
@@ -31,20 +35,37 @@ module ConfigurationBundles
         quality_score: quality_metric.composite_score,
         cost_cents: agent_run.cost_cents.to_i,
         duration_seconds: agent_run.duration_seconds,
-        tokens_used: agent_run.tokens_input.to_i + agent_run.tokens_output.to_i,
+        tokens_used: tokens_input + tokens_output,
         success: agent_run.status == "completed",
         metrics: {
           "component_scores" => quality_metric.scores || {},
           "completed_at" => agent_run.completed_at&.iso8601,
+          "created_at" => agent_run.created_at&.iso8601,
           "cost_score" => objective_result.cost_score,
+          "execution_duration_seconds" => agent_run.duration_seconds,
+          "outcome" => agent_run.status,
           "objective_score" => objective_result.objective_score,
           "quality_per_dollar" => objective_result.quality_per_dollar,
+          "queue_duration_seconds" => queue_duration_seconds,
           "speed_score" => objective_result.speed_score,
-          "status" => agent_run.status
-        }
+          "started_at" => agent_run.started_at&.iso8601,
+          "status" => agent_run.status,
+          "success" => agent_run.status == "completed",
+          "tokens_input" => tokens_input,
+          "tokens_output" => tokens_output,
+          "total_duration_seconds" => total_duration_seconds
+        }.compact
       )
       outcome.save!
       outcome
+    end
+
+    private
+
+    def duration_between(start_time, end_time)
+      return unless start_time && end_time
+
+      [ (end_time - start_time).round, 0 ].max
     end
   end
 end

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -197,10 +197,9 @@ module Activities
 
     def resume_queued_run(agent_run_id)
       agent_run = AgentRun.find(agent_run_id)
-      provider_changed = false
 
       if agent_run.queued?
-        provider_changed = validate_and_sync_resumed_provider!(agent_run)
+        validate_and_sync_resumed_provider!(agent_run)
       else
         logger.warn(
           message: "agent_execution.resume_queued_run_unexpected_status",
@@ -212,7 +211,7 @@ module Activities
 
       agent_run.issue&.update!(paid_state: "in_progress")
       select_model(agent_run) unless agent_run.model_selection
-      assign_configuration_bundle(agent_run) if provider_changed || agent_run.configuration_bundle.blank?
+      assign_configuration_bundle(agent_run)
 
       logger.info(
         message: "agent_execution.queued_run_resumed",

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -145,6 +145,7 @@ RSpec.describe ProcessRunQueueJob do
       described_class.new.perform
 
       expect(failing_run.reload.status).to eq("failed")
+      expect(failing_run.configuration_bundle).to be_present
       expect(failing_run.reload.error_message).to include("Connection refused")
       # temporal_workflow_id is intentionally kept on failure so
       # StaleRunDetectorJob can cancel a potentially-orphaned workflow

--- a/spec/services/configuration_bundles/assign_to_run_spec.rb
+++ b/spec/services/configuration_bundles/assign_to_run_spec.rb
@@ -61,19 +61,8 @@ RSpec.describe ConfigurationBundles::AssignToRun do
     expect(agent_run.reload.configuration_bundle).to eq(bundle)
     expect(agent_run.configuration_bundle_selection_mode).to eq("exploitative")
     expect(agent_run.configuration_bundle_selection_context).to eq("task")
-    expect(bundle.definition).to include(
-      "schema_version" => 1,
-      "goal" => agent_run.goal,
-      "agent_type" => agent_run.agent_type
-    )
-    expect(bundle.definition["model_selection"]).to eq(expected_model_selection)
-    expect(bundle.definition["service_container_ids"]).to eq([ first_service.id, second_service.id ].sort)
-    expect(bundle.definition["mcp_servers"]).to eq([ filesystem_mcp_snapshot ])
-    expect(bundle.definition.dig("experiments", "knowledge.token_budget")).to eq(
-      "configuration_experiment_id" => experiment.id,
-      "configuration_experiment_variant_id" => variant.id,
-      "value" => 8000
-    )
+    expect_bundle_definition(bundle)
+    expect_bundle_identity(bundle)
     expect(ConfigurationExperimentAssignment.find_by(configuration_experiment: experiment, agent_run: agent_run)).to be_present
   end
 
@@ -176,5 +165,31 @@ RSpec.describe ConfigurationBundles::AssignToRun do
       "env" => { "WORKDIR" => "/workspace" },
       "name" => "filesystem"
     }
+  end
+
+  def expect_bundle_definition(bundle)
+    expect(bundle.definition).to include(
+      "schema_version" => 1,
+      "goal" => agent_run.goal,
+      "agent_type" => agent_run.agent_type
+    )
+    expect(bundle.definition["model_selection"]).to eq(expected_model_selection)
+    expect(bundle.definition["service_container_ids"]).to eq([ first_service.id, second_service.id ].sort)
+    expect(bundle.definition["mcp_servers"]).to eq([ filesystem_mcp_snapshot ])
+    expect(bundle.definition.dig("experiments", "knowledge.token_budget")).to eq(
+      "configuration_experiment_id" => experiment.id,
+      "configuration_experiment_variant_id" => variant.id,
+      "value" => 8000
+    )
+  end
+
+  def expect_bundle_identity(bundle)
+    expect(bundle.context).to include(
+      "identity" => hash_including(
+        "fingerprint" => bundle.fingerprint,
+        "fingerprint_algorithm" => "sha256",
+        "schema_version" => 1
+      )
+    )
   end
 end

--- a/spec/services/configuration_bundles/assign_to_run_spec.rb
+++ b/spec/services/configuration_bundles/assign_to_run_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe ConfigurationBundles::AssignToRun do
 
     service = described_class.new(agent_run: agent_run)
     selection = ConfigurationBundles::Optimizer::Selection.new(
-      fingerprint: service.send(:bundle_fingerprint, service.send(:bundle_definition, experiment.id => challenger)),
+      fingerprint: Digest::SHA256.hexdigest("stale optimizer fingerprint"),
       variant_by_experiment_id: { experiment.id => challenger }
     )
     allow(ConfigurationBundles::Optimizer).to receive(:call).and_return(selection)

--- a/spec/services/configuration_bundles/assign_to_run_spec.rb
+++ b/spec/services/configuration_bundles/assign_to_run_spec.rb
@@ -158,6 +158,32 @@ RSpec.describe ConfigurationBundles::AssignToRun do
     expect(agent_run.configuration_bundle_selection_context).to eq("task")
   end
 
+  it "persists the fingerprint for the resolved assignment when a run already has an experiment assignment" do
+    challenger = create(:configuration_experiment_variant,
+      configuration_experiment: experiment,
+      config_value: JSON.generate(12_000))
+    create(:configuration_experiment_assignment,
+      configuration_experiment: experiment,
+      configuration_experiment_variant: variant,
+      agent_run: agent_run)
+
+    service = described_class.new(agent_run: agent_run)
+    selection = ConfigurationBundles::Optimizer::Selection.new(
+      fingerprint: service.send(:bundle_fingerprint, service.send(:bundle_definition, experiment.id => challenger)),
+      variant_by_experiment_id: { experiment.id => challenger }
+    )
+    allow(ConfigurationBundles::Optimizer).to receive(:call).and_return(selection)
+
+    bundle = described_class.call(agent_run: agent_run)
+
+    expect(bundle.fingerprint).to eq(service.send(:bundle_fingerprint, bundle.definition))
+    expect(bundle.fingerprint).not_to eq(selection.fingerprint)
+    expect(bundle.definition.dig("experiments", "knowledge.token_budget")).to include(
+      "configuration_experiment_variant_id" => variant.id,
+      "value" => 8000
+    )
+  end
+
   def filesystem_mcp_snapshot
     {
       "args" => [ "-y", "@modelcontextprotocol/server-filesystem", "/workspace" ],

--- a/spec/services/configuration_bundles/record_outcome_spec.rb
+++ b/spec/services/configuration_bundles/record_outcome_spec.rb
@@ -32,12 +32,8 @@ RSpec.describe ConfigurationBundles::RecordOutcome do
     expect(outcome.cost_cents).to eq(agent_run.cost_cents)
     expect(outcome.duration_seconds).to eq(agent_run.duration_seconds)
     expect(outcome.tokens_used).to eq(agent_run.tokens_input + agent_run.tokens_output)
-    expect(outcome.metrics).to include(
-      "component_scores" => { "pr_created" => 1.0 },
-      "objective_score" => be_within(0.001).of(0.684),
-      "quality_per_dollar" => be_within(0.001).of(0.56),
-      "status" => "completed"
-    )
+    expect_metric_summary(outcome)
+    expect_metric_timestamps(outcome)
   end
 
   it "updates an existing outcome on recollection" do
@@ -50,5 +46,27 @@ RSpec.describe ConfigurationBundles::RecordOutcome do
 
     expect(agent_run.reload.bundle_outcomes.sole.quality_score.to_f).to eq(0.65)
     expect(agent_run.bundle_outcomes.sole.metrics.fetch("component_scores")).to eq("pr_created" => 0.0)
+  end
+
+  def expect_metric_summary(outcome)
+    expect(outcome.metrics).to include(
+      "component_scores" => { "pr_created" => 1.0 },
+      "execution_duration_seconds" => agent_run.duration_seconds,
+      "objective_score" => be_within(0.001).of(0.684),
+      "outcome" => "completed",
+      "quality_per_dollar" => be_within(0.001).of(0.56),
+      "queue_duration_seconds" => be_a(Integer),
+      "status" => "completed",
+      "success" => true,
+      "tokens_input" => agent_run.tokens_input,
+      "tokens_output" => agent_run.tokens_output,
+      "total_duration_seconds" => be_a(Integer)
+    )
+  end
+
+  def expect_metric_timestamps(outcome)
+    expect(outcome.metrics.fetch("created_at")).to eq(agent_run.created_at.iso8601)
+    expect(outcome.metrics.fetch("started_at")).to eq(agent_run.started_at.iso8601)
+    expect(outcome.metrics.fetch("completed_at")).to eq(agent_run.completed_at.iso8601)
   end
 end

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -240,6 +240,28 @@ RSpec.describe Activities::CreateAgentRunActivity do
       )
     end
 
+    it "recomputes the configuration bundle on resume when model selection metadata becomes available" do
+      existing_bundle = create(:configuration_bundle,
+        account: project.account,
+        definition: existing_create_pr_bundle_definition)
+      queued_run = create(:agent_run,
+        :queued,
+        project: project,
+        issue: issue,
+        provider: claude_provider,
+        agent_type: "claude_code",
+        configuration_bundle: existing_bundle)
+      llm_model = create(:llm_model, provider: "openai", model_id: "gpt-5.4")
+
+      stub_model_selection(llm_model: llm_model)
+
+      activity.execute(agent_run_id: queued_run.id)
+
+      queued_run.reload
+      expect(queued_run.configuration_bundle).not_to eq(existing_bundle)
+      expect_model_selection_bundle(queued_run.configuration_bundle)
+    end
+
     def existing_review_bundle_definition
       {
         "schema_version" => 1,
@@ -270,6 +292,27 @@ RSpec.describe Activities::CreateAgentRunActivity do
         provider: claude_provider,
         agent_type: "claude_code",
         configuration_bundle: bundle)
+    end
+
+    def stub_model_selection(llm_model:)
+      allow(Models::Select).to receive(:call) do |agent_run:|
+        create(:model_selection,
+          agent_run: agent_run,
+          llm_model: llm_model,
+          selector_type: "override",
+          tier: "high")
+      end
+    end
+
+    def expect_model_selection_bundle(bundle)
+      expect(bundle.definition).to include(
+        "model_selection" => hash_including(
+          "llm_model_id" => "gpt-5.4",
+          "llm_provider" => "openai",
+          "selector_type" => "override",
+          "tier" => "high"
+        )
+      )
     end
 
     it "fails fast when a resumed queued run refreshes to a provider now disabled for agent runs" do

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -205,9 +205,7 @@ RSpec.describe Activities::CreateAgentRunActivity do
     end
 
     it "preserves the existing configuration bundle on resume when provider selection is unchanged" do
-      existing_bundle = create(:configuration_bundle,
-        account: project.account,
-        definition: existing_create_pr_bundle_definition)
+      existing_bundle = create_runtime_bundle(existing_create_pr_bundle_definition)
       queued_run = create(:agent_run,
         :queued,
         project: project,
@@ -292,6 +290,26 @@ RSpec.describe Activities::CreateAgentRunActivity do
         provider: claude_provider,
         agent_type: "claude_code",
         configuration_bundle: bundle)
+    end
+
+    def create_runtime_bundle(definition)
+      assigner = ConfigurationBundles::AssignToRun.new(agent_run: build(:agent_run, project: project, issue: issue))
+      fingerprint = assigner.send(:bundle_fingerprint, definition)
+
+      create(:configuration_bundle,
+        account: project.account,
+        definition: definition,
+        fingerprint: fingerprint,
+        context: {
+          "identity" => {
+            "fingerprint" => fingerprint,
+            "fingerprint_algorithm" => "sha256",
+            "schema_version" => 1
+          }
+        },
+        name: "Runtime Bundle #{fingerprint.first(12)}",
+        status: "active",
+        strategy: "runtime_snapshot")
     end
 
     def stub_model_selection(llm_model:)


### PR DESCRIPTION
## Summary

This change makes configuration bundle tracking reliable from queueing through completion so optimization work can accurately join each agent run back to the bundle definition it actually used. It also expands the recorded outcome data so downstream analysis has explicit result, timing, cost, and token metrics instead of relying on partial runtime state.

## Changes

- **Configuration bundles**
  - Centralizes bundle fingerprint generation so bundle identity is computed in one place instead of being reconstructed inconsistently across run paths.
  - Stores stable identity metadata on runtime bundles to make bundle attribution durable and queryable after execution.

- **Queued agent run lifecycle**
  - Assigns a provisional configuration bundle before `ProcessRunQueueJob` can fail, ensuring queued runs are attributable even if they never reach full execution.
  - Recomputes the bundle when a queued run resumes so final model selection is reflected in the persisted bundle identity rather than freezing an incomplete early snapshot.

- **Outcome persistence**
  - Expands `ConfigurationBundles::RecordOutcome` to persist explicit outcome data.
  - Captures timing, cost, and token breakdown metrics needed for optimization and bundle-level performance analysis.

- **Specs**
  - Adds coverage for bundle assignment and outcome persistence paths tied to queued runs and final bundle recording.

## Design Decisions

- Bundle identity is intentionally computed twice for queued runs: once provisionally at queue processing time for failure attribution, and again on resume so late-bound model selection is included in the final fingerprint. This favors correctness of optimization data over treating the first computed bundle as authoritative.
- Fingerprint generation was centralized rather than duplicated across services to keep bundle identity stable as additional run paths or bundle fields are introduced.
- Outcome recording now stores explicit optimization metrics at the bundle layer so analysis does not have to infer results from loosely related run state.

## Operational Concerns

- No manual deployment steps are expected beyond shipping the code.
- `bundle exec rubocop` passes.
- `bundle exec rspec` could not be executed in this container because PostgreSQL is unavailable; the suite aborts during `spec/rails_helper.rb` with `ActiveRecord::ConnectionNotEstablished`. `ALLOW_DBLESS_SPECS=true` was also attempted, but the relevant specs are database-backed and remain pending.

---

Closes #1798