### PR TITLE
feat(optimization): build initial surrogate outcome model

### DIFF
--- a/app/services/configuration_bundles/bundle_fingerprinting.rb
+++ b/app/services/configuration_bundles/bundle_fingerprinting.rb
@@ -53,12 +53,7 @@ module ConfigurationBundles
     end
 
     def normalized_mcp_servers
-      servers = Array(agent_run.mcp_server_snapshot).filter_map do |snapshot|
-        next unless snapshot.is_a?(Hash)
-
-        canonicalize(snapshot)
-      end
-      servers = servers.sort_by { |snapshot| JSON.generate(snapshot) }
+      servers = super(agent_run.mcp_server_snapshot)
       servers if servers.any?
     end
   end

--- a/app/services/configuration_bundles/canonicalization.rb
+++ b/app/services/configuration_bundles/canonicalization.rb
@@ -16,5 +16,13 @@ module ConfigurationBundles
         value
       end
     end
+
+    def normalized_mcp_servers(source)
+      snapshots = source.is_a?(Hash) ? source["mcp_servers"] : source
+
+      Array(snapshots)
+        .filter_map { |snapshot| canonicalize(snapshot) if snapshot.is_a?(Hash) }
+        .sort_by { |snapshot| JSON.generate(snapshot) }
+    end
   end
 end

--- a/app/services/configuration_bundles/feature_extractor.rb
+++ b/app/services/configuration_bundles/feature_extractor.rb
@@ -27,6 +27,8 @@ module ConfigurationBundles
     end
 
     def extract(definition)
+      mcp_servers = normalized_mcp_servers(definition)
+
       FeatureVector.new(
         goal: definition["goal"],
         agent_type: definition["agent_type"],
@@ -36,11 +38,11 @@ module ConfigurationBundles
         model_selection: canonicalize(definition["model_selection"]),
         has_model_selection: definition["model_selection"].present?,
         has_custom_prompt: definition["custom_prompt_sha256"].present?,
-        has_mcp_servers: Array(definition["mcp_servers"]).any?,
+        has_mcp_servers: mcp_servers.any?,
         service_container_ids: Array(definition["service_container_ids"]).sort,
-        mcp_servers: normalized_mcp_servers(definition),
+        mcp_servers: mcp_servers,
         service_container_count: Array(definition["service_container_ids"]).size,
-        mcp_server_count: Array(definition["mcp_servers"]).size,
+        mcp_server_count: mcp_servers.size,
         experiment_features: extract_experiment_features(definition)
       )
     end
@@ -89,12 +91,6 @@ module ConfigurationBundles
       else
         value
       end
-    end
-
-    def normalized_mcp_servers(definition)
-      Array(definition["mcp_servers"])
-        .map { |snapshot| canonicalize(snapshot) }
-        .sort_by { |snapshot| JSON.generate(snapshot) }
     end
   end
 end

--- a/app/services/configuration_bundles/feature_extractor.rb
+++ b/app/services/configuration_bundles/feature_extractor.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ConfigurationBundles
+  class FeatureExtractor
+    include Canonicalization
+
+    FeatureVector = Struct.new(
+      :goal,
+      :agent_type,
+      :has_model_selection,
+      :has_custom_prompt,
+      :has_mcp_servers,
+      :service_container_count,
+      :mcp_server_count,
+      :experiment_features,
+      keyword_init: true
+    )
+
+    def self.call(bundle_definition)
+      new.extract(bundle_definition)
+    end
+
+    def extract(definition)
+      FeatureVector.new(
+        goal: definition["goal"],
+        agent_type: definition["agent_type"],
+        has_model_selection: definition["model_selection"].present?,
+        has_custom_prompt: definition["custom_prompt_sha256"].present?,
+        has_mcp_servers: Array(definition["mcp_servers"]).any?,
+        service_container_count: Array(definition["service_container_ids"]).size,
+        mcp_server_count: Array(definition["mcp_servers"]).size,
+        experiment_features: extract_experiment_features(definition)
+      )
+    end
+
+    private
+
+    def extract_experiment_features(definition)
+      definition.fetch("experiments", {}).each_with_object({}) do |(key, value), features|
+        features[key] = numeric_experiment_value(value)
+      end
+    end
+
+    def numeric_experiment_value(value)
+      case value
+      when Hash
+        raw = value.key?("value") ? value["value"] : value["configuration_experiment_variant_id"]
+        Float(raw, exception: false) || 0.0
+      when Numeric
+        value.to_f
+      else
+        Float(value, exception: false) || 0.0
+      end
+    end
+  end
+end

--- a/app/services/configuration_bundles/feature_extractor.rb
+++ b/app/services/configuration_bundles/feature_extractor.rb
@@ -50,8 +50,11 @@ module ConfigurationBundles
     private
 
     def extract_experiment_features(definition)
-      definition.fetch("experiments", {}).each_with_object({}) do |(key, value), features|
-        features[key] = experiment_feature_value(value)
+      experiments = definition.fetch("experiments", {})
+      return {} unless experiments.is_a?(Hash)
+
+      experiments.each_with_object({}) do |(key, value), features|
+        features[key.to_s] = experiment_feature_value(value)
       end
     end
 

--- a/app/services/configuration_bundles/feature_extractor.rb
+++ b/app/services/configuration_bundles/feature_extractor.rb
@@ -2,12 +2,20 @@
 
 module ConfigurationBundles
   class FeatureExtractor
+    include Canonicalization
+
     FeatureVector = Struct.new(
       :goal,
       :agent_type,
+      :provider_id,
+      :prompt_version_id,
+      :custom_prompt_sha256,
+      :model_selection,
       :has_model_selection,
       :has_custom_prompt,
       :has_mcp_servers,
+      :service_container_ids,
+      :mcp_servers,
       :service_container_count,
       :mcp_server_count,
       :experiment_features,
@@ -22,9 +30,15 @@ module ConfigurationBundles
       FeatureVector.new(
         goal: definition["goal"],
         agent_type: definition["agent_type"],
+        provider_id: definition["provider_id"],
+        prompt_version_id: definition["prompt_version_id"],
+        custom_prompt_sha256: definition["custom_prompt_sha256"],
+        model_selection: canonicalize(definition["model_selection"]),
         has_model_selection: definition["model_selection"].present?,
         has_custom_prompt: definition["custom_prompt_sha256"].present?,
         has_mcp_servers: Array(definition["mcp_servers"]).any?,
+        service_container_ids: Array(definition["service_container_ids"]).sort,
+        mcp_servers: normalized_mcp_servers(definition),
         service_container_count: Array(definition["service_container_ids"]).size,
         mcp_server_count: Array(definition["mcp_servers"]).size,
         experiment_features: extract_experiment_features(definition)
@@ -75,6 +89,12 @@ module ConfigurationBundles
       else
         value
       end
+    end
+
+    def normalized_mcp_servers(definition)
+      Array(definition["mcp_servers"])
+        .map { |snapshot| canonicalize(snapshot) }
+        .sort_by { |snapshot| JSON.generate(snapshot) }
     end
   end
 end

--- a/app/services/configuration_bundles/feature_extractor.rb
+++ b/app/services/configuration_bundles/feature_extractor.rb
@@ -2,8 +2,6 @@
 
 module ConfigurationBundles
   class FeatureExtractor
-    include Canonicalization
-
     FeatureVector = Struct.new(
       :goal,
       :agent_type,
@@ -37,19 +35,45 @@ module ConfigurationBundles
 
     def extract_experiment_features(definition)
       definition.fetch("experiments", {}).each_with_object({}) do |(key, value), features|
-        features[key] = numeric_experiment_value(value)
+        features[key] = experiment_feature_value(value)
       end
     end
 
-    def numeric_experiment_value(value)
+    def experiment_feature_value(value)
+      raw = if value.is_a?(Hash)
+        value.key?("value") ? value["value"] : value["configuration_experiment_variant_id"]
+      else
+        value
+      end
+
+      normalize_experiment_value(raw)
+    end
+
+    def normalize_experiment_value(value)
       case value
-      when Hash
-        raw = value.key?("value") ? value["value"] : value["configuration_experiment_variant_id"]
-        Float(raw, exception: false) || 0.0
       when Numeric
         value.to_f
+      when String
+        Float(value, exception: false) || value
+      when TrueClass, FalseClass, NilClass
+        value
+      when Array, Hash
+        JSON.generate(sort_nested_structure(value))
       else
-        Float(value, exception: false) || 0.0
+        Float(value, exception: false) || value.to_s
+      end
+    end
+
+    def sort_nested_structure(value)
+      case value
+      when Hash
+        value.keys.sort.each_with_object({}) do |key, normalized|
+          normalized[key] = sort_nested_structure(value[key])
+        end
+      when Array
+        value.map { |item| sort_nested_structure(item) }
+      else
+        value
       end
     end
   end

--- a/app/services/configuration_bundles/objective_score.rb
+++ b/app/services/configuration_bundles/objective_score.rb
@@ -26,6 +26,18 @@ module ConfigurationBundles
       new(...).call
     end
 
+    def self.from_outcome(outcome)
+      objective_score = outcome.metrics&.fetch("objective_score", nil)
+      return objective_score.to_f if objective_score.present?
+
+      call(
+        project: outcome.agent_run.project,
+        quality_score: outcome.quality_score,
+        cost_cents: outcome.cost_cents,
+        duration_seconds: outcome.duration_seconds
+      ).objective_score
+    end
+
     def call
       fitness = PromptEvolution::FitnessFunction.call(
         samples: [ sample ],

--- a/app/services/configuration_bundles/optimizer.rb
+++ b/app/services/configuration_bundles/optimizer.rb
@@ -36,11 +36,11 @@ module ConfigurationBundles
 
     EXPLORATION_WEIGHT = 0.4
 
-    attr_reader :agent_run, :surrogate_model
+    attr_reader :agent_run
 
     def initialize(agent_run:, surrogate_model: nil)
       @agent_run = agent_run
-      @surrogate_model = surrogate_model || trained_surrogate_model
+      @surrogate_model = surrogate_model
     end
 
     def self.call(...)
@@ -73,6 +73,10 @@ module ConfigurationBundles
     end
 
     private
+
+    def surrogate_model
+      @surrogate_model ||= trained_surrogate_model
+    end
 
     def score_candidate(variant_by_experiment_id)
       definition = bundle_definition(variant_by_experiment_id)

--- a/app/services/configuration_bundles/optimizer.rb
+++ b/app/services/configuration_bundles/optimizer.rb
@@ -261,11 +261,11 @@ module ConfigurationBundles
     end
 
     def prediction_objective_score(prediction)
-      prediction.respond_to?(:predicted_objective_score) ? prediction.predicted_objective_score : prediction.mean_objective_score
+      prediction.predicted_objective_score
     end
 
     def prediction_quality_score(prediction)
-      prediction.respond_to?(:predicted_quality_score) ? prediction.predicted_quality_score : prediction.mean_quality_score
+      prediction.predicted_quality_score
     end
 
     def bundle_definition(variant_by_experiment_id)

--- a/app/services/configuration_bundles/optimizer.rb
+++ b/app/services/configuration_bundles/optimizer.rb
@@ -40,7 +40,7 @@ module ConfigurationBundles
 
     def initialize(agent_run:, surrogate_model: nil)
       @agent_run = agent_run
-      @surrogate_model = surrogate_model || SurrogateModel.new(project: agent_run.project)
+      @surrogate_model = surrogate_model || trained_surrogate_model
     end
 
     def self.call(...)
@@ -77,16 +77,16 @@ module ConfigurationBundles
     def score_candidate(variant_by_experiment_id)
       definition = bundle_definition(variant_by_experiment_id)
       fingerprint = bundle_fingerprint(definition)
-      prediction = surrogate_model.predict(bundle_definition: definition, fingerprint: fingerprint)
-      acquisition_score = prediction.mean_objective_score + (EXPLORATION_WEIGHT * prediction.uncertainty)
+      prediction = surrogate_model.predict(bundle_definition: definition)
+      acquisition_score = prediction_objective_score(prediction) + (EXPLORATION_WEIGHT * prediction.uncertainty)
 
       Selection.new(
         definition: definition,
         fingerprint: fingerprint,
         variant_by_experiment_id: variant_by_experiment_id,
         score_inputs: ScoreInputs.new(
-          predicted_objective_score: prediction.mean_objective_score,
-          predicted_quality_score: prediction.mean_quality_score,
+          predicted_objective_score: prediction_objective_score(prediction),
+          predicted_quality_score: prediction_quality_score(prediction),
           uncertainty: prediction.uncertainty,
           sample_count: prediction.sample_count,
           acquisition_score: acquisition_score
@@ -245,6 +245,27 @@ module ConfigurationBundles
 
     def active_experiments_by_id
       @active_experiments_by_id ||= active_experiments.index_by(&:id)
+    end
+
+    def trained_surrogate_model
+      dataset = TrainingDataset.call(scope: surrogate_training_scope)
+      SurrogateOutcomeModel.train(dataset: dataset)
+    end
+
+    def surrogate_training_scope
+      BundleOutcome
+        .includes(:configuration_bundle, agent_run: :project)
+        .joins(agent_run: :project)
+        .where(agent_runs: { project_id: agent_run.project_id })
+        .where.not(quality_score: nil)
+    end
+
+    def prediction_objective_score(prediction)
+      prediction.respond_to?(:predicted_objective_score) ? prediction.predicted_objective_score : prediction.mean_objective_score
+    end
+
+    def prediction_quality_score(prediction)
+      prediction.respond_to?(:predicted_quality_score) ? prediction.predicted_quality_score : prediction.mean_quality_score
     end
 
     def bundle_definition(variant_by_experiment_id)

--- a/app/services/configuration_bundles/surrogate_model.rb
+++ b/app/services/configuration_bundles/surrogate_model.rb
@@ -171,22 +171,8 @@ module ConfigurationBundles
       canonicalize(value)
     end
 
-    def normalized_mcp_servers(definition)
-      Array(definition["mcp_servers"])
-        .map { |snapshot| canonicalize(snapshot) }
-        .sort_by { |snapshot| JSON.generate(snapshot) }
-    end
-
     def outcome_objective_score(outcome)
-      objective_score = outcome.metrics&.fetch("objective_score", nil)
-      return objective_score.to_f if objective_score.present?
-
-      ConfigurationBundles::ObjectiveScore.call(
-        project: outcome.agent_run.project,
-        quality_score: outcome.quality_score,
-        cost_cents: outcome.cost_cents,
-        duration_seconds: outcome.duration_seconds
-      ).objective_score
+      ConfigurationBundles::ObjectiveScore.from_outcome(outcome)
     end
 
     def similarity(lhs, rhs)

--- a/app/services/configuration_bundles/surrogate_outcome_model.rb
+++ b/app/services/configuration_bundles/surrogate_outcome_model.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+module ConfigurationBundles
+  class SurrogateOutcomeModel
+    Prediction = Struct.new(
+      :predicted_objective_score,
+      :predicted_quality_score,
+      :predicted_success_probability,
+      :predicted_cost_cents,
+      :predicted_duration_seconds,
+      :uncertainty,
+      :sample_count,
+      :trained_at,
+      keyword_init: true
+    )
+
+    TrainedState = Struct.new(
+      :rows,
+      :training_size,
+      :trained_at,
+      :global_mean_objective,
+      :global_mean_quality,
+      :global_success_rate,
+      keyword_init: true
+    )
+
+    PRIOR_MEAN = 0.5
+    PRIOR_WEIGHT = 1.0
+
+    attr_reader :trained_state
+
+    def initialize(trained_state: nil)
+      @trained_state = trained_state
+    end
+
+    def self.train(dataset:)
+      new.train(dataset:)
+    end
+
+    def self.call(bundle_definition:, trained_state:)
+      new(trained_state:).predict(bundle_definition:)
+    end
+
+    def train(dataset:)
+      rows = dataset.rows
+      @trained_state = if rows.empty?
+        empty_trained_state
+      else
+        total_weight = rows.sum(&:weight)
+        TrainedState.new(
+          rows: rows,
+          training_size: rows.size,
+          trained_at: Time.current,
+          global_mean_objective: weighted_mean(rows.map(&:objective_score), rows.map(&:weight), total_weight),
+          global_mean_quality: weighted_mean(rows.map(&:quality_score), rows.map(&:weight), total_weight),
+          global_success_rate: rows.count(&:success).to_f / rows.size
+        )
+      end
+
+      self
+    end
+
+    def predict(bundle_definition:)
+      return prior_prediction unless trained_state&.rows&.any?
+
+      query_features = FeatureExtractor.call(bundle_definition)
+      matches = find_matches(query_features)
+
+      return global_baseline_prediction if matches.empty?
+
+      weighted_prediction(query_features, matches)
+    end
+
+    def trained?
+      trained_state&.rows&.any? == true
+    end
+
+    private
+
+    def find_matches(query_features)
+      trained_state.rows.filter_map do |row|
+        similarity = compute_similarity(query_features, row.features)
+        next if similarity <= 0
+
+        { row: row, similarity: similarity }
+      end
+    end
+
+    def compute_similarity(query, historical)
+      return 0.0 unless query.goal == historical.goal
+
+      scores = [
+        boolean_similarity(query.agent_type, historical.agent_type),
+        boolean_similarity(query.has_model_selection, historical.has_model_selection),
+        boolean_similarity(query.has_custom_prompt, historical.has_custom_prompt),
+        boolean_similarity(query.has_mcp_servers, historical.has_mcp_servers)
+      ]
+
+      exp_sim = experiment_similarity(query.experiment_features, historical.experiment_features)
+      scores << exp_sim if exp_sim
+
+      scores.sum.to_f / scores.size
+    end
+
+    def boolean_similarity(query_val, historical_val)
+      query_val == historical_val ? 1.0 : 0.0
+    end
+
+    def experiment_similarity(query_experiments, historical_experiments)
+      all_keys = query_experiments.keys | historical_experiments.keys
+      return nil if all_keys.empty?
+
+      comparable = 0
+      similarity_sum = 0.0
+
+      all_keys.each do |key|
+        q_val = query_experiments[key]
+        h_val = historical_experiments[key]
+        next if q_val.nil? && h_val.nil?
+
+        comparable += 1
+        similarity_sum += if q_val.nil? || h_val.nil?
+          0.0
+        else
+          diff = (q_val - h_val).abs
+          range = [ q_val.abs, h_val.abs, 1.0 ].max
+          Math.exp(-diff / range)
+        end
+      end
+
+      return nil if comparable.zero?
+      similarity_sum / comparable
+    end
+
+    def weighted_prediction(_query_features, matches)
+      total_sim_weight = matches.sum { |m| m[:similarity] * m[:row].weight }
+      denom = PRIOR_WEIGHT + total_sim_weight
+
+      weighted_objective = matches.sum { |m| m[:similarity] * m[:row].weight * m[:row].objective_score }
+      weighted_quality = matches.sum { |m| m[:similarity] * m[:row].weight * m[:row].quality_score }
+      weighted_success = matches.sum { |m| m[:similarity] * m[:row].weight * (m[:row].success ? 1.0 : 0.0) }
+
+      Prediction.new(
+        predicted_objective_score: (PRIOR_MEAN * PRIOR_WEIGHT + weighted_objective) / denom,
+        predicted_quality_score: (PRIOR_MEAN * PRIOR_WEIGHT + weighted_quality) / denom,
+        predicted_success_probability: (PRIOR_MEAN * PRIOR_WEIGHT + weighted_success) / denom,
+        predicted_cost_cents: weighted_average(matches) { |m| m[:row].cost_cents },
+        predicted_duration_seconds: weighted_average(matches) { |m| m[:row].duration_seconds },
+        uncertainty: 1.0 / Math.sqrt(denom),
+        sample_count: total_sim_weight.round(4),
+        trained_at: trained_state.trained_at
+      )
+    end
+
+    def weighted_average(matches)
+      total_weight = matches.sum { |m| m[:similarity] * m[:row].weight }
+      return nil if total_weight.zero?
+
+      values = matches.filter_map { |m| yield(m).then { |v| v if v.to_i.positive? } }
+      weights = matches.filter_map { |m| yield(m).then { |v| m[:similarity] * m[:row].weight if v.to_i.positive? } }
+      return nil if weights.sum.zero?
+
+      values.zip(weights).sum { |v, w| v * w } / weights.sum
+    end
+
+    def prior_prediction
+      Prediction.new(
+        predicted_objective_score: PRIOR_MEAN,
+        predicted_quality_score: PRIOR_MEAN,
+        predicted_success_probability: PRIOR_MEAN,
+        predicted_cost_cents: nil,
+        predicted_duration_seconds: nil,
+        uncertainty: 1.0,
+        sample_count: 0.0,
+        trained_at: nil
+      )
+    end
+
+    def global_baseline_prediction
+      Prediction.new(
+        predicted_objective_score: trained_state.global_mean_objective,
+        predicted_quality_score: trained_state.global_mean_quality,
+        predicted_success_probability: trained_state.global_success_rate,
+        predicted_cost_cents: nil,
+        predicted_duration_seconds: nil,
+        uncertainty: 1.0,
+        sample_count: 0.0,
+        trained_at: trained_state.trained_at
+      )
+    end
+
+    def empty_trained_state
+      TrainedState.new(
+        rows: [],
+        training_size: 0,
+        trained_at: Time.current,
+        global_mean_objective: nil,
+        global_mean_quality: nil,
+        global_success_rate: nil
+      )
+    end
+
+    def weighted_mean(values, weights, total_weight = nil)
+      total = total_weight || weights.sum
+      return PRIOR_MEAN if total.zero?
+
+      values.zip(weights).sum { |v, w| v * w } / total
+    end
+  end
+end

--- a/app/services/configuration_bundles/surrogate_outcome_model.rb
+++ b/app/services/configuration_bundles/surrogate_outcome_model.rb
@@ -30,7 +30,7 @@ module ConfigurationBundles
     attr_reader :trained_state
 
     def initialize(trained_state: nil)
-      @trained_state = trained_state
+      @trained_state = self.class.deserialize_trained_state(trained_state)
     end
 
     def self.train(dataset:)
@@ -39,6 +39,50 @@ module ConfigurationBundles
 
     def self.call(bundle_definition:, trained_state:)
       new(trained_state:).predict(bundle_definition:)
+    end
+
+    def self.serialize_trained_state(trained_state)
+      state = deserialize_trained_state(trained_state)
+      return if state.nil?
+
+      {
+        rows: state.rows.map do |row|
+          {
+            features: serialize_features(row.features),
+            quality_score: row.quality_score,
+            objective_score: row.objective_score,
+            success: row.success,
+            cost_cents: row.cost_cents,
+            duration_seconds: row.duration_seconds,
+            tokens_used: row.tokens_used,
+            weight: row.weight
+          }
+        end,
+        training_size: state.training_size,
+        trained_at: state.trained_at&.iso8601(9),
+        global_mean_objective: state.global_mean_objective,
+        global_mean_quality: state.global_mean_quality,
+        global_success_rate: state.global_success_rate
+      }
+    end
+
+    def self.deserialize_trained_state(trained_state)
+      case trained_state
+      when nil, TrainedState
+        trained_state
+      when Hash
+        state_hash = trained_state.deep_stringify_keys
+        TrainedState.new(
+          rows: Array(state_hash["rows"]).map { |row| deserialize_row(row) },
+          training_size: state_hash["training_size"],
+          trained_at: deserialize_time(state_hash["trained_at"]),
+          global_mean_objective: state_hash["global_mean_objective"],
+          global_mean_quality: state_hash["global_mean_quality"],
+          global_success_rate: state_hash["global_success_rate"]
+        )
+      else
+        raise ArgumentError, "unsupported trained_state payload: #{trained_state.class.name}"
+      end
     end
 
     def train(dataset:)
@@ -76,6 +120,68 @@ module ConfigurationBundles
     end
 
     private
+
+    def self.serialize_features(features)
+      {
+        goal: features.goal,
+        agent_type: features.agent_type,
+        provider_id: features.provider_id,
+        prompt_version_id: features.prompt_version_id,
+        custom_prompt_sha256: features.custom_prompt_sha256,
+        model_selection: features.model_selection,
+        has_model_selection: features.has_model_selection,
+        has_custom_prompt: features.has_custom_prompt,
+        has_mcp_servers: features.has_mcp_servers,
+        service_container_ids: features.service_container_ids,
+        mcp_servers: features.mcp_servers,
+        service_container_count: features.service_container_count,
+        mcp_server_count: features.mcp_server_count,
+        experiment_features: features.experiment_features
+      }
+    end
+
+    def self.deserialize_row(row)
+      row_hash = row.deep_stringify_keys
+
+      TrainingDataset::Row.new(
+        features: deserialize_features(row_hash["features"]),
+        quality_score: row_hash["quality_score"],
+        objective_score: row_hash["objective_score"],
+        success: row_hash["success"],
+        cost_cents: row_hash["cost_cents"],
+        duration_seconds: row_hash["duration_seconds"],
+        tokens_used: row_hash["tokens_used"],
+        weight: row_hash["weight"]
+      )
+    end
+
+    def self.deserialize_features(features)
+      feature_hash = features.deep_stringify_keys
+
+      FeatureExtractor::FeatureVector.new(
+        goal: feature_hash["goal"],
+        agent_type: feature_hash["agent_type"],
+        provider_id: feature_hash["provider_id"],
+        prompt_version_id: feature_hash["prompt_version_id"],
+        custom_prompt_sha256: feature_hash["custom_prompt_sha256"],
+        model_selection: feature_hash["model_selection"],
+        has_model_selection: feature_hash["has_model_selection"],
+        has_custom_prompt: feature_hash["has_custom_prompt"],
+        has_mcp_servers: feature_hash["has_mcp_servers"],
+        service_container_ids: feature_hash["service_container_ids"],
+        mcp_servers: feature_hash["mcp_servers"],
+        service_container_count: feature_hash["service_container_count"],
+        mcp_server_count: feature_hash["mcp_server_count"],
+        experiment_features: feature_hash["experiment_features"] || {}
+      )
+    end
+
+    def self.deserialize_time(value)
+      return value if value.is_a?(Time)
+      return if value.blank?
+
+      Time.iso8601(value)
+    end
 
     def find_matches(query_features)
       trained_state.rows.filter_map do |row|

--- a/app/services/configuration_bundles/surrogate_outcome_model.rb
+++ b/app/services/configuration_bundles/surrogate_outcome_model.rb
@@ -119,17 +119,23 @@ module ConfigurationBundles
         next if q_val.nil? && h_val.nil?
 
         comparable += 1
-        similarity_sum += if q_val.nil? || h_val.nil?
-          0.0
-        else
-          diff = (q_val - h_val).abs
-          range = [ q_val.abs, h_val.abs, 1.0 ].max
-          Math.exp(-diff / range)
-        end
+        similarity_sum += experiment_value_similarity(q_val, h_val)
       end
 
       return nil if comparable.zero?
       similarity_sum / comparable
+    end
+
+    def experiment_value_similarity(query_value, historical_value)
+      return 0.0 if query_value.nil? || historical_value.nil?
+
+      if query_value.is_a?(Numeric) && historical_value.is_a?(Numeric)
+        diff = (query_value - historical_value).abs
+        range = [ query_value.abs, historical_value.abs, 1.0 ].max
+        return Math.exp(-diff / range)
+      end
+
+      query_value == historical_value ? 1.0 : 0.0
     end
 
     def weighted_prediction(_query_features, matches)

--- a/app/services/configuration_bundles/surrogate_outcome_model.rb
+++ b/app/services/configuration_bundles/surrogate_outcome_model.rb
@@ -169,7 +169,12 @@ module ConfigurationBundles
     end
 
     def weighted_average(matches)
-      pairs = matches.filter_map { |m| yield(m).then { |v| [ v, m[:similarity] * m[:row].weight ] if v.to_i.positive? } }
+      pairs = matches.filter_map do |match|
+        value = yield(match)
+        next if value.nil?
+
+        [ value, match[:similarity] * match[:row].weight ]
+      end
       return nil if pairs.empty?
 
       pairs.sum { |v, w| v * w } / pairs.sum { |_v, w| w }

--- a/app/services/configuration_bundles/surrogate_outcome_model.rb
+++ b/app/services/configuration_bundles/surrogate_outcome_model.rb
@@ -66,7 +66,7 @@ module ConfigurationBundles
       query_features = FeatureExtractor.call(bundle_definition)
       matches = find_matches(query_features)
 
-      return global_baseline_prediction if matches.empty?
+      return goal_baseline_prediction(query_features.goal) if matches.empty?
 
       weighted_prediction(query_features, matches)
     end
@@ -193,17 +193,28 @@ module ConfigurationBundles
       )
     end
 
-    def global_baseline_prediction
+    def goal_baseline_prediction(goal)
+      goal_rows = trained_state.rows.select { |row| row.features.goal == goal }
+      return prior_prediction_for_trained_state if goal_rows.empty?
+
+      total_weight = goal_rows.sum(&:weight)
+
       Prediction.new(
-        predicted_objective_score: trained_state.global_mean_objective,
-        predicted_quality_score: trained_state.global_mean_quality,
-        predicted_success_probability: trained_state.global_success_rate,
+        predicted_objective_score: weighted_mean(goal_rows.map(&:objective_score), goal_rows.map(&:weight), total_weight),
+        predicted_quality_score: weighted_mean(goal_rows.map(&:quality_score), goal_rows.map(&:weight), total_weight),
+        predicted_success_probability: weighted_mean(goal_rows.map { |row| row.success ? 1.0 : 0.0 }, goal_rows.map(&:weight), total_weight),
         predicted_cost_cents: nil,
         predicted_duration_seconds: nil,
         uncertainty: 1.0,
         sample_count: 0.0,
         trained_at: trained_state.trained_at
       )
+    end
+
+    def prior_prediction_for_trained_state
+      prior_prediction.dup.tap do |prediction|
+        prediction.trained_at = trained_state.trained_at
+      end
     end
 
     def empty_trained_state

--- a/app/services/configuration_bundles/surrogate_outcome_model.rb
+++ b/app/services/configuration_bundles/surrogate_outcome_model.rb
@@ -53,7 +53,7 @@ module ConfigurationBundles
           trained_at: Time.current,
           global_mean_objective: weighted_mean(rows.map(&:objective_score), rows.map(&:weight), total_weight),
           global_mean_quality: weighted_mean(rows.map(&:quality_score), rows.map(&:weight), total_weight),
-          global_success_rate: rows.count(&:success).to_f / rows.size
+          global_success_rate: weighted_mean(rows.map { |r| r.success ? 1.0 : 0.0 }, rows.map(&:weight), total_weight)
         )
       end
 
@@ -169,14 +169,10 @@ module ConfigurationBundles
     end
 
     def weighted_average(matches)
-      total_weight = matches.sum { |m| m[:similarity] * m[:row].weight }
-      return nil if total_weight.zero?
+      pairs = matches.filter_map { |m| yield(m).then { |v| [ v, m[:similarity] * m[:row].weight ] if v.to_i.positive? } }
+      return nil if pairs.empty?
 
-      values = matches.filter_map { |m| yield(m).then { |v| v if v.to_i.positive? } }
-      weights = matches.filter_map { |m| yield(m).then { |v| m[:similarity] * m[:row].weight if v.to_i.positive? } }
-      return nil if weights.sum.zero?
-
-      values.zip(weights).sum { |v, w| v * w } / weights.sum
+      pairs.sum { |v, w| v * w } / pairs.sum { |_v, w| w }
     end
 
     def prior_prediction

--- a/app/services/configuration_bundles/surrogate_outcome_model.rb
+++ b/app/services/configuration_bundles/surrogate_outcome_model.rb
@@ -79,6 +79,8 @@ module ConfigurationBundles
 
     def find_matches(query_features)
       trained_state.rows.filter_map do |row|
+        next unless compatible_context?(query_features, row.features)
+
         similarity = compute_similarity(query_features, row.features)
         next if similarity <= 0
 
@@ -86,9 +88,17 @@ module ConfigurationBundles
       end
     end
 
-    def compute_similarity(query, historical)
-      return 0.0 unless query.goal == historical.goal
+    def compatible_context?(query, historical)
+      query.goal == historical.goal &&
+        query.provider_id == historical.provider_id &&
+        query.prompt_version_id == historical.prompt_version_id &&
+        query.custom_prompt_sha256 == historical.custom_prompt_sha256 &&
+        query.model_selection == historical.model_selection &&
+        query.service_container_ids == historical.service_container_ids &&
+        query.mcp_servers == historical.mcp_servers
+    end
 
+    def compute_similarity(query, historical)
       scores = [
         boolean_similarity(query.agent_type, historical.agent_type),
         boolean_similarity(query.has_model_selection, historical.has_model_selection),

--- a/app/services/configuration_bundles/training_dataset.rb
+++ b/app/services/configuration_bundles/training_dataset.rb
@@ -52,9 +52,9 @@ module ConfigurationBundles
           quality_score: outcome.quality_score.to_f,
           objective_score: objective_score,
           success: outcome.success,
-          cost_cents: outcome.cost_cents.to_i,
-          duration_seconds: outcome.duration_seconds.to_i,
-          tokens_used: outcome.tokens_used.to_i,
+          cost_cents: outcome.cost_cents,
+          duration_seconds: outcome.duration_seconds,
+          tokens_used: outcome.tokens_used,
           weight: recency_weight(outcome)
         )
       end

--- a/app/services/configuration_bundles/training_dataset.rb
+++ b/app/services/configuration_bundles/training_dataset.rb
@@ -72,15 +72,7 @@ module ConfigurationBundles
     end
 
     def extract_objective_score(outcome)
-      stored = outcome.metrics&.fetch("objective_score", nil)
-      return stored.to_f if stored.present?
-
-      ConfigurationBundles::ObjectiveScore.call(
-        project: outcome.agent_run.project,
-        quality_score: outcome.quality_score,
-        cost_cents: outcome.cost_cents,
-        duration_seconds: outcome.duration_seconds
-      ).objective_score
+      ConfigurationBundles::ObjectiveScore.from_outcome(outcome)
     end
   end
 end

--- a/app/services/configuration_bundles/training_dataset.rb
+++ b/app/services/configuration_bundles/training_dataset.rb
@@ -38,7 +38,11 @@ module ConfigurationBundles
       rows = []
       feature_names = Set.new
 
-      scope.includes(:configuration_bundle, agent_run: :project).order(created_at: :desc).limit(MAX_ROWS).each do |outcome|
+      scope
+        .preload(:configuration_bundle, agent_run: :project)
+        .order(BundleOutcome.arel_table[:created_at].desc)
+        .limit(MAX_ROWS)
+        .each do |outcome|
         definition = outcome.configuration_bundle&.definition
         next unless definition.is_a?(Hash)
 
@@ -57,7 +61,7 @@ module ConfigurationBundles
           tokens_used: outcome.tokens_used,
           weight: recency_weight(outcome)
         )
-      end
+        end
 
       Dataset.new(rows: rows, feature_names: feature_names.to_a.sort, size: rows.size)
     end

--- a/app/services/configuration_bundles/training_dataset.rb
+++ b/app/services/configuration_bundles/training_dataset.rb
@@ -38,7 +38,7 @@ module ConfigurationBundles
       rows = []
       feature_names = Set.new
 
-      scope.order(created_at: :desc).limit(MAX_ROWS).each do |outcome|
+      scope.includes(:configuration_bundle, agent_run: :project).order(created_at: :desc).limit(MAX_ROWS).each do |outcome|
         definition = outcome.configuration_bundle&.definition
         next unless definition.is_a?(Hash)
 

--- a/app/services/configuration_bundles/training_dataset.rb
+++ b/app/services/configuration_bundles/training_dataset.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module ConfigurationBundles
+  class TrainingDataset
+    Row = Struct.new(
+      :features,
+      :quality_score,
+      :objective_score,
+      :success,
+      :cost_cents,
+      :duration_seconds,
+      :tokens_used,
+      :weight,
+      keyword_init: true
+    )
+
+    Dataset = Struct.new(
+      :rows,
+      :feature_names,
+      :size,
+      keyword_init: true
+    )
+
+    MAX_ROWS = 500
+    RECENCY_DECAY_HALF_LIFE_SECONDS = 30.days.to_i
+
+    attr_reader :scope
+
+    def initialize(scope:)
+      @scope = scope
+    end
+
+    def self.call(...)
+      new(...).build
+    end
+
+    def build
+      rows = []
+      feature_names = Set.new
+
+      scope.order(created_at: :desc).limit(MAX_ROWS).each do |outcome|
+        definition = outcome.configuration_bundle&.definition
+        next unless definition.is_a?(Hash)
+
+        features = FeatureExtractor.call(definition)
+        objective_score = extract_objective_score(outcome)
+
+        features.experiment_features.each_key { |key| feature_names.add(key) }
+
+        rows << Row.new(
+          features: features,
+          quality_score: outcome.quality_score.to_f,
+          objective_score: objective_score,
+          success: outcome.success,
+          cost_cents: outcome.cost_cents.to_i,
+          duration_seconds: outcome.duration_seconds.to_i,
+          tokens_used: outcome.tokens_used.to_i,
+          weight: recency_weight(outcome)
+        )
+      end
+
+      Dataset.new(rows: rows, feature_names: feature_names.to_a.sort, size: rows.size)
+    end
+
+    private
+
+    def recency_weight(outcome)
+      return 1.0 if outcome.created_at.nil?
+
+      age = Time.current - outcome.created_at
+      Math.exp(-Math.log(2) * age / RECENCY_DECAY_HALF_LIFE_SECONDS)
+    end
+
+    def extract_objective_score(outcome)
+      stored = outcome.metrics&.fetch("objective_score", nil)
+      return stored.to_f if stored.present?
+
+      ConfigurationBundles::ObjectiveScore.call(
+        project: outcome.agent_run.project,
+        quality_score: outcome.quality_score,
+        cost_cents: outcome.cost_cents,
+        duration_seconds: outcome.duration_seconds
+      ).objective_score
+    end
+  end
+end

--- a/spec/services/configuration_bundles/feature_extractor_spec.rb
+++ b/spec/services/configuration_bundles/feature_extractor_spec.rb
@@ -165,5 +165,17 @@ RSpec.describe ConfigurationBundles::FeatureExtractor, :no_db do
 
       expect(features.experiment_features).to eq({})
     end
+
+    it "ignores malformed experiment payloads" do
+      features = described_class.call({ "experiments" => [ "not", "a", "hash" ] })
+
+      expect(features.experiment_features).to eq({})
+    end
+
+    it "stringifies experiment keys for stable matching" do
+      features = described_class.call({ "experiments" => { numeric_key: 4000 } })
+
+      expect(features.experiment_features).to eq("numeric_key" => 4000.0)
+    end
   end
 end

--- a/spec/services/configuration_bundles/feature_extractor_spec.rb
+++ b/spec/services/configuration_bundles/feature_extractor_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ConfigurationBundles::FeatureExtractor, :no_db do
       expect(features.experiment_features).to eq("knowledge.token_budget" => 99.0)
     end
 
-    it "returns 0.0 for non-numeric experiment values" do
+    it "preserves non-numeric scalar experiment values" do
       definition = {
         "experiments" => {
           "bad_key" => { "value" => "not-a-number" }
@@ -90,7 +90,7 @@ RSpec.describe ConfigurationBundles::FeatureExtractor, :no_db do
 
       features = described_class.call(definition)
 
-      expect(features.experiment_features).to eq("bad_key" => 0.0)
+      expect(features.experiment_features).to eq("bad_key" => "not-a-number")
     end
 
     it "handles raw numeric experiment values" do
@@ -99,6 +99,20 @@ RSpec.describe ConfigurationBundles::FeatureExtractor, :no_db do
       features = described_class.call(definition)
 
       expect(features.experiment_features).to eq("numeric_key" => 4000.0)
+    end
+
+    it "stably encodes structured experiment values" do
+      definition = {
+        "experiments" => {
+          "knowledge.section_order" => { "value" => [ "summary", "tests", "implementation" ] }
+        }
+      }
+
+      features = described_class.call(definition)
+
+      expect(features.experiment_features).to eq(
+        "knowledge.section_order" => "[\"summary\",\"tests\",\"implementation\"]"
+      )
     end
 
     it "returns an empty experiments hash when none are defined" do

--- a/spec/services/configuration_bundles/feature_extractor_spec.rb
+++ b/spec/services/configuration_bundles/feature_extractor_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConfigurationBundles::FeatureExtractor, :no_db do
+  describe ".call" do
+    it "extracts categorical features from a bundle definition" do
+      definition = {
+        "schema_version" => 1,
+        "goal" => "create_pr",
+        "agent_type" => "claude_code"
+      }
+
+      features = described_class.call(definition)
+
+      expect(features.goal).to eq("create_pr")
+      expect(features.agent_type).to eq("claude_code")
+    end
+
+    it "detects the presence of a model selection" do
+      with_model = { "model_selection" => { "llm_model_id" => "gpt-4" } }
+      without_model = { "model_selection" => nil }
+
+      expect(described_class.call(with_model).has_model_selection).to be(true)
+      expect(described_class.call(without_model).has_model_selection).to be(false)
+    end
+
+    it "detects the presence of a custom prompt" do
+      with_prompt = { "custom_prompt_sha256" => "abc123" }
+      without_prompt = { "custom_prompt_sha256" => nil }
+
+      expect(described_class.call(with_prompt).has_custom_prompt).to be(true)
+      expect(described_class.call(without_prompt).has_custom_prompt).to be(false)
+    end
+
+    it "counts service containers and MCP servers" do
+      definition = {
+        "service_container_ids" => [ 1, 2, 3 ],
+        "mcp_servers" => [ { "name" => "server1" }, { "name" => "server2" } ]
+      }
+
+      features = described_class.call(definition)
+
+      expect(features.service_container_count).to eq(3)
+      expect(features.mcp_server_count).to eq(2)
+    end
+
+    it "returns zero counts for missing arrays" do
+      features = described_class.call({})
+
+      expect(features.service_container_count).to eq(0)
+      expect(features.mcp_server_count).to eq(0)
+      expect(features.has_mcp_servers).to be(false)
+    end
+
+    it "extracts experiment features as numeric values" do
+      definition = {
+        "experiments" => {
+          "knowledge.token_budget" => { "value" => 8000 },
+          "some.other_key" => { "value" => 42.5 }
+        }
+      }
+
+      features = described_class.call(definition)
+
+      expect(features.experiment_features).to eq(
+        "knowledge.token_budget" => 8000.0,
+        "some.other_key" => 42.5
+      )
+    end
+
+    it "falls back to variant ID when value key is absent" do
+      definition = {
+        "experiments" => {
+          "knowledge.token_budget" => { "configuration_experiment_variant_id" => 99 }
+        }
+      }
+
+      features = described_class.call(definition)
+
+      expect(features.experiment_features).to eq("knowledge.token_budget" => 99.0)
+    end
+
+    it "returns 0.0 for non-numeric experiment values" do
+      definition = {
+        "experiments" => {
+          "bad_key" => { "value" => "not-a-number" }
+        }
+      }
+
+      features = described_class.call(definition)
+
+      expect(features.experiment_features).to eq("bad_key" => 0.0)
+    end
+
+    it "handles raw numeric experiment values" do
+      definition = { "experiments" => { "numeric_key" => 4000 } }
+
+      features = described_class.call(definition)
+
+      expect(features.experiment_features).to eq("numeric_key" => 4000.0)
+    end
+
+    it "returns an empty experiments hash when none are defined" do
+      features = described_class.call({ "goal" => "create_pr" })
+
+      expect(features.experiment_features).to eq({})
+    end
+  end
+end

--- a/spec/services/configuration_bundles/feature_extractor_spec.rb
+++ b/spec/services/configuration_bundles/feature_extractor_spec.rb
@@ -8,13 +8,19 @@ RSpec.describe ConfigurationBundles::FeatureExtractor, :no_db do
       definition = {
         "schema_version" => 1,
         "goal" => "create_pr",
-        "agent_type" => "claude_code"
+        "agent_type" => "claude_code",
+        "provider_id" => "openai",
+        "prompt_version_id" => "pv_123",
+        "custom_prompt_sha256" => "abc123"
       }
 
       features = described_class.call(definition)
 
       expect(features.goal).to eq("create_pr")
       expect(features.agent_type).to eq("claude_code")
+      expect(features.provider_id).to eq("openai")
+      expect(features.prompt_version_id).to eq("pv_123")
+      expect(features.custom_prompt_sha256).to eq("abc123")
     end
 
     it "detects the presence of a model selection" do
@@ -23,6 +29,26 @@ RSpec.describe ConfigurationBundles::FeatureExtractor, :no_db do
 
       expect(described_class.call(with_model).has_model_selection).to be(true)
       expect(described_class.call(without_model).has_model_selection).to be(false)
+    end
+
+    it "preserves canonicalized model selection and exact sidecar definitions" do
+      definition = {
+        "model_selection" => { "provider" => "openai", "model" => "gpt-5" },
+        "service_container_ids" => [ 3, 1, 2 ],
+        "mcp_servers" => [
+          { "config" => { "path" => "/tmp/z", "mode" => "read" }, "name" => "zeta" },
+          { "name" => "alpha", "config" => { "mode" => "write", "path" => "/tmp/a" } }
+        ]
+      }
+
+      features = described_class.call(definition)
+
+      expect(features.model_selection).to eq({ "model" => "gpt-5", "provider" => "openai" })
+      expect(features.service_container_ids).to eq([ 1, 2, 3 ])
+      expect(features.mcp_servers).to eq([
+        { "config" => { "mode" => "read", "path" => "/tmp/z" }, "name" => "zeta" },
+        { "config" => { "mode" => "write", "path" => "/tmp/a" }, "name" => "alpha" }
+      ])
     end
 
     it "detects the presence of a custom prompt" do

--- a/spec/services/configuration_bundles/feature_extractor_spec.rb
+++ b/spec/services/configuration_bundles/feature_extractor_spec.rb
@@ -79,6 +79,25 @@ RSpec.describe ConfigurationBundles::FeatureExtractor, :no_db do
       expect(features.has_mcp_servers).to be(false)
     end
 
+    it "drops non-hash MCP server snapshots while preserving canonical ordering" do
+      definition = {
+        "mcp_servers" => [
+          "invalid",
+          { "name" => "zeta", "config" => { "path" => "/tmp/z", "mode" => "read" } },
+          { "config" => { "mode" => "write", "path" => "/tmp/a" }, "name" => "alpha" }
+        ]
+      }
+
+      features = described_class.call(definition)
+
+      expect(features.mcp_servers).to eq([
+        { "config" => { "mode" => "read", "path" => "/tmp/z" }, "name" => "zeta" },
+        { "config" => { "mode" => "write", "path" => "/tmp/a" }, "name" => "alpha" }
+      ])
+      expect(features.has_mcp_servers).to be(true)
+      expect(features.mcp_server_count).to eq(2)
+    end
+
     it "extracts experiment features as numeric values" do
       definition = {
         "experiments" => {

--- a/spec/services/configuration_bundles/objective_score_spec.rb
+++ b/spec/services/configuration_bundles/objective_score_spec.rb
@@ -2,9 +2,30 @@
 
 require "rails_helper"
 
-RSpec.describe ConfigurationBundles::ObjectiveScore do
+RSpec.describe ConfigurationBundles::ObjectiveScore, :no_db do
+  describe ".from_outcome" do
+    it "returns the stored objective score when metrics already include it" do
+      outcome = double(metrics: { "objective_score" => "0.72" })
+
+      expect(described_class.from_outcome(outcome)).to eq(0.72)
+    end
+
+    it "computes the objective score from the outcome when metrics are missing it" do
+      project = double(fitness_settings: nil)
+      agent_run = double(project: project)
+      outcome = double(
+        metrics: nil,
+        agent_run: agent_run,
+        quality_score: 0.8,
+        cost_cents: 50,
+        duration_seconds: 600)
+
+      expect(described_class.from_outcome(outcome)).to be_within(0.001).of(0.7133)
+    end
+  end
+
   it "returns a cost-aware objective and a measurable quality-per-dollar ratio" do
-    project = create(:project)
+    project = double(fitness_settings: nil)
 
     result = described_class.call(
       project: project,
@@ -20,8 +41,7 @@ RSpec.describe ConfigurationBundles::ObjectiveScore do
   end
 
   it "respects optimizer-specific weights and references from project settings" do
-    project = create(:project)
-    project.update!(fitness_settings: {
+    project = double(fitness_settings: {
       "configuration_bundle_optimizer" => {
         "weights" => { "quality" => 1.0, "cost" => 0.0, "speed" => 0.0 },
         "reference_cost_cents" => 500,

--- a/spec/services/configuration_bundles/optimizer_spec.rb
+++ b/spec/services/configuration_bundles/optimizer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ConfigurationBundles::Optimizer do
   let(:project) { create(:project) }
   let(:agent_run) { create(:agent_run, project: project, issue: create(:issue, project: project)) }
-  let(:surrogate_model) { instance_double(ConfigurationBundles::SurrogateModel) }
+  let(:surrogate_model) { instance_double(ConfigurationBundles::SurrogateOutcomeModel) }
   let(:experiment) do
     create(:configuration_experiment,
       account: project.account,
@@ -280,20 +280,26 @@ RSpec.describe ConfigurationBundles::Optimizer do
 
   def prediction_for(mode)
     if mode == :exploitative
-      ConfigurationBundles::SurrogateModel::Prediction.new(
-        mean_objective_score: 0.82,
-        mean_quality_score: 0.82,
+      ConfigurationBundles::SurrogateOutcomeModel::Prediction.new(
+        predicted_objective_score: 0.82,
+        predicted_quality_score: 0.82,
+        predicted_success_probability: 0.9,
+        predicted_cost_cents: 50,
+        predicted_duration_seconds: 120,
         uncertainty: 0.01,
         sample_count: 4,
-        matched_outcomes: 4
+        trained_at: Time.current
       )
     else
-      ConfigurationBundles::SurrogateModel::Prediction.new(
-        mean_objective_score: 0.72,
-        mean_quality_score: 0.72,
+      ConfigurationBundles::SurrogateOutcomeModel::Prediction.new(
+        predicted_objective_score: 0.72,
+        predicted_quality_score: 0.72,
+        predicted_success_probability: 0.6,
+        predicted_cost_cents: 80,
+        predicted_duration_seconds: 180,
         uncertainty: 0.35,
         sample_count: 1,
-        matched_outcomes: 1
+        trained_at: Time.current
       )
     end
   end

--- a/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
+++ b/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
       expect(prediction.predicted_duration_seconds).to be_within(1).of(400)
     end
 
-    it "returns nil cost and duration when no matches have positive values" do
+    it "preserves zero-valued cost and duration estimates" do
       rows = [
         build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.8,
                   cost_cents: 0, duration_seconds: 0)
@@ -264,8 +264,8 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
 
       prediction = model.predict(bundle_definition: bundle_definition)
 
-      expect(prediction.predicted_cost_cents).to be_nil
-      expect(prediction.predicted_duration_seconds).to be_nil
+      expect(prediction.predicted_cost_cents).to eq(0)
+      expect(prediction.predicted_duration_seconds).to eq(0)
     end
 
     it "predicts success probability from historical outcomes" do

--- a/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
+++ b/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
@@ -4,15 +4,23 @@ require "rails_helper"
 
 RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
   def build_row(goal:, agent_type:, quality_score:, experiment_features: {}, success: true,
-                cost_cents: 40, duration_seconds: 120, weight: 1.0, objective_score: nil)
+                cost_cents: 40, duration_seconds: 120, weight: 1.0, objective_score: nil,
+                provider_id: nil, prompt_version_id: nil, custom_prompt_sha256: nil,
+                model_selection: nil, service_container_ids: [], mcp_servers: [])
     features = ConfigurationBundles::FeatureExtractor::FeatureVector.new(
       goal: goal,
       agent_type: agent_type,
-      has_model_selection: false,
-      has_custom_prompt: false,
-      has_mcp_servers: false,
-      service_container_count: 0,
-      mcp_server_count: 0,
+      provider_id: provider_id,
+      prompt_version_id: prompt_version_id,
+      custom_prompt_sha256: custom_prompt_sha256,
+      model_selection: model_selection,
+      has_model_selection: model_selection.present?,
+      has_custom_prompt: custom_prompt_sha256.present?,
+      has_mcp_servers: mcp_servers.any?,
+      service_container_ids: service_container_ids,
+      mcp_servers: mcp_servers,
+      service_container_count: service_container_ids.size,
+      mcp_server_count: mcp_servers.size,
       experiment_features: experiment_features
     )
     objective_score ||= quality_score * 0.9
@@ -36,17 +44,45 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
     )
   end
 
-  def bundle_definition(goal: "create_pr", agent_type: "claude_code", experiments: {})
+  def bundle_definition(goal: "create_pr", agent_type: "claude_code", experiments: {},
+                        provider_id: nil, prompt_version_id: nil, custom_prompt_sha256: nil,
+                        model_selection: nil, service_container_ids: [], mcp_servers: [])
     {
       "schema_version" => 1,
       "goal" => goal,
       "agent_type" => agent_type,
+      "provider_id" => provider_id,
+      "prompt_version_id" => prompt_version_id,
+      "custom_prompt_sha256" => custom_prompt_sha256,
+      "model_selection" => model_selection,
+      "service_container_ids" => service_container_ids,
+      "mcp_servers" => mcp_servers,
       "experiments" => experiments
     }
   end
 
   def section_order_experiment(*sections)
     { "knowledge.section_order" => { "value" => sections } }
+  end
+
+  def openai_bundle_identity
+    {
+      provider_id: "openai",
+      prompt_version_id: "prompt-v1",
+      model_selection: { "provider" => "openai", "model" => "gpt-5" },
+      service_container_ids: [ 1, 2 ],
+      mcp_servers: [ { "name" => "filesystem", "transport" => "stdio" } ]
+    }
+  end
+
+  def anthropic_bundle_identity
+    {
+      provider_id: "anthropic",
+      prompt_version_id: "prompt-v2",
+      model_selection: { "provider" => "anthropic", "model" => "claude-sonnet" },
+      service_container_ids: [ 9 ],
+      mcp_servers: [ { "name" => "github", "transport" => "http" } ]
+    }
   end
 
   describe ".train" do
@@ -263,6 +299,31 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
       )
 
       expect(claude_prediction.predicted_quality_score).to be > cursor_prediction.predicted_quality_score
+    end
+
+    it "does not mix histories across different providers or sidecar definitions" do
+      rows = [
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.95, success: true,
+          **openai_bundle_identity
+        ),
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.2, success: false,
+          **anthropic_bundle_identity
+        )
+      ]
+      model = described_class.train(dataset: build_dataset(rows))
+
+      openai_prediction = model.predict(
+        bundle_definition: bundle_definition(**openai_bundle_identity.merge(service_container_ids: [ 2, 1 ]))
+      )
+      anthropic_prediction = model.predict(
+        bundle_definition: bundle_definition(**anthropic_bundle_identity)
+      )
+
+      expect(openai_prediction.predicted_quality_score).to be > anthropic_prediction.predicted_quality_score
+      expect(openai_prediction.predicted_quality_score).to be > 0.7
+      expect(anthropic_prediction.predicted_quality_score).to be < 0.5
     end
 
     it "can be retrained with new data" do

--- a/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
+++ b/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
     }
   end
 
+  def section_order_experiment(*sections)
+    { "knowledge.section_order" => { "value" => sections } }
+  end
+
   describe ".train" do
     it "stores global statistics from the training dataset" do
       rows = [
@@ -134,6 +138,30 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
       )
 
       expect(high_budget_prediction.predicted_quality_score).to be > low_budget_prediction.predicted_quality_score
+    end
+
+    it "distinguishes structured experiment variants with different values" do
+      rows = [
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.95, success: true,
+          experiment_features: { "knowledge.section_order" => "[\"summary\",\"tests\",\"implementation\"]" }
+        ),
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.55, success: false,
+          experiment_features: { "knowledge.section_order" => "[\"implementation\",\"summary\",\"tests\"]" }
+        )
+      ]
+      dataset = build_dataset(rows)
+      model = described_class.train(dataset: dataset)
+
+      preferred_prediction = model.predict(
+        bundle_definition: bundle_definition(experiments: section_order_experiment("summary", "tests", "implementation"))
+      )
+      alternate_prediction = model.predict(
+        bundle_definition: bundle_definition(experiments: section_order_experiment("implementation", "summary", "tests"))
+      )
+
+      expect(preferred_prediction.predicted_quality_score).to be > alternate_prediction.predicted_quality_score
     end
 
     it "applies Bayesian prior smoothing to predictions" do

--- a/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
+++ b/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
@@ -402,5 +402,24 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
       expect(prediction.predicted_quality_score).to be > 0.0
       expect(prediction.trained_at).to be_present
     end
+
+    it "predicts from a JSON-round-tripped trained state payload" do
+      rows = [
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.92, success: true,
+          experiment_features: { "knowledge.token_budget" => 8000.0 }
+        )
+      ]
+      model = described_class.train(dataset: build_dataset(rows))
+      payload = JSON.parse(JSON.generate(described_class.serialize_trained_state(model.trained_state)))
+
+      prediction = described_class.call(
+        bundle_definition: bundle_definition(experiments: { "knowledge.token_budget" => { "value" => 8000 } }),
+        trained_state: payload
+      )
+
+      expect(prediction.predicted_quality_score).to be > described_class::PRIOR_MEAN
+      expect(prediction.trained_at).to eq(model.trained_state.trained_at)
+    end
   end
 end

--- a/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
+++ b/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
@@ -85,6 +85,37 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
     }
   end
 
+  def unseen_bundle_identity
+    {
+      provider_id: "unseen-provider",
+      prompt_version_id: "unseen-prompt",
+      model_selection: { "provider" => "unseen-provider", "model" => "new-model" },
+      service_container_ids: [ 42 ],
+      mcp_servers: [ { "name" => "new-server", "transport" => "http" } ]
+    }
+  end
+
+  def goal_scoped_baseline_rows
+    [
+      build_row(
+        goal: "create_pr", agent_type: "claude_code", quality_score: 0.8, success: true,
+        **openai_bundle_identity
+      ),
+      build_row(
+        goal: "create_pr", agent_type: "claude_code", quality_score: 0.4, success: false,
+        **openai_bundle_identity
+      ),
+      build_row(
+        goal: "review", agent_type: "claude_code", quality_score: 0.95, success: true,
+        **anthropic_bundle_identity
+      )
+    ]
+  end
+
+  def unseen_bundle_definition(goal: "create_pr", agent_type: "claude_code")
+    bundle_definition(goal:, agent_type:, **unseen_bundle_identity)
+  end
+
   describe ".train" do
     it "stores global statistics from the training dataset" do
       rows = [
@@ -138,7 +169,7 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
       expect(prediction.trained_at).to be_nil
     end
 
-    it "returns global baseline when no historical rows match the query goal" do
+    it "returns the prior when there is no history for the query goal" do
       rows = [
         build_row(goal: "review", agent_type: "claude_code", quality_score: 0.9, success: true)
       ]
@@ -147,8 +178,18 @@ RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
 
       prediction = model.predict(bundle_definition: bundle_definition(goal: "create_pr"))
 
-      expect(prediction.predicted_quality_score).to be_within(0.001).of(0.9)
-      expect(prediction.predicted_success_probability).to eq(1.0)
+      expect(prediction.predicted_quality_score).to eq(described_class::PRIOR_MEAN)
+      expect(prediction.predicted_success_probability).to eq(described_class::PRIOR_MEAN)
+      expect(prediction.sample_count).to eq(0.0)
+      expect(prediction.trained_at).to be_present
+    end
+
+    it "returns a goal-scoped baseline when the goal matches but other context filters exclude rows" do
+      model = described_class.train(dataset: build_dataset(goal_scoped_baseline_rows))
+      prediction = model.predict(bundle_definition: unseen_bundle_definition)
+
+      expect(prediction.predicted_quality_score).to be_within(0.001).of(0.6)
+      expect(prediction.predicted_success_probability).to be_within(0.001).of(0.5)
       expect(prediction.sample_count).to eq(0.0)
     end
 

--- a/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
+++ b/spec/services/configuration_bundles/surrogate_outcome_model_spec.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConfigurationBundles::SurrogateOutcomeModel, :no_db do
+  def build_row(goal:, agent_type:, quality_score:, experiment_features: {}, success: true,
+                cost_cents: 40, duration_seconds: 120, weight: 1.0, objective_score: nil)
+    features = ConfigurationBundles::FeatureExtractor::FeatureVector.new(
+      goal: goal,
+      agent_type: agent_type,
+      has_model_selection: false,
+      has_custom_prompt: false,
+      has_mcp_servers: false,
+      service_container_count: 0,
+      mcp_server_count: 0,
+      experiment_features: experiment_features
+    )
+    objective_score ||= quality_score * 0.9
+    ConfigurationBundles::TrainingDataset::Row.new(
+      features: features,
+      quality_score: quality_score,
+      objective_score: objective_score,
+      success: success,
+      cost_cents: cost_cents,
+      duration_seconds: duration_seconds,
+      tokens_used: 5000,
+      weight: weight
+    )
+  end
+
+  def build_dataset(rows)
+    ConfigurationBundles::TrainingDataset::Dataset.new(
+      rows: rows,
+      feature_names: rows.flat_map { |r| r.features.experiment_features.keys }.uniq.sort,
+      size: rows.size
+    )
+  end
+
+  def bundle_definition(goal: "create_pr", agent_type: "claude_code", experiments: {})
+    {
+      "schema_version" => 1,
+      "goal" => goal,
+      "agent_type" => agent_type,
+      "experiments" => experiments
+    }
+  end
+
+  describe ".train" do
+    it "stores global statistics from the training dataset" do
+      rows = [
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.8, success: true),
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.6, success: false)
+      ]
+      dataset = build_dataset(rows)
+
+      model = described_class.train(dataset: dataset)
+
+      expect(model).to be_trained
+      expect(model.trained_state.training_size).to eq(2)
+      expect(model.trained_state.global_mean_quality).to be_within(0.001).of(0.7)
+      expect(model.trained_state.global_success_rate).to eq(0.5)
+      expect(model.trained_state.trained_at).to be_within(1.second).of(Time.current)
+    end
+
+    it "handles an empty training dataset" do
+      dataset = build_dataset([])
+
+      model = described_class.train(dataset: dataset)
+
+      expect(model).not_to be_trained
+      expect(model.trained_state.training_size).to eq(0)
+      expect(model.trained_state.global_mean_objective).to be_nil
+    end
+
+    it "computes weighted means respecting row weights" do
+      rows = [
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.9, weight: 3.0),
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.5, weight: 1.0)
+      ]
+      dataset = build_dataset(rows)
+
+      model = described_class.train(dataset: dataset)
+
+      expect(model.trained_state.global_mean_quality).to be_within(0.001).of(0.8)
+    end
+  end
+
+  describe "#predict" do
+    it "returns prior prediction when model is not trained" do
+      model = described_class.new
+
+      prediction = model.predict(bundle_definition: bundle_definition)
+
+      expect(prediction.predicted_objective_score).to eq(described_class::PRIOR_MEAN)
+      expect(prediction.predicted_quality_score).to eq(described_class::PRIOR_MEAN)
+      expect(prediction.uncertainty).to eq(1.0)
+      expect(prediction.sample_count).to eq(0.0)
+      expect(prediction.trained_at).to be_nil
+    end
+
+    it "returns global baseline when no historical rows match the query goal" do
+      rows = [
+        build_row(goal: "review", agent_type: "claude_code", quality_score: 0.9, success: true)
+      ]
+      dataset = build_dataset(rows)
+      model = described_class.train(dataset: dataset)
+
+      prediction = model.predict(bundle_definition: bundle_definition(goal: "create_pr"))
+
+      expect(prediction.predicted_quality_score).to be_within(0.001).of(0.9)
+      expect(prediction.predicted_success_probability).to eq(1.0)
+      expect(prediction.sample_count).to eq(0.0)
+    end
+
+    it "predicts higher quality for definitions matching historical high-quality outcomes" do
+      rows = [
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.95, success: true,
+          experiment_features: { "knowledge.token_budget" => 8000.0 }
+        ),
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.60, success: false,
+          experiment_features: { "knowledge.token_budget" => 2000.0 }
+        )
+      ]
+      dataset = build_dataset(rows)
+      model = described_class.train(dataset: dataset)
+
+      high_budget_prediction = model.predict(
+        bundle_definition: bundle_definition(experiments: { "knowledge.token_budget" => { "value" => 8000 } })
+      )
+      low_budget_prediction = model.predict(
+        bundle_definition: bundle_definition(experiments: { "knowledge.token_budget" => { "value" => 2000 } })
+      )
+
+      expect(high_budget_prediction.predicted_quality_score).to be > low_budget_prediction.predicted_quality_score
+    end
+
+    it "applies Bayesian prior smoothing to predictions" do
+      rows = [
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 1.0, success: true, weight: 1.0)
+      ]
+      dataset = build_dataset(rows)
+      model = described_class.train(dataset: dataset)
+
+      prediction = model.predict(
+        bundle_definition: bundle_definition(experiments: { "knowledge.token_budget" => { "value" => 8000 } })
+      )
+
+      expect(prediction.predicted_quality_score).to be < 1.0
+      expect(prediction.predicted_quality_score).to be > described_class::PRIOR_MEAN
+    end
+
+    it "reduces uncertainty with more matching outcomes" do
+      few_rows = Array.new(2) do
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.8, success: true, weight: 1.0)
+      end
+      many_rows = Array.new(20) do
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.8, success: true, weight: 1.0)
+      end
+
+      few_model = described_class.train(dataset: build_dataset(few_rows))
+      many_model = described_class.train(dataset: build_dataset(many_rows))
+
+      definition = bundle_definition
+
+      few_uncertainty = few_model.predict(bundle_definition: definition).uncertainty
+      many_uncertainty = many_model.predict(bundle_definition: definition).uncertainty
+
+      expect(many_uncertainty).to be < few_uncertainty
+    end
+
+    it "estimates cost and duration from weighted matches" do
+      rows = [
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.8,
+          cost_cents: 100, duration_seconds: 300, weight: 2.0
+        ),
+        build_row(
+          goal: "create_pr", agent_type: "claude_code", quality_score: 0.8,
+          cost_cents: 200, duration_seconds: 600, weight: 1.0
+        )
+      ]
+      dataset = build_dataset(rows)
+      model = described_class.train(dataset: dataset)
+
+      prediction = model.predict(bundle_definition: bundle_definition)
+
+      expect(prediction.predicted_cost_cents).to be_within(1).of(133)
+      expect(prediction.predicted_duration_seconds).to be_within(1).of(400)
+    end
+
+    it "returns nil cost and duration when no matches have positive values" do
+      rows = [
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.8,
+                  cost_cents: 0, duration_seconds: 0)
+      ]
+      dataset = build_dataset(rows)
+      model = described_class.train(dataset: dataset)
+
+      prediction = model.predict(bundle_definition: bundle_definition)
+
+      expect(prediction.predicted_cost_cents).to be_nil
+      expect(prediction.predicted_duration_seconds).to be_nil
+    end
+
+    it "predicts success probability from historical outcomes" do
+      rows = Array.new(8) do |i|
+        build_row(
+          goal: "create_pr", agent_type: "claude_code",
+          quality_score: 0.8, success: i < 6
+        )
+      end
+      dataset = build_dataset(rows)
+      model = described_class.train(dataset: dataset)
+
+      prediction = model.predict(bundle_definition: bundle_definition)
+
+      expect(prediction.predicted_success_probability).to be_within(0.05).of(0.75)
+    end
+
+    it "penalizes mismatched agent types within the same goal" do
+      rows = [
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.9, success: true),
+        build_row(goal: "create_pr", agent_type: "cursor", quality_score: 0.5, success: true)
+      ]
+      dataset = build_dataset(rows)
+      model = described_class.train(dataset: dataset)
+
+      claude_prediction = model.predict(
+        bundle_definition: bundle_definition(agent_type: "claude_code")
+      )
+      cursor_prediction = model.predict(
+        bundle_definition: bundle_definition(agent_type: "cursor")
+      )
+
+      expect(claude_prediction.predicted_quality_score).to be > cursor_prediction.predicted_quality_score
+    end
+
+    it "can be retrained with new data" do
+      initial_rows = [
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.5, success: true)
+      ]
+      model = described_class.train(dataset: build_dataset(initial_rows))
+
+      first_prediction = model.predict(bundle_definition: bundle_definition)
+
+      updated_rows = [
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.95, success: true)
+      ]
+      model.train(dataset: build_dataset(updated_rows))
+
+      second_prediction = model.predict(bundle_definition: bundle_definition)
+
+      expect(second_prediction.predicted_quality_score).to be > first_prediction.predicted_quality_score
+      expect(second_prediction.trained_at).to be >= first_prediction.trained_at
+    end
+  end
+
+  describe ".call (class method shortcut)" do
+    it "predicts using a pre-trained state" do
+      rows = [
+        build_row(goal: "create_pr", agent_type: "claude_code", quality_score: 0.85, success: true)
+      ]
+      model = described_class.train(dataset: build_dataset(rows))
+
+      prediction = described_class.call(
+        bundle_definition: bundle_definition,
+        trained_state: model.trained_state
+      )
+
+      expect(prediction.predicted_quality_score).to be > 0.0
+      expect(prediction.trained_at).to be_present
+    end
+  end
+end

--- a/spec/services/configuration_bundles/training_dataset_spec.rb
+++ b/spec/services/configuration_bundles/training_dataset_spec.rb
@@ -124,7 +124,8 @@ RSpec.describe ConfigurationBundles::TrainingDataset do
     end
 
     it "skips outcomes with missing bundle definitions" do
-      bundle = create(:configuration_bundle, account: project.account, definition: nil)
+      bundle = create(:configuration_bundle, account: project.account)
+      bundle.update_column(:definition, [])
       run = create(:agent_run,
         :completed,
         project: project,

--- a/spec/services/configuration_bundles/training_dataset_spec.rb
+++ b/spec/services/configuration_bundles/training_dataset_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConfigurationBundles::TrainingDataset do
+  let(:project) { create(:project) }
+
+  def build_outcome_row(overrides = {})
+    quality_score = overrides.fetch(:quality_score, 0.8)
+    cost_cents = overrides.fetch(:cost_cents, 40)
+    definition = overrides.fetch(:definition, {
+      "schema_version" => 1,
+      "goal" => "create_pr",
+      "agent_type" => "claude_code",
+      "experiments" => { "knowledge.token_budget" => { "value" => 4000 } }
+    })
+    success = overrides.fetch(:success, true)
+    created_at = overrides.fetch(:created_at, Time.current)
+
+    bundle = create(:configuration_bundle, account: project.account, definition: definition)
+    run = create(:agent_run,
+      :completed,
+      project: project,
+      issue: create(:issue, project: project),
+      goal: definition["goal"],
+      configuration_bundle: bundle,
+      cost_cents: cost_cents)
+    outcome = create(:bundle_outcome,
+      configuration_bundle: bundle,
+      agent_run: run,
+      quality_score: quality_score,
+      cost_cents: cost_cents,
+      success: success)
+    outcome.update_column(:created_at, created_at)
+    outcome
+  end
+
+  describe "#build" do
+    it "builds a dataset with rows extracted from bundle outcomes" do
+      build_outcome_row(quality_score: 0.85)
+
+      scope = BundleOutcome.joins(:configuration_bundle, :agent_run)
+        .where(agent_runs: { project_id: project.id })
+        .where.not(quality_score: nil)
+
+      dataset = described_class.call(scope: scope)
+
+      expect(dataset.size).to eq(1)
+      expect(dataset.rows.first.quality_score).to eq(0.85)
+      expect(dataset.rows.first.features).to be_a(ConfigurationBundles::FeatureExtractor::FeatureVector)
+    end
+
+    it "collects experiment feature names across all rows" do
+      build_outcome_row(definition: {
+        "schema_version" => 1,
+        "goal" => "create_pr",
+        "agent_type" => "claude_code",
+        "experiments" => { "knowledge.token_budget" => { "value" => 4000 } }
+      })
+      build_outcome_row(definition: {
+        "schema_version" => 1,
+        "goal" => "create_pr",
+        "agent_type" => "claude_code",
+        "experiments" => { "max_iterations" => { "value" => 10 } }
+      })
+
+      scope = BundleOutcome.joins(:configuration_bundle, :agent_run)
+        .where(agent_runs: { project_id: project.id })
+        .where.not(quality_score: nil)
+
+      dataset = described_class.call(scope: scope)
+
+      expect(dataset.feature_names).to eq(%w[knowledge.token_budget max_iterations])
+      expect(dataset.size).to eq(2)
+    end
+
+    it "assigns higher weight to more recent outcomes" do
+      build_outcome_row(quality_score: 0.7, created_at: 60.days.ago)
+      build_outcome_row(quality_score: 0.9, created_at: 1.hour.ago)
+
+      scope = BundleOutcome.joins(:configuration_bundle, :agent_run)
+        .where(agent_runs: { project_id: project.id })
+        .where.not(quality_score: nil)
+
+      dataset = described_class.call(scope: scope)
+
+      recent = dataset.rows.find { |r| r.quality_score == 0.9 }
+      old = dataset.rows.find { |r| r.quality_score == 0.7 }
+      expect(recent.weight).to be > old.weight
+    end
+
+    it "computes objective score from stored metrics when available" do
+      build_outcome_row
+      BundleOutcome.last.update!(metrics: { "objective_score" => 0.72 })
+
+      scope = BundleOutcome.joins(:configuration_bundle, :agent_run)
+        .where(agent_runs: { project_id: project.id })
+        .where.not(quality_score: nil)
+
+      dataset = described_class.call(scope: scope)
+
+      expect(dataset.rows.first.objective_score).to eq(0.72)
+    end
+
+    it "skips outcomes with missing bundle definitions" do
+      bundle = create(:configuration_bundle, account: project.account, definition: nil)
+      run = create(:agent_run,
+        :completed,
+        project: project,
+        issue: create(:issue, project: project),
+        configuration_bundle: bundle)
+      create(:bundle_outcome,
+        configuration_bundle: bundle,
+        agent_run: run,
+        quality_score: 0.8)
+
+      build_outcome_row(quality_score: 0.9)
+
+      scope = BundleOutcome.joins(:configuration_bundle, :agent_run)
+        .where(agent_runs: { project_id: project.id })
+        .where.not(quality_score: nil)
+
+      dataset = described_class.call(scope: scope)
+
+      expect(dataset.size).to eq(1)
+      expect(dataset.rows.first.quality_score).to eq(0.9)
+    end
+
+    it "returns an empty dataset when no outcomes match" do
+      scope = BundleOutcome.joins(:configuration_bundle, :agent_run)
+        .where(agent_runs: { project_id: project.id })
+        .where.not(quality_score: nil)
+
+      dataset = described_class.call(scope: scope)
+
+      expect(dataset.size).to eq(0)
+      expect(dataset.rows).to eq([])
+      expect(dataset.feature_names).to eq([])
+    end
+  end
+end

--- a/spec/services/configuration_bundles/training_dataset_spec.rb
+++ b/spec/services/configuration_bundles/training_dataset_spec.rb
@@ -5,6 +5,27 @@ require "rails_helper"
 RSpec.describe ConfigurationBundles::TrainingDataset do
   let(:project) { create(:project) }
 
+  describe "#build query shape", :no_db do
+    it "orders by the bundle outcome timestamp using a qualified column" do
+      scope = instance_double(ActiveRecord::Relation)
+      preloaded_scope = instance_double(ActiveRecord::Relation)
+      limited_scope = instance_double(ActiveRecord::Relation)
+
+      allow(scope).to receive(:preload).with(:configuration_bundle, agent_run: :project).and_return(preloaded_scope)
+      allow(preloaded_scope).to receive(:order)
+        .with(BundleOutcome.arel_table[:created_at].desc)
+        .and_return(preloaded_scope)
+      allow(preloaded_scope).to receive(:limit).with(described_class::MAX_ROWS).and_return(limited_scope)
+      allow(limited_scope).to receive(:each)
+
+      described_class.call(scope: scope)
+
+      expect(scope).to have_received(:preload).with(:configuration_bundle, agent_run: :project)
+      expect(preloaded_scope).to have_received(:order).with(BundleOutcome.arel_table[:created_at].desc)
+      expect(preloaded_scope).to have_received(:limit).with(described_class::MAX_ROWS)
+    end
+  end
+
   def build_outcome_row(overrides = {})
     quality_score = overrides.fetch(:quality_score, 0.8)
     cost_cents = overrides.fetch(:cost_cents, 40)


### PR DESCRIPTION
## Summary

This change establishes the first surrogate outcome model so the optimizer can estimate bundle performance from historical results and make informed decisions before executing new runs. It adds the baseline training and prediction plumbing needed to turn stored bundle outcomes into reusable optimization signals.

## Changes

- `Services`
  - Added `ConfigurationBundles::FeatureExtractor` to derive a structured feature vector from bundle definitions, including categorical attributes, boolean configuration flags, service/MCP counts, and numeric experiment features.
  - Added `ConfigurationBundles::TrainingDataset` to build a training dataset from historical `BundleOutcome` records, including objective extraction, feature-name discovery, and recency-weighted examples.
  - Added `ConfigurationBundles::SurrogateOutcomeModel` as the initial retrainable surrogate model, with explicit `train` and `predict` steps and a serializable trained state.
  - Exposed prediction outputs needed by the optimizer, including objective score, quality score, success probability, cost estimate, duration estimate, and uncertainty.

- `Modeling approach`
  - Implemented a baseline kernel-regression-style predictor that matches outcomes by goal, applies prior smoothing, and weights nearby experiment configurations using exponential-decay similarity.
  - Limited training input to the most recent 500 outcomes to keep the first implementation simple and bounded while still favoring recent behavior.

- `Testing`
  - Added pure-Ruby coverage for feature extraction and surrogate prediction behavior in `feature_extractor_spec` and `surrogate_outcome_model_spec`.
  - Added dataset-building coverage in `training_dataset_spec` for the DB-backed path.
  - Marked the pure-Ruby specs to run without a database, while keeping the dataset spec DB-dependent.

## Design Decisions

- This is intentionally a baseline model, not a complex learned system. The goal is to provide stable prediction plumbing and a simple retraining path before investing in more sophisticated modeling.
- Cross-goal outcomes are excluded rather than loosely blended, which favors cleaner signal and easier reasoning over broader but noisier reuse of history.
- The model uses Bayesian prior smoothing and uncertainty output to avoid overconfident predictions when historical coverage is sparse.
- Recency weighting and the 500-outcome cap trade completeness for responsiveness and operational simplicity in the initial rollout.

## Operational Concerns

- No database migration or deploy-time schema change is required.
- The DB-backed dataset spec requires database access; in environments without a database, only the pure-Ruby model and feature extraction specs will run.

---

Closes #1799