### PR TITLE
fix: silence Ruby warnings in specs and quality_hooks

### DIFF
--- a/app/services/containers/quality_hooks.rb
+++ b/app/services/containers/quality_hooks.rb
@@ -4,9 +4,7 @@ module Containers
   module QualityHooks
     extend ActiveSupport::Concern
 
-    included do
-      DB_DEPENDENT_TEST_LANGUAGES = %w[ruby].freeze
-    end
+    DB_DEPENDENT_TEST_LANGUAGES = %w[ruby].freeze
 
     def install_quality_hooks(git_ops, agent_run)
       language = detect_language(agent_run.project)

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -1832,7 +1832,7 @@ RSpec.describe AgentRun do
       other_user.settings.update!(max_concurrent_runs: 5)
       other_project = create(:project, account: other_account, created_by: other_user)
 
-      owned_run = create(:agent_run, :queued, :manual, project: owned_project, created_at: 2.minutes.ago)
+      _owned_run = create(:agent_run, :queued, :manual, project: owned_project, created_at: 2.minutes.ago)
       other_run = create(:agent_run, :queued, :manual, project: other_project, created_at: 1.minute.ago)
 
       expect(described_class.peek_next_queued_run).to eq(other_run)

--- a/spec/requests/mcp_server_definitions_spec.rb
+++ b/spec/requests/mcp_server_definitions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "McpServerDefinitions" do
       end
 
       it "shows existing definitions" do
-        mcp = create(:mcp_server_definition, account: account, name: "test-mcp")
+        _mcp = create(:mcp_server_definition, account: account, name: "test-mcp")
         get mcp_server_definitions_path
         expect(response.body).to include("test-mcp")
       end

--- a/spec/services/ci/failure_context_spec.rb
+++ b/spec/services/ci/failure_context_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Ci::FailureContext do
       allow(github_client).to receive(:actions_run).with(repo, "111").and_return(run_response)
       allow(github_client).to receive_messages(check_run_log: "", file_content: "name: CI\non: push")
 
-      context = described_class.call(repo: repo, checks: [ check1, check2 ], github_client: github_client)
+      _context = described_class.call(repo: repo, checks: [ check1, check2 ], github_client: github_client)
 
       expect(github_client).to have_received(:actions_run).once
       expect(github_client).to have_received(:file_content).once

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Issues::AutoPick do
     end
 
     it "creates a create_pr run when auto_enhance_enabled is false" do
-      issue = create(:issue, project: project, github_state: "open")
+      _issue = create(:issue, project: project, github_state: "open")
 
       result = described_class.new(project).call
 


### PR DESCRIPTION
## Summary

- Prefix unused test variables with `_` in 4 spec files to suppress "assigned but unused variable" warnings
- Move `DB_DEPENDENT_TEST_LANGUAGES` from `included` block to module-level constant in `Containers::QualityHooks` to suppress "already initialized constant" warning

## Warnings fixed

```
spec/models/agent_run_spec.rb:1835: warning: assigned but unused variable - owned_run
spec/requests/mcp_server_definitions_spec.rb:32: warning: assigned but unused variable - mcp
spec/services/ci/failure_context_spec.rb:157: warning: assigned but unused variable - context
spec/services/issues/auto_pick_spec.rb:42: warning: assigned but unused variable - issue
app/services/containers/quality_hooks.rb:8: warning: already initialized constant
```