### PR TITLE
fix(agent-runs): display created_at in Created column

### DIFF
--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -77,7 +77,7 @@
                     <% end %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <%= time_ago_in_words(run.started_at || run.created_at) %> ago
+                    <%= time_ago_in_words(run.created_at) %> ago
                   </td>
                   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                     <% project_for_run = local_assigns[:project] || run.project %>


### PR DESCRIPTION
## Summary

- The agent runs list's **Created** column sorts by `created_at` (via `sort_link_to "Created", :created_at, q`) but the cell rendered `run.started_at || run.created_at`. When ordered by `created_at desc`, rows could appear visually out of order — e.g. a run created 3 hours ago but started 3 minutes ago looked newer than a run created 30 minutes ago that hadn't started yet.
- Render `run.created_at` so the label, sort key, and displayed value all agree. Started/elapsed info is already covered by the adjacent **Duration** column.

## Test plan

- [ ] Load `/agent_runs` with a mix of queued and running/completed runs and confirm the Created column is monotonically non-increasing top to bottom under the default `created_at desc` sort.
- [ ] Toggle the Created column header to ascending and confirm the order reverses correctly.
- [ ] Confirm the Duration column still surfaces started/elapsed info for in-flight runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)