### PR TITLE
fix(agent-runs): ProviderModelNotFoundError from opencode is misclassified as success

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -797,6 +797,11 @@ module Activities
             "Provider credit/quota error from #{provider}: #{sanitized_output.truncate(500)}"
         end
 
+        if provider_model_not_found_error?(sanitized_output)
+          raise ProviderExecutionError,
+            "Provider model not found error from #{provider}: #{sanitized_output.truncate(500)}"
+        end
+
         output_present = stdout.present? || stderr.present?
         track_harness_tokens(agent_run, provider_candidate, provider, user_settings.user, result, execution_started_at)
         agent_run.log!("system", "Agent execution succeeded with #{provider}")
@@ -915,6 +920,14 @@ module Activities
           )
         end
 
+        if provider_model_not_found_error?(sanitized_output)
+          raise_preflight_failure!(
+            agent_run: agent_run,
+            provider: provider,
+            reason: "Provider model not found error: #{sanitized_output.truncate(500)}"
+          )
+        end
+
         return
       end
 
@@ -1021,6 +1034,20 @@ module Activities
 
       ProviderSupport.aggregated_error_classification_patterns(:quota)
         .any? { |pattern| output.match?(pattern) }
+    end
+
+    MODEL_NOT_FOUND_MAX_OUTPUT_LENGTH = 1000
+
+    MODEL_NOT_FOUND_PATTERNS = [
+      /ProviderModelNotFoundError/i,
+      /Error:\s*Model not found:/i
+    ].freeze
+
+    def provider_model_not_found_error?(output)
+      return false if output.blank?
+      return false if output.length > MODEL_NOT_FOUND_MAX_OUTPUT_LENGTH
+
+      MODEL_NOT_FOUND_PATTERNS.any? { |pattern| output.match?(pattern) }
     end
 
     def strip_prompt_echo(output, prompt)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1043,11 +1043,31 @@ module Activities
       /Error:\s*Model not found:/i
     ].freeze
 
+    MODEL_NOT_FOUND_NOISE_LINE_PATTERNS = [
+      %r{\A\s*at\s+.+\z},
+      %r{\A\s*file://.+\z},
+      %r{\A\s*/.+:\d+:\d+\)?\z},
+      /\A\s*\^+\s*\z/
+    ].freeze
+
     def provider_model_not_found_error?(output)
       return false if output.blank?
-      return false if output.length > MODEL_NOT_FOUND_MAX_OUTPUT_LENGTH
 
-      MODEL_NOT_FOUND_PATTERNS.any? { |pattern| output.match?(pattern) }
+      signal = strip_model_not_found_noise(output)
+      return false if signal.length > MODEL_NOT_FOUND_MAX_OUTPUT_LENGTH
+
+      MODEL_NOT_FOUND_PATTERNS.any? { |pattern| signal.match?(pattern) }
+    end
+
+    def strip_model_not_found_noise(output)
+      output.each_line.reject { |line| model_not_found_noise_line?(line) }.join
+    end
+
+    def model_not_found_noise_line?(line)
+      normalized_line = line.to_s.strip
+      return false if normalized_line.blank?
+
+      MODEL_NOT_FOUND_NOISE_LINE_PATTERNS.any? { |pattern| normalized_line.match?(pattern) }
     end
 
     def strip_prompt_echo(output, prompt)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2921,6 +2921,43 @@ expect(container_service).to receive(:execute).with(
         expect(result[:success]).to be true
       end
 
+      it "detects ProviderModelNotFoundError returned with exit code 0" do
+        model_not_found_stderr = <<~ERR
+          Error: Model not found: glm-5.1/.
+          ProviderModelNotFoundError
+           data: {
+            providerID: "glm-5.1",
+            modelID: "",
+            suggestions: [],
+          }
+        ERR
+        model_not_found_success = Containers::Provision::Result.success(
+          stdout: "", stderr: model_not_found_stderr, exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(model_not_found_success)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("failed")
+        expect(agent_run.providers_attempted.first["error_type"]).to eq("error")
+        expect(agent_run.providers_attempted.first["error_message"]).to include("model not found error")
+      end
+
+      it "does not misclassify substantial agent output as model not found when ProviderModelNotFoundError appears in structured output" do
+        long_stdout = (1..40).map { |i| "line #{i}: processing test for ProviderModelNotFoundError handling" }.join("\n")
+        long_output_success = Containers::Provision::Result.success(
+          stdout: long_stdout, stderr: "", exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(long_output_success)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:success]).to be true
+      end
+
       it "preserves timeout handling when the timeout happens before provider execution starts" do
         allow(activity).to receive(:augment_prompt_for_goal)
           .and_raise(Containers::Provision::TimeoutError, "took too long before exec")

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2946,6 +2946,28 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.providers_attempted.first["error_message"]).to include("model not found error")
       end
 
+      it "detects ProviderModelNotFoundError even when stderr includes a long stack trace" do
+        stack_trace = Array.new(60) { |i| "    at resolveModel (file:///app/.opencode/vendor/index.js:#{200 + i}:17)" }.join("\n")
+        model_not_found_stderr = <<~ERR
+          Error: Model not found: glm-5.1/.
+          ProviderModelNotFoundError
+          #{stack_trace}
+        ERR
+        model_not_found_success = Containers::Provision::Result.success(
+          stdout: "", stderr: model_not_found_stderr, exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(model_not_found_success)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("failed")
+        expect(agent_run.providers_attempted.first["error_type"]).to eq("error")
+        expect(agent_run.providers_attempted.first["error_message"]).to include("model not found error")
+      end
+
       it "does not misclassify substantial agent output as model not found when ProviderModelNotFoundError appears in structured output" do
         long_stdout = (1..40).map { |i| "line #{i}: processing test for ProviderModelNotFoundError handling" }.join("\n")
         long_output_success = Containers::Provision::Result.success(


### PR DESCRIPTION
## Summary

This change makes agent runs fail loudly when opencode reports a provider/model misconfiguration so the workflow can retry or fall back instead of silently marking the run as completed. The expected outcome is that `ProviderModelNotFoundError` surfaces as a real provider execution failure rather than a false success with no output or PR.

## Changes

- Execution handling
  - Added detection for `ProviderModelNotFoundError` in sanitized agent output alongside the existing hidden credit/quota error handling.
  - Raised `ProviderExecutionError` when that pattern is present so provider fallback/retry logic can run instead of treating the invocation as successful.

- Preflight behavior
  - Applied the same model-not-found detection in the preflight execution path so configuration errors are classified consistently before and during the main run.

- Error classification
  - Introduced a dedicated `provider_model_not_found_error?` check to make this failure mode explicit and easier to extend if opencode or similar providers continue returning hard errors with exit code `0`.

- Test coverage
  - Added specs covering the model-not-found stderr pattern and asserting that these runs are treated as execution failures rather than successful completions.

## Design Decisions

- This fix follows the existing defensive pattern already used for hidden quota/billing failures, which keeps the change narrowly scoped and low risk.
- The classification remains in Paid for now to address the immediate silent-success bug, even though provider-specific execution behavior ideally belongs upstream in `agent_harness`.
- The implementation targets the explicit `ProviderModelNotFoundError` signature rather than a broader heuristic like `tokens_output == 0 && stderr =~ /Error:/i` to avoid false positives from benign stderr output until there is clearer evidence of additional affected cases.

---

Closes #1903