### PR TITLE
fix(providers): opencode GLM 5.1 runs fail silently — zai/zai_coding missing opencode_model_provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -27,17 +27,22 @@ class Provider < ApplicationRecord
     "openrouter" => { label: "OpenRouter", base_url: "https://openrouter.ai/api/v1", service_type: "openrouter",
                       opencode_model_provider: "openrouter" },
     "anthropic" => { label: "Anthropic", base_url: "https://api.anthropic.com", service_type: "anthropic",
-                     opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic" },
+                     opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic",
+                     opencode_model_provider: "anthropic" },
     "openai" => { label: "OpenAI", base_url: "https://api.openai.com/v1", service_type: "openai",
-                  kilocode_provider_id: "openai" },
+                  kilocode_provider_id: "openai", opencode_model_provider: "openai" },
     "inception" => { label: "InceptionLabs", base_url: "https://api.inceptionlabs.ai/v1", service_type: "inception",
-                     kilocode_provider_id: "inception" },
-    "deepseek" => { label: "DeepSeek", base_url: "https://api.deepseek.com/v1", service_type: "deepseek" },
-    "mistral" => { label: "Mistral", base_url: "https://api.mistral.ai/v1", service_type: "mistral" },
-    "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai" },
-    "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai" },
+                     kilocode_provider_id: "inception", opencode_model_provider: "inception" },
+    "deepseek" => { label: "DeepSeek", base_url: "https://api.deepseek.com/v1", service_type: "deepseek",
+                    opencode_model_provider: "deepseek" },
+    "mistral" => { label: "Mistral", base_url: "https://api.mistral.ai/v1", service_type: "mistral",
+                   opencode_model_provider: "mistral" },
+    "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai",
+               opencode_model_provider: "xai" },
+    "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai",
+               opencode_model_provider: "zai" },
     "zai_coding" => { label: "z.ai (Coding Plan)", base_url: "https://api.z.ai/api/coding/paas/v4", service_type: "zai_coding",
-                      kilocode_provider_id: "zai-coding-plan" }
+                      kilocode_provider_id: "zai-coding-plan", opencode_model_provider: "zai_coding" }
   }.freeze
 
   DIRECT_OUTBOUND_SERVICE_TYPES = DIRECT_OUTBOUND_API_PROVIDERS.values.map { |c| c[:service_type] }.to_set.freeze

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -843,6 +843,43 @@ RSpec.describe Provider do
       expect(runtime.metadata[:config]["provider"]).to eq({ "openrouter" => {} })
     end
 
+    it "qualifies zai_coding models with provider prefix" do
+      zai_key = create(:provider_api_key, user: user, api_service_type: "zai_coding", api_key: "sk-zai-secret")
+      zai_provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: zai_key,
+        config: { "opencode" => { "api_provider" => "zai_coding", "model" => "glm-5.1" } }
+      )
+
+      runtime = zai_provider.agent_harness_provider_runtime
+
+      expect(runtime.model).to eq("zai_coding/glm-5.1")
+      expect(runtime.env).to include(
+        "ZAI_CODING_API_KEY" => "sk-zai-secret",
+        "OPENAI_BASE_URL" => "https://api.z.ai/api/coding/paas/v4"
+      )
+      expect(runtime.metadata[:config]["provider"]).to eq({ "zai_coding" => {} })
+    end
+
+    it "qualifies zai models with provider prefix" do
+      zai_key = create(:provider_api_key, user: user, api_service_type: "zai", api_key: "sk-zai-secret")
+      zai_provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: zai_key,
+        config: { "opencode" => { "api_provider" => "zai", "model" => "glm-5.1" } }
+      )
+
+      runtime = zai_provider.agent_harness_provider_runtime
+
+      expect(runtime.model).to eq("zai/glm-5.1")
+    end
+
     it "does not enable direct outbound when the OpenCode model id is missing" do
       provider = build(
         :provider,


### PR DESCRIPTION
## Summary

This change ensures OpenCode provider runs actually reach the intended model instead of failing immediately with an unqualified model name and being reported as successful. The expected outcome is that `opencode` executions consistently pass provider-qualified model IDs, including for `zai` and `zai_coding`, so GLM 5.1 and other supported providers can execute normally.

## Changes

- Provider configuration
  - Added `opencode_model_provider` to every `DIRECT_OUTBOUND_API_PROVIDERS` entry that previously lacked it.
  - Updated the affected providers to include explicit OpenCode provider IDs: `anthropic`, `openai`, `inception`, `deepseek`, `mistral`, `xai`, `zai`, and `zai_coding`.
  - This makes `Provider#opencode_qualified_model` produce qualified values such as `zai_coding/glm-5.1` instead of passing bare model names like `glm-5.1`.

- Model/runtime behavior
  - Fixed the configuration gap that caused OpenCode CLI to interpret bare model IDs as invalid provider IDs and raise `ProviderModelNotFoundError`.
  - Addressed the broader class of failures, not just the reported `zai_coding` case, by bringing all supported direct outbound providers into the same qualified-model contract.

- Test coverage
  - Added provider specs covering `zai_coding` and `zai` qualification behavior to verify the runtime output includes the expected provider-prefixed model IDs.

## Design Decisions

- The fix was applied across all affected provider entries rather than patching only `zai_coding`. The failure mode came from a shared configuration pattern, so fixing it comprehensively reduces the chance of the same silent breakage surfacing later for other providers.
- The change stays within provider configuration instead of adding special-case logic to `opencode_qualified_model`. That keeps the qualification rule simple: providers supported by OpenCode must declare their OpenCode provider ID explicitly.
- This PR does not change success/error classification for failed OpenCode invocations. Silent success masking remains a separate concern tracked by the companion issue.

## Operational Concerns

- No database migrations or deployment steps are required.
- Verification in this environment was limited by unavailable PostgreSQL; the added specs were validated for syntax and linting, but full database-backed spec execution still needs to run in a normal app environment.

---

Closes #1902