### PR TITLE
fix(agent-runs): treat container-internal worktree_path as volume, not bind-mount

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1504,12 +1504,12 @@ module Containers
     end
 
     # Sets up the workspace for the container.
-    # When worktree_path is provided, validates it exists (bind mount from host).
-    # When nil, creates a Docker named volume for in-container git clone.
+    # When a host-side worktree_path is provided, validates it exists for bind-mount.
+    # When nil (or container-internal), creates a Docker named volume for in-container git clone.
     # Docker volumes live on the overlay2 disk, bypassing the VM root filesystem.
     def prepare_workspace!
-      if worktree_path.present?
-        raise ProvisionError, "Worktree path does not exist: #{worktree_path}" unless File.directory?(worktree_path)
+      if host_worktree_path.present?
+        raise ProvisionError, "Worktree path does not exist: #{host_worktree_path}" unless File.directory?(host_worktree_path)
       else
         @workspace_volume ||= pooled_container? ? "paid-pool-workspace-#{pool_entry.id}" : "paid-workspace-#{agent_run.id}"
         begin
@@ -1518,6 +1518,13 @@ module Containers
           Docker::Volume.create(@workspace_volume, volume_options)
         end
       end
+    end
+
+    def host_worktree_path
+      return nil if worktree_path.blank?
+      return nil if worktree_path == options[:workspace_mount]
+
+      worktree_path
     end
 
     def write_container_file(path, content)
@@ -1575,7 +1582,7 @@ module Containers
 
     def cleanup_workspace_volume
       volume_name = @workspace_volume
-      volume_name ||= "paid-workspace-#{agent_run.id}" if worktree_path.blank? && agent_run.present? && !pooled_container?
+      volume_name ||= "paid-workspace-#{agent_run.id}" if host_worktree_path.blank? && agent_run.present? && !pooled_container?
       return unless volume_name
 
       Docker::Volume.get(volume_name).remove
@@ -1677,8 +1684,8 @@ module Containers
       binds = []
       if @workspace_volume
         binds << "#{@workspace_volume}:#{options[:workspace_mount]}:rw"
-      elsif worktree_path.present?
-        binds << "#{worktree_path}:#{options[:workspace_mount]}:rw"
+      elsif host_worktree_path.present?
+        binds << "#{host_worktree_path}:#{options[:workspace_mount]}:rw"
       end
 
       binds << "#{heartbeat_dir_host}:#{HEARTBEAT_MOUNT_POINT}:rw" if heartbeat_dir_host

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -462,6 +462,23 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
+      it "creates a Docker volume instead of bind-mounting when worktree_path is the container mount point" do
+        container_internal_service = described_class.new(
+          agent_run: agent_run,
+          worktree_path: "/workspace"
+        )
+
+        expect(Docker::Volume).to receive(:create).with("paid-workspace-#{agent_run.id}", anything).and_return(mock_volume)
+        expect(Docker::Container).to receive(:create) do |config|
+          binds = config["HostConfig"]["Binds"]
+          expect(binds).not_to include("/workspace:/workspace:rw")
+          expect(binds).to include("paid-workspace-#{agent_run.id}:/workspace:rw")
+          mock_container
+        end
+
+        container_internal_service.provision
+      end
+
       it "configures environment variables for proxy access" do
         expect(Docker::Container).to receive(:create) do |config|
           env = config["Env"]


### PR DESCRIPTION
## Summary

- Fixes `"Worktree path does not exist: /workspace"` error that crashes agent runs when a fallback provider triggers container reprovisioning
- `GitOperations` stores the container-internal path `/workspace` as `agent_run.worktree_path`; `Provision#prepare_workspace!` was validating this as a host-side path via `File.directory?`, which always fails
- Introduces `host_worktree_path` helper in `Containers::Provision` that returns `nil` when `worktree_path` equals the container mount point, causing a Docker named volume to be created instead of attempting a host bind-mount

## Reproduction

1. Agent run starts, clone activity sets `worktree_path = "/workspace"` (in-container path)
2. Primary provider fails, triggering fallback via `reprovision_container_for_fallback!`
3. `agent_run.provision_container` passes `worktree_path: "/workspace"` to `Provision.new`
4. `prepare_workspace!` calls `File.directory?("/workspace")` on the host → `false` → `ProvisionError`

## Changes

- **`app/services/containers/provision.rb`**: Added private `host_worktree_path` method that returns `nil` for container-internal paths (equal to `workspace_mount`). Updated `prepare_workspace!`, `host_config`, and `cleanup_workspace_volume` to use it instead of `worktree_path` directly.
- **`spec/services/containers/provision_spec.rb`**: Added test verifying that `worktree_path: "/workspace"` creates a Docker volume (not a bind-mount) and correctly mounts it.

## Test plan

- [x] All 193 provision specs pass
- [x] All 126 git_operations specs pass
- [x] All 197 run_agent_activity specs pass
- [x] RuboCop clean on changed files
- [ ] Verify agent run 15555's scenario succeeds with this fix deployed