### PR TITLE
fix(knowledge): inject DATABASE_URL so routes collector can boot without a database

### DIFF
--- a/app/services/knowledge/collectors/routes_collector.rb
+++ b/app/services/knowledge/collectors/routes_collector.rb
@@ -5,23 +5,24 @@ module Knowledge
     class RoutesCollector < BaseCollector
       SCOPE_PATH = "config/routes.rb"
       BUNDLE_HOME = "/tmp/paid-bundle-home"
-      # Exception class names that indicate database connectivity issues.
-      # Checked against both error.class.name (local execution) and
-      # error.message (containerized execution, where ContainerError wraps
-      # the original class name in its message string).
+      # Exception class names that indicate database issues preventing
+      # `bin/rails routes` from booting. Checked against both
+      # error.class.name (local execution) and error.message (containerized
+      # execution, where ContainerError wraps the original class name).
       DATABASE_ERROR_CLASS_NAMES = [
         "ActiveRecord::ConnectionNotEstablished",
         "ActiveRecord::DatabaseConnectionError",
         "ActiveRecord::NoDatabaseError",
+        "ActiveRecord::AdapterNotFound",
         "Mysql2::Error::ConnectionError",
         "SQLite3::CantOpenException",
         "Sequel::DatabaseConnectionError",
         "PG::ConnectionBad"
       ].freeze
 
-      # Message patterns that unmistakably indicate database connection issues.
-      # Intentionally narrow to avoid false-positives from non-DB services
-      # that use similar "could not connect" wording.
+      # Message patterns that indicate database issues preventing
+      # `bin/rails routes` from booting. Intentionally narrow to avoid
+      # false-positives from non-DB services that use similar wording.
       DATABASE_ERROR_MESSAGE_PATTERNS = [
         /connection to server .+(?:PGSQL|PostgreSQL|5432).* failed/i,
         /could not connect to server:.*(?:PostgreSQL|5432|pg_hba)/i,
@@ -29,7 +30,9 @@ module Knowledge
         /unknown database/i,
         /unable to open database file/i,
         /no such database/i,
-        /database .* does not exist/i
+        /database .* does not exist/i,
+        /database adapter.*(?:not found|not loaded)/i,
+        /no such table/i
       ].freeze
 
       def collect
@@ -112,7 +115,7 @@ module Knowledge
 
         run_routes_command
       rescue StandardError => error
-        raise unless database_connection_error?(error)
+        raise unless routes_boot_error?(error)
 
         # Always preserve prior route artifacts on DB skip. We cannot
         # reliably detect whether config/routes.rb changed: containerized
@@ -138,6 +141,7 @@ module Knowledge
 
       def routes_command_env
         {
+          "DATABASE_URL" => "sqlite3::memory:",
           "BUNDLE_PATH" => "/tmp/bundle",
           "BUNDLE_APP_CONFIG" => "/tmp/bundle-config"
         }
@@ -207,7 +211,7 @@ module Knowledge
         raise teardown_error if original_error.nil? && teardown_error
       end
 
-      def database_connection_error?(error)
+      def routes_boot_error?(error)
         each_error_in_chain(error).any? do |current_error|
           matches_database_error_class?(current_error) ||
             matches_database_error_message?(current_error)

--- a/spec/services/knowledge/collectors/routes_collector_spec.rb
+++ b/spec/services/knowledge/collectors/routes_collector_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
         expect(command_collector.collect.length).to eq(11)
       end
 
-      it "passes only bundle configuration to bin/rails routes" do
+      it "passes bundle configuration and DATABASE_URL to bin/rails routes" do
         allow(command_collector).to receive(:run_command)
           .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
           .and_return(fixture_output)
@@ -204,13 +204,14 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
           "sh", "-c", /bin\/rails routes --expanded/,
           timeout: 120,
           env: {
+            "DATABASE_URL" => "sqlite3::memory:",
             "BUNDLE_PATH" => "/tmp/bundle",
             "BUNDLE_APP_CONFIG" => "/tmp/bundle-config"
           }
         )
       end
 
-      it "does not inject DATABASE_URL into the scanned app" do
+      it "injects DATABASE_URL to allow routes collection without a running database" do
         allow(command_collector).to receive(:run_command)
           .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
           .and_return(fixture_output)
@@ -220,7 +221,7 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
         expect(command_collector).to have_received(:run_command).with(
           "sh", "-c", /bin\/rails routes --expanded/,
           timeout: 120,
-          env: satisfy { |env| !env.key?("DATABASE_URL") }
+          env: satisfy { |env| env["DATABASE_URL"] == "sqlite3::memory:" }
         )
       end
 
@@ -337,13 +338,55 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
           .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
           .and_raise(
             Knowledge::ContainerizedRunner::ContainerError,
-            "Command failed (exit 1): SQLite3::SQLException: no such table: widgets"
+            "Command failed (exit 1): SQLite3::SQLException: near \"FROM\": syntax error"
           )
 
         expect { command_collector.collect }.to raise_error(
           Knowledge::ContainerizedRunner::ContainerError,
-          /no such table/
+          /syntax error/
         )
+      end
+
+      it "skips on sqlite no-such-table errors from the in-memory database" do
+        allow(command_collector).to receive(:run_command)
+          .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
+          .and_raise(
+            Knowledge::ContainerizedRunner::ContainerError,
+            "Command failed (exit 1): SQLite3::SQLException: no such table: settings"
+          )
+
+        expect { command_collector.collect }.to raise_error do |error|
+          expect(error).to be_a(Knowledge::SkipCollector)
+          expect(error.preserve_existing_artifacts?).to be(true)
+        end
+      end
+
+      it "skips when the sqlite3 gem is not in the target app" do
+        allow(command_collector).to receive(:run_command)
+          .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
+          .and_raise(
+            Knowledge::ContainerizedRunner::ContainerError,
+            'Command failed (exit 1): ActiveRecord::AdapterNotFound: database configuration specifies nonexistent adapter'
+          )
+
+        expect { command_collector.collect }.to raise_error do |error|
+          expect(error).to be_a(Knowledge::SkipCollector)
+          expect(error.preserve_existing_artifacts?).to be(true)
+        end
+      end
+
+      it "skips on database adapter not loaded message" do
+        allow(command_collector).to receive(:run_command)
+          .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
+          .and_raise(
+            Knowledge::ContainerizedRunner::ContainerError,
+            "Command failed (exit 1): Specified 'sqlite3' for database adapter, but the gem is not loaded"
+          )
+
+        expect { command_collector.collect }.to raise_error do |error|
+          expect(error).to be_a(Knowledge::SkipCollector)
+          expect(error.preserve_existing_artifacts?).to be(true)
+        end
       end
 
       it "cleans up credentials and disconnects network before running routes" do


### PR DESCRIPTION
## Summary

- Sets `DATABASE_URL=sqlite3::memory:` when running `bin/rails routes` in the container, allowing Rails to boot without a running PostgreSQL/MySQL database
- Expands error classification to gracefully skip (instead of hard-fail) when the sqlite3 gem is absent (`ActiveRecord::AdapterNotFound`) or when initializers query tables that don't exist in the empty in-memory DB
- Renames `database_connection_error?` → `routes_boot_error?` to reflect the broader classification scope

## Problem

Routes collection always skipped with `"routes require database access during Rails boot"` because the container has no database. This meant routes were never collected for any Rails app that connects to the DB during boot — which is most of them.

## Fix

The container now sets `DATABASE_URL=sqlite3::memory:` so Rails boots against an in-memory SQLite3 database. Routes are purely code-defined and don't query the DB, so this works for the common case.

To handle edge cases introduced by the dummy DB:
- Apps without the `sqlite3` gem get `ActiveRecord::AdapterNotFound` → now caught as a boot error, gracefully skipped
- Apps with initializers that query DB tables get `SQLite3::SQLException: no such table` → now caught as a boot error, gracefully skipped (in-memory DB has no schema)
- Non-connection SQL errors (syntax errors) still hard-fail as before