### PR TITLE
fix(agent-runs): improve reliability of paid_agent reviews and the smoke matrix

### DIFF
--- a/.github/workflows/pr-screenshots-publish.yml
+++ b/.github/workflows/pr-screenshots-publish.yml
@@ -34,6 +34,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_ACTION: ${{ github.event.action }}
         run: |
           ruby <<'RUBY'
@@ -44,6 +45,7 @@ jobs:
           repo = ENV.fetch("GITHUB_REPOSITORY")
           pr_number = Integer(ENV.fetch("PR_NUMBER"))
           head_sha = ENV.fetch("HEAD_SHA")
+          head_ref = ENV.fetch("HEAD_REF")
           pr_action = ENV.fetch("PR_ACTION")
           token = ENV.fetch("GITHUB_TOKEN")
           output_path = ENV.fetch("GITHUB_OUTPUT")
@@ -73,7 +75,9 @@ jobs:
             ).fetch("workflow_runs")
 
             run = runs.find do |candidate|
-              candidate["head_sha"] == head_sha &&
+              next false unless candidate["head_sha"] == head_sha
+
+              candidate["head_branch"] == head_ref ||
                 candidate.fetch("pull_requests", []).any? { |pr| pr["number"] == pr_number }
             end
 

--- a/spec/config/pr_screenshots_publish_workflow_file_spec.rb
+++ b/spec/config/pr_screenshots_publish_workflow_file_spec.rb
@@ -16,8 +16,14 @@ RSpec.describe PrScreenshotsPublishWorkflowFile do
 
   let(:job) { workflow.fetch("jobs").fetch("publish") }
   let(:resolve_step) { job.fetch("steps").find { |step| step["name"] == "Resolve PR capture run" } }
+  let(:resolve_env) { resolve_step.fetch("env") }
 
   it "queries screenshot capture runs by the PR head sha" do
     expect(resolve_step.fetch("run")).to include('head_sha=#{head_sha}&per_page=100')
+  end
+
+  it "passes the PR head ref to the resolver for branch-based fallback matching" do
+    expect(resolve_env).to include("HEAD_REF" => "${{ github.event.pull_request.head.ref }}")
+    expect(resolve_step.fetch("run")).to include('candidate["head_branch"] == head_ref')
   end
 end


### PR DESCRIPTION
## Summary

Investigation from the agent-runs page (18% completion rate, 53% failure rate over 153 recent runs) surfaced several distinct issues. This PR fixes the highest-impact ones and tightens the smoke matrix used to diagnose the remaining unknowns.

### Root causes addressed

- **paid-code-reviewer credential was an OpenSSH key** (already fixed manually in `9c8a35c1`, the commit this branch was opened against). Every review-goal run was burning tokens for hundreds of seconds before the proxy rejected the JWT mint. This PR adds parse-time validation so a future regression of this class fails project save instead of failing live runs.
- **Concurrent review + create_pr runs on the same PR.** 14 of the ~80 failed runs were `WorktreeConflict` because the scanner emitted both `paid_agent_review_pending` and CI/comment triggers in the same cycle, and the workflow dispatcher queued both. An existing Temporal patch was meant to gate this but doesn't take effect for long-running poll workflows started before it was added.
- **Copilot smoke test failure** when the CLI emits only `session.mcp_servers_loaded` (a session-lifecycle variant added since the previous fix at `7f445563`). The noisy-line filter missed it and surfaced raw JSON.

### Commits

1. `fix(review-bot)`: `Github::ReviewBotInstallationToken.configured?` attempts an RSA parse (memoized per key string), and `Project#validate_review_methods!` now distinguishes "credentials not configured" from "private key present but cannot be parsed as RSA (must be PEM, not OpenSSH)."
2. `fix(scheduler)`: Two-layer concurrency fix.
   - Scanner-level gate in `scan_paid_prs_activity` drops other actionable triggers in the same cycle when `paid_agent_review_pending` is pending; they re-detect on the next scan after the review posts. A new `pr_scanner.review_pending_gate` structured log emits the suppressed trigger types so operators can see why a CI failure was not picked up this cycle.
   - Queue-level dedup in `queue_agent_run_activity` is now goal-agnostic — defense-in-depth behind the scanner gate. Cross-goal dedups now log `requested_goal`, `existing_goal`, and `cross_goal: true` so they are diagnosable.
3. `fix(providers)`: `noisy_error_line?` now checks the broad `MCP_SESSION_EVENT_PATTERN` first, matching any future `session.*` variant. Adds `claude-diag-baseline` and `claude-diag-tool-required` scenarios to `bin/provider-smoke` for isolating where claude_code's `create_pr` runs hang (18 of 19 timeouts in the data are claude_code with `tokens_input=0`).

### Out of scope

- A true MCP-handshake diagnostic — the smoke `build_test_run` flow does not provision MCP servers, and layering that in is a deeper change than these scenarios are scoped for. Documented in the helper.
- Investigation of the underlying claude_code startup-hang itself. The diagnostic scenarios are meant to support that investigation rather than fix it.

## Test plan

- [x] `bin/rspec spec/services/github/review_bot_installation_token_spec.rb` — 6 examples (incl. new malformed-key & rotation cases)
- [x] `bin/rspec spec/models/project_spec.rb -e "paid_agent"` — 8 examples (incl. new "distinct message for malformed key" case)
- [x] `bin/rspec spec/temporal/activities/queue_agent_run_activity_spec.rb` — 31 examples (incl. new cross-goal dedup cases)
- [x] `bin/rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb` — 332 examples (incl. new `paid_agent_review_pending hard gate` context)
- [x] `bin/rspec spec/services/providers/test_agent_spec.rb` — incl. new `session.mcp_servers_loaded` regression
- [x] `bin/provider-smoke list` shows the new `claude-diagnostics` preset
- [ ] Run `bin/provider-smoke service claude-diagnostics` against the dev container to confirm baseline + tool-required behave as expected (requires Claude subscription auth in the dev env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)