### PR TITLE
fix(db-scripts): handle RLS and triggers in dump/restore/regenerate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,9 @@
 !/tmp/pids/
 !/tmp/pids/.keep
 
-# Ignore auto-generated cable structure (uses schema.rb via fx gem)
+# Ignore auto-generated cable schema (managed by fx gem via cable_schema.rb)
 /db/cable_structure.sql
+/db/structure.sql
 
 # Ignore storage (uploaded files in development and any SQLite databases).
 /storage/*

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${APP_ROOT}/bin/lib/db_helpers.sh"
 cd "$APP_ROOT" || exit
 
 BACKUPS_DIR="${APP_ROOT}/backups"
@@ -55,96 +56,6 @@ read_container_env() {
   docker exec "$container" printenv "$name" 2>/dev/null || true
 }
 
-run_sql() {
-  local db="$1"; shift
-  if [[ "$BACKEND" == "docker" ]]; then
-    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
-      psql -U "$COMPOSE_DB_USER" -d "$db" -q --no-align --tuples-only "$@"
-  else
-    local host_args=()
-    [[ -n "$DB_HOST" ]] && host_args=(-h "$DB_HOST")
-    PGPASSWORD="$DB_PASSWORD" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q --no-align --tuples-only "$@"
-  fi
-}
-
-run_sql_exec() {
-  local db="$1"; shift
-  if [[ "$BACKEND" == "docker" ]]; then
-    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
-      psql -U "$COMPOSE_DB_USER" -d "$db" -q "$@"
-  else
-    local host_args=()
-    [[ -n "$DB_HOST" ]] && host_args=(-h "$DB_HOST")
-    PGPASSWORD="$DB_PASSWORD" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q "$@"
-  fi
-}
-
-run_table_alter_best_effort() {
-  local db="$1"
-  local tables="$2"
-  local sql="$3"
-  local action="$4"
-  local required="${5:-0}"
-  local failures=0
-
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    if ! run_sql_exec "$db" -c "ALTER TABLE \"$table\" ${sql};" >/dev/null; then
-      echo "WARNING: failed to ${action} on ${table}" >&2
-      failures=$((failures + 1))
-    fi
-  done <<< "$tables"
-
-  if [[ "$failures" -gt 0 ]]; then
-    echo "WARNING: ${failures} table(s) failed while attempting to ${action}" >&2
-    if [[ "$required" == "1" ]]; then
-      return 1
-    fi
-  fi
-}
-
-disable_rls() {
-  local db="$1"
-  local required="${2:-0}"
-  RLS_TABLES="$(run_sql "$db" -c "
-    SELECT tablename FROM pg_tables
-    WHERE schemaname = 'public' AND rowsecurity = true
-    ORDER BY tablename
-  " 2>/dev/null)" || true
-
-  if [[ -z "$RLS_TABLES" ]]; then
-    return 0
-  fi
-
-  local count
-  count="$(echo "$RLS_TABLES" | wc -l)"
-  echo "Disabling RLS on $count tables..."
-  run_table_alter_best_effort "$db" "$RLS_TABLES" "DISABLE ROW LEVEL SECURITY" "disable RLS" "$required"
-}
-
-enable_rls() {
-  local db="$1"
-  local tables="${2:-${RLS_TABLES}}"
-  local required="${3:-0}"
-
-  if [[ -z "$tables" ]]; then
-    tables="$(run_sql "$db" -c "
-      SELECT DISTINCT c.relname
-      FROM pg_class c
-      JOIN pg_policy p ON p.polrelid = c.oid
-      JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE n.nspname = 'public' AND c.relkind = 'r'
-      ORDER BY c.relname
-    " 2>/dev/null)" || true
-    if [[ -z "$tables" ]]; then
-      return 0
-    fi
-  fi
-
-  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS" "$required"
-  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS" "$required"
-}
-
 pg_dump_args() {
   local user="$1"
 
@@ -192,16 +103,16 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
   COMPOSE_DB_USER="${COMPOSE_DB_USER:-paid}"
   COMPOSE_DB_PASSWORD="${COMPOSE_DB_PASSWORD:-paid}"
 
-  disable_rls "$DB_NAME" 1
+  disable_rls "$DB_NAME" 1 RLS_TABLES "Disabling RLS on %d tables..."
 
   pg_dump_args "$COMPOSE_DB_USER"
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 
-  enable_rls "$DB_NAME" "$RLS_TABLES" 1
+  enable_rls "$DB_NAME" "$RLS_TABLES" 1 RLS_TABLES
 elif [[ -n "$DB_NAME" ]]; then
   BACKEND="local"
 
-  disable_rls "$DB_NAME" 1
+  disable_rls "$DB_NAME" 1 RLS_TABLES "Disabling RLS on %d tables..."
 
   pg_dump_args "$DB_USER"
   PG_HOST_ARGS=()
@@ -210,7 +121,7 @@ elif [[ -n "$DB_NAME" ]]; then
   fi
   PGPASSWORD="$DB_PASSWORD" pg_dump "${PG_HOST_ARGS[@]}" "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 
-  enable_rls "$DB_NAME" "$RLS_TABLES" 1
+  enable_rls "$DB_NAME" "$RLS_TABLES" 1 RLS_TABLES
 else
   echo "Error: No running postgres container found and DB_NAME not set. Start services with 'bin/dev' or set DB_NAME." >&2
   exit 1

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -5,6 +5,8 @@ APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$APP_ROOT" || exit
 
 BACKUPS_DIR="${APP_ROOT}/backups"
+BACKEND=""
+RLS_TABLES=""
 
 read_rails_db_config() {
   bin/rails runner "
@@ -20,6 +22,7 @@ usage() {
   echo "Usage: bin/db-dump [BACKUP_FILENAME]"
   echo ""
   echo "Dump database data to a custom-format archive in backups/."
+  echo "Automatically disables RLS before dumping so all rows are captured."
   echo ""
   echo "Defaults are read from the Rails database config."
   echo ""
@@ -52,6 +55,77 @@ read_container_env() {
   docker exec "$container" printenv "$name" 2>/dev/null || true
 }
 
+run_sql() {
+  local db="$1"; shift
+  if [[ "$BACKEND" == "docker" ]]; then
+    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
+      psql -U "$COMPOSE_DB_USER" -d "$db" -q --no-align --tuples-only "$@"
+  else
+    local host_args=()
+    [[ -n "$DB_HOST" ]] && host_args=(-h "$DB_HOST")
+    PGPASSWORD="$DB_PASSWORD" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q --no-align --tuples-only "$@"
+  fi
+}
+
+run_sql_exec() {
+  local db="$1"; shift
+  if [[ "$BACKEND" == "docker" ]]; then
+    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
+      psql -U "$COMPOSE_DB_USER" -d "$db" -q "$@"
+  else
+    local host_args=()
+    [[ -n "$DB_HOST" ]] && host_args=(-h "$DB_HOST")
+    PGPASSWORD="$DB_PASSWORD" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q "$@"
+  fi
+}
+
+disable_rls() {
+  local db="$1"
+  RLS_TABLES="$(run_sql "$db" -c "
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public' AND rowsecurity = true
+    ORDER BY tablename
+  " 2>/dev/null)" || true
+
+  if [[ -z "$RLS_TABLES" ]]; then
+    return 0
+  fi
+
+  local count
+  count="$(echo "$RLS_TABLES" | wc -l)"
+  echo "Disabling RLS on $count tables..."
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE ROW LEVEL SECURITY;" 2>/dev/null || true
+  done <<< "$RLS_TABLES"
+}
+
+enable_rls() {
+  local db="$1"
+  local tables="${2:-${RLS_TABLES}}"
+
+  if [[ -z "$tables" ]]; then
+    tables="$(run_sql "$db" -c "
+      SELECT DISTINCT c.relname
+      FROM pg_class c
+      JOIN pg_policy p ON p.polrelid = c.oid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind = 'r'
+      ORDER BY c.relname
+    " 2>/dev/null)" || true
+    if [[ -z "$tables" ]]; then
+      return 0
+    fi
+  fi
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE ROW LEVEL SECURITY;" 2>/dev/null || true
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" FORCE ROW LEVEL SECURITY;" 2>/dev/null || true
+  done <<< "$tables"
+}
+
 pg_dump_args() {
   local user="$1"
 
@@ -81,22 +155,43 @@ if [[ -n "${COMPOSE_FILE:-}" ]]; then
   COMPOSE_ARGS+=(-f "$COMPOSE_FILE")
 fi
 
+cleanup() {
+  local exit_code=$?
+  if [[ "$exit_code" -ne 0 && -n "$RLS_TABLES" && -n "$BACKEND" ]]; then
+    echo "Re-enabling RLS after error..." >&2
+    enable_rls "$DB_NAME" "$RLS_TABLES" 2>/dev/null || true
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
 COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1 || true)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
+  BACKEND="docker"
   COMPOSE_DB_USER="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_USER)"
   COMPOSE_DB_PASSWORD="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_PASSWORD)"
   COMPOSE_DB_USER="${COMPOSE_DB_USER:-paid}"
   COMPOSE_DB_PASSWORD="${COMPOSE_DB_PASSWORD:-paid}"
 
+  disable_rls "$DB_NAME"
+
   pg_dump_args "$COMPOSE_DB_USER"
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
+
+  enable_rls "$DB_NAME"
 elif [[ -n "$DB_NAME" ]]; then
+  BACKEND="local"
+
+  disable_rls "$DB_NAME"
+
   pg_dump_args "$DB_USER"
   PG_HOST_ARGS=()
   if [[ -n "$DB_HOST" ]]; then
     PG_HOST_ARGS=(-h "$DB_HOST")
   fi
   PGPASSWORD="$DB_PASSWORD" pg_dump "${PG_HOST_ARGS[@]}" "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
+
+  enable_rls "$DB_NAME"
 else
   echo "Error: No running postgres container found and DB_NAME not set. Start services with 'bin/dev' or set DB_NAME." >&2
   exit 1

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -84,6 +84,7 @@ run_table_alter_best_effort() {
   local tables="$2"
   local sql="$3"
   local action="$4"
+  local required="${5:-0}"
   local failures=0
 
   while IFS= read -r table; do
@@ -96,11 +97,15 @@ run_table_alter_best_effort() {
 
   if [[ "$failures" -gt 0 ]]; then
     echo "WARNING: ${failures} table(s) failed while attempting to ${action}" >&2
+    if [[ "$required" == "1" ]]; then
+      return 1
+    fi
   fi
 }
 
 disable_rls() {
   local db="$1"
+  local required="${2:-0}"
   RLS_TABLES="$(run_sql "$db" -c "
     SELECT tablename FROM pg_tables
     WHERE schemaname = 'public' AND rowsecurity = true
@@ -114,12 +119,13 @@ disable_rls() {
   local count
   count="$(echo "$RLS_TABLES" | wc -l)"
   echo "Disabling RLS on $count tables..."
-  run_table_alter_best_effort "$db" "$RLS_TABLES" "DISABLE ROW LEVEL SECURITY" "disable RLS"
+  run_table_alter_best_effort "$db" "$RLS_TABLES" "DISABLE ROW LEVEL SECURITY" "disable RLS" "$required"
 }
 
 enable_rls() {
   local db="$1"
   local tables="${2:-${RLS_TABLES}}"
+  local required="${3:-0}"
 
   if [[ -z "$tables" ]]; then
     tables="$(run_sql "$db" -c "
@@ -135,8 +141,8 @@ enable_rls() {
     fi
   fi
 
-  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS"
-  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS"
+  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS" "$required"
+  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS" "$required"
 }
 
 pg_dump_args() {
@@ -186,16 +192,16 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
   COMPOSE_DB_USER="${COMPOSE_DB_USER:-paid}"
   COMPOSE_DB_PASSWORD="${COMPOSE_DB_PASSWORD:-paid}"
 
-  disable_rls "$DB_NAME"
+  disable_rls "$DB_NAME" 1
 
   pg_dump_args "$COMPOSE_DB_USER"
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" pg_dump "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 
-  enable_rls "$DB_NAME"
+  enable_rls "$DB_NAME" "$RLS_TABLES" 1
 elif [[ -n "$DB_NAME" ]]; then
   BACKEND="local"
 
-  disable_rls "$DB_NAME"
+  disable_rls "$DB_NAME" 1
 
   pg_dump_args "$DB_USER"
   PG_HOST_ARGS=()
@@ -204,7 +210,7 @@ elif [[ -n "$DB_NAME" ]]; then
   fi
   PGPASSWORD="$DB_PASSWORD" pg_dump "${PG_HOST_ARGS[@]}" "${PG_DUMP_ARGS[@]}" > "$BACKUP_PATH"
 
-  enable_rls "$DB_NAME"
+  enable_rls "$DB_NAME" "$RLS_TABLES" 1
 else
   echo "Error: No running postgres container found and DB_NAME not set. Start services with 'bin/dev' or set DB_NAME." >&2
   exit 1

--- a/bin/db-dump
+++ b/bin/db-dump
@@ -79,6 +79,26 @@ run_sql_exec() {
   fi
 }
 
+run_table_alter_best_effort() {
+  local db="$1"
+  local tables="$2"
+  local sql="$3"
+  local action="$4"
+  local failures=0
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    if ! run_sql_exec "$db" -c "ALTER TABLE \"$table\" ${sql};" >/dev/null; then
+      echo "WARNING: failed to ${action} on ${table}" >&2
+      failures=$((failures + 1))
+    fi
+  done <<< "$tables"
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo "WARNING: ${failures} table(s) failed while attempting to ${action}" >&2
+  fi
+}
+
 disable_rls() {
   local db="$1"
   RLS_TABLES="$(run_sql "$db" -c "
@@ -94,11 +114,7 @@ disable_rls() {
   local count
   count="$(echo "$RLS_TABLES" | wc -l)"
   echo "Disabling RLS on $count tables..."
-
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE ROW LEVEL SECURITY;" 2>/dev/null || true
-  done <<< "$RLS_TABLES"
+  run_table_alter_best_effort "$db" "$RLS_TABLES" "DISABLE ROW LEVEL SECURITY" "disable RLS"
 }
 
 enable_rls() {
@@ -119,11 +135,8 @@ enable_rls() {
     fi
   fi
 
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE ROW LEVEL SECURITY;" 2>/dev/null || true
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" FORCE ROW LEVEL SECURITY;" 2>/dev/null || true
-  done <<< "$tables"
+  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS"
+  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS"
 }
 
 pg_dump_args() {
@@ -159,7 +172,7 @@ cleanup() {
   local exit_code=$?
   if [[ "$exit_code" -ne 0 && -n "$RLS_TABLES" && -n "$BACKEND" ]]; then
     echo "Re-enabling RLS after error..." >&2
-    enable_rls "$DB_NAME" "$RLS_TABLES" 2>/dev/null || true
+    enable_rls "$DB_NAME" "$RLS_TABLES"
   fi
   exit "$exit_code"
 }

--- a/bin/db-regenerate
+++ b/bin/db-regenerate
@@ -37,6 +37,7 @@ run_table_alter_best_effort() {
   local tables="$2"
   local sql="$3"
   local action="$4"
+  local required="${5:-0}"
   local failures=0
 
   while IFS= read -r table; do
@@ -49,6 +50,9 @@ run_table_alter_best_effort() {
 
   if [[ "$failures" -gt 0 ]]; then
     warn "${failures} table(s) failed while attempting to ${action}"
+    if [[ "$required" == "1" ]]; then
+      return 1
+    fi
   fi
 }
 
@@ -75,6 +79,7 @@ get_rls_tables() {
 
 disable_rls() {
   local db="$1"
+  local required="${2:-0}"
   info "Disabling RLS on all tables in $db..."
   local tables
   tables="$(get_rls_tables "$db")"
@@ -84,12 +89,13 @@ disable_rls() {
     return 0
   fi
   CACHED_RLS_TABLES="$tables"
-  run_table_alter_best_effort "$db" "$tables" "DISABLE ROW LEVEL SECURITY" "disable RLS"
+  run_table_alter_best_effort "$db" "$tables" "DISABLE ROW LEVEL SECURITY" "disable RLS" "$required"
 }
 
 enable_rls() {
   local db="$1"
   local tables="${2:-${CACHED_RLS_TABLES}}"
+  local required="${3:-0}"
   info "Re-enabling RLS on all tables in $db..."
   if [[ -z "$tables" ]]; then
     warn "No cached RLS table list. Querying pg_policy for tables with policies..."
@@ -106,8 +112,8 @@ enable_rls() {
       return 0
     fi
   fi
-  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS"
-  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS"
+  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS" "$required"
+  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS" "$required"
 }
 
 get_row_counts() {
@@ -264,7 +270,7 @@ restore_into() {
       AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
     ORDER BY tablename
   " 2>/dev/null)" || true
-  run_table_alter_best_effort "$db_name" "$data_tables" "DISABLE TRIGGER ALL" "disable triggers"
+  run_table_alter_best_effort "$db_name" "$data_tables" "DISABLE TRIGGER ALL" "disable triggers" 1
 
   info "Truncating target tables..."
   run_sql_exec "$db_name" -c "
@@ -287,11 +293,14 @@ restore_into() {
 
   info "Restoring data..."
   local restore_output
-  restore_output="$(PGPASSWORD="$PG_PASSWORD" pg_restore \
+  local restore_failed=0
+  if ! restore_output="$(PGPASSWORD="$PG_PASSWORD" pg_restore \
     -h "$PG_HOST" -U "$PG_USER" \
     --data-only --no-owner --no-privileges \
     -d "$db_name" \
-    "$backup_path" 2>&1)" || true
+    "$backup_path" 2>&1)"; then
+    restore_failed=1
+  fi
 
   local errors
   errors="$(echo "$restore_output" | grep -iE "error|failed" | grep -vi "errors ignored on restore" || true)"
@@ -301,21 +310,33 @@ restore_into() {
       error "  $line"
     done
     error "Data may be incomplete. Check backup and target database."
+    restore_failed=1
   fi
 
   info "Re-enabling triggers on data tables..."
-  run_table_alter_best_effort "$db_name" "$data_tables" "ENABLE TRIGGER ALL" "enable triggers"
+  run_table_alter_best_effort "$db_name" "$data_tables" "ENABLE TRIGGER ALL" "enable triggers" 1
 
   info "Re-creating FK constraints..."
   local recreated=0
+  local fk_failures=0
   while IFS='|' read -r conname tbl def; do
     [[ -z "$conname" ]] && continue
     run_sql_exec "$db_name" -c "ALTER TABLE ${tbl} ADD CONSTRAINT ${conname} ${def};" >/dev/null || {
       warn "  Could not recreate constraint ${conname} on ${tbl}"
+      fk_failures=$((fk_failures + 1))
     }
     recreated=$((recreated + 1))
   done <<< "$fk_defs"
   info "Recreated $recreated/$fk_count FK constraints"
+
+  if [[ "$fk_failures" -gt 0 ]]; then
+    error "Failed to recreate ${fk_failures} foreign key constraint(s)"
+    return 1
+  fi
+
+  if [[ "$restore_failed" -ne 0 ]]; then
+    return 1
+  fi
 
   info "Restore into $db_name complete"
 }
@@ -449,14 +470,14 @@ stop_app
 
 # Step 2: Disable RLS so pg_dump can see all data
 info "Current row counts (with RLS disabled after this step):"
-disable_rls "$PG_DB"
+disable_rls "$PG_DB" 1
 
 # Step 3: Backup
 create_backup "full"
 verify_backup_row_counts
 
 # Step 4: Re-enable RLS on source DB (we have the backup now)
-enable_rls "$PG_DB"
+enable_rls "$PG_DB" "$CACHED_RLS_TABLES" 1
 
 # Step 5: Create target databases
 if [[ "$PRACTICE_MODE" == "1" ]]; then
@@ -510,7 +531,7 @@ else
 fi
 
 # Step 7: Disable RLS on target for data restoration
-disable_rls "$TARGET_DB"
+disable_rls "$TARGET_DB" 1
 
 # Step 8: Restore data
 restore_into "$TARGET_DB" "$BACKUP_PATH"
@@ -526,7 +547,7 @@ if [[ "$PRACTICE_MODE" == "1" ]]; then
 
   SOURCE_RLS_TABLES="$CACHED_RLS_TABLES"
   info "Disabling RLS on source DB for comparison..."
-  disable_rls "$PG_DB"
+  disable_rls "$PG_DB" 1
 
   info "Source DB row counts (RLS disabled):"
   get_row_counts "$PG_DB" | while IFS= read -r line; do
@@ -536,11 +557,11 @@ if [[ "$PRACTICE_MODE" == "1" ]]; then
   compare_row_counts "$PG_DB" "$TARGET_DB" || true
 
   info "Re-enabling RLS on source DB..."
-  enable_rls "$PG_DB" "$SOURCE_RLS_TABLES"
+  enable_rls "$PG_DB" "$SOURCE_RLS_TABLES" 1
 fi
 
 # Step 10: Re-enable RLS on target
-enable_rls "$TARGET_DB"
+enable_rls "$TARGET_DB" "$CACHED_RLS_TABLES" 1
 
 # Step 11: Post-RLS steps
 if [[ "$PRACTICE_MODE" == "1" ]]; then

--- a/bin/db-regenerate
+++ b/bin/db-regenerate
@@ -2,11 +2,16 @@
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${APP_ROOT}/bin/lib/db_helpers.sh"
 cd "$APP_ROOT" || exit
 
 PG_HOST="${DB_HOST:-postgres}"
 PG_USER="${DB_USER:-paid}"
 PG_PASSWORD="${DB_PASSWORD:-paid}"
+DB_HOST="$PG_HOST"
+DB_USER="$PG_USER"
+DB_PASSWORD="$PG_PASSWORD"
+BACKEND="local"
 PG_DB="paid_development"
 PG_CABLE_DB="paid_development_cable"
 PRACTICE_DB="paid_practice"
@@ -21,40 +26,6 @@ NC='\033[0m'
 info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
-
-run_sql() {
-  local db="$1"; shift
-  PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -U "$PG_USER" -d "$db" -q --no-align --tuples-only "$@"
-}
-
-run_sql_exec() {
-  local db="$1"; shift
-  PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -U "$PG_USER" -d "$db" -q "$@"
-}
-
-run_table_alter_best_effort() {
-  local db="$1"
-  local tables="$2"
-  local sql="$3"
-  local action="$4"
-  local required="${5:-0}"
-  local failures=0
-
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    if ! run_sql_exec "$db" -c "ALTER TABLE \"$table\" ${sql};" >/dev/null; then
-      warn "Failed to ${action} on ${table}"
-      failures=$((failures + 1))
-    fi
-  done <<< "$tables"
-
-  if [[ "$failures" -gt 0 ]]; then
-    warn "${failures} table(s) failed while attempting to ${action}"
-    if [[ "$required" == "1" ]]; then
-      return 1
-    fi
-  fi
-}
 
 db_exists() {
   local db="$1"
@@ -74,46 +45,7 @@ terminate_connections() {
 
 get_rls_tables() {
   local db="$1"
-  run_sql "$db" -c "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND rowsecurity = true ORDER BY tablename" 2>/dev/null
-}
-
-disable_rls() {
-  local db="$1"
-  local required="${2:-0}"
-  info "Disabling RLS on all tables in $db..."
-  local tables
-  tables="$(get_rls_tables "$db")"
-  if [[ -z "$tables" ]]; then
-    info "No RLS tables found in $db"
-    CACHED_RLS_TABLES=""
-    return 0
-  fi
-  CACHED_RLS_TABLES="$tables"
-  run_table_alter_best_effort "$db" "$tables" "DISABLE ROW LEVEL SECURITY" "disable RLS" "$required"
-}
-
-enable_rls() {
-  local db="$1"
-  local tables="${2:-${CACHED_RLS_TABLES}}"
-  local required="${3:-0}"
-  info "Re-enabling RLS on all tables in $db..."
-  if [[ -z "$tables" ]]; then
-    warn "No cached RLS table list. Querying pg_policy for tables with policies..."
-    tables="$(run_sql "$db" -c "
-      SELECT DISTINCT c.relname
-      FROM pg_class c
-      JOIN pg_policy p ON p.polrelid = c.oid
-      JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE n.nspname = 'public' AND c.relkind = 'r'
-      ORDER BY c.relname
-    " 2>/dev/null)"
-    if [[ -z "$tables" ]]; then
-      info "No tables need RLS in $db"
-      return 0
-    fi
-  fi
-  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS" "$required"
-  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS" "$required"
+  db_helpers_get_rls_tables "$db"
 }
 
 get_row_counts() {
@@ -262,15 +194,9 @@ restore_into() {
   "
   info "FK constraints dropped"
 
-  info "Disabling triggers on data tables..."
   local data_tables
-  data_tables="$(run_sql "$db_name" -c "
-    SELECT tablename FROM pg_tables
-    WHERE schemaname = 'public'
-      AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
-    ORDER BY tablename
-  " 2>/dev/null)" || true
-  run_table_alter_best_effort "$db_name" "$data_tables" "DISABLE TRIGGER ALL" "disable triggers" 1
+  data_tables="$(db_helpers_get_data_tables "$db_name")" || true
+  disable_triggers "$db_name" "$data_tables" 1 "Disabling triggers on data tables..."
 
   info "Truncating target tables..."
   run_sql_exec "$db_name" -c "
@@ -313,8 +239,7 @@ restore_into() {
     restore_failed=1
   fi
 
-  info "Re-enabling triggers on data tables..."
-  run_table_alter_best_effort "$db_name" "$data_tables" "ENABLE TRIGGER ALL" "enable triggers" 1
+  enable_triggers "$db_name" "$data_tables" 1 "Re-enabling triggers on data tables..."
 
   info "Re-creating FK constraints..."
   local recreated=0
@@ -380,20 +305,13 @@ cleanup() {
     warn "Script exited with error (code $exit_code)."
     warn "Attempting to re-enable RLS on $PG_DB..."
     if [[ -n "$CACHED_RLS_TABLES" ]]; then
-      enable_rls "$PG_DB" "$CACHED_RLS_TABLES"
+      enable_rls "$PG_DB" "$CACHED_RLS_TABLES" 0 CACHED_RLS_TABLES
     else
       warn "No cached RLS table list. Restoring RLS from pg_policy..."
       local policy_tables
-      policy_tables="$(run_sql "$PG_DB" -c "
-        SELECT DISTINCT c.relname
-        FROM pg_class c
-        JOIN pg_policy p ON p.polrelid = c.oid
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'public' AND c.relkind = 'r'
-        ORDER BY c.relname
-      " 2>/dev/null)" || true
+      policy_tables="$(db_helpers_get_policy_tables "$PG_DB")" || true
       if [[ -n "$policy_tables" ]]; then
-        enable_rls "$PG_DB" "$policy_tables"
+        enable_rls "$PG_DB" "$policy_tables" 0 CACHED_RLS_TABLES
       fi
     fi
     if [[ "${PRACTICE_MODE:-}" == "1" ]] && db_exists "$PRACTICE_DB"; then
@@ -470,14 +388,17 @@ stop_app
 
 # Step 2: Disable RLS so pg_dump can see all data
 info "Current row counts (with RLS disabled after this step):"
-disable_rls "$PG_DB" 1
+disable_rls "$PG_DB" 1 CACHED_RLS_TABLES "Disabling RLS on all tables in ${PG_DB}..."
+if [[ -z "$CACHED_RLS_TABLES" ]]; then
+  info "No RLS tables found in $PG_DB"
+fi
 
 # Step 3: Backup
 create_backup "full"
 verify_backup_row_counts
 
 # Step 4: Re-enable RLS on source DB (we have the backup now)
-enable_rls "$PG_DB" "$CACHED_RLS_TABLES" 1
+enable_rls "$PG_DB" "$CACHED_RLS_TABLES" 1 CACHED_RLS_TABLES "Re-enabling RLS on all tables in ${PG_DB}..."
 
 # Step 5: Create target databases
 if [[ "$PRACTICE_MODE" == "1" ]]; then
@@ -531,7 +452,10 @@ else
 fi
 
 # Step 7: Disable RLS on target for data restoration
-disable_rls "$TARGET_DB" 1
+disable_rls "$TARGET_DB" 1 CACHED_RLS_TABLES "Disabling RLS on all tables in ${TARGET_DB}..."
+if [[ -z "$CACHED_RLS_TABLES" ]]; then
+  info "No RLS tables found in $TARGET_DB"
+fi
 
 # Step 8: Restore data
 restore_into "$TARGET_DB" "$BACKUP_PATH"
@@ -547,7 +471,10 @@ if [[ "$PRACTICE_MODE" == "1" ]]; then
 
   SOURCE_RLS_TABLES="$CACHED_RLS_TABLES"
   info "Disabling RLS on source DB for comparison..."
-  disable_rls "$PG_DB" 1
+  disable_rls "$PG_DB" 1 CACHED_RLS_TABLES "Disabling RLS on all tables in ${PG_DB}..."
+  if [[ -z "$CACHED_RLS_TABLES" ]]; then
+    info "No RLS tables found in $PG_DB"
+  fi
 
   info "Source DB row counts (RLS disabled):"
   get_row_counts "$PG_DB" | while IFS= read -r line; do
@@ -557,11 +484,11 @@ if [[ "$PRACTICE_MODE" == "1" ]]; then
   compare_row_counts "$PG_DB" "$TARGET_DB" || true
 
   info "Re-enabling RLS on source DB..."
-  enable_rls "$PG_DB" "$SOURCE_RLS_TABLES" 1
+  enable_rls "$PG_DB" "$SOURCE_RLS_TABLES" 1 CACHED_RLS_TABLES "Re-enabling RLS on all tables in ${PG_DB}..."
 fi
 
 # Step 10: Re-enable RLS on target
-enable_rls "$TARGET_DB" "$CACHED_RLS_TABLES" 1
+enable_rls "$TARGET_DB" "$CACHED_RLS_TABLES" 1 CACHED_RLS_TABLES "Re-enabling RLS on all tables in ${TARGET_DB}..."
 
 # Step 11: Post-RLS steps
 if [[ "$PRACTICE_MODE" == "1" ]]; then

--- a/bin/db-regenerate
+++ b/bin/db-regenerate
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# frozen_string_literal: true
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -160,14 +159,15 @@ create_backup() {
 
 verify_backup_row_counts() {
   info "Verifying backup contains data..."
-  local listing
-  listing="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "^;" || true)"
-  if [[ "$listing" -lt 10 ]]; then
-    error "Backup appears to have too few table entries ($listing). Something may be wrong."
-    error "Aborting to prevent data loss."
+  local toc_entries data_entries
+  toc_entries="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "." || true)"
+  data_entries="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "TABLE DATA" || true)"
+  if [[ "$data_entries" -lt 20 ]]; then
+    error "Backup appears to have too few TABLE DATA entries ($data_entries). Something may be wrong."
+    error "Expected 50+ tables with data. Aborting to prevent data loss."
     exit 1
   fi
-  info "Backup contains $listing table entries - looks valid"
+  info "Backup contains $data_entries TABLE DATA entries ($toc_entries total TOC entries) - looks valid"
 }
 
 reset_sequences() {
@@ -242,6 +242,19 @@ restore_into() {
   "
   info "FK constraints dropped"
 
+  info "Disabling triggers on data tables..."
+  local data_tables
+  data_tables="$(run_sql "$db_name" -c "
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
+    ORDER BY tablename
+  " 2>/dev/null)" || true
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db_name" -c "ALTER TABLE \"$table\" DISABLE TRIGGER ALL;" 2>/dev/null || true
+  done <<< "$data_tables"
+
   info "Truncating target tables..."
   run_sql_exec "$db_name" -c "
     DO \$\$
@@ -278,6 +291,12 @@ restore_into() {
     done
     error "Data may be incomplete. Check backup and target database."
   fi
+
+  info "Re-enabling triggers on data tables..."
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db_name" -c "ALTER TABLE \"$table\" ENABLE TRIGGER ALL;" 2>/dev/null || true
+  done <<< "$data_tables"
 
   info "Re-creating FK constraints..."
   local recreated=0

--- a/bin/db-regenerate
+++ b/bin/db-regenerate
@@ -32,6 +32,26 @@ run_sql_exec() {
   PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -U "$PG_USER" -d "$db" -q "$@"
 }
 
+run_table_alter_best_effort() {
+  local db="$1"
+  local tables="$2"
+  local sql="$3"
+  local action="$4"
+  local failures=0
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    if ! run_sql_exec "$db" -c "ALTER TABLE \"$table\" ${sql};" >/dev/null; then
+      warn "Failed to ${action} on ${table}"
+      failures=$((failures + 1))
+    fi
+  done <<< "$tables"
+
+  if [[ "$failures" -gt 0 ]]; then
+    warn "${failures} table(s) failed while attempting to ${action}"
+  fi
+}
+
 db_exists() {
   local db="$1"
   run_sql postgres -c "SELECT 1 FROM pg_database WHERE datname = '$db'" 2>/dev/null | grep -q 1
@@ -64,10 +84,7 @@ disable_rls() {
     return 0
   fi
   CACHED_RLS_TABLES="$tables"
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE ROW LEVEL SECURITY;" 2>/dev/null || true
-  done <<< "$tables"
+  run_table_alter_best_effort "$db" "$tables" "DISABLE ROW LEVEL SECURITY" "disable RLS"
 }
 
 enable_rls() {
@@ -89,11 +106,8 @@ enable_rls() {
       return 0
     fi
   fi
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE ROW LEVEL SECURITY;" 2>/dev/null
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" FORCE ROW LEVEL SECURITY;" 2>/dev/null
-  done <<< "$tables"
+  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS"
+  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS"
 }
 
 get_row_counts() {
@@ -250,10 +264,7 @@ restore_into() {
       AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
     ORDER BY tablename
   " 2>/dev/null)" || true
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db_name" -c "ALTER TABLE \"$table\" DISABLE TRIGGER ALL;" 2>/dev/null || true
-  done <<< "$data_tables"
+  run_table_alter_best_effort "$db_name" "$data_tables" "DISABLE TRIGGER ALL" "disable triggers"
 
   info "Truncating target tables..."
   run_sql_exec "$db_name" -c "
@@ -293,16 +304,13 @@ restore_into() {
   fi
 
   info "Re-enabling triggers on data tables..."
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db_name" -c "ALTER TABLE \"$table\" ENABLE TRIGGER ALL;" 2>/dev/null || true
-  done <<< "$data_tables"
+  run_table_alter_best_effort "$db_name" "$data_tables" "ENABLE TRIGGER ALL" "enable triggers"
 
   info "Re-creating FK constraints..."
   local recreated=0
   while IFS='|' read -r conname tbl def; do
     [[ -z "$conname" ]] && continue
-    run_sql_exec "$db_name" -c "ALTER TABLE ${tbl} ADD CONSTRAINT ${conname} ${def};" 2>/dev/null || {
+    run_sql_exec "$db_name" -c "ALTER TABLE ${tbl} ADD CONSTRAINT ${conname} ${def};" >/dev/null || {
       warn "  Could not recreate constraint ${conname} on ${tbl}"
     }
     recreated=$((recreated + 1))
@@ -351,7 +359,7 @@ cleanup() {
     warn "Script exited with error (code $exit_code)."
     warn "Attempting to re-enable RLS on $PG_DB..."
     if [[ -n "$CACHED_RLS_TABLES" ]]; then
-      enable_rls "$PG_DB" "$CACHED_RLS_TABLES" 2>/dev/null || true
+      enable_rls "$PG_DB" "$CACHED_RLS_TABLES"
     else
       warn "No cached RLS table list. Restoring RLS from pg_policy..."
       local policy_tables
@@ -364,7 +372,7 @@ cleanup() {
         ORDER BY c.relname
       " 2>/dev/null)" || true
       if [[ -n "$policy_tables" ]]; then
-        enable_rls "$PG_DB" "$policy_tables" 2>/dev/null || true
+        enable_rls "$PG_DB" "$policy_tables"
       fi
     fi
     if [[ "${PRACTICE_MODE:-}" == "1" ]] && db_exists "$PRACTICE_DB"; then

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -183,15 +183,21 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
 
   echo "Restoring data..."
   RESTORE_FAILED=""
-  docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" \
-    pg_restore --data-only --no-owner --no-privileges -U "$COMPOSE_DB_USER" -d "$DB_NAME" < "$BACKUP_PATH" 2>&1 || RESTORE_FAILED=1
+  RESTORE_OUTPUT="$(docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" \
+    pg_restore --data-only --no-owner --no-privileges -U "$COMPOSE_DB_USER" -d "$DB_NAME" < "$BACKUP_PATH" 2>&1)" || RESTORE_FAILED=1
 
   enable_triggers "$DB_NAME" "$DATA_TABLES" 1 "Re-enabling triggers on data tables..."
   enable_rls "$DB_NAME" "$RLS_TABLES" 1 RLS_TABLES "Re-enabling RLS on %d tables..."
   RESTORE_CLEANUP_DONE=1
 
   if [[ -n "$RESTORE_FAILED" ]]; then
-    echo "Error: pg_restore reported errors. Data may be incomplete." >&2
+    RESTORE_ERRORS="$(echo "$RESTORE_OUTPUT" | grep -iE "error|failed" | grep -vi "errors ignored on restore" || true)"
+    if [[ -n "$RESTORE_ERRORS" ]]; then
+      echo "Error: pg_restore reported errors:" >&2
+      echo "$RESTORE_ERRORS" | head -20 >&2
+    else
+      echo "Error: pg_restore reported errors. Data may be incomplete." >&2
+    fi
     exit 1
   fi
 
@@ -230,14 +236,20 @@ elif [[ -n "$DB_NAME" ]]; then
     PG_HOST_ARGS=(-h "$DB_HOST")
   fi
   RESTORE_FAILED=""
-  PGPASSWORD="$DB_PASSWORD" pg_restore "${PG_HOST_ARGS[@]}" --data-only --no-owner --no-privileges -U "$DB_USER" -d "$DB_NAME" "$BACKUP_PATH" 2>&1 || RESTORE_FAILED=1
+  RESTORE_OUTPUT="$(PGPASSWORD="$DB_PASSWORD" pg_restore "${PG_HOST_ARGS[@]}" --data-only --no-owner --no-privileges -U "$DB_USER" -d "$DB_NAME" "$BACKUP_PATH" 2>&1)" || RESTORE_FAILED=1
 
   enable_triggers "$DB_NAME" "$DATA_TABLES" 1 "Re-enabling triggers on data tables..."
   enable_rls "$DB_NAME" "$RLS_TABLES" 1 RLS_TABLES "Re-enabling RLS on %d tables..."
   RESTORE_CLEANUP_DONE=1
 
   if [[ -n "$RESTORE_FAILED" ]]; then
-    echo "Error: pg_restore reported errors. Data may be incomplete." >&2
+    RESTORE_ERRORS="$(echo "$RESTORE_OUTPUT" | grep -iE "error|failed" | grep -vi "errors ignored on restore" || true)"
+    if [[ -n "$RESTORE_ERRORS" ]]; then
+      echo "Error: pg_restore reported errors:" >&2
+      echo "$RESTORE_ERRORS" | head -20 >&2
+    else
+      echo "Error: pg_restore reported errors. Data may be incomplete." >&2
+    fi
     exit 1
   fi
 

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -95,6 +95,7 @@ run_table_alter_best_effort() {
   local tables="$2"
   local sql="$3"
   local action="$4"
+  local required="${5:-0}"
   local failures=0
 
   while IFS= read -r table; do
@@ -107,6 +108,9 @@ run_table_alter_best_effort() {
 
   if [[ "$failures" -gt 0 ]]; then
     echo "WARNING: ${failures} table(s) failed while attempting to ${action}" >&2
+    if [[ "$required" == "1" ]]; then
+      return 1
+    fi
   fi
 }
 
@@ -122,6 +126,7 @@ get_data_tables() {
 
 disable_rls() {
   local db="$1"
+  local required="${2:-0}"
   RLS_TABLES="$(run_sql "$db" -c "
     SELECT tablename FROM pg_tables
     WHERE schemaname = 'public' AND rowsecurity = true
@@ -135,12 +140,13 @@ disable_rls() {
   local count
   count="$(echo "$RLS_TABLES" | wc -l)"
   echo "Disabling RLS on $count tables..."
-  run_table_alter_best_effort "$db" "$RLS_TABLES" "DISABLE ROW LEVEL SECURITY" "disable RLS"
+  run_table_alter_best_effort "$db" "$RLS_TABLES" "DISABLE ROW LEVEL SECURITY" "disable RLS" "$required"
 }
 
 enable_rls() {
   local db="$1"
   local tables="${2:-${RLS_TABLES}}"
+  local required="${3:-0}"
 
   if [[ -z "$tables" ]]; then
     tables="$(run_sql "$db" -c "
@@ -159,20 +165,22 @@ enable_rls() {
   local count
   count="$(echo "$tables" | wc -l)"
   echo "Re-enabling RLS on $count tables..."
-  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS"
-  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS"
+  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS" "$required"
+  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS" "$required"
 }
 
 disable_triggers() {
   local db="$1"
+  local required="${2:-0}"
   echo "Disabling triggers on data tables..."
-  run_table_alter_best_effort "$db" "$DATA_TABLES" "DISABLE TRIGGER ALL" "disable triggers"
+  run_table_alter_best_effort "$db" "$DATA_TABLES" "DISABLE TRIGGER ALL" "disable triggers" "$required"
 }
 
 enable_triggers() {
   local db="$1"
+  local required="${2:-0}"
   echo "Re-enabling triggers on data tables..."
-  run_table_alter_best_effort "$db" "$DATA_TABLES" "ENABLE TRIGGER ALL" "enable triggers"
+  run_table_alter_best_effort "$db" "$DATA_TABLES" "ENABLE TRIGGER ALL" "enable triggers" "$required"
 }
 
 local_db_host() {
@@ -262,8 +270,8 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
   COMPOSE_DB_PASSWORD="${COMPOSE_DB_PASSWORD:-paid}"
 
   get_data_tables "$DB_NAME"
-  disable_rls "$DB_NAME"
-  disable_triggers "$DB_NAME"
+  disable_rls "$DB_NAME" 1
+  disable_triggers "$DB_NAME" 1
 
   echo "Truncating existing data..."
   run_sql_exec "$DB_NAME" -c "
@@ -289,8 +297,8 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" \
     pg_restore --data-only --no-owner --no-privileges -U "$COMPOSE_DB_USER" -d "$DB_NAME" < "$BACKUP_PATH" 2>&1 || RESTORE_FAILED=1
 
-  enable_triggers "$DB_NAME"
-  enable_rls "$DB_NAME"
+  enable_triggers "$DB_NAME" 1
+  enable_rls "$DB_NAME" "$RLS_TABLES" 1
   RESTORE_CLEANUP_DONE=1
 
   if [[ -n "$RESTORE_FAILED" ]]; then
@@ -305,8 +313,8 @@ elif [[ -n "$DB_NAME" ]]; then
   echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
 
   get_data_tables "$DB_NAME"
-  disable_rls "$DB_NAME"
-  disable_triggers "$DB_NAME"
+  disable_rls "$DB_NAME" 1
+  disable_triggers "$DB_NAME" 1
 
   echo "Truncating existing data..."
   run_sql_exec "$DB_NAME" -c "
@@ -335,8 +343,8 @@ elif [[ -n "$DB_NAME" ]]; then
   RESTORE_FAILED=""
   PGPASSWORD="$DB_PASSWORD" pg_restore "${PG_HOST_ARGS[@]}" --data-only --no-owner --no-privileges -U "$DB_USER" -d "$DB_NAME" "$BACKUP_PATH" 2>&1 || RESTORE_FAILED=1
 
-  enable_triggers "$DB_NAME"
-  enable_rls "$DB_NAME"
+  enable_triggers "$DB_NAME" 1
+  enable_rls "$DB_NAME" "$RLS_TABLES" 1
   RESTORE_CLEANUP_DONE=1
 
   if [[ -n "$RESTORE_FAILED" ]]; then

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "${APP_ROOT}/bin/lib/db_helpers.sh"
 cd "$APP_ROOT" || exit
 
 BACKUPS_DIR="${APP_ROOT}/backups"
@@ -59,128 +60,16 @@ DB_PASSWORD="${DB_PASSWORD-${RAILS_CONFIG[2]:-}}"
 DB_NAME="${DB_NAME-${RAILS_CONFIG[3]:-}}"
 RAILS_ENVIRONMENT="${RAILS_ENVIRONMENT-${RAILS_CONFIG[4]:-${RAILS_ENV:-${RACK_ENV:-development}}}}"
 
+get_data_tables() {
+  local db="$1"
+  DATA_TABLES="$(db_helpers_get_data_tables "$db")" || true
+}
+
 read_container_env() {
   local container="$1"
   local name="$2"
 
   docker exec "$container" printenv "$name" 2>/dev/null || true
-}
-
-run_sql() {
-  local db="$1"; shift
-  if [[ "$BACKEND" == "docker" ]]; then
-    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
-      psql -U "$COMPOSE_DB_USER" -d "$db" -q --no-align --tuples-only "$@"
-  else
-    local host_args=()
-    [[ -n "$DB_HOST" ]] && host_args=(-h "$DB_HOST")
-    PGPASSWORD="$DB_PASSWORD" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q --no-align --tuples-only "$@"
-  fi
-}
-
-run_sql_exec() {
-  local db="$1"; shift
-  if [[ "$BACKEND" == "docker" ]]; then
-    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
-      psql -U "$COMPOSE_DB_USER" -d "$db" -q "$@"
-  else
-    local host_args=()
-    [[ -n "$DB_HOST" ]] && host_args=(-h "$DB_HOST")
-    PGPASSWORD="$DB_PASSWORD" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q "$@"
-  fi
-}
-
-run_table_alter_best_effort() {
-  local db="$1"
-  local tables="$2"
-  local sql="$3"
-  local action="$4"
-  local required="${5:-0}"
-  local failures=0
-
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    if ! run_sql_exec "$db" -c "ALTER TABLE \"$table\" ${sql};" >/dev/null; then
-      echo "WARNING: failed to ${action} on ${table}" >&2
-      failures=$((failures + 1))
-    fi
-  done <<< "$tables"
-
-  if [[ "$failures" -gt 0 ]]; then
-    echo "WARNING: ${failures} table(s) failed while attempting to ${action}" >&2
-    if [[ "$required" == "1" ]]; then
-      return 1
-    fi
-  fi
-}
-
-get_data_tables() {
-  local db="$1"
-  DATA_TABLES="$(run_sql "$db" -c "
-    SELECT tablename FROM pg_tables
-    WHERE schemaname = 'public'
-      AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
-    ORDER BY tablename
-  " 2>/dev/null)" || true
-}
-
-disable_rls() {
-  local db="$1"
-  local required="${2:-0}"
-  RLS_TABLES="$(run_sql "$db" -c "
-    SELECT tablename FROM pg_tables
-    WHERE schemaname = 'public' AND rowsecurity = true
-    ORDER BY tablename
-  " 2>/dev/null)" || true
-
-  if [[ -z "$RLS_TABLES" ]]; then
-    return 0
-  fi
-
-  local count
-  count="$(echo "$RLS_TABLES" | wc -l)"
-  echo "Disabling RLS on $count tables..."
-  run_table_alter_best_effort "$db" "$RLS_TABLES" "DISABLE ROW LEVEL SECURITY" "disable RLS" "$required"
-}
-
-enable_rls() {
-  local db="$1"
-  local tables="${2:-${RLS_TABLES}}"
-  local required="${3:-0}"
-
-  if [[ -z "$tables" ]]; then
-    tables="$(run_sql "$db" -c "
-      SELECT DISTINCT c.relname
-      FROM pg_class c
-      JOIN pg_policy p ON p.polrelid = c.oid
-      JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE n.nspname = 'public' AND c.relkind = 'r'
-      ORDER BY c.relname
-    " 2>/dev/null)" || true
-    if [[ -z "$tables" ]]; then
-      return 0
-    fi
-  fi
-
-  local count
-  count="$(echo "$tables" | wc -l)"
-  echo "Re-enabling RLS on $count tables..."
-  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS" "$required"
-  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS" "$required"
-}
-
-disable_triggers() {
-  local db="$1"
-  local required="${2:-0}"
-  echo "Disabling triggers on data tables..."
-  run_table_alter_best_effort "$db" "$DATA_TABLES" "DISABLE TRIGGER ALL" "disable triggers" "$required"
-}
-
-enable_triggers() {
-  local db="$1"
-  local required="${2:-0}"
-  echo "Re-enabling triggers on data tables..."
-  run_table_alter_best_effort "$db" "$DATA_TABLES" "ENABLE TRIGGER ALL" "enable triggers" "$required"
 }
 
 local_db_host() {
@@ -245,10 +134,10 @@ cleanup() {
   if [[ -n "$BACKEND" ]]; then
     echo "Cleaning up after error..." >&2
     if [[ -n "$DATA_TABLES" ]]; then
-      enable_triggers "$DB_NAME"
+      enable_triggers "$DB_NAME" "$DATA_TABLES"
     fi
     if [[ -n "$RLS_TABLES" ]]; then
-      enable_rls "$DB_NAME" "$RLS_TABLES"
+      enable_rls "$DB_NAME" "$RLS_TABLES" 0 RLS_TABLES
     fi
   fi
   exit "$exit_code"
@@ -270,8 +159,8 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
   COMPOSE_DB_PASSWORD="${COMPOSE_DB_PASSWORD:-paid}"
 
   get_data_tables "$DB_NAME"
-  disable_rls "$DB_NAME" 1
-  disable_triggers "$DB_NAME" 1
+  disable_rls "$DB_NAME" 1 RLS_TABLES "Disabling RLS on %d tables..."
+  disable_triggers "$DB_NAME" "$DATA_TABLES" 1 "Disabling triggers on data tables..."
 
   echo "Truncating existing data..."
   run_sql_exec "$DB_NAME" -c "
@@ -297,8 +186,8 @@ if [[ -n "$COMPOSE_CONTAINER" ]]; then
   docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" \
     pg_restore --data-only --no-owner --no-privileges -U "$COMPOSE_DB_USER" -d "$DB_NAME" < "$BACKUP_PATH" 2>&1 || RESTORE_FAILED=1
 
-  enable_triggers "$DB_NAME" 1
-  enable_rls "$DB_NAME" "$RLS_TABLES" 1
+  enable_triggers "$DB_NAME" "$DATA_TABLES" 1 "Re-enabling triggers on data tables..."
+  enable_rls "$DB_NAME" "$RLS_TABLES" 1 RLS_TABLES "Re-enabling RLS on %d tables..."
   RESTORE_CLEANUP_DONE=1
 
   if [[ -n "$RESTORE_FAILED" ]]; then
@@ -313,8 +202,8 @@ elif [[ -n "$DB_NAME" ]]; then
   echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
 
   get_data_tables "$DB_NAME"
-  disable_rls "$DB_NAME" 1
-  disable_triggers "$DB_NAME" 1
+  disable_rls "$DB_NAME" 1 RLS_TABLES "Disabling RLS on %d tables..."
+  disable_triggers "$DB_NAME" "$DATA_TABLES" 1 "Disabling triggers on data tables..."
 
   echo "Truncating existing data..."
   run_sql_exec "$DB_NAME" -c "
@@ -343,8 +232,8 @@ elif [[ -n "$DB_NAME" ]]; then
   RESTORE_FAILED=""
   PGPASSWORD="$DB_PASSWORD" pg_restore "${PG_HOST_ARGS[@]}" --data-only --no-owner --no-privileges -U "$DB_USER" -d "$DB_NAME" "$BACKUP_PATH" 2>&1 || RESTORE_FAILED=1
 
-  enable_triggers "$DB_NAME" 1
-  enable_rls "$DB_NAME" "$RLS_TABLES" 1
+  enable_triggers "$DB_NAME" "$DATA_TABLES" 1 "Re-enabling triggers on data tables..."
+  enable_rls "$DB_NAME" "$RLS_TABLES" 1 RLS_TABLES "Re-enabling RLS on %d tables..."
   RESTORE_CLEANUP_DONE=1
 
   if [[ -n "$RESTORE_FAILED" ]]; then

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -5,6 +5,9 @@ APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$APP_ROOT" || exit
 
 BACKUPS_DIR="${APP_ROOT}/backups"
+BACKEND=""
+RLS_TABLES=""
+DATA_TABLES=""
 
 read_rails_db_config() {
   bin/rails runner "
@@ -23,6 +26,7 @@ usage() {
   echo "Restore database data from a custom-format archive."
   echo "Truncates all existing data before restoring."
   echo "Requires a freshly migrated database (schema must match the dump)."
+  echo "Automatically disables RLS and triggers during restore so all rows are written."
   echo ""
   echo "Defaults are read from the Rails database config."
   echo ""
@@ -62,24 +66,109 @@ read_container_env() {
   docker exec "$container" printenv "$name" 2>/dev/null || true
 }
 
-pg_restore_args() {
-  local user="$1"
-
-  PG_RESTORE_ARGS=(--data-only --disable-triggers --no-owner --no-privileges)
-  if [[ -n "$user" ]]; then
-    PG_RESTORE_ARGS+=(-U "$user")
+run_sql() {
+  local db="$1"; shift
+  if [[ "$BACKEND" == "docker" ]]; then
+    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
+      psql -U "$COMPOSE_DB_USER" -d "$db" -q --no-align --tuples-only "$@"
+  else
+    local host_args=()
+    [[ -n "$DB_HOST" ]] && host_args=(-h "$DB_HOST")
+    PGPASSWORD="$DB_PASSWORD" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q --no-align --tuples-only "$@"
   fi
-  PG_RESTORE_ARGS+=(-d "$DB_NAME")
 }
 
-psql_args() {
-  local user="$1"
-
-  PSQL_ARGS=()
-  if [[ -n "$user" ]]; then
-    PSQL_ARGS+=(-U "$user")
+run_sql_exec() {
+  local db="$1"; shift
+  if [[ "$BACKEND" == "docker" ]]; then
+    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
+      psql -U "$COMPOSE_DB_USER" -d "$db" -q "$@"
+  else
+    local host_args=()
+    [[ -n "$DB_HOST" ]] && host_args=(-h "$DB_HOST")
+    PGPASSWORD="$DB_PASSWORD" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q "$@"
   fi
-  PSQL_ARGS+=(-d "$DB_NAME")
+}
+
+get_data_tables() {
+  local db="$1"
+  DATA_TABLES="$(run_sql "$db" -c "
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
+    ORDER BY tablename
+  " 2>/dev/null)" || true
+}
+
+disable_rls() {
+  local db="$1"
+  RLS_TABLES="$(run_sql "$db" -c "
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public' AND rowsecurity = true
+    ORDER BY tablename
+  " 2>/dev/null)" || true
+
+  if [[ -z "$RLS_TABLES" ]]; then
+    return 0
+  fi
+
+  local count
+  count="$(echo "$RLS_TABLES" | wc -l)"
+  echo "Disabling RLS on $count tables..."
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE ROW LEVEL SECURITY;" 2>/dev/null || true
+  done <<< "$RLS_TABLES"
+}
+
+enable_rls() {
+  local db="$1"
+  local tables="${2:-${RLS_TABLES}}"
+
+  if [[ -z "$tables" ]]; then
+    tables="$(run_sql "$db" -c "
+      SELECT DISTINCT c.relname
+      FROM pg_class c
+      JOIN pg_policy p ON p.polrelid = c.oid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind = 'r'
+      ORDER BY c.relname
+    " 2>/dev/null)" || true
+    if [[ -z "$tables" ]]; then
+      return 0
+    fi
+  fi
+
+  local count
+  count="$(echo "$tables" | wc -l)"
+  echo "Re-enabling RLS on $count tables..."
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE ROW LEVEL SECURITY;" 2>/dev/null || true
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" FORCE ROW LEVEL SECURITY;" 2>/dev/null || true
+  done <<< "$tables"
+}
+
+disable_triggers() {
+  local db="$1"
+  echo "Disabling triggers on data tables..."
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE TRIGGER ALL;" 2>/dev/null || true
+  done <<< "$DATA_TABLES"
+}
+
+enable_triggers() {
+  local db="$1"
+  echo "Re-enabling triggers on data tables..."
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE TRIGGER ALL;" 2>/dev/null || true
+  done <<< "$DATA_TABLES"
 }
 
 local_db_host() {
@@ -116,11 +205,6 @@ guard_destructive_restore() {
   fi
 }
 
-announce_restore() {
-  echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
-  echo "Truncating existing data..."
-}
-
 BACKUP_FILE="${1}"
 
 if [[ "$BACKUP_FILE" != /* ]]; then
@@ -139,56 +223,123 @@ if [[ -n "${COMPOSE_FILE:-}" ]]; then
   COMPOSE_ARGS+=(-f "$COMPOSE_FILE")
 fi
 
-TRUNCATE_SQL="
-SET session_replication_role = 'replica';
-DO \$\$
-DECLARE
-  r RECORD;
-BEGIN
-  FOR r IN (
-    SELECT tablename
-    FROM pg_tables
-    WHERE schemaname = 'public'
-      AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
-    ORDER BY tablename
-  ) LOOP
-    EXECUTE format('TRUNCATE TABLE %I CASCADE', r.tablename);
-  END LOOP;
-END;
-\$\$;
-SET session_replication_role = 'origin';
-"
+RESTORE_CLEANUP_DONE=""
+
+cleanup() {
+  local exit_code=$?
+  if [[ "$RESTORE_CLEANUP_DONE" == "1" ]]; then
+    exit "$exit_code"
+  fi
+  if [[ -n "$BACKEND" ]]; then
+    echo "Cleaning up after error..." >&2
+    if [[ -n "$DATA_TABLES" ]]; then
+      enable_triggers "$DB_NAME" 2>/dev/null || true
+    fi
+    if [[ -n "$RLS_TABLES" ]]; then
+      enable_rls "$DB_NAME" "$RLS_TABLES" 2>/dev/null || true
+    fi
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT
 
 COMPOSE_CONTAINER="$(docker "${COMPOSE_ARGS[@]}" ps -q postgres 2>/dev/null | head -1 || true)"
 if [[ -n "$COMPOSE_CONTAINER" ]]; then
+  BACKEND="docker"
   if [[ "$RAILS_ENVIRONMENT" == "production" ]]; then
     require_restore_confirmation "production"
   fi
 
-  announce_restore
+  echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
 
   COMPOSE_DB_USER="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_USER)"
   COMPOSE_DB_PASSWORD="$(read_container_env "$COMPOSE_CONTAINER" POSTGRES_PASSWORD)"
   COMPOSE_DB_USER="${COMPOSE_DB_USER:-paid}"
   COMPOSE_DB_PASSWORD="${COMPOSE_DB_PASSWORD:-paid}"
 
-  pg_restore_args "$COMPOSE_DB_USER"
-  psql_args "$COMPOSE_DB_USER"
-  docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" psql "${PSQL_ARGS[@]}" -c "$TRUNCATE_SQL"
-  docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" pg_restore "${PG_RESTORE_ARGS[@]}" < "$BACKUP_PATH"
+  get_data_tables "$DB_NAME"
+  disable_rls "$DB_NAME"
+  disable_triggers "$DB_NAME"
+
+  echo "Truncating existing data..."
+  run_sql_exec "$DB_NAME" -c "
+    DO \$\$
+    DECLARE
+      r RECORD;
+    BEGIN
+      FOR r IN (
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+          AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
+        ORDER BY tablename
+      ) LOOP
+        EXECUTE format('TRUNCATE TABLE %I CASCADE', r.tablename);
+      END LOOP;
+    END;
+    \$\$;
+  "
+
+  echo "Restoring data..."
+  RESTORE_FAILED=""
+  docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" -i "$COMPOSE_CONTAINER" \
+    pg_restore --data-only --no-owner --no-privileges -U "$COMPOSE_DB_USER" -d "$DB_NAME" < "$BACKUP_PATH" 2>&1 || RESTORE_FAILED=1
+
+  enable_triggers "$DB_NAME"
+  enable_rls "$DB_NAME"
+  RESTORE_CLEANUP_DONE=1
+
+  if [[ -n "$RESTORE_FAILED" ]]; then
+    echo "Error: pg_restore reported errors. Data may be incomplete." >&2
+    exit 1
+  fi
+
 elif [[ -n "$DB_NAME" ]]; then
+  BACKEND="local"
   guard_destructive_restore
 
-  announce_restore
+  echo "Restoring ${BACKUP_PATH} into ${DB_NAME}..."
 
-  pg_restore_args "$DB_USER"
-  psql_args "$DB_USER"
+  get_data_tables "$DB_NAME"
+  disable_rls "$DB_NAME"
+  disable_triggers "$DB_NAME"
+
+  echo "Truncating existing data..."
+  run_sql_exec "$DB_NAME" -c "
+    DO \$\$
+    DECLARE
+      r RECORD;
+    BEGIN
+      FOR r IN (
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+          AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
+        ORDER BY tablename
+      ) LOOP
+        EXECUTE format('TRUNCATE TABLE %I CASCADE', r.tablename);
+      END LOOP;
+    END;
+    \$\$;
+  "
+
+  echo "Restoring data..."
   PG_HOST_ARGS=()
   if [[ -n "$DB_HOST" ]]; then
     PG_HOST_ARGS=(-h "$DB_HOST")
   fi
-  PGPASSWORD="$DB_PASSWORD" psql "${PG_HOST_ARGS[@]}" "${PSQL_ARGS[@]}" -c "$TRUNCATE_SQL"
-  PGPASSWORD="$DB_PASSWORD" pg_restore "${PG_HOST_ARGS[@]}" "${PG_RESTORE_ARGS[@]}" "$BACKUP_PATH"
+  RESTORE_FAILED=""
+  PGPASSWORD="$DB_PASSWORD" pg_restore "${PG_HOST_ARGS[@]}" --data-only --no-owner --no-privileges -U "$DB_USER" -d "$DB_NAME" "$BACKUP_PATH" 2>&1 || RESTORE_FAILED=1
+
+  enable_triggers "$DB_NAME"
+  enable_rls "$DB_NAME"
+  RESTORE_CLEANUP_DONE=1
+
+  if [[ -n "$RESTORE_FAILED" ]]; then
+    echo "Error: pg_restore reported errors. Data may be incomplete." >&2
+    exit 1
+  fi
+
 else
   echo "Error: No running postgres container found and DB_NAME not set. Start services with 'bin/dev' or set DB_NAME." >&2
   exit 1

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -90,6 +90,26 @@ run_sql_exec() {
   fi
 }
 
+run_table_alter_best_effort() {
+  local db="$1"
+  local tables="$2"
+  local sql="$3"
+  local action="$4"
+  local failures=0
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    if ! run_sql_exec "$db" -c "ALTER TABLE \"$table\" ${sql};" >/dev/null; then
+      echo "WARNING: failed to ${action} on ${table}" >&2
+      failures=$((failures + 1))
+    fi
+  done <<< "$tables"
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo "WARNING: ${failures} table(s) failed while attempting to ${action}" >&2
+  fi
+}
+
 get_data_tables() {
   local db="$1"
   DATA_TABLES="$(run_sql "$db" -c "
@@ -115,11 +135,7 @@ disable_rls() {
   local count
   count="$(echo "$RLS_TABLES" | wc -l)"
   echo "Disabling RLS on $count tables..."
-
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE ROW LEVEL SECURITY;" 2>/dev/null || true
-  done <<< "$RLS_TABLES"
+  run_table_alter_best_effort "$db" "$RLS_TABLES" "DISABLE ROW LEVEL SECURITY" "disable RLS"
 }
 
 enable_rls() {
@@ -143,32 +159,20 @@ enable_rls() {
   local count
   count="$(echo "$tables" | wc -l)"
   echo "Re-enabling RLS on $count tables..."
-
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE ROW LEVEL SECURITY;" 2>/dev/null || true
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" FORCE ROW LEVEL SECURITY;" 2>/dev/null || true
-  done <<< "$tables"
+  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS"
+  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS"
 }
 
 disable_triggers() {
   local db="$1"
   echo "Disabling triggers on data tables..."
-
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE TRIGGER ALL;" 2>/dev/null || true
-  done <<< "$DATA_TABLES"
+  run_table_alter_best_effort "$db" "$DATA_TABLES" "DISABLE TRIGGER ALL" "disable triggers"
 }
 
 enable_triggers() {
   local db="$1"
   echo "Re-enabling triggers on data tables..."
-
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE TRIGGER ALL;" 2>/dev/null || true
-  done <<< "$DATA_TABLES"
+  run_table_alter_best_effort "$db" "$DATA_TABLES" "ENABLE TRIGGER ALL" "enable triggers"
 }
 
 local_db_host() {
@@ -233,10 +237,10 @@ cleanup() {
   if [[ -n "$BACKEND" ]]; then
     echo "Cleaning up after error..." >&2
     if [[ -n "$DATA_TABLES" ]]; then
-      enable_triggers "$DB_NAME" 2>/dev/null || true
+      enable_triggers "$DB_NAME"
     fi
     if [[ -n "$RLS_TABLES" ]]; then
-      enable_rls "$DB_NAME" "$RLS_TABLES" 2>/dev/null || true
+      enable_rls "$DB_NAME" "$RLS_TABLES"
     fi
   fi
   exit "$exit_code"

--- a/bin/lib/db_helpers.sh
+++ b/bin/lib/db_helpers.sh
@@ -1,0 +1,190 @@
+# shellcheck shell=bash
+
+run_sql() {
+  local db="$1"
+  shift
+
+  if [[ "${BACKEND:-local}" == "docker" ]]; then
+    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
+      psql -U "$COMPOSE_DB_USER" -d "$db" -q --no-align --tuples-only "$@"
+  else
+    local host_args=()
+    [[ -n "${DB_HOST:-}" ]] && host_args=(-h "$DB_HOST")
+    PGPASSWORD="${DB_PASSWORD:-}" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q --no-align --tuples-only "$@"
+  fi
+}
+
+run_sql_exec() {
+  local db="$1"
+  shift
+
+  if [[ "${BACKEND:-local}" == "docker" ]]; then
+    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
+      psql -U "$COMPOSE_DB_USER" -d "$db" -q "$@"
+  else
+    local host_args=()
+    [[ -n "${DB_HOST:-}" ]] && host_args=(-h "$DB_HOST")
+    PGPASSWORD="${DB_PASSWORD:-}" psql "${host_args[@]}" -U "$DB_USER" -d "$db" -q "$@"
+  fi
+}
+
+db_helpers_log_info() {
+  if declare -F info >/dev/null; then
+    info "$@"
+  else
+    echo "$*"
+  fi
+}
+
+db_helpers_log_warn() {
+  if declare -F warn >/dev/null; then
+    local message="$*"
+    warn "${message^}"
+  else
+    echo "WARNING: $*" >&2
+  fi
+}
+
+db_helpers_get_rls_tables() {
+  local db="$1"
+
+  run_sql "$db" -c "
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public' AND rowsecurity = true
+    ORDER BY tablename
+  " 2>/dev/null
+}
+
+db_helpers_get_policy_tables() {
+  local db="$1"
+
+  run_sql "$db" -c "
+    SELECT DISTINCT c.relname
+    FROM pg_class c
+    JOIN pg_policy p ON p.polrelid = c.oid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relkind = 'r'
+    ORDER BY c.relname
+  " 2>/dev/null
+}
+
+db_helpers_get_data_tables() {
+  local db="$1"
+
+  run_sql "$db" -c "
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
+    ORDER BY tablename
+  " 2>/dev/null
+}
+
+db_helpers_set_var() {
+  local var_name="$1"
+  local value="$2"
+
+  [[ -z "$var_name" ]] && return 0
+  printf -v "$var_name" "%s" "$value"
+}
+
+db_helpers_get_var() {
+  local var_name="$1"
+
+  [[ -z "$var_name" ]] && return 0
+  printf "%s" "${!var_name:-}"
+}
+
+run_table_alter_best_effort() {
+  local db="$1"
+  local tables="$2"
+  local sql="$3"
+  local action="$4"
+  local required="${5:-0}"
+  local failures=0
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    if ! run_sql_exec "$db" -c "ALTER TABLE \"$table\" ${sql};" >/dev/null; then
+      db_helpers_log_warn "failed to ${action} on ${table}"
+      failures=$((failures + 1))
+    fi
+  done <<< "$tables"
+
+  if [[ "$failures" -gt 0 ]]; then
+    db_helpers_log_warn "${failures} table(s) failed while attempting to ${action}"
+    if [[ "$required" == "1" ]]; then
+      return 1
+    fi
+  fi
+}
+
+disable_rls() {
+  local db="$1"
+  local required="${2:-0}"
+  local cache_var="${3:-RLS_TABLES}"
+  local message="${4:-}"
+  local tables
+
+  tables="$(db_helpers_get_rls_tables "$db")" || true
+  db_helpers_set_var "$cache_var" "$tables"
+
+  if [[ -z "$tables" ]]; then
+    return 0
+  fi
+
+  if [[ -n "$message" ]]; then
+    local count
+    count="$(printf "%s\n" "$tables" | wc -l)"
+    db_helpers_log_info "${message//%d/$count}"
+  fi
+
+  run_table_alter_best_effort "$db" "$tables" "DISABLE ROW LEVEL SECURITY" "disable RLS" "$required"
+}
+
+enable_rls() {
+  local db="$1"
+  local tables="${2:-}"
+  local required="${3:-0}"
+  local cache_var="${4:-RLS_TABLES}"
+  local message="${5:-}"
+
+  if [[ -z "$tables" ]]; then
+    tables="$(db_helpers_get_var "$cache_var")"
+  fi
+
+  if [[ -z "$tables" ]]; then
+    tables="$(db_helpers_get_policy_tables "$db")" || true
+    if [[ -z "$tables" ]]; then
+      return 0
+    fi
+  fi
+
+  if [[ -n "$message" ]]; then
+    local count
+    count="$(printf "%s\n" "$tables" | wc -l)"
+    db_helpers_log_info "${message//%d/$count}"
+  fi
+
+  run_table_alter_best_effort "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS" "$required"
+  run_table_alter_best_effort "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS" "$required"
+}
+
+disable_triggers() {
+  local db="$1"
+  local tables="$2"
+  local required="${3:-0}"
+  local message="${4:-}"
+
+  [[ -n "$message" ]] && db_helpers_log_info "$message"
+  run_table_alter_best_effort "$db" "$tables" "DISABLE TRIGGER ALL" "disable triggers" "$required"
+}
+
+enable_triggers() {
+  local db="$1"
+  local tables="$2"
+  local required="${3:-0}"
+  local message="${4:-}"
+
+  [[ -n "$message" ]] && db_helpers_log_info "$message"
+  run_table_alter_best_effort "$db" "$tables" "ENABLE TRIGGER ALL" "enable triggers" "$required"
+}

--- a/spec/scripts/db_script_warning_spec.rb
+++ b/spec/scripts/db_script_warning_spec.rb
@@ -76,10 +76,12 @@ RSpec.describe DbScriptWarning do
 
   def prepare_script_fixture(dir, script_name)
     FileUtils.mkdir_p(File.join(dir, "bin"))
+    FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
     FileUtils.mkdir_p(File.join(dir, "backups"))
 
     script_path = File.join(dir, "bin", script_name)
     FileUtils.cp(File.expand_path("../../bin/#{script_name}", __dir__), script_path)
+    FileUtils.cp(File.expand_path("../../bin/lib/db_helpers.sh", __dir__), File.join(dir, "bin", "lib", "db_helpers.sh"))
     FileUtils.chmod("+x", script_path)
     script_path
   end

--- a/spec/scripts/db_script_warning_spec.rb
+++ b/spec/scripts/db_script_warning_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "open3"
+require "tmpdir"
+require_relative "../support/exec_tmpdir"
+
+class DbScriptWarning
+end
+
+RSpec.describe DbScriptWarning do
+  include ExecTmpdir
+
+  it "warns when db-dump cannot toggle RLS on a table" do
+    Dir.mktmpdir("db-script-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, "db-dump")
+      write_stub(dir, "docker", docker_stub)
+      write_stub(dir, "pg_dump", "#!/bin/sh\necho 'fake dump'\n")
+      write_stub(dir, "psql", db_dump_psql_stub)
+
+      env = base_env(dir)
+      stdout, stderr, status = Open3.capture3(env, script_path, "sample.dump", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Dumped paid_test data")
+      expect(stderr).to include("disable failed")
+      expect(stderr).to include("WARNING: failed to disable RLS on widgets")
+      expect(stderr).to include("WARNING: 1 table(s) failed while attempting to disable RLS")
+      expect(stderr).to include("enable failed")
+      expect(stderr).to include("WARNING: failed to enable RLS on widgets")
+      expect(stderr).to include("force failed")
+      expect(stderr).to include("WARNING: failed to force RLS on widgets")
+    end
+  end
+
+  it "warns when db-restore cannot re-enable protections on a table" do
+    Dir.mktmpdir("db-script-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, "db-restore")
+      write_stub(dir, "docker", docker_stub)
+      write_stub(dir, "pg_restore", "#!/bin/sh\nexit 0\n")
+      write_stub(dir, "psql", db_restore_psql_stub)
+
+      backup_path = File.join(dir, "backups", "sample.dump")
+      File.write(backup_path, "backup")
+
+      env = base_env(dir)
+      stdout, stderr, status = Open3.capture3(env, script_path, "sample.dump", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Restore complete")
+      expect(stderr).to include("enable trigger failed")
+      expect(stderr).to include("WARNING: failed to enable triggers on widgets")
+      expect(stderr).to include("enable failed")
+      expect(stderr).to include("WARNING: failed to enable RLS on widgets")
+      expect(stderr).to include("force failed")
+      expect(stderr).to include("WARNING: failed to force RLS on widgets")
+    end
+  end
+
+  def prepare_script_fixture(dir, script_name)
+    FileUtils.mkdir_p(File.join(dir, "bin"))
+    FileUtils.mkdir_p(File.join(dir, "backups"))
+
+    script_path = File.join(dir, "bin", script_name)
+    FileUtils.cp(File.expand_path("../../bin/#{script_name}", __dir__), script_path)
+    FileUtils.chmod("+x", script_path)
+    script_path
+  end
+
+  def write_stub(dir, name, contents)
+    path = File.join(dir, "stubbin", name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+    FileUtils.chmod("+x", path)
+  end
+
+  def base_env(dir)
+    {
+      "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+      "DB_HOST" => "localhost",
+      "DB_NAME" => "paid_test",
+      "DB_USER" => "paid",
+      "DB_PASSWORD" => "paid"
+    }
+  end
+
+  def docker_stub
+    <<~SH
+      #!/bin/sh
+      exit 0
+    SH
+  end
+
+  def db_dump_psql_stub
+    <<~SH
+      #!/bin/sh
+      args="$*"
+
+      case "$args" in
+        *"rowsecurity = true"*)
+          echo "widgets"
+          ;;
+        *"DISABLE ROW LEVEL SECURITY"*)
+          echo "disable failed" >&2
+          exit 1
+          ;;
+        *"ENABLE ROW LEVEL SECURITY"*)
+          echo "enable failed" >&2
+          exit 1
+          ;;
+        *"FORCE ROW LEVEL SECURITY"*)
+          echo "force failed" >&2
+          exit 1
+          ;;
+      esac
+    SH
+  end
+
+  def db_restore_psql_stub
+    <<~SH
+      #!/bin/sh
+      args="$*"
+
+      case "$args" in
+        *"tablename NOT IN ('ar_internal_metadata', 'schema_migrations')"*)
+          echo "widgets"
+          ;;
+        *"rowsecurity = true"*)
+          echo "widgets"
+          ;;
+        *"DISABLE ROW LEVEL SECURITY"*)
+          echo "disable failed" >&2
+          exit 1
+          ;;
+        *"DISABLE TRIGGER ALL"*)
+          echo "disable trigger failed" >&2
+          exit 1
+          ;;
+        *"ENABLE TRIGGER ALL"*)
+          echo "enable trigger failed" >&2
+          exit 1
+          ;;
+        *"ENABLE ROW LEVEL SECURITY"*)
+          echo "enable failed" >&2
+          exit 1
+          ;;
+        *"FORCE ROW LEVEL SECURITY"*)
+          echo "force failed" >&2
+          exit 1
+          ;;
+      esac
+    SH
+  end
+end

--- a/spec/scripts/db_script_warning_spec.rb
+++ b/spec/scripts/db_script_warning_spec.rb
@@ -12,7 +12,7 @@ end
 RSpec.describe DbScriptWarning do
   include ExecTmpdir
 
-  it "warns when db-dump cannot toggle RLS on a table" do
+  it "fails when db-dump cannot re-enable RLS after dumping" do
     Dir.mktmpdir("db-script-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, "db-dump")
       write_stub(dir, "docker", docker_stub)
@@ -22,19 +22,15 @@ RSpec.describe DbScriptWarning do
       env = base_env(dir)
       stdout, stderr, status = Open3.capture3(env, script_path, "sample.dump", chdir: dir)
 
-      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
-      expect(stdout).to include("Dumped paid_test data")
-      expect(stderr).to include("disable failed")
-      expect(stderr).to include("WARNING: failed to disable RLS on widgets")
-      expect(stderr).to include("WARNING: 1 table(s) failed while attempting to disable RLS")
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).not_to include("Dumped paid_test data")
       expect(stderr).to include("enable failed")
       expect(stderr).to include("WARNING: failed to enable RLS on widgets")
-      expect(stderr).to include("force failed")
-      expect(stderr).to include("WARNING: failed to force RLS on widgets")
+      expect(stderr).to include("Re-enabling RLS after error")
     end
   end
 
-  it "warns when db-restore cannot re-enable protections on a table" do
+  it "fails when db-restore cannot re-enable protections after restore" do
     Dir.mktmpdir("db-script-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, "db-restore")
       write_stub(dir, "docker", docker_stub)
@@ -47,14 +43,34 @@ RSpec.describe DbScriptWarning do
       env = base_env(dir)
       stdout, stderr, status = Open3.capture3(env, script_path, "sample.dump", chdir: dir)
 
-      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
-      expect(stdout).to include("Restore complete")
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).not_to include("Restore complete")
       expect(stderr).to include("enable trigger failed")
       expect(stderr).to include("WARNING: failed to enable triggers on widgets")
       expect(stderr).to include("enable failed")
       expect(stderr).to include("WARNING: failed to enable RLS on widgets")
-      expect(stderr).to include("force failed")
-      expect(stderr).to include("WARNING: failed to force RLS on widgets")
+      expect(stderr).to include("Cleaning up after error")
+    end
+  end
+
+  it "fails when db-regenerate cannot re-enable RLS before completion" do
+    Dir.mktmpdir("db-script-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, "db-regenerate")
+      write_stub(dir, "psql", db_regenerate_psql_stub)
+      write_stub(dir, "pg_dump", "#!/bin/sh\necho 'fake dump'\n")
+      write_stub(dir, "pg_restore", db_regenerate_pg_restore_stub)
+      write_stub(dir, "overmind", "#!/bin/sh\nexit 1\n")
+      write_bin_stub(dir, "dev", "#!/bin/sh\nexit 0\n")
+      write_bin_stub(dir, "rails", "#!/bin/sh\nexit 0\n")
+
+      env = base_env(dir)
+      stdout, stderr, status = Open3.capture3(env, script_path, "--practice", chdir: dir)
+
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).not_to include("PRACTICE RUN COMPLETE")
+      expect(stderr).to include("enable failed")
+      expect(stdout).to include("Failed to enable RLS on widgets")
+      expect(stdout).to include("Script exited with error")
     end
   end
 
@@ -70,6 +86,13 @@ RSpec.describe DbScriptWarning do
 
   def write_stub(dir, name, contents)
     path = File.join(dir, "stubbin", name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+    FileUtils.chmod("+x", path)
+  end
+
+  def write_bin_stub(dir, name, contents)
+    path = File.join(dir, "bin", name)
     FileUtils.mkdir_p(File.dirname(path))
     File.write(path, contents)
     FileUtils.chmod("+x", path)
@@ -101,10 +124,6 @@ RSpec.describe DbScriptWarning do
         *"rowsecurity = true"*)
           echo "widgets"
           ;;
-        *"DISABLE ROW LEVEL SECURITY"*)
-          echo "disable failed" >&2
-          exit 1
-          ;;
         *"ENABLE ROW LEVEL SECURITY"*)
           echo "enable failed" >&2
           exit 1
@@ -129,17 +148,61 @@ RSpec.describe DbScriptWarning do
         *"rowsecurity = true"*)
           echo "widgets"
           ;;
-        *"DISABLE ROW LEVEL SECURITY"*)
-          echo "disable failed" >&2
-          exit 1
-          ;;
-        *"DISABLE TRIGGER ALL"*)
-          echo "disable trigger failed" >&2
-          exit 1
-          ;;
         *"ENABLE TRIGGER ALL"*)
           echo "enable trigger failed" >&2
           exit 1
+          ;;
+        *"ENABLE ROW LEVEL SECURITY"*)
+          echo "enable failed" >&2
+          exit 1
+          ;;
+        *"FORCE ROW LEVEL SECURITY"*)
+          echo "force failed" >&2
+          exit 1
+          ;;
+      esac
+    SH
+  end
+
+  def db_regenerate_pg_restore_stub
+    <<~SH
+      #!/bin/sh
+      if [ "$1" = "--list" ]; then
+        i=1
+        while [ "$i" -le 25 ]; do
+          echo "1234; 0 0 TABLE DATA public widgets_${i} paid"
+          i=$((i + 1))
+        done
+        exit 0
+      fi
+
+      exit 0
+    SH
+  end
+
+  def db_regenerate_psql_stub
+    <<~SH
+      #!/bin/sh
+      args="$*"
+
+      case "$args" in
+        *"SELECT 1 FROM pg_database WHERE datname = 'paid_practice'"*)
+          exit 0
+          ;;
+        *"SELECT 1 FROM pg_database WHERE datname = 'paid_practice_cable'"*)
+          exit 0
+          ;;
+        *"rowsecurity = true"*)
+          echo "widgets"
+          ;;
+        *"JOIN pg_policy"*)
+          echo "widgets"
+          ;;
+        *"tablename NOT IN ('ar_internal_metadata', 'schema_migrations')"*)
+          echo "widgets"
+          ;;
+        *"query_to_xml"*)
+          echo "widgets=1"
           ;;
         *"ENABLE ROW LEVEL SECURITY"*)
           echo "enable failed" >&2


### PR DESCRIPTION
## Summary

- Fix `bin/db-dump` to disable RLS before dumping so all rows are captured (was silently producing backups missing all RLS-protected data)
- Fix `bin/db-restore` to use explicit RLS + trigger management instead of `session_replication_role` (requires superuser, which `paid` is not) and surface pg_restore errors instead of silently reporting success
- Fix `bin/db-regenerate` `restore_into` to disable triggers during restore (logidze triggers caused COPY failures) and fix `verify_backup_row_counts` to count actual TABLE DATA entries instead of comment lines (old check always passed)

## Root cause

The `paid` database user has `FORCE ROW LEVEL SECURITY` on 89 tables. None of the scripts accounted for this — the table owner is subject to RLS, so `pg_dump` and `pg_restore` running as `paid` were blocked from reading/writing protected table data.

## Test plan

- [x] `bin/db-dump` produces a valid 42MB backup with all 105 tables (was 41MB with only 16 non-RLS tables)
- [x] `bin/db-restore` successfully restores data with triggers and RLS properly managed; exits non-zero on pg_restore errors
- [x] `bin/db-regenerate --practice` completes with all row counts matching across 105 tables
- [x] `db/schema.rb` regenerated from migrations is semantically identical (only cosmetic trigger ordering difference)