### PR TITLE
fix(agent-runs): keep heartbeats alive during post-run bookkeeping

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -212,28 +212,44 @@ module Activities
 
             # Skip git post-processing for goals that don't clone a repo.
             # These runs only interact via the GitHub API proxy — no git repo exists.
+            #
+            # Keep heartbeats flowing during post-run bookkeeping too. By the
+            # time we reach this block the provider may already have posted a PR
+            # review/comment, so a long-running git operation here can otherwise
+            # leave the AgentRun stuck in "running" until stale-run cleanup.
+            #
+            # Do not run infinite-loop detection here: the agent is no longer
+            # producing output, so re-scanning the same stdout snapshots during
+            # git bookkeeping can falsely classify a successful run as looping.
+            bookkeeping_result = with_periodic_heartbeat("post_run_bookkeeping", provider) do
+              # Evaluate pre-commit requirements against the working directory
+              # before committing, so blocking failures prevent commits.
+              if agent_run.repo_cloned?
+                pre_commit_result = evaluate_pre_commit_requirements(agent_run)
+                if pre_commit_result[:blocking]
+                  agent_run.log!("system", "Blocked by failing pre-commit requirements",
+                    metadata: { pre_commit_results: pre_commit_result[:results] })
+                  next {
+                    early_return: {
+                      agent_run_id: agent_run_id,
+                      success: false,
+                      has_changes: check_for_changes(agent_run, pre_agent_sha),
+                      output_present: provider_result.fetch(:output_present),
+                      final_provider: attempt_label,
+                      error: "pre_commit_requirements_failed"
+                    }
+                  }
+                end
 
-            # Evaluate pre-commit requirements against the working directory
-            # before committing, so blocking failures prevent commits.
-            if agent_run.repo_cloned?
-              pre_commit_result = evaluate_pre_commit_requirements(agent_run)
-              if pre_commit_result[:blocking]
-                agent_run.log!("system", "Blocked by failing pre-commit requirements",
-                  metadata: { pre_commit_results: pre_commit_result[:results] })
-                return {
-                  agent_run_id: agent_run_id,
-                  success: false,
-                  has_changes: check_for_changes(agent_run, pre_agent_sha),
-                  output_present: provider_result.fetch(:output_present),
-                  final_provider: attempt_label,
-                  error: "pre_commit_requirements_failed"
-                }
+                commit_uncommitted_changes(agent_run)
               end
 
-              commit_uncommitted_changes(agent_run)
+              { has_changes: agent_run.repo_cloned? ? check_for_changes(agent_run, pre_agent_sha) : false }
             end
 
-            has_changes = agent_run.repo_cloned? ? check_for_changes(agent_run, pre_agent_sha) : false
+            return bookkeeping_result[:early_return] if bookkeeping_result[:early_return]
+
+            has_changes = bookkeeping_result.fetch(:has_changes)
 
             if !has_changes && !provider_result.fetch(:output_present)
               agent_run.log!("system", "Provider completed with no output and no changes")

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1652,6 +1652,19 @@ expect(container_service).to receive(:execute).with(
         expect(result[:final_provider]).to eq("claude_code")
         expect(agent_run.reload.final_provider).to eq("claude_code")
       end
+
+      it "heartbeats during post-run bookkeeping after provider execution" do
+        allow(git_ops).to receive(:has_changes_since?).and_return(false)
+
+        allow(activity).to receive(:with_periodic_heartbeat).and_call_original
+
+        activity.execute(agent_run_id: agent_run.id)
+
+        expect(activity).to have_received(:with_periodic_heartbeat)
+          .with("post_run_bookkeeping", "claude_code")
+        expect(activity).not_to have_received(:with_periodic_heartbeat)
+          .with("post_run_bookkeeping", "claude_code", agent_run: agent_run)
+      end
     end
 
     context "when agent fails in container" do


### PR DESCRIPTION
## Summary
- keep Temporal heartbeats alive during post-run bookkeeping after provider execution
- avoid running infinite-loop detection during bookkeeping, where stale output can cause false positives
- add regression coverage for the bookkeeping heartbeat path

## Testing
- `bundle exec rubocop app/temporal/activities/run_agent_activity.rb spec/temporal/activities/run_agent_activity_spec.rb`
- `bundle exec rspec spec/temporal/activities/run_agent_activity_spec.rb spec/temporal/workflows/agent_execution_workflow_spec.rb`

## Notes
- The targeted RSpec run passes, but the command exits non-zero in this repo because partial runs do not satisfy the global SimpleCov minimum coverage threshold.