### PR TITLE
fix(strategies): seed baseline orchestration with system access

### DIFF
--- a/app/services/strategies/seed_baseline_orchestration.rb
+++ b/app/services/strategies/seed_baseline_orchestration.rb
@@ -7,8 +7,10 @@ module Strategies
     end
 
     def call
-      Strategies::BaselineOrchestration.definitions.map do |definition|
-        seed_definition(definition)
+      TenantContext.with_system_access do
+        Strategies::BaselineOrchestration.definitions.map do |definition|
+          seed_definition(definition)
+        end
       end
     end
 

--- a/db/migrate/20260509233216_seed_baseline_orchestration_strategies.rb
+++ b/db/migrate/20260509233216_seed_baseline_orchestration_strategies.rb
@@ -2,23 +2,25 @@
 
 class SeedBaselineOrchestrationStrategies < ActiveRecord::Migration[8.1]
   def up
-    Strategies::SeedBaselineOrchestration.call
-    backfill_baseline_strategy_versions
+    TenantContext.with_system_access do
+      Strategies::SeedBaselineOrchestration.call
+      backfill_baseline_strategy_versions
+    end
   end
 
   def down
-    OrchestrationDecision.where(
-      strategy_version_id: StrategyVersion.joins(:strategy)
-        .where(strategies: { slug: baseline_slugs, account_id: nil, project_id: nil })
-        .select(:id)
-    ).update_all(strategy_version_id: nil)
+    TenantContext.with_system_access do
+      clear_backfilled_strategy_versions
 
-    Strategy.global.where(slug: baseline_slugs).find_each(&:destroy!)
+      Strategy.global.where(slug: baseline_slugs).find_each(&:destroy!)
+    end
   end
 
   private
 
   def backfill_baseline_strategy_versions
+    return unless table_exists?(:orchestration_decisions)
+
     Strategies::BaselineOrchestration.definitions.each do |definition|
       version_id = Strategy.global
         .find_by!(slug: definition.fetch(:slug))
@@ -29,6 +31,16 @@ class SeedBaselineOrchestrationStrategies < ActiveRecord::Migration[8.1]
         strategy_version_id: nil
       ).update_all(strategy_version_id: version_id)
     end
+  end
+
+  def clear_backfilled_strategy_versions
+    return unless table_exists?(:orchestration_decisions)
+
+    OrchestrationDecision.where(
+      strategy_version_id: StrategyVersion.joins(:strategy)
+        .where(strategies: { slug: baseline_slugs, account_id: nil, project_id: nil })
+        .select(:id)
+    ).update_all(strategy_version_id: nil)
   end
 
   def baseline_slugs

--- a/spec/services/strategies/seed_baseline_orchestration_spec.rb
+++ b/spec/services/strategies/seed_baseline_orchestration_spec.rb
@@ -4,9 +4,8 @@ require "rails_helper"
 
 RSpec.describe Strategies::SeedBaselineOrchestration do
   describe ".call" do
-    it "creates active global strategies with promoted baseline versions" do
-      expect { described_class.call }.to change(Strategy, :count).by(3)
-        .and change(StrategyVersion, :count).by(3)
+    it "ensures active global strategies with promoted baseline versions exist" do
+      described_class.call
 
       Strategies::BaselineOrchestration.definitions.each do |definition|
         strategy = Strategy.global.find_by!(slug: definition[:slug])


### PR DESCRIPTION
## Summary
- run baseline strategy seeding under `TenantContext.with_system_access`
- guard orchestration decision backfill/rollback work for schema-load paths where `orchestration_decisions` is not present
- update the strategy seed spec to verify the seeded end state without assuming an empty database

## Testing
- `bin/setup --skip-server`
- `bundle exec rspec spec/services/strategies/seed_baseline_orchestration_spec.rb` (examples passed; targeted run still exits nonzero because the repo enforces global SimpleCov minimums)
