### PR TITLE
chore(dev): isolate Postgres databases per git worktree

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,8 @@
     "DB_HOST": "postgres",
     "DB_USERNAME": "paid",
     "DB_PASSWORD": "paid",
+    "DB_ADMIN_USERNAME": "postgres",
+    "DB_ADMIN_PASSWORD": "postgres",
     // Keep devcontainer worker concurrency conservative to avoid OOM-killing
     // Overmind when Rails, GoodJob, Temporal, and asset watchers are all live.
     "DB_POOL": "10",

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,11 @@
 # =============================================================================
 
 # Database connection
-DATABASE_URL=postgres://paid:paid@localhost:5432/paid_development
+# Avoid setting DATABASE_URL in development unless you intentionally want to pin
+# this checkout to one specific database name and bypass worktree isolation.
+DB_HOST=localhost
+DB_USERNAME=paid
+DB_PASSWORD=paid
 
 # Anthropic API key - required for agent execution via secrets proxy
 # ANTHROPIC_API_KEY=sk-ant-...

--- a/bin/db-regenerate
+++ b/bin/db-regenerate
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
+# frozen_string_literal: true
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-source "${APP_ROOT}/bin/lib/db_helpers.sh"
 cd "$APP_ROOT" || exit
+
+mapfile -t WORKTREE_DBS < <(ruby <<'RUBY'
+require File.expand_path("config/worktree_database_names", Dir.pwd)
+
+puts Paid::WorktreeDatabaseNames.development_primary_name
+puts Paid::WorktreeDatabaseNames.development_cable_name
+RUBY
+)
 
 PG_HOST="${DB_HOST:-postgres}"
 PG_USER="${DB_USER:-paid}"
 PG_PASSWORD="${DB_PASSWORD:-paid}"
-DB_HOST="$PG_HOST"
-DB_USER="$PG_USER"
-DB_PASSWORD="$PG_PASSWORD"
-BACKEND="local"
-PG_DB="paid_development"
-PG_CABLE_DB="paid_development_cable"
+PG_DB="${WORKTREE_DBS[0]}"
+PG_CABLE_DB="${WORKTREE_DBS[1]}"
 PRACTICE_DB="paid_practice"
 BACKUPS_DIR="${APP_ROOT}/backups"
 CACHED_RLS_TABLES=""
@@ -26,6 +30,16 @@ NC='\033[0m'
 info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+run_sql() {
+  local db="$1"; shift
+  PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -U "$PG_USER" -d "$db" -q --no-align --tuples-only "$@"
+}
+
+run_sql_exec() {
+  local db="$1"; shift
+  PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -U "$PG_USER" -d "$db" -q "$@"
+}
 
 db_exists() {
   local db="$1"
@@ -45,7 +59,50 @@ terminate_connections() {
 
 get_rls_tables() {
   local db="$1"
-  db_helpers_get_rls_tables "$db"
+  run_sql "$db" -c "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND rowsecurity = true ORDER BY tablename" 2>/dev/null
+}
+
+disable_rls() {
+  local db="$1"
+  info "Disabling RLS on all tables in $db..."
+  local tables
+  tables="$(get_rls_tables "$db")"
+  if [[ -z "$tables" ]]; then
+    info "No RLS tables found in $db"
+    CACHED_RLS_TABLES=""
+    return 0
+  fi
+  CACHED_RLS_TABLES="$tables"
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE ROW LEVEL SECURITY;" 2>/dev/null || true
+  done <<< "$tables"
+}
+
+enable_rls() {
+  local db="$1"
+  local tables="${2:-${CACHED_RLS_TABLES}}"
+  info "Re-enabling RLS on all tables in $db..."
+  if [[ -z "$tables" ]]; then
+    warn "No cached RLS table list. Querying pg_policy for tables with policies..."
+    tables="$(run_sql "$db" -c "
+      SELECT DISTINCT c.relname
+      FROM pg_class c
+      JOIN pg_policy p ON p.polrelid = c.oid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relkind = 'r'
+      ORDER BY c.relname
+    " 2>/dev/null)"
+    if [[ -z "$tables" ]]; then
+      info "No tables need RLS in $db"
+      return 0
+    fi
+  fi
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE ROW LEVEL SECURITY;" 2>/dev/null
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" FORCE ROW LEVEL SECURITY;" 2>/dev/null
+  done <<< "$tables"
 }
 
 get_row_counts() {
@@ -111,15 +168,14 @@ create_backup() {
 
 verify_backup_row_counts() {
   info "Verifying backup contains data..."
-  local toc_entries data_entries
-  toc_entries="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "." || true)"
-  data_entries="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "TABLE DATA" || true)"
-  if [[ "$data_entries" -lt 20 ]]; then
-    error "Backup appears to have too few TABLE DATA entries ($data_entries). Something may be wrong."
-    error "Expected 50+ tables with data. Aborting to prevent data loss."
+  local listing
+  listing="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "^;" || true)"
+  if [[ "$listing" -lt 10 ]]; then
+    error "Backup appears to have too few table entries ($listing). Something may be wrong."
+    error "Aborting to prevent data loss."
     exit 1
   fi
-  info "Backup contains $data_entries TABLE DATA entries ($toc_entries total TOC entries) - looks valid"
+  info "Backup contains $listing table entries - looks valid"
 }
 
 reset_sequences() {
@@ -194,10 +250,6 @@ restore_into() {
   "
   info "FK constraints dropped"
 
-  local data_tables
-  data_tables="$(db_helpers_get_data_tables "$db_name")" || true
-  disable_triggers "$db_name" "$data_tables" 1 "Disabling triggers on data tables..."
-
   info "Truncating target tables..."
   run_sql_exec "$db_name" -c "
     DO \$\$
@@ -219,14 +271,11 @@ restore_into() {
 
   info "Restoring data..."
   local restore_output
-  local restore_failed=0
-  if ! restore_output="$(PGPASSWORD="$PG_PASSWORD" pg_restore \
+  restore_output="$(PGPASSWORD="$PG_PASSWORD" pg_restore \
     -h "$PG_HOST" -U "$PG_USER" \
     --data-only --no-owner --no-privileges \
     -d "$db_name" \
-    "$backup_path" 2>&1)"; then
-    restore_failed=1
-  fi
+    "$backup_path" 2>&1)" || true
 
   local errors
   errors="$(echo "$restore_output" | grep -iE "error|failed" | grep -vi "errors ignored on restore" || true)"
@@ -236,32 +285,18 @@ restore_into() {
       error "  $line"
     done
     error "Data may be incomplete. Check backup and target database."
-    restore_failed=1
   fi
-
-  enable_triggers "$db_name" "$data_tables" 1 "Re-enabling triggers on data tables..."
 
   info "Re-creating FK constraints..."
   local recreated=0
-  local fk_failures=0
   while IFS='|' read -r conname tbl def; do
     [[ -z "$conname" ]] && continue
-    run_sql_exec "$db_name" -c "ALTER TABLE ${tbl} ADD CONSTRAINT ${conname} ${def};" >/dev/null || {
+    run_sql_exec "$db_name" -c "ALTER TABLE ${tbl} ADD CONSTRAINT ${conname} ${def};" 2>/dev/null || {
       warn "  Could not recreate constraint ${conname} on ${tbl}"
-      fk_failures=$((fk_failures + 1))
     }
     recreated=$((recreated + 1))
   done <<< "$fk_defs"
   info "Recreated $recreated/$fk_count FK constraints"
-
-  if [[ "$fk_failures" -gt 0 ]]; then
-    error "Failed to recreate ${fk_failures} foreign key constraint(s)"
-    return 1
-  fi
-
-  if [[ "$restore_failed" -ne 0 ]]; then
-    return 1
-  fi
 
   info "Restore into $db_name complete"
 }
@@ -305,13 +340,20 @@ cleanup() {
     warn "Script exited with error (code $exit_code)."
     warn "Attempting to re-enable RLS on $PG_DB..."
     if [[ -n "$CACHED_RLS_TABLES" ]]; then
-      enable_rls "$PG_DB" "$CACHED_RLS_TABLES" 0 CACHED_RLS_TABLES
+      enable_rls "$PG_DB" "$CACHED_RLS_TABLES" 2>/dev/null || true
     else
       warn "No cached RLS table list. Restoring RLS from pg_policy..."
       local policy_tables
-      policy_tables="$(db_helpers_get_policy_tables "$PG_DB")" || true
+      policy_tables="$(run_sql "$PG_DB" -c "
+        SELECT DISTINCT c.relname
+        FROM pg_class c
+        JOIN pg_policy p ON p.polrelid = c.oid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relkind = 'r'
+        ORDER BY c.relname
+      " 2>/dev/null)" || true
       if [[ -n "$policy_tables" ]]; then
-        enable_rls "$PG_DB" "$policy_tables" 0 CACHED_RLS_TABLES
+        enable_rls "$PG_DB" "$policy_tables" 2>/dev/null || true
       fi
     fi
     if [[ "${PRACTICE_MODE:-}" == "1" ]] && db_exists "$PRACTICE_DB"; then
@@ -329,7 +371,7 @@ usage() {
   echo "Regenerate development databases from scratch (drop, migrate, restore)."
   echo ""
   echo "  --practice   Dry run against paid_practice database (validates round-trip)"
-  echo "  --actual     Regenerate paid_development and paid_development_cable"
+  echo "  --actual     Regenerate ${PG_DB} and ${PG_CABLE_DB}"
   echo ""
   echo "Steps:"
   echo "  1. Stop application (overmind stop)"
@@ -388,17 +430,14 @@ stop_app
 
 # Step 2: Disable RLS so pg_dump can see all data
 info "Current row counts (with RLS disabled after this step):"
-disable_rls "$PG_DB" 1 CACHED_RLS_TABLES "Disabling RLS on all tables in ${PG_DB}..."
-if [[ -z "$CACHED_RLS_TABLES" ]]; then
-  info "No RLS tables found in $PG_DB"
-fi
+disable_rls "$PG_DB"
 
 # Step 3: Backup
 create_backup "full"
 verify_backup_row_counts
 
 # Step 4: Re-enable RLS on source DB (we have the backup now)
-enable_rls "$PG_DB" "$CACHED_RLS_TABLES" 1 CACHED_RLS_TABLES "Re-enabling RLS on all tables in ${PG_DB}..."
+enable_rls "$PG_DB"
 
 # Step 5: Create target databases
 if [[ "$PRACTICE_MODE" == "1" ]]; then
@@ -452,10 +491,7 @@ else
 fi
 
 # Step 7: Disable RLS on target for data restoration
-disable_rls "$TARGET_DB" 1 CACHED_RLS_TABLES "Disabling RLS on all tables in ${TARGET_DB}..."
-if [[ -z "$CACHED_RLS_TABLES" ]]; then
-  info "No RLS tables found in $TARGET_DB"
-fi
+disable_rls "$TARGET_DB"
 
 # Step 8: Restore data
 restore_into "$TARGET_DB" "$BACKUP_PATH"
@@ -471,10 +507,7 @@ if [[ "$PRACTICE_MODE" == "1" ]]; then
 
   SOURCE_RLS_TABLES="$CACHED_RLS_TABLES"
   info "Disabling RLS on source DB for comparison..."
-  disable_rls "$PG_DB" 1 CACHED_RLS_TABLES "Disabling RLS on all tables in ${PG_DB}..."
-  if [[ -z "$CACHED_RLS_TABLES" ]]; then
-    info "No RLS tables found in $PG_DB"
-  fi
+  disable_rls "$PG_DB"
 
   info "Source DB row counts (RLS disabled):"
   get_row_counts "$PG_DB" | while IFS= read -r line; do
@@ -484,11 +517,11 @@ if [[ "$PRACTICE_MODE" == "1" ]]; then
   compare_row_counts "$PG_DB" "$TARGET_DB" || true
 
   info "Re-enabling RLS on source DB..."
-  enable_rls "$PG_DB" "$SOURCE_RLS_TABLES" 1 CACHED_RLS_TABLES "Re-enabling RLS on all tables in ${PG_DB}..."
+  enable_rls "$PG_DB" "$SOURCE_RLS_TABLES"
 fi
 
 # Step 10: Re-enable RLS on target
-enable_rls "$TARGET_DB" "$CACHED_RLS_TABLES" 1 CACHED_RLS_TABLES "Re-enabling RLS on all tables in ${TARGET_DB}..."
+enable_rls "$TARGET_DB"
 
 # Step 11: Post-RLS steps
 if [[ "$PRACTICE_MODE" == "1" ]]; then

--- a/bin/db-regenerate
+++ b/bin/db-regenerate
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# frozen_string_literal: true
+# Regenerate development databases from scratch (drop, migrate, restore).
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -21,6 +21,7 @@ PG_CABLE_DB="${WORKTREE_DBS[1]}"
 PRACTICE_DB="paid_practice"
 BACKUPS_DIR="${APP_ROOT}/backups"
 CACHED_RLS_TABLES=""
+CACHED_TRIGGER_TABLES=""
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -60,6 +61,17 @@ terminate_connections() {
 get_rls_tables() {
   local db="$1"
   run_sql "$db" -c "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND rowsecurity = true ORDER BY tablename" 2>/dev/null
+}
+
+get_data_tables() {
+  local db="$1"
+  run_sql "$db" -c "
+    SELECT tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
+    ORDER BY tablename
+  " 2>/dev/null
 }
 
 disable_rls() {
@@ -102,6 +114,37 @@ enable_rls() {
     [[ -z "$table" ]] && continue
     run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE ROW LEVEL SECURITY;" 2>/dev/null
     run_sql_exec "$db" -c "ALTER TABLE \"$table\" FORCE ROW LEVEL SECURITY;" 2>/dev/null
+  done <<< "$tables"
+}
+
+disable_triggers() {
+  local db="$1"
+  info "Disabling triggers on data tables in $db..."
+  local tables
+  tables="$(get_data_tables "$db")"
+  if [[ -z "$tables" ]]; then
+    info "No data tables found in $db"
+    CACHED_TRIGGER_TABLES=""
+    return 0
+  fi
+  CACHED_TRIGGER_TABLES="$tables"
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" DISABLE TRIGGER ALL;" 2>/dev/null || true
+  done <<< "$tables"
+}
+
+enable_triggers() {
+  local db="$1"
+  local tables="${2:-${CACHED_TRIGGER_TABLES}}"
+  info "Re-enabling triggers on data tables in $db..."
+  if [[ -z "$tables" ]]; then
+    warn "No cached data table list available for trigger re-enable"
+    return 0
+  fi
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE TRIGGER ALL;" 2>/dev/null || true
   done <<< "$tables"
 }
 
@@ -251,6 +294,8 @@ restore_into() {
   "
   info "FK constraints dropped"
 
+  disable_triggers "$db_name"
+
   info "Truncating target tables..."
   run_sql_exec "$db_name" -c "
     DO \$\$
@@ -291,6 +336,8 @@ restore_into() {
     error "Data may be incomplete. Check backup and target database."
     restore_failed=1
   fi
+
+  enable_triggers "$db_name"
 
   info "Re-creating FK constraints..."
   local recreated=0
@@ -372,6 +419,10 @@ cleanup() {
         enable_rls "$PG_DB" "$policy_tables" 2>/dev/null || true
       fi
     fi
+    if [[ -n "$CACHED_TRIGGER_TABLES" ]]; then
+      warn "Attempting to re-enable triggers on cached target tables..."
+      enable_triggers "$TARGET_DB" "$CACHED_TRIGGER_TABLES" 2>/dev/null || true
+    fi
     if [[ "${PRACTICE_MODE:-}" == "1" ]] && db_exists "$PRACTICE_DB"; then
       warn "Cleaning up practice database..."
       run_sql postgres -c "DROP DATABASE IF EXISTS \"$PRACTICE_DB\"" 2>/dev/null || true
@@ -396,9 +447,9 @@ usage() {
   echo "  4. Re-enable RLS"
   echo "  5. Drop + recreate databases"
   echo "  6. Run migrations from scratch"
-  echo "  7. Disable RLS on fresh tables"
+  echo "  7. Disable RLS and data-table triggers on fresh tables"
   echo "  8. Restore data"
-  echo "  9. Re-enable RLS"
+  echo "  9. Re-enable data-table triggers and RLS"
   echo " 10. Reset sequences"
   echo " 11. Start application"
 }

--- a/bin/db-regenerate
+++ b/bin/db-regenerate
@@ -22,6 +22,8 @@ PRACTICE_DB="paid_practice"
 BACKUPS_DIR="${APP_ROOT}/backups"
 CACHED_RLS_TABLES=""
 CACHED_TRIGGER_TABLES=""
+IDENTIFIER_FORMAT='^[A-Za-z0-9_]+$'
+MAX_IDENTIFIER_LENGTH=63
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -32,6 +34,17 @@ info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
+validate_identifier() {
+  local kind="$1"
+  local value="$2"
+  local source="$3"
+
+  if [[ ! "$value" =~ $IDENTIFIER_FORMAT || "${#value}" -gt "$MAX_IDENTIFIER_LENGTH" ]]; then
+    error "Invalid ${kind} ${value@Q} from ${source}. Only letters, numbers, and underscores up to ${MAX_IDENTIFIER_LENGTH} characters are allowed."
+    exit 1
+  fi
+}
+
 run_sql() {
   local db="$1"; shift
   PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -U "$PG_USER" -d "$db" -q --no-align --tuples-only "$@"
@@ -41,6 +54,11 @@ run_sql_exec() {
   local db="$1"; shift
   PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -U "$PG_USER" -d "$db" -q "$@"
 }
+
+validate_identifier "role name" "$PG_USER" "DB_USER"
+validate_identifier "database name" "$PG_DB" "PAID_DEVELOPMENT_DATABASE / worktree derivation"
+validate_identifier "database name" "$PG_CABLE_DB" "PAID_DEVELOPMENT_CABLE_DATABASE / worktree derivation"
+validate_identifier "database name" "$PRACTICE_DB" "script constant"
 
 db_exists() {
   local db="$1"
@@ -72,6 +90,24 @@ get_data_tables() {
       AND tablename NOT IN ('ar_internal_metadata', 'schema_migrations')
     ORDER BY tablename
   " 2>/dev/null
+}
+
+run_table_alter_required() {
+  local db="$1"
+  local tables="$2"
+  local sql="$3"
+  local action="$4"
+  local failures=0
+
+  while IFS= read -r table; do
+    [[ -z "$table" ]] && continue
+    if ! run_sql_exec "$db" -c "ALTER TABLE \"$table\" ${sql};" 2>/dev/null; then
+      warn "Failed to ${action} on ${table}"
+      failures=$((failures + 1))
+    fi
+  done <<< "$tables"
+
+  return "$failures"
 }
 
 disable_rls() {
@@ -110,11 +146,9 @@ enable_rls() {
       return 0
     fi
   fi
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE ROW LEVEL SECURITY;" 2>/dev/null
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" FORCE ROW LEVEL SECURITY;" 2>/dev/null
-  done <<< "$tables"
+
+  run_table_alter_required "$db" "$tables" "ENABLE ROW LEVEL SECURITY" "enable RLS"
+  run_table_alter_required "$db" "$tables" "FORCE ROW LEVEL SECURITY" "force RLS"
 }
 
 disable_triggers() {
@@ -142,10 +176,8 @@ enable_triggers() {
     warn "No cached data table list available for trigger re-enable"
     return 0
   fi
-  while IFS= read -r table; do
-    [[ -z "$table" ]] && continue
-    run_sql_exec "$db" -c "ALTER TABLE \"$table\" ENABLE TRIGGER ALL;" 2>/dev/null || true
-  done <<< "$tables"
+
+  run_table_alter_required "$db" "$tables" "ENABLE TRIGGER ALL" "enable triggers"
 }
 
 get_row_counts() {

--- a/bin/db-regenerate
+++ b/bin/db-regenerate
@@ -168,14 +168,15 @@ create_backup() {
 
 verify_backup_row_counts() {
   info "Verifying backup contains data..."
-  local listing
-  listing="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "^;" || true)"
-  if [[ "$listing" -lt 10 ]]; then
-    error "Backup appears to have too few table entries ($listing). Something may be wrong."
-    error "Aborting to prevent data loss."
+  local toc_entries data_entries
+  toc_entries="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "." || true)"
+  data_entries="$(pg_restore --list "$BACKUP_PATH" 2>/dev/null | grep -c "TABLE DATA" || true)"
+  if [[ "$data_entries" -lt 20 ]]; then
+    error "Backup appears to have too few TABLE DATA entries ($data_entries). Something may be wrong."
+    error "Expected 50+ tables with data. Aborting to prevent data loss."
     exit 1
   fi
-  info "Backup contains $listing table entries - looks valid"
+  info "Backup contains $data_entries TABLE DATA entries ($toc_entries total TOC entries) - looks valid"
 }
 
 reset_sequences() {
@@ -271,11 +272,14 @@ restore_into() {
 
   info "Restoring data..."
   local restore_output
-  restore_output="$(PGPASSWORD="$PG_PASSWORD" pg_restore \
+  local restore_failed=0
+  if ! restore_output="$(PGPASSWORD="$PG_PASSWORD" pg_restore \
     -h "$PG_HOST" -U "$PG_USER" \
     --data-only --no-owner --no-privileges \
     -d "$db_name" \
-    "$backup_path" 2>&1)" || true
+    "$backup_path" 2>&1)"; then
+    restore_failed=1
+  fi
 
   local errors
   errors="$(echo "$restore_output" | grep -iE "error|failed" | grep -vi "errors ignored on restore" || true)"
@@ -285,18 +289,30 @@ restore_into() {
       error "  $line"
     done
     error "Data may be incomplete. Check backup and target database."
+    restore_failed=1
   fi
 
   info "Re-creating FK constraints..."
   local recreated=0
+  local fk_failures=0
   while IFS='|' read -r conname tbl def; do
     [[ -z "$conname" ]] && continue
     run_sql_exec "$db_name" -c "ALTER TABLE ${tbl} ADD CONSTRAINT ${conname} ${def};" 2>/dev/null || {
       warn "  Could not recreate constraint ${conname} on ${tbl}"
+      fk_failures=$((fk_failures + 1))
     }
     recreated=$((recreated + 1))
   done <<< "$fk_defs"
   info "Recreated $recreated/$fk_count FK constraints"
+
+  if [[ "$fk_failures" -gt 0 ]]; then
+    error "Failed to recreate ${fk_failures} foreign key constraint(s)"
+    return 1
+  fi
+
+  if [[ "$restore_failed" -ne 0 ]]; then
+    return 1
+  fi
 
   info "Restore into $db_name complete"
 }

--- a/bin/ensure-worktree-databases
+++ b/bin/ensure-worktree-databases
@@ -4,6 +4,14 @@ set -euo pipefail
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$APP_ROOT" || exit
 
+# When DATABASE_URL is set the user has pinned their checkout to a specific
+# database.  Probing DB_HOST / DB_USERNAME would target the wrong server, so
+# skip automatic database creation entirely — Rails will use DATABASE_URL.
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is set — skipping automatic worktree database creation."
+  exit 0
+fi
+
 db_names() {
   ruby <<'RUBY'
 require File.expand_path("config/worktree_database_names", Dir.pwd)

--- a/bin/ensure-worktree-databases
+++ b/bin/ensure-worktree-databases
@@ -36,6 +36,8 @@ ADMIN_DB_HOST="${DB_ADMIN_HOST:-$APP_DB_HOST}"
 MAINTENANCE_DB="${DB_ADMIN_DATABASE:-postgres}"
 CREATOR_PASSWORD=""
 CREATOR_ARGS=()
+IDENTIFIER_FORMAT='^[A-Za-z0-9_]+$'
+MAX_IDENTIFIER_LENGTH=63
 
 psql_base_args() {
   local host="$1"
@@ -60,6 +62,17 @@ query_psql() {
   shift
 
   PGPASSWORD="$password" psql "$@" 2>/dev/null
+}
+
+validate_identifier() {
+  local kind="$1"
+  local value="$2"
+  local source="$3"
+
+  if [[ ! "$value" =~ $IDENTIFIER_FORMAT || "${#value}" -gt "$MAX_IDENTIFIER_LENGTH" ]]; then
+    echo "Invalid ${kind} ${value@Q} from ${source}. Only letters, numbers, and underscores up to ${MAX_IDENTIFIER_LENGTH} characters are allowed." >&2
+    exit 1
+  fi
 }
 
 app_can_create_databases() {
@@ -105,6 +118,11 @@ use_creator() {
   mapfile -d '' -t CREATOR_ARGS < <(psql_base_args "$host" "$user" "$MAINTENANCE_DB")
   CREATOR_PASSWORD="$password"
 }
+
+validate_identifier "database name" "$DEV_DB" "PAID_DEVELOPMENT_DATABASE / worktree derivation"
+validate_identifier "database name" "$CABLE_DB" "PAID_DEVELOPMENT_CABLE_DATABASE / worktree derivation"
+validate_identifier "database name" "$TEST_DB" "PAID_TEST_DATABASE / worktree derivation"
+validate_identifier "role name" "$APP_DB_USER" "DB_USERNAME / DB_USER"
 
 if app_can_create_databases; then
   use_creator "$APP_DB_HOST" "$APP_DB_USER" "$APP_DB_PASSWORD"

--- a/bin/ensure-worktree-databases
+++ b/bin/ensure-worktree-databases
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$APP_ROOT" || exit
+
+db_names() {
+  ruby <<'RUBY'
+require File.expand_path("config/worktree_database_names", Dir.pwd)
+
+puts Paid::WorktreeDatabaseNames.development_primary_name
+puts Paid::WorktreeDatabaseNames.development_cable_name
+puts Paid::WorktreeDatabaseNames.test_name
+RUBY
+}
+
+mapfile -t DB_NAMES < <(db_names)
+DEV_DB="${DB_NAMES[0]}"
+CABLE_DB="${DB_NAMES[1]}"
+TEST_DB="${DB_NAMES[2]}"
+
+APP_DB_USER="${DB_USERNAME:-${DB_USER:-paid}}"
+APP_DB_PASSWORD="${DB_PASSWORD:-paid}"
+APP_DB_HOST="${DB_HOST:-}"
+ADMIN_DB_USER="${DB_ADMIN_USERNAME:-${POSTGRES_USER:-$APP_DB_USER}}"
+ADMIN_DB_PASSWORD="${DB_ADMIN_PASSWORD:-${POSTGRES_PASSWORD:-$APP_DB_PASSWORD}}"
+ADMIN_DB_HOST="${DB_ADMIN_HOST:-$APP_DB_HOST}"
+MAINTENANCE_DB="${DB_ADMIN_DATABASE:-postgres}"
+CREATOR_PASSWORD=""
+CREATOR_ARGS=()
+
+psql_base_args() {
+  local host="$1"
+  local user="$2"
+  local db="$3"
+  local -a args=(-U "$user" -d "$db" -v ON_ERROR_STOP=1 -q --no-align --tuples-only)
+  if [[ -n "$host" ]]; then
+    args=(-h "$host" "${args[@]}")
+  fi
+  printf '%s\0' "${args[@]}"
+}
+
+run_psql() {
+  local password="$1"
+  shift
+
+  PGPASSWORD="$password" psql "$@"
+}
+
+query_psql() {
+  local password="$1"
+  shift
+
+  PGPASSWORD="$password" psql "$@" 2>/dev/null
+}
+
+app_can_create_databases() {
+  can_create_databases "$APP_DB_HOST" "$APP_DB_USER" "$APP_DB_PASSWORD"
+}
+
+can_create_databases() {
+  local host="$1"
+  local user="$2"
+  local password="$3"
+  local -a args
+  mapfile -d '' -t args < <(psql_base_args "$host" "$user" "$MAINTENANCE_DB")
+
+  local createdb_flag
+  createdb_flag="$(query_psql "$password" "${args[@]}" -c "SELECT rolcreatedb FROM pg_roles WHERE rolname = current_user")"
+  [[ "$createdb_flag" == "t" ]]
+}
+
+database_exists() {
+  local db_name="$1"
+  local creator_password="$2"
+  shift 2
+  local -a args=("$@")
+
+  [[ "$(query_psql "$creator_password" "${args[@]}" -c "SELECT 1 FROM pg_database WHERE datname = '$db_name'")" == "1" ]]
+}
+
+create_database() {
+  local db_name="$1"
+  local creator_password="$2"
+  shift 2
+  local -a args=("$@")
+
+  echo "Creating database ${db_name}..."
+  run_psql "$creator_password" "${args[@]}" -c "CREATE DATABASE \"$db_name\" OWNER \"$APP_DB_USER\""
+}
+
+use_creator() {
+  local host="$1"
+  local user="$2"
+  local password="$3"
+
+  mapfile -d '' -t CREATOR_ARGS < <(psql_base_args "$host" "$user" "$MAINTENANCE_DB")
+  CREATOR_PASSWORD="$password"
+}
+
+if app_can_create_databases; then
+  use_creator "$APP_DB_HOST" "$APP_DB_USER" "$APP_DB_PASSWORD"
+elif can_create_databases "$ADMIN_DB_HOST" "$ADMIN_DB_USER" "$ADMIN_DB_PASSWORD"; then
+  use_creator "$ADMIN_DB_HOST" "$ADMIN_DB_USER" "$ADMIN_DB_PASSWORD"
+elif [[ "$APP_DB_HOST" == "postgres" ]] && can_create_databases "$APP_DB_HOST" "postgres" "postgres"; then
+  use_creator "$APP_DB_HOST" "postgres" "postgres"
+elif [[ "$APP_DB_HOST" == "postgres" ]] && can_create_databases "$APP_DB_HOST" "paid_admin" "paid_admin"; then
+  use_creator "$APP_DB_HOST" "paid_admin" "paid_admin"
+else
+  echo "Unable to ensure worktree databases: application role ${APP_DB_USER} lacks CREATEDB and no admin credentials are configured." >&2
+  echo "Set DB_ADMIN_USERNAME / DB_ADMIN_PASSWORD so setup can create branch-specific databases." >&2
+  exit 1
+fi
+
+for db_name in "$DEV_DB" "$CABLE_DB" "$TEST_DB"; do
+  if database_exists "$db_name" "$CREATOR_PASSWORD" "${CREATOR_ARGS[@]}"; then
+    continue
+  fi
+
+  create_database "$db_name" "$CREATOR_PASSWORD" "${CREATOR_ARGS[@]}"
+done

--- a/bin/setup
+++ b/bin/setup
@@ -36,6 +36,7 @@ FileUtils.chdir APP_ROOT do
   end
 
   puts "\n== Preparing database =="
+  system! "bin/ensure-worktree-databases"
   system! "bin/rails db:prepare"
   system! "bin/rails db:reset" if ARGV.include?("--reset")
 

--- a/bin/worktree-db
+++ b/bin/worktree-db
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../config/worktree_database_names"
+
+puts "development: #{Paid::WorktreeDatabaseNames.development_primary_name}"
+puts "cable: #{Paid::WorktreeDatabaseNames.development_cable_name}"
+puts "test: #{Paid::WorktreeDatabaseNames.test_name}"
+puts "suffix: #{Paid::WorktreeDatabaseNames.suffix || '(none)'}"

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,10 +1,9 @@
 <%
 require File.expand_path("config/worktree_database_names", Dir.pwd)
 
-app_root = File.expand_path("..", __dir__)
-development_primary_database = Paid::WorktreeDatabaseNames.development_primary_name(app_root:)
-development_cable_database = Paid::WorktreeDatabaseNames.development_cable_name(app_root:)
-test_database = Paid::WorktreeDatabaseNames.test_name(app_root:)
+development_primary_database = Paid::WorktreeDatabaseNames.development_primary_name
+development_cable_database = Paid::WorktreeDatabaseNames.development_cable_name
+test_database = Paid::WorktreeDatabaseNames.test_name
 %>
 
 # PostgreSQL. Versions 9.3 and up are supported.

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,5 @@
 <%
-require_relative "./worktree_database_names"
+require File.expand_path("config/worktree_database_names", Dir.pwd)
 
 app_root = File.expand_path("..", __dir__)
 development_primary_database = Paid::WorktreeDatabaseNames.development_primary_name(app_root:)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,3 +1,12 @@
+<%
+require_relative "./worktree_database_names"
+
+app_root = File.expand_path("..", __dir__)
+development_primary_database = Paid::WorktreeDatabaseNames.development_primary_name(app_root:)
+development_cable_database = Paid::WorktreeDatabaseNames.development_cable_name(app_root:)
+test_database = Paid::WorktreeDatabaseNames.test_name(app_root:)
+%>
+
 # PostgreSQL. Versions 9.3 and up are supported.
 #
 # Install the pg driver:
@@ -28,10 +37,10 @@ default: &default
 development:
   primary: &primary_development
     <<: *default
-    database: paid_development
+    database: <%= development_primary_database %>
   cable:
     <<: *primary_development
-    database: paid_development_cable
+    database: <%= development_cable_database %>
     migrations_paths: db/cable_migrate
 
   # The specified database role being used to connect to PostgreSQL.
@@ -66,7 +75,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: paid_test
+  database: <%= test_database %>
   # Disable prepared statements in tests to avoid cached-plan failures when
   # order-dependent examples recreate or change schema objects mid-suite.
   prepared_statements: false

--- a/config/worktree_database_names.rb
+++ b/config/worktree_database_names.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "digest"
+require "open3"
+
+module Paid
+  module WorktreeDatabaseNames
+    module_function
+
+    def development_primary_name(app_root: default_app_root)
+      explicit_name("PAID_DEVELOPMENT_DATABASE") || database_name("paid_development", app_root:)
+    end
+
+    def development_cable_name(app_root: default_app_root)
+      explicit_name("PAID_DEVELOPMENT_CABLE_DATABASE") || database_name("paid_development_cable", app_root:)
+    end
+
+    def test_name(app_root: default_app_root)
+      explicit_name("PAID_TEST_DATABASE") || database_name("paid_test", app_root:)
+    end
+
+    def suffix(app_root: default_app_root)
+      explicit = explicit_name("PAID_WORKTREE_DB_SUFFIX")
+      return sanitize(explicit) if explicit
+
+      return nil unless linked_worktree_checkout?(app_root:)
+
+      context = git_context(app_root:)
+      token = sanitize(context[:branch])
+      token = sanitize(File.basename(app_root)) if token.empty? || token == "head"
+      token = "worktree" if token.empty?
+
+      digest = Digest::SHA256.hexdigest(context[:identity])[0, 8]
+      "#{token}_#{digest}"
+    end
+
+    def database_name(base_name, app_root: default_app_root)
+      derived_suffix = suffix(app_root:)
+      return base_name if blank?(derived_suffix)
+
+      max_suffix_length = 63 - base_name.length - 1
+      truncated_suffix = derived_suffix[0, max_suffix_length]
+
+      "#{base_name}_#{truncated_suffix}"
+    end
+
+    def default_app_root
+      File.expand_path("..", __dir__)
+    end
+
+    def explicit_name(name)
+      value = ENV[name]
+      return if blank?(value)
+
+      value
+    end
+
+    def blank?(value)
+      value.nil? || value.strip.empty?
+    end
+
+    def git_context(app_root:)
+      {
+        branch: git_output(app_root, "rev-parse", "--abbrev-ref", "HEAD"),
+        git_dir: git_output(app_root, "rev-parse", "--absolute-git-dir"),
+        identity: git_output(app_root, "rev-parse", "--absolute-git-dir") || File.realpath(app_root)
+      }
+    end
+
+    def git_output(app_root, *args)
+      stdout, status = Open3.capture2("git", *args, chdir: app_root)
+      return unless status.success?
+
+      value = stdout.strip
+      value unless value.empty?
+    rescue Errno::ENOENT
+      nil
+    end
+
+    def linked_worktree_checkout?(app_root:)
+      File.file?(File.join(app_root, ".git"))
+    end
+
+    def sanitize(value)
+      value.to_s.downcase.gsub(/[^a-z0-9]+/, "_").gsub(/\A_+|_+\z/, "")
+    end
+  end
+end

--- a/config/worktree_database_names.rb
+++ b/config/worktree_database_names.rb
@@ -62,7 +62,6 @@ module Paid
     def git_context(app_root:)
       {
         branch: git_output(app_root, "rev-parse", "--abbrev-ref", "HEAD"),
-        git_dir: git_output(app_root, "rev-parse", "--absolute-git-dir"),
         identity: git_output(app_root, "rev-parse", "--absolute-git-dir") || File.realpath(app_root)
       }
     end

--- a/config/worktree_database_names.rb
+++ b/config/worktree_database_names.rb
@@ -5,6 +5,9 @@ require "open3"
 
 module Paid
   module WorktreeDatabaseNames
+    EXPLICIT_NAME_FORMAT = /\A[a-zA-Z0-9_]+\z/
+    MAX_DATABASE_NAME_LENGTH = 63
+
     module_function
 
     def development_primary_name(app_root: default_app_root)
@@ -52,6 +55,7 @@ module Paid
       value = ENV[name]
       return if blank?(value)
 
+      validate_explicit_name!(name, value)
       value
     end
 
@@ -82,6 +86,12 @@ module Paid
 
     def sanitize(value)
       value.to_s.downcase.gsub(/[^a-z0-9]+/, "_").gsub(/\A_+|_+\z/, "")
+    end
+
+    def validate_explicit_name!(env_name, value)
+      return if value.match?(EXPLICIT_NAME_FORMAT) && value.length <= MAX_DATABASE_NAME_LENGTH
+
+      raise ArgumentError, "Invalid database name #{value.inspect} in #{env_name}"
     end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,10 +71,11 @@ services:
         aliases:
           - paid-proxy
     environment:
-      DATABASE_URL: postgres://paid:paid@postgres:5432/paid_development
       DB_HOST: postgres
       DB_USERNAME: paid
       DB_PASSWORD: paid
+      DB_ADMIN_USERNAME: paid_admin
+      DB_ADMIN_PASSWORD: paid_admin
       RAILS_ENV: development
       REDIS_URL: redis://redis:6379/0
       TEMPORAL_HOST: temporal:7233
@@ -183,10 +184,11 @@ services:
       web:
         condition: service_healthy
     environment:
-      - DATABASE_URL=postgres://paid:paid@postgres:5432/paid_development
       - DB_HOST=postgres
       - DB_USERNAME=paid
       - DB_PASSWORD=paid
+      - DB_ADMIN_USERNAME=paid_admin
+      - DB_ADMIN_PASSWORD=paid_admin
       - REDIS_URL=redis://redis:6379/0
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_NAMESPACE=default

--- a/spec/lib/setup_script_spec.rb
+++ b/spec/lib/setup_script_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe "bin/setup" do # rubocop:disable RSpec/DescribeClass
     FileUtils.cp(log_truncator_source, File.join(dir, "lib", "paid", "log_truncator.rb"))
 
     write_executable(
+      File.join(dir, "bin", "ensure-worktree-databases"),
+      <<~BASH
+        #!/usr/bin/env bash
+        exit 0
+      BASH
+    )
+
+    write_executable(
       File.join(dir, "bin", "dev"),
       <<~BASH
         #!/usr/bin/env bash

--- a/spec/paid/database_yml_erb_spec.rb
+++ b/spec/paid/database_yml_erb_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "erb"
+require "spec_helper"
+
+class DatabaseYmlErb
+end
+
+RSpec.describe DatabaseYmlErb do
+  it "evaluates from the app root without relying on require_relative semantics" do
+    rendered = Dir.chdir(File.expand_path("../..", __dir__)) do
+      ERB.new(File.read("config/database.yml")).result
+    end
+
+    expect(rendered).to include("database: paid_development")
+    expect(rendered).to include("database: paid_development_cable")
+    expect(rendered).to include("database: paid_test")
+  end
+end

--- a/spec/paid/database_yml_erb_spec.rb
+++ b/spec/paid/database_yml_erb_spec.rb
@@ -2,18 +2,90 @@
 
 require "erb"
 require "spec_helper"
+require "fileutils"
+require "open3"
+require "tmpdir"
+require_relative "../support/exec_tmpdir"
 
 class DatabaseYmlErb
 end
 
 RSpec.describe DatabaseYmlErb do
-  it "evaluates from the app root without relying on require_relative semantics" do
-    rendered = Dir.chdir(File.expand_path("../..", __dir__)) do
-      ERB.new(File.read("config/database.yml")).result
+  include ExecTmpdir
+
+  around do |example|
+    original_env = ENV.to_hash
+    example.run
+  ensure
+    ENV.replace(original_env)
+  end
+
+  it "renders shared database names for a primary checkout" do
+    rendered = Dir.mktmpdir("database-yml-erb-spec", exec_tmpdir) do |dir|
+      prepare_fixture(dir)
+      render_fixture(dir)
     end
 
     expect(rendered).to include("database: paid_development")
     expect(rendered).to include("database: paid_development_cable")
     expect(rendered).to include("database: paid_test")
+  end
+
+  it "renders branch-specific database names for a linked worktree checkout" do
+    rendered = Dir.mktmpdir("database-yml-erb-spec", exec_tmpdir) do |dir|
+      prepare_fixture(dir, linked_worktree: true)
+      render_fixture(dir)
+    end
+
+    expect(rendered).to include("database: paid_development_feature_pay_1940_")
+    expect(rendered).to include("database: paid_development_cable_feature_pay_1940_")
+    expect(rendered).to include("database: paid_test_feature_pay_1940_")
+  end
+
+  def prepare_fixture(dir, linked_worktree: false)
+    FileUtils.mkdir_p(File.join(dir, "config"))
+    FileUtils.cp(File.expand_path("../../config/database.yml", __dir__), File.join(dir, "config", "database.yml"))
+    FileUtils.cp(File.expand_path("../../config/worktree_database_names.rb", __dir__), File.join(dir, "config", "worktree_database_names.rb"))
+    return unless linked_worktree
+
+    FileUtils.mkdir_p(File.join(dir, "stubbin"))
+    write_executable(
+      File.join(dir, "stubbin", "git"),
+      <<~BASH
+        #!/usr/bin/env bash
+        if [[ "$1" == "rev-parse" && "$2" == "--abbrev-ref" && "$3" == "HEAD" ]]; then
+          echo "feature/PAY-1940"
+          exit 0
+        fi
+
+        if [[ "$1" == "rev-parse" && "$2" == "--absolute-git-dir" ]]; then
+          echo "#{dir}/.git/worktrees/feature-pay-1940"
+          exit 0
+        fi
+
+        exit 1
+      BASH
+    )
+    File.write(File.join(dir, ".git"), "gitdir: #{dir}/.git/worktrees/feature-pay-1940\n")
+    ENV["PATH"] = "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}"
+  end
+
+  def render_fixture(dir)
+    stdout, stderr, status = Open3.capture3(
+      { "PATH" => ENV.fetch("PATH") },
+      "ruby",
+      "-rerb",
+      "-e",
+      "puts ERB.new(File.read('config/database.yml')).result",
+      chdir: dir
+    )
+
+    expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+    stdout
+  end
+
+  def write_executable(path, contents)
+    File.write(path, contents)
+    FileUtils.chmod("+x", path)
   end
 end

--- a/spec/paid/worktree_database_names_spec.rb
+++ b/spec/paid/worktree_database_names_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../config/worktree_database_names"
+
+RSpec.describe Paid::WorktreeDatabaseNames do
+  around do |example|
+    original_env = ENV.to_hash
+    example.run
+  ensure
+    ENV.replace(original_env)
+  end
+
+  describe ".development_primary_name" do
+    it "returns an explicit override when it is identifier-safe" do
+      ENV["PAID_DEVELOPMENT_DATABASE"] = "PaidDevelopment_123"
+
+      expect(described_class.development_primary_name).to eq("PaidDevelopment_123")
+    end
+
+    it "raises for an explicit override with unsafe characters" do
+      ENV["PAID_DEVELOPMENT_DATABASE"] = "x'; DROP DATABASE paid_production; --"
+
+      expect { described_class.development_primary_name }
+        .to raise_error(ArgumentError, /Invalid database name/)
+    end
+
+    it "raises for an explicit override longer than PostgreSQL allows" do
+      ENV["PAID_DEVELOPMENT_DATABASE"] = "a" * 64
+
+      expect { described_class.development_primary_name }
+        .to raise_error(ArgumentError, /Invalid database name/)
+    end
+  end
+
+  describe ".development_cable_name" do
+    it "validates explicit overrides" do
+      ENV["PAID_DEVELOPMENT_CABLE_DATABASE"] = "invalid-name"
+
+      expect { described_class.development_cable_name }
+        .to raise_error(ArgumentError, /PAID_DEVELOPMENT_CABLE_DATABASE/)
+    end
+  end
+
+  describe ".test_name" do
+    it "validates explicit overrides" do
+      ENV["PAID_TEST_DATABASE"] = "invalid-name"
+
+      expect { described_class.test_name }
+        .to raise_error(ArgumentError, /PAID_TEST_DATABASE/)
+    end
+  end
+
+  describe ".suffix" do
+    it "validates explicit suffix overrides" do
+      ENV["PAID_WORKTREE_DB_SUFFIX"] = "invalid-name"
+
+      expect { described_class.suffix }
+        .to raise_error(ArgumentError, /PAID_WORKTREE_DB_SUFFIX/)
+    end
+  end
+end

--- a/spec/scripts/db_script_warning_spec.rb
+++ b/spec/scripts/db_script_warning_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe DbScriptWarning do
 
       expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
       expect(stdout).not_to include("PRACTICE RUN COMPLETE")
-      expect(stderr).to include("enable failed")
       expect(stdout).to include("Failed to enable RLS on widgets")
       expect(stdout).to include("Script exited with error")
+      expect(stdout).to include("Attempting to re-enable RLS on paid_development")
     end
   end
 
@@ -78,10 +78,12 @@ RSpec.describe DbScriptWarning do
     FileUtils.mkdir_p(File.join(dir, "bin"))
     FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
     FileUtils.mkdir_p(File.join(dir, "backups"))
+    FileUtils.mkdir_p(File.join(dir, "config"))
 
     script_path = File.join(dir, "bin", script_name)
     FileUtils.cp(File.expand_path("../../bin/#{script_name}", __dir__), script_path)
     FileUtils.cp(File.expand_path("../../bin/lib/db_helpers.sh", __dir__), File.join(dir, "bin", "lib", "db_helpers.sh"))
+    FileUtils.cp(File.expand_path("../../config/worktree_database_names.rb", __dir__), File.join(dir, "config", "worktree_database_names.rb"))
     FileUtils.chmod("+x", script_path)
     script_path
   end

--- a/spec/scripts/ensure_worktree_databases_script_spec.rb
+++ b/spec/scripts/ensure_worktree_databases_script_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe EnsureWorktreeDatabasesScript do
   it "rejects invalid role names before creating databases" do
     Dir.mktmpdir("ensure-worktree-databases-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir)
-      env = base_env(dir).merge("DB_USER" => "paid\" SUPERUSER --")
+      env = base_env(dir).merge("DB_USERNAME" => "paid\" SUPERUSER --")
 
       stdout, stderr, status = Open3.capture3(env, script_path, chdir: dir)
 

--- a/spec/scripts/ensure_worktree_databases_script_spec.rb
+++ b/spec/scripts/ensure_worktree_databases_script_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "open3"
+require "tmpdir"
+require_relative "../support/exec_tmpdir"
+
+class EnsureWorktreeDatabasesScript
+end
+
+RSpec.describe EnsureWorktreeDatabasesScript do
+  include ExecTmpdir
+
+  it "rejects invalid explicit database names before querying Postgres" do
+    Dir.mktmpdir("ensure-worktree-databases-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+      env = base_env(dir).merge(
+        "PAID_DEVELOPMENT_DATABASE" => "x'; DROP DATABASE paid_production; --"
+      )
+
+      stdout, stderr, status = Open3.capture3(env, script_path, chdir: dir)
+
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stderr).to include("Invalid database name")
+      expect(stderr).to include("PAID_DEVELOPMENT_DATABASE")
+      expect(File.exist?(File.join(dir, "psql-invoked.log"))).to be(false)
+    end
+  end
+
+  it "rejects invalid role names before creating databases" do
+    Dir.mktmpdir("ensure-worktree-databases-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+      env = base_env(dir).merge("DB_USER" => "paid\" SUPERUSER --")
+
+      stdout, stderr, status = Open3.capture3(env, script_path, chdir: dir)
+
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stderr).to include("Invalid role name")
+      expect(stderr).to include("DB_USERNAME / DB_USER")
+      expect(File.exist?(File.join(dir, "psql-invoked.log"))).to be(false)
+    end
+  end
+
+  def prepare_script_fixture(dir)
+    FileUtils.mkdir_p(File.join(dir, "bin"))
+    FileUtils.mkdir_p(File.join(dir, "config"))
+    FileUtils.mkdir_p(File.join(dir, "stubbin"))
+
+    script_path = File.join(dir, "bin", "ensure-worktree-databases")
+    FileUtils.cp(File.expand_path("../../bin/ensure-worktree-databases", __dir__), script_path)
+    FileUtils.cp(File.expand_path("../../config/worktree_database_names.rb", __dir__), File.join(dir, "config", "worktree_database_names.rb"))
+    FileUtils.chmod("+x", script_path)
+
+    write_executable(
+      File.join(dir, "stubbin", "git"),
+      <<~BASH
+        #!/usr/bin/env bash
+        if [[ "$1" == "rev-parse" && "$2" == "--abbrev-ref" ]]; then
+          echo "feature/test"
+          exit 0
+        fi
+
+        if [[ "$1" == "rev-parse" && "$2" == "--absolute-git-dir" ]]; then
+          echo "#{dir}/.git/worktrees/test"
+          exit 0
+        fi
+
+        exit 1
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "stubbin", "psql"),
+      <<~BASH
+        #!/usr/bin/env bash
+        echo invoked > "#{dir}/psql-invoked.log"
+        exit 0
+      BASH
+    )
+
+    File.write(File.join(dir, ".git"), "gitdir: #{dir}/.git/worktrees/test\n")
+
+    script_path
+  end
+
+  def base_env(dir)
+    {
+      "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+      "DB_HOST" => "localhost",
+      "DB_PASSWORD" => "paid"
+    }
+  end
+
+  def write_executable(path, contents)
+    File.write(path, contents)
+    FileUtils.chmod("+x", path)
+  end
+end


### PR DESCRIPTION
## Summary
- derive development, cable, and test Postgres database names from git worktree context
- keep the primary checkout on the shared `paid_development` databases while giving linked worktrees isolated names
- ensure branch-specific databases exist during setup and honor the same naming in compose, devcontainer, and db regeneration tooling

## Testing
- `bin/worktree-db`
- `bin/ensure-worktree-databases`
- `bin/rails runner 'puts ActiveRecord::Base.connection_db_config.configuration_hash[:database]'`
- `bin/setup --skip-server`