### PR TITLE
fix(db): make scaling assignment index migration idempotent

### DIFF
--- a/db/migrate/20260510023311_remove_unique_scaling_observation_index_from_scaling_experiment_assignments.rb
+++ b/db/migrate/20260510023311_remove_unique_scaling_observation_index_from_scaling_experiment_assignments.rb
@@ -3,22 +3,26 @@
 class RemoveUniqueScalingObservationIndexFromScalingExperimentAssignments < ActiveRecord::Migration[8.1]
   def up
     remove_index :scaling_experiment_assignments,
-      name: "idx_scaling_experiment_assignments_observation_unique"
+      name: "idx_scaling_experiment_assignments_observation_unique",
+      if_exists: true
 
     add_index :scaling_experiment_assignments,
       :scaling_observation_id,
       where: "scaling_observation_id IS NOT NULL",
-      name: "idx_scaling_experiment_assignments_observation"
+      name: "idx_scaling_experiment_assignments_observation",
+      if_not_exists: true
   end
 
   def down
     remove_index :scaling_experiment_assignments,
-      name: "idx_scaling_experiment_assignments_observation"
+      name: "idx_scaling_experiment_assignments_observation",
+      if_exists: true
 
     add_index :scaling_experiment_assignments,
       :scaling_observation_id,
       name: "idx_scaling_experiment_assignments_observation_unique",
       unique: true,
-      where: "scaling_observation_id IS NOT NULL"
+      where: "scaling_observation_id IS NOT NULL",
+      if_not_exists: true
   end
 end


### PR DESCRIPTION
## Summary
- guard the scaling observation index removal with `if_exists`
- guard the replacement index creation with `if_not_exists`
- make the rollback path equally defensive so fresh and partially-applied databases can migrate cleanly

## Testing
- `DATABASE_URL=postgres://paid:paid@postgres:5432/paid_migfix_dev CABLE_DATABASE_URL=postgres://paid:paid@postgres:5432/paid_migfix_dev_cable bin/rails db:prepare`