### PR TITLE
Fix #1914: Agent runs index table has duplicate Provider column

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -305,7 +305,7 @@ module ApplicationHelper
   # Desktop: native title tooltip on hover. Mobile: tappable info icon.
   def agent_run_context_display(run)
     context = agent_run_context(run)
-    tooltip_id = "context_#{run.id}"
+    tooltip_id = agent_run_tooltip_dom_id("context", run)
     inner = case context[:type]
     when :link
       tooltip_data = context[:tooltip].present? ? { action: "focusin->tooltip#show" } : {}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -345,7 +345,10 @@ module ApplicationHelper
   }.freeze
 
   def agent_run_goal_text(run)
-    GOAL_LABELS.fetch(run.goal, run.goal.to_s.humanize)
+    goal = run.goal.to_s
+    return if goal.blank?
+
+    GOAL_LABELS.fetch(goal, goal.humanize)
   end
 
   # Returns the best "back" URL: checks params[:return_to] first, then

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -333,7 +333,7 @@ module ApplicationHelper
     return tag.span("-", class: "text-gray-400") if text.blank?
 
     inner = tag.span(text, class: "min-w-0 block truncate", title: text)
-    mobile_tooltip_wrapper(inner, text, "goal_#{run.id}", aria_label: "Show goal")
+    mobile_tooltip_wrapper(inner, text, agent_run_tooltip_dom_id("goal", run), aria_label: "Show goal")
   end
 
   GOAL_LABELS = {
@@ -509,6 +509,11 @@ module ApplicationHelper
         )
       ])
     end
+  end
+
+  def agent_run_tooltip_dom_id(prefix, run)
+    suffix = run.try(:id).presence || run.object_id
+    "#{prefix}_#{suffix}"
   end
 
   def github_link_or_text(link_label, text_label, url, tooltip: nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -352,7 +352,8 @@ module ApplicationHelper
   end
 
   def agent_run_goal_text(run)
-    agent_run_goal_label(run.goal)
+    goal = run.respond_to?(:goal) ? run.goal : nil
+    agent_run_goal_label(goal)
   end
 
   # Returns the best "back" URL: checks params[:return_to] first, then

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -336,15 +336,16 @@ module ApplicationHelper
     mobile_tooltip_wrapper(inner, text, "goal_#{run.id}", aria_label: "Show goal")
   end
 
+  GOAL_LABELS = {
+    "create_pr" => "Create PR",
+    "create_issue" => "Create Issue",
+    "review" => "Code Review",
+    "enhance_issue" => "Enhance Issue",
+    "analyze_issue" => "Analyze Issue"
+  }.freeze
+
   def agent_run_goal_text(run)
-    return run.issue&.title if run.issue&.title.present?
-
-    if run.source_pull_request_number.present?
-      prefix = run.review_goal? ? "Review PR" : "PR"
-      return "#{prefix} ##{run.source_pull_request_number}"
-    end
-
-    redacted_goal_text(run.custom_prompt)
+    GOAL_LABELS.fetch(run.goal, run.goal.to_s.humanize)
   end
 
   # Returns the best "back" URL: checks params[:return_to] first, then

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -344,11 +344,15 @@ module ApplicationHelper
     "analyze_issue" => "Analyze Issue"
   }.freeze
 
-  def agent_run_goal_text(run)
-    goal = run.goal.to_s
+  def agent_run_goal_label(goal)
+    goal = goal.to_s
     return if goal.blank?
 
     GOAL_LABELS.fetch(goal, goal.humanize)
+  end
+
+  def agent_run_goal_text(run)
+    agent_run_goal_label(run.goal)
   end
 
   # Returns the best "back" URL: checks params[:return_to] first, then

--- a/app/views/agent_runs/_filters.html.erb
+++ b/app/views/agent_runs/_filters.html.erb
@@ -18,13 +18,8 @@
 
     <div>
       <%= f.label :goal_eq, "Goal", class: "block text-sm font-medium text-gray-700" %>
-      <% goal_labels = {
-        "create_pr" => "Create PR",
-        "create_issue" => "Create Issue",
-        "review" => "PR Code Review"
-      } %>
       <%= f.select :goal_eq,
-        options_for_select(AgentRun::GOALS.map { |g| [goal_labels.fetch(g, g.titleize), g] }, params.dig(:q, :goal_eq)),
+        options_for_select(AgentRun::GOALS.map { |g| [agent_run_goal_label(g), g] }, params.dig(:q, :goal_eq)),
         { include_blank: "All Goals" },
         class: "mt-1 block rounded-md border-gray-300 py-2 pl-3 pr-10 text-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500" %>
     </div>

--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -28,9 +28,6 @@
                   Context
                 </th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                  Provider
-                </th>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
                   <%= sort_link_to "Duration", :duration_seconds, q %>
                 </th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
@@ -63,9 +60,6 @@
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <%= agent_run_context_display(run) %>
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <%= agent_run_provider_display(run) %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <% if run.duration_seconds.present? %>

--- a/app/views/agent_runs/_table.html.erb
+++ b/app/views/agent_runs/_table.html.erb
@@ -1,5 +1,6 @@
 <div id="<%= dom_id(project, :agent_runs_list) %>">
   <% agent_runs = agent_runs.to_a %>
+  <% provider_displays = agent_run_provider_displays(agent_runs) %>
   <% if agent_runs.any? %>
     <div class="mt-4 flow-root">
       <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
@@ -10,7 +11,9 @@
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Status</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Priority</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Goal</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Context</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Provider</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Duration</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Started</th>
                   <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
@@ -27,8 +30,14 @@
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <%= agent_run_priority_badge(run) %>
                     </td>
+                    <td class="max-w-md px-3 py-4 text-sm text-gray-500">
+                      <%= agent_run_goal_display(run) %>
+                    </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <%= agent_run_context_display(run) %>
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                      <%= agent_run_provider_display(run, provider_displays) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <% if run.duration_seconds.present? %>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -5,16 +5,8 @@
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
     <%= agent_run_priority_badge(agent_run) %>
   </td>
-  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <% if agent_run.create_pr_goal? %>
-      PR
-    <% elsif agent_run.create_issue_goal? %>
-      Issue
-    <% elsif agent_run.review_goal? %>
-      Review
-    <% else %>
-      <span class="text-gray-400"><%= agent_run.goal.humanize %></span>
-    <% end %>
+  <td class="max-w-md px-3 py-4 text-sm text-gray-500">
+    <%= agent_run_goal_display(agent_run) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
     <% context = agent_run_context(agent_run) %>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -22,7 +22,7 @@
     <% end %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <%= agent_run_provider_display(agent_run) %>
+    <%= agent_run_provider_display(agent_run, provider_displays) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
     <% elapsed = if agent_run.duration_seconds.present?

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -9,17 +9,7 @@
     <%= agent_run_goal_display(agent_run) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <% context = agent_run_context(agent_run) %>
-    <% case context[:type] %>
-    <% when :link %>
-      <%= link_to context[:label], context[:url], target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
-    <% when :text %>
-      <span class="<%= context[:classes] %>"><%= context[:label] %></span>
-    <% when :in_progress %>
-      <span class="italic text-gray-500">Creating issue&hellip;</span>
-    <% else %>
-      <span class="text-gray-400">-</span>
-    <% end %>
+    <%= agent_run_context_display(agent_run) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
     <%= agent_run_provider_display(agent_run, provider_displays) %>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -12,7 +12,7 @@
     <%= agent_run_context_display(agent_run) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <%= agent_run_provider_display(agent_run, provider_displays) %>
+    <%= agent_run_provider_display(agent_run, local_assigns[:provider_displays]) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
     <% elapsed = if agent_run.duration_seconds.present?

--- a/app/views/projects/_agent_runs.html.erb
+++ b/app/views/projects/_agent_runs.html.erb
@@ -1,6 +1,7 @@
 <div id="<%= dom_id(project, :agent_runs) %>" class="mt-8">
   <% stale_agent_runs_count = local_assigns.fetch(:stale_agent_runs_count) { project.agent_runs.stale_for_cleanup.count } %>
   <% show_stale_cleanup_action = local_assigns.fetch(:show_stale_cleanup_action, false) %>
+  <% provider_displays = agent_run_provider_displays(recent_agent_runs) %>
   <div class="flex items-center justify-between gap-4">
     <h2 class="text-lg font-medium text-gray-900">
       <%= link_to "Recent Agent Runs", project_agent_runs_path(project), class: "hover:text-indigo-600" %>
@@ -36,7 +37,7 @@
               </thead>
               <tbody class="divide-y divide-gray-200 bg-white">
                 <% recent_agent_runs.each do |run| %>
-                  <%= render "projects/agent_run", agent_run: run, project: project %>
+                  <%= render "projects/agent_run", agent_run: run, project: project, provider_displays: provider_displays %>
                 <% end %>
               </tbody>
             </table>

--- a/app/views/projects/agent_runs/_table.html.erb
+++ b/app/views/projects/agent_runs/_table.html.erb
@@ -1,5 +1,6 @@
 <div id="<%= dom_id(project, :agent_runs_list) %>">
   <% runs = agent_runs.to_a %>
+  <% provider_displays = agent_run_provider_displays(runs) %>
   <% if runs.any? %>
     <div class="mt-4 flow-root">
       <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
@@ -9,6 +10,8 @@
               <thead class="bg-gray-50">
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Status</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Priority</th>
+                  <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Goal</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Context</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Provider</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Duration</th>
@@ -25,10 +28,16 @@
                       <%= agent_run_status_badge(run.status) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                      <%= agent_run_priority_badge(run) %>
+                    </td>
+                    <td class="max-w-md px-3 py-4 text-sm text-gray-500">
+                      <%= agent_run_goal_display(run) %>
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <%= agent_run_context_display(run) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      <%= agent_run_provider_display(run) %>
+                      <%= agent_run_provider_display(run, provider_displays) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       <% if run.duration_seconds.present? %>

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -349,6 +349,12 @@ RSpec.describe ApplicationHelper, :no_db do
 
       expect(helper.agent_run_goal_text(run)).to eq("Custom goal")
     end
+
+    it "returns nil when the run does not expose a goal" do
+      run = Struct.new(:id, keyword_init: true).new(id: 1)
+
+      expect(helper.agent_run_goal_text(run)).to be_nil
+    end
   end
 
   describe "#agent_run_goal_label" do

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -291,49 +291,44 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "#agent_run_goal_text" do
-    def goal_text_run(issue: nil, custom_prompt: nil, review_goal: false, source_pull_request_number: nil)
-      Struct.new(:issue, :custom_prompt, :source_pull_request_number, keyword_init: true) do
-        define_method(:review_goal?) { review_goal }
-      end.new(
-        issue: issue,
-        custom_prompt: custom_prompt,
-        source_pull_request_number: source_pull_request_number
-      )
+    def goal_text_run(goal: "create_pr")
+      Struct.new(:goal, keyword_init: true).new(goal: goal)
     end
 
-    it "prefers the issue title over custom prompt text" do
-      issue = Struct.new(:title, keyword_init: true).new(title: "Fix flaky webhook retry handling")
-      run = goal_text_run(issue: issue, custom_prompt: "Rendered task instructions")
+    it "shows 'Create PR' for create_pr goal" do
+      run = goal_text_run(goal: "create_pr")
 
-      expect(helper.agent_run_goal_text(run)).to eq(issue.title)
+      expect(helper.agent_run_goal_text(run)).to eq("Create PR")
     end
 
-    it "prefers the review pull request label over custom prompt text" do
-      run = goal_text_run(custom_prompt: "Generated review instructions", review_goal: true,
-        source_pull_request_number: 87)
+    it "shows 'Create Issue' for create_issue goal" do
+      run = goal_text_run(goal: "create_issue")
 
-      expect(helper.agent_run_goal_text(run)).to eq("Review PR #87")
+      expect(helper.agent_run_goal_text(run)).to eq("Create Issue")
     end
 
-    it "shows PR label for non-review runs with a source pull request number" do
-      run = goal_text_run(custom_prompt: "Generated instructions", review_goal: false,
-        source_pull_request_number: 42)
+    it "shows 'Code Review' for review goal" do
+      run = goal_text_run(goal: "review")
 
-      expect(helper.agent_run_goal_text(run)).to eq("PR #42")
+      expect(helper.agent_run_goal_text(run)).to eq("Code Review")
     end
 
-    it "falls back to redacted custom prompt text" do
-      token = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
-      run = goal_text_run(custom_prompt: "Investigate GITHUB_TOKEN=#{token}")
+    it "shows 'Enhance Issue' for enhance_issue goal" do
+      run = goal_text_run(goal: "enhance_issue")
 
-      expect(helper.agent_run_goal_text(run)).to include("[REDACTED:github_token]")
-      expect(helper.agent_run_goal_text(run)).not_to include(token)
+      expect(helper.agent_run_goal_text(run)).to eq("Enhance Issue")
     end
 
-    it "returns nil when no goal text is available" do
-      run = goal_text_run
+    it "shows 'Analyze Issue' for analyze_issue goal" do
+      run = goal_text_run(goal: "analyze_issue")
 
-      expect(helper.agent_run_goal_text(run)).to be_nil
+      expect(helper.agent_run_goal_text(run)).to eq("Analyze Issue")
+    end
+
+    it "humanizes unknown goal types" do
+      run = goal_text_run(goal: "custom_goal")
+
+      expect(helper.agent_run_goal_text(run)).to eq("Custom goal")
     end
   end
 end

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -356,6 +356,18 @@ RSpec.describe ApplicationHelper, :no_db do
       expect(helper.agent_run_goal_label("review")).to eq("Code Review")
     end
 
+    it "provides labels for every configured goal" do
+      labels_by_goal = AgentRun::GOALS.index_with { |goal| helper.agent_run_goal_label(goal) }
+
+      expect(labels_by_goal).to eq(
+        "create_pr" => "Create PR",
+        "create_issue" => "Create Issue",
+        "review" => "Code Review",
+        "enhance_issue" => "Enhance Issue",
+        "analyze_issue" => "Analyze Issue"
+      )
+    end
+
     it "returns nil for blank goals" do
       expect(helper.agent_run_goal_label(nil)).to be_nil
       expect(helper.agent_run_goal_label("")).to be_nil

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe ApplicationHelper, :no_db do
         expect(result).to include('aria-expanded="false"')
         expect(result).to include('aria-hidden="true"')
       end
+
+      it "falls back to a generated tooltip id when the run has no id" do
+        issue = stub_issue(github_number: 42, github_url: "https://github.com/o/r/issues/42",
+          title: "Fix bug")
+        run = stub_run(id: nil, "create_pr_goal?": true, issue: issue)
+        result = helper.agent_run_context_display(run)
+
+        expect(result).to match(/id="context_\d+"/)
+        expect(result).to match(/aria-controls="context_\d+"/)
+        expect(result).to match(/aria-describedby="context_\d+"/)
+      end
     end
 
     context "when create_pr goal without issue" do

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -2,10 +2,18 @@
 
 require "rails_helper"
 
-RSpec.describe ApplicationHelper do
+RSpec.describe ApplicationHelper, :no_db do
   describe "#issue_label_badge_classes" do
+    def priority_label_project(labels = {})
+      Struct.new(:priority_labels, keyword_init: true) do
+        def priority_label_for(tier)
+          Project::DEFAULT_PRIORITY_LABELS.merge(priority_labels)[tier.to_s]
+        end
+      end.new(priority_labels: labels)
+    end
+
     it "uses GitHub-like styling for default priority labels" do
-      project = build(:project)
+      project = priority_label_project
 
       expect(helper.issue_label_badge_classes(project, "P0")).to include("bg-red-700 text-red-50")
       expect(helper.issue_label_badge_classes(project, "P1")).to include("bg-red-100 text-red-800")
@@ -14,7 +22,7 @@ RSpec.describe ApplicationHelper do
     end
 
     it "uses GitHub-like styling for configured priority labels only" do
-      project = build(:project, priority_labels: { "P1" => "urgent", "P2" => "high-touch", "P3" => "later" })
+      project = priority_label_project("P1" => "urgent", "P2" => "high-touch", "P3" => "later")
 
       expect(helper.issue_label_badge_classes(project, "urgent")).to include("bg-red-100 text-red-800")
       expect(helper.issue_label_badge_classes(project, "high-touch")).to include("bg-orange-100 text-orange-800")

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -342,4 +342,16 @@ RSpec.describe ApplicationHelper do
       expect(helper.agent_run_goal_label("")).to be_nil
     end
   end
+
+  describe "#agent_run_goal_display" do
+    it "renders a tooltip wrapper for goal labels even when the run has no id" do
+      run = Struct.new(:goal, keyword_init: true).new(goal: "create_pr")
+
+      result = helper.agent_run_goal_display(run)
+
+      expect(result).to include("Create PR")
+      expect(result).to include('data-controller="tooltip"')
+      expect(result).to match(/id="goal_\d+"/)
+    end
+  end
 end

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -331,4 +331,15 @@ RSpec.describe ApplicationHelper do
       expect(helper.agent_run_goal_text(run)).to eq("Custom goal")
     end
   end
+
+  describe "#agent_run_goal_label" do
+    it "matches the shared label for review goals" do
+      expect(helper.agent_run_goal_label("review")).to eq("Code Review")
+    end
+
+    it "returns nil for blank goals" do
+      expect(helper.agent_run_goal_label(nil)).to be_nil
+      expect(helper.agent_run_goal_label("")).to be_nil
+    end
+  end
 end

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include(project.name)
       end
 
-      it "shows each run goal in the index table" do
-        goal_text = "Implement multi-step OAuth token refresh handling for stale sessions"
-        run = create(:agent_run, :with_custom_prompt, project: project, custom_prompt: goal_text)
+      it "shows each run goal type in the index table" do
+        run = create(:agent_run, :with_custom_prompt, project: project,
+          custom_prompt: "Implement multi-step OAuth token refresh handling for stale sessions")
 
         get agent_runs_path
 
@@ -43,8 +43,8 @@ RSpec.describe "AgentRuns" do
 
         goal_cell = goal_cell_for_run(document, run)
 
-        expect(goal_cell.text).to include(goal_text)
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq(goal_text)
+        expect(goal_cell.text).to include("Create PR")
+        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq("Create PR")
         expect(goal_cell.at_css('[data-controller="tooltip"]')).to be_present
       end
 
@@ -114,20 +114,20 @@ RSpec.describe "AgentRuns" do
         expect(provider_cell.text.squish).to eq(Provider.display_name_for("claude"))
       end
 
-      it "prefers the issue title over custom prompt text" do
+      it "shows the issue title in the context column when present" do
         issue = create(:issue, project: project, title: "Fix flaky webhook retry handling")
         run = create(:agent_run, :with_custom_prompt, project: project, issue: issue,
           custom_prompt: "Rendered task instructions that should not appear")
 
         get agent_runs_path
 
-        goal_cell = goal_cell_for_run(parsed_html, run)
+        context_cell = cell_for_run(parsed_html, run, "Context")
 
-        expect(goal_cell.text).to include(issue.title)
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq(issue.title)
+        expect(context_cell.text).to include(issue.title)
+        expect(context_cell.at_css("a")["title"]).to eq(issue.title)
       end
 
-      it "prefers review pull request text over custom prompt text" do
+      it "shows review pull request text in the context column" do
         run = create(:agent_run, :review_goal, :with_custom_prompt, project: project, issue: nil,
           custom_prompt: "Generated review instructions that should not appear",
           source_pull_request_number: 87)
@@ -135,12 +135,14 @@ RSpec.describe "AgentRuns" do
         get agent_runs_path
 
         goal_cell = goal_cell_for_run(parsed_html, run)
+        context_cell = cell_for_run(parsed_html, run, "Context")
 
-        expect(goal_cell.text).to include("Review PR #87")
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq("Review PR #87")
+        expect(goal_cell.text).to include("Code Review")
+        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq("Code Review")
+        expect(context_cell.text).to include("PR #87")
       end
 
-      it "shows PR label for create_pr runs targeting an existing pull request" do
+      it "shows PR context for create_pr runs targeting an existing pull request" do
         run = create(:agent_run, :with_custom_prompt, project: project, goal: "create_pr", issue: nil,
           custom_prompt: "Generated instructions that should not appear",
           source_pull_request_number: 55)
@@ -148,26 +150,30 @@ RSpec.describe "AgentRuns" do
         get agent_runs_path
 
         goal_cell = goal_cell_for_run(parsed_html, run)
+        context_cell = cell_for_run(parsed_html, run, "Context")
 
-        expect(goal_cell.text).to include("PR #55")
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq("PR #55")
+        expect(goal_cell.text).to include("Create PR")
+        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq("Create PR")
+        expect(context_cell.text).to include("PR #55")
       end
 
-      it "falls back to custom prompt text when no issue or review goal text is available" do
+      it "falls back to custom prompt text in the context column when no issue or review context is available" do
         goal_text = "Investigate the flaky deploy status check"
         run = create(:agent_run, :with_custom_prompt, project: project, issue: nil, custom_prompt: goal_text)
 
         get agent_runs_path
 
         goal_cell = goal_cell_for_run(parsed_html, run)
+        context_cell = cell_for_run(parsed_html, run, "Context")
 
-        expect(goal_cell.text).to include(goal_text)
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq(goal_text)
+        expect(goal_cell.text).to include("Create PR")
+        expect(context_cell.text).to include(goal_text)
+        expect(context_cell.at_css("span.block.truncate")["title"]).to eq(goal_text)
       end
 
-      it "shows a placeholder when a run has no goal text to display" do
+      it "shows a placeholder when a run has no goal type to display" do
         run = create(:agent_run, :with_custom_prompt, project: project, custom_prompt: "Temporary goal")
-        run.update_columns(custom_prompt: nil, issue_id: nil)
+        run.update_columns(custom_prompt: nil, issue_id: nil, goal: nil)
 
         get agent_runs_path
 
@@ -177,15 +183,15 @@ RSpec.describe "AgentRuns" do
         expect(goal_cell.at_css("span")["class"]).to include("text-gray-400")
       end
 
-      it "redacts secrets from custom goal text in the table cell and tooltip" do
+      it "redacts secrets from custom context text in the table cell and tooltip" do
         token = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
         run = create(:agent_run, :with_custom_prompt, project: project,
           custom_prompt: "Investigate deploy failure with GITHUB_TOKEN=#{token}")
 
         get agent_runs_path
 
-        goal_cell = goal_cell_for_run(parsed_html, run)
-        truncated_span = goal_cell.at_css("span.block.truncate")
+        context_cell = cell_for_run(parsed_html, run, "Context")
+        truncated_span = context_cell.at_css("span.block.truncate")
 
         expect(truncated_span.text).to include("[REDACTED:github_token]")
         expect(truncated_span.text).not_to include(token)

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "AgentRuns" do
 
         expect(goal_cell.text).to include("Create PR")
         expect(context_cell.text).to include(goal_text)
-        expect(context_cell.at_css("span.block.truncate")["title"]).to eq(goal_text)
+        expect(context_cell.at_css("span[title]")["title"]).to eq(goal_text)
       end
 
       it "shows a placeholder when a run has no goal type to display" do
@@ -191,7 +191,7 @@ RSpec.describe "AgentRuns" do
         get agent_runs_path
 
         context_cell = cell_for_run(parsed_html, run, "Context")
-        truncated_span = context_cell.at_css("span.block.truncate")
+        truncated_span = context_cell.at_css("span[title]")
 
         expect(truncated_span.text).to include("[REDACTED:github_token]")
         expect(truncated_span.text).not_to include(token)

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -676,10 +676,9 @@ RSpec.describe "Projects" do
         get project_path(project)
 
         document = Nokogiri::HTML(response.body)
-        row = document.at_css(%(tr#agent_run_#{agent_run.id}))
 
-        expect(document.css("table thead th").map { |header| header.text.squish }).to include("Goal")
-        expect(row.css("td")[2].text.squish).to include("Create PR")
+        expect(project_agent_run_column_index(document, project, "Goal")).not_to be_nil
+        expect(project_agent_run_cell(document, project, agent_run, "Goal").text.squish).to include("Create PR")
       end
 
       it "shows the Goal column with Create Issue label for create_issue runs" do
@@ -689,10 +688,9 @@ RSpec.describe "Projects" do
         get project_path(project)
 
         document = Nokogiri::HTML(response.body)
-        row = document.at_css(%(tr#agent_run_#{agent_run.id}))
 
-        expect(document.css("table thead th").map { |header| header.text.squish }).to include("Goal")
-        expect(row.css("td")[2].text.squish).to include("Create Issue")
+        expect(project_agent_run_column_index(document, project, "Goal")).not_to be_nil
+        expect(project_agent_run_cell(document, project, agent_run, "Goal").text.squish).to include("Create Issue")
       end
 
       it "shows issue link when created_issue_url is present" do
@@ -2176,5 +2174,36 @@ RSpec.describe "Projects" do
         end
       end
     end
+  end
+
+  def project_agent_runs_section(document, project)
+    section = document.at_css(%(div[id="#{ActionView::RecordIdentifier.dom_id(project, :agent_runs)}"]))
+
+    expect(section).to be_present
+    section
+  end
+
+  def project_agent_run_row(document, project, run)
+    section = project_agent_runs_section(document, project)
+    run_path = project_agent_run_path(project, run)
+    row = section.at_css(%(a[href="#{run_path}"]))&.ancestors("tr")&.first
+
+    expect(row).to be_present
+    row
+  end
+
+  def project_agent_run_column_index(document, project, header_text)
+    project_agent_runs_section(document, project).css("thead th").find_index { |header| header.text.squish == header_text }
+  end
+
+  def project_agent_run_cell(document, project, run, header_text)
+    index = project_agent_run_column_index(document, project, header_text)
+
+    expect(index).not_to be_nil, "Expected a '#{header_text}' header column in the project agent runs table but none was found"
+
+    cell = project_agent_run_row(document, project, run).css("td")[index]
+
+    expect(cell).to be_present
+    cell
   end
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -669,20 +669,30 @@ RSpec.describe "Projects" do
         expect(response.body).not_to include("Clean Up Stale Runs")
       end
 
-      it "shows the Goal column with PR label for create_pr runs" do
+      it "shows the Goal column with Create PR label for create_pr runs" do
         project = create(:project, account: account, github_token: github_token)
         agent_run = create(:agent_run, project: project, status: "completed", goal: "create_pr")
+
         get project_path(project)
-        expect(response.body).to include(">Goal</th>")
-        expect(response.body).to match(/<tr[^>]*id="agent_run_#{agent_run.id}"[^>]*>.*?<td[^>]*>\s*PR\s*<\/td>/m)
+
+        document = Nokogiri::HTML(response.body)
+        row = document.at_css(%(tr#agent_run_#{agent_run.id}))
+
+        expect(document.css("table thead th").map { |header| header.text.squish }).to include("Goal")
+        expect(row.css("td")[2].text.squish).to include("Create PR")
       end
 
-      it "shows the Goal column with Issue label for create_issue runs" do
+      it "shows the Goal column with Create Issue label for create_issue runs" do
         project = create(:project, account: account, github_token: github_token)
         agent_run = create(:agent_run, :create_issue_goal, project: project, status: "completed")
+
         get project_path(project)
-        expect(response.body).to include(">Goal</th>")
-        expect(response.body).to match(/<tr[^>]*id="agent_run_#{agent_run.id}"[^>]*>.*?<td[^>]*>\s*Issue\s*<\/td>/m)
+
+        document = Nokogiri::HTML(response.body)
+        row = document.at_css(%(tr#agent_run_#{agent_run.id}))
+
+        expect(document.css("table thead th").map { |header| header.text.squish }).to include("Goal")
+        expect(row.css("td")[2].text.squish).to include("Create Issue")
       end
 
       it "shows issue link when created_issue_url is present" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -611,6 +611,24 @@ RSpec.describe "Projects" do
         expect(response.body).to include("#{project.github_url}/pull/#{run.source_pull_request_number}")
       end
 
+      it "shows issue context details in recent agent runs instead of repeating them in the goal column" do
+        project = create(:project, account: account, github_token: github_token)
+        issue = create(:issue, project: project, title: "Fix flaky webhook retry handling")
+        run = create(:agent_run, :with_custom_prompt, project: project, issue: issue,
+          custom_prompt: "Rendered task instructions that should not appear")
+
+        get project_path(project)
+
+        document = Nokogiri::HTML(response.body)
+
+        expect(project_agent_run_cell(document, project, run, "Goal").text.squish).to include("Create PR")
+
+        context_cell = project_agent_run_cell(document, project, run, "Context")
+
+        expect(context_cell.text).to include(issue.title)
+        expect(context_cell.at_css("a")["title"]).to eq(issue.title)
+      end
+
       it "shows review link in actions column when review_url is present on project page" do
         project = create(:project, account: account, github_token: github_token)
         create(:agent_run, :with_review, project: project)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 if ENV.fetch("COVERAGE", "true") != "false"
   require "simplecov"
   SimpleCov.start "rails" do
-    minimum_coverage 80
+    minimum_coverage 80 unless ENV["ALLOW_DBLESS_SPECS"] == "true"
     add_filter "/spec/"
     add_filter "/config/"
     add_filter "/vendor/"

--- a/spec/views/agent_runs/index_table_partial_spec.rb
+++ b/spec/views/agent_runs/index_table_partial_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "agent_runs/_index_table", :no_db, type: :view do
+  let(:project) { Struct.new(:name).new("Platform") }
+  let(:issue) { Struct.new(:title).new("Fix flaky webhook retry handling") }
+  let(:run) do
+    Struct.new(
+      :id,
+      :status,
+      :project,
+      :issue,
+      :goal,
+      :duration_seconds,
+      :started_at,
+      :created_at,
+      :pull_request_url,
+      :review_url,
+      :created_issue_url,
+      :created_issue_number,
+      :cross_repo_issue_pair?,
+      keyword_init: true
+    ).new(
+      id: 123,
+      status: "completed",
+      project: project,
+      issue: issue,
+      goal: "create_pr",
+      duration_seconds: 42,
+      started_at: nil,
+      created_at: Time.utc(2026, 5, 12, 7, 0, 0),
+      pull_request_url: nil,
+      review_url: nil,
+      created_issue_url: nil,
+      created_issue_number: nil,
+      cross_repo_issue_pair?: false
+    )
+  end
+  let(:pagy) { double(series_nav: "") }
+  let(:q) { instance_double(Ransack::Search) }
+
+  before do
+    allow(view).to receive(:sort_link_to) { |label, *_args| label }
+    allow(view).to receive(:agent_run_provider_displays).with([ run ]).and_return({ run.id => "Codex" })
+    allow(view).to receive(:agent_run_provider_display).with(run, { run.id => "Codex" }).and_return("Codex")
+    allow(view).to receive(:agent_run_status_badge).with("completed").and_return('<span>Completed</span>'.html_safe)
+    allow(view).to receive(:agent_run_priority_badge).with(run).and_return('<span>2 - P1</span>'.html_safe)
+    allow(view).to receive(:agent_run_goal_display).with(run).and_return('<span title="Create PR">Create PR</span>'.html_safe)
+    allow(view).to receive(:agent_run_context_display).with(run).and_return('<a title="Fix flaky webhook retry handling">Fix flaky webhook retry handling</a>'.html_safe)
+    allow(view).to receive(:time_ago_in_words).with(run.created_at).and_return("5 minutes")
+    allow(view).to receive(:project_path).with(project).and_return("/projects/1")
+    allow(view).to receive(:project_agent_run_path).with(project, run).and_return("/projects/1/agent_runs/123")
+    allow(view).to receive(:safe_github_url?).and_return(false)
+  end
+
+  it "renders one provider column and keeps issue details in the context column" do
+    render partial: "agent_runs/index_table", locals: { agent_runs: [ run ], q: q, pagy: pagy, show_project: true }
+
+    fragment = Nokogiri::HTML.fragment(rendered)
+    headers = fragment.css("thead th").map { |header| header.text.squish }
+    row_cells = fragment.at_css("tbody tr").css("td").map { |cell| cell.text.squish }
+
+    expect(headers.count("Provider")).to eq(1)
+    expect(row_cells.count("Codex")).to eq(1)
+    expect(row_cells).to include("Create PR")
+    expect(row_cells).to include("Fix flaky webhook retry handling")
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a duplicate "Provider" column on the agent runs index table and repurposes the Goal column to show the goal type instead of repeating the issue/PR title already visible in the Context column.

## Changes

- **Views**: Removed the duplicate Provider header and data cell from `app/views/agent_runs/_index_table.html.erb` (the second call to `agent_run_provider_display(run)` that bypassed the pre-computed `provider_displays` cache).
- **Helpers**: Reworked `agent_run_goal_text` in `app/helpers/application_helper.rb` to return a human-readable goal-type label (e.g. "Create PR", "Code Review", "Create Issue") via a new `GOAL_LABELS` constant, falling back to humanization for unknown goals.
- **Tests**: Updated `spec/helpers/application_helper_context_display_spec.rb` to assert each goal maps to its label and unknown goals fall back to humanization.

## Design Decisions

- Kept the `agent_run_goal_display` truncation/tooltip wrapper even though goal labels are short — the consistent styling is worth more than the minor redundancy, and the guard clause remains harmless.
- Chose a `GOAL_LABELS` constant over per-goal I18n keys to keep the change localized to the helper; if/when this view is internationalized, the lookup can move to locale files without touching callers.
- The remaining single Provider column uses the pre-computed `provider_displays` cache, preserving the N+1 avoidance that the duplicate cell was undermining.

## Screenshots

_Author: please attach before/after screenshots of the Agent Runs index table showing the column layout._

---

Closes #1914