### PR TITLE
Fix #1933: Show priority of active agent runs in dashboard table

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -16,6 +16,7 @@ class DashboardController < ApplicationController
       .order("agent_runs.created_at DESC")
       .limit(20)
     AgentRun.preload_final_provider_records(@active_runs)
+    AgentRun.preload_source_pull_requests(@active_runs)
     @paused_runs = live_agent_runs.paused.includes(:provider, :issue, :model_selection, project: [ :created_by, :account ])
       .order(paused_at: :desc, created_at: :desc)
       .limit(20)

--- a/app/services/dashboard/live_broadcaster.rb
+++ b/app/services/dashboard/live_broadcaster.rb
@@ -46,6 +46,7 @@ module Dashboard
         .limit(20)
         .to_a
       AgentRun.preload_final_provider_records(active_runs)
+      AgentRun.preload_source_pull_requests(active_runs)
 
       Turbo::StreamsChannel.broadcast_update_to(
         stream_name,

--- a/app/views/dashboard/_active_run_row.html.erb
+++ b/app/views/dashboard/_active_run_row.html.erb
@@ -2,6 +2,9 @@
   <td class="whitespace-nowrap px-4 py-3 text-sm">
     <%= agent_run_status_badge(run.status) %>
   </td>
+  <td class="whitespace-nowrap px-4 py-3 text-sm">
+    <%= agent_run_priority_badge(run) %>
+  </td>
   <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
     <%= link_to run.project.full_name, project_path(run.project), class: "hover:text-indigo-600" %>
   </td>

--- a/app/views/dashboard/_active_runs.html.erb
+++ b/app/views/dashboard/_active_runs.html.erb
@@ -4,6 +4,7 @@
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+          <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Priority</th>
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Project</th>
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Context</th>
           <th scope="col" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Goal</th>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -218,8 +218,12 @@ RSpec.describe "Dashboard" do
       it "shows the priority column in the active runs table" do
         issue = create(:issue, project: project, labels: [ "P1" ])
         run = create(:agent_run, :running, project: project, issue: issue)
+        preloaded_runs = []
 
-        expect(AgentRun).to receive(:preload_source_pull_requests).and_call_original
+        allow(AgentRun).to receive(:preload_source_pull_requests).and_wrap_original do |original, runs|
+          preloaded_runs << runs.to_a
+          original.call(runs)
+        end
 
         get dashboard_path
 
@@ -228,6 +232,7 @@ RSpec.describe "Dashboard" do
 
         expect(table).to be_present
         expect(table.css("thead th").map { |header| header.text.squish }).to include("Priority")
+        expect(preloaded_runs).to include(include(have_attributes(id: run.id)))
 
         row = document.at_css(%(tr[id="#{ActionView::RecordIdentifier.dom_id(run, :dashboard_row)}"]))
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -215,6 +215,24 @@ RSpec.describe "Dashboard" do
         expect(row.text).to include(provider.display_name)
       end
 
+      it "shows the priority column in the active runs table" do
+        issue = create(:issue, project: project, labels: [ "P1" ])
+        run = create(:agent_run, :running, project: project, issue: issue)
+
+        get dashboard_path
+
+        document = Nokogiri::HTML(response.body)
+        table = document.at_css("#active-runs table")
+
+        expect(table).to be_present
+        expect(table.css("thead th").map { |header| header.text.squish }).to include("Priority")
+
+        row = document.at_css(%(tr[id="#{ActionView::RecordIdentifier.dom_id(run, :dashboard_row)}"]))
+
+        expect(row).to be_present
+        expect(row.text).to include("2 - P1")
+      end
+
       it "shows the final provider label for legacy fallback runs in the active runs table" do
         initial_provider = create(:provider, user: user, provider_key: "codex")
         run = create(:agent_run, :running, project: project, provider: initial_provider, final_provider: "cursor")

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -219,6 +219,8 @@ RSpec.describe "Dashboard" do
         issue = create(:issue, project: project, labels: [ "P1" ])
         run = create(:agent_run, :running, project: project, issue: issue)
 
+        expect(AgentRun).to receive(:preload_source_pull_requests).and_call_original
+
         get dashboard_path
 
         document = Nokogiri::HTML(response.body)

--- a/spec/services/dashboard/live_broadcaster_spec.rb
+++ b/spec/services/dashboard/live_broadcaster_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe Dashboard::LiveBroadcaster do
       )
     end
 
+    it "preloads source pull requests for active-run priority badges" do
+      issue = create(:issue, :pull_request, project: project, github_number: 88, labels: [ "P1" ])
+      active_run = create(:agent_run,
+        project: project,
+        status: "running",
+        started_at: 1.minute.ago,
+        source_pull_request_number: issue.github_number)
+
+      described_class.call(account: account, agent_run: active_run)
+
+      expect(broadcasted_active_runs).to include(
+        have_attributes(
+          id: active_run.id,
+          source_pull_request_record: issue
+        )
+      )
+    end
+
     it "broadcasts activity stream when a run finishes" do
       agent_run.update!(status: "completed", completed_at: Time.current, duration_seconds: 30)
 

--- a/spec/views/dashboard/active_runs_partial_spec.rb
+++ b/spec/views/dashboard/active_runs_partial_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "dashboard/_active_runs", :no_db, type: :view do
+  let(:project) { Struct.new(:full_name).new("acme/platform") }
+  let(:issue) { Struct.new(:github_number, :title).new(42, "Show priority for active runs") }
+  let(:run) do
+    Struct.new(
+      :status,
+      :project,
+      :issue,
+      :custom_prompt,
+      :source_pull_request_number,
+      :id,
+      :goal,
+      :model_selection,
+      :started_at,
+      :duration,
+      keyword_init: true
+    ).new(
+      status: "running",
+      project: project,
+      issue: issue,
+      custom_prompt: nil,
+      source_pull_request_number: nil,
+      id: 123,
+      goal: "create_pr",
+      model_selection: nil,
+      started_at: nil,
+      duration: nil
+    )
+  end
+
+  before do
+    allow(view).to receive(:dom_id).with(run, :dashboard_row).and_return("agent_run_123_dashboard_row")
+    allow(view).to receive(:project_path).with(project).and_return("/projects/1")
+    allow(view).to receive(:project_agent_run_path).with(project, run).and_return("/projects/1/agent_runs/123")
+    allow(view).to receive(:dashboard_cancel_run_path).with(run).and_return("/dashboard/runs/123/cancel")
+    allow(view).to receive(:agent_run_status_badge).with("running").and_return('<span>Running</span>'.html_safe)
+    allow(view).to receive(:agent_run_priority_badge).with(run).and_return('<span>2 - P1</span>'.html_safe)
+    allow(view).to receive(:agent_run_provider_display).with(run).and_return("Codex")
+  end
+
+  it "renders the priority column and active run priority value" do
+    render partial: "dashboard/active_runs", locals: { active_runs: [ run ] }
+
+    fragment = Nokogiri::HTML.fragment(rendered)
+    headers = fragment.css("thead th").map { |header| header.text.squish }
+    row = fragment.at_css("tr#agent_run_123_dashboard_row")
+
+    expect(headers).to include("Priority")
+    expect(row).to be_present
+    expect(row.text).to include("2 - P1")
+  end
+end


### PR DESCRIPTION
## Summary

Adds a Priority column to the dashboard's active runs table so users can see scheduling priority at a glance without drilling into individual run details.

## Changes

- **Views**: Added a "Priority" column header in `app/views/dashboard/_active_runs.html.erb` and rendered the existing queue-priority badge in `app/views/dashboard/_active_run_row.html.erb`.
- **Tests**: Added request-path coverage in `spec/requests/dashboard_spec.rb` and a DB-less render spec in `spec/views/dashboard/active_runs_partial_spec.rb` for executable verification without a database.

## Design Decisions

- Reused the existing queue-priority badge component rather than introducing a second priority format, keeping the priority display consistent across the app.
- Added a DB-less view spec alongside the request spec so the partial can be verified in environments without PostgreSQL.

## Verification Notes

A full `bundle exec rspec` run was not possible in the authoring environment because PostgreSQL was unavailable and the request specs are DB-backed — please ensure CI runs the full suite. `bundle exec rubocop`, `bin/lint --staged`, and the DB-less view spec all passed locally.

## Screenshots

_Please attach before/after screenshots of the dashboard active runs table showing the new Priority column._

---

Closes #1933