### PR TITLE
feat(coordination): create coordination policy data model

### DIFF
--- a/app/models/coordination_policy.rb
+++ b/app/models/coordination_policy.rb
@@ -36,6 +36,15 @@ class CoordinationPolicy < ApplicationRecord
     project_id.present?
   end
 
+  def create_version!(attributes = {})
+    with_lock do
+      next_version = (coordination_policy_versions.maximum(:version) || 0) + 1
+      safe_attributes = attributes.except(:version, "version")
+
+      coordination_policy_versions.create!(safe_attributes.merge(version: next_version))
+    end
+  end
+
   def activate_version!(policy_version)
     raise ArgumentError, "policy_version must belong to this coordination policy" unless policy_version.coordination_policy_id == id
 

--- a/spec/models/coordination_policy_spec.rb
+++ b/spec/models/coordination_policy_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe CoordinationPolicy do
     it { is_expected.to validate_presence_of(:policy_type) }
     it { is_expected.to validate_inclusion_of(:policy_type).in_array(described_class::POLICY_TYPES) }
     it { is_expected.to validate_presence_of(:policy_key) }
+    it { is_expected.to validate_length_of(:policy_key).is_at_most(100) }
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(255) }
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
 
     it "rejects duplicate account-wide policy keys within a policy type" do
@@ -74,6 +76,40 @@ RSpec.describe CoordinationPolicy do
 
       expect(coordination_policy).to be_valid
       expect(coordination_policy.account).to eq(project.account)
+    end
+
+    it "requires context_selector to be a hash" do
+      coordination_policy.context_selector = []
+
+      expect(coordination_policy).not_to be_valid
+      expect(coordination_policy.errors[:context_selector]).to include("must be a JSON object")
+    end
+
+    it "requires metadata to be a hash" do
+      coordination_policy.metadata = []
+
+      expect(coordination_policy).not_to be_valid
+      expect(coordination_policy.errors[:metadata]).to include("must be a JSON object")
+    end
+  end
+
+  describe "#create_version!" do
+    it "creates policy versions with auto-incremented version numbers" do
+      policy = create(:coordination_policy)
+
+      version1 = policy.create_version!(rules: { "mode" => "linear" })
+      version2 = policy.create_version!(rules: { "mode" => "parallel" })
+
+      expect(version1.version).to eq(1)
+      expect(version2.version).to eq(2)
+    end
+
+    it "ignores caller-supplied version values" do
+      policy = create(:coordination_policy)
+
+      version = policy.create_version!(rules: { "mode" => "parallel" }, version: 99)
+
+      expect(version.version).to eq(1)
     end
   end
 

--- a/spec/models/coordination_policy_version_spec.rb
+++ b/spec/models/coordination_policy_version_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CoordinationPolicyVersion do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:version) }
+    it { is_expected.to validate_numericality_of(:version).only_integer.is_greater_than(0) }
     it { is_expected.to validate_uniqueness_of(:version).scoped_to(:coordination_policy_id) }
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
 
@@ -19,6 +20,20 @@ RSpec.describe CoordinationPolicyVersion do
 
       expect(coordination_policy_version).not_to be_valid
       expect(coordination_policy_version.errors[:rules]).to include("must be a JSON object")
+    end
+
+    it "requires parameters to be a hash" do
+      coordination_policy_version.parameters = []
+
+      expect(coordination_policy_version).not_to be_valid
+      expect(coordination_policy_version.errors[:parameters]).to include("must be a JSON object")
+    end
+
+    it "requires metadata to be a hash" do
+      coordination_policy_version.metadata = []
+
+      expect(coordination_policy_version).not_to be_valid
+      expect(coordination_policy_version.errors[:metadata]).to include("must be a JSON object")
     end
   end
 


### PR DESCRIPTION
## Summary

Harden the coordination policy model layer so version allocation is safe under concurrent writes and inputs are validated consistently. This completes the data-model groundwork needed for policy-driven execution.

## Changes

- **Models**: Add `CoordinationPolicy#create_version!` in `app/models/coordination_policy.rb` to allocate monotonic version numbers under lock, ignoring any caller-supplied `version` value.
- **Specs**: Extend `spec/models/coordination_policy_spec.rb` and `spec/models/coordination_policy_version_spec.rb` to cover length constraints, JSON object validation, numeric version validation, and the new version-creation behavior.

## Design Decisions

- **Server-assigned versions**: Callers cannot pass a `version` into `create_version!`; the next number is computed under a row lock on the parent policy. This prevents version collisions and gaps under concurrent writes and keeps the contract simple.
- **Validation depth at the model layer**: Length, JSON-object shape, and numeric version checks live on the model so any future call site (services, jobs, evolved policies) inherits the same guarantees without needing a service wrapper.

## Operational Notes

- No new migrations in this change; it builds on the existing coordination policy schema. RSpec was not executed in the working container because PostgreSQL was unavailable — please ensure CI runs the full suite before merging.

---

Closes #1804