### PR TITLE
feat(coordination): implement learned failure recovery service

### DIFF
--- a/app/services/coordination/failure_recovery.rb
+++ b/app/services/coordination/failure_recovery.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Coordination
-  # Classifies a failed agent run into a failure category and selects a
-  # recovery action from coordination policies. Persists the classification
-  # and chosen action for later learning.
+  # Persists the learned failure recovery decision for a failed agent run.
+  # Classification and policy-aware action selection live in
+  # Coordination::FailureRecoveryService.
   #
   # @example
   #   result = Coordination::FailureRecovery.call(agent_run: failed_run)
@@ -12,29 +12,6 @@ module Coordination
   #   result.failure_category    # => "provider_error"
   #   result.chosen_action       # => "retry_alternate_provider"
   class FailureRecovery
-    CATEGORY_PATTERNS = {
-      "rate_limit" => [ /RateLimit/i, /rate.?limit/i, /\b429\b/ ],
-      "auth_failure" => [ /AuthenticationError/i, /auth.?expir/i, /unauthorized/i, /\b403\b/ ],
-      "timeout" => [ /timeout/i, /timed?\s*out/i ],
-      "provider_error" => [ /AllProvidersExhausted/i, /ProxyUnavailable/i, /\bprovider.?(error|fail)/i ],
-      "container_error" => [ /ContainerNotProvisioned/i, /\bcontainer.?(error|fail)/i, /\bdocker.?(error|fail)/i ],
-      "prompt_error" => [ /MissingPrompt/i, /\bprompt.?(error|fail|missing)/i ],
-      "dependency_failure" => [ /dependency.?fail/i, /\bblocked.?by\b/i ],
-      "configuration_error" => [ /McpProvisioningFailed/i, /\bconfig\w*.?(error|fail|invalid)/i, /MissingUser/i ]
-    }.freeze
-
-    DEFAULT_POLICY = {
-      "rate_limit" => "retry_alternate_provider",
-      "auth_failure" => "pause_and_notify",
-      "timeout" => "retry_same_provider",
-      "provider_error" => "retry_alternate_provider",
-      "container_error" => "reconfigure_and_retry",
-      "prompt_error" => "pause_and_notify",
-      "dependency_failure" => "cancel_workflow",
-      "configuration_error" => "reconfigure_and_retry",
-      "unknown" => "pause_and_notify"
-    }.freeze
-
     def self.call(...)
       new(...).call
     end
@@ -46,33 +23,43 @@ module Coordination
     end
 
     def call
-      category = nil
-      action = nil
+      service_result = nil
 
       unless failed_run?
-        action = "noop"
         persist_non_failure_decision
         return non_failure_result
       end
 
-      category = classify_failure
-      action = select_action(category)
+      service_result = FailureRecoveryService.call(
+        agent_run: agent_run,
+        policy_overrides: policy_overrides,
+        run_snapshot: run_snapshot
+      )
 
-      classification = persist_classification(category, action)
-      persist_decision(classification, category, action)
+      classification = persist_classification(service_result)
+      persist_decision(classification, service_result)
 
       Rails.logger.info(
         message: "coordination.failure_classified",
         agent_run_id: agent_run.id,
-        failure_category: category,
-        chosen_action: action,
+        failure_category: service_result.failure_category,
+        chosen_action: service_result.chosen_action,
+        policy_source: service_result.policy["source"],
         parent_workflow_id: current_parent_workflow_id
       )
 
       Result.new(success: true, classification: classification,
-        failure_category: category, chosen_action: action)
+        failure_category: service_result.failure_category,
+        chosen_action: service_result.chosen_action)
     rescue ActiveRecord::RecordInvalid => e
-      persist_failed_decision(e, category: category, action: action)
+      persist_failed_decision(
+        e,
+        category: service_result&.failure_category,
+        subcategory: service_result&.failure_subcategory,
+        action: service_result&.chosen_action || "retry",
+        policy: service_result&.policy || {},
+        failure_context: service_result&.failure_context || {}
+      )
       Result.new(success: false, error: e.message)
     end
 
@@ -88,59 +75,29 @@ module Coordination
       Result.new(success: false, error: "agent run status must be a failure status")
     end
 
-    def classify_failure
-      error_text = build_error_text
-
-      CATEGORY_PATTERNS.each do |category, patterns|
-        return category if patterns.any? { |p| p.match?(error_text) }
-      end
-
-      classify_by_status || "unknown"
-    end
-
-    def build_error_text
-      [
-        current_error_message,
-        current_status,
-        current_guardrail_violation_type
-      ].compact.join(" ")
-    end
-
-    def classify_by_status
-      case current_status
-      when "timeout" then "timeout"
-      when "rate_limited" then "rate_limit"
-      when "auth_expired" then "auth_failure"
-      end
-    end
-
-    def select_action(category)
-      policy_overrides.fetch(category) { DEFAULT_POLICY.fetch(category, "pause_and_notify") }
-    end
-
-    def persist_classification(category, action)
+    def persist_classification(service_result)
       FailureClassification.create!(
         project: agent_run.project,
         agent_run: agent_run,
-        failure_category: category,
-        failure_subcategory: extract_subcategory,
-        chosen_action: action,
-        failure_context: build_failure_context,
-        action_params: build_action_params(category, action),
+        failure_category: service_result.failure_category,
+        failure_subcategory: service_result.failure_subcategory,
+        chosen_action: service_result.chosen_action,
+        failure_context: service_result.failure_context,
+        action_params: service_result.action_params,
         parent_workflow_id: current_parent_workflow_id
       )
     end
 
-    def persist_decision(classification, category, action)
+    def persist_decision(classification, service_result)
       OrchestrationDecision.record!(
         project: agent_run.project,
         issue: agent_run.issue,
         agent_run: agent_run,
         decision_point: "coordination_failure_recovery",
-        action: orchestration_action_for(action),
+        action: orchestration_action_for(service_result.chosen_action),
         status: "applied",
-        signals: build_decision_signals(category, action),
-        result: build_decision_result(classification, action)
+        signals: build_decision_signals(service_result),
+        result: build_decision_result(classification, service_result)
       )
     end
 
@@ -162,7 +119,7 @@ module Coordination
       )
     end
 
-    def persist_failed_decision(error, category:, action: "retry")
+    def persist_failed_decision(error, category:, subcategory: nil, action: "retry", policy: {}, failure_context: {})
       OrchestrationDecision.record(
         project: agent_run.project,
         issue: agent_run.issue,
@@ -170,57 +127,19 @@ module Coordination
         decision_point: "coordination_failure_recovery",
         action: orchestration_action_for(action),
         status: "failed",
-        signals: build_decision_signals(category, action),
+        signals: build_decision_signals_from_values(
+          category: category,
+          subcategory: subcategory,
+          action: action,
+          policy: policy,
+          failure_context: failure_context
+        ),
         result: {
           chosen_action: action,
           error_class: error.class.name,
           error_message: error.message
         }
       )
-    end
-
-    def extract_subcategory
-      return current_guardrail_violation_type if current_guardrail_violation_type.present?
-
-      known_types = OrchestrationStrategies::Defaults.feature_orchestration["known_failure_types"]
-      error = current_error_message.to_s
-      known_types&.find { |t| error.include?(t) }
-    end
-
-    def build_failure_context
-      {
-        error_message: current_error_message.to_s.truncate(1000),
-        status: current_status,
-        final_provider: current_final_provider,
-        providers_attempted: current_providers_attempted,
-        provider_switches: current_provider_switches,
-        guardrail_violation_type: current_guardrail_violation_type
-      }.compact_blank
-    end
-
-    def build_action_params(category, action)
-      params = { category: category, action: action }
-
-      case action
-      when "retry_alternate_provider"
-        params[:exclude_providers] = attempted_provider_identifiers
-      when "escalate_model"
-        params[:current_provider] = preferred_provider_identifier
-      when "retry_same_provider"
-        params[:provider] = preferred_provider_identifier
-      end
-
-      params
-    end
-
-    def attempted_provider_identifiers
-      Array(current_providers_attempted).filter_map do |attempt|
-        attempt.is_a?(Hash) ? attempt["provider"] : attempt
-      end
-    end
-
-    def preferred_provider_identifier
-      attempted_provider_identifiers.last || current_final_provider || agent_run.effective_provider
     end
 
     def current_status
@@ -281,23 +200,38 @@ module Coordination
       end
     end
 
-    def build_decision_signals(category, action)
-      {
-        failure_category: category,
-        failure_subcategory: extract_subcategory,
-        agent_run_status: current_status,
-        parent_workflow_id: current_parent_workflow_id,
-        chosen_action: action
-      }.merge(build_failure_context)
-        .compact
+    def build_decision_signals(service_result)
+      build_decision_signals_from_values(
+        category: service_result.failure_category,
+        subcategory: service_result.failure_subcategory,
+        action: service_result.chosen_action,
+        policy: service_result.policy,
+        failure_context: service_result.failure_context
+      )
     end
 
-    def build_decision_result(classification, action)
+    def build_decision_signals_from_values(category:, subcategory:, action:, policy:, failure_context:)
+      {
+        failure_category: category,
+        failure_subcategory: subcategory,
+        agent_run_status: current_status,
+        parent_workflow_id: current_parent_workflow_id,
+        chosen_action: action,
+        policy_source: policy["source"],
+        policy_key: policy["policy_key"],
+        coordination_policy_id: policy["coordination_policy_id"],
+        coordination_policy_version_id: policy["coordination_policy_version_id"],
+        coordination_policy_version: policy["coordination_policy_version"]
+      }.merge(failure_context).compact
+    end
+
+    def build_decision_result(classification, service_result)
       {
         failure_classification_id: classification.id,
-        chosen_action: action,
+        chosen_action: service_result.chosen_action,
         action_params: classification.action_params,
-        action_status: classification.action_status
+        action_status: classification.action_status,
+        policy_source: service_result.policy["source"]
       }.compact
     end
 

--- a/app/services/coordination/failure_recovery.rb
+++ b/app/services/coordination/failure_recovery.rb
@@ -146,26 +146,6 @@ module Coordination
       snapshot_value(:status)
     end
 
-    def current_error_message
-      snapshot_value(:error_message)
-    end
-
-    def current_guardrail_violation_type
-      snapshot_value(:guardrail_violation_type)
-    end
-
-    def current_final_provider
-      snapshot_value(:final_provider)
-    end
-
-    def current_providers_attempted
-      snapshot_value(:providers_attempted)
-    end
-
-    def current_provider_switches
-      snapshot_value(:provider_switches)
-    end
-
     def current_parent_workflow_id
       snapshot_value(:parent_workflow_id)
     end
@@ -217,12 +197,8 @@ module Coordination
         agent_run_status: current_status,
         parent_workflow_id: current_parent_workflow_id,
         chosen_action: action,
-        policy_source: policy["source"],
-        policy_key: policy["policy_key"],
-        coordination_policy_id: policy["coordination_policy_id"],
-        coordination_policy_version_id: policy["coordination_policy_version_id"],
-        coordination_policy_version: policy["coordination_policy_version"]
-      }.merge(failure_context).compact
+        **decision_policy_metadata(policy, failure_context)
+      }.merge(failure_context.except(*policy_metadata_keys)).compact
     end
 
     def build_decision_result(classification, service_result)
@@ -233,6 +209,26 @@ module Coordination
         action_status: classification.action_status,
         policy_source: service_result.policy["source"]
       }.compact
+    end
+
+    def decision_policy_metadata(policy, failure_context)
+      failure_context.slice(*policy_metadata_keys).symbolize_keys.presence || {
+        policy_source: policy["source"],
+        policy_key: policy["policy_key"],
+        coordination_policy_id: policy["coordination_policy_id"],
+        coordination_policy_version_id: policy["coordination_policy_version_id"],
+        coordination_policy_version: policy["coordination_policy_version"]
+      }.compact
+    end
+
+    def policy_metadata_keys
+      %w[
+        policy_source
+        policy_key
+        coordination_policy_id
+        coordination_policy_version_id
+        coordination_policy_version
+      ]
     end
 
     class Result

--- a/app/services/coordination/failure_recovery_policy.rb
+++ b/app/services/coordination/failure_recovery_policy.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Coordination
+  class FailureRecoveryPolicy
+    POLICY_TYPE = "recovery"
+    POLICY_KEY = "failure_recovery"
+    DEFAULT_ACTION = "pause_and_notify"
+
+    DEFAULT_ACTIONS = {
+      "rate_limit" => "retry_alternate_provider",
+      "auth_failure" => "pause_and_notify",
+      "timeout" => "retry_same_provider",
+      "provider_error" => "retry_alternate_provider",
+      "container_error" => "reconfigure_and_retry",
+      "prompt_error" => "pause_and_notify",
+      "dependency_failure" => "cancel_workflow",
+      "configuration_error" => "reconfigure_and_retry",
+      "unknown" => DEFAULT_ACTION
+    }.freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, overrides: {})
+      @project = project
+      @overrides = overrides
+    end
+
+    def call
+      return override_policy if overrides.present?
+      return fallback_policy("defaults") unless policy
+      return fallback_policy("defaults") unless current_version
+
+      merged_actions = DEFAULT_ACTIONS.merge(extract_actions(current_version.rules))
+        .merge(extract_actions(current_version.parameters))
+
+      {
+        "actions" => normalize_actions(merged_actions),
+        "default_action" => normalize_action(extract_default_action(current_version.rules)) ||
+          normalize_action(extract_default_action(current_version.parameters)) ||
+          DEFAULT_ACTION,
+        "source" => "coordination_policy",
+        "policy_key" => policy.policy_key,
+        "coordination_policy_id" => policy.id,
+        "coordination_policy_version_id" => current_version.id,
+        "coordination_policy_version" => current_version.version
+      }
+    rescue StandardError => e
+      Rails.logger.warn(
+        message: "coordination.failure_recovery_policy_resolution_failed",
+        project_id: project.id,
+        error_class: e.class.name,
+        error_message: e.message
+      )
+      fallback_policy("fallback")
+    end
+
+    private
+
+    attr_reader :project, :overrides
+
+    def policy
+      @policy ||= CoordinationPolicy
+        .active
+        .by_type(POLICY_TYPE)
+        .where(account: project.account, policy_key: POLICY_KEY)
+        .where(project_id: [ nil, project.id ])
+        .includes(:current_version)
+        .order(Arel.sql("CASE WHEN project_id IS NOT NULL THEN 0 ELSE 1 END"), id: :desc)
+        .find { |candidate| candidate.current_version.present? }
+    end
+
+    def current_version
+      policy&.current_version
+    end
+
+    def override_policy
+      {
+        "actions" => normalize_actions(DEFAULT_ACTIONS.merge(overrides.stringify_keys)),
+        "default_action" => DEFAULT_ACTION,
+        "source" => "override",
+        "policy_key" => POLICY_KEY,
+        "coordination_policy_id" => nil,
+        "coordination_policy_version_id" => nil,
+        "coordination_policy_version" => nil
+      }
+    end
+
+    def fallback_policy(source)
+      {
+        "actions" => DEFAULT_ACTIONS,
+        "default_action" => DEFAULT_ACTION,
+        "source" => source,
+        "policy_key" => POLICY_KEY,
+        "coordination_policy_id" => nil,
+        "coordination_policy_version_id" => nil,
+        "coordination_policy_version" => nil
+      }
+    end
+
+    def extract_actions(config)
+      return {} unless config.is_a?(Hash)
+
+      config.fetch("failure_actions", config.fetch("actions", {}))
+    end
+
+    def extract_default_action(config)
+      return unless config.is_a?(Hash)
+
+      config["default_action"]
+    end
+
+    def normalize_actions(actions)
+      actions.each_with_object({}) do |(category, action), normalized|
+        category = category.to_s
+        action = normalize_action(action)
+        next unless FailureClassification::FAILURE_CATEGORIES.include?(category)
+        next unless action
+
+        normalized[category] = action
+      end
+    end
+
+    def normalize_action(action)
+      action = action.to_s
+      return if action.blank?
+      return unless FailureClassification::ACTIONS.include?(action)
+
+      action
+    end
+  end
+end

--- a/app/services/coordination/failure_recovery_service.rb
+++ b/app/services/coordination/failure_recovery_service.rb
@@ -2,7 +2,7 @@
 
 module Coordination
   class FailureRecoveryService
-    FAILURE_HOOKS = {
+    CATEGORY_PATTERNS = {
       "rate_limit" => [ /RateLimit/i, /rate.?limit/i, /\b429\b/ ],
       "auth_failure" => [ /AuthenticationError/i, /auth.?expir/i, /unauthorized/i, /\b403\b/ ],
       "timeout" => [ /timeout/i, /timed?\s*out/i ],
@@ -45,7 +45,7 @@ module Coordination
     def classify_failure
       error_text = build_error_text
 
-      FAILURE_HOOKS.each do |category, patterns|
+      CATEGORY_PATTERNS.each do |category, patterns|
         return category if patterns.any? { |pattern| pattern.match?(error_text) }
       end
 

--- a/app/services/coordination/failure_recovery_service.rb
+++ b/app/services/coordination/failure_recovery_service.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module Coordination
+  class FailureRecoveryService
+    FAILURE_HOOKS = {
+      "rate_limit" => [ /RateLimit/i, /rate.?limit/i, /\b429\b/ ],
+      "auth_failure" => [ /AuthenticationError/i, /auth.?expir/i, /unauthorized/i, /\b403\b/ ],
+      "timeout" => [ /timeout/i, /timed?\s*out/i ],
+      "provider_error" => [ /AllProvidersExhausted/i, /ProxyUnavailable/i, /\bprovider.?(error|fail)/i ],
+      "container_error" => [ /ContainerNotProvisioned/i, /\bcontainer.?(error|fail)/i, /\bdocker.?(error|fail)/i ],
+      "prompt_error" => [ /MissingPrompt/i, /\bprompt.?(error|fail|missing)/i ],
+      "dependency_failure" => [ /dependency.?fail/i, /\bblocked.?by\b/i ],
+      "configuration_error" => [ /McpProvisioningFailed/i, /\bconfig\w*.?(error|fail|invalid)/i, /MissingUser/i ]
+    }.freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(agent_run:, policy_overrides: {}, run_snapshot: {})
+      @agent_run = agent_run
+      @policy_overrides = policy_overrides
+      @run_snapshot = run_snapshot
+    end
+
+    def call
+      category = classify_failure
+      policy = FailureRecoveryPolicy.call(project: agent_run.project, overrides: policy_overrides)
+      action = select_action(category, policy)
+
+      Result.new(
+        failure_category: category,
+        failure_subcategory: extract_subcategory,
+        chosen_action: action,
+        failure_context: build_failure_context.merge(policy_metadata(policy)),
+        action_params: build_action_params(category, action).merge(policy_metadata(policy)),
+        policy: policy
+      )
+    end
+
+    private
+
+    attr_reader :agent_run, :policy_overrides, :run_snapshot
+
+    def classify_failure
+      error_text = build_error_text
+
+      FAILURE_HOOKS.each do |category, patterns|
+        return category if patterns.any? { |pattern| pattern.match?(error_text) }
+      end
+
+      classify_by_status || "unknown"
+    end
+
+    def build_error_text
+      [
+        current_error_message,
+        current_status,
+        current_guardrail_violation_type
+      ].compact.join(" ")
+    end
+
+    def classify_by_status
+      case current_status
+      when "timeout" then "timeout"
+      when "rate_limited" then "rate_limit"
+      when "auth_expired" then "auth_failure"
+      end
+    end
+
+    def select_action(category, policy)
+      policy.fetch("actions", {}).fetch(category, policy.fetch("default_action", FailureRecoveryPolicy::DEFAULT_ACTION))
+    end
+
+    def extract_subcategory
+      return current_guardrail_violation_type if current_guardrail_violation_type.present?
+
+      known_types = OrchestrationStrategies::Defaults.feature_orchestration["known_failure_types"]
+      error = current_error_message.to_s
+      known_types&.find { |type| error.include?(type) }
+    end
+
+    def build_failure_context
+      {
+        error_message: current_error_message.to_s.truncate(1000),
+        status: current_status,
+        final_provider: current_final_provider,
+        providers_attempted: current_providers_attempted,
+        provider_switches: current_provider_switches,
+        guardrail_violation_type: current_guardrail_violation_type
+      }.compact_blank
+    end
+
+    def build_action_params(category, action)
+      {}.tap do |params|
+        params[:category] = category
+        params[:action] = action
+
+        case action
+        when "retry_alternate_provider"
+          params[:exclude_providers] = attempted_provider_identifiers
+        when "escalate_model"
+          params[:current_provider] = preferred_provider_identifier
+        when "retry_same_provider"
+          params[:provider] = preferred_provider_identifier
+        end
+      end
+    end
+
+    def policy_metadata(policy)
+      {
+        policy_source: policy["source"],
+        policy_key: policy["policy_key"],
+        coordination_policy_id: policy["coordination_policy_id"],
+        coordination_policy_version_id: policy["coordination_policy_version_id"],
+        coordination_policy_version: policy["coordination_policy_version"]
+      }.compact
+    end
+
+    def attempted_provider_identifiers
+      Array(current_providers_attempted).filter_map do |attempt|
+        attempt.is_a?(Hash) ? attempt["provider"] : attempt
+      end
+    end
+
+    def preferred_provider_identifier
+      attempted_provider_identifiers.last || current_final_provider || agent_run.effective_provider
+    end
+
+    def current_status
+      snapshot_value(:status)
+    end
+
+    def current_error_message
+      snapshot_value(:error_message)
+    end
+
+    def current_guardrail_violation_type
+      snapshot_value(:guardrail_violation_type)
+    end
+
+    def current_final_provider
+      snapshot_value(:final_provider)
+    end
+
+    def current_providers_attempted
+      snapshot_value(:providers_attempted)
+    end
+
+    def current_provider_switches
+      snapshot_value(:provider_switches)
+    end
+
+    def snapshot_value(key)
+      return run_snapshot[key] if run_snapshot.key?(key)
+
+      agent_run.public_send(key)
+    end
+
+    class Result
+      attr_reader :failure_category, :failure_subcategory, :chosen_action,
+        :failure_context, :action_params, :policy
+
+      def initialize(failure_category:, failure_subcategory:, chosen_action:,
+        failure_context:, action_params:, policy:)
+        @failure_category = failure_category
+        @failure_subcategory = failure_subcategory
+        @chosen_action = chosen_action
+        @failure_context = failure_context
+        @action_params = action_params
+        @policy = policy
+      end
+    end
+  end
+end

--- a/app/services/coordination/failure_recovery_service.rb
+++ b/app/services/coordination/failure_recovery_service.rb
@@ -32,8 +32,8 @@ module Coordination
         failure_category: category,
         failure_subcategory: extract_subcategory,
         chosen_action: action,
-        failure_context: build_failure_context.merge(policy_metadata(policy)),
-        action_params: build_action_params(category, action).merge(policy_metadata(policy)),
+        failure_context: build_failure_context.merge(policy_metadata(policy)).deep_stringify_keys,
+        action_params: build_action_params(category, action).merge(policy_metadata(policy)).deep_stringify_keys,
         policy: policy
       )
     end

--- a/spec/services/coordination/failure_recovery_orchestration_action_spec.rb
+++ b/spec/services/coordination/failure_recovery_orchestration_action_spec.rb
@@ -70,4 +70,53 @@ RSpec.describe Coordination::FailureRecovery, :no_db do
       expect_failed_decision_recorded(orchestration_action: "escalate", error_class_name: error_class.name)
     end
   end
+
+  describe "#build_decision_signals_from_values" do
+    let(:signal_builder) do
+      described_class.new(
+        agent_run: agent_run,
+        policy_overrides: {},
+        run_snapshot: { status: "timeout", parent_workflow_id: nil }
+      )
+    end
+
+    let(:policy) do
+      {
+        "source" => "defaults",
+        "policy_key" => "failure_recovery"
+      }
+    end
+
+    let(:failure_context) do
+      {
+        "policy_source" => "override",
+        "policy_key" => "failure_recovery",
+        "coordination_policy_id" => 12,
+        "error_message" => "timeout"
+      }
+    end
+
+    let(:signals) do
+      signal_builder.send(
+        :build_decision_signals_from_values,
+        category: "timeout",
+        subcategory: nil,
+        action: "escalate_model",
+        policy: policy,
+        failure_context: failure_context
+      )
+    end
+
+    it "uses a single policy metadata source when failure context already includes it" do
+      expect(signals).to include(
+        failure_category: "timeout",
+        chosen_action: "escalate_model",
+        policy_source: "override",
+        policy_key: "failure_recovery",
+        coordination_policy_id: 12
+      )
+      expect(signals["error_message"]).to eq("timeout")
+      expect(signals.keys.count(:policy_source)).to eq(1)
+    end
+  end
 end

--- a/spec/services/coordination/failure_recovery_orchestration_action_spec.rb
+++ b/spec/services/coordination/failure_recovery_orchestration_action_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Coordination::FailureRecovery, :no_db do
       decision_point: "coordination_failure_recovery",
       action: orchestration_action,
       status: "failed",
-      signals: {
+      signals: hash_including(
         failure_category: "timeout",
         chosen_action: "escalate_model"
-      },
+      ),
       result: hash_including(
         chosen_action: "escalate_model",
         error_class: error_class_name
@@ -49,7 +49,13 @@ RSpec.describe Coordination::FailureRecovery, :no_db do
         end
       end)
       allow(OrchestrationDecision).to receive(:record)
-      allow(service).to receive(:build_decision_signals).with("timeout", "escalate_model").and_return(
+      allow(service).to receive(:build_decision_signals_from_values).with(
+        category: "timeout",
+        subcategory: nil,
+        action: "escalate_model",
+        policy: {},
+        failure_context: {}
+      ).and_return(
         failure_category: "timeout",
         chosen_action: "escalate_model"
       )

--- a/spec/services/coordination/failure_recovery_policy_spec.rb
+++ b/spec/services/coordination/failure_recovery_policy_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Coordination::FailureRecoveryPolicy do
+  describe ".call" do
+    let(:project) { create(:project) }
+
+    it "returns the default recovery policy when no coordination policy exists" do
+      result = described_class.call(project: project)
+
+      expect(result).to include(
+        "source" => "defaults",
+        "policy_key" => "failure_recovery",
+        "default_action" => "pause_and_notify"
+      )
+      expect(result["actions"]).to include(
+        "timeout" => "retry_same_provider",
+        "dependency_failure" => "cancel_workflow"
+      )
+    end
+
+    it "uses the active account policy when present" do
+      policy = create(:coordination_policy, :active,
+        account: project.account,
+        policy_type: "recovery",
+        policy_key: "failure_recovery")
+      policy.current_version.update!(
+        rules: { "failure_actions" => { "timeout" => "escalate_model" } },
+        parameters: { "default_action" => "skip_and_continue" }
+      )
+
+      result = described_class.call(project: project)
+
+      expect(result).to include(
+        "source" => "coordination_policy",
+        "coordination_policy_id" => policy.id,
+        "coordination_policy_version_id" => policy.current_version.id
+      )
+      expect(result["actions"]["timeout"]).to eq("escalate_model")
+      expect(result["default_action"]).to eq("skip_and_continue")
+    end
+
+    it "prefers a project-scoped policy over an account-scoped one" do
+      create(:coordination_policy, :active,
+        account: project.account,
+        policy_type: "recovery",
+        policy_key: "failure_recovery").tap do |policy|
+        policy.current_version.update!(rules: { "failure_actions" => { "timeout" => "pause_and_notify" } })
+      end
+
+      scoped_policy = create(:coordination_policy, :active, :project_scoped,
+        account: project.account,
+        project: project,
+        policy_type: "recovery",
+        policy_key: "failure_recovery")
+      scoped_policy.current_version.update!(rules: { "failure_actions" => { "timeout" => "escalate_model" } })
+
+      result = described_class.call(project: project)
+
+      expect(result["coordination_policy_id"]).to eq(scoped_policy.id)
+      expect(result["actions"]["timeout"]).to eq("escalate_model")
+    end
+
+    it "applies explicit overrides ahead of stored policies" do
+      result = described_class.call(project: project, overrides: { "timeout" => "escalate_model" })
+
+      expect(result).to include(
+        "source" => "override",
+        "coordination_policy_id" => nil
+      )
+      expect(result["actions"]["timeout"]).to eq("escalate_model")
+    end
+  end
+end

--- a/spec/services/coordination/failure_recovery_service_spec.rb
+++ b/spec/services/coordination/failure_recovery_service_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Coordination::FailureRecoveryService do
+  describe ".call" do
+    let(:project) { create(:project) }
+    let(:anthropic_attempt) { { "provider" => "anthropic", "success" => false } }
+    let(:openai_attempt) { { "provider" => "openai", "success" => false } }
+
+    it "classifies common provider failures and selects the default recovery action" do
+      agent_run = create(:agent_run, :failed, project: project,
+        error_message: "AllProvidersExhausted: no available providers",
+        providers_attempted: [ anthropic_attempt, openai_attempt ])
+
+      result = described_class.call(agent_run: agent_run)
+
+      expect(result.failure_category).to eq("provider_error")
+      expect(result.chosen_action).to eq("retry_alternate_provider")
+      expect(result.action_params).to include(
+        "exclude_providers" => %w[anthropic openai],
+        "policy_source" => "defaults"
+      )
+    end
+
+    it "classifies common configuration failures and keeps the initial hook metadata" do
+      agent_run = create(:agent_run, :failed, project: project,
+        error_message: "McpProvisioningFailed: missing sidecar credentials")
+
+      result = described_class.call(agent_run: agent_run)
+
+      expect(result.failure_category).to eq("configuration_error")
+      expect(result.chosen_action).to eq("reconfigure_and_retry")
+      expect(result.failure_context).to include(
+        "policy_source" => "defaults",
+        "policy_key" => "failure_recovery"
+      )
+    end
+
+    it "supports policy-driven action overrides without changing classification" do
+      agent_run = create(:agent_run, :timeout, project: project,
+        error_message: "Agent execution timed out",
+        providers_attempted: [ anthropic_attempt ])
+
+      result = described_class.call(
+        agent_run: agent_run,
+        policy_overrides: { "timeout" => "escalate_model" }
+      )
+
+      expect(result.failure_category).to eq("timeout")
+      expect(result.chosen_action).to eq("escalate_model")
+      expect(result.action_params).to include(
+        "current_provider" => "anthropic",
+        "policy_source" => "override"
+      )
+    end
+  end
+end

--- a/spec/services/coordination/failure_recovery_spec.rb
+++ b/spec/services/coordination/failure_recovery_spec.rb
@@ -47,11 +47,14 @@ RSpec.describe Coordination::FailureRecovery do
         expect(decision.context["decision_status"]).to eq("applied")
         expect(decision.inputs).to include(
           "failure_category" => "rate_limit",
-          "chosen_action" => "retry_alternate_provider"
+          "chosen_action" => "retry_alternate_provider",
+          "policy_source" => "defaults",
+          "policy_key" => "failure_recovery"
         )
         expect(decision.outputs).to include(
           "chosen_action" => "retry_alternate_provider",
-          "action_status" => "pending"
+          "action_status" => "pending",
+          "policy_source" => "defaults"
         )
       end
 
@@ -71,7 +74,8 @@ RSpec.describe Coordination::FailureRecovery do
         expect(decision.context["decision_status"]).to eq("failed")
         expect(decision.inputs).to include(
           "failure_category" => "rate_limit",
-          "chosen_action" => "retry_alternate_provider"
+          "chosen_action" => "retry_alternate_provider",
+          "policy_source" => "defaults"
         )
         expect(decision.outputs).to include(
           "chosen_action" => "retry_alternate_provider",
@@ -306,7 +310,8 @@ RSpec.describe Coordination::FailureRecovery do
         expect(decision.context["decision_status"]).to eq("applied")
         expect(decision.inputs).to include(
           "failure_category" => "timeout",
-          "chosen_action" => "escalate_model"
+          "chosen_action" => "escalate_model",
+          "policy_source" => "override"
         )
       end
 
@@ -326,7 +331,8 @@ RSpec.describe Coordination::FailureRecovery do
         expect(decision.context["decision_status"]).to eq("failed")
         expect(decision.inputs).to include(
           "failure_category" => "timeout",
-          "chosen_action" => "escalate_model"
+          "chosen_action" => "escalate_model",
+          "policy_source" => "override"
         )
         expect(decision.outputs["chosen_action"]).to eq("escalate_model")
         expect(decision.outputs["error_class"]).to eq("ActiveRecord::RecordInvalid")
@@ -378,6 +384,7 @@ RSpec.describe Coordination::FailureRecovery do
         expect(ctx["final_provider"]).to eq("anthropic")
         expect(ctx["providers_attempted"]).to eq([ anthropic_attempt, openai_attempt ])
         expect(ctx["provider_switches"]).to eq(1)
+        expect(ctx["policy_source"]).to eq("defaults")
       end
     end
   end


### PR DESCRIPTION
## Summary

Introduces a learned failure recovery boundary so coordination failures are classified and matched to recovery actions through explicit, scoped policies — laying the groundwork for outcome-based policy learning. Classification, policy lookup, and persistence are now separated, and decision payloads carry policy metadata so future learning can attribute outcomes back to the policy that chose the action.

## Changes

- **Services**
  - Add `Coordination::FailureRecoveryService` as the boundary for failure classification and action selection.
  - Add `Coordination::FailureRecoveryPolicy` for account/project-scoped recovery rules with explicit overrides.
  - Refocus `Coordination::FailureRecovery` on persistence and orchestration-decision logging.
- **Persistence**
  - `FailureClassification` and decision payloads now include `policy_source`, policy ids, and policy version for later learning.
- **Specs**
  - New coverage for the service, policy, and the slimmed-down recovery orchestrator.

## Design Decisions

- Split the prior recovery class into three concerns (classify, choose-by-policy, persist) so policies can evolve independently and outcomes remain attributable.
- Policies resolve in scope order (explicit override → project → account → default) so operators can pin behavior without code changes.
- Policy metadata is persisted alongside the decision rather than derived later, ensuring learning can join outcomes to the exact policy/version that produced them even after policy edits.

## Operational Notes

- No schema migration introduced in this change; policy metadata rides on existing JSON payload columns.
- Full `bundle exec rspec` could not run in the authoring container (PostgreSQL unavailable); CI should be the source of truth for the DB-backed suite.

---

Closes #1806