### PR TITLE
feat(coordination): build coordination policy evolution workflow

### DIFF
--- a/app/models/coordination_policy.rb
+++ b/app/models/coordination_policy.rb
@@ -19,6 +19,7 @@ class CoordinationPolicy < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :status, presence: true, inclusion: { in: STATUSES }
   validate :current_version_belongs_to_policy
+  validate :current_version_must_be_activatable
   validate :status_matches_current_version
   validate :project_belongs_to_account
   validate :context_selector_is_object
@@ -47,6 +48,7 @@ class CoordinationPolicy < ApplicationRecord
 
   def activate_version!(policy_version)
     raise ArgumentError, "policy_version must belong to this coordination policy" unless policy_version.coordination_policy_id == id
+    raise CoordinationPolicyVersion::InvalidTransitionError, "cannot activate version pending review approval" unless policy_version.activatable?
 
     transaction do
       now = Time.current
@@ -70,6 +72,13 @@ class CoordinationPolicy < ApplicationRecord
     return if current_version.coordination_policy_id == id
 
     errors.add(:current_version, "must belong to this coordination policy")
+  end
+
+  def current_version_must_be_activatable
+    return if current_version.nil?
+    return if current_version.activatable?
+
+    errors.add(:current_version, "must be approved before it can become active")
   end
 
   def status_matches_current_version

--- a/app/models/coordination_policy_version.rb
+++ b/app/models/coordination_policy_version.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CoordinationPolicyVersion < ApplicationRecord
+  class InvalidTransitionError < StandardError; end
+
   STATUSES = %w[draft active superseded retired].freeze
 
   belongs_to :coordination_policy, touch: true
@@ -19,7 +21,27 @@ class CoordinationPolicyVersion < ApplicationRecord
     coordination_policy.activate_version!(self)
   end
 
+  def review_required?
+    approval_state.fetch("required", false) == true
+  end
+
+  def review_status
+    approval_state["status"]
+  end
+
+  def approved?
+    review_status == "approved"
+  end
+
+  def activatable?
+    !review_required? || approved?
+  end
+
   private
+
+  def approval_state
+    metadata.to_h.fetch("evolution", {}).fetch("approval", {})
+  end
 
   def rules_is_object
     validate_json_object(:rules)

--- a/app/services/coordination_policy_evolution/create_candidates.rb
+++ b/app/services/coordination_policy_evolution/create_candidates.rb
@@ -12,8 +12,8 @@ module CoordinationPolicyEvolution
       new(...).call
     end
 
-    def initialize(strategy_snapshot:, account:, mutations:)
-      @strategy_snapshot = strategy_snapshot.deep_symbolize_keys
+    def initialize(policy_snapshot:, account:, mutations:)
+      @policy_snapshot = policy_snapshot.deep_symbolize_keys
       @account = account
       @mutations = Array(mutations)
     end
@@ -23,16 +23,18 @@ module CoordinationPolicyEvolution
 
       ActiveRecord::Base.transaction do
         account.with_lock do
+          policy = coordination_policy
           next_version = next_version_number
 
           mutations.map do |mutation|
-            candidate = OrchestrationStrategy.create!(
-              account: account,
-              strategy_type: strategy_type,
-              name: strategy_name,
+            candidate = policy.coordination_policy_versions.create!(
               version: next_version,
-              configuration: candidate_configuration(mutation),
-              active: false
+              status: "draft",
+              rules: candidate_rules(mutation),
+              parameters: candidate_parameters(mutation),
+              metadata: candidate_metadata(mutation),
+              reasoning: mutation.reasoning,
+              llm_prompt: policy_snapshot[:llm_prompt]
             )
             next_version += 1
             candidate
@@ -43,26 +45,69 @@ module CoordinationPolicyEvolution
 
     private
 
-    attr_reader :strategy_snapshot, :account, :mutations
+    attr_reader :policy_snapshot, :account, :mutations
 
-    def strategy_type
-      strategy_snapshot.fetch(:strategy_type)
+    def coordination_policy
+      @coordination_policy ||= begin
+        account.coordination_policies.find_by(id: policy_snapshot[:id]) ||
+          account.coordination_policies.find_or_create_by!(
+            project_id: policy_snapshot[:project_id],
+            policy_type: policy_type,
+            policy_key: policy_key
+          ) do |policy|
+            policy.name = policy_name
+            policy.description = policy_snapshot[:description]
+            policy.status = "draft"
+            policy.context_selector = policy_snapshot[:context_selector] || {}
+            policy.metadata = {
+              "created_by" => self.class.name,
+              "bootstrap_source" => policy_snapshot[:source]
+            }.compact
+          end
+      end
     end
 
-    def strategy_name
-      strategy_snapshot.fetch(:name)
+    def policy_type
+      policy_snapshot.fetch(:policy_type)
+    end
+
+    def policy_key
+      policy_snapshot.fetch(:policy_key)
+    end
+
+    def policy_name
+      policy_snapshot.fetch(:name)
     end
 
     def next_version_number
-      current_max = OrchestrationStrategy.where(account:, strategy_type:).maximum(:version).to_i
+      current_max = coordination_policy.coordination_policy_versions.maximum(:version).to_i
       [ current_max + 1, 1 ].max
     end
 
-    def candidate_configuration(mutation)
-      mutation.configuration.deep_stringify_keys.merge(
-        "_evolution" => {
-          "source_strategy_id" => strategy_snapshot[:id],
-          "source_version" => strategy_snapshot[:version],
+    def candidate_rules(mutation)
+      decomposition = mutation.configuration.deep_stringify_keys.fetch("decomposition", {})
+
+      {
+        "enabled" => decomposition["enabled"],
+        "min_components_to_decompose" => decomposition["min_components_to_decompose"]
+      }.compact
+    end
+
+    def candidate_parameters(mutation)
+      decomposition = mutation.configuration.deep_stringify_keys.fetch("decomposition", {})
+
+      {
+        "max_tasks" => decomposition["max_tasks"],
+        "layer_order" => decomposition["layer_order"]
+      }.compact
+    end
+
+    def candidate_metadata(mutation)
+      {
+        "evolution" => {
+          "source_policy_id" => policy_snapshot[:id],
+          "source_policy_version_id" => policy_snapshot[:version_id],
+          "source_version" => policy_snapshot[:version],
           "generated_at" => Time.current.iso8601,
           "mutation_strategy" => mutation.strategy,
           "reasoning" => mutation.reasoning,
@@ -71,7 +116,7 @@ module CoordinationPolicyEvolution
           "provenance" => mutation.provenance,
           "approval" => APPROVAL_STATE
         }
-      )
+      }
     end
   end
 end

--- a/app/services/coordination_policy_evolution/generate_candidates.rb
+++ b/app/services/coordination_policy_evolution/generate_candidates.rb
@@ -6,8 +6,8 @@ module CoordinationPolicyEvolution
       new(...).call
     end
 
-    def initialize(strategy:, analysis:, options: {})
-      @strategy = strategy.deep_symbolize_keys
+    def initialize(policy:, analysis:, options: {})
+      @policy = policy.deep_symbolize_keys
       @analysis = analysis.deep_symbolize_keys
       @options = options.deep_symbolize_keys
     end
@@ -18,14 +18,24 @@ module CoordinationPolicyEvolution
 
     private
 
-    attr_reader :strategy, :analysis, :options
+    attr_reader :policy, :analysis, :options
 
     def mutations
       @mutations ||= StrategyEvolution::Mutate.call(
-        strategy: strategy,
+        strategy: mutation_strategy,
         analysis: analysis,
         options: options
       )
+    end
+
+    def mutation_strategy
+      {
+        id: policy[:version_id] || policy[:id],
+        strategy_type: policy[:policy_type],
+        version: policy[:version],
+        account_id: policy[:account_id],
+        configuration: policy.fetch(:configuration)
+      }
     end
 
     def stamp_provenance(mutation)
@@ -37,7 +47,10 @@ module CoordinationPolicyEvolution
         diff: mutation.diff,
         provenance: mutation.provenance.to_h.merge(
           "generated_by" => self.class.name,
-          "policy_type" => strategy[:strategy_type],
+          "policy_type" => policy[:policy_type],
+          "policy_key" => policy[:policy_key],
+          "source_policy_id" => policy[:id],
+          "source_policy_version_id" => policy[:version_id],
           "sampled_decision_ids" => sampled_decision_ids,
           "prior_versions" => prior_version_summary,
           "measured_outcomes" => measured_outcomes

--- a/app/services/coordination_policy_evolution/generate_candidates.rb
+++ b/app/services/coordination_policy_evolution/generate_candidates.rb
@@ -70,7 +70,7 @@ module CoordinationPolicyEvolution
         {
           id: row[:id],
           version: row[:version],
-          active: row[:active]
+          status: row[:status]
         }.compact
       end
     end

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -5,7 +5,8 @@ module CoordinationPolicyEvolution
     DEFAULT_LOOKBACK_DAYS = 60
     DEFAULT_MIN_DECISIONS = 10
     DEFAULT_SAMPLE_LIMIT = 5
-    POLICY_TYPE = DecompositionService::STRATEGY_TYPE
+    POLICY_TYPE = DecompositionService::POLICY_TYPE
+    POLICY_KEY = DecompositionService::POLICY_KEY
     NOOP_OUTCOMES = Orchestration::DecompositionDecisions::Log::NOOP_OUTCOMES
     FAILURE_OUTCOMES = %w[
       decomposition_failed
@@ -30,8 +31,8 @@ module CoordinationPolicyEvolution
 
     def call
       {
-        strategy: serialize_strategy(current_strategy),
-        prior_versions: prior_versions.map { |strategy| serialize_strategy(strategy) },
+        policy: serialize_policy_snapshot,
+        prior_versions: prior_versions.map { |version| serialize_policy_version(version) },
         performance: performance_summary,
         sample_successes: serialize_decisions(sample_successes),
         sample_failures: serialize_decisions(sample_failures)
@@ -42,17 +43,19 @@ module CoordinationPolicyEvolution
 
     attr_reader :account, :policy_type, :lookback_days, :min_decisions, :sample_limit
 
-    def current_strategy
-      @current_strategy ||= OrchestrationStrategies::Resolve.call(
-        strategy_type: policy_type,
-        account: account
-      )
+    def serialize_policy_snapshot
+      if coordination_policy&.current_version
+        serialize_existing_policy
+      else
+        serialize_bootstrap_policy
+      end
     end
 
     def prior_versions
-      @prior_versions ||= OrchestrationStrategy
-        .where(account:, strategy_type: policy_type)
-        .order(version: :desc, id: :desc)
+      return CoordinationPolicyVersion.none unless coordination_policy
+
+      @prior_versions ||= coordination_policy.coordination_policy_versions
+        .recent
         .limit(5)
     end
 
@@ -152,18 +155,124 @@ module CoordinationPolicyEvolution
       end
     end
 
-    def serialize_strategy(strategy)
-      return nil unless strategy
+    def coordination_policy
+      @coordination_policy ||= CoordinationPolicy
+        .where(account:, policy_type:, policy_key: POLICY_KEY, project_id: nil)
+        .includes(:current_version, :coordination_policy_versions)
+        .order(Arel.sql("CASE status WHEN 'active' THEN 0 WHEN 'draft' THEN 1 ELSE 2 END"), id: :desc)
+        .first
+    end
+
+    def current_strategy
+      @current_strategy ||= OrchestrationStrategies::Resolve.call(
+        strategy_type: DecompositionService::STRATEGY_TYPE,
+        account: account
+      )
+    end
+
+    def serialize_existing_policy
+      version = coordination_policy.current_version
 
       {
-        id: strategy.id,
-        strategy_type: strategy.strategy_type,
-        name: strategy.name,
-        version: strategy.version,
-        active: strategy.active,
-        account_id: strategy.account_id,
-        configuration: strategy.configuration
+        id: coordination_policy.id,
+        policy_type: coordination_policy.policy_type,
+        policy_key: coordination_policy.policy_key,
+        name: coordination_policy.name,
+        description: coordination_policy.description,
+        status: coordination_policy.status,
+        account_id: coordination_policy.account_id,
+        project_id: coordination_policy.project_id,
+        context_selector: coordination_policy.context_selector,
+        source: "coordination_policy",
+        version_id: version.id,
+        version: version.version,
+        version_status: version.status,
+        llm_prompt: version.llm_prompt,
+        reasoning: version.reasoning,
+        metadata: version.metadata,
+        rules: version.rules,
+        parameters: version.parameters,
+        configuration: effective_configuration(version.rules, version.parameters)
       }
+    end
+
+    def serialize_bootstrap_policy
+      {
+        id: coordination_policy&.id,
+        policy_type: policy_type,
+        policy_key: POLICY_KEY,
+        name: "Feature Decomposition",
+        description: "Account-level coordination policy for feature decomposition.",
+        status: coordination_policy&.status || "draft",
+        account_id: account.id,
+        project_id: nil,
+        context_selector: coordination_policy&.context_selector || {},
+        source: bootstrap_source,
+        version_id: nil,
+        version: nil,
+        version_status: nil,
+        llm_prompt: nil,
+        reasoning: nil,
+        metadata: {},
+        rules: {},
+        parameters: {},
+        configuration: bootstrap_configuration
+      }
+    end
+
+    def bootstrap_source
+      current_strategy.present? ? DecompositionService::STRATEGY_TYPE : "defaults"
+    end
+
+    def bootstrap_configuration
+      return current_strategy.configuration if current_strategy.present?
+
+      OrchestrationStrategies::Defaults.feature_orchestration
+    end
+
+    def serialize_policy_version(version)
+      {
+        id: version.id,
+        version: version.version,
+        status: version.status,
+        activated_at: version.activated_at&.iso8601,
+        retired_at: version.retired_at&.iso8601,
+        llm_prompt: version.llm_prompt,
+        reasoning: version.reasoning,
+        metadata: version.metadata,
+        rules: version.rules,
+        parameters: version.parameters,
+        configuration: effective_configuration(version.rules, version.parameters)
+      }
+    end
+
+    def effective_configuration(rules, parameters)
+      OrchestrationStrategies::Defaults.feature_orchestration.deep_dup.tap do |configuration|
+        configuration["decomposition"] = configuration.fetch("decomposition", {}).merge(
+          extract_decomposition_config(rules),
+          extract_decomposition_config(parameters)
+        )
+      end
+    end
+
+    def extract_decomposition_config(payload)
+      return {} unless payload.is_a?(Hash)
+
+      decomposition = payload.fetch("decomposition", {})
+
+      {}.tap do |config|
+        if decomposition.is_a?(Hash)
+          config["enabled"] = decomposition["enabled"] if decomposition.key?("enabled")
+          config["min_components_to_decompose"] = decomposition["min_components_to_decompose"] if decomposition.key?("min_components_to_decompose")
+          config["max_tasks"] = decomposition["max_tasks"] if decomposition.key?("max_tasks")
+          config["layer_order"] = decomposition["layer_order"] if decomposition.key?("layer_order")
+        end
+
+        config["enabled"] = payload["enabled"] if payload.key?("enabled")
+        config["min_components_to_decompose"] = payload["min_components_to_decompose"] if payload.key?("min_components_to_decompose")
+        config["max_tasks"] = payload["max_tasks"] if payload.key?("max_tasks")
+        config["layer_order"] = payload["layer_order"] if payload.key?("layer_order")
+      end.compact
     end
   end
 end

--- a/app/temporal/activities/generate_coordination_policy_candidates_activity.rb
+++ b/app/temporal/activities/generate_coordination_policy_candidates_activity.rb
@@ -6,7 +6,7 @@ module Activities
 
     def execute(input)
       mutations = CoordinationPolicyEvolution::GenerateCandidates.call(
-        strategy: input.fetch(:strategy),
+        policy: input.fetch(:policy),
         analysis: input.slice(:performance, :sample_successes, :sample_failures, :prior_versions),
         options: {
           mutation_count: input.fetch(:mutation_count, 2),
@@ -15,7 +15,7 @@ module Activities
       )
 
       {
-        policy_type: input.fetch(:strategy).fetch(:strategy_type),
+        policy_type: input.fetch(:policy).fetch(:policy_type),
         mutations: mutations.map do |mutation|
           {
             configuration: mutation.configuration,

--- a/app/temporal/activities/persist_coordination_policy_candidates_activity.rb
+++ b/app/temporal/activities/persist_coordination_policy_candidates_activity.rb
@@ -20,13 +20,13 @@ module Activities
       end
 
       candidates = CoordinationPolicyEvolution::CreateCandidates.call(
-        strategy_snapshot: input.fetch(:strategy),
+        policy_snapshot: input.fetch(:policy),
         account: account,
         mutations: mutations
       )
 
       {
-        policy_type: input.fetch(:strategy).fetch(:strategy_type),
+        policy_type: input.fetch(:policy).fetch(:policy_type),
         candidate_ids: candidates.map(&:id),
         candidate_count: candidates.size
       }

--- a/app/temporal/workflows/coordination_policy_evolution_workflow.rb
+++ b/app/temporal/workflows/coordination_policy_evolution_workflow.rb
@@ -58,7 +58,7 @@ module Workflows
         Activities::PersistCoordinationPolicyCandidatesActivity,
         {
           account_id: account_id,
-          strategy: inputs_result.fetch(:strategy),
+          policy: inputs_result.fetch(:policy),
           mutations: mutations
         },
         timeout: 30

--- a/spec/models/coordination_policy_spec.rb
+++ b/spec/models/coordination_policy_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe CoordinationPolicy do
       expect(coordination_policy.errors[:current_version]).to include("must be active before it can become current on an active policy")
     end
 
+    it "rejects a review-gated current version that is still pending approval" do
+      coordination_policy.current_version = build(:coordination_policy_version, coordination_policy:, status: "active", metadata: {
+        "evolution" => {
+          "approval" => {
+            "required" => true,
+            "status" => "pending_review"
+          }
+        }
+      })
+      coordination_policy.status = "active"
+
+      expect(coordination_policy).not_to be_valid
+      expect(coordination_policy.errors[:current_version]).to include("must be approved before it can become active")
+    end
+
     it "rejects an inactive policy that still points at an active current version" do
       active_version = create(:coordination_policy_version, :active, coordination_policy: coordination_policy)
       coordination_policy.current_version = active_version
@@ -140,6 +155,22 @@ RSpec.describe CoordinationPolicy do
         expect(next_version.reload.status).to eq("active")
         expect(next_version.activated_at).to eq(Time.current)
       end
+    end
+
+    it "refuses to activate a review-gated version until approved" do
+      policy = create(:coordination_policy)
+      pending_review_version = create(:coordination_policy_version, coordination_policy: policy, version: 1, metadata: {
+        "evolution" => {
+          "approval" => {
+            "required" => true,
+            "status" => "pending_review"
+          }
+        }
+      })
+
+      expect {
+        policy.activate_version!(pending_review_version)
+      }.to raise_error(CoordinationPolicyVersion::InvalidTransitionError, "cannot activate version pending review approval")
     end
   end
 end

--- a/spec/models/coordination_policy_version_spec.rb
+++ b/spec/models/coordination_policy_version_spec.rb
@@ -51,4 +51,44 @@ RSpec.describe CoordinationPolicyVersion do
       expect(next_version.reload.status).to eq("active")
     end
   end
+
+  describe "review state" do
+    it "treats versions without review metadata as activatable" do
+      version = build(:coordination_policy_version, metadata: {})
+
+      expect(version).to be_activatable
+      expect(version).not_to be_review_required
+    end
+
+    it "requires approval when metadata marks the version pending review" do
+      version = build(:coordination_policy_version, metadata: {
+        "evolution" => {
+          "approval" => {
+            "required" => true,
+            "status" => "pending_review"
+          }
+        }
+      })
+
+      expect(version).to be_review_required
+      expect(version.review_status).to eq("pending_review")
+      expect(version).not_to be_approved
+      expect(version).not_to be_activatable
+    end
+
+    it "allows activation once the required review is approved" do
+      version = build(:coordination_policy_version, metadata: {
+        "evolution" => {
+          "approval" => {
+            "required" => true,
+            "status" => "approved"
+          }
+        }
+      })
+
+      expect(version).to be_review_required
+      expect(version).to be_approved
+      expect(version).to be_activatable
+    end
+  end
 end

--- a/spec/services/coordination_policy_evolution/create_candidates_spec.rb
+++ b/spec/services/coordination_policy_evolution/create_candidates_spec.rb
@@ -5,11 +5,28 @@ require "rails_helper"
 RSpec.describe CoordinationPolicyEvolution::CreateCandidates do
   describe ".call" do
     let(:account) { create(:account) }
-    let(:strategy) { create(:orchestration_strategy, :feature_orchestration, account: account, version: 3) }
+    let(:policy) do
+      create(:coordination_policy, :active,
+        account: account,
+        policy_type: "decomposition",
+        policy_key: "feature_decomposition",
+        name: "Feature Decomposition").tap do |record|
+          record.current_version.update!(
+            version: 3,
+            rules: { "enabled" => true, "min_components_to_decompose" => 2 },
+            parameters: { "max_tasks" => 20, "layer_order" => %w[view model service controller] }
+          )
+        end
+    end
     let(:mutation) do
       StrategyEvolution::Mutate::Mutation.new(
-        configuration: strategy.configuration.deep_dup.tap do |config|
-          config["decomposition"] = { "max_tasks" => 12 }
+        configuration: OrchestrationStrategies::Defaults.feature_orchestration.deep_dup.tap do |config|
+          config["decomposition"] = {
+            "enabled" => true,
+            "min_components_to_decompose" => 2,
+            "max_tasks" => 12,
+            "layer_order" => %w[view controller service model]
+          }
         end,
         strategy: "risk_reduction",
         reasoning: "Reduce large decompositions",
@@ -18,29 +35,34 @@ RSpec.describe CoordinationPolicyEvolution::CreateCandidates do
         provenance: { "sampled_decision_ids" => [ 101, 202 ] }
       )
     end
-    let(:strategy_snapshot) do
+    let(:policy_snapshot) do
       {
-        id: strategy.id,
-        strategy_type: strategy.strategy_type,
-        name: strategy.name,
-        version: strategy.version,
-        configuration: strategy.configuration
+        id: policy.id,
+        policy_type: policy.policy_type,
+        policy_key: policy.policy_key,
+        name: policy.name,
+        version_id: policy.current_version.id,
+        version: policy.current_version.version,
+        llm_prompt: policy.current_version.llm_prompt,
+        configuration: OrchestrationStrategies::Defaults.feature_orchestration.deep_dup
       }
     end
 
-    it "persists inactive candidates with explicit pending approval metadata" do
-      candidates = described_class.call(strategy_snapshot: strategy_snapshot, account: account, mutations: [ mutation ])
+    it "persists draft policy versions with explicit pending approval metadata" do
+      candidates = described_class.call(policy_snapshot: policy_snapshot, account: account, mutations: [ mutation ])
 
       expect(candidates.size).to eq(1)
-      expect(candidates.first).not_to be_active
+      expect(candidates.first.status).to eq("draft")
       expect(candidates.first.version).to eq(4)
-      expect(candidates.first.configuration.dig("_evolution", "approval")).to eq(
+      expect(candidates.first.metadata.dig("evolution", "approval")).to eq(
         "required" => true,
         "status" => "pending_review",
         "auto_promote" => false
       )
-      expect(candidates.first.configuration.dig("_evolution", "provenance", "sampled_decision_ids")).to eq([ 101, 202 ])
-      expect(OrchestrationStrategy.active_for("feature_orchestration", account: account)).to eq(strategy)
+      expect(candidates.first.metadata.dig("evolution", "provenance", "sampled_decision_ids")).to eq([ 101, 202 ])
+      expect(candidates.first.rules).to include("enabled" => true, "min_components_to_decompose" => 2)
+      expect(candidates.first.parameters).to include("max_tasks" => 12)
+      expect(policy.reload.current_version).not_to eq(candidates.first)
     end
   end
 end

--- a/spec/services/coordination_policy_evolution/create_candidates_spec.rb
+++ b/spec/services/coordination_policy_evolution/create_candidates_spec.rb
@@ -64,5 +64,26 @@ RSpec.describe CoordinationPolicyEvolution::CreateCandidates do
       expect(candidates.first.parameters).to include("max_tasks" => 12)
       expect(policy.reload.current_version).not_to eq(candidates.first)
     end
+
+    it "creates non-activatable candidates until review approval is recorded" do
+      candidate = described_class.call(policy_snapshot: policy_snapshot, account: account, mutations: [ mutation ]).first
+
+      expect(candidate).not_to be_activatable
+      expect {
+        policy.activate_version!(candidate)
+      }.to raise_error(CoordinationPolicyVersion::InvalidTransitionError, "cannot activate version pending review approval")
+
+      candidate.update!(metadata: candidate.metadata.deep_merge(
+        "evolution" => {
+          "approval" => {
+            "required" => true,
+            "status" => "approved",
+            "auto_promote" => false
+          }
+        }
+      ))
+
+      expect(candidate.reload).to be_activatable
+    end
   end
 end

--- a/spec/services/coordination_policy_evolution/generate_candidates_spec.rb
+++ b/spec/services/coordination_policy_evolution/generate_candidates_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe CoordinationPolicyEvolution::GenerateCandidates, :no_db do
     let(:analysis) do
       {
         prior_versions: [
-          { id: 7, version: 3, active: true },
-          { id: 5, version: 2, active: false }
+          { id: 7, version: 3, status: "active" },
+          { id: 5, version: 2, status: "retired" }
         ],
         performance: {
           decision_count: 12,
@@ -63,7 +63,7 @@ RSpec.describe CoordinationPolicyEvolution::GenerateCandidates, :no_db do
         "sampled_decision_ids" => [ 101, 202 ]
       )
       expect(result.first.provenance.fetch("prior_versions")).to include(
-        include(id: 7, version: 3, active: true)
+        include(id: 7, version: 3, status: "active")
       )
       expect(result.first.provenance.fetch("measured_outcomes")).to include(
         decision_count: 12,

--- a/spec/services/coordination_policy_evolution/generate_candidates_spec.rb
+++ b/spec/services/coordination_policy_evolution/generate_candidates_spec.rb
@@ -2,12 +2,13 @@
 
 require "rails_helper"
 
-RSpec.describe CoordinationPolicyEvolution::GenerateCandidates do
+RSpec.describe CoordinationPolicyEvolution::GenerateCandidates, :no_db do
   describe ".call" do
-    let(:strategy) do
+    let(:policy) do
       {
         id: 7,
-        strategy_type: "feature_orchestration",
+        policy_type: "decomposition",
+        policy_key: "feature_decomposition",
         version: 3,
         account_id: 11,
         configuration: OrchestrationStrategies::Defaults.feature_orchestration
@@ -38,7 +39,7 @@ RSpec.describe CoordinationPolicyEvolution::GenerateCandidates do
     end
     let(:mutation) do
       StrategyEvolution::Mutate::Mutation.new(
-        configuration: strategy[:configuration].deep_dup,
+        configuration: policy[:configuration].deep_dup,
         strategy: "risk_reduction",
         reasoning: "Reduce over-parallelization",
         expected_improvement: "Fewer failed plans",
@@ -52,12 +53,13 @@ RSpec.describe CoordinationPolicyEvolution::GenerateCandidates do
     end
 
     it "adds reviewable coordination provenance to each candidate mutation" do
-      result = described_class.call(strategy: strategy, analysis: analysis, options: { mutation_count: 1 })
+      result = described_class.call(policy: policy, analysis: analysis, options: { mutation_count: 1 })
 
       expect(result.size).to eq(1)
       expect(result.first.provenance).to include(
         "generated_by" => "CoordinationPolicyEvolution::GenerateCandidates",
-        "policy_type" => "feature_orchestration",
+        "policy_type" => "decomposition",
+        "policy_key" => "feature_decomposition",
         "sampled_decision_ids" => [ 101, 202 ]
       )
       expect(result.first.provenance.fetch("prior_versions")).to include(

--- a/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
@@ -6,8 +6,25 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
   describe ".call" do
     let(:account) { create(:account) }
     let(:project) { create(:project, account: account) }
-    let!(:strategy) { create(:orchestration_strategy, :feature_orchestration, account: account, version: 2) }
-    let!(:older_version) { create(:orchestration_strategy, :feature_orchestration, account: account, version: 1, active: false) }
+    let!(:policy) do
+      create(:coordination_policy, :active,
+        account: account,
+        policy_type: described_class::POLICY_TYPE,
+        policy_key: described_class::POLICY_KEY,
+        name: "Feature Decomposition").tap do |record|
+          record.current_version.update!(
+            version: 2,
+            rules: { "enabled" => true, "min_components_to_decompose" => 2 },
+            parameters: { "max_tasks" => 12 }
+          )
+          create(:coordination_policy_version,
+            coordination_policy: record,
+            version: 1,
+            status: "superseded",
+            rules: { "enabled" => true, "min_components_to_decompose" => 3 },
+            parameters: { "max_tasks" => 8 })
+        end
+    end
     let(:result) { described_class.call(account: account, min_decisions: 2) }
 
     before do
@@ -53,8 +70,8 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
     end
 
     it "collects policy history for the account" do
-      expect(result[:strategy]).to include(id: strategy.id, version: 2, strategy_type: "feature_orchestration")
-      expect(result[:prior_versions].map { |row| row[:id] }).to include(strategy.id, older_version.id)
+      expect(result[:policy]).to include(id: policy.id, version: 2, policy_type: "decomposition")
+      expect(result[:prior_versions].map { |row| row[:id] }).to include(policy.current_version.id)
     end
 
     it "summarizes classified outcomes without counting noop decisions as successes" do
@@ -79,6 +96,14 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
       expect(result.dig(:performance, :average_task_count)).to eq(1.67)
       expect(result[:sample_successes].size).to eq(1)
       expect(result[:sample_failures].size).to eq(1)
+    end
+
+    it "includes effective policy configuration for mutation" do
+      expect(result.dig(:policy, :configuration, "decomposition")).to include(
+        "enabled" => true,
+        "min_components_to_decompose" => 2,
+        "max_tasks" => 12
+      )
     end
   end
 end

--- a/spec/temporal/activities/generate_coordination_policy_candidates_activity_spec.rb
+++ b/spec/temporal/activities/generate_coordination_policy_candidates_activity_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::GenerateCoordinationPolicyCandidatesActivity, :no_db do
+  let(:activity) { described_class.new }
+  let(:connection_pool) { instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool, active_connection?: false) }
+  let(:policy) do
+    {
+      id: 3,
+      policy_type: "decomposition",
+      policy_key: "feature_decomposition",
+      name: "Feature Decomposition",
+      version: 2,
+      account_id: 9,
+      configuration: OrchestrationStrategies::Defaults.feature_orchestration
+    }
+  end
+  let(:mutation) do
+    StrategyEvolution::Mutate::Mutation.new(
+      configuration: policy[:configuration],
+      strategy: "refinement",
+      reasoning: "Tune decomposition thresholds",
+      expected_improvement: "Higher planning success rate",
+      diff: [ { "path" => "/decomposition/max_tasks", "from" => 20, "to" => 12 } ],
+      provenance: { "source_version" => 2 }
+    )
+  end
+
+  before do
+    allow(TenantContext).to receive(:with_system_access).and_yield
+    allow(TenantContext).to receive(:with).and_yield
+    allow(ActiveRecord::Base).to receive(:connection_pool).and_return(connection_pool)
+  end
+
+  it "serializes generated policy mutations" do
+    allow(CoordinationPolicyEvolution::GenerateCandidates).to receive(:call).and_return([ mutation ])
+
+    result = activity.execute(
+      policy: policy,
+      performance: { decision_count: 12 },
+      sample_successes: [],
+      sample_failures: [],
+      mutation_count: 1
+    )
+
+    expect(result[:policy_type]).to eq("decomposition")
+    expect(result[:mutations]).to contain_exactly(
+      include(strategy: "refinement", expected_improvement: "Higher planning success rate")
+    )
+  end
+end

--- a/spec/temporal/activities/persist_coordination_policy_candidates_activity_spec.rb
+++ b/spec/temporal/activities/persist_coordination_policy_candidates_activity_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::PersistCoordinationPolicyCandidatesActivity do
+  let(:activity) { described_class.new }
+  let(:account) { create(:account) }
+  let(:policy) do
+    create(:coordination_policy, :active,
+      account: account,
+      policy_type: "decomposition",
+      policy_key: "feature_decomposition",
+      name: "Feature Decomposition").tap do |record|
+        record.current_version.update!(
+          version: 2,
+          rules: { "enabled" => true, "min_components_to_decompose" => 2 },
+          parameters: { "max_tasks" => 20, "layer_order" => %w[view model service controller] }
+        )
+      end
+  end
+  let(:input) do
+    {
+      account_id: account.id,
+      policy: {
+        id: policy.id,
+        policy_type: policy.policy_type,
+        policy_key: policy.policy_key,
+        name: policy.name,
+        version_id: policy.current_version.id,
+        version: policy.current_version.version,
+        configuration: OrchestrationStrategies::Defaults.feature_orchestration
+      },
+      mutations: [
+        {
+          configuration: OrchestrationStrategies::Defaults.feature_orchestration.deep_dup.tap do |config|
+            config["decomposition"] = {
+              "enabled" => true,
+              "min_components_to_decompose" => 2,
+              "max_tasks" => 12,
+              "layer_order" => %w[view controller service model]
+            }
+          end,
+          strategy: "observability",
+          reasoning: "Record more context",
+          expected_improvement: "Faster diagnosis",
+          diff: [ { "path" => "/decomposition/max_tasks", "from" => 20, "to" => 12 } ],
+          provenance: { "source_version" => policy.current_version.version }
+        }
+      ]
+    }
+  end
+
+  it "rehydrates mutations with the canonical mutation type" do
+    allow(CoordinationPolicyEvolution::CreateCandidates).to receive(:call).and_return([])
+
+    activity.execute(input)
+
+    expect(CoordinationPolicyEvolution::CreateCandidates).to have_received(:call) do |kwargs|
+      expect(kwargs[:mutations]).to all(be_a(StrategyEvolution::Mutate::Mutation))
+    end
+  end
+
+  it "persists draft policy candidates and returns their ids" do
+    result = activity.execute(input)
+
+    expect(result[:policy_type]).to eq("decomposition")
+    expect(result[:candidate_count]).to eq(1)
+    expect(result[:candidate_ids]).not_to be_empty
+    expect(CoordinationPolicyVersion.find(result[:candidate_ids].first).status).to eq("draft")
+  end
+end

--- a/spec/temporal/workflows/coordination_policy_evolution_workflow_spec.rb
+++ b/spec/temporal/workflows/coordination_policy_evolution_workflow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Workflows::CoordinationPolicyEvolutionWorkflow do
+RSpec.describe Workflows::CoordinationPolicyEvolutionWorkflow, :no_db do
   let(:workflow) { described_class.new }
   let(:input) { { account_id: 9 } }
   let(:mutation) do
@@ -18,11 +18,12 @@ RSpec.describe Workflows::CoordinationPolicyEvolutionWorkflow do
   let(:prepared_inputs) do
     {
       account_id: 9,
-      policy_type: "feature_orchestration",
-      strategy: {
+      policy_type: "decomposition",
+      policy: {
         id: 3,
-        strategy_type: "feature_orchestration",
-        name: "Feature Orchestration",
+        policy_type: "decomposition",
+        policy_key: "feature_decomposition",
+        name: "Feature Decomposition",
         version: 2,
         configuration: OrchestrationStrategies::Defaults.feature_orchestration
       },
@@ -59,9 +60,9 @@ RSpec.describe Workflows::CoordinationPolicyEvolutionWorkflow do
       when "Activities::PrepareCoordinationPolicyEvolutionInputsActivity"
         prepared_inputs
       when "Activities::GenerateCoordinationPolicyCandidatesActivity"
-        { policy_type: "feature_orchestration", mutations: [ mutation ] }
+        { policy_type: "decomposition", mutations: [ mutation ] }
       when "Activities::PersistCoordinationPolicyCandidatesActivity"
-        { policy_type: "feature_orchestration", candidate_ids: [ 101 ], candidate_count: 1 }
+        { policy_type: "decomposition", candidate_ids: [ 101 ], candidate_count: 1 }
       end
     end
 
@@ -69,7 +70,7 @@ RSpec.describe Workflows::CoordinationPolicyEvolutionWorkflow do
 
     expect(result).to include(
       status: :candidates_created,
-      policy_type: "feature_orchestration",
+      policy_type: "decomposition",
       candidate_ids: [ 101 ],
       candidate_count: 1
     )


### PR DESCRIPTION
## Summary

Reworks the coordination policy evolution workflow to produce reviewable draft `CoordinationPolicyVersion` candidates instead of mutating live `OrchestrationStrategy` rows, so proposed improvements flow through the existing approval controls rather than going live implicitly. This closes the loop between historical policy outcomes and human-gated policy revisions.

## Changes

- **Workflow inputs**: Build a policy snapshot from `CoordinationPolicy`/`CoordinationPolicyVersion` history combined with measured decomposition outcomes, replacing the prior strategy-derived inputs.
- **Candidate generation**: Stamp policy-specific provenance on each candidate so reviewers can trace which historical signals motivated a revision.
- **Persistence**: Create draft `CoordinationPolicyVersion` records with explicit pending-review metadata; no candidate becomes runtime-active without going through the standard approval path.
- **Temporal**: Update the `CoordinationPolicyEvolutionWorkflow` and its service to target the new policy model.
- **Specs**: Add Temporal activity specs for candidate generation and persistence; update workflow and service specs to match the new flow.

## Design Decisions

- **Draft versions, not strategy mutations**: Persisting candidates as draft `CoordinationPolicyVersion` rows keeps evolution non-bypassing of approval controls — the workflow only proposes, it never activates.
- **Snapshot inputs over live joins**: The workflow consumes a prepared snapshot of policy history + outcomes so candidate generation is reproducible and auditable from the stamped provenance.

## Operational Notes

- No migration is introduced by this change; it reuses the existing `CoordinationPolicy` / `CoordinationPolicyVersion` tables.
- Full `bundle exec rspec` was not run in the authoring environment because PostgreSQL was unavailable; the DB-less spec subset (`COVERAGE=false ALLOW_DBLESS_SPECS=true`) passed for the new and updated specs. Re-run the full suite in CI to confirm.

---

Closes #1808