### PR TITLE
feat(coordination): A/B test evolved coordination policies

### DIFF
--- a/app/models/coordination_experiment.rb
+++ b/app/models/coordination_experiment.rb
@@ -39,11 +39,12 @@ class CoordinationExperiment < ApplicationRecord
   end
 
   def baseline_policy
-    OrchestrationStrategies::Defaults.feature_orchestration.deep_merge(control_policy.deep_dup)
+    control_policy.deep_dup
   end
 
   def effective_policy_for(variant)
     return baseline_policy if variant.nil?
+    return baseline_policy if variant.is_control?
 
     variant.effective_policy(control_policy: baseline_policy)
   end

--- a/app/models/coordination_experiment.rb
+++ b/app/models/coordination_experiment.rb
@@ -38,6 +38,16 @@ class CoordinationExperiment < ApplicationRecord
     coordination_experiment_variants.find_by(is_control: true)
   end
 
+  def baseline_policy
+    OrchestrationStrategies::Defaults.feature_orchestration.deep_merge(control_policy.deep_dup)
+  end
+
+  def effective_policy_for(variant)
+    return baseline_policy if variant.nil?
+
+    variant.effective_policy(control_policy: baseline_policy)
+  end
+
   def includes_traffic?(workflow_id:)
     return false if traffic_percentage.zero?
     return true if traffic_percentage == 100

--- a/app/models/coordination_experiment_variant.rb
+++ b/app/models/coordination_experiment_variant.rb
@@ -11,4 +11,8 @@ class CoordinationExperimentVariant < ApplicationRecord
   def parsed_policy
     policy_config.deep_dup
   end
+
+  def effective_policy(control_policy:)
+    control_policy.deep_dup.deep_merge(parsed_policy)
+  end
 end

--- a/app/services/coordination_experiments/outcome_metrics.rb
+++ b/app/services/coordination_experiments/outcome_metrics.rb
@@ -29,15 +29,28 @@ module CoordinationExperiments
     attr_reader :task_count, :parallel_execution, :result
 
     def base_metrics
+      total_tasks = [ task_count, 1 ].max.to_f
+      completed_tasks = result.fetch(:completed, 0).to_i
+      failed_tasks = result.fetch(:failed, 0).to_i
+      queued_tasks = child_results.count { |child| child[:queued] }
+      dependency_failed_tasks = child_results.count { |child| child[:error] == "dependencies_failed" }
+      policy_cancelled_tasks = child_results.count { |child| child[:error] == "cancelled_by_policy" }
+
       {
+        "summary_version" => 1,
         "task_count" => task_count,
         "parallel_execution" => parallel_execution,
-        "completed_tasks" => result.fetch(:completed, 0).to_i,
-        "failed_tasks" => result.fetch(:failed, 0).to_i,
+        "completed_tasks" => completed_tasks,
+        "failed_tasks" => failed_tasks,
         "success" => !!result[:success],
-        "queued_tasks" => child_results.count { |child| child[:queued] },
-        "dependency_failed_tasks" => child_results.count { |child| child[:error] == "dependencies_failed" },
-        "policy_cancelled_tasks" => child_results.count { |child| child[:error] == "cancelled_by_policy" },
+        "queued_tasks" => queued_tasks,
+        "dependency_failed_tasks" => dependency_failed_tasks,
+        "policy_cancelled_tasks" => policy_cancelled_tasks,
+        "completion_rate" => (completed_tasks / total_tasks).round(4),
+        "failed_task_rate" => (failed_tasks / total_tasks).round(4),
+        "queued_task_rate" => (queued_tasks / total_tasks).round(4),
+        "dependency_failed_task_rate" => (dependency_failed_tasks / total_tasks).round(4),
+        "policy_cancelled_task_rate" => (policy_cancelled_tasks / total_tasks).round(4),
         "conflict_detected" => !!result.dig(:conflicts, :has_conflicts),
         "manual_review_required" => !!result.dig(:conflicts, :requires_manual_review),
         "aggregated_pr_created" => result[:aggregated_pr].present?
@@ -46,10 +59,19 @@ module CoordinationExperiments
 
     def run_metrics
       runs = AgentRun.where(id: successful_run_ids)
+      successful_run_count = successful_run_ids.size
+      total_cost_cents = runs.sum(:cost_cents).to_i
+      total_duration_seconds = runs.sum(:duration_seconds).to_i
       {
-        "successful_run_count" => successful_run_ids.size,
-        "total_cost_cents" => runs.sum(:cost_cents).to_i,
-        "total_duration_seconds" => runs.sum(:duration_seconds).to_i,
+        "child_run_count" => child_results.size,
+        "successful_run_count" => successful_run_count,
+        "successful_run_rate" => rate(successful_run_count, child_results.size),
+        "total_cost_cents" => total_cost_cents,
+        "total_duration_seconds" => total_duration_seconds,
+        "avg_cost_per_task_cents" => average(total_cost_cents, task_count),
+        "avg_cost_per_successful_run_cents" => average(total_cost_cents, successful_run_count),
+        "avg_duration_per_task_seconds" => average(total_duration_seconds, task_count),
+        "avg_duration_per_successful_run_seconds" => average(total_duration_seconds, successful_run_count),
         "avg_iterations" => runs.average(:iterations).to_f.round(4)
       }
     end
@@ -77,6 +99,18 @@ module CoordinationExperiments
       child_results.filter_map do |child|
         child[:agent_run_id] if child[:success]
       end
+    end
+
+    def rate(numerator, denominator)
+      return 0.0 if denominator.to_i <= 0
+
+      (numerator.to_f / denominator).round(4)
+    end
+
+    def average(total, count)
+      return 0.0 if count.to_i <= 0
+
+      (total.to_f / count).round(4)
     end
   end
 end

--- a/app/services/coordination_experiments/promotion_readiness.rb
+++ b/app/services/coordination_experiments/promotion_readiness.rb
@@ -4,10 +4,15 @@ module CoordinationExperiments
   class PromotionReadiness
     Result = Struct.new(:status, :candidate, :control_summary, :candidate_summary, :reasons, keyword_init: true)
 
+    MIN_COORDINATION_SCORE_DELTA = 0.0
     MAX_COST_INCREASE_RATIO = 1.1
+    MAX_DURATION_INCREASE_RATIO = 1.2
     MAX_CONFLICT_RATE_INCREASE = 0.1
     MAX_MANUAL_REVIEW_RATE_INCREASE = 0.1
     MIN_SUCCESS_RATE_DELTA = -0.05
+    MIN_COMPLETION_RATE_DELTA = -0.05
+    MAX_FAILED_TASK_RATE_INCREASE = 0.1
+    MAX_DEPENDENCY_FAILURE_RATE_INCREASE = 0.1
 
     def self.call(...)
       new(...).call
@@ -54,17 +59,40 @@ module CoordinationExperiments
         sample_count: assignments.size,
         avg_coordination_score: variant.avg_coordination_score.to_f,
         success_rate: rate(metrics) { |metric| metric["success"] },
+        completion_rate: average(metrics) { |metric| metric["completion_rate"].to_f },
+        failed_task_rate: average(metrics) { |metric| metric["failed_task_rate"].to_f },
+        dependency_failed_task_rate: average(metrics) { |metric| metric["dependency_failed_task_rate"].to_f },
         conflict_rate: rate(metrics) { |metric| metric["conflict_detected"] },
         manual_review_rate: rate(metrics) { |metric| metric["manual_review_required"] },
-        avg_cost_cents: average(metrics) { |metric| metric["total_cost_cents"].to_f }
+        avg_cost_cents: average(metrics) { |metric| metric["total_cost_cents"].to_f },
+        avg_duration_seconds: average(metrics) { |metric| metric["total_duration_seconds"].to_f },
+        avg_cost_per_task_cents: average(metrics) { |metric| metric["avg_cost_per_task_cents"].to_f },
+        avg_duration_per_task_seconds: average(metrics) { |metric| metric["avg_duration_per_task_seconds"].to_f },
+        aggregated_pr_rate: rate(metrics) { |metric| metric["aggregated_pr_created"] }
       }
     end
 
     def guardrail_failures(control_summary:, candidate_summary:)
       failures = []
 
+      if candidate_summary[:avg_coordination_score] < control_summary[:avg_coordination_score] + MIN_COORDINATION_SCORE_DELTA
+        failures << "coordination_score_not_improved"
+      end
+
       if candidate_summary[:success_rate] < control_summary[:success_rate] + MIN_SUCCESS_RATE_DELTA
         failures << "success_rate_regressed"
+      end
+
+      if candidate_summary[:completion_rate] < control_summary[:completion_rate] + MIN_COMPLETION_RATE_DELTA
+        failures << "completion_rate_regressed"
+      end
+
+      if candidate_summary[:failed_task_rate] > control_summary[:failed_task_rate] + MAX_FAILED_TASK_RATE_INCREASE
+        failures << "failed_task_rate_too_high"
+      end
+
+      if candidate_summary[:dependency_failed_task_rate] > control_summary[:dependency_failed_task_rate] + MAX_DEPENDENCY_FAILURE_RATE_INCREASE
+        failures << "dependency_failure_rate_too_high"
       end
 
       if candidate_summary[:conflict_rate] > control_summary[:conflict_rate] + MAX_CONFLICT_RATE_INCREASE
@@ -78,6 +106,11 @@ module CoordinationExperiments
       control_cost = control_summary[:avg_cost_cents]
       if control_cost.positive? && candidate_summary[:avg_cost_cents] > (control_cost * MAX_COST_INCREASE_RATIO)
         failures << "cost_increase_too_high"
+      end
+
+      control_duration = control_summary[:avg_duration_seconds]
+      if control_duration.positive? && candidate_summary[:avg_duration_seconds] > (control_duration * MAX_DURATION_INCREASE_RATIO)
+        failures << "duration_increase_too_high"
       end
 
       failures

--- a/app/services/coordination_experiments/promotion_readiness.rb
+++ b/app/services/coordination_experiments/promotion_readiness.rb
@@ -55,19 +55,24 @@ module CoordinationExperiments
     def summarize(variant)
       assignments = variant.coordination_experiment_assignments.recorded.to_a
       metrics = assignments.map(&:outcome_metrics)
+      total_tasks = summed(metrics) { |metric| metric["task_count"] }
+      total_cost_cents = summed(metrics) { |metric| metric["total_cost_cents"] }
+      total_duration_seconds = summed(metrics) { |metric| metric["total_duration_seconds"] }
+
       {
         sample_count: assignments.size,
+        total_task_count: total_tasks,
         avg_coordination_score: variant.avg_coordination_score.to_f,
         success_rate: rate(metrics) { |metric| metric["success"] },
-        completion_rate: average(metrics) { |metric| metric["completion_rate"].to_f },
-        failed_task_rate: average(metrics) { |metric| metric["failed_task_rate"].to_f },
-        dependency_failed_task_rate: average(metrics) { |metric| metric["dependency_failed_task_rate"].to_f },
+        completion_rate: ratio(metrics, denominator: total_tasks) { |metric| metric["completed_tasks"] },
+        failed_task_rate: ratio(metrics, denominator: total_tasks) { |metric| metric["failed_tasks"] },
+        dependency_failed_task_rate: ratio(metrics, denominator: total_tasks) { |metric| metric["dependency_failed_tasks"] },
         conflict_rate: rate(metrics) { |metric| metric["conflict_detected"] },
         manual_review_rate: rate(metrics) { |metric| metric["manual_review_required"] },
-        avg_cost_cents: average(metrics) { |metric| metric["total_cost_cents"].to_f },
-        avg_duration_seconds: average(metrics) { |metric| metric["total_duration_seconds"].to_f },
-        avg_cost_per_task_cents: average(metrics) { |metric| metric["avg_cost_per_task_cents"].to_f },
-        avg_duration_per_task_seconds: average(metrics) { |metric| metric["avg_duration_per_task_seconds"].to_f },
+        avg_cost_cents: average_metric(metrics) { |metric| metric["total_cost_cents"].to_f },
+        avg_duration_seconds: average_metric(metrics) { |metric| metric["total_duration_seconds"].to_f },
+        avg_cost_per_task_cents: average_total(total_cost_cents, total_tasks),
+        avg_duration_per_task_seconds: average_total(total_duration_seconds, total_tasks),
         aggregated_pr_rate: rate(metrics) { |metric| metric["aggregated_pr_created"] }
       }
     end
@@ -103,13 +108,13 @@ module CoordinationExperiments
         failures << "manual_review_rate_too_high"
       end
 
-      control_cost = control_summary[:avg_cost_cents]
-      if control_cost.positive? && candidate_summary[:avg_cost_cents] > (control_cost * MAX_COST_INCREASE_RATIO)
+      control_cost = control_summary[:avg_cost_per_task_cents]
+      if control_cost.positive? && candidate_summary[:avg_cost_per_task_cents] > (control_cost * MAX_COST_INCREASE_RATIO)
         failures << "cost_increase_too_high"
       end
 
-      control_duration = control_summary[:avg_duration_seconds]
-      if control_duration.positive? && candidate_summary[:avg_duration_seconds] > (control_duration * MAX_DURATION_INCREASE_RATIO)
+      control_duration = control_summary[:avg_duration_per_task_seconds]
+      if control_duration.positive? && candidate_summary[:avg_duration_per_task_seconds] > (control_duration * MAX_DURATION_INCREASE_RATIO)
         failures << "duration_increase_too_high"
       end
 
@@ -122,10 +127,26 @@ module CoordinationExperiments
       metrics.count { |metric| yield(metric) }.to_f / metrics.size
     end
 
-    def average(metrics)
+    def average_metric(metrics)
       return 0.0 if metrics.empty?
 
       metrics.sum { |metric| yield(metric) } / metrics.size
+    end
+
+    def ratio(metrics, denominator:)
+      return 0.0 if denominator.to_i <= 0
+
+      summed(metrics) { |metric| yield(metric) }.to_f / denominator
+    end
+
+    def summed(metrics)
+      metrics.sum { |metric| yield(metric).to_i }
+    end
+
+    def average_total(total, count)
+      return 0.0 if count.to_i <= 0
+
+      total.to_f / count
     end
   end
 end

--- a/app/temporal/activities/resolve_coordination_experiment_activity.rb
+++ b/app/temporal/activities/resolve_coordination_experiment_activity.rb
@@ -23,7 +23,7 @@ module Activities
         assignment_id: assignment.id,
         experiment_id: experiment.id,
         variant_id: assignment.coordination_experiment_variant_id,
-        coordination_policy: assignment.coordination_experiment_variant.parsed_policy
+        coordination_policy: experiment.effective_policy_for(assignment.coordination_experiment_variant)
       }
     end
   end

--- a/spec/models/coordination_experiment_spec.rb
+++ b/spec/models/coordination_experiment_spec.rb
@@ -50,5 +50,20 @@ RSpec.describe CoordinationExperiment do
         }
       )
     end
+
+    it "uses the experiment baseline directly for the control variant" do
+      experiment = create(:coordination_experiment,
+        control_policy: {
+          "parallel_execution" => { "max_batch_size" => 5, "cancel_remaining_on_failure" => false }
+        })
+      control_variant = create(:coordination_experiment_variant,
+        coordination_experiment: experiment,
+        is_control: true,
+        policy_config: {
+          "parallel_execution" => { "max_batch_size" => 1, "cancel_remaining_on_failure" => true }
+        })
+
+      expect(experiment.effective_policy_for(control_variant)).to eq(experiment.control_policy)
+    end
   end
 end

--- a/spec/models/coordination_experiment_spec.rb
+++ b/spec/models/coordination_experiment_spec.rb
@@ -25,4 +25,30 @@ RSpec.describe CoordinationExperiment do
       expect(described_class.active_for(account:, workflow_id: "wf-1")).to be_nil
     end
   end
+
+  describe "#effective_policy_for" do
+    it "merges variant overrides onto the experiment baseline policy" do
+      experiment = create(:coordination_experiment,
+        control_policy: {
+          "parallel_execution" => { "max_batch_size" => 3, "cancel_remaining_on_failure" => false },
+          "decomposition" => { "enabled" => true, "max_tasks" => 6 }
+        })
+      variant = create(:coordination_experiment_variant,
+        coordination_experiment: experiment,
+        policy_config: {
+          "parallel_execution" => { "max_batch_size" => 1 }
+        })
+
+      expect(experiment.effective_policy_for(variant)).to include(
+        "parallel_execution" => {
+          "max_batch_size" => 1,
+          "cancel_remaining_on_failure" => false
+        },
+        "decomposition" => {
+          "enabled" => true,
+          "max_tasks" => 6
+        }
+      )
+    end
+  end
 end

--- a/spec/services/coordination_experiments/assign_spec.rb
+++ b/spec/services/coordination_experiments/assign_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoordinationExperiments::Assign do
   let!(:variant) do
     create(:coordination_experiment_variant,
       coordination_experiment: experiment,
-      policy_config: experiment.control_policy.merge("parallel_execution" => { "max_batch_size" => 1 }))
+      policy_config: { "parallel_execution" => { "max_batch_size" => 1 } })
   end
 
   it "creates a workflow-scoped assignment" do

--- a/spec/services/coordination_experiments/assign_spec.rb
+++ b/spec/services/coordination_experiments/assign_spec.rb
@@ -54,4 +54,16 @@ RSpec.describe CoordinationExperiments::Assign do
     expect(counts.keys.size).to eq(2)
     counts.each_value { |count| expect(count).to be_between(2, 4) }
   end
+
+  it "rejects assignments for experiments that are not running" do
+    experiment.update!(status: "draft")
+
+    expect {
+      described_class.call(
+        coordination_experiment: experiment,
+        project: project,
+        workflow_id: "wf-123"
+      )
+    }.to raise_error(ArgumentError, /not running/)
+  end
 end

--- a/spec/services/coordination_experiments/promotion_readiness_spec.rb
+++ b/spec/services/coordination_experiments/promotion_readiness_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
   let!(:variant) do
     create(:coordination_experiment_variant,
       coordination_experiment: experiment,
-      policy_config: experiment.control_policy.merge("parallel_execution" => { "max_batch_size" => 1 }),
+      policy_config: { "parallel_execution" => { "max_batch_size" => 1 } },
       sample_count: 2,
       avg_coordination_score: 0.8,
       total_coordination_score: 1.6)
@@ -37,6 +37,10 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
         coordination_score: 0.6,
         outcome_metrics: {
           "success" => success,
+          "task_count" => 2,
+          "completed_tasks" => 2,
+          "failed_tasks" => 0,
+          "dependency_failed_tasks" => 0,
           "completion_rate" => 1.0,
           "failed_task_rate" => 0.0,
           "dependency_failed_task_rate" => 0.0,
@@ -58,6 +62,10 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
         coordination_score: 0.8,
         outcome_metrics: {
           "success" => success,
+          "task_count" => 2,
+          "completed_tasks" => 2,
+          "failed_tasks" => 0,
+          "dependency_failed_tasks" => 0,
           "completion_rate" => 1.0,
           "failed_task_rate" => 0.0,
           "dependency_failed_task_rate" => 0.0,
@@ -91,6 +99,96 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
     )
   end
 
+  def outcome_metrics(task_count:, completed_tasks:, failed_tasks:, dependency_failed_tasks:, total_cost_cents:,
+    total_duration_seconds:, aggregated_pr_created:, success: true)
+    {
+      "success" => success,
+      "task_count" => task_count,
+      "completed_tasks" => completed_tasks,
+      "failed_tasks" => failed_tasks,
+      "dependency_failed_tasks" => dependency_failed_tasks,
+      "completion_rate" => (completed_tasks.to_f / task_count).round(4),
+      "failed_task_rate" => (failed_tasks.to_f / task_count).round(4),
+      "dependency_failed_task_rate" => (dependency_failed_tasks.to_f / task_count).round(4),
+      "conflict_detected" => false,
+      "manual_review_required" => false,
+      "total_cost_cents" => total_cost_cents,
+      "total_duration_seconds" => total_duration_seconds,
+      "avg_cost_per_task_cents" => (total_cost_cents.to_f / task_count).round(4),
+      "avg_duration_per_task_seconds" => (total_duration_seconds.to_f / task_count).round(4),
+      "aggregated_pr_created" => aggregated_pr_created
+    }
+  end
+
+  def update_recorded_metrics!(scope, **metrics)
+    scope.update_all(outcome_metrics: outcome_metrics(**metrics))
+  end
+
+  def create_recorded_assignment!(variant:, workflow_id:, coordination_score:, **metrics)
+    create(:coordination_experiment_assignment,
+      coordination_experiment: experiment,
+      coordination_experiment_variant: variant,
+      project: project,
+      issue: issue,
+      workflow_id: workflow_id,
+      outcome_status: "recorded",
+      coordination_score: coordination_score,
+      outcome_metrics: outcome_metrics(**metrics))
+  end
+
+  def weighted_assignment_rows
+    [
+      {
+        variant: control,
+        workflow_id: "control-small",
+        coordination_score: 0.6,
+        task_count: 1,
+        completed_tasks: 1,
+        failed_tasks: 0,
+        dependency_failed_tasks: 0,
+        total_cost_cents: 50,
+        total_duration_seconds: 50,
+        aggregated_pr_created: false
+      },
+      {
+        variant: control,
+        workflow_id: "control-second",
+        coordination_score: 0.6,
+        task_count: 1,
+        completed_tasks: 1,
+        failed_tasks: 0,
+        dependency_failed_tasks: 0,
+        total_cost_cents: 50,
+        total_duration_seconds: 50,
+        aggregated_pr_created: false
+      },
+      {
+        variant: variant,
+        workflow_id: "variant-small",
+        coordination_score: 0.8,
+        task_count: 1,
+        completed_tasks: 0,
+        failed_tasks: 1,
+        dependency_failed_tasks: 0,
+        total_cost_cents: 50,
+        total_duration_seconds: 50,
+        aggregated_pr_created: true
+      },
+      {
+        variant: variant,
+        workflow_id: "variant-bulk",
+        coordination_score: 0.8,
+        task_count: 19,
+        completed_tasks: 19,
+        failed_tasks: 0,
+        dependency_failed_tasks: 0,
+        total_cost_cents: 950,
+        total_duration_seconds: 950,
+        aggregated_pr_created: true
+      }
+    ]
+  end
+
   it "marks the evolved variant ready when quality improves within guardrails" do
     result = described_class.call(coordination_experiment: experiment)
 
@@ -98,24 +196,18 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
     expect(result.candidate).to eq(variant)
     expect(result.reasons).to eq([])
     expect_ready_summary!(result)
+    expect(result.candidate_summary[:total_task_count]).to eq(4)
   end
 
   it "fails readiness when cost guardrails regress too far" do
-    variant.coordination_experiment_assignments.recorded.update_all(
-      outcome_metrics: {
-        "success" => true,
-        "completion_rate" => 1.0,
-        "failed_task_rate" => 0.0,
-        "dependency_failed_task_rate" => 0.0,
-        "conflict_detected" => false,
-        "manual_review_required" => false,
-        "total_cost_cents" => 200,
-        "total_duration_seconds" => 118,
-        "avg_cost_per_task_cents" => 100,
-        "avg_duration_per_task_seconds" => 59,
-        "aggregated_pr_created" => false
-      }
-    )
+    update_recorded_metrics!(variant.coordination_experiment_assignments.recorded,
+      task_count: 2,
+      completed_tasks: 2,
+      failed_tasks: 0,
+      dependency_failed_tasks: 0,
+      total_cost_cents: 200,
+      total_duration_seconds: 118,
+      aggregated_pr_created: false)
 
     result = described_class.call(coordination_experiment: experiment)
 
@@ -125,24 +217,37 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
 
   it "fails readiness when the evolved policy is slower and less complete than control" do
     variant.update!(avg_coordination_score: 0.7, total_coordination_score: 1.4)
-    variant.coordination_experiment_assignments.recorded.update_all(
-      outcome_metrics: {
-        "success" => true,
-        "completion_rate" => 0.5,
-        "failed_task_rate" => 0.5,
-        "dependency_failed_task_rate" => 0.25,
-        "conflict_detected" => false,
-        "manual_review_required" => false,
-        "total_cost_cents" => 105,
-        "total_duration_seconds" => 200,
-        "avg_cost_per_task_cents" => 52.5,
-        "avg_duration_per_task_seconds" => 100,
-        "aggregated_pr_created" => false
-      }
-    )
+    update_recorded_metrics!(variant.coordination_experiment_assignments.recorded,
+      task_count: 2,
+      completed_tasks: 1,
+      failed_tasks: 1,
+      dependency_failed_tasks: 1,
+      total_cost_cents: 105,
+      total_duration_seconds: 200,
+      aggregated_pr_created: false)
 
     result = described_class.call(coordination_experiment: experiment)
 
     expect_regressed_readiness!(result)
+  end
+
+  it "weights task-based guardrails by task count and normalizes duration/cost per task" do
+    control.coordination_experiment_assignments.recorded.destroy_all
+    variant.coordination_experiment_assignments.recorded.destroy_all
+
+    weighted_assignment_rows.each do |row|
+      create_recorded_assignment!(**row)
+    end
+
+    result = described_class.call(coordination_experiment: experiment)
+
+    expect(result.status).to eq(:ready)
+    expect(result.candidate_summary).to include(
+      total_task_count: 20,
+      completion_rate: 0.95,
+      failed_task_rate: 0.05,
+      avg_cost_per_task_cents: 50.0,
+      avg_duration_per_task_seconds: 50.0
+    )
   end
 end

--- a/spec/services/coordination_experiments/promotion_readiness_spec.rb
+++ b/spec/services/coordination_experiments/promotion_readiness_spec.rb
@@ -37,9 +37,16 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
         coordination_score: 0.6,
         outcome_metrics: {
           "success" => success,
+          "completion_rate" => 1.0,
+          "failed_task_rate" => 0.0,
+          "dependency_failed_task_rate" => 0.0,
           "conflict_detected" => false,
           "manual_review_required" => false,
-          "total_cost_cents" => 100
+          "total_cost_cents" => 100,
+          "total_duration_seconds" => 120,
+          "avg_cost_per_task_cents" => 50,
+          "avg_duration_per_task_seconds" => 60,
+          "aggregated_pr_created" => false
         })
       create(:coordination_experiment_assignment,
         coordination_experiment: experiment,
@@ -51,11 +58,37 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
         coordination_score: 0.8,
         outcome_metrics: {
           "success" => success,
+          "completion_rate" => 1.0,
+          "failed_task_rate" => 0.0,
+          "dependency_failed_task_rate" => 0.0,
           "conflict_detected" => false,
           "manual_review_required" => false,
-          "total_cost_cents" => 105
+          "total_cost_cents" => 105,
+          "total_duration_seconds" => 118,
+          "avg_cost_per_task_cents" => 52.5,
+          "avg_duration_per_task_seconds" => 59,
+          "aggregated_pr_created" => true
         })
     end
+  end
+
+  def expect_ready_summary!(result)
+    expect(result.candidate_summary).to include(
+      avg_coordination_score: 0.8,
+      completion_rate: 1.0,
+      avg_cost_cents: 105.0,
+      aggregated_pr_rate: 1.0
+    )
+  end
+
+  def expect_regressed_readiness!(result)
+    expect(result.status).to eq(:guardrail_failed)
+    expect(result.reasons).to include(
+      "completion_rate_regressed",
+      "failed_task_rate_too_high",
+      "dependency_failure_rate_too_high",
+      "duration_increase_too_high"
+    )
   end
 
   it "marks the evolved variant ready when quality improves within guardrails" do
@@ -64,15 +97,23 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
     expect(result.status).to eq(:ready)
     expect(result.candidate).to eq(variant)
     expect(result.reasons).to eq([])
+    expect_ready_summary!(result)
   end
 
   it "fails readiness when cost guardrails regress too far" do
     variant.coordination_experiment_assignments.recorded.update_all(
       outcome_metrics: {
         "success" => true,
+        "completion_rate" => 1.0,
+        "failed_task_rate" => 0.0,
+        "dependency_failed_task_rate" => 0.0,
         "conflict_detected" => false,
         "manual_review_required" => false,
-        "total_cost_cents" => 200
+        "total_cost_cents" => 200,
+        "total_duration_seconds" => 118,
+        "avg_cost_per_task_cents" => 100,
+        "avg_duration_per_task_seconds" => 59,
+        "aggregated_pr_created" => false
       }
     )
 
@@ -80,5 +121,28 @@ RSpec.describe CoordinationExperiments::PromotionReadiness do
 
     expect(result.status).to eq(:guardrail_failed)
     expect(result.reasons).to include("cost_increase_too_high")
+  end
+
+  it "fails readiness when the evolved policy is slower and less complete than control" do
+    variant.update!(avg_coordination_score: 0.7, total_coordination_score: 1.4)
+    variant.coordination_experiment_assignments.recorded.update_all(
+      outcome_metrics: {
+        "success" => true,
+        "completion_rate" => 0.5,
+        "failed_task_rate" => 0.5,
+        "dependency_failed_task_rate" => 0.25,
+        "conflict_detected" => false,
+        "manual_review_required" => false,
+        "total_cost_cents" => 105,
+        "total_duration_seconds" => 200,
+        "avg_cost_per_task_cents" => 52.5,
+        "avg_duration_per_task_seconds" => 100,
+        "aggregated_pr_created" => false
+      }
+    )
+
+    result = described_class.call(coordination_experiment: experiment)
+
+    expect_regressed_readiness!(result)
   end
 end

--- a/spec/services/coordination_experiments/record_outcome_spec.rb
+++ b/spec/services/coordination_experiments/record_outcome_spec.rb
@@ -34,26 +34,69 @@ RSpec.describe CoordinationExperiments::RecordOutcome do
     }
   end
 
-  it "records workflow metrics and updates variant aggregates" do
+  def record_outcome!(task_count:, result:)
     described_class.call(
       assignment: assignment,
-      task_count: 2,
+      task_count: task_count,
       parallel_execution: true,
-      result: result_payload
+      result: result
     )
+  end
+
+  def expect_recorded_metrics!
+    expect(assignment.outcome_metrics).to include(
+      "summary_version" => 1,
+      "task_count" => 2,
+      "parallel_execution" => true,
+      "completion_rate" => 1.0,
+      "failed_task_rate" => 0.0,
+      "dependency_failed_task_rate" => 0.0,
+      "successful_run_rate" => 0.5,
+      "total_cost_cents" => 250,
+      "total_duration_seconds" => 120,
+      "avg_cost_per_task_cents" => 125.0,
+      "avg_duration_per_task_seconds" => 60.0
+    )
+  end
+
+  def penalized_result_payload
+    {
+      success: false,
+      completed: 2,
+      failed: 2,
+      results: [
+        { success: true, agent_run_id: run.id },
+        { success: false, error: "dependencies_failed" },
+        { success: false, error: "cancelled_by_policy" },
+        { queued: true }
+      ],
+      conflicts: { has_conflicts: true, requires_manual_review: true }
+    }
+  end
+
+  it "records workflow metrics and updates variant aggregates" do
+    record_outcome!(task_count: 2, result: result_payload)
 
     assignment.reload
     variant.reload
 
     expect(assignment.outcome_status).to eq("recorded")
-    expect(assignment.outcome_metrics).to include(
-      "task_count" => 2,
-      "parallel_execution" => true,
-      "total_cost_cents" => 250,
-      "total_duration_seconds" => 120
-    )
+    expect_recorded_metrics!
     expect(assignment.coordination_score).to eq(1.0)
     expect(variant.sample_count).to eq(1)
     expect(variant.avg_coordination_score.to_f).to eq(1.0)
+  end
+
+  it "captures dependency and manual-review penalties in the recorded metrics" do
+    record_outcome!(task_count: 4, result: penalized_result_payload)
+
+    expect(assignment.reload.outcome_metrics).to include(
+      "queued_task_rate" => 0.25,
+      "dependency_failed_task_rate" => 0.25,
+      "policy_cancelled_task_rate" => 0.25,
+      "conflict_detected" => true,
+      "manual_review_required" => true
+    )
+    expect(assignment.coordination_score.to_f).to be < 0.3
   end
 end

--- a/spec/temporal/activities/resolve_coordination_experiment_activity_spec.rb
+++ b/spec/temporal/activities/resolve_coordination_experiment_activity_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::ResolveCoordinationExperimentActivity do
+  let(:activity) { described_class.new }
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account) }
+  let(:issue) { create(:issue, project: project) }
+  let(:experiment) do
+    create(:coordination_experiment,
+      account: account,
+      control_policy: {
+        "parallel_execution" => { "max_batch_size" => 3, "cancel_remaining_on_failure" => false },
+        "decomposition" => { "enabled" => true, "max_tasks" => 6 }
+      })
+  end
+  let!(:variant) do
+    create(:coordination_experiment_variant,
+      coordination_experiment: experiment,
+      policy_config: { "parallel_execution" => { "max_batch_size" => 1 } })
+  end
+
+  def assignment
+    create(:coordination_experiment_assignment,
+      coordination_experiment: experiment,
+      coordination_experiment_variant: variant,
+      project: project,
+      issue: issue)
+  end
+
+  def expect_merged_policy!(result)
+    expect(result).to include(
+      experiment_id: experiment.id,
+      variant_id: variant.id,
+      coordination_policy: {
+        "parallel_execution" => {
+          "max_batch_size" => 1,
+          "cancel_remaining_on_failure" => false
+        },
+        "decomposition" => {
+          "enabled" => true,
+          "max_tasks" => 6
+        }
+      }
+    )
+  end
+
+  it "returns a baseline-merged policy for the assigned variant" do
+    allow(CoordinationExperiment).to receive(:active_for).and_return(experiment)
+    allow(CoordinationExperiments::Assign).to receive(:call).and_return(assignment)
+
+    result = activity.execute(project_id: project.id, issue_id: issue.id, workflow_id: "wf-123")
+
+    expect_merged_policy!(result)
+  end
+end

--- a/spec/temporal/activities/resolve_coordination_experiment_activity_spec.rb
+++ b/spec/temporal/activities/resolve_coordination_experiment_activity_spec.rb
@@ -20,11 +20,19 @@ RSpec.describe Activities::ResolveCoordinationExperimentActivity do
       coordination_experiment: experiment,
       policy_config: { "parallel_execution" => { "max_batch_size" => 1 } })
   end
+  let!(:control_variant) do
+    create(:coordination_experiment_variant,
+      coordination_experiment: experiment,
+      is_control: true,
+      policy_config: {
+        "parallel_execution" => { "max_batch_size" => 99, "cancel_remaining_on_failure" => true }
+      })
+  end
 
-  def assignment
+  def assignment_for(assigned_variant)
     create(:coordination_experiment_assignment,
       coordination_experiment: experiment,
-      coordination_experiment_variant: variant,
+      coordination_experiment_variant: assigned_variant,
       project: project,
       issue: issue)
   end
@@ -48,10 +56,22 @@ RSpec.describe Activities::ResolveCoordinationExperimentActivity do
 
   it "returns a baseline-merged policy for the assigned variant" do
     allow(CoordinationExperiment).to receive(:active_for).and_return(experiment)
-    allow(CoordinationExperiments::Assign).to receive(:call).and_return(assignment)
+    allow(CoordinationExperiments::Assign).to receive(:call).and_return(assignment_for(variant))
 
     result = activity.execute(project_id: project.id, issue_id: issue.id, workflow_id: "wf-123")
 
     expect_merged_policy!(result)
+  end
+
+  it "keeps the experiment baseline for control assignments" do
+    allow(CoordinationExperiment).to receive(:active_for).and_return(experiment)
+    allow(CoordinationExperiments::Assign).to receive(:call).and_return(assignment_for(control_variant))
+
+    result = activity.execute(project_id: project.id, issue_id: issue.id, workflow_id: "wf-123")
+
+    expect(result).to include(
+      variant_id: control_variant.id,
+      coordination_policy: experiment.control_policy
+    )
   end
 end


### PR DESCRIPTION
## Summary

Hardens A/B testing of evolved coordination policies so we can measure them against the baseline before promotion. Promotion decisions now rest on richer outcome signals (completion, failures, dependency fallout, duration, conflict/manual review, and cost) rather than a single rolled-up score, and variant overrides are safely merged onto the baseline before orchestration consumes them.

## Changes

- **Services**
  - Merge experiment variant overrides onto the baseline coordination policy before orchestration uses them, so variants always inherit a complete, valid policy shape.
  - Expand `CoordinationExperiments::OutcomeMetrics` to capture completion, failure, dependency fallout, duration, conflict/manual review, and cost signals.
  - Strengthen `CoordinationExperiments::PromotionReadiness` to evaluate each of those signals as guardrails instead of a single aggregate score.
- **Temporal activities**
  - Resolve coordination experiment assignment safely during orchestration execution.
- **Tests**
  - Added coverage for policy merging, assignment guards, richer outcome aggregation, and promotion-readiness regressions.
  - New activity spec at `spec/temporal/activities/resolve_coordination_experiment_activity_spec.rb`.

## Design Decisions

- **Multi-signal promotion gating over a single score.** A composite score can mask real regressions (e.g., a variant that improves duration but increases dependency fallout or cost). Evaluating each guardrail independently makes regressions visible and keeps promotion conservative.
- **Variant-as-override on baseline.** Variants store overrides rather than full policies, so the baseline remains the source of truth for shape and defaults. Merging at resolution time avoids drift and keeps variants minimal.
- **Fail-safe assignment in orchestration.** Assignment resolution is wrapped so that experiment infrastructure issues fall back to baseline behavior rather than blocking orchestration.

## Operational Notes

- No migrations or infrastructure changes.
- `bundle exec rspec` was not run in the authoring environment because PostgreSQL was unavailable (`PG::ConnectionBad` in `spec/rails_helper.rb`); CI should exercise the full suite.

---

Closes #1809