### PR TITLE
feat(scaling): analyze orchestration parallelism effects

### DIFF
--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -290,12 +290,14 @@ module Scaling
         decision = summary_value(summary, :allocator_decision)
         next unless decision.is_a?(Hash)
         next unless summary_value(summary, :dimension)
+        sample_count = summary_value(summary, :sample_count, default: 0)
+        next unless sample_count >= MIN_OBSERVATIONS_FOR_CONFIDENCE
 
         {
           summary: summary,
           decision: decision,
           dimension: summary_value(summary, :dimension),
-          sample_count: summary_value(summary, :sample_count, default: 0)
+          sample_count: sample_count
         }
       end
     end

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -280,7 +280,7 @@ module Scaling
       @selected_experiment_allocator_decision ||= experiment_allocator_decisions.max_by do |entry|
         [
           confidence_rank(summary_value(entry[:decision], :confidence)),
-          entry[:sample_count]
+          entry[:decision_sample_count]
         ]
       end
     end
@@ -297,14 +297,15 @@ module Scaling
         next unless decision.is_a?(Hash)
         dimension = summary_value(summary, :dimension).to_s
         next unless ALLOCATOR_DECISION_DIMENSIONS.include?(dimension)
-        sample_count = summary_value(summary, :sample_count, default: 0)
-        next unless sample_count >= MIN_OBSERVATIONS_FOR_CONFIDENCE
+        decision_sample_count = summary_value(decision, :sample_count, default: 0)
+        next unless decision_sample_count >= MIN_OBSERVATIONS_FOR_CONFIDENCE
 
         {
           summary: summary,
           decision: decision,
           dimension: summary_value(summary, :dimension),
-          sample_count: sample_count
+          sample_count: summary_value(summary, :sample_count, default: 0),
+          decision_sample_count: decision_sample_count
         }
       end
     end
@@ -339,6 +340,7 @@ module Scaling
       "#{decision_summary[:dimension]} allocator decision " \
         "agents=#{summary_value(decision, :requested_agent_count, default: conservative_agent_count)} " \
         "parallelism=#{summary_value(decision, :max_batch_size, default: nil)} " \
+        "n=#{decision_summary[:decision_sample_count]} " \
         "confidence=#{summary_value(decision, :confidence, default: "unknown")}"
     end
 

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -293,6 +293,7 @@ module Scaling
 
     def experiment_allocator_decisions
       @experiment_allocator_decisions ||= experiment_summaries.filter_map do |summary|
+        next unless summary_value(summary, :status).to_s == "ready_for_analysis"
         decision = summary_value(summary, :allocator_decision)
         next unless decision.is_a?(Hash)
         dimension = summary_value(summary, :dimension).to_s

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -285,11 +285,18 @@ module Scaling
       end
     end
 
+    # Only parallelism-dimension summaries carry allocator decisions that
+    # should steer agent_count / parallelism_level.  Other dimensions
+    # (e.g. iteration_count, max_iterations) may have allocator_decision
+    # hashes but their values are not compatible with this code path.
+    ALLOCATOR_DECISION_DIMENSIONS = %w[parallelism].freeze
+
     def experiment_allocator_decisions
       @experiment_allocator_decisions ||= experiment_summaries.filter_map do |summary|
         decision = summary_value(summary, :allocator_decision)
         next unless decision.is_a?(Hash)
-        next unless summary_value(summary, :dimension)
+        dimension = summary_value(summary, :dimension).to_s
+        next unless ALLOCATOR_DECISION_DIMENSIONS.include?(dimension)
         sample_count = summary_value(summary, :sample_count, default: 0)
         next unless sample_count >= MIN_OBSERVATIONS_FOR_CONFIDENCE
 

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -59,6 +59,10 @@ module Scaling
     end
 
     def allocate_from_experiments
+      if (decision_summary = selected_experiment_allocator_decision)
+        return allocate_from_experiment_decision(decision_summary)
+      end
+
       best_summary = usable_experiment_summaries.max_by do |summary|
         [
           summary_value(summary, :success_rate, default: 0.0),
@@ -77,6 +81,21 @@ module Scaling
         parallelism_level: parallelism_cap(agent_count),
         source: :experiment,
         reason: "experiment leading value=#{value} success_rate=#{format_rate(summary_value(best_summary, :success_rate, default: 0.0))}"
+      )
+    end
+
+    def allocate_from_experiment_decision(decision_summary)
+      decision = decision_summary[:decision]
+      requested_agent_count = summary_value(decision, :requested_agent_count, default: conservative_agent_count)
+      agent_count = clamp_agents(requested_agent_count)
+      recommended_parallelism = summary_value(decision, :max_batch_size, default: parallelism_cap(agent_count))
+
+      build_allocation(
+        agent_count: agent_count,
+        max_iterations: 3,
+        parallelism_level: parallelism_cap([ recommended_parallelism.to_i, agent_count ].min),
+        source: :experiment,
+        reason: experiment_decision_reason(decision_summary)
       )
     end
 
@@ -257,6 +276,30 @@ module Scaling
       end
     end
 
+    def selected_experiment_allocator_decision
+      @selected_experiment_allocator_decision ||= experiment_allocator_decisions.max_by do |entry|
+        [
+          confidence_rank(summary_value(entry[:decision], :confidence)),
+          entry[:sample_count]
+        ]
+      end
+    end
+
+    def experiment_allocator_decisions
+      @experiment_allocator_decisions ||= experiment_summaries.filter_map do |summary|
+        decision = summary_value(summary, :allocator_decision)
+        next unless decision.is_a?(Hash)
+        next unless summary_value(summary, :dimension)
+
+        {
+          summary: summary,
+          decision: decision,
+          dimension: summary_value(summary, :dimension),
+          sample_count: summary_value(summary, :sample_count, default: 0)
+        }
+      end
+    end
+
     # Normalizes experiment summaries to a flat per-value format.
     # Accepts both flat value hashes (already per-value) and the nested
     # cached_summary shape produced by ScalingExperiments::SummarizeResults,
@@ -279,6 +322,15 @@ module Scaling
 
     def parallelism_cap(agent_count)
       [ agent_count, inputs.parallelism_limit ].min
+    end
+
+    def experiment_decision_reason(decision_summary)
+      decision = decision_summary[:decision]
+
+      "#{decision_summary[:dimension]} allocator decision " \
+        "agents=#{summary_value(decision, :requested_agent_count, default: conservative_agent_count)} " \
+        "parallelism=#{summary_value(decision, :max_batch_size, default: nil)} " \
+        "confidence=#{summary_value(decision, :confidence, default: "unknown")}"
     end
 
     def fallback_reason
@@ -314,6 +366,14 @@ module Scaling
 
     def format_rate(value)
       format("%.2f%%", (value || 0.0) * 100)
+    end
+
+    def confidence_rank(value)
+      case value
+      when "high" then 2
+      when "medium" then 1
+      else 0
+      end
     end
   end
 end

--- a/app/services/scaling_observations/analyze_parallelism.rb
+++ b/app/services/scaling_observations/analyze_parallelism.rb
@@ -92,13 +92,13 @@ module ScalingObservations
 
     def diminishing_returns_at
       grouped_values.find { |value| value["signals"].include?("diminishing_returns") }
-        &.fetch("agent_count", nil)
+        &.fetch("parallelism", nil)
     end
 
     def threshold_signal_at
       grouped_values.find do |value|
         value["signals"].any? { |signal| signal != "diminishing_returns" }
-      end&.fetch("agent_count", nil)
+      end&.fetch("parallelism", nil)
     end
 
     def recommendation
@@ -174,7 +174,6 @@ module ScalingObservations
       )
 
       {
-        "agent_count" => parallelism,
         "parallelism" => parallelism,
         "sample_count" => sample_count,
         "success_rate" => success_rate,

--- a/app/services/scaling_observations/analyze_parallelism.rb
+++ b/app/services/scaling_observations/analyze_parallelism.rb
@@ -119,6 +119,7 @@ module ScalingObservations
             "requested_agent_count" => candidate["recommended_agent_count"],
             "parallelism" => candidate["parallelism"],
             "max_batch_size" => candidate["parallelism"],
+            "sample_count" => candidate["sample_count"],
             "reason" => recommendation_reason(candidate),
             "confidence" => confidence_for(candidate)
           }

--- a/app/services/scaling_observations/analyze_parallelism.rb
+++ b/app/services/scaling_observations/analyze_parallelism.rb
@@ -6,6 +6,7 @@ module ScalingObservations
       :status,
       :sample_count,
       :recommended_agent_count,
+      :recommended_parallelism,
       :recommended_max_batch_size,
       :diminishing_returns_at,
       :threshold_signal_at,
@@ -18,6 +19,7 @@ module ScalingObservations
           "status" => status,
           "sample_count" => sample_count,
           "recommended_agent_count" => recommended_agent_count,
+          "recommended_parallelism" => recommended_parallelism,
           "recommended_max_batch_size" => recommended_max_batch_size,
           "diminishing_returns_at" => diminishing_returns_at,
           "threshold_signal_at" => threshold_signal_at,
@@ -48,6 +50,7 @@ module ScalingObservations
         status: analysis_status,
         sample_count: grouped_values.sum { |value| value["sample_count"] },
         recommended_agent_count: recommendation&.fetch("requested_agent_count", nil),
+        recommended_parallelism: recommendation&.fetch("parallelism", nil),
         recommended_max_batch_size: recommendation&.fetch("max_batch_size", nil),
         diminishing_returns_at: diminishing_returns_at,
         threshold_signal_at: threshold_signal_at,
@@ -62,14 +65,14 @@ module ScalingObservations
 
     def grouped_values
       @grouped_values ||= begin
-        grouped = observations.group_by { |observation| observation.agent_count_planned.to_i }
+        grouped = observations.group_by { |observation| observation.parallelism_planned.to_i }
         summaries = []
 
-        grouped.keys.sort.each do |agent_count|
-          rows = grouped.fetch(agent_count)
+        grouped.keys.sort.each do |parallelism|
+          rows = grouped.fetch(parallelism)
           previous = summaries.last
 
-          summaries << build_value_summary(agent_count:, rows:, previous:)
+          summaries << build_value_summary(parallelism:, rows:, previous:)
         end
 
         summaries
@@ -108,13 +111,14 @@ module ScalingObservations
             -value["avg_duration_seconds"],
             -value["avg_cost_cents"],
             -value["avg_parallelism_observed"],
-            -value["agent_count"]
+            -value["parallelism"]
           ]
         end
         if candidate
           {
-            "requested_agent_count" => candidate["agent_count"],
-            "max_batch_size" => candidate["agent_count"],
+            "requested_agent_count" => candidate["recommended_agent_count"],
+            "parallelism" => candidate["parallelism"],
+            "max_batch_size" => candidate["parallelism"],
             "reason" => recommendation_reason(candidate),
             "confidence" => confidence_for(candidate)
           }
@@ -142,12 +146,14 @@ module ScalingObservations
       candidate.fetch("sample_count", 0) >= (min_samples * 2) ? "high" : "medium"
     end
 
-    def build_value_summary(agent_count:, rows:, previous:)
+    def build_value_summary(parallelism:, rows:, previous:)
       sample_count = rows.size
       success_rate = rate(rows, &:success)
       avg_duration_seconds = average(rows, &:duration_seconds)
       avg_cost_cents = average(rows, &:total_cost_cents)
       avg_parallelism_observed = average(rows, &:parallelism_observed)
+      avg_agent_count_planned = average(rows, &:agent_count_planned)
+      avg_agent_count_launched = average(rows, &:agent_count_launched)
       launch_rate = ratio(
         rows.sum(&:agent_count_launched),
         rows.sum(&:agent_count_planned)
@@ -167,12 +173,16 @@ module ScalingObservations
       )
 
       {
-        "agent_count" => agent_count,
+        "agent_count" => parallelism,
+        "parallelism" => parallelism,
         "sample_count" => sample_count,
         "success_rate" => success_rate,
         "avg_duration_seconds" => avg_duration_seconds,
         "avg_cost_cents" => avg_cost_cents,
         "avg_parallelism_observed" => avg_parallelism_observed,
+        "avg_agent_count_planned" => avg_agent_count_planned,
+        "avg_agent_count_launched" => avg_agent_count_launched,
+        "recommended_agent_count" => recommended_agent_count_for(rows, avg_agent_count_planned),
         "launch_rate" => launch_rate,
         "blocked_rate" => blocked_rate,
         "marginal_duration_improvement_ratio" => marginal_duration_improvement_ratio,
@@ -216,6 +226,12 @@ module ScalingObservations
       return 0.0 if denominator.to_i <= 0
 
       (numerator.to_f / denominator).round(4)
+    end
+
+    def recommended_agent_count_for(rows, avg_agent_count_planned)
+      return rows.map(&:agent_count_planned).max.to_i if avg_agent_count_planned.zero?
+
+      avg_agent_count_planned.round
     end
   end
 end

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -289,6 +289,20 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.parallelism_level).to eq(2)
         expect(result.reason).to include("parallelism allocator decision")
       end
+
+      it "ignores allocator decisions that do not meet the minimum sample threshold" do
+        summaries = [
+          low_confidence_parallelism_summary,
+          experiment_summary(value: 2, success_rate: 0.8, avg_duration_seconds: 150, sample_count: 10, avg_cost_cents: 100.0)
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(2)
+        expect(result.parallelism_level).to eq(2)
+        expect(result.reason).to include("experiment leading value=2")
+      end
     end
 
     context "with experiment-based budget constraint" do
@@ -592,6 +606,27 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
       "values" => [
         { "assigned_value" => 1, "success_rate" => 1.0, "avg_duration_seconds" => 300, "sample_count" => 6, "avg_cost_cents" => 120.0 },
         { "assigned_value" => 2, "success_rate" => 1.0, "avg_duration_seconds" => 200, "sample_count" => 6, "avg_cost_cents" => 125.0 }
+      ]
+    }
+  end
+
+  def low_confidence_parallelism_summary
+    parallelism_experiment_summary.merge(
+      "sample_count" => 2,
+      "allocator_decision" => parallelism_experiment_summary.fetch("allocator_decision").merge(
+        "requested_agent_count" => 4,
+        "parallelism" => 4,
+        "max_batch_size" => 4
+      )
+    )
+  end
+
+  def experiment_summary(value:, **attributes)
+    {
+      "status" => "ready_for_analysis",
+      "dimension" => "agent_count",
+      "values" => [
+        { "assigned_value" => value }.merge(attributes.transform_keys(&:to_s))
       ]
     }
   end

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -340,6 +340,19 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.reason).not_to include("allocator decision")
       end
 
+      it "ignores allocator decisions from summaries that are not ready_for_analysis" do
+        summaries = [
+          parallelism_experiment_summary.merge("status" => "collecting"),
+          experiment_summary(value: 2, success_rate: 0.8, avg_duration_seconds: 150, sample_count: 10, avg_cost_cents: 100.0)
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(2)
+        expect(result.reason).not_to include("allocator decision")
+      end
+
       it "ignores allocator decisions that do not meet the minimum sample threshold" do
         summaries = [
           low_confidence_parallelism_summary,

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -2,12 +2,11 @@
 
 require "rails_helper"
 
-RSpec.describe Scaling::ResourceAllocator do
+RSpec.describe Scaling::ResourceAllocator, :no_db do
   let(:default_inputs) { Scaling::AllocationInputs.new(task_count: 4, max_agent_count: 8) }
 
   def build_observation(agent_count:, success:, created_at: Time.current, **overrides)
-    ScalingObservation.new(
-      project: build(:project),
+    observation_class.new(
       workflow_id: SecureRandom.uuid,
       workflow_name: "TestWorkflow",
       observation_type: "feature_orchestration",
@@ -29,10 +28,38 @@ RSpec.describe Scaling::ResourceAllocator do
       total_cost_cents: overrides.fetch(:total_cost_cents, 100 * agent_count),
       total_input_tokens: 500,
       total_output_tokens: 200,
-      metadata: {}
-    ) do |obs|
-      obs.created_at = created_at
-    end
+      metadata: {},
+      created_at: created_at
+    )
+  end
+
+  def observation_class
+    Struct.new(
+      :workflow_id,
+      :workflow_name,
+      :observation_type,
+      :status,
+      :success,
+      :parallel_execution,
+      :task_count,
+      :agent_count_planned,
+      :agent_count_launched,
+      :agent_count_succeeded,
+      :agent_count_failed,
+      :agent_count_blocked,
+      :total_iterations,
+      :max_iterations,
+      :parallelism_planned,
+      :parallelism_observed,
+      :batch_count,
+      :duration_seconds,
+      :total_cost_cents,
+      :total_input_tokens,
+      :total_output_tokens,
+      :metadata,
+      :created_at,
+      keyword_init: true
+    )
   end
 
   describe ".call" do
@@ -250,6 +277,17 @@ RSpec.describe Scaling::ResourceAllocator do
 
         expect(result.source).to eq(:experiment)
         expect(result.agent_count).to eq(2)
+      end
+
+      it "uses allocator decisions from parallelism experiment summaries" do
+        summaries = [ parallelism_experiment_summary ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(4)
+        expect(result.parallelism_level).to eq(2)
+        expect(result.reason).to include("parallelism allocator decision")
       end
     end
 
@@ -538,5 +576,23 @@ RSpec.describe Scaling::ResourceAllocator do
         expect(result.agent_count).to eq(2)
       end
     end
+  end
+
+  def parallelism_experiment_summary
+    {
+      "status" => "ready_for_analysis",
+      "dimension" => "parallelism",
+      "sample_count" => 12,
+      "allocator_decision" => {
+        "requested_agent_count" => 4,
+        "parallelism" => 2,
+        "max_batch_size" => 2,
+        "confidence" => "high"
+      },
+      "values" => [
+        { "assigned_value" => 1, "success_rate" => 1.0, "avg_duration_seconds" => 300, "sample_count" => 6, "avg_cost_cents" => 120.0 },
+        { "assigned_value" => 2, "success_rate" => 1.0, "avg_duration_seconds" => 200, "sample_count" => 6, "avg_cost_cents" => 125.0 }
+      ]
+    }
   end
 end

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -290,6 +290,31 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.reason).to include("parallelism allocator decision")
       end
 
+      it "ignores allocator decisions from non-parallelism dimensions" do
+        summaries = [
+          {
+            "status" => "ready_for_analysis",
+            "dimension" => "iteration_count",
+            "sample_count" => 12,
+            "allocator_decision" => {
+              "requested_agent_count" => 8,
+              "max_batch_size" => 8,
+              "confidence" => "high"
+            },
+            "values" => [
+              { "assigned_value" => 3, "success_rate" => 0.9, "avg_duration_seconds" => 200, "sample_count" => 6, "avg_cost_cents" => 100.0 },
+              { "assigned_value" => 5, "success_rate" => 0.8, "avg_duration_seconds" => 250, "sample_count" => 6, "avg_cost_cents" => 110.0 }
+            ]
+          }
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).not_to eq(8)
+        expect(result.reason).not_to include("allocator decision")
+      end
+
       it "ignores allocator decisions that do not meet the minimum sample threshold" do
         summaries = [
           low_confidence_parallelism_summary,

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -290,6 +290,31 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.reason).to include("parallelism allocator decision")
       end
 
+      it "ignores allocator decisions whose winning candidate is under-supported even when the summary total is sufficient" do
+        summaries = [
+          parallelism_experiment_summary.deep_merge(
+            "sample_count" => 12,
+            "allocator_decision" => {
+              "requested_agent_count" => 4,
+              "parallelism" => 4,
+              "max_batch_size" => 4,
+              "sample_count" => 2,
+              "confidence" => "high"
+            },
+            "values" => [
+              { "assigned_value" => 2, "success_rate" => 0.8, "avg_duration_seconds" => 150, "sample_count" => 10, "avg_cost_cents" => 100.0 }
+            ]
+          )
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(2)
+        expect(result.parallelism_level).to eq(2)
+        expect(result.reason).to include("experiment leading value=2")
+      end
+
       it "ignores allocator decisions from non-parallelism dimensions" do
         summaries = [
           {
@@ -626,6 +651,7 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         "requested_agent_count" => 4,
         "parallelism" => 2,
         "max_batch_size" => 2,
+        "sample_count" => 6,
         "confidence" => "high"
       },
       "values" => [
@@ -641,7 +667,8 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
       "allocator_decision" => parallelism_experiment_summary.fetch("allocator_decision").merge(
         "requested_agent_count" => 4,
         "parallelism" => 4,
-        "max_batch_size" => 4
+        "max_batch_size" => 4,
+        "sample_count" => 2
       )
     )
   end

--- a/spec/services/scaling_observations/analyze_parallelism_spec.rb
+++ b/spec/services/scaling_observations/analyze_parallelism_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe ScalingObservations::AnalyzeParallelism, :no_db do
     expect(result.allocator_decision).to include(
       "requested_agent_count" => 2,
       "max_batch_size" => 2,
+      "sample_count" => 3,
       "reason" => "best_success_rate_before_threshold"
     )
     expect(result.values).to include(
@@ -124,7 +125,8 @@ RSpec.describe ScalingObservations::AnalyzeParallelism, :no_db do
     expect(result.allocator_decision).to include(
       "requested_agent_count" => 4,
       "parallelism" => 2,
-      "max_batch_size" => 2
+      "max_batch_size" => 2,
+      "sample_count" => 3
     )
   end
 

--- a/spec/services/scaling_observations/analyze_parallelism_spec.rb
+++ b/spec/services/scaling_observations/analyze_parallelism_spec.rb
@@ -2,22 +2,20 @@
 
 require "rails_helper"
 
-RSpec.describe ScalingObservations::AnalyzeParallelism do
+RSpec.describe ScalingObservations::AnalyzeParallelism, :no_db do
   describe ".call" do
-    let(:project) { create(:project) }
-
     it "detects diminishing returns and capacity thresholds, then recommends the best safe count" do
-      seed_recommendation_dataset(project)
+      observations = seed_recommendation_dataset
 
-      result = described_class.call(observations: ScalingObservation.where(project: project))
+      result = described_class.call(observations:)
 
       expect_recommendation_result(result)
     end
 
     it "returns insufficient_data until enough samples exist for at least one value" do
-      seed_observations(project, 2, durations: [ 220 ], costs: [ 180 ], observed_parallelism: 2)
+      observations = seed_observations(2, durations: [ 220 ], costs: [ 180 ], observed_parallelism: 2)
 
-      result = described_class.call(observations: ScalingObservation.where(project: project), min_samples: 2)
+      result = described_class.call(observations:, min_samples: 2)
 
       expect(result.status).to eq("insufficient_data")
       expect(result.recommended_agent_count).to be_nil
@@ -32,29 +30,49 @@ RSpec.describe ScalingObservations::AnalyzeParallelism do
     end
 
     it "memoizes an empty recommendation across repeated calls" do
-      seed_observations(project, 4,
+      observations = seed_observations(4,
         durations: [ 205, 200 ],
         costs: [ 340, 335 ],
         launched: [ 3, 3 ],
         blocked: [ 1, 1 ],
         observed_parallelism: 3)
 
-      analyzer = described_class.new(observations: ScalingObservation.where(project: project), min_samples: 2)
+      analyzer = described_class.new(observations:, min_samples: 2)
 
       expect(analyzer.send(:recommendation)).to be_nil
       expect(analyzer.send(:recommendation)).to be_nil
       expect(analyzer.call.status).to eq("collecting")
       expect(analyzer.call.allocator_decision).to be_nil
     end
+
+    it "analyzes planned parallelism independently from total agent count" do
+      observations = seed_parallelism_dataset
+
+      result = described_class.call(observations:)
+
+      expect_parallelism_specific_result(result)
+    end
   end
 
-  def seed_recommendation_dataset(project)
-    seed_observations(project, 1, durations: [ 300, 290, 310 ], costs: [ 100, 95, 105 ])
-    seed_observations(project, 2, durations: [ 200, 190, 210 ], costs: [ 180, 175, 185 ], observed_parallelism: 2)
-    seed_observations(project, 3, durations: [ 180, 178, 182 ], costs: [ 255, 250, 260 ], observed_parallelism: 3)
-    seed_observations(project, 4,
+  def seed_recommendation_dataset
+    seed_observations(1, durations: [ 300, 290, 310 ], costs: [ 100, 95, 105 ]) +
+      seed_observations(2, durations: [ 200, 190, 210 ], costs: [ 180, 175, 185 ], observed_parallelism: 2) +
+      seed_observations(3, durations: [ 180, 178, 182 ], costs: [ 255, 250, 260 ], observed_parallelism: 3) +
+      seed_observations(4,
       durations: [ 175, 178, 182 ],
       costs: [ 340, 335, 345 ],
+      successes: [ true, false, false ],
+      launched: [ 3, 3, 3 ],
+      blocked: [ 1, 1, 1 ],
+      observed_parallelism: 3)
+  end
+
+  def seed_parallelism_dataset
+    seed_parallelism_observations(1, durations: [ 300, 295, 305 ], costs: [ 120, 118, 122 ]) +
+      seed_parallelism_observations(2, durations: [ 200, 198, 202 ], costs: [ 125, 124, 126 ]) +
+      seed_parallelism_observations(4,
+      durations: [ 190, 195, 188 ],
+      costs: [ 150, 152, 148 ],
       successes: [ true, false, false ],
       launched: [ 3, 3, 3 ],
       blocked: [ 1, 1, 1 ],
@@ -85,14 +103,38 @@ RSpec.describe ScalingObservations::AnalyzeParallelism do
     )
   end
 
-  def seed_observations(project, agent_count, durations:, costs:, successes: nil, launched: nil, blocked: nil, observed_parallelism: nil)
-    durations.each_with_index do |duration, index|
+  def expect_parallelism_specific_result(result)
+    expect(result.status).to eq("ready")
+    expect(result.recommended_parallelism).to eq(2)
+    expect(result.recommended_agent_count).to eq(4)
+    expect(result.recommended_max_batch_size).to eq(2)
+    expect(result.diminishing_returns_at).to eq(4)
+    expect(result.threshold_signal_at).to eq(4)
+    expect(result.values).to include(
+      hash_including(
+        "parallelism" => 1,
+        "recommended_agent_count" => 4,
+        "avg_agent_count_planned" => 4.0
+      ),
+      hash_including(
+        "parallelism" => 4,
+        "signals" => include("success_rate_regression")
+      )
+    )
+    expect(result.allocator_decision).to include(
+      "requested_agent_count" => 4,
+      "parallelism" => 2,
+      "max_batch_size" => 2
+    )
+  end
+
+  def seed_observations(agent_count, durations:, costs:, successes: nil, launched: nil, blocked: nil, observed_parallelism: nil)
+    durations.each_with_index.map do |duration, index|
       success = value_at(successes, index, true)
       launched_count = value_at(launched, index, agent_count)
       blocked_count = value_at(blocked, index, 0)
 
-      create(:scaling_observation,
-        project: project,
+      build_observation(
         workflow_id: "wf-#{agent_count}-#{index}",
         agent_count_planned: agent_count,
         agent_count_launched: launched_count,
@@ -107,9 +149,88 @@ RSpec.describe ScalingObservations::AnalyzeParallelism do
     end
   end
 
+  def seed_parallelism_observations(parallelism, durations:, costs:, successes: nil, launched: nil, blocked: nil, observed_parallelism: nil)
+    durations.each_with_index.map do |duration, index|
+      success = value_at(successes, index, true)
+      launched_count = value_at(launched, index, 4)
+      blocked_count = value_at(blocked, index, 0)
+
+      build_observation(
+        workflow_id: "wf-parallelism-#{parallelism}-#{index}",
+        agent_count_planned: 4,
+        agent_count_launched: launched_count,
+        agent_count_succeeded: success ? launched_count : 0,
+        agent_count_failed: success ? 0 : launched_count,
+        agent_count_blocked: blocked_count,
+        parallelism_planned: parallelism,
+        parallelism_observed: observed_parallelism || parallelism,
+        success: success,
+        duration_seconds: duration,
+        total_cost_cents: costs.fetch(index))
+    end
+  end
+
   def value_at(values, index, default)
     return default unless values
 
     values.fetch(index, default)
+  end
+
+  def build_observation(**attributes)
+    observation_class.new(**{
+      workflow_name: "FeatureOrchestrationWorkflow",
+      observation_type: "feature_orchestration",
+      status: "completed",
+      success: true,
+      parallel_execution: true,
+      task_count: 4,
+      dependency_edge_count: 1,
+      parallelizable_group_count: 1,
+      agent_count_planned: 2,
+      agent_count_launched: 2,
+      agent_count_succeeded: 2,
+      agent_count_failed: 0,
+      agent_count_blocked: 0,
+      total_iterations: 3,
+      max_iterations: 2,
+      parallelism_planned: 2,
+      parallelism_observed: 2,
+      batch_count: 1,
+      duration_seconds: 120,
+      total_cost_cents: 100,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      metadata: {}
+    }.merge(attributes))
+  end
+
+  def observation_class
+    Struct.new(
+      :workflow_id,
+      :workflow_name,
+      :observation_type,
+      :status,
+      :success,
+      :parallel_execution,
+      :task_count,
+      :dependency_edge_count,
+      :parallelizable_group_count,
+      :agent_count_planned,
+      :agent_count_launched,
+      :agent_count_succeeded,
+      :agent_count_failed,
+      :agent_count_blocked,
+      :total_iterations,
+      :max_iterations,
+      :parallelism_planned,
+      :parallelism_observed,
+      :batch_count,
+      :duration_seconds,
+      :total_cost_cents,
+      :total_input_tokens,
+      :total_output_tokens,
+      :metadata,
+      keyword_init: true
+    )
   end
 end

--- a/spec/services/scaling_observations/analyze_parallelism_spec.rb
+++ b/spec/services/scaling_observations/analyze_parallelism_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ScalingObservations::AnalyzeParallelism, :no_db do
       expect(result.allocator_decision).to be_nil
       expect(result.values).to contain_exactly(
         hash_including(
-          "agent_count" => 2,
+          "parallelism" => 2,
           "sample_count" => 1,
           "success_rate" => 1.0
         )
@@ -94,11 +94,11 @@ RSpec.describe ScalingObservations::AnalyzeParallelism, :no_db do
     )
     expect(result.values).to include(
       hash_including(
-        "agent_count" => 3,
+        "parallelism" => 3,
         "signals" => include("diminishing_returns")
       ),
       hash_including(
-        "agent_count" => 4,
+        "parallelism" => 4,
         "signals" => include("success_rate_regression", "blocked_capacity", "launch_shortfall")
       )
     )


### PR DESCRIPTION
## Summary

Builds the analysis layer that quantifies how orchestration parallelism affects outcomes and efficiency, so the allocator can make data-driven decisions about parallelism levels and batch sizes instead of relying on agent count as a proxy.

## Changes

- **Analysis service** — `app/services/scaling_observations/analyze_parallelism.rb` now analyzes actual planned parallelism (not agent count) and emits allocator-oriented findings: `recommended_parallelism`, `max_batch_size`, and an agent-count recommendation derived from sampled observations.
- **Allocator integration** — `app/services/scaling/resource_allocator.rb` consumes top-level experiment `allocator_decision` data, so `dimension: "parallelism"` summaries can influence `parallelism_level` without incorrectly rewriting agent count from the experiment value.
- **Specs** — added seeded-dataset coverage in `spec/services/scaling_observations/analyze_parallelism_spec.rb` and allocator reuse cases in `spec/services/scaling/resource_allocator_spec.rb`. Both specs were refactored to use plain Ruby observation objects so they can run without PostgreSQL.

## Design Decisions

- **Planned parallelism over agent count** — agent count conflated capacity with concurrency; analyzing planned parallelism directly gives a cleaner signal for diminishing-returns detection and keeps batch-size recommendations independent of agent provisioning.
- **Allocator decisions scoped by dimension** — surfacing findings as `allocator_decision` keyed by `dimension` lets the allocator apply parallelism guidance without leaking experiment values into unrelated knobs like agent count.
- **DB-less specs** — switching to plain Ruby observation objects keeps the analysis specs fast and runnable in environments without PostgreSQL, matching the pure-computation nature of the service.

## Operational Notes

- No migrations or infrastructure changes. The allocator change is backward compatible with experiments that do not emit `allocator_decision`.

---

Closes #1815