### PR TITLE
Fix #200001667: [Security] CodeQL: Sensitive data read from GET request (medium) — code-scanning-alert-1667

### DIFF
--- a/app/controllers/api/mcp_controller.rb
+++ b/app/controllers/api/mcp_controller.rb
@@ -76,10 +76,8 @@ module Api
     end
 
     def extract_session_token
-      # Check header first, then query param
       request.headers["X-Session-Token"].presence ||
-        request.headers["Authorization"]&.delete_prefix("Bearer ")&.presence ||
-        params[:session_token]
+        request.headers["Authorization"]&.delete_prefix("Bearer ")&.presence
     end
 
     def parse_request_body


### PR DESCRIPTION
## Summary

Removes the `params[:session_token]` query parameter fallback from `extract_session_token` to resolve CodeQL alert #1667 (rb/sensitive-get-query). Session tokens in GET query strings leak through server access logs, browser history, and HTTP Referer headers, so they must only be transmitted via request headers.

## Changes

- **Controller**: Drop the `params[:session_token]` fallback in `extract_session_token`; session tokens are now accepted exclusively from `X-Session-Token` or `Authorization: Bearer` headers.

## Design Decisions

- **No deprecation window**: Existing tests and clients already use header-based authentication, so the query-param path is dead code in practice. Removing it outright avoids leaving a vulnerable fallback active during a soft-deprecation period.
- **Header-only is the standard**: This aligns with the broader convention that bearer-style credentials should never appear in URLs, which are routinely captured by logging and observability infrastructure.

---

Closes #200001667