### PR TITLE
fix(auto-merge): evaluate all Dependabot PRs instead of only the first

### DIFF
--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -32,55 +32,95 @@ class DependabotAutoMergeJob < ApplicationJob
 
     client = project.github_token.client
 
-    dependabot_pr = find_dependabot_pr(client, project, pr_number)
-    return unless dependabot_pr
+    if pr_number
+      evaluate_single_pr(client, project, pr_number)
+    else
+      evaluate_all_prs(client, project)
+    end
+  end
 
-    pr_num = dependabot_pr.respond_to?(:number) ? dependabot_pr.number : dependabot_pr[:number]
+  private
 
-    unless mergeable?(dependabot_pr)
+  def evaluate_single_pr(client, project, pr_number)
+    pr_data = fetch_pr(client, project, pr_number)
+    return unless pr_data
+
+    return if skip_unmergeable?(client, project, pr_data)
+
+    merge_dependabot_pr(client, project, pr_data)
+  end
+
+  def evaluate_all_prs(client, project)
+    candidates = find_dependabot_candidates(client, project)
+    return if candidates.empty?
+
+    candidates.each do |pr_summary|
+      pr_num = pr_number_from(pr_summary)
+      pr_data = fetch_pr(client, project, pr_num)
+      next unless pr_data
+
+      next if skip_unmergeable?(client, project, pr_data)
+
+      merged = merge_dependabot_pr(client, project, pr_data)
+      break if merged
+    end
+  end
+
+  def pr_number_from(pr_data)
+    pr_data.respond_to?(:number) ? pr_data.number : pr_data[:number]
+  end
+
+  def skip_unmergeable?(client, project, pr_data)
+    pr_num = pr_number_from(pr_data)
+
+    unless mergeable?(pr_data)
       Rails.logger.info(
         message: "dependabot_auto_merge.skipped",
         project_id: project.id,
         pr_number: pr_num,
         reason: "not_mergeable"
       )
-      return
+      return true
     end
 
-    unless all_checks_green?(client, project, dependabot_pr)
+    unless all_checks_green?(client, project, pr_data)
       Rails.logger.info(
         message: "dependabot_auto_merge.skipped",
         project_id: project.id,
         pr_number: pr_num,
         reason: "checks_not_green"
       )
-      return
+      return true
     end
 
-    merge_dependabot_pr(client, project, dependabot_pr)
+    false
   end
 
-  private
+  def fetch_pr(client, project, pr_number)
+    pr_data = client.pull_request(project.full_name, pr_number)
+    return nil unless pr_data && dependabot_pr?(pr_data) && !merged?(pr_data)
 
-  def find_dependabot_pr(client, project, pr_number)
-    if pr_number
-      pr_data = client.pull_request(project.full_name, pr_number)
-      return pr_data if pr_data && dependabot_pr?(pr_data) && !merged?(pr_data)
-      return nil
-    end
+    pr_data
+  rescue GithubClient::Error => e
+    Rails.logger.warn(
+      message: "dependabot_auto_merge.fetch_pr_failed",
+      project_id: project.id,
+      pr_number: pr_number,
+      error: e.message
+    )
+    nil
+  end
 
+  def find_dependabot_candidates(client, project)
     prs = client.pull_requests(project.full_name, state: "open")
-    match = prs.find { |pr| dependabot_pr?(pr) && !merged?(pr) }
-    return nil unless match
-
-    client.pull_request(project.full_name, match.number)
+    prs.select { |pr| dependabot_pr?(pr) && !merged?(pr) }
   rescue GithubClient::Error => e
     Rails.logger.warn(
       message: "dependabot_auto_merge.find_pr_failed",
       project_id: project.id,
       error: e.message
     )
-    nil
+    []
   end
 
   def dependabot_pr?(pr_data)
@@ -101,7 +141,7 @@ class DependabotAutoMergeJob < ApplicationJob
   end
 
   def merge_dependabot_pr(client, project, pr_data)
-    pr_number = pr_data.respond_to?(:number) ? pr_data.number : pr_data[:number]
+    pr_number = pr_number_from(pr_data)
 
     client.merge_pull_request(
       project.full_name, pr_number,
@@ -116,16 +156,18 @@ class DependabotAutoMergeJob < ApplicationJob
       project_id: project.id,
       pr_number: pr_number
     )
+    true
   rescue GithubClient::ApiError => e
     raise unless EXPECTED_MERGE_STATUSES.include?(e.status)
 
     Rails.logger.warn(
       message: "dependabot_auto_merge.merge_failed_expected",
       project_id: project.id,
-      pr_number: pr_data.respond_to?(:number) ? pr_data.number : pr_data[:number],
+      pr_number: pr_number_from(pr_data),
       status: e.status,
       error: e.message
     )
+    false
   end
 
   def add_label(client, project, pr_number)

--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -163,7 +163,7 @@ class DependabotAutoMergeJob < ApplicationJob
     Rails.logger.warn(
       message: "dependabot_auto_merge.merge_failed_expected",
       project_id: project.id,
-      pr_number: pr_number_from(pr_data),
+      pr_number: pr_number,
       status: e.status,
       error: e.message
     )

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe DependabotAutoMergeJob do
         merged_at: nil,
         mergeable: true
       )
-      allow(client).to receive_messages(pull_requests: [ human_pr ], pull_request: human_pr)
+      allow(client).to receive(:pull_requests).and_return([ human_pr ])
 
       described_class.perform_now(project.id)
 
@@ -111,11 +111,72 @@ RSpec.describe DependabotAutoMergeJob do
         merged_at: Time.current,
         mergeable: true
       )
-      allow(client).to receive_messages(pull_requests: [ merged_pr ], pull_request: merged_pr)
+      allow(client).to receive(:pull_requests).and_return([ merged_pr ])
 
       described_class.perform_now(project.id)
 
       expect(client).not_to have_received(:merge_pull_request)
+    end
+
+    it "merges the second PR when the first has failing CI" do
+      failing_pr = OpenStruct.new(
+        number: 99,
+        title: "Bump a from 1.0 to 2.0",
+        user: OpenStruct.new(login: "dependabot[bot]"),
+        head: OpenStruct.new(sha: "fail123"),
+        merged_at: nil,
+        mergeable: true
+      )
+      allow(client).to receive(:pull_requests).and_return([ failing_pr, dependabot_pr ])
+      allow(client).to receive(:pull_request).and_return(failing_pr, dependabot_pr)
+      allow(client).to receive(:check_runs_for_ref) do |_repo, sha|
+        sha == "fail123" ? [ { conclusion: "failure", name: "ci" } ] : green_checks
+      end
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:merge_pull_request).with(
+        project.full_name, 42, merge_method: project.merge_method
+      )
+    end
+
+    it "stops after the first successful merge" do
+      green_pr_2 = OpenStruct.new(
+        number: 100,
+        title: "Bump b from 2.0 to 3.0",
+        user: OpenStruct.new(login: "dependabot[bot]"),
+        head: OpenStruct.new(sha: "green456"),
+        merged_at: nil,
+        mergeable: true
+      )
+      allow(client).to receive(:pull_requests).and_return([ dependabot_pr, green_pr_2 ])
+      allow(client).to receive(:pull_request).and_return(dependabot_pr, green_pr_2)
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:merge_pull_request).once
+      expect(client).to have_received(:merge_pull_request).with(
+        project.full_name, 42, merge_method: project.merge_method
+      )
+    end
+
+    it "fetches full PR lazily and skips unneeded fetches after merge" do
+      unmergeable_pr = OpenStruct.new(
+        number: 50,
+        title: "Bump c from 3.0 to 4.0",
+        user: OpenStruct.new(login: "dependabot[bot]"),
+        head: OpenStruct.new(sha: "conflict789"),
+        merged_at: nil,
+        mergeable: false
+      )
+      allow(client).to receive(:pull_requests).and_return([ unmergeable_pr, dependabot_pr ])
+      allow(client).to receive(:pull_request).and_return(unmergeable_pr, dependabot_pr)
+
+      described_class.perform_now(project.id)
+
+      expect(client).to have_received(:pull_request).with(project.full_name, 50)
+      expect(client).to have_received(:pull_request).with(project.full_name, 42)
+      expect(client).to have_received(:merge_pull_request).once
     end
 
     it "skips when no Dependabot PRs are found" do


### PR DESCRIPTION
## Summary

- **Bug**: `DependabotAutoMergeJob`'s poll-loop path used `Array#find` to locate only the first open Dependabot PR. When that PR had failing CI, the job skipped it and returned — never trying other Dependabot PRs with green CI. A single failing Dependabot PR could starve all others indefinitely.
- **Root cause**: Discovered via live diagnostics on HuntHelper projects — PR #3687 had a failed "Code Audit" workflow and blocked PRs #3662 and #3661 (both all-green) from ever being evaluated.
- **Fix**: Iterate all Dependabot PR candidates per poll cycle, fetching full PR data lazily, and stop after the first successful merge to avoid stale mergeability.

## Changes

- `find_dependabot_pr` (single-PR fetch) replaced with `find_dependabot_candidates` (list-only, 1 API call) + lazy `fetch_pr` per candidate
- `merge_dependabot_pr` returns `true`/`false` so the loop can `break` after a successful merge
- Extracted `evaluate_single_pr` / `evaluate_all_prs` / `skip_unmergeable?` for clarity
- 3 new test cases: skipping past failing CI to merge a green PR, break-after-merge, lazy fetch behavior

## Test plan

- [x] All 33 existing + new specs pass
- [x] `bin/rubocop` clean
- [ ] Monitor GoodJob logs for `dependabot_auto_merge.merged` on HuntHelper projects after deploy