### PR TITLE
fix(knowledge): skip routes collector on database.yml parse errors

### DIFF
--- a/app/services/knowledge/collectors/routes_collector.rb
+++ b/app/services/knowledge/collectors/routes_collector.rb
@@ -34,7 +34,8 @@ module Knowledge
         /database adapter.*(?:not found|not loaded)/i,
         /Error loading the .+ Active Record adapter/,
         /(?:Active Record adapter|database adapter).*is not part of the bundle/m,
-        /no such table/i
+        /no such table/i,
+        /Cannot load database configuration:/i
       ].freeze
 
       def collect

--- a/spec/services/knowledge/collectors/routes_collector_spec.rb
+++ b/spec/services/knowledge/collectors/routes_collector_spec.rb
@@ -389,6 +389,20 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
         end
       end
 
+      it "skips on database.yml YAML syntax errors" do
+        allow(command_collector).to receive(:run_command)
+          .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
+          .and_raise(
+            Knowledge::ContainerizedRunner::ContainerError,
+            "Command failed (exit 1): /tmp/bundle/ruby/3.4.0/gems/activesupport-8.1.3/lib/active_support/configuration_file.rb:38:in 'ActiveSupport::ConfigurationFile#parse': Cannot load database configuration: (RuntimeError) YAML syntax error occurred while parsing /workspace/config/database.yml. Please note that YAML must be consistently indented using spaces. Tabs are not allowed."
+          )
+
+        expect { command_collector.collect }.to raise_error do |error|
+          expect(error).to be_a(Knowledge::SkipCollector)
+          expect(error.preserve_existing_artifacts?).to be(true)
+        end
+      end
+
       it "skips when the sqlite3 adapter gem is missing from the bundle" do
         allow(command_collector).to receive(:run_command)
           .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))


### PR DESCRIPTION
## Summary

- When a target repo's `config/database.yml` has YAML syntax errors, `bin/rails routes` fails to boot even though `DATABASE_URL` is set — Rails still parses `database.yml` during boot before using `DATABASE_URL` for the connection
- Added `Cannot load database configuration:` to the routes collector's database error skip patterns so the collector gracefully preserves existing route artifacts instead of failing the entire knowledge collection run
- Added test covering the exact error message from the field report