### PR TITLE
fix(knowledge): stub database.yml to prevent routes collector boot failures

### DIFF
--- a/app/services/knowledge/containerized_runner.rb
+++ b/app/services/knowledge/containerized_runner.rb
@@ -331,8 +331,8 @@ module Knowledge
       exec_setup!(
         [
           "sh", "-c",
-          "if [ -f #{workspace}/config/database.yml ]; then " \
-          "cat > #{workspace}/config/database.yml <<'STUB'\n#{stub_content}\nSTUB\nfi"
+          "if [ -f '#{workspace}/config/database.yml' ]; then " \
+          "cat > '#{workspace}/config/database.yml' <<'STUB'\n#{stub_content}\nSTUB\nfi"
         ],
         "write database.yml stub"
       )

--- a/app/services/knowledge/containerized_runner.rb
+++ b/app/services/knowledge/containerized_runner.rb
@@ -331,7 +331,7 @@ module Knowledge
       exec_setup!(
         [
           "sh", "-c",
-          "if [ -f '#{workspace}/config/database.yml' ]; then " \
+          "if [ -f '#{workspace}/config/database.yml' ] && [ ! -L '#{workspace}/config/database.yml' ]; then " \
           "cat > '#{workspace}/config/database.yml' <<'STUB'\n#{stub_content}\nSTUB\nfi"
         ],
         "write database.yml stub"

--- a/app/services/knowledge/containerized_runner.rb
+++ b/app/services/knowledge/containerized_runner.rb
@@ -52,6 +52,26 @@ module Knowledge
     PROJECT_NAME_PATTERN = %r{\A[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+\z}
     ALLOWED_NETWORK_MODES = %w[none bridge].freeze
 
+    # Minimal database.yml stub written over the repo's copy so the routes
+    # collector can boot the target Rails app regardless of the original
+    # file's content.  Rails parses config/database.yml during boot even
+    # when DATABASE_URL is set, so a broken YAML file (invalid syntax, ERB
+    # referencing undefined variables, tabs instead of spaces, etc.)
+    # prevents `bin/rails routes` from running.  The stub provides valid
+    # YAML for all standard environments; DATABASE_URL=sqlite3::memory:
+    # overrides the actual connection at runtime.
+    DATABASE_YML_STUB = <<~YAML.freeze
+      test:
+        adapter: sqlite3
+        database: ":memory:"
+      development:
+        adapter: sqlite3
+        database: ":memory:"
+      production:
+        adapter: sqlite3
+        database: ":memory:"
+    YAML
+
     attr_reader :project, :commit_sha, :branch, :committed_at, :options, :host_repo_dir
 
     def initialize(project:, commit_sha:, branch: "main", committed_at: nil, options: {})
@@ -268,6 +288,14 @@ module Knowledge
       # CAP_DAC_OVERRIDE so even root cannot create new entries there.
       exec_setup!([ "mkdir", "-p", *writable_paths ], "create Rails writable directories")
 
+      # Overwrite config/database.yml with a minimal stub so the routes
+      # collector can boot the target Rails app regardless of the original
+      # file's content.  Must happen BEFORE chmod — after `chmod -R a=rX`,
+      # CapDrop: ALL strips CAP_DAC_OVERRIDE so even root cannot write.
+      # Only overwrites when the repo already has a config/database.yml;
+      # non-Rails repos are unaffected.
+      write_database_yml_stub!(workspace)
+
       # Set read + execute (for directories) for all users so the agent can
       # read the codebase for analysis. Collectors should write only to
       # the size-limited tmpfs locations (/tmp, /home/agent/.cache) and
@@ -296,6 +324,18 @@ module Knowledge
       return if status.to_i.zero?
 
       raise ContainerError, "Failed to #{failing_action} (exit #{status})"
+    end
+
+    def write_database_yml_stub!(workspace)
+      stub_content = DATABASE_YML_STUB.chomp
+      exec_setup!(
+        [
+          "sh", "-c",
+          "if [ -f #{workspace}/config/database.yml ]; then " \
+          "cat > #{workspace}/config/database.yml <<'STUB'\n#{stub_content}\nSTUB\nfi"
+        ],
+        "write database.yml stub"
+      )
     end
 
     def stream_repo_tar_to_container!

--- a/spec/services/knowledge/containerized_runner_spec.rb
+++ b/spec/services/knowledge/containerized_runner_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
       described_class.new(project: project, commit_sha: commit_sha).run
 
       expect(mock_container).to have_received(:exec).with(
-        [ "sh", "-c", a_string_including("if [ -f /workspace/config/database.yml ]") ],
+        [ "sh", "-c", a_string_including("if [ -f '/workspace/config/database.yml' ]") ],
         user: "root"
       )
     end

--- a/spec/services/knowledge/containerized_runner_spec.rb
+++ b/spec/services/knowledge/containerized_runner_spec.rb
@@ -296,11 +296,11 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
       )
     end
 
-    it "guards stub write behind file-existence check for non-Rails repos" do
+    it "guards stub write behind file-existence and symlink checks" do
       described_class.new(project: project, commit_sha: commit_sha).run
 
       expect(mock_container).to have_received(:exec).with(
-        [ "sh", "-c", a_string_including("if [ -f '/workspace/config/database.yml' ]") ],
+        [ "sh", "-c", a_string_including("if [ -f '/workspace/config/database.yml' ] && [ ! -L '/workspace/config/database.yml' ]") ],
         user: "root"
       )
     end

--- a/spec/services/knowledge/containerized_runner_spec.rb
+++ b/spec/services/knowledge/containerized_runner_spec.rb
@@ -81,6 +81,20 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
     end
   end
 
+  describe "DATABASE_YML_STUB" do
+    it "is valid YAML" do
+      expect { YAML.safe_load(described_class::DATABASE_YML_STUB) }.not_to raise_error
+    end
+
+    it "provides sqlite3 in-memory config for all standard environments" do
+      config = YAML.safe_load(described_class::DATABASE_YML_STUB)
+      expect(config.keys).to contain_exactly("test", "development", "production")
+      config.each_value do |env_config|
+        expect(env_config).to eq({ "adapter" => "sqlite3", "database" => ":memory:" })
+      end
+    end
+  end
+
   describe "#run" do
     let(:runner_result) do
       {
@@ -271,6 +285,51 @@ RSpec.describe Knowledge::ContainerizedRunner, :no_db do
         Knowledge::ContainerizedRunner::ContainerError,
         /Failed to set workspace permissions/
       )
+    end
+
+    it "writes database.yml stub before locking workspace permissions" do
+      described_class.new(project: project, commit_sha: commit_sha).run
+
+      expect(mock_container).to have_received(:exec).with(
+        [ "sh", "-c", a_string_including("config/database.yml") ],
+        user: "root"
+      )
+    end
+
+    it "guards stub write behind file-existence check for non-Rails repos" do
+      described_class.new(project: project, commit_sha: commit_sha).run
+
+      expect(mock_container).to have_received(:exec).with(
+        [ "sh", "-c", a_string_including("if [ -f /workspace/config/database.yml ]") ],
+        user: "root"
+      )
+    end
+
+    it "raises ContainerError when database.yml stub write fails" do
+      allow(mock_container).to receive(:exec)
+        .with([ "sh", "-c", a_string_including("database.yml") ], user: "root")
+        .and_return([ [], [ "write error" ], 1 ])
+
+      expect {
+        described_class.new(project: project, commit_sha: commit_sha).run
+      }.to raise_error(
+        Knowledge::ContainerizedRunner::ContainerError,
+        /Failed to write database.yml stub/
+      )
+    end
+
+    it "writes database.yml stub between mkdir and chmod" do
+      described_class.new(project: project, commit_sha: commit_sha).run
+
+      expect(mock_container).to have_received(:exec).with(
+        [ "mkdir", "-p", "/workspace/log", "/workspace/tmp" ], user: "root"
+      ).ordered
+      expect(mock_container).to have_received(:exec).with(
+        [ "sh", "-c", a_string_including("database.yml") ], user: "root"
+      ).ordered
+      expect(mock_container).to have_received(:exec).with(
+        [ "chmod", "-R", "a=rX", "/workspace" ], user: "root"
+      ).ordered
     end
 
     it "wraps Docker errors from seed_workspace! as ContainerError" do


### PR DESCRIPTION
## Summary

- Write a minimal valid `database.yml` stub during container `seed_workspace!`, before the chmod lockdown makes the workspace read-only
- Rails parses `config/database.yml` during boot even when `DATABASE_URL` is set, so any broken YAML (invalid syntax, ERB referencing undefined variables, tabs instead of spaces) prevents `bin/rails routes` from running
- The stub provides valid YAML for all standard Rails environments (`test`, `development`, `production`) while `DATABASE_URL=sqlite3::memory:` overrides the actual connection at runtime
- Only overwrites when the repo already has a `config/database.yml`; non-Rails repos are unaffected
- Prevents the entire class of database config errors at the source, rather than catching each error type individually via message-pattern matching

## Test plan

- [x] 56 containerized runner specs pass (including 5 new: stub content validation, write ordering, file-existence guard, failure handling)
- [x] 48 routes collector specs pass (unchanged — stub is transparent to the collector)
- [x] RuboCop clean

Closes #1962 (supersedes — that PR added error-message matching; this PR prevents the error entirely)