### PR TITLE
Fix #1914: Agent runs index table has duplicate Provider column

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -340,7 +340,10 @@ module ApplicationHelper
     text = agent_run_goal_text(run)
     return tag.span("-", class: "text-gray-400") if text.blank?
 
-    tag.span(text, class: "min-w-0 block truncate", title: text)
+    inner = tag.span(text, class: "min-w-0 block truncate", title: text)
+    tooltip_id = "goal_#{run.id || run.object_id}"
+
+    mobile_tooltip_wrapper(inner, text, tooltip_id, aria_label: "Show goal details")
   end
 
   def agent_run_goal_text(run)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -328,14 +328,14 @@ module ApplicationHelper
     mobile_tooltip_wrapper(inner, context[:tooltip], tooltip_id, aria_label: "Show context details")
   end
 
+  AGENT_RUN_GOAL_LABEL_OVERRIDES = {
+    "create_pr" => "PR Creation",
+    "create_issue" => "Issue Creation",
+    "review" => "Code Review"
+  }.freeze
+
   AGENT_RUN_GOAL_LABELS = AgentRun::GOALS.index_with do |goal|
-    {
-      "create_pr" => "PR Creation",
-      "create_issue" => "Issue Creation",
-      "review" => "Code Review",
-      "enhance_issue" => "Enhance Issue",
-      "analyze_issue" => "Analyze Issue"
-    }.fetch(goal, goal.to_s.titleize)
+    AGENT_RUN_GOAL_LABEL_OVERRIDES.fetch(goal, goal.to_s.titleize)
   end.freeze
 
   def agent_run_goal_display(run)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -328,23 +328,23 @@ module ApplicationHelper
     mobile_tooltip_wrapper(inner, context[:tooltip], tooltip_id, aria_label: "Show context details")
   end
 
+  AGENT_RUN_GOAL_LABELS = {
+    "create_pr" => "PR Creation",
+    "create_issue" => "Issue Creation",
+    "review" => "Code Review",
+    "enhance_issue" => "Enhance Issue",
+    "analyze_issue" => "Analyze Issue"
+  }.freeze
+
   def agent_run_goal_display(run)
     text = agent_run_goal_text(run)
     return tag.span("-", class: "text-gray-400") if text.blank?
 
-    inner = tag.span(text, class: "min-w-0 block truncate", title: text)
-    mobile_tooltip_wrapper(inner, text, "goal_#{run.id}", aria_label: "Show goal")
+    tag.span(text, class: "min-w-0 block truncate", title: text)
   end
 
   def agent_run_goal_text(run)
-    return run.issue&.title if run.issue&.title.present?
-
-    if run.source_pull_request_number.present?
-      prefix = run.review_goal? ? "Review PR" : "PR"
-      return "#{prefix} ##{run.source_pull_request_number}"
-    end
-
-    redacted_goal_text(run.custom_prompt)
+    AGENT_RUN_GOAL_LABELS.fetch(run.goal, run.goal.to_s.titleize)
   end
 
   # Returns the best "back" URL: checks params[:return_to] first, then

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -328,13 +328,15 @@ module ApplicationHelper
     mobile_tooltip_wrapper(inner, context[:tooltip], tooltip_id, aria_label: "Show context details")
   end
 
-  AGENT_RUN_GOAL_LABELS = {
-    "create_pr" => "PR Creation",
-    "create_issue" => "Issue Creation",
-    "review" => "Code Review",
-    "enhance_issue" => "Enhance Issue",
-    "analyze_issue" => "Analyze Issue"
-  }.freeze
+  AGENT_RUN_GOAL_LABELS = AgentRun::GOALS.index_with do |goal|
+    {
+      "create_pr" => "PR Creation",
+      "create_issue" => "Issue Creation",
+      "review" => "Code Review",
+      "enhance_issue" => "Enhance Issue",
+      "analyze_issue" => "Analyze Issue"
+    }.fetch(goal, goal.to_s.titleize)
+  end.freeze
 
   def agent_run_goal_display(run)
     text = agent_run_goal_text(run)

--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -28,9 +28,6 @@
                   Context
                 </th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                  Provider
-                </th>
-                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
                   <%= sort_link_to "Duration", :duration_seconds, q %>
                 </th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
@@ -63,9 +60,6 @@
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <%= agent_run_context_display(run) %>
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <%= agent_run_provider_display(run) %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     <% if run.duration_seconds.present? %>

--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -40,7 +40,7 @@
             </thead>
             <tbody class="divide-y divide-gray-200 bg-white">
               <% runs.each do |run| %>
-                <tr>
+                <tr id="<%= dom_id(run) %>">
                   <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
                     <%= agent_run_status_badge(run.status) %>
                   </td>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -6,15 +6,7 @@
     <%= agent_run_priority_badge(agent_run) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <% if agent_run.create_pr_goal? %>
-      PR
-    <% elsif agent_run.create_issue_goal? %>
-      Issue
-    <% elsif agent_run.review_goal? %>
-      Review
-    <% else %>
-      <span class="text-gray-400"><%= agent_run.goal.humanize %></span>
-    <% end %>
+    <%= agent_run_goal_text(agent_run) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
     <% context = agent_run_context(agent_run) %>

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -325,4 +325,29 @@ RSpec.describe ApplicationHelper do
       expect(helper.agent_run_goal_text(run)).to eq("Some New Goal")
     end
   end
+
+  describe "#agent_run_goal_display" do
+    def goal_display_run(id:, goal:)
+      Struct.new(:id, :goal, keyword_init: true).new(id: id, goal: goal)
+    end
+
+    it "renders the goal label with a mobile tooltip wrapper" do
+      run = goal_display_run(id: 42, goal: "create_pr")
+      result = helper.agent_run_goal_display(run)
+
+      expect(result).to include("PR Creation")
+      expect(result).to include('title="PR Creation"')
+      expect(result).to include('data-controller="tooltip"')
+      expect(result).to include('role="tooltip"')
+      expect(result).to include('aria-label="Show goal details"')
+      expect(result).to include('aria-controls="goal_42"')
+    end
+
+    it "titleizes unknown goal values in the rendered label" do
+      run = goal_display_run(id: 7, goal: "some_new_goal")
+      result = helper.agent_run_goal_display(run)
+
+      expect(result).to include("Some New Goal")
+    end
+  end
 end

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -291,49 +291,38 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "#agent_run_goal_text" do
-    def goal_text_run(issue: nil, custom_prompt: nil, review_goal: false, source_pull_request_number: nil)
-      Struct.new(:issue, :custom_prompt, :source_pull_request_number, keyword_init: true) do
-        define_method(:review_goal?) { review_goal }
-      end.new(
-        issue: issue,
-        custom_prompt: custom_prompt,
-        source_pull_request_number: source_pull_request_number
-      )
+    def goal_text_run(goal:)
+      Struct.new(:goal, keyword_init: true).new(goal: goal)
     end
 
-    it "prefers the issue title over custom prompt text" do
-      issue = Struct.new(:title, keyword_init: true).new(title: "Fix flaky webhook retry handling")
-      run = goal_text_run(issue: issue, custom_prompt: "Rendered task instructions")
-
-      expect(helper.agent_run_goal_text(run)).to eq(issue.title)
+    it "returns 'PR Creation' for create_pr goal" do
+      run = goal_text_run(goal: "create_pr")
+      expect(helper.agent_run_goal_text(run)).to eq("PR Creation")
     end
 
-    it "prefers the review pull request label over custom prompt text" do
-      run = goal_text_run(custom_prompt: "Generated review instructions", review_goal: true,
-        source_pull_request_number: 87)
-
-      expect(helper.agent_run_goal_text(run)).to eq("Review PR #87")
+    it "returns 'Issue Creation' for create_issue goal" do
+      run = goal_text_run(goal: "create_issue")
+      expect(helper.agent_run_goal_text(run)).to eq("Issue Creation")
     end
 
-    it "shows PR label for non-review runs with a source pull request number" do
-      run = goal_text_run(custom_prompt: "Generated instructions", review_goal: false,
-        source_pull_request_number: 42)
-
-      expect(helper.agent_run_goal_text(run)).to eq("PR #42")
+    it "returns 'Code Review' for review goal" do
+      run = goal_text_run(goal: "review")
+      expect(helper.agent_run_goal_text(run)).to eq("Code Review")
     end
 
-    it "falls back to redacted custom prompt text" do
-      token = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
-      run = goal_text_run(custom_prompt: "Investigate GITHUB_TOKEN=#{token}")
-
-      expect(helper.agent_run_goal_text(run)).to include("[REDACTED:github_token]")
-      expect(helper.agent_run_goal_text(run)).not_to include(token)
+    it "returns 'Enhance Issue' for enhance_issue goal" do
+      run = goal_text_run(goal: "enhance_issue")
+      expect(helper.agent_run_goal_text(run)).to eq("Enhance Issue")
     end
 
-    it "returns nil when no goal text is available" do
-      run = goal_text_run
+    it "returns 'Analyze Issue' for analyze_issue goal" do
+      run = goal_text_run(goal: "analyze_issue")
+      expect(helper.agent_run_goal_text(run)).to eq("Analyze Issue")
+    end
 
-      expect(helper.agent_run_goal_text(run)).to be_nil
+    it "titleizes unknown goal values" do
+      run = goal_text_run(goal: "some_new_goal")
+      expect(helper.agent_run_goal_text(run)).to eq("Some New Goal")
     end
   end
 end

--- a/spec/helpers/application_helper_context_display_spec.rb
+++ b/spec/helpers/application_helper_context_display_spec.rb
@@ -324,6 +324,10 @@ RSpec.describe ApplicationHelper do
       run = goal_text_run(goal: "some_new_goal")
       expect(helper.agent_run_goal_text(run)).to eq("Some New Goal")
     end
+
+    it "covers every goal in AgentRun::GOALS" do
+      expect(ApplicationHelper::AGENT_RUN_GOAL_LABELS.keys).to match_array(AgentRun::GOALS)
+    end
   end
 
   describe "#agent_run_goal_display" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include(project.name)
       end
 
-      it "shows each run goal in the index table" do
-        goal_text = "Implement multi-step OAuth token refresh handling for stale sessions"
-        run = create(:agent_run, :with_custom_prompt, project: project, custom_prompt: goal_text)
+      it "shows each run goal type label in the index table with a mobile tooltip wrapper" do
+        run = create(:agent_run, :with_custom_prompt, project: project, goal: "create_pr",
+          custom_prompt: "Implement multi-step OAuth token refresh handling for stale sessions")
 
         get agent_runs_path
 
@@ -42,10 +42,14 @@ RSpec.describe "AgentRuns" do
         expect(goal_column_index(document)).not_to be_nil
 
         goal_cell = goal_cell_for_run(document, run)
+        tooltip_wrapper = goal_cell.at_css('[data-controller="tooltip"]')
+        truncated_label = goal_cell.at_css("span.block.truncate")
 
-        expect(goal_cell.text).to include(goal_text)
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq(goal_text)
-        expect(goal_cell.at_css('[data-controller="tooltip"]')).to be_present
+        expect(goal_cell.text).to include("PR Creation")
+        expect(truncated_label["title"]).to eq("PR Creation")
+        expect(tooltip_wrapper).to be_present
+        expect(tooltip_wrapper.at_css('button[aria-label="Show goal details"]')).to be_present
+        expect(tooltip_wrapper.at_css('span[role="tooltip"]')["id"]).to eq("goal_#{run.id}")
       end
 
       it "aligns the Provider header with provider values in each row" do
@@ -114,83 +118,67 @@ RSpec.describe "AgentRuns" do
         expect(provider_cell.text.squish).to eq(Provider.display_name_for("claude"))
       end
 
-      it "prefers the issue title over custom prompt text" do
+      it "shows distinct goal and context values for create_pr runs" do
         issue = create(:issue, project: project, title: "Fix flaky webhook retry handling")
         run = create(:agent_run, :with_custom_prompt, project: project, issue: issue,
           custom_prompt: "Rendered task instructions that should not appear")
 
         get agent_runs_path
 
-        goal_cell = goal_cell_for_run(parsed_html, run)
+        document = parsed_html
+        goal_cell = goal_cell_for_run(document, run)
+        context_cell = cell_for_run(document, run, "Context")
 
-        expect(goal_cell.text).to include(issue.title)
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq(issue.title)
+        expect(goal_cell.text).to include("PR Creation")
+        expect(goal_cell.text).not_to include(issue.title)
+        expect(goal_cell.text).not_to include(run.custom_prompt)
+        expect(context_cell.text).to include("Issue ##{issue.github_number}")
       end
 
-      it "prefers review pull request text over custom prompt text" do
+      it "shows review goal labels separately from review context" do
         run = create(:agent_run, :review_goal, :with_custom_prompt, project: project, issue: nil,
           custom_prompt: "Generated review instructions that should not appear",
           source_pull_request_number: 87)
 
         get agent_runs_path
 
-        goal_cell = goal_cell_for_run(parsed_html, run)
+        document = parsed_html
+        goal_cell = goal_cell_for_run(document, run)
+        context_cell = cell_for_run(document, run, "Context")
 
-        expect(goal_cell.text).to include("Review PR #87")
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq("Review PR #87")
+        expect(goal_cell.text).to include("Code Review")
+        expect(goal_cell.text).not_to include("PR #87")
+        expect(goal_cell.text).not_to include(run.custom_prompt)
+        expect(context_cell.text).to include("PR #87")
       end
 
-      it "shows PR label for create_pr runs targeting an existing pull request" do
-        run = create(:agent_run, :with_custom_prompt, project: project, goal: "create_pr", issue: nil,
-          custom_prompt: "Generated instructions that should not appear",
-          source_pull_request_number: 55)
-
-        get agent_runs_path
-
-        goal_cell = goal_cell_for_run(parsed_html, run)
-
-        expect(goal_cell.text).to include("PR #55")
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq("PR #55")
-      end
-
-      it "falls back to custom prompt text when no issue or review goal text is available" do
+      it "shows custom prompt context separately from the goal label" do
         goal_text = "Investigate the flaky deploy status check"
-        run = create(:agent_run, :with_custom_prompt, project: project, issue: nil, custom_prompt: goal_text)
+        run = create(:agent_run, :with_custom_prompt, project: project, goal: "create_pr",
+          issue: nil, custom_prompt: goal_text)
 
         get agent_runs_path
 
-        goal_cell = goal_cell_for_run(parsed_html, run)
+        document = parsed_html
+        goal_cell = goal_cell_for_run(document, run)
+        context_cell = cell_for_run(document, run, "Context")
 
-        expect(goal_cell.text).to include(goal_text)
-        expect(goal_cell.at_css("span.block.truncate")["title"]).to eq(goal_text)
+        expect(goal_cell.text).to include("PR Creation")
+        expect(goal_cell.text).not_to include(goal_text)
+        expect(context_cell.text).to include(goal_text)
+        expect(context_cell.at_css("span.block.truncate")["title"]).to eq(goal_text)
+        expect(context_cell.at_css('[data-controller="tooltip"]')).to be_present
       end
 
-      it "shows a placeholder when a run has no goal text to display" do
+      it "shows a titleized fallback label for unexpected goal values" do
         run = create(:agent_run, :with_custom_prompt, project: project, custom_prompt: "Temporary goal")
-        run.update_columns(custom_prompt: nil, issue_id: nil)
+        run.update_columns(goal: "some_new_goal")
 
         get agent_runs_path
 
         goal_cell = goal_cell_for_run(parsed_html, run)
 
-        expect(goal_cell.text.squish).to eq("-")
-        expect(goal_cell.at_css("span")["class"]).to include("text-gray-400")
-      end
-
-      it "redacts secrets from custom goal text in the table cell and tooltip" do
-        token = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
-        run = create(:agent_run, :with_custom_prompt, project: project,
-          custom_prompt: "Investigate deploy failure with GITHUB_TOKEN=#{token}")
-
-        get agent_runs_path
-
-        goal_cell = goal_cell_for_run(parsed_html, run)
-        truncated_span = goal_cell.at_css("span.block.truncate")
-
-        expect(truncated_span.text).to include("[REDACTED:github_token]")
-        expect(truncated_span.text).not_to include(token)
-        expect(truncated_span["title"]).to include("[REDACTED:github_token]")
-        expect(truncated_span["title"]).not_to include(token)
+        expect(goal_cell.text).to include("Some New Goal")
       end
 
       it "shows the provider column with the resolved provider name" do

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -70,6 +70,20 @@ RSpec.describe "AgentRuns" do
         expect(provider_cell.text.squish).to eq(configured_provider.display_name)
       end
 
+      it "renders exactly one Provider column" do
+        run = create(:agent_run, :with_custom_prompt, project: project, goal: "create_pr")
+
+        get agent_runs_path
+
+        document = parsed_html
+        provider_headers = document.css("thead th").select { |header| header.text.squish == "Provider" }
+        provider_cells = document.css("tbody tr##{ActionView::RecordIdentifier.dom_id(run)} td")
+          .select { |cell| cell.text.squish == Provider.display_name_for(run.effective_provider) }
+
+        expect(provider_headers.size).to eq(1)
+        expect(provider_cells.size).to eq(1)
+      end
+
       it "shows a deleted-provider fallback label in the Provider column" do
         run = create(:agent_run, :with_custom_prompt, project: project, provider: nil,
           final_provider: "provider:999999")

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe "AgentRuns" do
         expect(goal_cell.text).to include("PR Creation")
         expect(goal_cell.text).not_to include(goal_text)
         expect(context_cell.text).to include(goal_text)
-        expect(context_cell.at_css("span.block.truncate")["title"]).to eq(goal_text)
+        expect(context_cell.at_css("span[title]")["title"]).to eq(goal_text)
         expect(context_cell.at_css('[data-controller="tooltip"]')).to be_present
       end
 

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "AgentRuns" do
       end
 
       it "shows the provider column with the resolved provider name" do
-        provider = create(:provider, user: user, provider_key: "codex")
+        provider = create(:provider, user: project.effective_owner, provider_key: "codex")
         run = create(:agent_run, project: project, provider: provider, final_provider: provider.routing_key)
 
         get agent_runs_path
@@ -216,7 +216,7 @@ RSpec.describe "AgentRuns" do
       end
 
       it "shows the final provider label for legacy fallback runs" do
-        initial_provider = create(:provider, user: user, provider_key: "codex")
+        initial_provider = create(:provider, user: project.effective_owner, provider_key: "codex")
         run = create(:agent_run, project: project, provider: initial_provider, final_provider: "cursor")
 
         get agent_runs_path
@@ -600,7 +600,7 @@ RSpec.describe "AgentRuns" do
       end
 
       it "shows the provider column with the resolved provider name" do
-        provider = create(:provider, user: user, provider_key: "cursor")
+        provider = create(:provider, user: project.effective_owner, provider_key: "cursor")
         run = create(:agent_run, project: project, provider: provider, final_provider: provider.routing_key)
 
         get project_agent_runs_path(project)
@@ -612,7 +612,7 @@ RSpec.describe "AgentRuns" do
       end
 
       it "shows the final provider label for legacy fallback runs" do
-        initial_provider = create(:provider, user: user, provider_key: "codex")
+        initial_provider = create(:provider, user: project.effective_owner, provider_key: "codex")
         run = create(:agent_run, project: project, provider: initial_provider, final_provider: "cursor")
 
         get project_agent_runs_path(project)
@@ -2514,8 +2514,7 @@ RSpec.describe "AgentRuns" do
   end
 
   def row_for_run(document, run)
-    run_path = project_agent_run_path(run.project, run)
-    row = document.at_css(%(a[href="#{run_path}"]))&.ancestors("tr")&.first
+    row = document.at_css(%(tr##{ActionView::RecordIdentifier.dom_id(run)}))
 
     expect(row).to be_present
     row

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -673,16 +673,26 @@ RSpec.describe "Projects" do
         project = create(:project, account: account, github_token: github_token)
         agent_run = create(:agent_run, project: project, status: "completed", goal: "create_pr")
         get project_path(project)
-        expect(response.body).to include(">Goal</th>")
-        expect(response.body).to match(/<tr[^>]*id="agent_run_#{agent_run.id}"[^>]*>.*?<td[^>]*>\s*PR Creation\s*<\/td>/m)
+        document = Nokogiri::HTML(response.body)
+        goal_index = document.css("table thead th").find_index { |header| header.text.squish == "Goal" }
+        row = document.at_css(%(tr#agent_run_#{agent_run.id}))
+
+        expect(goal_index).not_to be_nil
+        expect(row).to be_present
+        expect(row.css("td")[goal_index].text).to include("PR Creation")
       end
 
       it "shows the Goal column with the Issue Creation label for create_issue runs" do
         project = create(:project, account: account, github_token: github_token)
         agent_run = create(:agent_run, :create_issue_goal, project: project, status: "completed")
         get project_path(project)
-        expect(response.body).to include(">Goal</th>")
-        expect(response.body).to match(/<tr[^>]*id="agent_run_#{agent_run.id}"[^>]*>.*?<td[^>]*>\s*Issue Creation\s*<\/td>/m)
+        document = Nokogiri::HTML(response.body)
+        goal_index = document.css("table thead th").find_index { |header| header.text.squish == "Goal" }
+        row = document.at_css(%(tr#agent_run_#{agent_run.id}))
+
+        expect(goal_index).not_to be_nil
+        expect(row).to be_present
+        expect(row.css("td")[goal_index].text).to include("Issue Creation")
       end
 
       it "shows issue link when created_issue_url is present" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -669,20 +669,20 @@ RSpec.describe "Projects" do
         expect(response.body).not_to include("Clean Up Stale Runs")
       end
 
-      it "shows the Goal column with PR label for create_pr runs" do
+      it "shows the Goal column with the PR Creation label for create_pr runs" do
         project = create(:project, account: account, github_token: github_token)
         agent_run = create(:agent_run, project: project, status: "completed", goal: "create_pr")
         get project_path(project)
         expect(response.body).to include(">Goal</th>")
-        expect(response.body).to match(/<tr[^>]*id="agent_run_#{agent_run.id}"[^>]*>.*?<td[^>]*>\s*PR\s*<\/td>/m)
+        expect(response.body).to match(/<tr[^>]*id="agent_run_#{agent_run.id}"[^>]*>.*?<td[^>]*>\s*PR Creation\s*<\/td>/m)
       end
 
-      it "shows the Goal column with Issue label for create_issue runs" do
+      it "shows the Goal column with the Issue Creation label for create_issue runs" do
         project = create(:project, account: account, github_token: github_token)
         agent_run = create(:agent_run, :create_issue_goal, project: project, status: "completed")
         get project_path(project)
         expect(response.body).to include(">Goal</th>")
-        expect(response.body).to match(/<tr[^>]*id="agent_run_#{agent_run.id}"[^>]*>.*?<td[^>]*>\s*Issue\s*<\/td>/m)
+        expect(response.body).to match(/<tr[^>]*id="agent_run_#{agent_run.id}"[^>]*>.*?<td[^>]*>\s*Issue Creation\s*<\/td>/m)
       end
 
       it "shows issue link when created_issue_url is present" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -556,7 +556,7 @@ RSpec.describe "Projects" do
 
       it "shows the provider column for recent agent runs" do
         project = create(:project, account: account, github_token: github_token, created_by: user)
-        provider = create(:provider, user: user, provider_key: "codex")
+        provider = create(:provider, user: project.effective_owner, provider_key: "codex")
         run = create(:agent_run, project: project, provider: provider, final_provider: provider.routing_key)
 
         get project_path(project)
@@ -575,7 +575,7 @@ RSpec.describe "Projects" do
 
       it "shows the final provider label for legacy fallback runs in recent agent runs" do
         project = create(:project, account: account, github_token: github_token, created_by: user)
-        initial_provider = create(:provider, user: user, provider_key: "codex")
+        initial_provider = create(:provider, user: project.effective_owner, provider_key: "codex")
         run = create(:agent_run, project: project, provider: initial_provider, final_provider: "cursor")
 
         get project_path(project)

--- a/spec/views/agent_runs/index_table_partial_spec.rb
+++ b/spec/views/agent_runs/index_table_partial_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "agent_runs/_index_table", :no_db, type: :view do
+  let(:project) { Struct.new(:name).new("Platform") }
+  let(:run) do
+    Struct.new(
+      :id,
+      :project,
+      :status,
+      :duration_seconds,
+      :started_at,
+      :created_at,
+      :pull_request_url,
+      :review_url,
+      :created_issue_url,
+      :created_issue_number,
+      keyword_init: true
+    ) do
+      def running? = false
+
+      def cross_repo_issue_pair? = false
+    end.new(
+      id: 123,
+      project: project,
+      status: "completed",
+      duration_seconds: 12,
+      started_at: nil,
+      created_at: Time.zone.parse("2026-05-13 00:00:00 UTC"),
+      pull_request_url: nil,
+      review_url: nil,
+      created_issue_url: nil,
+      created_issue_number: nil
+    )
+  end
+  let(:pagy) { Struct.new(:series_nav).new("") }
+
+  before do
+    allow(view).to receive(:sort_link_to) { |label, *_args| label }
+    allow(view).to receive(:dom_id).with(run).and_return("agent_run_123")
+    allow(view).to receive(:agent_run_provider_displays).with([ run ]).and_return({ run.id => "Cursor Stable" })
+    allow(view).to receive(:agent_run_status_badge).with(run.status).and_return('<span>Completed</span>'.html_safe)
+    allow(view).to receive(:agent_run_priority_badge).with(run).and_return('<span>2 - P1</span>'.html_safe)
+    allow(view).to receive(:agent_run_provider_display).with(run, { run.id => "Cursor Stable" }).and_return("Cursor Stable")
+    allow(view).to receive(:agent_run_goal_display).with(run).and_return('<span class="goal-label">Code Review</span>'.html_safe)
+    allow(view).to receive(:agent_run_context_display).with(run).and_return('<span class="context-label">PR #87</span>'.html_safe)
+    allow(view).to receive(:time_ago_in_words).with(run.created_at).and_return("5 minutes")
+    allow(view).to receive(:safe_github_url?).and_return(false)
+    allow(view).to receive(:project_agent_run_path).with(project, run).and_return("/projects/1/agent_runs/123")
+  end
+
+  it "renders a single Provider column and keeps goal content distinct from context" do
+    render partial: "agent_runs/index_table", locals: {
+      agent_runs: [ run ],
+      q: nil,
+      pagy: pagy,
+      show_project: false,
+      project: project
+    }
+
+    fragment = Nokogiri::HTML.fragment(rendered)
+    headers = fragment.css("thead th").map { |header| header.text.squish }
+    row = fragment.at_css("tr#agent_run_123")
+
+    expect(headers.count("Provider")).to eq(1)
+    expect(row).to be_present
+
+    goal_index = headers.index("Goal")
+    context_index = headers.index("Context")
+    provider_index = headers.index("Provider")
+
+    expect(row.css("td")[goal_index].text.squish).to eq("Code Review")
+    expect(row.css("td")[context_index].text.squish).to eq("PR #87")
+    expect(row.css("td")[provider_index].text.squish).to eq("Cursor Stable")
+  end
+end


### PR DESCRIPTION
## Summary

Removes the accidental duplicate "Provider" column from the agent runs index table and corrects the Goal column to display the goal type label, so each column shows distinct information.

## Changes

- **Views**: Removed the duplicate "Provider" header and data cell from `app/views/agent_runs/_index_table.html.erb`; fixed the Goal column to render the goal type label.

## Screenshots

_Please attach before/after screenshots of the Agent Runs index table._

---

Closes #1914