### PR TITLE
Fix #1965: Improve business context wizard: single-question navigation with Turbo Frames and auto-save

### DIFF
--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -30,6 +30,7 @@ module Knowledge
       authorize @project, :update?
 
       save_current_response!
+      @session.reload
 
       if finish_navigation?
         complete_session!
@@ -102,7 +103,7 @@ module Knowledge
       ContextIntake::SaveResponse.call(
         session: @session,
         question_key: params[:question_key],
-        answer_text: params[:answer_text],
+        answer_text: normalized_answer_text,
         skipped: skip_navigation?
       )
     end
@@ -162,7 +163,7 @@ module Knowledge
 
     def validate_required_answer!
       return unless answer_required_for_navigation?
-      return if params[:answer_text].present?
+      return if normalized_answer_text.present?
 
       raise ActiveRecord::RecordInvalid.new(@session),
         "Please answer this required question before continuing."
@@ -187,7 +188,7 @@ module Knowledge
     end
 
     def submitted_answer_text_for(target_question_key)
-      params[:answer_text] if target_question_key == params[:question_key]
+      normalized_answer_text if target_question_key == params[:question_key]
     end
 
     def first_unanswered_required_question_key
@@ -201,6 +202,13 @@ module Knowledge
 
     def wizard_state
       @wizard_state ||= ContextIntake::WizardState.new(responses: @responses)
+    end
+
+    def normalized_answer_text
+      answer_text = params[:answer_text].to_s
+      return if answer_text.strip.empty?
+
+      answer_text
     end
 
     def abort_if_in_progress!

--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -39,7 +39,10 @@ module Knowledge
       end
     rescue ArgumentError, ActiveRecord::RecordInvalid => e
       @wizard_error = e.message
-      load_wizard_state(active_question_key: error_question_key)
+      load_wizard_state(
+        active_question_key: error_question_key,
+        submitted_answer_text: params[:answer_text]
+      )
       render_wizard_response(status: :unprocessable_entity)
     end
 
@@ -77,7 +80,7 @@ module Knowledge
       @project.context_intake_sessions.latest_first.first
     end
 
-    def load_wizard_state(active_question_key: nil)
+    def load_wizard_state(active_question_key: nil, submitted_answer_text: nil)
       @responses = @session.context_intake_responses.ordered.index_by(&:question_key)
       @progress = @session.progress
       @wizard_state = ContextIntake::WizardState.new(
@@ -87,11 +90,14 @@ module Knowledge
       @current_question_index = @wizard_state.current_question_index
       @current_question = @wizard_state.current_question
       @current_response = @responses[@current_question[:key]]
+      @current_answer_text = submitted_answer_text.nil? ? @current_response&.answer_text : submitted_answer_text
       @previous_question = @wizard_state.previous_question
       @next_question = @wizard_state.next_question
     end
 
     def save_current_response!
+      validate_required_answer!
+
       ContextIntake::SaveResponse.call(
         session: @session,
         question_key: params[:question_key],
@@ -121,6 +127,7 @@ module Knowledge
         project: @project,
         current_question: @current_question,
         current_question_index: @current_question_index,
+        current_answer_text: @current_answer_text,
         current_response: @current_response,
         previous_question: @previous_question,
         next_question: @next_question,
@@ -150,6 +157,26 @@ module Knowledge
         current_question_key: params[:question_key],
         direction: normalized_navigation_action
       )
+    end
+
+    def validate_required_answer!
+      return unless answer_required_for_navigation?
+      return if params[:answer_text].present?
+
+      raise ActiveRecord::RecordInvalid.new(@session),
+        "Please answer this required question before continuing."
+    end
+
+    def answer_required_for_navigation?
+      current_question_required? && !skip_navigation? && !previous_navigation?
+    end
+
+    def current_question_required?
+      ContextIntake::QuestionnaireSchema.find_question(params[:question_key])&.dig(:question, :required)
+    end
+
+    def previous_navigation?
+      normalized_navigation_action == "previous"
     end
 
     def error_question_key

--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -39,9 +39,10 @@ module Knowledge
       end
     rescue ArgumentError, ActiveRecord::RecordInvalid => e
       @wizard_error = e.message
+      target_question_key = error_question_key
       load_wizard_state(
-        active_question_key: error_question_key,
-        submitted_answer_text: params[:answer_text]
+        active_question_key: target_question_key,
+        submitted_answer_text: submitted_answer_text_for(target_question_key)
       )
       render_wizard_response(status: :unprocessable_entity)
     end
@@ -183,6 +184,10 @@ module Knowledge
       return first_unanswered_required_question_key if finish_navigation?
 
       params[:question_key]
+    end
+
+    def submitted_answer_text_for(target_question_key)
+      params[:answer_text] if target_question_key == params[:question_key]
     end
 
     def first_unanswered_required_question_key

--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -48,6 +48,7 @@ module Knowledge
 
       ContextIntake::CompleteSession.call(session: @session)
       redirect_to project_context_intake_path(@project),
+        status: :see_other,
         notice: "Business context saved and synthesized into project knowledge."
     rescue ActiveRecord::RecordInvalid => e
       redirect_to project_context_intake_path(@project), alert: e.message
@@ -101,14 +102,9 @@ module Knowledge
 
     def complete_session!
       ContextIntake::CompleteSession.call(session: @session)
-
-      if turbo_frame_request?
-        render partial: "knowledge/context_intake/summary_frame",
-          locals: { project: @project, session: @session }
-      else
-        redirect_to project_context_intake_path(@project),
-          notice: "Business context saved and synthesized into project knowledge."
-      end
+      redirect_to project_context_intake_path(@project),
+        status: :see_other,
+        notice: "Business context saved and synthesized into project knowledge."
     end
 
     def render_wizard_response(status: :ok)

--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -127,8 +127,8 @@ module Knowledge
     def wizard_locals
       {
         project: @project,
+        wizard_state: @wizard_state,
         current_question: @current_question,
-        current_question_index: @current_question_index,
         current_answer_text: @current_answer_text,
         current_response: @current_response,
         previous_question: @previous_question,

--- a/app/controllers/knowledge/context_intake_controller.rb
+++ b/app/controllers/knowledge/context_intake_controller.rb
@@ -2,6 +2,8 @@
 
 module Knowledge
   class ContextIntakeController < ApplicationController
+    WIZARD_FRAME_ID = "context_intake_wizard"
+
     before_action :authenticate_user!
     before_action :set_project
     before_action :set_session, only: [ :show, :update, :complete ]
@@ -10,7 +12,10 @@ module Knowledge
     def show
       authorize @project, :show?
       @session ||= latest_session
-      load_wizard_state(active_section_key: params[:section]) if @session&.in_progress?
+      return unless @session&.in_progress?
+
+      load_wizard_state(active_question_key: params[:question])
+      render_wizard_response if turbo_frame_request?
     end
 
     def create
@@ -24,21 +29,18 @@ module Knowledge
     def update
       authorize @project, :update?
 
-      question_key = params[:question_key]
-      skipped = params[:skipped] == "true"
-      answer_text = params[:answer_text]
+      save_current_response!
 
-      ContextIntake::SaveResponse.call(
-        session: @session,
-        question_key: question_key,
-        answer_text: answer_text,
-        skipped: skipped
-      )
-
-      load_wizard_state(active_section_key: preferred_section_after_update(question_key))
-      render :show
-    rescue ArgumentError => e
-      redirect_to project_context_intake_path(@project), alert: e.message
+      if finish_navigation?
+        complete_session!
+      else
+        load_wizard_state(active_question_key: navigation_question_key)
+        render_wizard_response
+      end
+    rescue ArgumentError, ActiveRecord::RecordInvalid => e
+      @wizard_error = e.message
+      load_wizard_state(active_question_key: error_question_key)
+      render_wizard_response(status: :unprocessable_entity)
     end
 
     def complete
@@ -74,52 +76,103 @@ module Knowledge
       @project.context_intake_sessions.latest_first.first
     end
 
-    def load_wizard_state(active_section_key: nil)
-      @sections = ContextIntake::QuestionnaireSchema.sections
+    def load_wizard_state(active_question_key: nil)
       @responses = @session.context_intake_responses.ordered.index_by(&:question_key)
       @progress = @session.progress
-      @active_section_key = resolve_active_section_key(active_section_key)
+      @wizard_state = ContextIntake::WizardState.new(
+        responses: @responses,
+        active_question_key: active_question_key
+      )
+      @current_question_index = @wizard_state.current_question_index
+      @current_question = @wizard_state.current_question
+      @current_response = @responses[@current_question[:key]]
+      @previous_question = @wizard_state.previous_question
+      @next_question = @wizard_state.next_question
     end
 
-    def resolve_active_section_key(active_section_key)
-      valid_section_keys = @sections.map { |section| section[:key] }
-      requested_section = active_section_key.presence_in(valid_section_keys)
-
-      requested_section || next_incomplete_section_key || @sections.first&.fetch(:key, nil)
+    def save_current_response!
+      ContextIntake::SaveResponse.call(
+        session: @session,
+        question_key: params[:question_key],
+        answer_text: params[:answer_text],
+        skipped: skip_navigation?
+      )
     end
 
-    def next_incomplete_section_key
-      @sections.find do |section|
-        section[:questions].any? { |question| !@responses[question[:key]]&.answered? }
-      end&.fetch(:key, nil)
-    end
+    def complete_session!
+      ContextIntake::CompleteSession.call(session: @session)
 
-    def preferred_section_after_update(question_key)
-      section_key = ContextIntake::QuestionnaireSchema.find_question(question_key)&.dig(:section, :key)
-      return unless section_key
-
-      responses = @session.context_intake_responses.index_by(&:question_key)
-
-      return section_key if section_has_unanswered_questions?(section_key, responses)
-
-      next_incomplete_section_key_for_session(responses) || section_key
-    end
-
-    def section_has_unanswered_questions?(section_key, responses)
-      section = ContextIntake::QuestionnaireSchema.sections.find { |entry| entry[:key] == section_key }
-      return false unless section
-
-      section[:questions].any? do |question|
-        !responses[question[:key]]&.answered?
+      if turbo_frame_request?
+        render partial: "knowledge/context_intake/summary_frame",
+          locals: { project: @project, session: @session }
+      else
+        redirect_to project_context_intake_path(@project),
+          notice: "Business context saved and synthesized into project knowledge."
       end
     end
 
-    def next_incomplete_section_key_for_session(responses)
-      ContextIntake::QuestionnaireSchema.sections.find do |section|
-        section[:questions].any? do |question|
-          !responses[question[:key]]&.answered?
-        end
-      end&.fetch(:key, nil)
+    def render_wizard_response(status: :ok)
+      if turbo_frame_request?
+        render partial: "knowledge/context_intake/wizard_frame",
+          locals: wizard_locals, status: status
+      else
+        render :show, status: status
+      end
+    end
+
+    def wizard_locals
+      {
+        project: @project,
+        current_question: @current_question,
+        current_question_index: @current_question_index,
+        current_response: @current_response,
+        previous_question: @previous_question,
+        next_question: @next_question,
+        progress: @progress,
+        wizard_error: @wizard_error
+      }
+    end
+
+    def navigation_action
+      params[:navigation_action].presence || "next"
+    end
+
+    def skip_navigation?
+      navigation_action.start_with?("skip_")
+    end
+
+    def normalized_navigation_action
+      navigation_action.delete_prefix("skip_")
+    end
+
+    def finish_navigation?
+      normalized_navigation_action == "finish"
+    end
+
+    def navigation_question_key
+      wizard_state.navigation_question_key(
+        current_question_key: params[:question_key],
+        direction: normalized_navigation_action
+      )
+    end
+
+    def error_question_key
+      return first_unanswered_required_question_key if finish_navigation?
+
+      params[:question_key]
+    end
+
+    def first_unanswered_required_question_key
+      responses = @session.context_intake_responses.ordered.index_by(&:question_key)
+
+      ContextIntake::WizardState.new(
+        responses: responses,
+        active_question_key: params[:question_key]
+      ).first_unanswered_required_question_key
+    end
+
+    def wizard_state
+      @wizard_state ||= ContextIntake::WizardState.new(responses: @responses)
     end
 
     def abort_if_in_progress!

--- a/app/services/knowledge/context_intake/save_response.rb
+++ b/app/services/knowledge/context_intake/save_response.rb
@@ -23,7 +23,7 @@ module Knowledge
 
         ActiveRecord::Base.transaction do
           response.update!(
-            answer_text: skipped ? nil : answer_text,
+            answer_text: skipped ? nil : normalized_answer_text,
             skipped: skipped,
             provenance: "human"
           )
@@ -49,6 +49,12 @@ module Knowledge
                                 .answered
                                 .count
         session.update!(current_step: answered_count)
+      end
+
+      def normalized_answer_text
+        return if answer_text.to_s.strip.empty?
+
+        answer_text
       end
     end
   end

--- a/app/services/knowledge/context_intake/wizard_state.rb
+++ b/app/services/knowledge/context_intake/wizard_state.rb
@@ -6,7 +6,7 @@ module Knowledge
       attr_reader :responses, :active_question_key
 
       def initialize(responses:, active_question_key: nil)
-        @responses = responses
+        @responses = responses || {}
         @active_question_key = active_question_key
       end
 
@@ -37,6 +37,14 @@ module Knowledge
 
       def next_question
         ordered_questions[current_question_index + 1]
+      end
+
+      def first_question?
+        current_question_index.zero?
+      end
+
+      def last_question?
+        current_question_index == ordered_questions.length - 1
       end
 
       def navigation_question_key(current_question_key:, direction:)

--- a/app/services/knowledge/context_intake/wizard_state.rb
+++ b/app/services/knowledge/context_intake/wizard_state.rb
@@ -29,6 +29,14 @@ module Knowledge
         ordered_questions.fetch(current_question_index)
       end
 
+      def total_questions
+        ordered_questions.length
+      end
+
+      def current_question_number
+        current_question_index + 1
+      end
+
       def previous_question
         return if current_question_index.zero?
 
@@ -44,13 +52,13 @@ module Knowledge
       end
 
       def last_question?
-        current_question_index == ordered_questions.length - 1
+        current_question_index == total_questions - 1
       end
 
       def navigation_question_key(current_question_key:, direction:)
         offset = direction == "previous" ? -1 : 1
         current_index = ordered_questions.index { |question| question[:key] == current_question_key } || 0
-        target_index = (current_index + offset).clamp(0, ordered_questions.length - 1)
+        target_index = (current_index + offset).clamp(0, total_questions - 1)
 
         ordered_questions.fetch(target_index).fetch(:key)
       end

--- a/app/services/knowledge/context_intake/wizard_state.rb
+++ b/app/services/knowledge/context_intake/wizard_state.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Knowledge
+  module ContextIntake
+    class WizardState
+      attr_reader :responses, :active_question_key
+
+      def initialize(responses:, active_question_key: nil)
+        @responses = responses
+        @active_question_key = active_question_key
+      end
+
+      def ordered_questions
+        @ordered_questions ||= QuestionnaireSchema.sections.flat_map do |section|
+          section[:questions].map do |question|
+            question.merge(section_key: section[:key], section_title: section[:title])
+          end
+        end
+      end
+
+      def current_question_index
+        @current_question_index ||= begin
+          requested_question_index = ordered_questions.index { |question| question[:key] == active_question_key }
+          requested_question_index || next_incomplete_question_index || 0
+        end
+      end
+
+      def current_question
+        ordered_questions.fetch(current_question_index)
+      end
+
+      def previous_question
+        return if current_question_index.zero?
+
+        ordered_questions[current_question_index - 1]
+      end
+
+      def next_question
+        ordered_questions[current_question_index + 1]
+      end
+
+      def navigation_question_key(current_question_key:, direction:)
+        offset = direction == "previous" ? -1 : 1
+        current_index = ordered_questions.index { |question| question[:key] == current_question_key } || 0
+        target_index = (current_index + offset).clamp(0, ordered_questions.length - 1)
+
+        ordered_questions.fetch(target_index).fetch(:key)
+      end
+
+      def first_unanswered_required_question_key
+        required_keys = QuestionnaireSchema.required_questions.map { |question| question[:key] }
+
+        ordered_questions.find do |question|
+          required_keys.include?(question[:key]) && !responses[question[:key]]&.answered?
+        end&.fetch(:key, active_question_key)
+      end
+
+      private
+
+      def next_incomplete_question_index
+        ordered_questions.index do |question|
+          !responses[question[:key]]&.answered?
+        end
+      end
+    end
+  end
+end

--- a/app/views/knowledge/context_intake/_summary_frame.html.erb
+++ b/app/views/knowledge/context_intake/_summary_frame.html.erb
@@ -1,3 +1,0 @@
-<%= turbo_frame_tag Knowledge::ContextIntakeController::WIZARD_FRAME_ID do %>
-  <%= render "summary", session: session, project: project %>
-<% end %>

--- a/app/views/knowledge/context_intake/_summary_frame.html.erb
+++ b/app/views/knowledge/context_intake/_summary_frame.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag Knowledge::ContextIntakeController::WIZARD_FRAME_ID do %>
+  <%= render "summary", session: session, project: project %>
+<% end %>

--- a/app/views/knowledge/context_intake/_wizard.html.erb
+++ b/app/views/knowledge/context_intake/_wizard.html.erb
@@ -1,87 +1,11 @@
 <div class="mt-6">
-  <div class="overflow-hidden rounded-lg bg-white shadow">
-    <div class="px-4 py-4 sm:px-6">
-      <div class="flex items-center justify-between">
-        <p class="text-sm font-medium text-gray-700">
-          Progress: <%= progress[:answered] %> / <%= progress[:total] %> questions answered
-        </p>
-        <p class="text-sm text-gray-500"><%= progress[:percentage] %>%</p>
-      </div>
-      <div class="mt-2 w-full bg-gray-200 rounded-full h-2">
-        <div class="bg-indigo-600 h-2 rounded-full transition-all duration-300" style="width: <%= progress[:percentage] %>%"></div>
-      </div>
-    </div>
-  </div>
-
-  <%# Section navigation %>
-  <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
-    <nav class="flex overflow-x-auto px-4 py-3 sm:px-6" aria-label="Sections">
-      <% sections.each do |section| %>
-        <%= link_to project_context_intake_path(project, section: section[:key]),
-              class: "mr-2 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-colors #{section[:key] == active_section_key ? 'bg-indigo-100 text-indigo-700' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'}" do %>
-          <%= section[:title] %>
-        <% end %>
-      <% end %>
-    </nav>
-  </div>
-
-  <%# Questions per section %>
-  <% sections.each do |section| %>
-    <div class="mt-4 overflow-hidden rounded-lg bg-white shadow"
-         data-section="<%= section[:key] %>"
-         style="<%= section[:key] == active_section_key ? '' : 'display: none;' %>">
-      <div class="px-4 py-5 sm:p-6">
-        <h3 class="text-lg font-medium text-gray-900 mb-4"><%= section[:title] %></h3>
-
-        <% section[:questions].each do |question| %>
-          <% response = responses[question[:key]] %>
-          <div class="mb-6 last:mb-0">
-            <%= form_with url: project_context_intake_path(project),
-                          method: :patch,
-                          data: { turbo: false } do |f| %>
-              <%= f.hidden_field :question_key, value: question[:key] %>
-
-              <label class="block text-sm font-medium text-gray-700 mb-1">
-                <%= question[:text] %>
-                <% if question[:required] %>
-                  <span class="text-red-500 ml-1">*</span>
-                <% end %>
-              </label>
-
-              <%= f.text_area :answer_text,
-                    value: response&.answer_text,
-                    rows: 3,
-                    placeholder: "Enter your answer...",
-                    class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
-
-              <div class="mt-2 flex items-center gap-3">
-                <%= f.submit "Save",
-                      class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
-
-                <% unless question[:required] %>
-                  <button type="submit" name="skipped" value="true"
-                          class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer">
-                    Skip
-                  </button>
-                <% end %>
-
-                <% if response&.answered? %>
-                  <span class="text-xs text-green-600 font-medium">Saved</span>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
-
-  <%# Complete button %>
-  <div class="mt-6 flex justify-end">
-    <%= button_to "Complete & Save Business Context",
-          complete_project_context_intake_path(project),
-          method: :post,
-          class: "inline-flex items-center rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 cursor-pointer",
-          data: { turbo_confirm: "Are you sure you want to complete the questionnaire? You can start a new one later to update." } %>
-  </div>
+  <%= render "wizard_frame",
+    project: project,
+    current_question: current_question,
+    current_question_index: current_question_index,
+    current_response: current_response,
+    previous_question: previous_question,
+    next_question: next_question,
+    progress: progress,
+    wizard_error: wizard_error %>
 </div>

--- a/app/views/knowledge/context_intake/_wizard.html.erb
+++ b/app/views/knowledge/context_intake/_wizard.html.erb
@@ -3,6 +3,7 @@
     project: project,
     current_question: current_question,
     current_question_index: current_question_index,
+    current_answer_text: current_answer_text,
     current_response: current_response,
     previous_question: previous_question,
     next_question: next_question,

--- a/app/views/knowledge/context_intake/_wizard.html.erb
+++ b/app/views/knowledge/context_intake/_wizard.html.erb
@@ -1,8 +1,8 @@
 <div class="mt-6">
   <%= render "wizard_frame",
     project: project,
+    wizard_state: wizard_state,
     current_question: current_question,
-    current_question_index: current_question_index,
     current_answer_text: current_answer_text,
     current_response: current_response,
     previous_question: previous_question,

--- a/app/views/knowledge/context_intake/_wizard_frame.html.erb
+++ b/app/views/knowledge/context_intake/_wizard_frame.html.erb
@@ -1,0 +1,84 @@
+<%= turbo_frame_tag Knowledge::ContextIntakeController::WIZARD_FRAME_ID do %>
+  <div class="overflow-hidden rounded-lg bg-white shadow">
+    <div class="px-4 py-4 sm:px-6">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <p class="text-sm font-medium text-gray-700">
+            Question <%= current_question_index + 1 %> of <%= progress[:total] %>
+          </p>
+          <p class="mt-1 text-sm text-gray-500">
+            <%= progress[:answered] %> answered · <%= progress[:percentage] %>% complete
+          </p>
+        </div>
+        <p class="text-sm font-medium text-gray-500"><%= current_question[:section_title] %></p>
+      </div>
+      <div class="mt-3 h-2 w-full rounded-full bg-gray-200">
+        <div class="h-2 rounded-full bg-indigo-600 transition-all duration-300" style="width: <%= progress[:percentage] %>%"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+    <div class="px-4 py-5 sm:p-6">
+      <% if wizard_error.present? %>
+        <div class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <%= wizard_error %>
+        </div>
+      <% end %>
+
+      <%= form_with url: project_context_intake_path(project),
+            method: :patch,
+            data: { turbo_frame: Knowledge::ContextIntakeController::WIZARD_FRAME_ID } do |f| %>
+        <%= f.hidden_field :question_key, value: current_question[:key] %>
+
+        <p class="text-xs font-semibold uppercase tracking-wide text-indigo-600"><%= current_question[:section_title] %></p>
+        <label class="mt-2 block text-lg font-medium text-gray-900" for="answer_text">
+          <%= current_question[:text] %>
+          <% if current_question[:required] %>
+            <span class="ml-1 text-red-500">*</span>
+          <% end %>
+        </label>
+
+        <% unless current_question[:required] %>
+          <p class="mt-1 text-sm text-gray-500">Optional. Leave blank or skip if this does not apply.</p>
+        <% end %>
+
+        <%= f.text_area :answer_text,
+              value: current_response&.answer_text,
+              rows: 5,
+              placeholder: "Enter your answer...",
+              class: "mt-4 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+
+        <div class="mt-4 flex items-center justify-between gap-3">
+          <div>
+            <% if current_response&.answered? %>
+              <span class="text-xs font-medium text-green-600">Saved</span>
+            <% end %>
+          </div>
+
+          <div class="flex items-center gap-3">
+            <% if previous_question.present? %>
+              <button type="submit" name="navigation_action" value="previous"
+                      class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer">
+                Previous
+              </button>
+            <% end %>
+
+            <% unless current_question[:required] %>
+              <button type="submit" name="navigation_action"
+                      value="<%= next_question.present? ? 'skip_next' : 'skip_finish' %>"
+                      class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer">
+                <%= next_question.present? ? "Skip and Next" : "Skip and Finish" %>
+              </button>
+            <% end %>
+
+            <button type="submit" name="navigation_action" value="<%= next_question.present? ? 'next' : 'finish' %>"
+                    class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer">
+              <%= next_question.present? ? "Next" : "Finish" %>
+            </button>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/knowledge/context_intake/_wizard_frame.html.erb
+++ b/app/views/knowledge/context_intake/_wizard_frame.html.erb
@@ -44,7 +44,7 @@
         <% end %>
 
         <%= f.text_area :answer_text,
-              value: current_response&.answer_text,
+              value: current_answer_text,
               rows: 5,
               placeholder: "Enter your answer...",
               class: "mt-4 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>

--- a/app/views/knowledge/context_intake/_wizard_frame.html.erb
+++ b/app/views/knowledge/context_intake/_wizard_frame.html.erb
@@ -65,17 +65,30 @@
             <% end %>
 
             <% unless current_question[:required] %>
-              <button type="submit" name="navigation_action"
-                      value="<%= next_question.present? ? 'skip_next' : 'skip_finish' %>"
-                      class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer">
-                <%= next_question.present? ? "Skip and Next" : "Skip and Finish" %>
-              </button>
+              <% if next_question.present? %>
+                <button type="submit" name="navigation_action" value="skip_next"
+                        class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer">
+                  Skip and Next
+                </button>
+              <% else %>
+                <button type="submit" name="navigation_action" value="skip_finish" data-turbo-frame="_top"
+                        class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer">
+                  Skip and Finish
+                </button>
+              <% end %>
             <% end %>
 
-            <button type="submit" name="navigation_action" value="<%= next_question.present? ? 'next' : 'finish' %>"
-                    class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer">
-              <%= next_question.present? ? "Next" : "Finish" %>
-            </button>
+            <% if next_question.present? %>
+              <button type="submit" name="navigation_action" value="next"
+                      class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer">
+                Next
+              </button>
+            <% else %>
+              <button type="submit" name="navigation_action" value="finish" data-turbo-frame="_top"
+                      class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer">
+                Finish
+              </button>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/knowledge/context_intake/_wizard_frame.html.erb
+++ b/app/views/knowledge/context_intake/_wizard_frame.html.erb
@@ -4,7 +4,7 @@
       <div class="flex items-center justify-between gap-4">
         <div>
           <p class="text-sm font-medium text-gray-700">
-            Question <%= current_question_index + 1 %> of <%= progress[:total] %>
+            Question <%= wizard_state.current_question_number %> of <%= wizard_state.total_questions %>
           </p>
           <p class="mt-1 text-sm text-gray-500">
             <%= progress[:answered] %> answered · <%= progress[:percentage] %>% complete

--- a/app/views/knowledge/context_intake/_wizard_frame.html.erb
+++ b/app/views/knowledge/context_intake/_wizard_frame.html.erb
@@ -73,7 +73,7 @@
               <% else %>
                 <button type="submit" name="navigation_action" value="skip_finish" data-turbo-frame="_top" formtarget="_top"
                         class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer">
-                  Skip and Finish
+                  Skip This Question
                 </button>
               <% end %>
             <% end %>

--- a/app/views/knowledge/context_intake/_wizard_frame.html.erb
+++ b/app/views/knowledge/context_intake/_wizard_frame.html.erb
@@ -71,7 +71,7 @@
                   Skip and Next
                 </button>
               <% else %>
-                <button type="submit" name="navigation_action" value="skip_finish" data-turbo-frame="_top"
+                <button type="submit" name="navigation_action" value="skip_finish" data-turbo-frame="_top" formtarget="_top"
                         class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer">
                   Skip and Finish
                 </button>
@@ -84,7 +84,7 @@
                 Next
               </button>
             <% else %>
-              <button type="submit" name="navigation_action" value="finish" data-turbo-frame="_top"
+              <button type="submit" name="navigation_action" value="finish" data-turbo-frame="_top" formtarget="_top"
                       class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer">
                 Finish
               </button>

--- a/app/views/knowledge/context_intake/show.html.erb
+++ b/app/views/knowledge/context_intake/show.html.erb
@@ -18,7 +18,15 @@
   <% if @session.nil? %>
     <%= render "no_session", project: @project %>
   <% elsif @session.in_progress? %>
-    <%= render "wizard", progress: @progress, sections: @sections, project: @project, active_section_key: @active_section_key, responses: @responses %>
+    <%= render "wizard",
+      project: @project,
+      current_question: @current_question,
+      current_question_index: @current_question_index,
+      current_response: @current_response,
+      previous_question: @previous_question,
+      next_question: @next_question,
+      progress: @progress,
+      wizard_error: @wizard_error %>
   <% else %>
     <%= render "summary", session: @session, project: @project %>
   <% end %>

--- a/app/views/knowledge/context_intake/show.html.erb
+++ b/app/views/knowledge/context_intake/show.html.erb
@@ -21,8 +21,8 @@
   <% elsif @session.in_progress? %>
     <%= render "wizard",
       project: @project,
+      wizard_state: @wizard_state,
       current_question: @current_question,
-      current_question_index: @current_question_index,
       current_answer_text: @current_answer_text,
       current_response: @current_response,
       previous_question: @previous_question,

--- a/app/views/knowledge/context_intake/show.html.erb
+++ b/app/views/knowledge/context_intake/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { "Business Context - #{@project.name} - Paid" } %>
+<% turbo_page_requires_reload if @session.present? && !@session.in_progress? %>
 
 <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="sm:flex sm:items-center sm:justify-between">

--- a/app/views/knowledge/context_intake/show.html.erb
+++ b/app/views/knowledge/context_intake/show.html.erb
@@ -23,6 +23,7 @@
       project: @project,
       current_question: @current_question,
       current_question_index: @current_question_index,
+      current_answer_text: @current_answer_text,
       current_response: @current_response,
       previous_question: @previous_question,
       next_question: @next_question,

--- a/spec/lib/knowledge/context_intake/wizard_state_spec.rb
+++ b/spec/lib/knowledge/context_intake/wizard_state_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Knowledge::ContextIntake::WizardState, :no_db do
 
       expect(state.current_question.fetch(:key)).to eq("business_model")
       expect(state.current_question_index).to eq(1)
+      expect(state.current_question_number).to eq(2)
     end
 
     it "uses the explicitly requested question when it exists" do
@@ -26,6 +27,17 @@ RSpec.describe Knowledge::ContextIntake::WizardState, :no_db do
 
       expect(state.current_question.fetch(:key)).to eq("primary_users")
       expect(state.current_question.fetch(:section_title)).to eq("Target Users & Markets")
+    end
+  end
+
+  describe "step position helpers" do
+    it "reports the schema-backed current step and total question count" do
+      state = described_class.new(responses: responses, active_question_key: "primary_users")
+
+      expect(state.current_question_number).to eq(3)
+      expect(state.total_questions).to eq(
+        Knowledge::ContextIntake::QuestionnaireSchema.total_questions
+      )
     end
   end
 

--- a/spec/lib/knowledge/context_intake/wizard_state_spec.rb
+++ b/spec/lib/knowledge/context_intake/wizard_state_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::ContextIntake::WizardState, :no_db do
+  let(:response_class) { Struct.new(:answered?, keyword_init: true) }
+
+  let(:responses) do
+    {
+      "product_description" => response_class.new(answered?: true),
+      "business_model" => response_class.new(answered?: false),
+      "primary_users" => response_class.new(answered?: false)
+    }
+  end
+
+  describe "#current_question" do
+    it "defaults to the next incomplete question when no explicit key is provided" do
+      state = described_class.new(responses: responses)
+
+      expect(state.current_question.fetch(:key)).to eq("business_model")
+      expect(state.current_question_index).to eq(1)
+    end
+
+    it "uses the explicitly requested question when it exists" do
+      state = described_class.new(responses: responses, active_question_key: "primary_users")
+
+      expect(state.current_question.fetch(:key)).to eq("primary_users")
+      expect(state.current_question.fetch(:section_title)).to eq("Target Users & Markets")
+    end
+  end
+
+  describe "#navigation_question_key" do
+    it "moves backward and forward within the questionnaire bounds" do
+      state = described_class.new(responses: responses)
+
+      expect(state.navigation_question_key(current_question_key: "business_model", direction: "previous"))
+        .to eq("product_description")
+      expect(state.navigation_question_key(current_question_key: "product_description", direction: "previous"))
+        .to eq("product_description")
+      expect(state.navigation_question_key(current_question_key: "naming_conventions", direction: "next"))
+        .to eq("naming_conventions")
+    end
+  end
+
+  describe "#first_unanswered_required_question_key" do
+    it "returns the first unanswered required question in questionnaire order" do
+      state = described_class.new(
+        responses: responses.merge("critical_journeys" => response_class.new(answered?: false)),
+        active_question_key: "naming_conventions"
+      )
+
+      expect(state.first_unanswered_required_question_key).to eq("primary_users")
+    end
+  end
+end

--- a/spec/lib/knowledge/context_intake/wizard_state_spec.rb
+++ b/spec/lib/knowledge/context_intake/wizard_state_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe Knowledge::ContextIntake::WizardState, :no_db do
     end
   end
 
+  describe "boundary helpers" do
+    it "does not expose a previous question for the first step" do
+      state = described_class.new(responses: responses, active_question_key: "product_description")
+
+      expect(state.first_question?).to be(true)
+      expect(state.previous_question).to be_nil
+    end
+
+    it "marks the last step and omits a next question there" do
+      state = described_class.new(responses: responses, active_question_key: "naming_conventions")
+
+      expect(state.last_question?).to be(true)
+      expect(state.next_question).to be_nil
+    end
+  end
+
   describe "#first_unanswered_required_question_key" do
     it "returns the first unanswered required question in questionnaire order" do
       state = described_class.new(

--- a/spec/requests/knowledge/context_intake_spec.rb
+++ b/spec/requests/knowledge/context_intake_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe "Knowledge::ContextIntake" do
     end
   end
 
+  describe "GET /projects/:project_id/context_intake" do
+    it "marks completed pages for full reload when loaded from a turbo frame" do
+      session.update!(status: "completed", completed_at: Time.current)
+
+      get project_context_intake_path(project),
+        headers: { "Turbo-Frame" => Knowledge::ContextIntakeController::WIZARD_FRAME_ID }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(name="turbo-visit-control" content="reload"))
+      expect(response.body).to include("Business context captured")
+    end
+  end
+
   describe "PATCH /projects/:project_id/context_intake" do
     it "redirects turbo-frame finish submissions to the full page with a success notice" do
       patch project_context_intake_path(project),

--- a/spec/requests/knowledge/context_intake_spec.rb
+++ b/spec/requests/knowledge/context_intake_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Knowledge::ContextIntake" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :owner, account: account) }
+  let(:project) { create(:project, account: account, created_by: user) }
+  let(:session) { create(:context_intake_session, project: project, started_by: user) }
+  let(:questions) do
+    Knowledge::ContextIntake::QuestionnaireSchema.sections.flat_map do |section|
+      section[:questions].map { |question| question.merge(section_key: section[:key]) }
+    end
+  end
+  let(:last_question) { questions.last }
+
+  before do
+    sign_in user
+
+    questions.each_with_index do |question, index|
+      create(
+        :context_intake_response,
+        context_intake_session: session,
+        question_key: question.fetch(:key),
+        question_text: question.fetch(:text),
+        section: question.fetch(:section_key),
+        sequence: index,
+        answer_text: index == questions.length - 1 ? nil : "Answer #{index}"
+      )
+    end
+  end
+
+  describe "PATCH /projects/:project_id/context_intake" do
+    it "redirects turbo-frame finish submissions to the full page with a success notice" do
+      patch project_context_intake_path(project),
+        params: {
+          question_key: last_question.fetch(:key),
+          answer_text: "Final answer",
+          navigation_action: "finish"
+        },
+        headers: { "Turbo-Frame" => Knowledge::ContextIntakeController::WIZARD_FRAME_ID }
+
+      expect(response).to have_http_status(:see_other)
+      expect(response).to redirect_to(project_context_intake_path(project))
+      expect(flash[:notice]).to eq("Business context saved and synthesized into project knowledge.")
+
+      follow_redirect!
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Business context saved and synthesized into project knowledge.")
+      expect(response.body).to include("Business context captured")
+    end
+
+    it "redirects turbo-frame skip-finish submissions to the full page with a success notice" do
+      patch project_context_intake_path(project),
+        params: {
+          question_key: last_question.fetch(:key),
+          answer_text: "",
+          navigation_action: "skip_finish"
+        },
+        headers: { "Turbo-Frame" => Knowledge::ContextIntakeController::WIZARD_FRAME_ID }
+
+      expect(response).to have_http_status(:see_other)
+      expect(response).to redirect_to(project_context_intake_path(project))
+      expect(flash[:notice]).to eq("Business context saved and synthesized into project knowledge.")
+
+      follow_redirect!
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Business context saved and synthesized into project knowledge.")
+      expect(response.body).to include("Business context captured")
+    end
+  end
+end

--- a/spec/requests/knowledge/context_intake_spec.rb
+++ b/spec/requests/knowledge/context_intake_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "Knowledge::ContextIntake" do
       section[:questions].map { |question| question.merge(section_key: section[:key]) }
     end
   end
+  let(:first_question) { questions.first }
+  let(:second_question) { questions.second }
   let(:last_question) { questions.last }
 
   before do
@@ -44,6 +46,24 @@ RSpec.describe "Knowledge::ContextIntake" do
   end
 
   describe "PATCH /projects/:project_id/context_intake" do
+    it "keeps required questions in place when navigating forward without an answer" do
+      session.context_intake_responses.find_by!(question_key: first_question.fetch(:key))
+             .update!(answer_text: nil)
+
+      patch project_context_intake_path(project),
+        params: {
+          question_key: first_question.fetch(:key),
+          answer_text: "",
+          navigation_action: "next"
+        },
+        headers: { "Turbo-Frame" => Knowledge::ContextIntakeController::WIZARD_FRAME_ID }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Please answer this required question before continuing.")
+      expect(response.body).to include(first_question.fetch(:text))
+      expect(response.body).not_to include(second_question.fetch(:text))
+    end
+
     it "redirects turbo-frame finish submissions to the full page with a success notice" do
       patch project_context_intake_path(project),
         params: {

--- a/spec/system/knowledge/context_intake_spec.rb
+++ b/spec/system/knowledge/context_intake_spec.rb
@@ -18,6 +18,22 @@ RSpec.describe "Business context questionnaire", system_driver: :rack_test, type
     expect_later_prompt_to_include_business_context(answers)
   end
 
+  it "shows one question at a time and preserves answers when navigating backward" do
+    sign_in_and_start_questionnaire
+
+    first_question, second_question = ordered_questions.first(2)
+    first_answer = questionnaire_answers.fetch(first_question[:key])
+
+    expect_current_question(first_question, position: 1)
+    answer_question(first_question[:key], first_answer, button: "Next")
+
+    expect_current_question(second_question, position: 2)
+    click_button "Previous"
+
+    expect_current_question(first_question, position: 1)
+    expect(page).to have_field("answer_text", with: first_answer)
+  end
+
   def sign_in_and_start_questionnaire
     visit new_user_session_path
     fill_in "Email", with: user.email
@@ -31,26 +47,12 @@ RSpec.describe "Business context questionnaire", system_driver: :rack_test, type
   end
 
   def complete_questionnaire(answers)
-    sections = Knowledge::ContextIntake::QuestionnaireSchema.sections
+    ordered_questions.each_with_index do |question, index|
+      expect_current_question(question, position: index + 1)
 
-    sections.each_with_index do |section, section_index|
-      expect_active_section(section[:key], section[:title])
-
-      section[:questions].each_with_index do |question, question_index|
-        answer_question(question[:key], answers.fetch(question[:key]))
-
-        next_section_key = if question_index < section[:questions].length - 1
-          section[:key]
-        else
-          sections[section_index + 1]&.fetch(:key, section[:key]) || section[:key]
-        end
-
-        next_section_title = sections.find { |entry| entry[:key] == next_section_key }[:title]
-        expect_active_section(next_section_key, next_section_title)
-      end
+      button = index == ordered_questions.length - 1 ? "Finish" : "Next"
+      answer_question(question[:key], answers.fetch(question[:key]), button: button)
     end
-
-    click_button "Complete & Save Business Context"
 
     expect(page).to have_content("Business context saved and synthesized into project knowledge.")
     expect(page).to have_content("Business context captured")
@@ -81,24 +83,31 @@ RSpec.describe "Business context questionnaire", system_driver: :rack_test, type
     expect(prompt).to include(answers.fetch("domain_terms"))
   end
 
-  def within_section_panel(section_key, &)
-    within(find(%([data-section="#{section_key}"]), visible: true)) do
-      yield
-    end
+  def expect_current_question(question, position:)
+    expect(page).to have_css("turbo-frame#context_intake_wizard")
+    expect(page).to have_css("form", count: 1)
+    expect(page).to have_css("textarea", count: 1)
+    expect(page).to have_no_button("Save")
+    expect(page).to have_content("Question #{position} of #{ordered_questions.length}")
+    expect(page).to have_content(question[:section_title])
+    expect(page).to have_content(question[:text])
+
+    other_question = ordered_questions.find { |entry| entry[:key] != question[:key] }
+    expect(page).to have_no_content(other_question[:text]) if other_question
   end
 
-  def expect_active_section(section_key, section_title)
-    expect(page).to have_css("[data-section]", visible: true, count: 1)
-
-    within_section_panel(section_key) do
-      expect(page).to have_css("h3", text: section_title)
-    end
-  end
-
-  def answer_question(question_key, answer_text)
+  def answer_question(question_key, answer_text, button:)
     within(:xpath, %(.//form[input[@name='question_key' and @value='#{question_key}']])) do
       fill_in "answer_text", with: answer_text
-      click_button "Save"
+      click_button button
+    end
+  end
+
+  def ordered_questions
+    @ordered_questions ||= Knowledge::ContextIntake::QuestionnaireSchema.sections.flat_map do |section|
+      section[:questions].map do |question|
+        question.merge(section_title: section[:title])
+      end
     end
   end
 

--- a/spec/system/knowledge/context_intake_spec.rb
+++ b/spec/system/knowledge/context_intake_spec.rb
@@ -85,15 +85,18 @@ RSpec.describe "Business context questionnaire", system_driver: :rack_test, type
 
   def expect_current_question(question, position:)
     expect(page).to have_css("turbo-frame#context_intake_wizard")
-    expect(page).to have_css("form", count: 1)
-    expect(page).to have_css("textarea", count: 1)
-    expect(page).to have_no_button("Save")
-    expect(page).to have_content("Question #{position} of #{ordered_questions.length}")
-    expect(page).to have_content(question[:section_title])
-    expect(page).to have_content(question[:text])
 
-    other_question = ordered_questions.find { |entry| entry[:key] != question[:key] }
-    expect(page).to have_no_content(other_question[:text]) if other_question
+    within("turbo-frame#context_intake_wizard") do
+      expect(page).to have_css("form", count: 1)
+      expect(page).to have_css("textarea", count: 1)
+      expect(page).to have_no_button("Save")
+      expect(page).to have_content("Question #{position} of #{ordered_questions.length}")
+      expect(page).to have_content(question[:section_title])
+      expect(page).to have_content(question[:text])
+
+      other_question = ordered_questions.find { |entry| entry[:key] != question[:key] }
+      expect(page).to have_no_content(other_question[:text]) if other_question
+    end
   end
 
   def answer_question(question_key, answer_text, button:)

--- a/spec/system/knowledge/context_intake_spec.rb
+++ b/spec/system/knowledge/context_intake_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Business context questionnaire", system_driver: :rack_test, type
   def answer_question(question_key, answer_text, button:)
     within(:xpath, %(.//form[input[@name='question_key' and @value='#{question_key}']])) do
       fill_in "answer_text", with: answer_text
-      click_button button
+      click_button button, exact: true
     end
   end
 


### PR DESCRIPTION
## Summary

Redesigns the business context knowledge base intake wizard to present one question at a time with Turbo Frame navigation and auto-save, replacing the previous all-questions-on-one-screen layout and per-field save buttons. This reduces cognitive load for users completing the wizard and produces a smoother, more guided intake experience.

## Changes

- **Views**: Wrap the question/answer area in a `turbo_frame_tag` so Previous/Next/Finish drive the frame instead of full page reloads. Render a single question at a time with a "Question N of M" progress indicator. Remove the per-question save button; swap Next for Finish on the last step.
- **Controller**: The action serving the next/previous question now persists the submitted answer before rendering the new step, providing auto-save on navigation. Inline validation feedback is preserved within the Turbo Frame.
- **Services / lib**: Extract navigation and step-position logic into a new `Knowledge::ContextIntake::WizardState` object so the controller stays thin and the linear-flow rules live in one place.
- **Tests**: Update the system spec to walk the wizard linearly through Previous/Next/Finish. Add a database-less unit spec for `WizardState` covering boundary behavior (first step has no Previous, last step shows Finish) and progress calculation.

## Design Decisions

- **Save-on-navigation, not debounced save**: Persistence is tied to Previous/Next/Finish submissions rather than blur/debounce. This keeps the controller flow simple (one form submission = one save) and avoids partial-answer races; debounced/on-blur save can be layered on later if needed.
- **WizardState extraction**: Step ordering, boundary detection, and progress are non-trivial enough that embedding them in the controller would have made the action hard to test. The new object is pure logic and covered by a db-less spec.
- **Turbo Frame scope**: Only the question card is framed, so the surrounding chrome (header, layout) is untouched and standard Rails validation rendering inside the frame still works.

## Operational Notes

- No migrations or infrastructure changes.
- Full RSpec suite was not run in the agent environment because PostgreSQL was unavailable; `rubocop`, `bin/lint --staged`, and the new db-less `WizardState` spec all passed. CI should run the full suite on the PR.

## Screenshots

_Please attach before/after screenshots of the wizard (multi-question layout vs. single-question Turbo Frame view, including the progress indicator and the Finish state on the last step)._

---

Closes #1965