### PR TITLE
Fix #1964: Answer issue clarifying questions via Paid UI wizard

### DIFF
--- a/app/controllers/projects/clarifying_questions_controller.rb
+++ b/app/controllers/projects/clarifying_questions_controller.rb
@@ -51,6 +51,9 @@ module Projects
     end
 
     def fetch_questions
+      questions = ClarifyingQuestions::Parse.call(comment_body: @issue.body)
+      return questions if questions.any?
+
       client = @project.github_token.client
       comments = client.issue_comments(@project.full_name, @issue.github_number)
       enhancement_comment = comments.reverse.find do |comment|

--- a/app/controllers/projects/clarifying_questions_controller.rb
+++ b/app/controllers/projects/clarifying_questions_controller.rb
@@ -29,9 +29,9 @@ module Projects
 
       redirect_to project_path(@project), notice: "Answers posted to GitHub issue ##{@issue.github_number}. The agent will pick them up on the next run."
     rescue ArgumentError => e
-      redirect_to project_issue_clarifying_question_path(@project, @issue), alert: e.message
+      redirect_to project_issue_clarifying_questions_path(@project, @issue), alert: e.message
     rescue GithubClient::Error => e
-      redirect_to project_issue_clarifying_question_path(@project, @issue), alert: "Failed to post answers: #{e.message}"
+      redirect_to project_issue_clarifying_questions_path(@project, @issue), alert: "Failed to post answers: #{e.message}"
     end
 
     private

--- a/app/controllers/projects/clarifying_questions_controller.rb
+++ b/app/controllers/projects/clarifying_questions_controller.rb
@@ -9,15 +9,17 @@ module Projects
     before_action :authorize_project_update, only: [ :create ]
 
     def show
-      @questions = fetch_questions
+      @questions = ClarifyingQuestions::Load.call(project: @project, issue: @issue)
 
       if @questions.empty?
         redirect_to project_path(@project), alert: "No clarifying questions found for issue ##{@issue.github_number}."
       end
+    rescue GithubClient::Error => e
+      redirect_to project_path(@project), alert: "Failed to load clarifying questions: #{e.message}"
     end
 
     def create
-      questions_and_answers = build_questions_and_answers
+      questions_and_answers = build_questions_and_answers(questions: current_questions)
 
       ClarifyingQuestions::SubmitAnswers.call(
         project: @project,
@@ -50,24 +52,13 @@ module Projects
       authorize @project, :update?
     end
 
-    def fetch_questions
-      questions = ClarifyingQuestions::Parse.call(comment_body: @issue.body)
-      return questions if questions.any?
-
-      client = @project.github_token.client
-      comments = client.issue_comments(@project.full_name, @issue.github_number)
-      enhancement_comment = comments.reverse.find do |comment|
-        comment.body.to_s.include?(ClarifyingQuestions::Parse::ENHANCEMENT_MARKER) &&
-          comment.body.to_s.include?("## Clarifying questions")
-      end
-      return [] unless enhancement_comment
-
-      ClarifyingQuestions::Parse.call(comment_body: enhancement_comment.body)
+    def current_questions
+      @current_questions ||= ClarifyingQuestions::Load.call(project: @project, issue: @issue)
     end
 
-    def build_questions_and_answers
-      questions = params[:questions] || []
+    def build_questions_and_answers(questions:)
       answers = params[:answers] || []
+      raise ArgumentError, "No clarifying questions found for this issue." if questions.empty?
 
       questions.each_with_index.map do |question, i|
         { question: question, answer: answers[i].to_s.strip }

--- a/app/controllers/projects/clarifying_questions_controller.rb
+++ b/app/controllers/projects/clarifying_questions_controller.rb
@@ -57,8 +57,13 @@ module Projects
     end
 
     def build_questions_and_answers(questions:)
-      answers = params[:answers] || []
+      answers = Array(params[:answers])
+      submitted_questions = Array(params[:questions]).map { |question| question.to_s.strip }
+
       raise ArgumentError, "No clarifying questions found for this issue." if questions.empty?
+      unless submitted_questions == questions
+        raise ArgumentError, "Clarifying questions changed. Please reload and try again."
+      end
 
       questions.each_with_index.map do |question, i|
         { question: question, answer: answers[i].to_s.strip }

--- a/app/controllers/projects/clarifying_questions_controller.rb
+++ b/app/controllers/projects/clarifying_questions_controller.rb
@@ -27,9 +27,9 @@ module Projects
 
       redirect_to project_path(@project), notice: "Answers posted to GitHub issue ##{@issue.github_number}. The agent will pick them up on the next run."
     rescue ArgumentError => e
-      redirect_to project_issue_clarifying_questions_path(@project, @issue), alert: e.message
+      redirect_to project_issue_clarifying_question_path(@project, @issue), alert: e.message
     rescue GithubClient::Error => e
-      redirect_to project_issue_clarifying_questions_path(@project, @issue), alert: "Failed to post answers: #{e.message}"
+      redirect_to project_issue_clarifying_question_path(@project, @issue), alert: "Failed to post answers: #{e.message}"
     end
 
     private

--- a/app/controllers/projects/clarifying_questions_controller.rb
+++ b/app/controllers/projects/clarifying_questions_controller.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Projects
+  class ClarifyingQuestionsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_project
+    before_action :set_issue
+    before_action :authorize_project_show, only: [ :show ]
+    before_action :authorize_project_update, only: [ :create ]
+
+    def show
+      @questions = fetch_questions
+
+      if @questions.empty?
+        redirect_to project_path(@project), alert: "No clarifying questions found for issue ##{@issue.github_number}."
+      end
+    end
+
+    def create
+      questions_and_answers = build_questions_and_answers
+
+      ClarifyingQuestions::SubmitAnswers.call(
+        project: @project,
+        issue: @issue,
+        questions_and_answers: questions_and_answers
+      )
+
+      redirect_to project_path(@project), notice: "Answers posted to GitHub issue ##{@issue.github_number}. The agent will pick them up on the next run."
+    rescue ArgumentError => e
+      redirect_to project_issue_clarifying_questions_path(@project, @issue), alert: e.message
+    rescue GithubClient::Error => e
+      redirect_to project_issue_clarifying_questions_path(@project, @issue), alert: "Failed to post answers: #{e.message}"
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).find(params[:project_id])
+    end
+
+    def set_issue
+      @issue = @project.issues.issues_only.find(params[:issue_id])
+    end
+
+    def authorize_project_show
+      authorize @project, :show?
+    end
+
+    def authorize_project_update
+      authorize @project, :update?
+    end
+
+    def fetch_questions
+      client = @project.github_token.client
+      comments = client.issue_comments(@project.full_name, @issue.github_number)
+      enhancement_comment = comments.reverse.find do |comment|
+        comment.body.to_s.include?(ClarifyingQuestions::Parse::ENHANCEMENT_MARKER) &&
+          comment.body.to_s.include?("## Clarifying questions")
+      end
+      return [] unless enhancement_comment
+
+      ClarifyingQuestions::Parse.call(comment_body: enhancement_comment.body)
+    end
+
+    def build_questions_and_answers
+      questions = params[:questions] || []
+      answers = params[:answers] || []
+
+      questions.each_with_index.map do |question, i|
+        { question: question, answer: answers[i].to_s.strip }
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/clarifying_questions_controller.js
+++ b/app/javascript/controllers/clarifying_questions_controller.js
@@ -1,0 +1,65 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["step", "answer", "progressBar", "progressAnswered", "progressPercent", "form", "submitButton"]
+  static values = { total: Number }
+
+  connect() {
+    this.currentIndex = 0
+    this.updateProgress()
+  }
+
+  next() {
+    if (!this.validateCurrentStep()) return
+    if (this.currentIndex < this.stepTargets.length - 1) {
+      this.currentIndex++
+      this.showStep(this.currentIndex)
+    }
+  }
+
+  previous() {
+    if (this.currentIndex > 0) {
+      this.currentIndex--
+      this.showStep(this.currentIndex)
+    }
+  }
+
+  showStep(index) {
+    this.stepTargets.forEach((step, i) => {
+      step.style.display = i === index ? "" : "none"
+    })
+    this.updateProgress()
+  }
+
+  validateCurrentStep() {
+    const currentStep = this.stepTargets[this.currentIndex]
+    if (!currentStep) return true
+
+    const textarea = currentStep.querySelector("textarea")
+    if (textarea && textarea.required && !textarea.value.trim()) {
+      textarea.focus()
+      textarea.classList.add("border-red-500")
+      return false
+    }
+    if (textarea) {
+      textarea.classList.remove("border-red-500")
+    }
+    return true
+  }
+
+  updateProgress() {
+    const total = this.totalValue
+    const answered = this.answerTargets.filter(a => a.value.trim().length > 0).length
+    const percent = total > 0 ? Math.round((answered / total) * 100) : 0
+
+    if (this.hasProgressBarTarget) {
+      this.progressBarTarget.style.width = `${percent}%`
+    }
+    if (this.hasProgressAnsweredTarget) {
+      this.progressAnsweredTarget.textContent = answered
+    }
+    if (this.hasProgressPercentTarget) {
+      this.progressPercentTarget.textContent = percent
+    }
+  }
+}

--- a/app/javascript/controllers/clarifying_questions_controller.js
+++ b/app/javascript/controllers/clarifying_questions_controller.js
@@ -24,6 +24,13 @@ export default class extends Controller {
     }
   }
 
+  submit(event) {
+    if (this.allAnswersPresent()) return
+
+    event.preventDefault()
+    this.focusFirstBlankAnswer()
+  }
+
   showStep(index) {
     this.stepTargets.forEach((step, i) => {
       step.style.display = i === index ? "" : "none"
@@ -49,8 +56,13 @@ export default class extends Controller {
 
   updateProgress() {
     const total = this.totalValue
-    const answered = this.answerTargets.filter(a => a.value.trim().length > 0).length
+    const answered = this.answerTargets.filter((answer) => {
+      const present = answer.value.trim().length > 0
+      if (present) answer.classList.remove("border-red-500")
+      return present
+    }).length
     const percent = total > 0 ? Math.round((answered / total) * 100) : 0
+    const allAnswered = total > 0 && answered === total
 
     if (this.hasProgressBarTarget) {
       this.progressBarTarget.style.width = `${percent}%`
@@ -61,5 +73,24 @@ export default class extends Controller {
     if (this.hasProgressPercentTarget) {
       this.progressPercentTarget.textContent = percent
     }
+    if (this.hasSubmitButtonTarget) {
+      this.submitButtonTarget.disabled = !allAnswered
+      this.submitButtonTarget.setAttribute("aria-disabled", (!allAnswered).toString())
+    }
+  }
+
+  allAnswersPresent() {
+    return this.answerTargets.every(answer => answer.value.trim().length > 0)
+  }
+
+  focusFirstBlankAnswer() {
+    const blankAnswer = this.answerTargets.find(answer => answer.value.trim().length === 0)
+    if (!blankAnswer) return
+
+    const stepIndex = Number(blankAnswer.dataset.stepIndex)
+    this.currentIndex = stepIndex
+    this.showStep(stepIndex)
+    blankAnswer.classList.add("border-red-500")
+    blankAnswer.focus()
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -28,6 +28,9 @@ application.register("chat-session-list", ChatSessionListController)
 import ChatStreamController from "./chat_stream_controller"
 application.register("chat-stream", ChatStreamController)
 
+import ClarifyingQuestionsController from "./clarifying_questions_controller"
+application.register("clarifying-questions", ClarifyingQuestionsController)
+
 import ConfirmDeleteController from "./confirm_delete_controller"
 application.register("confirm-delete", ConfirmDeleteController)
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -193,7 +193,7 @@ class Issue < ApplicationRecord
   end
 
   def needs_input?
-    paid_state == "needs_input"
+    paid_state == "needs_input" && has_label?(project.enhance_issue_needs_input_label_name)
   end
 
   def draft_phase?

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -192,6 +192,10 @@ class Issue < ApplicationRecord
     end
   end
 
+  def needs_input?
+    paid_state == "needs_input"
+  end
+
   def draft_phase?
     pr_review_phase.in?(%w[draft restarted])
   end

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -45,6 +45,7 @@ module ClarifyingQuestions
       latest_answer_comment = latest_answer_comment()
       return false unless latest_answer_comment
       return true if body_questions.any? && enhancement_comment.blank?
+      return false if enhancement_comment.blank?
 
       comment_timestamp(latest_answer_comment) > comment_timestamp(enhancement_comment)
     end

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -15,10 +15,9 @@ module ClarifyingQuestions
 
     def call
       body_questions = Parse.call(comment_body: issue.body)
-      return body_questions if body_questions.any? && !github_available?
-
       enhancement_comment = latest_enhancement_comment
-      return [] if answered_after_enhancement?(enhancement_comment)
+      return body_questions if body_questions.any? && !github_available?
+      return [] if answered_after_latest_questions?(body_questions:, enhancement_comment:)
       return body_questions if body_questions.any?
       return [] unless enhancement_comment
 
@@ -42,15 +41,18 @@ module ClarifyingQuestions
       end
     end
 
-    def answered_after_enhancement?(enhancement_comment)
-      return false unless enhancement_comment
-
-      latest_answer_comment = issue_comments.reverse.find do |comment|
-        comment_body(comment).include?(ANSWER_MARKER)
-      end
+    def answered_after_latest_questions?(body_questions:, enhancement_comment:)
+      latest_answer_comment = latest_answer_comment()
       return false unless latest_answer_comment
+      return true if body_questions.any? && enhancement_comment.blank?
 
       comment_timestamp(latest_answer_comment) > comment_timestamp(enhancement_comment)
+    end
+
+    def latest_answer_comment
+      issue_comments.reverse.find do |comment|
+        comment_body(comment).include?(ANSWER_MARKER)
+      end
     end
 
     def comment_body(comment)

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -54,10 +54,23 @@ module ClarifyingQuestions
     def answered_after_latest_questions?(body_questions:, enhancement_comment:)
       latest_answer_comment = latest_answer_comment()
       return false unless latest_answer_comment
-      return true if body_questions.any? && enhancement_comment.blank?
-      return false if enhancement_comment.blank?
 
-      comment_timestamp(latest_answer_comment) > comment_timestamp(enhancement_comment)
+      latest_answer_timestamp = comment_timestamp(latest_answer_comment)
+      latest_question_timestamp = latest_question_timestamp(
+        body_questions: body_questions,
+        enhancement_comment: enhancement_comment
+      )
+      return false unless latest_question_timestamp
+
+      latest_answer_timestamp > latest_question_timestamp
+    end
+
+    def latest_question_timestamp(body_questions:, enhancement_comment:)
+      timestamps = []
+      timestamps << issue_timestamp if body_questions.any?
+      timestamps << comment_timestamp(enhancement_comment) if enhancement_comment.present?
+
+      timestamps.compact.max
     end
 
     def latest_answer_comment
@@ -72,6 +85,10 @@ module ClarifyingQuestions
 
     def comment_timestamp(comment)
       comment.created_at&.to_time || Time.at(0)
+    end
+
+    def issue_timestamp
+      issue.github_updated_at&.to_time || issue.updated_at&.to_time || Time.at(0)
     end
 
     def issue_comments

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -2,6 +2,8 @@
 
 module ClarifyingQuestions
   class Load
+    ANSWER_MARKER = "<!-- paid:clarifying-answers -->"
+
     def self.call(...)
       new(...).call
     end
@@ -12,22 +14,52 @@ module ClarifyingQuestions
     end
 
     def call
-      questions = Parse.call(comment_body: issue.body)
-      return questions if questions.any?
-      return [] unless project.github_token
+      body_questions = Parse.call(comment_body: issue.body)
+      return body_questions if body_questions.any? && !github_available?
 
-      enhancement_comment = issue_comments.reverse.find do |comment|
-        comment.body.to_s.include?(Parse::ENHANCEMENT_MARKER) &&
-          comment.body.to_s.include?("## Clarifying questions")
-      end
+      enhancement_comment = latest_enhancement_comment
+      return [] if answered_after_enhancement?(enhancement_comment)
+      return body_questions if body_questions.any?
       return [] unless enhancement_comment
 
-      Parse.call(comment_body: enhancement_comment.body)
+      Parse.call(comment_body: comment_body(enhancement_comment))
     end
 
     private
 
     attr_reader :project, :issue
+
+    def github_available?
+      project.github_token.present?
+    end
+
+    def latest_enhancement_comment
+      return unless github_available?
+
+      issue_comments.reverse.find do |comment|
+        comment_body(comment).include?(Parse::ENHANCEMENT_MARKER) &&
+          comment_body(comment).include?("## Clarifying questions")
+      end
+    end
+
+    def answered_after_enhancement?(enhancement_comment)
+      return false unless enhancement_comment
+
+      latest_answer_comment = issue_comments.reverse.find do |comment|
+        comment_body(comment).include?(ANSWER_MARKER)
+      end
+      return false unless latest_answer_comment
+
+      comment_timestamp(latest_answer_comment) > comment_timestamp(enhancement_comment)
+    end
+
+    def comment_body(comment)
+      comment.body.to_s
+    end
+
+    def comment_timestamp(comment)
+      comment.created_at&.to_time || Time.at(0)
+    end
 
     def issue_comments
       project.github_token.client.issue_comments(project.full_name, issue.github_number)

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ClarifyingQuestions
+  class Load
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, issue:)
+      @project = project
+      @issue = issue
+    end
+
+    def call
+      questions = Parse.call(comment_body: issue.body)
+      return questions if questions.any?
+      return [] unless project.github_token
+
+      enhancement_comment = issue_comments.reverse.find do |comment|
+        comment.body.to_s.include?(Parse::ENHANCEMENT_MARKER) &&
+          comment.body.to_s.include?("## Clarifying questions")
+      end
+      return [] unless enhancement_comment
+
+      Parse.call(comment_body: enhancement_comment.body)
+    end
+
+    private
+
+    attr_reader :project, :issue
+
+    def issue_comments
+      project.github_token.client.issue_comments(project.full_name, issue.github_number)
+    end
+  end
+end

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -15,10 +15,20 @@ module ClarifyingQuestions
 
     def call
       body_questions = Parse.call(comment_body: issue.body)
+
+      if body_questions.any?
+        return body_questions unless github_available?
+
+        enhancement_comment = latest_enhancement_comment
+        return [] if answered_after_latest_questions?(body_questions:, enhancement_comment:)
+
+        return body_questions
+      end
+
+      return [] unless github_available?
+
       enhancement_comment = latest_enhancement_comment
-      return body_questions if body_questions.any? && !github_available?
       return [] if answered_after_latest_questions?(body_questions:, enhancement_comment:)
-      return body_questions if body_questions.any?
       return [] unless enhancement_comment
 
       Parse.call(comment_body: comment_body(enhancement_comment))
@@ -65,7 +75,7 @@ module ClarifyingQuestions
     end
 
     def issue_comments
-      project.github_token.client.issue_comments(project.full_name, issue.github_number)
+      @issue_comments ||= project.github_token.client.issue_comments(project.full_name, issue.github_number)
     end
   end
 end

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -32,6 +32,10 @@ module ClarifyingQuestions
       return [] unless enhancement_comment
 
       Parse.call(comment_body: comment_body(enhancement_comment))
+    rescue GithubClient::Error
+      raise if body_questions.empty?
+
+      body_questions
     end
 
     private

--- a/app/services/clarifying_questions/parse.rb
+++ b/app/services/clarifying_questions/parse.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module ClarifyingQuestions
+  class Parse
+    ENHANCEMENT_MARKER = "<!-- paid:enhance-issue -->"
+    CLARIFYING_SECTION_PATTERN = /## Clarifying questions\s*\n(.+?)(?=\n## |\z)/m.freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(comment_body:)
+      @comment_body = comment_body.to_s
+    end
+
+    def call
+      return [] unless comment_body.include?(ENHANCEMENT_MARKER)
+      return [] unless comment_body.include?("## Clarifying questions")
+
+      section = extract_clarifying_section
+      return [] unless section
+
+      parse_numbered_items(section)
+    end
+
+    private
+
+    attr_reader :comment_body
+
+    def extract_clarifying_section
+      match = comment_body.match(CLARIFYING_SECTION_PATTERN)
+      match ? match[1] : nil
+    end
+
+    def parse_numbered_items(text)
+      questions = []
+      current = nil
+
+      text.each_line do |line|
+        stripped = line.strip
+        if (match = stripped.match(/\A\d+\.\s+(.+)\z/))
+          questions << current if current
+          current = match[1]
+        elsif current.present? && stripped.present?
+          current += " " + stripped
+        end
+      end
+      questions << current if current
+
+      questions
+    end
+  end
+end

--- a/app/services/clarifying_questions/submit_answers.rb
+++ b/app/services/clarifying_questions/submit_answers.rb
@@ -23,6 +23,13 @@ module ClarifyingQuestions
     attr_reader :project, :issue, :questions_and_answers
 
     def validate_answers!
+      raise ArgumentError, "No clarifying questions found for this issue." if questions_and_answers.empty?
+
+      missing_questions = questions_and_answers.select { |qa| qa[:question].blank? }
+      if missing_questions.any?
+        raise ArgumentError, "Clarifying question text is missing for #{missing_questions.size} item(s)."
+      end
+
       missing = questions_and_answers.select { |qa| qa[:answer].blank? }
       return if missing.empty?
 

--- a/app/services/clarifying_questions/submit_answers.rb
+++ b/app/services/clarifying_questions/submit_answers.rb
@@ -2,6 +2,8 @@
 
 module ClarifyingQuestions
   class SubmitAnswers
+    ANSWER_MARKER = Load::ANSWER_MARKER
+
     def self.call(...)
       new(...).call
     end
@@ -14,7 +16,7 @@ module ClarifyingQuestions
 
     def call
       validate_answers!
-      client = project.github_token.client
+      client = github_client
       client.add_comment(project.full_name, issue.github_number, formatted_comment)
     end
 
@@ -24,6 +26,7 @@ module ClarifyingQuestions
 
     def validate_answers!
       raise ArgumentError, "No clarifying questions found for this issue." if questions_and_answers.empty?
+      raise ArgumentError, "GitHub access is not configured for this project." unless github_client
 
       missing_questions = questions_and_answers.select { |qa| qa[:question].blank? }
       if missing_questions.any?
@@ -37,13 +40,17 @@ module ClarifyingQuestions
     end
 
     def formatted_comment
-      parts = [ "<!-- paid:clarifying-answers -->", "", "## Clarifying question answers", "" ]
+      parts = [ ANSWER_MARKER, "", "## Clarifying question answers", "" ]
       questions_and_answers.each_with_index do |qa, i|
         parts << "**Q#{i + 1}: #{qa[:question]}**"
-        parts << qa[:answer]
+        parts << "**A#{i + 1}:** #{qa[:answer]}"
         parts << ""
       end
       parts.join("\n")
+    end
+
+    def github_client
+      project.github_token&.client
     end
   end
 end

--- a/app/services/clarifying_questions/submit_answers.rb
+++ b/app/services/clarifying_questions/submit_answers.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ClarifyingQuestions
+  class SubmitAnswers
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, issue:, questions_and_answers:)
+      @project = project
+      @issue = issue
+      @questions_and_answers = questions_and_answers
+    end
+
+    def call
+      validate_answers!
+      client = project.github_token.client
+      client.add_comment(project.full_name, issue.github_number, formatted_comment)
+    end
+
+    private
+
+    attr_reader :project, :issue, :questions_and_answers
+
+    def validate_answers!
+      missing = questions_and_answers.select { |qa| qa[:answer].blank? }
+      return if missing.empty?
+
+      raise ArgumentError, "All questions must be answered. #{missing.size} question(s) are blank."
+    end
+
+    def formatted_comment
+      parts = [ "<!-- paid:clarifying-answers -->", "", "## Clarifying question answers", "" ]
+      questions_and_answers.each_with_index do |qa, i|
+        parts << "**Q#{i + 1}: #{qa[:question]}**"
+        parts << qa[:answer]
+        parts << ""
+      end
+      parts.join("\n")
+    end
+  end
+end

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -226,6 +226,11 @@ module Screenshots
     }.freeze
 
     def targets_for(path)
+      if path.start_with?("app/javascript/controllers/")
+        explicit_targets = targets_for_javascript_controller(path.delete_prefix("app/javascript/controllers/"))
+        return explicit_targets if explicit_targets.any?
+      end
+
       return SHARED_TARGET_KEYS if shared_ui_file?(path)
 
       if path.start_with?("app/views/")
@@ -252,6 +257,14 @@ module Screenshots
         path == "app/views/layouts/application.html.erb" ||
         path.start_with?("app/views/shared/") ||
         path == "app/helpers/application_helper.rb"
+    end
+
+    def targets_for_javascript_controller(relative_path)
+      case relative_path
+      when "clarifying_questions_controller.js" then [ :project_issue_clarifying_questions ]
+      else
+        []
+      end
     end
 
     def targets_for_helper(path)

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -275,7 +275,7 @@ module Screenshots
         .flat_map { |file| targets_for_javascript_controller(file.delete_prefix("app/javascript/controllers/")) }
         .uniq
 
-      return nil if explicit_targets.any?
+      return explicit_targets if explicit_targets.any?
 
       SHARED_TARGET_KEYS
     end

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -148,8 +148,8 @@ module Screenshots
       return materialize(SHARED_TARGET_KEYS) if @changed_files.empty?
 
       mapping = @changed_files.each_with_object({}) { |path, h| h[path] = targets_for(path) }
-      target_keys = mapping.values.flatten.uniq
-      unresolved_files = mapping.select { |_, targets| targets.empty? }.keys
+      target_keys = mapping.values.compact.flatten.uniq
+      unresolved_files = mapping.select { |_, targets| targets == [] }.keys
 
       if unresolved_files.any?
         raise UnmappedUiChangeError,
@@ -226,6 +226,8 @@ module Screenshots
     }.freeze
 
     def targets_for(path)
+      return targets_for_javascript_registry if path == "app/javascript/controllers/index.js"
+
       if path.start_with?("app/javascript/controllers/")
         explicit_targets = targets_for_javascript_controller(path.delete_prefix("app/javascript/controllers/"))
         return explicit_targets if explicit_targets.any?
@@ -265,6 +267,17 @@ module Screenshots
       else
         []
       end
+    end
+
+    def targets_for_javascript_registry
+      explicit_targets = @changed_files
+        .grep(%r{\Aapp/javascript/controllers/(?!index\.js\z)})
+        .flat_map { |file| targets_for_javascript_controller(file.delete_prefix("app/javascript/controllers/")) }
+        .uniq
+
+      return nil if explicit_targets.any?
+
+      SHARED_TARGET_KEYS
     end
 
     def targets_for_helper(path)

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -109,6 +109,13 @@ module Screenshots
       projects: Target.new(slug: "projects", path_builder: "/projects", requires_auth: true),
       project_new: Target.new(slug: "project_new", path_builder: "/projects/new", requires_auth: true),
       project_show: Target.new(slug: "project_show", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}" }, requires_auth: true),
+      project_issue_clarifying_questions: Target.new(
+        slug: "project_issue_clarifying_questions",
+        path_builder: ->(seed_data) {
+          "/projects/#{seed_data.fetch(:project).id}/issues/#{seed_data.fetch(:clarifying_issue).id}/clarifying_questions"
+        },
+        requires_auth: true
+      ),
       project_edit: Target.new(slug: "project_edit", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/edit" }, requires_auth: true),
       project_agent_runs: Target.new(slug: "project_agent_runs", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/agent_runs" }, requires_auth: true),
       project_agent_run_new: Target.new(slug: "project_agent_run_new", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/agent_runs/new" }, requires_auth: true),
@@ -203,6 +210,7 @@ module Screenshots
       "knowledge/artifacts_controller.rb" => [ :project_knowledge_artifact_show ],
       "knowledge/context_intake_controller.rb" => [ :project_context_intake ],
       "projects/cost_budgets_controller.rb" => [ :project_cost_dashboard ],
+      "projects/clarifying_questions_controller.rb" => [ :project_issue_clarifying_questions ],
       "projects/issue_merge_subscriptions_controller.rb" => [ :project_show ],
       "projects/pr_templates_controller.rb" => [ :project_edit ],
       "projects/pre_commit_requirements_controller.rb" => [ :project_edit ],
@@ -378,6 +386,7 @@ module Screenshots
       when "new.html.erb" then [ :project_new ]
       when "show.html.erb" then [ :project_show ]
       when "edit.html.erb" then [ :project_edit ]
+      when "clarifying_questions/show.html.erb" then [ :project_issue_clarifying_questions ]
       when /\A_/
         base = File.basename(leaf, ".html.erb")
         if PROJECT_SHOW_PARTIALS.include?(base)

--- a/app/services/screenshots/seed_data/paid.rb
+++ b/app/services/screenshots/seed_data/paid.rb
@@ -46,6 +46,27 @@ module Screenshots
             record.allowed_github_usernames = [ user.email ]
           end
 
+          clarifying_issue = project.issues.find_or_create_by!(github_issue_id: 9_999_991) do |record|
+            record.github_number = 1964
+            record.title = "Answer issue clarifying questions via Paid UI wizard"
+            record.body = <<~MARKDOWN
+              <!-- paid:enhance-issue -->
+
+              ## Clarifying questions
+              1. What is the desired end-to-end behavior after the user submits answers?
+              2. Should the wizard allow editing previous answers before submission?
+
+              ## Current context
+              - Waiting for a trusted collaborator to answer in the Paid UI.
+            MARKDOWN
+            record.github_creator_login = user.email
+            record.github_state = "open"
+            record.github_created_at = 1.day.ago
+            record.github_updated_at = Time.current
+            record.paid_state = "needs_input"
+            record.labels = [ project.enhance_issue_needs_input_label_name ]
+          end
+
           provider = user.providers.subscription.first!
           provider.update!(enabled_for_agent_runs: true, enabled_for_fallback: true)
 
@@ -200,6 +221,7 @@ module Screenshots
           {
             "user" => { "id" => user.id, "email" => user.email, "password" => password },
             "project" => { "id" => project.id, "name" => project.name, "slug" => project.repo },
+            "clarifying_issue" => { "id" => clarifying_issue.id, "github_number" => clarifying_issue.github_number },
             "provider" => { "id" => provider.id, "name" => provider.name },
             "github_token" => { "id" => github_token.id, "name" => github_token.name },
             "integration_credential" => { "id" => integration_credential.id, "name" => integration_credential.name },

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -13,6 +13,11 @@
           Paused by <%= guardrail_violation_label_for(paused_run).downcase %>
         </span>
       <% end %>
+      <% if issue.needs_input? && policy(project).update? %>
+        <%= link_to "Answer Questions",
+              project_issue_clarifying_questions_path(project, issue),
+              class: "inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-200" %>
+      <% end %>
     </div>
     <% if issue.labels.any? %>
       <div class="mt-1 flex flex-wrap gap-1">

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -15,7 +15,7 @@
       <% end %>
       <% if issue.needs_input? && policy(project).update? %>
         <%= link_to "Answer Questions",
-              project_issue_clarifying_questions_path(project, issue),
+              project_issue_clarifying_question_path(project, issue),
               class: "inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-200" %>
       <% end %>
     </div>

--- a/app/views/projects/_issue.html.erb
+++ b/app/views/projects/_issue.html.erb
@@ -15,7 +15,7 @@
       <% end %>
       <% if issue.needs_input? && policy(project).update? %>
         <%= link_to "Answer Questions",
-              project_issue_clarifying_question_path(project, issue),
+              project_issue_clarifying_questions_path(project, issue),
               class: "inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-200" %>
       <% end %>
     </div>

--- a/app/views/projects/clarifying_questions/show.html.erb
+++ b/app/views/projects/clarifying_questions/show.html.erb
@@ -40,7 +40,7 @@
       </div>
     </div>
 
-    <%= form_with url: project_issue_clarifying_questions_path(@project, @issue),
+    <%= form_with url: project_issue_clarifying_question_path(@project, @issue),
                   method: :post,
                   data: { clarifying_questions_target: "form" } do |f| %>
 

--- a/app/views/projects/clarifying_questions/show.html.erb
+++ b/app/views/projects/clarifying_questions/show.html.erb
@@ -1,0 +1,109 @@
+<% content_for(:title) { "Answer Questions - #{@issue.title} - Paid" } %>
+
+<div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8"
+     data-controller="clarifying-questions"
+     data-clarifying-questions-total-value="<%= @questions.size %>">
+
+  <div class="sm:flex sm:items-center sm:justify-between">
+    <div class="sm:flex-auto">
+      <h1 class="text-2xl font-semibold leading-6 text-gray-900">Clarifying Questions</h1>
+      <p class="mt-2 text-sm text-gray-700">
+        Answer questions for <strong><%= link_to "##{@issue.github_number} #{@issue.title}",
+              @issue.github_url, target: "_blank", rel: "noopener noreferrer",
+              class: "text-indigo-600 hover:text-indigo-500" %></strong>
+        in <strong><%= @project.name %></strong>.
+      </p>
+    </div>
+    <div class="mt-4 sm:mt-0 sm:ml-4">
+      <%= link_to back_link_path(project_path(@project)), class: "text-sm text-indigo-600 hover:text-indigo-500" do %>
+        &larr; Back to project
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-6">
+    <div class="overflow-hidden rounded-lg bg-white shadow">
+      <div class="px-4 py-4 sm:px-6">
+        <div class="flex items-center justify-between">
+          <p class="text-sm font-medium text-gray-700">
+            Progress: <span data-clarifying-questions-target="progressAnswered">0</span> / <%= @questions.size %> questions answered
+          </p>
+          <p class="text-sm text-gray-500">
+            <span data-clarifying-questions-target="progressPercent">0</span>%
+          </p>
+        </div>
+        <div class="mt-2 w-full bg-gray-200 rounded-full h-2">
+          <div class="bg-indigo-600 h-2 rounded-full transition-all duration-300"
+               data-clarifying-questions-target="progressBar"
+               style="width: 0%"></div>
+        </div>
+      </div>
+    </div>
+
+    <%= form_with url: project_issue_clarifying_questions_path(@project, @issue),
+                  method: :post,
+                  data: { clarifying_questions_target: "form" } do |f| %>
+
+      <% @questions.each_with_index do |question, index| %>
+        <div class="mt-4 overflow-hidden rounded-lg bg-white shadow"
+             data-clarifying-questions-target="step"
+             data-step-index="<%= index %>"
+             style="<%= index == 0 ? '' : 'display: none;' %>">
+          <div class="px-4 py-5 sm:p-6">
+            <div class="mb-2 flex items-center justify-between">
+              <span class="text-xs font-medium text-gray-500">
+                Question <%= index + 1 %> of <%= @questions.size %>
+              </span>
+            </div>
+            <h3 class="text-lg font-medium text-gray-900 mb-4"><%= question %></h3>
+
+            <%= f.hidden_field "questions[]", value: question, id: "question_#{index}" %>
+
+            <label for="answer_<%= index %>" class="block text-sm font-medium text-gray-700 mb-1">
+              Your answer <span class="text-red-500">*</span>
+            </label>
+            <%= text_area_tag "answers[]", nil,
+                  id: "answer_#{index}",
+                  rows: 4,
+                  required: true,
+                  placeholder: "Enter your answer...",
+                  class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+                  data: {
+                    clarifying_questions_target: "answer",
+                    step_index: index,
+                    action: "input->clarifying-questions#updateProgress"
+                  } %>
+
+            <div class="mt-4 flex items-center justify-between">
+              <div>
+                <% if index > 0 %>
+                  <button type="button"
+                          class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer"
+                          data-action="click->clarifying-questions#previous">
+                    &larr; Previous
+                  </button>
+                <% end %>
+              </div>
+              <div class="flex items-center gap-3">
+                <% if index < @questions.size - 1 %>
+                  <button type="button"
+                          class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer"
+                          data-action="click->clarifying-questions#next">
+                    Next &rarr;
+                  </button>
+                <% else %>
+                  <%= f.submit "Submit All Answers",
+                        class: "inline-flex items-center rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 cursor-pointer",
+                        data: {
+                          clarifying_questions_target: "submitButton",
+                          turbo_confirm: "Submit your answers? They will be posted as a comment on the GitHub issue."
+                        } %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/projects/clarifying_questions/show.html.erb
+++ b/app/views/projects/clarifying_questions/show.html.erb
@@ -40,7 +40,7 @@
       </div>
     </div>
 
-    <%= form_with url: project_issue_clarifying_question_path(@project, @issue),
+    <%= form_with url: project_issue_clarifying_questions_path(@project, @issue),
                   method: :post,
                   data: {
                     clarifying_questions_target: "form",

--- a/app/views/projects/clarifying_questions/show.html.erb
+++ b/app/views/projects/clarifying_questions/show.html.erb
@@ -42,7 +42,10 @@
 
     <%= form_with url: project_issue_clarifying_question_path(@project, @issue),
                   method: :post,
-                  data: { clarifying_questions_target: "form" } do |f| %>
+                  data: {
+                    clarifying_questions_target: "form",
+                    action: "submit->clarifying-questions#submit"
+                  } do |f| %>
 
       <% @questions.each_with_index do |question, index| %>
         <div class="mt-4 overflow-hidden rounded-lg bg-white shadow"
@@ -93,7 +96,8 @@
                   </button>
                 <% else %>
                   <%= f.submit "Submit All Answers",
-                        class: "inline-flex items-center rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 cursor-pointer",
+                        class: "inline-flex items-center rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 disabled:cursor-not-allowed disabled:bg-green-300 disabled:hover:bg-green-300",
+                        disabled: true,
                         data: {
                           clarifying_questions_target: "submitButton",
                           turbo_confirm: "Submit your answers? They will be posted as a comment on the GitHub issue."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,8 @@ Rails.application.routes.draw do
     resources :issues, only: [] do
       resource :merge_subscription, only: [ :show, :create, :destroy ],
         controller: "projects/issue_merge_subscriptions"
+      resource :clarifying_questions, only: [ :show, :create ],
+        controller: "projects/clarifying_questions"
     end
     post :detect_services, on: :member
     resource :context_intake, only: [ :show, :create, :update ],

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -41,6 +41,7 @@ FactoryBot.define do
 
     trait :needs_input do
       paid_state { "needs_input" }
+      labels { [ project.enhance_issue_needs_input_label_name ] }
     end
 
     trait :recommend_close do

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -850,6 +850,16 @@ RSpec.describe Issue do
     end
   end
 
+  describe "#needs_input?" do
+    it "returns true when the issue is waiting on user answers" do
+      expect(build(:issue, paid_state: "needs_input")).to be_needs_input
+    end
+
+    it "returns false for other paid states" do
+      expect(build(:issue, paid_state: "planning")).not_to be_needs_input
+    end
+  end
+
   describe "broadcast callbacks" do
     let(:project) { create(:project) }
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -852,11 +852,21 @@ RSpec.describe Issue do
 
   describe "#needs_input?" do
     it "returns true when the issue is waiting on user answers" do
-      expect(build(:issue, paid_state: "needs_input")).to be_needs_input
+      project = build(:project, enhance_issue_needs_input_label_name: "paid-enhance-needs-input")
+      issue = build(:issue, :needs_input, project: project, labels: [ "paid-enhance-needs-input" ])
+
+      expect(issue).to be_needs_input
     end
 
     it "returns false for other paid states" do
       expect(build(:issue, paid_state: "planning")).not_to be_needs_input
+    end
+
+    it "returns false for non-enhancement needs-input issues" do
+      project = build(:project, enhance_issue_needs_input_label_name: "paid-enhance-needs-input")
+      issue = build(:issue, :needs_input, project: project, labels: [ "paid-needs-input" ])
+
+      expect(issue).not_to be_needs_input
     end
   end
 

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
       end
 
       it "renders the wizard view" do
-        get project_issue_clarifying_questions_path(project, issue)
+        get project_issue_clarifying_question_path(project, issue)
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Clarifying Questions")
@@ -49,7 +49,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
       end
 
       it "redirects to project page with alert" do
-        get project_issue_clarifying_questions_path(project, issue)
+        get project_issue_clarifying_question_path(project, issue)
 
         expect(response).to redirect_to(project_path(project))
         follow_redirect!
@@ -65,7 +65,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
 
     context "when all answers are provided" do
       it "posts answers as a GitHub comment and redirects" do
-        post project_issue_clarifying_questions_path(project, issue), params: {
+        post project_issue_clarifying_question_path(project, issue), params: {
           questions: [ "What is X?", "Should this be enabled?" ],
           answers: [ "X is a feature", "Yes, by default" ]
         }
@@ -83,12 +83,12 @@ RSpec.describe "Projects::ClarifyingQuestions" do
 
     context "when some answers are blank" do
       it "redirects back with an alert" do
-        post project_issue_clarifying_questions_path(project, issue), params: {
+        post project_issue_clarifying_question_path(project, issue), params: {
           questions: [ "What is X?", "Should this be enabled?" ],
           answers: [ "X is a feature", "" ]
         }
 
-        expect(response).to redirect_to(project_issue_clarifying_questions_path(project, issue))
+        expect(response).to redirect_to(project_issue_clarifying_question_path(project, issue))
       end
     end
   end

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -6,8 +6,21 @@ RSpec.describe "Projects::ClarifyingQuestions" do
   let(:account) { create(:account) }
   let(:user) { create(:user, account: account) }
   let(:project) { create(:project, account: account) }
-  let(:issue) { create(:issue, :needs_input, project: project) }
+  let(:issue_body) { "This is the issue body" }
+  let(:issue) { create(:issue, :needs_input, project: project, body: issue_body) }
   let(:github_client) { instance_double(GithubClient) }
+  let(:comment_body) do
+    <<~COMMENT
+      <!-- paid:enhance-issue -->
+
+      ## Clarifying questions
+      1. What is the expected behavior?
+      2. Should this be behind a flag?
+
+      ## Current context
+      - Some context
+    COMMENT
+  end
 
   before do
     sign_in user
@@ -18,17 +31,6 @@ RSpec.describe "Projects::ClarifyingQuestions" do
   describe "GET /projects/:project_id/issues/:issue_id/clarifying_questions" do
     context "when enhancement comment with clarifying questions exists" do
       before do
-        comment_body = <<~COMMENT
-          <!-- paid:enhance-issue -->
-
-          ## Clarifying questions
-          1. What is the expected behavior?
-          2. Should this be behind a flag?
-
-          ## Current context
-          - Some context
-        COMMENT
-
         comment = double(body: comment_body)
         allow(github_client).to receive(:issue_comments).and_return([ comment ])
       end
@@ -66,6 +68,10 @@ RSpec.describe "Projects::ClarifyingQuestions" do
     end
 
     context "when all answers are provided" do
+      before do
+        allow(github_client).to receive(:issue_comments).and_return([ double(body: comment_body) ])
+      end
+
       it "posts answers as a GitHub comment and redirects" do
         post project_issue_clarifying_question_path(project, issue), params: {
           questions: [ "What is X?", "Should this be enabled?" ],
@@ -84,6 +90,10 @@ RSpec.describe "Projects::ClarifyingQuestions" do
     end
 
     context "when some answers are blank" do
+      before do
+        allow(github_client).to receive(:issue_comments).and_return([ double(body: comment_body) ])
+      end
+
       it "redirects back with an alert" do
         post project_issue_clarifying_question_path(project, issue), params: {
           questions: [ "What is X?", "Should this be enabled?" ],

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -93,5 +93,21 @@ RSpec.describe "Projects::ClarifyingQuestions" do
         expect(response).to redirect_to(project_issue_clarifying_question_path(project, issue))
       end
     end
+
+    context "when the issue no longer has clarifying questions" do
+      before do
+        allow(github_client).to receive(:issue_comments).and_return([])
+      end
+
+      it "redirects back with an alert instead of posting an empty comment" do
+        post project_issue_clarifying_question_path(project, issue), params: {
+          questions: [ "Tampered question?" ],
+          answers: [ "Tampered answer" ]
+        }
+
+        expect(github_client).not_to have_received(:add_comment)
+        expect(response).to redirect_to(project_issue_clarifying_question_path(project, issue))
+      end
+    end
   end
 end

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
 
       it "posts answers as a GitHub comment and redirects" do
         post project_issue_clarifying_questions_path(project, issue), params: {
-          questions: [ "What is X?", "Should this be enabled?" ],
+          questions: [ "What is the expected behavior?", "Should this be behind a flag?" ],
           answers: [ "X is a feature", "Yes, by default" ]
         }
 
@@ -96,10 +96,26 @@ RSpec.describe "Projects::ClarifyingQuestions" do
 
       it "redirects back with an alert" do
         post project_issue_clarifying_questions_path(project, issue), params: {
-          questions: [ "What is X?", "Should this be enabled?" ],
+          questions: [ "What is the expected behavior?", "Should this be behind a flag?" ],
           answers: [ "X is a feature", "" ]
         }
 
+        expect(response).to redirect_to(project_issue_clarifying_questions_path(project, issue))
+      end
+    end
+
+    context "when the submitted questions no longer match the current questions" do
+      before do
+        allow(github_client).to receive(:issue_comments).and_return([ double(body: comment_body) ])
+      end
+
+      it "redirects back with an alert instead of posting mismatched answers" do
+        post project_issue_clarifying_questions_path(project, issue), params: {
+          questions: [ "Tampered question?" ],
+          answers: [ "Tampered answer" ]
+        }
+
+        expect(github_client).not_to have_received(:add_comment)
         expect(response).to redirect_to(project_issue_clarifying_questions_path(project, issue))
       end
     end

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe "Projects::ClarifyingQuestions" do
         expect(response.body).to include("Clarifying Questions")
         expect(response.body).to include("What is the expected behavior?")
         expect(response.body).to include("Should this be behind a flag?")
+        expect(response.body).to include('submit-&gt;clarifying-questions#submit')
+        expect(response.body).to include('disabled="disabled"')
       end
     end
 

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
       end
 
       it "renders the wizard view" do
-        get project_issue_clarifying_question_path(project, issue)
+        get project_issue_clarifying_questions_path(project, issue)
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Clarifying Questions")
@@ -53,7 +53,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
       end
 
       it "redirects to project page with alert" do
-        get project_issue_clarifying_question_path(project, issue)
+        get project_issue_clarifying_questions_path(project, issue)
 
         expect(response).to redirect_to(project_path(project))
         follow_redirect!
@@ -73,7 +73,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
       end
 
       it "posts answers as a GitHub comment and redirects" do
-        post project_issue_clarifying_question_path(project, issue), params: {
+        post project_issue_clarifying_questions_path(project, issue), params: {
           questions: [ "What is X?", "Should this be enabled?" ],
           answers: [ "X is a feature", "Yes, by default" ]
         }
@@ -95,12 +95,12 @@ RSpec.describe "Projects::ClarifyingQuestions" do
       end
 
       it "redirects back with an alert" do
-        post project_issue_clarifying_question_path(project, issue), params: {
+        post project_issue_clarifying_questions_path(project, issue), params: {
           questions: [ "What is X?", "Should this be enabled?" ],
           answers: [ "X is a feature", "" ]
         }
 
-        expect(response).to redirect_to(project_issue_clarifying_question_path(project, issue))
+        expect(response).to redirect_to(project_issue_clarifying_questions_path(project, issue))
       end
     end
 
@@ -110,13 +110,13 @@ RSpec.describe "Projects::ClarifyingQuestions" do
       end
 
       it "redirects back with an alert instead of posting an empty comment" do
-        post project_issue_clarifying_question_path(project, issue), params: {
+        post project_issue_clarifying_questions_path(project, issue), params: {
           questions: [ "Tampered question?" ],
           answers: [ "Tampered answer" ]
         }
 
         expect(github_client).not_to have_received(:add_comment)
-        expect(response).to redirect_to(project_issue_clarifying_question_path(project, issue))
+        expect(response).to redirect_to(project_issue_clarifying_questions_path(project, issue))
       end
     end
   end

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Projects::ClarifyingQuestions" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+  let(:project) { create(:project, account: account) }
+  let(:issue) { create(:issue, :needs_input, project: project) }
+  let(:github_client) { instance_double(GithubClient) }
+
+  before do
+    sign_in user
+    user.add_role(:admin, account)
+    allow(project.github_token).to receive(:client).and_return(github_client)
+  end
+
+  describe "GET /projects/:project_id/issues/:issue_id/clarifying_questions" do
+    context "when enhancement comment with clarifying questions exists" do
+      before do
+        comment_body = <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What is the expected behavior?
+          2. Should this be behind a flag?
+
+          ## Current context
+          - Some context
+        COMMENT
+
+        comment = double(body: comment_body)
+        allow(github_client).to receive(:issue_comments).and_return([ comment ])
+      end
+
+      it "renders the wizard view" do
+        get project_issue_clarifying_questions_path(project, issue)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Clarifying Questions")
+        expect(response.body).to include("What is the expected behavior?")
+        expect(response.body).to include("Should this be behind a flag?")
+      end
+    end
+
+    context "when no clarifying questions found" do
+      before do
+        allow(github_client).to receive(:issue_comments).and_return([])
+      end
+
+      it "redirects to project page with alert" do
+        get project_issue_clarifying_questions_path(project, issue)
+
+        expect(response).to redirect_to(project_path(project))
+        follow_redirect!
+        expect(response.body).to include("No clarifying questions found")
+      end
+    end
+  end
+
+  describe "POST /projects/:project_id/issues/:issue_id/clarifying_questions" do
+    before do
+      allow(github_client).to receive(:add_comment).and_return(double(html_url: "https://github.com/test"))
+    end
+
+    context "when all answers are provided" do
+      it "posts answers as a GitHub comment and redirects" do
+        post project_issue_clarifying_questions_path(project, issue), params: {
+          questions: [ "What is X?", "Should this be enabled?" ],
+          answers: [ "X is a feature", "Yes, by default" ]
+        }
+
+        expect(github_client).to have_received(:add_comment).with(
+          project.full_name,
+          issue.github_number,
+          a_string_matching(/Clarifying question answers/)
+        )
+        expect(response).to redirect_to(project_path(project))
+        follow_redirect!
+        expect(response.body).to include("Answers posted to GitHub issue")
+      end
+    end
+
+    context "when some answers are blank" do
+      it "redirects back with an alert" do
+        post project_issue_clarifying_questions_path(project, issue), params: {
+          questions: [ "What is X?", "Should this be enabled?" ],
+          answers: [ "X is a feature", "" ]
+        }
+
+        expect(response).to redirect_to(project_issue_clarifying_questions_path(project, issue))
+      end
+    end
+  end
+end

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
   before do
     sign_in user
     user.add_role(:admin, account)
-    allow(project.github_token).to receive(:client).and_return(github_client)
+    allow(GithubClient).to receive(:new).and_return(github_client)
   end
 
   describe "GET /projects/:project_id/issues/:issue_id/clarifying_questions" do

--- a/spec/routing/projects/clarifying_questions_routing_spec.rb
+++ b/spec/routing/projects/clarifying_questions_routing_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "projects clarifying questions routing", :no_db do
+  include Rails.application.routes.url_helpers
+
+  it "uses the plural clarifying_questions helper for the issue wizard" do
+    expect(project_issue_clarifying_questions_path("1", "2")).to eq(
+      "/projects/1/issues/2/clarifying_questions"
+    )
+  end
+end

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
   let(:issue) do
     double(
       body: issue_body,
-      github_number: 1964
+      github_number: 1964,
+      github_updated_at: 2.minutes.ago
     )
   end
   let(:comment_body) do
@@ -120,6 +121,40 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
 
       it "returns an empty array" do
         expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+    end
+
+    context "when the issue body was updated after answers were posted" do
+      let(:issue_body) { comment_body }
+      let(:issue) do
+        double(
+          body: issue_body,
+          github_number: 1964,
+          github_updated_at: 30.seconds.ago
+        )
+      end
+
+      before do
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          created_at: 1.minute.ago
+        )
+
+        allow(github_client).to receive(:issue_comments).and_return([ answers_comment ])
+      end
+
+      it "returns the refreshed body questions" do
+        expect(described_class.call(project: project, issue: issue)).to eq([
+          "What is the expected behavior?",
+          "Should this be behind a flag?"
+        ])
       end
     end
 

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
 
         expect(questions).to eq([ "What should happen next?" ])
       end
+
+      it "only loads GitHub comments once to check for newer answers" do
+        described_class.call(project: project, issue: issue)
+
+        expect(github_client).to have_received(:issue_comments).once
+      end
     end
 
     context "when clarifying questions only exist in GitHub comments" do

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -2,16 +2,36 @@
 
 require "rails_helper"
 
-RSpec.describe ClarifyingQuestions::Load do
-  let(:account) { create(:account) }
-  let(:project) { create(:project, account: account) }
-  let(:issue) { create(:issue, :needs_input, project: project, body: issue_body) }
+RSpec.describe ClarifyingQuestions::Load, :no_db do
   let(:issue_body) { "Original issue body" }
   let(:github_client) { instance_double(GithubClient) }
-
-  before do
-    allow(project.github_token).to receive(:client).and_return(github_client)
+  let(:github_token) { double(client: github_client) }
+  let(:project) do
+    double(
+      github_token: github_token,
+      full_name: "paid/app"
+    )
   end
+  let(:issue) do
+    double(
+      body: issue_body,
+      github_number: 1964
+    )
+  end
+  let(:comment_body) do
+    <<~COMMENT
+      <!-- paid:enhance-issue -->
+
+      ## Clarifying questions
+      1. What is the expected behavior?
+      2. Should this be behind a flag?
+
+      ## Current context
+      - Some context
+    COMMENT
+  end
+
+  before { allow(github_client).to receive(:issue_comments).and_return([]) }
 
   describe ".call" do
     context "when the issue body already contains clarifying questions" do
@@ -24,26 +44,16 @@ RSpec.describe ClarifyingQuestions::Load do
         COMMENT
       end
 
-      it "returns questions from the issue body without fetching comments" do
+      it "returns questions from the issue body" do
         questions = described_class.call(project: project, issue: issue)
 
         expect(questions).to eq([ "What should happen next?" ])
-        expect(github_client).not_to have_received(:issue_comments)
       end
     end
 
     context "when clarifying questions only exist in GitHub comments" do
       before do
-        comment = double(body: <<~COMMENT)
-          <!-- paid:enhance-issue -->
-
-          ## Clarifying questions
-          1. What is the expected behavior?
-          2. Should this be behind a flag?
-
-          ## Current context
-          - Some context
-        COMMENT
+        comment = double(body: comment_body)
         allow(github_client).to receive(:issue_comments).and_return([ comment ])
       end
 
@@ -57,13 +67,55 @@ RSpec.describe ClarifyingQuestions::Load do
       end
     end
 
-    context "when no clarifying questions are available" do
+    context "when the latest clarifying questions were already answered" do
       before do
-        allow(github_client).to receive(:issue_comments).and_return([])
+        enhancement_comment = double(
+          body: comment_body,
+          created_at: 2.minutes.ago
+        )
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          created_at: 1.minute.ago
+        )
+
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement_comment, answers_comment ])
       end
 
       it "returns an empty array" do
         expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+    end
+
+    context "when no clarifying questions are available" do
+      it "returns an empty array" do
+        expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+    end
+
+    context "when GitHub access is not configured" do
+      let(:project) do
+        double(
+          github_token: nil
+        )
+      end
+      let(:issue_body) do
+        <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What should happen next?
+        COMMENT
+      end
+
+      it "returns questions from the issue body" do
+        expect(described_class.call(project: project, issue: issue)).to eq([ "What should happen next?" ])
       end
     end
   end

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClarifyingQuestions::Load do
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account) }
+  let(:issue) { create(:issue, :needs_input, project: project, body: issue_body) }
+  let(:issue_body) { "Original issue body" }
+  let(:github_client) { instance_double(GithubClient) }
+
+  before do
+    allow(project.github_token).to receive(:client).and_return(github_client)
+  end
+
+  describe ".call" do
+    context "when the issue body already contains clarifying questions" do
+      let(:issue_body) do
+        <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What should happen next?
+        COMMENT
+      end
+
+      it "returns questions from the issue body without fetching comments" do
+        questions = described_class.call(project: project, issue: issue)
+
+        expect(questions).to eq([ "What should happen next?" ])
+        expect(github_client).not_to have_received(:issue_comments)
+      end
+    end
+
+    context "when clarifying questions only exist in GitHub comments" do
+      before do
+        comment = double(body: <<~COMMENT)
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What is the expected behavior?
+          2. Should this be behind a flag?
+
+          ## Current context
+          - Some context
+        COMMENT
+        allow(github_client).to receive(:issue_comments).and_return([ comment ])
+      end
+
+      it "loads questions from the latest enhancement comment" do
+        questions = described_class.call(project: project, issue: issue)
+
+        expect(questions).to eq([
+          "What is the expected behavior?",
+          "Should this be behind a flag?"
+        ])
+      end
+    end
+
+    context "when no clarifying questions are available" do
+      before do
+        allow(github_client).to receive(:issue_comments).and_return([])
+      end
+
+      it "returns an empty array" do
+        expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
 
         expect(github_client).to have_received(:issue_comments).once
       end
+
+      it "falls back to body questions when GitHub comments cannot be loaded" do
+        allow(github_client).to receive(:issue_comments).and_raise(GithubClient::Error, "GitHub unavailable")
+
+        questions = described_class.call(project: project, issue: issue)
+
+        expect(questions).to eq([ "What should happen next?" ])
+      end
     end
 
     context "when clarifying questions only exist in GitHub comments" do

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -93,6 +93,30 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
       end
     end
 
+    context "when the issue body still contains questions after answers were posted" do
+      let(:issue_body) { comment_body }
+
+      before do
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          created_at: 1.minute.ago
+        )
+
+        allow(github_client).to receive(:issue_comments).and_return([ answers_comment ])
+      end
+
+      it "returns an empty array" do
+        expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+    end
+
     context "when no clarifying questions are available" do
       it "returns an empty array" do
         expect(described_class.call(project: project, issue: issue)).to eq([])

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -117,6 +117,28 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
       end
     end
 
+    context "when only an answers comment remains" do
+      before do
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          created_at: 1.minute.ago
+        )
+
+        allow(github_client).to receive(:issue_comments).and_return([ answers_comment ])
+      end
+
+      it "returns an empty array" do
+        expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+    end
+
     context "when no clarifying questions are available" do
       it "returns an empty array" do
         expect(described_class.call(project: project, issue: issue)).to eq([])

--- a/spec/services/clarifying_questions/parse_spec.rb
+++ b/spec/services/clarifying_questions/parse_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClarifyingQuestions::Parse do
+  describe ".call" do
+    context "when comment has clarifying questions" do
+      it "parses numbered questions from the clarifying section" do
+        body = <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What is the expected behavior for edge case X?
+          2. Should the feature be behind a feature flag?
+          3. What databases need to be updated?
+
+          ## Current context
+          - The issue mentions a new feature
+        COMMENT
+
+        questions = described_class.call(comment_body: body)
+
+        expect(questions).to eq([
+          "What is the expected behavior for edge case X?",
+          "Should the feature be behind a feature flag?",
+          "What databases need to be updated?"
+        ])
+      end
+
+      it "handles multi-line questions by joining them" do
+        body = <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What is the expected behavior for the edge case where the user
+             has not yet confirmed their email address?
+          2. Should this be enabled by default?
+
+          ## Current context
+          - Some context
+        COMMENT
+
+        questions = described_class.call(comment_body: body)
+
+        expect(questions.size).to eq(2)
+        expect(questions[0]).to eq("What is the expected behavior for the edge case where the user has not yet confirmed their email address?")
+        expect(questions[1]).to eq("Should this be enabled by default?")
+      end
+    end
+
+    context "when comment has sufficient context (no clarifying questions)" do
+      it "returns empty array" do
+        body = <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Implementation context
+          ### Relevant files
+          - app/models/user.rb
+        COMMENT
+
+        questions = described_class.call(comment_body: body)
+
+        expect(questions).to eq([])
+      end
+    end
+
+    context "when comment does not have the enhancement marker" do
+      it "returns empty array" do
+        body = "Some random comment"
+
+        questions = described_class.call(comment_body: body)
+
+        expect(questions).to eq([])
+      end
+    end
+
+    context "when comment body is nil" do
+      it "returns empty array" do
+        questions = described_class.call(comment_body: nil)
+
+        expect(questions).to eq([])
+      end
+    end
+
+    context "when clarifying section has no numbered items" do
+      it "returns empty array" do
+        body = <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+
+          ## Current context
+          - Some context
+        COMMENT
+
+        questions = described_class.call(comment_body: body)
+
+        expect(questions).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/clarifying_questions/parse_spec.rb
+++ b/spec/services/clarifying_questions/parse_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ClarifyingQuestions::Parse do
+RSpec.describe ClarifyingQuestions::Parse, :no_db do
   describe ".call" do
     context "when comment has clarifying questions" do
       it "parses numbered questions from the clarifying section" do

--- a/spec/services/clarifying_questions/submit_answers_spec.rb
+++ b/spec/services/clarifying_questions/submit_answers_spec.rb
@@ -101,5 +101,17 @@ RSpec.describe ClarifyingQuestions::SubmitAnswers do
         expect(github_client).not_to have_received(:add_comment)
       end
     end
+
+    context "when there are no questions to answer" do
+      it "raises ArgumentError" do
+        expect {
+          described_class.call(
+            project: project,
+            issue: issue,
+            questions_and_answers: []
+          )
+        }.to raise_error(ArgumentError, /No clarifying questions found/)
+      end
+    end
   end
 end

--- a/spec/services/clarifying_questions/submit_answers_spec.rb
+++ b/spec/services/clarifying_questions/submit_answers_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClarifyingQuestions::SubmitAnswers do
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account) }
+  let(:issue) { create(:issue, :needs_input, project: project) }
+  let(:github_client) { instance_double(GithubClient) }
+
+  before do
+    allow(project.github_token).to receive(:client).and_return(github_client)
+    allow(github_client).to receive(:add_comment).and_return(double(html_url: "https://github.com/test"))
+  end
+
+  describe ".call" do
+    context "when all questions are answered" do
+      it "posts a comment with formatted answers to the GitHub issue" do
+        questions_and_answers = [
+          { question: "What is the expected behavior?", answer: "Return a 404 error" },
+          { question: "Should this be behind a flag?", answer: "Yes, use feature flag X" }
+        ]
+
+        described_class.call(
+          project: project,
+          issue: issue,
+          questions_and_answers: questions_and_answers
+        )
+
+        expect(github_client).to have_received(:add_comment).with(
+          project.full_name,
+          issue.github_number,
+          a_string_matching(/Clarifying question answers/)
+        )
+      end
+
+      it "includes the paid clarifying-answers marker" do
+        questions_and_answers = [
+          { question: "Q1?", answer: "A1" }
+        ]
+
+        described_class.call(
+          project: project,
+          issue: issue,
+          questions_and_answers: questions_and_answers
+        )
+
+        expect(github_client).to have_received(:add_comment).with(
+          anything, anything,
+          a_string_matching(/<!-- paid:clarifying-answers -->/)
+        )
+      end
+
+      it "formats questions and answers with Q/A labels" do
+        questions_and_answers = [
+          { question: "What is X?", answer: "X is Y" }
+        ]
+
+        described_class.call(
+          project: project,
+          issue: issue,
+          questions_and_answers: questions_and_answers
+        )
+
+        expect(github_client).to have_received(:add_comment).with(
+          anything, anything,
+          a_string_matching(/\*\*Q1: What is X\?\*\*/).and(a_string_matching(/X is Y/))
+        )
+      end
+    end
+
+    context "when some answers are blank" do
+      it "raises ArgumentError" do
+        questions_and_answers = [
+          { question: "Q1?", answer: "A1" },
+          { question: "Q2?", answer: "" }
+        ]
+
+        expect {
+          described_class.call(
+            project: project,
+            issue: issue,
+            questions_and_answers: questions_and_answers
+          )
+        }.to raise_error(ArgumentError, /All questions must be answered/)
+      end
+
+      it "does not post a comment" do
+        questions_and_answers = [
+          { question: "Q1?", answer: "" }
+        ]
+
+        expect {
+          described_class.call(
+            project: project,
+            issue: issue,
+            questions_and_answers: questions_and_answers
+          )
+        }.to raise_error(ArgumentError)
+
+        expect(github_client).not_to have_received(:add_comment)
+      end
+    end
+  end
+end

--- a/spec/services/clarifying_questions/submit_answers_spec.rb
+++ b/spec/services/clarifying_questions/submit_answers_spec.rb
@@ -2,14 +2,22 @@
 
 require "rails_helper"
 
-RSpec.describe ClarifyingQuestions::SubmitAnswers do
-  let(:account) { create(:account) }
-  let(:project) { create(:project, account: account) }
-  let(:issue) { create(:issue, :needs_input, project: project) }
+RSpec.describe ClarifyingQuestions::SubmitAnswers, :no_db do
   let(:github_client) { instance_double(GithubClient) }
+  let(:github_token) { double(client: github_client) }
+  let(:project) do
+    double(
+      github_token: github_token,
+      full_name: "paid/app"
+    )
+  end
+  let(:issue) do
+    double(
+      github_number: 1964
+    )
+  end
 
   before do
-    allow(project.github_token).to receive(:client).and_return(github_client)
     allow(github_client).to receive(:add_comment).and_return(double(html_url: "https://github.com/test"))
   end
 
@@ -64,7 +72,8 @@ RSpec.describe ClarifyingQuestions::SubmitAnswers do
 
         expect(github_client).to have_received(:add_comment).with(
           anything, anything,
-          a_string_matching(/\*\*Q1: What is X\?\*\*/).and(a_string_matching(/X is Y/))
+          a_string_matching(/\*\*Q1: What is X\?\*\*/)
+            .and(a_string_matching(/\*\*A1:\*\* X is Y/))
         )
       end
     end
@@ -111,6 +120,24 @@ RSpec.describe ClarifyingQuestions::SubmitAnswers do
             questions_and_answers: []
           )
         }.to raise_error(ArgumentError, /No clarifying questions found/)
+      end
+    end
+
+    context "when GitHub access is not configured" do
+      before do
+        allow(project).to receive(:github_token).and_return(nil)
+      end
+
+      it "raises ArgumentError before attempting to post" do
+        expect {
+          described_class.call(
+            project: project,
+            issue: issue,
+            questions_and_answers: [ { question: "Q1?", answer: "A1" } ]
+          )
+        }.to raise_error(ArgumentError, /GitHub access is not configured/)
+
+        expect(github_client).not_to have_received(:add_comment)
       end
     end
   end

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe Screenshots::CaptureTargets do
       expect(targets.map(&:slug)).to eq([ "project_cost_dashboard" ])
     end
 
+    it "maps the clarifying-questions wizard controller to its screenshot target" do
+      targets = described_class.call(changed_files: [ "app/controllers/projects/clarifying_questions_controller.rb" ])
+
+      expect(targets.map(&:slug)).to eq([ "project_issue_clarifying_questions" ])
+    end
+
     it "maps projects/agent_runs_controller to include the new action target" do
       targets = described_class.call(changed_files: [ "app/controllers/projects/agent_runs_controller.rb" ])
 
@@ -152,6 +158,12 @@ RSpec.describe Screenshots::CaptureTargets do
       targets = described_class.call(changed_files: [ "app/views/projects/_issues.html.erb" ])
 
       expect(targets.map(&:slug)).to eq([ "project_show" ])
+    end
+
+    it "maps the clarifying-questions wizard view to its screenshot target" do
+      targets = described_class.call(changed_files: [ "app/views/projects/clarifying_questions/show.html.erb" ])
+
+      expect(targets.map(&:slug)).to eq([ "project_issue_clarifying_questions" ])
     end
 
     it "maps project index partials to projects target" do

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -88,6 +88,17 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       expect(targets.map(&:slug)).to eq([ "project_issue_clarifying_questions" ])
     end
 
+    it "does not broaden screenshot capture when the controller registry changes alongside a mapped Stimulus controller" do
+      targets = described_class.call(
+        changed_files: [
+          "app/javascript/controllers/index.js",
+          "app/javascript/controllers/clarifying_questions_controller.js"
+        ]
+      )
+
+      expect(targets.map(&:slug)).to eq([ "project_issue_clarifying_questions" ])
+    end
+
     it "maps projects/agent_runs_controller to include the new action target" do
       targets = described_class.call(changed_files: [ "app/controllers/projects/agent_runs_controller.rb" ])
 

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -82,6 +82,12 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       expect(targets.map(&:slug)).to eq([ "project_issue_clarifying_questions" ])
     end
 
+    it "maps the clarifying-questions Stimulus controller to its screenshot target" do
+      targets = described_class.call(changed_files: [ "app/javascript/controllers/clarifying_questions_controller.js" ])
+
+      expect(targets.map(&:slug)).to eq([ "project_issue_clarifying_questions" ])
+    end
+
     it "maps projects/agent_runs_controller to include the new action target" do
       targets = described_class.call(changed_files: [ "app/controllers/projects/agent_runs_controller.rb" ])
 

--- a/spec/services/screenshots/seed_data/paid_spec.rb
+++ b/spec/services/screenshots/seed_data/paid_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe Screenshots::SeedData::Paid do
       "name" => "Screenshot Style Guide"
     )
   end
+
+  it "returns the seeded clarifying issue metadata" do
+    result = described_class.call
+
+    issue = Issue.find(result.dig("clarifying_issue", "id"))
+
+    expect(result.fetch("clarifying_issue")).to eq(
+      "id" => issue.id,
+      "github_number" => 1964
+    )
+    expect(issue).to be_needs_input
+  end
 end


### PR DESCRIPTION
## Summary

Lets users answer issue clarifying questions directly in the Paid UI instead of leaving for GitHub, streamlining the issue enhancement flow. Unanswered questions are surfaced on issue rows, and a wizard walks the user through one question at a time before posting the formatted answers back to the GitHub issue so the existing agent flow can resume unchanged.

## Changes

- **Models**: Added `needs_input?` predicate to `Issue` to flag issues waiting on user answers to clarifying questions.
- **Services**: New service objects to load unanswered clarifying questions for an issue and to post the formatted answer comment to GitHub on wizard completion.
- **Controller & routes**: New controller and route to render the wizard and accept submitted answers; delegates persistence/comment posting to the services above.
- **Views**: Added a wizard view that presents one question at a time with a progress bar and forward/back navigation, modeled on the business context knowledge base collection wizard. Updated the issue partial to show a visual indicator when `needs_input?` is true, linking into the wizard.
- **JavaScript**: New Stimulus controller driving wizard navigation, progress, and the submit gate that requires every question to be answered before completion.
- **Tests**: Added model spec for `needs_input?`, service specs for question loading and GitHub comment posting, and a request spec covering the wizard controller (rendering, navigation, and submission).

## Design Decisions

- **No agent-side changes** — On submission, the wizard posts a formatted answer comment to the GitHub issue using the existing agent flow's comment-driven pickup, keeping the change additive and avoiding any divergence between in-app and GitHub answer paths.
- **All-or-nothing submission** — The wizard enforces that every question is answered before submit, matching the acceptance criteria and avoiding partial-state handling on the agent side.
- **UX parity with the business context wizard** — Reused the existing wizard pattern (one question per step, progress bar, forward/back) for consistency rather than introducing a new pattern.
- **Predicate on `Issue`** — Added `needs_input?` rather than introducing a new state column, since "needs input" is derivable from existing clarifying-question state and the agent flow already drives the underlying lifecycle.

## Screenshots

_Please attach before/after screenshots of the project page issue row indicator and the wizard (first question, mid-progress, and completion states)._

---

Closes #1964