### PR TITLE
feat(auto-merge): add PR dependency blocking for auto-merge

### DIFF
--- a/app/models/exception_incident.rb
+++ b/app/models/exception_incident.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class ExceptionIncident < ApplicationRecord
-  has_logidze
+  begin
+    has_logidze if columns_hash.key?("log_data")
+  rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+    # Allow boot in db-less contexts and when the DB schema has not caught up yet.
+  end
+
   belongs_to :account
   belongs_to :project, optional: true
 

--- a/app/services/automation/strategies/auto_merge.rb
+++ b/app/services/automation/strategies/auto_merge.rb
@@ -22,12 +22,14 @@ module Automation
     # - No outstanding review feedback
     # - All blocking review methods complete
     # - Reviews not stale for HEAD
+    # - Dependency PRs already merged
     #
     # *Bot-authored PRs* (Dependabot, Renovate) have a simpler path:
     # - Auto-merge enabled on the project
     # - Dependabot auto-merge enabled
     # - All CI checks green
     # - PR mergeable
+    # - Dependency PRs already merged
     #
     # Bot-authored PRs skip owner-approval and review-feedback gates
     # because bot dependency updates are treated as trusted.
@@ -66,13 +68,15 @@ module Automation
           signals.mergeable? &&
           signals.review_feedback_clear? &&
           signals.blocking_reviews_complete? &&
-          signals.reviews_fresh?
+          signals.reviews_fresh? &&
+          signals.dependencies_resolved?
       end
 
       def bot_eligible?(signals)
         signals.dependabot_eligible? &&
           signals.checks_green? &&
-          signals.mergeable?
+          signals.mergeable? &&
+          signals.dependencies_resolved?
       end
     end
   end

--- a/app/services/automation/strategies/auto_merge/signals.rb
+++ b/app/services/automation/strategies/auto_merge/signals.rb
@@ -27,6 +27,9 @@ module Automation
       #   method (+ci_action+, +manual+) has a completion signal.
       # * +reviews_fresh+ — the HEAD commit was not pushed after the
       #   latest blocking approval(s).
+      # * +dependencies_resolved+ — every declared PR dependency has
+      #   already merged. Cross-repo and missing PR references remain
+      #   blocking until Paid can verify them.
       # * +bot_authored+ — the PR was created by a known bot user
       #   (Dependabot, Renovate, etc.).
       # * +dependabot_eligible+ — the project allows auto-merging
@@ -40,6 +43,7 @@ module Automation
         :review_feedback_clear,
         :blocking_reviews_complete,
         :reviews_fresh,
+        :dependencies_resolved,
         :bot_authored,
         :dependabot_eligible
       )
@@ -56,6 +60,7 @@ module Automation
               review_feedback_clear: kwargs.fetch(:review_feedback_clear, false),
               blocking_reviews_complete: kwargs.fetch(:blocking_reviews_complete, false),
               reviews_fresh: kwargs.fetch(:reviews_fresh, false),
+              dependencies_resolved: kwargs.fetch(:dependencies_resolved, false),
               bot_authored: kwargs.fetch(:bot_authored, false),
               dependabot_eligible: kwargs.fetch(:dependabot_eligible, false)
             )
@@ -68,6 +73,7 @@ module Automation
         def review_feedback_clear? = review_feedback_clear == true
         def blocking_reviews_complete? = blocking_reviews_complete == true
         def reviews_fresh? = reviews_fresh == true
+        def dependencies_resolved? = dependencies_resolved == true
         def bot_authored? = bot_authored == true
         def dependabot_eligible? = dependabot_eligible == true
       end

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -113,7 +113,7 @@ module Issues
       @issue = issue
       @adjacency = adjacency
       @comments = comments || []
-      @body = body
+      @body = body || issue&.body
     end
 
     def self.call(...)

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -107,20 +107,27 @@ module Issues
     MARKDOWN_HEADING_PATTERN = /^[ \t]{0,3}\#{1,6}[ \t]+(.+?)\s*#*\s*$/
     FENCED_CODE_BLOCK_PATTERN = /^[ \t]{0,3}(```|~~~)/
 
-    attr_reader :issue, :adjacency, :comments
+    attr_reader :issue, :adjacency, :comments, :body
 
-    def initialize(issue:, adjacency: nil, comments: [])
+    def initialize(issue:, adjacency: nil, comments: [], body: nil)
       @issue = issue
       @adjacency = adjacency
       @comments = comments || []
+      @body = body
     end
 
     def self.call(...)
       new(...).call
     end
 
+    def self.extract(body:, comments: [])
+      new(issue: nil, body: body, comments: comments).extract
+    end
+
     def call
-      local_deps, cross_deps = resolve_dependencies
+      raise ArgumentError, "issue is required" if issue.nil?
+
+      local_deps, cross_deps = extract
 
       current_deps = issue.issue_dependencies.to_a
       current_local_by_id = current_deps.select(&:local?).index_by(&:depends_on_issue_id)
@@ -140,6 +147,12 @@ module Issues
       remove_stale_external_deps(current_external_by_key.keys.to_set, new_cross_refs[:external_keys])
     end
 
+    def extract
+      local_deps, cross_deps = resolve_dependencies
+
+      [ local_deps, cross_deps ]
+    end
+
     private
 
     # Processes body then comments in the order given. Within a single comment,
@@ -155,8 +168,8 @@ module Issues
       local_deps = {}
       cross_deps = {}
 
-      if issue.body.present?
-        extract_body_refs(issue.body, local_deps, cross_deps)
+      if body.present?
+        extract_body_refs(body, local_deps, cross_deps)
       end
 
       comments.each do |comment_body|

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -611,7 +611,7 @@ module Activities
         checks = fetch_check_runs(client, project, pr_data)
 
         if bot_user?(issue.github_creator_login)
-          if auto_merge_eligible_bot?(project, issue,
+          if auto_merge_eligible_bot?(project, client, issue,
                checks: checks, mergeable: pr_data[:mergeable])
             return owner_approved_trigger(issue)
           end
@@ -2404,7 +2404,8 @@ module Activities
         blocking_reviews_complete: all_blocking_review_methods_complete?(
           project, reviews, checks, pr_data: pr_data
         ),
-        reviews_fresh: !review_stale_for_head?(client, project, issue, pr_data, reviews)
+        reviews_fresh: !review_stale_for_head?(client, project, issue, pr_data, reviews),
+        dependencies_resolved: dependencies_resolved?(client, project, issue)
       )
 
       evaluate_auto_merge(project, signals)
@@ -2412,17 +2413,56 @@ module Activities
 
     # Evaluates bot-authored PR merge eligibility via the AutoMerge
     # strategy. Bot PRs skip owner-approval and review-feedback gates.
-    def auto_merge_eligible_bot?(project, issue, checks:, mergeable:)
+    def auto_merge_eligible_bot?(project, client, issue, checks:, mergeable:)
       signals = Automation::Strategies::AutoMerge::Signals.build(
         issue_id: issue.id,
         pr_number: issue.github_number,
         bot_authored: true,
         dependabot_eligible: project.auto_merge_dependabot?,
         checks_green: !checks.nil? && checks.any? && all_checks_green?(checks),
-        mergeable: mergeable == true
+        mergeable: mergeable == true,
+        dependencies_resolved: dependencies_resolved?(client, project, issue)
       )
 
       evaluate_auto_merge(project, signals)
+    end
+
+    def dependencies_resolved?(client, project, issue)
+      local_deps, cross_deps = Issues::ParseDependencies.extract(
+        body: issue.body,
+        comments: dependency_comment_bodies(client, project, issue)
+      )
+
+      return true if local_deps.empty? && cross_deps.empty?
+
+      same_repo = [ project.owner.downcase, project.repo.downcase ]
+      same_repo_numbers = cross_deps.each_with_object(Set.new) do |(owner, repo, number), numbers|
+        return false if [ owner, repo ] != same_repo
+
+        numbers << number
+      end
+
+      (local_deps.keys.to_set | same_repo_numbers).all? do |pr_number|
+        dependency_pull_request_merged?(client, project, pr_number)
+      end
+    rescue GithubClient::Error => e
+      log_signal_error("dependencies_resolved", project, issue, e)
+      false
+    end
+
+    def dependency_comment_bodies(client, project, issue)
+      client.issue_comments(project.full_name, issue.github_number).map(&:body)
+    end
+
+    def dependency_pull_request_merged?(client, project, pr_number)
+      pr_data = client.pull_request(project.full_name, pr_number)
+      pull_request_merged?(pr_data)
+    rescue GithubClient::NotFoundError
+      false
+    end
+
+    def pull_request_merged?(pr_data)
+      pr_data&.merged == true || pr_data&.merged_at.present?
     end
 
     def evaluate_auto_merge(project, signals)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -2392,20 +2392,39 @@ module Activities
     def auto_merge_eligible?(project, client, issue, pr_data:, checks:, reviews:)
       return false unless project.auto_merge_enabled? && pr_data.present?
 
+      owner_approved = owner_approved_or_self_authored?(project, reviews, pr_data)
+      checks_green = !checks.nil? && all_checks_green?(checks)
+      mergeable = pr_data[:mergeable] == true
+      review_feedback_clear = no_outstanding_review_feedback?(
+        project, client, issue, reviews, checks: checks, pr_data: pr_data
+      )
+      blocking_reviews_complete = all_blocking_review_methods_complete?(
+        project, reviews, checks, pr_data: pr_data
+      )
+      reviews_fresh = !review_stale_for_head?(client, project, issue, pr_data, reviews)
+      dependencies_resolved = if human_dependency_check_required?(
+        owner_approved: owner_approved,
+        checks_green: checks_green,
+        mergeable: mergeable,
+        review_feedback_clear: review_feedback_clear,
+        blocking_reviews_complete: blocking_reviews_complete,
+        reviews_fresh: reviews_fresh
+      )
+        dependencies_resolved?(client, project, issue)
+      else
+        false
+      end
+
       signals = Automation::Strategies::AutoMerge::Signals.build(
         issue_id: issue.id,
         pr_number: issue.github_number,
-        owner_approved: owner_approved_or_self_authored?(project, reviews, pr_data),
-        checks_green: !checks.nil? && all_checks_green?(checks),
-        mergeable: pr_data[:mergeable] == true,
-        review_feedback_clear: no_outstanding_review_feedback?(
-          project, client, issue, reviews, checks: checks, pr_data: pr_data
-        ),
-        blocking_reviews_complete: all_blocking_review_methods_complete?(
-          project, reviews, checks, pr_data: pr_data
-        ),
-        reviews_fresh: !review_stale_for_head?(client, project, issue, pr_data, reviews),
-        dependencies_resolved: dependencies_resolved?(client, project, issue)
+        owner_approved: owner_approved,
+        checks_green: checks_green,
+        mergeable: mergeable,
+        review_feedback_clear: review_feedback_clear,
+        blocking_reviews_complete: blocking_reviews_complete,
+        reviews_fresh: reviews_fresh,
+        dependencies_resolved: dependencies_resolved
       )
 
       evaluate_auto_merge(project, signals)
@@ -2414,17 +2433,46 @@ module Activities
     # Evaluates bot-authored PR merge eligibility via the AutoMerge
     # strategy. Bot PRs skip owner-approval and review-feedback gates.
     def auto_merge_eligible_bot?(project, client, issue, checks:, mergeable:)
+      dependabot_eligible = project.auto_merge_dependabot?
+      checks_green = !checks.nil? && checks.any? && all_checks_green?(checks)
+      mergeable_signal = mergeable == true
+      dependencies_resolved = if bot_dependency_check_required?(
+        dependabot_eligible: dependabot_eligible,
+        checks_green: checks_green,
+        mergeable: mergeable_signal
+      )
+        dependencies_resolved?(client, project, issue)
+      else
+        false
+      end
+
       signals = Automation::Strategies::AutoMerge::Signals.build(
         issue_id: issue.id,
         pr_number: issue.github_number,
         bot_authored: true,
-        dependabot_eligible: project.auto_merge_dependabot?,
-        checks_green: !checks.nil? && checks.any? && all_checks_green?(checks),
-        mergeable: mergeable == true,
-        dependencies_resolved: dependencies_resolved?(client, project, issue)
+        dependabot_eligible: dependabot_eligible,
+        checks_green: checks_green,
+        mergeable: mergeable_signal,
+        dependencies_resolved: dependencies_resolved
       )
 
       evaluate_auto_merge(project, signals)
+    end
+
+    def human_dependency_check_required?(owner_approved:, checks_green:, mergeable:,
+      review_feedback_clear:, blocking_reviews_complete:, reviews_fresh:)
+      owner_approved &&
+        checks_green &&
+        mergeable &&
+        review_feedback_clear &&
+        blocking_reviews_complete &&
+        reviews_fresh
+    end
+
+    def bot_dependency_check_required?(dependabot_eligible:, checks_green:, mergeable:)
+      dependabot_eligible &&
+        checks_green &&
+        mergeable
     end
 
     def dependencies_resolved?(client, project, issue)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -2451,7 +2451,9 @@ module Activities
     end
 
     def dependency_comment_bodies(client, project, issue)
-      client.issue_comments(project.full_name, issue.github_number).map(&:body)
+      client.issue_comments(project.full_name, issue.github_number).map do |comment|
+        dependency_value(comment, :body)
+      end
     end
 
     def dependency_pull_request_merged?(client, project, pr_number)
@@ -2462,7 +2464,19 @@ module Activities
     end
 
     def pull_request_merged?(pr_data)
-      pr_data&.merged == true || pr_data&.merged_at.present?
+      dependency_value(pr_data, :merged) == true || dependency_value(pr_data, :merged_at).present?
+    end
+
+    def dependency_value(source, key)
+      return nil if source.nil?
+
+      if source.respond_to?(key)
+        source.public_send(key)
+      elsif source.respond_to?(:key?) && source.key?(key)
+        source[key]
+      elsif source.respond_to?(:[])
+        source[key.to_s]
+      end
     end
 
     def evaluate_auto_merge(project, signals)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -2436,7 +2436,7 @@ module Activities
       return true if local_deps.empty? && cross_deps.empty?
 
       same_repo = [ project.owner.downcase, project.repo.downcase ]
-      same_repo_numbers = cross_deps.each_with_object(Set.new) do |(owner, repo, number), numbers|
+      same_repo_numbers = cross_deps.each_with_object(Set.new) do |((owner, repo, number), _), numbers|
         return false if [ owner, repo ] != same_repo
 
         numbers << number

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -2451,7 +2451,7 @@ module Activities
     end
 
     def dependency_comment_bodies(client, project, issue)
-      client.issue_comments(project.full_name, issue.github_number).map do |comment|
+      Array(client.issue_comments(project.full_name, issue.github_number)).filter_map do |comment|
         dependency_value(comment, :body)
       end
     end

--- a/spec/migrations/add_account_to_service_containers_spec.rb
+++ b/spec/migrations/add_account_to_service_containers_spec.rb
@@ -9,6 +9,7 @@ require Rails.root.join("db/migrate/20260426011810_enable_rls_on_llm_output_metr
 require Rails.root.join("db/migrate/20260426231639_enable_rls_on_chat_tables")
 require Rails.root.join("db/migrate/20260427225726_enable_rls_on_knowledge_recommendations")
 require Rails.root.join("db/migrate/20260428140000_create_exception_incidents")
+require Rails.root.join("db/migrate/20260512120010_add_logidze_to_exception_incidents")
 require Rails.root.join("db/migrate/20260503093418_enable_rls_on_issue_merge_subscriptions")
 require Rails.root.join("db/migrate/20260508120219_create_failure_classifications")
 require Rails.root.join("db/migrate/20260507125050_create_decomposition_decisions")
@@ -74,6 +75,7 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
       knowledge_recommendations_rls_migration.up unless knowledge_recommendations_has_rls?
       issue_merge_subscriptions_rls_migration.up unless issue_merge_subscriptions_have_rls?
       exception_incidents_migration.up unless exception_incidents_table_exists?
+      restore_exception_incidents_logidze!
       failure_classifications_migration.up unless failure_classifications_table_exists?
       orchestration_decisions_migration.up unless orchestration_decisions_table_exists?
       add_strategy_version_to_orchestration_decisions_migration.migrate(:up) unless orchestration_decisions_have_strategy_version_reference?
@@ -336,6 +338,17 @@ RSpec.describe AddAccountToServiceContainers, :aggregate_failures do
 
   def exception_incidents_migration
     @exception_incidents_migration ||= CreateExceptionIncidents.new
+  end
+
+  def exception_incidents_logidze_migration
+    @exception_incidents_logidze_migration ||= AddLogidzeToExceptionIncidents.new
+  end
+
+  def restore_exception_incidents_logidze!
+    return unless exception_incidents_table_exists?
+    return if ActiveRecord::Base.connection.column_exists?(:exception_incidents, :log_data)
+
+    exception_incidents_logidze_migration.migrate(:up)
   end
 
   def failure_classifications_migration

--- a/spec/security/tenant_context_spec.rb
+++ b/spec/security/tenant_context_spec.rb
@@ -9,6 +9,7 @@ require Rails.root.join("db/migrate/20260426231639_enable_rls_on_chat_tables")
 require Rails.root.join("db/migrate/20260427225726_enable_rls_on_knowledge_recommendations")
 require Rails.root.join("db/migrate/20260503093418_enable_rls_on_issue_merge_subscriptions")
 require Rails.root.join("db/migrate/20260428140000_create_exception_incidents")
+require Rails.root.join("db/migrate/20260512120010_add_logidze_to_exception_incidents")
 require Rails.root.join("db/migrate/20260508120219_create_failure_classifications")
 require Rails.root.join("db/migrate/20260507125050_create_decomposition_decisions")
 require Rails.root.join("db/migrate/20260507164917_create_orchestration_decisions")
@@ -250,6 +251,7 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnKnowledgeRecommendations.new.up unless knowledge_recommendations_has_rls?
       EnableRlsOnIssueMergeSubscriptions.new.up unless issue_merge_subscriptions_has_rls?
       CreateExceptionIncidents.new.up unless exception_incidents_table_exists?
+      restore_exception_incidents_logidze!
       CreateFailureClassifications.new.up unless failure_classifications_table_exists?
       CreateOrchestrationDecisions.new.up unless orchestration_decisions_table_exists?
       AddStrategyVersionToOrchestrationDecisions.new.migrate(:up) unless orchestration_decisions_have_strategy_version_reference?
@@ -329,6 +331,13 @@ RSpec.describe TenantContext, :tenant_isolation do
 
   def exception_incidents_table_exists?
     ActiveRecord::Base.connection.table_exists?(:exception_incidents)
+  end
+
+  def restore_exception_incidents_logidze!
+    return unless exception_incidents_table_exists?
+    return if ActiveRecord::Base.connection.column_exists?(:exception_incidents, :log_data)
+
+    AddLogidzeToExceptionIncidents.new.migrate(:up)
   end
 
   def failure_classifications_table_exists?

--- a/spec/services/automation/strategies/auto_merge/signals_spec.rb
+++ b/spec/services/automation/strategies/auto_merge/signals_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Automation::Strategies::AutoMerge::Signals do
+RSpec.describe Automation::Strategies::AutoMerge::Signals, :no_db do
   describe ".build" do
     it "defaults boolean fields to false" do
       signals = described_class.build(issue_id: 1, pr_number: 42)
@@ -13,6 +13,7 @@ RSpec.describe Automation::Strategies::AutoMerge::Signals do
       expect(signals.review_feedback_clear?).to be false
       expect(signals.blocking_reviews_complete?).to be false
       expect(signals.reviews_fresh?).to be false
+      expect(signals.dependencies_resolved?).to be false
       expect(signals.bot_authored?).to be false
       expect(signals.dependabot_eligible?).to be false
     end
@@ -33,7 +34,8 @@ RSpec.describe Automation::Strategies::AutoMerge::Signals do
         mergeable: true,
         review_feedback_clear: true,
         blocking_reviews_complete: true,
-        reviews_fresh: true
+        reviews_fresh: true,
+        dependencies_resolved: true
       )
 
       expect(signals.owner_approved?).to be true
@@ -42,6 +44,7 @@ RSpec.describe Automation::Strategies::AutoMerge::Signals do
       expect(signals.review_feedback_clear?).to be true
       expect(signals.blocking_reviews_complete?).to be true
       expect(signals.reviews_fresh?).to be true
+      expect(signals.dependencies_resolved?).to be true
     end
 
     it "accepts bot-authored fields" do

--- a/spec/services/automation/strategies/auto_merge_spec.rb
+++ b/spec/services/automation/strategies/auto_merge_spec.rb
@@ -2,10 +2,16 @@
 
 require "rails_helper"
 
-RSpec.describe Automation::Strategies::AutoMerge do
+RSpec.describe Automation::Strategies::AutoMerge, :no_db do
   subject(:strategy) { described_class.new }
 
-  let(:project) { build_stubbed(:project) }
+  let(:project) do
+    Class.new do
+      attr_accessor :merge_method, :auto_fix_merge_conflicts
+
+      def auto_merge_enabled? = true
+    end.new
+  end
 
   def build_context(signals: nil)
     Automation::Context.build(
@@ -25,6 +31,7 @@ RSpec.describe Automation::Strategies::AutoMerge do
       review_feedback_clear: true,
       blocking_reviews_complete: true,
       reviews_fresh: true,
+      dependencies_resolved: true,
       **overrides
     )
   end
@@ -37,6 +44,7 @@ RSpec.describe Automation::Strategies::AutoMerge do
       dependabot_eligible: true,
       checks_green: true,
       mergeable: true,
+      dependencies_resolved: true,
       **overrides
     )
   end
@@ -119,6 +127,13 @@ RSpec.describe Automation::Strategies::AutoMerge do
 
         expect(result.decisions.map(&:type)).to eq([ "noop" ])
       end
+
+      it "returns noop when dependencies are unresolved" do
+        signals = human_signals(dependencies_resolved: false)
+        result = strategy.evaluate(build_context(signals: signals))
+
+        expect(result.decisions.map(&:type)).to eq([ "noop" ])
+      end
     end
 
     context "with a bot-authored PR" do
@@ -146,6 +161,13 @@ RSpec.describe Automation::Strategies::AutoMerge do
 
       it "returns noop when PR is not mergeable" do
         signals = bot_signals(mergeable: false)
+        result = strategy.evaluate(build_context(signals: signals))
+
+        expect(result.decisions.map(&:type)).to eq([ "noop" ])
+      end
+
+      it "returns noop when dependencies are unresolved" do
+        signals = bot_signals(dependencies_resolved: false)
         result = strategy.evaluate(build_context(signals: signals))
 
         expect(result.decisions.map(&:type)).to eq([ "noop" ])

--- a/spec/services/automation/strategy_parity_spec.rb
+++ b/spec/services/automation/strategy_parity_spec.rb
@@ -284,10 +284,10 @@ RSpec.describe Automation::Strategy do
     let(:all_human_preconditions) do
       { issue_id: 42, pr_number: 10, owner_approved: true, checks_green: true,
         mergeable: true, review_feedback_clear: true, blocking_reviews_complete: true,
-        reviews_fresh: true }
+        reviews_fresh: true, dependencies_resolved: true }
     end
 
-    it "merges a human PR when all six preconditions are met" do
+    it "merges a human PR when all preconditions are met" do
       signals = Automation::Strategies::AutoMerge::Signals.build(**all_human_preconditions)
       result = evaluate_auto_merge(signals: signals)
 
@@ -295,7 +295,8 @@ RSpec.describe Automation::Strategy do
     end
 
     %i[owner_approved checks_green mergeable
-       review_feedback_clear blocking_reviews_complete reviews_fresh].each do |field|
+       review_feedback_clear blocking_reviews_complete reviews_fresh
+       dependencies_resolved].each do |field|
       it "returns noop for human PR when #{field} is false" do
         signals = Automation::Strategies::AutoMerge::Signals.build(
           **all_human_preconditions.merge(field => false)
@@ -306,11 +307,11 @@ RSpec.describe Automation::Strategy do
       end
     end
 
-    it "bot PR requires only dependabot_eligible, checks_green, mergeable" do
+    it "bot PR requires only dependabot_eligible, checks_green, mergeable, and resolved dependencies" do
       signals = Automation::Strategies::AutoMerge::Signals.build(
         issue_id: 42, pr_number: 10,
         bot_authored: true, dependabot_eligible: true,
-        checks_green: true, mergeable: true,
+        checks_green: true, mergeable: true, dependencies_resolved: true,
         owner_approved: false, review_feedback_clear: false
       )
 

--- a/spec/services/issues/parse_dependencies_extract_spec.rb
+++ b/spec/services/issues/parse_dependencies_extract_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Issues::ParseDependencies, :no_db do
+  describe ".extract" do
+    it "uses issue.body when body is not passed explicitly" do
+      issue = Data.define(:body).new("Depends on #9043")
+
+      local_deps, cross_deps = described_class.new(issue: issue, comments: []).extract
+
+      expect(local_deps).to eq(9043 => false)
+      expect(cross_deps).to eq({})
+    end
+  end
+end

--- a/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
@@ -106,4 +106,50 @@ RSpec.describe Activities::ScanPaidPrsActivity, :no_db do
       expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(true)
     end
   end
+
+  describe "#human_dependency_check_required?" do
+    it "returns false when any earlier human auto-merge gate already failed" do
+      expect(activity.send(
+        :human_dependency_check_required?,
+        owner_approved: false,
+        checks_green: true,
+        mergeable: true,
+        review_feedback_clear: true,
+        blocking_reviews_complete: true,
+        reviews_fresh: true
+      )).to be(false)
+    end
+
+    it "returns true only when the other human gates are satisfied" do
+      expect(activity.send(
+        :human_dependency_check_required?,
+        owner_approved: true,
+        checks_green: true,
+        mergeable: true,
+        review_feedback_clear: true,
+        blocking_reviews_complete: true,
+        reviews_fresh: true
+      )).to be(true)
+    end
+  end
+
+  describe "#bot_dependency_check_required?" do
+    it "returns false when any earlier bot auto-merge gate already failed" do
+      expect(activity.send(
+        :bot_dependency_check_required?,
+        dependabot_eligible: false,
+        checks_green: true,
+        mergeable: true
+      )).to be(false)
+    end
+
+    it "returns true only when the other bot gates are satisfied" do
+      expect(activity.send(
+        :bot_dependency_check_required?,
+        dependabot_eligible: true,
+        checks_green: true,
+        mergeable: true
+      )).to be(true)
+    end
+  end
 end

--- a/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe Activities::ScanPaidPrsActivity, :no_db do
+  subject(:activity) { described_class.new }
+
+  let(:client) { instance_double(GithubClient) }
+  let(:project) do
+    Data.define(:full_name, :owner, :repo, :id).new(
+      full_name: "acme/widgets",
+      owner: "acme",
+      repo: "widgets",
+      id: 1
+    )
+  end
+  let(:issue) do
+    Data.define(:body, :github_number).new(
+      body: body,
+      github_number: 42
+    )
+  end
+  let(:body) { "Depends on #41" }
+  let(:comments) { [] }
+
+  before do
+    allow(client).to receive(:issue_comments)
+      .with(project.full_name, issue.github_number)
+      .and_return(comments)
+  end
+
+  describe "#dependencies_resolved?" do
+    it "returns false when a same-repo dependency PR is unmerged" do
+      allow(client).to receive(:pull_request)
+        .with(project.full_name, 41)
+        .and_return(OpenStruct.new(number: 41, merged: false, merged_at: nil))
+
+      expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(false)
+    end
+
+    it "returns true when a removed dependency no longer applies" do
+      allow(client).to receive(:issue_comments)
+        .with(project.full_name, issue.github_number)
+        .and_return([ OpenStruct.new(body: "No longer depends on #41") ])
+
+      expect(client).not_to receive(:pull_request).with(project.full_name, 41)
+
+      expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(true)
+    end
+
+    it "returns false for cross-repo dependencies" do
+      cross_repo_issue = Data.define(:body, :github_number).new(
+        body: "Depends on other/repo#41",
+        github_number: 42
+      )
+
+      expect(activity.send(:dependencies_resolved?, client, project, cross_repo_issue)).to be(false)
+    end
+
+    it "returns true when all same-repo dependency PRs are merged" do
+      allow(client).to receive(:pull_request)
+        .with(project.full_name, 41)
+        .and_return(OpenStruct.new(number: 41, merged: true, merged_at: Time.current))
+
+      expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(true)
+    end
+  end
+end

--- a/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe Activities::ScanPaidPrsActivity, :no_db do
       expect(activity.send(:dependencies_resolved?, client, project, cross_repo_issue)).to be(false)
     end
 
+    it "treats same-repo fully-qualified dependencies as local merge checks" do
+      same_repo_issue = Data.define(:body, :github_number).new(
+        body: "Depends on acme/widgets#41",
+        github_number: 42
+      )
+
+      allow(client).to receive(:pull_request)
+        .with(project.full_name, 41)
+        .and_return(OpenStruct.new(number: 41, merged: true, merged_at: Time.current))
+
+      expect(activity.send(:dependencies_resolved?, client, project, same_repo_issue)).to be(true)
+    end
+
     it "returns true when all same-repo dependency PRs are merged" do
       allow(client).to receive(:pull_request)
         .with(project.full_name, 41)

--- a/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
@@ -94,5 +94,16 @@ RSpec.describe Activities::ScanPaidPrsActivity, :no_db do
 
       expect(activity.send(:dependencies_resolved?, client, project, hash_body_issue)).to be(true)
     end
+
+    it "ignores nil comment collections and body-less comment payloads" do
+      allow(client).to receive(:issue_comments)
+        .with(project.full_name, issue.github_number)
+        .and_return([ nil, OpenStruct.new(body: nil) ])
+      allow(client).to receive(:pull_request)
+        .with(project.full_name, 41)
+        .and_return(OpenStruct.new(number: 41, merged: true, merged_at: Time.current))
+
+      expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(true)
+    end
   end
 end

--- a/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
@@ -78,5 +78,21 @@ RSpec.describe Activities::ScanPaidPrsActivity, :no_db do
 
       expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(true)
     end
+
+    it "accepts hash-shaped GitHub payloads for comments and PRs" do
+      allow(client).to receive(:issue_comments)
+        .with(project.full_name, issue.github_number)
+        .and_return([ { "body" => "Depends on #41" } ])
+      allow(client).to receive(:pull_request)
+        .with(project.full_name, 41)
+        .and_return({ "number" => 41, "merged" => true, "merged_at" => Time.current.iso8601 })
+
+      hash_body_issue = Data.define(:body, :github_number).new(
+        body: nil,
+        github_number: 42
+      )
+
+      expect(activity.send(:dependencies_resolved?, client, project, hash_body_issue)).to be(true)
+    end
   end
 end

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -93,6 +93,55 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     end
   end
 
+  describe "#dependencies_resolved?" do
+    let(:pr_issue) do
+      create(:issue, :pull_request,
+        project: project,
+        github_number: 42,
+        body: body)
+    end
+    let(:body) { "Depends on #41" }
+
+    before do
+      allow(github_client).to receive(:issue_comments)
+        .with(project.full_name, 42)
+        .and_return(issue_comments)
+    end
+
+    context "when a same-repo dependency PR is not merged" do
+      let(:issue_comments) { [] }
+
+      before do
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, 41)
+          .and_return(OpenStruct.new(number: 41, merged: false, merged_at: nil))
+      end
+
+      it "returns false" do
+        expect(activity.send(:dependencies_resolved?, github_client, project, pr_issue)).to be(false)
+      end
+    end
+
+    context "when a dependency was removed in comments" do
+      let(:issue_comments) { [ OpenStruct.new(body: "No longer depends on #41") ] }
+
+      it "returns true without checking the removed PR" do
+        expect(github_client).not_to receive(:pull_request).with(project.full_name, 41)
+
+        expect(activity.send(:dependencies_resolved?, github_client, project, pr_issue)).to be(true)
+      end
+    end
+
+    context "when a dependency references another repo" do
+      let(:body) { "Depends on other/repo#41" }
+      let(:issue_comments) { [] }
+
+      it "returns false conservatively" do
+        expect(activity.send(:dependencies_resolved?, github_client, project, pr_issue)).to be(false)
+      end
+    end
+  end
+
   describe "#execute" do
     context "when project is missing" do
       it "returns empty result with project_missing flag" do
@@ -4915,6 +4964,21 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "does not emit owner_approved when auto_merge is disabled" do
         project.update!(auto_merge_mode: "off")
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:prs_to_trigger]).to eq([])
+      end
+
+      it "does not emit owner_approved when a dependency PR is not merged" do
+        issue = Issue.find_by!(project: project, github_number: 42)
+        issue.update!(body: "Depends on #41")
+        allow(github_client).to receive(:issue_comments)
+          .with(project.full_name, 42)
+          .and_return([])
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, 41)
+          .and_return(OpenStruct.new(number: 41, merged: false, merged_at: nil))
 
         result = activity.execute(project_id: project.id)
 


### PR DESCRIPTION
## Summary

Auto-merge currently evaluates each PR in isolation, which means a dependent PR can land before its parent PR has merged — dangerous for staged rollouts like the providers→runners rename. This PR adds a new gate that blocks auto-merge when a PR declares unresolved dependencies on other PRs.

## Changes

- **Auto-merge strategy**: Added a `dependencies_resolved` signal to `Automation::Strategies::AutoMerge::Signals` and included it in both `human_eligible?` and `bot_eligible?` checks.
- **Signal collection**: `ScanPaidPrsActivity` now parses dependency declarations from PR body/comments and queries each referenced parent PR's merge status on GitHub.
- **Dependency parsing**: Reuses `Issues::ParseDependencies.extract` so PR-level dependencies use the same `Depends on #123` / `Depends on owner/repo#456` syntax as issue dependencies.
- **Conservative resolution**: Cross-repo, missing, or unmerged dependency references remain blocking — a dependency is only considered satisfied when the parent PR is actually merged.
- **Tests**: Added coverage for the new signal and a db-less scanner spec for the dependency-resolution path.

## Design Decisions

- **Merged, not deployed**: The gate currently only requires the parent PR to be *merged*, not deployed. Auto-deploy doesn't exist yet; once it lands, this gate should be extended to require deployment confirmation before allowing the dependent PR to merge.
- **Reuse over reinvention**: PR dependency syntax intentionally mirrors issue dependency syntax via `Issues::ParseDependencies.extract`, avoiding a parallel parser and keeping author-facing conventions consistent.
- **Fail closed**: Any ambiguous dependency reference (cross-repo, nonexistent PR, unmerged PR) is treated as unresolved. This favors safety over throughput for the staged-rollout use case that motivated the change.

## Follow-up

Once auto-deploy is supported, extend `dependencies_resolved` to require the parent PR's deploy to complete before the dependent PR can merge. This will likely need a new `deploy_status` concept on PRs or commits.

---

Closes #1948