### PR TITLE
feat(coordination): Phase 4.4 — Self-Improving Agent Coordination

### DIFF
--- a/app/services/coordination_policy_evolution/create_candidates.rb
+++ b/app/services/coordination_policy_evolution/create_candidates.rb
@@ -7,6 +7,7 @@ module CoordinationPolicyEvolution
       "status" => "pending_review",
       "auto_promote" => false
     }.freeze
+    SUPPORTED_POLICY_TYPES = %w[decomposition recovery escalation].freeze
 
     def self.call(...)
       new(...).call
@@ -16,6 +17,8 @@ module CoordinationPolicyEvolution
       @policy_snapshot = policy_snapshot.deep_symbolize_keys
       @account = account
       @mutations = Array(mutations)
+
+      validate_policy_type!
     end
 
     def call
@@ -46,6 +49,12 @@ module CoordinationPolicyEvolution
     private
 
     attr_reader :policy_snapshot, :account, :mutations
+
+    def validate_policy_type!
+      return if SUPPORTED_POLICY_TYPES.include?(policy_type)
+
+      raise ArgumentError, "unsupported coordination policy type: #{policy_type.inspect}"
+    end
 
     def coordination_policy
       @coordination_policy ||= begin

--- a/app/services/coordination_policy_evolution/create_candidates.rb
+++ b/app/services/coordination_policy_evolution/create_candidates.rb
@@ -164,11 +164,15 @@ module CoordinationPolicyEvolution
       decomposition = configuration.fetch("decomposition", {})
 
       {}.tap do |config|
-        config["enabled"] = decomposition["enabled"] if decomposition.key?("enabled")
-        config["min_components_to_decompose"] = decomposition["min_components_to_decompose"] if decomposition.key?("min_components_to_decompose")
-        config["max_tasks"] = decomposition["max_tasks"] if decomposition.key?("max_tasks")
-        config["layer_order"] = decomposition["layer_order"] if decomposition.key?("layer_order")
+        if decomposition.is_a?(Hash)
+          config["enabled"] = decomposition["enabled"] if decomposition.key?("enabled")
+          config["min_components_to_decompose"] = decomposition["min_components_to_decompose"] if decomposition.key?("min_components_to_decompose")
+          config["max_tasks"] = decomposition["max_tasks"] if decomposition.key?("max_tasks")
+          config["layer_order"] = decomposition["layer_order"] if decomposition.key?("layer_order")
+        end
+
         config["enabled"] = configuration["enabled"] if configuration.key?("enabled")
+        config["enabled"] = configuration["decomposition_enabled"] if configuration.key?("decomposition_enabled")
         config["min_components_to_decompose"] = configuration["min_components_to_decompose"] if configuration.key?("min_components_to_decompose")
         config["max_tasks"] = configuration["max_tasks"] if configuration.key?("max_tasks")
         config["layer_order"] = configuration["layer_order"] if configuration.key?("layer_order")
@@ -177,12 +181,14 @@ module CoordinationPolicyEvolution
 
     def extract_recovery_config(configuration)
       recovery = configuration.fetch("recovery", {})
-      actions = recovery["actions"] || recovery["failure_actions"]
+      actions = if recovery.is_a?(Hash)
+        recovery["actions"] || recovery["failure_actions"]
+      end
       actions ||= configuration["actions"] || configuration["failure_actions"]
 
       {}.tap do |config|
         config["actions"] = actions if actions.is_a?(Hash)
-        config["default_action"] = recovery["default_action"] if recovery.key?("default_action")
+        config["default_action"] = recovery["default_action"] if recovery.is_a?(Hash) && recovery.key?("default_action")
         config["default_action"] = configuration["default_action"] if configuration.key?("default_action")
       end.compact
     end
@@ -198,7 +204,7 @@ module CoordinationPolicyEvolution
           weights
           interruption_cost
         ].each do |key|
-          config[key] = escalation[key] if escalation.key?(key)
+          config[key] = escalation[key] if escalation.is_a?(Hash) && escalation.key?(key)
           config[key] = configuration[key] if configuration.key?(key)
         end
       end.compact

--- a/app/services/coordination_policy_evolution/create_candidates.rb
+++ b/app/services/coordination_policy_evolution/create_candidates.rb
@@ -94,7 +94,7 @@ module CoordinationPolicyEvolution
     end
 
     def candidate_rules(mutation)
-      configuration = mutation.configuration.deep_stringify_keys
+      configuration = policy_specific_configuration(mutation)
 
       case policy_type
       when "decomposition"
@@ -123,7 +123,7 @@ module CoordinationPolicyEvolution
     end
 
     def candidate_parameters(mutation)
-      configuration = mutation.configuration.deep_stringify_keys
+      configuration = policy_specific_configuration(mutation)
 
       case policy_type
       when "decomposition"
@@ -150,6 +150,10 @@ module CoordinationPolicyEvolution
       else
         {}
       end
+    end
+
+    def policy_specific_configuration(mutation)
+      base_configuration.deep_merge(mutation.configuration.to_h.deep_stringify_keys)
     end
 
     def candidate_metadata(mutation)
@@ -217,6 +221,10 @@ module CoordinationPolicyEvolution
           config[key] = configuration[key] if configuration.key?(key)
         end
       end.compact
+    end
+
+    def base_configuration
+      @base_configuration ||= policy_snapshot.fetch(:configuration, {}).to_h.deep_stringify_keys
     end
   end
 end

--- a/app/services/coordination_policy_evolution/create_candidates.rb
+++ b/app/services/coordination_policy_evolution/create_candidates.rb
@@ -89,21 +89,20 @@ module CoordinationPolicyEvolution
 
       case policy_type
       when "decomposition"
-        decomposition = configuration.fetch("decomposition", {})
+        decomposition = extract_decomposition_config(configuration)
 
         {
           "enabled" => decomposition["enabled"],
           "min_components_to_decompose" => decomposition["min_components_to_decompose"]
         }.compact
       when "recovery"
-        recovery = configuration.fetch("recovery", {})
-        actions = recovery["actions"] || recovery["failure_actions"]
+        recovery = extract_recovery_config(configuration)
 
         {
-          "failure_actions" => actions
+          "failure_actions" => recovery["actions"]
         }.compact
       when "escalation"
-        escalation = configuration.fetch("escalation", {})
+        escalation = extract_escalation_config(configuration)
 
         {
           "explicit_triggers" => escalation["explicit_triggers"],
@@ -119,20 +118,20 @@ module CoordinationPolicyEvolution
 
       case policy_type
       when "decomposition"
-        decomposition = configuration.fetch("decomposition", {})
+        decomposition = extract_decomposition_config(configuration)
 
         {
           "max_tasks" => decomposition["max_tasks"],
           "layer_order" => decomposition["layer_order"]
         }.compact
       when "recovery"
-        recovery = configuration.fetch("recovery", {})
+        recovery = extract_recovery_config(configuration)
 
         {
           "default_action" => recovery["default_action"]
         }.compact
       when "escalation"
-        escalation = configuration.fetch("escalation", {})
+        escalation = extract_escalation_config(configuration)
 
         {
           "human_value_threshold" => escalation["human_value_threshold"],
@@ -159,6 +158,50 @@ module CoordinationPolicyEvolution
           "approval" => APPROVAL_STATE
         }
       }
+    end
+
+    def extract_decomposition_config(configuration)
+      decomposition = configuration.fetch("decomposition", {})
+
+      {}.tap do |config|
+        config["enabled"] = decomposition["enabled"] if decomposition.key?("enabled")
+        config["min_components_to_decompose"] = decomposition["min_components_to_decompose"] if decomposition.key?("min_components_to_decompose")
+        config["max_tasks"] = decomposition["max_tasks"] if decomposition.key?("max_tasks")
+        config["layer_order"] = decomposition["layer_order"] if decomposition.key?("layer_order")
+        config["enabled"] = configuration["enabled"] if configuration.key?("enabled")
+        config["min_components_to_decompose"] = configuration["min_components_to_decompose"] if configuration.key?("min_components_to_decompose")
+        config["max_tasks"] = configuration["max_tasks"] if configuration.key?("max_tasks")
+        config["layer_order"] = configuration["layer_order"] if configuration.key?("layer_order")
+      end.compact
+    end
+
+    def extract_recovery_config(configuration)
+      recovery = configuration.fetch("recovery", {})
+      actions = recovery["actions"] || recovery["failure_actions"]
+      actions ||= configuration["actions"] || configuration["failure_actions"]
+
+      {}.tap do |config|
+        config["actions"] = actions if actions.is_a?(Hash)
+        config["default_action"] = recovery["default_action"] if recovery.key?("default_action")
+        config["default_action"] = configuration["default_action"] if configuration.key?("default_action")
+      end.compact
+    end
+
+    def extract_escalation_config(configuration)
+      escalation = configuration.fetch("escalation", {})
+
+      {}.tap do |config|
+        %w[
+          human_value_threshold
+          explicit_triggers
+          auto_resolve_trigger_types
+          weights
+          interruption_cost
+        ].each do |key|
+          config[key] = escalation[key] if escalation.key?(key)
+          config[key] = configuration[key] if configuration.key?(key)
+        end
+      end.compact
     end
   end
 end

--- a/app/services/coordination_policy_evolution/create_candidates.rb
+++ b/app/services/coordination_policy_evolution/create_candidates.rb
@@ -85,21 +85,63 @@ module CoordinationPolicyEvolution
     end
 
     def candidate_rules(mutation)
-      decomposition = mutation.configuration.deep_stringify_keys.fetch("decomposition", {})
+      configuration = mutation.configuration.deep_stringify_keys
 
-      {
-        "enabled" => decomposition["enabled"],
-        "min_components_to_decompose" => decomposition["min_components_to_decompose"]
-      }.compact
+      case policy_type
+      when "decomposition"
+        decomposition = configuration.fetch("decomposition", {})
+
+        {
+          "enabled" => decomposition["enabled"],
+          "min_components_to_decompose" => decomposition["min_components_to_decompose"]
+        }.compact
+      when "recovery"
+        recovery = configuration.fetch("recovery", {})
+        actions = recovery["actions"] || recovery["failure_actions"]
+
+        {
+          "failure_actions" => actions
+        }.compact
+      when "escalation"
+        escalation = configuration.fetch("escalation", {})
+
+        {
+          "explicit_triggers" => escalation["explicit_triggers"],
+          "auto_resolve_trigger_types" => escalation["auto_resolve_trigger_types"]
+        }.compact
+      else
+        {}
+      end
     end
 
     def candidate_parameters(mutation)
-      decomposition = mutation.configuration.deep_stringify_keys.fetch("decomposition", {})
+      configuration = mutation.configuration.deep_stringify_keys
 
-      {
-        "max_tasks" => decomposition["max_tasks"],
-        "layer_order" => decomposition["layer_order"]
-      }.compact
+      case policy_type
+      when "decomposition"
+        decomposition = configuration.fetch("decomposition", {})
+
+        {
+          "max_tasks" => decomposition["max_tasks"],
+          "layer_order" => decomposition["layer_order"]
+        }.compact
+      when "recovery"
+        recovery = configuration.fetch("recovery", {})
+
+        {
+          "default_action" => recovery["default_action"]
+        }.compact
+      when "escalation"
+        escalation = configuration.fetch("escalation", {})
+
+        {
+          "human_value_threshold" => escalation["human_value_threshold"],
+          "weights" => escalation["weights"],
+          "interruption_cost" => escalation["interruption_cost"]
+        }.compact
+      else
+        {}
+      end
     end
 
     def candidate_metadata(mutation)

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -244,15 +244,17 @@ module CoordinationPolicyEvolution
     end
 
     def serialize_orchestration_decision(decision)
+      context = decision.context.to_h
+
       {
         id: decision.id,
         decision_type: decision.decision_type,
         created_at: decision.created_at.iso8601,
         actor: decision.actor,
-        decision_status: decision.context["decision_status"],
-        context: decision.context,
-        inputs: decision.inputs,
-        outputs: decision.outputs
+        decision_status: context["decision_status"],
+        context: context,
+        inputs: decision.inputs.to_h,
+        outputs: decision.outputs.to_h
       }
     end
 
@@ -391,6 +393,7 @@ module CoordinationPolicyEvolution
         end
 
         config["enabled"] = payload["enabled"] if payload.key?("enabled")
+        config["enabled"] = payload["decomposition_enabled"] if payload.key?("decomposition_enabled")
         config["min_components_to_decompose"] = payload["min_components_to_decompose"] if payload.key?("min_components_to_decompose")
         config["max_tasks"] = payload["max_tasks"] if payload.key?("max_tasks")
         config["layer_order"] = payload["layer_order"] if payload.key?("layer_order")

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -420,8 +420,6 @@ module CoordinationPolicyEvolution
       escalation = payload.fetch("escalation", {})
 
       {}.tap do |config|
-        source = escalation.is_a?(Hash) ? escalation : payload
-
         %w[
           human_value_threshold
           explicit_triggers
@@ -429,7 +427,8 @@ module CoordinationPolicyEvolution
           weights
           interruption_cost
         ].each do |key|
-          config[key] = source[key] if source.key?(key)
+          config[key] = escalation[key] if escalation.is_a?(Hash) && escalation.key?(key)
+          config[key] = payload[key] if payload.key?(key)
         end
       end.compact
     end

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -5,6 +5,7 @@ module CoordinationPolicyEvolution
     DEFAULT_LOOKBACK_DAYS = 60
     DEFAULT_MIN_DECISIONS = 10
     DEFAULT_SAMPLE_LIMIT = 5
+    SUPPORTED_POLICY_TYPES = %w[decomposition recovery escalation].freeze
     POLICY_TYPE = DecompositionService::POLICY_TYPE
     POLICY_KEY = DecompositionService::POLICY_KEY
     POLICY_KEYS = {
@@ -47,6 +48,8 @@ module CoordinationPolicyEvolution
       @lookback_days = lookback_days
       @min_decisions = min_decisions
       @sample_limit = sample_limit
+
+      validate_policy_type!
     end
 
     def call
@@ -62,6 +65,12 @@ module CoordinationPolicyEvolution
     private
 
     attr_reader :account, :policy_type, :lookback_days, :min_decisions, :sample_limit
+
+    def validate_policy_type!
+      return if SUPPORTED_POLICY_TYPES.include?(policy_type)
+
+      raise ArgumentError, "unsupported coordination policy type: #{policy_type.inspect}"
+    end
 
     def serialize_policy_snapshot
       if coordination_policy&.current_version

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -109,15 +109,13 @@ module CoordinationPolicyEvolution
     end
 
     def successful_orchestration_decisions
-      statuses = orchestration_success_statuses
-      placeholders = statuses.map { |s| "'#{s}'" }.join(", ")
       @successful_orchestration_decisions ||= scoped_decisions
-        .where(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN (#{placeholders})"))
+        .where("COALESCE(context->>'decision_status', 'unknown') IN (?)", orchestration_success_statuses)
     end
 
     def failed_orchestration_decisions
       @failed_orchestration_decisions ||= scoped_decisions
-        .where(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('failed')"))
+        .where("COALESCE(context->>'decision_status', 'unknown') IN (?)", ORCHESTRATION_FAILURE_STATUSES)
     end
 
     def performance_summary

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -374,12 +374,7 @@ module CoordinationPolicyEvolution
     end
 
     def default_configuration
-      @default_configuration ||= OrchestrationStrategies::Defaults.feature_orchestration.tap do |configuration|
-        configuration["recovery"] ||= {
-          "actions" => Coordination::FailureRecoveryPolicy::DEFAULT_ACTIONS.deep_dup,
-          "default_action" => Coordination::FailureRecoveryPolicy::DEFAULT_ACTION
-        }
-      end
+      @default_configuration ||= OrchestrationStrategies::Defaults.feature_orchestration.deep_dup
     end
 
     def extract_decomposition_config(payload)

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -31,6 +31,7 @@ module CoordinationPolicyEvolution
       parallelization_failed
     ].freeze
     ORCHESTRATION_SUCCESS_STATUSES = %w[applied].freeze
+    ESCALATION_SUCCESS_STATUSES = %w[applied deferred resolved].freeze
     ORCHESTRATION_FAILURE_STATUSES = %w[failed].freeze
     ORCHESTRATION_NOOP_STATUSES = %w[noop].freeze
 
@@ -108,8 +109,10 @@ module CoordinationPolicyEvolution
     end
 
     def successful_orchestration_decisions
+      statuses = orchestration_success_statuses
+      placeholders = statuses.map { |s| "'#{s}'" }.join(", ")
       @successful_orchestration_decisions ||= scoped_decisions
-        .where(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('applied')"))
+        .where(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN (#{placeholders})"))
     end
 
     def failed_orchestration_decisions
@@ -144,7 +147,7 @@ module CoordinationPolicyEvolution
 
     def orchestration_performance_summary
       decision_count = scoped_decisions.count
-      success_count = count_orchestration_statuses(ORCHESTRATION_SUCCESS_STATUSES)
+      success_count = count_orchestration_statuses(orchestration_success_statuses)
       failure_count = count_orchestration_statuses(ORCHESTRATION_FAILURE_STATUSES)
       noop_count = count_orchestration_statuses(ORCHESTRATION_NOOP_STATUSES)
       classified_decision_count = success_count + failure_count
@@ -444,6 +447,10 @@ module CoordinationPolicyEvolution
 
     def orchestration_policy_type?
       %w[recovery escalation].include?(policy_type)
+    end
+
+    def orchestration_success_statuses
+      policy_type == "escalation" ? ESCALATION_SUCCESS_STATUSES : ORCHESTRATION_SUCCESS_STATUSES
     end
 
     def orchestration_decision_actor

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -30,6 +30,9 @@ module CoordinationPolicyEvolution
       parallelization_planning_failed
       parallelization_failed
     ].freeze
+    ORCHESTRATION_SUCCESS_STATUSES = %w[applied].freeze
+    ORCHESTRATION_FAILURE_STATUSES = %w[failed].freeze
+    ORCHESTRATION_NOOP_STATUSES = %w[noop].freeze
 
     def self.call(...)
       new(...).call
@@ -106,12 +109,12 @@ module CoordinationPolicyEvolution
 
     def successful_orchestration_decisions
       @successful_orchestration_decisions ||= scoped_decisions
-        .where.not(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('failed', 'noop')"))
+        .where(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('applied')"))
     end
 
     def failed_orchestration_decisions
       @failed_orchestration_decisions ||= scoped_decisions
-        .where(Arel.sql("COALESCE(context->>'decision_status', 'unknown') = 'failed'"))
+        .where(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('failed')"))
     end
 
     def performance_summary
@@ -141,9 +144,9 @@ module CoordinationPolicyEvolution
 
     def orchestration_performance_summary
       decision_count = scoped_decisions.count
-      failure_count = orchestration_status_counts.fetch("failed", 0)
-      noop_count = orchestration_status_counts.fetch("noop", 0)
-      success_count = decision_count - failure_count - noop_count
+      success_count = count_orchestration_statuses(ORCHESTRATION_SUCCESS_STATUSES)
+      failure_count = count_orchestration_statuses(ORCHESTRATION_FAILURE_STATUSES)
+      noop_count = count_orchestration_statuses(ORCHESTRATION_NOOP_STATUSES)
       classified_decision_count = success_count + failure_count
 
       {
@@ -209,6 +212,10 @@ module CoordinationPolicyEvolution
       @orchestration_status_counts ||= scoped_decisions
         .group(Arel.sql("COALESCE(context->>'decision_status', 'unknown')"))
         .count
+    end
+
+    def count_orchestration_statuses(statuses)
+      orchestration_status_counts.slice(*statuses).values.sum
     end
 
     def count_outcomes(outcomes)

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -374,7 +374,7 @@ module CoordinationPolicyEvolution
     end
 
     def default_configuration
-      OrchestrationStrategies::Defaults.feature_orchestration.deep_dup.tap do |configuration|
+      @default_configuration ||= OrchestrationStrategies::Defaults.feature_orchestration.tap do |configuration|
         configuration["recovery"] ||= {
           "actions" => Coordination::FailureRecoveryPolicy::DEFAULT_ACTIONS.deep_dup,
           "default_action" => Coordination::FailureRecoveryPolicy::DEFAULT_ACTION

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -7,6 +7,21 @@ module CoordinationPolicyEvolution
     DEFAULT_SAMPLE_LIMIT = 5
     POLICY_TYPE = DecompositionService::POLICY_TYPE
     POLICY_KEY = DecompositionService::POLICY_KEY
+    POLICY_KEYS = {
+      "decomposition" => DecompositionService::POLICY_KEY,
+      "recovery" => Coordination::FailureRecoveryPolicy::POLICY_KEY,
+      "escalation" => Coordination::EscalationPolicy::POLICY_KEY
+    }.freeze
+    POLICY_NAMES = {
+      "decomposition" => "Feature Decomposition",
+      "recovery" => "Failure Recovery",
+      "escalation" => "Human Intervention"
+    }.freeze
+    POLICY_DESCRIPTIONS = {
+      "decomposition" => "Account-level coordination policy for feature decomposition.",
+      "recovery" => "Account-level coordination policy for failed agent run recovery.",
+      "escalation" => "Account-level coordination policy for human escalation decisions."
+    }.freeze
     NOOP_OUTCOMES = Orchestration::DecompositionDecisions::Log::NOOP_OUTCOMES
     FAILURE_OUTCOMES = %w[
       decomposition_failed
@@ -60,6 +75,8 @@ module CoordinationPolicyEvolution
     end
 
     def scoped_decisions
+      return scoped_orchestration_decisions if orchestration_policy_type?
+
       @scoped_decisions ||= DecompositionDecision
         .joins(:project)
         .where(projects: { account_id: account.id })
@@ -67,15 +84,39 @@ module CoordinationPolicyEvolution
         .where(created_at: lookback_days.days.ago..Time.current)
     end
 
+    def scoped_orchestration_decisions
+      @scoped_orchestration_decisions ||= OrchestrationDecision
+        .joins(:project)
+        .where(projects: { account_id: account.id })
+        .where(actor: orchestration_decision_actor)
+        .where(created_at: lookback_days.days.ago..Time.current)
+    end
+
     def successful_decisions
+      return successful_orchestration_decisions if orchestration_policy_type?
+
       @successful_decisions ||= scoped_decisions.where.not(outcome: NOOP_OUTCOMES + FAILURE_OUTCOMES)
     end
 
     def failed_decisions
+      return failed_orchestration_decisions if orchestration_policy_type?
+
       @failed_decisions ||= scoped_decisions.where(outcome: FAILURE_OUTCOMES)
     end
 
+    def successful_orchestration_decisions
+      @successful_orchestration_decisions ||= scoped_decisions
+        .where.not(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('failed', 'noop')"))
+    end
+
+    def failed_orchestration_decisions
+      @failed_orchestration_decisions ||= scoped_decisions
+        .where(Arel.sql("COALESCE(context->>'decision_status', 'unknown') = 'failed'"))
+    end
+
     def performance_summary
+      return orchestration_performance_summary if orchestration_policy_type?
+
       decision_count = outcome_counts.values.sum
       failure_count = count_outcomes(FAILURE_OUTCOMES)
       noop_count = count_outcomes(NOOP_OUTCOMES)
@@ -98,6 +139,29 @@ module CoordinationPolicyEvolution
       }
     end
 
+    def orchestration_performance_summary
+      decision_count = scoped_decisions.count
+      failure_count = orchestration_status_counts.fetch("failed", 0)
+      noop_count = orchestration_status_counts.fetch("noop", 0)
+      success_count = decision_count - failure_count - noop_count
+      classified_decision_count = success_count + failure_count
+
+      {
+        decision_count: decision_count,
+        classified_decision_count: classified_decision_count,
+        min_decisions: min_decisions,
+        success_count: success_count,
+        failure_count: failure_count,
+        noop_count: noop_count,
+        success_rate: success_rate(classified_decision_count, success_count),
+        lookback_days: lookback_days,
+        decision_type_counts: decision_type_counts,
+        outcome_counts: orchestration_status_counts,
+        policy_source_counts: policy_source_counts,
+        average_task_count: nil
+      }
+    end
+
     def sample_successes
       @sample_successes ||= successful_decisions.order(created_at: :desc, id: :desc).limit(sample_limit)
     end
@@ -113,8 +177,16 @@ module CoordinationPolicyEvolution
     end
 
     def policy_source_counts
+      return orchestration_policy_source_counts if orchestration_policy_type?
+
       scoped_decisions
         .group(Arel.sql("COALESCE(metadata->>'policy_source', 'unknown')"))
+        .count
+    end
+
+    def orchestration_policy_source_counts
+      scoped_decisions
+        .group(Arel.sql("COALESCE(inputs->>'policy_source', 'unknown')"))
         .count
     end
 
@@ -133,12 +205,20 @@ module CoordinationPolicyEvolution
       @outcome_counts ||= scoped_decisions.group(:outcome).count
     end
 
+    def orchestration_status_counts
+      @orchestration_status_counts ||= scoped_decisions
+        .group(Arel.sql("COALESCE(context->>'decision_status', 'unknown')"))
+        .count
+    end
+
     def count_outcomes(outcomes)
       outcome_counts.slice(*outcomes).values.sum
     end
 
     def serialize_decisions(rows)
       rows.map do |decision|
+        next serialize_orchestration_decision(decision) if orchestration_policy_type?
+
         {
           id: decision.id,
           decision_key: decision.decision_key,
@@ -155,15 +235,30 @@ module CoordinationPolicyEvolution
       end
     end
 
+    def serialize_orchestration_decision(decision)
+      {
+        id: decision.id,
+        decision_type: decision.decision_type,
+        created_at: decision.created_at.iso8601,
+        actor: decision.actor,
+        decision_status: decision.context["decision_status"],
+        context: decision.context,
+        inputs: decision.inputs,
+        outputs: decision.outputs
+      }
+    end
+
     def coordination_policy
       @coordination_policy ||= CoordinationPolicy
-        .where(account:, policy_type:, policy_key: POLICY_KEY, project_id: nil)
+        .where(account:, policy_type:, policy_key: policy_key, project_id: nil)
         .includes(:current_version, :coordination_policy_versions)
         .order(Arel.sql("CASE status WHEN 'active' THEN 0 WHEN 'draft' THEN 1 ELSE 2 END"), id: :desc)
         .first
     end
 
     def current_strategy
+      return unless decomposition_policy_type?
+
       @current_strategy ||= OrchestrationStrategies::Resolve.call(
         strategy_type: DecompositionService::STRATEGY_TYPE,
         account: account
@@ -200,9 +295,9 @@ module CoordinationPolicyEvolution
       {
         id: coordination_policy&.id,
         policy_type: policy_type,
-        policy_key: POLICY_KEY,
-        name: "Feature Decomposition",
-        description: "Account-level coordination policy for feature decomposition.",
+        policy_key: policy_key,
+        name: policy_name,
+        description: policy_description,
         status: coordination_policy&.status || "draft",
         account_id: account.id,
         project_id: nil,
@@ -221,13 +316,15 @@ module CoordinationPolicyEvolution
     end
 
     def bootstrap_source
-      current_strategy.present? ? DecompositionService::STRATEGY_TYPE : "defaults"
+      return DecompositionService::STRATEGY_TYPE if decomposition_policy_type? && current_strategy.present?
+
+      "defaults"
     end
 
     def bootstrap_configuration
-      return current_strategy.configuration if current_strategy.present?
+      return current_strategy.configuration if decomposition_policy_type? && current_strategy.present?
 
-      OrchestrationStrategies::Defaults.feature_orchestration
+      default_configuration
     end
 
     def serialize_policy_version(version)
@@ -247,11 +344,33 @@ module CoordinationPolicyEvolution
     end
 
     def effective_configuration(rules, parameters)
+      default_configuration.deep_dup.tap do |configuration|
+        case policy_type
+        when "decomposition"
+          configuration["decomposition"] = configuration.fetch("decomposition", {}).merge(
+            extract_decomposition_config(rules),
+            extract_decomposition_config(parameters)
+          )
+        when "recovery"
+          configuration["recovery"] = configuration.fetch("recovery", {}).merge(
+            extract_recovery_config(rules),
+            extract_recovery_config(parameters)
+          )
+        when "escalation"
+          configuration["escalation"] = configuration.fetch("escalation", {}).merge(
+            extract_escalation_config(rules),
+            extract_escalation_config(parameters)
+          )
+        end
+      end
+    end
+
+    def default_configuration
       OrchestrationStrategies::Defaults.feature_orchestration.deep_dup.tap do |configuration|
-        configuration["decomposition"] = configuration.fetch("decomposition", {}).merge(
-          extract_decomposition_config(rules),
-          extract_decomposition_config(parameters)
-        )
+        configuration["recovery"] ||= {
+          "actions" => Coordination::FailureRecoveryPolicy::DEFAULT_ACTIONS.deep_dup,
+          "default_action" => Coordination::FailureRecoveryPolicy::DEFAULT_ACTION
+        }
       end
     end
 
@@ -273,6 +392,70 @@ module CoordinationPolicyEvolution
         config["max_tasks"] = payload["max_tasks"] if payload.key?("max_tasks")
         config["layer_order"] = payload["layer_order"] if payload.key?("layer_order")
       end.compact
+    end
+
+    def extract_recovery_config(payload)
+      return {} unless payload.is_a?(Hash)
+
+      recovery = payload.fetch("recovery", {})
+
+      {}.tap do |config|
+        actions = if recovery.is_a?(Hash)
+          recovery["actions"] || recovery["failure_actions"]
+        end
+        actions ||= payload["failure_actions"] || payload["actions"]
+
+        config["actions"] = actions if actions.is_a?(Hash)
+        config["default_action"] = recovery["default_action"] if recovery.is_a?(Hash) && recovery.key?("default_action")
+        config["default_action"] = payload["default_action"] if payload.key?("default_action")
+      end.compact
+    end
+
+    def extract_escalation_config(payload)
+      return {} unless payload.is_a?(Hash)
+
+      escalation = payload.fetch("escalation", {})
+
+      {}.tap do |config|
+        source = escalation.is_a?(Hash) ? escalation : payload
+
+        %w[
+          human_value_threshold
+          explicit_triggers
+          auto_resolve_trigger_types
+          weights
+          interruption_cost
+        ].each do |key|
+          config[key] = source[key] if source.key?(key)
+        end
+      end.compact
+    end
+
+    def decomposition_policy_type?
+      policy_type == "decomposition"
+    end
+
+    def orchestration_policy_type?
+      %w[recovery escalation].include?(policy_type)
+    end
+
+    def orchestration_decision_actor
+      case policy_type
+      when "recovery" then "coordination_failure_recovery"
+      when "escalation" then "coordination_escalation_service"
+      end
+    end
+
+    def policy_key
+      POLICY_KEYS.fetch(policy_type, POLICY_KEY)
+    end
+
+    def policy_name
+      POLICY_NAMES.fetch(policy_type, policy_type.humanize)
+    end
+
+    def policy_description
+      POLICY_DESCRIPTIONS.fetch(policy_type, "Account-level coordination policy.")
     end
   end
 end

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -366,6 +366,9 @@ module CoordinationPolicyEvolution
     end
 
     def effective_configuration(rules, parameters)
+      rules = rules.to_h.deep_stringify_keys
+      parameters = parameters.to_h.deep_stringify_keys
+
       default_configuration.deep_dup.tap do |configuration|
         case policy_type
         when "decomposition"

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -34,6 +34,7 @@ module CoordinationPolicyEvolution
     ESCALATION_SUCCESS_STATUSES = %w[applied deferred resolved].freeze
     ORCHESTRATION_FAILURE_STATUSES = %w[failed].freeze
     ORCHESTRATION_NOOP_STATUSES = %w[noop].freeze
+    DEFAULT_ORCHESTRATION_DECISION_STATUS = "applied"
 
     def self.call(...)
       new(...).call
@@ -110,12 +111,14 @@ module CoordinationPolicyEvolution
 
     def successful_orchestration_decisions
       @successful_orchestration_decisions ||= scoped_decisions
-        .where("COALESCE(context->>'decision_status', 'unknown') IN (?)", orchestration_success_statuses)
+        .where("COALESCE(context->>'decision_status', ?) IN (?)",
+          DEFAULT_ORCHESTRATION_DECISION_STATUS, orchestration_success_statuses)
     end
 
     def failed_orchestration_decisions
       @failed_orchestration_decisions ||= scoped_decisions
-        .where("COALESCE(context->>'decision_status', 'unknown') IN (?)", ORCHESTRATION_FAILURE_STATUSES)
+        .where("COALESCE(context->>'decision_status', ?) IN (?)",
+          DEFAULT_ORCHESTRATION_DECISION_STATUS, ORCHESTRATION_FAILURE_STATUSES)
     end
 
     def performance_summary
@@ -211,7 +214,7 @@ module CoordinationPolicyEvolution
 
     def orchestration_status_counts
       @orchestration_status_counts ||= scoped_decisions
-        .group(Arel.sql("COALESCE(context->>'decision_status', 'unknown')"))
+        .group(Arel.sql("COALESCE(context->>'decision_status', '#{DEFAULT_ORCHESTRATION_DECISION_STATUS}')"))
         .count
     end
 
@@ -251,7 +254,7 @@ module CoordinationPolicyEvolution
         decision_type: decision.decision_type,
         created_at: decision.created_at.iso8601,
         actor: decision.actor,
-        decision_status: context["decision_status"],
+        decision_status: context.fetch("decision_status", DEFAULT_ORCHESTRATION_DECISION_STATUS),
         context: context,
         inputs: decision.inputs.to_h,
         outputs: decision.outputs.to_h

--- a/app/services/orchestration_strategies/defaults.rb
+++ b/app/services/orchestration_strategies/defaults.rb
@@ -178,6 +178,10 @@ module OrchestrationStrategies
             "escalated_phase_discount" => 0.1
           }
         },
+        "recovery" => {
+          "actions" => Coordination::FailureRecoveryPolicy::DEFAULT_ACTIONS.deep_dup,
+          "default_action" => Coordination::FailureRecoveryPolicy::DEFAULT_ACTION
+        },
         "decomposition" => {
           "enabled" => true,
           "max_tasks" => 20,

--- a/spec/services/coordination_policy_evolution/create_candidates_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/create_candidates_no_db_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CoordinationPolicyEvolution::CreateCandidates, :no_db do
+  describe "policy-specific extraction" do
+    def build_service(policy_type)
+      described_class.new(
+        policy_snapshot: {
+          id: 1,
+          policy_type: policy_type,
+          policy_key: "#{policy_type}_policy",
+          name: policy_type.humanize
+        },
+        account: Object.new,
+        mutations: []
+      )
+    end
+
+    it "persists recovery candidates from persisted top-level policy fields" do
+      service = build_service("recovery")
+      mutation = instance_double(
+        StrategyEvolution::Mutate::Mutation,
+        configuration: {
+          "failure_actions" => { "timeout" => "retry_same_provider" },
+          "default_action" => "pause_and_notify"
+        }
+      )
+
+      expect(service.send(:candidate_rules, mutation)).to eq(
+        "failure_actions" => { "timeout" => "retry_same_provider" }
+      )
+      expect(service.send(:candidate_parameters, mutation)).to eq(
+        "default_action" => "pause_and_notify"
+      )
+    end
+
+    it "persists escalation candidates from persisted top-level policy fields" do
+      service = build_service("escalation")
+      mutation = instance_double(
+        StrategyEvolution::Mutate::Mutation,
+        configuration: {
+          "explicit_triggers" => %w[operational_failure_breaker],
+          "auto_resolve_trigger_types" => %w[owner_approved],
+          "human_value_threshold" => 0.45,
+          "weights" => { "review_goal_retry_pressure" => 0.6 },
+          "interruption_cost" => { "base" => 0.2 }
+        }
+      )
+
+      expect(service.send(:candidate_rules, mutation)).to eq(
+        "explicit_triggers" => %w[operational_failure_breaker],
+        "auto_resolve_trigger_types" => %w[owner_approved]
+      )
+      expect(service.send(:candidate_parameters, mutation)).to eq(
+        "human_value_threshold" => 0.45,
+        "weights" => { "review_goal_retry_pressure" => 0.6 },
+        "interruption_cost" => { "base" => 0.2 }
+      )
+    end
+  end
+end

--- a/spec/services/coordination_policy_evolution/create_candidates_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/create_candidates_no_db_spec.rb
@@ -58,5 +58,26 @@ RSpec.describe CoordinationPolicyEvolution::CreateCandidates, :no_db do
         "interruption_cost" => { "base" => 0.2 }
       )
     end
+
+    it "accepts legacy flat decomposition flags and ignores nil nested policy sections" do
+      service = build_service("decomposition")
+      mutation = instance_double(
+        StrategyEvolution::Mutate::Mutation,
+        configuration: {
+          "decomposition" => nil,
+          "decomposition_enabled" => false,
+          "min_components_to_decompose" => 4,
+          "max_tasks" => 10
+        }
+      )
+
+      expect(service.send(:candidate_rules, mutation)).to eq(
+        "enabled" => false,
+        "min_components_to_decompose" => 4
+      )
+      expect(service.send(:candidate_parameters, mutation)).to eq(
+        "max_tasks" => 10
+      )
+    end
   end
 end

--- a/spec/services/coordination_policy_evolution/create_candidates_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/create_candidates_no_db_spec.rb
@@ -4,13 +4,14 @@ require "rails_helper"
 
 RSpec.describe CoordinationPolicyEvolution::CreateCandidates, :no_db do
   describe "policy-specific extraction" do
-    def build_service(policy_type)
+    def build_service(policy_type, configuration = {})
       described_class.new(
         policy_snapshot: {
           id: 1,
           policy_type: policy_type,
           policy_key: "#{policy_type}_policy",
-          name: policy_type.humanize
+          name: policy_type.humanize,
+          configuration: configuration
         },
         account: Object.new,
         mutations: []
@@ -35,6 +36,26 @@ RSpec.describe CoordinationPolicyEvolution::CreateCandidates, :no_db do
       )
     end
 
+    it "preserves unchanged recovery actions when a mutation only changes the default action" do
+      service = build_service("recovery", {
+        "recovery" => {
+          "actions" => { "timeout" => "retry_same_provider" },
+          "default_action" => "pause_and_notify"
+        }
+      })
+      mutation = instance_double(
+        StrategyEvolution::Mutate::Mutation,
+        configuration: { "recovery" => { "default_action" => "skip_and_continue" } }
+      )
+
+      expect(service.send(:candidate_rules, mutation)).to eq(
+        "failure_actions" => { "timeout" => "retry_same_provider" }
+      )
+      expect(service.send(:candidate_parameters, mutation)).to eq(
+        "default_action" => "skip_and_continue"
+      )
+    end
+
     it "persists escalation candidates from persisted top-level policy fields" do
       service = build_service("escalation")
       mutation = instance_double(
@@ -56,6 +77,28 @@ RSpec.describe CoordinationPolicyEvolution::CreateCandidates, :no_db do
         "human_value_threshold" => 0.45,
         "weights" => { "review_goal_retry_pressure" => 0.6 },
         "interruption_cost" => { "base" => 0.2 }
+      )
+    end
+
+    it "preserves unchanged escalation triggers when a mutation only changes scoring parameters" do
+      service = build_service("escalation", {
+        "escalation" => {
+          "human_value_threshold" => 0.65,
+          "explicit_triggers" => %w[operational_failure_breaker],
+          "auto_resolve_trigger_types" => %w[owner_approved]
+        }
+      })
+      mutation = instance_double(
+        StrategyEvolution::Mutate::Mutation,
+        configuration: { "escalation" => { "human_value_threshold" => 0.45 } }
+      )
+
+      expect(service.send(:candidate_rules, mutation)).to eq(
+        "explicit_triggers" => %w[operational_failure_breaker],
+        "auto_resolve_trigger_types" => %w[owner_approved]
+      )
+      expect(service.send(:candidate_parameters, mutation)).to eq(
+        "human_value_threshold" => 0.45
       )
     end
 

--- a/spec/services/coordination_policy_evolution/create_candidates_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/create_candidates_no_db_spec.rb
@@ -79,5 +79,11 @@ RSpec.describe CoordinationPolicyEvolution::CreateCandidates, :no_db do
         "max_tasks" => 10
       )
     end
+
+    it "fails fast for unsupported policy types" do
+      expect {
+        build_service("lifecycle_state")
+      }.to raise_error(ArgumentError, 'unsupported coordination policy type: "lifecycle_state"')
+    end
   end
 end

--- a/spec/services/coordination_policy_evolution/create_candidates_spec.rb
+++ b/spec/services/coordination_policy_evolution/create_candidates_spec.rb
@@ -85,5 +85,109 @@ RSpec.describe CoordinationPolicyEvolution::CreateCandidates do
 
       expect(candidate.reload).to be_activatable
     end
+
+    context "with recovery mutations" do
+      let(:recovery_policy) do
+        create(:coordination_policy, :active,
+          account: account,
+          policy_type: "recovery",
+          policy_key: Coordination::FailureRecoveryPolicy::POLICY_KEY,
+          name: "Failure Recovery")
+      end
+      let(:recovery_mutation) do
+        StrategyEvolution::Mutate::Mutation.new(
+          configuration: OrchestrationStrategies::Defaults.feature_orchestration.deep_dup.merge(
+            "recovery" => {
+              "actions" => {
+                "timeout" => "retry_same_provider",
+                "provider_error" => "retry_alternate_provider"
+              },
+              "default_action" => "pause_and_notify"
+            }
+          ),
+          strategy: "recovery_refinement",
+          reasoning: "Tighten learned timeout handling",
+          expected_improvement: "Higher successful retries",
+          diff: [ { "path" => "/recovery/actions/timeout", "from" => nil, "to" => "retry_same_provider" } ],
+          provenance: {}
+        )
+      end
+      let(:recovery_candidate) do
+        described_class.call(
+          policy_snapshot: {
+            id: recovery_policy.id,
+            policy_type: "recovery",
+            policy_key: recovery_policy.policy_key,
+            name: recovery_policy.name,
+            version_id: recovery_policy.current_version.id,
+            version: recovery_policy.current_version.version,
+            configuration: recovery_mutation.configuration
+          },
+          account: account,
+          mutations: [ recovery_mutation ]
+        ).first
+      end
+
+      it "persists recovery candidates using recovery-specific rule and parameter keys" do
+        expect(recovery_candidate.rules).to include(
+          "failure_actions" => include("timeout" => "retry_same_provider")
+        )
+        expect(recovery_candidate.parameters).to include("default_action" => "pause_and_notify")
+      end
+    end
+
+    context "with escalation mutations" do
+      let(:escalation_policy) do
+        create(:coordination_policy, :active,
+          account: account,
+          policy_type: "escalation",
+          policy_key: Coordination::EscalationPolicy::POLICY_KEY,
+          name: "Human Intervention")
+      end
+      let(:escalation_mutation) do
+        StrategyEvolution::Mutate::Mutation.new(
+          configuration: OrchestrationStrategies::Defaults.feature_orchestration.deep_dup.tap do |config|
+            config["escalation"] = config.fetch("escalation", {}).merge(
+              "human_value_threshold" => 0.45,
+              "explicit_triggers" => %w[operational_failure_breaker],
+              "auto_resolve_trigger_types" => %w[owner_approved],
+              "weights" => { "review_goal_retry_pressure" => 0.6 },
+              "interruption_cost" => { "base" => 0.2 }
+            )
+          end,
+          strategy: "escalation_refinement",
+          reasoning: "Lower threshold where humans historically help",
+          expected_improvement: "Faster handoff on genuinely blocked PRs",
+          diff: [ { "path" => "/escalation/human_value_threshold", "from" => 0.65, "to" => 0.45 } ],
+          provenance: {}
+        )
+      end
+      let(:escalation_candidate) do
+        described_class.call(
+          policy_snapshot: {
+            id: escalation_policy.id,
+            policy_type: "escalation",
+            policy_key: escalation_policy.policy_key,
+            name: escalation_policy.name,
+            version_id: escalation_policy.current_version.id,
+            version: escalation_policy.current_version.version,
+            configuration: escalation_mutation.configuration
+          },
+          account: account,
+          mutations: [ escalation_mutation ]
+        ).first
+      end
+
+      it "persists escalation candidates using escalation-specific rule and parameter keys" do
+        expect(escalation_candidate.rules).to include(
+          "explicit_triggers" => %w[operational_failure_breaker],
+          "auto_resolve_trigger_types" => %w[owner_approved]
+        )
+        expect(escalation_candidate.parameters).to include(
+          "human_value_threshold" => 0.45,
+          "weights" => { "review_goal_retry_pressure" => 0.6 }
+        )
+      end
+    end
   end
 end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -58,12 +58,24 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
 
       allow(service).to receive(:scoped_decisions).and_return(scoped)
       allow(scoped).to receive(:where)
-        .with("COALESCE(context->>'decision_status', 'unknown') IN (?)", %w[applied deferred resolved])
+        .with("COALESCE(context->>'decision_status', ?) IN (?)", "applied", %w[applied deferred resolved])
         .and_return(successful)
       allow(successful).to receive(:order).with(created_at: :desc, id: :desc).and_return(successful)
       allow(successful).to receive(:limit).with(5).and_return(sampled)
 
       expect(service.send(:sample_successes)).to eq(sampled)
+    end
+
+    it "treats missing decision statuses as applied for historical orchestration records" do
+      scoped = instance_double(ActiveRecord::Relation)
+      successful = instance_double(ActiveRecord::Relation)
+
+      allow(service).to receive(:scoped_decisions).and_return(scoped)
+      allow(scoped).to receive(:where)
+        .with("COALESCE(context->>'decision_status', ?) IN (?)", "applied", %w[applied deferred resolved])
+        .and_return(successful)
+
+      expect(service.send(:successful_decisions)).to eq(successful)
     end
   end
 

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
       )
     end
 
-    it "counts only applied decisions as successes" do
+    it "classifies applied, deferred, and resolved escalation decisions as successes" do
       summary = service.send(:orchestration_performance_summary)
 
       expect(summary).to include(
         decision_count: 3,
-        classified_decision_count: 1,
-        success_count: 1,
+        classified_decision_count: 3,
+        success_count: 3,
         failure_count: 0,
         noop_count: 0,
         success_rate: 1.0
@@ -51,14 +51,14 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
       )
     end
 
-    it "samples only applied orchestration decisions as successes" do
+    it "samples all escalation success statuses as successes" do
       scoped = instance_double(ActiveRecord::Relation)
       successful = instance_double(ActiveRecord::Relation)
       sampled = [ Object.new ]
 
       allow(service).to receive(:scoped_decisions).and_return(scoped)
       allow(scoped).to receive(:where)
-        .with(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('applied')"))
+        .with(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('applied', 'deferred', 'resolved')"))
         .and_return(successful)
       allow(successful).to receive(:order).with(created_at: :desc, id: :desc).and_return(successful)
       allow(successful).to receive(:limit).with(5).and_return(sampled)

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -126,4 +126,12 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
       )
     end
   end
+
+  describe "unsupported policy types" do
+    it "fails fast instead of falling back to decomposition inputs" do
+      expect {
+        described_class.new(account: account, policy_type: "lifecycle_state")
+      }.to raise_error(ArgumentError, 'unsupported coordination policy type: "lifecycle_state"')
+    end
+  end
 end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
+  let(:account) { Struct.new(:id).new(1) }
+  let(:service) { described_class.new(account: account, policy_type: "escalation", min_decisions: 1) }
+  let(:status_counts) do
+    {
+      "applied" => 1,
+      "deferred" => 1,
+      "resolved" => 1
+    }
+  end
+
+  describe "orchestration status classification" do
+    before do
+      relation = instance_double(ActiveRecord::Relation, count: 3)
+
+      allow(service).to receive_messages(
+        scoped_decisions: relation,
+        orchestration_status_counts: status_counts,
+        decision_type_counts: { "escalate" => 3 },
+        policy_source_counts: {
+          "defaults" => 2,
+          "coordination_policy" => 1
+        }
+      )
+    end
+
+    it "counts only applied decisions as successes" do
+      summary = service.send(:orchestration_performance_summary)
+
+      expect(summary).to include(
+        decision_count: 3,
+        classified_decision_count: 1,
+        success_count: 1,
+        failure_count: 0,
+        noop_count: 0,
+        success_rate: 1.0
+      )
+    end
+
+    it "keeps deferred and resolved decisions in the raw outcome counts" do
+      summary = service.send(:orchestration_performance_summary)
+
+      expect(summary[:outcome_counts]).to include(
+        "applied" => 1,
+        "deferred" => 1,
+        "resolved" => 1
+      )
+    end
+
+    it "samples only applied orchestration decisions as successes" do
+      scoped = instance_double(ActiveRecord::Relation)
+      successful = instance_double(ActiveRecord::Relation)
+      sampled = [ Object.new ]
+
+      allow(service).to receive(:scoped_decisions).and_return(scoped)
+      allow(scoped).to receive(:where)
+        .with(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('applied')"))
+        .and_return(successful)
+      allow(successful).to receive(:order).with(created_at: :desc, id: :desc).and_return(successful)
+      allow(successful).to receive(:limit).with(5).and_return(sampled)
+
+      expect(service.send(:sample_successes)).to eq(sampled)
+    end
+  end
+end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -66,4 +66,29 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
       expect(service.send(:sample_successes)).to eq(sampled)
     end
   end
+
+  describe "escalation configuration extraction" do
+    it "reconstructs escalation config from persisted top-level rules and parameters" do
+      configuration = service.send(
+        :effective_configuration,
+        {
+          "explicit_triggers" => %w[operational_failure_breaker],
+          "auto_resolve_trigger_types" => %w[owner_approved]
+        },
+        {
+          "human_value_threshold" => 0.45,
+          "weights" => { "review_goal_retry_pressure" => 0.6 },
+          "interruption_cost" => { "base" => 0.2 }
+        }
+      )
+
+      expect(configuration.fetch("escalation")).to include(
+        "human_value_threshold" => 0.45,
+        "explicit_triggers" => %w[operational_failure_breaker],
+        "auto_resolve_trigger_types" => %w[owner_approved],
+        "weights" => { "review_goal_retry_pressure" => 0.6 },
+        "interruption_cost" => { "base" => 0.2 }
+      )
+    end
+  end
 end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -91,4 +91,27 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
       )
     end
   end
+
+  describe "legacy decomposition config extraction" do
+    it "accepts flat decomposition_enabled fields from older strategy snapshots" do
+      decomposition_service = described_class.new(account: account, policy_type: "decomposition")
+
+      configuration = decomposition_service.send(
+        :effective_configuration,
+        {
+          "decomposition_enabled" => false,
+          "min_components_to_decompose" => 4
+        },
+        {
+          "max_tasks" => 10
+        }
+      )
+
+      expect(configuration.fetch("decomposition")).to include(
+        "enabled" => false,
+        "min_components_to_decompose" => 4,
+        "max_tasks" => 10
+      )
+    end
+  end
 end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
 
       allow(service).to receive(:scoped_decisions).and_return(scoped)
       allow(scoped).to receive(:where)
-        .with(Arel.sql("COALESCE(context->>'decision_status', 'unknown') IN ('applied', 'deferred', 'resolved')"))
+        .with("COALESCE(context->>'decision_status', 'unknown') IN (?)", %w[applied deferred resolved])
         .and_return(successful)
       allow(successful).to receive(:order).with(created_at: :desc, id: :desc).and_return(successful)
       allow(successful).to receive(:limit).with(5).and_return(sampled)

--- a/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
@@ -166,6 +166,20 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
           context: { "decision_status" => "applied" },
           inputs: { "policy_source" => "defaults" },
           outputs: { "human_value_score" => 0.9 })
+        create(:orchestration_decision,
+          project: project,
+          decision_type: "escalate",
+          actor: "coordination_escalation_service",
+          context: { "decision_status" => "deferred" },
+          inputs: { "policy_source" => "defaults" },
+          outputs: { "human_value_score" => 0.2 })
+        create(:orchestration_decision,
+          project: project,
+          decision_type: "escalate",
+          actor: "coordination_escalation_service",
+          context: { "decision_status" => "resolved" },
+          inputs: { "policy_source" => "coordination_policy" },
+          outputs: { "human_value_score" => 0.1 })
       end
 
       it "supports escalation bootstrap policies without a persisted coordination policy" do
@@ -180,7 +194,19 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
           "weights",
           "interruption_cost"
         )
-        expect(escalation_result.dig(:performance, :decision_type_counts)).to include("escalate" => 1)
+      end
+
+      it "classifies only applied escalation decisions as successes" do
+        expect(escalation_result.dig(:performance, :decision_type_counts)).to include("escalate" => 3)
+        expect(escalation_result.dig(:performance, :outcome_counts)).to include(
+          "applied" => 1,
+          "deferred" => 1,
+          "resolved" => 1
+        )
+        expect(escalation_result.dig(:performance, :success_count)).to eq(1)
+        expect(escalation_result.dig(:performance, :classified_decision_count)).to eq(1)
+        expect(escalation_result.dig(:performance, :success_rate)).to eq(1.0)
+        expect(escalation_result[:sample_successes].map { |row| row[:decision_status] }).to eq([ "applied" ])
       end
     end
   end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
@@ -105,5 +105,83 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
         "max_tasks" => 12
       )
     end
+
+    context "with recovery policy evolution inputs" do
+      let!(:recovery_policy) do
+        create(:coordination_policy, :active,
+          account: account,
+          policy_type: "recovery",
+          policy_key: Coordination::FailureRecoveryPolicy::POLICY_KEY,
+          name: "Failure Recovery").tap do |record|
+            record.current_version.update!(
+              version: 2,
+              rules: { "failure_actions" => { "timeout" => "retry_same_provider" } },
+              parameters: { "default_action" => "pause_and_notify" }
+            )
+          end
+      end
+      let(:recovery_result) { described_class.call(account: account, policy_type: "recovery", min_decisions: 2) }
+
+      before do
+        create(:orchestration_decision,
+          project: project,
+          decision_type: "retry",
+          actor: "coordination_failure_recovery",
+          context: { "decision_status" => "applied" },
+          inputs: { "policy_source" => "coordination_policy" },
+          outputs: { "chosen_action" => "retry_same_provider" })
+        create(:orchestration_decision,
+          project: project,
+          decision_type: "pause",
+          actor: "coordination_failure_recovery",
+          context: { "decision_status" => "failed" },
+          inputs: { "policy_source" => "defaults" },
+          outputs: { "chosen_action" => "pause_and_notify" })
+      end
+
+      it "supports recovery policy snapshots and orchestration decision metrics" do
+        expect(recovery_result[:policy]).to include(id: recovery_policy.id, policy_type: "recovery")
+        expect(recovery_result.dig(:policy, :configuration, "recovery")).to include(
+          "actions" => include("timeout" => "retry_same_provider"),
+          "default_action" => "pause_and_notify"
+        )
+        expect(recovery_result.dig(:performance, :decision_count)).to eq(2)
+        expect(recovery_result.dig(:performance, :classified_decision_count)).to eq(2)
+        expect(recovery_result.dig(:performance, :failure_count)).to eq(1)
+        expect(recovery_result.dig(:performance, :policy_source_counts)).to include(
+          "coordination_policy" => 1,
+          "defaults" => 1
+        )
+      end
+    end
+
+    context "with escalation policy evolution inputs" do
+      let(:escalation_result) { described_class.call(account: account, policy_type: "escalation", min_decisions: 1) }
+
+      before do
+        create(:orchestration_decision,
+          project: project,
+          decision_type: "escalate",
+          actor: "coordination_escalation_service",
+          context: { "decision_status" => "applied" },
+          inputs: { "policy_source" => "defaults" },
+          outputs: { "human_value_score" => 0.9 })
+      end
+
+      it "supports escalation bootstrap policies without a persisted coordination policy" do
+        expect(escalation_result[:policy]).to include(
+          policy_type: "escalation",
+          policy_key: Coordination::EscalationPolicy::POLICY_KEY,
+          source: "defaults"
+        )
+        expect(escalation_result.dig(:policy, :configuration, "escalation")).to include(
+          "human_value_threshold",
+          "explicit_triggers",
+          "weights",
+          "interruption_cost"
+        )
+        expect(escalation_result.dig(:performance, :decision_type_counts)).to include("escalate" => 1)
+      end
+    end
   end
 end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
@@ -196,17 +196,20 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
         )
       end
 
-      it "classifies only applied escalation decisions as successes" do
+      it "classifies applied, deferred, and resolved escalation decisions as successes" do
         expect(escalation_result.dig(:performance, :decision_type_counts)).to include("escalate" => 3)
         expect(escalation_result.dig(:performance, :outcome_counts)).to include(
           "applied" => 1,
           "deferred" => 1,
           "resolved" => 1
         )
-        expect(escalation_result.dig(:performance, :success_count)).to eq(1)
-        expect(escalation_result.dig(:performance, :classified_decision_count)).to eq(1)
+        expect(escalation_result.dig(:performance, :success_count)).to eq(3)
+        expect(escalation_result.dig(:performance, :classified_decision_count)).to eq(3)
+        expect(escalation_result.dig(:performance, :failure_count)).to eq(0)
         expect(escalation_result.dig(:performance, :success_rate)).to eq(1.0)
-        expect(escalation_result[:sample_successes].map { |row| row[:decision_status] }).to eq([ "applied" ])
+        expect(escalation_result[:sample_successes].map { |row| row[:decision_status] }).to match_array(
+          %w[applied deferred resolved]
+        )
       end
     end
   end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
 
       before do
         create(:orchestration_decision,
+          :without_agent_run,
           project: project,
           decision_type: "retry",
           actor: "coordination_failure_recovery",
@@ -131,6 +132,7 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
           inputs: { "policy_source" => "coordination_policy" },
           outputs: { "chosen_action" => "retry_same_provider" })
         create(:orchestration_decision,
+          :without_agent_run,
           project: project,
           decision_type: "pause",
           actor: "coordination_failure_recovery",
@@ -160,6 +162,7 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
 
       before do
         create(:orchestration_decision,
+          :without_agent_run,
           project: project,
           decision_type: "escalate",
           actor: "coordination_escalation_service",
@@ -167,6 +170,7 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
           inputs: { "policy_source" => "defaults" },
           outputs: { "human_value_score" => 0.9 })
         create(:orchestration_decision,
+          :without_agent_run,
           project: project,
           decision_type: "escalate",
           actor: "coordination_escalation_service",
@@ -174,6 +178,7 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
           inputs: { "policy_source" => "defaults" },
           outputs: { "human_value_score" => 0.2 })
         create(:orchestration_decision,
+          :without_agent_run,
           project: project,
           decision_type: "escalate",
           actor: "coordination_escalation_service",

--- a/spec/services/orchestration_strategies/defaults_spec.rb
+++ b/spec/services/orchestration_strategies/defaults_spec.rb
@@ -115,6 +115,13 @@ RSpec.describe OrchestrationStrategies::Defaults do
       )
     end
 
+    it "includes recovery policy defaults" do
+      expect(config["recovery"]).to include(
+        "actions" => include("timeout" => "retry_same_provider"),
+        "default_action" => "pause_and_notify"
+      )
+    end
+
     it "preserves all planning outcomes returned by the workflow" do
       mappings = Workflows::PlanningWorkflow.outcome_mappings
       outcomes = mappings[:success] + mappings[:failure].values


### PR DESCRIPTION
## Summary

Extends the coordination policy evolution pipeline beyond decomposition to also evolve `recovery` and `escalation` policies from observed outcomes. This unlocks Phase 4.4's goal of data-driven failure classification and escalation tuning, replacing static heuristics with policies that improve as orchestration history accumulates.

## Changes

- **Services**:
  - `app/services/coordination_policy_evolution/prepare_inputs.rb` — input prep now sources orchestration-decision history, applies bootstrap/default configs, and extracts policy-specific config for `recovery` and `escalation` in addition to `decomposition`.
  - `app/services/coordination_policy_evolution/create_candidates.rb` — candidate persistence writes the correct rule/parameter shapes per policy type so evolved recovery and escalation policies round-trip cleanly.
- **Tests**:
  - `spec/services/coordination_policy_evolution/prepare_inputs_spec.rb` — adds coverage for the new policy types and their config-extraction paths.
  - `spec/services/coordination_policy_evolution/create_candidates_spec.rb` — verifies candidate shapes for each policy type.

## Design Decisions

- **Single pipeline, policy-aware branches** — rather than forking parallel services per policy type, the existing evolution pipeline was generalized so all three policy types share input prep and candidate persistence, differing only in config extraction and rule shape. This keeps the A/B and evolution workflow (Phase 4.4 deliverables) uniform across policy types.
- **Bootstrap/default configs** — when no prior orchestration-decision history exists for a policy type, prep falls back to defaults so evolution can begin from a known baseline instead of failing closed.

## Operational Notes

- No schema or migration changes in this PR.
- Verification was partial in the build environment: `yarn install` hit `ENOSPC`, and DB-backed RSpec could not run without PostgreSQL. Db-less coordination evolution specs passed; reviewers should re-run the full RSpec suite in CI to confirm DB-backed specs.

---

Closes #1810