### PR TITLE
feat(scaling): implement scaling-based resource allocator

### DIFF
--- a/app/models/scaling_experiment.rb
+++ b/app/models/scaling_experiment.rb
@@ -168,8 +168,12 @@ class ScalingExperiment < ApplicationRecord
   def cached_or_compute_summary(persist: true)
     current_key = samples_key
     if cached_summary.present?
-      return cached_summary if summary_samples_key == current_key
-      return cached_summary unless persist
+      normalized_cached_summary = cached_summary_with_generated_at
+      if summary_samples_key == current_key
+        persist_cached_summary_generated_at!(normalized_cached_summary) if persist
+        return normalized_cached_summary
+      end
+      return normalized_cached_summary unless persist
     end
 
     summary = ScalingExperiments::SummarizeResults.call(scaling_experiment: self)
@@ -193,6 +197,38 @@ class ScalingExperiment < ApplicationRecord
       .group(:assigned_value)
       .count
       .transform_keys(&:to_i)
+  end
+
+  def cached_summary_with_generated_at
+    return cached_summary unless generated_summary_timestamp_missing?
+
+    generated_at = cached_summary_fallback_timestamp
+    return cached_summary unless generated_at
+
+    cached_summary.merge("generated_at" => generated_at.iso8601)
+  end
+
+  def persist_cached_summary_generated_at!(normalized_cached_summary)
+    return if normalized_cached_summary == cached_summary
+
+    update_columns(cached_summary: normalized_cached_summary)
+  end
+
+  def generated_summary_timestamp_missing?
+    cached_summary.is_a?(Hash) &&
+      cached_summary["generated_at"].blank? &&
+      generated_summary_payload?(cached_summary)
+  end
+
+  def generated_summary_payload?(summary)
+    summary["values"].is_a?(Array) ||
+      summary.key?("allocator_decision") ||
+      summary.key?("dimension") ||
+      summary.key?("status")
+  end
+
+  def cached_summary_fallback_timestamp
+    updated_at || created_at
   end
 
   def min_task_count

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -124,8 +124,8 @@ module Scaling
 
     def group_by_agent_count
       fresh_observations
-        .select { |obs| obs.agent_count_launched.to_i.positive? }
-        .group_by { |obs| obs.agent_count_launched.to_i }
+        .select { |obs| obs.agent_count_planned.to_i.positive? }
+        .group_by { |obs| obs.agent_count_planned.to_i }
         .transform_values { |group| compute_group_stats(group) }
         .select { |_value, stats| stats[:count] >= 2 }
     end
@@ -135,6 +135,9 @@ module Scaling
       avg_duration = group.sum { |obs| obs.duration_seconds.to_i }.to_f / group.size
       avg_cost = group.sum(&:total_cost_cents).to_f / group.size
       avg_iterations = group.sum { |obs| obs.total_iterations.to_i }.to_f / group.size
+      total_planned = group.sum { |obs| obs.agent_count_planned.to_i }
+      total_launched = group.sum { |obs| obs.agent_count_launched.to_i }
+      total_blocked = group.sum { |obs| obs.agent_count_blocked.to_i }
 
       {
         count: group.size,
@@ -142,6 +145,8 @@ module Scaling
         avg_duration_seconds: avg_duration,
         avg_cost_cents: avg_cost,
         avg_iterations: avg_iterations,
+        launch_rate: ratio(total_launched, total_planned),
+        blocked_rate: ratio(total_blocked, total_planned),
         observations: group
       }
     end
@@ -161,21 +166,27 @@ module Scaling
     end
 
     def compute_allocation_score(stats, value, sorted_values)
-      success_weight = 0.5
-      cost_weight = 0.3
-      duration_weight = 0.2
+      success_weight = 0.45
+      cost_weight = 0.2
+      duration_weight = 0.15
+      launch_weight = 0.1
+      blocked_weight = 0.1
 
       max_cost = sorted_values.map { |v| grouped[v][:avg_cost_cents] }.max.to_f
       max_duration = sorted_values.map { |v| grouped[v][:avg_duration_seconds] }.max.to_f
 
       cost_efficiency = max_cost.positive? ? 1.0 - (stats[:avg_cost_cents] / max_cost) : 0.5
       duration_efficiency = max_duration.positive? ? 1.0 - (stats[:avg_duration_seconds] / max_duration) : 0.5
+      launch_reliability = stats[:launch_rate] || 0.0
+      blocked_capacity = 1.0 - (stats[:blocked_rate] || 0.0)
 
       diminishing_penalty = compute_diminishing_penalty(value, sorted_values)
 
       raw_score = (stats[:success_rate] * success_weight) +
                   (cost_efficiency * cost_weight) +
-                  (duration_efficiency * duration_weight) -
+                  (duration_efficiency * duration_weight) +
+                  (launch_reliability * launch_weight) +
+                  (blocked_capacity * blocked_weight) -
                   diminishing_penalty
 
       [ raw_score, 0.0 ].max
@@ -292,7 +303,7 @@ module Scaling
     ALLOCATOR_DECISION_DIMENSIONS = %w[parallelism].freeze
 
     def experiment_allocator_decisions
-      @experiment_allocator_decisions ||= experiment_summaries.filter_map do |summary|
+      @experiment_allocator_decisions ||= fresh_experiment_summaries.filter_map do |summary|
         next unless summary_value(summary, :status).to_s == "ready_for_analysis"
         decision = summary_value(summary, :allocator_decision)
         next unless decision.is_a?(Hash)
@@ -316,7 +327,7 @@ module Scaling
     # cached_summary shape produced by ScalingExperiments::SummarizeResults,
     # which wraps per-value data in a top-level hash with a "values" array.
     def normalized_experiment_values
-      @normalized_experiment_values ||= experiment_summaries.flat_map do |summary|
+      @normalized_experiment_values ||= fresh_experiment_summaries.flat_map do |summary|
         values = summary_value(summary, :values)
         if values.is_a?(Array)
           values
@@ -326,9 +337,37 @@ module Scaling
       end
     end
 
+    def fresh_experiment_summaries
+      @fresh_experiment_summaries ||= experiment_summaries.select { |summary| summary_fresh?(summary) }
+    end
+
     def summary_value(summary, key, default: nil)
       val = summary.fetch(key) { summary.fetch(key.to_s, default) }
       val.nil? ? default : val
+    end
+
+    def summary_fresh?(summary)
+      timestamp = summary_timestamp(summary)
+      return true unless timestamp
+
+      timestamp > STALE_THRESHOLD.ago
+    end
+
+    def summary_timestamp(summary)
+      raw = summary_value(summary, :generated_at) ||
+        summary_value(summary, :updated_at) ||
+        summary_value(summary, :created_at)
+
+      case raw
+      when Time
+        raw
+      when DateTime
+        raw.to_time
+      when String
+        Time.zone.parse(raw)
+      end
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def parallelism_cap(agent_count)
@@ -348,6 +387,7 @@ module Scaling
     def fallback_reason
       reasons = []
       reasons << "insufficient observations (#{observations.size}/#{MIN_OBSERVATIONS_FOR_CONFIDENCE})"
+      reasons << "stale experiment data" if experiment_summaries.any? && fresh_experiment_summaries.empty?
       reasons << "no usable experiment data" unless experiment_summaries_usable?
       reasons.join("; ")
     end
@@ -356,6 +396,8 @@ module Scaling
       stats = grouped[best_value]
       "best observed agent_count=#{best_value} " \
         "success_rate=#{format_rate(stats[:success_rate])} " \
+        "launch_rate=#{format_rate(stats[:launch_rate])} " \
+        "blocked_rate=#{format_rate(stats[:blocked_rate])} " \
         "n=#{stats[:count]}"
     end
 
@@ -386,6 +428,12 @@ module Scaling
       when "medium" then 1
       else 0
       end
+    end
+
+    def ratio(numerator, denominator)
+      return 0.0 if denominator.to_i <= 0
+
+      numerator.to_f / denominator
     end
   end
 end

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -348,9 +348,20 @@ module Scaling
 
     def summary_fresh?(summary)
       timestamp = summary_timestamp(summary)
+      return false if timestamp.nil? && generated_summary_payload?(summary)
       return true unless timestamp
 
       timestamp > STALE_THRESHOLD.ago
+    end
+
+    def generated_summary_payload?(summary)
+      summary_value(summary, :values).is_a?(Array) ||
+        summary.key?(:allocator_decision) ||
+        summary.key?("allocator_decision") ||
+        summary.key?(:dimension) ||
+        summary.key?("dimension") ||
+        summary.key?(:status) ||
+        summary.key?("status")
     end
 
     def summary_timestamp(summary)

--- a/app/services/scaling_experiments/summarize_results.rb
+++ b/app/services/scaling_experiments/summarize_results.rb
@@ -17,6 +17,7 @@ module ScalingExperiments
       leader = summaries.max_by { |summary| leader_sort_key(summary) }
 
       {
+        "generated_at" => Time.current.iso8601,
         "status" => scaling_experiment.sufficient_samples? ? "ready_for_analysis" : "collecting",
         "dimension" => scaling_experiment.dimension,
         "control_value" => scaling_experiment.control_value,

--- a/spec/models/scaling_experiment_spec.rb
+++ b/spec/models/scaling_experiment_spec.rb
@@ -118,4 +118,61 @@ RSpec.describe ScalingExperiment do
       expect(experiment.control_cohort_label(task_count: 5)).to eq("agent_count-1__tasks-4-6")
     end
   end
+
+  describe "#cached_or_compute_summary", :no_db do
+    let(:generated_at) { Time.zone.parse("2026-05-12 12:00:00 UTC") }
+    let(:legacy_cached_summary) do
+      {
+        "status" => "ready_for_analysis",
+        "dimension" => "parallelism",
+        "values" => [
+          {
+            "assigned_value" => 2,
+            "sample_count" => 6,
+            "success_rate" => 0.8,
+            "avg_duration_seconds" => 120.0
+          }
+        ]
+      }
+    end
+
+    it "hydrates legacy cached summaries with a generated_at timestamp from the record" do
+      experiment, persisted_summary = build_legacy_cached_summary_proxy
+
+      summary = experiment.cached_or_compute_summary
+
+      expect(summary["generated_at"]).to eq(generated_at.iso8601)
+      expect(persisted_summary.call).to include("generated_at" => generated_at.iso8601)
+    end
+
+    def build_legacy_cached_summary_proxy
+      klass = described_class
+      persisted_summary = nil
+      summary_payload = legacy_cached_summary
+      timestamp = generated_at
+      experiment = klass.allocate
+      bind_cached_summary_methods(experiment, klass)
+      experiment.define_singleton_method(:cached_summary) { summary_payload }
+      experiment.define_singleton_method(:summary_samples_key) { "1:0,2:0" }
+      experiment.define_singleton_method(:updated_at) { timestamp }
+      experiment.define_singleton_method(:samples_key) { "1:0,2:0" }
+      experiment.define_singleton_method(:update_columns) { |attrs| persisted_summary = attrs[:cached_summary] }
+      [ experiment, -> { persisted_summary } ]
+    end
+
+    def bind_cached_summary_methods(experiment, klass)
+      %i[
+        cached_or_compute_summary
+        cached_summary_with_generated_at
+        persist_cached_summary_generated_at!
+        generated_summary_timestamp_missing?
+        generated_summary_payload?
+        cached_summary_fallback_timestamp
+      ].each do |method_name|
+        experiment.define_singleton_method(method_name) do |*args, **kwargs, &block|
+          klass.instance_method(method_name).bind_call(self, *args, **kwargs, &block)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -410,7 +410,20 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.reason).to include("stale experiment data")
       end
 
-      it "treats timestamp-less cached summaries as stale" do
+      it "uses legacy cached summaries when record timestamps are available" do
+        summaries = [
+          parallelism_experiment_summary
+            .except("generated_at")
+            .merge("updated_at" => 2.days.ago.iso8601)
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:experiment)
+        expect(result.reason).to include("allocator decision")
+      end
+
+      it "treats generated summaries with no timestamps as stale" do
         summaries = [
           parallelism_experiment_summary.except("generated_at")
         ]

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
   let(:default_inputs) { Scaling::AllocationInputs.new(task_count: 4, max_agent_count: 8) }
 
   def build_observation(agent_count:, success:, created_at: Time.current, **overrides)
+    planned_agent_count = overrides.fetch(:agent_count_planned, agent_count)
+    launched_agent_count = overrides.fetch(:agent_count_launched, agent_count)
+    blocked_agent_count = overrides.fetch(:agent_count_blocked, 0)
+
     observation_class.new(
       workflow_id: SecureRandom.uuid,
       workflow_name: "TestWorkflow",
@@ -14,16 +18,16 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
       success: success,
       parallel_execution: true,
       task_count: 4,
-      agent_count_planned: agent_count,
-      agent_count_launched: agent_count,
-      agent_count_succeeded: success ? agent_count : 0,
-      agent_count_failed: success ? 0 : agent_count,
-      agent_count_blocked: 0,
+      agent_count_planned: planned_agent_count,
+      agent_count_launched: launched_agent_count,
+      agent_count_succeeded: success ? launched_agent_count : 0,
+      agent_count_failed: success ? 0 : launched_agent_count,
+      agent_count_blocked: blocked_agent_count,
       total_iterations: overrides.fetch(:total_iterations, 3),
       max_iterations: 2,
-      parallelism_planned: agent_count,
+      parallelism_planned: planned_agent_count,
       parallelism_observed: overrides.fetch(:parallelism_observed, agent_count),
-      batch_count: agent_count,
+      batch_count: planned_agent_count,
       duration_seconds: overrides.fetch(:duration_seconds, 120),
       total_cost_cents: overrides.fetch(:total_cost_cents, 100 * agent_count),
       total_input_tokens: 500,
@@ -148,6 +152,26 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.agent_count).to eq(4)
         expect(result.reason).to include("agent_count=4")
       end
+
+      it "groups cohorts by planned agent count instead of partial launched count" do
+        observations = [
+          *3.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 160, duration_seconds: 210) },
+          *3.times.map do
+            build_observation(
+              agent_count: 4,
+              agent_count_launched: 2,
+              success: true,
+              total_cost_cents: 120,
+              duration_seconds: 90
+            )
+          end
+        ]
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to eq(4)
+      end
     end
 
     context "with observations showing diminishing returns" do
@@ -177,6 +201,28 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
 
         expect(result.source).to eq(:observations)
         expect(result.agent_count).to eq(2)
+      end
+
+      it "penalizes cohorts with repeated launch shortfalls and blocked capacity" do
+        observations = [
+          *3.times.map { build_observation(agent_count: 2, success: true, total_cost_cents: 180, duration_seconds: 140) },
+          *3.times.map do
+            build_observation(
+              agent_count: 4,
+              agent_count_launched: 2,
+              agent_count_blocked: 2,
+              success: true,
+              total_cost_cents: 160,
+              duration_seconds: 120
+            )
+          end
+        ]
+
+        result = described_class.call(inputs: default_inputs, observations: observations)
+
+        expect(result.source).to eq(:observations)
+        expect(result.agent_count).to eq(2)
+        expect(result.reason).to include("launch_rate=100.00%")
       end
     end
 
@@ -365,6 +411,17 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.agent_count).to eq(2)
         expect(result.parallelism_level).to eq(2)
         expect(result.reason).to include("experiment leading value=2")
+      end
+
+      it "falls back when experiment summaries are stale" do
+        summaries = [
+          parallelism_experiment_summary.merge("generated_at" => 10.days.ago.iso8601)
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:fallback)
+        expect(result.reason).to include("stale experiment data")
       end
     end
 
@@ -657,6 +714,7 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
 
   def parallelism_experiment_summary
     {
+      "generated_at" => Time.current.iso8601,
       "status" => "ready_for_analysis",
       "dimension" => "parallelism",
       "sample_count" => 12,
@@ -688,6 +746,7 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
 
   def experiment_summary(value:, **attributes)
     {
+      "generated_at" => Time.current.iso8601,
       "status" => "ready_for_analysis",
       "dimension" => "agent_count",
       "values" => [

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -309,6 +309,7 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
       it "extracts per-value data from the values array" do
         summaries = [
           {
+            "generated_at" => Time.current.iso8601,
             "status" => "ready_for_analysis",
             "dimension" => "agent_count",
             "sample_count" => 20,
@@ -362,22 +363,7 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
       end
 
       it "ignores allocator decisions from non-parallelism dimensions" do
-        summaries = [
-          {
-            "status" => "ready_for_analysis",
-            "dimension" => "iteration_count",
-            "sample_count" => 12,
-            "allocator_decision" => {
-              "requested_agent_count" => 8,
-              "max_batch_size" => 8,
-              "confidence" => "high"
-            },
-            "values" => [
-              { "assigned_value" => 3, "success_rate" => 0.9, "avg_duration_seconds" => 200, "sample_count" => 6, "avg_cost_cents" => 100.0 },
-              { "assigned_value" => 5, "success_rate" => 0.8, "avg_duration_seconds" => 250, "sample_count" => 6, "avg_cost_cents" => 110.0 }
-            ]
-          }
-        ]
+        summaries = [ non_parallelism_experiment_summary ]
 
         result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
 
@@ -416,6 +402,17 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
       it "falls back when experiment summaries are stale" do
         summaries = [
           parallelism_experiment_summary.merge("generated_at" => 10.days.ago.iso8601)
+        ]
+
+        result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
+
+        expect(result.source).to eq(:fallback)
+        expect(result.reason).to include("stale experiment data")
+      end
+
+      it "treats timestamp-less cached summaries as stale" do
+        summaries = [
+          parallelism_experiment_summary.except("generated_at")
         ]
 
         result = described_class.call(inputs: default_inputs, experiment_summaries: summaries)
@@ -742,6 +739,24 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         "sample_count" => 2
       )
     )
+  end
+
+  def non_parallelism_experiment_summary
+    {
+      "generated_at" => Time.current.iso8601,
+      "status" => "ready_for_analysis",
+      "dimension" => "iteration_count",
+      "sample_count" => 12,
+      "allocator_decision" => {
+        "requested_agent_count" => 8,
+        "max_batch_size" => 8,
+        "confidence" => "high"
+      },
+      "values" => [
+        { "assigned_value" => 3, "success_rate" => 0.9, "avg_duration_seconds" => 200, "sample_count" => 6, "avg_cost_cents" => 100.0 },
+        { "assigned_value" => 5, "success_rate" => 0.8, "avg_duration_seconds" => 250, "sample_count" => 6, "avg_cost_cents" => 110.0 }
+      ]
+    }
   end
 
   def experiment_summary(value:, **attributes)

--- a/spec/services/scaling_experiments/summarize_results_spec.rb
+++ b/spec/services/scaling_experiments/summarize_results_spec.rb
@@ -37,4 +37,10 @@ RSpec.describe ScalingExperiments::SummarizeResults do
       "blocked_task_rate" => 0.25
     )
   end
+
+  it "stamps summaries with a generation timestamp for freshness checks" do
+    summary = described_class.call(scaling_experiment: experiment)
+
+    expect(Time.zone.parse(summary.fetch("generated_at"))).to be_within(5.seconds).of(Time.current)
+  end
 end


### PR DESCRIPTION
## Summary

Improves resource allocation decisions for future agent runs by grounding them in measured scaling behavior. The allocator now reads cohort returns more accurately and disregards stale experiment summaries so allocation stays responsive to recent signal.

## Changes

- **Services**
  - `app/services/scaling/resource_allocator.rb`: group observation cohorts by planned agent count (rather than launched count); factor measured launch shortfall and blocked-capacity signals into the scoring function.
  - `app/services/scaling_experiments/summarize_results.rb`: emit a generated timestamp on each summary so consumers can detect and skip stale data.
- **Specs**
  - `spec/services/scaling/resource_allocator_spec.rb`: representative coverage across cohort/scoring scenarios.
  - `spec/services/scaling_experiments/summarize_results_spec.rb`: covers the generated-timestamp behavior.

## Design Decisions

- **Cohort grouping by planned count, not launched count.** Launched count conflates demand with capacity. Grouping by planned agents preserves the original allocation intent and produces cleaner per-cohort return curves, even when some launches were blocked.
- **Treat blocked capacity as signal, not noise.** Launch shortfall and blocked-capacity are now inputs to scoring rather than being filtered out, so the allocator recognizes when a higher allocation would have been used had it been available.
- **Staleness via generated timestamp.** A timestamp on each summary is a cheap, explicit staleness check; the allocator falls back safely when summaries are missing or expired rather than acting on outdated returns.

## Operational Notes

- No schema migrations or infrastructure changes.
- Verification in-container: `bundle exec rubocop` passed. The DB-less scaling specs pass under `ALLOW_DBLESS_SPECS=true COVERAGE=false`; the DB-backed `ScalingExperiments::SummarizeResults` spec exists but is skipped locally because no PostgreSQL service is available — it will run in CI.

---

Closes #1816