### PR TITLE
Fix #1938: [P2] knowledge: Knowledge::ContainerizedRunner::ContainerError

### DIFF
--- a/app/services/knowledge/collectors/routes_collector.rb
+++ b/app/services/knowledge/collectors/routes_collector.rb
@@ -5,7 +5,7 @@ module Knowledge
     class RoutesCollector < BaseCollector
       SCOPE_PATH = "config/routes.rb"
       BUNDLE_HOME = "/tmp/paid-bundle-home"
-      SQLITE3_GEMFILE_PATTERN = /^\s*gem\s+["']sqlite3["']/.freeze
+      SQLITE3_GEMFILE_PATTERN = /^\s*gem(?:\s+|\s*\()\s*["']sqlite3["']/.freeze
       SQLITE3_LOCKFILE_PATTERN = /^\s{2,4}sqlite3(?:\s|\(|$)/.freeze
       # Exception class names that indicate database issues preventing
       # `bin/rails routes` from booting. Checked against both

--- a/app/services/knowledge/collectors/routes_collector.rb
+++ b/app/services/knowledge/collectors/routes_collector.rb
@@ -5,7 +5,7 @@ module Knowledge
     class RoutesCollector < BaseCollector
       SCOPE_PATH = "config/routes.rb"
       BUNDLE_HOME = "/tmp/paid-bundle-home"
-      SQLITE3_GEMFILE_PATTERN = /gem\s+["']sqlite3["']/.freeze
+      SQLITE3_GEMFILE_PATTERN = /^\s*gem\s+["']sqlite3["']/.freeze
       SQLITE3_LOCKFILE_PATTERN = /^\s{2,4}sqlite3(?:\s|\(|$)/.freeze
       # Exception class names that indicate database issues preventing
       # `bin/rails routes` from booting. Checked against both

--- a/app/services/knowledge/collectors/routes_collector.rb
+++ b/app/services/knowledge/collectors/routes_collector.rb
@@ -5,6 +5,8 @@ module Knowledge
     class RoutesCollector < BaseCollector
       SCOPE_PATH = "config/routes.rb"
       BUNDLE_HOME = "/tmp/paid-bundle-home"
+      SQLITE3_GEMFILE_PATTERN = /gem\s+["']sqlite3["']/.freeze
+      SQLITE3_LOCKFILE_PATTERN = /^\s{2,4}sqlite3(?:\s|\(|$)/.freeze
       # Exception class names that indicate database issues preventing
       # `bin/rails routes` from booting. Checked against both
       # error.class.name (local execution) and error.message (containerized
@@ -105,6 +107,13 @@ module Knowledge
           raise "routes collector requires containerized mode — failing on host for security"
         end
 
+        unless sqlite3_available_for_in_memory_routes?
+          skip!(
+            "routes require sqlite3 support for in-memory boot fallback",
+            preserve_existing_artifacts: true
+          )
+        end
+
         # Install gems so `bin/rails routes` can boot the application.
         # The container workspace is read-only, so gems are installed to
         # /tmp/bundle (a writable tmpfs mount).
@@ -173,6 +182,22 @@ module Knowledge
           "git config --global --add url.\\\"https://github.com/\\\".insteadOf ssh://git@github.com/ && " \
           "git config --global --add url.\\\"https://github.com/\\\".insteadOf git@github.com: && " \
           "bundle install --jobs 4 --retry 3"
+      end
+
+      def sqlite3_available_for_in_memory_routes?
+        gemfile_lock_includes_sqlite3? || gemfile_declares_sqlite3?
+      end
+
+      def gemfile_lock_includes_sqlite3?
+        return false unless repo_file_exists?("Gemfile.lock")
+
+        read_repo_file("Gemfile.lock").match?(SQLITE3_LOCKFILE_PATTERN)
+      end
+
+      def gemfile_declares_sqlite3?
+        return false unless repo_file_exists?("Gemfile")
+
+        read_repo_file("Gemfile").match?(SQLITE3_GEMFILE_PATTERN)
       end
 
       def install_bundle_env

--- a/spec/services/knowledge/collectors/routes_collector_spec.rb
+++ b/spec/services/knowledge/collectors/routes_collector_spec.rb
@@ -253,6 +253,25 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
         expect(command_collector.collect.length).to eq(11)
       end
 
+      it "does not treat commented Gemfile mentions as sqlite3 support" do
+        allow(command_collector).to receive(:repo_file_exists?).with("Gemfile.lock").and_return(false)
+        allow(command_collector).to receive(:read_repo_file).with("Gemfile").and_return(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          # gem "sqlite3"
+          gem "pg" # gem "sqlite3"
+        GEMFILE
+
+        expect { command_collector.collect }.to raise_error do |error|
+          expect(error).to be_a(Knowledge::SkipCollector)
+          expect(error.reason).to match(/sqlite3 support/)
+          expect(error.preserve_existing_artifacts?).to be(true)
+        end
+
+        expect(command_collector).not_to have_received(:run_command)
+          .with("sh", "-c", /bundle install/, timeout: 300, env: kind_of(Hash))
+      end
+
       it "passes bundle configuration and DATABASE_URL to bin/rails routes" do
         allow(command_collector).to receive(:run_command)
           .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))

--- a/spec/services/knowledge/collectors/routes_collector_spec.rb
+++ b/spec/services/knowledge/collectors/routes_collector_spec.rb
@@ -253,6 +253,20 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
         expect(command_collector.collect.length).to eq(11)
       end
 
+      it "accepts sqlite3 declared with parenthesized Gemfile syntax" do
+        allow(command_collector).to receive(:repo_file_exists?).with("Gemfile.lock").and_return(false)
+        allow(command_collector).to receive(:read_repo_file).with("Gemfile").and_return(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          gem("sqlite3", "~> 2.2")
+        GEMFILE
+        allow(command_collector).to receive(:run_command)
+          .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
+          .and_return(fixture_output)
+
+        expect(command_collector.collect.length).to eq(11)
+      end
+
       it "does not treat commented Gemfile mentions as sqlite3 support" do
         allow(command_collector).to receive(:repo_file_exists?).with("Gemfile.lock").and_return(false)
         allow(command_collector).to receive(:read_repo_file).with("Gemfile").and_return(<<~GEMFILE)

--- a/spec/services/knowledge/collectors/routes_collector_spec.rb
+++ b/spec/services/knowledge/collectors/routes_collector_spec.rb
@@ -12,11 +12,20 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
     )
   end
 
-  let(:project) { instance_double(Project, id: 1, github_token: github_token) }
+  let(:project) { instance_double(FakeProject, id: 1, github_token: github_token) }
   let(:project_version) { Struct.new(:id, :commit_sha).new(1, "a" * 40) }
   let(:collector_run) { Struct.new(:id).new(1) }
   let(:fixture_file) { Rails.root.join("spec/fixtures/knowledge/routes_expanded.txt").to_s }
   let(:github_token) { nil }
+
+  before do
+    stub_const("FakeProject", Struct.new(:id, :github_token))
+    stub_const("FakeGithubToken", Class.new do
+      def active? = true
+      def token = "github_pat_test_token"
+      def touch_last_used!; end
+    end)
+  end
 
   describe "#collector_type" do
     it "returns routes" do
@@ -150,14 +159,7 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
       end
 
       let(:fixture_output) { File.read(fixture_file) }
-      let(:active_github_token) do
-        instance_double(
-          GithubToken,
-          active?: true,
-          token: "github_pat_test_token",
-          touch_last_used!: true
-        )
-      end
+      let(:active_github_token) { instance_double(FakeGithubToken, active?: true, token: "github_pat_test_token", touch_last_used!: true) }
 
       before do
         allow(command_collector).to receive(:repo_file_exists?)
@@ -166,6 +168,10 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
           .with("bin/rails").and_return(true)
         allow(command_collector).to receive(:repo_file_exists?)
           .with("Gemfile").and_return(true)
+        allow(command_collector).to receive(:repo_file_exists?)
+          .with("Gemfile.lock").and_return(false)
+        allow(command_collector).to receive(:read_repo_file)
+          .with("Gemfile").and_return("gem \"sqlite3\"")
         allow(command_collector).to receive(:run_command)
           .with("sh", "-c", /bundle install/, timeout: 300, env: kind_of(Hash))
           .and_return("")
@@ -186,6 +192,60 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
       end
 
       it "runs bin/rails routes --expanded" do
+        allow(command_collector).to receive(:run_command)
+          .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
+          .and_return(fixture_output)
+
+        expect(command_collector.collect.length).to eq(11)
+      end
+
+      it "skips before bundle install when sqlite3 support is unavailable" do
+        allow(command_collector).to receive(:repo_file_exists?).with("Gemfile.lock").and_return(true)
+        allow(command_collector).to receive(:read_repo_file).with("Gemfile.lock").and_return(<<~LOCKFILE)
+          GEM
+            specs:
+              pg (1.6.3)
+        LOCKFILE
+        allow(command_collector).to receive(:repo_file_exists?).with("Gemfile").and_return(true)
+        allow(command_collector).to receive(:read_repo_file).with("Gemfile").and_return(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          gem "rails"
+          gem "pg"
+        GEMFILE
+
+        expect { command_collector.collect }.to raise_error do |error|
+          expect(error).to be_a(Knowledge::SkipCollector)
+          expect(error.reason).to match(/sqlite3 support/)
+          expect(error.preserve_existing_artifacts?).to be(true)
+        end
+
+        expect(command_collector).not_to have_received(:run_command)
+          .with("sh", "-c", /bundle install/, timeout: 300, env: kind_of(Hash))
+      end
+
+      it "accepts sqlite3 declared in Gemfile.lock" do
+        allow(command_collector).to receive(:repo_file_exists?).with("Gemfile.lock").and_return(true)
+        allow(command_collector).to receive(:read_repo_file).with("Gemfile.lock").and_return(<<~LOCKFILE)
+          GEM
+            specs:
+              sqlite3 (2.2.0)
+        LOCKFILE
+        allow(command_collector).to receive(:run_command)
+          .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
+          .and_return(fixture_output)
+
+        expect(command_collector.collect.length).to eq(11)
+      end
+
+      it "accepts sqlite3 declared in Gemfile when lockfile is absent" do
+        allow(command_collector).to receive(:repo_file_exists?).with("Gemfile.lock").and_return(false)
+        allow(command_collector).to receive(:read_repo_file).with("Gemfile").and_return(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          gem "rails"
+          gem "sqlite3"
+        GEMFILE
         allow(command_collector).to receive(:run_command)
           .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
           .and_return(fixture_output)
@@ -503,6 +563,13 @@ RSpec.describe Knowledge::Collectors::RoutesCollector, :no_db do
       it "skips bundle install when Gemfile is absent" do
         allow(command_collector).to receive(:repo_file_exists?)
           .with("Gemfile").and_return(false)
+        allow(command_collector).to receive(:repo_file_exists?)
+          .with("Gemfile.lock").and_return(true)
+        allow(command_collector).to receive(:read_repo_file).with("Gemfile.lock").and_return(<<~LOCKFILE)
+          GEM
+            specs:
+              sqlite3 (2.2.0)
+        LOCKFILE
         allow(command_collector).to receive(:run_command)
           .with("sh", "-c", /bin\/rails routes --expanded/, timeout: 120, env: kind_of(Hash))
           .and_return(fixture_output)


### PR DESCRIPTION
## Summary

Prevents a recurring `Knowledge::ContainerizedRunner::ContainerError` when running the routes collector against repos that don't bundle `sqlite3`. The collector now preflights the target repo for SQLite support and gracefully skips collection (preserving prior artifacts) instead of crashing the container.

## Changes

- **Services**: `app/services/knowledge/collectors/routes_collector.rb` now inspects `Gemfile.lock`/`Gemfile` for `sqlite3` before attempting the in-memory SQLite boot fallback used to render `rails routes`. When absent, the collector skips and retains existing route artifacts.
- **Tests**: `spec/services/knowledge/collectors/routes_collector_spec.rb` adds coverage for the preflight skip path and supports running under the db-less spec harness.

## Design Decisions

- **Skip vs. fail**: A missing `sqlite3` gem in the target repo is a normal configuration (many Rails apps use Postgres/MySQL only), not an error. Surfacing it as a `ContainerError` produced noisy P2 incidents on every run, so the collector now treats it as "not applicable" and preserves the last successful artifact rather than wiping state.
- **Detection via lockfile**: We inspect `Gemfile.lock`/`Gemfile` rather than attempting the boot and rescuing `LoadError`, because the failure originates inside the containerized Rails process and the error surface was the container exit status — too coarse to distinguish "sqlite3 missing" from other boot failures.

---

Closes #1938