### PR TITLE
ci: add concurrency groups to all workflows

### DIFF
--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -32,6 +32,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: agent-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   agent-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,10 @@ on:
   repository_dispatch:
     types: [claude-review]
 
+concurrency:
+  group: claude-review-${{ github.event.client_payload.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     name: Claude Code Review

--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pr-artifact-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,9 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-please
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_prof.yml
+++ b/.github/workflows/test_prof.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: test-prof-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   profile:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- Adds `concurrency` groups to the 7 workflows that were missing them (`ci`, `security`, `pr-artifact-check`, `agent-image`, `claude-code-review`, `test_prof`, `release-please`)
- Only `pr-screenshots`, `pr-screenshots-publish`, and `system_tests` had concurrency groups previously
- Without concurrency groups, every push to a PR spawns new runs without cancelling superseded ones, causing severe runner queue backups (observed 27 concurrent queued runs and ~18 min queue times with multiple Paid agent PRs)

## Design

| Workflow | Group key | Cancel in progress |
|---|---|---|
| `ci.yml` | `ci-{ref}` | PRs only |
| `security.yml` | `security-{ref}` | PRs only |
| `pr-artifact-check.yml` | `pr-artifact-check-{PR number}` | Always |
| `agent-image.yml` | `agent-image-{ref}` | PRs only |
| `claude-code-review.yml` | `claude-review-{PR number}` | Always |
| `test_prof.yml` | `test-prof-{ref}` | Always |
| `release-please.yml` | `release-please` | Never |

PR+main workflows only cancel superseded runs for PRs, not main pushes. `release-please` never cancels since release operations must complete.