### PR TITLE
ci: add timeouts to long-running CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
 
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
 
     services:
       postgres:
@@ -204,6 +205,7 @@ jobs:
 
   performance:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

Add explicit job timeouts to the two long-running service-backed jobs in CI so stuck GitHub runners fail within a bounded window instead of sitting in progress for hours.

## Changes

- add `timeout-minutes: 45` to the `test` job in `.github/workflows/ci.yml`
- add `timeout-minutes: 45` to the `performance` job in `.github/workflows/ci.yml`

## Why

A recent PR had the `test` job remain in progress for hours after entering the `Run tests` step. The setup steps had already completed, and the job appeared wedged in Actions infrastructure rather than failing fast. These guards give us a clear upper bound for the two CI jobs most likely to burn time when a runner or service-backed step gets stuck.

## Verification

- verified the workflow diff locally
- did not run GitHub Actions locally