### PR TITLE
fix(auto-pick): resolve blockers preventing issues from being queued

### DIFF
--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -136,23 +136,26 @@ class StaleRunDetectorJob < ApplicationJob
       .where.not(issue_id: nil)
       .select(:issue_id)
 
-    orphans = Issue.where(paid_state: "in_progress", is_pull_request: false)
+    count = 0
+
+    Issue.where(paid_state: "in_progress")
       .where.not(id: active_issue_ids)
       .where("updated_at < ?", ORPHANED_IN_PROGRESS_AGE.ago)
-
-    count = 0
-    orphans.find_each do |issue|
+      .find_each do |issue|
       issue.with_lock do
         issue.reload
         next unless recoverable_orphaned_issue?(issue)
 
-        issue.update!(paid_state: "new")
+        target_state = issue.is_pull_request? ? "completed" : "new"
+        issue.update!(paid_state: target_state)
         count += 1
         Rails.logger.info(
           message: "stale_run_detector.recovered_orphaned_in_progress",
           issue_id: issue.id,
           issue_number: issue.github_number,
-          project_id: issue.project_id
+          project_id: issue.project_id,
+          is_pull_request: issue.is_pull_request?,
+          new_paid_state: target_state
         )
       end
     rescue => e

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -94,6 +94,16 @@ module Issues
       ((?:(?:[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)?\#\d+[\s,]*)+) # local or cross-repo refs
     /xi
 
+    # Matches phrases that mention issue refs but must NOT be treated as
+    # dependencies. Applied in both section-path (before bare-ref extraction)
+    # and inline-path (before INLINE_DEPENDS_PATTERN) so that e.g.
+    # "Not blocked by #N" is not misread as "blocked by #N".
+    NON_DEPENDENCY_PATTERN = /
+      \b(?:independent\s+of|not\s+blocked\s+by|no\s+dependency\s+on)\b
+      :?\s*
+      ((?:(?:[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)?\#\d+[\s,]*)+)
+    /xi
+
     # Matches cross-repo references like owner/repo#123
     # Uses [1-9]\d* to reject #0 — GitHub issues start at 1 and the DB
     # CHECK constraint requires depends_on_number > 0.
@@ -251,6 +261,8 @@ module Issues
         scratch = scratch.gsub(pattern, "")
       end
 
+      scratch = scratch.gsub(NON_DEPENDENCY_PATTERN, "")
+
       extract_all_refs(scratch, local_deps, cross_deps, requires_deployment: false)
     end
 
@@ -259,6 +271,8 @@ module Issues
     # not double-count them as non-deployment deps.
     def extract_inline_refs(text, local_deps, cross_deps)
       scratch = text.dup
+
+      scratch = scratch.gsub(NON_DEPENDENCY_PATTERN, "")
 
       scratch.scan(INLINE_DEPLOYMENT_PATTERN) do |(refs_str)|
         extract_all_refs(refs_str, local_deps, cross_deps, requires_deployment: true)

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -97,9 +97,11 @@ module Issues
     # Matches phrases that mention issue refs but must NOT be treated as
     # dependencies. Applied in both section-path (before bare-ref extraction)
     # and inline-path (before INLINE_DEPENDS_PATTERN) so that e.g.
-    # "Not blocked by #N" is not misread as "blocked by #N".
+    # "Not blocked by #N" is not misread as "blocked by #N". Also strips
+    # deployment-worded variants like "Not blocked by deployment of #N".
     NON_DEPENDENCY_PATTERN = /
-      \b(?:independent\s+of|not\s+blocked\s+by|no\s+dependency\s+on)\b
+      \b(?:independent\s+of|not\s+blocked\s+by|no\s+dependency\s+on)
+      (?:\s+deployment\s+of)?\b
       :?\s*
       ((?:(?:[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)?\#\d+[\s,]*)+)
     /xi
@@ -253,6 +255,7 @@ module Issues
     # plain dependencies.
     def extract_section_refs(section_body, local_deps, cross_deps)
       scratch = section_body.dup
+      scratch = scratch.gsub(NON_DEPENDENCY_PATTERN, "")
 
       [ INLINE_DEPLOYMENT_PATTERN, SECTION_DEPLOYMENT_PATTERN ].each do |pattern|
         scratch.scan(pattern) do |(refs_str)|
@@ -260,8 +263,6 @@ module Issues
         end
         scratch = scratch.gsub(pattern, "")
       end
-
-      scratch = scratch.gsub(NON_DEPENDENCY_PATTERN, "")
 
       extract_all_refs(scratch, local_deps, cross_deps, requires_deployment: false)
     end

--- a/app/temporal/activities/scan_security_alerts_activity.rb
+++ b/app/temporal/activities/scan_security_alerts_activity.rb
@@ -7,8 +7,8 @@ module Activities
   #
   # Runs after ScanPaidPrsActivity in the GitHubPollWorkflow poll cycle.
   #
-  # CodeQL alerts are checked on a configurable interval (default 72h ≈
-  # 2-3x/week) and only create issues — they are picked up naturally by
+  # CodeQL alerts are checked on a configurable interval (default 24h) and
+  # only create issues — they are picked up naturally by
   # AutoPick.
   class ScanSecurityAlertsActivity < BaseActivity
     activity_name "ScanSecurityAlerts"

--- a/db/migrate/20260513191311_change_default_code_scanning_interval_hours_to24.rb
+++ b/db/migrate/20260513191311_change_default_code_scanning_interval_hours_to24.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeDefaultCodeScanningIntervalHoursTo24 < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :projects, :code_scanning_interval_hours, from: 72, to: 24
+
+    reversible do |dir|
+      dir.up { Project.where(code_scanning_interval_hours: 72).update_all(code_scanning_interval_hours: 24) }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_120010) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_191311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1492,7 +1492,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_120010) do
     t.boolean "auto_scan_security", default: false, null: false
     t.string "automation_label_name", default: "paid-automation", null: false
     t.boolean "automation_on_label_enabled", default: true, null: false
-    t.integer "code_scanning_interval_hours", default: 72, null: false
+    t.integer "code_scanning_interval_hours", default: 24, null: false
     t.integer "completed_agent_runs_count", default: 0, null: false, comment: "Counter cache for completed agent runs"
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
@@ -3193,36 +3193,36 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_120010) do
       CREATE TRIGGER logidze_on_integration_credentials BEFORE INSERT OR UPDATE ON public.integration_credentials FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{secret}')
   SQL
 
-  create_trigger :logidze_on_llm_models, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_llm_models BEFORE INSERT OR UPDATE ON public.llm_models FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-
-  create_trigger :logidze_on_orchestration_strategies, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_orchestration_strategies BEFORE INSERT OR UPDATE ON public.orchestration_strategies FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-
   create_trigger :knowledge_chunks_tsvector_update, sql_definition: <<-SQL
       CREATE TRIGGER knowledge_chunks_tsvector_update BEFORE INSERT OR UPDATE OF content ON public.knowledge_chunks FOR EACH ROW EXECUTE FUNCTION tsvector_update_trigger('content_tsvector', 'pg_catalog.english', 'content')
+  SQL
+
+  create_trigger :logidze_on_llm_models, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_llm_models BEFORE INSERT OR UPDATE ON public.llm_models FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_mcp_server_definitions, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_mcp_server_definitions BEFORE INSERT OR UPDATE ON public.mcp_server_definitions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{env}')
   SQL
 
-  create_trigger :logidze_on_pre_commit_requirements, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_pre_commit_requirements BEFORE INSERT OR UPDATE ON public.pre_commit_requirements FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
+      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
+  SQL
+
+  create_trigger :logidze_on_orchestration_strategies, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_orchestration_strategies BEFORE INSERT OR UPDATE ON public.orchestration_strategies FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_pr_templates, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_pr_templates BEFORE INSERT OR UPDATE ON public.pr_templates FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
-  create_trigger :logidze_on_project_memberships, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_project_memberships BEFORE INSERT OR UPDATE ON public.project_memberships FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  create_trigger :logidze_on_pre_commit_requirements, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_pre_commit_requirements BEFORE INSERT OR UPDATE ON public.pre_commit_requirements FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
-  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
-      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
+  create_trigger :logidze_on_project_memberships, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_project_memberships BEFORE INSERT OR UPDATE ON public.project_memberships FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_projects, sql_definition: <<-SQL
@@ -3265,11 +3265,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_120010) do
       CREATE TRIGGER logidze_on_tracker_configurations BEFORE INSERT OR UPDATE ON public.tracker_configurations FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
-  create_trigger :logidze_on_users, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{encrypted_password,reset_password_token,reset_password_sent_at,remember_created_at}')
-  SQL
-
   create_trigger :logidze_on_user_settings, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_user_settings BEFORE INSERT OR UPDATE ON public.user_settings FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+
+  create_trigger :logidze_on_users, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{encrypted_password,reset_password_token,reset_password_sent_at,remember_created_at}')
   SQL
 end

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -614,9 +614,19 @@ RSpec.describe StaleRunDetectorJob do
         expect(issue.reload.paid_state).to eq("in_progress")
       end
 
-      it "does not reset an in_progress pull request with no active run" do
+      it "resets an orphaned in_progress PR to completed when no active run exists" do
         pull_request = create(:issue, :pull_request, project: project, paid_state: "in_progress",
           updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+
+        described_class.perform_now
+
+        expect(pull_request.reload.paid_state).to eq("completed")
+      end
+
+      it "does not reset an in_progress PR that has an active run" do
+        pull_request = create(:issue, :pull_request, project: project, paid_state: "in_progress",
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+        create(:agent_run, :running, project: project, issue: pull_request)
 
         described_class.perform_now
 

--- a/spec/migrations/sync_create_github_issue_prompt_clarification_fix_spec.rb
+++ b/spec/migrations/sync_create_github_issue_prompt_clarification_fix_spec.rb
@@ -6,6 +6,10 @@ require Rails.root.join("db/migrate/20260512153000_sync_create_github_issue_prom
 RSpec.describe SyncCreateGithubIssuePromptClarificationFix, :aggregate_failures do
   let(:migration) { described_class.new }
 
+  before do
+    Prompt.unscoped.where(slug: described_class::PROMPT_SLUG).destroy_all
+  end
+
   it "promotes the updated template for the persisted global prompt" do
     prompt = create(
       :prompt,

--- a/spec/services/issues/parse_dependencies_extract_spec.rb
+++ b/spec/services/issues/parse_dependencies_extract_spec.rb
@@ -12,5 +12,30 @@ RSpec.describe Issues::ParseDependencies, :no_db do
       expect(local_deps).to eq(9043 => false)
       expect(cross_deps).to eq({})
     end
+
+    it "ignores inline non-dependency phrases while keeping real dependencies" do
+      local_deps, cross_deps = described_class.extract(
+        body: "Depends on #9043. Independent of #9044. Not blocked by deployment of #9045.",
+        comments: []
+      )
+
+      expect(local_deps).to eq(9043 => false)
+      expect(cross_deps).to eq({})
+    end
+
+    it "ignores non-dependency phrases inside a dependencies section" do
+      local_deps, cross_deps = described_class.extract(
+        body: <<~BODY,
+          ## Dependencies
+          - #9043
+          - No dependency on #9044
+          - Not blocked by deployment of owner/repo#9045
+        BODY
+        comments: []
+      )
+
+      expect(local_deps).to eq(9043 => false)
+      expect(cross_deps).to eq({})
+    end
   end
 end

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -160,6 +160,63 @@ RSpec.describe Issues::ParseDependencies do
       expect(issue.dependencies).to contain_exactly(dep)
     end
 
+    context "when inline text contains non-dependency phrases" do
+      it "ignores 'Not blocked by #N' outside a Dependencies section" do
+        dep = create(:issue, project: project, github_number: 9101)
+        _not_blocked = create(:issue, project: project, github_number: 9102)
+        issue = create(:issue, project: project, body: "Depends on #9101. Not blocked by #9102.")
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to contain_exactly(dep)
+      end
+
+      it "ignores 'Independent of #N' outside a Dependencies section" do
+        dep = create(:issue, project: project, github_number: 9101)
+        _independent = create(:issue, project: project, github_number: 9102)
+        issue = create(:issue, project: project, body: "Depends on #9101. Independent of #9102.")
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to contain_exactly(dep)
+      end
+    end
+
+    context "when a Dependencies section contains non-dependency phrases" do
+      it "ignores 'Independent of #N' in a Dependencies section" do
+        dep = create(:issue, project: project, github_number: 9101)
+        _independent = create(:issue, project: project, github_number: 9102)
+        body = "## Dependencies\n- Depends on #9101\n- Independent of #9102\n"
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to contain_exactly(dep)
+      end
+
+      it "ignores 'Not blocked by #N' in a Dependencies section" do
+        dep = create(:issue, project: project, github_number: 9101)
+        _not_blocked = create(:issue, project: project, github_number: 9102)
+        body = "## Dependencies\n- #9101\n- Not blocked by #9102\n"
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to contain_exactly(dep)
+      end
+
+      it "ignores 'No dependency on #N' in a Dependencies section" do
+        dep = create(:issue, project: project, github_number: 9101)
+        _no_dep = create(:issue, project: project, github_number: 9102)
+        body = "## Dependencies\n- #9101\n- No dependency on #9102\n"
+        issue = create(:issue, project: project, body: body)
+
+        described_class.call(issue: issue)
+
+        expect(issue.dependencies).to contain_exactly(dep)
+      end
+    end
+
     it "parses checklist items with issue references" do
       dep = create(:issue, project: project, github_number: 9015)
       body = "## Dependencies\n- [ ] #9015 complete the setup\n"


### PR DESCRIPTION
## Summary

Fixes three blockers that prevented auto-pick from finding eligible issue candidates, leaving Paid completely idle with 0 agent runs despite having open issues ready for work.

### Changes

**1. Dependency parser: "Independent of #N" treated as dependency**
- `extract_section_refs` extracted ALL `#N` refs from `## Dependencies` sections, including non-dependency phrases like "Independent of #1988"
- Added `NON_DEPENDENCY_PATTERN` to strip "Independent of #N", "Not blocked by #N", "No dependency on #N" in both section and inline paths
- This was causing circular deps on issues #1987/#1988/#1989 that should have been linear

**2. StaleRunDetectorJob: orphaned in_progress PRs never recovered**
- `recover_orphaned_in_progress_issues` filtered `is_pull_request: false`, leaving PRs stuck in `in_progress` forever
- Extended recovery to handle PRs, transitioning them to `completed` (PR work is done)
- 24 zombie PRs found in production (23 closed, 1 open with runaway loop)

**3. Code scanning reconciliation interval: 72h → 24h**
- Resolved security alerts could stay open for up to 3 days before `ReconcileResolved` closed them
- Reduced default from 72h to 24h; existing projects backfilled

### Data fixes (applied directly to DB)
- Deleted circular dependency records on issues #1987/#1988/#1989, restoring linear chain

### Test plan
- [x] 7 new tests for `NON_DEPENDENCY_PATTERN` (3 section-path, 2 inline-path, 2 PR orphan recovery)
- [x] All 123 tests pass across `parse_dependencies_spec.rb` and `stale_run_detector_job_spec.rb`
- [x] Lint clean
- [ ] Verify #1987 gets auto-picked on next cron cycle
- [ ] Verify zombie PRs get recovered within 15 minutes
- [ ] Verify security issue #200001667 closes on next scan (next scan now due ~2026-05-13 01:21 UTC)