### PR TITLE
feat(quality): Focus-scoped quality scoring — focus-specific weights + focus_resolved attribution

### DIFF
--- a/app/models/quality_metric.rb
+++ b/app/models/quality_metric.rb
@@ -42,12 +42,6 @@ class QualityMetric < ApplicationRecord
       "lint_clean" => 0.10,
       "tests_pass" => 0.10
     },
-    issue_implementation: {
-      "focus_resolved" => 0.50,
-      "ci_passed" => 0.20,
-      "lint_clean" => 0.15,
-      "iterations" => 0.15
-    },
     label_action: {
       "focus_resolved" => 0.60,
       "iterations" => 0.20,

--- a/app/models/quality_metric.rb
+++ b/app/models/quality_metric.rb
@@ -47,6 +47,13 @@ class QualityMetric < ApplicationRecord
       "iterations" => 0.20,
       "lint_clean" => 0.10,
       "tests_pass" => 0.10
+    },
+    "issue_implementation" => {
+      "focus_resolved" => 0.50,
+      "ci_passed" => 0.15,
+      "iterations" => 0.15,
+      "lint_clean" => 0.10,
+      "tests_pass" => 0.10
     }
   }.freeze
 

--- a/app/models/quality_metric.rb
+++ b/app/models/quality_metric.rb
@@ -19,30 +19,30 @@ class QualityMetric < ApplicationRecord
   }.freeze
 
   FOCUS_WEIGHTS = {
-    ci_fix: {
+    "ci_fix" => {
       "ci_passed" => 0.50,
       "lint_clean" => 0.20,
       "tests_pass" => 0.20,
       "iterations" => 0.10
     },
-    review_feedback: {
+    "review_feedback" => {
       "focus_resolved" => 0.60,
       "iterations" => 0.20,
       "lint_clean" => 0.10,
       "tests_pass" => 0.10
     },
-    merge_conflict: {
+    "merge_conflict" => {
       "focus_resolved" => 0.70,
       "ci_passed" => 0.15,
       "iterations" => 0.15
     },
-    conversation: {
+    "conversation" => {
       "focus_resolved" => 0.60,
       "iterations" => 0.20,
       "lint_clean" => 0.10,
       "tests_pass" => 0.10
     },
-    label_action: {
+    "label_action" => {
       "focus_resolved" => 0.60,
       "iterations" => 0.20,
       "lint_clean" => 0.10,
@@ -139,7 +139,7 @@ class QualityMetric < ApplicationRecord
     goal_weights = GOAL_WEIGHTS.fetch(goal, SCORE_WEIGHTS)
     return goal_weights unless goal == "create_pr"
 
-    FOCUS_WEIGHTS.fetch(focus.to_s.presence&.to_sym, SCORE_WEIGHTS)
+    FOCUS_WEIGHTS.fetch(focus.to_s, SCORE_WEIGHTS)
   end
 
   # Calculates composite score from individual scores using goal-specific weights.

--- a/app/models/quality_metric.rb
+++ b/app/models/quality_metric.rb
@@ -47,13 +47,6 @@ class QualityMetric < ApplicationRecord
       "iterations" => 0.20,
       "lint_clean" => 0.10,
       "tests_pass" => 0.10
-    },
-    "issue_implementation" => {
-      "focus_resolved" => 0.50,
-      "ci_passed" => 0.15,
-      "iterations" => 0.15,
-      "lint_clean" => 0.10,
-      "tests_pass" => 0.10
     }
   }.freeze
 

--- a/app/models/quality_metric.rb
+++ b/app/models/quality_metric.rb
@@ -18,6 +18,44 @@ class QualityMetric < ApplicationRecord
     "agent_rerun_count" => 0.10
   }.freeze
 
+  FOCUS_WEIGHTS = {
+    ci_fix: {
+      "ci_passed" => 0.50,
+      "lint_clean" => 0.20,
+      "tests_pass" => 0.20,
+      "iterations" => 0.10
+    },
+    review_feedback: {
+      "focus_resolved" => 0.60,
+      "iterations" => 0.20,
+      "lint_clean" => 0.10,
+      "tests_pass" => 0.10
+    },
+    merge_conflict: {
+      "focus_resolved" => 0.70,
+      "ci_passed" => 0.15,
+      "iterations" => 0.15
+    },
+    conversation: {
+      "focus_resolved" => 0.60,
+      "iterations" => 0.20,
+      "lint_clean" => 0.10,
+      "tests_pass" => 0.10
+    },
+    issue_implementation: {
+      "focus_resolved" => 0.50,
+      "ci_passed" => 0.20,
+      "lint_clean" => 0.15,
+      "iterations" => 0.15
+    },
+    label_action: {
+      "focus_resolved" => 0.60,
+      "iterations" => 0.20,
+      "lint_clean" => 0.10,
+      "tests_pass" => 0.10
+    }
+  }.freeze
+
   # Goal-specific weights for composite quality scoring.
   # Each goal type has different signals relevant to its output quality.
   GOAL_WEIGHTS = {
@@ -103,12 +141,20 @@ class QualityMetric < ApplicationRecord
     (weighted_sum / total_weight).round(4)
   end
 
+  def self.weights_for(goal: "create_pr", focus: "general")
+    goal_weights = GOAL_WEIGHTS.fetch(goal, SCORE_WEIGHTS)
+    return goal_weights unless goal == "create_pr"
+
+    FOCUS_WEIGHTS.fetch(focus.to_s.presence&.to_sym, SCORE_WEIGHTS)
+  end
+
   # Calculates composite score from individual scores using goal-specific weights.
   #
   # @return [Float, nil] Score between 0.0 and 1.0, or nil if no scores
   def calculate_composite_score
-    goal = agent_run&.goal
-    weights = GOAL_WEIGHTS.fetch(goal, SCORE_WEIGHTS)
+    goal = agent_run&.goal || "create_pr"
+    focus = agent_run&.focus || "general"
+    weights = self.class.weights_for(goal:, focus:)
     self.class.weighted_average(scores, weights: weights)
   end
 

--- a/app/services/quality_metrics/calculate_composite_score.rb
+++ b/app/services/quality_metrics/calculate_composite_score.rb
@@ -21,7 +21,7 @@ module QualityMetrics
     #
     # @return [Float, nil] The composite score (0.0..1.0), or nil if no metrics exist
     def calculate
-      metrics = agent_run.quality_metrics.to_a
+      metrics = QualityMetric.where(agent_run_id: agent_run.id).to_a
       return nil if metrics.empty?
 
       merged_scores = metrics.each_with_object({}) do |metric, combined|

--- a/app/services/quality_metrics/calculate_composite_score.rb
+++ b/app/services/quality_metrics/calculate_composite_score.rb
@@ -28,7 +28,7 @@ module QualityMetrics
         metric.scores.each { |key, value| combined[key] = value.to_f }
       end
 
-      weights = QualityMetric::GOAL_WEIGHTS.fetch(agent_run.goal, QualityMetric::SCORE_WEIGHTS)
+      weights = QualityMetric.weights_for(goal: agent_run.goal, focus: agent_run.focus)
       QualityMetric.weighted_average(merged_scores, weights: weights)
     end
   end

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -102,7 +102,7 @@ module QualityMetrics
       case agent_run.focus
       when "merge_conflict"
         build_merge_conflict_scores
-      when "ci_fix", "review_feedback", "conversation", "label_action", "issue_implementation"
+      when "ci_fix", "review_feedback", "conversation", "label_action"
         build_iteration_and_lint_scores
       else
         build_pr_scores

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -100,14 +100,10 @@ module QualityMetrics
 
     def build_focused_scores
       case agent_run.focus
-      when "ci_fix"
-        build_iteration_and_lint_scores
-      when "review_feedback", "conversation", "label_action"
-        build_iteration_and_lint_scores
-      when "issue_implementation"
-        build_iteration_and_lint_scores
       when "merge_conflict"
         build_merge_conflict_scores
+      when "ci_fix", "review_feedback", "conversation", "label_action", "issue_implementation"
+        build_iteration_and_lint_scores
       else
         build_pr_scores
       end

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -101,9 +101,8 @@ module QualityMetrics
     def build_focused_scores
       case agent_run.focus
       when "ci_fix"
-        build_ci_fix_scores
       when "review_feedback", "conversation", "label_action"
-        build_focus_resolution_scores
+        build_iteration_and_lint_scores
       when "merge_conflict"
         build_merge_conflict_scores
       else
@@ -125,15 +124,7 @@ module QualityMetrics
       scores
     end
 
-    def build_ci_fix_scores
-      scores = {}
-      scores["iterations"] = iteration_score if agent_run.iterations&.positive?
-      lint = lint_clean_score
-      scores["lint_clean"] = lint unless lint.nil?
-      scores
-    end
-
-    def build_focus_resolution_scores
+    def build_iteration_and_lint_scores
       scores = {}
       scores["iterations"] = iteration_score if agent_run.iterations&.positive?
       lint = lint_clean_score

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -102,7 +102,7 @@ module QualityMetrics
       case agent_run.focus
       when "ci_fix"
         build_ci_fix_scores
-      when "review_feedback", "conversation", "issue_implementation", "label_action"
+      when "review_feedback", "conversation", "label_action"
         build_focus_resolution_scores
       when "merge_conflict"
         build_merge_conflict_scores

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -101,7 +101,10 @@ module QualityMetrics
     def build_focused_scores
       case agent_run.focus
       when "ci_fix"
+        build_iteration_and_lint_scores
       when "review_feedback", "conversation", "label_action"
+        build_iteration_and_lint_scores
+      when "issue_implementation"
         build_iteration_and_lint_scores
       when "merge_conflict"
         build_merge_conflict_scores

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -54,7 +54,7 @@ module QualityMetrics
 
     def record_quality_metric
       scores = build_scores
-      weights = QualityMetric::GOAL_WEIGHTS.fetch(agent_run.goal, QualityMetric::SCORE_WEIGHTS)
+      weights = QualityMetric.weights_for(goal: agent_run.goal, focus: agent_run.focus)
       automated_metric.assign_attributes(
         prompt_version: agent_run.prompt_version,
         feedback_source: "system",
@@ -87,12 +87,27 @@ module QualityMetrics
     # the completion-time agent run does not carry finalized CI/test/merge
     # outcomes, and weighted_average renormalizes over present keys.
     def build_scores
+      return build_focused_scores if agent_run.create_pr_goal? && agent_run.focused?
+
       case agent_run.goal
       when "create_pr" then build_pr_scores
       when "create_issue" then build_issue_scores
       when "review" then build_review_scores
       when "enhance_issue" then build_enhance_issue_scores
       else build_pr_scores
+      end
+    end
+
+    def build_focused_scores
+      case agent_run.focus
+      when "ci_fix"
+        build_ci_fix_scores
+      when "review_feedback", "conversation", "issue_implementation", "label_action"
+        build_focus_resolution_scores
+      when "merge_conflict"
+        build_merge_conflict_scores
+      else
+        build_pr_scores
       end
     end
 
@@ -107,6 +122,28 @@ module QualityMetrics
         scores["review_comment_count"] = comment_score unless comment_score.nil?
         scores["agent_rerun_count"] = agent_rerun_count_score
       end
+      scores
+    end
+
+    def build_ci_fix_scores
+      scores = {}
+      scores["iterations"] = iteration_score if agent_run.iterations&.positive?
+      lint = lint_clean_score
+      scores["lint_clean"] = lint unless lint.nil?
+      scores
+    end
+
+    def build_focus_resolution_scores
+      scores = {}
+      scores["iterations"] = iteration_score if agent_run.iterations&.positive?
+      lint = lint_clean_score
+      scores["lint_clean"] = lint unless lint.nil?
+      scores
+    end
+
+    def build_merge_conflict_scores
+      scores = {}
+      scores["iterations"] = iteration_score if agent_run.iterations&.positive?
       scores
     end
 

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -102,7 +102,7 @@ module QualityMetrics
       case agent_run.focus
       when "merge_conflict"
         build_merge_conflict_scores
-      when "ci_fix", "review_feedback", "conversation", "label_action"
+      when "ci_fix", "review_feedback", "conversation", "label_action", "issue_implementation"
         build_iteration_and_lint_scores
       else
         build_pr_scores

--- a/app/services/quality_metrics/dashboard_stats.rb
+++ b/app/services/quality_metrics/dashboard_stats.rb
@@ -79,7 +79,7 @@ module QualityMetrics
 
         weights_by_focus = {}
         QualityMetric::FOCUS_WEIGHTS.each do |focus, weights|
-          weights_by_focus[focus.to_s] = weights[key] if weights.key?(key)
+          weights_by_focus[focus] = weights[key] if weights.key?(key)
         end
 
         {

--- a/app/services/quality_metrics/dashboard_stats.rb
+++ b/app/services/quality_metrics/dashboard_stats.rb
@@ -77,11 +77,17 @@ module QualityMetrics
           weights_by_goal[goal] = weights[key] if weights.key?(key)
         end
 
+        weights_by_focus = {}
+        QualityMetric::FOCUS_WEIGHTS.each do |focus, weights|
+          weights_by_focus[focus.to_s] = weights[key] if weights.key?(key)
+        end
+
         {
           key: key,
           name: display[:name],
           description: display[:description],
           weights_by_goal: weights_by_goal,
+          weights_by_focus: weights_by_focus,
           goal_types: display[:collected_for],
           signal_type: display[:signal_type]
         }

--- a/app/services/quality_metrics/dashboard_stats.rb
+++ b/app/services/quality_metrics/dashboard_stats.rb
@@ -49,6 +49,7 @@ module QualityMetrics
       "pr_created" => { name: "PR Created", description: "Whether the agent successfully created a pull request.", signal_type: "automated", collected_for: %w[create_pr] },
       "pr_merged" => { name: "PR Merged", description: "Whether the pull request was merged.", signal_type: "human", collected_for: %w[create_pr] },
       "ci_passed" => { name: "CI Passed", description: "Whether CI checks passed on the pull request.", signal_type: "automated", collected_for: %w[create_pr] },
+      "focus_resolved" => { name: "Focus Resolved", description: "Whether the focused run resolved the specific PR problem it was targeting on the next scan cycle.", signal_type: "automated", collected_for: %w[create_pr] },
       "iterations" => { name: "Iterations", description: "Fewer iterations to complete = higher quality. Degrades by 0.1 per extra iteration.", signal_type: "automated", collected_for: %w[create_pr] },
       "lint_clean" => { name: "Lint Clean", description: "Whether the agent produced code with no lint offenses.", signal_type: "automated", collected_for: %w[create_pr] },
       "tests_pass" => { name: "Tests Pass", description: "Whether tests pass on the agent's output.", signal_type: "automated", collected_for: %w[create_pr] },
@@ -194,7 +195,10 @@ module QualityMetrics
     end
 
     def score_breakdown
-      valid_keys = QualityMetric::GOAL_WEIGHTS.values.flat_map(&:keys).uniq
+      valid_keys = (
+        QualityMetric::GOAL_WEIGHTS.values.flat_map(&:keys) +
+        QualityMetric::FOCUS_WEIGHTS.values.flat_map(&:keys)
+      ).uniq
       rows = QualityMetric.by_project(project.id).automated.with_composite_score
         .joins(:agent_run).where(AgentRun.quality_scoreable_sql)
         .where("scores <> '{}'::jsonb")

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1131,7 +1131,7 @@ module Activities
       when "ci_fix"
         ci_focus_resolution_scores(project, client, issue)
       when "review_feedback"
-        review_feedback_resolution_scores(project, client, issue)
+        review_feedback_resolution_scores(project, client, issue, focused_run)
       when "merge_conflict"
         merge_conflict_resolution_scores(project, client, issue)
       when "conversation"
@@ -1154,11 +1154,30 @@ module Activities
       { "focus_resolved" => score, "ci_passed" => score }
     end
 
-    def review_feedback_resolution_scores(project, client, issue)
+    def review_feedback_resolution_scores(project, client, issue, focused_run)
+      pr_data = fetch_pr_data(client, project, issue)
+      return nil if pr_data.nil?
+
+      checks = fetch_check_runs(client, project, pr_data)
+      return nil if checks.nil?
+
+      reviews = fetch_reviews(client, project, issue)
+      return nil if reviews.nil?
+
       unresolved_threads = fetch_unresolved_threads(client, project, issue)
       return nil if unresolved_threads.nil?
 
-      { "focus_resolved" => unresolved_threads.empty? ? 1.0 : 0.0 }
+      triggers = []
+      triggers.concat(human_review_thread_triggers(project, unresolved_threads))
+      triggers.concat(check_review_bot_status(reviews, unresolved_threads,
+        project: project, last_run: focused_run, client: client, issue: issue))
+      triggers.concat(check_non_enabled_bot_reviews(reviews, unresolved_threads,
+        project: project, last_run: focused_run, client: client, issue: issue))
+      triggers.concat(changes_requested_from_reviews(project, reviews, focused_run))
+      triggers.concat(check_conversation_comments(client, project, issue, focused_run))
+      triggers.concat(non_bot_review_gate_triggers(project, issue, pr_data, reviews, checks))
+
+      { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
     end
 
     def merge_conflict_resolution_scores(project, client, issue)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1131,6 +1131,8 @@ module Activities
 
     def ci_focus_resolution_scores(project, client, issue)
       pr_data = fetch_pr_data(client, project, issue)
+      return nil if pr_data.nil?
+
       checks = fetch_check_runs(client, project, pr_data)
       return nil if checks.nil? || checks_pending?(checks)
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -218,6 +218,7 @@ module Activities
     end
 
     def scan_pr(project, client, issue)
+      record_focus_resolution(project, client, issue)
       return :skipped if active_run_exists?(project, issue)
 
       # Escalate PRs that are repeatedly failing due to operational issues
@@ -1064,6 +1065,102 @@ module Activities
         .first
     end
 
+    def last_completed_focused_run(project, issue)
+      project.agent_runs
+        .where(
+          "source_pull_request_number = :pr_num OR pull_request_number = :pr_num",
+          pr_num: issue.github_number
+        )
+        .where(goal: "create_pr")
+        .where.not(focus: "general")
+        .completed
+        .order(completed_at: :desc)
+        .first
+    end
+
+    def record_focus_resolution(project, client, issue)
+      focused_run = last_completed_focused_run(project, issue)
+      return unless focused_run
+
+      score_updates = focus_resolution_scores(project, client, issue, focused_run)
+      return if score_updates.nil?
+
+      metric = QualityMetric.find_or_initialize_by(
+        agent_run: focused_run,
+        metric_type: "automated"
+      )
+      metric.assign_attributes(
+        prompt_version: focused_run.prompt_version,
+        feedback_source: "system",
+        scores: (metric.scores || {}).merge(score_updates)
+      )
+      metric.save! if metric.changed?
+
+      composite_score = QualityMetrics::CalculateCompositeScore.call(agent_run: focused_run)
+      return unless metric.composite_score != composite_score
+
+      metric.update!(composite_score:)
+    end
+
+    def focus_resolution_scores(project, client, issue, focused_run)
+      case focused_run.focus
+      when "ci_fix"
+        ci_focus_resolution_scores(project, client, issue)
+      when "review_feedback"
+        review_feedback_resolution_scores(project, client, issue)
+      when "merge_conflict"
+        merge_conflict_resolution_scores(project, client, issue)
+      when "conversation"
+        conversation_resolution_scores(project, client, issue, focused_run)
+      when "issue_implementation"
+        issue_implementation_resolution_scores(project, client, issue, focused_run)
+      when "label_action"
+        label_action_resolution_scores(project, issue)
+      end
+    end
+
+    def ci_focus_resolution_scores(project, client, issue)
+      pr_data = fetch_pr_data(client, project, issue)
+      checks = fetch_check_runs(client, project, pr_data)
+      return nil if checks.nil? || checks_pending?(checks)
+
+      score = all_checks_green?(checks) ? 1.0 : 0.0
+      { "focus_resolved" => score, "ci_passed" => score }
+    end
+
+    def review_feedback_resolution_scores(project, client, issue)
+      unresolved_threads = fetch_unresolved_threads(client, project, issue)
+      return nil if unresolved_threads.nil?
+
+      { "focus_resolved" => unresolved_threads.empty? ? 1.0 : 0.0 }
+    end
+
+    def merge_conflict_resolution_scores(project, client, issue)
+      pr_data = fetch_pr_data(client, project, issue)
+      return nil if pr_data.nil? || pr_data.mergeable.nil?
+
+      { "focus_resolved" => pr_data.mergeable ? 1.0 : 0.0 }
+    end
+
+    def conversation_resolution_scores(project, client, issue, focused_run)
+      triggers = check_conversation_comments(client, project, issue, focused_run)
+      { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
+    end
+
+    def issue_implementation_resolution_scores(project, client, issue, focused_run)
+      triggers = issue_implementation_triggers(project, client, issue, focused_run)
+      { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
+    end
+
+    def label_action_resolution_scores(project, issue)
+      triggers = check_actionable_labels(project, issue)
+      { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
+    end
+
+    def issue_implementation_triggers(_project, _client, _issue, _focused_run)
+      []
+    end
+
     def fetch_pr_data(client, project, issue)
       client.pull_request(project.full_name, issue.github_number)
     rescue GithubClient::Error => e
@@ -1168,6 +1265,13 @@ module Activities
       return true if checks.empty?
 
       checks.all? { |c| %w[success skipped neutral].include?(c[:conclusion]) }
+    end
+
+    def checks_pending?(checks)
+      Array(checks).any? do |check|
+        %w[queued in_progress pending requested waiting].include?(check[:status]) ||
+          check[:conclusion].blank?
+      end
     end
 
     # Returns pending-style triggers when an enabled non-bot review method

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1065,7 +1065,7 @@ module Activities
         .first
     end
 
-    def last_completed_focused_run(project, issue)
+    def completed_focused_runs_for(project, issue)
       project.agent_runs
         .where(
           "source_pull_request_number = :pr_num OR pull_request_number = :pr_num",
@@ -1075,11 +1075,21 @@ module Activities
         .where.not(focus: "general")
         .completed
         .order(completed_at: :desc)
-        .first
+    end
+
+    def last_unattributed_focused_run(project, issue)
+      completed_focused_runs_for(project, issue)
+        .includes(:quality_metrics)
+        .detect { |run| focus_resolution_pending?(run) }
+    end
+
+    def focus_resolution_pending?(focused_run)
+      metric = focused_run.quality_metrics.find { |quality_metric| quality_metric.metric_type == "automated" }
+      metric.blank? || !metric.scores.to_h.key?("focus_resolved")
     end
 
     def record_focus_resolution(project, client, issue)
-      focused_run = last_completed_focused_run(project, issue)
+      focused_run = last_unattributed_focused_run(project, issue)
       return unless focused_run
 
       score_updates = focus_resolution_scores(project, client, issue, focused_run)
@@ -1149,6 +1159,8 @@ module Activities
 
     def issue_implementation_resolution_scores(project, client, issue, focused_run)
       triggers = issue_implementation_triggers(project, client, issue, focused_run)
+      return nil if triggers.nil?
+
       { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
     end
 
@@ -1158,7 +1170,7 @@ module Activities
     end
 
     def issue_implementation_triggers(_project, _client, _issue, _focused_run)
-      []
+      nil
     end
 
     def fetch_pr_data(client, project, issue)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1135,11 +1135,6 @@ module Activities
         merge_conflict_resolution_scores(project, client, issue)
       when "conversation"
         conversation_resolution_scores(project, client, issue, focused_run)
-      when "issue_implementation"
-        # Deferred until the scanner has a concrete implementation-gap detector.
-        # Falling back to general create_pr scoring is less misleading than
-        # inventing a placeholder focus_resolved score.
-        issue_implementation_resolution_scores(project, client, issue, focused_run)
       when "label_action"
         label_action_resolution_scores(project, issue)
       end
@@ -1175,21 +1170,15 @@ module Activities
       { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
     end
 
-    def issue_implementation_resolution_scores(project, client, issue, focused_run)
-      triggers = issue_implementation_triggers(project, client, issue, focused_run)
-      return nil if triggers.nil?
-
-      { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
-    end
-
     def label_action_resolution_scores(project, issue)
       triggers = check_actionable_labels(project, issue)
       { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
     end
 
-    def issue_implementation_triggers(_project, _client, _issue, _focused_run)
-      nil
-    end
+    # issue_implementation focus uses the general create_pr scoring path until
+    # a concrete implementation-gap detector is built. See FOCUS_WEIGHTS in
+    # QualityMetric — issue_implementation is intentionally absent so it falls
+    # back to SCORE_WEIGHTS.
 
     def fetch_pr_data(client, project, issue)
       client.pull_request(project.full_name, issue.github_number)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -58,6 +58,7 @@ module Activities
       review_feedback
       merge_conflict
       conversation
+      issue_implementation
       label_action
     ].freeze
     FOCUS_PRIORITY = %w[
@@ -1135,6 +1136,8 @@ module Activities
         merge_conflict_resolution_scores(project, client, issue)
       when "conversation"
         conversation_resolution_scores(project, client, issue, focused_run)
+      when "issue_implementation"
+        issue_implementation_resolution_scores(project, client, issue, focused_run)
       when "label_action"
         label_action_resolution_scores(project, issue)
       end
@@ -1170,14 +1173,37 @@ module Activities
       { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
     end
 
+    def issue_implementation_resolution_scores(project, client, issue, focused_run)
+      pr_data = fetch_pr_data(client, project, issue)
+      return nil if pr_data.nil? || pr_data.mergeable.nil?
+
+      checks = fetch_check_runs(client, project, pr_data)
+      return nil if checks.nil? || checks_pending?(checks)
+
+      unresolved_threads = fetch_unresolved_threads(client, project, issue)
+      return nil if unresolved_threads.nil?
+
+      reviews = fetch_reviews(client, project, issue)
+      return nil if reviews.nil?
+
+      ci_passed = all_checks_green?(checks) ? 1.0 : 0.0
+      resolved = ci_passed == 1.0 &&
+        human_review_thread_triggers(project, unresolved_threads).empty? &&
+        changes_requested_from_reviews(project, reviews, focused_run).empty? &&
+        check_conversation_comments(client, project, issue, focused_run).empty? &&
+        check_actionable_labels(project, issue).empty? &&
+        check_merge_conflicts(project, pr_data).empty?
+
+      {
+        "focus_resolved" => resolved ? 1.0 : 0.0,
+        "ci_passed" => ci_passed
+      }
+    end
+
     def label_action_resolution_scores(project, issue)
       triggers = check_actionable_labels(project, issue)
       { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
     end
-
-    # issue_implementation uses focused collection weights, but scanner-side
-    # focus_resolved attribution remains deferred until a concrete
-    # implementation-gap detector exists.
 
     def fetch_pr_data(client, project, issue)
       client.pull_request(project.full_name, issue.github_number)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1175,10 +1175,9 @@ module Activities
       { "focus_resolved" => triggers.empty? ? 1.0 : 0.0 }
     end
 
-    # issue_implementation focus uses the general create_pr scoring path until
-    # a concrete implementation-gap detector is built. See FOCUS_WEIGHTS in
-    # QualityMetric — issue_implementation is intentionally absent so it falls
-    # back to SCORE_WEIGHTS.
+    # issue_implementation uses focused collection weights, but scanner-side
+    # focus_resolved attribution remains deferred until a concrete
+    # implementation-gap detector exists.
 
     def fetch_pr_data(client, project, issue)
       client.pull_request(project.full_name, issue.github_number)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -1084,10 +1084,10 @@ module Activities
         .order(completed_at: :desc)
     end
 
-    def last_unattributed_focused_run(project, issue)
+    def latest_completed_focused_run(project, issue)
       completed_focused_runs_for(project, issue)
         .includes(:quality_metrics)
-        .detect { |run| focus_resolution_pending?(run) }
+        .first
     end
 
     def focus_resolution_pending?(focused_run)
@@ -1102,8 +1102,8 @@ module Activities
     end
 
     def record_focus_resolution(project, client, issue)
-      focused_run = last_unattributed_focused_run(project, issue)
-      return unless focused_run
+      focused_run = latest_completed_focused_run(project, issue)
+      return unless focused_run && focus_resolution_pending?(focused_run)
 
       score_updates = focus_resolution_scores(project, client, issue, focused_run)
       return if score_updates.nil?

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -53,6 +53,13 @@ module Activities
       "review_goal_retry" => "review_feedback",
       "review_threads" => "review_feedback"
     }.freeze
+    FOCUS_RESOLUTION_ATTRIBUTION_FOCUSES = %w[
+      ci_fix
+      review_feedback
+      merge_conflict
+      conversation
+      label_action
+    ].freeze
     FOCUS_PRIORITY = %w[
       merge_conflict
       ci_fix
@@ -1084,8 +1091,14 @@ module Activities
     end
 
     def focus_resolution_pending?(focused_run)
+      return false unless focus_resolution_attribution_enabled?(focused_run.focus)
+
       metric = focused_run.quality_metrics.find { |quality_metric| quality_metric.metric_type == "automated" }
       metric.blank? || !metric.scores.to_h.key?("focus_resolved")
+    end
+
+    def focus_resolution_attribution_enabled?(focus)
+      FOCUS_RESOLUTION_ATTRIBUTION_FOCUSES.include?(focus.to_s)
     end
 
     def record_focus_resolution(project, client, issue)
@@ -1123,6 +1136,9 @@ module Activities
       when "conversation"
         conversation_resolution_scores(project, client, issue, focused_run)
       when "issue_implementation"
+        # Deferred until the scanner has a concrete implementation-gap detector.
+        # Falling back to general create_pr scoring is less misleading than
+        # inventing a placeholder focus_resolved score.
         issue_implementation_resolution_scores(project, client, issue, focused_run)
       when "label_action"
         label_action_resolution_scores(project, issue)

--- a/app/views/quality_dashboards/show.html.erb
+++ b/app/views/quality_dashboards/show.html.erb
@@ -149,9 +149,12 @@
                 <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= metric[:name] %></td>
                 <td class="px-4 py-3 text-sm text-gray-500"><%= metric[:description] %></td>
                 <td class="px-4 py-3 text-sm text-gray-500 text-right">
-                  <% if metric[:weights_by_goal].any? %>
+                  <% if metric[:weights_by_goal].any? || metric[:weights_by_focus].any? %>
                     <% metric[:weights_by_goal].each do |goal, weight| %>
                       <div class="whitespace-nowrap"><%= goal.titleize %>: <%= format("%.0f%%", weight * 100) %></div>
+                    <% end %>
+                    <% metric[:weights_by_focus].each do |focus, weight| %>
+                      <div class="whitespace-nowrap">Create Pr / <%= focus.titleize %>: <%= format("%.0f%%", weight * 100) %></div>
                     <% end %>
                   <% else %>
                     —

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -215,8 +215,8 @@ RSpec.describe QualityMetric do
       expect(described_class.weights_for(focus: "general")).to eq(described_class::SCORE_WEIGHTS)
     end
 
-    it "falls back to general create_pr weights for issue_implementation focus" do
-      expect(described_class.weights_for(focus: "issue_implementation")).to eq(described_class::SCORE_WEIGHTS)
+    it "returns focus-specific weights for issue_implementation focus" do
+      expect(described_class.weights_for(focus: "issue_implementation")).to eq(described_class::FOCUS_WEIGHTS["issue_implementation"])
     end
 
     it "returns goal-specific weights for non-create_pr goals" do

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -215,8 +215,8 @@ RSpec.describe QualityMetric do
       expect(described_class.weights_for(focus: "general")).to eq(described_class::SCORE_WEIGHTS)
     end
 
-    it "returns focus-specific weights for issue_implementation focus" do
-      expect(described_class.weights_for(focus: "issue_implementation")).to eq(described_class::FOCUS_WEIGHTS["issue_implementation"])
+    it "falls back to general weights for issue_implementation focus (no detector yet)" do
+      expect(described_class.weights_for(focus: "issue_implementation")).to eq(described_class::SCORE_WEIGHTS)
     end
 
     it "returns goal-specific weights for non-create_pr goals" do

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe QualityMetric do
 
       score = metric.calculate_composite_score
 
-      expect(score).to eq(0.95)
+      expect(score).to eq(0.9556)
     end
 
     it "calculates weighted average using goal-specific weights for create_pr" do

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -85,6 +85,19 @@ RSpec.describe QualityMetric do
   end
 
   describe "#calculate_composite_score" do
+    it "uses focus-specific weights for focused create_pr runs" do
+      agent_run = build(:agent_run, goal: "create_pr", focus: "review_feedback")
+      metric = build(:quality_metric, agent_run: agent_run, scores: {
+        "focus_resolved" => 1.0,
+        "iterations" => 0.8,
+        "lint_clean" => 1.0
+      })
+
+      score = metric.calculate_composite_score
+
+      expect(score).to eq(0.95)
+    end
+
     it "calculates weighted average using goal-specific weights for create_pr" do
       agent_run = build(:agent_run, goal: "create_pr")
       metric = build(:quality_metric, agent_run: agent_run, scores: {
@@ -190,6 +203,22 @@ RSpec.describe QualityMetric do
 
       # pr_created=0.25, ci_passed=0.15 -> (0.25*1.0 + 0.15*0.0) / 0.40 = 0.625
       expect(metric.reload.composite_score).to eq(0.625)
+    end
+  end
+
+  describe ".weights_for" do
+    it "returns focus-specific weights for focused create_pr runs" do
+      expect(described_class.weights_for(focus: "ci_fix")).to eq(described_class::FOCUS_WEIGHTS[:ci_fix])
+    end
+
+    it "returns general create_pr weights for general focus" do
+      expect(described_class.weights_for(focus: "general")).to eq(described_class::SCORE_WEIGHTS)
+    end
+
+    it "returns goal-specific weights for non-create_pr goals" do
+      expect(described_class.weights_for(goal: "review", focus: "review_feedback")).to eq(
+        described_class::GOAL_WEIGHTS["review"]
+      )
     end
   end
 end

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -215,6 +215,10 @@ RSpec.describe QualityMetric do
       expect(described_class.weights_for(focus: "general")).to eq(described_class::SCORE_WEIGHTS)
     end
 
+    it "falls back to general create_pr weights for issue_implementation focus" do
+      expect(described_class.weights_for(focus: "issue_implementation")).to eq(described_class::SCORE_WEIGHTS)
+    end
+
     it "returns goal-specific weights for non-create_pr goals" do
       expect(described_class.weights_for(goal: "review", focus: "review_feedback")).to eq(
         described_class::GOAL_WEIGHTS["review"]

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -215,8 +215,10 @@ RSpec.describe QualityMetric do
       expect(described_class.weights_for(focus: "general")).to eq(described_class::SCORE_WEIGHTS)
     end
 
-    it "falls back to general weights for issue_implementation focus (no detector yet)" do
-      expect(described_class.weights_for(focus: "issue_implementation")).to eq(described_class::SCORE_WEIGHTS)
+    it "returns focus-specific weights for issue_implementation focus" do
+      expect(described_class.weights_for(focus: "issue_implementation")).to eq(
+        described_class::FOCUS_WEIGHTS["issue_implementation"]
+      )
     end
 
     it "returns goal-specific weights for non-create_pr goals" do

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -206,9 +206,9 @@ RSpec.describe QualityMetric do
     end
   end
 
-  describe ".weights_for" do
+  describe ".weights_for", :no_db do
     it "returns focus-specific weights for focused create_pr runs" do
-      expect(described_class.weights_for(focus: "ci_fix")).to eq(described_class::FOCUS_WEIGHTS[:ci_fix])
+      expect(described_class.weights_for(focus: "ci_fix")).to eq(described_class::FOCUS_WEIGHTS["ci_fix"])
     end
 
     it "returns general create_pr weights for general focus" do

--- a/spec/services/quality_metrics/calculate_composite_score_spec.rb
+++ b/spec/services/quality_metrics/calculate_composite_score_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe QualityMetrics::CalculateCompositeScore do
 
       score = described_class.call(agent_run: agent_run)
 
-      expect(score).to eq(0.95)
+      expect(score).to eq(0.9556)
     end
   end
 end

--- a/spec/services/quality_metrics/calculate_composite_score_spec.rb
+++ b/spec/services/quality_metrics/calculate_composite_score_spec.rb
@@ -3,6 +3,49 @@
 require "rails_helper"
 
 RSpec.describe QualityMetrics::CalculateCompositeScore do
+  def build_fake_quality_metric_class
+    Class.new do
+      def self.where(agent_run_id:)
+        raise "unexpected agent_run_id: #{agent_run_id}" unless agent_run_id == 123
+
+        [
+          Struct.new(:scores).new({
+            "focus_resolved" => 1.0,
+            "ci_passed" => 1.0,
+            "iterations" => 0.9
+          })
+        ]
+      end
+
+      def self.weights_for(goal:, focus:)
+        raise "unexpected goal: #{goal}" unless goal == "create_pr"
+        raise "unexpected focus: #{focus}" unless focus == "ci_fix"
+
+        {
+          "ci_passed" => 0.50,
+          "lint_clean" => 0.20,
+          "tests_pass" => 0.20,
+          "iterations" => 0.10
+        }
+      end
+
+      def self.weighted_average(scores_hash, weights:)
+        total_weight = 0.0
+        weighted_sum = 0.0
+
+        scores_hash.each do |key, value|
+          weight = weights[key]
+          next unless weight
+
+          total_weight += weight
+          weighted_sum += weight * value.to_f
+        end
+
+        (weighted_sum / total_weight).round(4)
+      end
+    end
+  end
+
   describe ".call" do
     it "merges automated and human scores into a composite" do
       agent_run = create(:agent_run, :completed)
@@ -60,6 +103,19 @@ RSpec.describe QualityMetrics::CalculateCompositeScore do
       score = described_class.call(agent_run: agent_run)
 
       expect(score).to eq(0.9556)
+    end
+  end
+
+  describe "#calculate", :no_db do
+    it "reads fresh metrics instead of a stale preloaded association cache" do
+      stale_association = Struct.new(:to_a).new([])
+      agent_run = Struct.new(:id, :goal, :focus, :quality_metrics)
+        .new(123, "create_pr", "ci_fix", stale_association)
+      stub_const("QualityMetric", build_fake_quality_metric_class)
+
+      score = described_class.call(agent_run: agent_run)
+
+      expect(score).to eq(0.9833)
     end
   end
 end

--- a/spec/services/quality_metrics/calculate_composite_score_spec.rb
+++ b/spec/services/quality_metrics/calculate_composite_score_spec.rb
@@ -48,5 +48,18 @@ RSpec.describe QualityMetrics::CalculateCompositeScore do
       # 0.25/0.40 = 0.625
       expect(score).to eq(0.625)
     end
+
+    it "uses focus-specific weights for focused create_pr runs" do
+      agent_run = create(:agent_run, :completed, focus: "review_feedback")
+      create(:quality_metric, :automated, agent_run: agent_run, scores: {
+        "focus_resolved" => 1.0,
+        "iterations" => 0.8,
+        "lint_clean" => 1.0
+      })
+
+      score = described_class.call(agent_run: agent_run)
+
+      expect(score).to eq(0.95)
+    end
   end
 end

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -180,16 +180,10 @@ RSpec.describe QualityMetrics::Collect do
     context "with issue_implementation focus" do
       let(:agent_run) { create(:agent_run, :completed, focus: "issue_implementation", iterations: 3) }
 
-      it "uses focused scoring for issue_implementation runs" do
+      it "uses general create_pr scoring until focus attribution exists" do
         metric = described_class.call(agent_run: agent_run)
 
-        expect(metric.scores).to include("iterations", "lint_clean")
-        expect(metric.scores).not_to include(
-          "pr_created",
-          "pr_merged",
-          "review_comment_count",
-          "agent_rerun_count"
-        )
+        expect(metric.scores).to include("pr_created", "iterations")
       end
     end
 

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -180,10 +180,16 @@ RSpec.describe QualityMetrics::Collect do
     context "with issue_implementation focus" do
       let(:agent_run) { create(:agent_run, :completed, focus: "issue_implementation", iterations: 3) }
 
-      it "uses general create_pr scoring until focus attribution exists" do
+      it "uses focused scoring for issue_implementation runs" do
         metric = described_class.call(agent_run: agent_run)
 
-        expect(metric.scores).to include("pr_created", "iterations")
+        expect(metric.scores).to include("iterations", "lint_clean")
+        expect(metric.scores).not_to include(
+          "pr_created",
+          "pr_merged",
+          "review_comment_count",
+          "agent_rerun_count"
+        )
       end
     end
 

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -180,11 +180,16 @@ RSpec.describe QualityMetrics::Collect do
     context "with issue_implementation focus" do
       let(:agent_run) { create(:agent_run, :completed, focus: "issue_implementation", iterations: 3) }
 
-      it "falls back to general create_pr scoring until focus attribution exists" do
+      it "uses focused scoring for issue_implementation runs" do
         metric = described_class.call(agent_run: agent_run)
 
-        expect(metric.scores).to include("pr_created", "iterations", "lint_clean", "agent_rerun_count")
-        expect(metric.scores).not_to include("focus_resolved")
+        expect(metric.scores).to include("iterations", "lint_clean")
+        expect(metric.scores).not_to include(
+          "pr_created",
+          "pr_merged",
+          "review_comment_count",
+          "agent_rerun_count"
+        )
       end
     end
 

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -177,6 +177,17 @@ RSpec.describe QualityMetrics::Collect do
       end
     end
 
+    context "with issue_implementation focus" do
+      let(:agent_run) { create(:agent_run, :completed, focus: "issue_implementation", iterations: 3) }
+
+      it "falls back to general create_pr scoring until focus attribution exists" do
+        metric = described_class.call(agent_run: agent_run)
+
+        expect(metric.scores).to include("pr_created", "iterations", "lint_clean", "agent_rerun_count")
+        expect(metric.scores).not_to include("focus_resolved")
+      end
+    end
+
     context "with create_issue goal" do
       let(:agent_run) do
         create(:agent_run, :with_created_issue, status: "completed",

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -155,6 +155,28 @@ RSpec.describe QualityMetrics::Collect do
       end
     end
 
+    context "with focused create_pr goal" do
+      let(:agent_run) { create(:agent_run, :completed, focus: "ci_fix", iterations: 3) }
+
+      it "uses focus-specific weights for the composite score" do
+        metric = described_class.call(agent_run: agent_run)
+
+        expect(metric.composite_score).to eq(0.9333)
+      end
+
+      it "skips irrelevant general PR metrics" do
+        metric = described_class.call(agent_run: agent_run)
+
+        expect(metric.scores).to include("iterations", "lint_clean")
+        expect(metric.scores).not_to include(
+          "pr_created",
+          "pr_merged",
+          "review_comment_count",
+          "agent_rerun_count"
+        )
+      end
+    end
+
     context "with create_issue goal" do
       let(:agent_run) do
         create(:agent_run, :with_created_issue, status: "completed",

--- a/spec/services/quality_metrics/dashboard_stats_spec.rb
+++ b/spec/services/quality_metrics/dashboard_stats_spec.rb
@@ -12,15 +12,13 @@ RSpec.describe QualityMetrics::DashboardStats do
 
       expect(ci_passed[:weights_by_focus]).to eq(
         "ci_fix" => 0.50,
-        "merge_conflict" => 0.15,
-        "issue_implementation" => 0.15
+        "merge_conflict" => 0.15
       )
       expect(focus_resolved[:weights_by_focus]).to eq(
         "review_feedback" => 0.60,
         "merge_conflict" => 0.70,
         "conversation" => 0.60,
-        "label_action" => 0.60,
-        "issue_implementation" => 0.50
+        "label_action" => 0.60
       )
     end
   end
@@ -184,15 +182,13 @@ RSpec.describe QualityMetrics::DashboardStats do
       expect(pr_created[:goal_types]).to include("create_pr")
       expect(ci_passed[:weights_by_focus]).to eq(
         "ci_fix" => 0.50,
-        "merge_conflict" => 0.15,
-        "issue_implementation" => 0.15
+        "merge_conflict" => 0.15
       )
       expect(focus_resolved[:weights_by_focus]).to eq(
         "review_feedback" => 0.60,
         "merge_conflict" => 0.70,
         "conversation" => 0.60,
-        "label_action" => 0.60,
-        "issue_implementation" => 0.50
+        "label_action" => 0.60
       )
     end
 

--- a/spec/services/quality_metrics/dashboard_stats_spec.rb
+++ b/spec/services/quality_metrics/dashboard_stats_spec.rb
@@ -142,26 +142,44 @@ RSpec.describe QualityMetrics::DashboardStats do
       end
     end
 
-    it "includes metrics reference in response" do
+    it "includes the metrics reference collection in the response" do
       result = described_class.call(project: project)
 
       expect(result[:metrics_reference]).to be_an(Array)
       expect(result[:metrics_reference].size).to be > 0
+    end
+
+    it "includes goal and focus weight metadata for create_pr metrics" do
+      result = described_class.call(project: project)
 
       pr_created = result[:metrics_reference].find { |m| m[:key] == "pr_created" }
+      ci_passed = result[:metrics_reference].find { |m| m[:key] == "ci_passed" }
+      focus_resolved = result[:metrics_reference].find { |m| m[:key] == "focus_resolved" }
+
       expect(pr_created[:name]).to eq("PR Created")
       expect(pr_created[:weights_by_goal]).to eq("create_pr" => 0.25)
+      expect(pr_created[:weights_by_focus]).to eq({})
       expect(pr_created[:goal_types]).to include("create_pr")
+      expect(ci_passed[:weights_by_focus]).to eq("ci_fix" => 0.50, "merge_conflict" => 0.15)
+      expect(focus_resolved[:weights_by_focus]).to eq(
+        "review_feedback" => 0.60,
+        "merge_conflict" => 0.70,
+        "conversation" => 0.60,
+        "label_action" => 0.60
+      )
+    end
+
+    it "includes goal metadata for non-create_pr metrics" do
+      result = described_class.call(project: project)
 
       issue_created = result[:metrics_reference].find { |m| m[:key] == "issue_created" }
-      expect(issue_created[:goal_types]).to include("create_issue")
-
       review_posted = result[:metrics_reference].find { |m| m[:key] == "review_posted" }
-      expect(review_posted[:goal_types]).to include("review")
-
-      # reaction_score is collected for all goals but is not weighted for create_pr
       reaction = result[:metrics_reference].find { |m| m[:key] == "reaction_score" }
+
+      expect(issue_created[:goal_types]).to include("create_issue")
+      expect(review_posted[:goal_types]).to include("review")
       expect(reaction[:weights_by_goal]).to eq("create_issue" => 0.60, "review" => 0.60, "enhance_issue" => 0.35)
+      expect(reaction[:weights_by_focus]).to eq({})
       expect(reaction[:goal_types]).to contain_exactly("create_pr", "create_issue", "review", "enhance_issue")
     end
 

--- a/spec/services/quality_metrics/dashboard_stats_spec.rb
+++ b/spec/services/quality_metrics/dashboard_stats_spec.rb
@@ -3,6 +3,28 @@
 require "rails_helper"
 
 RSpec.describe QualityMetrics::DashboardStats do
+  describe ".metrics_reference", :no_db do
+    it "includes focus-specific weights for create_pr metrics" do
+      result = described_class.metrics_reference
+
+      ci_passed = result.find { |metric| metric[:key] == "ci_passed" }
+      focus_resolved = result.find { |metric| metric[:key] == "focus_resolved" }
+
+      expect(ci_passed[:weights_by_focus]).to eq(
+        "ci_fix" => 0.50,
+        "merge_conflict" => 0.15,
+        "issue_implementation" => 0.15
+      )
+      expect(focus_resolved[:weights_by_focus]).to eq(
+        "review_feedback" => 0.60,
+        "merge_conflict" => 0.70,
+        "conversation" => 0.60,
+        "label_action" => 0.60,
+        "issue_implementation" => 0.50
+      )
+    end
+  end
+
   describe ".overview" do
     let(:project) { create(:project) }
 
@@ -160,12 +182,17 @@ RSpec.describe QualityMetrics::DashboardStats do
       expect(pr_created[:weights_by_goal]).to eq("create_pr" => 0.25)
       expect(pr_created[:weights_by_focus]).to eq({})
       expect(pr_created[:goal_types]).to include("create_pr")
-      expect(ci_passed[:weights_by_focus]).to eq("ci_fix" => 0.50, "merge_conflict" => 0.15)
+      expect(ci_passed[:weights_by_focus]).to eq(
+        "ci_fix" => 0.50,
+        "merge_conflict" => 0.15,
+        "issue_implementation" => 0.15
+      )
       expect(focus_resolved[:weights_by_focus]).to eq(
         "review_feedback" => 0.60,
         "merge_conflict" => 0.70,
         "conversation" => 0.60,
-        "label_action" => 0.60
+        "label_action" => 0.60,
+        "issue_implementation" => 0.50
       )
     end
 

--- a/spec/services/quality_metrics/dashboard_stats_spec.rb
+++ b/spec/services/quality_metrics/dashboard_stats_spec.rb
@@ -12,13 +12,15 @@ RSpec.describe QualityMetrics::DashboardStats do
 
       expect(ci_passed[:weights_by_focus]).to eq(
         "ci_fix" => 0.50,
-        "merge_conflict" => 0.15
+        "merge_conflict" => 0.15,
+        "issue_implementation" => 0.15
       )
       expect(focus_resolved[:weights_by_focus]).to eq(
         "review_feedback" => 0.60,
         "merge_conflict" => 0.70,
         "conversation" => 0.60,
-        "label_action" => 0.60
+        "label_action" => 0.60,
+        "issue_implementation" => 0.50
       )
     end
   end
@@ -182,13 +184,15 @@ RSpec.describe QualityMetrics::DashboardStats do
       expect(pr_created[:goal_types]).to include("create_pr")
       expect(ci_passed[:weights_by_focus]).to eq(
         "ci_fix" => 0.50,
-        "merge_conflict" => 0.15
+        "merge_conflict" => 0.15,
+        "issue_implementation" => 0.15
       )
       expect(focus_resolved[:weights_by_focus]).to eq(
         "review_feedback" => 0.60,
         "merge_conflict" => 0.70,
         "conversation" => 0.60,
-        "label_action" => 0.60
+        "label_action" => 0.60,
+        "issue_implementation" => 0.50
       )
     end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_focus_resolution_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_focus_resolution_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::ScanPaidPrsActivity do
+  describe "#review_feedback_resolution_scores", :no_db do
+    let(:activity) { described_class.new }
+    let(:project) { instance_double(ProjectDouble) }
+    let(:client) { instance_double(GithubClientDouble) }
+    let(:issue) { instance_double(IssueDouble) }
+    let(:focused_run) { instance_double(AgentRunDouble) }
+    let(:pr_data) { instance_double(PrDataDouble) }
+    let(:checks) { [ { name: "ci", conclusion: "success" } ] }
+    let(:reviews) { [ { user_login: "paid-code-reviewer[bot]", state: "COMMENTED" } ] }
+    let(:unresolved_threads) { [] }
+
+    before do
+      stub_const("ProjectDouble", Class.new)
+      stub_const("GithubClientDouble", Class.new)
+      stub_const("IssueDouble", Class.new)
+      stub_const("AgentRunDouble", Class.new)
+      stub_const("PrDataDouble", Class.new)
+      allow(activity).to receive(:fetch_pr_data).with(client, project, issue).and_return(pr_data)
+      allow(activity).to receive(:fetch_check_runs).with(client, project, pr_data).and_return(checks)
+      allow(activity).to receive(:fetch_reviews).with(client, project, issue).and_return(reviews)
+      allow(activity).to receive(:fetch_unresolved_threads).with(client, project, issue).and_return(unresolved_threads)
+      allow(activity).to receive(:human_review_thread_triggers).with(project, unresolved_threads).and_return([])
+      allow(activity).to receive(:check_non_enabled_bot_reviews)
+        .with(reviews, unresolved_threads, project:, last_run: focused_run, client:, issue:)
+        .and_return([])
+      allow(activity).to receive(:changes_requested_from_reviews).with(project, reviews, focused_run).and_return([])
+      allow(activity).to receive(:check_conversation_comments).with(client, project, issue, focused_run).and_return([])
+      allow(activity).to receive(:non_bot_review_gate_triggers)
+        .with(project, issue, pr_data, reviews, checks)
+        .and_return([])
+    end
+
+    it "returns 0.0 when body-only review feedback is still pending" do
+      allow(activity).to receive(:check_review_bot_status)
+        .with(reviews, unresolved_threads, project:, last_run: focused_run, client:, issue:)
+        .and_return([ { type: "review_bot_comments" } ])
+
+      result = activity.send(:review_feedback_resolution_scores, project, client, issue, focused_run)
+
+      expect(result).to eq("focus_resolved" => 0.0)
+    end
+
+    it "returns 1.0 when no review feedback signals remain" do
+      allow(activity).to receive(:check_review_bot_status)
+        .with(reviews, unresolved_threads, project:, last_run: focused_run, client:, issue:)
+        .and_return([])
+
+      result = activity.send(:review_feedback_resolution_scores, project, client, issue, focused_run)
+
+      expect(result).to eq("focus_resolved" => 1.0)
+    end
+
+    it "defers attribution when required review data cannot be fetched" do
+      allow(activity).to receive(:fetch_reviews).with(client, project, issue).and_return(nil)
+
+      result = activity.send(:review_feedback_resolution_scores, project, client, issue, focused_run)
+
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -670,17 +670,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           composite_score: 1.0)
       end
 
-      it "records 0.0 when implementation-gap triggers remain" do
-        stub_github_for_pr
-        allow(activity).to receive(:issue_implementation_triggers)
-          .and_return([ { type: "issue_implementation_gap" } ])
-
-        activity.execute(project_id: project.id)
-
-        expect(metric.reload.scores["focus_resolved"]).to eq(0.0)
-      end
-
-      it "defers recording when implementation-gap detection is unavailable" do
+      it "defers focus attribution until implementation-gap detection exists" do
         stub_github_for_pr
 
         activity.execute(project_id: project.id)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -520,6 +520,22 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(metric.reload.scores).not_to include("focus_resolved", "ci_passed")
         expect(metric.composite_score).to eq(0.9)
       end
+
+      it "does not overwrite an existing focus_resolved score on later scans" do
+        metric.update!(
+          scores: metric.scores.merge("focus_resolved" => 1.0, "ci_passed" => 1.0),
+          composite_score: 0.9833
+        )
+        stub_github_for_pr(checks: [ { name: "ci", conclusion: "failure" } ])
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores).to include(
+          "focus_resolved" => 1.0,
+          "ci_passed" => 1.0
+        )
+        expect(metric.composite_score).to eq(0.9833)
+      end
     end
 
     context "when attributing focus resolution for a review_feedback run" do
@@ -651,6 +667,15 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         activity.execute(project_id: project.id)
 
         expect(metric.reload.scores["focus_resolved"]).to eq(0.0)
+      end
+
+      it "defers recording when implementation-gap detection is unavailable" do
+        stub_github_for_pr
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores).not_to include("focus_resolved")
+        expect(metric.composite_score).to eq(1.0)
       end
     end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -584,6 +584,26 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         expect(metric.reload.scores["focus_resolved"]).to eq(0.0)
       end
+
+      it "does not backfill an older focused run once a newer focused run exists" do
+        older_metric = metric
+        newer_run = create(:agent_run, :completed,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          focus: "ci_fix",
+          completed_at: 5.minutes.ago)
+        create(:quality_metric, :automated,
+          agent_run: newer_run,
+          scores: { "iterations" => 1.0 },
+          composite_score: 1.0)
+
+        stub_github_for_pr(checks: [ { name: "ci", conclusion: "success" } ])
+
+        activity.execute(project_id: project.id)
+
+        expect(older_metric.reload.scores).not_to include("focus_resolved")
+      end
     end
 
     context "when attributing focus resolution for a merge_conflict run" do

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -479,6 +479,214 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when attributing focus resolution for a ci_fix run" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+      end
+      let!(:focused_run) do
+        create(:agent_run, :completed,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          focus: "ci_fix",
+          iterations: 2)
+      end
+      let!(:metric) do
+        create(:quality_metric, :automated,
+          agent_run: focused_run,
+          scores: { "iterations" => 0.9 },
+          composite_score: 0.9)
+      end
+
+      it "records focus_resolved and recalculates the composite when CI is green" do
+        stub_github_for_pr(checks: [ { name: "ci", conclusion: "success" } ])
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores).to include(
+          "focus_resolved" => 1.0,
+          "ci_passed" => 1.0
+        )
+        expect(metric.composite_score).to eq(0.9833)
+      end
+
+      it "defers recording while CI is still pending" do
+        stub_github_for_pr(checks: [ { name: "ci", conclusion: nil } ])
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores).not_to include("focus_resolved", "ci_passed")
+        expect(metric.composite_score).to eq(0.9)
+      end
+    end
+
+    context "when attributing focus resolution for a review_feedback run" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+      end
+      let!(:focused_run) do
+        create(:agent_run, :completed,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          focus: "review_feedback")
+      end
+      let!(:metric) do
+        create(:quality_metric, :automated,
+          agent_run: focused_run,
+          scores: { "iterations" => 1.0, "lint_clean" => 1.0 },
+          composite_score: 1.0)
+      end
+
+      it "records 0.0 when unresolved threads remain" do
+        stub_github_for_pr(
+          review_threads: [
+            {
+              id: "thread_1",
+              is_resolved: false,
+              comments: [ { body: "Please fix this", path: "app/model.rb", line: 10, author: "viamin" } ]
+            }
+          ]
+        )
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores["focus_resolved"]).to eq(0.0)
+      end
+    end
+
+    context "when attributing focus resolution for a merge_conflict run" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+      end
+      let!(:focused_run) do
+        create(:agent_run, :completed,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          focus: "merge_conflict")
+      end
+      let!(:metric) do
+        create(:quality_metric, :automated,
+          agent_run: focused_run,
+          scores: { "iterations" => 1.0 },
+          composite_score: 1.0)
+      end
+
+      it "records 1.0 when the PR is mergeable again" do
+        stub_github_for_pr(mergeable: true)
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores["focus_resolved"]).to eq(1.0)
+      end
+    end
+
+    context "when attributing focus resolution for a conversation run" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+      end
+      let!(:focused_run) do
+        create(:agent_run, :completed,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          focus: "conversation",
+          completed_at: 30.minutes.ago)
+      end
+      let!(:metric) do
+        create(:quality_metric, :automated,
+          agent_run: focused_run,
+          scores: { "iterations" => 1.0, "lint_clean" => 1.0 },
+          composite_score: 1.0)
+      end
+
+      it "records 1.0 when no actionable comments remain" do
+        old_comment = OpenStruct.new(
+          user: OpenStruct.new(login: "viamin"),
+          body: "Already addressed in the last run",
+          created_at: 2.hours.ago
+        )
+        stub_github_for_pr(issue_comments: [ old_comment ])
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores["focus_resolved"]).to eq(1.0)
+      end
+    end
+
+    context "when attributing focus resolution for an issue_implementation run" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+      end
+      let!(:focused_run) do
+        create(:agent_run, :completed,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          focus: "issue_implementation")
+      end
+      let!(:metric) do
+        create(:quality_metric, :automated,
+          agent_run: focused_run,
+          scores: { "iterations" => 1.0, "lint_clean" => 1.0 },
+          composite_score: 1.0)
+      end
+
+      it "records 0.0 when implementation-gap triggers remain" do
+        stub_github_for_pr
+        allow(activity).to receive(:issue_implementation_triggers)
+          .and_return([ { type: "issue_implementation_gap" } ])
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores["focus_resolved"]).to eq(0.0)
+      end
+    end
+
+    context "when attributing focus resolution for a label_action run" do
+      let!(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed")
+      end
+      let!(:focused_run) do
+        create(:agent_run, :completed,
+          project: project,
+          issue: pr_issue,
+          source_pull_request_number: 42,
+          focus: "label_action")
+      end
+      let!(:metric) do
+        create(:quality_metric, :automated,
+          agent_run: focused_run,
+          scores: { "iterations" => 1.0, "lint_clean" => 1.0 },
+          composite_score: 1.0)
+      end
+
+      before do
+        project.update!(pr_action_labels: [ "needs-docs" ])
+      end
+
+      it "records 1.0 when actionable labels are gone" do
+        stub_github_for_pr
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores["focus_resolved"]).to eq(1.0)
+      end
+    end
+
     context "when checks are still pending" do
       before do
         create(:issue, :pull_request,

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -690,12 +690,15 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           composite_score: 1.0)
       end
 
-      it "skips focus attribution — issue_implementation uses general scoring" do
+      it "records focus_resolved once follow-up signals are cleared" do
         stub_github_for_pr
 
         activity.execute(project_id: project.id)
 
-        expect(metric.reload.scores).not_to include("focus_resolved")
+        expect(metric.reload.scores).to include(
+          "focus_resolved" => 1.0,
+          "ci_passed" => 1.0
+        )
         expect(metric.composite_score).to eq(1.0)
       end
     end

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -521,6 +521,17 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(metric.composite_score).to eq(0.9)
       end
 
+      it "defers recording when PR data cannot be fetched" do
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, 42)
+          .and_raise(GithubClient::Error, "GitHub API unavailable")
+
+        activity.execute(project_id: project.id)
+
+        expect(metric.reload.scores).not_to include("focus_resolved", "ci_passed")
+        expect(metric.composite_score).to eq(0.9)
+      end
+
       it "does not overwrite an existing focus_resolved score on later scans" do
         metric.update!(
           scores: metric.scores.merge("focus_resolved" => 1.0, "ci_passed" => 1.0),

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -587,6 +587,10 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "does not backfill an older focused run once a newer focused run exists" do
         older_metric = metric
+        focused_run.update!(
+          started_at: 15.minutes.ago,
+          completed_at: 10.minutes.ago
+        )
         newer_run = create(:agent_run, :completed,
           project: project,
           issue: pr_issue,

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -650,7 +650,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
-    context "when attributing focus resolution for an issue_implementation run" do
+    context "when an issue_implementation run exists" do
       let!(:pr_issue) do
         create(:issue, :pull_request,
           project: project, github_number: 42,
@@ -670,7 +670,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           composite_score: 1.0)
       end
 
-      it "defers focus attribution until implementation-gap detection exists" do
+      it "skips focus attribution — issue_implementation uses general scoring" do
         stub_github_for_pr
 
         activity.execute(project_id: project.id)


### PR DESCRIPTION
## Summary

Implement focus-scoped quality scoring so that focused agent runs (CI fixes, review feedback, merge conflicts, etc.) are evaluated against weights and metrics that reflect their actual goal, rather than the generic `create_pr` profile. Adds a `focus_resolved` metric and scanner-side attribution so we can measure whether a focused run actually fixed its target issue. Part of the Focused Agent Runs initiative ([RDR-031](../blob/main/docs/rdrs/RDR-031-focused-agent-runs.md)).

## Changes

- **Models**
  - `app/models/quality_metric.rb`: Add `FOCUS_WEIGHTS` map (ci_fix, review_feedback, merge_conflict, conversation, issue_implementation, label_action) and a `weights_for(focus:)` class method that falls back to existing `SCORE_WEIGHTS` for general runs.
- **Services**
  - `app/services/quality_metrics/collect.rb`: Branch on `agent_run.focused?` to select focus-specific weights and a `build_focused_scores` path that skips irrelevant metrics (e.g., no `pr_merged`/`review_comment_count` for a `ci_fix` run).
  - `app/services/quality_metrics/calculate_composite_score.rb`: Use focus-specific weights when recomputing composite scores so attribution updates propagate correctly.
  - `app/services/quality_metrics/dashboard_stats.rb`: Update metric metadata to surface `focus_resolved` alongside existing metrics.
- **Scanner**
  - `app/temporal/activities/scan_paid_prs_activity.rb`: Add `record_focus_resolution` at the start of `scan_pr`. Looks up the last completed focused run for the PR, compares current PR state against the run's focus, writes `focus_resolved` (1.0/0.0) to the run's `QualityMetric`, and triggers composite-score recalculation. Defers recording for `ci_fix` while CI checks are still `queued`/`in_progress`.
- **Tests**
  - Added spec coverage for `weights_for`, focus-aware collection, composite recalculation, and scanner attribution for each focus type.

## Design Decisions

- **Hard-coded weight maps**: `FOCUS_WEIGHTS` lives as a frozen constant rather than per-project/account configuration. Keeps the first cut simple; configurable weights are explicitly deferred.
- **Skip vs. zero for irrelevant metrics**: Focused runs omit irrelevant metrics entirely (e.g., `pr_merged` for `ci_fix`) instead of scoring them as 0, so they don't drag composite scores down for metrics the run was never trying to influence.
- **Deferred CI attribution**: When CI is still in flight, the scanner defers `focus_resolved` rather than recording a premature 0.0. Attribution settles naturally on the next scan cycle once checks reach a terminal state.
- **No changes to quality gates**: Gate/pause logic works automatically through the recalculated composite score — no separate code path needed.

## Operational Notes

- No migrations. Existing general (non-focused) runs continue to use `SCORE_WEIGHTS` and produce identical scores.
- `focus_resolved` is recorded on the next scanner cycle after a focused run completes; expect a short lag between run completion and the metric appearing.
- RSpec was not run locally because PostgreSQL was unavailable in the dev container (`ActiveRecord::ConnectionNotEstablished`); CI must be green before merge.

---

Closes #1989