### PR TITLE
feat(prompts): Focused prompt scoping — single-problem sections + other-issues context

### DIFF
--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -45,7 +45,7 @@ module Prompts
     end
 
     def includes_review_threads?
-      include_section?(:code_review) && unresolved_threads.any?
+      include_section?(:code_review) && review_threads_present?
     end
 
     def unresolved_review_thread_ids
@@ -136,14 +136,18 @@ module Prompts
     end
 
     def priority_list
-      return focused_priority_list if focused?
+      return focused_priority_list if use_focused_priority_list?
 
+      dynamic_priority_list
+    end
+
+    def dynamic_priority_list
       priorities = []
-      priorities << "Resolve merge conflicts" unless rebase_succeeded
-      priorities << "Fix CI failures" if ci_failure_context.failing?
-      priorities << "Close implementation gaps against the linked issue" if linked_issue?
-      priorities << "Address code review comments" if includes_review_threads?
-      priorities << "Address conversation comments" if trusted_comments.any?
+      priorities << "Resolve merge conflicts" if merge_conflicts_present?
+      priorities << "Fix CI failures" if ci_failures_present?
+      priorities << "Close implementation gaps against the linked issue" if issue_requirements_present?
+      priorities << "Address code review comments" if review_threads_present?
+      priorities << "Address conversation comments" if conversation_comments_present?
       priorities.each_with_index.map { |p, i| "#{i + 1}. #{p}" }.join("\n")
     end
 
@@ -387,19 +391,53 @@ module Prompts
     end
 
     def include_issue_requirements_section?
-      include_section?(:issue_requirements) && linked_issue?
+      include_section?(:issue_requirements) && issue_requirements_present?
     end
 
     def include_merge_conflicts_section?
-      include_section?(:merge_conflicts) && !rebase_succeeded
+      include_section?(:merge_conflicts) && merge_conflicts_present?
     end
 
     def include_ci_failures_section?
-      include_section?(:ci_failures) && ci_failure_context.failing?
+      include_section?(:ci_failures) && ci_failures_present?
     end
 
     def include_conversation_section?
-      include_section?(:conversation) && trusted_comments.any?
+      include_section?(:conversation) && conversation_comments_present?
+    end
+
+    def merge_conflicts_present?
+      !rebase_succeeded
+    end
+
+    def ci_failures_present?
+      ci_failure_context.failing?
+    end
+
+    def issue_requirements_present?
+      linked_issue?
+    end
+
+    def review_threads_present?
+      unresolved_threads.any?
+    end
+
+    def conversation_comments_present?
+      trusted_comments.any?
+    end
+
+    def use_focused_priority_list?
+      focused_priority_section_present? || focus == "label_action"
+    end
+
+    def focused_priority_section_present?
+      {
+        "ci_fix" => include_ci_failures_section?,
+        "review_feedback" => includes_review_threads?,
+        "merge_conflict" => include_merge_conflicts_section?,
+        "conversation" => include_conversation_section?,
+        "issue_implementation" => include_issue_requirements_section?
+      }.fetch(focus, false)
     end
 
     def focused_priority_list
@@ -419,11 +457,11 @@ module Prompts
 
     def deferred_issue_descriptions
       descriptions = []
-      descriptions << "merge conflicts with the base branch" if defer_issue?(:merge_conflicts) && !rebase_succeeded
-      descriptions << "failing CI checks" if defer_issue?(:ci_failures) && ci_failure_context.failing?
-      descriptions << "implementation gaps against the linked issue" if defer_issue?(:issue_requirements) && linked_issue?
-      descriptions << "unresolved code review comments" if defer_issue?(:code_review) && unresolved_threads.any?
-      descriptions << "actionable conversation comments" if defer_issue?(:conversation) && trusted_comments.any?
+      descriptions << "merge conflicts with the base branch" if defer_issue?(:merge_conflicts) && merge_conflicts_present?
+      descriptions << "failing CI checks" if defer_issue?(:ci_failures) && ci_failures_present?
+      descriptions << "implementation gaps against the linked issue" if defer_issue?(:issue_requirements) && issue_requirements_present?
+      descriptions << "unresolved code review comments" if defer_issue?(:code_review) && review_threads_present?
+      descriptions << "actionable conversation comments" if defer_issue?(:conversation) && conversation_comments_present?
       descriptions
     end
 

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -24,10 +24,11 @@ module Prompts
     ALREADY_ADDRESSED_MARKER = "PAID_REVIEW_THREADS_ALREADY_ADDRESSED"
 
     attr_reader :project, :pr_number, :github_client, :rebase_succeeded,
-                :lint_command, :test_command, :issue, :prompt_version
+                :lint_command, :test_command, :issue, :prompt_version, :focus
 
     def initialize(project:, pr_number:, github_client:, rebase_succeeded:,
-                   lint_command: nil, test_command: nil, issue: nil, prompt_version: nil)
+                   lint_command: nil, test_command: nil, issue: nil, prompt_version: nil,
+                   focus: "general")
       @project = project
       @pr_number = pr_number
       @github_client = github_client
@@ -36,6 +37,7 @@ module Prompts
       @test_command = test_command || detected_test_command
       @issue = issue
       @prompt_version = prompt_version
+      @focus = focus
     end
 
     def self.call(...)
@@ -43,10 +45,12 @@ module Prompts
     end
 
     def includes_review_threads?
-      unresolved_threads.any?
+      include_section?(:code_review) && unresolved_threads.any?
     end
 
     def unresolved_review_thread_ids
+      return [] unless includes_review_threads?
+
       unresolved_threads.filter_map { |thread| thread[:id] }
     end
 
@@ -95,11 +99,12 @@ module Prompts
     def build
       sections = []
       sections << task_section
-      sections << issue_requirements_section if linked_issue?
-      sections << merge_conflicts_section unless rebase_succeeded
-      sections << ci_failures_section if ci_failure_context.failing?
+      sections << issue_requirements_section if include_issue_requirements_section?
+      sections << merge_conflicts_section if include_merge_conflicts_section?
+      sections << ci_failures_section if include_ci_failures_section?
       sections << code_review_section if includes_review_threads?
-      sections << conversation_section if trusted_comments.any?
+      sections << conversation_section if include_conversation_section?
+      sections << other_issues_section if other_issues_section.present?
       sections << instructions_and_rules_shell
       sections << service_environment_section
       base_prompt = sections.join("\n").delete("\x00")
@@ -130,6 +135,8 @@ module Prompts
     end
 
     def priority_list
+      return focused_priority_list if focused?
+
       priorities = []
       priorities << "Resolve merge conflicts" unless rebase_succeeded
       priorities << "Fix CI failures" if ci_failure_context.failing?
@@ -137,6 +144,10 @@ module Prompts
       priorities << "Address code review comments" if includes_review_threads?
       priorities << "Address conversation comments" if trusted_comments.any?
       priorities.each_with_index.map { |p, i| "#{i + 1}. #{p}" }.join("\n")
+    end
+
+    def focused?
+      focus != "general"
     end
 
     # Returns true when a separate issue is linked (not the PR's own Issue record).
@@ -318,6 +329,23 @@ module Prompts
       SECTION
     end
 
+    def other_issues_section
+      return "" unless focused?
+
+      issues = deferred_issue_descriptions
+      return "" if issues.empty?
+
+      <<~SECTION
+        # Other Issues on This PR (Deferred)
+
+        This PR also has the following issues that are **not** your responsibility this run:
+        #{issues.map { |issue| "- #{issue}" }.join("\n")}
+
+        Ignore the "fix forward" directive for these unrelated problems. Follow-up runs will address them.
+        Do not attempt to fix these issues. Focus solely on the task described above.
+      SECTION
+    end
+
     # When reviewers have flagged specific issues, tell the agent to scan for
     # the same class of problem across the whole diff — not just the flagged lines.
     def review_scan_instruction
@@ -335,6 +363,71 @@ module Prompts
         "addressed on the current branch and no code changes are needed, do not " \
         "make a no-op commit. End your final response with a standalone line " \
         "containing exactly `#{ALREADY_ADDRESSED_MARKER}`."
+    end
+
+    def include_section?(section)
+      return true if general_or_label_action_focus?
+
+      scoped_section_for_focus == section
+    end
+
+    def general_or_label_action_focus?
+      focus.in?([ "general", "label_action" ])
+    end
+
+    def scoped_section_for_focus
+      {
+        "ci_fix" => :ci_failures,
+        "review_feedback" => :code_review,
+        "merge_conflict" => :merge_conflicts,
+        "conversation" => :conversation,
+        "issue_implementation" => :issue_requirements
+      }[focus]
+    end
+
+    def include_issue_requirements_section?
+      include_section?(:issue_requirements) && linked_issue?
+    end
+
+    def include_merge_conflicts_section?
+      include_section?(:merge_conflicts) && !rebase_succeeded
+    end
+
+    def include_ci_failures_section?
+      include_section?(:ci_failures) && ci_failure_context.failing?
+    end
+
+    def include_conversation_section?
+      include_section?(:conversation) && trusted_comments.any?
+    end
+
+    def focused_priority_list
+      "1. #{focused_priority_item}"
+    end
+
+    def focused_priority_item
+      {
+        "ci_fix" => "Fix the failing CI checks on this PR",
+        "review_feedback" => "Address the unresolved code review comments on this PR",
+        "merge_conflict" => "Resolve the merge conflicts on this PR",
+        "conversation" => "Address the actionable conversation comments on this PR",
+        "issue_implementation" => "Close implementation gaps against the linked issue for this PR",
+        "label_action" => "Handle the actionable labels on this PR"
+      }.fetch(focus, "Complete the scoped task for this PR")
+    end
+
+    def deferred_issue_descriptions
+      descriptions = []
+      descriptions << "merge conflicts with the base branch" if defer_issue?(:merge_conflicts) && !rebase_succeeded
+      descriptions << "failing CI checks" if defer_issue?(:ci_failures) && ci_failure_context.failing?
+      descriptions << "implementation gaps against the linked issue" if defer_issue?(:issue_requirements) && linked_issue?
+      descriptions << "unresolved code review comments" if defer_issue?(:code_review) && unresolved_threads.any?
+      descriptions << "actionable conversation comments" if defer_issue?(:conversation) && trusted_comments.any?
+      descriptions
+    end
+
+    def defer_issue?(section)
+      focused? && !include_section?(section)
     end
 
     # Memoized data fetchers

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -37,7 +37,7 @@ module Prompts
       @test_command = test_command || detected_test_command
       @issue = issue
       @prompt_version = prompt_version
-      @focus = focus
+      @focus = focus.presence || "general"
     end
 
     def self.call(...)

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -104,7 +104,8 @@ module Prompts
       sections << ci_failures_section if include_ci_failures_section?
       sections << code_review_section if includes_review_threads?
       sections << conversation_section if include_conversation_section?
-      sections << other_issues_section if other_issues_section.present?
+      other_issues = other_issues_section
+      sections << other_issues if other_issues.present?
       sections << instructions_and_rules_shell
       sections << service_environment_section
       base_prompt = sections.join("\n").delete("\x00")

--- a/app/temporal/activities/prepare_pr_prompt_activity.rb
+++ b/app/temporal/activities/prepare_pr_prompt_activity.rb
@@ -13,7 +13,7 @@ module Activities
       agent_run_id = input[:agent_run_id]
       rebase_succeeded = input.fetch(:rebase_succeeded, true)
       agent_run = AgentRun.find(agent_run_id)
-      focus = input[:focus] || agent_run.focus
+      focus = input[:focus].presence || agent_run.focus.presence || "general"
       track_phase(agent_run_id: agent_run_id, phase_key: "prepare_pr_prompt", phase_group: "prompt", agent_run: agent_run) do
         project = agent_run.project
         client = project.github_token.client

--- a/app/temporal/activities/prepare_pr_prompt_activity.rb
+++ b/app/temporal/activities/prepare_pr_prompt_activity.rb
@@ -28,7 +28,8 @@ module Activities
           github_client: client,
           rebase_succeeded: rebase_succeeded,
           issue: agent_run.issue,
-          prompt_version: prompt_version
+          prompt_version: prompt_version,
+          focus: focus
         )
         prompt = prompt_builder.build
         includes_review_threads = prompt_builder.includes_review_threads?

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -871,6 +871,23 @@ RSpec.describe Prompts::BuildForPr do
         expect(prompt).not_to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
         expect(prompt).not_to include("same classes of issues the reviewers")
       end
+
+      context "when the CI failures have already cleared" do
+        before do
+          allow(github_client).to receive(:check_runs_for_ref)
+            .with(project.full_name, "abc123")
+            .and_return([])
+        end
+
+        it "falls back to the live priority list instead of stale focused instructions" do
+          expect(prompt).not_to include("CI Status: FAILING")
+          expect(prompt).not_to include("1. Fix the failing CI checks on this PR")
+          expect(prompt).to include("1. Resolve merge conflicts")
+          expect(prompt).to include("2. Close implementation gaps against the linked issue")
+          expect(prompt).to include("3. Address code review comments")
+          expect(prompt).to include("4. Address conversation comments")
+        end
+      end
     end
 
     context "with review_feedback focus" do
@@ -902,6 +919,25 @@ RSpec.describe Prompts::BuildForPr do
         expect(prompt).to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
         expect(prompt).to include("same classes of issues the reviewers")
       end
+
+      context "when the review threads have already been resolved" do
+        before do
+          allow(github_client).to receive(:review_threads)
+            .with(project.full_name, 42)
+            .and_return([])
+        end
+
+        it "falls back to the live priority list and omits review-only metadata" do
+          expect(prompt).not_to include("Code Review Comments")
+          expect(prompt).not_to include("1. Address the unresolved code review comments on this PR")
+          expect(prompt).to include("1. Resolve merge conflicts")
+          expect(prompt).to include("2. Fix CI failures")
+          expect(prompt).to include("3. Close implementation gaps against the linked issue")
+          expect(prompt).to include("4. Address conversation comments")
+          expect(prompt).not_to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
+          expect(prompt).not_to include("same classes of issues the reviewers")
+        end
+      end
     end
 
     context "with merge_conflict focus" do
@@ -927,6 +963,30 @@ RSpec.describe Prompts::BuildForPr do
           "actionable conversation comments"
         )
         expect(prompt).to include("1. Resolve the merge conflicts on this PR")
+      end
+
+      context "when the merge conflict has already cleared" do
+        subject(:prompt) do
+          described_class.call(
+            project: project,
+            pr_number: 42,
+            github_client: github_client,
+            rebase_succeeded: rebase_succeeded,
+            issue: issue,
+            focus: "merge_conflict"
+          )
+        end
+
+        let(:rebase_succeeded) { true }
+
+        it "falls back to the live priority list" do
+          expect(prompt).not_to include("Merge Conflicts")
+          expect(prompt).not_to include("1. Resolve the merge conflicts on this PR")
+          expect(prompt).to include("1. Fix CI failures")
+          expect(prompt).to include("2. Close implementation gaps against the linked issue")
+          expect(prompt).to include("3. Address code review comments")
+          expect(prompt).to include("4. Address conversation comments")
+        end
       end
     end
   end
@@ -991,6 +1051,28 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("1. Fix the failing CI checks on this PR")
     end
 
+    it "falls back to live priorities when a ci_fix run reaches a green PR" do
+      allow(github_client).to receive(:check_runs_for_ref)
+        .with(project.full_name, "abc123")
+        .and_return([])
+
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue,
+        focus: "ci_fix"
+      )
+
+      expect(prompt).not_to include("CI Status: FAILING")
+      expect(prompt).not_to include("1. Fix the failing CI checks on this PR")
+      expect(prompt).to include("1. Resolve merge conflicts")
+      expect(prompt).to include("2. Close implementation gaps against the linked issue")
+      expect(prompt).to include("3. Address code review comments")
+      expect(prompt).to include("4. Address conversation comments")
+    end
+
     it "builds a scoped review_feedback prompt with review-only instructions" do
       prompt = described_class.call(
         project: project,
@@ -1006,6 +1088,30 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("1. Address the unresolved code review comments on this PR")
       expect(prompt).to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
       expect(prompt).to include("same classes of issues the reviewers")
+    end
+
+    it "falls back to live priorities when a review_feedback run reaches a cleared review queue" do
+      allow(github_client).to receive(:review_threads)
+        .with(project.full_name, 42)
+        .and_return([])
+
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue,
+        focus: "review_feedback"
+      )
+
+      expect(prompt).not_to include("Code Review Comments")
+      expect(prompt).not_to include("1. Address the unresolved code review comments on this PR")
+      expect(prompt).to include("1. Resolve merge conflicts")
+      expect(prompt).to include("2. Fix CI failures")
+      expect(prompt).to include("3. Close implementation gaps against the linked issue")
+      expect(prompt).to include("4. Address conversation comments")
+      expect(prompt).not_to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
+      expect(prompt).not_to include("same classes of issues the reviewers")
     end
   end
 

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe Prompts::BuildForPr do
     expect(prompt).to include("Focus solely on the task described above.")
   end
 
+  def expect_priority_list(prompt, expected_lines)
+    priority_list = prompt[/Priority order:\n(.*?)\n\nSteps:/m, 1]
+
+    expect(priority_list).to eq(expected_lines.join("\n"))
+  end
+
   let(:project) { create(:project, allowed_github_usernames: [ "trusteduser" ]) }
   let(:github_client) { instance_double(GithubClient) }
   let(:user_settings) { OpenStruct.new(max_prompt_comments: 20, max_comment_length: 2000) }
@@ -866,8 +872,7 @@ RSpec.describe Prompts::BuildForPr do
       end
 
       it "uses a single focused priority without review-only instructions" do
-        expect(prompt).to include("1. Fix the failing CI checks on this PR")
-        expect(prompt).not_to include("2.")
+        expect_priority_list(prompt, [ "1. Fix the failing CI checks on this PR" ])
         expect(prompt).not_to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
         expect(prompt).not_to include("same classes of issues the reviewers")
       end

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -31,9 +31,24 @@ RSpec.describe Prompts::BuildForPr do
     OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: body)
   end
 
+  def expect_prompt_to_exclude_sections(prompt, *section_names)
+    section_names.each do |section_name|
+      expect(prompt).not_to include(section_name)
+    end
+  end
+
+  def expect_deferred_issues_section(prompt, *issues)
+    expect(prompt).to include("# Other Issues on This PR (Deferred)")
+    issues.each do |issue|
+      expect(prompt).to include("- #{issue}")
+    end
+    expect(prompt).to include("Ignore the \"fix forward\" directive")
+    expect(prompt).to include("Focus solely on the task described above.")
+  end
+
   let(:project) { create(:project, allowed_github_usernames: [ "trusteduser" ]) }
   let(:github_client) { instance_double(GithubClient) }
-  let(:user_settings) { instance_double(UserSetting, max_prompt_comments: 20, max_comment_length: 2000) }
+  let(:user_settings) { OpenStruct.new(max_prompt_comments: 20, max_comment_length: 2000) }
 
   let(:pr_data) do
     OpenStruct.new(
@@ -774,6 +789,223 @@ RSpec.describe Prompts::BuildForPr do
       expect(ci_pos).to be < issue_pos
       expect(issue_pos).to be < review_pos
       expect(review_pos).to be < comments_pos
+    end
+  end
+
+  describe "focused prompt scoping" do
+    let(:issue) do
+      create(:issue,
+        project: project,
+        title: "Add dark mode",
+        github_number: 99,
+        body: "Implement dark mode toggle in settings.")
+    end
+
+    before do
+      allow(github_client).to receive(:check_runs_for_ref)
+        .with(project.full_name, "abc123")
+        .and_return([
+          { id: 1, name: "rspec", conclusion: "failure", output_text: "failed" }
+        ])
+      allow(github_client).to receive(:check_run_log).and_return("")
+      allow(github_client).to receive(:review_threads)
+        .with(project.full_name, 42)
+        .and_return([
+          { id: "thread_1", is_resolved: false, comments: [ { body: "Needs a fix", path: "app/models/user.rb", line: 42, author: "reviewer" } ] }
+        ])
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: 1)
+        .and_return([
+          OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Please also fix the tests")
+        ])
+    end
+
+    it "keeps explicit general focus identical to the default prompt" do
+      default_prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue
+      )
+
+      general_prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue,
+        focus: "general"
+      )
+
+      expect(general_prompt).to eq(default_prompt)
+    end
+
+    context "with ci_fix focus" do
+      subject(:prompt) do
+        described_class.call(
+          project: project,
+          pr_number: 42,
+          github_client: github_client,
+          rebase_succeeded: false,
+          issue: issue,
+          focus: "ci_fix"
+        )
+      end
+
+      it "scopes prompts to CI failures and deferred context" do
+        expect(prompt).to include("CI Status: FAILING")
+        expect_prompt_to_exclude_sections(prompt, "Merge Conflicts", "Code Review Comments", "Conversation Comments", "Issue Requirements")
+        expect_deferred_issues_section(
+          prompt,
+          "merge conflicts with the base branch",
+          "implementation gaps against the linked issue",
+          "unresolved code review comments",
+          "actionable conversation comments"
+        )
+      end
+
+      it "uses a single focused priority without review-only instructions" do
+        expect(prompt).to include("1. Fix the failing CI checks on this PR")
+        expect(prompt).not_to include("2.")
+        expect(prompt).not_to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
+        expect(prompt).not_to include("same classes of issues the reviewers")
+      end
+    end
+
+    context "with review_feedback focus" do
+      subject(:prompt) do
+        described_class.call(
+          project: project,
+          pr_number: 42,
+          github_client: github_client,
+          rebase_succeeded: false,
+          issue: issue,
+          focus: "review_feedback"
+        )
+      end
+
+      it "scopes prompts to code review only" do
+        expect(prompt).to include("Code Review Comments")
+        expect_prompt_to_exclude_sections(prompt, "CI Status: FAILING", "Merge Conflicts", "Conversation Comments", "Issue Requirements")
+        expect_deferred_issues_section(
+          prompt,
+          "failing CI checks",
+          "merge conflicts with the base branch",
+          "implementation gaps against the linked issue",
+          "actionable conversation comments"
+        )
+      end
+
+      it "keeps review-specific instructions and a single focused priority" do
+        expect(prompt).to include("1. Address the unresolved code review comments on this PR")
+        expect(prompt).to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
+        expect(prompt).to include("same classes of issues the reviewers")
+      end
+    end
+
+    context "with merge_conflict focus" do
+      subject(:prompt) do
+        described_class.call(
+          project: project,
+          pr_number: 42,
+          github_client: github_client,
+          rebase_succeeded: false,
+          issue: issue,
+          focus: "merge_conflict"
+        )
+      end
+
+      it "scopes prompts to merge conflicts only" do
+        expect(prompt).to include("Merge Conflicts")
+        expect_prompt_to_exclude_sections(prompt, "CI Status: FAILING", "Code Review Comments", "Conversation Comments", "Issue Requirements")
+        expect_deferred_issues_section(
+          prompt,
+          "failing CI checks",
+          "implementation gaps against the linked issue",
+          "unresolved code review comments",
+          "actionable conversation comments"
+        )
+        expect(prompt).to include("1. Resolve the merge conflicts on this PR")
+      end
+    end
+  end
+
+  describe "focused prompt scoping without a database", :no_db do
+    let(:project) do
+      OpenStruct.new(full_name: "owner/repo", service_containers: [], detected_language: "ruby").tap do |proj|
+        proj.define_singleton_method(:trusted_github_user?) { |login| login == "trusteduser" }
+      end
+    end
+    let(:issue) do
+      OpenStruct.new(
+        title: "Add dark mode",
+        github_number: 99,
+        body: "Implement dark mode toggle in settings.",
+        is_pull_request?: false
+      )
+    end
+
+    before do
+      allow(StyleGuides::InjectIntoPrompt).to receive(:call) { |prompt:, project:| prompt }
+      allow(Prompts::Render).to receive(:call) do |slug:, project:, variables:, fallback:|
+        fallback.call
+      end
+      allow(github_client).to receive(:check_runs_for_ref)
+        .with(project.full_name, "abc123")
+        .and_return([
+          { id: 1, name: "rspec", conclusion: "failure", output_text: "failed" }
+        ])
+      allow(github_client).to receive(:check_run_log).and_return("")
+      allow(github_client).to receive(:review_threads)
+        .with(project.full_name, 42)
+        .and_return([
+          { id: "thread_1", is_resolved: false, comments: [ { body: "Needs a fix", path: "app/models/user.rb", line: 42, author: "reviewer" } ] }
+        ])
+      allow(github_client).to receive(:recent_issue_comments)
+        .with(project.full_name, 42, pages: 1)
+        .and_return([
+          OpenStruct.new(user: OpenStruct.new(login: "trusteduser"), body: "Please also fix the tests")
+        ])
+    end
+
+    it "builds a scoped ci_fix prompt with deferred issues" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue,
+        focus: "ci_fix"
+      )
+
+      expect(prompt).to include("CI Status: FAILING")
+      expect_prompt_to_exclude_sections(prompt, "Merge Conflicts", "Code Review Comments", "Conversation Comments", "Issue Requirements")
+      expect_deferred_issues_section(
+        prompt,
+        "merge conflicts with the base branch",
+        "implementation gaps against the linked issue",
+        "unresolved code review comments",
+        "actionable conversation comments"
+      )
+      expect(prompt).to include("1. Fix the failing CI checks on this PR")
+    end
+
+    it "builds a scoped review_feedback prompt with review-only instructions" do
+      prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue,
+        focus: "review_feedback"
+      )
+
+      expect(prompt).to include("Code Review Comments")
+      expect_prompt_to_exclude_sections(prompt, "CI Status: FAILING", "Merge Conflicts", "Conversation Comments", "Issue Requirements")
+      expect(prompt).to include("1. Address the unresolved code review comments on this PR")
+      expect(prompt).to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
+      expect(prompt).to include("same classes of issues the reviewers")
     end
   end
 

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -1113,6 +1113,28 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).not_to include(Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER)
       expect(prompt).not_to include("same classes of issues the reviewers")
     end
+
+    it "treats a nil focus like general for backward compatibility" do
+      general_prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue,
+        focus: "general"
+      )
+
+      nil_focus_prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: false,
+        issue: issue,
+        focus: nil
+      )
+
+      expect(nil_focus_prompt).to eq(general_prompt)
+    end
   end
 
   describe "error resilience" do

--- a/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
+++ b/spec/temporal/activities/prepare_pr_prompt_activity_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Activities::PreparePrPromptActivity do
   end
   let(:github_client) { instance_double(GithubClient) }
   let(:activity) { described_class.new }
-  let!(:prompt) do
+  let(:prompt) do
     Prompt.find_by(slug: Prompts::BuildForPr::PROMPT_SLUG)&.destroy!
     create(:prompt, :global, slug: Prompts::BuildForPr::PROMPT_SLUG).tap do |record|
       record.create_version!(
-        template: "Priority order:\n{{priority_list}}\n# Code Review Comments",
+        template: "Priority order:\n{{priority_list}}\n# Instructions",
         variables: [
           { "name" => "priority_list", "required" => true, "description" => "Priority list" }
         ]
@@ -45,6 +45,8 @@ RSpec.describe Activities::PreparePrPromptActivity do
   end
 
   describe "#execute" do
+    before { prompt }
+
     it "stores the generated prompt in custom_prompt" do
       activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
 
@@ -93,10 +95,45 @@ RSpec.describe Activities::PreparePrPromptActivity do
       expect(result[:prompt_version_id]).to eq(prompt.current_version.id)
     end
 
-    it "accepts focus input without changing prompt generation" do
-      activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true, focus: "ci_fix")
+    it "passes explicit focus through to the prompt builder" do
+      allow(github_client).to receive(:check_runs_for_ref)
+        .with(project.full_name, "abc123")
+        .and_return([
+          { id: 1, name: "rspec", conclusion: "failure", output_text: "failed" }
+        ])
+      allow(github_client).to receive(:check_run_log).and_return("")
+      allow(github_client).to receive(:review_threads)
+        .with(project.full_name, 42)
+        .and_return([
+          { id: "thread_1", is_resolved: false, comments: [ { body: "Needs a fix", path: "app/models/user.rb", line: 42, author: "reviewer" } ] }
+        ])
 
-      expect(agent_run.reload.custom_prompt).to include("Fix the bug")
+      result = activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true, focus: "ci_fix")
+
+      expect(agent_run.reload.custom_prompt).to include("CI Status: FAILING")
+      expect(agent_run.custom_prompt).not_to include("Code Review Comments")
+      expect(result[:includes_review_threads]).to be(false)
+      expect(result[:review_thread_ids]).to eq([])
+    end
+
+    it "uses the agent run focus when input focus is not provided" do
+      agent_run.update!(focus: "ci_fix")
+      allow(github_client).to receive(:check_runs_for_ref)
+        .with(project.full_name, "abc123")
+        .and_return([
+          { id: 1, name: "rspec", conclusion: "failure", output_text: "failed" }
+        ])
+      allow(github_client).to receive(:check_run_log).and_return("")
+      allow(github_client).to receive(:review_threads)
+        .with(project.full_name, 42)
+        .and_return([
+          { id: "thread_1", is_resolved: false, comments: [ { body: "Needs a fix", path: "app/models/user.rb", line: 42, author: "reviewer" } ] }
+        ])
+
+      activity.execute(agent_run_id: agent_run.id, rebase_succeeded: true)
+
+      expect(agent_run.reload.custom_prompt).to include("CI Status: FAILING")
+      expect(agent_run.custom_prompt).not_to include("Code Review Comments")
     end
 
     it "passes rebase_succeeded through to the prompt builder" do


### PR DESCRIPTION
## Summary

Wire focused agent runs into the PR prompt builder so each run sees only the sections relevant to its focus, plus a brief note about deferred issues. This is part of the **Focused Agent Runs** initiative ([RDR-031](docs/rdrs/RDR-031-focused-agent-runs.md)). The `focus` field on `agent_run` was added in #1991.

## Changes

### Services
- `app/services/prompts/build_for_pr.rb` — Accept a `focus:` parameter (default `"general"`); conditionally include only the sections relevant to the focus (`ci_fix`, `review_feedback`, `merge_conflict`, `conversation`, `issue_implementation`, `label_action`, `general`); collapse the priority list to a single item for focused runs; append an "Other Issues on This PR (Deferred)" section that lists the deferred problems and tells the agent to ignore the "fix forward" directive for them. Review-thread metadata is now prompt-scope-aware so it is only surfaced for the relevant focus.

### Workflows / Activities
- `app/temporal/activities/prepare_pr_prompt_activity.rb` — Read the resolved focus from the agent run and pass it through to `BuildForPr`.

### Tests
- `spec/services/prompts/build_for_pr_spec.rb` — Cover section gating per focus, the deferred-issues context block, and the focused single-item priority list. `focus: "general"` continues to produce the existing prompt.
- `spec/temporal/activities/prepare_pr_prompt_activity_spec.rb` — Verify focus is read from the agent run and forwarded to the builder.

## Design Decisions

- **Compose in Ruby, not in the template.** The `coding.pr_review_rebase` template is unchanged; the deferred-issues context and focused priority list are injected by the builder. This keeps focus-aware logic in one place and avoids template branching.
- **`focus: "general"` is a true no-op.** Existing callers and unfocused runs produce byte-identical prompts to today, which keeps this change safe to ship ahead of the rest of RDR-031.
- **Explicit "ignore fix-forward" instruction.** Focused runs see deferred issues by name and are explicitly told not to act on them, so the standard "fix forward" guidance in the base prompt does not pull them off-task.
- **Review-goal prompt path is untouched.** It already has its own focus mechanism; duplicating it here was out of scope.

## Operational Notes

No migrations, no infrastructure changes. The `agent_run.focus` field (added in #1991) is already in production; until this PR merges, all focused-prompt calls fall through the `"general"` branch and behavior is unchanged.

---

Closes #1988
