### PR TITLE
feat(strategy): Phase 4.2 — Learned Orchestration Strategies

### DIFF
--- a/app/services/strategies/seed_baseline_orchestration.rb
+++ b/app/services/strategies/seed_baseline_orchestration.rb
@@ -2,6 +2,10 @@
 
 module Strategies
   class SeedBaselineOrchestration
+    BASELINE_PROVENANCE_SOURCE = "baseline_workflow_extraction"
+    SEED_CHANGE_REASONING = "Extracted from current hardcoded workflow defaults without semantic changes."
+    SEED_CHANGE_NOTES = "Baseline strategy version seeded from runtime behavior."
+
     def self.call
       new.call
     end
@@ -27,22 +31,41 @@ module Strategies
       )
       strategy.save! if strategy.changed?
 
-      return strategy if strategy.current_version.present?
+      strategy.with_lock do
+        current_version = strategy.reload.current_version
+        return strategy if current_version_matches_definition?(current_version, definition)
 
-      version = strategy.create_version!(
-        content: definition.fetch(:content),
-        provenance: {
-          "source" => "baseline_workflow_extraction",
-          "decision_type" => definition.fetch(:decision_type)
-        },
-        promotion_state: "active",
-        created_by: "seed",
-        reasoning: "Extracted from current hardcoded workflow defaults without semantic changes.",
-        change_notes: "Initial baseline strategy version seeded from runtime behavior.",
-        promoted_at: Time.current
-      )
-      strategy.update!(current_version: version)
+        promoted_at = Time.current
+        version = strategy.create_version!(
+          content: definition.fetch(:content),
+          provenance: baseline_provenance(definition),
+          promotion_state: "active",
+          created_by: "seed",
+          reasoning: SEED_CHANGE_REASONING,
+          change_notes: SEED_CHANGE_NOTES,
+          promoted_at: promoted_at
+        )
+        current_version&.update!(
+          promotion_state: "retired",
+          retired_at: promoted_at
+        )
+        strategy.update!(current_version: version)
+      end
+
       strategy
+    end
+
+    def current_version_matches_definition?(current_version, definition)
+      current_version&.active? &&
+        current_version.content == definition.fetch(:content) &&
+        current_version.provenance == baseline_provenance(definition)
+    end
+
+    def baseline_provenance(definition)
+      {
+        "source" => BASELINE_PROVENANCE_SOURCE,
+        "decision_type" => definition.fetch(:decision_type)
+      }
     end
   end
 end

--- a/app/services/strategies/seed_baseline_orchestration.rb
+++ b/app/services/strategies/seed_baseline_orchestration.rb
@@ -36,6 +36,10 @@ module Strategies
         return strategy if current_version_matches_definition?(current_version, definition)
 
         promoted_at = Time.current
+        current_version&.update!(
+          promotion_state: "retired",
+          retired_at: promoted_at
+        )
         version = strategy.create_version!(
           content: definition.fetch(:content),
           provenance: baseline_provenance(definition),
@@ -44,10 +48,6 @@ module Strategies
           reasoning: SEED_CHANGE_REASONING,
           change_notes: SEED_CHANGE_NOTES,
           promoted_at: promoted_at
-        )
-        current_version&.update!(
-          promotion_state: "retired",
-          retired_at: promoted_at
         )
         strategy.update!(current_version: version)
       end

--- a/spec/services/strategies/seed_baseline_orchestration_spec.rb
+++ b/spec/services/strategies/seed_baseline_orchestration_spec.rb
@@ -30,5 +30,44 @@ RSpec.describe Strategies::SeedBaselineOrchestration do
       expect { described_class.call }.not_to change(Strategy, :count)
       expect { described_class.call }.not_to change(StrategyVersion, :count)
     end
+
+    it "promotes a new baseline version when the current content drifts" do
+      described_class.call
+
+      definition = Strategies::BaselineOrchestration.definitions.first
+      strategy = Strategy.global.find_by!(slug: definition[:slug])
+      replacement = create_drifted_current_version!(strategy, definition)
+
+      expect {
+        described_class.call
+      }.to change { strategy.reload.strategy_versions.count }.by(1)
+
+      expect(strategy.reload.current_version).to be_active
+      expect(strategy.current_version.content).to eq(definition[:content])
+      expect(strategy.current_version.provenance).to include(
+        "source" => "baseline_workflow_extraction",
+        "decision_type" => definition[:decision_type]
+      )
+      expect(replacement.reload).to be_retired
+    end
+
+    def create_drifted_current_version!(strategy, definition)
+      strategy.current_version.update!(
+        promotion_state: "retired",
+        retired_at: 1.day.ago
+      )
+      strategy.create_version!(
+        content: { "drifted" => true },
+        provenance: {
+          "source" => "manual_override",
+          "decision_type" => definition[:decision_type]
+        },
+        promotion_state: "active",
+        created_by: "seed",
+        reasoning: "Temporary drift",
+        change_notes: "Drifted from extracted baseline.",
+        promoted_at: 1.hour.ago
+      ).tap { |version| strategy.update!(current_version: version) }
+    end
   end
 end


### PR DESCRIPTION
## Summary

Ensures the baseline orchestration strategy stays in sync with its hardcoded definition by detecting drift in the current version and promoting a fresh active baseline, preventing stale extracted behavior from silently persisting across deploys.

## Changes

- **Services**: Updated `app/services/strategies/seed_baseline_orchestration.rb` to detect drift in an existing global strategy's current version and promote a new active baseline version instead of leaving stale data in place.
- **Tests**: Added regression coverage for the reseed-on-drift path in `spec/services/strategies/seed_baseline_orchestration_spec.rb`.

## Design Decisions

- **Reseed on drift rather than mutate in place** — promoting a fresh active version preserves the immutable version history that Phase 4.2 relies on for A/B testing and human review, while still keeping the active baseline aligned with the canonical hardcoded definition.
- **Detection is content-based, not timestamp-based** — drift is determined by comparing the current version's payload against the freshly extracted baseline, so reseeds only happen when behavior actually diverges.

## Operational Notes

- Idempotent: the seeder is a no-op when the current version already matches the canonical baseline.
- On first deploy after this change, any project whose stored baseline has drifted from the hardcoded definition will receive a new active version on next seed run.
- RSpec was not executed in the authoring environment because PostgreSQL was unavailable; CI will run the full suite against the new spec.

---

Closes #1796