### PR TITLE
feat(scaling): Phase 4.5 — Orchestration Scaling Laws

### DIFF
--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -97,7 +97,7 @@ module Scaling
       requested_agent_count = summary_value(agent_decision || parallelism_decision || {}, :requested_agent_count,
         default: conservative_agent_count)
       agent_count = clamp_agents(requested_agent_count)
-      recommended_parallelism = summary_value(parallelism_decision || agent_decision || {}, :max_batch_size,
+      recommended_parallelism = summary_value(parallelism_decision || {}, :max_batch_size,
         default: parallelism_cap(agent_count))
       max_iterations = summary_value(iteration_decision || {}, :max_iterations,
         default: summary_value(iteration_decision || {}, :requested_iteration_count, default: 3))

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -59,8 +59,8 @@ module Scaling
     end
 
     def allocate_from_experiments
-      if (decision_summary = selected_experiment_allocator_decision)
-        return allocate_from_experiment_decision(decision_summary)
+      if experiment_allocator_decisions.any?
+        return allocate_from_experiment_decisions
       end
 
       best_summary = usable_experiment_summaries.max_by do |summary|
@@ -84,18 +84,27 @@ module Scaling
       )
     end
 
-    def allocate_from_experiment_decision(decision_summary)
-      decision = decision_summary[:decision]
-      requested_agent_count = summary_value(decision, :requested_agent_count, default: conservative_agent_count)
+    def allocate_from_experiment_decisions
+      decisions_by_dimension = experiment_allocator_decisions.index_by { |entry| entry[:dimension].to_s }
+      agent_decision = decisions_by_dimension["agent_count"]&.fetch(:decision, nil)
+      parallelism_decision = decisions_by_dimension["parallelism"]&.fetch(:decision, nil)
+      iteration_decision = decisions_by_dimension["max_iterations"]&.fetch(:decision, nil) ||
+        decisions_by_dimension["iteration_count"]&.fetch(:decision, nil)
+
+      requested_agent_count = summary_value(agent_decision || parallelism_decision || {}, :requested_agent_count,
+        default: conservative_agent_count)
       agent_count = clamp_agents(requested_agent_count)
-      recommended_parallelism = summary_value(decision, :max_batch_size, default: parallelism_cap(agent_count))
+      recommended_parallelism = summary_value(parallelism_decision || agent_decision || {}, :max_batch_size,
+        default: parallelism_cap(agent_count))
+      max_iterations = summary_value(iteration_decision || {}, :max_iterations,
+        default: summary_value(iteration_decision || {}, :requested_iteration_count, default: 3))
 
       build_allocation(
         agent_count: agent_count,
-        max_iterations: 3,
+        max_iterations: max_iterations.to_i.clamp(1, 10),
         parallelism_level: parallelism_cap([ recommended_parallelism.to_i, agent_count ].min),
         source: :experiment,
-        reason: experiment_decision_reason(decision_summary)
+        reason: experiment_decisions_reason(decisions_by_dimension)
       )
     end
 
@@ -119,7 +128,7 @@ module Scaling
     end
 
     def experiment_summaries_usable?
-      usable_experiment_summaries.any?
+      usable_experiment_summaries.any? || experiment_allocator_decisions.any?
     end
 
     def group_by_agent_count
@@ -276,20 +285,7 @@ module Scaling
       end
     end
 
-    def selected_experiment_allocator_decision
-      @selected_experiment_allocator_decision ||= experiment_allocator_decisions.max_by do |entry|
-        [
-          confidence_rank(summary_value(entry[:decision], :confidence)),
-          entry[:decision_sample_count]
-        ]
-      end
-    end
-
-    # Only parallelism-dimension summaries carry allocator decisions that
-    # should steer agent_count / parallelism_level.  Other dimensions
-    # (e.g. iteration_count, max_iterations) may have allocator_decision
-    # hashes but their values are not compatible with this code path.
-    ALLOCATOR_DECISION_DIMENSIONS = %w[parallelism].freeze
+    ALLOCATOR_DECISION_DIMENSIONS = %w[agent_count iteration_count max_iterations parallelism].freeze
 
     def experiment_allocator_decisions
       @experiment_allocator_decisions ||= experiment_summaries.filter_map do |summary|
@@ -335,14 +331,18 @@ module Scaling
       [ agent_count, inputs.parallelism_limit ].min
     end
 
-    def experiment_decision_reason(decision_summary)
-      decision = decision_summary[:decision]
+    def experiment_decisions_reason(decisions_by_dimension)
+      decisions_by_dimension.sort.map do |dimension, entry|
+        decision = entry[:decision]
 
-      "#{decision_summary[:dimension]} allocator decision " \
-        "agents=#{summary_value(decision, :requested_agent_count, default: conservative_agent_count)} " \
-        "parallelism=#{summary_value(decision, :max_batch_size, default: nil)} " \
-        "n=#{decision_summary[:decision_sample_count]} " \
-        "confidence=#{summary_value(decision, :confidence, default: "unknown")}"
+        "#{dimension} decision " \
+          "value=#{summary_value(decision, :recommended_value, default: nil)} " \
+          "agents=#{summary_value(decision, :requested_agent_count, default: nil)} " \
+          "parallelism=#{summary_value(decision, :max_batch_size, default: nil)} " \
+          "iterations=#{summary_value(decision, :max_iterations, default: summary_value(decision, :requested_iteration_count, default: nil))} " \
+          "n=#{entry[:decision_sample_count]} " \
+          "confidence=#{summary_value(decision, :confidence, default: "unknown")}"
+      end.join("; ")
     end
 
     def fallback_reason
@@ -378,14 +378,6 @@ module Scaling
 
     def format_rate(value)
       format("%.2f%%", (value || 0.0) * 100)
-    end
-
-    def confidence_rank(value)
-      case value
-      when "high" then 2
-      when "medium" then 1
-      else 0
-      end
     end
   end
 end

--- a/app/services/scaling/resource_allocator.rb
+++ b/app/services/scaling/resource_allocator.rb
@@ -16,6 +16,7 @@ module Scaling
     STALE_THRESHOLD = 7.days
     MIN_SUCCESS_RATE_FOR_LEARNING = 0.3
     DIMINISHING_RETURNS_THRESHOLD = 0.05
+    CONFIDENCE_RANK = { "high" => 3, "medium" => 2, "low" => 1 }.freeze
 
     attr_reader :inputs, :observations, :experiment_summaries
 
@@ -85,7 +86,9 @@ module Scaling
     end
 
     def allocate_from_experiment_decisions
-      decisions_by_dimension = experiment_allocator_decisions.index_by { |entry| entry[:dimension].to_s }
+      decisions_by_dimension = experiment_allocator_decisions
+        .group_by { |entry| entry[:dimension].to_s }
+        .transform_values { |entries| pick_strongest_decision(entries) }
       agent_decision = decisions_by_dimension["agent_count"]&.fetch(:decision, nil)
       parallelism_decision = decisions_by_dimension["parallelism"]&.fetch(:decision, nil)
       iteration_decision = decisions_by_dimension["max_iterations"]&.fetch(:decision, nil) ||
@@ -286,6 +289,13 @@ module Scaling
     end
 
     ALLOCATOR_DECISION_DIMENSIONS = %w[agent_count iteration_count max_iterations parallelism].freeze
+
+    def pick_strongest_decision(entries)
+      entries.max_by do |entry|
+        confidence_rank = CONFIDENCE_RANK.fetch(summary_value(entry[:decision], :confidence, default: "low"), 0)
+        [ confidence_rank, entry[:decision_sample_count] ]
+      end
+    end
 
     def experiment_allocator_decisions
       @experiment_allocator_decisions ||= experiment_summaries.filter_map do |summary|

--- a/app/services/scaling_experiments/analyze_scaling_law.rb
+++ b/app/services/scaling_experiments/analyze_scaling_law.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+module ScalingExperiments
+  class AnalyzeScalingLaw
+    Result = Struct.new(
+      :status,
+      :dimension,
+      :primary_metric,
+      :objective,
+      :sample_count,
+      :control_value,
+      :leading_value,
+      :recommended_value,
+      :scaling_exponent,
+      :diminishing_returns_at,
+      :efficiency_gain_at_recommendation,
+      :allocator_decision,
+      :values,
+      keyword_init: true
+    ) do
+      def to_h
+        {
+          "status" => status,
+          "dimension" => dimension,
+          "primary_metric" => primary_metric,
+          "objective" => objective,
+          "sample_count" => sample_count,
+          "control_value" => control_value,
+          "leading_value" => leading_value,
+          "recommended_value" => recommended_value,
+          "scaling_exponent" => scaling_exponent,
+          "diminishing_returns_at" => diminishing_returns_at,
+          "efficiency_gain_at_recommendation" => efficiency_gain_at_recommendation,
+          "allocator_decision" => allocator_decision,
+          "values" => values
+        }.compact
+      end
+    end
+
+    MIN_SAMPLES = 2
+    DIMINISHING_RETURNS_RATIO = 0.10
+    MIN_EFFICIENCY_GAIN = 0.10
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(scaling_experiment:, value_summaries:)
+      @scaling_experiment = scaling_experiment
+      @value_summaries = Array(value_summaries)
+    end
+
+    def call
+      return empty_result if control_summary.blank?
+
+      Result.new(
+        status: analysis_status,
+        dimension: scaling_experiment.dimension,
+        primary_metric: primary_metric_key,
+        objective: primary_metric_objective,
+        sample_count: analyzed_values.sum { |value| value["sample_count"] },
+        control_value: scaling_experiment.control_value,
+        leading_value: leading_summary&.fetch("assigned_value", nil),
+        recommended_value: recommended_summary&.fetch("assigned_value", nil),
+        scaling_exponent: scaling_exponent,
+        diminishing_returns_at: diminishing_returns_at,
+        efficiency_gain_at_recommendation: recommended_summary&.fetch("efficiency_gain_vs_control", nil),
+        allocator_decision: allocator_decision,
+        values: analyzed_values
+      )
+    end
+
+    private
+
+    attr_reader :scaling_experiment, :value_summaries
+
+    def empty_result
+      Result.new(
+        status: "insufficient_data",
+        dimension: scaling_experiment.dimension,
+        primary_metric: primary_metric_key,
+        objective: primary_metric_objective,
+        sample_count: 0,
+        control_value: scaling_experiment.control_value,
+        values: []
+      )
+    end
+
+    def analysis_status
+      return "insufficient_data" if viable_values.empty?
+      return "ready" if recommended_summary.present?
+
+      "collecting"
+    end
+
+    def analyzed_values
+      @analyzed_values ||= begin
+        previous = nil
+
+        normalized_values.map do |summary|
+          enriched = enrich_summary(summary, previous:)
+          previous = enriched
+          enriched
+        end
+      end
+    end
+
+    def normalized_values
+      @normalized_values ||= value_summaries
+        .map { |summary| summary.deep_dup.stringify_keys }
+        .sort_by { |summary| summary["assigned_value"].to_i }
+    end
+
+    def control_summary
+      @control_summary ||= normalized_values.find do |summary|
+        summary["assigned_value"].to_i == scaling_experiment.control_value.to_i
+      end
+    end
+
+    def viable_values
+      @viable_values ||= analyzed_values.select { |summary| summary["sample_count"].to_i >= MIN_SAMPLES }
+    end
+
+    def leading_summary
+      @leading_summary ||= viable_values.max_by do |summary|
+        [
+          summary["primary_metric_value"].to_f,
+          summary["efficiency_score"].to_f,
+          summary["sample_count"].to_i
+        ]
+      end
+    end
+
+    def recommended_summary
+      return @recommended_summary if defined?(@recommended_summary)
+
+      @recommended_summary = begin
+        candidates = viable_values.reject { |summary| blocked_by_signals?(summary) }
+        candidates = viable_values if candidates.empty?
+        candidates.max_by do |summary|
+          [
+            summary["efficiency_score"].to_f,
+            summary["primary_metric_value"].to_f,
+            summary["sample_count"].to_i
+          ]
+        end
+      end
+    end
+
+    def blocked_by_signals?(summary)
+      summary["signals"].include?("diminishing_returns") &&
+        summary["efficiency_gain_vs_control"].to_f < MIN_EFFICIENCY_GAIN
+    end
+
+    def enrich_summary(summary, previous:)
+      primary_value = metric_value(summary, primary_metric_key)
+      transformed = transformed_primary_metric(primary_value)
+      control_transformed = transformed_primary_metric(metric_value(control_summary, primary_metric_key))
+      efficiency_score = efficiency_score(summary, transformed, control_transformed)
+      marginal_gain = marginal_gain(previous:, current_transformed: transformed)
+
+      summary.merge(
+        "primary_metric_value" => primary_value,
+        "efficiency_score" => efficiency_score,
+        "efficiency_gain_vs_control" => efficiency_gain_vs_control(efficiency_score),
+        "marginal_primary_gain" => marginal_gain,
+        "scaling_exponent_vs_control" => exponent_for(summary:, transformed:, control_transformed: control_transformed),
+        "signals" => build_signals(summary:, previous:, marginal_gain:)
+      )
+    end
+
+    def primary_metric_key
+      @primary_metric_key ||= begin
+        metric = scaling_experiment.outcome_metrics.find { |candidate| candidate["primary"] == true }
+        metric&.fetch("key", nil) || "success_rate"
+      end
+    end
+
+    def primary_metric_objective
+      @primary_metric_objective ||= begin
+        metric = scaling_experiment.outcome_metrics.find { |candidate| candidate["key"] == primary_metric_key }
+        metric&.fetch("objective", "maximize")
+      end
+    end
+
+    def metric_value(summary, key)
+      summary.fetch(key.to_s, nil)&.to_f
+    end
+
+    def transformed_primary_metric(value)
+      return nil unless value
+
+      case primary_metric_objective
+      when "minimize"
+        return nil unless value.positive?
+
+        1.0 / value
+      else
+        value
+      end
+    end
+
+    def efficiency_score(summary, transformed, control_transformed)
+      return 0.0 unless transformed
+
+      primary_gain = relative_change(transformed, control_transformed) || 0.0
+      duration_gain = inverse_relative_change(
+        metric_value(summary, :avg_duration_seconds),
+        metric_value(control_summary, :avg_duration_seconds)
+      ) || 0.0
+      cost_gain = inverse_relative_change(
+        metric_value(summary, :avg_cost_cents),
+        metric_value(control_summary, :avg_cost_cents)
+      ) || 0.0
+
+      (primary_gain * 0.6 + duration_gain * 0.25 + cost_gain * 0.15).round(4)
+    end
+
+    def efficiency_gain_vs_control(score)
+      return nil unless score
+
+      score.round(4)
+    end
+
+    def relative_change(current, baseline)
+      return nil unless current && baseline
+      return 1.0 if baseline.zero? && current.positive?
+      return 0.0 if baseline.zero?
+
+      ((current - baseline) / baseline).round(4)
+    end
+
+    def inverse_relative_change(current, baseline)
+      return nil unless current && baseline
+      return nil if baseline.zero?
+
+      ((baseline - current) / baseline).round(4)
+    end
+
+    def marginal_gain(previous:, current_transformed:)
+      return nil unless previous && current_transformed
+
+      previous_transformed = transformed_primary_metric(previous["primary_metric_value"])
+      relative_change(current_transformed, previous_transformed)
+    end
+
+    def exponent_for(summary:, transformed:, control_transformed:)
+      return nil unless transformed && control_transformed
+
+      value = summary["assigned_value"].to_i
+      control = scaling_experiment.control_value.to_i
+      return nil if value <= 0 || control <= 0 || value == control
+      return nil unless transformed.positive? && control_transformed.positive?
+
+      (Math.log(transformed / control_transformed) / Math.log(value.to_f / control)).round(4)
+    end
+
+    def scaling_exponent
+      exponents = viable_values.filter_map { |summary| summary["scaling_exponent_vs_control"]&.to_f }
+      return nil if exponents.empty?
+
+      (exponents.sum / exponents.size).round(4)
+    end
+
+    def diminishing_returns_at
+      analyzed_values.find do |summary|
+        summary["signals"].include?("diminishing_returns")
+      end&.fetch("assigned_value", nil)
+    end
+
+    def build_signals(summary:, previous:, marginal_gain:)
+      [].tap do |signals|
+        if previous && marginal_gain && marginal_gain <= DIMINISHING_RETURNS_RATIO
+          signals << "diminishing_returns"
+        end
+
+        if previous && regression?(summary, previous)
+          signals << "primary_metric_regression"
+        end
+
+        if efficiency_score(summary, transformed_primary_metric(summary["primary_metric_value"]),
+          transformed_primary_metric(metric_value(control_summary, primary_metric_key))) < 0
+          signals << "efficiency_regression"
+        end
+      end
+    end
+
+    def regression?(summary, previous)
+      current = transformed_primary_metric(summary["primary_metric_value"])
+      prior = transformed_primary_metric(previous["primary_metric_value"])
+      return false unless current && prior
+
+      current < prior
+    end
+
+    def allocator_decision
+      return unless recommended_summary
+
+      value = recommended_summary["assigned_value"].to_i
+      decision = {
+        "dimension" => scaling_experiment.dimension,
+        "recommended_value" => value,
+        "sample_count" => recommended_summary["sample_count"],
+        "confidence" => confidence_for(recommended_summary),
+        "reason" => recommendation_reason(recommended_summary),
+        "efficiency_gain_vs_control" => recommended_summary["efficiency_gain_vs_control"],
+        "scaling_exponent" => scaling_exponent,
+        "diminishing_returns_at" => diminishing_returns_at
+      }
+
+      case scaling_experiment.dimension
+      when "agent_count"
+        decision.merge!(
+          "requested_agent_count" => value,
+          "max_batch_size" => value
+        )
+      when "parallelism"
+        decision["max_batch_size"] = value
+      when "iteration_count"
+        decision.merge!(
+          "requested_iteration_count" => value,
+          "max_iterations" => value
+        )
+      when "max_iterations"
+        decision["max_iterations"] = value
+      end
+
+      decision
+    end
+
+    def confidence_for(summary)
+      return "high" if summary["sample_count"].to_i >= 4 && summary["efficiency_gain_vs_control"].to_f >= MIN_EFFICIENCY_GAIN
+      return "medium" if summary["sample_count"].to_i >= MIN_SAMPLES
+
+      "low"
+    end
+
+    def recommendation_reason(summary)
+      if summary["signals"].include?("diminishing_returns")
+        "highest_efficiency_at_threshold"
+      else
+        "highest_efficiency_before_threshold"
+      end
+    end
+  end
+end

--- a/app/services/scaling_experiments/analyze_scaling_law.rb
+++ b/app/services/scaling_experiments/analyze_scaling_law.rb
@@ -325,7 +325,10 @@ module ScalingExperiments
 
       case scaling_experiment.dimension
       when "agent_count"
-        decision["requested_agent_count"] = value
+        decision.merge!(
+          "requested_agent_count" => value,
+          "max_batch_size" => value
+        )
       when "parallelism"
         decision["max_batch_size"] = value
       when "iteration_count"

--- a/app/services/scaling_experiments/analyze_scaling_law.rb
+++ b/app/services/scaling_experiments/analyze_scaling_law.rb
@@ -173,7 +173,14 @@ module ScalingExperiments
         "efficiency_gain_vs_control" => efficiency_gain_vs_control(efficiency_score),
         "marginal_primary_gain" => marginal_gain,
         "scaling_exponent_vs_control" => exponent_for(summary:, transformed:, control_transformed: control_transformed),
-        "signals" => build_signals(summary:, previous:, marginal_gain:)
+        "signals" => build_signals(
+          summary:,
+          previous:,
+          marginal_gain:,
+          primary_value:,
+          transformed:,
+          control_transformed:
+        )
       )
     end
 
@@ -277,25 +284,24 @@ module ScalingExperiments
       end&.fetch("assigned_value", nil)
     end
 
-    def build_signals(summary:, previous:, marginal_gain:)
+    def build_signals(summary:, previous:, marginal_gain:, primary_value:, transformed:, control_transformed:)
       [].tap do |signals|
         if previous && marginal_gain && marginal_gain <= DIMINISHING_RETURNS_RATIO
           signals << "diminishing_returns"
         end
 
-        if previous && regression?(summary, previous)
+        if previous && regression?(primary_value:, previous:)
           signals << "primary_metric_regression"
         end
 
-        if efficiency_score(summary, transformed_primary_metric(summary["primary_metric_value"]),
-          transformed_primary_metric(metric_value(control_summary, primary_metric_key))) < 0
+        if efficiency_score(summary, transformed, control_transformed) < 0
           signals << "efficiency_regression"
         end
       end
     end
 
-    def regression?(summary, previous)
-      current = transformed_primary_metric(summary["primary_metric_value"])
+    def regression?(primary_value:, previous:)
+      current = transformed_primary_metric(primary_value)
       prior = transformed_primary_metric(previous["primary_metric_value"])
       return false unless current && prior
 

--- a/app/services/scaling_experiments/analyze_scaling_law.rb
+++ b/app/services/scaling_experiments/analyze_scaling_law.rb
@@ -124,7 +124,7 @@ module ScalingExperiments
     def leading_summary
       @leading_summary ||= viable_values.max_by do |summary|
         [
-          summary["primary_metric_value"].to_f,
+          summary["transformed_primary_metric"].to_f,
           summary["efficiency_score"].to_f,
           summary["sample_count"].to_i
         ]
@@ -140,7 +140,7 @@ module ScalingExperiments
         candidates.max_by do |summary|
           [
             summary["efficiency_score"].to_f,
-            summary["primary_metric_value"].to_f,
+            summary["transformed_primary_metric"].to_f,
             summary["sample_count"].to_i
           ]
         end
@@ -161,6 +161,7 @@ module ScalingExperiments
 
       summary.merge(
         "primary_metric_value" => primary_value,
+        "transformed_primary_metric" => transformed,
         "efficiency_score" => efficiency_score,
         "efficiency_gain_vs_control" => efficiency_gain_vs_control(efficiency_score),
         "marginal_primary_gain" => marginal_gain,

--- a/app/services/scaling_experiments/analyze_scaling_law.rb
+++ b/app/services/scaling_experiments/analyze_scaling_law.rb
@@ -41,6 +41,13 @@ module ScalingExperiments
     DIMINISHING_RETURNS_RATIO = 0.10
     MIN_EFFICIENCY_GAIN = 0.10
 
+    # Maps validated outcome_metrics keys to summary field names emitted by SummarizeResults.
+    METRIC_KEY_TO_SUMMARY_FIELD = {
+      "duration_seconds" => "avg_duration_seconds",
+      "total_cost_cents" => "avg_cost_cents",
+      "parallelism_observed" => "avg_parallelism_observed"
+    }.freeze
+
     def self.call(...)
       new(...).call
     end
@@ -185,7 +192,8 @@ module ScalingExperiments
     end
 
     def metric_value(summary, key)
-      summary.fetch(key.to_s, nil)&.to_f
+      field = METRIC_KEY_TO_SUMMARY_FIELD.fetch(key.to_s, key.to_s)
+      summary.fetch(field, nil)&.to_f
     end
 
     def transformed_primary_metric(value)
@@ -311,10 +319,7 @@ module ScalingExperiments
 
       case scaling_experiment.dimension
       when "agent_count"
-        decision.merge!(
-          "requested_agent_count" => value,
-          "max_batch_size" => value
-        )
+        decision["requested_agent_count"] = value
       when "parallelism"
         decision["max_batch_size"] = value
       when "iteration_count"

--- a/app/services/scaling_experiments/summarize_results.rb
+++ b/app/services/scaling_experiments/summarize_results.rb
@@ -13,6 +13,7 @@ module ScalingExperiments
     def call
       summaries = value_summaries
       analysis = parallelism_analysis
+      scaling_law = scaling_law_analysis(summaries)
       control = summaries.find { |summary| summary["assigned_value"] == scaling_experiment.control_value }
       leader = summaries.max_by { |summary| leader_sort_key(summary) }
 
@@ -25,8 +26,9 @@ module ScalingExperiments
         "cohort_strategy" => scaling_experiment.cohort_settings.slice("assignment_strategy", "cadence", "label_template"),
         "sample_count" => summaries.sum { |summary| summary["sample_count"] },
         "values" => summaries,
+        "scaling_law" => scaling_law,
         "parallelism_analysis" => analysis,
-        "allocator_decision" => analysis["allocator_decision"],
+        "allocator_decision" => allocator_decision_for(scaling_law, analysis),
         "leading_value" => leader&.fetch("assigned_value", nil),
         "improvement_over_control" => (comparison = improvement_over_control(control:, leader:)),
         "initial_results" => initial_results(control:, leader:, comparison:)
@@ -81,6 +83,21 @@ module ScalingExperiments
 
     def parallelism_analysis
       ScalingObservations::AnalyzeParallelism.call(observations: recorded_observations).to_h
+    end
+
+    def scaling_law_analysis(summaries)
+      ScalingExperiments::AnalyzeScalingLaw.call(
+        scaling_experiment: scaling_experiment,
+        value_summaries: summaries
+      ).to_h
+    end
+
+    def allocator_decision_for(scaling_law, parallelism_analysis)
+      if scaling_experiment.dimension == "parallelism"
+        parallelism_analysis["allocator_decision"] || scaling_law["allocator_decision"]
+      else
+        scaling_law["allocator_decision"]
+      end
     end
 
     def improvement_over_control(control:, leader:)

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -198,10 +198,10 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
 
       it "picks the strongest decision per dimension when duplicates exist" do
         low_confidence = build_experiment_decision_summary("agent_count",
-          recommended_value: 9, requested_agent_count: 9, max_batch_size: 9,
+          recommended_value: 9, requested_agent_count: 9,
           sample_count: 6, confidence: "low")
         high_confidence = build_experiment_decision_summary("agent_count",
-          recommended_value: 2, requested_agent_count: 2, max_batch_size: 2,
+          recommended_value: 2, requested_agent_count: 2,
           sample_count: 10, confidence: "high")
         parallelism = build_experiment_decision_summary("parallelism",
           recommended_value: 3, requested_agent_count: 2, max_batch_size: 3,
@@ -735,7 +735,6 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
       build_experiment_decision_summary("agent_count",
         recommended_value: 3,
         requested_agent_count: 3,
-        max_batch_size: 3,
         sample_count: 6,
         confidence: "high"),
       build_experiment_decision_summary("parallelism",

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -181,6 +181,21 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
     end
 
     context "with experiment summaries but no observations" do
+      it "combines agent-count, parallelism, and iteration experiment decisions" do
+        result = described_class.call(
+          inputs: default_inputs,
+          experiment_summaries: experiment_decision_summaries
+        )
+
+        expect(result.source).to eq(:experiment)
+        expect(result.agent_count).to eq(3)
+        expect(result.parallelism_level).to eq(2)
+        expect(result.max_iterations).to eq(4)
+        expect(result.reason).to include("agent_count decision")
+        expect(result.reason).to include("parallelism decision")
+        expect(result.reason).to include("iteration_count decision")
+      end
+
       it "allocates based on the experiment's leading value" do
         summaries = [
           { assigned_value: 1, success_rate: 0.4, avg_duration_seconds: 300, sample_count: 10 },
@@ -287,7 +302,7 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.source).to eq(:experiment)
         expect(result.agent_count).to eq(4)
         expect(result.parallelism_level).to eq(2)
-        expect(result.reason).to include("parallelism allocator decision")
+        expect(result.reason).to include("parallelism decision")
       end
 
       it "ignores allocator decisions whose winning candidate is under-supported even when the summary total is sufficient" do
@@ -693,6 +708,37 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
       "values" => [
         { "assigned_value" => value }.merge(attributes.transform_keys(&:to_s))
       ]
+    }
+  end
+
+  def experiment_decision_summaries
+    [
+      build_experiment_decision_summary("agent_count",
+        recommended_value: 3,
+        requested_agent_count: 3,
+        max_batch_size: 3,
+        sample_count: 6,
+        confidence: "high"),
+      build_experiment_decision_summary("parallelism",
+        recommended_value: 2,
+        requested_agent_count: 3,
+        max_batch_size: 2,
+        sample_count: 6,
+        confidence: "high"),
+      build_experiment_decision_summary("iteration_count",
+        recommended_value: 4,
+        requested_iteration_count: 4,
+        max_iterations: 4,
+        sample_count: 6,
+        confidence: "medium")
+    ]
+  end
+
+  def build_experiment_decision_summary(dimension, **decision)
+    {
+      dimension: dimension,
+      status: "ready_for_analysis",
+      allocator_decision: decision
     }
   end
 end

--- a/spec/services/scaling/resource_allocator_spec.rb
+++ b/spec/services/scaling/resource_allocator_spec.rb
@@ -196,6 +196,25 @@ RSpec.describe Scaling::ResourceAllocator, :no_db do
         expect(result.reason).to include("iteration_count decision")
       end
 
+      it "picks the strongest decision per dimension when duplicates exist" do
+        low_confidence = build_experiment_decision_summary("agent_count",
+          recommended_value: 9, requested_agent_count: 9, max_batch_size: 9,
+          sample_count: 6, confidence: "low")
+        high_confidence = build_experiment_decision_summary("agent_count",
+          recommended_value: 2, requested_agent_count: 2, max_batch_size: 2,
+          sample_count: 10, confidence: "high")
+        parallelism = build_experiment_decision_summary("parallelism",
+          recommended_value: 3, requested_agent_count: 2, max_batch_size: 3,
+          sample_count: 6, confidence: "medium")
+
+        result = described_class.call(
+          inputs: default_inputs,
+          experiment_summaries: [ low_confidence, high_confidence, parallelism ]
+        )
+
+        expect(result.agent_count).to eq(2)
+      end
+
       it "allocates based on the experiment's leading value" do
         summaries = [
           { assigned_value: 1, success_rate: 0.4, avg_duration_seconds: 300, sample_count: 10 },

--- a/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
+++ b/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
@@ -45,12 +45,32 @@ RSpec.describe ScalingExperiments::AnalyzeScalingLaw, :no_db do
     )
   end
 
+  it "maps validated metric keys to summary field names (total_cost_cents -> avg_cost_cents)" do
+    allow(experiment).to receive(:outcome_metrics).and_return(
+      [
+        { "key" => "total_cost_cents", "primary" => true, "objective" => "minimize" },
+        { "key" => "duration_seconds", "primary" => false, "objective" => "minimize" }
+      ]
+    )
+
+    result = analyze(
+      build_summary(1, sample_count: 3, success_rate: 0.90, duration: 120, cost: 400),
+      build_summary(2, sample_count: 3, success_rate: 0.85, duration: 100, cost: 200)
+    )
+
+    # The primary metric value should be the avg_cost_cents from the summary, not nil
+    values = result.fetch("values")
+    expect(values.first["primary_metric_value"]).to eq(400.0)
+    expect(values.last["primary_metric_value"]).to eq(200.0)
+    expect(result["scaling_exponent"]).not_to be_nil
+  end
+
   it "ranks on transformed metric so minimize objectives pick lowest cost as leading value" do
     allow(experiment).to receive(:outcome_metrics).and_return(
       [
-        { "key" => "avg_cost_cents", "primary" => true, "objective" => "minimize" },
+        { "key" => "total_cost_cents", "primary" => true, "objective" => "minimize" },
         { "key" => "success_rate", "primary" => false, "objective" => "maximize" },
-        { "key" => "avg_duration_seconds", "primary" => false, "objective" => "minimize" }
+        { "key" => "duration_seconds", "primary" => false, "objective" => "minimize" }
       ]
     )
 

--- a/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
+++ b/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe ScalingExperiments::AnalyzeScalingLaw, :no_db do
     )
   end
 
+  it "ranks on transformed metric so minimize objectives pick lowest cost as leading value" do
+    allow(experiment).to receive(:outcome_metrics).and_return(
+      [
+        { "key" => "avg_cost_cents", "primary" => true, "objective" => "minimize" },
+        { "key" => "success_rate", "primary" => false, "objective" => "maximize" },
+        { "key" => "avg_duration_seconds", "primary" => false, "objective" => "minimize" }
+      ]
+    )
+
+    result = analyze(
+      build_summary(1, sample_count: 3, success_rate: 0.90, duration: 120, cost: 500),
+      build_summary(2, sample_count: 3, success_rate: 0.85, duration: 150, cost: 200),
+      build_summary(4, sample_count: 3, success_rate: 0.80, duration: 200, cost: 100)
+    )
+
+    expect(result["leading_value"]).to eq(4)
+  end
+
   it "emits iteration allocation guidance for iteration-count experiments" do
     allow(experiment).to receive(:dimension).and_return("iteration_count")
 

--- a/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
+++ b/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe ScalingExperiments::AnalyzeScalingLaw, :no_db do
     )
     expect(result["scaling_exponent"]).to be > 0
     expect(result.dig("allocator_decision", "requested_agent_count")).to eq(2)
+    expect(result.dig("allocator_decision", "max_batch_size")).to eq(2)
     expect(result.dig("allocator_decision", "efficiency_gain_vs_control")).to be >= 0.10
     expect(result.fetch("values")).to include(
       hash_including("assigned_value" => 4, "signals" => include("diminishing_returns"))

--- a/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
+++ b/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScalingExperiments::AnalyzeScalingLaw, :no_db do
+  let(:dimension) { "agent_count" }
+  let(:values_tested) { [ 1, 2, 4 ] }
+  let(:control_value) { 1 }
+  let(:experiment) do
+    Struct.new(:dimension, :values_tested, :control_value, :outcome_metrics, keyword_init: true).new(
+      dimension: dimension,
+      values_tested: values_tested,
+      control_value: control_value,
+      outcome_metrics: outcome_metrics
+    )
+  end
+  let(:outcome_metrics) do
+    [
+      { "key" => "success_rate", "primary" => true, "objective" => "maximize" },
+      { "key" => "duration_seconds", "primary" => false, "objective" => "minimize" },
+      { "key" => "total_cost_cents", "primary" => false, "objective" => "minimize" }
+    ]
+  end
+
+  it "estimates a scaling exponent and recommends the most efficient value before diminishing returns" do
+    result = analyze(
+      build_summary(1, sample_count: 3, success_rate: 0.50, duration: 300, cost: 100),
+      build_summary(2, sample_count: 3, success_rate: 0.90, duration: 180, cost: 160),
+      build_summary(4, sample_count: 3, success_rate: 0.95, duration: 170, cost: 360)
+    )
+
+    expect(result).to include(
+      "status" => "ready",
+      "dimension" => "agent_count",
+      "control_value" => 1,
+      "recommended_value" => 2,
+      "leading_value" => 4,
+      "diminishing_returns_at" => 4
+    )
+    expect(result["scaling_exponent"]).to be > 0
+    expect(result.dig("allocator_decision", "requested_agent_count")).to eq(2)
+    expect(result.dig("allocator_decision", "efficiency_gain_vs_control")).to be >= 0.10
+    expect(result.fetch("values")).to include(
+      hash_including("assigned_value" => 4, "signals" => include("diminishing_returns"))
+    )
+  end
+
+  it "emits iteration allocation guidance for iteration-count experiments" do
+    allow(experiment).to receive(:dimension).and_return("iteration_count")
+
+    result = analyze(
+      build_summary(1, sample_count: 3, success_rate: 0.55, duration: 260, cost: 110),
+      build_summary(2, sample_count: 3, success_rate: 0.82, duration: 180, cost: 135),
+      build_summary(4, sample_count: 3, success_rate: 0.84, duration: 178, cost: 220)
+    )
+
+    expect(result.dig("allocator_decision", "requested_iteration_count")).to eq(2)
+    expect(result.dig("allocator_decision", "max_iterations")).to eq(2)
+  end
+
+  def analyze(*value_summaries)
+    described_class.call(
+      scaling_experiment: experiment,
+      value_summaries: value_summaries
+    ).to_h
+  end
+
+  def build_summary(assigned_value, sample_count:, success_rate:, duration:, cost:)
+    {
+      "assigned_value" => assigned_value,
+      "sample_count" => sample_count,
+      "success_rate" => success_rate,
+      "avg_duration_seconds" => duration,
+      "avg_cost_cents" => cost
+    }
+  end
+end

--- a/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
+++ b/spec/services/scaling_experiments/analyze_scaling_law_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe ScalingExperiments::AnalyzeScalingLaw, :no_db do
     expect(result.dig("allocator_decision", "max_iterations")).to eq(2)
   end
 
+  it "emits regression signals when the primary metric and efficiency fall below the prior value" do
+    result = analyze(
+      build_summary(1, sample_count: 3, success_rate: 0.80, duration: 200, cost: 100),
+      build_summary(2, sample_count: 3, success_rate: 0.95, duration: 150, cost: 120),
+      build_summary(4, sample_count: 3, success_rate: 0.70, duration: 260, cost: 180)
+    )
+
+    expect(result.fetch("values")).to include(
+      hash_including(
+        "assigned_value" => 4,
+        "signals" => include("primary_metric_regression", "efficiency_regression")
+      )
+    )
+  end
+
   def analyze(*value_summaries)
     described_class.call(
       scaling_experiment: experiment,

--- a/spec/services/scaling_experiments/summarize_results_spec.rb
+++ b/spec/services/scaling_experiments/summarize_results_spec.rb
@@ -2,39 +2,146 @@
 
 require "rails_helper"
 
-RSpec.describe ScalingExperiments::SummarizeResults do
-  let(:project) { create(:project) }
-  let(:experiment) do
-    create(:scaling_experiment,
-      project: project,
-      values_tested: [ 1, 2 ],
-      cached_summary: {})
-  end
-
-  def create_recorded_assignment(outcome_summary)
-    create(:scaling_experiment_assignment,
-      scaling_experiment: experiment,
-      project: project,
-      assigned_value: 2,
-      outcome_status: "recorded",
-      outcome_summary: outcome_summary,
-      scaling_observation: create(:scaling_observation, project: project, task_count: 2, parallelism_observed: 2, agent_count_launched: 2))
+RSpec.describe ScalingExperiments::SummarizeResults, :no_db do
+  let(:outcome_metrics) do
+    [
+      { "key" => "success_rate", "primary" => true },
+      { "key" => "duration_seconds", "primary" => false },
+      { "key" => "total_cost_cents", "primary" => false },
+      { "key" => "agent_launch_success_rate", "primary" => false },
+      { "key" => "blocked_task_rate", "primary" => false }
+    ]
   end
 
   it "excludes missing rollout summary metrics from aggregate averages" do
-    create_recorded_assignment("cohort_label" => "agent_count-2__tasks-2-3")
-    create_recorded_assignment(
-      "cohort_label" => "agent_count-2__tasks-2-3",
-      "agent_launch_success_rate" => 0.75,
-      "blocked_task_rate" => 0.25
-    )
+    assignments = [
+      build_assignment(2, observation: build_observation(2), outcome_summary: { "cohort_label" => "agent_count-2__tasks-2-3" }),
+      build_assignment(2,
+        observation: build_observation(2),
+        outcome_summary: {
+          "cohort_label" => "agent_count-2__tasks-2-3",
+          "agent_launch_success_rate" => 0.75,
+          "blocked_task_rate" => 0.25
+        })
+    ]
 
-    summary = described_class.call(scaling_experiment: experiment)
+    summary = summarize(assignments)
     value_summary = summary.fetch("values").find { |value| value["assigned_value"] == 2 }
 
     expect(value_summary).to include(
       "agent_launch_success_rate" => 0.75,
       "blocked_task_rate" => 0.25
+    )
+  end
+
+  it "adds scaling-law analysis and allocator guidance to the cached summary" do
+    assignments = [
+      build_assignment(1,
+        observation: build_observation(1, success: false, duration: 300, cost: 100),
+        outcome_summary: { "cohort_label" => "agent_count-1__tasks-2-3" }),
+      build_assignment(2,
+        observation: build_observation(2, duration: 180, cost: 160),
+        outcome_summary: { "cohort_label" => "agent_count-2__tasks-2-3", "avg_quality_score" => 0.9, "quality_metric_sample_count" => 1 }),
+      build_assignment(2,
+        observation: build_observation(2, duration: 175, cost: 165),
+        outcome_summary: { "cohort_label" => "agent_count-2__tasks-2-3", "avg_quality_score" => 0.95, "quality_metric_sample_count" => 1 })
+    ]
+
+    summary = summarize(assignments)
+
+    expect(summary.dig("scaling_law", "status")).to eq("ready")
+    expect(summary.dig("scaling_law", "recommended_value")).to eq(2)
+    expect(summary.dig("allocator_decision", "requested_agent_count")).to eq(2)
+    expect(summary.dig("scaling_law", "allocator_decision", "efficiency_gain_vs_control")).to be >= 0.10
+  end
+
+  def summarize(assignments)
+    described_class.call(scaling_experiment: build_experiment(assignments))
+  end
+
+  def build_experiment(assignments)
+    Struct.new(
+      :dimension,
+      :control_value,
+      :outcome_metrics,
+      :cohort_settings,
+      :values_tested,
+      :scaling_experiment_assignments,
+      keyword_init: true
+    ) do
+      def sufficient_samples?
+        true
+      end
+
+      def samples_key
+        "1:1,2:2"
+      end
+    end.new(
+      dimension: "agent_count",
+      control_value: 1,
+      outcome_metrics: outcome_metrics,
+      cohort_settings: {
+        "assignment_strategy" => "balanced_underfilled",
+        "cadence" => "continuous",
+        "label_template" => "%<dimension>s-%<value>s__%<task_bucket>s"
+      },
+      values_tested: [ 1, 2 ],
+      scaling_experiment_assignments: build_assignment_relation(assignments)
+    )
+  end
+
+  def build_assignment_relation(assignments)
+    Struct.new(:assignments, keyword_init: true) do
+      def recorded
+        self
+      end
+
+      def includes(*)
+        self
+      end
+
+      def to_a
+        assignments
+      end
+    end.new(assignments: assignments)
+  end
+
+  def build_assignment(assigned_value, observation:, outcome_summary:)
+    Struct.new(:assigned_value, :scaling_observation, :outcome_summary, keyword_init: true).new(
+      assigned_value: assigned_value,
+      scaling_observation: observation,
+      outcome_summary: outcome_summary
+    )
+  end
+
+  def build_observation(agent_count, success: true, duration: 120, cost: 300)
+    Struct.new(
+      :success,
+      :total_iterations,
+      :max_iterations,
+      :duration_seconds,
+      :total_cost_cents,
+      :parallelism_observed,
+      :agent_count_launched,
+      :status,
+      :parallel_execution,
+      :parallelism_planned,
+      :agent_count_planned,
+      :agent_count_blocked,
+      keyword_init: true
+    ).new(
+      success: success,
+      total_iterations: 3,
+      max_iterations: 2,
+      duration_seconds: duration,
+      total_cost_cents: cost,
+      parallelism_observed: agent_count,
+      agent_count_launched: agent_count,
+      status: "completed",
+      parallel_execution: true,
+      parallelism_planned: agent_count,
+      agent_count_planned: agent_count,
+      agent_count_blocked: 0
     )
   end
 end


### PR DESCRIPTION
## Summary

Phase 4.5 introduces orchestration scaling-law analysis so resource allocation decisions are driven by measured exponents and diminishing-returns thresholds across multiple dimensions, rather than parallelism alone. This closes out the scaling-law discovery deliverable by wiring analysis output into both experiment summaries and the runtime allocator.

## Changes

- **Services**
  - Add `ScalingExperiments::AnalyzeScalingLaw` to estimate scaling exponents, identify diminishing-returns thresholds, and emit recommended allocations.
  - Feed analyzer output into experiment summaries so results surface alongside other experiment data.
- **Resource allocation**
  - Extend `Scaling::ResourceAllocator` to combine per-dimension decisions across `agent_count`, `parallelism`, and iteration count, replacing the previous parallelism-only path.
- **Tests**
  - Convert affected scaling specs to DB-less coverage so they can run without PostgreSQL.

## Design Decisions

- The allocator merges decisions across three independent dimensions (`agent_count`, `parallelism`, iterations) rather than collapsing them into a single signal. This preserves per-dimension scaling behavior and lets diminishing-returns thresholds apply independently, which matters because the curves differ in shape across dimensions.
- Analysis output is attached to experiment summaries rather than stored in a new dedicated table, keeping the data path simple and tied to the experiment lifecycle.
- Spec coverage in this area was moved to DB-less to keep the scaling code path independently verifiable; this matches the focus of the change but means the broader suite (which still includes DB-bound specs outside this scope) was not exercised end-to-end in the local sandbox.

## Operational Notes

- No migrations or infrastructure changes.
- Full `bundle exec rspec` was not run locally because PostgreSQL is unavailable in the sandbox; CI should be the source of truth for the full suite. Focused scaling specs pass with `ALLOW_DBLESS_SPECS=true COVERAGE=false`, and `bundle exec rubocop` is clean.

---

Closes #1781