### PR TITLE
feat(ci): ephemeral PR test workflow

### DIFF
--- a/.ephemeral-tests/README.md
+++ b/.ephemeral-tests/README.md
@@ -1,0 +1,49 @@
+# Ephemeral PR Tests
+
+One-off system/integration tests that live **only on PR branches**. They run
+in CI for the PR but are not merged to `main`.
+
+## When to use this
+
+- Complex multi-step scenarios that only need to run once for a specific change
+- Exploratory integration tests that validate a new feature end-to-end
+- Tests that are too slow, brittle, or specialized for the permanent suite
+- Validating a migration path or data transformation before merge
+
+## How it works
+
+1. Add `*_spec.rb` (RSpec/Capybara) files to `.ephemeral-tests/` as part
+   of your PR. (Playwright/JS support may be added later.)
+2. CI detects the files and runs the ephemeral test job automatically.
+3. Results are posted as a PR comment.
+4. When the PR merges, the test files don't land on `main` — they exist only
+   on the PR branch.
+
+## Security
+
+- **Same-repo PRs only.** Fork PRs are excluded — tests never execute for
+  external contributions.
+- **Minimal permissions.** The job has `contents: read`, `checks: write`,
+  and `pull-requests: write` (for posting result comments) only.
+- **Standard frameworks only.** Tests run through RSpec, not arbitrary scripts.
+
+## Example
+
+```ruby
+# .ephemeral-tests/multi_agent_orchestration_spec.rb
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Multi-agent orchestration", type: :system do
+  it "runs two agents in sequence and merges both results" do
+    # ... your one-off test ...
+  end
+end
+```
+
+## Cleanup
+
+No cleanup is needed. Tests live on the PR branch and are discarded when the
+branch is deleted after merge. If you want to keep a test permanently, move it
+to `spec/system/` or `spec/integration/` before merging.

--- a/.ephemeral-tests/README.md
+++ b/.ephemeral-tests/README.md
@@ -16,8 +16,8 @@ in CI for the PR but are not merged to `main`.
    of your PR. (Playwright/JS support may be added later.)
 2. CI detects the files and runs the ephemeral test job automatically.
 3. Results are posted as a PR comment.
-4. When the PR merges, the test files don't land on `main` — they exist only
-   on the PR branch.
+4. Remove the test files from `.ephemeral-tests/` before merging — a CI
+   guard on `main` rejects stray test files.
 
 ## Security
 
@@ -44,6 +44,7 @@ end
 
 ## Cleanup
 
-No cleanup is needed. Tests live on the PR branch and are discarded when the
-branch is deleted after merge. If you want to keep a test permanently, move it
+Remove test files from `.ephemeral-tests/` before merging. A CI guard
+job on `main` (`ephemeral-tests-guard` in `ci.yml`) will reject the push
+if stray test files are found. If you want to keep a test permanently, move it
 to `spec/system/` or `spec/integration/` before merging.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,27 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  ephemeral-tests-guard:
+    name: No ephemeral tests on main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Check for stray ephemeral test files
+        run: |
+          stray=$(find .ephemeral-tests -type f \( -name '*_spec.rb' -o -name '*_test.js' -o -name '*_test.ts' \) 2>/dev/null || true)
+          if [ -n "$stray" ]; then
+            echo "::error::Ephemeral test files found on main (should only exist on PR branches):"
+            echo "$stray"
+            echo "::group::Files found"
+            echo "$stray"
+            echo "::endgroup::"
+            exit 1
+          fi
+          echo "No stray ephemeral test files."
+
   lint:
     runs-on: ubuntu-latest
     env:
@@ -74,6 +95,7 @@ jobs:
           systest=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/system_tests.yml | head -1 | awk '{print $NF}')
           test_prof=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/test_prof.yml | head -1 | awk '{print $NF}')
           screenshots=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/pr-screenshots.yml | head -1 | awk '{print $NF}')
+          ephemeral=$(grep -oE 'image:[[:space:]]+postgres:[^[:space:]]+' .github/workflows/ephemeral_tests.yml | head -1 | awk '{print $NF}')
           version=${compose#postgres:}
           major=${version%%.*}
           bookworm_client="postgresql-client-${major}=${version}-1.pgdg12+1"
@@ -86,14 +108,15 @@ jobs:
           echo ".github/workflows/system_tests:  ${systest:-<none>}"
           echo ".github/workflows/test_prof.yml: ${test_prof:-<none>}"
           echo ".github/workflows/pr-screenshots:${screenshots:-<none>}"
+          echo ".github/workflows/ephemeral:     ${ephemeral:-<none>}"
           echo "expected Bookworm client:        ${bookworm_client}"
           echo "expected Trixie client:          ${trixie_client}"
           echo "expected Noble client:           ${noble_client}"
-          if [ -z "$dev" ] || [ -z "$compose" ] || [ -z "$ci" ] || [ -z "$systest" ] || [ -z "$test_prof" ] || [ -z "$screenshots" ]; then
+          if [ -z "$dev" ] || [ -z "$compose" ] || [ -z "$ci" ] || [ -z "$systest" ] || [ -z "$test_prof" ] || [ -z "$screenshots" ] || [ -z "$ephemeral" ]; then
             echo "::error::Postgres image pin missing in one or more files"
             exit 1
           fi
-          if [ "$dev" != "$compose" ] || [ "$compose" != "$ci" ] || [ "$ci" != "$systest" ] || [ "$systest" != "$test_prof" ] || [ "$test_prof" != "$screenshots" ]; then
+          if [ "$dev" != "$compose" ] || [ "$compose" != "$ci" ] || [ "$ci" != "$systest" ] || [ "$systest" != "$test_prof" ] || [ "$test_prof" != "$screenshots" ] || [ "$screenshots" != "$ephemeral" ]; then
             echo "::error::Postgres image pins are out of sync. Update all workflow and compose references together."
             exit 1
           fi
@@ -106,6 +129,7 @@ jobs:
           check_contains .github/workflows/system_tests.yml "$noble_client" ".github/workflows/system_tests.yml is not pinned to $noble_client"
           check_contains .github/workflows/test_prof.yml "$noble_client" ".github/workflows/test_prof.yml is not pinned to $noble_client"
           check_contains .github/workflows/pr-screenshots.yml "$noble_client" ".github/workflows/pr-screenshots.yml is not pinned to $noble_client"
+          check_contains .github/workflows/ephemeral_tests.yml "$noble_client" ".github/workflows/ephemeral_tests.yml is not pinned to $noble_client"
 
   test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ephemeral_tests.yml
+++ b/.github/workflows/ephemeral_tests.yml
@@ -14,8 +14,7 @@ name: Ephemeral PR Tests
 
 on:
   pull_request:
-    paths:
-      - '.ephemeral-tests/**'
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -157,15 +156,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          marker="<!-- ephemeral-tests-result -->"
           conclusion="${{ job.status }}"
           if [ "$conclusion" = "success" ]; then
-            body="## Ephemeral Tests: passed
+            body="${marker}
+          ## Ephemeral Tests: passed
 
           All one-off tests passed. These tests will not run on \`${{ github.base_ref }}\` after merge."
           else
-            body="## Ephemeral Tests: ${conclusion}
+            body="${marker}
+          ## Ephemeral Tests: ${conclusion}
 
           One or more ephemeral tests failed. Check the logs for details."
           fi
 
-          gh pr comment "${{ github.event.pull_request.number }}" --body "$body"
+          # Find existing marker comment and update it, or create a new one
+          existing_comment_id=$(gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" \
+            | head -n 1)
+
+          if [ -n "$existing_comment_id" ]; then
+            gh api \
+              "repos/${{ github.repository }}/issues/comments/${existing_comment_id}" \
+              --method PATCH \
+              --field body="$body"
+          else
+            gh pr comment "${{ github.event.pull_request.number }}" --body "$body"
+          fi

--- a/.github/workflows/ephemeral_tests.yml
+++ b/.github/workflows/ephemeral_tests.yml
@@ -151,13 +151,37 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Comment results on PR
-        if: always()
+  comment-results:
+    name: Reconcile ephemeral test PR comment
+    needs: [detect, run-tests]
+    if: >-
+      always()
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update PR comment
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          HAS_TESTS: ${{ needs.detect.outputs.has_tests }}
+          RUN_TESTS_RESULT: ${{ needs.run-tests.result }}
         run: |
           marker="<!-- ephemeral-tests-result -->"
-          conclusion="${{ job.status }}"
+          existing_comment_id=$(gh api \
+            --paginate \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" \
+            | head -n 1)
+
+          if [ "$HAS_TESTS" != "true" ]; then
+            if [ -n "$existing_comment_id" ]; then
+              gh api \
+                "repos/${{ github.repository }}/issues/comments/${existing_comment_id}" \
+                --method DELETE
+            fi
+            exit 0
+          fi
+
+          conclusion="$RUN_TESTS_RESULT"
           if [ "$conclusion" = "success" ]; then
             body="${marker}
           ## Ephemeral Tests: passed
@@ -167,14 +191,8 @@ jobs:
             body="${marker}
           ## Ephemeral Tests: ${conclusion}
 
-          One or more ephemeral tests failed. Check the logs for details."
+          Ephemeral tests did not complete successfully. Check the logs for details."
           fi
-
-          # Find existing marker comment and update it, or create a new one
-          existing_comment_id=$(gh api \
-            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" \
-            | head -n 1)
 
           if [ -n "$existing_comment_id" ]; then
             gh api \

--- a/.github/workflows/ephemeral_tests.yml
+++ b/.github/workflows/ephemeral_tests.yml
@@ -43,7 +43,7 @@ jobs:
             echo "has_tests=true" >> "$GITHUB_OUTPUT"
             echo "Ephemeral test files found."
           elif find .ephemeral-tests \( -name '*_test.js' -o -name '*_test.ts' \) -print -quit | grep -q .; then
-            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
             echo "Ephemeral test files found (JS/TS only — not yet supported)."
             echo "::warning::JS/TS ephemeral tests are detected but not yet supported. Use *_spec.rb instead."
           else

--- a/.github/workflows/ephemeral_tests.yml
+++ b/.github/workflows/ephemeral_tests.yml
@@ -1,0 +1,171 @@
+name: Ephemeral PR Tests
+
+# One-off system/integration tests that live only on PR branches.
+# See .ephemeral-tests/README.md for usage.
+#
+# Security model:
+#   - Only runs for same-repo PRs (trusted collaborators).
+#   - Fork PRs are explicitly excluded — no secret access, no execution.
+#   - GITHUB_TOKEN is scoped to contents:read + checks:write +
+#     pull-requests:write (for posting result comments) only.
+#   - Tests run through standard RSpec / Capybara / Playwright — no raw
+#     shell execution from PR content.
+#   - Hard 20-minute timeout prevents runaway tests.
+
+on:
+  pull_request:
+    paths:
+      - '.ephemeral-tests/**'
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: ephemeral-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: Detect ephemeral tests
+    runs-on: ubuntu-latest
+    outputs:
+      has_tests: ${{ steps.check.outputs.has_tests }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Check for test files
+        id: check
+        run: |
+          if find .ephemeral-tests -name '*_spec.rb' -print -quit | grep -q .; then
+            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+            echo "Ephemeral test files found."
+          elif find .ephemeral-tests \( -name '*_test.js' -o -name '*_test.ts' \) -print -quit | grep -q .; then
+            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+            echo "Ephemeral test files found (JS/TS only — not yet supported)."
+            echo "::warning::JS/TS ephemeral tests are detected but not yet supported. Use *_spec.rb instead."
+          else
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+            echo "No ephemeral test files found."
+          fi
+
+  run-tests:
+    name: Run ephemeral tests
+    needs: detect
+    if: >-
+      needs.detect.outputs.has_tests == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:16.13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      BUNDLE_FROZEN: "true"
+      RAILS_ENV: test
+      RAILS_TEST_KEY: ${{ secrets.RAILS_TEST_KEY }}
+      DB_HOST: localhost
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      COVERAGE: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde
+        with:
+          ruby-version: .tool-versions
+          bundler-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .tool-versions
+          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile && bin/yarn-postinstall
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc >/dev/null
+          . /etc/os-release
+          printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" | sudo tee /etc/apt/sources.list.d/pgdg.sources >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-16=16.13-1.pgdg24.04+1
+
+      - name: Locate Chromium-family browser
+        run: |
+          path="$(command -v google-chrome || command -v chromium-browser || command -v chromium)"
+          if [ -n "$path" ]; then
+            echo "CHROMIUM_PATH=$path" >> "$GITHUB_ENV"
+            "$path" --version
+          else
+            echo "No Chromium-family browser found; falling back to rack_test."
+          fi
+
+      - name: Build assets
+        run: yarn build && yarn build:css
+
+      - name: Set up database
+        run: bin/rails db:prepare
+
+      - name: Run ephemeral RSpec tests
+        run: |
+          spec_files=$(find .ephemeral-tests -name '*_spec.rb')
+          if [ -n "$spec_files" ]; then
+            # shellcheck disable=SC2086
+            bin/rspec $spec_files
+          else
+            echo "::error::No RSpec test files found. Only *_spec.rb files are supported."
+            exit 1
+          fi
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ephemeral-test-failures
+          path: |
+            tmp/capybara/**
+            log/test.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Comment results on PR
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          conclusion="${{ job.status }}"
+          if [ "$conclusion" = "success" ]; then
+            body="## Ephemeral Tests: passed
+
+          All one-off tests passed. These tests will not run on \`${{ github.base_ref }}\` after merge."
+          else
+            body="## Ephemeral Tests: ${conclusion}
+
+          One or more ephemeral tests failed. Check the logs for details."
+          fi
+
+          gh pr comment "${{ github.event.pull_request.number }}" --body "$body"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,7 @@ record.diff_from(version: 2)             # diff between versions
 - Test behavior/interfaces, not implementation details
 - Mock external dependencies only, never application code
 - Pending specs require issue reference: `pending "supports feature (#45)"`
+- **Ephemeral PR tests** — One-off system/integration tests for the PR that don't need to persist in the permanent suite. Add `*_spec.rb` files to `.ephemeral-tests/` on the PR branch. CI runs them automatically (same-repo PRs only). Remove test files before merge; a CI guard rejects stray test files on `main`. See `.ephemeral-tests/README.md`.
 
 ## Logging
 

--- a/docs/LLM_STYLE_GUIDE.md
+++ b/docs/LLM_STYLE_GUIDE.md
@@ -84,6 +84,15 @@ Analyzing meaning or making a judgment?
 - **No `sleep` in tests** -- use explicit timestamps or `travel_to`. `STYLE_GUIDE:809-844`
 - Target 85-100% coverage for business logic. `STYLE_GUIDE:846-862`
 
+### Ephemeral PR Tests
+
+- One-off system/integration tests that run in CI for a single PR but don't join the permanent suite.
+- **When to use**: new feature validation, complex multi-step scenarios, migration path tests, or any system test too specialized for every PR.
+- **How**: add `*_spec.rb` to `.ephemeral-tests/` on the PR branch. CI auto-detects and runs them.
+- **Security**: same-repo PRs only (trusted collaborators). Minimal CI permissions (`contents: read`).
+- **Cleanup**: remove test files before merge. A CI guard on `main` rejects stray test files.
+- If a test proves valuable long-term, move it to `spec/system/` or `spec/integration/` before merging.
+
 ### Pending Specs (Strict)
 
 | Case | Allowed? |

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -889,6 +889,46 @@ pending "not working"
 
 **Rationale**: Pending specs without tracking accumulate and become noise. They represent technical debt that's not tracked anywhere. Requiring issue references ensures the work is visible and prioritized.
 
+### Ephemeral PR Tests
+
+One-off system/integration tests that run in CI for a single PR but are not part of the permanent test suite.
+
+**When to use**:
+
+- Validating a new feature end-to-end before it's had real-world exposure
+- Complex multi-step scenarios that are too specialized for every PR
+- Testing migration paths, data transformations, or orchestration flows
+- Exploratory integration tests that would be brittle as permanent fixtures
+
+**When NOT to use**:
+
+- Regression tests (add to `spec/` permanently)
+- Unit or service-level tests (add to the appropriate `spec/` subdirectory)
+- Tests that need to run on every future PR
+
+**How it works**:
+
+1. Add `*_spec.rb` files to `.ephemeral-tests/` on the PR branch.
+2. CI auto-detects the files and runs them as a separate job (`.github/workflows/ephemeral_tests.yml`).
+3. The job only runs for same-repo PRs (trusted collaborators). Fork PRs are excluded.
+4. Results are posted as a PR comment.
+5. Remove test files before merge. A CI guard on `main` (`ephemeral-tests-guard` job in `ci.yml`) rejects stray test files.
+
+**Promote valuable tests**: If an ephemeral test proves it would catch future regressions, move it to `spec/system/` or `spec/integration/` before merging.
+
+```ruby
+# .ephemeral-tests/multi_agent_handoff_spec.rb
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Multi-agent handoff", type: :system do
+  it "completes a full agent handoff workflow end-to-end" do
+    # ... one-off test specific to this PR's changes ...
+  end
+end
+```
+
 ---
 
 ## Error Handling


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ephemeral_tests.yml` — one-off system/integration tests that live only on PR branches. PR authors add `*_spec.rb` files to `.ephemeral-tests/` and CI runs them automatically.
- Add `ephemeral-tests-guard` job to `ci.yml` — rejects stray test files on `main` and is included in the Postgres pin sync check.
- Add `.ephemeral-tests/README.md` — usage documentation for contributors.
- Update `CLAUDE.md`, `STYLE_GUIDE.md`, and `LLM_STYLE_GUIDE.md` with ephemeral test guidance for AI assistants.

### Security model

- Same-repo PRs only — fork PRs are explicitly excluded
- Minimal permissions: `contents: read`, `checks: write`, `pull-requests: write`
- 20-minute hard timeout
- Standard RSpec/Capybara execution only

### Test plan

- [ ] Open a same-repo PR with a `*_spec.rb` file in `.ephemeral-tests/` and verify the workflow triggers
- [ ] Verify fork PRs with `.ephemeral-tests/` changes do NOT trigger the `run-tests` job
- [ ] Verify the guard job runs on `push: main` and fails if test files are present
- [ ] Verify the PR comment is posted correctly on pass/fail
- [ ] Verify Postgres pin sync check includes the new workflow