### PR TITLE
feat(dashboard): add bundle performance analysis dashboard

### DIFF
--- a/app/services/projects/bundle_performance_dashboard_stats.rb
+++ b/app/services/projects/bundle_performance_dashboard_stats.rb
@@ -311,8 +311,9 @@ module Projects
       @active_experiments ||= ConfigurationExperiment
         .running
         .where(config_key: ConfigurationExperiment::TRACKED_CONFIG_KEYS)
+        .where(account_id: [ project.account_id, nil ])
         .select { |experiment| experiment.includes_traffic?(project: project) }
-        .sort_by(&:id)
+        .sort_by { |experiment| [ experiment.account_id == project.account_id ? 0 : 1, experiment.id ] }
     end
 
     def experiment_variants_by_experiment_id

--- a/app/services/projects/bundle_performance_dashboard_stats.rb
+++ b/app/services/projects/bundle_performance_dashboard_stats.rb
@@ -124,7 +124,7 @@ module Projects
     end
 
     def experiment_confidence
-      active_experiments.map do |experiment|
+      @experiment_confidence ||= active_experiments.map do |experiment|
         variant_stats = project_scoped_variant_stats(experiment)
         variants = experiment_variants_by_experiment_id.fetch(experiment.id, [])
 
@@ -311,7 +311,6 @@ module Projects
       @active_experiments ||= ConfigurationExperiment
         .running
         .where(config_key: ConfigurationExperiment::TRACKED_CONFIG_KEYS)
-        .includes(:configuration_experiment_variants)
         .select { |experiment| experiment.includes_traffic?(project: project) }
         .sort_by(&:id)
     end

--- a/app/services/projects/bundle_performance_dashboard_stats.rb
+++ b/app/services/projects/bundle_performance_dashboard_stats.rb
@@ -21,6 +21,7 @@ module Projects
 
       {
         summary: summary,
+        sparse_details: sparse_details(insights),
         bundle_rankings: bundle_rankings,
         experiment_confidence: experiment_confidence,
         optimizer_insights: insights,
@@ -58,6 +59,16 @@ module Projects
       return false unless summary[:outcome_count].zero? && summary[:active_experiment_count].zero?
 
       insights.none? { |insight| insight[:candidates].present? }
+    end
+
+    def sparse_details(insights)
+      {
+        sparse_bundle_count: summary[:sparse_bundle_count],
+        sparse_experiment_count: experiment_confidence.count do |experiment|
+          experiment[:variants].any? { |variant| variant[:sparse] }
+        end,
+        sparse_goal_count: insights.count { |insight| insight[:sparse] }
+      }
     end
 
     def bundle_rankings
@@ -300,13 +311,9 @@ module Projects
       @active_experiments ||= ConfigurationExperiment
         .running
         .where(config_key: ConfigurationExperiment::TRACKED_CONFIG_KEYS)
-        .where(
-          id: ConfigurationExperimentAssignment
-            .joins(:agent_run)
-            .where(agent_runs: { project_id: project.id })
-            .select(:configuration_experiment_id)
-        )
-        .to_a
+        .includes(:configuration_experiment_variants)
+        .select { |experiment| experiment.includes_traffic?(project: project) }
+        .sort_by(&:id)
     end
 
     def experiment_variants_by_experiment_id

--- a/app/services/projects/bundle_performance_dashboard_stats.rb
+++ b/app/services/projects/bundle_performance_dashboard_stats.rb
@@ -308,12 +308,9 @@ module Projects
     end
 
     def active_experiments
-      @active_experiments ||= ConfigurationExperiment
-        .running
-        .where(config_key: ConfigurationExperiment::TRACKED_CONFIG_KEYS)
-        .where(account_id: [ project.account_id, nil ])
-        .select { |experiment| experiment.includes_traffic?(project: project) }
-        .sort_by { |experiment| [ experiment.account_id == project.account_id ? 0 : 1, experiment.id ] }
+      @active_experiments ||= ConfigurationExperiment::TRACKED_CONFIG_KEYS.filter_map do |config_key|
+        ConfigurationExperiment.active_for(config_key, project: project)
+      end
     end
 
     def experiment_variants_by_experiment_id

--- a/app/services/projects/bundle_performance_dashboard_stats.rb
+++ b/app/services/projects/bundle_performance_dashboard_stats.rb
@@ -308,9 +308,38 @@ module Projects
     end
 
     def active_experiments
-      @active_experiments ||= ConfigurationExperiment::TRACKED_CONFIG_KEYS.filter_map do |config_key|
-        ConfigurationExperiment.active_for(config_key, project: project)
+      @active_experiments ||= begin
+        project_relevant = ConfigurationExperiment::TRACKED_CONFIG_KEYS.filter_map do |config_key|
+          ConfigurationExperiment.active_for(config_key, project: project)
+        end
+
+        (project_relevant + assignment_backed_active_experiments)
+          .uniq(&:id)
+          .sort_by { |experiment| active_experiment_sort_key(experiment) }
       end
+    end
+
+    def assignment_backed_active_experiments
+      experiment_scope_for_project
+        .joins(configuration_experiment_assignments: :agent_run)
+        .where(agent_runs: { project_id: project.id })
+        .distinct
+        .to_a
+    end
+
+    def experiment_scope_for_project
+      ConfigurationExperiment
+        .running
+        .where(config_key: ConfigurationExperiment::TRACKED_CONFIG_KEYS)
+        .where(account_id: [ project.account_id, nil ])
+    end
+
+    def active_experiment_sort_key(experiment)
+      [
+        ConfigurationExperiment::TRACKED_CONFIG_KEYS.index(experiment.config_key) || ConfigurationExperiment::TRACKED_CONFIG_KEYS.length,
+        experiment.account_id == project.account_id ? 0 : 1,
+        experiment.id
+      ]
     end
 
     def experiment_variants_by_experiment_id

--- a/app/services/projects/bundle_performance_dashboard_stats.rb
+++ b/app/services/projects/bundle_performance_dashboard_stats.rb
@@ -309,12 +309,12 @@ module Projects
 
     def active_experiments
       @active_experiments ||= begin
-        project_relevant = ConfigurationExperiment::TRACKED_CONFIG_KEYS.filter_map do |config_key|
-          ConfigurationExperiment.active_for(config_key, project: project)
-        end
+        assignment_backed_by_key = assignment_backed_active_experiments.index_by(&:config_key)
 
-        (project_relevant + assignment_backed_active_experiments)
-          .uniq(&:id)
+        ConfigurationExperiment::TRACKED_CONFIG_KEYS.filter_map do |config_key|
+          ConfigurationExperiment.active_for(config_key, project: project) ||
+            assignment_backed_by_key[config_key]
+        end
           .sort_by { |experiment| active_experiment_sort_key(experiment) }
       end
     end

--- a/app/views/projects/bundle_performance_dashboards/show.html.erb
+++ b/app/views/projects/bundle_performance_dashboards/show.html.erb
@@ -44,6 +44,26 @@
       </div>
     </div>
 
+    <% sparse_details = @stats[:sparse_details] %>
+    <% if sparse_details[:sparse_bundle_count].positive? || sparse_details[:sparse_experiment_count].positive? || sparse_details[:sparse_goal_count].positive? %>
+      <div class="mt-6 rounded-lg bg-yellow-50 p-4 ring-1 ring-inset ring-yellow-200">
+        <h2 class="text-sm font-semibold text-yellow-900">Sparse Evidence Summary</h2>
+        <p class="mt-1 text-sm text-yellow-800">
+          <% sparse_notes = [] %>
+          <% if sparse_details[:sparse_bundle_count].positive? %>
+            <% sparse_notes << "#{pluralize(sparse_details[:sparse_bundle_count], 'bundle')} below the 3-sample review threshold" %>
+          <% end %>
+          <% if sparse_details[:sparse_experiment_count].positive? %>
+            <% sparse_notes << "#{pluralize(sparse_details[:sparse_experiment_count], 'active experiment')} still needs more samples" %>
+          <% end %>
+          <% if sparse_details[:sparse_goal_count].positive? %>
+            <% sparse_notes << "#{pluralize(sparse_details[:sparse_goal_count], 'optimizer goal')} currently relies on sparse predictions" %>
+          <% end %>
+          <%= sparse_notes.join(". ") %>.
+        </p>
+      </div>
+    <% end %>
+
     <div class="mt-8">
       <h2 class="text-lg font-semibold text-gray-900">Bundle Performance</h2>
       <p class="mt-1 text-sm text-gray-500">Top bundles ranked by the observed outcome-cost objective, with raw quality and efficiency shown alongside sparse evidence warnings.</p>

--- a/app/views/projects/bundle_performance_dashboards/show.html.erb
+++ b/app/views/projects/bundle_performance_dashboards/show.html.erb
@@ -54,10 +54,10 @@
             <% sparse_notes << "#{pluralize(sparse_details[:sparse_bundle_count], 'bundle')} below the 3-sample review threshold" %>
           <% end %>
           <% if sparse_details[:sparse_experiment_count].positive? %>
-            <% sparse_notes << "#{pluralize(sparse_details[:sparse_experiment_count], 'active experiment')} still need more samples" %>
+            <% sparse_notes << "#{pluralize(sparse_details[:sparse_experiment_count], 'active experiment')} still #{sparse_details[:sparse_experiment_count] == 1 ? 'needs' : 'need'} more samples" %>
           <% end %>
           <% if sparse_details[:sparse_goal_count].positive? %>
-            <% sparse_notes << "#{pluralize(sparse_details[:sparse_goal_count], 'optimizer goal')} currently rely on sparse predictions" %>
+            <% sparse_notes << "#{pluralize(sparse_details[:sparse_goal_count], 'optimizer goal')} currently #{sparse_details[:sparse_goal_count] == 1 ? 'relies' : 'rely'} on sparse predictions" %>
           <% end %>
           <%= sparse_notes.join(". ") %>.
         </p>

--- a/app/views/projects/bundle_performance_dashboards/show.html.erb
+++ b/app/views/projects/bundle_performance_dashboards/show.html.erb
@@ -54,10 +54,10 @@
             <% sparse_notes << "#{pluralize(sparse_details[:sparse_bundle_count], 'bundle')} below the 3-sample review threshold" %>
           <% end %>
           <% if sparse_details[:sparse_experiment_count].positive? %>
-            <% sparse_notes << "#{pluralize(sparse_details[:sparse_experiment_count], 'active experiment')} still needs more samples" %>
+            <% sparse_notes << "#{pluralize(sparse_details[:sparse_experiment_count], 'active experiment')} still need more samples" %>
           <% end %>
           <% if sparse_details[:sparse_goal_count].positive? %>
-            <% sparse_notes << "#{pluralize(sparse_details[:sparse_goal_count], 'optimizer goal')} currently relies on sparse predictions" %>
+            <% sparse_notes << "#{pluralize(sparse_details[:sparse_goal_count], 'optimizer goal')} currently rely on sparse predictions" %>
           <% end %>
           <%= sparse_notes.join(". ") %>.
         </p>

--- a/spec/requests/projects/bundle_performance_dashboards_spec.rb
+++ b/spec/requests/projects/bundle_performance_dashboards_spec.rb
@@ -39,6 +39,27 @@ RSpec.describe "Projects::BundlePerformanceDashboards" do
         expect(response.body).to include(bundle.name)
         expect(response.body).to include("knowledge.token_budget=8000")
       end
+
+      it "shows active experiments with sparse guidance before the project has assignments" do
+        experiment = create(:configuration_experiment,
+          account: account,
+          status: "running",
+          min_samples_per_variant: 2)
+        create(:configuration_experiment_variant,
+          configuration_experiment: experiment,
+          config_value: experiment.control_value,
+          is_control: true)
+        create(:configuration_experiment_variant,
+          configuration_experiment: experiment,
+          config_value: JSON.generate(8000))
+
+        get project_bundle_performance_dashboard_path(project)
+
+        expect(response.body).to include("Sparse Evidence Summary")
+        expect(response.body).to include("1 active experiment still needs more samples")
+        expect(response.body).to include("Knowledge Token Budget")
+        expect(response.body).to include("Needs more data")
+      end
     end
   end
 

--- a/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
+++ b/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
@@ -172,23 +172,24 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
 
     it "keeps assignment-backed active experiments visible when project rollout excludes the project" do
       experiment, control, variant = create_experiment(project:, traffic_percentage: 50)
-      assigned_project, assigned_run = create_assignment_backed_project_for(experiment)
+      assigned_project, assigned_runs = create_assignment_backed_project_for(experiment, run_count: 2)
+      control_run, variant_run = assigned_runs
 
       create(:configuration_experiment_assignment,
         configuration_experiment: experiment,
         configuration_experiment_variant: control,
-        agent_run: assigned_run,
+        agent_run: control_run,
         quality_score: 0.4)
       create(:configuration_experiment_assignment,
         configuration_experiment: experiment,
         configuration_experiment_variant: variant,
-        agent_run: assigned_run,
+        agent_run: variant_run,
         quality_score: 0.8)
 
       stats = described_class.call(project: assigned_project)
 
       expect(experiment.includes_traffic?(project: assigned_project)).to be(false)
-      expect(experiment.includes_traffic?(agent_run: assigned_run)).to be(true)
+      expect(assigned_runs).to all(satisfy { |run| experiment.includes_traffic?(agent_run: run) })
       expect(stats[:summary][:active_experiment_count]).to eq(1)
       expect(stats[:experiment_confidence].map { |row| row[:experiment] }).to eq([ experiment ])
       expect(stats[:experiment_confidence].first[:variants].map { |row| row[:sample_count] }).to eq([ 1, 1 ])
@@ -197,17 +198,18 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
     it "prefers the runtime-active experiment over assignment-backed history for the same config key" do
       global_experiment, = create_experiment(project:, account: nil, config_key: "knowledge.token_budget")
       stale_experiment, stale_control, stale_variant = create_experiment(project:, config_key: "knowledge.token_budget", traffic_percentage: 50)
-      assigned_project, assigned_run = create_assignment_backed_project_for(stale_experiment)
+      assigned_project, assigned_runs = create_assignment_backed_project_for(stale_experiment, run_count: 2)
+      control_run, variant_run = assigned_runs
 
       create(:configuration_experiment_assignment,
         configuration_experiment: stale_experiment,
         configuration_experiment_variant: stale_control,
-        agent_run: assigned_run,
+        agent_run: control_run,
         quality_score: 0.4)
       create(:configuration_experiment_assignment,
         configuration_experiment: stale_experiment,
         configuration_experiment_variant: stale_variant,
-        agent_run: assigned_run,
+        agent_run: variant_run,
         quality_score: 0.8)
 
       stats = described_class.call(project: assigned_project)
@@ -357,20 +359,25 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
     shared_issues[project.id] ||= create(:issue, project: project)
   end
 
-  def create_assignment_backed_project_for(experiment)
+  def create_assignment_backed_project_for(experiment, run_count:)
     50.times do
       project = create(:project, account: experiment.account)
       next if experiment.includes_traffic?(project: project)
 
-      run = create(:agent_run,
-        :completed,
-        project: project,
-        issue: create(:issue, project: project),
-        goal: "create_pr")
-      return [ project, run ] if experiment.includes_traffic?(agent_run: run)
+      runs = Array.new(run_count) do
+        create(:agent_run,
+          :completed,
+          project: project,
+          issue: create(:issue, project: project),
+          goal: "create_pr")
+      end
+
+      next unless runs.all? { |run| experiment.includes_traffic?(agent_run: run) }
+
+      return [ project, runs ]
     end
 
-    raise "Could not create a project excluded from project rollout with an included assigned run"
+    raise "Could not create a project excluded from project rollout with included assigned runs"
   end
 
   def mock_optimizer_selection

--- a/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
+++ b/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
@@ -148,6 +148,17 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
       expect(stats[:experiment_confidence].map { |row| row[:experiment] }).to eq([ selected_experiment ])
     end
 
+    it "excludes running experiments from other accounts even when rollout membership matches" do
+      selected_experiment, = create_experiment(project:)
+      other_account_project = create(:project)
+      create_experiment(project: other_account_project)
+
+      stats = described_class.call(project: project)
+
+      expect(stats[:summary][:active_experiment_count]).to eq(1)
+      expect(stats[:experiment_confidence].map { |row| row[:experiment] }).to eq([ selected_experiment ])
+    end
+
     it "includes active project experiments before they have assignment data" do
       experiment, = create_experiment(project:)
 

--- a/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
+++ b/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
@@ -194,6 +194,30 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
       expect(stats[:experiment_confidence].first[:variants].map { |row| row[:sample_count] }).to eq([ 1, 1 ])
     end
 
+    it "prefers the runtime-active experiment over assignment-backed history for the same config key" do
+      global_experiment, = create_experiment(project:, account: nil, config_key: "knowledge.token_budget")
+      stale_experiment, stale_control, stale_variant = create_experiment(project:, config_key: "knowledge.token_budget")
+      assigned_project, assigned_run = create_assignment_backed_project_for(stale_experiment)
+
+      create(:configuration_experiment_assignment,
+        configuration_experiment: stale_experiment,
+        configuration_experiment_variant: stale_control,
+        agent_run: assigned_run,
+        quality_score: 0.4)
+      create(:configuration_experiment_assignment,
+        configuration_experiment: stale_experiment,
+        configuration_experiment_variant: stale_variant,
+        agent_run: assigned_run,
+        quality_score: 0.8)
+
+      stats = described_class.call(project: assigned_project)
+
+      expect(stale_experiment.includes_traffic?(project: assigned_project)).to be(false)
+      expect(ConfigurationExperiment.active_for("knowledge.token_budget", project: assigned_project)).to eq(global_experiment)
+      expect(stats[:summary][:active_experiment_count]).to eq(1)
+      expect(stats[:experiment_confidence].map { |row| row[:experiment] }).to eq([ global_experiment ])
+    end
+
     it "loads experiment variants once per experiment when building confidence stats" do
       experiment, control, variant = create_experiment(project:)
       create_bundle(project:, experiment:, variant:)

--- a/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
+++ b/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
@@ -148,6 +148,17 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
       expect(stats[:experiment_confidence].map { |row| row[:experiment] }).to eq([ selected_experiment ])
     end
 
+    it "includes active project experiments before they have assignment data" do
+      experiment, = create_experiment(project:)
+
+      stats = described_class.call(project: project)
+
+      expect(stats[:summary][:active_experiment_count]).to eq(1)
+      expect(stats[:experiment_confidence].map { |row| row[:experiment] }).to eq([ experiment ])
+      expect(stats[:experiment_confidence].first[:variants]).to all(include(sample_count: 0, sparse: true))
+      expect(stats[:sparse_details][:sparse_experiment_count]).to eq(1)
+    end
+
     it "loads experiment variants once per experiment when building confidence stats" do
       experiment, control, variant = create_experiment(project:)
       create_bundle(project:, experiment:, variant:)

--- a/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
+++ b/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
 
     it "prefers the runtime-active experiment over assignment-backed history for the same config key" do
       global_experiment, = create_experiment(project:, account: nil, config_key: "knowledge.token_budget")
-      stale_experiment, stale_control, stale_variant = create_experiment(project:, config_key: "knowledge.token_budget")
+      stale_experiment, stale_control, stale_variant = create_experiment(project:, config_key: "knowledge.token_budget", traffic_percentage: 50)
       assigned_project, assigned_run = create_assignment_backed_project_for(stale_experiment)
 
       create(:configuration_experiment_assignment,

--- a/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
+++ b/spec/services/projects/bundle_performance_dashboard_stats_spec.rb
@@ -170,6 +170,30 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
       expect(stats[:sparse_details][:sparse_experiment_count]).to eq(1)
     end
 
+    it "keeps assignment-backed active experiments visible when project rollout excludes the project" do
+      experiment, control, variant = create_experiment(project:, traffic_percentage: 50)
+      assigned_project, assigned_run = create_assignment_backed_project_for(experiment)
+
+      create(:configuration_experiment_assignment,
+        configuration_experiment: experiment,
+        configuration_experiment_variant: control,
+        agent_run: assigned_run,
+        quality_score: 0.4)
+      create(:configuration_experiment_assignment,
+        configuration_experiment: experiment,
+        configuration_experiment_variant: variant,
+        agent_run: assigned_run,
+        quality_score: 0.8)
+
+      stats = described_class.call(project: assigned_project)
+
+      expect(experiment.includes_traffic?(project: assigned_project)).to be(false)
+      expect(experiment.includes_traffic?(agent_run: assigned_run)).to be(true)
+      expect(stats[:summary][:active_experiment_count]).to eq(1)
+      expect(stats[:experiment_confidence].map { |row| row[:experiment] }).to eq([ experiment ])
+      expect(stats[:experiment_confidence].first[:variants].map { |row| row[:sample_count] }).to eq([ 1, 1 ])
+    end
+
     it "loads experiment variants once per experiment when building confidence stats" do
       experiment, control, variant = create_experiment(project:)
       create_bundle(project:, experiment:, variant:)
@@ -307,6 +331,22 @@ RSpec.describe Projects::BundlePerformanceDashboardStats do
 
   def shared_issue_for(project)
     shared_issues[project.id] ||= create(:issue, project: project)
+  end
+
+  def create_assignment_backed_project_for(experiment)
+    50.times do
+      project = create(:project, account: experiment.account)
+      next if experiment.includes_traffic?(project: project)
+
+      run = create(:agent_run,
+        :completed,
+        project: project,
+        issue: create(:issue, project: project),
+        goal: "create_pr")
+      return [ project, run ] if experiment.includes_traffic?(agent_run: run)
+    end
+
+    raise "Could not create a project excluded from project rollout with an included assigned run"
   end
 
   def mock_optimizer_selection

--- a/spec/system/projects/bundle_performance_dashboard_spec.rb
+++ b/spec/system/projects/bundle_performance_dashboard_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "warden/test/helpers"
+
+RSpec.describe "Project bundle performance dashboard", system_driver: :rack_test, type: :system do
+  include Warden::Test::Helpers
+
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :owner, account: account) }
+  let(:github_token) { create(:github_token, account: account) }
+  let!(:project) { create(:project, account: account, github_token: github_token) }
+
+  before do
+    Warden.test_mode!
+    login_as(user, scope: :user)
+  end
+
+  after do
+    Warden.test_reset!
+  end
+
+  it "links from the project page and shows sparse dashboard guidance" do
+    experiment = create(:configuration_experiment,
+      account: account,
+      status: "running",
+      min_samples_per_variant: 2)
+    create(:configuration_experiment_variant,
+      configuration_experiment: experiment,
+      config_value: experiment.control_value,
+      is_control: true)
+    create(:configuration_experiment_variant,
+      configuration_experiment: experiment,
+      config_value: JSON.generate(8000))
+
+    visit project_path(project)
+    click_link "Bundle Analysis"
+
+    expect(page).to have_current_path(project_bundle_performance_dashboard_path(project))
+    expect(page).to have_content("Bundle Performance Analysis")
+    expect(page).to have_content("Sparse Evidence Summary")
+    expect(page).to have_content("Knowledge Token Budget")
+    expect(page).to have_content("Needs more data")
+  end
+end


### PR DESCRIPTION
## Summary

Exposes bundle performance data through a new dashboard so configuration experiment results are understandable and reviewable, with explicit handling for sparse-evidence scenarios that previously left users without signal.

## Changes

- **UI / Dashboard**: New bundle analysis dashboard with sections for bundle performance, confidence, and outcome-cost tradeoffs; surfaces active project-relevant configuration experiments even before they have assignment data; adds a `Sparse Evidence Summary` callout when signal is thin.
- **Navigation**: Entry point from the project page into the bundle analysis dashboard.
- **Data wiring**: Connected dashboard views to bundle outcome and optimizer data sources.
- **Tests**: Request and service specs covering the sparse-experiment case; new system spec exercising project page → bundle analysis navigation.

## Design Decisions

- **Sparse-data is a first-class state, not an empty view.** Rather than hiding sections until thresholds are met, the dashboard renders active experiments with a `Sparse Evidence Summary` callout so reviewers can see what's being measured before outcomes accumulate.
- **Reused existing bundle/confidence/tradeoff sections** rather than restructuring — the sparse-signal work is additive and leaves established surfaces intact.

## Operational Notes

- No migrations or infrastructure changes.
- Full `bundle exec rspec` could not be run in the authoring container (PostgreSQL unavailable); RuboCop and the staged lint hook passed. Please confirm the suite is green in CI before merge.

## Screenshots

_Before/after screenshots of the bundle analysis dashboard (including the sparse-evidence state) to be attached by the author._

---

Closes #1802