### PR TITLE
feat(coordination): Phase 4.4 — Self-Improving Agent Coordination

### DIFF
--- a/.github/workflows/pr-screenshots-publish.yml
+++ b/.github/workflows/pr-screenshots-publish.yml
@@ -5,7 +5,7 @@ on:
     types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency:
-  group: pr-screenshots-publish-${{ github.event.pull_request.number }}
+  group: pr-screenshots-publish-${{ github.event.pull_request.number }}-${{ github.event.action }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -12,11 +12,13 @@ on:
 # trusted publish/comment work runs from `pr-screenshots-publish.yml` on
 # `pull_request_target` using base-branch code.
 
-# Cancel in-progress screenshot runs on the same PR when a new commit is pushed.
-# Uses PR number instead of github.ref so pull_request_target events (which resolve
-# to the base branch) don't collide across PRs.
+# Cancel in-progress screenshot runs when the same PR event type is retriggered.
+# Including the action avoids "synchronize" and "ready_for_review" runs for the
+# same SHA canceling each other and leaving duplicate cancelled checks behind.
+# Uses PR number instead of github.ref so pull_request_target events (which
+# resolve to the base branch) don't collide across PRs.
 concurrency:
-  group: pr-screenshots-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: pr-screenshots-${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
   cancel-in-progress: true
 
 jobs:

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -490,7 +490,7 @@ module CoordinationPolicyEvolution
     end
 
     def policy_provenance(metadata)
-      metadata.to_h.slice(*POLICY_PROVENANCE_KEYS).deep_symbolize_keys
+      metadata.to_h.deep_stringify_keys.slice(*POLICY_PROVENANCE_KEYS).deep_symbolize_keys
     end
   end
 end

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -490,7 +490,7 @@ module CoordinationPolicyEvolution
     end
 
     def policy_provenance(metadata)
-      metadata.to_h.slice(*POLICY_PROVENANCE_KEYS)
+      metadata.to_h.slice(*POLICY_PROVENANCE_KEYS).deep_symbolize_keys
     end
   end
 end

--- a/app/services/coordination_policy_evolution/prepare_inputs.rb
+++ b/app/services/coordination_policy_evolution/prepare_inputs.rb
@@ -36,6 +36,13 @@ module CoordinationPolicyEvolution
     ORCHESTRATION_FAILURE_STATUSES = %w[failed].freeze
     ORCHESTRATION_NOOP_STATUSES = %w[noop].freeze
     DEFAULT_ORCHESTRATION_DECISION_STATUS = "applied"
+    POLICY_PROVENANCE_KEYS = %w[
+      policy_source
+      policy_key
+      coordination_policy_id
+      coordination_policy_version_id
+      coordination_policy_version
+    ].freeze
 
     def self.call(...)
       new(...).call
@@ -251,7 +258,7 @@ module CoordinationPolicyEvolution
           hints: decision.hints,
           error_details: decision.error_details,
           metadata: decision.metadata
-        }
+        }.merge(policy_provenance(decision.metadata))
       end
     end
 
@@ -480,6 +487,10 @@ module CoordinationPolicyEvolution
 
     def policy_description
       POLICY_DESCRIPTIONS.fetch(policy_type, "Account-level coordination policy.")
+    end
+
+    def policy_provenance(metadata)
+      metadata.to_h.slice(*POLICY_PROVENANCE_KEYS)
     end
   end
 end

--- a/app/services/decomposition_service.rb
+++ b/app/services/decomposition_service.rb
@@ -146,7 +146,8 @@ class DecompositionService
   end
 
   def extract_decomposition_config_from_hash(config, ignore_default_nested_values: false)
-    return {} unless config.is_a?(Hash)
+    config = normalize_json_object(config)
+    return {} if config.empty?
 
     {}.tap do |result|
       decomposition = config.fetch("decomposition", {})
@@ -241,7 +242,7 @@ class DecompositionService
   end
 
   def normalize_json_object(value)
-    value.is_a?(Hash) ? value : {}
+    value.is_a?(Hash) ? value.deep_stringify_keys : {}
   end
 
   def normalize_max_tasks(value)

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -73,7 +73,7 @@ module Activities
         {
         tasks: tasks,
         prompt_source: prompt_data[:prompt_source],
-        policy_metadata: {}
+        policy_metadata: policy_context[:metadata]
       }
       )
     rescue Temporalio::Error::ApplicationError => e

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -73,9 +73,7 @@ module Activities
         {
         tasks: tasks,
         prompt_source: prompt_data[:prompt_source],
-        policy_source: policy_context[:source],
-        skip_reason: policy_context[:skip_reason],
-        policy_metadata: fallback_policy_metadata(policy_context)
+        policy_metadata: {}
       }
       )
     rescue Temporalio::Error::ApplicationError => e
@@ -332,13 +330,6 @@ module Activities
         coordination_policy_id: decomposition_result.policy_applied["coordination_policy_id"],
         coordination_policy_version_id: decomposition_result.policy_applied["coordination_policy_version_id"],
         coordination_policy_version: decomposition_result.policy_applied["coordination_policy_version"]
-      }.compact
-    end
-
-    def fallback_policy_metadata(policy_context)
-      {
-        policy_source: policy_context[:source],
-        skip_reason: policy_context[:skip_reason]
       }.compact
     end
 

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -92,7 +92,7 @@ module Activities
           error_message: e.message
         }
       )
-      raise
+      raise application_error_with_policy_provenance(e, policy_context)
     end
 
     private
@@ -116,6 +116,7 @@ module Activities
       context[:source] = decomposition_result.policy_source
       context[:present] = policy_source_present?(decomposition_result.policy_source)
       context[:skip_reason] = decomposition_result.skip_reason
+      context[:metadata] = result_policy_metadata(decomposition_result)
 
       return [ nil, context ] unless use_policy_service_result?(decomposition_result)
 
@@ -317,6 +318,7 @@ module Activities
         present: false,
         source: nil,
         skip_reason: nil,
+        metadata: {},
         error_details: {},
         scope_analysis: {}
       }
@@ -345,6 +347,25 @@ module Activities
       payload.merge(
         policy_metadata: normalized_metadata,
         **normalized_metadata
+      )
+    end
+
+    def application_error_with_policy_provenance(error, policy_context)
+      metadata = policy_context[:metadata].to_h
+      return error if metadata.empty?
+
+      existing_details = Array(error.details)
+      provenance_details = existing_details.find { |detail| detail.is_a?(Hash) && detail.key?(:policy_metadata) }
+      return error if provenance_details
+
+      Temporalio::Error::ApplicationError.new(
+        error.message,
+        *existing_details,
+        { policy_metadata: metadata },
+        type: error.type,
+        non_retryable: error.non_retryable,
+        next_retry_delay: error.next_retry_delay,
+        category: error.category
       )
     end
 

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -323,13 +323,15 @@ module Activities
     end
 
     def result_policy_metadata(decomposition_result)
+      policy_applied = decomposition_result.policy_applied.to_h.deep_stringify_keys
+
       {
         policy_source: decomposition_result.policy_source,
         skip_reason: decomposition_result.skip_reason,
-        policy_key: decomposition_result.policy_applied["policy_key"],
-        coordination_policy_id: decomposition_result.policy_applied["coordination_policy_id"],
-        coordination_policy_version_id: decomposition_result.policy_applied["coordination_policy_version_id"],
-        coordination_policy_version: decomposition_result.policy_applied["coordination_policy_version"]
+        policy_key: policy_applied["policy_key"],
+        coordination_policy_id: policy_applied["coordination_policy_id"],
+        coordination_policy_version_id: policy_applied["coordination_policy_version_id"],
+        coordination_policy_version: policy_applied["coordination_policy_version"]
       }.compact
     end
 

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -13,6 +13,14 @@ module Activities
     POLICY_PROMPT_SOURCE = "policy_service"
     TIMEOUT = 60
     MAX_TASKS = 20
+    POLICY_METADATA_KEYS = %i[
+      policy_source
+      skip_reason
+      policy_key
+      coordination_policy_id
+      coordination_policy_version_id
+      coordination_policy_version
+    ].freeze
 
     def execute(input)
       project_id = input[:project_id]
@@ -339,10 +347,8 @@ module Activities
 
     def with_policy_provenance(result)
       payload = result.to_h.deep_symbolize_keys
-      metadata = payload[:policy_metadata]
-      return payload unless metadata.respond_to?(:to_h)
-
-      normalized_metadata = metadata.to_h.deep_symbolize_keys
+      normalized_metadata = normalized_policy_metadata(payload)
+      return payload if normalized_metadata.empty?
 
       payload.merge(
         policy_metadata: normalized_metadata,
@@ -369,6 +375,18 @@ module Activities
         next_retry_delay: error.next_retry_delay,
         category: error.category
       )
+    end
+
+    def normalized_policy_metadata(payload)
+      payload = payload.to_h.deep_symbolize_keys
+      top_level_metadata = payload.slice(*POLICY_METADATA_KEYS)
+      nested_metadata = payload[:policy_metadata]
+
+      return top_level_metadata.compact unless nested_metadata.respond_to?(:to_h)
+
+      top_level_metadata.merge(
+        nested_metadata.to_h.deep_symbolize_keys.slice(*POLICY_METADATA_KEYS)
+      ).compact
     end
 
     def log_decomposition_strategy_decision(project:, issue:, workflow_name:, workflow_id:, input_context:, tasks:,

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -351,11 +351,13 @@ module Activities
     end
 
     def application_error_with_policy_provenance(error, policy_context)
-      metadata = policy_context[:metadata].to_h
+      metadata = policy_context[:metadata].to_h.deep_symbolize_keys
       return error if metadata.empty?
 
       existing_details = Array(error.details)
-      provenance_details = existing_details.find { |detail| detail.is_a?(Hash) && detail.key?(:policy_metadata) }
+      provenance_details = existing_details.find do |detail|
+        detail.is_a?(Hash) && (detail.key?(:policy_metadata) || detail.key?("policy_metadata"))
+      end
       return error if provenance_details
 
       Temporalio::Error::ApplicationError.new(

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -346,7 +346,12 @@ module Activities
       metadata = result[:policy_metadata]
       return result unless metadata.respond_to?(:to_h)
 
-      result.merge(metadata.to_h.deep_symbolize_keys)
+      normalized_metadata = metadata.to_h.deep_symbolize_keys
+
+      result.merge(
+        policy_metadata: normalized_metadata,
+        **normalized_metadata
+      )
     end
 
     def log_decomposition_strategy_decision(project:, issue:, workflow_name:, workflow_id:, input_context:, tasks:,

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -43,7 +43,7 @@ module Activities
           policy_context: policy_context,
           outcome: policy_strategy_outcome_for(policy_result)
         )
-        return policy_result
+        return with_policy_provenance(policy_result)
       end
 
       prompt_data = render_prompt(issue, knowledge_context)
@@ -69,13 +69,15 @@ module Activities
         outcome: llm_strategy_outcome_for(policy_context)
       )
 
-      {
+      with_policy_provenance(
+        {
         tasks: tasks,
         prompt_source: prompt_data[:prompt_source],
         policy_source: policy_context[:source],
         skip_reason: policy_context[:skip_reason],
         policy_metadata: fallback_policy_metadata(policy_context)
       }
+      )
     rescue Temporalio::Error::ApplicationError => e
       log_decomposition_strategy_decision(
         project: project,
@@ -338,6 +340,13 @@ module Activities
         policy_source: policy_context[:source],
         skip_reason: policy_context[:skip_reason]
       }.compact
+    end
+
+    def with_policy_provenance(result)
+      metadata = result[:policy_metadata]
+      return result unless metadata.respond_to?(:to_h)
+
+      result.merge(metadata.to_h.deep_symbolize_keys)
     end
 
     def log_decomposition_strategy_decision(project:, issue:, workflow_name:, workflow_id:, input_context:, tasks:,

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -336,12 +336,13 @@ module Activities
     end
 
     def with_policy_provenance(result)
-      metadata = result[:policy_metadata]
-      return result unless metadata.respond_to?(:to_h)
+      payload = result.to_h.deep_symbolize_keys
+      metadata = payload[:policy_metadata]
+      return payload unless metadata.respond_to?(:to_h)
 
       normalized_metadata = metadata.to_h.deep_symbolize_keys
 
-      result.merge(
+      payload.merge(
         policy_metadata: normalized_metadata,
         **normalized_metadata
       )

--- a/app/temporal/activities/decompose_feature_activity.rb
+++ b/app/temporal/activities/decompose_feature_activity.rb
@@ -69,7 +69,13 @@ module Activities
         outcome: llm_strategy_outcome_for(policy_context)
       )
 
-      { tasks: tasks, prompt_source: prompt_data[:prompt_source] }
+      {
+        tasks: tasks,
+        prompt_source: prompt_data[:prompt_source],
+        policy_source: policy_context[:source],
+        skip_reason: policy_context[:skip_reason],
+        policy_metadata: fallback_policy_metadata(policy_context)
+      }
     rescue Temporalio::Error::ApplicationError => e
       log_decomposition_strategy_decision(
         project: project,
@@ -128,7 +134,8 @@ module Activities
         tasks: tasks,
         prompt_source: POLICY_PROMPT_SOURCE,
         policy_source: decomposition_result.policy_source,
-        skip_reason: decomposition_result.skip_reason
+        skip_reason: decomposition_result.skip_reason,
+        policy_metadata: result_policy_metadata(decomposition_result)
       }, context ]
     rescue StandardError => e
       context[:error_details] = {
@@ -313,6 +320,24 @@ module Activities
         error_details: {},
         scope_analysis: {}
       }
+    end
+
+    def result_policy_metadata(decomposition_result)
+      {
+        policy_source: decomposition_result.policy_source,
+        skip_reason: decomposition_result.skip_reason,
+        policy_key: decomposition_result.policy_applied["policy_key"],
+        coordination_policy_id: decomposition_result.policy_applied["coordination_policy_id"],
+        coordination_policy_version_id: decomposition_result.policy_applied["coordination_policy_version_id"],
+        coordination_policy_version: decomposition_result.policy_applied["coordination_policy_version"]
+      }.compact
+    end
+
+    def fallback_policy_metadata(policy_context)
+      {
+        policy_source: policy_context[:source],
+        skip_reason: policy_context[:skip_reason]
+      }.compact
     end
 
     def log_decomposition_strategy_decision(project:, issue:, workflow_name:, workflow_id:, input_context:, tasks:,

--- a/app/temporal/workflows/base_workflow.rb
+++ b/app/temporal/workflows/base_workflow.rb
@@ -91,5 +91,18 @@ module Workflows
         nested_metadata.to_h.deep_symbolize_keys.slice(*DECOMPOSITION_POLICY_METADATA_KEYS)
       ).compact
     end
+
+    def decomposition_policy_metadata_from_error(error)
+      return {} unless error.is_a?(Temporalio::Error::ApplicationError)
+
+      Array(error.details).each do |detail|
+        next unless detail.respond_to?(:to_h)
+
+        metadata = decomposition_policy_metadata(detail)
+        return metadata if metadata.present?
+      end
+
+      {}
+    end
   end
 end

--- a/app/temporal/workflows/base_workflow.rb
+++ b/app/temporal/workflows/base_workflow.rb
@@ -14,6 +14,15 @@ module Workflows
   # Use `run_activity` instead of `Temporalio::Workflow.execute_activity` to
   # automatically normalize activity return values as well.
   class BaseWorkflow < Temporalio::Workflow::Definition
+    DECOMPOSITION_POLICY_METADATA_KEYS = %i[
+      policy_source
+      skip_reason
+      policy_key
+      coordination_policy_id
+      coordination_policy_version_id
+      coordination_policy_version
+    ].freeze
+
     module InputNormalizer
       def execute(input)
         super(input.is_a?(Hash) ? input.deep_symbolize_keys : input)
@@ -69,6 +78,13 @@ module Workflows
       when Array then obj.map { |item| deep_symbolize(item) }
       else obj
       end
+    end
+
+    def decomposition_policy_metadata(decompose_result)
+      metadata = decompose_result[:policy_metadata]
+      return {} unless metadata.respond_to?(:to_h)
+
+      metadata.to_h.deep_symbolize_keys.slice(*DECOMPOSITION_POLICY_METADATA_KEYS)
     end
   end
 end

--- a/app/temporal/workflows/base_workflow.rb
+++ b/app/temporal/workflows/base_workflow.rb
@@ -81,8 +81,9 @@ module Workflows
     end
 
     def decomposition_policy_metadata(decompose_result)
-      top_level_metadata = decompose_result.slice(*DECOMPOSITION_POLICY_METADATA_KEYS)
-      nested_metadata = decompose_result[:policy_metadata]
+      payload = decompose_result.to_h.deep_symbolize_keys
+      top_level_metadata = payload.slice(*DECOMPOSITION_POLICY_METADATA_KEYS)
+      nested_metadata = payload[:policy_metadata]
 
       return top_level_metadata.compact unless nested_metadata.respond_to?(:to_h)
 

--- a/app/temporal/workflows/base_workflow.rb
+++ b/app/temporal/workflows/base_workflow.rb
@@ -81,10 +81,14 @@ module Workflows
     end
 
     def decomposition_policy_metadata(decompose_result)
-      metadata = decompose_result[:policy_metadata]
-      return {} unless metadata.respond_to?(:to_h)
+      top_level_metadata = decompose_result.slice(*DECOMPOSITION_POLICY_METADATA_KEYS)
+      nested_metadata = decompose_result[:policy_metadata]
 
-      metadata.to_h.deep_symbolize_keys.slice(*DECOMPOSITION_POLICY_METADATA_KEYS)
+      return top_level_metadata.compact unless nested_metadata.respond_to?(:to_h)
+
+      top_level_metadata.merge(
+        nested_metadata.to_h.deep_symbolize_keys.slice(*DECOMPOSITION_POLICY_METADATA_KEYS)
+      ).compact
     end
   end
 end

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -314,6 +314,7 @@ module Workflows
         aggregated_pr: parallel_result[:aggregated_pr]
       }
     rescue => e
+      planning_policy_metadata = planning_policy_metadata.presence || decomposition_policy_metadata_from_error(e)
       failed_step = @decision_step || decision_step
 
       safe_log_decomposition_decision(

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -105,7 +105,7 @@ module Workflows
       created_issues = planning_result[:created_issues]
       planning_context = planning_result[:context] || {}
       prompt_source = planning_result[:prompt_source]
-      planning_policy_metadata = planning_result[:policy_metadata] || {}
+      planning_policy_metadata = decomposition_policy_metadata(planning_result)
 
       scaling_experiment_context = safely_resolve_scaling_experiment(
         project_id: project_id,

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -547,20 +547,6 @@ module Workflows
       )
     end
 
-    def decomposition_policy_metadata(decompose_result)
-      metadata = decompose_result[:policy_metadata]
-      return {} unless metadata.respond_to?(:to_h)
-
-      metadata.to_h.deep_symbolize_keys.slice(
-        :policy_source,
-        :skip_reason,
-        :policy_key,
-        :coordination_policy_id,
-        :coordination_policy_version_id,
-        :coordination_policy_version
-      )
-    end
-
     def safe_record_scaling_observation(payload)
       run_activity(
         Activities::RecordScalingObservationActivity,

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -81,6 +81,7 @@ module Workflows
       parallel_result = nil
       planning_context = {}
       prompt_source = nil
+      planning_policy_metadata = {}
       coordination_policy = nil
       coordination_assignment_id = nil
       scaling_assignments = []
@@ -104,6 +105,7 @@ module Workflows
       created_issues = planning_result[:created_issues]
       planning_context = planning_result[:context] || {}
       prompt_source = planning_result[:prompt_source]
+      planning_policy_metadata = planning_result[:policy_metadata] || {}
 
       scaling_experiment_context = safely_resolve_scaling_experiment(
         project_id: project_id,
@@ -147,6 +149,7 @@ module Workflows
         },
         metadata: {
           prompt_source: prompt_source,
+          **planning_policy_metadata,
           failed_step: nil,
           activity_boundaries: %w[
             Activities::FetchPlanningContextActivity
@@ -175,6 +178,7 @@ module Workflows
           },
           metadata: {
             prompt_source: prompt_source,
+            **planning_policy_metadata,
             failed_step: nil,
             activity_boundaries: [ "Workflows::ParallelAgentExecutionWorkflow" ]
           }
@@ -246,6 +250,7 @@ module Workflows
         },
         metadata: {
           prompt_source: prompt_source,
+          **planning_policy_metadata,
           failed_step: nil,
           activity_boundaries: [ "Workflows::ParallelAgentExecutionWorkflow" ]
         }
@@ -414,6 +419,7 @@ module Workflows
 
       tasks = decompose_result[:tasks]
       prompt_source = decompose_result[:prompt_source]
+      policy_metadata = decomposition_policy_metadata(decompose_result)
       created_issues = []
 
       # Step 3: Create sub-issues if multiple tasks
@@ -440,7 +446,13 @@ module Workflows
         created_issues = create_result[:created_issues]
       end
 
-      { tasks: tasks, created_issues: created_issues, context: context_result[:context], prompt_source: prompt_source }
+      {
+        tasks: tasks,
+        created_issues: created_issues,
+        context: context_result[:context],
+        prompt_source: prompt_source,
+        policy_metadata: policy_metadata
+      }
     end
 
     def build_sub_tasks(tasks, created_issues, scaling_assignments:, learned_scaling_allocation:)
@@ -531,6 +543,20 @@ module Workflows
         workflow_id: Temporalio::Workflow.info.workflow_id,
         error_class: log_error.class.to_s,
         error: log_error.message
+      )
+    end
+
+    def decomposition_policy_metadata(decompose_result)
+      metadata = decompose_result[:policy_metadata]
+      return {} unless metadata.respond_to?(:to_h)
+
+      metadata.to_h.deep_symbolize_keys.slice(
+        :policy_source,
+        :skip_reason,
+        :policy_key,
+        :coordination_policy_id,
+        :coordination_policy_version_id,
+        :coordination_policy_version
       )
     end
 

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -335,6 +335,7 @@ module Workflows
         },
         metadata: {
           prompt_source: prompt_source,
+          **planning_policy_metadata,
           failed_step: failed_step
         }
       )

--- a/app/temporal/workflows/planning_workflow.rb
+++ b/app/temporal/workflows/planning_workflow.rb
@@ -158,6 +158,8 @@ module Workflows
       }
 
     rescue => e
+      policy_metadata = policy_metadata.presence || decomposition_policy_metadata_from_error(e)
+
       safe_log_decomposition_decision(
         project_id: project_id,
         issue_id: issue_id,

--- a/app/temporal/workflows/planning_workflow.rb
+++ b/app/temporal/workflows/planning_workflow.rb
@@ -223,19 +223,5 @@ module Workflows
         error: log_error.message
       )
     end
-
-    def decomposition_policy_metadata(decompose_result)
-      metadata = decompose_result[:policy_metadata]
-      return {} unless metadata.respond_to?(:to_h)
-
-      metadata.to_h.deep_symbolize_keys.slice(
-        :policy_source,
-        :skip_reason,
-        :policy_key,
-        :coordination_policy_id,
-        :coordination_policy_version_id,
-        :coordination_policy_version
-      )
-    end
   end
 end

--- a/app/temporal/workflows/planning_workflow.rb
+++ b/app/temporal/workflows/planning_workflow.rb
@@ -64,6 +64,7 @@ module Workflows
       tasks = []
       created_issues = []
       prompt_source = nil
+      policy_metadata = {}
       decision_step = "fetch_planning_context"
 
       # Step 1: Fetch knowledge base context for informed decomposition
@@ -89,6 +90,7 @@ module Workflows
 
       tasks = Array(decompose_result[:tasks])
       prompt_source = decompose_result[:prompt_source]
+      policy_metadata = decomposition_policy_metadata(decompose_result)
 
       # Step 3: Create sub-issues from the plan (skip if single-task or empty)
       if tasks.present? && tasks.size > 1
@@ -136,6 +138,7 @@ module Workflows
         },
         metadata: {
           prompt_source: prompt_source,
+          **policy_metadata,
           failed_step: nil,
           activity_boundaries: %w[
             Activities::FetchPlanningContextActivity
@@ -174,6 +177,7 @@ module Workflows
         },
         metadata: {
           prompt_source: prompt_source,
+          **policy_metadata,
           failed_step: decision_step,
           activity_boundaries: %w[
             Activities::FetchPlanningContextActivity
@@ -217,6 +221,20 @@ module Workflows
         workflow_id: Temporalio::Workflow.info.workflow_id,
         error_class: log_error.class.to_s,
         error: log_error.message
+      )
+    end
+
+    def decomposition_policy_metadata(decompose_result)
+      metadata = decompose_result[:policy_metadata]
+      return {} unless metadata.respond_to?(:to_h)
+
+      metadata.to_h.deep_symbolize_keys.slice(
+        :policy_source,
+        :skip_reason,
+        :policy_key,
+        :coordination_policy_id,
+        :coordination_policy_version_id,
+        :coordination_policy_version
       )
     end
   end

--- a/spec/config/pr_screenshots_publish_workflow_file_spec.rb
+++ b/spec/config/pr_screenshots_publish_workflow_file_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe PrScreenshotsPublishWorkflowFile, :no_db do
   let(:resolve_step) { job.fetch("steps").find { |step| step["name"] == "Resolve PR capture run" } }
   let(:resolve_env) { resolve_step.fetch("env") }
 
+  it "scopes concurrency by PR number and action to avoid cross-event self-cancellation" do
+    expect(workflow.fetch("concurrency")).to include(
+      "group" => "pr-screenshots-publish-${{ github.event.pull_request.number }}-${{ github.event.action }}",
+      "cancel-in-progress" => true
+    )
+  end
+
   it "queries screenshot capture runs by the PR head sha" do
     expect(resolve_step.fetch("run")).to include('head_sha=#{head_sha}&per_page=100')
   end

--- a/spec/config/pr_screenshots_workflow_file_spec.rb
+++ b/spec/config/pr_screenshots_workflow_file_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "psych"
+
+class PrScreenshotsWorkflowFile < Pathname
+end
+
+RSpec.describe PrScreenshotsWorkflowFile, :no_db do
+  subject(:workflow) do
+    Psych.safe_load_file(
+      Rails.root.join(".github/workflows/pr-screenshots.yml"),
+      aliases: true
+    )
+  end
+
+  it "scopes concurrency by PR number and action to avoid cross-event self-cancellation" do
+    expect(workflow.fetch("concurrency")).to include(
+      "group" => "pr-screenshots-${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.action }}",
+      "cancel-in-progress" => true
+    )
+  end
+end

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -149,6 +149,27 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
       )
       expect(provenance.keys).to all(be_a(Symbol))
     end
+
+    it "extracts provenance from symbol-keyed metadata" do
+      provenance = service.send(
+        :policy_provenance,
+        {
+          policy_source: "coordination_policy",
+          policy_key: "feature_decomposition",
+          coordination_policy_id: 12,
+          coordination_policy_version_id: 34,
+          coordination_policy_version: 5
+        }
+      )
+
+      expect(provenance).to include(
+        policy_source: "coordination_policy",
+        policy_key: "feature_decomposition",
+        coordination_policy_id: 12,
+        coordination_policy_version_id: 34,
+        coordination_policy_version: 5
+      )
+    end
   end
 
   describe "unsupported policy types" do

--- a/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_no_db_spec.rb
@@ -127,6 +127,30 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs, :no_db do
     end
   end
 
+  describe "policy provenance serialization" do
+    it "symbolizes provenance keys from persisted metadata" do
+      provenance = service.send(
+        :policy_provenance,
+        {
+          "policy_source" => "coordination_policy",
+          "policy_key" => "feature_decomposition",
+          "coordination_policy_id" => 12,
+          "coordination_policy_version_id" => 34,
+          "coordination_policy_version" => 5
+        }
+      )
+
+      expect(provenance).to include(
+        policy_source: "coordination_policy",
+        policy_key: "feature_decomposition",
+        coordination_policy_id: 12,
+        coordination_policy_version_id: 34,
+        coordination_policy_version: 5
+      )
+      expect(provenance.keys).to all(be_a(Symbol))
+    end
+  end
+
   describe "unsupported policy types" do
     it "fails fast instead of falling back to decomposition inputs" do
       expect {

--- a/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
+++ b/spec/services/coordination_policy_evolution/prepare_inputs_spec.rb
@@ -35,7 +35,13 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
         decision_type: "planning_outcome",
         outcome: "sub_issues_created",
         hints: { "task_count" => 3 },
-        metadata: { "policy_source" => "feature_orchestration" }
+        metadata: {
+          "policy_source" => "feature_orchestration",
+          "policy_key" => described_class::POLICY_KEY,
+          "coordination_policy_id" => policy.id,
+          "coordination_policy_version_id" => policy.current_version.id,
+          "coordination_policy_version" => policy.current_version.version
+        }
       )
       create(
         :decomposition_decision,
@@ -96,6 +102,19 @@ RSpec.describe CoordinationPolicyEvolution::PrepareInputs do
       expect(result.dig(:performance, :average_task_count)).to eq(1.67)
       expect(result[:sample_successes].size).to eq(1)
       expect(result[:sample_failures].size).to eq(1)
+    end
+
+    it "surfaces policy provenance on sampled outcome decisions" do
+      expect(result[:sample_successes].first).to include(
+        policy_source: "feature_orchestration",
+        policy_key: described_class::POLICY_KEY,
+        coordination_policy_id: policy.id,
+        coordination_policy_version_id: policy.current_version.id,
+        coordination_policy_version: policy.current_version.version
+      )
+      expect(result[:sample_failures].first).to include(
+        policy_source: "defaults"
+      )
     end
 
     it "includes effective policy configuration for mutation" do

--- a/spec/services/decomposition_service_spec.rb
+++ b/spec/services/decomposition_service_spec.rb
@@ -158,6 +158,27 @@ RSpec.describe DecompositionService, :no_db do
     expect(OrchestrationStrategies::Resolve).not_to have_received(:call)
   end
 
+  it "accepts symbol-keyed policy overrides from workflow/activity boundaries" do
+    service = build_service(policy_override: {
+      decomposition: {
+        enabled: false,
+        max_tasks: 1
+      }
+    })
+    allow(OrchestrationStrategies::Resolve).to receive(:call)
+
+    result = service.call
+
+    expect(result).to be_skipped
+    expect(result.skip_reason).to eq("decomposition_disabled_by_policy")
+    expect(result.policy_source).to eq("experiment")
+    expect(result.policy_applied).to include(
+      "enabled" => false,
+      "max_tasks" => 1
+    )
+    expect(OrchestrationStrategies::Resolve).not_to have_received(:call)
+  end
+
   it "supports nested coordination policy payloads" do
     service = build_service
     allow(service).to receive(:coordination_policy).and_return(build_nested_coordination_policy)

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -70,6 +70,38 @@ RSpec.describe Activities::DecomposeFeatureActivity do
     end
   end
 
+  describe "#application_error_with_policy_provenance", :no_db do
+    let(:policy_metadata) do
+      {
+        policy_source: "coordination_policy",
+        policy_key: DecompositionService::POLICY_KEY,
+        coordination_policy_version: 5
+      }
+    end
+
+    it "appends policy provenance to Temporal application error details" do
+      error = Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed")
+
+      enriched_error = activity.send(
+        :application_error_with_policy_provenance,
+        error,
+        { metadata: policy_metadata }
+      )
+
+      expect(enriched_error).not_to be(error)
+      expect(enriched_error.details).to include(policy_metadata:)
+      expect(enriched_error.type).to eq("DecompositionFailed")
+    end
+
+    it "leaves errors untouched when no policy metadata is available" do
+      error = Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed")
+
+      expect(
+        activity.send(:application_error_with_policy_provenance, error, { metadata: {} })
+      ).to be(error)
+    end
+  end
+
   describe "#execute" do
     let(:logged_decision) { build_stubbed(:decomposition_decision, decision_type: "decomposition_strategy") }
     let(:llm_response) do

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -30,6 +30,32 @@ RSpec.describe Activities::DecomposeFeatureActivity do
     end
   end
 
+  describe "#result_policy_metadata", :no_db do
+    it "extracts provenance from symbol-keyed policy payloads" do
+      decomposition_result = instance_double(
+        DecompositionService::Result,
+        policy_source: "coordination_policy",
+        skip_reason: nil,
+        policy_applied: {
+          policy_key: DecompositionService::POLICY_KEY,
+          coordination_policy_id: 12,
+          coordination_policy_version_id: 34,
+          coordination_policy_version: 5
+        }
+      )
+
+      result = activity.send(:result_policy_metadata, decomposition_result)
+
+      expect(result).to eq(
+        policy_source: "coordination_policy",
+        policy_key: DecompositionService::POLICY_KEY,
+        coordination_policy_id: 12,
+        coordination_policy_version_id: 34,
+        coordination_policy_version: 5
+      )
+    end
+  end
+
   describe "#execute" do
     let(:logged_decision) { build_stubbed(:decomposition_decision, decision_type: "decomposition_strategy") }
     let(:llm_response) do

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
       expect_oauth_tasks(result[:tasks])
       expect(result[:prompt_source]).to eq("fallback_prompt")
-      expect(result[:policy_metadata]).to eq({})
+      expect(result[:policy_metadata]).to include(policy_source: "defaults")
       expect_llm_strategy_decision_logged(
         workflow_name: "Workflows::PlanningWorkflow",
         workflow_id: "planning-wf-1",

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe Activities::DecomposeFeatureActivity do
       expect(result[:policy_metadata]).to eq(policy_metadata)
       expect(result).to include(policy_metadata)
     end
+
+    it "normalizes fully string-keyed policy payloads" do
+      result = activity.send(
+        :with_policy_provenance,
+        {
+          "tasks" => [],
+          "policy_metadata" => policy_metadata.deep_stringify_keys
+        }
+      )
+
+      expect(result).to include(tasks: [])
+      expect(result[:policy_metadata]).to eq(policy_metadata)
+      expect(result).to include(policy_metadata)
+    end
   end
 
   describe "#result_policy_metadata", :no_db do

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -7,6 +7,29 @@ RSpec.describe Activities::DecomposeFeatureActivity do
   let(:project) { create(:project) }
   let(:issue) { create(:issue, project: project, title: "Add OAuth", body: "Implement OAuth 2.0 login") }
 
+  describe "#with_policy_provenance", :no_db do
+    let(:policy_metadata) do
+      {
+        policy_source: "coordination_policy",
+        policy_key: DecompositionService::POLICY_KEY,
+        coordination_policy_version: 5
+      }
+    end
+
+    it "normalizes nested policy_metadata keys while exposing top-level provenance" do
+      result = activity.send(
+        :with_policy_provenance,
+        {
+          tasks: [],
+          policy_metadata: policy_metadata.deep_stringify_keys
+        }
+      )
+
+      expect(result[:policy_metadata]).to eq(policy_metadata)
+      expect(result).to include(policy_metadata)
+    end
+  end
+
   describe "#execute" do
     let(:logged_decision) { build_stubbed(:decomposition_decision, decision_type: "decomposition_strategy") }
     let(:llm_response) do

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -42,6 +42,30 @@ RSpec.describe Activities::DecomposeFeatureActivity do
       expect(result[:policy_metadata]).to eq(policy_metadata)
       expect(result).to include(policy_metadata)
     end
+
+    it "backfills nested policy_metadata from top-level provenance" do
+      result = activity.send(
+        :with_policy_provenance,
+        {
+          "tasks" => [],
+          "policy_source" => "coordination_policy",
+          "policy_key" => DecompositionService::POLICY_KEY,
+          "coordination_policy_version" => 5
+        }
+      )
+
+      expect(result).to include(
+        tasks: [],
+        policy_source: "coordination_policy",
+        policy_key: DecompositionService::POLICY_KEY,
+        coordination_policy_version: 5
+      )
+      expect(result[:policy_metadata]).to eq(
+        policy_source: "coordination_policy",
+        policy_key: DecompositionService::POLICY_KEY,
+        coordination_policy_version: 5
+      )
+    end
   end
 
   describe "#result_policy_metadata", :no_db do

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Activities::DecomposeFeatureActivity do
       )
     end
 
-    context "when policy-based decomposition applies" do
+    context "when default policy-based decomposition applies" do
       let(:issue) do
         create(
           :issue,
@@ -288,10 +288,7 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
         expect(result[:prompt_source]).to eq(described_class::POLICY_PROMPT_SOURCE)
         expect(result[:tasks]).to all(include(:dependencies, :parallel_group, :scope))
-        expect(result[:policy_metadata]).to include(
-          policy_source: "feature_orchestration",
-          policy_key: DecompositionService::POLICY_KEY
-        )
+        expect(result[:policy_metadata]).to include(policy_source: "defaults")
         expect(AgentHarness).not_to have_received(:send_message)
         expect_policy_decomposition_logged(
           workflow_name: "Workflows::FeatureOrchestrationWorkflow",

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -96,6 +96,23 @@ RSpec.describe Activities::DecomposeFeatureActivity do
       expect(tasks[2][:dependencies]).to eq([ 1 ])
     end
 
+    def expect_policy_skip_result(result)
+      expect(result[:prompt_source]).to eq(described_class::POLICY_PROMPT_SOURCE)
+      expect(result[:tasks]).to eq([])
+      expect(result[:skip_reason]).to eq("decomposition_disabled_by_policy")
+      expect(result[:policy_metadata]).to include(policy_source: "feature_orchestration")
+      expect(AgentHarness).not_to have_received(:send_message)
+      expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
+        hash_including(
+          outcome: "policy_skipped",
+          input_context: hash_including(
+            coordination_policy_present: true
+          ),
+          plan_data: hash_including(tasks: [])
+        )
+      )
+    end
+
     it "returns parsed tasks from LLM output" do
       result = execute_with_workflow_context(
         workflow_name: "Workflows::PlanningWorkflow",
@@ -104,6 +121,7 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
       expect_oauth_tasks(result[:tasks])
       expect(result[:prompt_source]).to eq("fallback_prompt")
+      expect(result[:policy_metadata]).to eq({})
       expect_llm_strategy_decision_logged(
         workflow_name: "Workflows::PlanningWorkflow",
         workflow_id: "planning-wf-1",
@@ -135,6 +153,10 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
         expect(result[:prompt_source]).to eq(described_class::POLICY_PROMPT_SOURCE)
         expect(result[:tasks]).to all(include(:dependencies, :parallel_group, :scope))
+        expect(result[:policy_metadata]).to include(
+          policy_source: "feature_orchestration",
+          policy_key: DecompositionService::POLICY_KEY
+        )
         expect(AgentHarness).not_to have_received(:send_message)
         expect_policy_decomposition_logged(
           workflow_name: "Workflows::FeatureOrchestrationWorkflow",
@@ -195,19 +217,7 @@ RSpec.describe Activities::DecomposeFeatureActivity do
           workflow_id: "orchestration-wf-2"
         )
 
-        expect(result[:prompt_source]).to eq(described_class::POLICY_PROMPT_SOURCE)
-        expect(result[:tasks]).to eq([])
-        expect(result[:skip_reason]).to eq("decomposition_disabled_by_policy")
-        expect(AgentHarness).not_to have_received(:send_message)
-        expect(Orchestration::DecompositionDecisions::Log).to have_received(:call).with(
-          hash_including(
-            outcome: "policy_skipped",
-            input_context: hash_including(
-              coordination_policy_present: true
-            ),
-            plan_data: hash_including(tasks: [])
-          )
-        )
+        expect_policy_skip_result(result)
       end
     end
 
@@ -247,6 +257,10 @@ RSpec.describe Activities::DecomposeFeatureActivity do
 
         expect(result[:prompt_source]).to eq(described_class::POLICY_PROMPT_SOURCE)
         expect(result[:tasks].size).to eq(2)
+        expect(result[:policy_metadata]).to include(
+          policy_source: "coordination_policy",
+          policy_key: DecompositionService::POLICY_KEY
+        )
         expect(AgentHarness).not_to have_received(:send_message)
         expect_policy_decomposition_logged(
           workflow_name: "Workflows::FeatureOrchestrationWorkflow",

--- a/spec/temporal/activities/decompose_feature_activity_spec.rb
+++ b/spec/temporal/activities/decompose_feature_activity_spec.rb
@@ -100,6 +100,22 @@ RSpec.describe Activities::DecomposeFeatureActivity do
         activity.send(:application_error_with_policy_provenance, error, { metadata: {} })
       ).to be(error)
     end
+
+    it "does not duplicate provenance when error details are string-keyed" do
+      error = Temporalio::Error::ApplicationError.new(
+        "LLM failed",
+        { "policy_metadata" => policy_metadata.deep_stringify_keys },
+        type: "DecompositionFailed"
+      )
+
+      expect(
+        activity.send(
+          :application_error_with_policy_provenance,
+          error,
+          { metadata: policy_metadata.deep_stringify_keys }
+        )
+      ).to be(error)
+    end
   end
 
   describe "#execute" do

--- a/spec/temporal/workflows/base_workflow_spec.rb
+++ b/spec/temporal/workflows/base_workflow_spec.rb
@@ -42,6 +42,32 @@ RSpec.describe Workflows::BaseWorkflow, :no_db do
     end
   end
 
+  describe "#decomposition_policy_metadata_from_error" do
+    it "extracts nested provenance from Temporal application error details" do
+      error = Temporalio::Error::ApplicationError.new(
+        "LLM failed",
+        {
+          policy_metadata: {
+            policy_source: "coordination_policy",
+            policy_key: "feature_decomposition",
+            coordination_policy_id: 12,
+            coordination_policy_version_id: 34,
+            coordination_policy_version: 5
+          }
+        },
+        type: "DecompositionFailed"
+      )
+
+      expect(workflow.send(:decomposition_policy_metadata_from_error, error)).to eq(
+        policy_source: "coordination_policy",
+        policy_key: "feature_decomposition",
+        coordination_policy_id: 12,
+        coordination_policy_version_id: 34,
+        coordination_policy_version: 5
+      )
+    end
+  end
+
   describe "#feature_flag_enabled?" do
     it "loads the workflow flag snapshot through an activity and memoizes it per project" do
       allow(workflow).to receive(:run_activity)

--- a/spec/temporal/workflows/base_workflow_spec.rb
+++ b/spec/temporal/workflows/base_workflow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Workflows::BaseWorkflow do
+RSpec.describe Workflows::BaseWorkflow, :no_db do
   let(:workflow_class) do
     Class.new(described_class) do
       def execute(input)
@@ -15,6 +15,32 @@ RSpec.describe Workflows::BaseWorkflow do
   end
 
   let(:workflow) { workflow_class.new }
+
+  describe "#decomposition_policy_metadata" do
+    it "normalizes string-keyed top-level and nested provenance payloads" do
+      result = workflow.send(
+        :decomposition_policy_metadata,
+        {
+          "policy_source" => "top_level_source",
+          "policy_metadata" => {
+            "policy_source" => "coordination_policy",
+            "policy_key" => "feature_decomposition",
+            "coordination_policy_id" => 12,
+            "coordination_policy_version_id" => 34,
+            "coordination_policy_version" => 5
+          }
+        }
+      )
+
+      expect(result).to eq(
+        policy_source: "coordination_policy",
+        policy_key: "feature_decomposition",
+        coordination_policy_id: 12,
+        coordination_policy_version_id: 34,
+        coordination_policy_version: 5
+      )
+    end
+  end
 
   describe "#feature_flag_enabled?" do
     it "loads the workflow flag snapshot through an activity and memoizes it per project" do

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -407,7 +407,15 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
           .with(Activities::LogDecompositionDecisionActivity,
             hash_including(
               decision_type: "parallelization_outcome",
-              outcome: "parallelization_planning_failed"
+              outcome: "parallelization_planning_failed",
+              metadata: hash_including(
+                policy_source: "coordination_policy",
+                policy_key: "feature_decomposition",
+                coordination_policy_id: 12,
+                coordination_policy_version_id: 34,
+                coordination_policy_version: 5,
+                failed_step: "build_sub_tasks"
+              )
             ),
             timeout: 30,
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Workflows::FeatureOrchestrationWorkflow do
+RSpec.describe Workflows::FeatureOrchestrationWorkflow, :no_db do
   let(:workflow) { described_class.new }
 
   describe "class" do

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -196,6 +196,17 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow, :no_db do
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
 
+      it "propagates top-level provenance into planning and parallelization outcome logs" do
+        stub_top_level_planning_activities(tasks: tasks, created_issues: created_issues)
+        stub_parallel_execution(parallel_result)
+        stub_update_labels
+
+        workflow.execute(input)
+
+        expect_top_level_provenance_logged!("planning_outcome")
+        expect_top_level_provenance_logged!("parallelization_outcome")
+      end
+
       it "records a scaling observation after parallel execution" do
         workflow.execute(input)
 
@@ -745,6 +756,65 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow, :no_db do
     end
   end
 
+  def stub_top_level_planning_activities(tasks:, created_issues:)
+    allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+      case activity_class.name
+      when "Activities::ResolveCoordinationExperimentActivity"
+        { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
+      when "Activities::ResolveScalingExperimentActivity"
+        {
+          assignments: [
+            {
+              assignment_id: 88,
+              dimension: "agent_count",
+              execution_plan: {
+                "dimension" => "agent_count",
+                "requested_agent_count" => 2,
+                "max_batch_size" => 2
+              }
+            },
+            {
+              assignment_id: 99,
+              dimension: "iteration_count",
+              execution_plan: {
+                "dimension" => "iteration_count",
+                "requested_iteration_count" => 3,
+                "application_mode" => "task_prompt_budget",
+                "prompt_suffix" => "Iteration budget: aim to complete this task within 3 agent iterations."
+              }
+            }
+          ]
+        }
+      when "Activities::FetchPlanningContextActivity"
+        { context: { issue_title: "Feature", knowledge_snippets: [] } }
+      when "Activities::DecomposeFeatureActivity"
+        {
+          tasks: tasks,
+          prompt_source: "policy_service",
+          policy_source: "coordination_policy",
+          policy_key: "feature_decomposition",
+          coordination_policy_id: 12,
+          coordination_policy_version_id: 34,
+          coordination_policy_version: 5
+        }
+      when "Activities::CreateSubIssuesActivity"
+        { created_issues: created_issues }
+      when "Activities::UpdatePlanningLabelsActivity"
+        { success: true }
+      when "Activities::RecordCoordinationExperimentOutcomeActivity"
+        { assignment_id: 77, outcome_status: "recorded" }
+      when "Activities::RecordScalingExperimentResultActivity"
+        { assignment_id: 88, outcome_status: "recorded" }
+      when "Activities::LogDecompositionDecisionActivity"
+        { decomposition_decision_id: 1 }
+      when "Activities::RecordScalingObservationActivity"
+        { scaling_observation_id: 1 }
+      else
+        {}
+      end
+    end
+  end
+
   def stub_parallel_execution(result)
     allow(Temporalio::Workflow).to receive(:execute_child_workflow)
       .with(Workflows::ParallelAgentExecutionWorkflow, anything, anything)
@@ -823,6 +893,26 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow, :no_db do
         hash_including(
           assignment_id: assignment_id,
           scaling_observation_id: 1
+        ),
+        timeout: 30,
+        retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY
+      )
+  end
+
+  def expect_top_level_provenance_logged!(decision_type)
+    expect(workflow).to have_received(:run_activity)
+      .with(
+        Activities::LogDecompositionDecisionActivity,
+        hash_including(
+          decision_type: decision_type,
+          metadata: hash_including(
+            prompt_source: "policy_service",
+            policy_source: "coordination_policy",
+            policy_key: "feature_decomposition",
+            coordination_policy_id: 12,
+            coordination_policy_version_id: 34,
+            coordination_policy_version: 5
+          )
         ),
         timeout: 30,
         retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         )
     end
 
+    def expect_feature_planning_decision_logged
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::LogDecompositionDecisionActivity,
+          hash_including(
+            decision_type: "planning_outcome",
+            outcome: "sub_issues_created",
+            metadata: hash_including(
+              policy_source: "coordination_policy",
+              policy_key: "feature_decomposition",
+              coordination_policy_id: 12
+            )
+          ),
+          timeout: 30,
+          retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
+    end
+
     it "accepts a single input parameter" do
       params = workflow.method(:execute).parameters
       expect(params).to eq([ [ :req, :input ] ])
@@ -107,11 +123,7 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             timeout: 120
           )
         expect_orchestration_sub_issue_creation!
-        expect(workflow).to have_received(:run_activity)
-          .with(Activities::LogDecompositionDecisionActivity,
-            hash_including(decision_type: "planning_outcome", outcome: "sub_issues_created"),
-            timeout: 30,
-            retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
+        expect_feature_planning_decision_logged
       end
 
       it "launches ParallelAgentExecutionWorkflow as child workflow" do
@@ -173,7 +185,12 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             hash_including(
               decision_type: "parallelization_outcome",
               outcome: "parallel_execution_planned",
-              plan_data: hash_including(sub_tasks: array_including(hash_including(issue_id: 10)))
+              plan_data: hash_including(sub_tasks: array_including(hash_including(issue_id: 10))),
+              metadata: hash_including(
+                policy_source: "coordination_policy",
+                policy_key: "feature_decomposition",
+                coordination_policy_id: 12
+              )
             ),
             timeout: 30,
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
@@ -244,7 +261,11 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
           .with(Activities::LogDecompositionDecisionActivity,
             hash_including(
               decision_type: "parallelization_outcome",
-              outcome: "parallel_execution_skipped_single_task"
+              outcome: "parallel_execution_skipped_single_task",
+              metadata: hash_including(
+                policy_source: "coordination_policy",
+                policy_key: "feature_decomposition"
+              )
             ),
             timeout: 30,
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
@@ -283,7 +304,13 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         expect(Temporalio::Workflow).not_to have_received(:execute_child_workflow)
         expect(workflow).to have_received(:run_activity)
           .with(Activities::LogDecompositionDecisionActivity,
-            hash_including(outcome: "parallel_execution_skipped_empty_plan"),
+            hash_including(
+              outcome: "parallel_execution_skipped_empty_plan",
+              metadata: hash_including(
+                policy_source: "coordination_policy",
+                policy_key: "feature_decomposition"
+              )
+            ),
             timeout: 30,
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)
       end
@@ -682,7 +709,16 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
       when "Activities::FetchPlanningContextActivity"
         { context: { issue_title: "Feature", knowledge_snippets: [] } }
       when "Activities::DecomposeFeatureActivity"
-        { tasks: tasks }
+        {
+          tasks: tasks,
+          policy_metadata: {
+            policy_source: "coordination_policy",
+            policy_key: "feature_decomposition",
+            coordination_policy_id: 12,
+            coordination_policy_version_id: 34,
+            coordination_policy_version: 5
+          }
+        }
       when "Activities::CreateSubIssuesActivity"
         { created_issues: created_issues }
       when "Activities::UpdatePlanningLabelsActivity"

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -449,6 +449,16 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow, :no_db do
     end
 
     context "when an activity raises an error" do
+      let(:failure_policy_metadata) do
+        {
+          policy_source: "coordination_policy",
+          policy_key: "feature_decomposition",
+          coordination_policy_id: 12,
+          coordination_policy_version_id: 34,
+          coordination_policy_version: 5
+        }
+      end
+
       before do
         allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
           case activity_class.name
@@ -481,7 +491,11 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow, :no_db do
           when "Activities::FetchPlanningContextActivity"
             { context: {} }
           when "Activities::DecomposeFeatureActivity"
-            raise Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed")
+            raise Temporalio::Error::ApplicationError.new(
+              "LLM failed",
+              { policy_metadata: failure_policy_metadata },
+              type: "DecompositionFailed"
+            )
           when "Activities::RecordCoordinationExperimentOutcomeActivity"
             { assignment_id: 77, outcome_status: "recorded" }
           when "Activities::RecordScalingExperimentResultActivity"
@@ -500,7 +514,8 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow, :no_db do
           .with(Activities::LogDecompositionDecisionActivity,
             hash_including(
               decision_type: "planning_outcome",
-              outcome: "decomposition_failed"
+              outcome: "decomposition_failed",
+              metadata: hash_including(**failure_policy_metadata)
             ),
             timeout: 30,
             retry_policy: Workflows::FeatureOrchestrationWorkflow::NO_RETRY)

--- a/spec/temporal/workflows/planning_workflow_spec.rb
+++ b/spec/temporal/workflows/planning_workflow_spec.rb
@@ -70,6 +70,29 @@ RSpec.describe Workflows::PlanningWorkflow, :no_db do
       end
     end
 
+    def stub_top_level_policy_driven_decomposition(tasks)
+      allow(workflow).to receive(:run_activity) do |activity_class, _activity_input, **_opts|
+        case activity_class.name
+        when "Activities::FetchPlanningContextActivity"
+          { context: { issue_title: "Feature", knowledge_snippets: [] } }
+        when "Activities::DecomposeFeatureActivity"
+          {
+            tasks: tasks,
+            prompt_source: "policy_service",
+            **policy_metadata_payload
+          }
+        when "Activities::CreateSubIssuesActivity"
+          { created_issues: [ { issue_id: 10 }, { issue_id: 11 }, { issue_id: 12 } ] }
+        when "Activities::UpdatePlanningLabelsActivity"
+          { success: true }
+        when "Activities::LogDecompositionDecisionActivity"
+          { decomposition_decision_id: 1 }
+        else
+          {}
+        end
+      end
+    end
+
     it "accepts a single input parameter" do
       params = workflow.method(:execute).parameters
       expect(params).to eq([ [ :req, :input ] ])
@@ -145,6 +168,22 @@ RSpec.describe Workflows::PlanningWorkflow, :no_db do
 
       it "propagates decomposition policy metadata into planning outcome logs" do
         stub_policy_driven_decomposition(tasks)
+
+        workflow.execute(input)
+
+        expect(workflow).to have_received(:run_activity)
+          .with(
+            Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              metadata: hash_including(prompt_source: "policy_service", **policy_metadata_payload)
+            ),
+            timeout: 30,
+            retry_policy: Workflows::PlanningWorkflow::NO_RETRY
+          )
+      end
+
+      it "propagates top-level provenance when policy_metadata is omitted" do
+        stub_top_level_policy_driven_decomposition(tasks)
 
         workflow.execute(input)
 

--- a/spec/temporal/workflows/planning_workflow_spec.rb
+++ b/spec/temporal/workflows/planning_workflow_spec.rb
@@ -279,13 +279,27 @@ RSpec.describe Workflows::PlanningWorkflow, :no_db do
     end
 
     context "when an activity raises an error" do
+      let(:failure_policy_metadata) do
+        {
+          policy_source: "coordination_policy",
+          policy_key: "feature_decomposition",
+          coordination_policy_id: 12,
+          coordination_policy_version_id: 34,
+          coordination_policy_version: 5
+        }
+      end
+
       before do
         allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
           case activity_class.name
           when "Activities::FetchPlanningContextActivity"
             { context: {} }
           when "Activities::DecomposeFeatureActivity"
-            raise Temporalio::Error::ApplicationError.new("LLM failed", type: "DecompositionFailed")
+            raise Temporalio::Error::ApplicationError.new(
+              "LLM failed",
+              { policy_metadata: failure_policy_metadata },
+              type: "DecompositionFailed"
+            )
           when "Activities::LogDecompositionDecisionActivity"
             { decomposition_decision_id: 4 }
           else
@@ -301,7 +315,8 @@ RSpec.describe Workflows::PlanningWorkflow, :no_db do
             hash_including(
               decision_type: "planning_outcome",
               outcome: "decomposition_failed",
-              error_details: hash_including(error_message: "LLM failed")
+              error_details: hash_including(error_message: "LLM failed"),
+              metadata: hash_including(**failure_policy_metadata)
             ),
             timeout: 30,
             retry_policy: Workflows::PlanningWorkflow::NO_RETRY)

--- a/spec/temporal/workflows/planning_workflow_spec.rb
+++ b/spec/temporal/workflows/planning_workflow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Workflows::PlanningWorkflow do
+RSpec.describe Workflows::PlanningWorkflow, :no_db do
   let(:workflow) { described_class.new }
 
   describe "class" do

--- a/spec/temporal/workflows/planning_workflow_spec.rb
+++ b/spec/temporal/workflows/planning_workflow_spec.rb
@@ -37,6 +37,39 @@ RSpec.describe Workflows::PlanningWorkflow do
         )
     end
 
+    def policy_metadata_payload
+      {
+        policy_source: "coordination_policy",
+        policy_key: "feature_decomposition",
+        coordination_policy_id: 12,
+        coordination_policy_version_id: 34,
+        coordination_policy_version: 5
+      }
+    end
+
+    def stub_policy_driven_decomposition(tasks)
+      allow(workflow).to receive(:run_activity) do |activity_class, _activity_input, **_opts|
+        case activity_class.name
+        when "Activities::FetchPlanningContextActivity"
+          { context: { issue_title: "Feature", knowledge_snippets: [] } }
+        when "Activities::DecomposeFeatureActivity"
+          {
+            tasks: tasks,
+            prompt_source: "policy_service",
+            policy_metadata: policy_metadata_payload
+          }
+        when "Activities::CreateSubIssuesActivity"
+          { created_issues: [ { issue_id: 10 }, { issue_id: 11 }, { issue_id: 12 } ] }
+        when "Activities::UpdatePlanningLabelsActivity"
+          { success: true }
+        when "Activities::LogDecompositionDecisionActivity"
+          { decomposition_decision_id: 1 }
+        else
+          {}
+        end
+      end
+    end
+
     it "accepts a single input parameter" do
       params = workflow.method(:execute).parameters
       expect(params).to eq([ [ :req, :input ] ])
@@ -103,10 +136,27 @@ RSpec.describe Workflows::PlanningWorkflow do
               workflow_name: "Workflows::PlanningWorkflow",
               decision_type: "planning_outcome",
               outcome: "sub_issues_created",
-              plan_data: hash_including(tasks: tasks)
+              plan_data: hash_including(tasks: tasks),
+              metadata: hash_including(prompt_source: nil)
             ),
             timeout: 30,
             retry_policy: Workflows::PlanningWorkflow::NO_RETRY)
+      end
+
+      it "propagates decomposition policy metadata into planning outcome logs" do
+        stub_policy_driven_decomposition(tasks)
+
+        workflow.execute(input)
+
+        expect(workflow).to have_received(:run_activity)
+          .with(
+            Activities::LogDecompositionDecisionActivity,
+            hash_including(
+              metadata: hash_including(prompt_source: "policy_service", **policy_metadata_payload)
+            ),
+            timeout: 30,
+            retry_policy: Workflows::PlanningWorkflow::NO_RETRY
+          )
       end
     end
 
@@ -121,7 +171,7 @@ RSpec.describe Workflows::PlanningWorkflow do
           when "Activities::FetchPlanningContextActivity"
             { context: {} }
           when "Activities::DecomposeFeatureActivity"
-            { tasks: tasks, prompt_source: "fallback_prompt" }
+            { tasks: tasks, prompt_source: "fallback_prompt", policy_metadata: { policy_source: "defaults" } }
           when "Activities::UpdatePlanningLabelsActivity"
             { success: true }
           when "Activities::LogDecompositionDecisionActivity"
@@ -144,7 +194,7 @@ RSpec.describe Workflows::PlanningWorkflow do
           .with(Activities::LogDecompositionDecisionActivity,
             hash_including(
               outcome: "single_task_plan",
-              metadata: hash_including(prompt_source: "fallback_prompt")
+              metadata: hash_including(prompt_source: "fallback_prompt", policy_source: "defaults")
             ),
             timeout: 30,
             retry_policy: Workflows::PlanningWorkflow::NO_RETRY)
@@ -158,7 +208,7 @@ RSpec.describe Workflows::PlanningWorkflow do
           when "Activities::FetchPlanningContextActivity"
             { context: {} }
           when "Activities::DecomposeFeatureActivity"
-            { tasks: [] }
+            { tasks: [], policy_metadata: { policy_source: "feature_orchestration", skip_reason: "below_complexity_threshold" } }
           when "Activities::UpdatePlanningLabelsActivity"
             { success: true }
           when "Activities::LogDecompositionDecisionActivity"
@@ -177,7 +227,13 @@ RSpec.describe Workflows::PlanningWorkflow do
         expect(result[:created_issues]).to eq([])
         expect(workflow).to have_received(:run_activity)
           .with(Activities::LogDecompositionDecisionActivity,
-            hash_including(outcome: "empty_plan"),
+            hash_including(
+              outcome: "empty_plan",
+              metadata: hash_including(
+                policy_source: "feature_orchestration",
+                skip_reason: "below_complexity_threshold"
+              )
+            ),
             timeout: 30,
             retry_policy: Workflows::PlanningWorkflow::NO_RETRY)
       end


### PR DESCRIPTION
## Summary

Closes a gap in the Phase 4.4 coordination policy evolution loop: decomposition policy provenance was only recorded on the intermediate `decomposition_strategy` record, so downstream `PrepareInputs` analysis could not correlate real planning and parallelization outcomes back to the policy that produced them. This change carries `policy_source`, `policy_key`, and coordination policy version metadata through the actual outcome logs, enabling outcome-driven policy evolution to operate on accurate data.

## Changes

- **Temporal activities**: `app/temporal/activities/decompose_feature_activity.rb` now attaches decomposition policy provenance to the activity result so it flows to downstream outcome logging.
- **Temporal workflows**:
  - `app/temporal/workflows/planning_workflow.rb` propagates policy provenance into planning outcome logs.
  - `app/temporal/workflows/feature_orchestration_workflow.rb` propagates policy provenance into parallelization outcome logs.
- **Specs**: Updated `decompose_feature_activity_spec.rb`, `planning_workflow_spec.rb`, and `feature_orchestration_workflow_spec.rb` to assert provenance is preserved in the logged outcomes.

## Design Decisions

- Provenance is threaded through existing outcome-logging paths rather than introducing a new join or lookup at evolution time. This keeps `PrepareInputs` mechanically simple (ZFC) and avoids reconstructing policy linkage from indirect records.
- Provenance fields mirror what is already stored on `decomposition_strategy` (`policy_source`, `policy_key`, coordination policy version), so no new schema is required and the evolution workflow can consume outcomes uniformly.

---

Closes #1774