### PR TITLE
fix: stop silently parking issues and PRs that need attention

### DIFF
--- a/app/services/projects/ensure_standard_labels.rb
+++ b/app/services/projects/ensure_standard_labels.rb
@@ -10,6 +10,8 @@ module Projects
   # - automation_label_name (e.g. "paid-automation")
   # - enhance_issue_needs_input_label_name (e.g. "paid-needs-input")
   # - enhance_issue_enhanced_label_name    (e.g. "paid-enhanced")
+  # - recommend_close                      (e.g. "paid-recommend-close"; overridable via
+  #                                         Project#label_for_stage("recommend_close"))
   # - Priority labels       (P1, P2, P3 by default)
   #
   # @example
@@ -24,6 +26,7 @@ module Projects
       automation: { color: "1d76db", description: "Triggers Paid automation" },
       enhance_issue_needs_input: { color: "d876e3", description: "Paid needs answers before enhancing this issue again" },
       enhance_issue_enhanced: { color: "0e8a16", description: "Paid has added implementation context to this issue" },
+      recommend_close: { color: "fbca04", description: "Paid ran but produced no PR — human review needed" },
       priority: {
         "P1" => { color: "d93f0b", description: "High priority" },
         "P2" => { color: "ff9800", description: "Medium priority" },
@@ -98,6 +101,17 @@ module Projects
         name: project.enhance_issue_enhanced_label_name,
         color: LABEL_DEFINITIONS[:enhance_issue_enhanced][:color],
         description: LABEL_DEFINITIONS[:enhance_issue_enhanced][:description]
+      }
+
+      # No dedicated column for the recommend_close label; the runtime
+      # resolves it via Project#label_for_stage with a constant fallback,
+      # so mirror that resolution here.
+      recommend_close_name = project.label_for_stage("recommend_close") ||
+        Activities::HandleNoOutputIssueRunActivity::PAID_RECOMMEND_CLOSE_LABEL
+      labels << {
+        name: recommend_close_name,
+        color: LABEL_DEFINITIONS[:recommend_close][:color],
+        description: LABEL_DEFINITIONS[:recommend_close][:description]
       }
 
       project.effective_priority_labels.each do |tier, label_name|

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -19,6 +19,7 @@ module Activities
     activity_name "HandleNoOutputIssueRun"
 
     PAID_NEEDS_INPUT_LABEL = "paid-needs-input"
+    PAID_RECOMMEND_CLOSE_LABEL = "paid-recommend-close"
     NEEDS_INPUT_COMMENT_MARKER = "<!-- paid:needs-input -->"
     RECOMMEND_CLOSE_COMMENT_MARKER = "<!-- paid:recommend-close -->"
 
@@ -45,7 +46,17 @@ module Activities
       /failed to create container/i,
       /sandbox.*error/i,
       /docker.*permission denied/i,
-      /exec format error/i
+      /exec format error/i,
+      # Agent CLI misconfiguration: the agent process started but its
+      # configured model is not resolvable (e.g. opencode's
+      # ProviderModelNotFoundError when the configured provider/model
+      # pair is missing). The agent does no work, so this must not be
+      # misclassified as recommend_close. The trailing colon in the
+      # `Model not found:` pattern matches opencode's actual output
+      # (`Error: Model not found: glm-5.1/.`) and avoids false-positives
+      # on agents that simply quote that phrase from an issue body.
+      /ProviderModelNotFoundError/,
+      /Model not found:/i
     ].freeze
 
     def execute(input)
@@ -161,6 +172,7 @@ module Activities
       issue = agent_run.issue
       issue.update!(paid_state: "needs_input")
       add_needs_input_label(client, project, issue)
+      remove_recommend_close_label(client, project, issue, agent_run.id)
       remove_trigger_labels(client, project, issue, agent_run.id)
       post_needs_input_comment(client, project, issue, agent_summary)
     end
@@ -171,6 +183,7 @@ module Activities
       issue.update!(paid_state: "recommend_close")
       remove_trigger_labels(client, project, issue, agent_run.id)
       remove_needs_input_label(client, project, issue, agent_run.id)
+      add_recommend_close_label(client, project, issue)
       post_recommend_close_comment(client, project, issue, agent_summary)
     end
 
@@ -194,6 +207,11 @@ module Activities
       add_phase_label(client, project, issue.github_number, label)
     end
 
+    def add_recommend_close_label(client, project, issue)
+      label = project.label_for_stage("recommend_close") || PAID_RECOMMEND_CLOSE_LABEL
+      add_phase_label(client, project, issue.github_number, label)
+    end
+
     def remove_needs_input_label(client, project, issue, agent_run_id)
       label = project.label_for_stage("needs_input") || PAID_NEEDS_INPUT_LABEL
       return unless issue.has_label?(label)
@@ -202,6 +220,21 @@ module Activities
     rescue GithubClient::Error => e
       logger.warn(
         message: "agent_execution.remove_needs_input_label_failed",
+        agent_run_id: agent_run_id,
+        issue_number: issue.github_number,
+        label: label,
+        error: e.message
+      )
+    end
+
+    def remove_recommend_close_label(client, project, issue, agent_run_id)
+      label = project.label_for_stage("recommend_close") || PAID_RECOMMEND_CLOSE_LABEL
+      return unless issue.has_label?(label)
+
+      client.remove_label_from_issue(project.full_name, issue.github_number, label)
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "agent_execution.remove_recommend_close_label_failed",
         agent_run_id: agent_run_id,
         issue_number: issue.github_number,
         label: label,

--- a/app/temporal/activities/mark_escalated_activity.rb
+++ b/app/temporal/activities/mark_escalated_activity.rb
@@ -18,6 +18,11 @@ module Activities
       phase_before = issue.pr_review_phase
       issue.update!(pr_review_phase: "escalated")
 
+      # Escalation invalidates the prior "ready" claim. Strip the label
+      # before applying paid-escalated so human triage queues and any
+      # "merge when green" automation never see a window where both
+      # labels coexist on the same PR.
+      remove_ready_label(client, project, issue)
       add_phase_label(client, project, issue.github_number, PAID_ESCALATED_LABEL)
       post_escalation_comment(client, project, issue, input[:reason])
 
@@ -48,6 +53,20 @@ module Activities
     end
 
     private
+
+    def remove_ready_label(client, project, issue)
+      label = MarkPrReadyActivity::PAID_READY_LABEL
+      return unless issue.has_label?(label)
+
+      client.remove_label_from_issue(project.full_name, issue.github_number, label)
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "pr_review.remove_ready_label_failed",
+        issue_id: issue.id,
+        pr_number: issue.github_number,
+        error: e.message
+      )
+    end
 
     # Best-effort dedupe: skips posting if COMMENT_MARKER is found in the most
     # recent 100 comments. On very long-lived PRs with 100+ comments after the

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -588,7 +588,20 @@ module Activities
                   "(#{review_goal_consecutive_failure_count(project, issue)} consecutive failures)")
       end
 
-      return nil if followup_limit_reached?(project, issue)
+      # Follow-up budget exhausted: escalate if cheap signals (CI,
+      # merge conflicts, actionable labels — all derivable from data
+      # already fetched above) show unresolved work. Otherwise
+      # short-circuit BEFORE the expensive review-thread / comment
+      # fetches that detect_ready_triggers would issue. This preserves
+      # the historical "silent skip when nothing visibly wrong"
+      # behavior on budget-exhausted PRs while ensuring failing CI no
+      # longer leaves a PR wedged in `paid-ready` with no signal.
+      if followup_limit_reached?(project, issue)
+        cheap_triggers = cheap_ready_triggers(project, issue, pr_data: pr_data, checks: checks)
+        return followup_limit_escalation(issue, cheap_triggers) if cheap_triggers.any?
+
+        return nil
+      end
 
       triggers = detect_ready_triggers(project, client, issue,
         pr_data: pr_data, checks: checks, reviews: reviews)
@@ -612,14 +625,11 @@ module Activities
     # Auto-merge is handled by EvaluateDependabotAutoMergeActivity + DependabotAutoMergeJob.
     # This method only detects follow-up triggers (CI failures, merge conflicts, labels).
     def scan_bot_authored_ready_pr(project, client, issue, pr_data:, checks:, mergeable:)
-      return nil if followup_limit_reached?(project, issue)
-
-      ci_triggers = ci_failure_triggers(checks || [])
-      merge_conflict_triggers = check_merge_conflicts(project, pr_data)
-      label_triggers = check_actionable_labels(project, issue)
-      triggers = ci_triggers + merge_conflict_triggers + label_triggers
+      triggers = cheap_ready_triggers(project, issue, pr_data: pr_data, checks: checks)
 
       return nil if triggers.empty?
+
+      return followup_limit_escalation(issue, triggers) if followup_limit_reached?(project, issue)
 
       log_triggers(project, issue, triggers)
 
@@ -632,6 +642,24 @@ module Activities
         labels_to_remove: extract_actionable_labels(triggers),
         current_followup_count: issue.pr_followup_count
       }
+    end
+
+    # Triggers detectable without additional GitHub API calls when checks
+    # and pr_data are already in hand. Used as a cheap pre-gate before
+    # the more expensive review-thread / comment-fetch path.
+    def cheap_ready_triggers(project, issue, pr_data:, checks:)
+      ci_failure_triggers(checks || []) +
+        check_merge_conflicts(project, pr_data) +
+        check_actionable_labels(project, issue)
+    end
+
+    def followup_limit_escalation(issue, triggers)
+      project = issue.project
+      types_summary = triggers.map { |t| t[:type] }.uniq.join(", ")
+      escalate_trigger(issue,
+        reason: "Follow-up run limit reached " \
+                "(#{issue.pr_followup_count}/#{project.max_pr_followup_runs}); " \
+                "unresolved: #{types_summary}")
     end
 
     # --- Escalated phase scanning ---

--- a/app/temporal/activities/update_issue_with_pr_activity.rb
+++ b/app/temporal/activities/update_issue_with_pr_activity.rb
@@ -20,6 +20,7 @@ module Activities
 
         post_pr_comment(client, project, issue, pull_request_url, agent_run_id)
         remove_trigger_labels(client, project, issue, agent_run_id)
+        remove_stale_attention_labels(client, project, issue, agent_run_id)
 
         agent_run.log!("system", "Issue ##{issue.github_number} updated with PR link")
 
@@ -67,6 +68,31 @@ module Activities
         issue_number: issue.github_number,
         error: e.message
       )
+    end
+
+    # When an issue produces a PR, any prior attention labels
+    # (paid-needs-input, paid-recommend-close) are stale claims about
+    # the issue's state. Leaving them on a now-completed issue
+    # pollutes the human-review queues those labels exist to serve.
+    def remove_stale_attention_labels(client, project, issue, agent_run_id)
+      needs_input_label = project.label_for_stage("needs_input") ||
+        Activities::HandleNoOutputIssueRunActivity::PAID_NEEDS_INPUT_LABEL
+      recommend_close_label = project.label_for_stage("recommend_close") ||
+        Activities::HandleNoOutputIssueRunActivity::PAID_RECOMMEND_CLOSE_LABEL
+
+      [ needs_input_label, recommend_close_label ].uniq.each do |label|
+        next unless issue.has_label?(label)
+
+        client.remove_label_from_issue(project.full_name, issue.github_number, label)
+      rescue GithubClient::Error => e
+        logger.warn(
+          message: "agent_execution.remove_attention_label_failed",
+          agent_run_id: agent_run_id,
+          issue_number: issue.github_number,
+          label: label,
+          error: e.message
+        )
+      end
     end
   end
 end

--- a/spec/services/projects/ensure_standard_labels_spec.rb
+++ b/spec/services/projects/ensure_standard_labels_spec.rb
@@ -6,23 +6,30 @@ require "ostruct"
 RSpec.describe Projects::EnsureStandardLabels do
   let(:github_client) { instance_double(GithubClient) }
   let(:github_token_stub) { Struct.new(:client).new(github_client) }
-  let(:project) do
+  let(:project_class) do
     Struct.new(:id, :full_name, :owner, :repo, :github_token,
                :generated_label_name, :automation_label_name,
                :enhance_issue_needs_input_label_name, :enhance_issue_enhanced_label_name,
-               :effective_priority_labels, keyword_init: true)
-      .new(
-        id: 1,
-        full_name: "test-owner/test-repo",
-        owner: "test-owner",
-        repo: "test-repo",
-        github_token: github_token_stub,
-        generated_label_name: "paid-generated",
-        automation_label_name: "paid-automation",
-        enhance_issue_needs_input_label_name: "paid-needs-input",
-        enhance_issue_enhanced_label_name: "paid-enhanced",
-        effective_priority_labels: { "P1" => "P1", "P2" => "P2", "P3" => "P3" }
-      )
+               :effective_priority_labels, :label_mappings, keyword_init: true) do
+      def label_for_stage(stage)
+        (label_mappings || {})[stage.to_s]
+      end
+    end
+  end
+  let(:project) do
+    project_class.new(
+      id: 1,
+      full_name: "test-owner/test-repo",
+      owner: "test-owner",
+      repo: "test-repo",
+      github_token: github_token_stub,
+      generated_label_name: "paid-generated",
+      automation_label_name: "paid-automation",
+      enhance_issue_needs_input_label_name: "paid-needs-input",
+      enhance_issue_enhanced_label_name: "paid-enhanced",
+      effective_priority_labels: { "P1" => "P1", "P2" => "P2", "P3" => "P3" },
+      label_mappings: {}
+    )
   end
 
   def make_label(name, color: "000000", description: "")
@@ -40,7 +47,8 @@ RSpec.describe Projects::EnsureStandardLabels do
         result = described_class.call(project: project)
 
         expect(result.created).to contain_exactly("paid-generated", "paid-automation",
-          "paid-needs-input", "paid-enhanced", "P1", "P2", "P3")
+          "paid-needs-input", "paid-enhanced", "paid-recommend-close",
+          "P1", "P2", "P3")
         expect(result.existing).to be_empty
         expect(result.divergent).to be_empty
         expect(result.errors).to be_empty
@@ -54,6 +62,7 @@ RSpec.describe Projects::EnsureStandardLabels do
           "paid-automation" => { color: "1d76db", description: "Triggers Paid automation" },
           "paid-needs-input" => { color: "d876e3", description: "Paid needs answers before enhancing this issue again" },
           "paid-enhanced" => { color: "0e8a16", description: "Paid has added implementation context to this issue" },
+          "paid-recommend-close" => { color: "fbca04", description: "Paid ran but produced no PR — human review needed" },
           "P1" => { color: "d93f0b", description: "High priority" },
           "P2" => { color: "ff9800", description: "Medium priority" },
           "P3" => { color: "fbca04", description: "Low priority" }
@@ -74,6 +83,7 @@ RSpec.describe Projects::EnsureStandardLabels do
           make_label("paid-automation", color: "1d76db", description: "Triggers Paid automation"),
           make_label("paid-needs-input", color: "d876e3", description: "Paid needs answers before enhancing this issue again"),
           make_label("paid-enhanced", color: "0e8a16", description: "Paid has added implementation context to this issue"),
+          make_label("paid-recommend-close", color: "fbca04", description: "Paid ran but produced no PR — human review needed"),
           make_label("P1", color: "d93f0b", description: "High priority"),
           make_label("P2", color: "ff9800", description: "Medium priority"),
           make_label("P3", color: "fbca04", description: "Low priority")
@@ -85,7 +95,8 @@ RSpec.describe Projects::EnsureStandardLabels do
 
         expect(result.created).to be_empty
         expect(result.existing).to contain_exactly("paid-generated", "paid-automation",
-          "paid-needs-input", "paid-enhanced", "P1", "P2", "P3")
+          "paid-needs-input", "paid-enhanced", "paid-recommend-close",
+          "P1", "P2", "P3")
         expect(result.divergent).to be_empty
         expect(result.errors).to be_empty
       end
@@ -98,6 +109,7 @@ RSpec.describe Projects::EnsureStandardLabels do
           make_label("paid-automation", color: "1d76db", description: "Triggers Paid automation"),
           make_label("paid-needs-input", color: "d876e3", description: "Paid needs answers before enhancing this issue again"),
           make_label("paid-enhanced", color: "0e8a16", description: "Paid has added implementation context to this issue"),
+          make_label("paid-recommend-close", color: "fbca04", description: "Paid ran but produced no PR — human review needed"),
           make_label("P1", color: "000000", description: "High priority"),
           make_label("P2", color: "ff9800", description: "Medium priority"),
           make_label("P3", color: "fbca04", description: "Low priority")
@@ -125,7 +137,7 @@ RSpec.describe Projects::EnsureStandardLabels do
       it "records permission errors for each label" do
         result = described_class.call(project: project)
 
-        expect(result.errors.size).to eq(7)
+        expect(result.errors.size).to eq(8)
         result.errors.each do |err|
           expect(err[:error]).to include("Insufficient permissions")
         end
@@ -164,22 +176,19 @@ RSpec.describe Projects::EnsureStandardLabels do
 
     context "with custom priority label names" do
       let(:project) do
-        Struct.new(:id, :full_name, :owner, :repo, :github_token,
-                   :generated_label_name, :automation_label_name,
-                   :enhance_issue_needs_input_label_name, :enhance_issue_enhanced_label_name,
-                   :effective_priority_labels, keyword_init: true)
-          .new(
-            id: 1,
-            full_name: "test-owner/test-repo",
-            owner: "test-owner",
-            repo: "test-repo",
-            github_token: github_token_stub,
-            generated_label_name: "paid-generated",
-            automation_label_name: "paid-automation",
-            enhance_issue_needs_input_label_name: "paid-needs-input",
-            enhance_issue_enhanced_label_name: "paid-enhanced",
-            effective_priority_labels: { "P1" => "critical", "P2" => "medium", "P3" => "low" }
-          )
+        project_class.new(
+          id: 1,
+          full_name: "test-owner/test-repo",
+          owner: "test-owner",
+          repo: "test-repo",
+          github_token: github_token_stub,
+          generated_label_name: "paid-generated",
+          automation_label_name: "paid-automation",
+          enhance_issue_needs_input_label_name: "paid-needs-input",
+          enhance_issue_enhanced_label_name: "paid-enhanced",
+          effective_priority_labels: { "P1" => "critical", "P2" => "medium", "P3" => "low" },
+          label_mappings: {}
+        )
       end
 
       before do
@@ -201,6 +210,7 @@ RSpec.describe Projects::EnsureStandardLabels do
           make_label("PAID-AUTOMATION", color: "1d76db", description: "Triggers Paid automation"),
           make_label("PAID-NEEDS-INPUT", color: "d876e3", description: "Paid needs answers before enhancing this issue again"),
           make_label("PAID-ENHANCED", color: "0e8a16", description: "Paid has added implementation context to this issue"),
+          make_label("PAID-RECOMMEND-CLOSE", color: "fbca04", description: "Paid ran but produced no PR — human review needed"),
           make_label("p1", color: "d93f0b", description: "High priority"),
           make_label("p2", color: "ff9800", description: "Medium priority"),
           make_label("p3", color: "fbca04", description: "Low priority")
@@ -211,7 +221,37 @@ RSpec.describe Projects::EnsureStandardLabels do
         result = described_class.call(project: project)
 
         expect(result.created).to be_empty
-        expect(result.existing.size).to eq(7)
+        expect(result.existing.size).to eq(8)
+      end
+    end
+
+    context "when the project configures a custom recommend_close label" do
+      let(:project) do
+        project_class.new(
+          id: 1,
+          full_name: "test-owner/test-repo",
+          owner: "test-owner",
+          repo: "test-repo",
+          github_token: github_token_stub,
+          generated_label_name: "paid-generated",
+          automation_label_name: "paid-automation",
+          enhance_issue_needs_input_label_name: "paid-needs-input",
+          enhance_issue_enhanced_label_name: "paid-enhanced",
+          effective_priority_labels: { "P1" => "P1", "P2" => "P2", "P3" => "P3" },
+          label_mappings: { "recommend_close" => "needs-review" }
+        )
+      end
+
+      before do
+        allow(github_client).to receive(:labels).with("test-owner/test-repo").and_return([])
+        allow(github_client).to receive(:create_label)
+      end
+
+      it "provisions the configured label name instead of the default" do
+        result = described_class.call(project: project)
+
+        expect(result.created).to include("needs-review")
+        expect(result.created).not_to include("paid-recommend-close")
       end
     end
   end

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -125,6 +125,30 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
         expect(client).not_to have_received(:add_labels_to_issue)
+          .with(project.full_name, issue.github_number, [ "paid-needs-input" ])
+      end
+
+      it "adds the paid-recommend-close label so the issue surfaces for human review" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(client).to have_received(:add_labels_to_issue)
+          .with(project.full_name, issue.github_number, [ "paid-recommend-close" ])
+      end
+
+      it "uses the project-configured recommend_close label when set" do
+        custom_project = create(:project,
+          label_mappings: { "recommend_close" => "needs-review" },
+          automation_on_label_enabled: false)
+        issue = create(:issue, :in_progress, project: custom_project)
+        agent_run = create(:agent_run, :running, project: custom_project, issue: issue)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(client).to have_received(:add_labels_to_issue)
+          .with(custom_project.full_name, issue.github_number, [ "needs-review" ])
       end
 
       it "returns outcome recommend_close" do
@@ -402,6 +426,78 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         result = activity.execute(agent_run_id: agent_run.id, output_present: true)
 
         expect(result[:outcome]).to eq("recommend_close")
+      end
+
+      it "detects opencode ProviderModelNotFoundError as infrastructure error" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "Error: Model not found: glm-5.1/.\nProviderModelNotFoundError: ProviderModelNotFoundError")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("infrastructure_error")
+      end
+
+      it "transitions misconfigured opencode runs to failed for auto-pick retry" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "Error: Model not found: glm-5.1/.")
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(issue.reload.paid_state).to eq("failed")
+        expect(agent_run.reload.status).to eq("failed")
+      end
+
+      it "does not match a bare 'model not found' phrase quoted in agent output" do
+        # The colon in /Model not found:/ guards against false-positives on
+        # natural-language mentions of the phrase that the agent might quote
+        # back from issue bodies or web fetches.
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "The user reported a model not found bug last week")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("recommend_close")
+      end
+    end
+
+    context "when an issue cycles through outcomes (label hygiene)" do
+      it "clears a stale paid-recommend-close label when the next outcome is needs_input" do
+        issue = create(:issue, :in_progress, project: project,
+          labels: [ "paid-build", "paid-recommend-close" ])
+        agent_run = create(:agent_run, :running, project: project, issue: issue)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: false)
+
+        expect(client).to have_received(:remove_label_from_issue)
+          .with(project.full_name, issue.github_number, "paid-recommend-close")
+      end
+
+      it "skips remove_label_from_issue for paid-recommend-close when not present" do
+        issue = create(:issue, :in_progress, project: project, labels: [ "paid-build" ])
+        agent_run = create(:agent_run, :running, project: project, issue: issue)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: false)
+
+        expect(client).not_to have_received(:remove_label_from_issue)
+          .with(project.full_name, issue.github_number, "paid-recommend-close")
+      end
+
+      it "is re-applied (idempotent) when a re-run produces the same recommend_close outcome" do
+        issue = create(:issue, :in_progress, project: project,
+          labels: [ "paid-build", "paid-recommend-close" ])
+        agent_run = create(:agent_run, :running, project: project, issue: issue)
+
+        activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        # Same label is re-added; GitHub's add_labels_to_issue is idempotent.
+        expect(client).to have_received(:add_labels_to_issue)
+          .with(project.full_name, issue.github_number, [ "paid-recommend-close" ])
       end
     end
 

--- a/spec/temporal/activities/mark_escalated_activity_spec.rb
+++ b/spec/temporal/activities/mark_escalated_activity_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Activities::MarkEscalatedActivity do
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
     allow(github_client).to receive(:add_comment)
+    allow(github_client).to receive(:remove_label_from_issue)
     allow(github_client).to receive(:recent_issue_comments).and_return([])
   end
 
@@ -169,6 +170,52 @@ RSpec.describe Activities::MarkEscalatedActivity do
         result = activity.execute(issue_id: issue.id)
 
         expect(result[:updated]).to be true
+      end
+    end
+
+    context "when issue carries the paid-ready label" do
+      let(:issue) do
+        create(:issue, :pull_request,
+          pr_review_phase: "ready",
+          labels: [ "paid-generated", "paid-automation", "paid-ready" ])
+      end
+
+      before do
+        allow(github_client).to receive(:add_labels_to_issue)
+      end
+
+      it "removes the paid-ready label so the label reflects the escalated state" do
+        activity.execute(issue_id: issue.id)
+
+        expect(github_client).to have_received(:remove_label_from_issue)
+          .with(issue.project.full_name, issue.github_number, "paid-ready")
+      end
+
+      it "still adds paid-escalated even if removing paid-ready fails" do
+        allow(github_client).to receive(:remove_label_from_issue)
+          .and_raise(GithubClient::Error, "transient")
+
+        activity.execute(issue_id: issue.id)
+
+        expect(github_client).to have_received(:add_labels_to_issue)
+          .with(issue.project.full_name, issue.github_number, [ "paid-escalated" ])
+      end
+    end
+
+    context "when issue does not carry the paid-ready label" do
+      let(:issue) do
+        create(:issue, :pull_request, pr_review_phase: "draft", labels: [ "paid-automation" ])
+      end
+
+      before do
+        allow(github_client).to receive(:add_labels_to_issue)
+      end
+
+      it "does not call remove_label_from_issue for paid-ready" do
+        activity.execute(issue_id: issue.id)
+
+        expect(github_client).not_to have_received(:remove_label_from_issue)
+          .with(anything, anything, "paid-ready")
       end
     end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -1291,18 +1291,63 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     end
 
     context "when followup limit is reached" do
-      before do
-        create(:issue, :pull_request,
-          project: project, github_number: 42,
-          labels: [ "paid-generated", "paid-automation" ], paid_state: "completed",
-          pr_followup_count: 3)
-        stub_github_for_pr
+      context "without any actionable triggers present" do
+        before do
+          create(:issue, :pull_request,
+            project: project, github_number: 42,
+            labels: [ "paid-generated", "paid-automation" ], paid_state: "completed",
+            pr_followup_count: 3)
+          stub_github_for_pr
+        end
+
+        it "skips the PR (no work needed, even though the budget is exhausted)" do
+          result = activity.execute(project_id: project.id)
+
+          expect(result[:prs_to_trigger]).to eq([])
+        end
       end
 
-      it "skips the PR" do
-        result = activity.execute(project_id: project.id)
+      context "when the PR still has failing CI" do
+        before do
+          create(:issue, :pull_request,
+            project: project, github_number: 42,
+            labels: [ "paid-generated", "paid-automation", "paid-ready" ],
+            pr_review_phase: "ready", paid_state: "completed",
+            pr_followup_count: 3)
+          stub_github_for_pr(checks: [ { name: "ci", conclusion: "failure" } ])
+        end
 
-        expect(result[:prs_to_trigger]).to eq([])
+        it "escalates rather than silently skipping" do
+          result = activity.execute(project_id: project.id)
+
+          expect(result[:prs_to_trigger].size).to eq(1)
+          trigger = result[:prs_to_trigger].first[:triggers].first
+          expect(trigger[:type]).to eq("escalate_to_owner")
+          expect(trigger[:details]).to include("Follow-up run limit reached")
+        end
+      end
+
+      context "when a bot-authored PR still has failing CI" do
+        before do
+          create(:issue, :pull_request,
+            project: project, github_number: 42,
+            github_creator_login: "dependabot[bot]",
+            labels: [ "paid-generated", "paid-automation", "paid-ready" ],
+            pr_review_phase: "ready", paid_state: "completed",
+            pr_followup_count: 3)
+          stub_github_for_pr(
+            author_login: "dependabot[bot]",
+            checks: [ { name: "ci", conclusion: "failure" } ]
+          )
+        end
+
+        it "escalates the bot PR rather than silently skipping" do
+          result = activity.execute(project_id: project.id)
+
+          expect(result[:prs_to_trigger].size).to eq(1)
+          trigger = result[:prs_to_trigger].first[:triggers].first
+          expect(trigger[:type]).to eq("escalate_to_owner")
+        end
       end
     end
 

--- a/spec/temporal/activities/update_issue_with_pr_activity_spec.rb
+++ b/spec/temporal/activities/update_issue_with_pr_activity_spec.rb
@@ -105,6 +105,50 @@ RSpec.describe Activities::UpdateIssueWithPrActivity do
       activity.execute(agent_run_id: agent_run.id, pull_request_url: pr_url)
     end
 
+    it "removes a stale paid-recommend-close label from a previously-stuck issue" do
+      issue.update!(labels: [ "paid-build", "paid-recommend-close", "bug" ])
+
+      expect(github_client).to receive(:remove_label_from_issue).with(
+        project.full_name, issue.github_number, "paid-recommend-close"
+      )
+
+      activity.execute(agent_run_id: agent_run.id, pull_request_url: pr_url)
+    end
+
+    it "removes a stale paid-needs-input label from a previously-stuck issue" do
+      issue.update!(labels: [ "paid-build", "paid-needs-input", "bug" ])
+
+      expect(github_client).to receive(:remove_label_from_issue).with(
+        project.full_name, issue.github_number, "paid-needs-input"
+      )
+
+      activity.execute(agent_run_id: agent_run.id, pull_request_url: pr_url)
+    end
+
+    it "does not remove attention labels when the issue does not carry them" do
+      expect(github_client).not_to receive(:remove_label_from_issue)
+        .with(anything, anything, "paid-recommend-close")
+      expect(github_client).not_to receive(:remove_label_from_issue)
+        .with(anything, anything, "paid-needs-input")
+
+      activity.execute(agent_run_id: agent_run.id, pull_request_url: pr_url)
+    end
+
+    it "does not abort when removing one attention label fails" do
+      issue.update!(labels: [ "paid-build", "paid-recommend-close", "paid-needs-input" ])
+      allow(github_client).to receive(:remove_label_from_issue)
+        .with(project.full_name, issue.github_number, "paid-recommend-close")
+        .and_raise(GithubClient::ApiError.new("transient 502"))
+
+      expect(github_client).to receive(:remove_label_from_issue).with(
+        project.full_name, issue.github_number, "paid-needs-input"
+      )
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id, pull_request_url: pr_url)
+      }.not_to raise_error
+    end
+
     it "raises ActiveRecord::RecordNotFound for invalid agent_run_id" do
       expect {
         activity.execute(agent_run_id: -1, pull_request_url: pr_url)


### PR DESCRIPTION
## Summary

Two related bugs that left work silently parked with no signal to the operator:

- **`recommend_close` misclassification**: opencode CLI misconfig (`ProviderModelNotFoundError` / `Model not found:`) was being classified as "issue is resolved" instead of an infrastructure error, parking real work indefinitely. The `recommend_close` outcome also applied no label at all, so issues that legitimately needed human review never surfaced in any GitHub queue.
- **`paid-ready` PRs wedged at follow-up budget**: when `pr_followup_count >= max_pr_followup_runs`, the scanner silently returned `nil` even if CI was still failing or merge conflicts remained. PRs sat with `paid-ready` + red CI for hours with no fix runs and no escalation. The draft-side budget-exhaustion path correctly escalates; the ready-side path now does too.

### Commit 1 — `fix(recommend-close)`
- Add `ProviderModelNotFoundError` and `Model not found:` to `INFRASTRUCTURE_ERROR_PATTERNS` (colon-anchored to avoid false-positives on natural-language quotes).
- Apply `paid-recommend-close` label on the `recommend_close` outcome, overridable via `Project#label_for_stage("recommend_close")`.
- Provision the label with curated color/description in `Projects::EnsureStandardLabels`.
- Clear stale attention labels (`paid-needs-input` + `paid-recommend-close`) when the issue transitions to a different outcome (`handle_needs_input`) or when a PR is created (`UpdateIssueWithPrActivity`). The pre-existing `paid-needs-input` gap on PR success is fixed in the same place.

### Commit 2 — `fix(pr-review)`
- Escalate `paid-ready` PRs when the follow-up budget exhausts AND triggers remain. Uses a new `cheap_ready_triggers` helper (CI, merge conflicts, actionable labels — all from data already fetched) as a pre-gate so no new GitHub API calls are added per scan tick for healthy budget-exhausted PRs.
- Reason string lists unresolved trigger types (e.g. `"ci_failure, merge_conflict"`) so the operator gets actionable detail.
- `MarkEscalatedActivity` strips `paid-ready` before adding `paid-escalated` so the label reflects reality.
- Symmetric fix for bot-authored PRs (Dependabot / Renovate).

## Test plan
- [x] 460 specs pass across the 6 affected spec files (`handle_no_output_issue_run_activity_spec`, `update_issue_with_pr_activity_spec`, `ensure_standard_labels_spec`, `scan_paid_prs_activity_spec`, `scan_paid_prs_activity_dependencies_spec`, `mark_escalated_activity_spec`).
- [x] RuboCop clean.
- [ ] Manual: after deploy, verify that ready PRs with failing CI either (a) get a fix run, or (b) get escalated with `paid-escalated` and `paid-ready` removed.
- [ ] Manual: verify a freshly-created project gets `paid-recommend-close` provisioned with the curated color via `Projects::EnsureStandardLabels`.
- [ ] Manual: verify that an opencode run with a misconfigured model now fails the run and re-queues the issue rather than parking it in `recommend_close`.

## Notes for reviewers
- The two commits are independent and could land separately if preferred.
- Out of scope: no `Project#recommend_close_label_name` DB column (uses `label_for_stage` for overrides instead — single inline comment explains the asymmetry). No cleanup of orphaned renamed labels in `EnsureStandardLabels` (pre-existing for all labels, not a regression).