### PR TITLE
feat(scaling): Phase 4.5 — Orchestration Scaling Laws

### DIFF
--- a/app/temporal/activities/resolve_scaling_experiment_activity.rb
+++ b/app/temporal/activities/resolve_scaling_experiment_activity.rb
@@ -10,6 +10,7 @@ module Activities
       task_count = input[:task_count].to_i
       issue = input[:issue_id] ? project.issues.find(input[:issue_id]) : nil
 
+      learned_allocation = resolve_learned_allocation(project:, task_count:)
       assignments = ScalingExperiment.running
         .where(project: project)
         .order(:id)
@@ -37,7 +38,39 @@ module Activities
 
       {
         assignment_ids: assignments.map { |assignment| assignment[:assignment_id] },
-        assignments: assignments
+        assignments: assignments,
+        learned_allocation: serialize_allocation(learned_allocation)
+      }
+    end
+
+    private
+
+    def resolve_learned_allocation(project:, task_count:)
+      allocation = Scaling::ResourceAllocator.call(
+        inputs: Scaling::AllocationInputs.new(task_count: task_count, max_agent_count: task_count),
+        observations: ScalingObservation.for_project(project)
+          .by_observation_type("feature_orchestration")
+          .recent
+          .to_a,
+        experiment_summaries: ScalingExperiment
+          .where(project: project, status: %w[running completed])
+          .where.not(cached_summary: nil)
+          .pluck(:cached_summary)
+      )
+
+      allocation unless allocation.source == :fallback
+    end
+
+    def serialize_allocation(allocation)
+      return unless allocation
+
+      {
+        agent_count: allocation.agent_count,
+        max_iterations: allocation.max_iterations,
+        parallelism_level: allocation.parallelism_level,
+        source: allocation.source,
+        reason: allocation.reason,
+        metrics: allocation.metrics
       }
     end
   end

--- a/app/temporal/workflows/feature_orchestration_workflow.rb
+++ b/app/temporal/workflows/feature_orchestration_workflow.rb
@@ -84,6 +84,7 @@ module Workflows
       coordination_policy = nil
       coordination_assignment_id = nil
       scaling_assignments = []
+      learned_scaling_allocation = nil
       decision_phase = "planning"
       decision_step = "fetch_planning_context"
       @decision_step = decision_step
@@ -111,7 +112,12 @@ module Workflows
         task_count: tasks.size
       )
       scaling_assignments = Array(scaling_experiment_context[:assignments])
-      coordination_policy = apply_scaling_execution_plans(coordination_policy, scaling_assignments)
+      learned_scaling_allocation = scaling_experiment_context[:learned_allocation]
+      coordination_policy = apply_scaling_execution_plans(
+        coordination_policy,
+        scaling_assignments,
+        learned_scaling_allocation:
+      )
 
       # Update labels/state immediately after planning completes (mirrors PlanningWorkflow step 4)
       decision_step = "update_planning_labels"
@@ -197,7 +203,8 @@ module Workflows
           metadata: {
             prompt_source: prompt_source,
             created_issues: created_issues,
-            scaling_experiments: scaling_metadata(scaling_assignments)
+            scaling_experiments: scaling_metadata(scaling_assignments),
+            learned_allocation: learned_allocation_metadata(learned_scaling_allocation)
           }
         )
         safely_record_scaling_experiment_results(
@@ -216,7 +223,12 @@ module Workflows
       # Phase 2: Launch parallel execution on all sub-tasks
       decision_step = "build_sub_tasks"
       @decision_step = decision_step
-      sub_tasks = build_sub_tasks(tasks, created_issues, scaling_assignments: scaling_assignments)
+      sub_tasks = build_sub_tasks(
+        tasks,
+        created_issues,
+        scaling_assignments: scaling_assignments,
+        learned_scaling_allocation:
+      )
 
       safe_log_decomposition_decision(
         project_id: project_id,
@@ -276,7 +288,8 @@ module Workflows
         metadata: {
           prompt_source: prompt_source,
           created_issues: created_issues,
-          scaling_experiments: scaling_metadata(scaling_assignments)
+          scaling_experiments: scaling_metadata(scaling_assignments),
+          learned_allocation: learned_allocation_metadata(learned_scaling_allocation)
         }
       )
       safely_record_scaling_experiment_results(
@@ -337,7 +350,8 @@ module Workflows
         metadata: {
           prompt_source: prompt_source,
           created_issues: created_issues,
-          scaling_experiments: scaling_metadata(scaling_assignments)
+          scaling_experiments: scaling_metadata(scaling_assignments),
+          learned_allocation: learned_allocation_metadata(learned_scaling_allocation)
         }
       )
       safely_record_scaling_experiment_results(
@@ -429,8 +443,11 @@ module Workflows
       { tasks: tasks, created_issues: created_issues, context: context_result[:context], prompt_source: prompt_source }
     end
 
-    def build_sub_tasks(tasks, created_issues, scaling_assignments:)
-      iteration_prompt_suffix = iteration_prompt_suffix_for(scaling_assignments)
+    def build_sub_tasks(tasks, created_issues, scaling_assignments:, learned_scaling_allocation:)
+      iteration_prompt_suffix = iteration_prompt_suffix_for(
+        scaling_assignments,
+        learned_scaling_allocation:
+      )
       created_issues_by_index = created_issues.each_with_index.each_with_object({}) do |(issue, fallback_index), memo|
         memo[issue.fetch(:index, fallback_index)] = issue
       end
@@ -616,13 +633,14 @@ module Workflows
       end
     end
 
-    def apply_scaling_execution_plans(policy, scaling_assignments)
+    def apply_scaling_execution_plans(policy, scaling_assignments, learned_scaling_allocation:)
       normalized_policy = (policy || {}).deep_dup
+      apply_learned_allocation!(normalized_policy, learned_scaling_allocation)
 
       Array(scaling_assignments).each do |assignment|
         execution_plan = assignment[:execution_plan] || assignment["execution_plan"] || {}
         dimension = execution_plan[:dimension] || execution_plan["dimension"]
-        next unless dimension == "agent_count"
+        next unless %w[agent_count parallelism].include?(dimension)
 
         requested_agent_count = execution_plan[:max_batch_size] || execution_plan["max_batch_size"]
         next unless requested_agent_count
@@ -632,6 +650,17 @@ module Workflows
       end
 
       normalized_policy.presence || policy
+    end
+
+    def apply_learned_allocation!(policy, learned_scaling_allocation)
+      return unless learned_scaling_allocation
+
+      max_batch_size = learned_scaling_allocation[:parallelism_level] || learned_scaling_allocation["parallelism_level"] ||
+        learned_scaling_allocation[:agent_count] || learned_scaling_allocation["agent_count"]
+      return unless max_batch_size
+
+      policy["parallel_execution"] ||= {}
+      policy["parallel_execution"]["max_batch_size"] = max_batch_size
     end
 
     def scaling_metadata(scaling_assignments)
@@ -652,16 +681,37 @@ module Workflows
       end
     end
 
-    def iteration_prompt_suffix_for(scaling_assignments)
+    def learned_allocation_metadata(learned_scaling_allocation)
+      return unless learned_scaling_allocation
+
+      {
+        agent_count: learned_scaling_allocation[:agent_count] || learned_scaling_allocation["agent_count"],
+        max_iterations: learned_scaling_allocation[:max_iterations] || learned_scaling_allocation["max_iterations"],
+        parallelism_level: learned_scaling_allocation[:parallelism_level] || learned_scaling_allocation["parallelism_level"],
+        source: learned_scaling_allocation[:source] || learned_scaling_allocation["source"],
+        reason: learned_scaling_allocation[:reason] || learned_scaling_allocation["reason"]
+      }.compact
+    end
+
+    def iteration_prompt_suffix_for(scaling_assignments, learned_scaling_allocation:)
       iteration_assignment = Array(scaling_assignments).find do |assignment|
         execution_plan = assignment[:execution_plan] || assignment["execution_plan"] || {}
         dimension = assignment[:dimension] || assignment["dimension"] || execution_plan[:dimension] || execution_plan["dimension"]
         dimension == "iteration_count"
       end
-      return unless iteration_assignment
+      if iteration_assignment
+        execution_plan = iteration_assignment[:execution_plan] || iteration_assignment["execution_plan"] || {}
+        return execution_plan[:prompt_suffix] || execution_plan["prompt_suffix"]
+      end
 
-      execution_plan = iteration_assignment[:execution_plan] || iteration_assignment["execution_plan"] || {}
-      execution_plan[:prompt_suffix] || execution_plan["prompt_suffix"]
+      learned_iterations = learned_scaling_allocation&.dig(:max_iterations) ||
+        learned_scaling_allocation&.dig("max_iterations")
+      return if learned_iterations.blank?
+
+      <<~PROMPT.strip
+        Iteration budget: aim to complete this task within #{learned_iterations} agent iterations.
+        If you cannot finish safely within that budget, stop and report the blocker instead of continuing indefinitely.
+      PROMPT
     end
 
     def append_scaling_prompt(prompt, prompt_suffix)

--- a/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
+++ b/spec/temporal/workflows/feature_orchestration_workflow_spec.rb
@@ -541,6 +541,94 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
           )
       end
     end
+
+    context "when learned allocation is available without an iteration experiment" do
+      let(:tasks) do
+        [
+          { index: 0, title: "Task A", description: "Do A", dependencies: [], parallel_group: 0 },
+          { index: 1, title: "Task B", description: "Do B", dependencies: [], parallel_group: 0 }
+        ]
+      end
+
+      let(:parallel_result) do
+        {
+          success: true,
+          total: 2,
+          completed: 2,
+          failed: 0,
+          results: [],
+          conflicts: { has_conflicts: false, conflicting_pairs: [] }
+        }
+      end
+
+      before do
+        allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+          case activity_class.name
+          when "Activities::ResolveCoordinationExperimentActivity"
+            { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
+          when "Activities::ResolveScalingExperimentActivity"
+            {
+              learned_allocation: {
+                agent_count: 3,
+                max_iterations: 4,
+                parallelism_level: 2,
+                source: :observations,
+                reason: "best observed agent_count=3"
+              },
+              assignments: [
+                {
+                  assignment_id: 88,
+                  dimension: "agent_count",
+                  execution_plan: {
+                    "dimension" => "agent_count",
+                    "requested_agent_count" => 3,
+                    "max_batch_size" => 3
+                  }
+                }
+              ]
+            }
+          when "Activities::FetchPlanningContextActivity"
+            { context: { issue_title: "Feature", knowledge_snippets: [] } }
+          when "Activities::DecomposeFeatureActivity"
+            { tasks: tasks }
+          when "Activities::CreateSubIssuesActivity"
+            { created_issues: [ { issue_id: 10 }, { issue_id: 11 } ] }
+          when "Activities::UpdatePlanningLabelsActivity"
+            { success: true }
+          when "Activities::RecordCoordinationExperimentOutcomeActivity"
+            { assignment_id: 77, outcome_status: "recorded" }
+          when "Activities::RecordScalingExperimentResultActivity"
+            { assignment_id: 88, outcome_status: "recorded" }
+          when "Activities::LogDecompositionDecisionActivity"
+            { decomposition_decision_id: 1 }
+          when "Activities::RecordScalingObservationActivity"
+            { scaling_observation_id: 1 }
+          else
+            {}
+          end
+        end
+
+        stub_parallel_execution(parallel_result)
+      end
+
+      it "uses learned iteration guidance and applies learned parallelism before experiment overrides" do
+        workflow.execute(input)
+
+        expect(Temporalio::Workflow).to have_received(:execute_child_workflow)
+          .with(
+            Workflows::ParallelAgentExecutionWorkflow,
+            hash_including(
+              coordination_policy: hash_including(
+                "parallel_execution" => hash_including("max_batch_size" => 3)
+              ),
+              sub_tasks: array_including(
+                hash_including(custom_prompt: include("within 4 agent iterations"))
+              )
+            ),
+            anything
+          )
+      end
+    end
   end
 
   private
@@ -562,6 +650,13 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
         { assignment_id: 77, coordination_policy: OrchestrationStrategies::Defaults.feature_orchestration }
       when "Activities::ResolveScalingExperimentActivity"
         {
+          learned_allocation: {
+            agent_count: 2,
+            max_iterations: 4,
+            parallelism_level: 2,
+            source: :observations,
+            reason: "best observed agent_count=2"
+          },
           assignments: [
             {
               assignment_id: 88,
@@ -650,6 +745,12 @@ RSpec.describe Workflows::FeatureOrchestrationWorkflow do
             execution_summary: hash_including(max_parallelism_observed: 1)
           ),
           metadata: hash_including(
+            learned_allocation: hash_including(
+              agent_count: 2,
+              max_iterations: 4,
+              parallelism_level: 2,
+              source: :observations
+            ),
             scaling_experiments: array_including(
               hash_including(
                 assignment_id: 88,


### PR DESCRIPTION
## Summary

Closes the loop on Phase 4.5 by making the orchestrator actually *use* the scaling laws it has been learning: feature orchestration now resolves a learned allocation per run and applies learned batch-size and iteration guidance as the default policy, while still letting active scaling experiments override per dimension. This unlocks the 10%+ dynamic-allocation efficiency goal called out in the phase deliverables.

## Changes

- **Orchestration workflow**: `FeatureOrchestrationWorkflow` now threads a resolved learned allocation through the run, applying learned batch-size guidance as the baseline orchestration policy.
- **Scaling activity**: `ResolveScalingExperimentActivity` resolves the learned allocation alongside any active experiment assignments, so callers receive a single coherent policy decision.
- **Experiment override semantics**: Active scaling experiment assignments override the learned baseline per dimension, preserving controlled-experiment integrity while still benefiting non-assigned dimensions from learned defaults.
- **Iteration policy**: When no explicit iteration experiment assignment is active, learned iteration guidance is appended as an iteration-budget prompt instead of falling back to a static default.
- **Observability**: The resolved learned allocation is recorded in scaling-observation metadata, so downstream analysis can attribute outcomes to the specific allocation that was applied.

## Design Decisions

- **Experiments win over learned defaults, per dimension.** Rather than picking one source of truth, learned guidance acts as the baseline and experiment assignments override only the dimensions they explicitly control. This keeps experiments clean while ensuring non-experimental runs still benefit from prior learning.
- **Iteration guidance is surfaced via prompt, not hard cap.** Learned iteration budgets are appended to the prompt rather than enforced as a workflow-level limit, matching the existing pattern for soft guidance and avoiding a regression for runs that legitimately need to exceed the learned norm.
- **Allocation is captured in observation metadata.** Without recording the applied allocation per run, future scaling-law refits would conflate runs from different policies. Persisting it inside the observation record keeps the feedback loop honest.

## Operational Notes

- No schema migration in this change; the allocation flows through workflow inputs and observation metadata fields that already exist.
- RSpec could not be executed end-to-end in the build environment (no PostgreSQL available — suite aborts with `ActiveRecord::ConnectionNotEstablished`). A reduced db-less workflow run reported 0 failures but exited nonzero due to SimpleCov's global coverage threshold. CI should be relied on for the full suite verification before merge.
- `bundle exec rubocop` passed repo-wide.

---

Closes #1817