### PR TITLE
fix(auto-merge): resolve "Depends on #N" against issue state when N is not a PR

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -2729,8 +2729,8 @@ module Activities
         numbers << number
       end
 
-      (local_deps.keys.to_set | same_repo_numbers).all? do |pr_number|
-        dependency_pull_request_merged?(client, project, pr_number)
+      (local_deps.keys.to_set | same_repo_numbers).all? do |number|
+        dependency_resolved?(client, project, number)
       end
     rescue GithubClient::Error => e
       log_signal_error("dependencies_resolved", project, issue, e)
@@ -2743,9 +2743,22 @@ module Activities
       end
     end
 
-    def dependency_pull_request_merged?(client, project, pr_number)
-      pr_data = client.pull_request(project.full_name, pr_number)
-      pull_request_merged?(pr_data)
+    # A "Depends on #N" ref can point to either a PR or an issue. Treat
+    # the dep as satisfied when #N is a merged PR OR a closed issue —
+    # both mean the upstream work is done. Without the issue fallback,
+    # depending on a tracking issue would silently block auto-merge
+    # forever because the pull_request endpoint 404s for issue numbers.
+    def dependency_resolved?(client, project, number)
+      pr_data = begin
+        client.pull_request(project.full_name, number)
+      rescue GithubClient::NotFoundError
+        nil
+      end
+
+      return pull_request_merged?(pr_data) if pr_data
+
+      issue_data = client.issue(project.full_name, number)
+      dependency_value(issue_data, :state) == "closed"
     rescue GithubClient::NotFoundError
       false
     end

--- a/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_dependencies_spec.rb
@@ -105,6 +105,47 @@ RSpec.describe Activities::ScanPaidPrsActivity, :no_db do
 
       expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(true)
     end
+
+    context "when a dependency ref points to an issue rather than a PR" do
+      before do
+        # GitHub's pull_request endpoint 404s when N is an issue.
+        allow(client).to receive(:pull_request)
+          .with(project.full_name, 41)
+          .and_raise(GithubClient::NotFoundError.new("Not Found"))
+      end
+
+      it "returns true when the issue is closed (upstream work is done)" do
+        allow(client).to receive(:issue)
+          .with(project.full_name, 41)
+          .and_return(OpenStruct.new(number: 41, state: "closed"))
+
+        expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(true)
+      end
+
+      it "returns false when the issue is open" do
+        allow(client).to receive(:issue)
+          .with(project.full_name, 41)
+          .and_return(OpenStruct.new(number: 41, state: "open"))
+
+        expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(false)
+      end
+
+      it "returns false when the ref does not exist as either PR or issue" do
+        allow(client).to receive(:issue)
+          .with(project.full_name, 41)
+          .and_raise(GithubClient::NotFoundError.new("Not Found"))
+
+        expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(false)
+      end
+
+      it "accepts hash-shaped issue payloads" do
+        allow(client).to receive(:issue)
+          .with(project.full_name, 41)
+          .and_return({ "number" => 41, "state" => "closed" })
+
+        expect(activity.send(:dependencies_resolved?, client, project, issue)).to be(true)
+      end
+    end
   end
 
   describe "#human_dependency_check_required?" do


### PR DESCRIPTION
## Summary

`ScanPaidPrsActivity#dependencies_resolved?` parsed every `#N` ref in a PR body as if it were a PR number, calling `client.pull_request(repo, N)` and treating the inevitable 404 (when N is actually an issue) as "dependency unmerged." The PR then sat in `paid-ready` indefinitely with no auto-merge and no signal — the same "silently parking work" failure mode as the follow-up budget and `recommend_close` bugs.

## Concrete example (caught in dev)

PR #1994 had `Depends on #1987` in its body. `#1987` is the **issue** for "Foundation for focused agent runs", which was closed by PR #1991 merging. Auto-merge stalled because the scanner asked GitHub for `pulls/1987` (404), and the rescue returned `false`. All seven other auto-merge signals were green; only `dependencies_resolved?` was false.

## Fix

A "Depends on #N" reference should resolve when:
- N is a PR that has been merged, **or**
- N is an issue that has been closed (the upstream work is done)

Renamed `dependency_pull_request_merged?` → `dependency_resolved?` to reflect the broader semantic. One extra API call is made (to the issues endpoint) **only** when the PR lookup 404s. PR refs keep their current behavior (one call, check `merged`).

## Test plan
- [x] 369 specs pass across `scan_paid_prs_activity_spec.rb` + `scan_paid_prs_activity_dependencies_spec.rb` (4 new examples covering: closed issue → resolved; open issue → not resolved; neither PR nor issue exists → not resolved; hash-shaped issue payload → resolved).
- [x] RuboCop clean.
- [ ] Manual: after deploy, verify PR auto-merge fires for ready PRs whose dependency ref is a closed issue.

## Notes for reviewers
- Companion to #2001 (the two fixes are the same class of bug — system silently parks work with no signal — and the dev environment has both ailments at once).
- The branch is small and self-contained; it touches one helper method and one `:no_db` spec file.