### PR TITLE
fix(dashboard): use shared helpers for active-run context and goal labels

### DIFF
--- a/app/views/dashboard/_active_run_row.html.erb
+++ b/app/views/dashboard/_active_run_row.html.erb
@@ -9,17 +9,9 @@
     <%= link_to run.project.full_name, project_path(run.project), class: "hover:text-indigo-600" %>
   </td>
   <td class="px-4 py-3 text-sm text-gray-500">
-    <% if run.issue.present? %>
-      <%= link_to "##{run.issue.github_number} #{run.issue.title.truncate(60)}", project_agent_run_path(run.project, run), class: "hover:text-indigo-600" %>
-    <% elsif run.custom_prompt.present? %>
-      <%= link_to "Custom prompt", project_agent_run_path(run.project, run), class: "hover:text-indigo-600" %>
-    <% elsif run.source_pull_request_number.present? %>
-      <%= link_to "PR ##{run.source_pull_request_number}", project_agent_run_path(run.project, run), class: "hover:text-indigo-600" %>
-    <% else %>
-      <%= link_to "Run ##{run.id}", project_agent_run_path(run.project, run), class: "hover:text-indigo-600" %>
-    <% end %>
+    <%= agent_run_context_display(run) %>
   </td>
-  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500"><%= run.goal.titleize %></td>
+  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500"><%= agent_run_goal_display(run) %></td>
   <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500"><%= agent_run_provider_display(run) %></td>
   <td class="whitespace-nowrap px-4 py-3 text-sm">
     <% run_tier = run.model_selection&.tier %>
@@ -37,9 +29,12 @@
     <span data-elapsed-time-target="display"><%= run.started_at ? format_duration(run.duration) : "--" %></span>
   </td>
   <td class="whitespace-nowrap px-4 py-3 text-right text-sm">
-    <%= button_to "Cancel", dashboard_cancel_run_path(run),
-      method: :post,
-      class: "inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100",
-      data: { turbo_confirm: "Cancel this agent run?" } %>
+    <div class="inline-flex items-center gap-2">
+      <%= link_to "View", project_agent_run_path(run.project, run), class: "text-indigo-600 hover:text-indigo-900" %>
+      <%= button_to "Cancel", dashboard_cancel_run_path(run),
+        method: :post,
+        class: "inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100",
+        data: { turbo_confirm: "Cancel this agent run?" } %>
+    </div>
   </td>
 </tr>

--- a/spec/views/dashboard/active_runs_partial_spec.rb
+++ b/spec/views/dashboard/active_runs_partial_spec.rb
@@ -39,10 +39,12 @@ RSpec.describe "dashboard/_active_runs", :no_db, type: :view do
     allow(view).to receive(:dashboard_cancel_run_path).with(run).and_return("/dashboard/runs/123/cancel")
     allow(view).to receive(:agent_run_status_badge).with("running").and_return('<span>Running</span>'.html_safe)
     allow(view).to receive(:agent_run_priority_badge).with(run).and_return('<span>2 - P1</span>'.html_safe)
+    allow(view).to receive(:agent_run_context_display).with(run).and_return('<span class="context-label">Issue #42</span>'.html_safe)
+    allow(view).to receive(:agent_run_goal_display).with(run).and_return('<span class="goal-label">PR Creation</span>'.html_safe)
     allow(view).to receive(:agent_run_provider_display).with(run).and_return("Codex")
   end
 
-  it "renders the priority column and active run priority value" do
+  it "renders the priority column and shared helper output" do
     render partial: "dashboard/active_runs", locals: { active_runs: [ run ] }
 
     fragment = Nokogiri::HTML.fragment(rendered)
@@ -52,5 +54,7 @@ RSpec.describe "dashboard/_active_runs", :no_db, type: :view do
     expect(headers).to include("Priority")
     expect(row).to be_present
     expect(row.text).to include("2 - P1")
+    expect(row.text).to include("Issue #42")
+    expect(row.text).to include("PR Creation")
   end
 end


### PR DESCRIPTION
## Summary

- The dashboard's active-runs table hand-rolled its context cell and rendered a generic `"Custom prompt"` label whenever an agent run had a custom prompt — hiding the actual prompt content from operators watching the run.
- The same partial also rendered goal labels via `run.goal.titleize`, producing ugly strings like "Create Pr" instead of the "PR Creation" / "Code Review" / "Issue Creation" labels used everywhere else in the app.
- Switched both columns to the shared helpers (`agent_run_context_display`, `agent_run_goal_display`) already used by the queue preview and the agent-runs index tables, so operators see redacted + truncated prompt text with hover tooltips and consistent goal labels.
- Added an explicit "View" action so the row still drills into the run details page (the helper renders external GitHub links rather than being the click target, matching the pattern in `app/views/agent_runs/_index_table.html.erb`).

## Test plan

- [ ] Visit `/dashboard` with active runs that have a custom prompt — confirm the context cell shows a (redacted) snippet of the prompt with a tooltip showing the full redacted prompt, instead of the generic "Custom prompt" label.
- [ ] Confirm active runs tied to a GitHub issue render `Issue #N` with title tooltip, and runs tied to a source PR render `PR #N` linking to the PR on GitHub.
- [ ] Confirm the Goal column renders "PR Creation" / "Issue Creation" / "Code Review" / "Enhance Issue" / "Analyze Issue" instead of "Create Pr" etc.
- [ ] Confirm the new "View" link in the Actions column navigates to the run detail page and the Cancel button still cancels the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)