### PR TITLE
fix(eligibility): align lifecycle badge with auto-pick rules

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -70,12 +70,16 @@ class Issue < ApplicationRecord
   scope :pull_requests_only, -> { where(is_pull_request: true) }
   scope :auto_continue_active, -> { where(auto_continue_paused: false) }
   scope :ready_for_work, ->(project) {
+    # Match blocking_issues / lifecycle_statuses semantics: open dependencies
+    # excluding recommend_close (treated as effectively resolved pending
+    # human confirmation, so they should not gate downstream work).
     blocked_by_local_open = IssueDependency
       .joins(:issue, :depends_on_issue)
       .where(
         depends_on_issue: { github_state: "open" },
         issues: { project_id: project.id }
       )
+      .where.not(depends_on_issue: { paid_state: "recommend_close" })
       .select(:issue_id)
 
     # Deployment-blocked deps: target PR has merged/closed, but has not
@@ -320,7 +324,18 @@ class Issue < ApplicationRecord
       .pluck(:issue_id)
       .to_set
 
-    blocked_ids = blocked_by_local | blocked_by_deployment_pending | blocked_by_external
+    # Match auto-pick's without_open_non_pr_subissues semantics: a parent is
+    # blocked while it still has open non-PR sub-issues. Mirrors the
+    # dependency rule above by exempting recommend_close sub-issues.
+    blocked_by_open_subissues = where(
+      parent_issue_id: issue_ids,
+      is_pull_request: false,
+      github_state: "open"
+    ).where.not(paid_state: "recommend_close")
+      .pluck(:parent_issue_id)
+      .to_set
+
+    blocked_ids = blocked_by_local | blocked_by_deployment_pending | blocked_by_external | blocked_by_open_subissues
 
     active_run_ids = AgentRun
       .where(issue_id: issue_ids, status: AgentRun::UNFINISHED_STATUSES)

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -204,6 +204,7 @@ module Automation
                   AND sub_issues.project_id = issues.project_id
                   AND sub_issues.is_pull_request = FALSE
                   AND sub_issues.github_state = 'open'
+                  AND sub_issues.paid_state IS DISTINCT FROM 'recommend_close'
               )
             SQL
           end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe Issue do
         expect(described_class.ready_for_work(project)).to include(issue)
       end
 
+      it "includes issues whose only open dep is paid_state recommend_close" do
+        dep = create(:issue, :recommend_close, project: project, github_state: "open")
+        issue = create(:issue, project: project)
+        create(:issue_dependency, issue: issue, depends_on_issue: dep)
+
+        expect(described_class.ready_for_work(project)).to include(issue)
+      end
+
       it "excludes closed issues" do
         issue = create(:issue, project: project, github_state: "closed")
 
@@ -1298,6 +1306,24 @@ RSpec.describe Issue do
       result = described_class.lifecycle_statuses([ issue ])
 
       expect(result[issue.id]).to eq(:eligible)
+    end
+
+    it "returns :blocked for a parent with an open non-PR sub-issue" do
+      parent = create(:issue, project: project, github_state: "open")
+      create(:issue, project: project, github_state: "open", parent_issue: parent)
+
+      result = described_class.lifecycle_statuses([ parent ])
+
+      expect(result[parent.id]).to eq(:blocked)
+    end
+
+    it "returns :eligible when the only open sub-issue is paid_state recommend_close" do
+      parent = create(:issue, project: project, github_state: "open")
+      create(:issue, :recommend_close, project: project, github_state: "open", parent_issue: parent)
+
+      result = described_class.lifecycle_statuses([ parent ])
+
+      expect(result[parent.id]).to eq(:eligible)
     end
 
     it "returns :eligible for an issue with only completed agent runs" do

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -129,6 +129,15 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
       expect(scope.pluck(:id)).to contain_exactly(child.id, standalone.id)
     end
+
+    it "keeps a parent eligible when its only open sub-issue is recommend_close" do
+      parent = create(:issue, project: project, github_number: 1)
+      create(:issue, :recommend_close, project: project, github_number: 2, parent_issue: parent)
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to include(parent.id)
+    end
   end
 
   describe ".eligible_issue_ids" do


### PR DESCRIPTION
## Summary

- Aligns the "⚡ Unblocked" UI badge with auto-pick eligibility so the dashboard's upcoming queue and per-issue badges agree.
- Treats `paid_state = recommend_close` uniformly across dependencies AND sub-issues, in both the lifecycle (UI) and the auto-pick scope.
- Fixes the UX bug where a parent like #1789 displayed "Unblocked" but never entered the queue.

## Why

Two checks computed eligibility independently and diverged:

- `Issue.lifecycle_statuses` (UI): didn't consider open non-PR sub-issues; exempted `recommend_close` from open dependencies.
- `Issue.ready_for_work` + `Automation::Strategies::AutoPick::DefaultCandidateSource#without_open_non_pr_subissues` (auto-pick): excluded parents with any open non-PR sub-issue; did NOT exempt `recommend_close` — neither for deps nor sub-issues.

So a parent issue whose only blocker was a `recommend_close` sub-issue or dependency would show as Unblocked, but auto-pick would silently skip it.

## What changed

- `Issue.lifecycle_statuses` now marks a parent `:blocked` when it has any open non-PR sub-issue (excluding `recommend_close`).
- `Issue.ready_for_work` exempts `recommend_close` from open dependency blocking — matches `Issue#blocking_issues` and the UI.
- `without_open_non_pr_subissues` exempts `recommend_close` sub-issues — matches the dependency rule.

After this PR, "blocked" means the same thing everywhere: an open non-PR dependency or sub-issue that isn't `recommend_close`.

## Test plan

- [x] `bin/rspec spec/models/issue_spec.rb spec/services/automation/strategies/auto_pick/` — 182 examples, 0 failures
- [x] New `Issue.lifecycle_statuses` specs cover open non-PR sub-issue → :blocked, and `recommend_close` sub-issue → :eligible.
- [x] New `Issue.ready_for_work` spec covers `recommend_close` open dep → included.
- [x] New `DefaultCandidateSource.eligible_scope` spec covers `recommend_close` open sub-issue → parent included.
- [ ] After deploy: confirm #1789 reflects correct lifecycle status and is eligible for auto-pick once the next GitHub sync runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)