### PR TITLE
fix(classify): prevent false recommend_close when agent did no work

### DIFF
--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -4,9 +4,11 @@ module Activities
   # Handles issue-based agent runs that complete without producing a PR or commit.
   #
   # Classifies the outcome as either:
-  # - `recommend_close`: agent produced output but no code changes (issue may be
-  #   already satisfied, obsolete, or not actionable)
-  # - `needs_input`: agent produced no output and no changes (issue is likely
+  # - `recommend_close`: agent performed real work (iterations/cost > 0) but
+  #   produced no code changes (issue may be already satisfied, obsolete, or
+  #   not actionable)
+  # - `needs_input`: agent produced no output, or produced output with zero
+  #   iterations and zero cost (no evidence of real work; issue is likely
   #   underspecified or ambiguous)
   # - `provider_error`: provider returned an error (e.g. credit/quota exhaustion)
   #   before the agent actually ran. The run is failed so retry / provider
@@ -117,11 +119,15 @@ module Activities
 
       # Guard: if the agent produced output but shows no evidence of having
       # actually run (zero iterations AND zero cost), the "output" is likely
-      # a provider-level error (e.g. credit exhaustion) rather than a real
-      # agent response. Confirm by checking the output for error patterns.
+      # a provider-level error (e.g. credit exhaustion) or trivial CLI
+      # boilerplate rather than a real agent response. Confirm by checking
+      # the output for error patterns; if neither matches, classify as
+      # needs_input since the agent did not perform meaningful work.
       if agent_run.iterations.to_i.zero? && agent_run.cost_cents.to_i.zero?
         return "provider_error" if provider_error_output?(agent_summary)
         return "infrastructure_error" if infrastructure_error_output?(agent_summary)
+
+        return "needs_input"
       end
 
       "recommend_close"

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -101,7 +101,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
     context "when output_present is true (recommend_close)" do
       it "sets issue paid_state to recommend_close" do
         issue = create(:issue, :in_progress, project: project)
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -110,7 +111,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
       it "posts a recommend-close comment on the issue" do
         issue = create(:issue, :in_progress, project: project)
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -120,7 +122,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
       it "does not add the paid-needs-input label" do
         issue = create(:issue, :in_progress, project: project)
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -130,7 +133,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
       it "adds the paid-recommend-close label so the issue surfaces for human review" do
         issue = create(:issue, :in_progress, project: project)
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -143,7 +147,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
           label_mappings: { "recommend_close" => "needs-review" },
           automation_on_label_enabled: false)
         issue = create(:issue, :in_progress, project: custom_project)
-        agent_run = create(:agent_run, :running, project: custom_project, issue: issue)
+        agent_run = create(:agent_run, :running, project: custom_project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -153,7 +158,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
       it "returns outcome recommend_close" do
         issue = create(:issue, :in_progress, project: project)
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         result = activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -162,7 +168,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
       it "removes the needs-input label if present" do
         issue = create(:issue, :in_progress, project: project, labels: [ "paid-needs-input" ])
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -172,7 +179,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
       it "does not attempt to remove needs-input label when not present" do
         issue = create(:issue, :in_progress, project: project, labels: [])
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -211,7 +219,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
       it "removes the automation trigger label on recommend_close in batch" do
         issue = create(:issue, :in_progress, project: auto_project, labels: [ "my-auto" ])
-        agent_run = create(:agent_run, :running, project: auto_project, issue: issue)
+        agent_run = create(:agent_run, :running, project: auto_project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 
@@ -248,7 +257,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
       it "skips posting recommend-close comment if marker already exists" do
         issue = create(:issue, :in_progress, project: project)
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         existing_comment = Struct.new(:body).new("<!-- paid:recommend-close -->\nOld comment")
         allow(client).to receive(:recent_issue_comments).and_return([ existing_comment ])
@@ -454,7 +464,9 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
       it "does not match a bare 'model not found' phrase quoted in agent output" do
         # The colon in /Model not found:/ guards against false-positives on
         # natural-language mentions of the phrase that the agent might quote
-        # back from issue bodies or web fetches.
+        # back from issue bodies or web fetches. With zero iterations and
+        # zero cost the agent did no real work, so the correct fallback is
+        # needs_input (not recommend_close).
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue,
           iterations: 0, cost_cents: 0)
@@ -462,7 +474,19 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
         result = activity.execute(agent_run_id: agent_run.id, output_present: true)
 
-        expect(result[:outcome]).to eq("recommend_close")
+        expect(result[:outcome]).to eq("needs_input")
+      end
+
+      it "classifies trivial output with zero iterations and zero cost as needs_input" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "OK.")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("needs_input")
+        expect(issue.reload.paid_state).to eq("needs_input")
       end
     end
 
@@ -491,7 +515,8 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
       it "is re-applied (idempotent) when a re-run produces the same recommend_close outcome" do
         issue = create(:issue, :in_progress, project: project,
           labels: [ "paid-build", "paid-recommend-close" ])
-        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
 
         activity.execute(agent_run_id: agent_run.id, output_present: true)
 


### PR DESCRIPTION
## Summary

- Fixes a false `recommend_close` classification in `HandleNoOutputIssueRunActivity` when the agent produces trivial output (e.g. "OK.") with zero iterations and zero cost
- The `classify_outcome` method now falls through to `needs_input` instead of `recommend_close` when output is present but the agent performed no real work
- Adds regression test for the exact "OK." scenario from issue #1897

## Why this matters

Issue #1897 tracks an unresolved upstream dependency (`viamin/agent-harness#212`). An agent run produced only "OK." with zero iterations/cost — clear evidence the agent didn't do meaningful work — yet the system posted a "Recommend Close" comment claiming the issue "may already be resolved, obsolete, or not actionable." The issue is none of those things; it's waiting on an upstream fix.

## Root cause

`classify_outcome` had a guard for zero-iterations/zero-cost output that checked for provider error patterns and infrastructure error patterns, but had no fallback — it fell through to `recommend_close`. Any non-error trivial output (CLI boilerplate, empty acknowledgments) was misclassified.

## Fix

Added `return "needs_input"` as the final branch in the zero-iterations/zero-cost guard. Now:

| iterations | cost | output matches error? | outcome |
|---|---|---|---|
| 0 | 0 | provider error | `provider_error` (run failed, retry) |
| 0 | 0 | infrastructure error | `infrastructure_error` (run failed, retry) |
| 0 | 0 | no error match | **`needs_input`** (needs human attention) |
| >0 or >0 | any | any | `recommend_close` (agent did real work) |

## Test plan

- [x] `bin/rspec spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb` — 47 examples, 0 failures
- [x] `bin/rspec spec/models/issue_spec.rb` — 165 examples, 0 failures
- [x] `bin/rspec spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb` — 17 examples, 0 failures
- [x] `bin/lint --changed` — all checks passed