### PR TITLE
feat(auto-pick): add Issues::EnqueueEligible and Issues::BulkEnqueueEligible services

### DIFF
--- a/.github/workflows/pr-screenshots-publish.yml
+++ b/.github/workflows/pr-screenshots-publish.yml
@@ -77,8 +77,12 @@ jobs:
             run = runs.find do |candidate|
               next false unless candidate["head_sha"] == head_sha
 
-              candidate["head_branch"] == head_ref ||
-                candidate.fetch("pull_requests", []).any? { |pr| pr["number"] == pr_number }
+              pull_requests = candidate.fetch("pull_requests", [])
+              if pull_requests.any?
+                pull_requests.any? { |pr| pr["number"] == pr_number }
+              else
+                candidate["head_branch"] == head_ref
+              end
             end
 
             break if run && run["status"] == "completed"

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -170,10 +170,11 @@ class ProcessRunQueueJob < ApplicationJob
         break if seeded >= MAX_SEEDS_PER_PERFORM
         next unless project.effective_owner
 
-        run = Issues::AutoPick.new(project).call
-        next unless run
+        runs = Issues::BulkEnqueueEligible.call(project: project)
+        created = runs.count(&:previously_new_record?)
+        next if created.zero?
 
-        seeded += 1
+        seeded += created
         created_in_pass = true
       end
 

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -37,7 +37,6 @@ class ProcessRunQueueJob < ApplicationJob
   # with unbounded INSERTs in a single pass. The next perform will pick
   # up where this one left off.
   MAX_SEEDS_PER_PERFORM = 200
-  PAID_READY_LABEL = Issues::AutoPick::PAID_READY_LABEL
 
   def perform
     # Use a PostgreSQL advisory lock to ensure only one job processes the queue at a time.
@@ -170,7 +169,6 @@ class ProcessRunQueueJob < ApplicationJob
       ordered_auto_pick_projects.each do |project|
         break if seeded >= MAX_SEEDS_PER_PERFORM
         next unless project.effective_owner
-        next if auto_pick_deferred_by_pr_attention_limit?(project)
 
         runs = Issues::BulkEnqueueEligible.call(project: project, limit: 1)
         created = runs.count(&:previously_new_record?)
@@ -225,38 +223,6 @@ class ProcessRunQueueJob < ApplicationJob
         ]
       end
     end
-  end
-
-  def auto_pick_deferred_by_pr_attention_limit?(project)
-    limit = max_auto_pick_open_prs(project)
-    return false if limit <= 0
-
-    prs_needing_attention_count(project) >= limit
-  end
-
-  def prs_needing_attention_count(project)
-    base = Issue.where(
-      project: project,
-      is_pull_request: true,
-      github_state: "open",
-      paid_state: %w[in_progress failed]
-    )
-
-    handed_off = base
-      .where(paid_state: "in_progress")
-      .where("labels @> ?::jsonb", [ project.automation_label_name, PAID_READY_LABEL ].to_json)
-      .where.not(pr_review_phase: %w[draft restarted])
-
-    escalated = base.where(pr_review_phase: "escalated")
-
-    base.where.not(id: handed_off).where.not(id: escalated).count
-  end
-
-  def max_auto_pick_open_prs(project)
-    owner = project.effective_owner
-    return 1 unless owner
-
-    owner.settings.max_auto_pick_open_prs
   end
 
   def start_claimed_run(agent_run)

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -37,6 +37,7 @@ class ProcessRunQueueJob < ApplicationJob
   # with unbounded INSERTs in a single pass. The next perform will pick
   # up where this one left off.
   MAX_SEEDS_PER_PERFORM = 200
+  PAID_READY_LABEL = Issues::AutoPick::PAID_READY_LABEL
 
   def perform
     # Use a PostgreSQL advisory lock to ensure only one job processes the queue at a time.
@@ -169,6 +170,7 @@ class ProcessRunQueueJob < ApplicationJob
       ordered_auto_pick_projects.each do |project|
         break if seeded >= MAX_SEEDS_PER_PERFORM
         next unless project.effective_owner
+        next if auto_pick_deferred_by_pr_attention_limit?(project)
 
         runs = Issues::BulkEnqueueEligible.call(project: project, limit: 1)
         created = runs.count(&:previously_new_record?)
@@ -223,6 +225,38 @@ class ProcessRunQueueJob < ApplicationJob
         ]
       end
     end
+  end
+
+  def auto_pick_deferred_by_pr_attention_limit?(project)
+    limit = max_auto_pick_open_prs(project)
+    return false if limit <= 0
+
+    prs_needing_attention_count(project) >= limit
+  end
+
+  def prs_needing_attention_count(project)
+    base = Issue.where(
+      project: project,
+      is_pull_request: true,
+      github_state: "open",
+      paid_state: %w[in_progress failed]
+    )
+
+    handed_off = base
+      .where(paid_state: "in_progress")
+      .where("labels @> ?::jsonb", [ project.automation_label_name, PAID_READY_LABEL ].to_json)
+      .where.not(pr_review_phase: %w[draft restarted])
+
+    escalated = base.where(pr_review_phase: "escalated")
+
+    base.where.not(id: handed_off).where.not(id: escalated).count
+  end
+
+  def max_auto_pick_open_prs(project)
+    owner = project.effective_owner
+    return 1 unless owner
+
+    owner.settings.max_auto_pick_open_prs
   end
 
   def start_claimed_run(agent_run)

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -169,6 +169,7 @@ class ProcessRunQueueJob < ApplicationJob
       ordered_auto_pick_projects.each do |project|
         break if seeded >= MAX_SEEDS_PER_PERFORM
         next unless project.effective_owner
+        next if auto_pick_deferred_by_pr_attention?(project)
 
         runs = Issues::BulkEnqueueEligible.call(project: project, limit: 1)
         created = runs.count(&:previously_new_record?)
@@ -223,6 +224,32 @@ class ProcessRunQueueJob < ApplicationJob
         ]
       end
     end
+  end
+
+  def auto_pick_deferred_by_pr_attention?(project)
+    prs_needing_attention_count(project) >= max_auto_pick_open_prs(project)
+  end
+
+  def prs_needing_attention_count(project)
+    base = Issue.where(
+      project: project,
+      is_pull_request: true,
+      github_state: "open",
+      paid_state: %w[in_progress failed]
+    )
+
+    handed_off = base
+      .where(paid_state: "in_progress")
+      .where("labels @> ?::jsonb", [ project.automation_label_name, Issues::AutoPick::PAID_READY_LABEL ].to_json)
+      .where.not(pr_review_phase: %w[draft restarted])
+
+    escalated = base.where(pr_review_phase: "escalated")
+
+    base.where.not(id: handed_off).where.not(id: escalated).count
+  end
+
+  def max_auto_pick_open_prs(project)
+    project.effective_owner&.settings&.max_auto_pick_open_prs || 1
   end
 
   def start_claimed_run(agent_run)

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -170,7 +170,7 @@ class ProcessRunQueueJob < ApplicationJob
         break if seeded >= MAX_SEEDS_PER_PERFORM
         next unless project.effective_owner
 
-        runs = Issues::BulkEnqueueEligible.call(project: project)
+        runs = Issues::BulkEnqueueEligible.call(project: project, limit: 1)
         created = runs.count(&:previously_new_record?)
         next if created.zero?
 

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -93,14 +93,17 @@ module Automation
             scope
           end
 
-          def next_candidate(project)
+          def ordered_scope(project)
             eligible_scope(project)
               .order(
                 Arel.sql("#{priority_label_order_sql(project)} ASC"),
                 Arel.sql("#{dependency_tree_order_sql} ASC"),
                 Arel.sql("issues.github_number ASC")
               )
-              .first
+          end
+
+          def next_candidate(project)
+            ordered_scope(project).first
           end
 
           # Identifies tracker issues whose body references other issues

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -221,11 +221,13 @@ module Automation
             effective = project.effective_priority_labels
             issues = Issue.arel_table
             priority_case = Arel::Nodes::Case.new
+            configured_tiers = 0
 
             Project::PRIORITY_TIERS.each_with_index do |tier, index|
               label_name = effective[tier]
               next if label_name.blank?
 
+              configured_tiers += 1
               condition = Arel::Nodes::InfixOperation.new(
                 "@>",
                 issues[:labels],
@@ -233,6 +235,8 @@ module Automation
               )
               priority_case.when(condition).then(index + 1)
             end
+
+            return Arel.sql((Project::PRIORITY_TIERS.size + 1).to_s) if configured_tiers.zero?
 
             priority_case.else(Project::PRIORITY_TIERS.size + 1)
           end

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -242,21 +242,15 @@ module Automation
           # same-account local graph, not just the current project, because
           # IssueDependency supports cross-project links within an account.
           def dependency_tree_order_node
-            issues = Issue.arel_table
-            dependencies = IssueDependency.arel_table.alias("id_dep")
-            dependent_issues = Issue.arel_table.alias("dep_issue")
-
-            dependency_exists = dependencies
-              .project(Arel.sql("1"))
-              .join(dependent_issues).on(dependent_issues[:id].eq(dependencies[:issue_id]))
-              .where(dependencies[:depends_on_issue_id].eq(issues[:id]))
-              .where(dependent_issues[:github_state].eq("open"))
-              .where(dependent_issues[:is_pull_request].eq(false))
-
-            Arel::Nodes::Case.new
-              .when(Arel::Nodes::Exists.new(dependency_exists))
-              .then(1)
-              .else(2)
+            Arel.sql(<<~SQL.squish)
+              CASE WHEN EXISTS (
+                SELECT 1 FROM issue_dependencies id_dep
+                JOIN issues dep_issue ON dep_issue.id = id_dep.issue_id
+                WHERE id_dep.depends_on_issue_id = issues.id
+                  AND dep_issue.github_state = 'open'
+                  AND dep_issue.is_pull_request = FALSE
+              ) THEN 1 ELSE 2 END
+            SQL
           end
         end
       end

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -96,9 +96,9 @@ module Automation
           def ordered_scope(project)
             eligible_scope(project)
               .order(
-                Arel.sql("#{priority_label_order_sql(project)} ASC"),
-                Arel.sql("#{dependency_tree_order_sql} ASC"),
-                Arel.sql("issues.github_number ASC")
+                Arel::Nodes::Ascending.new(priority_label_order_node(project)),
+                Arel::Nodes::Ascending.new(dependency_tree_order_node),
+                Issue.arel_table[:github_number].asc
               )
           end
 
@@ -212,42 +212,51 @@ module Automation
             SQL
           end
 
-          # Returns a CASE expression that maps each issue to a numeric
+          # Returns a CASE node that maps each issue to a numeric
           # priority rank based on the project's configured priority
           # labels (+Project#effective_priority_labels+). Lower rank sorts
           # first, so P1-labeled issues beat P2/P3/unlabeled, P2 beats
-          # P3/unlabeled, and P3 beats unlabeled. Label names are
-          # interpolated via +connection.quote+ to keep the CASE safe
-          # for use with +Arel.sql+.
-          def priority_label_order_sql(project)
+          # P3/unlabeled, and P3 beats unlabeled.
+          def priority_label_order_node(project)
             effective = project.effective_priority_labels
-            conn = Issue.connection
-            cases = Project::PRIORITY_TIERS.each_with_index.filter_map do |tier, index|
+            issues = Issue.arel_table
+            priority_case = Arel::Nodes::Case.new
+
+            Project::PRIORITY_TIERS.each_with_index.each do |tier, index|
               label_name = effective[tier]
               next if label_name.blank?
 
-              quoted = conn.quote([ label_name ].to_json)
-              "WHEN issues.labels @> #{quoted}::jsonb THEN #{index + 1}"
+              condition = Arel::Nodes::InfixOperation.new(
+                "@>",
+                issues[:labels],
+                Arel::Nodes::NamedFunction.new("jsonb_build_array", [ Arel::Nodes.build_quoted(label_name) ])
+              )
+              priority_case.when(condition).then(index + 1)
             end
-            return (Project::PRIORITY_TIERS.size + 1).to_s if cases.empty?
 
-            "CASE #{cases.join(' ')} ELSE #{Project::PRIORITY_TIERS.size + 1} END"
+            priority_case.else(Project::PRIORITY_TIERS.size + 1)
           end
 
           # Among already-eligible issues, prefer runnable roots of a
           # dependency tree over standalone work. Count dependents across the
           # same-account local graph, not just the current project, because
           # IssueDependency supports cross-project links within an account.
-          def dependency_tree_order_sql
-            <<~SQL.squish
-              CASE WHEN EXISTS (
-                SELECT 1 FROM issue_dependencies id_dep
-                JOIN issues dep_issue ON dep_issue.id = id_dep.issue_id
-                WHERE id_dep.depends_on_issue_id = issues.id
-                  AND dep_issue.github_state = 'open'
-                  AND dep_issue.is_pull_request = FALSE
-              ) THEN 1 ELSE 2 END
-            SQL
+          def dependency_tree_order_node
+            issues = Issue.arel_table
+            dependencies = IssueDependency.arel_table.alias("id_dep")
+            dependent_issues = Issue.arel_table.alias("dep_issue")
+
+            dependency_exists = dependencies
+              .project(Arel.sql("1"))
+              .join(dependent_issues).on(dependent_issues[:id].eq(dependencies[:issue_id]))
+              .where(dependencies[:depends_on_issue_id].eq(issues[:id]))
+              .where(dependent_issues[:github_state].eq("open"))
+              .where(dependent_issues[:is_pull_request].eq(false))
+
+            Arel::Nodes::Case.new
+              .when(Arel::Nodes::Exists.new(dependency_exists))
+              .then(1)
+              .else(2)
           end
         end
       end

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -222,7 +222,7 @@ module Automation
             issues = Issue.arel_table
             priority_case = Arel::Nodes::Case.new
 
-            Project::PRIORITY_TIERS.each_with_index.each do |tier, index|
+            Project::PRIORITY_TIERS.each_with_index do |tier, index|
               label_name = effective[tier]
               next if label_name.blank?
 

--- a/app/services/issues/bulk_enqueue_eligible.rb
+++ b/app/services/issues/bulk_enqueue_eligible.rb
@@ -48,7 +48,7 @@ module Issues
     attr_reader :limit
 
     def each_eligible_issue(&)
-      return ordered_eligible_scope.each(&) if limit.present?
+      return ordered_eligible_scope.limit(limit_query_cap).each(&) if limit.present?
 
       eligible_scope.find_each(&)
     end
@@ -63,6 +63,10 @@ module Issues
 
     def limit_reached?(counts)
       limit.present? && counts[:created] >= limit
+    end
+
+    def limit_query_cap
+      limit * 10
     end
   end
 end

--- a/app/services/issues/bulk_enqueue_eligible.rb
+++ b/app/services/issues/bulk_enqueue_eligible.rb
@@ -17,7 +17,7 @@ module Issues
       counts = { created: 0, existing: 0, skipped: 0 }
       runs = []
 
-      eligible_scope.find_each do |issue|
+      each_eligible_issue do |issue|
         run = EnqueueEligible.call(issue, project: project)
 
         if run.nil?
@@ -47,8 +47,18 @@ module Issues
     attr_reader :project
     attr_reader :limit
 
+    def each_eligible_issue(&)
+      return ordered_eligible_scope.each(&) if limit.present?
+
+      eligible_scope.find_each(&)
+    end
+
     def eligible_scope
       Automation::Strategies::AutoPick::DefaultCandidateSource.eligible_scope(project)
+    end
+
+    def ordered_eligible_scope
+      Automation::Strategies::AutoPick::DefaultCandidateSource.ordered_scope(project)
     end
 
     def limit_reached?(counts)

--- a/app/services/issues/bulk_enqueue_eligible.rb
+++ b/app/services/issues/bulk_enqueue_eligible.rb
@@ -48,7 +48,7 @@ module Issues
     attr_reader :limit
 
     def each_eligible_issue(&)
-      return ordered_eligible_scope.limit(limit_query_cap).each(&) if limit.present?
+      return ordered_eligible_scope.each(&) if limit.present?
 
       eligible_scope.find_each(&)
     end
@@ -63,10 +63,6 @@ module Issues
 
     def limit_reached?(counts)
       limit.present? && counts[:created] >= limit
-    end
-
-    def limit_query_cap
-      limit * 10
     end
   end
 end

--- a/app/services/issues/bulk_enqueue_eligible.rb
+++ b/app/services/issues/bulk_enqueue_eligible.rb
@@ -6,8 +6,9 @@ module Issues
       new(...).call
     end
 
-    def initialize(project:)
+    def initialize(project:, limit: nil)
       @project = project
+      @limit = limit
     end
 
     def call
@@ -27,6 +28,7 @@ module Issues
         runs << run
         key = run.previously_new_record? ? :created : :existing
         counts[key] += 1
+        break if limit_reached?(counts)
       end
 
       Rails.logger.info(
@@ -43,9 +45,14 @@ module Issues
     private
 
     attr_reader :project
+    attr_reader :limit
 
     def eligible_scope
       Automation::Strategies::AutoPick::DefaultCandidateSource.eligible_scope(project)
+    end
+
+    def limit_reached?(counts)
+      limit.present? && counts[:created] >= limit
     end
   end
 end

--- a/app/services/issues/bulk_enqueue_eligible.rb
+++ b/app/services/issues/bulk_enqueue_eligible.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Issues
+  class BulkEnqueueEligible
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:)
+      @project = project
+    end
+
+    def call
+      return [] unless project.auto_pick_enabled?
+
+      counts = { created: 0, existing: 0, skipped: 0 }
+      runs = []
+
+      eligible_scope.find_each do |issue|
+        run = EnqueueEligible.call(issue, project: project)
+
+        if run.nil?
+          counts[:skipped] += 1
+          next
+        end
+
+        runs << run
+        key = run.previously_new_record? ? :created : :existing
+        counts[key] += 1
+      end
+
+      Rails.logger.info(
+        message: "bulk_enqueue_eligible.completed",
+        project_id: project.id,
+        created_count: counts[:created],
+        existing_count: counts[:existing],
+        skipped_count: counts[:skipped]
+      )
+
+      runs
+    end
+
+    private
+
+    attr_reader :project
+
+    def eligible_scope
+      Automation::Strategies::AutoPick::DefaultCandidateSource.eligible_scope(project)
+    end
+  end
+end

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -24,13 +24,12 @@ module Issues
         return nil
       end
 
-      run = blocking_runs.find_or_create_by!(project: project, issue: issue) do |agent_run|
+      run = blocking_runs(goal).find_or_create_by!(project: project, issue: issue, goal: goal) do |agent_run|
         agent_run.provider = provider
         agent_run.agent_type = Provider.agent_type_for(provider.provider_key)
         agent_run.status = "queued"
         agent_run.trigger_type = "automatic"
         agent_run.auto_pick = true
-        agent_run.goal = goal
       end
 
       if run.previously_new_record?
@@ -44,7 +43,8 @@ module Issues
       message = e.cause&.message || e.message
       raise unless message&.include?("idx_agent_runs_unique_active_issue")
 
-      run = blocking_runs.find_by(project: project, issue: issue)
+      goal = seeded_goal
+      run = blocking_runs(goal).find_by(project: project, issue: issue, goal: goal)
       if run
         log_existing(run)
         run
@@ -73,8 +73,8 @@ module Issues
       project.auto_enhance_enabled? ? "analyze_issue" : "create_pr"
     end
 
-    def blocking_runs
-      AgentRun.where(status: AgentRun::AUTO_PICK_BLOCKING_STATUSES)
+    def blocking_runs(goal)
+      AgentRun.where(status: AgentRun::AUTO_PICK_BLOCKING_STATUSES, goal: goal)
     end
 
     def log_created(run)

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -24,12 +24,13 @@ module Issues
         return nil
       end
 
-      run = blocking_runs.find_or_create_by!(project: project, issue: issue, goal: goal) do |agent_run|
+      run = blocking_runs.find_or_create_by!(project: project, issue: issue) do |agent_run|
         agent_run.provider = provider
         agent_run.agent_type = Provider.agent_type_for(provider.provider_key)
         agent_run.status = "queued"
         agent_run.trigger_type = "automatic"
         agent_run.auto_pick = true
+        agent_run.goal = goal
       end
 
       if run.previously_new_record?
@@ -43,7 +44,7 @@ module Issues
       message = e.cause&.message || e.message
       raise unless message&.include?("idx_agent_runs_unique_active_issue")
 
-      run = blocking_runs.find_by(project: project, issue: issue, goal: goal)
+      run = blocking_runs.find_by(project: project, issue: issue)
       if run
         log_existing(run)
         run

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -24,13 +24,12 @@ module Issues
         return nil
       end
 
-      run = blocking_runs.find_or_create_by!(project: project, issue: issue) do |agent_run|
+      run = blocking_runs.find_or_create_by!(project: project, issue: issue, goal: goal) do |agent_run|
         agent_run.provider = provider
         agent_run.agent_type = Provider.agent_type_for(provider.provider_key)
         agent_run.status = "queued"
         agent_run.trigger_type = "automatic"
         agent_run.auto_pick = true
-        agent_run.goal = goal
       end
 
       if run.previously_new_record?
@@ -44,7 +43,7 @@ module Issues
       message = e.cause&.message || e.message
       raise unless message&.include?("idx_agent_runs_unique_active_issue")
 
-      run = blocking_runs.find_by(project: project, issue: issue)
+      run = blocking_runs.find_by(project: project, issue: issue, goal: goal)
       if run
         log_existing(run)
         run

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Issues
+  class EnqueueEligible
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(issue, project:)
+      @issue = issue
+      @project = project
+    end
+
+    def call
+      unless eligible?
+        log_ineligible
+        return nil
+      end
+
+      provider = resolve_provider
+      unless provider
+        log_no_provider
+        return nil
+      end
+
+      run = blocking_runs.find_or_create_by!(project: project, issue: issue) do |agent_run|
+        agent_run.provider = provider
+        agent_run.agent_type = Provider.agent_type_for(provider.provider_key)
+        agent_run.status = "queued"
+        agent_run.trigger_type = "automatic"
+        agent_run.auto_pick = true
+        agent_run.goal = "create_pr"
+      end
+
+      if run.previously_new_record?
+        log_created(run)
+      else
+        log_existing(run)
+      end
+
+      run
+    rescue ActiveRecord::RecordNotUnique => e
+      message = e.cause&.message || e.message
+      raise unless message&.include?("idx_agent_runs_unique_active_issue")
+
+      run = blocking_runs.find_by(project: project, issue: issue)
+      if run
+        log_existing(run)
+        run
+      else
+        nil
+      end
+    end
+
+    private
+
+    attr_reader :issue, :project
+
+    def eligible?
+      Automation::Strategies::AutoPick::DefaultCandidateSource
+        .eligible_scope(project)
+        .where(id: issue.id)
+        .exists?
+    end
+
+    def resolve_provider
+      provider_id, = AgentRuns::ProviderResolver.call(project: project, goal: "create_pr")
+      Provider.kept_only.find_by(id: provider_id) if provider_id
+    end
+
+    def blocking_runs
+      AgentRun.where(status: AgentRun::AUTO_PICK_BLOCKING_STATUSES)
+    end
+
+    def log_created(run)
+      Rails.logger.info(log_context("enqueue_eligible.created", agent_run_id: run.id))
+    end
+
+    def log_existing(run)
+      Rails.logger.info(log_context("enqueue_eligible.existing", agent_run_id: run.id))
+    end
+
+    def log_ineligible
+      Rails.logger.info(log_context("enqueue_eligible.ineligible"))
+    end
+
+    def log_no_provider
+      Rails.logger.warn(log_context("enqueue_eligible.no_provider"))
+    end
+
+    def log_context(message, extra = {})
+      {
+        message: message,
+        project_id: project.id,
+        issue_id: issue.id,
+        issue_number: issue.github_number
+      }.merge(extra)
+    end
+  end
+end

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -17,7 +17,8 @@ module Issues
         return nil
       end
 
-      provider = resolve_provider
+      goal = seeded_goal
+      provider = resolve_provider(goal)
       unless provider
         log_no_provider
         return nil
@@ -29,7 +30,7 @@ module Issues
         agent_run.status = "queued"
         agent_run.trigger_type = "automatic"
         agent_run.auto_pick = true
-        agent_run.goal = "create_pr"
+        agent_run.goal = goal
       end
 
       if run.previously_new_record?
@@ -63,9 +64,13 @@ module Issues
         .exists?
     end
 
-    def resolve_provider
-      provider_id, = AgentRuns::ProviderResolver.call(project: project, goal: "create_pr")
+    def resolve_provider(goal)
+      provider_id, = AgentRuns::ProviderResolver.call(project: project, goal: goal)
       Provider.kept_only.find_by(id: provider_id) if provider_id
+    end
+
+    def seeded_goal
+      project.auto_enhance_enabled? ? "analyze_issue" : "create_pr"
     end
 
     def blocking_runs

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -24,7 +24,7 @@ module Issues
         return nil
       end
 
-      run = blocking_runs.find_or_create_by!(project: project, issue: issue) do |agent_run|
+      run = blocking_runs.find_or_create_by!(project: project, issue: issue, goal: goal) do |agent_run|
         agent_run.provider = provider
         agent_run.agent_type = Provider.agent_type_for(provider.provider_key)
         agent_run.status = "queued"
@@ -44,7 +44,7 @@ module Issues
       message = e.cause&.message || e.message
       raise unless message&.include?("idx_agent_runs_unique_active_issue")
 
-      run = blocking_runs.find_by(project: project, issue: issue)
+      run = blocking_runs.find_by(project: project, issue: issue, goal: goal)
       if run
         log_existing(run)
         run

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -24,7 +24,7 @@ module Issues
         return nil
       end
 
-      run = blocking_runs.find_or_create_by!(project: project, issue: issue, goal: goal) do |agent_run|
+      run = blocking_runs.find_or_create_by!(project: project, issue: issue) do |agent_run|
         agent_run.provider = provider
         agent_run.agent_type = Provider.agent_type_for(provider.provider_key)
         agent_run.status = "queued"
@@ -44,7 +44,7 @@ module Issues
       message = e.cause&.message || e.message
       raise unless message&.include?("idx_agent_runs_unique_active_issue")
 
-      run = blocking_runs.find_by(project: project, issue: issue, goal: goal)
+      run = blocking_runs.find_by(project: project, issue: issue)
       if run
         log_existing(run)
         run

--- a/spec/config/pr_screenshots_publish_workflow_file_spec.rb
+++ b/spec/config/pr_screenshots_publish_workflow_file_spec.rb
@@ -31,7 +31,13 @@ RSpec.describe PrScreenshotsPublishWorkflowFile, :no_db do
 
   it "passes the PR head ref to the resolver for branch-based fallback matching" do
     expect(resolve_env).to include("HEAD_REF" => "${{ github.event.pull_request.head.ref }}")
+    expect(resolve_step.fetch("run")).to include('if pull_requests.any?')
     expect(resolve_step.fetch("run")).to include('candidate["head_branch"] == head_ref')
+  end
+
+  it "uses branch fallback matching only when the workflow run is not already attached to a PR" do
+    expect(resolve_step.fetch("run")).to include('pull_requests = candidate.fetch("pull_requests", [])')
+    expect(resolve_step.fetch("run")).to include('pull_requests.any? { |pr| pr["number"] == pr_number }')
   end
 
   it "treats missing capture jobs as skipped only when detect completed cleanly" do

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe ProcessRunQueueJob do
       auto_pick_enabled: true)
   end
 
+  def stub_single_seeded_run(project:, issue:)
+    created_run = nil
+    call_count = 0
+
+    allow(Issues::BulkEnqueueEligible).to receive(:call)
+      .with(project: having_attributes(id: project.id), limit: 1) do
+        call_count += 1
+        if call_count == 1
+          created_run = create(:agent_run, :queued, project: project, issue: issue)
+          [ created_run ]
+        else
+          []
+        end
+      end
+
+    -> { created_run }
+  end
+
   describe "#perform" do
     it "starts the oldest queued run when capacity is available" do
       queued_run = create(:agent_run, :queued, created_at: 2.minutes.ago)
@@ -289,24 +307,13 @@ RSpec.describe ProcessRunQueueJob do
         project = create(:project, auto_pick_enabled: true)
         issue = create(:issue, project: project)
 
-        created_run = nil
-        call_count = 0
-        allow(Issues::BulkEnqueueEligible).to receive(:call)
-          .with(project: having_attributes(id: project.id), limit: 1) do
-            call_count += 1
-            if call_count == 1
-              created_run = create(:agent_run, :queued, project: project, issue: issue)
-              [ created_run ]
-            else
-              []
-            end
-          end
+        created_run = stub_single_seeded_run(project:, issue:)
 
         described_class.new.perform
 
         expect(Issues::BulkEnqueueEligible).to have_received(:call)
           .with(project: having_attributes(id: project.id), limit: 1).at_least(:once)
-        expect(created_run.reload.status).to eq("queued")
+        expect(created_run.call.reload.status).to eq("queued")
       end
 
       it "stops seeding when no new runs are created" do
@@ -380,18 +387,13 @@ RSpec.describe ProcessRunQueueJob do
           pr_review_phase: "ready")
         issue = create(:issue, project: project)
 
-        created_run = nil
-        allow(Issues::BulkEnqueueEligible).to receive(:call)
-          .with(project: having_attributes(id: project.id), limit: 1) do
-            created_run = create(:agent_run, :queued, project: project, issue: issue)
-            [ created_run ]
-          end
+        created_run = stub_single_seeded_run(project:, issue:)
 
         described_class.new.perform
 
         expect(Issues::BulkEnqueueEligible).to have_received(:call)
           .with(project: having_attributes(id: project.id), limit: 1).at_least(:once)
-        expect(created_run.reload.status).to eq("queued")
+        expect(created_run.call.reload.status).to eq("queued")
       end
 
       it "fills idle capacity from one project when no others have pickable work" do

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -355,19 +355,6 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
       end
 
-      it "skips auto-pick seeding when open PRs already need attention" do
-        project = create(:project, auto_pick_enabled: true)
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
-        create(:issue, :pull_request, :in_progress, project: project)
-        create(:issue, project: project)
-
-        expect(Issues::BulkEnqueueEligible).not_to receive(:call)
-
-        described_class.new.perform
-
-        expect(project.agent_runs.where(auto_pick: true)).to be_empty
-      end
-
       it "fills idle capacity from one project when no others have pickable work" do
         project = create(:project, auto_pick_enabled: true)
         user = project.created_by

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -355,6 +355,19 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
       end
 
+      it "skips auto-pick seeding when open PRs already need attention" do
+        project = create(:project, auto_pick_enabled: true)
+        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
+        create(:issue, :pull_request, :in_progress, project: project)
+        create(:issue, project: project)
+
+        expect(Issues::BulkEnqueueEligible).not_to receive(:call)
+
+        described_class.new.perform
+
+        expect(project.agent_runs.where(auto_pick: true)).to be_empty
+      end
+
       it "fills idle capacity from one project when no others have pickable work" do
         project = create(:project, auto_pick_enabled: true)
         user = project.created_by

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -355,6 +355,45 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
       end
 
+      it "skips auto-pick seeding when open PRs already need attention" do
+        project = create(:project, auto_pick_enabled: true)
+        project.created_by.settings.update!(max_auto_pick_open_prs: 1)
+        create(:issue, :pull_request,
+          project: project,
+          github_state: "open",
+          paid_state: "failed")
+        create(:issue, project: project)
+
+        expect(Issues::BulkEnqueueEligible).not_to receive(:call)
+
+        described_class.new.perform
+      end
+
+      it "still seeds auto-pick work when paid-ready PRs no longer need attention" do
+        project = create(:project, auto_pick_enabled: true)
+        project.created_by.settings.update!(max_auto_pick_open_prs: 1)
+        create(:issue, :pull_request,
+          project: project,
+          github_state: "open",
+          paid_state: "in_progress",
+          labels: [ project.automation_label_name, "paid-ready" ],
+          pr_review_phase: "ready")
+        issue = create(:issue, project: project)
+
+        created_run = nil
+        allow(Issues::BulkEnqueueEligible).to receive(:call)
+          .with(project: having_attributes(id: project.id), limit: 1) do
+            created_run = create(:agent_run, :queued, project: project, issue: issue)
+            [ created_run ]
+          end
+
+        described_class.new.perform
+
+        expect(Issues::BulkEnqueueEligible).to have_received(:call)
+          .with(project: having_attributes(id: project.id), limit: 1).at_least(:once)
+        expect(created_run.reload.status).to eq("queued")
+      end
+
       it "fills idle capacity from one project when no others have pickable work" do
         project = create(:project, auto_pick_enabled: true)
         user = project.created_by

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -289,41 +289,42 @@ RSpec.describe ProcessRunQueueJob do
         project = create(:project, auto_pick_enabled: true)
         issue = create(:issue, project: project)
 
-        auto_pick_service = instance_double(Issues::AutoPick)
-        allow(Issues::AutoPick).to receive(:new)
-          .with(having_attributes(id: project.id))
-          .and_return(auto_pick_service)
+        created_run = nil
         call_count = 0
-        allow(auto_pick_service).to receive(:call) do
-          call_count += 1
-          call_count == 1 ? create(:agent_run, :queued, project: project, issue: issue) : nil
-        end
+        allow(Issues::BulkEnqueueEligible).to receive(:call)
+          .with(project: having_attributes(id: project.id)) do
+            call_count += 1
+            if call_count == 1
+              created_run = create(:agent_run, :queued, project: project, issue: issue)
+              [ created_run ]
+            else
+              []
+            end
+          end
 
         described_class.new.perform
 
-        expect(Issues::AutoPick).to have_received(:new)
-          .with(having_attributes(id: project.id)).at_least(:once)
-        expect(AgentRun.last.status).to eq("queued")
+        expect(Issues::BulkEnqueueEligible).to have_received(:call)
+          .with(project: having_attributes(id: project.id)).at_least(:once)
+        expect(created_run.reload.status).to eq("queued")
       end
 
       it "stops seeding when no new runs are created" do
         project = create(:project, auto_pick_enabled: true)
 
-        auto_pick_service = instance_double(Issues::AutoPick)
-        allow(Issues::AutoPick).to receive(:new)
-          .with(having_attributes(id: project.id))
-          .and_return(auto_pick_service)
-        allow(auto_pick_service).to receive(:call).and_return(nil)
+        allow(Issues::BulkEnqueueEligible).to receive(:call)
+          .with(project: having_attributes(id: project.id))
+          .and_return([])
 
         described_class.new.perform
 
-        expect(auto_pick_service).to have_received(:call).once
+        expect(Issues::BulkEnqueueEligible).to have_received(:call).once
       end
 
       it "skips projects with auto_pick_enabled disabled" do
         create(:project, auto_pick_enabled: false)
 
-        expect(Issues::AutoPick).not_to receive(:new)
+        expect(Issues::BulkEnqueueEligible).not_to receive(:call)
 
         described_class.new.perform
       end
@@ -333,7 +334,7 @@ RSpec.describe ProcessRunQueueJob do
         paused_user = create(:user, account: paused_account)
         create_auto_pick_project(account: paused_account, user: paused_user)
 
-        expect(Issues::AutoPick).not_to receive(:new)
+        expect(Issues::BulkEnqueueEligible).not_to receive(:call)
 
         described_class.new.perform
       end

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe ProcessRunQueueJob do
         created_run = nil
         call_count = 0
         allow(Issues::BulkEnqueueEligible).to receive(:call)
-          .with(project: having_attributes(id: project.id)) do
+          .with(project: having_attributes(id: project.id), limit: 1) do
             call_count += 1
             if call_count == 1
               created_run = create(:agent_run, :queued, project: project, issue: issue)
@@ -305,7 +305,7 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
 
         expect(Issues::BulkEnqueueEligible).to have_received(:call)
-          .with(project: having_attributes(id: project.id)).at_least(:once)
+          .with(project: having_attributes(id: project.id), limit: 1).at_least(:once)
         expect(created_run.reload.status).to eq("queued")
       end
 
@@ -313,7 +313,7 @@ RSpec.describe ProcessRunQueueJob do
         project = create(:project, auto_pick_enabled: true)
 
         allow(Issues::BulkEnqueueEligible).to receive(:call)
-          .with(project: having_attributes(id: project.id))
+          .with(project: having_attributes(id: project.id), limit: 1)
           .and_return([])
 
         described_class.new.perform
@@ -327,6 +327,22 @@ RSpec.describe ProcessRunQueueJob do
         expect(Issues::BulkEnqueueEligible).not_to receive(:call)
 
         described_class.new.perform
+      end
+
+      it "seeds at most one new auto-pick run per project in each pass" do
+        stub_const("#{described_class}::MAX_SEEDS_PER_PERFORM", 2)
+        account = create(:account)
+        user = create(:user, account: account)
+        user.settings.update!(max_concurrent_runs: 2)
+        first_project = create_auto_pick_project(account: account, user: user)
+        second_project = create_auto_pick_project(account: account, user: user)
+        2.times { create(:issue, project: first_project) }
+        2.times { create(:issue, project: second_project) }
+
+        described_class.new.perform
+
+        expect(first_project.agent_runs.where(auto_pick: true).count).to eq(1)
+        expect(second_project.agent_runs.where(auto_pick: true).count).to eq(1)
       end
 
       it "skips auto-pick seeding for projects whose account is paused" do

--- a/spec/services/issues/bulk_enqueue_eligible_spec.rb
+++ b/spec/services/issues/bulk_enqueue_eligible_spec.rb
@@ -100,11 +100,9 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
     third_issue = instance_double(issue_class)
     existing_run = instance_double(run_class, issue: first_issue, previously_new_record?: false)
     created_run = instance_double(run_class, issue: second_issue, previously_new_record?: true)
-    limited_scope = instance_double(ActiveRecord::Relation)
 
     allow(scope).to receive(:find_each)
-    allow(ordered_scope).to receive(:limit).with(10).and_return(limited_scope)
-    allow(limited_scope).to receive(:each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
+    allow(ordered_scope).to receive(:each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
     allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(existing_run)
     allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(created_run)
     allow(Rails.logger).to receive(:info)
@@ -113,8 +111,28 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
 
     expect(result).to eq([ existing_run, created_run ])
     expect(Automation::Strategies::AutoPick::DefaultCandidateSource).to have_received(:ordered_scope).with(project)
-    expect(ordered_scope).to have_received(:limit).with(10)
+    expect(ordered_scope).to have_received(:each)
     expect(scope).not_to have_received(:find_each)
     expect(Issues::EnqueueEligible).not_to have_received(:call).with(third_issue, project: project)
+  end
+
+  it "keeps scanning ordered issues until it creates the requested number of runs" do
+    limited_service = described_class.new(project: project, limit: 1)
+    first_issue = instance_double(issue_class)
+    second_issue = instance_double(issue_class)
+    third_issue = instance_double(issue_class)
+    existing_run = instance_double(run_class, issue: first_issue, previously_new_record?: false)
+    created_run = instance_double(run_class, issue: third_issue, previously_new_record?: true)
+
+    allow(ordered_scope).to receive(:each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
+    allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(existing_run)
+    allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(nil)
+    allow(Issues::EnqueueEligible).to receive(:call).with(third_issue, project: project).and_return(created_run)
+    allow(Rails.logger).to receive(:info)
+
+    result = limited_service.call
+
+    expect(result).to eq([ existing_run, created_run ])
+    expect(Issues::EnqueueEligible).to have_received(:call).with(third_issue, project: project)
   end
 end

--- a/spec/services/issues/bulk_enqueue_eligible_spec.rb
+++ b/spec/services/issues/bulk_enqueue_eligible_spec.rb
@@ -9,6 +9,7 @@ BulkTestRun = Struct.new(:issue, :previously_new_record?)
 RSpec.describe Issues::BulkEnqueueEligible, :no_db do
   let(:project) { instance_double(BulkTestProject, id: 7, auto_pick_enabled?: auto_pick_enabled) }
   let(:scope) { instance_double(ActiveRecord::Relation) }
+  let(:ordered_scope) { instance_double(ActiveRecord::Relation) }
   let(:service) { described_class.new(project: project) }
   let(:auto_pick_enabled) { true }
 
@@ -16,6 +17,9 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
     allow(Automation::Strategies::AutoPick::DefaultCandidateSource).to receive(:eligible_scope)
       .with(project)
       .and_return(scope)
+    allow(Automation::Strategies::AutoPick::DefaultCandidateSource).to receive(:ordered_scope)
+      .with(project)
+      .and_return(ordered_scope)
   end
 
   it "queues all eligible issues for a project" do
@@ -97,7 +101,8 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
     existing_run = instance_double(BulkTestRun, issue: first_issue, previously_new_record?: false)
     created_run = instance_double(BulkTestRun, issue: second_issue, previously_new_record?: true)
 
-    allow(scope).to receive(:find_each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
+    allow(scope).to receive(:find_each)
+    allow(ordered_scope).to receive(:each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
     allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(existing_run)
     allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(created_run)
     allow(Rails.logger).to receive(:info)
@@ -105,6 +110,8 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
     result = limited_service.call
 
     expect(result).to eq([ existing_run, created_run ])
+    expect(Automation::Strategies::AutoPick::DefaultCandidateSource).to have_received(:ordered_scope).with(project)
+    expect(scope).not_to have_received(:find_each)
     expect(Issues::EnqueueEligible).not_to have_received(:call).with(third_issue, project: project)
   end
 end

--- a/spec/services/issues/bulk_enqueue_eligible_spec.rb
+++ b/spec/services/issues/bulk_enqueue_eligible_spec.rb
@@ -88,4 +88,23 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
 
     expect(scope).to have_received(:find_each)
   end
+
+  it "stops after reaching the created-run limit" do
+    limited_service = described_class.new(project: project, limit: 1)
+    first_issue = instance_double(BulkTestIssue)
+    second_issue = instance_double(BulkTestIssue)
+    third_issue = instance_double(BulkTestIssue)
+    existing_run = instance_double(BulkTestRun, issue: first_issue, previously_new_record?: false)
+    created_run = instance_double(BulkTestRun, issue: second_issue, previously_new_record?: true)
+
+    allow(scope).to receive(:find_each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
+    allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(existing_run)
+    allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(created_run)
+    allow(Rails.logger).to receive(:info)
+
+    result = limited_service.call
+
+    expect(result).to eq([ existing_run, created_run ])
+    expect(Issues::EnqueueEligible).not_to have_received(:call).with(third_issue, project: project)
+  end
 end

--- a/spec/services/issues/bulk_enqueue_eligible_spec.rb
+++ b/spec/services/issues/bulk_enqueue_eligible_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+BulkTestProject = Struct.new(:id, :auto_pick_enabled?)
+BulkTestIssue = Struct.new(:id)
+BulkTestRun = Struct.new(:issue, :previously_new_record?)
+
+RSpec.describe Issues::BulkEnqueueEligible, :no_db do
+  let(:project) { instance_double(BulkTestProject, id: 7, auto_pick_enabled?: auto_pick_enabled) }
+  let(:scope) { instance_double(ActiveRecord::Relation) }
+  let(:service) { described_class.new(project: project) }
+  let(:auto_pick_enabled) { true }
+
+  before do
+    allow(Automation::Strategies::AutoPick::DefaultCandidateSource).to receive(:eligible_scope)
+      .with(project)
+      .and_return(scope)
+  end
+
+  it "queues all eligible issues for a project" do
+    first_issue = instance_double(BulkTestIssue)
+    second_issue = instance_double(BulkTestIssue)
+    first_run = instance_double(BulkTestRun, issue: first_issue, previously_new_record?: true)
+    second_run = instance_double(BulkTestRun, issue: second_issue, previously_new_record?: true)
+    allow(scope).to receive(:find_each).and_yield(first_issue).and_yield(second_issue)
+    allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(first_run)
+    allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(second_run)
+    allow(Rails.logger).to receive(:info)
+
+    result = service.call
+
+    expect(result).to eq([ first_run, second_run ])
+  end
+
+  it "returns early when auto_pick is disabled" do
+    allow(project).to receive(:auto_pick_enabled?).and_return(false)
+
+    expect(Issues::EnqueueEligible).not_to receive(:call)
+
+    expect(service.call).to eq([])
+  end
+
+  it "queues only eligible issues from a mixed set" do
+    eligible_issue = instance_double(BulkTestIssue)
+    ineligible_issue = instance_double(BulkTestIssue)
+    eligible_run = instance_double(BulkTestRun, issue: eligible_issue, previously_new_record?: true)
+    allow(scope).to receive(:find_each).and_yield(eligible_issue).and_yield(ineligible_issue)
+    allow(Issues::EnqueueEligible).to receive(:call).with(eligible_issue, project: project).and_return(eligible_run)
+    allow(Issues::EnqueueEligible).to receive(:call).with(ineligible_issue, project: project).and_return(nil)
+    allow(Rails.logger).to receive(:info)
+
+    result = service.call
+
+    expect(result).to eq([ eligible_run ])
+  end
+
+  it "logs created, existing, and skipped counts" do
+    first_issue = instance_double(BulkTestIssue)
+    second_issue = instance_double(BulkTestIssue)
+    third_issue = instance_double(BulkTestIssue)
+    created_run = instance_double(BulkTestRun, issue: first_issue, previously_new_record?: true)
+    existing_run = instance_double(BulkTestRun, issue: second_issue, previously_new_record?: false)
+    allow(scope).to receive(:find_each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
+    allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(created_run)
+    allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(existing_run)
+    allow(Issues::EnqueueEligible).to receive(:call).with(third_issue, project: project).and_return(nil)
+    allow(Rails.logger).to receive(:info)
+
+    service.call
+
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(
+        message: "bulk_enqueue_eligible.completed",
+        project_id: project.id,
+        created_count: 1,
+        existing_count: 1,
+        skipped_count: 1
+      )
+    )
+  end
+
+  it "iterates eligible issues with find_each" do
+    allow(scope).to receive(:find_each)
+    allow(Rails.logger).to receive(:info)
+
+    service.call
+
+    expect(scope).to have_received(:find_each)
+  end
+end

--- a/spec/services/issues/bulk_enqueue_eligible_spec.rb
+++ b/spec/services/issues/bulk_enqueue_eligible_spec.rb
@@ -2,12 +2,12 @@
 
 require "rails_helper"
 
-BulkTestProject = Struct.new(:id, :auto_pick_enabled?)
-BulkTestIssue = Struct.new(:id)
-BulkTestRun = Struct.new(:issue, :previously_new_record?)
-
 RSpec.describe Issues::BulkEnqueueEligible, :no_db do
-  let(:project) { instance_double(BulkTestProject, id: 7, auto_pick_enabled?: auto_pick_enabled) }
+  let(:project_class) { Struct.new(:id, :auto_pick_enabled?) }
+  let(:issue_class) { Struct.new(:id) }
+  let(:run_class) { Struct.new(:issue, :previously_new_record?) }
+
+  let(:project) { instance_double(project_class, id: 7, auto_pick_enabled?: auto_pick_enabled) }
   let(:scope) { instance_double(ActiveRecord::Relation) }
   let(:ordered_scope) { instance_double(ActiveRecord::Relation) }
   let(:service) { described_class.new(project: project) }
@@ -23,10 +23,10 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
   end
 
   it "queues all eligible issues for a project" do
-    first_issue = instance_double(BulkTestIssue)
-    second_issue = instance_double(BulkTestIssue)
-    first_run = instance_double(BulkTestRun, issue: first_issue, previously_new_record?: true)
-    second_run = instance_double(BulkTestRun, issue: second_issue, previously_new_record?: true)
+    first_issue = instance_double(issue_class)
+    second_issue = instance_double(issue_class)
+    first_run = instance_double(run_class, issue: first_issue, previously_new_record?: true)
+    second_run = instance_double(run_class, issue: second_issue, previously_new_record?: true)
     allow(scope).to receive(:find_each).and_yield(first_issue).and_yield(second_issue)
     allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(first_run)
     allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(second_run)
@@ -46,9 +46,9 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
   end
 
   it "queues only eligible issues from a mixed set" do
-    eligible_issue = instance_double(BulkTestIssue)
-    ineligible_issue = instance_double(BulkTestIssue)
-    eligible_run = instance_double(BulkTestRun, issue: eligible_issue, previously_new_record?: true)
+    eligible_issue = instance_double(issue_class)
+    ineligible_issue = instance_double(issue_class)
+    eligible_run = instance_double(run_class, issue: eligible_issue, previously_new_record?: true)
     allow(scope).to receive(:find_each).and_yield(eligible_issue).and_yield(ineligible_issue)
     allow(Issues::EnqueueEligible).to receive(:call).with(eligible_issue, project: project).and_return(eligible_run)
     allow(Issues::EnqueueEligible).to receive(:call).with(ineligible_issue, project: project).and_return(nil)
@@ -60,11 +60,11 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
   end
 
   it "logs created, existing, and skipped counts" do
-    first_issue = instance_double(BulkTestIssue)
-    second_issue = instance_double(BulkTestIssue)
-    third_issue = instance_double(BulkTestIssue)
-    created_run = instance_double(BulkTestRun, issue: first_issue, previously_new_record?: true)
-    existing_run = instance_double(BulkTestRun, issue: second_issue, previously_new_record?: false)
+    first_issue = instance_double(issue_class)
+    second_issue = instance_double(issue_class)
+    third_issue = instance_double(issue_class)
+    created_run = instance_double(run_class, issue: first_issue, previously_new_record?: true)
+    existing_run = instance_double(run_class, issue: second_issue, previously_new_record?: false)
     allow(scope).to receive(:find_each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
     allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(created_run)
     allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(existing_run)
@@ -95,14 +95,16 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
 
   it "stops after reaching the created-run limit" do
     limited_service = described_class.new(project: project, limit: 1)
-    first_issue = instance_double(BulkTestIssue)
-    second_issue = instance_double(BulkTestIssue)
-    third_issue = instance_double(BulkTestIssue)
-    existing_run = instance_double(BulkTestRun, issue: first_issue, previously_new_record?: false)
-    created_run = instance_double(BulkTestRun, issue: second_issue, previously_new_record?: true)
+    first_issue = instance_double(issue_class)
+    second_issue = instance_double(issue_class)
+    third_issue = instance_double(issue_class)
+    existing_run = instance_double(run_class, issue: first_issue, previously_new_record?: false)
+    created_run = instance_double(run_class, issue: second_issue, previously_new_record?: true)
+    limited_scope = instance_double(ActiveRecord::Relation)
 
     allow(scope).to receive(:find_each)
-    allow(ordered_scope).to receive(:each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
+    allow(ordered_scope).to receive(:limit).with(10).and_return(limited_scope)
+    allow(limited_scope).to receive(:each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
     allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(existing_run)
     allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(created_run)
     allow(Rails.logger).to receive(:info)
@@ -111,6 +113,7 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
 
     expect(result).to eq([ existing_run, created_run ])
     expect(Automation::Strategies::AutoPick::DefaultCandidateSource).to have_received(:ordered_scope).with(project)
+    expect(ordered_scope).to have_received(:limit).with(10)
     expect(scope).not_to have_received(:find_each)
     expect(Issues::EnqueueEligible).not_to have_received(:call).with(third_issue, project: project)
   end

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     run = build_run(id: 99, previously_new_record: true)
 
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue)
+      expect(attrs).to eq(project: project, issue: issue, goal: "create_pr")
       block.call(run)
       run
     end
@@ -56,7 +56,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     result = service.call
 
     expect(result).to eq(run)
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "create_pr")
     expect(run.provider).to eq(provider)
     expect(run.agent_type).to eq("claude_code")
     expect(run.status).to eq("queued")
@@ -106,7 +106,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "create_pr").and_return(existing_run)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -142,7 +142,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue)
+      expect(attrs).to eq(project: project, issue: issue, goal: "analyze_issue")
       block.call(run)
       run
     end
@@ -150,22 +150,22 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     service.call
 
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "analyze_issue")
     expect(run.goal).to eq("analyze_issue")
   end
 
-  it "returns an existing blocking run even when its goal differs from the current seed goal" do
-    existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
+  it "does not reuse a blocking run for a different goal after a unique-index race" do
+    other_goal_run = instance_double(run_class, id: 123, previously_new_record?: false)
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
-    allow(Rails.logger).to receive(:info)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "analyze_issue").and_return(nil)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "create_pr").and_return(other_goal_run)
 
     result = service.call
 
-    expect(result).to eq(existing_run)
+    expect(result).to be_nil
   end
 end

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "ostruct"
 
-TestProject = Struct.new(:id)
+TestProject = Struct.new(:id) do
+  def auto_enhance_enabled? = false
+end
 TestIssue = Struct.new(:id, :github_number)
 TestProvider = Struct.new(:id, :provider_key)
 TestRun = Struct.new(:id, :previously_new_record?) do
@@ -10,7 +13,7 @@ TestRun = Struct.new(:id, :previously_new_record?) do
 end
 
 RSpec.describe Issues::EnqueueEligible, :no_db do
-  let(:project) { instance_double(TestProject, id: 7) }
+  let(:project) { instance_double(TestProject, id: 7, auto_enhance_enabled?: false) }
   let(:issue) { instance_double(TestIssue, id: 11, github_number: 42) }
   let(:eligible_scope) { instance_double(ActiveRecord::Relation) }
   let(:issue_scope) { instance_double(ActiveRecord::Relation, exists?: true) }
@@ -27,9 +30,12 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   end
 
   it "creates a queued automatic auto-pick run for an eligible issue" do
-    run = instance_double(TestRun, id: 99, previously_new_record?: true)
-    allow(blocking_runs).to receive(:find_or_create_by!) do |attrs|
+    run = OpenStruct.new(id: 99)
+    def run.previously_new_record? = true
+
+    allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
       expect(attrs).to eq(project: project, issue: issue)
+      block.call(run)
       run
     end
     allow(Rails.logger).to receive(:info)
@@ -38,9 +44,26 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     expect(result).to eq(run)
     expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(run.provider).to eq(provider)
+    expect(run.agent_type).to eq("claude_code")
+    expect(run.status).to eq("queued")
+    expect(run.trigger_type).to eq("automatic")
+    expect(run.auto_pick).to be(true)
+    expect(run.goal).to eq("create_pr")
     expect(Rails.logger).to have_received(:info).with(
       hash_including(message: "enqueue_eligible.created", issue_id: issue.id, agent_run_id: run.id)
     )
+  end
+
+  it "resolves the provider for analyze_issue when auto_enhance is enabled" do
+    allow(project).to receive(:auto_enhance_enabled?).and_return(true)
+    allow(service).to receive(:resolve_provider).with("analyze_issue").and_return(provider)
+    allow(blocking_runs).to receive(:find_or_create_by!).and_return(instance_double(TestRun, id: 99, previously_new_record?: true))
+    allow(Rails.logger).to receive(:info)
+
+    service.call
+
+    expect(service).to have_received(:resolve_provider).with("analyze_issue")
   end
 
   it "returns nil when DefaultCandidateSource excludes the issue for paid_state reasons" do
@@ -88,7 +111,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   end
 
   it "returns nil and warns when no provider can be resolved" do
-    allow(service).to receive(:resolve_provider).and_return(nil)
+    allow(service).to receive(:resolve_provider).with("create_pr").and_return(nil)
     allow(Rails.logger).to receive(:warn)
 
     result = service.call

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     run = build_run(id: 99, previously_new_record: true)
 
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue, goal: "create_pr")
+      expect(attrs).to eq(project: project, issue: issue)
       block.call(run)
       run
     end
@@ -56,7 +56,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     result = service.call
 
     expect(result).to eq(run)
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "create_pr")
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
     expect(run.provider).to eq(provider)
     expect(run.agent_type).to eq("claude_code")
     expect(run.status).to eq("queued")
@@ -106,7 +106,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "create_pr").and_return(existing_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -142,7 +142,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue, goal: "analyze_issue")
+      expect(attrs).to eq(project: project, issue: issue)
       block.call(run)
       run
     end
@@ -150,22 +150,21 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     service.call
 
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "analyze_issue")
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
     expect(run.goal).to eq("analyze_issue")
   end
 
-  it "does not reuse a blocking run for a different goal after a unique-index race" do
-    other_goal_run = instance_double(run_class, id: 123, previously_new_record?: false)
+  it "returns the existing blocking run after a unique-index race even when goals differ" do
+    existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "analyze_issue").and_return(nil)
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "create_pr").and_return(other_goal_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
 
     result = service.call
 
-    expect(result).to be_nil
+    expect(result).to eq(existing_run)
   end
 end

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -1,24 +1,34 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "ostruct"
-
-TestProject = Struct.new(:id) do
-  def auto_enhance_enabled? = false
-end
-TestIssue = Struct.new(:id, :github_number)
-TestProvider = Struct.new(:id, :provider_key)
-TestRun = Struct.new(:id, :previously_new_record?) do
-  def issue = nil
-end
 
 RSpec.describe Issues::EnqueueEligible, :no_db do
-  let(:project) { instance_double(TestProject, id: 7, auto_enhance_enabled?: false) }
-  let(:issue) { instance_double(TestIssue, id: 11, github_number: 42) }
+  def project_class
+    @project_class ||= Struct.new(:id) do
+      def auto_enhance_enabled? = false
+    end
+  end
+
+  def issue_class
+    @issue_class ||= Struct.new(:id, :github_number)
+  end
+
+  def provider_class
+    @provider_class ||= Struct.new(:id, :provider_key)
+  end
+
+  def run_class
+    @run_class ||= Struct.new(:id, :previously_new_record?) do
+      attr_accessor :provider, :agent_type, :status, :trigger_type, :auto_pick
+    end
+  end
+
+  let(:project) { instance_double(project_class, id: 7, auto_enhance_enabled?: false) }
+  let(:issue) { instance_double(issue_class, id: 11, github_number: 42) }
   let(:eligible_scope) { instance_double(ActiveRecord::Relation) }
   let(:issue_scope) { instance_double(ActiveRecord::Relation, exists?: true) }
   let(:blocking_runs) { instance_double(ActiveRecord::Relation) }
-  let(:provider) { instance_double(TestProvider, id: 5, provider_key: "claude") }
+  let(:provider) { instance_double(provider_class, id: 5, provider_key: "claude") }
   let(:service) { described_class.new(issue, project: project) }
 
   before do
@@ -29,9 +39,12 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(service).to receive_messages(blocking_runs: blocking_runs, resolve_provider: provider)
   end
 
+  def build_run(id:, previously_new_record:)
+    run_class.new(id, previously_new_record)
+  end
+
   it "creates a queued automatic auto-pick run for an eligible issue" do
-    run = OpenStruct.new(id: 99)
-    def run.previously_new_record? = true
+    run = build_run(id: 99, previously_new_record: true)
 
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
       expect(attrs).to eq(project: project, issue: issue, goal: "create_pr")
@@ -57,7 +70,9 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   it "resolves the provider for analyze_issue when auto_enhance is enabled" do
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(service).to receive(:resolve_provider).with("analyze_issue").and_return(provider)
-    allow(blocking_runs).to receive(:find_or_create_by!).and_return(instance_double(TestRun, id: 99, previously_new_record?: true))
+    allow(blocking_runs).to receive(:find_or_create_by!).and_return(
+      instance_double(run_class, id: 99, previously_new_record?: true)
+    )
     allow(Rails.logger).to receive(:info)
 
     service.call
@@ -86,7 +101,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   end
 
   it "returns the existing run when a unique-index race occurs" do
-    existing_run = instance_double(TestRun, id: 123, previously_new_record?: false)
+    existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
@@ -122,8 +137,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   end
 
   it "scopes queued-run lookup by analyze_issue goal when auto_enhance is enabled" do
-    run = OpenStruct.new(id: 99)
-    def run.previously_new_record? = true
+    run = build_run(id: 99, previously_new_record: true)
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     run = build_run(id: 99, previously_new_record: true)
 
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue)
+      expect(attrs).to eq(project: project, issue: issue, goal: "create_pr")
       block.call(run)
       run
     end
@@ -56,7 +56,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     result = service.call
 
     expect(result).to eq(run)
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "create_pr")
     expect(run.provider).to eq(provider)
     expect(run.agent_type).to eq("claude_code")
     expect(run.status).to eq("queued")
@@ -106,7 +106,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "create_pr").and_return(existing_run)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -142,7 +142,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue)
+      expect(attrs).to eq(project: project, issue: issue, goal: "analyze_issue")
       block.call(run)
       run
     end
@@ -150,18 +150,18 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     service.call
 
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "analyze_issue")
     expect(run.goal).to eq("analyze_issue")
   end
 
-  it "returns the existing blocking run after a unique-index race even when goals differ" do
+  it "looks up the existing blocking run by goal after a unique-index race" do
     existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "analyze_issue").and_return(existing_run)
 
     result = service.call
 

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     run = build_run(id: 99, previously_new_record: true)
 
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue, goal: "create_pr")
+      expect(attrs).to eq(project: project, issue: issue)
       block.call(run)
       run
     end
@@ -56,7 +56,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     result = service.call
 
     expect(result).to eq(run)
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "create_pr")
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
     expect(run.provider).to eq(provider)
     expect(run.agent_type).to eq("claude_code")
     expect(run.status).to eq("queued")
@@ -106,7 +106,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "create_pr").and_return(existing_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -142,7 +142,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue, goal: "analyze_issue")
+      expect(attrs).to eq(project: project, issue: issue)
       block.call(run)
       run
     end
@@ -150,21 +150,39 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     service.call
 
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "analyze_issue")
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
     expect(run.goal).to eq("analyze_issue")
   end
 
-  it "looks up the existing blocking run by goal after a unique-index race" do
+  it "looks up the existing blocking run after a unique-index race" do
     existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "analyze_issue").and_return(existing_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
 
     result = service.call
 
     expect(result).to eq(existing_run)
+  end
+
+  it "returns an existing blocking run even when it was created with a different goal" do
+    existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
+
+    allow(project).to receive(:auto_enhance_enabled?).and_return(true)
+    allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
+      ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
+    )
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(Rails.logger).to receive(:info)
+
+    result = service.call
+
+    expect(result).to eq(existing_run)
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(message: "enqueue_eligible.existing", issue_id: issue.id, agent_run_id: existing_run.id)
+    )
   end
 end

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   let(:issue) { instance_double(issue_class, id: 11, github_number: 42) }
   let(:eligible_scope) { instance_double(ActiveRecord::Relation) }
   let(:issue_scope) { instance_double(ActiveRecord::Relation, exists?: true) }
-  let(:blocking_runs) { instance_double(ActiveRecord::Relation) }
+  let(:create_pr_blocking_runs) { instance_double(ActiveRecord::Relation) }
+  let(:analyze_issue_blocking_runs) { instance_double(ActiveRecord::Relation) }
   let(:provider) { instance_double(provider_class, id: 5, provider_key: "claude") }
   let(:service) { described_class.new(issue, project: project) }
 
@@ -36,7 +37,9 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
       .with(project)
       .and_return(eligible_scope)
     allow(eligible_scope).to receive(:where).with(id: issue.id).and_return(issue_scope)
-    allow(service).to receive_messages(blocking_runs: blocking_runs, resolve_provider: provider)
+    allow(service).to receive(:blocking_runs).with("create_pr").and_return(create_pr_blocking_runs)
+    allow(service).to receive(:blocking_runs).with("analyze_issue").and_return(analyze_issue_blocking_runs)
+    allow(service).to receive(:resolve_provider).and_return(provider)
   end
 
   def build_run(id:, previously_new_record:)
@@ -46,8 +49,8 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   it "creates a queued automatic auto-pick run for an eligible issue" do
     run = build_run(id: 99, previously_new_record: true)
 
-    allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue)
+    allow(create_pr_blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
+      expect(attrs).to eq(project: project, issue: issue, goal: "create_pr")
       block.call(run)
       run
     end
@@ -56,13 +59,14 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     result = service.call
 
     expect(result).to eq(run)
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(create_pr_blocking_runs).to have_received(:find_or_create_by!).with(
+      project: project, issue: issue, goal: "create_pr"
+    )
     expect(run.provider).to eq(provider)
     expect(run.agent_type).to eq("claude_code")
     expect(run.status).to eq("queued")
     expect(run.trigger_type).to eq("automatic")
     expect(run.auto_pick).to be(true)
-    expect(run.goal).to eq("create_pr")
     expect(Rails.logger).to have_received(:info).with(
       hash_including(message: "enqueue_eligible.created", issue_id: issue.id, agent_run_id: run.id)
     )
@@ -71,7 +75,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   it "resolves the provider for analyze_issue when auto_enhance is enabled" do
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(service).to receive(:resolve_provider).with("analyze_issue").and_return(provider)
-    allow(blocking_runs).to receive(:find_or_create_by!).and_return(
+    allow(analyze_issue_blocking_runs).to receive(:find_or_create_by!).and_return(
       instance_double(run_class, id: 99, previously_new_record?: true)
     )
     allow(Rails.logger).to receive(:info)
@@ -103,10 +107,12 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
   it "returns the existing run when a unique-index race occurs" do
     existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
-    allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
+    allow(create_pr_blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(create_pr_blocking_runs).to receive(:find_by)
+      .with(project: project, issue: issue, goal: "create_pr")
+      .and_return(existing_run)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -118,7 +124,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   end
 
   it "re-raises unrelated unique-index errors" do
-    allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
+    allow(create_pr_blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("some_other_index")
     )
 
@@ -141,8 +147,8 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     run = build_run(id: 99, previously_new_record: true)
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
-    allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue)
+    allow(analyze_issue_blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
+      expect(attrs).to eq(project: project, issue: issue, goal: "analyze_issue")
       block.call(run)
       run
     end
@@ -150,39 +156,38 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     service.call
 
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
-    expect(run.goal).to eq("analyze_issue")
+    expect(analyze_issue_blocking_runs).to have_received(:find_or_create_by!).with(
+      project: project, issue: issue, goal: "analyze_issue"
+    )
   end
 
   it "looks up the existing blocking run after a unique-index race" do
     existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
-    allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
+    allow(analyze_issue_blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(analyze_issue_blocking_runs).to receive(:find_by)
+      .with(project: project, issue: issue, goal: "analyze_issue")
+      .and_return(existing_run)
 
     result = service.call
 
     expect(result).to eq(existing_run)
   end
 
-  it "returns an existing blocking run even when it was created with a different goal" do
-    existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
-
+  it "does not return a blocking run created for a different goal after a unique-index race" do
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
-    allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
+    allow(analyze_issue_blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
-    allow(Rails.logger).to receive(:info)
+    allow(analyze_issue_blocking_runs).to receive(:find_by)
+      .with(project: project, issue: issue, goal: "analyze_issue")
+      .and_return(nil)
 
     result = service.call
 
-    expect(result).to eq(existing_run)
-    expect(Rails.logger).to have_received(:info).with(
-      hash_including(message: "enqueue_eligible.existing", issue_id: issue.id, agent_run_id: existing_run.id)
-    )
+    expect(result).to be_nil
   end
 end

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     def run.previously_new_record? = true
 
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue)
+      expect(attrs).to eq(project: project, issue: issue, goal: "create_pr")
       block.call(run)
       run
     end
@@ -43,13 +43,12 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     result = service.call
 
     expect(result).to eq(run)
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "create_pr")
     expect(run.provider).to eq(provider)
     expect(run.agent_type).to eq("claude_code")
     expect(run.status).to eq("queued")
     expect(run.trigger_type).to eq("automatic")
     expect(run.auto_pick).to be(true)
-    expect(run.goal).to eq("create_pr")
     expect(Rails.logger).to have_received(:info).with(
       hash_including(message: "enqueue_eligible.created", issue_id: issue.id, agent_run_id: run.id)
     )
@@ -91,7 +90,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "create_pr").and_return(existing_run)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -119,6 +118,27 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     expect(result).to be_nil
     expect(Rails.logger).to have_received(:warn).with(
       hash_including(message: "enqueue_eligible.no_provider", issue_id: issue.id, project_id: project.id)
+    )
+  end
+
+  it "scopes queued-run lookup by analyze_issue goal when auto_enhance is enabled" do
+    run = OpenStruct.new(id: 99)
+    def run.previously_new_record? = true
+
+    allow(project).to receive(:auto_enhance_enabled?).and_return(true)
+    allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
+      expect(attrs).to eq(project: project, issue: issue, goal: "analyze_issue")
+      block.call(run)
+      run
+    end
+    allow(Rails.logger).to receive(:info)
+
+    service.call
+
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(
+      project: project,
+      issue: issue,
+      goal: "analyze_issue"
     )
   end
 end

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
   def run_class
     @run_class ||= Struct.new(:id, :previously_new_record?) do
-      attr_accessor :provider, :agent_type, :status, :trigger_type, :auto_pick
+      attr_accessor :provider, :agent_type, :status, :trigger_type, :auto_pick, :goal
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     run = build_run(id: 99, previously_new_record: true)
 
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue, goal: "create_pr")
+      expect(attrs).to eq(project: project, issue: issue)
       block.call(run)
       run
     end
@@ -56,12 +56,13 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     result = service.call
 
     expect(result).to eq(run)
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue, goal: "create_pr")
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
     expect(run.provider).to eq(provider)
     expect(run.agent_type).to eq("claude_code")
     expect(run.status).to eq("queued")
     expect(run.trigger_type).to eq("automatic")
     expect(run.auto_pick).to be(true)
+    expect(run.goal).to eq("create_pr")
     expect(Rails.logger).to have_received(:info).with(
       hash_including(message: "enqueue_eligible.created", issue_id: issue.id, agent_run_id: run.id)
     )
@@ -105,7 +106,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
       ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
-    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue, goal: "create_pr").and_return(existing_run)
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -141,7 +142,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     allow(project).to receive(:auto_enhance_enabled?).and_return(true)
     allow(blocking_runs).to receive(:find_or_create_by!) do |attrs, &block|
-      expect(attrs).to eq(project: project, issue: issue, goal: "analyze_issue")
+      expect(attrs).to eq(project: project, issue: issue)
       block.call(run)
       run
     end
@@ -149,10 +150,22 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
 
     service.call
 
-    expect(blocking_runs).to have_received(:find_or_create_by!).with(
-      project: project,
-      issue: issue,
-      goal: "analyze_issue"
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(run.goal).to eq("analyze_issue")
+  end
+
+  it "returns an existing blocking run even when its goal differs from the current seed goal" do
+    existing_run = instance_double(run_class, id: 123, previously_new_record?: false)
+
+    allow(project).to receive(:auto_enhance_enabled?).and_return(true)
+    allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
+      ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
     )
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(Rails.logger).to receive(:info)
+
+    result = service.call
+
+    expect(result).to eq(existing_run)
   end
 end

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+TestProject = Struct.new(:id)
+TestIssue = Struct.new(:id, :github_number)
+TestProvider = Struct.new(:id, :provider_key)
+TestRun = Struct.new(:id, :previously_new_record?) do
+  def issue = nil
+end
+
+RSpec.describe Issues::EnqueueEligible, :no_db do
+  let(:project) { instance_double(TestProject, id: 7) }
+  let(:issue) { instance_double(TestIssue, id: 11, github_number: 42) }
+  let(:eligible_scope) { instance_double(ActiveRecord::Relation) }
+  let(:issue_scope) { instance_double(ActiveRecord::Relation, exists?: true) }
+  let(:blocking_runs) { instance_double(ActiveRecord::Relation) }
+  let(:provider) { instance_double(TestProvider, id: 5, provider_key: "claude") }
+  let(:service) { described_class.new(issue, project: project) }
+
+  before do
+    allow(Automation::Strategies::AutoPick::DefaultCandidateSource).to receive(:eligible_scope)
+      .with(project)
+      .and_return(eligible_scope)
+    allow(eligible_scope).to receive(:where).with(id: issue.id).and_return(issue_scope)
+    allow(service).to receive_messages(blocking_runs: blocking_runs, resolve_provider: provider)
+  end
+
+  it "creates a queued automatic auto-pick run for an eligible issue" do
+    run = instance_double(TestRun, id: 99, previously_new_record?: true)
+    allow(blocking_runs).to receive(:find_or_create_by!) do |attrs|
+      expect(attrs).to eq(project: project, issue: issue)
+      run
+    end
+    allow(Rails.logger).to receive(:info)
+
+    result = service.call
+
+    expect(result).to eq(run)
+    expect(blocking_runs).to have_received(:find_or_create_by!).with(project: project, issue: issue)
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(message: "enqueue_eligible.created", issue_id: issue.id, agent_run_id: run.id)
+    )
+  end
+
+  it "returns nil when DefaultCandidateSource excludes the issue for paid_state reasons" do
+    allow(issue_scope).to receive_messages(exists?: false)
+    allow(Rails.logger).to receive(:info)
+
+    result = service.call
+
+    expect(result).to be_nil
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(message: "enqueue_eligible.ineligible", issue_id: issue.id)
+    )
+  end
+
+  it "returns nil when DefaultCandidateSource excludes the issue for labels, dependencies, or active runs" do
+    allow(issue_scope).to receive_messages(exists?: false)
+
+    aggregate_failures do
+      3.times { expect(service.call).to be_nil }
+    end
+  end
+
+  it "returns the existing run when a unique-index race occurs" do
+    existing_run = instance_double(TestRun, id: 123, previously_new_record?: false)
+    allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
+      ActiveRecord::RecordNotUnique.new("idx_agent_runs_unique_active_issue")
+    )
+    allow(blocking_runs).to receive(:find_by).with(project: project, issue: issue).and_return(existing_run)
+    allow(Rails.logger).to receive(:info)
+
+    result = service.call
+
+    expect(result).to eq(existing_run)
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(message: "enqueue_eligible.existing", issue_id: issue.id, agent_run_id: existing_run.id)
+    )
+  end
+
+  it "re-raises unrelated unique-index errors" do
+    allow(blocking_runs).to receive(:find_or_create_by!).and_raise(
+      ActiveRecord::RecordNotUnique.new("some_other_index")
+    )
+
+    expect { service.call }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  it "returns nil and warns when no provider can be resolved" do
+    allow(service).to receive(:resolve_provider).and_return(nil)
+    allow(Rails.logger).to receive(:warn)
+
+    result = service.call
+
+    expect(result).to be_nil
+    expect(Rails.logger).to have_received(:warn).with(
+      hash_including(message: "enqueue_eligible.no_provider", issue_id: issue.id, project_id: project.id)
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Lay the foundation for eager queue seeding (RDR-032) by introducing dedicated services that replace `Issues::AutoPick` for single-issue and bulk seeding paths. These services centralize eligibility checks, provider resolution, and queued-run creation so subsequent issues can hook them into sync and dependency-resolution flows.

## Changes

- **Services**
  - Add `Issues::EnqueueEligible`: applies `DefaultCandidateSource` eligibility, resolves a provider via `AgentRuns::ProviderResolver`, and creates a queued `AgentRun` (`status: "queued"`, `trigger_type: "automatic"`, `auto_pick: true`) using `find_or_create_by!` scoped to the active-run uniqueness conditions.
  - Add `Issues::BulkEnqueueEligible`: short-circuits when `project.auto_pick_enabled?` is false, otherwise iterates `DefaultCandidateSource.eligible_scope(project).find_each` and delegates per-issue work to `EnqueueEligible`.
- **Jobs**
  - Switch queue seeding in `app/jobs/process_run_queue_job.rb` to use the new services in place of `Issues::AutoPick`.
- **Logging**
  - Emit structured events: `enqueue_eligible.created`, `enqueue_eligible.existing`, `enqueue_eligible.ineligible`, `enqueue_eligible.no_provider`, plus bulk created/existing/skipped counts.
- **Tests**
  - Add `spec/services/issues/enqueue_eligible_spec.rb` and `spec/services/issues/bulk_enqueue_eligible_spec.rb` covering eligible/ineligible paths, duplicate-race recovery, missing-provider, and bulk mixed-eligibility scenarios.

## Design Decisions

- **Race safety via DB uniqueness, not application locking** — `find_or_create_by!` against the existing unique index over `(project, issue, status IN AUTO_PICK_BLOCKING_STATUSES)`, with `ActiveRecord::RecordNotUnique` rescued to return the existing run. This keeps the service idempotent under concurrent sync hooks and the periodic bulk job without introducing advisory locks.
- **Reuse `DefaultCandidateSource` rather than re-deriving eligibility** — keeps a single source of truth for `ready_for_work`, `paid_state`, excluded labels, trusted creators, and dependency checks; both services share identical semantics.
- **Batched bulk iteration** — `find_each` over `eligible_scope` bounds memory for projects with large backlogs.
- **Scope kept tight to RDR-032 Issue 1** — sync hook integration, removal of `seed_auto_pick_queue` and the PR attention limit, and dependency-close re-evaluation are intentionally deferred to their follow-up issues.

## Operational Notes

- No schema or migration changes; relies on the existing active-run unique index.
- `Issues::AutoPick` is still referenced by call sites outside the queue seeder and is not removed in this PR — follow-up issues will retire it once the sync and dependency-close paths are migrated.

---

Closes #2019