### PR TITLE
feat(reviews): auto-dismiss stale CHANGES_REQUESTED reviews from paid-code-reviewer

### DIFF
--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -188,17 +188,17 @@ module Api
 
       body = parse_response_body(response.body)
       return unless body.is_a?(Hash) && body["id"].present?
-      return if @agent_run.review_posted_at.present? && @agent_run.review_url.present?
+      if @agent_run.review_posted_at.blank? || @agent_run.review_url.blank?
+        review_url = body["html_url"].presence || review_url_for(match[:number], body["id"])
+        @agent_run.update!(
+          review_posted_at: @agent_run.review_posted_at || Time.current,
+          review_url: review_url
+        )
 
-      review_url = body["html_url"].presence || review_url_for(match[:number], body["id"])
-      @agent_run.update!(
-        review_posted_at: @agent_run.review_posted_at || Time.current,
-        review_url: review_url
-      )
-
-      log_info("github_proxy.review_created",
-        review_id: body["id"],
-        review_url: review_url)
+        log_info("github_proxy.review_created",
+          review_id: body["id"],
+          review_url: review_url)
+      end
 
       warn_if_missing_inline_comments(body)
       dismiss_stale_changes_requested_reviews(match, body)

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -236,7 +236,8 @@ module Api
       project = authenticated_project
       return unless project&.review_method_enabled?("paid_agent")
       return unless Github::ReviewBotInstallationToken.configured?
-      bot_logins = Github::ReviewBotInstallationToken.bot_logins.to_set(&:downcase)
+      bot_logins = project.enabled_review_bot_logins
+      return if bot_logins.empty?
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"].to_i
 

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -236,7 +236,8 @@ module Api
       project = authenticated_project
       return unless project&.review_method_enabled?("paid_agent")
       return unless Github::ReviewBotInstallationToken.configured?
-      bot_logins = Github::ReviewBotInstallationToken.bot_logins.map(&:downcase)
+      bot_logins = project.enabled_review_bot_logins
+      return if bot_logins.empty?
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"].to_i
 

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -83,7 +83,7 @@ module Api
         match_data = endpoint[:pattern].match(path)
         next unless match_data
 
-        return { owner: match_data[:owner], repo: match_data[:repo] }
+        return match_data.named_captures.symbolize_keys
       end
 
       nil

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -259,6 +259,7 @@ module Api
 
       stale.each do |review|
         review_id = review_attribute(review, :id).to_i
+        next if review_id.zero?
 
         bot_client.dismiss_pull_request_review(
           project.full_name, pr_number, review_id,

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -236,7 +236,8 @@ module Api
       project = authenticated_project
       return unless project&.review_method_enabled?("paid_agent")
       return unless Github::ReviewBotInstallationToken.configured?
-      bot_logins = ProviderSupport.provider_bot_usernames_for("paid_agent")
+      bot_logins = project.enabled_review_bot_logins &
+        ProviderSupport.provider_bot_usernames_for("paid_agent")
       return if bot_logins.empty?
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"].to_i

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -242,6 +242,7 @@ module Api
       return if path_match[:number].blank? || new_review["id"].blank?
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"].to_i
+      return if pr_number.zero? || new_review_id.zero?
 
       bot_client = GithubClient.new(
         token: Github::ReviewBotInstallationToken.new(
@@ -253,7 +254,7 @@ module Api
       stale = reviews.select do |r|
         review_state(review_attribute(r, :state)) == "CHANGES_REQUESTED" &&
           bot_logins.include?(review_attribute(r, :user_login).to_s.downcase) &&
-          stale_review?(r, new_review_id)
+          stale_review?(r, new_review)
       end
 
       stale.each do |review|
@@ -315,11 +316,30 @@ module Api
       review[key] || review[key.to_s]
     end
 
-    def stale_review?(review, new_review_id)
+    def stale_review?(review, new_review)
+      review_submitted_at = review_submitted_at(review)
+      new_review_submitted_at = review_submitted_at(new_review)
+      if review_submitted_at && new_review_submitted_at
+        return review_submitted_at < new_review_submitted_at
+      end
+
       review_id = review_attribute(review, :id).to_i
       return false if review_id.zero?
 
+      new_review_id = review_attribute(new_review, :id).to_i
+      return false if new_review_id.zero?
+
       review_id < new_review_id
+    end
+
+    def review_submitted_at(review)
+      value = review_attribute(review, :submitted_at)
+      return value if value.is_a?(Time)
+      return if value.blank?
+
+      Time.zone.parse(value.to_s)
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def log_error(message, error)

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -236,7 +236,7 @@ module Api
       project = authenticated_project
       return unless project&.review_method_enabled?("paid_agent")
       return unless Github::ReviewBotInstallationToken.configured?
-      bot_logins = project.enabled_review_bot_logins
+      bot_logins = ProviderSupport.provider_bot_usernames_for("paid_agent")
       return if bot_logins.empty?
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"].to_i

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -251,18 +251,20 @@ module Api
 
       reviews = Array(bot_client.pull_request_reviews(project.full_name, pr_number))
       stale = reviews.select do |r|
-        review_state(r[:state]) == "CHANGES_REQUESTED" &&
-          bot_logins.include?(r[:user_login].to_s.downcase) &&
-          r[:id].to_i < new_review_id
+        review_state(review_attribute(r, :state)) == "CHANGES_REQUESTED" &&
+          bot_logins.include?(review_attribute(r, :user_login).to_s.downcase) &&
+          stale_review?(r, new_review_id)
       end
 
       stale.each do |review|
+        review_id = review_attribute(review, :id).to_i
+
         bot_client.dismiss_pull_request_review(
-          project.full_name, pr_number, review[:id],
+          project.full_name, pr_number, review_id,
           message: STALE_REVIEW_DISMISSAL_MESSAGE
         )
         log_info("github_proxy.dismissed_stale_review",
-          review_id: review[:id],
+          review_id: review_id,
           pr_number: pr_number)
       end
     rescue => e
@@ -307,6 +309,17 @@ module Api
 
     def review_state(value)
       value.to_s.upcase
+    end
+
+    def review_attribute(review, key)
+      review[key] || review[key.to_s]
+    end
+
+    def stale_review?(review, new_review_id)
+      review_id = review_attribute(review, :id).to_i
+      return false if review_id.zero?
+
+      review_id < new_review_id
     end
 
     def log_error(message, error)

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -236,7 +236,7 @@ module Api
       project = authenticated_project
       return unless project&.review_method_enabled?("paid_agent")
       return unless Github::ReviewBotInstallationToken.configured?
-      bot_logins = Github::ReviewBotInstallationToken.bot_logins.to_set { |login| login.downcase }
+      bot_logins = Github::ReviewBotInstallationToken.bot_logins.to_set(&:downcase)
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"].to_i
 

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -7,6 +7,7 @@ module Api
 
     REVIEW_COMMENT_MARKER = "<!-- paid:code-review -->"
     REVIEW_HEADER = "## Code Review"
+    STALE_REVIEW_DISMISSAL_MESSAGE = "Subsequent review found no remaining actionable issues."
 
     # Allowlisted GitHub API endpoints (regex with named captures for owner/repo).
     ALLOWED_ENDPOINTS = [
@@ -230,14 +231,14 @@ module Api
     # Without this, stale change requests block PR merging even after the
     # issues have been addressed.
     def dismiss_stale_changes_requested_reviews(path_match, new_review)
-      return if new_review["state"].to_s.casecmp("CHANGES_REQUESTED").zero?
+      return if review_state(new_review["state"]) == "CHANGES_REQUESTED"
 
       project = authenticated_project
       return unless project&.review_method_enabled?("paid_agent")
       return unless Github::ReviewBotInstallationToken.configured?
-      bot_logins = Github::ReviewBotInstallationToken.bot_logins
+      bot_logins = Github::ReviewBotInstallationToken.bot_logins.map(&:downcase)
       pr_number = path_match[:number].to_i
-      new_review_id = new_review["id"]
+      new_review_id = new_review["id"].to_i
 
       bot_client = GithubClient.new(
         token: Github::ReviewBotInstallationToken.new(
@@ -247,15 +248,15 @@ module Api
 
       reviews = bot_client.pull_request_reviews(project.full_name, pr_number)
       stale = reviews.select do |r|
-        r[:state] == "CHANGES_REQUESTED" &&
-          bot_logins.include?(r[:user_login]) &&
-          r[:id] != new_review_id
+        review_state(r[:state]) == "CHANGES_REQUESTED" &&
+          bot_logins.include?(r[:user_login].to_s.downcase) &&
+          r[:id].to_i != new_review_id
       end
 
       stale.each do |review|
         bot_client.dismiss_pull_request_review(
           project.full_name, pr_number, review[:id],
-          message: "Subsequent review found no remaining actionable issues."
+          message: STALE_REVIEW_DISMISSAL_MESSAGE
         )
         log_info("github_proxy.dismissed_stale_review",
           review_id: review[:id],
@@ -299,6 +300,10 @@ module Api
 
     def clean_review_body?(body)
       body.to_s.include?("<!-- paid-review-clean -->")
+    end
+
+    def review_state(value)
+      value.to_s.upcase
     end
 
     def log_error(message, error)

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -239,6 +239,7 @@ module Api
       bot_logins = project.enabled_review_bot_logins &
         ProviderSupport.provider_bot_usernames_for("paid_agent")
       return if bot_logins.empty?
+      return if path_match[:number].blank? || new_review["id"].blank?
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"].to_i
 
@@ -248,7 +249,7 @@ module Api
         ).fetch
       )
 
-      reviews = bot_client.pull_request_reviews(project.full_name, pr_number)
+      reviews = Array(bot_client.pull_request_reviews(project.full_name, pr_number))
       stale = reviews.select do |r|
         review_state(r[:state]) == "CHANGES_REQUESTED" &&
           bot_logins.include?(r[:user_login].to_s.downcase) &&

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -201,6 +201,7 @@ module Api
         review_url: review_url)
 
       warn_if_missing_inline_comments(body)
+      dismiss_stale_changes_requested_reviews(match, body)
     rescue => e
       log_error("github_proxy.track_review_failed", e.message)
     end
@@ -222,6 +223,45 @@ module Api
         review_id: response_body["id"],
         comment_count: comment_count
       )
+    end
+
+    # When a new review is posted that does NOT request changes, dismiss any
+    # previous CHANGES_REQUESTED reviews from the paid-code-reviewer bot.
+    # Without this, stale change requests block PR merging even after the
+    # issues have been addressed.
+    def dismiss_stale_changes_requested_reviews(path_match, new_review)
+      return if new_review["state"].to_s.casecmp("CHANGES_REQUESTED").zero?
+      return unless Github::ReviewBotInstallationToken.configured?
+
+      project = authenticated_project
+      bot_logins = Github::ReviewBotInstallationToken.bot_logins
+      pr_number = path_match[:number].to_i
+      new_review_id = new_review["id"]
+
+      bot_client = GithubClient.new(
+        token: Github::ReviewBotInstallationToken.new(
+          repo_full_name: project.full_name
+        ).fetch
+      )
+
+      reviews = bot_client.pull_request_reviews(project.full_name, pr_number)
+      stale = reviews.select do |r|
+        r[:state] == "CHANGES_REQUESTED" &&
+          bot_logins.include?(r[:user_login]) &&
+          r[:id] != new_review_id
+      end
+
+      stale.each do |review|
+        bot_client.dismiss_pull_request_review(
+          project.full_name, pr_number, review[:id],
+          message: "Subsequent review found no remaining actionable issues."
+        )
+        log_info("github_proxy.dismissed_stale_review",
+          review_id: review[:id],
+          pr_number: pr_number)
+      end
+    rescue => e
+      log_error("github_proxy.dismiss_stale_reviews_failed", e.message)
     end
 
     def parse_response_body(body)

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -313,7 +313,12 @@ module Api
     end
 
     def review_attribute(review, key)
-      review[key] || review[key.to_s]
+      direct_value = review[key] || review[key.to_s]
+      return direct_value if direct_value.present?
+      return unless key.to_sym == :user_login
+
+      user = review[:user] || review["user"]
+      user&.dig(:login) || user&.dig("login")
     end
 
     def stale_review?(review, new_review)

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -236,8 +236,7 @@ module Api
       project = authenticated_project
       return unless project&.review_method_enabled?("paid_agent")
       return unless Github::ReviewBotInstallationToken.configured?
-      bot_logins = project.enabled_review_bot_logins
-      return if bot_logins.empty?
+      bot_logins = Github::ReviewBotInstallationToken.bot_logins.to_set { |login| login.downcase }
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"].to_i
 

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -250,7 +250,7 @@ module Api
       stale = reviews.select do |r|
         review_state(r[:state]) == "CHANGES_REQUESTED" &&
           bot_logins.include?(r[:user_login].to_s.downcase) &&
-          r[:id].to_i != new_review_id
+          r[:id].to_i < new_review_id
       end
 
       stale.each do |review|

--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -231,9 +231,10 @@ module Api
     # issues have been addressed.
     def dismiss_stale_changes_requested_reviews(path_match, new_review)
       return if new_review["state"].to_s.casecmp("CHANGES_REQUESTED").zero?
-      return unless Github::ReviewBotInstallationToken.configured?
 
       project = authenticated_project
+      return unless project&.review_method_enabled?("paid_agent")
+      return unless Github::ReviewBotInstallationToken.configured?
       bot_logins = Github::ReviewBotInstallationToken.bot_logins
       pr_number = path_match[:number].to_i
       new_review_id = new_review["id"]

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -760,7 +760,7 @@ class GithubClient
   # @raise [NotFoundError] if the pull request does not exist
   def pull_request_reviews(repo, number)
     handle_errors do
-      reviews = client.pull_request_reviews(repo, number)
+      reviews = with_auto_paginate { client.pull_request_reviews(repo, number) }
       reviews.map do |r|
         {
           id: r.id,

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -783,10 +783,7 @@ class GithubClient
   # @param message [String] Reason for dismissal
   def dismiss_pull_request_review(repo, pull_number, review_id, message:)
     handle_errors do
-      client.put(
-        "#{Octokit::Repository.path(repo)}/pulls/#{pull_number}/reviews/#{review_id}/dismissals",
-        message: message
-      )
+      client.dismiss_pull_request_review(repo, pull_number, review_id, message)
     end
   end
 

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -783,7 +783,10 @@ class GithubClient
   # @param message [String] Reason for dismissal
   def dismiss_pull_request_review(repo, pull_number, review_id, message:)
     handle_errors do
-      client.dismiss_pull_request_review(repo, pull_number, review_id, message)
+      client.put(
+        "#{Octokit::Repository.path(repo)}/pulls/#{pull_number}/reviews/#{review_id}/dismissals",
+        message: message
+      )
     end
   end
 

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -783,7 +783,7 @@ class GithubClient
   # @param message [String] Reason for dismissal
   def dismiss_pull_request_review(repo, pull_number, review_id, message:)
     handle_errors do
-      client.dismiss_pull_request_review(repo, pull_number, review_id, message: message)
+      client.dismiss_pull_request_review(repo, pull_number, review_id, message)
     end
   end
 

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -774,6 +774,19 @@ class GithubClient
     end
   end
 
+  # Dismisses a pull request review. Requires write access on the repository
+  # and the review must be in CHANGES_REQUESTED state.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param pull_number [Integer] Pull request number
+  # @param review_id [Integer] The review ID to dismiss
+  # @param message [String] Reason for dismissal
+  def dismiss_pull_request_review(repo, pull_number, review_id, message:)
+    handle_errors do
+      client.dismiss_pull_request_review(repo, pull_number, review_id, message: message)
+    end
+  end
+
   # Replies to a review comment on a pull request.
   #
   # @param repo [String] Repository in "owner/name" format

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -760,7 +760,7 @@ class GithubClient
   # @raise [NotFoundError] if the pull request does not exist
   def pull_request_reviews(repo, number)
     handle_errors do
-      reviews = with_auto_paginate { client.pull_request_reviews(repo, number) }
+      reviews = with_auto_paginate { client.pull_request_reviews(repo, number, per_page: 100) }
       reviews.map do |r|
         {
           id: r.id,

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -2337,6 +2337,12 @@ module Activities
       - Case A: "comments" array is NON-EMPTY, each entry has "path", "line", and "body"
       - Case B: body starts with EXACTLY "Generated no new comments." and "comments" is []
 
+      CRITICAL: Always use `"event": "COMMENT"` — never use `"event":
+      "REQUEST_CHANGES"` or `"event": "APPROVE"`. Change requests are
+      expressed through inline comments in the "comments" array, not
+      through the review event. Using REQUEST_CHANGES blocks PR merging
+      and will be automatically dismissed.
+
       IMPORTANT: You MUST post exactly one PR review via the
       `/pulls/{{pr_number}}/reviews` endpoint — either Case A (with inline
       actionable comments) or Case B (clean review). This is how your review is

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -741,6 +741,12 @@ upsert_global_prompt.call(
     - Case A: "comments" array is NON-EMPTY, each entry has "path", "line", and "body"
     - Case B: body starts with EXACTLY "Generated no new comments." and "comments" is []
 
+    CRITICAL: Always use `"event": "COMMENT"` — never use `"event":
+    "REQUEST_CHANGES"` or `"event": "APPROVE"`. Change requests are
+    expressed through inline comments in the "comments" array, not
+    through the review event. Using REQUEST_CHANGES blocks PR merging
+    and will be automatically dismissed.
+
     IMPORTANT: You MUST post exactly one PR review via the
     `/pulls/{{pr_number}}/reviews` endpoint — either Case A (with inline
     actionable comments) or Case B (clean review). This is how your review is

--- a/spec/controllers/api/github_proxy_controller_spec.rb
+++ b/spec/controllers/api/github_proxy_controller_spec.rb
@@ -62,6 +62,28 @@ RSpec.describe Api::GithubProxyController, :no_db, type: :controller do
       )
     end
 
+    it "prefers submitted_at over review id when deciding staleness" do
+      timed_review = {
+        "id" => 500,
+        "state" => "COMMENTED",
+        "submitted_at" => "2026-05-15T12:00:00Z"
+      }
+      allow(client).to receive(:pull_request_reviews).with("testowner/testrepo", 10).and_return([
+        { id: 1001, user_login: "paid-code-reviewer[bot]", state: "CHANGES_REQUESTED", submitted_at: "2026-05-15T11:00:00Z" },
+        { id: 101, user_login: "paid-code-reviewer[bot]", state: "CHANGES_REQUESTED", submitted_at: "2026-05-15T13:00:00Z" }
+      ])
+
+      controller.send(:dismiss_stale_changes_requested_reviews, path_match, timed_review)
+
+      expect(client).to have_received(:dismiss_pull_request_review).with(
+        "testowner/testrepo", 10, 1001,
+        message: Api::GithubProxyController::STALE_REVIEW_DISMISSAL_MESSAGE
+      ).once
+      expect(client).not_to have_received(:dismiss_pull_request_review).with(
+        "testowner/testrepo", 10, 101, any_args
+      )
+    end
+
     it "skips dismissal when the new review requests changes" do
       allow(client).to receive(:pull_request_reviews)
 

--- a/spec/controllers/api/github_proxy_controller_spec.rb
+++ b/spec/controllers/api/github_proxy_controller_spec.rb
@@ -116,5 +116,16 @@ RSpec.describe Api::GithubProxyController, :no_db, type: :controller do
       expect(client).not_to have_received(:pull_request_reviews)
       expect(client).not_to have_received(:dismiss_pull_request_review)
     end
+
+    it "skips malformed stale reviews without an id" do
+      allow(client).to receive(:pull_request_reviews).with("testowner/testrepo", 10).and_return([
+        { user_login: "paid-code-reviewer[bot]", state: "CHANGES_REQUESTED" },
+        { id: 999, user_login: "paid-code-reviewer[bot]", state: "COMMENTED" }
+      ])
+
+      dismiss_stale_reviews
+
+      expect(client).not_to have_received(:dismiss_pull_request_review)
+    end
   end
 end

--- a/spec/controllers/api/github_proxy_controller_spec.rb
+++ b/spec/controllers/api/github_proxy_controller_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::GithubProxyController, :no_db, type: :controller do
+  describe "#dismiss_stale_changes_requested_reviews" do
+    subject(:dismiss_stale_reviews) do
+      controller.send(:dismiss_stale_changes_requested_reviews, path_match, new_review)
+    end
+
+    let(:project_stub_class) do
+      Class.new(Struct.new(:full_name, :enabled_review_bot_logins)) do
+        def review_method_enabled?(_method)
+          true
+        end
+      end
+    end
+
+    let(:path_match) { { number: "10" } }
+    let(:new_review) { { "id" => 999, "state" => "COMMENTED" } }
+    let(:project) do
+      instance_double(
+        project_stub_class,
+        full_name: "testowner/testrepo",
+        review_method_enabled?: true,
+        enabled_review_bot_logins: Set["paid-code-reviewer[bot]"]
+      )
+    end
+    let(:token_provider) { instance_double(Github::ReviewBotInstallationToken, fetch: "ghs_review_bot_token") }
+    let(:client) { instance_double(GithubClient) }
+
+    before do
+      allow(controller).to receive(:authenticated_project).and_return(project)
+      allow(Github::ReviewBotInstallationToken).to receive_messages(configured?: true, new: token_provider)
+      allow(ProviderSupport).to receive(:provider_bot_usernames_for).with("paid_agent")
+        .and_return(Set["paid-code-reviewer[bot]"])
+      allow(GithubClient).to receive(:new).with(token: "ghs_review_bot_token").and_return(client)
+      allow(client).to receive(:dismiss_pull_request_review)
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it "dismisses only older paid-code-reviewer change requests" do
+      allow(client).to receive(:pull_request_reviews).with("testowner/testrepo", 10).and_return([
+        { id: 101, user_login: "paid-code-reviewer[bot]", state: "CHANGES_REQUESTED" },
+        { id: 999, user_login: "paid-code-reviewer[bot]", state: "COMMENTED" },
+        { id: 1001, user_login: "paid-code-reviewer[bot]", state: "CHANGES_REQUESTED" },
+        { id: 102, user_login: "copilot-pull-request-reviewer[bot]", state: "CHANGES_REQUESTED" }
+      ])
+
+      dismiss_stale_reviews
+
+      expect(client).to have_received(:dismiss_pull_request_review).with(
+        "testowner/testrepo", 10, 101,
+        message: Api::GithubProxyController::STALE_REVIEW_DISMISSAL_MESSAGE
+      ).once
+      expect(client).not_to have_received(:dismiss_pull_request_review).with(
+        "testowner/testrepo", 10, 1001, any_args
+      )
+      expect(client).not_to have_received(:dismiss_pull_request_review).with(
+        "testowner/testrepo", 10, 102, any_args
+      )
+    end
+
+    it "skips dismissal when the new review requests changes" do
+      allow(client).to receive(:pull_request_reviews)
+
+      controller.send(:dismiss_stale_changes_requested_reviews, path_match, { "id" => 999, "state" => "CHANGES_REQUESTED" })
+
+      expect(client).not_to have_received(:pull_request_reviews)
+      expect(client).not_to have_received(:dismiss_pull_request_review)
+    end
+
+    it "skips dismissal when no paid-agent bot logins are enabled" do
+      allow(project).to receive(:enabled_review_bot_logins).and_return(Set.new)
+      allow(client).to receive(:pull_request_reviews)
+
+      dismiss_stale_reviews
+
+      expect(client).not_to have_received(:pull_request_reviews)
+      expect(client).not_to have_received(:dismiss_pull_request_review)
+    end
+  end
+end

--- a/spec/controllers/api/github_proxy_controller_spec.rb
+++ b/spec/controllers/api/github_proxy_controller_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe Api::GithubProxyController, :no_db, type: :controller do
       )
     end
 
+    it "matches bot logins from raw GitHub user payloads" do
+      allow(client).to receive(:pull_request_reviews).with("testowner/testrepo", 10).and_return([
+        { id: 101, user: { login: "paid-code-reviewer[bot]" }, state: "CHANGES_REQUESTED" },
+        { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED" }
+      ])
+
+      dismiss_stale_reviews
+
+      expect(client).to have_received(:dismiss_pull_request_review).with(
+        "testowner/testrepo", 10, 101,
+        message: Api::GithubProxyController::STALE_REVIEW_DISMISSAL_MESSAGE
+      ).once
+    end
+
     it "prefers submitted_at over review id when deciding staleness" do
       timed_review = {
         "id" => 500,

--- a/spec/db/seeds_prompts_spec.rb
+++ b/spec/db/seeds_prompts_spec.rb
@@ -112,6 +112,25 @@ RSpec.describe Prompt, type: :model do
         .to include('Case B: body starts with EXACTLY "Generated no new comments." and "comments" is []')
     end
 
+    it "seeded template forbids REQUEST_CHANGES and APPROVE review events" do
+      template = described_class.global.find_by(slug: "goal.review_pull_request").current_version.template
+      expect(template).to include('Always use `"event": "COMMENT"`')
+      expect(template).to include('"REQUEST_CHANGES"')
+      expect(template).to include('"APPROVE"')
+      expect(template).to include("will be automatically dismissed")
+    end
+
+    it "FALLBACK_REVIEW_GOAL_PROMPT forbids REQUEST_CHANGES and APPROVE review events" do
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
+        .to include('Always use `"event": "COMMENT"`')
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
+        .to include('"REQUEST_CHANGES"')
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
+        .to include('"APPROVE"')
+      expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
+        .to include("will be automatically dismissed")
+    end
+
     it "seeded template tells reviewers to install bundled gems before Ruby validation" do
       template = described_class.global.find_by(slug: "goal.review_pull_request").current_version.template
       expect(template).to include(

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -582,8 +582,8 @@ RSpec.describe "Api::GithubProxy" do
           expect(WebMock).not_to have_requested(:put, dismiss_url)
         end
 
-        it "does not dismiss stale change requests when enabled review bot logins resolve empty" do
-          allow(project).to receive(:enabled_review_bot_logins).and_return(Set.new)
+        it "does not dismiss stale change requests when paid_agent bot logins resolve empty" do
+          allow(ProviderSupport).to receive(:provider_bot_usernames_for).with("paid_agent").and_return(Set.new)
           stub_review_list_response([
             { id: 101, user: { login: "paid-code-reviewer[bot]" }, state: "CHANGES_REQUESTED", body: "Needs work" },
             { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Latest review" }

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -560,6 +560,27 @@ RSpec.describe "Api::GithubProxy" do
 
           expect(WebMock).not_to have_requested(:put, dismiss_url)
         end
+
+        it "does not dismiss stale change requests from other enabled review bots" do
+          project.update!(review_settings: {
+            "enabled" => true,
+            "methods" => {
+              "paid_agent" => { "enabled" => true },
+              "copilot" => { "enabled" => true }
+            }
+          })
+          stub_review_list_response([
+            { id: 101, user: { login: "copilot-pull-request-reviewer[bot]" }, state: "CHANGES_REQUESTED", body: "Copilot request" },
+            { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Latest review" }
+          ])
+          dismiss_url = "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/101/dismissals"
+
+          post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+            params: { body: "Looks good", event: "COMMENT" }.to_json,
+            headers: valid_headers
+
+          expect(WebMock).not_to have_requested(:put, dismiss_url)
+        end
       end
 
       it "does not dismiss reviews when the latest review requests changes" do

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -523,6 +523,26 @@ RSpec.describe "Api::GithubProxy" do
             hash_including(message: "github_proxy.dismissed_stale_review", review_id: 101, pr_number: 10)
           )
         end
+
+        it "dismisses stale bot change requests even when the review was already tracked on the run" do
+          agent_run.update!(
+            review_posted_at: 1.hour.ago,
+            review_url: "https://github.com/testowner/testrepo/pull/10#pullrequestreview-previous"
+          )
+          stub_review_list_response([
+            { id: 101, user: { login: "paid-code-reviewer[bot]" }, state: "CHANGES_REQUESTED", body: "Needs work" },
+            { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Latest review" }
+          ])
+          dismiss_url = stub_stale_review_dismissal
+
+          post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+            params: { body: "Looks good", event: "COMMENT" }.to_json,
+            headers: valid_headers
+
+          expect(WebMock).to have_requested(:put, dismiss_url).once
+          expect(agent_run.reload.review_url)
+            .to eq("https://github.com/testowner/testrepo/pull/10#pullrequestreview-previous")
+        end
       end
 
       it "does not dismiss reviews when the latest review requests changes" do

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -581,6 +581,21 @@ RSpec.describe "Api::GithubProxy" do
 
           expect(WebMock).not_to have_requested(:put, dismiss_url)
         end
+
+        it "does not dismiss stale change requests when enabled review bot logins resolve empty" do
+          allow(project).to receive(:enabled_review_bot_logins).and_return(Set.new)
+          stub_review_list_response([
+            { id: 101, user: { login: "paid-code-reviewer[bot]" }, state: "CHANGES_REQUESTED", body: "Needs work" },
+            { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Latest review" }
+          ])
+          dismiss_url = "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/101/dismissals"
+
+          post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+            params: { body: "Looks good", event: "COMMENT" }.to_json,
+            headers: valid_headers
+
+          expect(WebMock).not_to have_requested(:put, dismiss_url)
+        end
       end
 
       it "does not dismiss reviews when the latest review requests changes" do

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -203,7 +203,34 @@ RSpec.describe "Api::GithubProxy" do
     before do
       stub_request(:post, target_url)
         .to_return(status: 200, body: review_response_body, headers: { "Content-Type" => "application/json" })
+      stub_request(:get, target_url)
+        .to_return(status: 200, body: [].to_json, headers: { "Content-Type" => "application/json" })
       allow(Rails.logger).to receive(:warn).and_call_original
+    end
+
+    def stub_stale_review_dismissal(review_id: 101)
+      dismiss_url = "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/#{review_id}/dismissals"
+
+      stub_request(:get, target_url)
+        .with(headers: hash_including("Authorization" => "token ghs_review_bot_token"))
+        .to_return(
+          status: 200,
+          body: [
+            { id: review_id, user: { login: "paid-code-reviewer[bot]" }, state: "CHANGES_REQUESTED", body: "Needs work" },
+            { id: 102, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Looks good" },
+            { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Latest review" },
+            { id: 103, user: { login: "human-reviewer" }, state: "CHANGES_REQUESTED", body: "Human request" }
+          ].to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+      stub_request(:put, dismiss_url)
+        .with(
+          headers: hash_including("Authorization" => "token ghs_review_bot_token"),
+          body: { message: "Subsequent review found no remaining actionable issues." }.to_json
+        )
+        .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+
+      dismiss_url
     end
 
     it "proxies review creation" do
@@ -465,6 +492,39 @@ RSpec.describe "Api::GithubProxy" do
               headers: valid_headers
           }.not_to change { github_token.reload.last_used_at }
         end
+      end
+
+      it "dismisses older paid-code-reviewer change requests after a non-blocking review" do
+        dismiss_url = stub_stale_review_dismissal
+        allow(Rails.logger).to receive(:info)
+
+        post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+          params: { body: "Looks good", event: "COMMENT" }.to_json,
+          headers: valid_headers
+
+        expect(WebMock).to have_requested(:put, dismiss_url).once
+        expect(Rails.logger).to have_received(:info).with(
+          hash_including(message: "github_proxy.dismissed_stale_review", review_id: 101, pr_number: 10)
+        )
+      end
+
+      it "does not dismiss reviews when the latest review requests changes" do
+        changes_requested_response = {
+          id: 999,
+          body: "Needs fixes",
+          html_url: "https://github.com/testowner/testrepo/pull/10#pullrequestreview-999",
+          state: "CHANGES_REQUESTED"
+        }.to_json
+        dismiss_url = "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/101/dismissals"
+
+        stub_request(:post, target_url)
+          .to_return(status: 200, body: changes_requested_response, headers: { "Content-Type" => "application/json" })
+
+        post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+          params: { body: "Needs fixes", event: "REQUEST_CHANGES" }.to_json,
+          headers: valid_headers
+
+        expect(WebMock).not_to have_requested(:put, dismiss_url)
       end
 
       it "returns 503 when the review bot is not configured" do

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -208,7 +208,10 @@ RSpec.describe "Api::GithubProxy" do
 
     def stub_review_list_response(reviews = [])
       stub_request(:get, target_url)
-        .with(headers: hash_including("Authorization" => "token ghs_review_bot_token"))
+        .with(
+          headers: hash_including("Authorization" => "token ghs_review_bot_token"),
+          query: hash_including("per_page" => "100")
+        )
         .to_return(
           status: 200,
           body: reviews.to_json,

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -203,26 +203,22 @@ RSpec.describe "Api::GithubProxy" do
     before do
       stub_request(:post, target_url)
         .to_return(status: 200, body: review_response_body, headers: { "Content-Type" => "application/json" })
-      stub_request(:get, target_url)
-        .to_return(status: 200, body: [].to_json, headers: { "Content-Type" => "application/json" })
       allow(Rails.logger).to receive(:warn).and_call_original
+    end
+
+    def stub_review_list_response(reviews = [])
+      stub_request(:get, target_url)
+        .with(headers: hash_including("Authorization" => "token ghs_review_bot_token"))
+        .to_return(
+          status: 200,
+          body: reviews.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
     end
 
     def stub_stale_review_dismissal(review_id: 101)
       dismiss_url = "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/#{review_id}/dismissals"
 
-      stub_request(:get, target_url)
-        .with(headers: hash_including("Authorization" => "token ghs_review_bot_token"))
-        .to_return(
-          status: 200,
-          body: [
-            { id: review_id, user: { login: "paid-code-reviewer[bot]" }, state: "CHANGES_REQUESTED", body: "Needs work" },
-            { id: 102, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Looks good" },
-            { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Latest review" },
-            { id: 103, user: { login: "human-reviewer" }, state: "CHANGES_REQUESTED", body: "Human request" }
-          ].to_json,
-          headers: { "Content-Type" => "application/json" }
-        )
       stub_request(:put, dismiss_url)
         .with(
           headers: hash_including("Authorization" => "token ghs_review_bot_token"),
@@ -231,6 +227,16 @@ RSpec.describe "Api::GithubProxy" do
         .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
 
       dismiss_url
+    end
+
+    def clean_review_response_body
+      {
+        id: 999,
+        body: "Generated no new comments. The PR looks ready as-is. <!-- paid-review-clean -->",
+        html_url: "https://github.com/testowner/testrepo/pull/10#pullrequestreview-999",
+        state: "commented",
+        comments: []
+      }.to_json
     end
 
     it "proxies review creation" do
@@ -471,6 +477,8 @@ RSpec.describe "Api::GithubProxy" do
       end
 
       it "forwards review creation with the review bot token" do
+        stub_review_list_response
+
         post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
           params: { body: "Looks good", event: "COMMENT" }.to_json,
           headers: valid_headers
@@ -485,6 +493,7 @@ RSpec.describe "Api::GithubProxy" do
       it "does not touch last_used_at on the project GitHub token" do
         freeze_time do
           github_token.update_column(:last_used_at, 2.days.ago)
+          stub_review_list_response
 
           expect {
             post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
@@ -494,18 +503,26 @@ RSpec.describe "Api::GithubProxy" do
         end
       end
 
-      it "dismisses older paid-code-reviewer change requests after a non-blocking review" do
-        dismiss_url = stub_stale_review_dismissal
-        allow(Rails.logger).to receive(:info)
+      context "when older paid-code-reviewer change requests exist" do
+        it "dismisses the stale bot change request" do
+          stub_review_list_response([
+            { id: 101, user: { login: "paid-code-reviewer[bot]" }, state: "CHANGES_REQUESTED", body: "Needs work" },
+            { id: 102, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Looks good" },
+            { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Latest review" },
+            { id: 103, user: { login: "human-reviewer" }, state: "CHANGES_REQUESTED", body: "Human request" }
+          ])
+          dismiss_url = stub_stale_review_dismissal
+          allow(Rails.logger).to receive(:info)
 
-        post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
-          params: { body: "Looks good", event: "COMMENT" }.to_json,
-          headers: valid_headers
+          post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+            params: { body: "Looks good", event: "COMMENT" }.to_json,
+            headers: valid_headers
 
-        expect(WebMock).to have_requested(:put, dismiss_url).once
-        expect(Rails.logger).to have_received(:info).with(
-          hash_including(message: "github_proxy.dismissed_stale_review", review_id: 101, pr_number: 10)
-        )
+          expect(WebMock).to have_requested(:put, dismiss_url).once
+          expect(Rails.logger).to have_received(:info).with(
+            hash_including(message: "github_proxy.dismissed_stale_review", review_id: 101, pr_number: 10)
+          )
+        end
       end
 
       it "does not dismiss reviews when the latest review requests changes" do
@@ -542,6 +559,7 @@ RSpec.describe "Api::GithubProxy" do
 
       it "logs a warning when a non-clean review body is posted without inline comments" do
         allow(Rails.logger).to receive(:warn)
+        stub_review_list_response
 
         post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
           params: { body: "Found two issues to fix before merge.", event: "COMMENT", comments: [] }.to_json,
@@ -559,6 +577,7 @@ RSpec.describe "Api::GithubProxy" do
 
       it "does not log a warning when the submitted review includes inline comments" do
         allow(Rails.logger).to receive(:warn)
+        stub_review_list_response
 
         post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
           params: {
@@ -577,13 +596,7 @@ RSpec.describe "Api::GithubProxy" do
 
       it "does not log a warning for the clean review body-only format" do
         allow(Rails.logger).to receive(:warn)
-        clean_review_response_body = {
-          id: 999,
-          body: "Generated no new comments. The PR looks ready as-is. <!-- paid-review-clean -->",
-          html_url: "https://github.com/testowner/testrepo/pull/10#pullrequestreview-999",
-          state: "commented",
-          comments: []
-        }.to_json
+        stub_review_list_response
         stub_request(:post, target_url)
           .to_return(status: 200, body: clean_review_response_body, headers: { "Content-Type" => "application/json" })
 

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -477,11 +477,10 @@ RSpec.describe "Api::GithubProxy" do
           "enabled" => true,
           "methods" => { "paid_agent" => { "enabled" => true } }
         })
+        stub_review_list_response
       end
 
       it "forwards review creation with the review bot token" do
-        stub_review_list_response
-
         post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
           params: { body: "Looks good", event: "COMMENT" }.to_json,
           headers: valid_headers
@@ -496,7 +495,6 @@ RSpec.describe "Api::GithubProxy" do
       it "does not touch last_used_at on the project GitHub token" do
         freeze_time do
           github_token.update_column(:last_used_at, 2.days.ago)
-          stub_review_list_response
 
           expect {
             post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
@@ -650,7 +648,6 @@ RSpec.describe "Api::GithubProxy" do
 
       it "logs a warning when a non-clean review body is posted without inline comments" do
         allow(Rails.logger).to receive(:warn)
-        stub_review_list_response
 
         post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
           params: { body: "Found two issues to fix before merge.", event: "COMMENT", comments: [] }.to_json,
@@ -668,7 +665,6 @@ RSpec.describe "Api::GithubProxy" do
 
       it "does not log a warning when the submitted review includes inline comments" do
         allow(Rails.logger).to receive(:warn)
-        stub_review_list_response
 
         post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
           params: {
@@ -687,7 +683,6 @@ RSpec.describe "Api::GithubProxy" do
 
       it "does not log a warning for the clean review body-only format" do
         allow(Rails.logger).to receive(:warn)
-        stub_review_list_response
         stub_request(:post, target_url)
           .to_return(status: 200, body: clean_review_response_body, headers: { "Content-Type" => "application/json" })
 

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -617,6 +617,24 @@ RSpec.describe "Api::GithubProxy" do
         expect(WebMock).not_to have_requested(:put, dismiss_url)
       end
 
+      it "does not query or dismiss stale reviews when the review response lacks an id" do
+        no_id_response = {
+          body: "Looks good",
+          html_url: "https://github.com/testowner/testrepo/pull/10#pullrequestreview-999",
+          state: "commented"
+        }.to_json
+        review_list_url = "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews"
+
+        stub_request(:post, target_url)
+          .to_return(status: 200, body: no_id_response, headers: { "Content-Type" => "application/json" })
+
+        post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+          params: { body: "Looks good", event: "COMMENT" }.to_json,
+          headers: valid_headers
+
+        expect(WebMock).not_to have_requested(:get, review_list_url)
+      end
+
       it "returns 503 when the review bot is not configured" do
         allow(review_bot_token_provider)
           .to receive(:fetch)

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -546,6 +546,20 @@ RSpec.describe "Api::GithubProxy" do
           expect(agent_run.reload.review_url)
             .to eq("https://github.com/testowner/testrepo/pull/10#pullrequestreview-previous")
         end
+
+        it "does not dismiss newer bot change requests" do
+          stub_review_list_response([
+            { id: 1001, user: { login: "paid-code-reviewer[bot]" }, state: "CHANGES_REQUESTED", body: "Needs work" },
+            { id: 999, user: { login: "paid-code-reviewer[bot]" }, state: "COMMENTED", body: "Latest review" }
+          ])
+          dismiss_url = "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/1001/dismissals"
+
+          post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+            params: { body: "Looks good", event: "COMMENT" }.to_json,
+            headers: valid_headers
+
+          expect(WebMock).not_to have_requested(:put, dismiss_url)
+        end
       end
 
       it "does not dismiss reviews when the latest review requests changes" do

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe "Api::GithubProxy" do
     def stub_review_list_response(reviews = [])
       stub_request(:get, target_url)
         .with(
-          headers: hash_including("Authorization" => "token ghs_review_bot_token"),
+          headers: { "Authorization" => "token ghs_review_bot_token" },
           query: hash_including("per_page" => "100")
         )
         .to_return(
@@ -224,7 +224,7 @@ RSpec.describe "Api::GithubProxy" do
 
       stub_request(:put, dismiss_url)
         .with(
-          headers: hash_including("Authorization" => "token ghs_review_bot_token"),
+          headers: { "Authorization" => "token ghs_review_bot_token" },
           body: { message: "Subsequent review found no remaining actionable issues." }.to_json
         )
         .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -1252,7 +1252,7 @@ RSpec.describe GithubClient do
     context "when reviews exist" do
       before do
         stub_request(:get, "#{api_base}/repos/#{repo}/pulls/42/reviews")
-          .with(query: hash_excluding("page" => "2"))
+          .with(query: hash_including("per_page" => "100"))
           .to_return(
             status: 200,
             body: [
@@ -1276,7 +1276,7 @@ RSpec.describe GithubClient do
           )
 
         stub_request(:get, "#{api_base}/repos/#{repo}/pulls/42/reviews")
-          .with(query: hash_including("page" => "2"))
+          .with(query: hash_including("page" => "2", "per_page" => "100"))
           .to_return(
             status: 200,
             body: [
@@ -1316,7 +1316,7 @@ RSpec.describe GithubClient do
     context "when pull request does not exist" do
       before do
         stub_request(:get, "#{api_base}/repos/#{repo}/pulls/999/reviews")
-          .with(query: hash_excluding("page" => "2"))
+          .with(query: hash_including("per_page" => "100"))
           .to_return(status: 404, body: { message: "Not Found" }.to_json)
       end
 

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -1246,7 +1246,7 @@ RSpec.describe GithubClient do
     end
   end
 
-  describe "#pull_request_reviews" do
+  describe "#pull_request_reviews", :no_db do
     let(:repo) { "owner/repo" }
 
     context "when reviews exist" do
@@ -1276,7 +1276,7 @@ RSpec.describe GithubClient do
           )
 
         stub_request(:get, "#{api_base}/repos/#{repo}/pulls/42/reviews")
-          .with(query: hash_including("page" => "2", "per_page" => "100"))
+          .with(query: hash_including("page" => "2"))
           .to_return(
             status: 200,
             body: [

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -1252,6 +1252,7 @@ RSpec.describe GithubClient do
     context "when reviews exist" do
       before do
         stub_request(:get, "#{api_base}/repos/#{repo}/pulls/42/reviews")
+          .with(query: hash_excluding("page" => "2"))
           .to_return(
             status: 200,
             body: [
@@ -1268,26 +1269,54 @@ RSpec.describe GithubClient do
                 submitted_at: "2026-02-21T10:00:00Z"
               }
             ].to_json,
+            headers: {
+              "Content-Type" => "application/json",
+              "Link" => "<#{api_base}/repos/#{repo}/pulls/42/reviews?page=2>; rel=\"next\""
+            }
+          )
+
+        stub_request(:get, "#{api_base}/repos/#{repo}/pulls/42/reviews")
+          .with(query: hash_including("page" => "2"))
+          .to_return(
+            status: 200,
+            body: [
+              {
+                id: 3,
+                user: { login: "commenter" },
+                state: "COMMENTED",
+                submitted_at: "2026-02-22T10:00:00Z"
+              }
+            ].to_json,
             headers: { "Content-Type" => "application/json" }
           )
       end
 
-      it "returns reviews with user, state, and submitted_at parsed as Time" do
+      it "returns reviews from all pages with user, state, and submitted_at parsed as Time" do
         result = client.pull_request_reviews(repo, 42)
 
-        expect(result.size).to eq(2)
+        expect(result.size).to eq(3)
         expect(result.first[:id]).to eq(1)
         expect(result.first[:user_login]).to eq("reviewer")
         expect(result.first[:state]).to eq("CHANGES_REQUESTED")
         expect(result.first[:submitted_at]).to be_a(Time)
         expect(result.first[:submitted_at]).to eq(Time.parse("2026-02-20T10:00:00Z"))
-        expect(result.last[:state]).to eq("APPROVED")
+        expect(result.last[:state]).to eq("COMMENTED")
+        expect(result.last[:user_login]).to eq("commenter")
+      end
+
+      it "temporarily enables auto_paginate and restores it" do
+        expect(client.client.auto_paginate).to be false
+
+        client.pull_request_reviews(repo, 42)
+
+        expect(client.client.auto_paginate).to be false
       end
     end
 
     context "when pull request does not exist" do
       before do
         stub_request(:get, "#{api_base}/repos/#{repo}/pulls/999/reviews")
+          .with(query: hash_excluding("page" => "2"))
           .to_return(status: 404, body: { message: "Not Found" }.to_json)
       end
 

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -1562,6 +1562,29 @@ RSpec.describe GithubClient do
     end
   end
 
+  describe "#dismiss_pull_request_review", :no_db do
+    let(:repo) { "owner/repo" }
+    let(:dismiss_url) { "#{api_base}/repos/#{repo}/pulls/42/reviews/100/dismissals" }
+    let(:message) { "Subsequent review found no remaining actionable issues." }
+
+    before do
+      stub_request(:put, dismiss_url)
+        .with(body: { message: message }.to_json)
+        .to_return(
+          status: 200,
+          body: { id: 100, state: "DISMISSED" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    end
+
+    it "sends the dismissal message in the request body" do
+      result = client.dismiss_pull_request_review(repo, 42, 100, message: message)
+
+      expect(result.state).to eq("DISMISSED")
+      expect(a_request(:put, dismiss_url).with(body: { message: message }.to_json)).to have_been_made.once
+    end
+  end
+
   describe "#request_bot_review" do
     let(:repo) { "owner/repo" }
     let(:pr_node_id) { "PR_kwDOTest123" }


### PR DESCRIPTION
## Summary

- When the paid-code-reviewer bot posts a new review that does **not** request changes, any previous `CHANGES_REQUESTED` reviews from the same bot are automatically dismissed via the GitHub API
- Adds `GithubClient#dismiss_pull_request_review` wrapping Octokit's dismiss endpoint
- Strengthens the review prompt (seeded + fallback) to explicitly prohibit `REQUEST_CHANGES` — agents must always use `COMMENT`

## Problem

The paid-code-reviewer bot sometimes posts reviews with `CHANGES_REQUESTED` event (ignoring the prompt's `"event": "COMMENT"` instruction). When subsequent reviews find no remaining issues, those earlier `CHANGES_REQUESTED` reviews are never dismissed, blocking PR merging indefinitely.

## Files Changed

- `app/controllers/api/github_proxy_controller.rb` — after tracking a new review, fetches all bot reviews on the PR and dismisses any stale `CHANGES_REQUESTED` entries
- `app/services/github_client.rb` — adds `dismiss_pull_request_review` method
- `db/seeds/prompts.rb` — adds `CRITICAL` instruction to never use `REQUEST_CHANGES`
- `app/temporal/activities/run_agent_activity.rb` — same instruction in fallback prompt

## Testing

- Lint passes on all changed files
- Manually dismissed the two stale `CHANGES_REQUESTED` reviews on #1950 to unblock that PR