### PR TITLE
Fix #2040: Optimize slow spec: Optimizer.ranked_candidates incumbent retention test (111s)

### DIFF
--- a/spec/services/configuration_bundles/optimizer_spec.rb
+++ b/spec/services/configuration_bundles/optimizer_spec.rb
@@ -247,6 +247,8 @@ RSpec.describe ConfigurationBundles::Optimizer do
     end
 
     it "keeps the incumbent from older outcomes outside the surrogate training window" do
+      stub_const("ConfigurationBundles::TrainingDataset::MAX_ROWS", 3)
+
       create_bundle_history(
         experiment: experiment,
         variant: challenger,
@@ -257,8 +259,8 @@ RSpec.describe ConfigurationBundles::Optimizer do
       create_bundle_history(
         experiment: experiment,
         variant: control,
-        quality_scores: Array.new(ConfigurationBundles::SurrogateModel::MAX_OUTCOME_ROWS, 0.7),
-        objective_scores: Array.new(ConfigurationBundles::SurrogateModel::MAX_OUTCOME_ROWS, 0.7)
+        quality_scores: Array.new(3, 0.7),
+        objective_scores: Array.new(3, 0.7)
       )
 
       ranked = described_class.ranked_candidates(agent_run: agent_run)


### PR DESCRIPTION
## Summary

Reduces the runtime of `ConfigurationBundles::Optimizer.ranked_candidates` incumbent retention spec from ~112s to a fraction of that, by stubbing the training dataset window size instead of creating 500 real records. The behavior under test — that the incumbent `best_observed_objective_score` is retained from outcomes outside the training window — is unchanged.

## Changes

- **Spec (`spec/services/configuration_bundles/optimizer_spec.rb:249`)**: Stub `TrainingDataset::MAX_ROWS` to `3` and create only 3 `BundleOutcome` records (plus associated `AgentRun`/`Issue` fixtures) instead of 500, since the assertion only depends on outcomes falling outside the window — not on the window's absolute size.

## Design Decisions

- **Stub `MAX_ROWS` rather than the optimizer internals**: Keeps the full optimization pipeline exercised end-to-end while shrinking only the dataset volume. This preserves coverage of the real code path that pulls `best_observed_objective_score` from the unlimited `prior_objective_outcomes_for_goal` query, which is the actual behavior under test.
- **Constant stubbing is safe here**: `MAX_ROWS` is a window threshold, not a value with semantic meaning at `500` specifically — any value smaller than the total outcome count produces the same "incumbent is outside the window" condition.

---

Closes #2040