### PR TITLE
Fix #2038: Max draft review rounds not saving for projects (missing from strong params)

### DIFF
--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1300,10 +1300,21 @@ RSpec.describe "Projects" do
       it "persists max draft review rounds" do
         project = create(:project, account: account, github_token: github_token, max_draft_review_rounds: 10)
 
-        patch project_path(project), params: { project: { max_draft_review_rounds: 4 } }
+        expect {
+          patch project_path(project), params: { project: { max_draft_review_rounds: 4 } }
+        }.to change { project.reload.max_draft_review_rounds }.from(10).to(4)
 
         expect(response).to redirect_to(project_path(project))
-        expect(project.reload.max_draft_review_rounds).to eq(4)
+      end
+
+      it "persists zero max draft review rounds" do
+        project = create(:project, account: account, github_token: github_token, max_draft_review_rounds: 10)
+
+        expect {
+          patch project_path(project), params: { project: { max_draft_review_rounds: 0 } }
+        }.to change { project.reload.max_draft_review_rounds }.from(10).to(0)
+
+        expect(response).to redirect_to(project_path(project))
       end
 
       it "persists screenshot settings" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1297,6 +1297,15 @@ RSpec.describe "Projects" do
         expect(project.reload.auto_fix_merge_conflicts).to be true
       end
 
+      it "persists max draft review rounds" do
+        project = create(:project, account: account, github_token: github_token, max_draft_review_rounds: 10)
+
+        patch project_path(project), params: { project: { max_draft_review_rounds: 4 } }
+
+        expect(response).to redirect_to(project_path(project))
+        expect(project.reload.max_draft_review_rounds).to eq(4)
+      end
+
       it "persists screenshot settings" do
         project = create(:project, account: account, github_token: github_token)
         patch project_path(project), params: screenshot_update_params


### PR DESCRIPTION
## Summary

Lock in the fix for issue where `max_draft_review_rounds` updates were silently dropped by adding regression coverage. The controller already permits the attribute on this branch, so this PR ensures a future change cannot reintroduce the bug without a failing test.

## Changes

- **Tests**: Added a request spec in `spec/requests/projects_spec.rb` exercising `PATCH /projects/:id` with `max_draft_review_rounds` and asserting the new value persists after reload.

## Design Decisions

- **Test-only change**: The strong-params permit for `max_draft_review_rounds` is already in place on this branch, so no controller change was needed. The regression spec is the durable contract that prevents the attribute from being dropped from permitted params again.
- **Request spec over controller spec**: Exercises the full update path (params filtering + model persistence + reload) rather than asserting on permitted-params internals, matching the user-observed failure mode in the issue.

## Operational Notes

- No migrations, deploy steps, or infrastructure changes.
- Local verification: `bundle exec rubocop` passed. `bundle exec rspec` could not run in the authoring container due to PostgreSQL being unavailable (`ActiveRecord::ConnectionNotEstablished` during test DB setup); CI will execute the new spec.

---

Closes #2038