### PR TITLE
feat(auto-pick): seed queued runs on issue sync, import, and auto-pick toggle

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -168,10 +168,9 @@ class ProcessRunQueueJob < ApplicationJob
 
       ordered_auto_pick_projects.each do |project|
         break if seeded >= MAX_SEEDS_PER_PERFORM
-        next unless project.effective_owner
-        next if auto_pick_deferred_by_pr_attention?(project)
+        next unless Issues::AutoPickProjectGate.call(project)
 
-        runs = Issues::BulkEnqueueEligible.call(project: project, limit: 1)
+        runs = Issues::BulkEnqueueEligible.call(project: project, limit: 1, skip_project_gate: true)
         created = runs.count(&:previously_new_record?)
         next if created.zero?
 
@@ -224,32 +223,6 @@ class ProcessRunQueueJob < ApplicationJob
         ]
       end
     end
-  end
-
-  def auto_pick_deferred_by_pr_attention?(project)
-    prs_needing_attention_count(project) >= max_auto_pick_open_prs(project)
-  end
-
-  def prs_needing_attention_count(project)
-    base = Issue.where(
-      project: project,
-      is_pull_request: true,
-      github_state: "open",
-      paid_state: %w[in_progress failed]
-    )
-
-    handed_off = base
-      .where(paid_state: "in_progress")
-      .where("labels @> ?::jsonb", [ project.automation_label_name, Issues::AutoPick::PAID_READY_LABEL ].to_json)
-      .where.not(pr_review_phase: %w[draft restarted])
-
-    escalated = base.where(pr_review_phase: "escalated")
-
-    base.where.not(id: handed_off).where.not(id: escalated).count
-  end
-
-  def max_auto_pick_open_prs(project)
-    project.effective_owner&.settings&.max_auto_pick_open_prs || 1
   end
 
   def start_claimed_run(agent_run)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -877,7 +877,9 @@ class Project < ApplicationRecord
   end
 
   def seed_eligible_issues
-    Issues::BulkEnqueueEligible.call(project: self)
+    return unless Issues::AutoPickProjectGate.call(self)
+
+    Issues::BulkEnqueueEligible.call(project: self, skip_project_gate: true)
   rescue => e
     Rails.logger.error(message: "auto_pick.bulk_seed_failed", project_id: id, error: e.message)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -232,7 +232,7 @@ class Project < ApplicationRecord
   after_create_commit :enqueue_knowledge_collection
   after_update_commit :toggle_github_polling, if: :saved_change_to_active?
   after_update_commit :clear_scheduler_pause_on_token_change, if: :saved_change_to_github_token_id?
-  after_update_commit :trigger_auto_pick, if: :auto_pick_just_enabled?
+  after_update_commit :seed_eligible_issues, if: :auto_pick_just_enabled?
   after_destroy_commit :stop_github_polling
   after_destroy_commit :cleanup_qdrant_collection
 
@@ -876,10 +876,10 @@ class Project < ApplicationRecord
     saved_change_to_auto_pick_enabled? && auto_pick_enabled?
   end
 
-  def trigger_auto_pick
-    ProcessRunQueueJob.perform_later
+  def seed_eligible_issues
+    Issues::BulkEnqueueEligible.call(project: self)
   rescue => e
-    Rails.logger.error(message: "auto_pick.trigger_failed", project_id: id, error: e.message)
+    Rails.logger.error(message: "auto_pick.bulk_seed_failed", project_id: id, error: e.message)
   end
 
   def enqueue_knowledge_collection

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -117,47 +117,7 @@ module Issues
       # Avoid expensive PR-attention query when early guards will noop.
       return context unless @project.auto_pick_enabled? && !@project.quality_paused?
 
-      context.with_metadata(
-        Automation::Strategies::AutoPick::PR_ATTENTION_COUNT_KEY => prs_needing_attention_count,
-        Automation::Strategies::AutoPick::PR_ATTENTION_LIMIT_KEY => max_auto_pick_open_prs
-      )
-    end
-
-    # Returns the count of open PRs that still need Paid's attention.
-    # A PR "needs attention" if it is failed, or in_progress but not
-    # yet handed off (missing the automation/ready labels, or still in
-    # draft/restarted phase).
-    #
-    # Escalated PRs are excluded because they have already been surfaced
-    # to the owner for attention — keeping them in the count would let
-    # operationally stalled PRs (e.g. provider exhaustion, repeated
-    # timeouts) block auto-pick indefinitely even after escalation.
-    #
-    # Uses a single COUNT query. The handed_off subquery only matches
-    # in_progress rows, so failed PRs are never excluded by it.
-    def prs_needing_attention_count
-      base = Issue.where(
-        project: @project,
-        is_pull_request: true,
-        github_state: "open",
-        paid_state: %w[in_progress failed]
-      )
-
-      handed_off = base
-        .where(paid_state: "in_progress")
-        .where("labels @> ?::jsonb", [ @project.automation_label_name, PAID_READY_LABEL ].to_json)
-        .where.not(pr_review_phase: %w[draft restarted])
-
-      escalated = base.where(pr_review_phase: "escalated")
-
-      base.where.not(id: handed_off).where.not(id: escalated).count
-    end
-
-    def max_auto_pick_open_prs
-      owner = @project.effective_owner
-      return 1 unless owner
-
-      owner.settings.max_auto_pick_open_prs
+      context.with_metadata(Issues::AutoPickProjectGate.new(@project).context_metadata)
     end
 
     def create_agent_run(issue, goal: "create_pr")

--- a/app/services/issues/auto_pick_project_gate.rb
+++ b/app/services/issues/auto_pick_project_gate.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Issues
+  class AutoPickProjectGate
+    def self.call(project)
+      new(project).call
+    end
+
+    def initialize(project)
+      @project = project
+    end
+
+    def call
+      return false unless project.auto_pick_enabled?
+      return false if project.quality_paused?
+      return false if project.scheduler_paused?
+      return false if project.account&.scheduler_paused?
+      return false unless owner
+      return false if deferred_by_pr_attention_limit?
+
+      true
+    end
+
+    def context_metadata
+      {
+        Automation::Strategies::AutoPick::PR_ATTENTION_COUNT_KEY => prs_needing_attention_count,
+        Automation::Strategies::AutoPick::PR_ATTENTION_LIMIT_KEY => max_auto_pick_open_prs
+      }
+    end
+
+    private
+
+    attr_reader :project
+
+    def owner
+      @owner ||= project.effective_owner
+    end
+
+    def deferred_by_pr_attention_limit?
+      limit = max_auto_pick_open_prs
+      return false if limit <= 0
+
+      prs_needing_attention_count >= limit
+    end
+
+    def prs_needing_attention_count
+      base = Issue.where(
+        project: project,
+        is_pull_request: true,
+        github_state: "open",
+        paid_state: %w[in_progress failed]
+      )
+
+      handed_off = base
+        .where(paid_state: "in_progress")
+        .where("labels @> ?::jsonb", [ project.automation_label_name, Issues::AutoPick::PAID_READY_LABEL ].to_json)
+        .where.not(pr_review_phase: %w[draft restarted])
+
+      escalated = base.where(pr_review_phase: "escalated")
+
+      base.where.not(id: handed_off).where.not(id: escalated).count
+    end
+
+    def max_auto_pick_open_prs
+      owner&.settings&.max_auto_pick_open_prs || 1
+    end
+  end
+end

--- a/app/services/issues/bulk_enqueue_eligible.rb
+++ b/app/services/issues/bulk_enqueue_eligible.rb
@@ -6,19 +6,20 @@ module Issues
       new(...).call
     end
 
-    def initialize(project:, limit: nil)
+    def initialize(project:, limit: nil, skip_project_gate: false)
       @project = project
       @limit = limit
+      @skip_project_gate = skip_project_gate
     end
 
     def call
-      return [] unless project.auto_pick_enabled?
+      return [] unless skip_project_gate || Issues::AutoPickProjectGate.call(project)
 
       counts = { created: 0, existing: 0, skipped: 0 }
       runs = []
 
       each_eligible_issue do |issue|
-        run = EnqueueEligible.call(issue, project: project)
+        run = EnqueueEligible.call(issue, project: project, skip_project_gate: true)
 
         if run.nil?
           counts[:skipped] += 1
@@ -46,6 +47,7 @@ module Issues
 
     attr_reader :project
     attr_reader :limit
+    attr_reader :skip_project_gate
 
     def each_eligible_issue(&)
       return ordered_eligible_scope.each(&) if limit.present?

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -6,12 +6,18 @@ module Issues
       new(...).call
     end
 
-    def initialize(issue, project:)
+    def initialize(issue, project:, skip_project_gate: false)
       @issue = issue
       @project = project
+      @skip_project_gate = skip_project_gate
     end
 
     def call
+      unless skip_project_gate || Issues::AutoPickProjectGate.call(project)
+        log_project_deferred
+        return nil
+      end
+
       unless eligible?
         log_ineligible
         return nil
@@ -56,6 +62,7 @@ module Issues
     private
 
     attr_reader :issue, :project
+    attr_reader :skip_project_gate
 
     def eligible?
       Automation::Strategies::AutoPick::DefaultCandidateSource
@@ -87,6 +94,10 @@ module Issues
 
     def log_ineligible
       Rails.logger.info(log_context("enqueue_eligible.ineligible"))
+    end
+
+    def log_project_deferred
+      Rails.logger.info(log_context("enqueue_eligible.project_deferred"))
     end
 
     def log_no_provider

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -28,6 +28,7 @@ module Activities
 
       client = project.github_token.client
       incremental = project.last_issue_sync_at.present?
+      eager_queue_enabled = incremental && Issues::AutoPickProjectGate.call(project)
       sync_started_at = Time.current
 
       github_issues, truncated = fetch_all_issues(client, project.full_name, since: project.last_issue_sync_at)
@@ -40,7 +41,7 @@ module Activities
       enhance_issue_rechecks = []
 
       Project.suppress_broadcasts do
-        synced_issues = github_issues.map { |gi| sync_issue(project, gi, incremental: incremental) }
+        synced_issues = github_issues.map { |gi| sync_issue(project, gi, eager_queue_enabled: eager_queue_enabled) }
         sync_changed ||= synced_issues.any? { |issue_data| issue_data[:changed] }
         relationship_changes = parse_issue_relationships(project, synced_issues)
         sync_changed ||= relationship_changes
@@ -255,7 +256,7 @@ module Activities
       [ issues, truncated ]
     end
 
-    def sync_issue(project, github_issue, incremental: true)
+    def sync_issue(project, github_issue, eager_queue_enabled: false)
       creator_login = github_issue.user&.login || "unknown"
       trusted = project.trusted_github_user?(creator_login)
       existing_issue = project.issues.find_by(github_issue_id: github_issue.id)
@@ -275,7 +276,7 @@ module Activities
         github_issue: github_issue,
         body: trusted ? github_issue.body : nil
       )
-      enqueue_eligible_issue(project, issue) if incremental
+      enqueue_eligible_issue(project, issue) if eager_queue_enabled
 
       { id: issue.id, github_number: issue.github_number, labels: issue.labels,
         github_state: issue.github_state, trusted: trusted, removed_labels: previous_labels - issue.labels,
@@ -287,7 +288,7 @@ module Activities
       return unless issue.github_state == "open"
       return if issue.is_pull_request?
 
-      Issues::EnqueueEligible.call(issue, project: project)
+      Issues::EnqueueEligible.call(issue, project: project, skip_project_gate: true)
     end
 
     def detect_enhance_issue_rechecks(project, synced_issues)

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -299,6 +299,13 @@ module Activities
       else
         Issues::BulkEnqueueEligible.call(project: project)
       end
+    rescue => e
+      logger.error(
+        message: "github_sync.seed_eligible_failed",
+        project_id: project.id,
+        incremental: incremental,
+        error: e.message
+      )
     end
 
     def detect_enhance_issue_rechecks(project, synced_issues)

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -61,6 +61,8 @@ module Activities
           stale_issue_count = stale_issue_result[:closed_count]
           sync_changed ||= stale_issue_result[:changed]
         end
+
+        Issues::BulkEnqueueEligible.call(project: project) unless incremental
       end
 
       if sync_changed
@@ -273,10 +275,19 @@ module Activities
         github_issue: github_issue,
         body: trusted ? github_issue.body : nil
       )
+      enqueue_eligible_issue(project, issue)
 
       { id: issue.id, github_number: issue.github_number, labels: issue.labels,
         github_state: issue.github_state, trusted: trusted, removed_labels: previous_labels - issue.labels,
         changed: issue.previous_changes.present? }
+    end
+
+    def enqueue_eligible_issue(project, issue)
+      return unless project.auto_pick_enabled?
+      return unless issue.github_state == "open"
+      return if issue.is_pull_request?
+
+      Issues::EnqueueEligible.call(issue, project: project)
     end
 
     def detect_enhance_issue_rechecks(project, synced_issues)

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -63,12 +63,8 @@ module Activities
           stale_issue_count = stale_issue_result[:closed_count]
           sync_changed ||= stale_issue_result[:changed]
         end
+        seed_eligible_issues(project, eligible_issues, incremental: incremental)
       end
-
-      # Seed queued runs outside suppress_broadcasts so AgentRun after_commit
-      # broadcasts are not suppressed. Deferring avoids per-run UI broadcast
-      # fan-out during the sync block.
-      seed_eligible_issues(project, eligible_issues, incremental: incremental)
 
       if sync_changed
         project.broadcast_project_show_refresh

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -39,9 +39,10 @@ module Activities
       stale_pr_count = nil
       stale_issue_count = nil
       enhance_issue_rechecks = []
+      eligible_issues = []
 
       Project.suppress_broadcasts do
-        synced_issues = github_issues.map { |gi| sync_issue(project, gi, eager_queue_enabled: eager_queue_enabled) }
+        synced_issues = github_issues.map { |gi| sync_issue(project, gi, eager_queue_enabled: eager_queue_enabled, eligible_issues: eligible_issues) }
         sync_changed ||= synced_issues.any? { |issue_data| issue_data[:changed] }
         relationship_changes = parse_issue_relationships(project, synced_issues)
         sync_changed ||= relationship_changes
@@ -62,9 +63,12 @@ module Activities
           stale_issue_count = stale_issue_result[:closed_count]
           sync_changed ||= stale_issue_result[:changed]
         end
-
-        Issues::BulkEnqueueEligible.call(project: project) unless incremental
       end
+
+      # Seed queued runs outside suppress_broadcasts so AgentRun after_commit
+      # broadcasts are not suppressed. Deferring avoids per-run UI broadcast
+      # fan-out during the sync block.
+      seed_eligible_issues(project, eligible_issues, incremental: incremental)
 
       if sync_changed
         project.broadcast_project_show_refresh
@@ -256,7 +260,7 @@ module Activities
       [ issues, truncated ]
     end
 
-    def sync_issue(project, github_issue, eager_queue_enabled: false)
+    def sync_issue(project, github_issue, eager_queue_enabled: false, eligible_issues: nil)
       creator_login = github_issue.user&.login || "unknown"
       trusted = project.trusted_github_user?(creator_login)
       existing_issue = project.issues.find_by(github_issue_id: github_issue.id)
@@ -276,19 +280,29 @@ module Activities
         github_issue: github_issue,
         body: trusted ? github_issue.body : nil
       )
-      enqueue_eligible_issue(project, issue) if eager_queue_enabled
+      collect_eligible_issue(project, issue, eligible_issues) if eager_queue_enabled
 
       { id: issue.id, github_number: issue.github_number, labels: issue.labels,
         github_state: issue.github_state, trusted: trusted, removed_labels: previous_labels - issue.labels,
         changed: issue.previous_changes.present? }
     end
 
-    def enqueue_eligible_issue(project, issue)
+    def collect_eligible_issue(project, issue, eligible_issues)
       return unless project.auto_pick_enabled?
       return unless issue.github_state == "open"
       return if issue.is_pull_request?
 
-      Issues::EnqueueEligible.call(issue, project: project, skip_project_gate: true)
+      eligible_issues << issue
+    end
+
+    def seed_eligible_issues(project, eligible_issues, incremental:)
+      if incremental
+        eligible_issues.each do |issue|
+          Issues::EnqueueEligible.call(issue, project: project, skip_project_gate: true)
+        end
+      else
+        Issues::BulkEnqueueEligible.call(project: project)
+      end
     end
 
     def detect_enhance_issue_rechecks(project, synced_issues)

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -40,7 +40,7 @@ module Activities
       enhance_issue_rechecks = []
 
       Project.suppress_broadcasts do
-        synced_issues = github_issues.map { |gi| sync_issue(project, gi) }
+        synced_issues = github_issues.map { |gi| sync_issue(project, gi, incremental: incremental) }
         sync_changed ||= synced_issues.any? { |issue_data| issue_data[:changed] }
         relationship_changes = parse_issue_relationships(project, synced_issues)
         sync_changed ||= relationship_changes
@@ -255,7 +255,7 @@ module Activities
       [ issues, truncated ]
     end
 
-    def sync_issue(project, github_issue)
+    def sync_issue(project, github_issue, incremental: true)
       creator_login = github_issue.user&.login || "unknown"
       trusted = project.trusted_github_user?(creator_login)
       existing_issue = project.issues.find_by(github_issue_id: github_issue.id)
@@ -275,7 +275,7 @@ module Activities
         github_issue: github_issue,
         body: trusted ? github_issue.body : nil
       )
-      enqueue_eligible_issue(project, issue)
+      enqueue_eligible_issue(project, issue) if incremental
 
       { id: issue.id, github_number: issue.github_number, labels: issue.labels,
         github_state: issue.github_state, trusted: trusted, removed_labels: previous_labels - issue.labels,

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProcessRunQueueJob do
     call_count = 0
 
     allow(Issues::BulkEnqueueEligible).to receive(:call)
-      .with(project: having_attributes(id: project.id), limit: 1) do
+      .with(project: having_attributes(id: project.id), limit: 1, skip_project_gate: true) do
         call_count += 1
         if call_count == 1
           created_run = create(:agent_run, :queued, project: project, issue: issue)
@@ -312,7 +312,7 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
 
         expect(Issues::BulkEnqueueEligible).to have_received(:call)
-          .with(project: having_attributes(id: project.id), limit: 1).at_least(:once)
+          .with(project: having_attributes(id: project.id), limit: 1, skip_project_gate: true).at_least(:once)
         expect(created_run.call.reload.status).to eq("queued")
       end
 
@@ -320,7 +320,7 @@ RSpec.describe ProcessRunQueueJob do
         project = create(:project, auto_pick_enabled: true)
 
         allow(Issues::BulkEnqueueEligible).to receive(:call)
-          .with(project: having_attributes(id: project.id), limit: 1)
+          .with(project: having_attributes(id: project.id), limit: 1, skip_project_gate: true)
           .and_return([])
 
         described_class.new.perform
@@ -392,7 +392,7 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
 
         expect(Issues::BulkEnqueueEligible).to have_received(:call)
-          .with(project: having_attributes(id: project.id), limit: 1).at_least(:once)
+          .with(project: having_attributes(id: project.id), limit: 1, skip_project_gate: true).at_least(:once)
         expect(created_run.call.reload.status).to eq("queued")
       end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -379,41 +379,42 @@ RSpec.describe Project do
     before do
       allow(Paid).to receive_messages(temporal_client: temporal_client, poll_task_queue: "paid-poll-tasks")
       allow(temporal_client).to receive(:start_workflow)
+      allow(Issues::BulkEnqueueEligible).to receive(:call)
     end
 
-    it "enqueues ProcessRunQueueJob when auto_pick is enabled" do
+    it "bulk seeds eligible issues when auto_pick is enabled" do
       project = create(:project, auto_pick_enabled: false)
 
-      expect {
-        project.update!(auto_pick_enabled: true)
-      }.to have_enqueued_job(ProcessRunQueueJob)
+      project.update!(auto_pick_enabled: true)
+
+      expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
     end
 
-    it "does not enqueue ProcessRunQueueJob when auto_pick is disabled" do
+    it "does not bulk seed when auto_pick is disabled" do
       project = create(:project, auto_pick_enabled: true)
 
-      expect {
-        project.update!(auto_pick_enabled: false)
-      }.not_to have_enqueued_job(ProcessRunQueueJob)
+      project.update!(auto_pick_enabled: false)
+
+      expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
     end
 
-    it "does not enqueue ProcessRunQueueJob when other attributes change" do
+    it "does not bulk seed when other attributes change" do
       project = create(:project, auto_pick_enabled: true)
 
-      expect {
-        project.update!(name: "new-name")
-      }.not_to have_enqueued_job(ProcessRunQueueJob)
+      project.update!(name: "new-name")
+
+      expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
     end
 
-    it "logs error when ProcessRunQueueJob fails to enqueue" do
+    it "logs error when bulk seeding fails" do
       project = create(:project, auto_pick_enabled: false)
-      allow(ProcessRunQueueJob).to receive(:perform_later).and_raise(StandardError, "queue unavailable")
+      allow(Issues::BulkEnqueueEligible).to receive(:call).and_raise(StandardError, "queue unavailable")
       allow(Rails.logger).to receive(:error)
 
       project.update!(auto_pick_enabled: true)
 
       expect(Rails.logger).to have_received(:error).with(
-        hash_including(message: "auto_pick.trigger_failed", project_id: project.id)
+        hash_including(message: "auto_pick.bulk_seed_failed", project_id: project.id)
       )
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -387,7 +387,22 @@ RSpec.describe Project do
 
       project.update!(auto_pick_enabled: true)
 
-      expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
+      expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project, skip_project_gate: true)
+    end
+
+    it "does not bulk seed when the project is already at the PR-attention cap" do
+      project = create(:project, auto_pick_enabled: false)
+      create(:issue,
+        project: project,
+        is_pull_request: true,
+        github_state: "open",
+        paid_state: "in_progress",
+        labels: [])
+      project.created_by.settings.update!(max_auto_pick_open_prs: 1)
+
+      project.update!(auto_pick_enabled: true)
+
+      expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
     end
 
     it "does not bulk seed when auto_pick is disabled" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1589,18 +1589,22 @@ RSpec.describe "Projects" do
         expect(response.body).not_to include("Auto-Pick Issues")
       end
 
-      it "enqueues ProcessRunQueueJob when enabling auto_pick" do
+      it "bulk seeds eligible issues when enabling auto_pick" do
         project = create(:project, account: account, github_token: github_token, auto_pick_enabled: false)
-        expect {
-          post toggle_auto_pick_project_path(project)
-        }.to have_enqueued_job(ProcessRunQueueJob)
+        allow(Issues::BulkEnqueueEligible).to receive(:call)
+
+        post toggle_auto_pick_project_path(project)
+
+        expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
       end
 
-      it "does not enqueue ProcessRunQueueJob when disabling auto_pick" do
+      it "does not bulk seed when disabling auto_pick" do
         project = create(:project, account: account, github_token: github_token, auto_pick_enabled: true)
-        expect {
-          post toggle_auto_pick_project_path(project)
-        }.not_to have_enqueued_job(ProcessRunQueueJob)
+        allow(Issues::BulkEnqueueEligible).to receive(:call)
+
+        post toggle_auto_pick_project_path(project)
+
+        expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
       end
     end
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1595,7 +1595,7 @@ RSpec.describe "Projects" do
 
         post toggle_auto_pick_project_path(project)
 
-        expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
+        expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project, skip_project_gate: true)
       end
 
       it "does not bulk seed when disabling auto_pick" do

--- a/spec/services/issues/bulk_enqueue_eligible_spec.rb
+++ b/spec/services/issues/bulk_enqueue_eligible_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
   let(:auto_pick_enabled) { true }
 
   before do
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
     allow(Automation::Strategies::AutoPick::DefaultCandidateSource).to receive(:eligible_scope)
       .with(project)
       .and_return(scope)
@@ -22,14 +23,20 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
       .and_return(ordered_scope)
   end
 
+  def stub_enqueue(issue, result)
+    allow(Issues::EnqueueEligible).to receive(:call)
+      .with(issue, project: project, skip_project_gate: true)
+      .and_return(result)
+  end
+
   it "queues all eligible issues for a project" do
     first_issue = instance_double(issue_class)
     second_issue = instance_double(issue_class)
     first_run = instance_double(run_class, issue: first_issue, previously_new_record?: true)
     second_run = instance_double(run_class, issue: second_issue, previously_new_record?: true)
     allow(scope).to receive(:find_each).and_yield(first_issue).and_yield(second_issue)
-    allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(first_run)
-    allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(second_run)
+    stub_enqueue(first_issue, first_run)
+    stub_enqueue(second_issue, second_run)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -38,7 +45,7 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
   end
 
   it "returns early when auto_pick is disabled" do
-    allow(project).to receive(:auto_pick_enabled?).and_return(false)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
 
     expect(Issues::EnqueueEligible).not_to receive(:call)
 
@@ -50,8 +57,8 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
     ineligible_issue = instance_double(issue_class)
     eligible_run = instance_double(run_class, issue: eligible_issue, previously_new_record?: true)
     allow(scope).to receive(:find_each).and_yield(eligible_issue).and_yield(ineligible_issue)
-    allow(Issues::EnqueueEligible).to receive(:call).with(eligible_issue, project: project).and_return(eligible_run)
-    allow(Issues::EnqueueEligible).to receive(:call).with(ineligible_issue, project: project).and_return(nil)
+    stub_enqueue(eligible_issue, eligible_run)
+    stub_enqueue(ineligible_issue, nil)
     allow(Rails.logger).to receive(:info)
 
     result = service.call
@@ -66,9 +73,9 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
     created_run = instance_double(run_class, issue: first_issue, previously_new_record?: true)
     existing_run = instance_double(run_class, issue: second_issue, previously_new_record?: false)
     allow(scope).to receive(:find_each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
-    allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(created_run)
-    allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(existing_run)
-    allow(Issues::EnqueueEligible).to receive(:call).with(third_issue, project: project).and_return(nil)
+    stub_enqueue(first_issue, created_run)
+    stub_enqueue(second_issue, existing_run)
+    stub_enqueue(third_issue, nil)
     allow(Rails.logger).to receive(:info)
 
     service.call
@@ -103,8 +110,8 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
 
     allow(scope).to receive(:find_each)
     allow(ordered_scope).to receive(:each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
-    allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(existing_run)
-    allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(created_run)
+    stub_enqueue(first_issue, existing_run)
+    stub_enqueue(second_issue, created_run)
     allow(Rails.logger).to receive(:info)
 
     result = limited_service.call
@@ -113,7 +120,8 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
     expect(Automation::Strategies::AutoPick::DefaultCandidateSource).to have_received(:ordered_scope).with(project)
     expect(ordered_scope).to have_received(:each)
     expect(scope).not_to have_received(:find_each)
-    expect(Issues::EnqueueEligible).not_to have_received(:call).with(third_issue, project: project)
+    expect(Issues::EnqueueEligible).not_to have_received(:call)
+      .with(third_issue, project: project, skip_project_gate: true)
   end
 
   it "keeps scanning ordered issues until it creates the requested number of runs" do
@@ -125,14 +133,15 @@ RSpec.describe Issues::BulkEnqueueEligible, :no_db do
     created_run = instance_double(run_class, issue: third_issue, previously_new_record?: true)
 
     allow(ordered_scope).to receive(:each).and_yield(first_issue).and_yield(second_issue).and_yield(third_issue)
-    allow(Issues::EnqueueEligible).to receive(:call).with(first_issue, project: project).and_return(existing_run)
-    allow(Issues::EnqueueEligible).to receive(:call).with(second_issue, project: project).and_return(nil)
-    allow(Issues::EnqueueEligible).to receive(:call).with(third_issue, project: project).and_return(created_run)
+    stub_enqueue(first_issue, existing_run)
+    stub_enqueue(second_issue, nil)
+    stub_enqueue(third_issue, created_run)
     allow(Rails.logger).to receive(:info)
 
     result = limited_service.call
 
     expect(result).to eq([ existing_run, created_run ])
-    expect(Issues::EnqueueEligible).to have_received(:call).with(third_issue, project: project)
+    expect(Issues::EnqueueEligible).to have_received(:call)
+      .with(third_issue, project: project, skip_project_gate: true)
   end
 end

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   let(:service) { described_class.new(issue, project: project) }
 
   before do
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
     allow(Automation::Strategies::AutoPick::DefaultCandidateSource).to receive(:eligible_scope)
       .with(project)
       .and_return(eligible_scope)
@@ -141,6 +142,19 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     expect(Rails.logger).to have_received(:warn).with(
       hash_including(message: "enqueue_eligible.no_provider", issue_id: issue.id, project_id: project.id)
     )
+  end
+
+  it "returns nil when the project-level auto-pick gate defers seeding" do
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
+    allow(Rails.logger).to receive(:info)
+
+    result = service.call
+
+    expect(result).to be_nil
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(message: "enqueue_eligible.project_deferred", issue_id: issue.id, project_id: project.id)
+    )
+    expect(eligible_scope).not_to have_received(:where)
   end
 
   it "scopes queued-run lookup by analyze_issue goal when auto_enhance is enabled" do

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -90,16 +90,41 @@ RSpec.describe Activities::FetchIssuesActivity do
       .once
   end
 
-  describe "#enqueue_eligible_issue", :no_db do
+  describe "#collect_eligible_issue", :no_db do
     let(:project_class) { Struct.new(:auto_pick_enabled?) }
     let(:issue_class) { Struct.new(:github_state, :is_pull_request?) }
     let(:project) { project_class.new(true) }
     let(:issue) { issue_class.new("open", false) }
 
-    it "enqueues eligible synced issues immediately" do
+    it "collects eligible synced issues into the list" do
+      eligible_issues = []
+
+      activity.send(:collect_eligible_issue, project, issue, eligible_issues)
+
+      expect(eligible_issues).to eq([ issue ])
+    end
+
+    it "skips ineligible synced issues" do
+      eligible_issues = []
+
+      activity.send(:collect_eligible_issue, project_class.new(false), issue, eligible_issues)
+      activity.send(:collect_eligible_issue, project, issue_class.new("closed", false), eligible_issues)
+      activity.send(:collect_eligible_issue, project, issue_class.new("open", true), eligible_issues)
+
+      expect(eligible_issues).to be_empty
+    end
+  end
+
+  describe "#seed_eligible_issues", :no_db do
+    let(:project_class) { Struct.new(:auto_pick_enabled?) }
+    let(:issue_class) { Struct.new(:github_state, :is_pull_request?) }
+    let(:project) { project_class.new(true) }
+    let(:issue) { issue_class.new("open", false) }
+
+    it "enqueues each collected issue during incremental sync" do
       allow(Issues::EnqueueEligible).to receive(:call)
 
-      activity.send(:enqueue_eligible_issue, project, issue)
+      activity.send(:seed_eligible_issues, project, [ issue ], incremental: true)
 
       expect(Issues::EnqueueEligible).to have_received(:call).with(
         issue,
@@ -108,14 +133,12 @@ RSpec.describe Activities::FetchIssuesActivity do
       )
     end
 
-    it "skips ineligible synced issues" do
-      allow(Issues::EnqueueEligible).to receive(:call)
+    it "bulk seeds during initial sync" do
+      allow(Issues::BulkEnqueueEligible).to receive(:call).and_return([])
 
-      activity.send(:enqueue_eligible_issue, project_class.new(false), issue)
-      activity.send(:enqueue_eligible_issue, project, issue_class.new("closed", false))
-      activity.send(:enqueue_eligible_issue, project, issue_class.new("open", true))
+      activity.send(:seed_eligible_issues, project, [], incremental: false)
 
-      expect(Issues::EnqueueEligible).not_to have_received(:call)
+      expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
     end
   end
 

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -90,6 +90,31 @@ RSpec.describe Activities::FetchIssuesActivity do
       .once
   end
 
+  describe "#enqueue_eligible_issue", :no_db do
+    let(:project_class) { Struct.new(:auto_pick_enabled?) }
+    let(:issue_class) { Struct.new(:github_state, :is_pull_request?) }
+    let(:project) { project_class.new(true) }
+    let(:issue) { issue_class.new("open", false) }
+
+    it "enqueues eligible synced issues immediately" do
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      activity.send(:enqueue_eligible_issue, project, issue)
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(issue, project: project)
+    end
+
+    it "skips ineligible synced issues" do
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      activity.send(:enqueue_eligible_issue, project_class.new(false), issue)
+      activity.send(:enqueue_eligible_issue, project, issue_class.new("closed", false))
+      activity.send(:enqueue_eligible_issue, project, issue_class.new("open", true))
+
+      expect(Issues::EnqueueEligible).not_to have_received(:call)
+    end
+  end
+
   describe "#execute" do
     context "when issues are found" do
       let(:build_issue) do
@@ -214,6 +239,36 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
     end
 
+    context "when auto-pick is enabled" do
+      let(:project) { create(:project, auto_pick_enabled: true, label_mappings: { "build" => "paid-build" }) }
+      let(:eligible_issue) { github_issue(7) }
+      let(:pull_request_issue) { github_pr_issue(8) }
+      let(:closed_issue) do
+        github_issue(9).tap { |issue| issue.state = "closed" }
+      end
+
+      before do
+        allow(Issues::EnqueueEligible).to receive(:call)
+      end
+
+      it "queues an eligible synced issue immediately" do
+        stub_issues_by_label(nil => [ eligible_issue ])
+
+        activity.execute(project_id: project.id)
+
+        synced_issue = project.issues.find_by!(github_issue_id: eligible_issue.id)
+        expect(Issues::EnqueueEligible).to have_received(:call).with(synced_issue, project: project)
+      end
+
+      it "does not queue synced pull requests or closed issues" do
+        stub_issues_by_label(nil => [ pull_request_issue, closed_issue ])
+
+        activity.execute(project_id: project.id)
+
+        expect(Issues::EnqueueEligible).not_to have_received(:call)
+      end
+    end
+
     context "when no issues match" do
       before do
         allow(github_client).to receive(:issues).and_return([])
@@ -224,6 +279,30 @@ RSpec.describe Activities::FetchIssuesActivity do
 
         expect(result[:issues]).to eq([])
         expect(project.issues.count).to eq(0)
+      end
+    end
+
+    context "when running the first sync" do
+      let(:project) { create(:project, auto_pick_enabled: auto_pick_enabled, last_issue_sync_at: nil) }
+      let(:auto_pick_enabled) { true }
+
+      before do
+        allow(github_client).to receive(:issues).and_return([])
+        allow(Issues::BulkEnqueueEligible).to receive(:call).and_return([])
+      end
+
+      it "bulk seeds eligible issues after the initial sync" do
+        activity.execute(project_id: project.id)
+
+        expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
+      end
+
+      it "still invokes the bulk seeder when auto-pick is disabled so the service can no-op internally" do
+        allow(project).to receive(:auto_pick_enabled?).and_return(false)
+
+        activity.execute(project_id: project.id)
+
+        expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
       end
     end
 

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -116,9 +116,9 @@ RSpec.describe Activities::FetchIssuesActivity do
   end
 
   describe "#seed_eligible_issues", :no_db do
-    let(:project_class) { Struct.new(:auto_pick_enabled?) }
+    let(:project_class) { Struct.new(:id, :auto_pick_enabled?) }
     let(:issue_class) { Struct.new(:github_state, :is_pull_request?) }
-    let(:project) { project_class.new(true) }
+    let(:project) { project_class.new(7, true) }
     let(:issue) { issue_class.new("open", false) }
 
     it "enqueues each collected issue during incremental sync" do
@@ -139,6 +139,44 @@ RSpec.describe Activities::FetchIssuesActivity do
       activity.send(:seed_eligible_issues, project, [], incremental: false)
 
       expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
+    end
+
+    it "logs and swallows incremental enqueue failures" do
+      allow(Issues::EnqueueEligible).to receive(:call).and_raise(StandardError, "queue unavailable")
+      allow(activity).to receive(:logger).and_return(Rails.logger)
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        activity.send(:seed_eligible_issues, project, [ issue ], incremental: true)
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(
+        hash_including(
+          message: "github_sync.seed_eligible_failed",
+          project_id: project.id,
+          incremental: true,
+          error: "queue unavailable"
+        )
+      )
+    end
+
+    it "logs and swallows initial bulk seed failures" do
+      allow(Issues::BulkEnqueueEligible).to receive(:call).and_raise(StandardError, "queue unavailable")
+      allow(activity).to receive(:logger).and_return(Rails.logger)
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        activity.send(:seed_eligible_issues, project, [], incremental: false)
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(
+        hash_including(
+          message: "github_sync.seed_eligible_failed",
+          project_id: project.id,
+          incremental: false,
+          error: "queue unavailable"
+        )
+      )
     end
   end
 

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -239,8 +239,8 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
     end
 
-    context "when auto-pick is enabled" do
-      let(:project) { create(:project, auto_pick_enabled: true, label_mappings: { "build" => "paid-build" }) }
+    context "when auto-pick is enabled (incremental sync)" do
+      let(:project) { create(:project, auto_pick_enabled: true, label_mappings: { "build" => "paid-build" }, last_issue_sync_at: 10.minutes.ago) }
       let(:eligible_issue) { github_issue(7) }
       let(:pull_request_issue) { github_pr_issue(8) }
       let(:closed_issue) do
@@ -249,6 +249,7 @@ RSpec.describe Activities::FetchIssuesActivity do
 
       before do
         allow(Issues::EnqueueEligible).to receive(:call)
+        project.update_column(:last_issue_reconciliation_at, Time.current)
       end
 
       it "queues an eligible synced issue immediately" do
@@ -266,6 +267,25 @@ RSpec.describe Activities::FetchIssuesActivity do
         activity.execute(project_id: project.id)
 
         expect(Issues::EnqueueEligible).not_to have_received(:call)
+      end
+    end
+
+    context "when auto-pick is enabled (initial sync)" do
+      let(:project) { create(:project, auto_pick_enabled: true, label_mappings: { "build" => "paid-build" }, last_issue_sync_at: nil) }
+      let(:eligible_issue) { github_issue(7) }
+
+      before do
+        allow(Issues::EnqueueEligible).to receive(:call)
+        allow(Issues::BulkEnqueueEligible).to receive(:call).and_return([])
+      end
+
+      it "skips per-issue enqueue and relies on bulk seeding" do
+        stub_issues_by_label(nil => [ eligible_issue ])
+
+        activity.execute(project_id: project.id)
+
+        expect(Issues::EnqueueEligible).not_to have_received(:call)
+        expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project)
       end
     end
 

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -101,7 +101,11 @@ RSpec.describe Activities::FetchIssuesActivity do
 
       activity.send(:enqueue_eligible_issue, project, issue)
 
-      expect(Issues::EnqueueEligible).to have_received(:call).with(issue, project: project)
+      expect(Issues::EnqueueEligible).to have_received(:call).with(
+        issue,
+        project: project,
+        skip_project_gate: true
+      )
     end
 
     it "skips ineligible synced issues" do
@@ -258,11 +262,30 @@ RSpec.describe Activities::FetchIssuesActivity do
         activity.execute(project_id: project.id)
 
         synced_issue = project.issues.find_by!(github_issue_id: eligible_issue.id)
-        expect(Issues::EnqueueEligible).to have_received(:call).with(synced_issue, project: project)
+        expect(Issues::EnqueueEligible).to have_received(:call).with(
+          synced_issue,
+          project: project,
+          skip_project_gate: true
+        )
       end
 
       it "does not queue synced pull requests or closed issues" do
         stub_issues_by_label(nil => [ pull_request_issue, closed_issue ])
+
+        activity.execute(project_id: project.id)
+
+        expect(Issues::EnqueueEligible).not_to have_received(:call)
+      end
+
+      it "does not eagerly enqueue when the project is already at the PR-attention cap" do
+        create(:issue,
+          project: project,
+          is_pull_request: true,
+          github_state: "open",
+          paid_state: "in_progress",
+          labels: [])
+        project.created_by.settings.update!(max_auto_pick_open_prs: 1)
+        stub_issues_by_label(nil => [ eligible_issue ])
 
         activity.execute(project_id: project.id)
 

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       it "still invokes the bulk seeder when auto-pick is disabled so the service can no-op internally" do
-        allow(project).to receive(:auto_pick_enabled?).and_return(false)
+        project.update!(auto_pick_enabled: false)
 
         activity.execute(project_id: project.id)
 


### PR DESCRIPTION
## Summary

Eliminates the auto-pick polling delay by seeding queued runs eagerly during issue sync, initial project import, and `auto_pick_enabled` toggles. Implements Issue 2 of RDR-032 (Eager Queue Seeding), so eligible issues become queued runs the moment they enter the system rather than waiting for the next `ProcessRunQueueJob` tick.

## Changes

- **Sync pipeline (`FetchIssuesActivity`)**: After each `Issues::UpsertFromGithub` for an open, non-PR issue, calls `Issues::EnqueueEligible` when the project has `auto_pick_enabled?`. Runs inside the existing `Project.suppress_broadcasts` block so no extra UI churn during sync.
- **Initial import hook**: The non-incremental `FetchIssuesActivity` pass now invokes `Issues::BulkEnqueueEligible` to backfill the queue. This branch has no standalone `Projects::Import` service, so the initial-fetch path is used as the import seeding hook.
- **Project model**: Replaces the `trigger_auto_pick` callback (which queued `ProcessRunQueueJob.perform_later`) with `seed_eligible_issues`, which calls `Issues::BulkEnqueueEligible.call(project: self)`. The `auto_pick_just_enabled?` guard is preserved; failures are logged as `auto_pick.bulk_seed_failed` and swallowed, matching the prior pattern.
- **Tests**: Updated specs assert bulk seeding fires on toggle, eager enqueue runs during sync for eligible issues, and ineligible issues are skipped. Added a db-less helper spec for the new fetch hook.

## Design Decisions

- **Reusing the initial fetch as the import hook**: Rather than introducing a `Projects::Import` service (which doesn't exist on this branch), the initial-pass branch of `FetchIssuesActivity` carries the `BulkEnqueueEligible` call. This keeps the seeding contract intact without speculative scaffolding.
- **Swallow-and-log on bulk seed failure**: Mirrors the previous `trigger_auto_pick` semantics — seeding is a best-effort optimization, and a failure should not block the toggle or sync from completing. `ProcessRunQueueJob` remains as the eventual-consistency backstop until it is removed in the follow-up issue.
- **Suppressed broadcasts during sync**: Eager enqueue runs inside the existing `suppress_broadcasts` scope so a large sync doesn't fan out per-issue Turbo updates.

## Operational Concerns

- No migrations or infrastructure changes.
- The old `ProcessRunQueueJob.seed_auto_pick_queue` path is intentionally still present; its removal is tracked as a separate follow-up issue per RDR-032 scope.
- RSpec could not be exercised in this environment due to missing PostgreSQL; the db-less subset (`fetch_issues_activity_spec`, `enqueue_eligible_spec`, `bulk_enqueue_eligible_spec`) passes (101 examples, 0 failures). Full suite should be run in CI before merge.

---

Closes #2020