### PR TITLE
Fix #2037: Configurable skip labels for auto-pick at tenant, user, and project levels

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -141,6 +141,7 @@ class ProjectsController < ApplicationController
 
     update_params = project_params
     update_params = update_params.merge(allowed_github_usernames: parse_usernames_csv) if params.dig(:project, :allowed_github_usernames_csv)
+    update_params = update_params.merge(auto_pick_skip_labels: parse_auto_pick_skip_labels) if auto_pick_skip_labels_param_submitted?
     update_params = update_params.merge(review_settings: build_review_settings) if params.dig(:project, :review_settings)
     update_params = update_params.merge(screenshot_settings: build_screenshot_settings) if params.dig(:project, :screenshot_settings)
     if screenshot_action_requested?
@@ -337,6 +338,7 @@ class ProjectsController < ApplicationController
       :auto_enhance_enabled,
       :knowledge_evolution_enabled,
       :auto_release_granularity,
+      auto_pick_skip_labels: [],
       allowed_github_usernames: [],
       priority_labels: Project::PRIORITY_TIERS)
   end
@@ -489,6 +491,21 @@ class ProjectsController < ApplicationController
 
   def parse_usernames_csv
     params.dig(:project, :allowed_github_usernames_csv).to_s.split(",").map(&:strip).reject(&:blank?).uniq
+  end
+
+  def auto_pick_skip_labels_param_submitted?
+    raw = params[:project]
+    raw&.key?(:auto_pick_skip_labels) ||
+      raw&.key?(:auto_pick_skip_labels_csv) ||
+      raw&.key?(:auto_pick_skip_labels_override)
+  end
+
+  def parse_auto_pick_skip_labels
+    raw = params.require(:project)
+    return AutoPickSkipLabels.normalize(raw[:auto_pick_skip_labels]) if raw.key?(:auto_pick_skip_labels)
+    return nil unless ActiveModel::Type::Boolean.new.cast(raw[:auto_pick_skip_labels_override])
+
+    AutoPickSkipLabels.parse_csv(raw[:auto_pick_skip_labels_csv])
   end
 
   def load_screenshot_settings_context

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -78,10 +78,12 @@ class TenantConfigurationsController < ApplicationController
   end
 
   def tenant_setting_params
-    attrs = params.require(:tenant_setting).permit(
+    raw_params = params.require(:tenant_setting)
+    attrs = raw_params.permit(
       :max_concurrent_runs, :max_projects, :max_users, :max_tokens_per_run, :max_monthly_cost_cents,
       :self_repo_full_name,
       allowed_provider_keys: [],
+      auto_pick_skip_labels: [],
       provider_preferences: [
         api_key_ids: ProviderSupport.api_service_types.keys,
         model_preferences: ProviderSupport.supported_provider_keys
@@ -100,6 +102,16 @@ class TenantConfigurationsController < ApplicationController
       ],
       features: FeatureFlags::DEFINITIONS.keys
     ).to_h
+
+    if raw_params.key?(:auto_pick_skip_labels)
+      attrs["auto_pick_skip_labels"] = AutoPickSkipLabels.normalize(raw_params[:auto_pick_skip_labels])
+    elsif raw_params.key?(:auto_pick_skip_labels_override) || raw_params.key?(:auto_pick_skip_labels_csv)
+      attrs["auto_pick_skip_labels"] =
+        if ActiveModel::Type::Boolean.new.cast(raw_params[:auto_pick_skip_labels_override])
+          AutoPickSkipLabels.parse_csv(raw_params[:auto_pick_skip_labels_csv])
+        end
+    end
+
     attrs["features"] ||= {}
     FeatureFlags::DEFINITIONS.each_key do |flag_name|
       attrs["features"][flag_name.to_s] = ActiveModel::Type::Boolean.new.cast(attrs["features"][flag_name.to_s])

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -71,8 +71,18 @@ class UserSettingsController < ApplicationController
       :fallback_enabled,
       :fallback_providers,
       :kb_embedding_provider,
-      :kb_chat_provider
+      :kb_chat_provider,
+      auto_pick_skip_labels: []
     )
+
+    if raw_params.key?(:auto_pick_skip_labels)
+      permitted[:auto_pick_skip_labels] = AutoPickSkipLabels.normalize(raw_params[:auto_pick_skip_labels])
+    elsif raw_params.key?(:auto_pick_skip_labels_override) || raw_params.key?(:auto_pick_skip_labels_csv)
+      permitted[:auto_pick_skip_labels] =
+        if ActiveModel::Type::Boolean.new.cast(raw_params[:auto_pick_skip_labels_override])
+          AutoPickSkipLabels.parse_csv(raw_params[:auto_pick_skip_labels_csv])
+        end
+    end
 
     %i[
       fallback_providers

--- a/app/models/concerns/auto_pick_skip_labels.rb
+++ b/app/models/concerns/auto_pick_skip_labels.rb
@@ -1,21 +1,43 @@
 # frozen_string_literal: true
 
 module AutoPickSkipLabels
+  extend ActiveSupport::Concern
+
   DEFAULTS = %w[planning research waiting tracking epic needs-manual-setup].freeze
 
-  module_function
+  included do
+    before_validation :normalize_auto_pick_skip_labels
+  end
 
-  def normalize(value)
+  def auto_pick_skip_labels_configured?
+    !auto_pick_skip_labels.nil?
+  end
+
+  def auto_pick_skip_labels_csv
+    AutoPickSkipLabels.to_csv(auto_pick_skip_labels)
+  end
+
+  def auto_pick_skip_labels_csv=(value)
+    self.auto_pick_skip_labels = AutoPickSkipLabels.parse_csv(value)
+  end
+
+  def self.normalize(value)
     return nil if value.nil?
 
     Array(value).map(&:to_s).map(&:strip).reject(&:blank?).uniq
   end
 
-  def parse_csv(value)
+  def self.parse_csv(value)
     normalize(value.to_s.split(",")) || []
   end
 
-  def to_csv(value)
+  def self.to_csv(value)
     Array(value).join(", ")
+  end
+
+  private
+
+  def normalize_auto_pick_skip_labels
+    self.auto_pick_skip_labels = AutoPickSkipLabels.normalize(auto_pick_skip_labels)
   end
 end

--- a/app/models/concerns/auto_pick_skip_labels.rb
+++ b/app/models/concerns/auto_pick_skip_labels.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AutoPickSkipLabels
+  DEFAULTS = %w[planning research waiting tracking epic needs-manual-setup].freeze
+
+  module_function
+
+  def normalize(value)
+    return nil if value.nil?
+
+    Array(value).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+  end
+
+  def parse_csv(value)
+    normalize(value.to_s.split(",")) || []
+  end
+
+  def to_csv(value)
+    Array(value).join(", ")
+  end
+end

--- a/app/models/concerns/auto_pick_skip_labels.rb
+++ b/app/models/concerns/auto_pick_skip_labels.rb
@@ -24,7 +24,7 @@ module AutoPickSkipLabels
   def self.normalize(value)
     return nil if value.nil?
 
-    Array(value).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+    Array(value).map(&:to_s).map(&:strip).reject(&:blank?).map(&:downcase).uniq
   end
 
   def self.parse_csv(value)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -278,7 +278,7 @@ class Project < ApplicationRecord
   def effective_auto_pick_skip_labels
     return auto_pick_skip_labels unless auto_pick_skip_labels.nil?
 
-    owner_labels = effective_owner&.settings&.auto_pick_skip_labels
+    owner_labels = effective_owner&.user_setting&.auto_pick_skip_labels
     return owner_labels unless owner_labels.nil?
 
     tenant_labels = account&.tenant_setting&.auto_pick_skip_labels

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -180,6 +180,7 @@ class Project < ApplicationRecord
   encrypts :webhook_secret
 
   before_validation :normalize_priority_labels
+  before_validation :normalize_auto_pick_skip_labels
   after_update_commit :invalidate_relationship_parsing_on_trust_change
 
   validates :name, presence: true
@@ -272,6 +273,30 @@ class Project < ApplicationRecord
     overrides = (priority_labels || {}).slice(*PRIORITY_TIERS)
       .reject { |_, v| v.nil? || (v.is_a?(String) && v.strip.empty?) }
     DEFAULT_PRIORITY_LABELS.merge(overrides)
+  end
+
+  def auto_pick_skip_labels_configured?
+    !auto_pick_skip_labels.nil?
+  end
+
+  def auto_pick_skip_labels_csv
+    AutoPickSkipLabels.to_csv(auto_pick_skip_labels)
+  end
+
+  def auto_pick_skip_labels_csv=(value)
+    self.auto_pick_skip_labels = AutoPickSkipLabels.parse_csv(value)
+  end
+
+  def effective_auto_pick_skip_labels
+    return auto_pick_skip_labels unless auto_pick_skip_labels.nil?
+
+    owner_labels = effective_owner&.settings&.auto_pick_skip_labels
+    return owner_labels unless owner_labels.nil?
+
+    tenant_labels = account&.tenant_setting&.auto_pick_skip_labels
+    return tenant_labels unless tenant_labels.nil?
+
+    AutoPickSkipLabels::DEFAULTS
   end
 
   # All configured priority label names, used by queue ordering and PR inheritance.
@@ -828,6 +853,10 @@ class Project < ApplicationRecord
   def normalized_screenshot_driver(value)
     value = value.to_s
     SCREENSHOT_DRIVERS.key?(value) ? value : DEFAULT_SCREENSHOT_SETTINGS["driver"]
+  end
+
+  def normalize_auto_pick_skip_labels
+    self.auto_pick_skip_labels = AutoPickSkipLabels.normalize(auto_pick_skip_labels)
   end
 
   def normalize_string_array(value)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -128,6 +128,7 @@ class Project < ApplicationRecord
   ].freeze
 
   include TenantScoped
+  include AutoPickSkipLabels
 
   belongs_to :github_token, counter_cache: true
   belongs_to :created_by, class_name: "User", optional: true
@@ -180,7 +181,6 @@ class Project < ApplicationRecord
   encrypts :webhook_secret
 
   before_validation :normalize_priority_labels
-  before_validation :normalize_auto_pick_skip_labels
   after_update_commit :invalidate_relationship_parsing_on_trust_change
 
   validates :name, presence: true
@@ -273,18 +273,6 @@ class Project < ApplicationRecord
     overrides = (priority_labels || {}).slice(*PRIORITY_TIERS)
       .reject { |_, v| v.nil? || (v.is_a?(String) && v.strip.empty?) }
     DEFAULT_PRIORITY_LABELS.merge(overrides)
-  end
-
-  def auto_pick_skip_labels_configured?
-    !auto_pick_skip_labels.nil?
-  end
-
-  def auto_pick_skip_labels_csv
-    AutoPickSkipLabels.to_csv(auto_pick_skip_labels)
-  end
-
-  def auto_pick_skip_labels_csv=(value)
-    self.auto_pick_skip_labels = AutoPickSkipLabels.parse_csv(value)
   end
 
   def effective_auto_pick_skip_labels
@@ -853,10 +841,6 @@ class Project < ApplicationRecord
   def normalized_screenshot_driver(value)
     value = value.to_s
     SCREENSHOT_DRIVERS.key?(value) ? value : DEFAULT_SCREENSHOT_SETTINGS["driver"]
-  end
-
-  def normalize_auto_pick_skip_labels
-    self.auto_pick_skip_labels = AutoPickSkipLabels.normalize(auto_pick_skip_labels)
   end
 
   def normalize_string_array(value)

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -166,6 +166,18 @@ class TenantSetting < ApplicationRecord
     [ limit, max_tokens_per_run ].compact.min
   end
 
+  def auto_pick_skip_labels_configured?
+    !auto_pick_skip_labels.nil?
+  end
+
+  def auto_pick_skip_labels_csv
+    AutoPickSkipLabels.to_csv(auto_pick_skip_labels)
+  end
+
+  def auto_pick_skip_labels_csv=(value)
+    self.auto_pick_skip_labels = AutoPickSkipLabels.parse_csv(value)
+  end
+
   def effective_worker_settings
     DEFAULT_WORKER_SETTINGS.deep_dup.merge(
       worker_settings.is_a?(Hash) ? worker_settings.deep_stringify_keys : {}
@@ -214,6 +226,7 @@ class TenantSetting < ApplicationRecord
     self.guardrails = normalize_integer_hash(guardrails, %w[max_concurrent_runs max_tokens_per_run max_monthly_cost_cents])
     self.quality_thresholds = normalize_quality_thresholds(quality_thresholds)
     self.agent_settings = normalize_agent_settings(agent_settings)
+    self.auto_pick_skip_labels = AutoPickSkipLabels.normalize(auto_pick_skip_labels)
     self.worker_settings = normalize_worker_settings(worker_settings)
     self.features = normalize_hash(features)
     apply_guardrail_columns

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TenantSetting < ApplicationRecord
+  include AutoPickSkipLabels
   has_logidze
   PG_INT_MAX = 2_147_483_647
   BUDGET_TYPES = CostBudget::BUDGET_TYPES
@@ -166,18 +167,6 @@ class TenantSetting < ApplicationRecord
     [ limit, max_tokens_per_run ].compact.min
   end
 
-  def auto_pick_skip_labels_configured?
-    !auto_pick_skip_labels.nil?
-  end
-
-  def auto_pick_skip_labels_csv
-    AutoPickSkipLabels.to_csv(auto_pick_skip_labels)
-  end
-
-  def auto_pick_skip_labels_csv=(value)
-    self.auto_pick_skip_labels = AutoPickSkipLabels.parse_csv(value)
-  end
-
   def effective_worker_settings
     DEFAULT_WORKER_SETTINGS.deep_dup.merge(
       worker_settings.is_a?(Hash) ? worker_settings.deep_stringify_keys : {}
@@ -226,7 +215,6 @@ class TenantSetting < ApplicationRecord
     self.guardrails = normalize_integer_hash(guardrails, %w[max_concurrent_runs max_tokens_per_run max_monthly_cost_cents])
     self.quality_thresholds = normalize_quality_thresholds(quality_thresholds)
     self.agent_settings = normalize_agent_settings(agent_settings)
-    self.auto_pick_skip_labels = AutoPickSkipLabels.normalize(auto_pick_skip_labels)
     self.worker_settings = normalize_worker_settings(worker_settings)
     self.features = normalize_hash(features)
     apply_guardrail_columns

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class UserSetting < ApplicationRecord
+  include AutoPickSkipLabels
   has_logidze
   # Max value for PostgreSQL integer columns (32-bit signed)
   PG_INT_MAX = 2_147_483_647
@@ -19,8 +20,6 @@ class UserSetting < ApplicationRecord
 
   belongs_to :user
   has_many :provider_states, through: :user
-
-  before_validation :normalize_auto_pick_skip_labels
 
   # Theme
   validates :theme_preference, inclusion: { in: THEME_PREFERENCES }
@@ -229,18 +228,6 @@ class UserSetting < ApplicationRecord
     self.allowed_service_images = value.to_s.split(",").map(&:strip).reject(&:blank?).uniq
   end
 
-  def auto_pick_skip_labels_configured?
-    !auto_pick_skip_labels.nil?
-  end
-
-  def auto_pick_skip_labels_csv
-    AutoPickSkipLabels.to_csv(auto_pick_skip_labels)
-  end
-
-  def auto_pick_skip_labels_csv=(value)
-    self.auto_pick_skip_labels = AutoPickSkipLabels.parse_csv(value)
-  end
-
   # Returns the ordered list of providers to try: primary first, then fallbacks.
   #
   # @return [Array<String>] Provider names in priority order
@@ -385,10 +372,6 @@ class UserSetting < ApplicationRecord
   end
 
   private
-
-  def normalize_auto_pick_skip_labels
-    self.auto_pick_skip_labels = AutoPickSkipLabels.normalize(auto_pick_skip_labels)
-  end
 
   # Picks a candidate at random, weighted by each provider's weight column.
   # Falls back to uniform random when weights cannot be resolved (e.g. no

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -20,6 +20,8 @@ class UserSetting < ApplicationRecord
   belongs_to :user
   has_many :provider_states, through: :user
 
+  before_validation :normalize_auto_pick_skip_labels
+
   # Theme
   validates :theme_preference, inclusion: { in: THEME_PREFERENCES }
 
@@ -227,6 +229,18 @@ class UserSetting < ApplicationRecord
     self.allowed_service_images = value.to_s.split(",").map(&:strip).reject(&:blank?).uniq
   end
 
+  def auto_pick_skip_labels_configured?
+    !auto_pick_skip_labels.nil?
+  end
+
+  def auto_pick_skip_labels_csv
+    AutoPickSkipLabels.to_csv(auto_pick_skip_labels)
+  end
+
+  def auto_pick_skip_labels_csv=(value)
+    self.auto_pick_skip_labels = AutoPickSkipLabels.parse_csv(value)
+  end
+
   # Returns the ordered list of providers to try: primary first, then fallbacks.
   #
   # @return [Array<String>] Provider names in priority order
@@ -371,6 +385,10 @@ class UserSetting < ApplicationRecord
   end
 
   private
+
+  def normalize_auto_pick_skip_labels
+    self.auto_pick_skip_labels = AutoPickSkipLabels.normalize(auto_pick_skip_labels)
+  end
 
   # Picks a candidate at random, weighted by each provider's weight column.
   # Falls back to uniform random when weights cannot be resolved (e.g. no

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -13,7 +13,7 @@ module Automation
       # - Open, non-PR issues with all structured dependencies satisfied
       # - No unfinished agent run already attached to the issue
       # - No open PR linked back to the issue via +parent_issue_id+
-      # - Not labeled with any of {EXCLUDED_LABELS}
+      # - Not labeled with any configured auto-pick skip labels
       # - Not a parent issue with still-open sub-issues, and not a tracker /
       #   meta issue whose body still references open work items
       # - Issue creator is in the project's trusted allowlist when one is
@@ -30,10 +30,6 @@ module Automation
       #   get starved by newer issues)
       module DefaultCandidateSource
         extend CandidateSource
-
-        # Each label here must also exist as a GitHub label in the repo so
-        # it can be applied to issues.
-        EXCLUDED_LABELS = %w[planning research waiting tracking epic needs-manual-setup].freeze
 
         # SQL ILIKE patterns used to pre-filter potential tracker issues
         # before applying the full Ruby-level +Issue#tracker_issue?+
@@ -193,7 +189,7 @@ module Automation
             trusted_usernames = Array(project.allowed_github_usernames).presence
             base = base.where(github_creator_login: trusted_usernames) if trusted_usernames
 
-            EXCLUDED_LABELS.reduce(base) do |scope, label|
+            project.effective_auto_pick_skip_labels.reduce(base) do |scope, label|
               scope.where.not("labels @> ?::jsonb", [ label ].to_json)
             end
           end

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -618,6 +618,18 @@
                 Periodically scan GitHub CodeQL alerts and create synthetic issues for all open alerts. Issues are labeled with a priority tier matching severity (critical/high &rarr; P1, medium &rarr; P2, low &rarr; P3).
               </p>
             </div>
+
+            <div>
+              <label class="flex items-center gap-2 text-sm font-medium leading-6 text-gray-900">
+                <%= hidden_field_tag "project[auto_pick_skip_labels_override]", "0" %>
+                <%= check_box_tag "project[auto_pick_skip_labels_override]", "1", @project.auto_pick_skip_labels_configured?, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+                Override Auto-Pick Skip Labels
+              </label>
+              <div class="mt-2">
+                <%= text_field_tag "project[auto_pick_skip_labels_csv]", @project.auto_pick_skip_labels_csv, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: "planning, research" %>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">Comma-separated labels that prevent auto-pick for this project. When override is off, Paid falls back to the creator's user setting, then the tenant setting, then built-in defaults. When override is on and this field is blank, no labels are skipped.</p>
+            </div>
           </fieldset>
 
           <%= render "screenshot_settings", form: form,

--- a/app/views/tenant_configurations/edit.html.erb
+++ b/app/views/tenant_configurations/edit.html.erb
@@ -117,6 +117,18 @@
         </div>
       </div>
 
+      <div class="mt-6">
+        <label class="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+          <%= hidden_field_tag "tenant_setting[auto_pick_skip_labels_override]", "0" %>
+          <%= check_box_tag "tenant_setting[auto_pick_skip_labels_override]", "1", @tenant_setting.auto_pick_skip_labels_configured? %>
+          Override Auto-pick Skip Labels
+        </label>
+        <%= text_field_tag "tenant_setting[auto_pick_skip_labels_csv]", @tenant_setting.auto_pick_skip_labels_csv,
+          placeholder: "planning, research",
+          class: "mt-2 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Comma-separated labels that prevent auto-pick across this tenant. When override is off, Paid uses the built-in default skip labels. When override is on and this field is blank, no labels are skipped.</p>
+      </div>
+
       <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
         Tenant overrides apply only to this account. Percentage rollout controls update the shared Flipper gates for each flag.
       </p>

--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -202,6 +202,18 @@
           </div>
 
           <div>
+            <label class="flex items-center gap-2 text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
+              <%= hidden_field_tag "user_setting[auto_pick_skip_labels_override]", "0" %>
+              <%= check_box_tag "user_setting[auto_pick_skip_labels_override]", "1", @user_setting.auto_pick_skip_labels_configured?, class: "h-4 w-4 rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-indigo-600 focus:ring-indigo-600" %>
+              Override Auto-Pick Skip Labels
+            </label>
+            <div class="mt-2">
+              <%= text_field_tag "user_setting[auto_pick_skip_labels_csv]", @user_setting.auto_pick_skip_labels_csv, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 dark:text-gray-100 dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: "planning, research" %>
+            </div>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Comma-separated labels that prevent auto-pick for this user. When override is off, Paid falls back to tenant labels, then built-in defaults. When override is on and this field is blank, no labels are skipped.</p>
+          </div>
+
+          <div>
             <%= form.label :container_timeout_seconds, "Container Timeout (seconds)", class: "block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100" %>
             <div class="mt-2">
               <%= form.number_field :container_timeout_seconds, min: 60, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 dark:text-gray-100 dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>

--- a/db/migrate/20260515110029_add_auto_pick_skip_labels_to_tenant_settings_user_settings_and_projects.rb
+++ b/db/migrate/20260515110029_add_auto_pick_skip_labels_to_tenant_settings_user_settings_and_projects.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddAutoPickSkipLabelsToTenantSettingsUserSettingsAndProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tenant_settings, :auto_pick_skip_labels, :jsonb,
+      comment: "Optional tenant-level override for labels that make auto-pick skip an issue. Null means use built-in defaults."
+    add_column :user_settings, :auto_pick_skip_labels, :jsonb,
+      comment: "Optional user-level override for labels that make auto-pick skip an issue. Null means inherit tenant or built-in defaults."
+    add_column :projects, :auto_pick_skip_labels, :jsonb,
+      comment: "Optional project-level override for labels that make auto-pick skip an issue. Null means inherit user, tenant, or built-in defaults."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_193654) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_15_110029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1489,6 +1489,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_193654) do
     t.boolean "auto_fix_merge_conflicts", default: true, null: false
     t.string "auto_merge_mode", default: "off", null: false
     t.boolean "auto_pick_enabled", default: false, null: false
+    t.jsonb "auto_pick_skip_labels", comment: "Optional project-level override for labels that make auto-pick skip an issue. Null means inherit user, tenant, or built-in defaults."
     t.string "auto_release_granularity", default: "off", null: false
     t.boolean "auto_scan_prs", default: true, null: false
     t.boolean "auto_scan_security", default: false, null: false
@@ -2007,6 +2008,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_193654) do
     t.bigint "account_id", null: false
     t.jsonb "agent_settings", default: {}, null: false
     t.text "allowed_provider_keys", default: [], array: true
+    t.jsonb "auto_pick_skip_labels", comment: "Optional tenant-level override for labels that make auto-pick skip an issue. Null means use built-in defaults."
     t.datetime "created_at", null: false
     t.jsonb "default_budgets", default: {}, null: false
     t.jsonb "features", default: {}, null: false
@@ -2072,6 +2074,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_193654) do
   create_table "user_settings", force: :cascade do |t|
     t.integer "agent_timeout_seconds", default: 3600, null: false
     t.jsonb "allowed_service_images", default: ["postgres:16.13", "redis:7-alpine", "selenium/standalone-chromium:latest"]
+    t.jsonb "auto_pick_skip_labels", comment: "Optional user-level override for labels that make auto-pick skip an issue. Null means inherit tenant or built-in defaults."
     t.integer "circuit_breaker_failure_threshold", default: 5, null: false
     t.integer "circuit_breaker_timeout_seconds", default: 300, null: false
     t.bigint "container_memory_bytes", default: 4294967296, null: false

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -931,6 +931,47 @@ RSpec.describe Project do
       end
     end
 
+    describe "#effective_auto_pick_skip_labels" do
+      it "uses project labels before user, tenant, and defaults" do
+        project = create(:project, auto_pick_skip_labels: %w[blocked])
+        project.created_by.settings.update!(auto_pick_skip_labels: %w[user-skip])
+        project.account.tenant_setting!.update!(auto_pick_skip_labels: %w[tenant-skip])
+
+        expect(project.effective_auto_pick_skip_labels).to eq(%w[blocked])
+      end
+
+      it "falls back to user labels when the project does not override them" do
+        project = create(:project, auto_pick_skip_labels: nil)
+        project.created_by.settings.update!(auto_pick_skip_labels: %w[user-skip])
+        project.account.tenant_setting!.update!(auto_pick_skip_labels: %w[tenant-skip])
+
+        expect(project.effective_auto_pick_skip_labels).to eq(%w[user-skip])
+      end
+
+      it "falls back to tenant labels when the project and user do not override them" do
+        project = create(:project, auto_pick_skip_labels: nil)
+        project.created_by.settings.update!(auto_pick_skip_labels: nil)
+        project.account.tenant_setting!.update!(auto_pick_skip_labels: %w[tenant-skip])
+
+        expect(project.effective_auto_pick_skip_labels).to eq(%w[tenant-skip])
+      end
+
+      it "falls back to built-in defaults when no override exists" do
+        project = create(:project, auto_pick_skip_labels: nil)
+        project.created_by.settings.update!(auto_pick_skip_labels: nil)
+        project.account.tenant_setting!.update!(auto_pick_skip_labels: nil)
+
+        expect(project.effective_auto_pick_skip_labels).to eq(AutoPickSkipLabels::DEFAULTS)
+      end
+
+      it "allows a project override to disable skip labels entirely" do
+        project = create(:project, auto_pick_skip_labels: [])
+        project.created_by.settings.update!(auto_pick_skip_labels: %w[user-skip])
+
+        expect(project.effective_auto_pick_skip_labels).to eq([])
+      end
+    end
+
     describe "#effective_screenshot_settings" do
       it "returns defaults when screenshot_settings is empty" do
         project = build(:project, screenshot_settings: {})

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -970,6 +970,14 @@ RSpec.describe Project do
 
         expect(project.effective_auto_pick_skip_labels).to eq([])
       end
+
+      it "does not create a user setting record while resolving fallback labels" do
+        project = create(:project)
+
+        expect(project.created_by.user_setting).to be_nil
+        expect { project.effective_auto_pick_skip_labels }.not_to change(UserSetting, :count)
+        expect(project.effective_auto_pick_skip_labels).to eq(AutoPickSkipLabels::DEFAULTS)
+      end
     end
 
     describe "#effective_screenshot_settings" do

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -141,6 +141,13 @@ RSpec.describe TenantSetting do
       expect(setting.auto_pick_skip_labels).to eq(%w[planning research])
     end
 
+    it "normalizes labels to lowercase before deduplicating" do
+      setting = build(:tenant_setting)
+      setting.auto_pick_skip_labels_csv = " Planning, research, PLANNING "
+
+      expect(setting.auto_pick_skip_labels).to eq(%w[planning research])
+    end
+
     it "allows configuring an empty skip-label list" do
       setting = build(:tenant_setting)
       setting.auto_pick_skip_labels_csv = ""

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -119,6 +119,36 @@ RSpec.describe TenantSetting do
     end
   end
 
+  describe "#auto_pick_skip_labels_csv" do
+    it "returns labels as a comma-separated string" do
+      setting = build(:tenant_setting, auto_pick_skip_labels: %w[planning research])
+
+      expect(setting.auto_pick_skip_labels_csv).to eq("planning, research")
+    end
+
+    it "returns an empty string when labels are not configured" do
+      setting = build(:tenant_setting, auto_pick_skip_labels: nil)
+
+      expect(setting.auto_pick_skip_labels_csv).to eq("")
+    end
+  end
+
+  describe "#auto_pick_skip_labels_csv=" do
+    it "parses comma-separated labels into a deduplicated array" do
+      setting = build(:tenant_setting)
+      setting.auto_pick_skip_labels_csv = " planning, research, planning "
+
+      expect(setting.auto_pick_skip_labels).to eq(%w[planning research])
+    end
+
+    it "allows configuring an empty skip-label list" do
+      setting = build(:tenant_setting)
+      setting.auto_pick_skip_labels_csv = ""
+
+      expect(setting.auto_pick_skip_labels).to eq([])
+    end
+  end
+
   describe "#provider_api_key_for" do
     it "resolves API keys owned by account users" do
       account = create(:account)

--- a/spec/models/user_setting_spec.rb
+++ b/spec/models/user_setting_spec.rb
@@ -301,6 +301,36 @@ RSpec.describe UserSetting do
     end
   end
 
+  describe "#auto_pick_skip_labels_csv" do
+    it "returns labels as a comma-separated string" do
+      setting = build(:user_setting, auto_pick_skip_labels: %w[planning research])
+
+      expect(setting.auto_pick_skip_labels_csv).to eq("planning, research")
+    end
+
+    it "returns an empty string when labels are not configured" do
+      setting = build(:user_setting, auto_pick_skip_labels: nil)
+
+      expect(setting.auto_pick_skip_labels_csv).to eq("")
+    end
+  end
+
+  describe "#auto_pick_skip_labels_csv=" do
+    it "parses comma-separated labels into a deduplicated array" do
+      setting = build(:user_setting)
+      setting.auto_pick_skip_labels_csv = " planning, research, planning "
+
+      expect(setting.auto_pick_skip_labels).to eq(%w[planning research])
+    end
+
+    it "allows configuring an empty skip-label list" do
+      setting = build(:user_setting)
+      setting.auto_pick_skip_labels_csv = ""
+
+      expect(setting.auto_pick_skip_labels).to eq([])
+    end
+  end
+
   describe "default values" do
     let(:user) { create(:user) }
     let(:setting) { described_class.create!(user: user) }

--- a/spec/models/user_setting_spec.rb
+++ b/spec/models/user_setting_spec.rb
@@ -323,6 +323,13 @@ RSpec.describe UserSetting do
       expect(setting.auto_pick_skip_labels).to eq(%w[planning research])
     end
 
+    it "normalizes labels to lowercase before deduplicating" do
+      setting = build(:user_setting)
+      setting.auto_pick_skip_labels_csv = " Planning, research, PLANNING "
+
+      expect(setting.auto_pick_skip_labels).to eq(%w[planning research])
+    end
+
     it "allows configuring an empty skip-label list" do
       setting = build(:user_setting)
       setting.auto_pick_skip_labels_csv = ""

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1351,6 +1351,48 @@ RSpec.describe "Projects" do
         expect(project.reload.priority_labels).to eq("P1" => "urgent", "P2" => "normal", "P3" => "low")
       end
 
+      it "allows updating project auto-pick skip labels" do
+        project = create(:project, account: account, github_token: github_token)
+
+        patch project_path(project), params: {
+          project: {
+            auto_pick_skip_labels_override: "1",
+            auto_pick_skip_labels_csv: "planning, research"
+          }
+        }
+
+        expect(response).to redirect_to(project)
+        expect(project.reload.auto_pick_skip_labels).to eq(%w[planning research])
+      end
+
+      it "allows a project override to skip no labels" do
+        project = create(:project, account: account, github_token: github_token, auto_pick_skip_labels: %w[planning])
+
+        patch project_path(project), params: {
+          project: {
+            auto_pick_skip_labels_override: "1",
+            auto_pick_skip_labels_csv: ""
+          }
+        }
+
+        expect(response).to redirect_to(project)
+        expect(project.reload.auto_pick_skip_labels).to eq([])
+      end
+
+      it "clears the project skip-label override when override is disabled" do
+        project = create(:project, account: account, github_token: github_token, auto_pick_skip_labels: %w[planning])
+
+        patch project_path(project), params: {
+          project: {
+            auto_pick_skip_labels_override: "0",
+            auto_pick_skip_labels_csv: "planning, research"
+          }
+        }
+
+        expect(response).to redirect_to(project)
+        expect(project.reload.auto_pick_skip_labels).to be_nil
+      end
+
       it "rejects blank priority label values" do
         project = create(:project, account: account, github_token: github_token,
           priority_labels: { "P1" => "P1", "P2" => "P2", "P3" => "P3" })

--- a/spec/requests/tenant_configurations_spec.rb
+++ b/spec/requests/tenant_configurations_spec.rb
@@ -55,6 +55,46 @@ RSpec.describe "TenantConfigurations" do
       )
     end
 
+    it "updates tenant-level auto-pick skip labels" do
+      patch tenant_configuration_path, params: {
+        tenant_setting: {
+          auto_pick_skip_labels_override: "1",
+          auto_pick_skip_labels_csv: "planning, research"
+        }
+      }
+
+      expect(response).to redirect_to(edit_tenant_configuration_path)
+      expect(account.tenant_setting.reload.auto_pick_skip_labels).to eq(%w[planning research])
+    end
+
+    it "allows an empty tenant-level skip-label override" do
+      account.tenant_setting!.update!(auto_pick_skip_labels: %w[planning])
+
+      patch tenant_configuration_path, params: {
+        tenant_setting: {
+          auto_pick_skip_labels_override: "1",
+          auto_pick_skip_labels_csv: ""
+        }
+      }
+
+      expect(response).to redirect_to(edit_tenant_configuration_path)
+      expect(account.tenant_setting.reload.auto_pick_skip_labels).to eq([])
+    end
+
+    it "clears the tenant-level override when skip labels are not overridden" do
+      account.tenant_setting!.update!(auto_pick_skip_labels: %w[planning])
+
+      patch tenant_configuration_path, params: {
+        tenant_setting: {
+          auto_pick_skip_labels_override: "0",
+          auto_pick_skip_labels_csv: "planning, research"
+        }
+      }
+
+      expect(response).to redirect_to(edit_tenant_configuration_path)
+      expect(account.tenant_setting.reload.auto_pick_skip_labels).to be_nil
+    end
+
     it "disables auto-continue when the checkbox submits its hidden false value" do
       account.tenant_setting!.update!(agent_settings: { "auto_continue" => true })
 

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -144,6 +144,46 @@ RSpec.describe "UserSettings" do
         expect(settings.default_allowed_github_usernames).to eq(%w[alice bob])
       end
 
+      it "updates auto-pick skip labels for the user" do
+        patch user_settings_path, params: {
+          user_setting: {
+            auto_pick_skip_labels_override: "1",
+            auto_pick_skip_labels_csv: "planning, research"
+          }
+        }
+
+        expect(response).to redirect_to(edit_user_settings_path)
+        expect(user.reload.settings.auto_pick_skip_labels).to eq(%w[planning research])
+      end
+
+      it "allows the user to override defaults with an empty skip-label list" do
+        user.settings.update!(auto_pick_skip_labels: %w[planning])
+
+        patch user_settings_path, params: {
+          user_setting: {
+            auto_pick_skip_labels_override: "1",
+            auto_pick_skip_labels_csv: ""
+          }
+        }
+
+        expect(response).to redirect_to(edit_user_settings_path)
+        expect(user.reload.settings.auto_pick_skip_labels).to eq([])
+      end
+
+      it "clears the user override when auto-pick skip labels are not overridden" do
+        user.settings.update!(auto_pick_skip_labels: %w[planning])
+
+        patch user_settings_path, params: {
+          user_setting: {
+            auto_pick_skip_labels_override: "0",
+            auto_pick_skip_labels_csv: "planning, research"
+          }
+        }
+
+        expect(response).to redirect_to(edit_user_settings_path)
+        expect(user.reload.settings.auto_pick_skip_labels).to be_nil
+      end
+
       it "updates advanced settings" do
         patch user_settings_path, params: {
           user_setting: {

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -138,6 +138,58 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
       expect(scope.pluck(:id)).to include(parent.id)
     end
+
+    it "uses project skip labels before user, tenant, and defaults" do
+      project.update!(auto_pick_skip_labels: %w[blocked])
+      project.created_by.settings.update!(auto_pick_skip_labels: %w[user-skip])
+      project.account.tenant_setting!.update!(auto_pick_skip_labels: %w[tenant-skip])
+      create(:issue, project: project, labels: [ "blocked" ])
+      eligible = create(:issue, project: project, labels: [ "planning" ])
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(eligible.id)
+    end
+
+    it "falls back to user skip labels when the project does not override them" do
+      project.update!(auto_pick_skip_labels: nil)
+      project.created_by.settings.update!(auto_pick_skip_labels: %w[user-skip])
+      project.account.tenant_setting!.update!(auto_pick_skip_labels: %w[tenant-skip])
+      create(:issue, project: project, labels: [ "user-skip" ])
+      eligible = create(:issue, project: project, labels: [ "planning" ])
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(eligible.id)
+    end
+
+    it "falls back to tenant skip labels when neither project nor user override them" do
+      project.update!(auto_pick_skip_labels: nil)
+      project.created_by.settings.update!(auto_pick_skip_labels: nil)
+      project.account.tenant_setting!.update!(auto_pick_skip_labels: %w[tenant-skip])
+      create(:issue, project: project, labels: [ "tenant-skip" ])
+      eligible = create(:issue, project: project, labels: [ "planning" ])
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(eligible.id)
+    end
+
+    it "falls back to the built-in skip labels when no overrides exist" do
+      project.update!(auto_pick_skip_labels: nil)
+      project.created_by.settings.update!(auto_pick_skip_labels: nil)
+      project.account.tenant_setting!.update!(auto_pick_skip_labels: nil)
+      create(:issue, project: project, labels: [ "planning" ])
+
+      expect(described_class.eligible_scope(project)).to be_empty
+    end
+
+    it "allows an explicit empty override to disable skip labels entirely" do
+      project.update!(auto_pick_skip_labels: [])
+      create(:issue, project: project, labels: [ "planning" ])
+
+      expect(described_class.eligible_scope(project).pluck(:labels)).to include([ "planning" ])
+    end
   end
 
   describe ".eligible_issue_ids" do


### PR DESCRIPTION
## Summary

Adds configurable auto-pick skip labels at tenant, user, and project scope so teams can control which GitHub labels exclude issues from automated agent pickup without code changes. Configured values fully replace the hardcoded defaults, including an explicit empty list to skip nothing, with resolution order `project > user > tenant > built-in defaults`.

## Changes

- **Database**: New migration adds `auto_pick_skip_labels` columns to `tenant_settings`, `user_settings`, and `projects`.
- **Models**: New `AutoPickSkipLabels` concern (`app/models/concerns/auto_pick_skip_labels.rb`) provides storage and normalization helpers; `Project#auto_pick_skip_labels` resolves the hierarchy (`app/models/project.rb:278`).
- **Services**: `Automation::Strategies::AutoPick::DefaultCandidateSource` now reads the resolved label set instead of hardcoded constants (`app/services/automation/strategies/auto_pick/default_candidate_source.rb:189`).
- **Controllers/UI**: Tenant, user, and project settings controllers and their edit views accept and persist skip-label configuration (`tenant_configurations_controller.rb:80`, `user_settings_controller.rb:29`, `projects_controller.rb:141`).
- **Tests**: Request, model, and strategy specs expanded to cover override semantics and hierarchy resolution.

## Design Decisions

- **Replace, don't merge**: Configured labels fully override lower levels — including an empty list, which intentionally disables skip behavior entirely. This matches the issue's acceptance criterion that defaults must be removable.
- **Defaults are a fallback, not a baseline**: The hardcoded labels apply only when no level has configuration set, so users opting in get exactly what they configured.
- **Shared concern over duplicated columns logic**: Normalization (trimming, dedup, case handling) lives in one concern reused across the three models to keep behavior consistent.

## Operational Notes

- Requires running the new migration. No data backfill needed — `nil` is the "unset" sentinel that triggers fallback to the next level.
- `bundle exec rspec` was not run in the build container (PostgreSQL unavailable); please confirm the full suite passes in CI before merge.

## Screenshots

_Author: please attach before/after screenshots of the tenant, user, and project settings edit pages showing the new skip-labels input._

---

Closes #2037