### PR TITLE
feat(auto-pick): remove seed_auto_pick_queue and PR attention limit throttling

### DIFF
--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -44,7 +44,6 @@ class UserSettingsController < ApplicationController
       :default_agent_provider,
       :container_memory_gb,
       :max_concurrent_runs,
-      :max_auto_pick_open_prs,
       :container_timeout_seconds,
       :default_branch,
       :default_project_active,

--- a/app/jobs/auto_pick_queue_backfill_job.rb
+++ b/app/jobs/auto_pick_queue_backfill_job.rb
@@ -68,7 +68,6 @@ class AutoPickQueueBackfillJob < ApplicationJob
   def remaining_project_ids
     eligible_projects.each_with_object([]) do |project, remaining|
       next if project_backfilled?(project.id)
-      next unless Issues::AutoPickProjectGate.call(project)
 
       remaining << project.id
     end

--- a/app/jobs/auto_pick_queue_backfill_job.rb
+++ b/app/jobs/auto_pick_queue_backfill_job.rb
@@ -37,12 +37,13 @@ class AutoPickQueueBackfillJob < ApplicationJob
       )
     end
 
-    mark_completed if remaining_project_ids.empty?
+    remaining = remaining_project_ids
+    mark_completed if remaining.empty?
 
     Rails.logger.info(
       message: "auto_pick_queue_backfill.completed",
       processed_projects: processed,
-      remaining_projects: remaining_project_ids.size
+      remaining_projects: remaining.size
     )
   end
 

--- a/app/jobs/auto_pick_queue_backfill_job.rb
+++ b/app/jobs/auto_pick_queue_backfill_job.rb
@@ -65,7 +65,12 @@ class AutoPickQueueBackfillJob < ApplicationJob
   end
 
   def remaining_project_ids
-    eligible_projects.pluck(:id).reject { |id| project_backfilled?(id) }
+    eligible_projects.each_with_object([]) do |project, remaining|
+      next if project_backfilled?(project.id)
+      next unless Issues::AutoPickProjectGate.call(project)
+
+      remaining << project.id
+    end
   end
 
   def eligible_projects

--- a/app/jobs/auto_pick_queue_backfill_job.rb
+++ b/app/jobs/auto_pick_queue_backfill_job.rb
@@ -22,8 +22,9 @@ class AutoPickQueueBackfillJob < ApplicationJob
 
     processed = 0
 
-    Project.where(auto_pick_enabled: true).find_each do |project|
+    eligible_projects.find_each do |project|
       next if project_backfilled?(project.id)
+      next unless Issues::AutoPickProjectGate.call(project)
 
       Issues::BulkEnqueueEligible.call(project: project, skip_project_gate: true)
       mark_project_backfilled(project.id)
@@ -64,7 +65,11 @@ class AutoPickQueueBackfillJob < ApplicationJob
   end
 
   def remaining_project_ids
-    Project.where(auto_pick_enabled: true).pluck(:id).reject { |id| project_backfilled?(id) }
+    eligible_projects.pluck(:id).reject { |id| project_backfilled?(id) }
+  end
+
+  def eligible_projects
+    Project.active.where(auto_pick_enabled: true)
   end
 
   def completed_cache_key

--- a/app/jobs/auto_pick_queue_backfill_job.rb
+++ b/app/jobs/auto_pick_queue_backfill_job.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# One-time backfill for projects that already had auto-pick enabled before
+# eager queue seeding shipped. Without this pass, unchanged eligible issues can
+# remain unqueued indefinitely because incremental GitHub sync only re-enqueues
+# issues it touches after last_issue_sync_at.
+class AutoPickQueueBackfillJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :maintenance
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: "auto_pick_queue_backfill"
+  )
+
+  CACHE_NAMESPACE = "auto_pick_queue_backfill/v1"
+
+  def perform
+    return if completed?
+
+    processed = 0
+
+    Project.where(auto_pick_enabled: true).find_each do |project|
+      next if project_backfilled?(project.id)
+
+      Issues::BulkEnqueueEligible.call(project: project, skip_project_gate: true)
+      mark_project_backfilled(project.id)
+      processed += 1
+    rescue => e
+      Rails.logger.error(
+        message: "auto_pick_queue_backfill.project_failed",
+        project_id: project.id,
+        error: e.message
+      )
+    end
+
+    mark_completed if remaining_project_ids.empty?
+
+    Rails.logger.info(
+      message: "auto_pick_queue_backfill.completed",
+      processed_projects: processed,
+      remaining_projects: remaining_project_ids.size
+    )
+  end
+
+  private
+
+  def completed?
+    Rails.cache.read(completed_cache_key) == true
+  end
+
+  def mark_completed
+    Rails.cache.write(completed_cache_key, true)
+  end
+
+  def project_backfilled?(project_id)
+    Rails.cache.read(project_cache_key(project_id)) == true
+  end
+
+  def mark_project_backfilled(project_id)
+    Rails.cache.write(project_cache_key(project_id), true)
+  end
+
+  def remaining_project_ids
+    Project.where(auto_pick_enabled: true).pluck(:id).reject { |id| project_backfilled?(id) }
+  end
+
+  def completed_cache_key
+    "#{CACHE_NAMESPACE}/completed"
+  end
+
+  def project_cache_key(project_id)
+    "#{CACHE_NAMESPACE}/projects/#{project_id}"
+  end
+end

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -31,13 +31,6 @@ class ProcessRunQueueJob < ApplicationJob
   # can't start due to per-user capacity limits.
   MAX_ITERATIONS_PER_PERFORM = 100
 
-  # Sanity ceiling on auto-pick rows seeded per perform invocation.
-  # Capacity is enforced at execution, not at queueing — but a project
-  # with thousands of eligible issues could otherwise tie up this job
-  # with unbounded INSERTs in a single pass. The next perform will pick
-  # up where this one left off.
-  MAX_SEEDS_PER_PERFORM = 200
-
   def perform
     # Use a PostgreSQL advisory lock to ensure only one job processes the queue at a time.
     # If another instance is already running, this job exits immediately (no-op).
@@ -58,8 +51,6 @@ class ProcessRunQueueJob < ApplicationJob
       skipped_ids = Set.new
       blocked_user_ids = Set.new
       @user_capacity = {}  # { user_id => { active: count, max: limit } }
-
-      seed_auto_pick_queue
 
       loop do
         iterations += 1
@@ -149,80 +140,6 @@ class ProcessRunQueueJob < ApplicationJob
   def record_started_run(user)
     cap = @user_capacity[user.id]
     cap[:active] += 1 if cap
-  end
-
-  # Seeds the queue with every eligible auto-pickable issue across projects.
-  # Capacity is enforced at start-time, not at queueing — so a project with
-  # many P3/auto-pick issues will queue them all up rather than starving on
-  # higher-priority work elsewhere. MAX_SEEDS_PER_PERFORM bounds DB load if a
-  # project has thousands of eligible issues; subsequent performs catch up.
-  #
-  # The project list is sorted once and reused across passes. Each pass seeds
-  # at most one issue per project, so projects round-robin naturally; the
-  # cross-project fair-share at start-time (QUEUE_ORDER PROJECT_ACTIVE_COUNT)
-  # handles the actual interleaving, not the seed order.
-  def seed_auto_pick_queue
-    seeded = 0
-    loop do
-      created_in_pass = false
-
-      ordered_auto_pick_projects.each do |project|
-        break if seeded >= MAX_SEEDS_PER_PERFORM
-        next unless Issues::AutoPickProjectGate.call(project)
-
-        runs = Issues::BulkEnqueueEligible.call(project: project, limit: 1, skip_project_gate: true)
-        created = runs.count(&:previously_new_record?)
-        next if created.zero?
-
-        seeded += created
-        created_in_pass = true
-      end
-
-      break if !created_in_pass || seeded >= MAX_SEEDS_PER_PERFORM
-    end
-  end
-
-  # Memoized within a single perform so repeated auto-pick passes
-  # don't re-query the project list and aggregate stats each time.
-  def ordered_auto_pick_projects
-    @ordered_auto_pick_projects ||= begin
-      projects = Project.active.where(auto_pick_enabled: true, quality_paused_at: nil, scheduler_paused_at: nil)
-        .includes(:created_by, :account)
-        .joins(:account).where(accounts: { scheduler_paused_at: nil })
-        .order(:id).to_a
-      return projects if projects.empty?
-
-      project_ids = projects.map(&:id)
-      auto_pick_scope = AgentRun.where(
-        project_id: project_ids,
-        trigger_type: "automatic",
-        source_pull_request_number: nil
-      ).where.not(issue_id: nil)
-
-      active_counts = auto_pick_scope.where(
-        status: AgentRun::UNFINISHED_STATUSES
-      ).group(:project_id).count
-
-      # Collapse the two aggregate queries (max created_at, max id)
-      # into a single grouped pluck to reduce DB round-trips.
-      last_stats = {}
-      auto_pick_scope
-        .group(:project_id)
-        .pluck(:project_id, Arel.sql("MAX(created_at)"), Arel.sql("MAX(id)"))
-        .each do |project_id, max_created_at, max_id|
-          last_stats[project_id] = { at: max_created_at, id: max_id }
-        end
-
-      projects.sort_by do |project|
-        stats = last_stats[project.id]
-        [
-          active_counts.fetch(project.id, 0),
-          stats ? stats[:at] : Time.at(0),
-          stats ? stats[:id] : 0,
-          project.id
-        ]
-      end
-    end
   end
 
   def start_claimed_run(agent_run)

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -50,6 +50,8 @@ class UserSetting < ApplicationRecord
     numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 }
   validates :max_parallel_agents_per_project,
     numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 20 }
+  # Deprecated: retained only for migration safety. Auto-pick no longer
+  # uses this setting; max_concurrent_runs is the capacity control.
   validates :max_auto_pick_open_prs,
     numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
 

--- a/app/services/automation/strategies/auto_pick.rb
+++ b/app/services/automation/strategies/auto_pick.rb
@@ -4,15 +4,13 @@ module Automation
   module Strategies
     # Auto-pick selection policy, extracted from {Issues::AutoPick}.
     #
-    # The strategy is pure policy — it performs no I/O of its own. Given
-    # an {Automation::Context} that carries project-level guard signals
-    # (open-PR attention counts, configured limits) and a CandidateSource
-    # for data access, it returns an {Automation::Result} describing
-    # whether to queue a new +create_pr+ agent run for some issue.
+    # The strategy is pure policy — it performs no I/O of its own.
+    # Given an {Automation::Context} and a CandidateSource for data
+    # access, it returns an {Automation::Result} describing whether to
+    # queue a new +create_pr+ agent run for some issue.
     #
     # Responsibilities:
-    # - Enforce project-level guards: +auto_pick_enabled+ and the WIP cap
-    #   on PRs still needing attention.
+    # - Enforce project-level guards: +auto_pick_enabled+ and quality pause.
     # - Ask the candidate source for the next work item that satisfies
     #   per-issue eligibility and prioritization rules.
     # - Emit a {Decision.queue_create_pr_run} decision when a candidate is
@@ -23,10 +21,6 @@ module Automation
     # {Issues::AutoPick}.
     class AutoPick
       include Automation::Strategy
-
-      # Metadata keys read from {Automation::Context#metadata}.
-      PR_ATTENTION_COUNT_KEY = :pr_attention_count
-      PR_ATTENTION_LIMIT_KEY = :pr_attention_limit
 
       # @param candidate_source [#next_candidate] Provider-backed data
       #   access for auto-pick candidates. Defaults to the local-DB /
@@ -41,7 +35,6 @@ module Automation
         project = context.project
         return noop_result unless auto_pick_enabled?(project)
         return noop_result if project.quality_paused?
-        return noop_result if deferred_by_pr_attention_limit?(context)
 
         issue = @candidate_source.next_candidate(project)
         return noop_result unless issue
@@ -59,17 +52,6 @@ module Automation
 
       def auto_pick_enabled?(project)
         Configuration::AutoPick.from_project(project).enabled?
-      end
-
-      # When the configured limit is zero there is no cap — auto-pick is
-      # never deferred on that signal. A positive limit defers auto-pick
-      # once the number of PRs still needing attention reaches it.
-      def deferred_by_pr_attention_limit?(context)
-        limit = context.metadata_fetch(PR_ATTENTION_LIMIT_KEY, 0).to_i
-        return false if limit <= 0
-
-        count = context.metadata_fetch(PR_ATTENTION_COUNT_KEY, 0).to_i
-        count >= limit
       end
     end
   end

--- a/app/services/issues/auto_pick.rb
+++ b/app/services/issues/auto_pick.rb
@@ -5,8 +5,6 @@ module Issues
   # {Automation::Strategies::AutoPick}.
   #
   # Responsibilities kept here (orchestration):
-  # - Collecting project-level guard signals (count of open PRs that still
-  #   need attention, configured WIP limit).
   # - Running the pure-policy strategy and executing the resulting
   #   decision — resolving a runnable provider and creating the queued
   #   {AgentRun}.
@@ -27,10 +25,9 @@ module Issues
     PAID_READY_LABEL = "paid-ready"
 
     # Returns the Set of issue IDs from +displayed_issues+ that are
-    # currently eligible for auto-picking (per-issue criteria only;
-    # ignores transient project-level guards like active runs or PRs
-    # needing attention). Scoping to the displayed issues helps limit
-    # query cost and focuses results on the currently displayed subset.
+    # currently eligible for auto-picking. Scoping to the displayed
+    # issues helps limit query cost and focuses results on the currently
+    # displayed subset.
     def self.eligible_issue_ids(displayed_issues)
       Automation::Strategies::AutoPick::DefaultCandidateSource
         .eligible_issue_ids(displayed_issues)
@@ -41,7 +38,7 @@ module Issues
     end
 
     def call
-      result = strategy.evaluate(build_context)
+      result = strategy.evaluate(Automation::Context.build(record: nil, project: @project, metadata: {}))
       decision = result.decisions.first
       return nil if decision.nil? || decision.type == "noop"
 
@@ -110,14 +107,6 @@ module Issues
         strategy_type: :auto_pick,
         project: @project
       )
-    end
-
-    def build_context
-      context = Automation::Context.build(record: nil, project: @project, metadata: {})
-      # Avoid expensive PR-attention query when early guards will noop.
-      return context unless @project.auto_pick_enabled? && !@project.quality_paused?
-
-      context.with_metadata(Issues::AutoPickProjectGate.new(@project).context_metadata)
     end
 
     def create_agent_run(issue, goal: "create_pr")

--- a/app/services/issues/auto_pick_project_gate.rb
+++ b/app/services/issues/auto_pick_project_gate.rb
@@ -16,16 +16,8 @@ module Issues
       return false if project.scheduler_paused?
       return false if project.account&.scheduler_paused?
       return false unless owner
-      return false if deferred_by_pr_attention_limit?
 
       true
-    end
-
-    def context_metadata
-      {
-        Automation::Strategies::AutoPick::PR_ATTENTION_COUNT_KEY => prs_needing_attention_count,
-        Automation::Strategies::AutoPick::PR_ATTENTION_LIMIT_KEY => max_auto_pick_open_prs
-      }
     end
 
     private
@@ -34,35 +26,6 @@ module Issues
 
     def owner
       @owner ||= project.effective_owner
-    end
-
-    def deferred_by_pr_attention_limit?
-      limit = max_auto_pick_open_prs
-      return false if limit <= 0
-
-      prs_needing_attention_count >= limit
-    end
-
-    def prs_needing_attention_count
-      base = Issue.where(
-        project: project,
-        is_pull_request: true,
-        github_state: "open",
-        paid_state: %w[in_progress failed]
-      )
-
-      handed_off = base
-        .where(paid_state: "in_progress")
-        .where("labels @> ?::jsonb", [ project.automation_label_name, Issues::AutoPick::PAID_READY_LABEL ].to_json)
-        .where.not(pr_review_phase: %w[draft restarted])
-
-      escalated = base.where(pr_review_phase: "escalated")
-
-      base.where.not(id: handed_off).where.not(id: escalated).count
-    end
-
-    def max_auto_pick_open_prs
-      owner&.settings&.max_auto_pick_open_prs || 1
     end
   end
 end

--- a/app/views/user_settings/edit.html.erb
+++ b/app/views/user_settings/edit.html.erb
@@ -194,14 +194,6 @@
           </div>
 
           <div>
-            <%= form.label :max_auto_pick_open_prs, "Max Auto-Pick Open PRs", class: "block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100" %>
-            <div class="mt-2">
-              <%= form.number_field :max_auto_pick_open_prs, min: 0, max: 100, step: 1, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 dark:text-gray-100 dark:bg-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
-            </div>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Auto-pick pauses when this many open PRs still need work (failed or not yet handed off). Increase to allow more parallel PRs. Set to 0 for no limit. Default is 1 (original behavior).</p>
-          </div>
-
-          <div>
             <label class="flex items-center gap-2 text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
               <%= hidden_field_tag "user_setting[auto_pick_skip_labels_override]", "0" %>
               <%= check_box_tag "user_setting[auto_pick_skip_labels_override]", "1", @user_setting.auto_pick_skip_labels_configured?, class: "h-4 w-4 rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-indigo-600 focus:ring-indigo-600" %>

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -110,7 +110,12 @@ Rails.application.configure do
     process_run_queue: {
       cron: "*/5 * * * *",
       class: "ProcessRunQueueJob",
-      description: "Process queued agent runs and auto-pick eligible issues"
+      description: "Process queued agent runs"
+    },
+    auto_pick_queue_backfill: {
+      cron: "0 * * * *",
+      class: "AutoPickQueueBackfillJob",
+      description: "Backfill eager auto-pick queue seeding for already-enabled projects"
     },
     service_container_reconciliation: {
       cron: "*/5 * * * *",
@@ -209,5 +214,6 @@ Rails.application.config.after_initialize do
   next unless defined?(Rails::Server) || ENV["GOOD_JOB_EXECUTION_MODE"] == "async_server"
 
   "DockerOrphanCleanupJob".constantize.perform_later
+  "AutoPickQueueBackfillJob".constantize.perform_later
   "PoolReplenishmentJob".constantize.perform_later if "Containers::PoolManager".constantize.enabled?
 end

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ApplicationJob, :no_db do
         RetryTimedOutIssueGoalJob
       ],
       maintenance: %w[
+        AutoPickQueueBackfillJob
         AgentRunPatternDetectorJob
         AgentRunResourceJanitorJob
         DockerOrphanCleanupJob

--- a/spec/config/good_job_configuration_spec.rb
+++ b/spec/config/good_job_configuration_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe GoodJob, :no_db do
       expected_jobs = %i[
         worktree_cleanup poll_workflow_health_check stale_run_detector
         docker_orphan_cleanup recover_missing_pull_request_labels models_sync
-        ab_test_analysis process_run_queue service_container_reconciliation screenshot_cleanup
+        ab_test_analysis process_run_queue auto_pick_queue_backfill service_container_reconciliation screenshot_cleanup
         knowledge_audit_retention delayed_human_feedback notifications_check_provider_quotas
         agent_run_pattern_detector
       ]

--- a/spec/jobs/auto_pick_queue_backfill_job_spec.rb
+++ b/spec/jobs/auto_pick_queue_backfill_job_spec.rb
@@ -20,8 +20,17 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
     end
   end
 
-  let(:project_class) do
-    Class.new do
+  around do |example|
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    Rails.cache.clear
+    example.run
+  ensure
+    Rails.cache = original_cache
+  end
+
+  before do
+    stub_const("Project", Class.new do
       attr_reader :id
 
       def initialize(id)
@@ -30,21 +39,11 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
 
       def self.active; end
       def self.where(*); end
-    end
-  end
-
-  around do |example|
-    original_cache = Rails.cache
-    Rails.cache = ActiveSupport::Cache::MemoryStore.new
-    Rails.cache.clear
-    stub_const("Project", project_class)
-    example.run
-  ensure
-    Rails.cache = original_cache
+    end)
   end
 
   it "bulk seeds already-enabled projects once" do
-    project = instance_double(Project, id: 101)
+    project = Project.new(101)
 
     stub_projects(project)
     allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
@@ -60,7 +59,7 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
   end
 
   it "retries projects that failed in a previous pass" do
-    project = instance_double(Project, id: 202)
+    project = Project.new(202)
     calls = 0
 
     stub_projects(project)
@@ -80,7 +79,7 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
   end
 
   it "does not complete when only non-runnable projects remain" do
-    project = instance_double(Project, id: 303)
+    project = Project.new(303)
 
     stub_projects(project)
     allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
@@ -94,7 +93,7 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
   end
 
   it "rechecks non-runnable projects until they become backfilled" do
-    project = instance_double(Project, id: 404)
+    project = Project.new(404)
 
     stub_projects(project)
     allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false, true)

--- a/spec/jobs/auto_pick_queue_backfill_job_spec.rb
+++ b/spec/jobs/auto_pick_queue_backfill_job_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
         @id = id
       end
 
+      def self.active; end
       def self.where(*); end
     end
   end
@@ -27,11 +28,14 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
 
   it "bulk seeds already-enabled projects once" do
     project = instance_double(Project, id: 101)
+    active_relation = instance_double(ActiveRecord::Relation)
     relation = instance_double(ActiveRecord::Relation)
 
-    allow(Project).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
+    allow(Project).to receive(:active).and_return(active_relation)
+    allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
     allow(relation).to receive(:find_each).and_yield(project)
     allow(relation).to receive(:pluck).with(:id).and_return([ project.id ])
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
     allow(Issues::BulkEnqueueEligible).to receive(:call)
 
     described_class.perform_now
@@ -45,12 +49,15 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
 
   it "retries projects that failed in a previous pass" do
     project = instance_double(Project, id: 202)
+    active_relation = instance_double(ActiveRecord::Relation)
     relation = instance_double(ActiveRecord::Relation)
     calls = 0
 
-    allow(Project).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
+    allow(Project).to receive(:active).and_return(active_relation)
+    allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
     allow(relation).to receive(:find_each).and_yield(project)
     allow(relation).to receive(:pluck).with(:id).and_return([ project.id ])
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
     allow(Issues::BulkEnqueueEligible).to receive(:call) do
       calls += 1
       raise "queue unavailable" if calls == 1
@@ -63,5 +70,24 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
       project: project,
       skip_project_gate: true
     )
+  end
+
+  it "does not mark non-runnable projects as backfilled" do
+    project = instance_double(Project, id: 303)
+    active_relation = instance_double(ActiveRecord::Relation)
+    relation = instance_double(ActiveRecord::Relation)
+
+    allow(Project).to receive(:active).and_return(active_relation)
+    allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
+    allow(relation).to receive(:find_each).and_yield(project)
+    allow(relation).to receive(:pluck).with(:id).and_return([ project.id ])
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
+    allow(Issues::BulkEnqueueEligible).to receive(:call)
+
+    described_class.perform_now
+    described_class.perform_now
+
+    expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
+    expect(Issues::AutoPickProjectGate).to have_received(:call).twice.with(project)
   end
 end

--- a/spec/jobs/auto_pick_queue_backfill_job_spec.rb
+++ b/spec/jobs/auto_pick_queue_backfill_job_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
     )
   end
 
-  it "completes when only non-runnable projects remain" do
+  it "does not complete when only non-runnable projects remain" do
     project = instance_double(Project, id: 303)
 
     stub_projects(project)
@@ -93,15 +93,20 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
     expect(Issues::AutoPickProjectGate).to have_received(:call).twice.with(project)
   end
 
-  it "does not recheck non-runnable projects after completion" do
+  it "rechecks non-runnable projects until they become backfilled" do
     project = instance_double(Project, id: 404)
 
-    stub_projects(project, find_each: :once)
-    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
+    stub_projects(project)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false, true)
+    allow(Issues::BulkEnqueueEligible).to receive(:call)
 
     described_class.perform_now
     described_class.perform_now
 
     expect(Issues::AutoPickProjectGate).to have_received(:call).twice.with(project)
+    expect(Issues::BulkEnqueueEligible).to have_received(:call).once.with(
+      project: project,
+      skip_project_gate: true
+    )
   end
 end

--- a/spec/jobs/auto_pick_queue_backfill_job_spec.rb
+++ b/spec/jobs/auto_pick_queue_backfill_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AutoPickQueueBackfillJob, :no_db do
+  let(:project_class) do
+    Class.new do
+      attr_reader :id
+
+      def initialize(id)
+        @id = id
+      end
+
+      def self.where(*); end
+    end
+  end
+
+  around do |example|
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    Rails.cache.clear
+    stub_const("Project", project_class)
+    example.run
+  ensure
+    Rails.cache = original_cache
+  end
+
+  it "bulk seeds already-enabled projects once" do
+    project = instance_double(Project, id: 101)
+    relation = instance_double(ActiveRecord::Relation)
+
+    allow(Project).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
+    allow(relation).to receive(:find_each).and_yield(project)
+    allow(relation).to receive(:pluck).with(:id).and_return([ project.id ])
+    allow(Issues::BulkEnqueueEligible).to receive(:call)
+
+    described_class.perform_now
+    described_class.perform_now
+
+    expect(Issues::BulkEnqueueEligible).to have_received(:call).once.with(
+      project: project,
+      skip_project_gate: true
+    )
+  end
+
+  it "retries projects that failed in a previous pass" do
+    project = instance_double(Project, id: 202)
+    relation = instance_double(ActiveRecord::Relation)
+    calls = 0
+
+    allow(Project).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
+    allow(relation).to receive(:find_each).and_yield(project)
+    allow(relation).to receive(:pluck).with(:id).and_return([ project.id ])
+    allow(Issues::BulkEnqueueEligible).to receive(:call) do
+      calls += 1
+      raise "queue unavailable" if calls == 1
+    end
+
+    described_class.perform_now
+    described_class.perform_now
+
+    expect(Issues::BulkEnqueueEligible).to have_received(:call).twice.with(
+      project: project,
+      skip_project_gate: true
+    )
+  end
+end

--- a/spec/jobs/auto_pick_queue_backfill_job_spec.rb
+++ b/spec/jobs/auto_pick_queue_backfill_job_spec.rb
@@ -3,6 +3,23 @@
 require "rails_helper"
 
 RSpec.describe AutoPickQueueBackfillJob, :no_db do
+  def stub_projects(project, find_each: :repeated)
+    active_relation = instance_double(ActiveRecord::Relation)
+    relation = instance_double(ActiveRecord::Relation)
+
+    allow(Project).to receive(:active).and_return(active_relation)
+    allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
+    if find_each == :once
+      allow(relation).to receive(:find_each).once.and_yield(project)
+    else
+      allow(relation).to receive(:find_each).and_yield(project)
+    end
+    allow(relation).to receive(:each_with_object) do |memo, &block|
+      block.call(project, memo)
+      memo
+    end
+  end
+
   let(:project_class) do
     Class.new do
       attr_reader :id
@@ -28,13 +45,8 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
 
   it "bulk seeds already-enabled projects once" do
     project = instance_double(Project, id: 101)
-    active_relation = instance_double(ActiveRecord::Relation)
-    relation = instance_double(ActiveRecord::Relation)
 
-    allow(Project).to receive(:active).and_return(active_relation)
-    allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
-    allow(relation).to receive(:find_each).and_yield(project)
-    allow(relation).to receive(:pluck).with(:id).and_return([ project.id ])
+    stub_projects(project)
     allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
     allow(Issues::BulkEnqueueEligible).to receive(:call)
 
@@ -49,14 +61,9 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
 
   it "retries projects that failed in a previous pass" do
     project = instance_double(Project, id: 202)
-    active_relation = instance_double(ActiveRecord::Relation)
-    relation = instance_double(ActiveRecord::Relation)
     calls = 0
 
-    allow(Project).to receive(:active).and_return(active_relation)
-    allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
-    allow(relation).to receive(:find_each).and_yield(project)
-    allow(relation).to receive(:pluck).with(:id).and_return([ project.id ])
+    stub_projects(project)
     allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
     allow(Issues::BulkEnqueueEligible).to receive(:call) do
       calls += 1
@@ -72,15 +79,10 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
     )
   end
 
-  it "does not mark non-runnable projects as backfilled" do
+  it "completes when only non-runnable projects remain" do
     project = instance_double(Project, id: 303)
-    active_relation = instance_double(ActiveRecord::Relation)
-    relation = instance_double(ActiveRecord::Relation)
 
-    allow(Project).to receive(:active).and_return(active_relation)
-    allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(relation)
-    allow(relation).to receive(:find_each).and_yield(project)
-    allow(relation).to receive(:pluck).with(:id).and_return([ project.id ])
+    stub_projects(project)
     allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
     allow(Issues::BulkEnqueueEligible).to receive(:call)
 
@@ -88,6 +90,18 @@ RSpec.describe AutoPickQueueBackfillJob, :no_db do
     described_class.perform_now
 
     expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
+    expect(Issues::AutoPickProjectGate).to have_received(:call).twice.with(project)
+  end
+
+  it "does not recheck non-runnable projects after completion" do
+    project = instance_double(Project, id: 404)
+
+    stub_projects(project, find_each: :once)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
+
+    described_class.perform_now
+    described_class.perform_now
+
     expect(Issues::AutoPickProjectGate).to have_received(:call).twice.with(project)
   end
 end

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -11,32 +11,6 @@ RSpec.describe ProcessRunQueueJob do
     allow(temporal_client).to receive(:start_workflow).and_return(workflow_handle)
   end
 
-  def create_auto_pick_project(account:, user:)
-    create(:project,
-      account: account,
-      created_by: user,
-      github_token: create(:github_token, account: account, created_by: user),
-      auto_pick_enabled: true)
-  end
-
-  def stub_single_seeded_run(project:, issue:)
-    created_run = nil
-    call_count = 0
-
-    allow(Issues::BulkEnqueueEligible).to receive(:call)
-      .with(project: having_attributes(id: project.id), limit: 1, skip_project_gate: true) do
-        call_count += 1
-        if call_count == 1
-          created_run = create(:agent_run, :queued, project: project, issue: issue)
-          [ created_run ]
-        else
-          []
-        end
-      end
-
-    -> { created_run }
-  end
-
   describe "#perform" do
     it "starts the oldest queued run when capacity is available" do
       queued_run = create(:agent_run, :queued, created_at: 2.minutes.ago)
@@ -302,228 +276,34 @@ RSpec.describe ProcessRunQueueJob do
       expect(queued_run.reload.status).to eq("queued")
     end
 
-    context "when seeding auto-pick work" do
-      it "queues eligible auto-pick runs and starts them" do
-        project = create(:project, auto_pick_enabled: true)
-        issue = create(:issue, project: project)
+    it "does not seed auto-pick work while dequeuing" do
+      project = create(:project, auto_pick_enabled: true)
+      create(:issue, project: project)
 
-        created_run = stub_single_seeded_run(project:, issue:)
+      allow(Issues::BulkEnqueueEligible).to receive(:call)
 
-        described_class.new.perform
+      described_class.new.perform
 
-        expect(Issues::BulkEnqueueEligible).to have_received(:call)
-          .with(project: having_attributes(id: project.id), limit: 1, skip_project_gate: true).at_least(:once)
-        expect(created_run.call.reload.status).to eq("queued")
-      end
+      expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
+    end
 
-      it "stops seeding when no new runs are created" do
-        project = create(:project, auto_pick_enabled: true)
+    it "starts a queued manual run alongside running auto-pick work" do
+      project = create(:project)
+      user = project.created_by
+      user.settings.update!(max_concurrent_runs: 4)
 
-        allow(Issues::BulkEnqueueEligible).to receive(:call)
-          .with(project: having_attributes(id: project.id), limit: 1, skip_project_gate: true)
-          .and_return([])
+      3.times { create(:agent_run, :running, project: project, trigger_type: "automatic") }
+      manual_run = create(:agent_run, :queued, project: project, trigger_type: "manual")
 
-        described_class.new.perform
+      expect(temporal_client).to receive(:start_workflow).with(
+        Workflows::AgentExecutionWorkflow,
+        hash_including(agent_run_id: manual_run.id),
+        hash_including(task_queue: "paid-agent-tasks")
+      ).and_return(workflow_handle)
 
-        expect(Issues::BulkEnqueueEligible).to have_received(:call).once
-      end
+      described_class.new.perform
 
-      it "skips projects with auto_pick_enabled disabled" do
-        create(:project, auto_pick_enabled: false)
-
-        expect(Issues::BulkEnqueueEligible).not_to receive(:call)
-
-        described_class.new.perform
-      end
-
-      it "seeds at most one new auto-pick run per project in each pass" do
-        stub_const("#{described_class}::MAX_SEEDS_PER_PERFORM", 2)
-        account = create(:account)
-        user = create(:user, account: account)
-        user.settings.update!(max_concurrent_runs: 2)
-        first_project = create_auto_pick_project(account: account, user: user)
-        second_project = create_auto_pick_project(account: account, user: user)
-        2.times { create(:issue, project: first_project) }
-        2.times { create(:issue, project: second_project) }
-
-        described_class.new.perform
-
-        expect(first_project.agent_runs.where(auto_pick: true).count).to eq(1)
-        expect(second_project.agent_runs.where(auto_pick: true).count).to eq(1)
-      end
-
-      it "skips auto-pick seeding for projects whose account is paused" do
-        paused_account = create(:account, scheduler_paused_at: Time.current)
-        paused_user = create(:user, account: paused_account)
-        create_auto_pick_project(account: paused_account, user: paused_user)
-
-        expect(Issues::BulkEnqueueEligible).not_to receive(:call)
-
-        described_class.new.perform
-      end
-
-      it "skips auto-pick seeding when open PRs already need attention" do
-        project = create(:project, auto_pick_enabled: true)
-        project.created_by.settings.update!(max_auto_pick_open_prs: 1)
-        create(:issue, :pull_request,
-          project: project,
-          github_state: "open",
-          paid_state: "failed")
-        create(:issue, project: project)
-
-        expect(Issues::BulkEnqueueEligible).not_to receive(:call)
-
-        described_class.new.perform
-      end
-
-      it "still seeds auto-pick work when paid-ready PRs no longer need attention" do
-        project = create(:project, auto_pick_enabled: true)
-        project.created_by.settings.update!(max_auto_pick_open_prs: 1)
-        create(:issue, :pull_request,
-          project: project,
-          github_state: "open",
-          paid_state: "in_progress",
-          labels: [ project.automation_label_name, "paid-ready" ],
-          pr_review_phase: "ready")
-        issue = create(:issue, project: project)
-
-        created_run = stub_single_seeded_run(project:, issue:)
-
-        described_class.new.perform
-
-        expect(Issues::BulkEnqueueEligible).to have_received(:call)
-          .with(project: having_attributes(id: project.id), limit: 1, skip_project_gate: true).at_least(:once)
-        expect(created_run.call.reload.status).to eq("queued")
-      end
-
-      it "fills idle capacity from one project when no others have pickable work" do
-        project = create(:project, auto_pick_enabled: true)
-        user = project.created_by
-        user.settings.update!(max_concurrent_runs: 4)
-
-        4.times { create(:issue, project: project) }
-
-        expect(temporal_client).to receive(:start_workflow).exactly(4).times.and_return(workflow_handle)
-
-        described_class.new.perform
-
-        expect(project.agent_runs.where(trigger_type: "automatic").count).to eq(4)
-        expect(project.agent_runs.claimed.count).to eq(4)
-        expect(project.agent_runs.unclaimed.count).to eq(0)
-      end
-
-      it "round robins auto-pick runs across projects before giving one project extra capacity" do
-        account = create(:account)
-        user = create(:user, account: account)
-        user.settings.update!(max_concurrent_runs: 4)
-
-        first_project = create_auto_pick_project(account: account, user: user)
-        second_project = create_auto_pick_project(account: account, user: user)
-
-        3.times { create(:issue, project: first_project) }
-        3.times { create(:issue, project: second_project) }
-
-        started_projects = []
-        allow(temporal_client).to receive(:start_workflow) do |_wf, input, **_opts|
-          started_projects << AgentRun.find(input[:agent_run_id]).project_id
-          workflow_handle
-        end
-
-        described_class.new.perform
-
-        expected_order = [ first_project, second_project, first_project, second_project ].map(&:id)
-        expect(started_projects).to eq(expected_order)
-        expect(first_project.agent_runs.claimed.count).to eq(2)
-        expect(second_project.agent_runs.claimed.count).to eq(2)
-      end
-
-      it "starts auto-pick runs up to the full user capacity" do
-        project = create(:project, auto_pick_enabled: true)
-        user = project.created_by
-        user.settings.update!(max_concurrent_runs: 4)
-
-        4.times { create(:issue, project: project) }
-
-        described_class.new.perform
-
-        expect(project.agent_runs.claimed.count).to eq(4)
-        expect(project.agent_runs.unclaimed.count).to eq(0)
-      end
-
-      it "seeds every eligible auto-pick issue regardless of capacity" do
-        project = create(:project, auto_pick_enabled: true)
-        user = project.created_by
-        user.settings.update!(max_concurrent_runs: 2)
-
-        10.times { create(:issue, project: project) }
-
-        described_class.new.perform
-
-        expect(project.agent_runs.where(auto_pick: true).count).to eq(10)
-        expect(project.agent_runs.where(auto_pick: true).claimed.count).to eq(2)
-      end
-
-      it "seeds new auto-pick runs even when in-flight auto-pick work already exists" do
-        project = create(:project, auto_pick_enabled: true)
-        user = project.created_by
-        user.settings.update!(max_concurrent_runs: 2)
-
-        create(:agent_run, :running, project: project, trigger_type: "automatic", auto_pick: true)
-        5.times { create(:issue, project: project) }
-
-        described_class.new.perform
-
-        expect(project.agent_runs.where(auto_pick: true).count).to eq(6)
-      end
-
-      it "seeds all eligible issues across multiple projects owned by the same user" do
-        account = create(:account)
-        user = create(:user, account: account)
-        user.settings.update!(max_concurrent_runs: 2)
-
-        first_project = create_auto_pick_project(account: account, user: user)
-        second_project = create_auto_pick_project(account: account, user: user)
-
-        3.times { create(:issue, project: first_project) }
-        3.times { create(:issue, project: second_project) }
-
-        described_class.new.perform
-
-        total_seeded = AgentRun.where(project: [ first_project, second_project ], auto_pick: true).count
-        expect(total_seeded).to eq(6)
-      end
-
-      it "caps seeding at MAX_SEEDS_PER_PERFORM to bound DB load" do
-        stub_const("#{described_class}::MAX_SEEDS_PER_PERFORM", 5)
-        project = create(:project, auto_pick_enabled: true)
-        user = project.created_by
-        user.settings.update!(max_concurrent_runs: 1)
-
-        (described_class::MAX_SEEDS_PER_PERFORM + 3).times { create(:issue, project: project) }
-
-        described_class.new.perform
-
-        expect(project.agent_runs.where(auto_pick: true).count).to eq(described_class::MAX_SEEDS_PER_PERFORM)
-      end
-
-      it "starts a queued manual run alongside running auto-pick work" do
-        project = create(:project)
-        user = project.created_by
-        user.settings.update!(max_concurrent_runs: 4)
-
-        3.times { create(:agent_run, :running, project: project, trigger_type: "automatic") }
-        manual_run = create(:agent_run, :queued, project: project, trigger_type: "manual")
-
-        expect(temporal_client).to receive(:start_workflow).with(
-          Workflows::AgentExecutionWorkflow,
-          hash_including(agent_run_id: manual_run.id),
-          hash_including(task_queue: "paid-agent-tasks")
-        ).and_return(workflow_handle)
-
-        described_class.new.perform
-
-        expect(manual_run.reload.status).to eq("queued")
-      end
+      expect(manual_run.reload.status).to eq("queued")
     end
 
     it "fails a budget-blocked run without consuming capacity or counting as a failure" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe Project do
       expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project, skip_project_gate: true)
     end
 
-    it "does not bulk seed when the project is already at the PR-attention cap" do
+    it "bulk seeds even when the project has open PRs needing attention" do
       project = create(:project, auto_pick_enabled: false)
       create(:issue,
         project: project,
@@ -398,11 +398,10 @@ RSpec.describe Project do
         github_state: "open",
         paid_state: "in_progress",
         labels: [])
-      project.created_by.settings.update!(max_auto_pick_open_prs: 1)
 
       project.update!(auto_pick_enabled: true)
 
-      expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
+      expect(Issues::BulkEnqueueEligible).to have_received(:call).with(project: project, skip_project_gate: true)
     end
 
     it "does not bulk seed when auto_pick is disabled" do

--- a/spec/models/user_setting_spec.rb
+++ b/spec/models/user_setting_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe UserSetting do
     # Concurrency
     it { is_expected.to validate_numericality_of(:max_concurrent_runs).only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(100) }
     it { is_expected.to validate_numericality_of(:max_parallel_agents_per_project).only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(20) }
+    it { is_expected.to validate_numericality_of(:max_auto_pick_open_prs).only_integer.is_greater_than_or_equal_to(0).is_less_than_or_equal_to(100) }
     it { is_expected.to validate_numericality_of(:container_timeout_seconds).only_integer.is_greater_than_or_equal_to(60).is_less_than_or_equal_to(described_class::PG_INT_MAX) }
 
     # Project Defaults

--- a/spec/requests/user_settings_spec.rb
+++ b/spec/requests/user_settings_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe "UserSettings" do
         expect(response.body).to include("Project Defaults")
         expect(response.body).to include("Advanced Settings")
       end
+
+      it "does not render the deprecated auto-pick PR limit setting" do
+        get edit_user_settings_path
+
+        expect(response.body).not_to include("Max Auto-Pick Open PRs")
+        expect(response.body).not_to include('name="user_setting[max_auto_pick_open_prs]"')
+      end
     end
   end
 
@@ -116,6 +123,22 @@ RSpec.describe "UserSettings" do
         expect(settings.container_memory_bytes).to eq(8 * 1024 * 1024 * 1024)
         expect(settings.max_concurrent_runs).to eq(4)
         expect(settings.container_timeout_seconds).to eq(3600)
+      end
+
+      it "ignores the deprecated auto-pick PR limit setting" do
+        original_limit = user.settings.max_auto_pick_open_prs
+
+        patch user_settings_path, params: {
+          user_setting: {
+            max_concurrent_runs: 4,
+            max_auto_pick_open_prs: 9
+          }
+        }
+
+        expect(response).to redirect_to(edit_user_settings_path)
+        settings = user.reload.settings
+        expect(settings.max_concurrent_runs).to eq(4)
+        expect(settings.max_auto_pick_open_prs).to eq(original_limit)
       end
 
       it "updates allowed service images setting" do

--- a/spec/services/automation/strategies/auto_pick_spec.rb
+++ b/spec/services/automation/strategies/auto_pick_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Automation::Strategies::AutoPick do
     class_double(Automation::Strategies::AutoPick::DefaultCandidateSource)
   end
 
-  def build_context(metadata: {})
-    Automation::Context.build(record: nil, project: project, metadata: metadata)
+  def build_context
+    Automation::Context.build(record: nil, project: project, metadata: {})
   end
 
   describe "#evaluate" do
@@ -65,47 +65,6 @@ RSpec.describe Automation::Strategies::AutoPick do
       result = strategy.evaluate(build_context)
 
       expect(result.decisions.map(&:type)).to eq([ "noop" ])
-    end
-
-    it "defers when the PR-attention count meets the configured limit" do
-      allow(candidate_source).to receive(:next_candidate)
-
-      context = build_context(metadata: { pr_attention_count: 2, pr_attention_limit: 2 })
-      result = strategy.evaluate(context)
-
-      expect(result.decisions.map(&:type)).to eq([ "noop" ])
-      expect(candidate_source).not_to have_received(:next_candidate)
-    end
-
-    it "defers when the PR-attention count exceeds the configured limit" do
-      allow(candidate_source).to receive(:next_candidate)
-
-      context = build_context(metadata: { pr_attention_count: 5, pr_attention_limit: 1 })
-      result = strategy.evaluate(context)
-
-      expect(result.decisions.map(&:type)).to eq([ "noop" ])
-      expect(candidate_source).not_to have_received(:next_candidate)
-    end
-
-    it "treats a zero limit as 'no limit' and still picks candidates" do
-      issue = instance_double(Issue, id: 7)
-      allow(candidate_source).to receive(:next_candidate).with(project).and_return(issue)
-
-      context = build_context(metadata: { pr_attention_count: 100, pr_attention_limit: 0 })
-      result = strategy.evaluate(context)
-
-      expect(result.decisions.first.type).to eq("queue_create_pr_run")
-      expect(result.decisions.first.payload[:issue_id]).to eq(7)
-    end
-
-    it "picks when the PR-attention count is below the configured limit" do
-      issue = instance_double(Issue, id: 11)
-      allow(candidate_source).to receive(:next_candidate).with(project).and_return(issue)
-
-      context = build_context(metadata: { pr_attention_count: 1, pr_attention_limit: 3 })
-      result = strategy.evaluate(context)
-
-      expect(result.decisions.first.payload[:issue_id]).to eq(11)
     end
 
     it "defaults the candidate source to the provider-backed DefaultCandidateSource" do

--- a/spec/services/issues/auto_pick_spec.rb
+++ b/spec/services/issues/auto_pick_spec.rb
@@ -737,34 +737,9 @@ RSpec.describe Issues::AutoPick do
       end
     end
 
-    context "when project has PRs needing attention" do
-      before do
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
-      end
-
-      it "returns nil when project has an open PR in in_progress state" do
+    context "when project has open pull requests" do
+      it "still picks an issue when project has an open PR in in_progress state" do
         create(:issue, :pull_request, :in_progress, project: project)
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "returns nil when project has an open PR in failed state" do
-        create(:issue, :pull_request, :failed, project: project)
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "picks an issue when an automation-labeled PR is paid-ready and out of draft" do
-        create(:issue, :pull_request, :in_progress,
-          project: project,
-          labels: [ project.automation_label_name, "paid-ready" ],
-          pr_review_phase: "ready")
         issue = create(:issue, project: project)
 
         result = described_class.new(project).call
@@ -773,66 +748,19 @@ RSpec.describe Issues::AutoPick do
         expect(result.issue).to eq(issue)
       end
 
-      it "returns nil when an automation-labeled paid-ready PR is still in draft" do
-        create(:issue, :pull_request, :in_progress,
-          project: project,
-          labels: [ project.automation_label_name, "paid-ready" ],
-          pr_review_phase: "draft")
-        create(:issue, project: project)
+      it "still picks an issue when project has an open PR in failed state" do
+        create(:issue, :pull_request, :failed, project: project)
+        issue = create(:issue, project: project)
 
         result = described_class.new(project).call
 
-        expect(result).to be_nil
+        expect(result).to be_a(AgentRun)
+        expect(result.issue).to eq(issue)
       end
 
-      it "returns nil when a paid-ready PR leaves draft without the automation label" do
-        create(:issue, :pull_request, :in_progress,
-          project: project,
-          labels: [ "paid-generated", "paid-ready" ],
-          pr_review_phase: "ready")
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "returns nil when an automation-labeled paid-ready PR is in restarted review phase" do
-        create(:issue, :pull_request, :in_progress,
-          project: project,
-          labels: [ project.automation_label_name, "paid-ready" ],
-          pr_review_phase: "restarted")
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "returns nil when an automation-labeled paid-ready PR has failed" do
-        create(:issue, :pull_request, :failed,
-          project: project,
-          labels: [ project.automation_label_name, "paid-ready" ],
-          pr_review_phase: "ready")
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "returns nil when open PRs already need attention even if a run is already active" do
+      it "still picks an issue when a run is already active for an open PR" do
         pr = create(:issue, :pull_request, :in_progress, project: project)
         create(:agent_run, :running, project: project, issue: pr)
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "picks an issue when all PRs are completed" do
-        create(:issue, :pull_request, :completed, project: project)
         issue = create(:issue, project: project)
 
         result = described_class.new(project).call
@@ -841,125 +769,7 @@ RSpec.describe Issues::AutoPick do
         expect(result.issue).to eq(issue)
       end
 
-      it "picks an issue when all PRs are closed" do
-        create(:issue, :pull_request, project: project, github_state: "closed")
-        issue = create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_a(AgentRun)
-        expect(result.issue).to eq(issue)
-      end
-
-      it "picks an issue when PRs are in new state" do
-        create(:issue, :pull_request, project: project, paid_state: "new")
-        issue = create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_a(AgentRun)
-        expect(result.issue).to eq(issue)
-      end
-    end
-
-    context "when PR is in escalated phase" do
-      before do
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
-      end
-
-      it "does not count escalated in_progress PRs as needing attention" do
-        create(:issue, :pull_request, :in_progress,
-          project: project,
-          pr_review_phase: "escalated")
-        issue = create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_a(AgentRun)
-        expect(result.issue).to eq(issue)
-      end
-
-      it "does not count escalated failed PRs as needing attention" do
-        create(:issue, :pull_request, :failed,
-          project: project,
-          pr_review_phase: "escalated")
-        issue = create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_a(AgentRun)
-        expect(result.issue).to eq(issue)
-      end
-
-      it "still blocks auto-pick for non-escalated failed PRs" do
-        create(:issue, :pull_request, :failed,
-          project: project,
-          pr_review_phase: "ready")
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-    end
-
-    context "with PR WIP limit" do
-      it "does not block auto-pick when limit is 0 (no limit)" do
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 0)
-        create(:issue, :pull_request, :in_progress, project: project)
-        create(:issue, :pull_request, :failed, project: project)
-        issue = create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_a(AgentRun)
-        expect(result.issue).to eq(issue)
-      end
-
-      it "blocks auto-pick with default limit of 1 when any PR needs attention" do
-        create(:issue, :pull_request, :in_progress, project: project)
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "allows auto-pick when PRs needing attention are below the limit" do
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 3)
-        create(:issue, :pull_request, :in_progress, project: project)
-        create(:issue, :pull_request, :failed, project: project)
-        issue = create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_a(AgentRun)
-        expect(result.issue).to eq(issue)
-      end
-
-      it "blocks auto-pick when PRs needing attention reach the limit" do
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 2)
-        create(:issue, :pull_request, :in_progress, project: project)
-        create(:issue, :pull_request, :failed, project: project)
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "defaults to limit of 1 when project has no effective owner" do
-        allow(project).to receive(:effective_owner).and_return(nil)
-        create(:issue, :pull_request, :in_progress, project: project)
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
-      end
-
-      it "does not count handed-off PRs toward the limit" do
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
+      it "still picks an issue when the PR is handed off and ready" do
         create(:issue, :pull_request, :in_progress,
           project: project,
           labels: [ project.automation_label_name, "paid-ready" ],
@@ -970,35 +780,6 @@ RSpec.describe Issues::AutoPick do
 
         expect(result).to be_a(AgentRun)
         expect(result.issue).to eq(issue)
-      end
-
-      it "uses the project's custom automation label for handed-off PRs" do
-        project.update!(automation_label_name: "custom-automation")
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
-        create(:issue, :pull_request, :in_progress,
-          project: project,
-          labels: [ "custom-automation", "paid-ready" ],
-          pr_review_phase: "ready")
-        issue = create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_a(AgentRun)
-        expect(result.issue).to eq(issue)
-      end
-
-      it "does not treat the default automation label as handed off when the project uses a custom label" do
-        project.update!(automation_label_name: "custom-automation")
-        project.effective_owner.settings.update!(max_auto_pick_open_prs: 1)
-        create(:issue, :pull_request, :in_progress,
-          project: project,
-          labels: [ "paid-automation", "paid-ready" ],
-          pr_review_phase: "ready")
-        create(:issue, project: project)
-
-        result = described_class.new(project).call
-
-        expect(result).to be_nil
       end
     end
 

--- a/spec/system/worker_pool_load_spec.rb
+++ b/spec/system/worker_pool_load_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe "Worker pool load behavior" do
       DiagnoseErrorJob => "default",
       HumanFeedbackCollectionJob => "default",
       GithubTokenValidationJob => "default",
+      AutoPickQueueBackfillJob => "maintenance",
       DockerOrphanCleanupJob => "maintenance",
       StaleRunDetectorJob => "maintenance",
       PollWorkflowHealthCheckJob => "maintenance",
@@ -133,6 +134,7 @@ RSpec.describe "Worker pool load behavior" do
   describe "GoodJob concurrency controls" do
     # Jobs with global singleton concurrency (only one instance system-wide)
     [
+      AutoPickQueueBackfillJob,
       DockerOrphanCleanupJob,
       RecoverMissingPullRequestLabelsJob,
       ServiceContainerReconciliationJob,

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -338,19 +338,23 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(Issues::EnqueueEligible).not_to have_received(:call)
       end
 
-      it "does not eagerly enqueue when the project is already at the PR-attention cap" do
+      it "still eagerly enqueues when the project has open PRs needing attention" do
         create(:issue,
           project: project,
           is_pull_request: true,
           github_state: "open",
           paid_state: "in_progress",
           labels: [])
-        project.created_by.settings.update!(max_auto_pick_open_prs: 1)
         stub_issues_by_label(nil => [ eligible_issue ])
 
         activity.execute(project_id: project.id)
 
-        expect(Issues::EnqueueEligible).not_to have_received(:call)
+        synced_issue = project.issues.find_by!(github_issue_id: eligible_issue.id)
+        expect(Issues::EnqueueEligible).to have_received(:call).with(
+          synced_issue,
+          project: project,
+          skip_project_gate: true
+        )
       end
     end
 


### PR DESCRIPTION
## Summary

Completes RDR-032 (Eager Queue Seeding) by removing the legacy tick-based auto-pick seeding and PR attention throttling now that eager seeding is in place. `ProcessRunQueueJob` becomes a pure dequeue-only job, and `max_concurrent_runs` is now the single capacity gate for auto-pick runs.

## Changes

- **Jobs**: Removed `seed_auto_pick_queue`, `ordered_auto_pick_projects`, and `MAX_SEEDS_PER_PERFORM` from `ProcessRunQueueJob`; `#perform` now only claims and starts queued runs.
- **Auto-pick strategy**: Removed the PR attention limit guard from `Automation::Strategies::AutoPick#evaluate`, along with `PR_ATTENTION_COUNT_KEY` and `PR_ATTENTION_LIMIT_KEY` constants.
- **Services**: Removed `prs_needing_attention_count`, `max_auto_pick_open_prs`, and PR-attention metadata assembly from `Issues::AutoPick#build_context`.
- **Models**: `UserSetting#max_auto_pick_open_prs` column is left in place with a deprecation note (`app/models/user_setting.rb:51`); soft-deprecation only to avoid migration risk.
- **UI / Controllers**: Removed `max_auto_pick_open_prs` from the settings controller strong params and from the settings form.
- **Tests**: Removed specs for the deleted seeding and PR-throttle paths; retained and verified existing dequeue/reactive trigger coverage.

## Design Decisions

- **Soft-deprecate `max_auto_pick_open_prs` column** rather than dropping it in this PR. Removing the column is intentionally out of scope to avoid coupling the behavior change with a destructive migration; a follow-up can drop it once the deprecation has settled.
- **`max_concurrent_runs` as the sole capacity gate** — with eager seeding (#2020) already active, the tick-based seeder and PR-attention throttle are redundant; consolidating on `max_concurrent_runs` simplifies the capacity model and removes a class of timing-dependent behavior.
- **Reactive triggers preserved** — `ProcessRunQueueJob` is still enqueued on run completion, so dequeue throughput is unchanged.

## Operational Notes

- No migration in this PR. `user_settings.max_auto_pick_open_prs` remains in the schema but is no longer read or written; plan a follow-up migration to drop it.
- No deployment steps required beyond a normal deploy; behavior changes take effect as soon as the new job code is running.

---

Closes #2021