### PR TITLE
feat(auto-pick): enqueue newly-unblocked dependents when a blocking issue closes

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -504,9 +504,14 @@ class Issue < ApplicationRecord
       )
 
       Issues::EnqueueEligible.call(dependent, project: dependent.project, skip_project_gate: true)
+    rescue => e
+      Rails.logger.error(
+        message: "enqueue_eligible.dependency_resolution_failed",
+        issue_id: id,
+        dependent_issue_id: dependent.id,
+        error: e.message
+      )
     end
-  rescue => e
-    Rails.logger.error(message: "enqueue_eligible.dependency_resolution_failed", issue_id: id, error: e.message)
   end
 
   def auto_pick_enabled_dependents

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -492,6 +492,7 @@ class Issue < ApplicationRecord
 
   def enqueue_newly_unblocked_dependents
     auto_pick_enabled_dependents.find_each do |dependent|
+      next unless Issues::AutoPickProjectGate.call(dependent.project)
       next unless Issue.ready_for_work(dependent.project).where(id: dependent.id).exists?
 
       Rails.logger.info(

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -61,6 +61,7 @@ class Issue < ApplicationRecord
 
   after_commit :broadcast_current_section, on: [ :create, :destroy ]
   after_update_commit :broadcast_changed_sections
+  after_update_commit :enqueue_newly_unblocked_dependents, if: :github_just_closed?
   after_commit :update_project_last_github_activity_at, on: [ :create, :update ]
 
   scope :by_paid_state, ->(state) { where(paid_state: state) }
@@ -483,5 +484,35 @@ class Issue < ApplicationRecord
     else
       project.broadcast_issues_update
     end
+  end
+
+  def github_just_closed?
+    saved_change_to_github_state? && github_state == "closed"
+  end
+
+  def enqueue_newly_unblocked_dependents
+    auto_pick_enabled_dependents.find_each do |dependent|
+      next unless Issue.ready_for_work(dependent.project).where(id: dependent.id).exists?
+
+      Rails.logger.info(
+        message: "enqueue_eligible.dependency_resolved",
+        blocker_issue_id: id,
+        blocker_issue_number: github_number,
+        dependent_issue_id: dependent.id,
+        dependent_issue_number: dependent.github_number,
+        project_id: dependent.project_id
+      )
+
+      Issues::EnqueueEligible.call(dependent, project: dependent.project, skip_project_gate: true)
+    end
+  rescue => e
+    Rails.logger.error(message: "enqueue_eligible.dependency_resolution_failed", issue_id: id, error: e.message)
+  end
+
+  def auto_pick_enabled_dependents
+    Issue
+      .includes(:project)
+      .joins(:project)
+      .where(id: reverse_issue_dependencies.select(:issue_id), projects: { auto_pick_enabled: true })
   end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -209,6 +209,86 @@ RSpec.describe Issue do
     end
   end
 
+  describe "after_update_commit on github_state change" do
+    it "enqueues a newly unblocked dependent when the blocker closes" do
+      project = create(:project, auto_pick_enabled: true)
+      blocker = create(:issue, project: project, github_state: "open")
+      dependent = create(:issue, project: project, github_state: "open")
+      create(:issue_dependency, issue: dependent, depends_on_issue: blocker)
+      allow(Issues::EnqueueEligible).to receive(:call)
+      allow(Rails.logger).to receive(:info)
+
+      blocker.update!(github_state: "closed")
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(dependent, project: project, skip_project_gate: true)
+      expect(Rails.logger).to have_received(:info).with(
+        hash_including(
+          message: "enqueue_eligible.dependency_resolved",
+          blocker_issue_id: blocker.id,
+          dependent_issue_id: dependent.id
+        )
+      )
+    end
+
+    it "does not enqueue a dependent that still has another open dependency" do
+      project = create(:project, auto_pick_enabled: true)
+      closing_blocker = create(:issue, project: project, github_state: "open")
+      other_blocker = create(:issue, project: project, github_state: "open")
+      dependent = create(:issue, project: project, github_state: "open")
+      create(:issue_dependency, issue: dependent, depends_on_issue: closing_blocker)
+      create(:issue_dependency, issue: dependent, depends_on_issue: other_blocker)
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      closing_blocker.update!(github_state: "closed")
+
+      expect(Issues::EnqueueEligible).not_to have_received(:call)
+    end
+
+    it "does not enqueue anything when the closed issue has no dependents" do
+      issue = create(:issue, github_state: "open")
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      issue.update!(github_state: "closed")
+
+      expect(Issues::EnqueueEligible).not_to have_received(:call)
+    end
+
+    it "enqueues dependents transitively as blockers close in sequence" do
+      project = create(:project, auto_pick_enabled: true)
+      issue_a = create(:issue, project: project, github_state: "open")
+      issue_b = create(:issue, project: project, github_state: "open")
+      issue_c = create(:issue, project: project, github_state: "open")
+      create(:issue_dependency, issue: issue_b, depends_on_issue: issue_a)
+      create(:issue_dependency, issue: issue_c, depends_on_issue: issue_b)
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      issue_a.update!(github_state: "closed")
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(issue_b, project: project, skip_project_gate: true)
+      expect(Issues::EnqueueEligible).not_to have_received(:call).with(issue_c, project: project, skip_project_gate: true)
+
+      issue_b.update!(github_state: "closed")
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(issue_c, project: project, skip_project_gate: true)
+    end
+
+    it "enqueues cross-project dependents when their project has auto_pick enabled" do
+      account = create(:account)
+      github_token = create(:github_token, account: account)
+      user = create(:user, account: account)
+      blocker_project = create(:project, account: account, github_token: github_token, created_by: user, auto_pick_enabled: true)
+      dependent_project = create(:project, account: account, github_token: github_token, created_by: user, auto_pick_enabled: true)
+      blocker = create(:issue, project: blocker_project, github_state: "open")
+      dependent = create(:issue, project: dependent_project, github_state: "open")
+      create(:issue_dependency, issue: dependent, depends_on_issue: blocker)
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      blocker.update!(github_state: "closed")
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(dependent, project: dependent_project, skip_project_gate: true)
+    end
+  end
+
   describe "instance methods" do
     describe "#github_url" do
       it "returns the GitHub issue URL for issues" do

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -287,6 +287,30 @@ RSpec.describe Issue do
 
       expect(Issues::EnqueueEligible).to have_received(:call).with(dependent, project: dependent_project, skip_project_gate: true)
     end
+
+    it "continues processing later dependents after one enqueue fails" do
+      project = create(:project, auto_pick_enabled: true)
+      blocker = create(:issue, project: project, github_state: "open")
+      first_dependent = create(:issue, project: project, github_state: "open")
+      second_dependent = create(:issue, project: project, github_state: "open")
+      create(:issue_dependency, issue: first_dependent, depends_on_issue: blocker)
+      create(:issue_dependency, issue: second_dependent, depends_on_issue: blocker)
+      allow(Rails.logger).to receive(:error)
+      allow(Issues::EnqueueEligible).to receive(:call) { |issue, **| raise StandardError, "transient failure" if issue == first_dependent }
+
+      blocker.update!(github_state: "closed")
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(first_dependent, project: project, skip_project_gate: true)
+      expect(Issues::EnqueueEligible).to have_received(:call).with(second_dependent, project: project, skip_project_gate: true)
+      expect(Rails.logger).to have_received(:error).with(
+        hash_including(
+          message: "enqueue_eligible.dependency_resolution_failed",
+          issue_id: blocker.id,
+          dependent_issue_id: first_dependent.id,
+          error: "transient failure"
+        )
+      )
+    end
   end
 
   describe "instance methods" do

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -288,6 +288,18 @@ RSpec.describe Issue do
       expect(Issues::EnqueueEligible).to have_received(:call).with(dependent, project: dependent_project, skip_project_gate: true)
     end
 
+    it "does not enqueue dependents for paused projects" do
+      project = create(:project, auto_pick_enabled: true, quality_paused_at: Time.current)
+      blocker = create(:issue, project: project, github_state: "open")
+      dependent = create(:issue, project: project, github_state: "open")
+      create(:issue_dependency, issue: dependent, depends_on_issue: blocker)
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      blocker.update!(github_state: "closed")
+
+      expect(Issues::EnqueueEligible).not_to have_received(:call)
+    end
+
     it "continues processing later dependents after one enqueue fails" do
       project = create(:project, auto_pick_enabled: true)
       blocker = create(:issue, project: project, github_state: "open")


### PR DESCRIPTION
## Summary

When a blocking issue closes, dependents that become fully unblocked are now enqueued immediately instead of waiting for the next full GitHub sync. This closes the dependency-resolution gap in RDR-032 (Eager Queue Seeding, Issue 4) so auto-pick reacts to dependency state changes in near real-time.

## Changes

- **Models** — Added an `after_update_commit` callback in `app/models/issue.rb` that fires when `github_state` transitions to `"closed"`. The callback finds dependents via `IssueDependency`, filters to those whose project has `auto_pick_enabled`, re-checks readiness through `Issue.ready_for_work(dependent.project)`, and dispatches `Issues::EnqueueEligible` with `skip_project_gate: true`.
- **Logging** — Emits `enqueue_eligible.dependency_resolved` structured log entries with blocker and dependent issue IDs.
- **Tests** — Extended `spec/models/issue_spec.rb` to cover the new callback path.

## Design Decisions

- **No recursive resolution** — Transitive chains (A → B → C) resolve naturally: closing A enqueues B, and closing B later enqueues C via the same callback. Avoids the complexity of recursive traversal in a single callback invocation.
- **Cross-project enqueue with `skip_project_gate: true`** — A dependent in a different project is still enqueued as long as that project has `auto_pick_enabled`, even if it hasn't been synced recently. `EnqueueEligible` re-validates current eligibility, so stale sync state is safe.
- **`ready_for_work` as the gate** — Multi-blocker dependents are only enqueued when *all* blockers resolve. The closing issue's callback dispatches unconditionally; `ready_for_work` filters out anything still blocked.
- **Duplicate-run safety** — `EnqueueEligible` uses `find_or_create_by!`, so a dependent that already has an active run won't be double-enqueued.

## Operational Notes

- No migrations or infrastructure changes.
- Reviewer note: full `bundle exec rspec` could not run in the authoring container because PostgreSQL was unavailable (`ActiveRecord::ConnectionNotEstablished` from `spec/rails_helper.rb`). The db-less subset (`spec/services/issues/enqueue_eligible_spec.rb`, `spec/services/issues/bulk_enqueue_eligible_spec.rb`) passed; `spec/models/issue_spec.rb` should be re-run in CI.

---

Closes #2022