### PR TITLE
Fix #2045: Pressing Enter in project settings form inputs triggers auto-detect instead of saving

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -73,6 +73,9 @@ application.register("notification-dropdown", NotificationDropdownController)
 import ProviderFormController from "./provider_form_controller"
 application.register("provider-form", ProviderFormController)
 
+import ProjectSettingsFormController from "./project_settings_form_controller"
+application.register("project-settings-form", ProjectSettingsFormController)
+
 import RepositorySelectorController from "./repository_selector_controller"
 application.register("repository-selector", RepositorySelectorController)
 

--- a/app/javascript/controllers/project_settings_form_controller.js
+++ b/app/javascript/controllers/project_settings_form_controller.js
@@ -40,6 +40,6 @@ export default class extends Controller {
   submittableInput(target) {
     if (!target || target.tagName !== "INPUT") return false
 
-    SUBMITTABLE_INPUT_TYPES.has(target.type)
+    return SUBMITTABLE_INPUT_TYPES.has(target.type)
   }
 }

--- a/app/javascript/controllers/project_settings_form_controller.js
+++ b/app/javascript/controllers/project_settings_form_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus"
+
+const SUBMITTABLE_INPUT_TYPES = new Set([
+  "date",
+  "datetime-local",
+  "email",
+  "month",
+  "number",
+  "password",
+  "search",
+  "tel",
+  "text",
+  "time",
+  "url",
+  "week"
+])
+
+export default class extends Controller {
+  static targets = ["saveButton"]
+
+  submitOnEnter(event) {
+    if (!this.shouldSubmitOnEnter(event)) return
+
+    event.preventDefault()
+    this.element.requestSubmit(this.saveButtonTarget)
+  }
+
+  shouldSubmitOnEnter(event) {
+    return event.key === "Enter" &&
+      !event.defaultPrevented &&
+      !event.isComposing &&
+      !event.shiftKey &&
+      !event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      this.hasSaveButtonTarget &&
+      this.submittableInput(event.target)
+  }
+
+  submittableInput(target) {
+    if (!target || target.tagName !== "INPUT") return false
+
+    SUBMITTABLE_INPUT_TYPES.has(target.type)
+  }
+}

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -99,7 +99,8 @@
         <% end %>
       </div>
 
-      <%= form_with model: @project, url: project_path(@project), method: :patch, class: "mt-6" do |form| %>
+      <%= form_with model: @project, url: project_path(@project), method: :patch, class: "mt-6",
+        data: { controller: "project-settings-form", action: "keydown->project-settings-form#submitOnEnter" } do |form| %>
         <% if @project.errors.any? %>
           <div class="mb-6 rounded-md bg-red-50 p-4">
             <div class="flex">
@@ -693,7 +694,9 @@
 
         <div class="mt-6 flex items-center justify-end gap-x-4">
           <%= link_to "Cancel", project_path(@project), class: "text-sm font-semibold leading-6 text-gray-900 hover:text-gray-700" %>
-          <%= form.submit "Save Changes", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 cursor-pointer" %>
+          <%= form.submit "Save Changes",
+            class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 cursor-pointer",
+            data: { project_settings_form_target: "saveButton" } %>
         </div>
       <% end %>
     </div>

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1233,6 +1233,22 @@ RSpec.describe "Projects" do
         expect(response.body).to include("Config Conflicts")
         expect(response.body).to include("driver: cuprite")
       end
+
+      it "wires Enter in settings inputs to the save submitter" do
+        project = create(:project, account: account, github_token: github_token)
+
+        get edit_project_path(project)
+
+        doc = Nokogiri::HTML(response.body)
+        form = doc.at_css("form[action='#{project_path(project)}']")
+        save_button = form.at_css("input[data-project-settings-form-target='saveButton']")
+        auto_detect_button = doc.at_css("button[name='screenshot_action'][value='detect']")
+
+        expect(form["data-controller"]).to include("project-settings-form")
+        expect(form["data-action"]).to include("keydown->project-settings-form#submitOnEnter")
+        expect(save_button).to be_present
+        expect(auto_detect_button["type"]).to eq("submit")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes a bug where pressing Enter in project settings form inputs triggered the framework auto-detect action instead of saving the form. Users now get the expected behavior: Enter submits the settings form via the Save Changes button.

## Changes

- **Views**: Updated `app/views/projects/edit.html.erb` to wire the project settings form to a new Stimulus controller.
- **JavaScript**: Added `app/javascript/controllers/project_settings_form_controller.js` to intercept Enter keypresses on single-line inputs and route submission through the explicit Save Changes button instead of the screenshot action submitters. Registered the controller in `app/javascript/controllers/index.js`.
- **Tests**: Added a regression spec in `spec/requests/projects_spec.rb` asserting the rendered form contract.

## Design Decisions

- Chose a Stimulus controller over restructuring the page into separate `<form>` elements to keep the existing layout and form-sharing intact while addressing the default-submitter ordering issue at the JS layer.
- Targets single-line inputs only so Enter still inserts newlines in textareas as expected.

## Screenshots

_Author: please attach before/after screenshots demonstrating that pressing Enter in a settings input now saves rather than triggering auto-detect._

## Notes

`bundle exec rspec` could not run in the implementation container because PostgreSQL was unavailable (`ActiveRecord::ConnectionNotEstablished` during test DB preparation). Reviewer/CI should confirm the new spec passes.

---

Closes #2045