### PR TITLE
fix(providers): classify glm free model usage limits correctly

### DIFF
--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -288,11 +288,13 @@ module Providers
       message = normalize_output_text(result[:message]).presence
       output = normalize_output_text(result[:output]).presence
       display_message = message || output || "Provider health check returned no message"
+      classification_message = [ message, output ].compact.uniq.join("\n")
 
-      if status == "ok" || smoke_test_output_success?(output || message)
+      if smoke_test_output_success?(output) || smoke_test_output_success?(message)
+        Result.new(success: true, error_type: nil, message: "Agent is healthy")
+      elsif status == "ok" && !smoke_test_failure_output?(classification_message)
         Result.new(success: true, error_type: nil, message: "Agent is healthy")
       else
-        classification_message = [ message, output ].compact.uniq.join("\n")
         translated_message = translate_and_extract_error(classification_message.presence || display_message)
         error_type = resolve_error_type(
           harness_error_type: map_harness_error_category(result[:error_category]),
@@ -309,6 +311,14 @@ module Providers
 
     def smoke_test_output_success?(text)
       text.to_s.strip.match?(/\AOK[.!]?\z/i)
+    end
+
+    def smoke_test_failure_output?(text)
+      message = sanitize_error_message(text)
+      return false if message.empty?
+      return true if message.match?(/Model not found:/i)
+
+      classify_failed_response(message) != :unexpected
     end
 
     def map_harness_error_category(category)

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -285,22 +285,24 @@ module Providers
 
     def process_harness_result(result)
       status = result[:status].to_s
-      message = normalize_output_text(result[:message]).presence || "Provider health check returned no message"
+      message = normalize_output_text(result[:message]).presence
       output = normalize_output_text(result[:output]).presence
+      display_message = message || output || "Provider health check returned no message"
 
       if status == "ok" || smoke_test_output_success?(output || message)
         Result.new(success: true, error_type: nil, message: "Agent is healthy")
       else
-        translated_message = translate_and_extract_error(message)
+        classification_message = [ message, output ].compact.uniq.join("\n")
+        translated_message = translate_and_extract_error(classification_message.presence || display_message)
         error_type = resolve_error_type(
           harness_error_type: map_harness_error_category(result[:error_category]),
-          message: translated_message.presence || message
+          message: translated_message.presence || classification_message.presence || display_message
         )
 
         Result.new(
           success: false,
           error_type: error_type,
-          message: translated_message.presence || message
+          message: translated_message.presence || display_message
         )
       end
     end

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -287,19 +287,31 @@ module Providers
       status = result[:status].to_s
       message = normalize_output_text(result[:message]).presence
       output = normalize_output_text(result[:output]).presence
+      harness_error_type = map_harness_error_category(result[:error_category])
       display_message = message || output || "Provider health check returned no message"
       classification_message = [ message, output ].compact.uniq.join("\n")
 
       if smoke_test_failure_output?(classification_message)
         translated_message = translate_and_extract_error(classification_message.presence || display_message)
         error_type = resolve_error_type(
-          harness_error_type: map_harness_error_category(result[:error_category]),
+          harness_error_type: harness_error_type,
           message: translated_message.presence || classification_message.presence || display_message
         )
 
         Result.new(
           success: false,
           error_type: error_type,
+          message: translated_message.presence || display_message
+        )
+      elsif harness_error_type.present? && !smoke_test_output_success?(output) && !smoke_test_output_success?(message)
+        translated_message = translate_and_extract_error(classification_message.presence || display_message)
+
+        Result.new(
+          success: false,
+          error_type: resolve_error_type(
+            harness_error_type: harness_error_type,
+            message: translated_message.presence || classification_message.presence || display_message
+          ),
           message: translated_message.presence || display_message
         )
       elsif smoke_test_output_success?(output) || smoke_test_output_success?(message)
@@ -309,7 +321,7 @@ module Providers
       else
         translated_message = translate_and_extract_error(classification_message.presence || display_message)
         error_type = resolve_error_type(
-          harness_error_type: map_harness_error_category(result[:error_category]),
+          harness_error_type: harness_error_type,
           message: translated_message.presence || classification_message.presence || display_message
         )
 

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -536,6 +536,11 @@ module Providers
         .reject { |line| line.match?(/\A[^\p{Alnum}]+\z/) }
         .reject { |line| noisy_error_line?(line) }
 
+      classified_line = cleaned_lines.find do |line|
+        line.match?(/Model not found:/i) || classify_failed_response(line) != :unexpected
+      end
+      return classified_line if classified_line
+
       cleaned_lines.first || fallback_message_from(message)
     end
 

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -343,7 +343,9 @@ module Providers
       classified_error_type = classify_failed_response(message)
       return :unexpected if message.match?(/Model not found:/i)
       return classified_error_type if harness_error_type.nil? || harness_error_type == :unexpected
-      return classified_error_type if harness_error_type == :rate_limited && classified_error_type != :rate_limited
+      return classified_error_type if harness_error_type == :rate_limited &&
+        classified_error_type != :rate_limited &&
+        classified_error_type != :unexpected
 
       harness_error_type
     end

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -290,9 +290,21 @@ module Providers
       display_message = message || output || "Provider health check returned no message"
       classification_message = [ message, output ].compact.uniq.join("\n")
 
-      if smoke_test_output_success?(output) || smoke_test_output_success?(message)
+      if smoke_test_failure_output?(classification_message)
+        translated_message = translate_and_extract_error(classification_message.presence || display_message)
+        error_type = resolve_error_type(
+          harness_error_type: map_harness_error_category(result[:error_category]),
+          message: translated_message.presence || classification_message.presence || display_message
+        )
+
+        Result.new(
+          success: false,
+          error_type: error_type,
+          message: translated_message.presence || display_message
+        )
+      elsif smoke_test_output_success?(output) || smoke_test_output_success?(message)
         Result.new(success: true, error_type: nil, message: "Agent is healthy")
-      elsif status == "ok" && !smoke_test_failure_output?(classification_message)
+      elsif status == "ok"
         Result.new(success: true, error_type: nil, message: "Agent is healthy")
       else
         translated_message = translate_and_extract_error(classification_message.presence || display_message)

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -33,6 +33,17 @@ module Activities
       /\b429\b/,
       /free model usage limit reached/i,
       /(?:weekly(?:\/monthly)?|monthly) (?:usage )?limit (?:reached|exceeded|hit|exhausted)/i,
+      /requires more credits,? or fewer max_tokens/i,
+      /can only afford \d+/i,
+      %r{visit .*/credits .*add more credits}i,
+      /add more credits/i,
+      /not enough credits/i,
+      /purchase (?:more )?credits/i,
+      /buy (?:more )?credits/i,
+      /requires? more credits/i
+    ].freeze
+
+    COMMENT_REDACTION_ONLY_PATTERNS = [
       /add more credits/i,
       /not enough credits/i,
       /purchase (?:more )?credits/i,
@@ -145,7 +156,13 @@ module Activities
     def provider_error_output?(text)
       return false if text.blank?
 
-      provider_error_patterns.any? { |pattern| text.match?(pattern) }
+      provider_error_classification_patterns.any? { |pattern| text.match?(pattern) }
+    end
+
+    def provider_error_redaction_line?(text)
+      return false if text.blank?
+
+      provider_error_redaction_patterns.any? { |pattern| text.match?(pattern) }
     end
 
     def infrastructure_error_output?(text)
@@ -166,8 +183,13 @@ module Activities
       normalized_text(recent_output)
     end
 
-    def provider_error_patterns
-      @provider_error_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota) +
+    def provider_error_classification_patterns
+      @provider_error_classification_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota) +
+        SUPPLEMENTARY_ERROR_PATTERNS.reject { |pattern| COMMENT_REDACTION_ONLY_PATTERNS.include?(pattern) }
+    end
+
+    def provider_error_redaction_patterns
+      @provider_error_redaction_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota) +
         SUPPLEMENTARY_ERROR_PATTERNS
     end
 
@@ -301,7 +323,7 @@ module Activities
     def sanitize_summary_for_github(text)
       return text if text.blank?
 
-      text.each_line.reject { |line| provider_error_output?(line) }.join.strip
+      text.each_line.reject { |line| provider_error_redaction_line?(line) }.join.strip
     end
 
     def post_needs_input_comment(client, project, issue, agent_summary)

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -155,14 +155,15 @@ module Activities
     end
 
     def classification_text_for(agent_run)
-      raw_output = agent_run.agent_run_logs
+      recent_output = agent_run.agent_run_logs
         .where(log_type: %w[stdout stderr])
-        .order(:created_at)
+        .order(created_at: :desc)
         .limit(CLASSIFICATION_LOG_LIMIT)
         .pluck(:content)
+        .reverse
         .join("\n")
 
-      normalized_text(raw_output)
+      normalized_text(recent_output)
     end
 
     def provider_error_patterns

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -157,7 +157,7 @@ module Activities
     def classification_text_for(agent_run)
       recent_output = agent_run.agent_run_logs
         .where(log_type: %w[stdout stderr])
-        .order(created_at: :desc)
+        .order(created_at: :desc, id: :desc)
         .limit(CLASSIFICATION_LOG_LIMIT)
         .pluck(:content)
         .reverse

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -31,6 +31,7 @@ module Activities
       /too many requests/i,
       /\b429\b/,
       /free model usage limit reached/i,
+      /(?:weekly(?:\/monthly)?|monthly) (?:usage )?limit (?:reached|exceeded|hit|exhausted)/i,
       /add more credits/i,
       /not enough credits/i,
       /purchase (?:more )?credits/i,

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -117,7 +117,12 @@ module Activities
     # even if RunAgentActivity failed to detect a provider error, this check
     # prevents credit/quota errors from being misclassified as recommend_close.
     def classify_outcome(agent_run, output_present, agent_summary)
-      return "needs_input" unless output_present
+      unless output_present
+        return "provider_error" if provider_error_output?(agent_summary)
+        return "infrastructure_error" if infrastructure_error_output?(agent_summary)
+
+        return "needs_input"
+      end
 
       # Guard: if the agent produced output but shows no evidence of having
       # actually run (zero iterations AND zero cost), the "output" is likely

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -156,7 +156,7 @@ module Activities
     def provider_error_output?(text)
       return false if text.blank?
 
-      provider_error_classification_patterns.any? { |pattern| text.match?(pattern) }
+      normalized_text(text).each_line.any? { |line| provider_error_signal_line?(line) }
     end
 
     def provider_error_redaction_line?(text)
@@ -184,13 +184,35 @@ module Activities
     end
 
     def provider_error_classification_patterns
-      @provider_error_classification_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota) +
-        SUPPLEMENTARY_ERROR_PATTERNS.reject { |pattern| COMMENT_REDACTION_ONLY_PATTERNS.include?(pattern) }
+      @provider_error_classification_patterns ||= begin
+        combined = ProviderSupport.aggregated_error_classification_patterns(:quota) + SUPPLEMENTARY_ERROR_PATTERNS
+        combined.reject { |pattern| redaction_only_pattern?(pattern) }.uniq
+      end
+    end
+
+    def provider_error_upstream_patterns
+      @provider_error_upstream_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota)
     end
 
     def provider_error_redaction_patterns
       @provider_error_redaction_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota) +
         SUPPLEMENTARY_ERROR_PATTERNS
+    end
+
+    def provider_error_signal_line?(line)
+      normalized_line = normalized_text(line)
+      return false if normalized_line.blank?
+
+      return true if provider_error_classification_patterns.any? { |pattern| normalized_line.match?(pattern) }
+
+      provider_error_upstream_patterns.any? { |pattern| normalized_line.match?(pattern) } &&
+        !provider_error_redaction_line?(normalized_line)
+    end
+
+    def redaction_only_pattern?(pattern)
+      COMMENT_REDACTION_ONLY_PATTERNS.any? do |redaction_pattern|
+        pattern.source == redaction_pattern.source && pattern.options == redaction_pattern.options
+      end
     end
 
     def normalized_text(text)

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -30,6 +30,7 @@ module Activities
       /rate.?limit/i,
       /too many requests/i,
       /\b429\b/,
+      /free model usage limit reached/i,
       /add more credits/i,
       /not enough credits/i,
       /purchase (?:more )?credits/i,

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -44,6 +44,7 @@ module Activities
     ].freeze
 
     COMMENT_REDACTION_ONLY_PATTERNS = [
+      /requires more credits/i,
       /add more credits/i,
       /not enough credits/i,
       /purchase (?:more )?credits/i,

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -20,6 +20,7 @@ module Activities
   class HandleNoOutputIssueRunActivity < BaseActivity
     activity_name "HandleNoOutputIssueRun"
 
+    CLASSIFICATION_LOG_LIMIT = 500
     PAID_NEEDS_INPUT_LABEL = "paid-needs-input"
     PAID_RECOMMEND_CLOSE_LABEL = "paid-recommend-close"
     NEEDS_INPUT_COMMENT_MARKER = "<!-- paid:needs-input -->"
@@ -79,7 +80,8 @@ module Activities
       project = agent_run.project
       client = project.github_token.client
       agent_summary = agent_run.agent_summary_with_stderr_fallback(limit: 100)
-      outcome = classify_outcome(agent_run, output_present, agent_summary)
+      diagnostic_output = classification_text_for(agent_run)
+      outcome = classify_outcome(agent_run, output_present, diagnostic_output)
 
       track_phase(agent_run_id: agent_run_id, phase_key: "handle_no_output_issue_run", phase_group: "post", agent_run: agent_run, metadata: { outcome: outcome }) do
         case outcome
@@ -116,10 +118,10 @@ module Activities
     # and evidence that the agent actually performed work. Defense in depth:
     # even if RunAgentActivity failed to detect a provider error, this check
     # prevents credit/quota errors from being misclassified as recommend_close.
-    def classify_outcome(agent_run, output_present, agent_summary)
+    def classify_outcome(agent_run, output_present, diagnostic_output)
       unless output_present
-        return "provider_error" if provider_error_output?(agent_summary)
-        return "infrastructure_error" if infrastructure_error_output?(agent_summary)
+        return "provider_error" if provider_error_output?(diagnostic_output)
+        return "infrastructure_error" if infrastructure_error_output?(diagnostic_output)
 
         return "needs_input"
       end
@@ -131,8 +133,8 @@ module Activities
       # the output for error patterns; if neither matches, classify as
       # needs_input since the agent did not perform meaningful work.
       if agent_run.iterations.to_i.zero? && agent_run.cost_cents.to_i.zero?
-        return "provider_error" if provider_error_output?(agent_summary)
-        return "infrastructure_error" if infrastructure_error_output?(agent_summary)
+        return "provider_error" if provider_error_output?(diagnostic_output)
+        return "infrastructure_error" if infrastructure_error_output?(diagnostic_output)
 
         return "needs_input"
       end
@@ -152,9 +154,24 @@ module Activities
       INFRASTRUCTURE_ERROR_PATTERNS.any? { |pattern| text.match?(pattern) }
     end
 
+    def classification_text_for(agent_run)
+      raw_output = agent_run.agent_run_logs
+        .where(log_type: %w[stdout stderr])
+        .order(:created_at)
+        .limit(CLASSIFICATION_LOG_LIMIT)
+        .pluck(:content)
+        .join("\n")
+
+      normalized_text(raw_output)
+    end
+
     def provider_error_patterns
       @provider_error_patterns ||= ProviderSupport.aggregated_error_classification_patterns(:quota) +
         SUPPLEMENTARY_ERROR_PATTERNS
+    end
+
+    def normalized_text(text)
+      text.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "\uFFFD").strip
     end
 
     def handle_provider_error(agent_run, agent_summary)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -938,7 +938,6 @@ module Activities
       stdout = normalize_output_text(result[:stdout])
       stderr = normalize_output_text(result[:stderr])
       combined_output = [ stderr, stdout ].compact.join("\n").strip
-      output = [ stderr.presence, stdout.presence ].compact.first.to_s.strip
       sanitized_output = strip_prompt_echo(combined_output, prompt)
 
       if result.success?

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -38,6 +38,7 @@ module Activities
       /quota exceeded/i,
       /free tier limit reached/i,
       /free model usage limit reached/i,
+      /(?:weekly(?:\/monthly)?|monthly) (?:usage )?limit (?:reached|exceeded|hit|exhausted)/i,
       /(?:you'?ve|you have)\s+hit\s+your\s+limit/i,
       /exhausted\s+your\s+capacity/i,
       /exhausted.*capacity/i, # intentionally loose — only used for exit-code failures, not timeout reclassification
@@ -66,6 +67,7 @@ module Activities
       /quota exceeded/i,
       /free tier limit reached/i,
       /free model usage limit reached/i,
+      /(?:weekly(?:\/monthly)?|monthly) (?:usage )?limit (?:reached|exceeded|hit|exhausted)/i,
       /(?:rate.?limit|usage limit) +(?:exceeded|reached|hit)/i,
       /(?:you'?ve|you have) +hit +your +limit/i,
       /exhausted(?: +your)? +capacity/i,

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -812,14 +812,17 @@ module Activities
         # so treat this as a provider failure to trigger fallback/retry.
         combined_output = [ stdout, stderr ].compact.join("\n")
         sanitized_output = strip_prompt_echo(combined_output, prompt)
-        if insufficient_credits_error?(sanitized_output)
-          raise ProviderExecutionError,
-            "Provider credit/quota error from #{provider}: #{sanitized_output.truncate(500)}"
-        end
-
+        # Rate-limit classification takes precedence over generic quota
+        # failures because some providers use quota-shaped wording for
+        # retryable usage caps (for example, GLM free-model limits).
         if successful_exit_rate_limit_error?(sanitized_output)
           reset_at = rate_limit_reset_at(provider, sanitized_output)
           raise ProviderRateLimitError.new("Rate limited by #{provider}", reset_at: reset_at)
+        end
+
+        if insufficient_credits_error?(sanitized_output)
+          raise ProviderExecutionError,
+            "Provider credit/quota error from #{provider}: #{sanitized_output.truncate(500)}"
         end
 
         if provider_model_not_found_error?(sanitized_output)
@@ -937,18 +940,20 @@ module Activities
       sanitized_output = strip_prompt_echo(output, prompt)
 
       if result.success?
+        # Keep the same precedence as the main execution path so preflight
+        # retryable limits do not degrade into generic provider failures.
+        if successful_exit_rate_limit_error?(sanitized_output)
+          reset_at = rate_limit_reset_at(provider, sanitized_output)
+          log_preflight_failure(agent_run: agent_run, provider: provider, reason: "Rate limited by #{provider} during preflight")
+          raise ProviderRateLimitError.new("Rate limited by #{provider}", reset_at: reset_at)
+        end
+
         if insufficient_credits_error?(sanitized_output)
           raise_preflight_failure!(
             agent_run: agent_run,
             provider: provider,
             reason: "Provider credit/quota error: #{sanitized_output.truncate(500)}"
           )
-        end
-
-        if successful_exit_rate_limit_error?(sanitized_output)
-          reset_at = rate_limit_reset_at(provider, sanitized_output)
-          log_preflight_failure(agent_run: agent_run, provider: provider, reason: "Rate limited by #{provider} during preflight")
-          raise ProviderRateLimitError.new("Rate limited by #{provider}", reset_at: reset_at)
         end
 
         if provider_model_not_found_error?(sanitized_output)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1080,10 +1080,23 @@ module Activities
     # output that merely discusses rate limits is not reclassified as a
     # provider failure.
     def successful_exit_rate_limit_error?(output)
-      return false if output.blank?
-      return false if output.length > SUCCESS_RATE_LIMIT_MAX_OUTPUT_LENGTH
+      standalone_rate_limit_signal(output).present?
+    end
 
-      TIMEOUT_RATE_LIMIT_PATTERNS.any? { |pattern| output.match?(pattern) }
+    def standalone_rate_limit_signal(output)
+      return nil if output.blank?
+
+      normalized_output = normalize_output_text(output)
+      if normalized_output.length <= SUCCESS_RATE_LIMIT_MAX_OUTPUT_LENGTH &&
+          TIMEOUT_RATE_LIMIT_PATTERNS.any? { |pattern| normalized_output.match?(pattern) }
+        return normalized_output
+      end
+
+      normalized_output.each_line.map(&:strip).find do |line|
+        line.present? &&
+          line.length <= SUCCESS_RATE_LIMIT_MAX_OUTPUT_LENGTH &&
+          TIMEOUT_RATE_LIMIT_PATTERNS.any? { |pattern| line.match?(pattern) }
+      end
     end
 
     MODEL_NOT_FOUND_MAX_OUTPUT_LENGTH = 1000

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -37,6 +37,7 @@ module Activities
       /(?:\bHTTP[\/\s]*429\b|status[:\s]*429\b)/i,
       /quota exceeded/i,
       /free tier limit reached/i,
+      /free model usage limit reached/i,
       /(?:you'?ve|you have)\s+hit\s+your\s+limit/i,
       /exhausted\s+your\s+capacity/i,
       /exhausted.*capacity/i, # intentionally loose — only used for exit-code failures, not timeout reclassification
@@ -64,6 +65,7 @@ module Activities
       /\bstatus[:\s]*429\b/i,
       /quota exceeded/i,
       /free tier limit reached/i,
+      /free model usage limit reached/i,
       /(?:rate.?limit|usage limit) +(?:exceeded|reached|hit)/i,
       /(?:you'?ve|you have) +hit +your +limit/i,
       /exhausted(?: +your)? +capacity/i,
@@ -813,6 +815,11 @@ module Activities
             "Provider credit/quota error from #{provider}: #{sanitized_output.truncate(500)}"
         end
 
+        if successful_exit_rate_limit_error?(sanitized_output)
+          reset_at = rate_limit_reset_at(provider, sanitized_output)
+          raise ProviderRateLimitError.new("Rate limited by #{provider}", reset_at: reset_at)
+        end
+
         if provider_model_not_found_error?(sanitized_output)
           raise ProviderExecutionError,
             "Provider model not found error from #{provider}: #{sanitized_output.truncate(500)}"
@@ -936,6 +943,12 @@ module Activities
           )
         end
 
+        if successful_exit_rate_limit_error?(sanitized_output)
+          reset_at = rate_limit_reset_at(provider, sanitized_output)
+          log_preflight_failure(agent_run: agent_run, provider: provider, reason: "Rate limited by #{provider} during preflight")
+          raise ProviderRateLimitError.new("Rate limited by #{provider}", reset_at: reset_at)
+        end
+
         if provider_model_not_found_error?(sanitized_output)
           raise_preflight_failure!(
             agent_run: agent_run,
@@ -1033,6 +1046,7 @@ module Activities
     end
 
     QUOTA_ERROR_MAX_OUTPUT_LENGTH = 500
+    SUCCESS_RATE_LIMIT_MAX_OUTPUT_LENGTH = 500
 
     # Detects provider-level credit/quota exhaustion errors surfaced as
     # agent output. Used in the successful-exit-code path to catch cases
@@ -1050,6 +1064,18 @@ module Activities
 
       ProviderSupport.aggregated_error_classification_patterns(:quota)
         .any? { |pattern| output.match?(pattern) }
+    end
+
+    # Detects short standalone rate-limit responses that some providers surface
+    # with exit code 0. We intentionally use the stricter timeout patterns here
+    # instead of the broader execution-failure matcher so substantial agent
+    # output that merely discusses rate limits is not reclassified as a
+    # provider failure.
+    def successful_exit_rate_limit_error?(output)
+      return false if output.blank?
+      return false if output.length > SUCCESS_RATE_LIMIT_MAX_OUTPUT_LENGTH
+
+      TIMEOUT_RATE_LIMIT_PATTERNS.any? { |pattern| output.match?(pattern) }
     end
 
     MODEL_NOT_FOUND_MAX_OUTPUT_LENGTH = 1000

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -840,8 +840,9 @@ module Activities
         }
       end
 
-      output = (stderr.presence || stdout).to_s.strip
-      rate_limit_output = strip_prompt_echo(output, prompt)
+      combined_output = [ stderr, stdout ].compact.join("\n").strip
+      output = combined_output.presence || (stderr.presence || stdout).to_s.strip
+      rate_limit_output = strip_prompt_echo(combined_output, prompt)
 
       if auth_expired_error?(provider, rate_limit_output)
         raise ProviderAuthExpiredError.new(output.truncate(500), provider: provider)
@@ -936,8 +937,9 @@ module Activities
       )
       stdout = normalize_output_text(result[:stdout])
       stderr = normalize_output_text(result[:stderr])
-      output = [ stderr.presence, stdout.presence ].compact.first.to_s.strip
-      sanitized_output = strip_prompt_echo(output, prompt)
+      combined_output = [ stderr, stdout ].compact.join("\n").strip
+      output = combined_output.presence || [ stderr.presence, stdout.presence ].compact.first.to_s.strip
+      sanitized_output = strip_prompt_echo(combined_output, prompt)
 
       if result.success?
         # Keep the same precedence as the main execution path so preflight

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -841,7 +841,7 @@ module Activities
       end
 
       combined_output = [ stderr, stdout ].compact.join("\n").strip
-      output = combined_output.presence || (stderr.presence || stdout).to_s.strip
+      output = (stderr.presence || stdout).to_s.strip
       rate_limit_output = strip_prompt_echo(combined_output, prompt)
 
       if auth_expired_error?(provider, rate_limit_output)
@@ -938,7 +938,7 @@ module Activities
       stdout = normalize_output_text(result[:stdout])
       stderr = normalize_output_text(result[:stderr])
       combined_output = [ stderr, stdout ].compact.join("\n").strip
-      output = combined_output.presence || [ stderr.presence, stdout.presence ].compact.first.to_s.strip
+      output = [ stderr.presence, stdout.presence ].compact.first.to_s.strip
       sanitized_output = strip_prompt_echo(combined_output, prompt)
 
       if result.success?

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1117,6 +1117,32 @@ RSpec.describe Providers::TestAgent do
         expect(result.message).to include("Process exited abnormally")
       end
     end
+
+    context "when the harness returns failure details only in output" do
+      let(:provider_record) { create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode,
+          status: "error",
+          message: "",
+          output: "Free model usage limit reached. Please try again later.",
+          latency_ms: 10,
+          error_category: nil,
+          check: :smoke_test
+        )
+      end
+
+      it "classifies the output-only failure as rate limited" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+        expect(result.message).to eq("Free model usage limit reached. Please try again later.")
+      end
+    end
   end
 
   describe "token and auth pattern classification via .call" do

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1219,6 +1219,32 @@ RSpec.describe Providers::TestAgent do
         expect(result.message).to eq("Free model usage limit reached. Please try again later.")
       end
     end
+
+    context "when the harness returns OK in one field but a weekly limit failure in the other" do
+      let(:provider_record) { create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode,
+          status: "ok",
+          message: "OK.",
+          output: "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32",
+          latency_ms: 10,
+          error_category: nil,
+          check: :smoke_test
+        )
+      end
+
+      it "surfaces the rate limit message instead of the OK line" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+        expect(result.message).to eq("Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32")
+      end
+    end
   end
 
   describe "token and auth pattern classification via .call" do

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -782,6 +782,30 @@ RSpec.describe Providers::TestAgent do
       end
     end
 
+    context "when kilocode glm exits 0 but reports the free model usage limit wording in the message" do
+      let(:provider_record) do
+        create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false)
+      end
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode, status: "ok",
+          message: "Free model usage limit reached. Please try again later.",
+          latency_ms: 10, error_category: nil, check: :smoke_test
+        )
+      end
+
+      it "classifies the result as rate limited" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+        expect(result.message).to eq("Free model usage limit reached. Please try again later.")
+      end
+    end
+
     context "when a z.ai coding plan provider reports the weekly/monthly limit wording" do
       let(:provider_record) do
         create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false)
@@ -1127,6 +1151,32 @@ RSpec.describe Providers::TestAgent do
         stub_container_smoke_test(
           name: :kilocode,
           status: "error",
+          message: "",
+          output: "Free model usage limit reached. Please try again later.",
+          latency_ms: 10,
+          error_category: nil,
+          check: :smoke_test
+        )
+      end
+
+      it "classifies the output-only failure as rate limited" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+        expect(result.message).to eq("Free model usage limit reached. Please try again later.")
+      end
+    end
+
+    context "when the harness exits 0 and returns failure details only in output" do
+      let(:provider_record) { create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode,
+          status: "ok",
           message: "",
           output: "Free model usage limit reached. Please try again later.",
           latency_ms: 10,

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -782,6 +782,30 @@ RSpec.describe Providers::TestAgent do
       end
     end
 
+    context "when kilocode zai coding plan reports the weekly/monthly limit wording" do
+      let(:provider_record) do
+        create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false)
+      end
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode, status: "error",
+          message: "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32",
+          latency_ms: 10, error_category: nil, check: :smoke_test
+        )
+      end
+
+      it "classifies the result as rate limited" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+        expect(result.message).to eq("Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32")
+      end
+    end
+
     context "when the harness returns a binary encoded rate limit message" do
       let(:provider_record) { create(:provider, user: user, provider_key: "gemini", enabled_for_agent_runs: false, enabled_for_fallback: false) }
 

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1106,6 +1106,19 @@ RSpec.describe Providers::TestAgent do
         expect(result).not_to be_success
         expect(result.error_type).to eq(:rate_limited)
       end
+
+      it "preserves a harness-classified rate limit when the provider exits 0" do
+        stub_container_smoke_test(
+          name: :gemini, status: "ok",
+          message: "Provider health check failed",
+          latency_ms: 10, error_category: :rate_limited, check: :smoke_test
+        )
+
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+      end
     end
 
     context "when the harness marks a noisy provider failure as rate limited" do

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1193,6 +1193,32 @@ RSpec.describe Providers::TestAgent do
         expect(result.message).to eq("Free model usage limit reached. Please try again later.")
       end
     end
+
+    context "when the harness returns OK in one field but a provider failure in the other" do
+      let(:provider_record) { create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false) }
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode,
+          status: "ok",
+          message: "OK.",
+          output: "Free model usage limit reached. Please try again later.",
+          latency_ms: 10,
+          error_category: nil,
+          check: :smoke_test
+        )
+      end
+
+      it "treats the smoke test as failed" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+        expect(result.message).to eq("Free model usage limit reached. Please try again later.")
+      end
+    end
   end
 
   describe "token and auth pattern classification via .call" do

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -782,7 +782,7 @@ RSpec.describe Providers::TestAgent do
       end
     end
 
-    context "when kilocode zai coding plan reports the weekly/monthly limit wording" do
+    context "when a z.ai coding plan provider reports the weekly/monthly limit wording" do
       let(:provider_record) do
         create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false)
       end
@@ -792,6 +792,40 @@ RSpec.describe Providers::TestAgent do
           container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
         stub_container_smoke_test(
           name: :kilocode, status: "error",
+          message: "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32",
+          latency_ms: 10, error_category: nil, check: :smoke_test
+        )
+      end
+
+      it "classifies the result as rate limited" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+        expect(result.message).to eq("Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32")
+      end
+    end
+
+    context "when opencode on z.ai coding plan reports the weekly/monthly limit wording" do
+      let(:provider_record) do
+        api_key_record = create(:provider_api_key, user: user, api_service_type: "zai_coding")
+        create(
+          :provider,
+          :api_key,
+          user: user,
+          provider_key: "opencode",
+          enabled_for_agent_runs: false,
+          enabled_for_fallback: false,
+          provider_api_key: api_key_record,
+          config: { "opencode" => { "api_provider" => "zai_coding", "model" => "glm-5.1" } }
+        )
+      end
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "opencode")
+        stub_container_smoke_test(
+          name: :opencode, status: "error",
           message: "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32",
           latency_ms: 10, error_category: nil, check: :smoke_test
         )

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -1093,6 +1093,19 @@ RSpec.describe Providers::TestAgent do
         expect(result).not_to be_success
         expect(result.error_type).to eq(:rate_limited)
       end
+
+      it "preserves a harness-classified rate limit when the message is not locally classifiable" do
+        stub_container_smoke_test(
+          name: :gemini, status: "error",
+          message: "Provider health check failed",
+          latency_ms: 10, error_category: :rate_limited, check: :smoke_test
+        )
+
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+      end
     end
 
     context "when the harness marks a noisy provider failure as rate limited" do

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -758,6 +758,30 @@ RSpec.describe Providers::TestAgent do
       end
     end
 
+    context "when kilocode glm reports the free model usage limit wording" do
+      let(:provider_record) do
+        create(:provider, user: user, provider_key: "kilocode", enabled_for_agent_runs: false, enabled_for_fallback: false)
+      end
+
+      before do
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "kilocode")
+        stub_container_smoke_test(
+          name: :kilocode, status: "error",
+          message: "Free model usage limit reached. Please try again later.",
+          latency_ms: 10, error_category: nil, check: :smoke_test
+        )
+      end
+
+      it "classifies the result as rate limited" do
+        result = described_class.call(provider: provider)
+
+        expect(result).not_to be_success
+        expect(result.error_type).to eq(:rate_limited)
+        expect(result.message).to eq("Free model usage limit reached. Please try again later.")
+      end
+    end
+
     context "when the harness returns a binary encoded rate limit message" do
       let(:provider_record) { create(:provider, user: user, provider_key: "gemini", enabled_for_agent_runs: false, enabled_for_fallback: false) }
 

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -89,6 +89,30 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         expect(result[:outcome]).to eq("needs_input")
       end
 
+      it "classifies hidden provider quota output as provider_error" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run.log!("stderr", "Free model usage limit reached. Please try again later.")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: false)
+
+        expect(result[:outcome]).to eq("provider_error")
+        expect(agent_run.reload.status).to eq("failed")
+        expect(issue.reload.paid_state).to eq("failed")
+      end
+
+      it "classifies hidden infrastructure output as infrastructure_error" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue)
+        agent_run.log!("stderr", "bwrap: No permissions to create a new namespace")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: false)
+
+        expect(result[:outcome]).to eq("infrastructure_error")
+        expect(agent_run.reload.status).to eq("failed")
+        expect(issue.reload.paid_state).to eq("failed")
+      end
+
       it "enqueues ProcessRunQueueJob" do
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue)

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -385,6 +385,17 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
         expect(result[:outcome]).to eq("provider_error")
       end
+
+      it "detects weekly limit wording as a provider error" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("provider_error")
+      end
     end
 
     context "when output is present but agent hit infrastructure errors" do

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -113,6 +113,21 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         expect(issue.reload.paid_state).to eq("failed")
       end
 
+      it "classifies hidden provider output from the most recent logs" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue)
+
+        Activities::HandleNoOutputIssueRunActivity::CLASSIFICATION_LOG_LIMIT.times do |i|
+          agent_run.log!("stdout", "progress line #{i}")
+        end
+        agent_run.log!("stderr", "Free model usage limit reached. Please try again later.")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: false)
+
+        expect(result[:outcome]).to eq("provider_error")
+        expect(agent_run.reload.status).to eq("failed")
+      end
+
       it "enqueues ProcessRunQueueJob" do
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue)

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -410,6 +410,18 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         expect(result[:outcome]).to eq("provider_error")
       end
 
+      it "detects provider errors from stderr even when stdout contains trivial output" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "OK.")
+        agent_run.log!("stderr", "Free model usage limit reached. Please try again later.")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("provider_error")
+      end
+
       it "detects weekly limit wording as a provider error" do
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue,

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -374,6 +374,17 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
         expect(result[:outcome]).to eq("provider_error")
       end
+
+      it "detects free model usage limit wording as a provider error" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "Free model usage limit reached. Please try again later.")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("provider_error")
+      end
     end
 
     context "when output is present but agent hit infrastructure errors" do

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -619,7 +619,9 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         agent_run = create(:agent_run, :running, project: project, issue: issue)
         agent_run.log!("stderr", "Some context\nrequires more credits\nMore context")
 
-        activity.execute(agent_run_id: agent_run.id, output_present: false)
+        result = activity.execute(agent_run_id: agent_run.id, output_present: false)
+
+        expect(result[:outcome]).to eq("needs_input")
 
         expect(client).to have_received(:add_comment) do |_repo, _number, body|
           expect(body).to include("Needs Input")

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2968,6 +2968,21 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.providers_attempted.first["error_type"]).to eq("rate_limited")
       end
 
+      it "detects a weekly limit error returned with exit code 0" do
+        rate_limit_success = Containers::Provision::Result.success(
+          stdout: "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32", stderr: "", exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(rate_limit_success)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("rate_limited")
+        expect(agent_run.providers_attempted.first["error_type"]).to eq("rate_limited")
+      end
+
       it "detects ProviderModelNotFoundError returned with exit code 0" do
         model_not_found_stderr = <<~ERR
           Error: Model not found: glm-5.1/.
@@ -3082,6 +3097,22 @@ expect(container_service).to receive(:execute).with(
           error: "exit 1", stdout: "", stderr: "Free model usage limit reached. Please try again later.", exit_code: 1
         )
         allow(container_service).to receive(:execute).and_return(glm_rate_limit)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("rate_limited")
+        expect(agent_run.error_message).to include("rate limited")
+        expect(agent_run.rate_limited_until).to be_present
+      end
+
+      it "classifies weekly limit wording as a rate limit" do
+        weekly_rate_limit = Containers::Provision::Result.failure(
+          error: "exit 1", stdout: "", stderr: "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32", exit_code: 1
+        )
+        allow(container_service).to receive(:execute).and_return(weekly_rate_limit)
 
         expect {
           activity.execute(agent_run_id: agent_run.id)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2983,6 +2983,23 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.providers_attempted.first["error_type"]).to eq("rate_limited")
       end
 
+      it "detects a short rate limit line wrapped in otherwise successful output" do
+        rate_limit_success = Containers::Provision::Result.success(
+          stdout: "OK.\nWeekly/Monthly Limit Exhausted. Your limit will reset at 2026-05-18 11:22:32",
+          stderr: "",
+          exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(rate_limit_success)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("rate_limited")
+        expect(agent_run.providers_attempted.first["error_type"]).to eq("rate_limited")
+      end
+
       it "detects ProviderModelNotFoundError returned with exit code 0" do
         model_not_found_stderr = <<~ERR
           Error: Model not found: glm-5.1/.

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2953,6 +2953,21 @@ expect(container_service).to receive(:execute).with(
         expect(result[:success]).to be true
       end
 
+      it "detects a short standalone rate limit error returned with exit code 0" do
+        rate_limit_success = Containers::Provision::Result.success(
+          stdout: "Free model usage limit reached. Please try again later.", stderr: "", exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(rate_limit_success)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("rate_limited")
+        expect(agent_run.providers_attempted.first["error_type"]).to eq("rate_limited")
+      end
+
       it "detects ProviderModelNotFoundError returned with exit code 0" do
         model_not_found_stderr = <<~ERR
           Error: Model not found: glm-5.1/.
@@ -3051,6 +3066,22 @@ expect(container_service).to receive(:execute).with(
           error: "exit 1", stdout: "", stderr: "You have exhausted your capacity on this model.", exit_code: 1
         )
         allow(container_service).to receive(:execute).and_return(gemini_rate_limit)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("rate_limited")
+        expect(agent_run.error_message).to include("rate limited")
+        expect(agent_run.rate_limited_until).to be_present
+      end
+
+      it "classifies kilocode glm free model usage limit wording as a rate limit" do
+        glm_rate_limit = Containers::Provision::Result.failure(
+          error: "exit 1", stdout: "", stderr: "Free model usage limit reached. Please try again later.", exit_code: 1
+        )
+        allow(container_service).to receive(:execute).and_return(glm_rate_limit)
 
         expect {
           activity.execute(agent_run_id: agent_run.id)


### PR DESCRIPTION
## Summary
- classify KiloCode GLM `Free model usage limit reached` responses as rate limits in test-agent and runtime paths
- catch short standalone rate-limit responses even when a provider exits with code `0`
- add defense-in-depth no-output classification so quota failures do not degrade into misleading `needs_input` outcomes

## Testing
- `ruby -c app/temporal/activities/run_agent_activity.rb`
- `ruby -c app/temporal/activities/handle_no_output_issue_run_activity.rb`
- `bundle exec rspec` could not be completed in this workspace because the local test DB/bootstrap state is broken (`paid_test` recreation/pending migrations, and the branch worktree DB hook also reported a missing branch-specific development database)
