### PR TITLE
feat(containers): Phase 2 — Remote Docker Backend

### DIFF
--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -26,10 +26,20 @@ class DockerOrphanCleanupJob < ApplicationJob
   POOL_VOLUME_PREFIX = "paid-pool-workspace-"
 
   def perform
-    agent_removed = cleanup_agent_containers
-    pool_removed = cleanup_pool_containers
-    service_removed = cleanup_service_containers
-    volume_result = cleanup_volumes
+    agent_removed = 0
+    pool_removed = 0
+    service_removed = 0
+    volume_result = { found: 0, removed: 0, failed: 0, active: 0, retained: 0 }
+
+    Containers.all_backends.each do |backend|
+      agent_removed += cleanup_agent_containers(backend: backend)
+      pool_removed += cleanup_pool_containers(backend: backend)
+      service_removed += cleanup_service_containers(backend: backend)
+      backend_volume_result = cleanup_volumes(backend: backend)
+      volume_result = volume_result.merge(
+        volume_result.keys.to_h { |key| [ key, volume_result[key] + backend_volume_result.fetch(key, 0) ] }
+      )
+    end
 
     Rails.logger.info(
       message: "container_manager.orphan_cleanup_complete",
@@ -48,8 +58,8 @@ class DockerOrphanCleanupJob < ApplicationJob
 
   # Phase 1: Remove agent containers whose runs are no longer active.
   # Skips containers for runs with an unexpired retention TTL.
-  def cleanup_agent_containers
-    containers = list_containers_by_label("paid.agent_run_id")
+  def cleanup_agent_containers(backend:)
+    containers = list_containers_by_label("paid.agent_run_id", backend: backend)
     return 0 if containers.empty?
 
     agent_run_ids = containers.filter_map { |c| c.info.dig("Labels", "paid.agent_run_id") }
@@ -65,14 +75,14 @@ class DockerOrphanCleanupJob < ApplicationJob
       next if active_ids.include?(run_id)
       next if retained_ids.include?(run_id)
 
-      removed += 1 if stop_and_remove_container(container, "agent", run_id)
+      removed += 1 if stop_and_remove_container(container, "agent", run_id, backend: backend)
     end
     removed
   end
 
   # Phase 2: Remove stale warm-pool containers no longer tracked in the DB.
-  def cleanup_pool_containers
-    containers = list_containers_by_label("paid.container_pool=true")
+  def cleanup_pool_containers(backend:)
+    containers = list_containers_by_label("paid.container_pool=true", backend: backend)
     return 0 if containers.empty?
 
     removed = 0
@@ -81,15 +91,15 @@ class DockerOrphanCleanupJob < ApplicationJob
       entry = ContainerPoolEntry.find_by(id: entry_id) if entry_id.present?
       next if entry&.status.in?(%w[warm warming claimed]) && pool_entry_active?(entry)
 
-      removed += 1 if stop_and_remove_container(container, "pool", entry_id)
+      removed += 1 if stop_and_remove_container(container, "pool", entry_id, backend: backend)
       entry&.destroy!
     end
     removed
   end
 
   # Phase 3: Remove service containers with zero in-flight capacity runs.
-  def cleanup_service_containers
-    containers = list_containers_by_label("paid.service_container=true")
+  def cleanup_service_containers(backend:)
+    containers = list_containers_by_label("paid.service_container=true", backend: backend)
     return 0 if containers.empty?
 
     removed = 0
@@ -98,7 +108,7 @@ class DockerOrphanCleanupJob < ApplicationJob
       service_container = ServiceContainer.find_by(id: sc_id) if sc_id.present?
 
       if service_container.nil? || service_container.capacity_inflight_agent_run_count == 0
-        if stop_and_remove_container(container, "service", sc_id)
+        if stop_and_remove_container(container, "service", sc_id, backend: backend)
           begin
             service_container&.update!(status: "stopped", docker_container_id: nil)
           rescue ActiveRecord::ActiveRecordError => e
@@ -118,8 +128,8 @@ class DockerOrphanCleanupJob < ApplicationJob
 
   # Phase 4: Remove orphaned workspace volumes.
   # Skips volumes for runs with an unexpired retention TTL.
-  def cleanup_volumes
-    volumes = list_paid_volumes
+  def cleanup_volumes(backend:)
+    volumes = list_paid_volumes(backend: backend)
     return { found: 0, removed: 0, failed: 0, active: 0 } if volumes.empty?
 
     numeric_agent_run_ids = volumes
@@ -141,7 +151,7 @@ class DockerOrphanCleanupJob < ApplicationJob
           next
         end
 
-        if remove_volume(volume, nil)
+        if remove_volume(volume, nil, backend: backend)
           removed += 1
         else
           failed += 1
@@ -159,7 +169,7 @@ class DockerOrphanCleanupJob < ApplicationJob
         next
       end
 
-      if remove_volume(volume, agent_run_id)
+      if remove_volume(volume, agent_run_id, backend: backend)
         removed += 1
       else
         failed += 1
@@ -168,25 +178,26 @@ class DockerOrphanCleanupJob < ApplicationJob
     { found: volumes.size, removed: removed, failed: failed, active: active, retained: retained }
   end
 
-  def list_containers_by_label(label)
-    Containers.backend.list_containers(all: true, filters: { label: [ label ] }.to_json)
+  def list_containers_by_label(label, backend:)
+    backend.list_containers(all: true, filters: { label: [ label ] }.to_json)
   rescue Docker::Error::DockerError => e
     Rails.logger.error(
       message: "container_manager.container_list_failed",
       label: label,
+      backend: backend.identifier,
       error: e.message
     )
     []
   end
 
-  def stop_and_remove_container(container, kind, resource_id)
+  def stop_and_remove_container(container, kind, resource_id, backend:)
     begin
-      Containers.backend.stop_container(container, timeout: 10)
+      backend.stop_container(container, timeout: 10)
     rescue Docker::Error::NotFoundError, Docker::Error::ClientError
       # Already stopped or gone
     end
     begin
-      Containers.backend.delete_container(container, force: true, v: true)
+      backend.delete_container(container, force: true, v: true)
     rescue Docker::Error::NotFoundError
       # Container disappeared between stop and delete (race condition)
     end
@@ -196,23 +207,25 @@ class DockerOrphanCleanupJob < ApplicationJob
       message: "container_manager.orphaned_container_removal_failed",
       kind: kind,
       resource_id: resource_id,
+      backend: backend.identifier,
       error: e.message
     )
     false
   end
 
-  def list_paid_volumes
-    Containers.backend.list_volumes.select { |v| v.id.start_with?(VOLUME_PREFIX) || v.id.start_with?(POOL_VOLUME_PREFIX) }
+  def list_paid_volumes(backend:)
+    backend.list_volumes.select { |v| v.id.start_with?(VOLUME_PREFIX) || v.id.start_with?(POOL_VOLUME_PREFIX) }
   rescue Docker::Error::DockerError => e
     Rails.logger.error(
       message: "container_manager.volume_list_failed",
+      backend: backend.identifier,
       error: e.message
     )
     []
   end
 
-  def remove_volume(volume, agent_run_id)
-    volume.remove
+  def remove_volume(volume, agent_run_id, backend:)
+    backend.delete_volume(volume)
     true
   rescue Docker::Error::NotFoundError
     true # Volume disappeared between listing and removal (race condition)
@@ -221,6 +234,7 @@ class DockerOrphanCleanupJob < ApplicationJob
       message: "container_manager.orphaned_volume_removal_failed",
       volume_name: volume.id,
       agent_run_id: agent_run_id,
+      backend: backend.identifier,
       error: e.message
     )
     false

--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -36,9 +36,7 @@ class DockerOrphanCleanupJob < ApplicationJob
       pool_removed += cleanup_pool_containers(backend: backend)
       service_removed += cleanup_service_containers(backend: backend)
       backend_volume_result = cleanup_volumes(backend: backend)
-      volume_result = volume_result.merge(
-        volume_result.keys.to_h { |key| [ key, volume_result[key] + backend_volume_result.fetch(key, 0) ] }
-      )
+      volume_result = volume_result.merge(backend_volume_result) { |_key, old_val, new_val| old_val + new_val }
     end
 
     Rails.logger.info(

--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -147,7 +147,7 @@ class DockerOrphanCleanupJob < ApplicationJob
   # Skips volumes for runs with an unexpired retention TTL.
   def cleanup_volumes(backend:)
     volumes = list_paid_volumes(backend: backend)
-    return { found: 0, removed: 0, failed: 0, active: 0 } if volumes.empty?
+    return { found: 0, removed: 0, failed: 0, active: 0, retained: 0 } if volumes.empty?
 
     numeric_agent_run_ids = volumes
                               .map { |v| v.id.delete_prefix(VOLUME_PREFIX) }

--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -103,6 +103,8 @@ class DockerOrphanCleanupJob < ApplicationJob
   end
 
   # Phase 3: Remove service containers with zero in-flight capacity runs.
+  # Also removes stale containers whose docker_container_id no longer matches
+  # the DB record (e.g. reprovisioned onto a different backend).
   def cleanup_service_containers(backend:)
     containers = list_containers_by_label("paid.service_container=true", backend: backend)
     return 0 if containers.empty?
@@ -112,8 +114,18 @@ class DockerOrphanCleanupJob < ApplicationJob
       sc_id = container.info.dig("Labels", "paid.service_container_id")
       service_container = ServiceContainer.find_by(id: sc_id) if sc_id.present?
 
-      if service_container.nil? || service_container.capacity_inflight_agent_run_count == 0
-        if stop_and_remove_container(container, "service", sc_id, backend: backend)
+      # Container is orphaned if:
+      # 1. No matching DB record exists, OR
+      # 2. The DB record points to a different Docker container (reprovisioned on another backend), OR
+      # 3. No agent runs are currently using this service container
+      stale_on_backend = service_container&.docker_container_id.present? &&
+        service_container.docker_container_id != container.id
+      orphaned = service_container.nil? || stale_on_backend ||
+        service_container.capacity_inflight_agent_run_count == 0
+
+      if orphaned && stop_and_remove_container(container, "service", sc_id, backend: backend)
+        # Only clear the DB record if this container is still the active one
+        unless stale_on_backend
           begin
             service_container&.update!(status: "stopped", docker_container_id: nil)
           rescue ActiveRecord::ActiveRecordError => e
@@ -124,8 +136,8 @@ class DockerOrphanCleanupJob < ApplicationJob
               error: e.message
             )
           end
-          removed += 1
         end
+        removed += 1
       end
     end
     removed

--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -276,12 +276,12 @@ class DockerOrphanCleanupJob < ApplicationJob
   end
 
   def active_pool_volume_names_for_backend(backend)
-    warm_names = pool_entries_for_backend(backend).warm.pluck(:workspace_volume)
-    warming_names = pool_entries_for_backend(backend).active_warming.pluck(:workspace_volume)
-    claimed_names = active_claimed_pool_entries(backend).pluck(:workspace_volume)
-
     @active_pool_volume_names ||= {}
     @active_pool_volume_names[backend.identifier] ||= begin
+      warm_names = pool_entries_for_backend(backend).warm.pluck(:workspace_volume)
+      warming_names = pool_entries_for_backend(backend).active_warming.pluck(:workspace_volume)
+      claimed_names = active_claimed_pool_entries(backend).pluck(:workspace_volume)
+
       (warm_names + warming_names + claimed_names).to_set
     end
   end

--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -62,10 +62,17 @@ class DockerOrphanCleanupJob < ApplicationJob
 
     agent_run_ids = containers.filter_map { |c| c.info.dig("Labels", "paid.agent_run_id") }
     numeric_ids = agent_run_ids.select { |id| id.match?(/\A\d+\z/) }
-    active_ids = AgentRun.capacity_inflight.where(id: numeric_ids).pluck(:id).map(&:to_s).to_set
-    retained_ids = AgentRun.where(id: numeric_ids)
+    active_ids = agent_runs_for_backend(backend, AgentRun.capacity_inflight)
+      .where(id: numeric_ids)
+      .pluck(:id)
+      .map(&:to_s)
+      .to_set
+    retained_ids = agent_runs_for_backend(backend, AgentRun.all)
+      .where(id: numeric_ids)
       .where("container_retained_until > ?", Time.current)
-      .pluck(:id).map(&:to_s).to_set
+      .pluck(:id)
+      .map(&:to_s)
+      .to_set
 
     removed = 0
     containers.each do |container|
@@ -86,7 +93,7 @@ class DockerOrphanCleanupJob < ApplicationJob
     removed = 0
     containers.each do |container|
       entry_id = container.info.dig("Labels", "paid.container_pool_entry_id")
-      entry = ContainerPoolEntry.find_by(id: entry_id) if entry_id.present?
+      entry = pool_entries_for_backend(backend).find_by(id: entry_id) if entry_id.present?
       next if entry&.status.in?(%w[warm warming claimed]) && pool_entry_active?(entry)
 
       removed += 1 if stop_and_remove_container(container, "pool", entry_id, backend: backend)
@@ -133,15 +140,23 @@ class DockerOrphanCleanupJob < ApplicationJob
     numeric_agent_run_ids = volumes
                               .map { |v| v.id.delete_prefix(VOLUME_PREFIX) }
                               .select { |id| id.match?(/\A\d+\z/) }
-    active_ids = AgentRun.capacity_inflight.where(id: numeric_agent_run_ids).pluck(:id).map(&:to_s).to_set
-    retained_ids = AgentRun.where(id: numeric_agent_run_ids)
+    active_ids = agent_runs_for_backend(backend, AgentRun.capacity_inflight)
+      .where(id: numeric_agent_run_ids)
+      .pluck(:id)
+      .map(&:to_s)
+      .to_set
+    retained_ids = agent_runs_for_backend(backend, AgentRun.all)
+      .where(id: numeric_agent_run_ids)
       .where("container_retained_until > ?", Time.current)
-      .pluck(:id).map(&:to_s).to_set
+      .pluck(:id)
+      .map(&:to_s)
+      .to_set
 
     removed = 0
     failed = 0
     active = 0
     retained = 0
+    active_pool_volume_names = active_pool_volume_names_for_backend(backend)
     volumes.each do |volume|
       if volume.id.start_with?(POOL_VOLUME_PREFIX)
         if active_pool_volume_names.include?(volume.id)
@@ -245,28 +260,39 @@ class DockerOrphanCleanupJob < ApplicationJob
     claimed_pool_entry_active?(entry)
   end
 
-  def active_pool_volume_names
-    @active_pool_volume_names ||= begin
-      warm_names = ContainerPoolEntry.warm.pluck(:workspace_volume)
-      warming_names = ContainerPoolEntry.active_warming.pluck(:workspace_volume)
-      claimed_names = active_claimed_pool_entries.pluck(:workspace_volume)
-
-      (warm_names + warming_names + claimed_names).to_set
-    end
-  end
-
   def claimed_pool_entry_active?(entry)
     agent_run = entry.agent_run
     agent_run&.status.in?(AgentRun::UNFINISHED_STATUSES) || agent_run&.container_retained?
   end
 
-  def active_claimed_pool_entries
-    ContainerPoolEntry.claimed
+  def active_claimed_pool_entries(backend)
+    pool_entries_for_backend(backend).claimed
       .joins(:agent_run)
       .where(
         AgentRun.arel_table[:status].in(AgentRun::UNFINISHED_STATUSES).or(
           AgentRun.arel_table[:container_retained_until].gt(Time.current)
         )
       )
+  end
+
+  def active_pool_volume_names_for_backend(backend)
+    warm_names = pool_entries_for_backend(backend).warm.pluck(:workspace_volume)
+    warming_names = pool_entries_for_backend(backend).active_warming.pluck(:workspace_volume)
+    claimed_names = active_claimed_pool_entries(backend).pluck(:workspace_volume)
+
+    (warm_names + warming_names + claimed_names).to_set
+  end
+
+  def agent_runs_for_backend(backend, scope)
+    return scope.where(container_host: [ nil, "", backend.identifier ]) unless backend.remote?
+
+    scope.where(container_host: backend.identifier)
+  end
+
+  def pool_entries_for_backend(backend)
+    scope = ContainerPoolEntry.all
+    return scope.where(container_host: [ nil, "", backend.identifier ]) unless backend.remote?
+
+    scope.where(container_host: backend.identifier)
   end
 end

--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -292,15 +292,15 @@ class DockerOrphanCleanupJob < ApplicationJob
   end
 
   def agent_runs_for_backend(backend, scope)
-    return scope.where(container_host: [ nil, "", backend.identifier ]) unless backend.remote?
+    return scope.where(container_host: backend.identifier) if backend.remote?
 
-    scope.where(container_host: backend.identifier)
+    scope.where(container_host: [ nil, "" ] + backend.all_host_identifiers)
   end
 
   def pool_entries_for_backend(backend)
     scope = ContainerPoolEntry.all
-    return scope.where(container_host: [ nil, "", backend.identifier ]) unless backend.remote?
+    return scope.where(container_host: backend.identifier) if backend.remote?
 
-    scope.where(container_host: backend.identifier)
+    scope.where(container_host: [ nil, "" ] + backend.all_host_identifiers)
   end
 end

--- a/app/services/containers.rb
+++ b/app/services/containers.rb
@@ -17,5 +17,21 @@ module Containers
 
       Backends::Resolver.for(host.to_sym)
     end
+
+    def all_backends
+      active_backend = backend
+      backends = { active_backend.identifier => active_backend }
+
+      Backends::Resolver.backend_types.each do |backend_type|
+        candidate = Backends::Resolver.for(backend_type)
+        backends[candidate.identifier] = candidate
+      end
+
+      backends.values
+    end
+
+    def remote_backend_active?
+      backend.remote?
+    end
   end
 end

--- a/app/services/containers.rb
+++ b/app/services/containers.rb
@@ -26,7 +26,10 @@ module Containers
     def all_backends
       active_backend = backend
       backends = { active_backend.identifier => active_backend }
-      [ local_backend, remote_backend ].compact.each do |candidate|
+      Backends::Resolver.backend_types.each do |backend_type|
+        candidate = resolve_optional_backend(backend_type)
+        next unless candidate
+
         backends[candidate.identifier] = candidate
       end
       backends.values

--- a/app/services/containers.rb
+++ b/app/services/containers.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module Containers
+  LOCAL_BACKEND_KEY = :local
+  REMOTE_BACKEND_KEY = :remote
+
   class << self
     def backend
       Rails.application.config.x.container_backend || Backends::Resolver.for(
@@ -13,7 +16,8 @@ module Containers
     # matches the active backend's identifier.
     def backend_for(host)
       resolved_backend = backend
-      return resolved_backend if host.blank? || host.to_s == resolved_backend.identifier
+      return local_backend || resolved_backend if host.blank?
+      return resolved_backend if host.to_s == resolved_backend.identifier
       return resolved_backend if resolved_backend.owns_host?(host)
 
       Backends::Resolver.for(host.to_sym)
@@ -22,13 +26,26 @@ module Containers
     def all_backends
       active_backend = backend
       backends = { active_backend.identifier => active_backend }
-
-      Backends::Resolver.backend_types.each do |backend_type|
-        candidate = Backends::Resolver.for(backend_type)
+      [ local_backend, remote_backend ].compact.each do |candidate|
         backends[candidate.identifier] = candidate
       end
-
       backends.values
+    end
+
+    private
+
+    def local_backend
+      resolve_optional_backend(LOCAL_BACKEND_KEY)
+    end
+
+    def remote_backend
+      resolve_optional_backend(REMOTE_BACKEND_KEY)
+    end
+
+    def resolve_optional_backend(backend_type)
+      return unless Backends::Resolver.backend_types.include?(backend_type)
+
+      Backends::Resolver.for(backend_type)
     end
   end
 end

--- a/app/services/containers.rb
+++ b/app/services/containers.rb
@@ -26,7 +26,8 @@ module Containers
     def all_backends
       active_backend = backend
       backends = { active_backend.identifier => active_backend }
-      Backends::Resolver.backend_types.each do |backend_type|
+
+      cleanup_backend_keys(active_backend).each do |backend_type|
         candidate = resolve_optional_backend(backend_type)
         next unless candidate
 
@@ -36,6 +37,15 @@ module Containers
     end
 
     private
+
+    def cleanup_backend_keys(active_backend)
+      return [] if active_backend.identifier.to_sym == :swarm
+
+      keys = []
+      keys << LOCAL_BACKEND_KEY if active_backend.remote?
+      keys << REMOTE_BACKEND_KEY if active_backend.identifier.to_sym == LOCAL_BACKEND_KEY
+      keys
+    end
 
     def local_backend
       resolve_optional_backend(LOCAL_BACKEND_KEY)

--- a/app/services/containers/backends/base.rb
+++ b/app/services/containers/backends/base.rb
@@ -3,6 +3,10 @@
 module Containers
   module Backends
     class Base
+      def remote?
+        false
+      end
+
       def identifier
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end

--- a/app/services/containers/backends/base.rb
+++ b/app/services/containers/backends/base.rb
@@ -23,6 +23,13 @@ module Containers
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 
+      # Returns all container_host values this backend may have persisted.
+      # Used by cleanup jobs to scope queries to the correct backend.
+      # Backends with multiple hosts (e.g., swarm) should override this.
+      def all_host_identifiers
+        [ identifier ]
+      end
+
       def container_host_for(_container)
         identifier
       end

--- a/app/services/containers/backends/remote_docker.rb
+++ b/app/services/containers/backends/remote_docker.rb
@@ -94,11 +94,11 @@ module Containers
         Docker::Volume.all({}, connection)
       end
 
-      def create_volume(name, options = {})
-        Docker::Volume.create(name, options, connection)
+      def create_volume(name, options = nil, host: nil, **keyword_options)
+        Docker::Volume.create(name, normalize_volume_options(options, keyword_options), connection)
       end
 
-      def get_volume(name)
+      def get_volume(name, host: nil)
         Docker::Volume.get(name, connection)
       end
 
@@ -110,6 +110,10 @@ module Containers
 
       def build_tls_config(tls_config)
         tls_config.to_h.compact.merge(scheme: "https")
+      end
+
+      def normalize_volume_options(options, keyword_options)
+        (options || {}).merge(keyword_options.transform_keys(&:to_s))
       end
 
       def validate_tls_config!

--- a/app/services/containers/backends/remote_docker.rb
+++ b/app/services/containers/backends/remote_docker.rb
@@ -42,6 +42,10 @@ module Containers
         false
       end
 
+      def owns_host?(host)
+        host.present? && host.to_s == remote_host
+      end
+
       def ping
         Docker.ping(connection)
       end
@@ -142,6 +146,12 @@ module Containers
 
       def derive_identifier(url)
         URI.parse(url).host
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      def remote_host
+        @remote_host ||= URI.parse(@docker_url).host
       rescue URI::InvalidURIError
         nil
       end

--- a/app/services/containers/backends/remote_docker.rb
+++ b/app/services/containers/backends/remote_docker.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "docker-api"
+require "uri"
+
+module Containers
+  module Backends
+    class RemoteDocker < Base
+      DEFAULT_PORT = 2376
+      REQUIRED_TLS_OPTIONS = {
+        client_cert: "REMOTE_DOCKER_CERT",
+        client_key: "REMOTE_DOCKER_KEY",
+        ssl_ca_file: "REMOTE_DOCKER_CA"
+      }.freeze
+
+      attr_reader :connection, :docker_url
+
+      def self.from_env(env = ENV)
+        host = env["REMOTE_DOCKER_HOST"].presence
+        return unless host
+
+        new(
+          host: host,
+          identifier: env["REMOTE_DOCKER_IDENTIFIER"].presence,
+          tls_config: REQUIRED_TLS_OPTIONS.to_h { |key, env_key| [ key, env[env_key].presence ] }
+        )
+      end
+
+      def initialize(host:, identifier: nil, tls_config:)
+        @docker_url = normalize_url(host)
+        @identifier = identifier.presence || derive_identifier(@docker_url)
+        @tls_config = build_tls_config(tls_config)
+        validate_tls_config!
+        @connection = Docker::Connection.new(@docker_url, @tls_config)
+      end
+
+      def remote?
+        true
+      end
+
+      def identifier
+        @identifier
+      end
+
+      def ping
+        Docker.ping(connection)
+      end
+
+      def get_container(id)
+        Docker::Container.get(id, {}, connection)
+      end
+
+      def create_container(config)
+        Docker::Container.create(config, connection)
+      end
+
+      def start_container(container)
+        container.start
+      end
+
+      def stop_container(container, **options)
+        container.stop(**options)
+      end
+
+      def delete_container(container, **options)
+        container.delete(**options)
+      end
+
+      def exec_in_container(container, command, **options, &block)
+        container.exec(command, **options, &block)
+      end
+
+      def container_stats(container, **options)
+        container.stats(**options)
+      end
+
+      def container_logs(container, **options)
+        container.streaming_logs(**options)
+      end
+
+      def list_containers(**options)
+        Docker::Container.all(options, connection)
+      end
+
+      def get_network(name)
+        Docker::Network.get(name, {}, connection)
+      end
+
+      def create_network(name, config)
+        Docker::Network.create(name, config, connection)
+      end
+
+      def pull_image(config)
+        Docker::Image.create(config, nil, connection)
+      end
+
+      def list_volumes
+        Docker::Volume.all({}, connection)
+      end
+
+      def create_volume(name, options = {})
+        Docker::Volume.create(name, options, connection)
+      end
+
+      def get_volume(name)
+        Docker::Volume.get(name, connection)
+      end
+
+      def delete_volume(volume, **options)
+        volume.remove(**options)
+      end
+
+      private
+
+      def build_tls_config(tls_config)
+        tls_config.to_h.compact.merge(scheme: "https")
+      end
+
+      def validate_tls_config!
+        missing = REQUIRED_TLS_OPTIONS.keys.reject { |key| @tls_config[key].present? }
+        return if missing.empty?
+
+        missing_env_keys = missing.map { |key| REQUIRED_TLS_OPTIONS.fetch(key) }
+        raise ArgumentError, "Remote Docker TLS config requires #{missing_env_keys.join(', ')}"
+      end
+
+      def normalize_url(host)
+        url = host.to_s
+        url = "tcp://#{url}" unless url.include?("://")
+
+        uri = URI.parse(url)
+        return url if uri.port
+
+        "#{url}:#{DEFAULT_PORT}"
+      rescue URI::InvalidURIError => e
+        raise ArgumentError, "Invalid remote Docker host #{host.inspect}: #{e.message}"
+      end
+
+      def derive_identifier(url)
+        URI.parse(url).host
+      rescue URI::InvalidURIError
+        nil
+      end
+    end
+  end
+end

--- a/app/services/containers/backends/remote_docker.rb
+++ b/app/services/containers/backends/remote_docker.rb
@@ -38,6 +38,10 @@ module Containers
         true
       end
 
+      def supports_host_paths?
+        false
+      end
+
       def ping
         Docker.ping(connection)
       end

--- a/app/services/containers/backends/remote_docker.rb
+++ b/app/services/containers/backends/remote_docker.rb
@@ -13,7 +13,7 @@ module Containers
         ssl_ca_file: "REMOTE_DOCKER_CA"
       }.freeze
 
-      attr_reader :connection, :docker_url
+      attr_reader :connection, :docker_url, :identifier
 
       def self.from_env(env = ENV)
         host = env["REMOTE_DOCKER_HOST"].presence
@@ -36,10 +36,6 @@ module Containers
 
       def remote?
         true
-      end
-
-      def identifier
-        @identifier
       end
 
       def ping

--- a/app/services/containers/backends/resolver.rb
+++ b/app/services/containers/backends/resolver.rb
@@ -26,6 +26,10 @@ module Containers
           factory.call
         end
 
+        def backend_types
+          registry.keys
+        end
+
         private
 
         def registry

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -107,6 +107,10 @@ module Containers
         cached_node_hostnames.include?(host.to_s)
       end
 
+      def all_host_identifiers
+        cached_node_hostnames.to_a + [ identifier ]
+      end
+
       def ping
         manager_connection.ping
       end

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -96,7 +96,7 @@ module Containers
       end
 
       def remote?
-        true
+        false
       end
 
       def supports_host_paths?

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -95,6 +95,10 @@ module Containers
         "swarm"
       end
 
+      def remote?
+        true
+      end
+
       def supports_host_paths?
         false
       end

--- a/app/services/containers/mcp_provisioner.rb
+++ b/app/services/containers/mcp_provisioner.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "docker-api"
-require "socket"
-
 module Containers
   # Provisions MCP (Model Context Protocol) servers for agent runs.
   #
@@ -151,7 +149,7 @@ module Containers
 
       begin
         Containers.backend.start_container(container) unless container_running?(container)
-        wait_for_health!(hostname, port)
+        wait_for_health!(container, hostname, port)
       rescue => e
         remove_container(container)
         raise Error, "Failed to start MCP sidecar #{name}: #{e.message}"
@@ -227,11 +225,11 @@ module Containers
       raise Error, "Failed to pull MCP server image #{image}: #{e.message}"
     end
 
-    def wait_for_health!(hostname, port)
+    def wait_for_health!(container, hostname, port)
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + HEALTH_CHECK_TIMEOUT
 
       loop do
-        return if tcp_port_open?(hostname, port)
+        return if TcpHealthProbe.open?(backend: Containers.backend, container: container, host: hostname, port: port)
 
         if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
           raise Error, "Health check timeout for MCP sidecar #{hostname}:#{port}"
@@ -240,15 +238,6 @@ module Containers
         sleep HEALTH_CHECK_INTERVAL
       end
     end
-
-    def tcp_port_open?(host, port)
-      socket = Socket.tcp(host, port, connect_timeout: HEALTH_CHECK_INTERVAL)
-      socket.close
-      true
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, SocketError
-      false
-    end
-
     def sidecar_hostname(agent_run, name)
       suffix = "run#{agent_run.id}"
       budget = [ MAX_NAME_LENGTH - CONTAINER_NAME_PREFIX.length - suffix.length - 2, 1 ].max

--- a/app/services/containers/mcp_provisioner.rb
+++ b/app/services/containers/mcp_provisioner.rb
@@ -130,7 +130,7 @@ module Containers
         raise Error, "docker_image MCP server #{definition["name"].inspect} requires transport \"sse\", got #{transport.inspect}"
       end
 
-      NetworkPolicy.ensure_network!(network: @network)
+      NetworkPolicy.ensure_network!(network: @network, backend: Containers.backend)
 
       image = definition["image"]
       name = definition["name"]

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -2023,13 +2023,7 @@ module Containers
     end
 
     def proxy_base_url
-      if backend.remote? && ENV["PAID_PROXY_EXTERNAL_URL"].present?
-        return ENV["PAID_PROXY_EXTERNAL_URL"]
-      end
-
-      proxy_port = Rails.application.config.x.paid_proxy_port
-      proxy_host = network_contract.restricted? ? "paid-proxy" : "web"
-      "http://#{proxy_host}:#{proxy_port}"
+      Containers::ProxyUrl.resolve(backend:, restricted: network_contract.restricted?)
     end
 
     # Returns the Docker-host path to the Claude config directory.

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -2023,6 +2023,10 @@ module Containers
     end
 
     def proxy_base_url
+      if backend.remote? && ENV["PAID_PROXY_EXTERNAL_URL"].present?
+        return ENV["PAID_PROXY_EXTERNAL_URL"]
+      end
+
       proxy_port = Rails.application.config.x.paid_proxy_port
       proxy_host = network_contract.restricted? ? "paid-proxy" : "web"
       "http://#{proxy_host}:#{proxy_port}"
@@ -2231,7 +2235,7 @@ module Containers
 
     def detected_config_mount(suffix)
       hostname = Socket.gethostname
-      container = Containers.backend.get_container(hostname)
+      container = local_runtime_backend.get_container(hostname)
       mounts = container.info["Mounts"] || []
       mounts.find { |mount| mount["Destination"]&.end_with?(suffix) }
     rescue Docker::Error::DockerError
@@ -2263,7 +2267,7 @@ module Containers
       return @current_container_mounts if defined?(@current_container_mounts)
 
       hostname = Socket.gethostname
-      container = Containers.backend.get_container(hostname)
+      container = local_runtime_backend.get_container(hostname)
       @current_container_mounts = container.info["Mounts"] || []
     rescue Docker::Error::DockerError
       @current_container_mounts = nil
@@ -2306,7 +2310,7 @@ module Containers
     end
 
     def ensure_network!
-      NetworkPolicy.ensure_network!(network: network_name)
+      NetworkPolicy.ensure_network!(network: network_name, backend: backend)
       log_system("container.network.ready", network: network_name, mode: network_contract.mode)
     rescue NetworkPolicy::Error => e
       raise ProvisionError, "Network setup failed: #{e.message}"
@@ -2317,7 +2321,8 @@ module Containers
 
       NetworkPolicy.apply_firewall_rules(
         container,
-        service_destinations: resolve_service_destinations
+        service_destinations: resolve_service_destinations,
+        backend: backend
       )
       log_system("container.firewall.applied", container_id: container.id)
     rescue NetworkPolicy::Error => e
@@ -2342,6 +2347,12 @@ module Containers
         agent_run: agent_run,
         logger: method(:log_system)
       )
+    end
+
+    def local_runtime_backend
+      @local_runtime_backend ||= Containers.backend_for("local")
+    rescue Containers::Backends::Resolver::UnknownBackendError
+      Containers.backend
     end
 
     def streaming_event_command?(command)

--- a/app/services/containers/proxy_url.rb
+++ b/app/services/containers/proxy_url.rb
@@ -22,6 +22,7 @@ module Containers
     def validate_external_url!(url)
       uri = URI.parse(url)
       raise ArgumentError, "PAID_PROXY_EXTERNAL_URL must include scheme and host" if uri.scheme.blank? || uri.host.blank?
+      raise ArgumentError, "PAID_PROXY_EXTERNAL_URL must use http or https" unless uri.scheme.in?(%w[http https])
       raise ArgumentError, "PAID_PROXY_EXTERNAL_URL port must be between 1 and 65535" unless uri.port.between?(1, 65_535)
 
       url

--- a/app/services/containers/proxy_url.rb
+++ b/app/services/containers/proxy_url.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Containers
+  module ProxyUrl
+    module_function
+
+    def resolve(backend:, restricted:)
+      if backend.remote? && ENV["PAID_PROXY_EXTERNAL_URL"].present?
+        return ENV["PAID_PROXY_EXTERNAL_URL"]
+      end
+
+      proxy_port = Rails.application.config.x.paid_proxy_port
+      proxy_host = restricted ? "paid-proxy" : "web"
+      "http://#{proxy_host}:#{proxy_port}"
+    end
+  end
+end

--- a/app/services/containers/proxy_url.rb
+++ b/app/services/containers/proxy_url.rb
@@ -7,8 +7,11 @@ module Containers
     module_function
 
     def resolve(backend:, restricted:)
-      if backend.remote? && ENV["PAID_PROXY_EXTERNAL_URL"].present?
-        return validate_external_url!(ENV.fetch("PAID_PROXY_EXTERNAL_URL"))
+      if backend.remote?
+        external_url = ENV["PAID_PROXY_EXTERNAL_URL"].presence
+        raise ArgumentError, "PAID_PROXY_EXTERNAL_URL is required when CONTAINER_BACKEND is remote" if external_url.blank?
+
+        return validate_external_url!(external_url)
       end
 
       proxy_port = Rails.application.config.x.paid_proxy_port

--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -105,7 +105,7 @@ module Containers
       return {} if service_containers.empty?
 
       @network = network
-      NetworkPolicy.ensure_network!(network: @network)
+      NetworkPolicy.ensure_network!(network: @network, backend: Containers.backend)
 
       # Record association early so concurrent cleanup counts this run.
       container_ids = service_containers.map(&:id)

--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -417,6 +417,7 @@ module Containers
     def wait_for_health!(service_container)
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + HEALTH_CHECK_TIMEOUT
       has_healthcheck = nil # nil = unknown, true/false once determined
+      docker_container = Containers.backend.get_container(service_container.docker_container_id)
 
       loop do
         # Only query Docker HEALTHCHECK when we haven't confirmed its absence.
@@ -433,7 +434,9 @@ module Containers
         end
 
         # Fall back to TCP probe when no Docker HEALTHCHECK is configured.
-        if has_healthcheck == false && tcp_port_open?(service_container)
+        # Service containers (postgres, redis) should always have probe tools,
+        # so we pass fallback_on_missing_tools: false to avoid false-healthy.
+        if has_healthcheck == false && tcp_port_open?(service_container, docker_container: docker_container)
           log_info("service_provisioner.healthy", name: service_container.name)
           return
         end
@@ -463,13 +466,14 @@ module Containers
       nil
     end
 
-    def tcp_port_open?(service_container)
-      container = Containers.backend.get_container(service_container.docker_container_id)
+    def tcp_port_open?(service_container, docker_container: nil, fallback_on_missing_tools: false)
+      docker_container ||= Containers.backend.get_container(service_container.docker_container_id)
       Containers::TcpHealthProbe.open?(
         backend: Containers.backend,
-        container: container,
+        container: docker_container,
         host: runtime_name(service_container),
-        port: service_container.port
+        port: service_container.port,
+        fallback_on_missing_tools: fallback_on_missing_tools
       )
     rescue Docker::Error::DockerError, Excon::Error
       false

--- a/app/services/containers/service_provisioner.rb
+++ b/app/services/containers/service_provisioner.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "docker-api"
-require "socket"
 require "uri"
 
 module Containers
@@ -434,7 +433,7 @@ module Containers
         end
 
         # Fall back to TCP probe when no Docker HEALTHCHECK is configured.
-        if has_healthcheck == false && tcp_port_open?(runtime_name(service_container), service_container.port)
+        if has_healthcheck == false && tcp_port_open?(service_container)
           log_info("service_provisioner.healthy", name: service_container.name)
           return
         end
@@ -464,11 +463,15 @@ module Containers
       nil
     end
 
-    def tcp_port_open?(host, port)
-      socket = Socket.tcp(host, port, connect_timeout: HEALTH_CHECK_INTERVAL)
-      socket.close
-      true
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, SocketError
+    def tcp_port_open?(service_container)
+      container = Containers.backend.get_container(service_container.docker_container_id)
+      TcpHealthProbe.open?(
+        backend: Containers.backend,
+        container: container,
+        host: runtime_name(service_container),
+        port: service_container.port
+      )
+    rescue Docker::Error::DockerError, Excon::Error
       false
     end
 

--- a/app/services/containers/tcp_health_probe.rb
+++ b/app/services/containers/tcp_health_probe.rb
@@ -29,6 +29,9 @@ module Containers
       end
 
       def probe_script(port)
+        port = Integer(port)
+        raise ArgumentError, "Invalid probe port: #{port}" unless port.between?(1, 65_535)
+
         <<~SH
           set -eu
           if command -v nc >/dev/null 2>&1; then
@@ -51,6 +54,8 @@ module Containers
           fi
           exit 127
         SH
+      rescue ArgumentError, TypeError
+        raise ArgumentError, "Invalid probe port: #{port.inspect}"
       end
     end
   end

--- a/app/services/containers/tcp_health_probe.rb
+++ b/app/services/containers/tcp_health_probe.rb
@@ -16,6 +16,11 @@ module Containers
         return false if container.blank?
 
         _stdout, _stderr, status = backend.exec_in_container(container, [ "sh", "-c", probe_script(port) ])
+        # Exit 127 means none of the probe tools (nc, bash, ruby, python, node)
+        # were found in the container. Fall back to assuming healthy to avoid
+        # blocking minimal/distroless images that lack these executables.
+        return true if status == 127
+
         status.zero?
       rescue Docker::Error::DockerError, Excon::Error
         false

--- a/app/services/containers/tcp_health_probe.rb
+++ b/app/services/containers/tcp_health_probe.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "socket"
+
+module Containers
+  class TcpHealthProbe
+    class << self
+      def open?(backend:, container:, host:, port:)
+        backend.remote? ? remote_port_open?(backend: backend, container: container, port: port) : local_port_open?(host, port)
+      end
+
+      private
+
+      def remote_port_open?(backend:, container:, port:)
+        return false if container.blank?
+
+        _stdout, _stderr, status = backend.exec_in_container(container, [ "sh", "-lc", probe_script(port) ])
+        status.zero?
+      rescue Docker::Error::DockerError, Excon::Error
+        false
+      end
+
+      def local_port_open?(host, port)
+        socket = Socket.tcp(host, port, connect_timeout: 1)
+        socket.close
+        true
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, SocketError
+        false
+      end
+
+      def probe_script(port)
+        <<~SH
+          set -eu
+          if command -v nc >/dev/null 2>&1; then
+            exec nc -z 127.0.0.1 #{port}
+          fi
+          if command -v bash >/dev/null 2>&1; then
+            exec bash -lc "exec 3<>/dev/tcp/127.0.0.1/#{port}"
+          fi
+          if command -v ruby >/dev/null 2>&1; then
+            exec ruby -rsocket -e "Socket.tcp('127.0.0.1', #{port}, connect_timeout: 1).close"
+          fi
+          if command -v python3 >/dev/null 2>&1; then
+            exec python3 -c "import socket; s=socket.create_connection(('127.0.0.1', #{port}), 1); s.close()"
+          fi
+          if command -v python >/dev/null 2>&1; then
+            exec python -c "import socket; s=socket.create_connection(('127.0.0.1', #{port}), 1); s.close()"
+          fi
+          if command -v node >/dev/null 2>&1; then
+            exec node -e "const net=require('net'); const s=net.createConnection({host:'127.0.0.1', port:#{port}}); s.on('connect',()=>{s.end(); process.exit(0)}); s.on('error',()=>process.exit(1)); setTimeout(()=>process.exit(1), 1000);"
+          fi
+          exit 127
+        SH
+      end
+    end
+  end
+end

--- a/app/services/containers/tcp_health_probe.rb
+++ b/app/services/containers/tcp_health_probe.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "docker-api"
 require "socket"
 
 module Containers

--- a/app/services/containers/tcp_health_probe.rb
+++ b/app/services/containers/tcp_health_probe.rb
@@ -6,20 +6,22 @@ require "socket"
 module Containers
   class TcpHealthProbe
     class << self
-      def open?(backend:, container:, host:, port:)
-        backend.remote? ? remote_port_open?(backend: backend, container: container, port: port) : local_port_open?(host, port)
+      def open?(backend:, container:, host:, port:, fallback_on_missing_tools: true)
+        backend.remote? ? remote_port_open?(backend: backend, container: container, port: port, fallback_on_missing_tools: fallback_on_missing_tools) : local_port_open?(host, port)
       end
 
       private
 
-      def remote_port_open?(backend:, container:, port:)
+      def remote_port_open?(backend:, container:, port:, fallback_on_missing_tools: true)
         return false if container.blank?
 
         _stdout, _stderr, status = backend.exec_in_container(container, [ "sh", "-c", probe_script(port) ])
         # Exit 127 means none of the probe tools (nc, bash, ruby, python, node)
-        # were found in the container. Fall back to assuming healthy to avoid
-        # blocking minimal/distroless images that lack these executables.
-        return true if status == 127
+        # were found in the container. When fallback_on_missing_tools is true,
+        # assume healthy to avoid blocking minimal/distroless images. When false
+        # (e.g. service containers like postgres/redis that should have tools),
+        # report unhealthy so the caller keeps waiting.
+        return fallback_on_missing_tools if status == 127
 
         status.zero?
       rescue Docker::Error::DockerError, Excon::Error

--- a/app/services/knowledge/analysis_runner.rb
+++ b/app/services/knowledge/analysis_runner.rb
@@ -200,6 +200,7 @@ module Knowledge
 
         uri = URI("#{proxy_url}/api/proxy/anthropic/v1/messages")
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
         http.open_timeout = 10
         http.read_timeout = timeout
 
@@ -243,6 +244,7 @@ module Knowledge
 
         uri = URI("#{proxy_url}/api/proxy/openai/v1/chat/completions")
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
         http.open_timeout = 10
         http.read_timeout = timeout
 

--- a/app/services/knowledge/analysis_runner.rb
+++ b/app/services/knowledge/analysis_runner.rb
@@ -201,6 +201,7 @@ module Knowledge
 
         uri = URI("#{proxy_url}/api/proxy/anthropic/v1/messages")
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
         http.open_timeout = 10
         http.read_timeout = timeout
 
@@ -244,6 +245,7 @@ module Knowledge
 
         uri = URI("#{proxy_url}/api/proxy/openai/v1/chat/completions")
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
         http.open_timeout = 10
         http.read_timeout = timeout
 

--- a/app/services/knowledge/analysis_runner.rb
+++ b/app/services/knowledge/analysis_runner.rb
@@ -38,11 +38,12 @@ module Knowledge
     # API service types supported for containerized LLM calls.
     SUPPORTED_API_TYPES = %w[anthropic openai].freeze
 
-    attr_reader :project, :knowledge_run
+    attr_reader :project, :knowledge_run, :backend
 
-    def initialize(project:, knowledge_run:)
+    def initialize(project:, knowledge_run:, backend: Containers.backend)
       @project = project
       @knowledge_run = knowledge_run
+      @backend = backend
       @container = nil
     end
 
@@ -96,8 +97,8 @@ module Knowledge
 
     def provision!
       log("provision.start")
-      @container = Containers.backend.create_container(container_config)
-      Containers.backend.start_container(@container)
+      @container = backend.create_container(container_config)
+      backend.start_container(@container)
       log("provision.success", container_id: @container.id)
     rescue Docker::Error::DockerError => e
       cleanup!
@@ -109,12 +110,12 @@ module Knowledge
 
       log("cleanup.start", container_id: @container.id)
       begin
-        Containers.backend.stop_container(@container, timeout: 5)
+        backend.stop_container(@container, timeout: 5)
       rescue Docker::Error::DockerError
         # Container may already be stopped
       end
       begin
-        Containers.backend.delete_container(@container, force: true)
+        backend.delete_container(@container, force: true)
       rescue Docker::Error::DockerError
         # Container may already be removed
       end
@@ -140,7 +141,7 @@ module Knowledge
       end
 
       begin
-        result = Containers.backend.exec_in_container(@container, cmd, **exec_options)
+        result = backend.exec_in_container(@container, cmd, **exec_options)
       rescue Docker::Error::DockerError => e
         raise TimeoutError, "LLM call timed out after #{timeout}s" if mutex.synchronize { timed_out }
         raise ContainerError, "Container execution failed: #{e.message}"
@@ -304,8 +305,7 @@ module Knowledge
     end
 
     def proxy_base_url
-      proxy_port = Rails.application.config.x.paid_proxy_port
-      "http://paid-proxy:#{proxy_port}"
+      Containers::ProxyUrl.resolve(backend:, restricted: true)
     end
 
     def start_watchdog(timeout)
@@ -315,7 +315,7 @@ module Knowledge
         next unless should_stop
 
         begin
-          Containers.backend.stop_container(@container, timeout: 0) if @container
+          backend.stop_container(@container, timeout: 0) if @container
         rescue Docker::Error::DockerError
           # Container may already be stopped
         end

--- a/app/services/knowledge/embedding_runner.rb
+++ b/app/services/knowledge/embedding_runner.rb
@@ -184,6 +184,7 @@ module Knowledge
         texts = JSON.parse(File.read(input_path))
         uri = URI("#{proxy_url}/api/proxy/openai/v1/embeddings")
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
         http.open_timeout = 10
         http.read_timeout = timeout
 

--- a/app/services/knowledge/embedding_runner.rb
+++ b/app/services/knowledge/embedding_runner.rb
@@ -20,11 +20,12 @@ module Knowledge
       timeout_seconds: 120
     }.freeze
 
-    attr_reader :project, :knowledge_run
+    attr_reader :project, :knowledge_run, :backend
 
-    def initialize(project:, knowledge_run:)
+    def initialize(project:, knowledge_run:, backend: Containers.backend)
       @project = project
       @knowledge_run = knowledge_run
+      @backend = backend
       @container = nil
       @input_dir = nil
     end
@@ -65,10 +66,10 @@ module Knowledge
       return if @container
 
       cleanup_input_dir!
-      NetworkPolicy.ensure_network!(network: NetworkPolicy::NETWORK_NAME)
+      NetworkPolicy.ensure_network!(network: NetworkPolicy::NETWORK_NAME, backend:)
       @input_dir = Dir.mktmpdir("paid-embedding-runner-")
-      @container = Containers.backend.create_container(container_config)
-      Containers.backend.start_container(@container)
+      @container = backend.create_container(container_config)
+      backend.start_container(@container)
       apply_network_restrictions!
     rescue Docker::Error::DockerError => e
       cleanup!
@@ -81,12 +82,12 @@ module Knowledge
     def cleanup_container!
       return unless @container
 
-      Containers.backend.stop_container(@container, timeout: 5)
+      backend.stop_container(@container, timeout: 5)
     rescue Docker::Error::DockerError
       nil
     ensure
       begin
-        Containers.backend.delete_container(@container, force: true) if @container
+        backend.delete_container(@container, force: true) if @container
       rescue Docker::Error::DockerError
         nil
       end
@@ -120,11 +121,11 @@ module Knowledge
           next if exec_completed
 
           timed_out = true
-          Containers.backend.stop_container(@container, timeout: 0) if @container
+          backend.stop_container(@container, timeout: 0) if @container
         end
       end
 
-      result = Containers.backend.exec_in_container(@container, cmd, **exec_options)
+      result = backend.exec_in_container(@container, cmd, **exec_options)
       raise TimeoutError, "Embedding generation timed out after #{timeout}s" if mutex.synchronize { timed_out }
 
       stdout = Array(result[0]).join
@@ -150,12 +151,12 @@ module Knowledge
     end
 
     def apply_network_restrictions!
-      NetworkPolicy.apply_firewall_rules(@container)
+      NetworkPolicy.apply_firewall_rules(@container, backend:)
     end
 
     def script_env(provider:, model:, dimensions:, timeout:)
       {
-        "PROXY_BASE_URL" => "http://paid-proxy:#{Rails.application.config.x.paid_proxy_port}",
+        "PROXY_BASE_URL" => proxy_base_url,
         "KNOWLEDGE_RUN_ID" => knowledge_run.id.to_s,
         "PROXY_TOKEN" => knowledge_run.ensure_proxy_token!,
         "EMBEDDING_PROVIDER" => provider,
@@ -205,6 +206,10 @@ module Knowledge
 
         $stdout.print(res.body)
       RUBY
+    end
+
+    def proxy_base_url
+      Containers::ProxyUrl.resolve(backend:, restricted: true)
     end
 
     def container_config

--- a/app/services/knowledge/embedding_runner.rb
+++ b/app/services/knowledge/embedding_runner.rb
@@ -71,7 +71,7 @@ module Knowledge
       end
 
       cleanup_input_dir!
-      NetworkPolicy.ensure_network!(network: NetworkPolicy::NETWORK_NAME)
+      NetworkPolicy.ensure_network!(network: NetworkPolicy::NETWORK_NAME, backend: Containers.backend)
       @input_dir = Dir.mktmpdir("paid-embedding-runner-")
       @container = Containers.backend.create_container(container_config)
       Containers.backend.start_container(@container)

--- a/app/services/knowledge/embedding_runner.rb
+++ b/app/services/knowledge/embedding_runner.rb
@@ -185,6 +185,7 @@ module Knowledge
         texts = JSON.parse(File.read(input_path))
         uri = URI("#{proxy_url}/api/proxy/openai/v1/embeddings")
         http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
         http.open_timeout = 10
         http.read_timeout = timeout
 

--- a/app/services/knowledge/embedding_runner.rb
+++ b/app/services/knowledge/embedding_runner.rb
@@ -30,7 +30,10 @@ module Knowledge
     end
 
     def self.available?
-      Containers.backend.ping == "OK"
+      backend = Containers.backend
+      return false unless backend.supports_host_paths?
+
+      backend.ping == "OK"
     rescue Excon::Error, Docker::Error::DockerError
       false
     end
@@ -63,6 +66,9 @@ module Knowledge
 
     def ensure_container!
       return if @container
+      unless Containers.backend.supports_host_paths?
+        raise ContainerError, "Embedding containers require a backend with host path support"
+      end
 
       cleanup_input_dir!
       NetworkPolicy.ensure_network!(network: NetworkPolicy::NETWORK_NAME)

--- a/app/services/network_policy.rb
+++ b/app/services/network_policy.rb
@@ -349,8 +349,11 @@ class NetworkPolicy
     end
 
     def default_proxy_destination(backend: Containers.backend)
-      if backend.remote? && ENV["PAID_PROXY_EXTERNAL_URL"].present?
-        return external_proxy_destination
+      if backend.remote?
+        external_url = ENV["PAID_PROXY_EXTERNAL_URL"].presence
+        raise Error, "PAID_PROXY_EXTERNAL_URL is required when CONTAINER_BACKEND is remote" if external_url.blank?
+
+        return external_proxy_destination(external_url)
       end
 
       # Default to the hostname used by agents to reach the secrets proxy.
@@ -358,8 +361,8 @@ class NetworkPolicy
       { host: "paid-proxy", port: SECRETS_PROXY_PORT }
     end
 
-    def external_proxy_destination
-      uri = URI.parse(ENV.fetch("PAID_PROXY_EXTERNAL_URL"))
+    def external_proxy_destination(url)
+      uri = URI.parse(url)
       host = uri.host.presence or raise Error, "Invalid PAID_PROXY_EXTERNAL_URL: missing host"
       { host: host, port: uri.port }
     rescue URI::InvalidURIError => e

--- a/app/services/network_policy.rb
+++ b/app/services/network_policy.rb
@@ -140,7 +140,7 @@ class NetworkPolicy
 
       validated_ips = github_ips.map { |cidr| validate_cidr!(cidr) }
       validated_host = validate_host!(proxy_destination.fetch(:host))
-      validated_port = validate_port!(proxy_destination.fetch(:port))
+      validated_port = validate_port!(proxy_destination.fetch(:port), label: "proxy port")
 
       script = build_firewall_script(
         github_ips: validated_ips,
@@ -339,13 +339,13 @@ class NetworkPolicy
       host
     end
 
-    def validate_port!(port)
+    def validate_port!(port, label: "port")
       port = Integer(port)
-      raise Error, "Invalid proxy port: #{port}" unless port.between?(1, 65_535)
+      raise Error, "Invalid #{label}: #{port}" unless port.between?(1, 65_535)
 
       port
     rescue ArgumentError, TypeError
-      raise Error, "Invalid proxy port: #{port.inspect}"
+      raise Error, "Invalid #{label}: #{port.inspect}"
     end
 
     def default_proxy_destination(backend: Containers.backend)
@@ -375,7 +375,8 @@ class NetworkPolicy
       end
 
       service_rules = service_destinations.map do |dest|
-        "iptables -A OUTPUT -d #{validate_host!(dest[:ip])} -p tcp --dport #{dest[:port].to_i} -j ACCEPT"
+        service_port = validate_port!(dest[:port], label: "service port")
+        "iptables -A OUTPUT -d #{validate_host!(dest[:ip])} -p tcp --dport #{service_port} -j ACCEPT"
       end
 
       <<~SCRIPT

--- a/app/services/network_policy.rb
+++ b/app/services/network_policy.rb
@@ -136,14 +136,16 @@ class NetworkPolicy
     #   each with :ip and :port keys (e.g., { ip: "172.28.0.5", port: 5432 })
     def apply_firewall_rules(container, github_ips: nil, proxy_host: nil, service_destinations: [], backend: Containers.backend)
       github_ips ||= DEFAULT_GITHUB_IPS
-      proxy_host ||= default_proxy_host(backend: backend)
+      proxy_destination = proxy_host.present? ? { host: proxy_host, port: SECRETS_PROXY_PORT } : default_proxy_destination(backend: backend)
 
       validated_ips = github_ips.map { |cidr| validate_cidr!(cidr) }
-      validated_host = validate_host!(proxy_host)
+      validated_host = validate_host!(proxy_destination.fetch(:host))
+      validated_port = validate_port!(proxy_destination.fetch(:port))
 
       script = build_firewall_script(
         github_ips: validated_ips,
         proxy_host: validated_host,
+        proxy_port: validated_port,
         service_destinations: service_destinations
       )
 
@@ -337,26 +339,34 @@ class NetworkPolicy
       host
     end
 
-    def default_proxy_host(backend: Containers.backend)
+    def validate_port!(port)
+      port = Integer(port)
+      raise Error, "Invalid proxy port: #{port}" unless port.between?(1, 65_535)
+
+      port
+    rescue ArgumentError, TypeError
+      raise Error, "Invalid proxy port: #{port.inspect}"
+    end
+
+    def default_proxy_destination(backend: Containers.backend)
       if backend.remote? && ENV["PAID_PROXY_EXTERNAL_URL"].present?
-        return external_proxy_host
+        return external_proxy_destination
       end
 
       # Default to the hostname used by agents to reach the secrets proxy.
       # This keeps firewall rules aligned with the container environment.
-      "paid-proxy"
+      { host: "paid-proxy", port: SECRETS_PROXY_PORT }
     end
 
-    def external_proxy_host
+    def external_proxy_destination
       uri = URI.parse(ENV.fetch("PAID_PROXY_EXTERNAL_URL"))
       host = uri.host.presence or raise Error, "Invalid PAID_PROXY_EXTERNAL_URL: missing host"
-
-      host
+      { host: host, port: uri.port }
     rescue URI::InvalidURIError => e
       raise Error, "Invalid PAID_PROXY_EXTERNAL_URL: #{e.message}"
     end
 
-    def build_firewall_script(github_ips:, proxy_host:, service_destinations: [])
+    def build_firewall_script(github_ips:, proxy_host:, proxy_port:, service_destinations: [])
       github_rules = github_ips.flat_map do |cidr|
         [
           "iptables -A OUTPUT -d #{cidr} -p tcp --dport 443 -j ACCEPT",
@@ -383,7 +393,7 @@ class NetworkPolicy
         iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
 
         # Allow secrets proxy
-        iptables -A OUTPUT -d #{proxy_host} -p tcp --dport #{SECRETS_PROXY_PORT} -j ACCEPT
+        iptables -A OUTPUT -d #{proxy_host} -p tcp --dport #{proxy_port} -j ACCEPT
 
         # Allow GitHub
         #{github_rules.join("\n")}

--- a/app/services/network_policy.rb
+++ b/app/services/network_policy.rb
@@ -360,9 +360,11 @@ class NetworkPolicy
     end
 
     def external_proxy_destination(url)
-      uri = URI.parse(url)
+      uri = URI.parse(Containers::ProxyUrl.validate_external_url!(url))
       host = uri.host.presence or raise Error, "Invalid PAID_PROXY_EXTERNAL_URL: missing host"
       { host: host, port: uri.port }
+    rescue ArgumentError => e
+      raise Error, e.message
     rescue URI::InvalidURIError => e
       raise Error, "Invalid PAID_PROXY_EXTERNAL_URL: #{e.message}"
     end

--- a/app/services/network_policy.rb
+++ b/app/services/network_policy.rb
@@ -2,8 +2,9 @@
 
 require "docker-api"
 require "ipaddr"
-require "net/http"
 require "json"
+require "net/http"
+require "uri"
 
 # Manages Docker network selection and isolation for agent containers.
 #
@@ -100,19 +101,19 @@ class NetworkPolicy
     #
     # @return [Docker::Network] the agent network
     # @raise [Error] if network creation fails
-    def ensure_network!(network: NETWORK_NAME)
-      Containers.backend.get_network(network)
+    def ensure_network!(network: NETWORK_NAME, backend: Containers.backend)
+      backend.get_network(network)
     rescue Docker::Error::NotFoundError
       raise Error, "Docker network #{network} does not exist" unless network == NETWORK_NAME
 
-      create_network
+      create_network(backend: backend)
     end
 
     # Checks whether the agent network exists.
     #
     # @return [Boolean]
-    def network_exists?
-      Containers.backend.get_network(NETWORK_NAME)
+    def network_exists?(backend: Containers.backend)
+      backend.get_network(NETWORK_NAME)
       true
     rescue Docker::Error::NotFoundError
       false
@@ -133,9 +134,9 @@ class NetworkPolicy
     # @param proxy_host [String] hostname or IPv4 address of the secrets proxy
     # @param service_destinations [Array<Hash>] service containers to allow,
     #   each with :ip and :port keys (e.g., { ip: "172.28.0.5", port: 5432 })
-    def apply_firewall_rules(container, github_ips: nil, proxy_host: nil, service_destinations: [])
+    def apply_firewall_rules(container, github_ips: nil, proxy_host: nil, service_destinations: [], backend: Containers.backend)
       github_ips ||= DEFAULT_GITHUB_IPS
-      proxy_host ||= default_proxy_host
+      proxy_host ||= default_proxy_host(backend: backend)
 
       validated_ips = github_ips.map { |cidr| validate_cidr!(cidr) }
       validated_host = validate_host!(proxy_host)
@@ -146,7 +147,7 @@ class NetworkPolicy
         service_destinations: service_destinations
       )
 
-      _stdout, stderr, exit_code = container.exec([ "sh", "-c", script ])
+      _stdout, stderr, exit_code = backend.exec_in_container(container, [ "sh", "-c", script ])
 
       return if exit_code == 0
 
@@ -294,7 +295,7 @@ class NetworkPolicy
       ENV["HOME"].presence || (Dir.respond_to?(:home) ? Dir.home : nil)
     end
 
-    def create_network
+    def create_network(backend:)
       Rails.logger.info(
         message: "network_policy.create_network",
         network: NETWORK_NAME,
@@ -315,7 +316,7 @@ class NetworkPolicy
         }
       end
 
-      Containers.backend.create_network(NETWORK_NAME, config)
+      backend.create_network(NETWORK_NAME, config)
     rescue Docker::Error::DockerError => e
       raise Error, "Failed to create agent network: #{e.message}"
     end
@@ -336,10 +337,23 @@ class NetworkPolicy
       host
     end
 
-    def default_proxy_host
+    def default_proxy_host(backend: Containers.backend)
+      if backend.remote? && ENV["PAID_PROXY_EXTERNAL_URL"].present?
+        return external_proxy_host
+      end
+
       # Default to the hostname used by agents to reach the secrets proxy.
       # This keeps firewall rules aligned with the container environment.
       "paid-proxy"
+    end
+
+    def external_proxy_host
+      uri = URI.parse(ENV.fetch("PAID_PROXY_EXTERNAL_URL"))
+      host = uri.host.presence or raise Error, "Invalid PAID_PROXY_EXTERNAL_URL: missing host"
+
+      host
+    rescue URI::InvalidURIError => e
+      raise Error, "Invalid PAID_PROXY_EXTERNAL_URL: #{e.message}"
     end
 
     def build_firewall_script(github_ips:, proxy_host:, service_destinations: [])

--- a/config/initializers/container_backend.rb
+++ b/config/initializers/container_backend.rb
@@ -11,4 +11,10 @@ Rails.application.config.to_prepare do
 
   backend_type = ENV.fetch("CONTAINER_BACKEND", "local").to_sym
   Rails.application.config.x.container_backend = resolver.for(backend_type)
+
+  if Rails.application.config.x.container_backend.remote? && ENV["PAID_PROXY_EXTERNAL_URL"].blank?
+    Rails.logger.warn(
+      "Remote Docker backend is active but PAID_PROXY_EXTERNAL_URL is not set; remote containers will be unable to reach the secrets proxy"
+    )
+  end
 end

--- a/config/initializers/container_backend.rb
+++ b/config/initializers/container_backend.rb
@@ -2,8 +2,12 @@
 
 Rails.application.config.to_prepare do
   resolver = Containers::Backends::Resolver
-  resolver.reset!(:local)
+  resolver.reset!
   resolver.register(:local, -> { Containers::Backends::LocalDocker.new })
+  if (remote_backend = Containers::Backends::RemoteDocker.from_env)
+    resolver.register(remote_backend.identifier, -> { remote_backend })
+    resolver.register(:remote, -> { remote_backend })
+  end
 
   backend_type = ENV.fetch("CONTAINER_BACKEND", "local").to_sym
   Rails.application.config.x.container_backend = resolver.for(backend_type)

--- a/docs/guides/remote-docker-setup.md
+++ b/docs/guides/remote-docker-setup.md
@@ -1,0 +1,115 @@
+# Remote Docker Setup
+
+This guide configures Paid to run agent containers on one remote Docker host over TCP with mutual TLS.
+
+## Overview
+
+Paid keeps the existing named-volume plus in-container clone workflow. The only runtime difference is that Docker API calls go to a remote daemon instead of `/var/run/docker.sock`.
+
+Required pieces:
+
+- Remote Docker Engine listening on TCP with client-certificate auth
+- A routable proxy address for agent containers via `PAID_PROXY_EXTERNAL_URL`
+- The Paid app configured with `CONTAINER_BACKEND=remote` and remote TLS cert paths
+
+## 1. Configure the Remote Docker Host
+
+Enable the Docker API on the worker host with TLS verification. Docker’s TLS guidance is here:
+
+- <https://docs.docker.com/engine/security/https/>
+
+Typical daemon flags:
+
+```bash
+dockerd \
+  --host=unix:///var/run/docker.sock \
+  --host=tcp://0.0.0.0:2376 \
+  --tlsverify \
+  --tlscacert=/etc/docker/tls/ca.pem \
+  --tlscert=/etc/docker/tls/server-cert.pem \
+  --tlskey=/etc/docker/tls/server-key.pem
+```
+
+Lock TCP/2376 down to the Paid control plane network only. Do not expose it publicly without network controls.
+
+## 2. Generate Client TLS Material
+
+Paid ships a helper task:
+
+```bash
+bundle exec rake remote_docker:generate_certs[tmp/remote-docker-certs,paid-worker-client]
+```
+
+This writes:
+
+- `ca.pem`
+- `ca-key.pem`
+- `client-cert.pem`
+- `client-key.pem`
+
+For production, treat `ca-key.pem` as sensitive and store it outside the app host once you have signed the needed certificates.
+
+## 3. Provide a Proxy Route
+
+Remote agent containers cannot resolve Docker-local names like `paid-proxy`. Set `PAID_PROXY_EXTERNAL_URL` to the address they can reach.
+
+Recommended options:
+
+- `WireGuard VPN`: best default for NAS/LAN workers
+- `SSH tunnel`: simplest for one remote host
+- `Cloudflare Tunnel`: useful for VMs without inbound IPs
+- `Load balancer + mTLS`: good cloud baseline when the proxy is internet-routable
+
+Examples:
+
+```bash
+PAID_PROXY_EXTERNAL_URL=http://10.20.30.40:3000
+PAID_PROXY_EXTERNAL_URL=https://paid-proxy.internal.example.com
+```
+
+When the remote backend is active, Paid uses this URL for container proxy env vars and firewall proxy allowlisting.
+
+## 4. Configure Paid
+
+Set these environment variables on the Paid control plane:
+
+```bash
+CONTAINER_BACKEND=remote
+REMOTE_DOCKER_HOST=worker-1.internal:2376
+REMOTE_DOCKER_IDENTIFIER=worker-1
+REMOTE_DOCKER_CERT=/etc/paid/remote-docker/client-cert.pem
+REMOTE_DOCKER_KEY=/etc/paid/remote-docker/client-key.pem
+REMOTE_DOCKER_CA=/etc/paid/remote-docker/ca.pem
+PAID_PROXY_EXTERNAL_URL=https://paid-proxy.internal.example.com
+```
+
+Notes:
+
+- `REMOTE_DOCKER_IDENTIFIER` is what Paid persists into `agent_runs.container_host` and `container_pool_entries.container_host`.
+- `REMOTE_DOCKER_HOST` may be `host:port` or a full `tcp://host:port` URL.
+
+## 5. Verify Connectivity
+
+Run:
+
+```bash
+bundle exec rake remote_docker:test_connection
+```
+
+Expected output is an `OK` ping from the configured remote backend.
+
+## 6. Validate Security Expectations
+
+Confirm all of these before enabling production traffic:
+
+- Docker API only accepts mTLS-authenticated clients
+- `PAID_PROXY_EXTERNAL_URL` is encrypted in transit
+- Agent containers still receive proxy-issued credentials, not raw provider API keys
+- Remote containers join the same expected Docker networks and pass network-policy smoke tests
+- The remote host has the `paid-agent:latest` image available, or can pull it
+
+## Operational Notes
+
+- Workspace volumes remain host-local named volumes on the remote daemon.
+- Orphan cleanup now scans all registered backends, so local leftovers can still be reaped after moving to remote execution.
+- Metrics collection follows `container_host`, so agent-run stats are read from the correct daemon.

--- a/lib/tasks/remote_docker.rake
+++ b/lib/tasks/remote_docker.rake
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "openssl"
+require "pathname"
+
+namespace :remote_docker do
+  desc "Generate a CA and client certificate bundle for remote Docker mTLS"
+  task :generate_certs, [ :output_dir, :common_name ] => :environment do |_task, args|
+    output_dir = Pathname.new(args[:output_dir].presence || "tmp/remote-docker-certs")
+    common_name = args[:common_name].presence || "paid-remote-docker-client"
+
+    FileUtils.mkdir_p(output_dir)
+
+    ca_key = OpenSSL::PKey::RSA.new(4096)
+    ca_cert = build_certificate(
+      subject: "/CN=paid-remote-docker-ca",
+      issuer: nil,
+      public_key: ca_key.public_key,
+      signing_key: ca_key,
+      serial: 1,
+      is_ca: true
+    )
+
+    client_key = OpenSSL::PKey::RSA.new(4096)
+    client_cert = build_certificate(
+      subject: "/CN=#{common_name}",
+      issuer: ca_cert,
+      public_key: client_key.public_key,
+      signing_key: ca_key,
+      serial: 2,
+      is_ca: false,
+      extended_key_usage: "clientAuth"
+    )
+
+    write_pem(output_dir.join("ca.pem"), ca_cert.to_pem)
+    write_pem(output_dir.join("ca-key.pem"), ca_key.to_pem, mode: 0o600)
+    write_pem(output_dir.join("client-cert.pem"), client_cert.to_pem)
+    write_pem(output_dir.join("client-key.pem"), client_key.to_pem, mode: 0o600)
+
+    puts "Generated remote Docker TLS assets in #{output_dir}"
+    puts "Use these env vars:"
+    puts "  REMOTE_DOCKER_CERT=#{output_dir.join('client-cert.pem')}"
+    puts "  REMOTE_DOCKER_KEY=#{output_dir.join('client-key.pem')}"
+    puts "  REMOTE_DOCKER_CA=#{output_dir.join('ca.pem')}"
+    puts "Install ca.pem on the remote Docker host and sign or trust the server certificate separately."
+  end
+
+  desc "Ping the configured remote Docker backend over TCP+TLS"
+  task test_connection: :environment do
+    backend = Containers::Backends::RemoteDocker.from_env
+    raise "REMOTE_DOCKER_HOST is not configured" unless backend
+
+    response = backend.ping
+    puts "Remote backend #{backend.identifier} responded with #{response.inspect}"
+  end
+
+  def build_certificate(subject:, issuer:, public_key:, signing_key:, serial:, is_ca:, extended_key_usage: nil)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = serial
+    cert.subject = OpenSSL::X509::Name.parse(subject)
+    cert.issuer = issuer ? issuer.subject : cert.subject
+    cert.public_key = public_key
+    cert.not_before = Time.now
+    cert.not_after = 365.days.from_now
+
+    extension_factory = OpenSSL::X509::ExtensionFactory.new
+    extension_factory.subject_certificate = cert
+    extension_factory.issuer_certificate = issuer || cert
+    cert.add_extension(extension_factory.create_extension("basicConstraints", is_ca ? "CA:TRUE" : "CA:FALSE", true))
+    cert.add_extension(extension_factory.create_extension("keyUsage", is_ca ? "keyCertSign,cRLSign" : "digitalSignature,keyEncipherment", true))
+    cert.add_extension(extension_factory.create_extension("subjectKeyIdentifier", "hash"))
+    cert.add_extension(extension_factory.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always"))
+    if extended_key_usage
+      cert.add_extension(extension_factory.create_extension("extendedKeyUsage", extended_key_usage))
+    end
+
+    cert.sign(signing_key, OpenSSL::Digest::SHA256.new)
+    cert
+  end
+
+  def write_pem(path, contents, mode: 0o644)
+    File.write(path, contents)
+    File.chmod(mode, path)
+  end
+end

--- a/lib/tasks/remote_docker.rake
+++ b/lib/tasks/remote_docker.rake
@@ -4,56 +4,8 @@ require "fileutils"
 require "openssl"
 require "pathname"
 
-namespace :remote_docker do
-  desc "Generate a CA and client certificate bundle for remote Docker mTLS"
-  task :generate_certs, [ :output_dir, :common_name ] => :environment do |_task, args|
-    output_dir = Pathname.new(args[:output_dir].presence || "tmp/remote-docker-certs")
-    common_name = args[:common_name].presence || "paid-remote-docker-client"
-
-    FileUtils.mkdir_p(output_dir)
-
-    ca_key = OpenSSL::PKey::RSA.new(4096)
-    ca_cert = build_certificate(
-      subject: "/CN=paid-remote-docker-ca",
-      issuer: nil,
-      public_key: ca_key.public_key,
-      signing_key: ca_key,
-      serial: 1,
-      is_ca: true
-    )
-
-    client_key = OpenSSL::PKey::RSA.new(4096)
-    client_cert = build_certificate(
-      subject: "/CN=#{common_name}",
-      issuer: ca_cert,
-      public_key: client_key.public_key,
-      signing_key: ca_key,
-      serial: 2,
-      is_ca: false,
-      extended_key_usage: "clientAuth"
-    )
-
-    write_pem(output_dir.join("ca.pem"), ca_cert.to_pem)
-    write_pem(output_dir.join("ca-key.pem"), ca_key.to_pem, mode: 0o600)
-    write_pem(output_dir.join("client-cert.pem"), client_cert.to_pem)
-    write_pem(output_dir.join("client-key.pem"), client_key.to_pem, mode: 0o600)
-
-    puts "Generated remote Docker TLS assets in #{output_dir}"
-    puts "Use these env vars:"
-    puts "  REMOTE_DOCKER_CERT=#{output_dir.join('client-cert.pem')}"
-    puts "  REMOTE_DOCKER_KEY=#{output_dir.join('client-key.pem')}"
-    puts "  REMOTE_DOCKER_CA=#{output_dir.join('ca.pem')}"
-    puts "Install ca.pem on the remote Docker host and sign or trust the server certificate separately."
-  end
-
-  desc "Ping the configured remote Docker backend over TCP+TLS"
-  task test_connection: :environment do
-    backend = Containers::Backends::RemoteDocker.from_env
-    raise "REMOTE_DOCKER_HOST is not configured" unless backend
-
-    response = backend.ping
-    puts "Remote backend #{backend.identifier} responded with #{response.inspect}"
-  end
+module RemoteDockerCertHelper
+  module_function
 
   def build_certificate(subject:, issuer:, public_key:, signing_key:, serial:, is_ca:, extended_key_usage: nil)
     cert = OpenSSL::X509::Certificate.new
@@ -83,5 +35,57 @@ namespace :remote_docker do
   def write_pem(path, contents, mode: 0o644)
     File.write(path, contents)
     File.chmod(mode, path)
+  end
+end
+
+namespace :remote_docker do
+  desc "Generate a CA and client certificate bundle for remote Docker mTLS"
+  task :generate_certs, [ :output_dir, :common_name ] => :environment do |_task, args|
+    output_dir = Pathname.new(args[:output_dir].presence || "tmp/remote-docker-certs")
+    common_name = args[:common_name].presence || "paid-remote-docker-client"
+
+    FileUtils.mkdir_p(output_dir)
+
+    ca_key = OpenSSL::PKey::RSA.new(4096)
+    ca_cert = RemoteDockerCertHelper.build_certificate(
+      subject: "/CN=paid-remote-docker-ca",
+      issuer: nil,
+      public_key: ca_key.public_key,
+      signing_key: ca_key,
+      serial: 1,
+      is_ca: true
+    )
+
+    client_key = OpenSSL::PKey::RSA.new(4096)
+    client_cert = RemoteDockerCertHelper.build_certificate(
+      subject: "/CN=#{common_name}",
+      issuer: ca_cert,
+      public_key: client_key.public_key,
+      signing_key: ca_key,
+      serial: 2,
+      is_ca: false,
+      extended_key_usage: "clientAuth"
+    )
+
+    RemoteDockerCertHelper.write_pem(output_dir.join("ca.pem"), ca_cert.to_pem)
+    RemoteDockerCertHelper.write_pem(output_dir.join("ca-key.pem"), ca_key.to_pem, mode: 0o600)
+    RemoteDockerCertHelper.write_pem(output_dir.join("client-cert.pem"), client_cert.to_pem)
+    RemoteDockerCertHelper.write_pem(output_dir.join("client-key.pem"), client_key.to_pem, mode: 0o600)
+
+    puts "Generated remote Docker TLS assets in #{output_dir}"
+    puts "Use these env vars:"
+    puts "  REMOTE_DOCKER_CERT=#{output_dir.join('client-cert.pem')}"
+    puts "  REMOTE_DOCKER_KEY=#{output_dir.join('client-key.pem')}"
+    puts "  REMOTE_DOCKER_CA=#{output_dir.join('ca.pem')}"
+    puts "Install ca.pem on the remote Docker host and sign or trust the server certificate separately."
+  end
+
+  desc "Ping the configured remote Docker backend over TCP+TLS"
+  task test_connection: :environment do
+    backend = Containers::Backends::RemoteDocker.from_env
+    raise "REMOTE_DOCKER_HOST is not configured" unless backend
+
+    response = backend.ping
+    puts "Remote backend #{backend.identifier} responded with #{response.inspect}"
   end
 end

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe DockerOrphanCleanupJob do
   let(:backend) { Containers.backend }
 
   def build_backend(identifier:, remote:)
-    instance_double(Containers::Backends::Base, identifier: identifier, remote?: remote)
+    instance_double(
+      Containers::Backends::Base,
+      identifier: identifier,
+      remote?: remote,
+      all_host_identifiers: [ identifier ]
+    )
   end
 
   def stub_no_containers

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe DockerOrphanCleanupJob do
   let(:service_filter) { { label: [ "paid.service_container=true" ] }.to_json }
   let(:backend) { Containers.backend }
 
+  def build_backend(identifier:, remote:)
+    instance_double(Containers::Backends::Base, identifier: identifier, remote?: remote)
+  end
+
   def stub_no_containers
     allow(backend).to receive(:list_containers).and_return([])
   end
@@ -42,25 +46,26 @@ RSpec.describe DockerOrphanCleanupJob do
       delete: true)
   end
 
+  def stub_backend_resources(target_backend, agent: [], pool: [], service: [], volumes: [])
+    allow(target_backend).to receive(:list_containers).with(all: true, filters: agent_filter).and_return(agent)
+    allow(target_backend).to receive(:list_containers).with(all: true, filters: pool_filter).and_return(pool)
+    allow(target_backend).to receive(:list_containers).with(all: true, filters: service_filter).and_return(service)
+    allow(target_backend).to receive(:list_volumes).and_return(volumes)
+  end
+
   describe "#perform" do
     it "cleans up resources across all registered backends" do
-      local_backend = instance_double(Containers::Backends::Base, identifier: "local")
-      remote_backend = instance_double(Containers::Backends::Base, identifier: "worker-1")
+      local_backend = build_backend(identifier: "local", remote: false)
+      remote_backend = build_backend(identifier: "worker-1", remote: true)
       local_container = make_container(labels: { "paid.agent_run_id" => "999999" })
       remote_container = make_container(labels: { "paid.agent_run_id" => "888888" })
 
       allow(Containers).to receive(:all_backends).and_return([ local_backend, remote_backend ])
-      allow(local_backend).to receive(:list_containers).with(all: true, filters: agent_filter).and_return([ local_container ])
-      allow(local_backend).to receive(:list_containers).with(all: true, filters: pool_filter).and_return([])
-      allow(local_backend).to receive(:list_containers).with(all: true, filters: service_filter).and_return([])
-      allow(local_backend).to receive(:list_volumes).and_return([])
+      stub_backend_resources(local_backend, agent: [ local_container ])
       allow(local_backend).to receive(:stop_container).with(local_container, timeout: 10)
       allow(local_backend).to receive(:delete_container).with(local_container, force: true, v: true)
 
-      allow(remote_backend).to receive(:list_containers).with(all: true, filters: agent_filter).and_return([ remote_container ])
-      allow(remote_backend).to receive(:list_containers).with(all: true, filters: pool_filter).and_return([])
-      allow(remote_backend).to receive(:list_containers).with(all: true, filters: service_filter).and_return([])
-      allow(remote_backend).to receive(:list_volumes).and_return([])
+      stub_backend_resources(remote_backend, agent: [ remote_container ])
       allow(remote_backend).to receive(:stop_container).with(remote_container, timeout: 10)
       allow(remote_backend).to receive(:delete_container).with(remote_container, force: true, v: true)
 
@@ -165,6 +170,26 @@ RSpec.describe DockerOrphanCleanupJob do
         job.perform
 
         expect(container).to have_received(:delete).with(force: true, v: true)
+      end
+
+      it "removes wrong-host orphaned containers even when the run is still active on another backend" do
+        remote_run = create(:agent_run, :running, container_host: "worker-1")
+        local_backend = build_backend(identifier: "local", remote: false)
+        remote_backend = build_backend(identifier: "worker-1", remote: true)
+        local_container = make_container(labels: { "paid.agent_run_id" => remote_run.id.to_s })
+        remote_container = make_container(labels: { "paid.agent_run_id" => remote_run.id.to_s })
+
+        allow(Containers).to receive(:all_backends).and_return([ local_backend, remote_backend ])
+        stub_backend_resources(local_backend, agent: [ local_container ])
+        allow(local_backend).to receive(:stop_container).with(local_container, timeout: 10)
+        allow(local_backend).to receive(:delete_container).with(local_container, force: true, v: true)
+
+        stub_backend_resources(remote_backend, agent: [ remote_container ])
+
+        job.perform
+
+        expect(local_backend).to have_received(:delete_container).with(local_container, force: true, v: true)
+        expect(remote_backend).not_to have_received(:delete_container)
       end
 
       it "continues processing when individual container removal fails" do
@@ -320,6 +345,32 @@ RSpec.describe DockerOrphanCleanupJob do
 
         expect(container).not_to have_received(:delete)
       end
+
+      it "removes wrong-host orphaned pool containers even when the entry is active on another backend" do
+        remote_entry = create(:container_pool_entry, container_host: "worker-1")
+        local_backend = build_backend(identifier: "local", remote: false)
+        remote_backend = build_backend(identifier: "worker-1", remote: true)
+        local_container = make_container(labels: {
+          "paid.container_pool" => "true",
+          "paid.container_pool_entry_id" => remote_entry.id.to_s
+        })
+        remote_container = make_container(labels: {
+          "paid.container_pool" => "true",
+          "paid.container_pool_entry_id" => remote_entry.id.to_s
+        })
+
+        allow(Containers).to receive(:all_backends).and_return([ local_backend, remote_backend ])
+        stub_backend_resources(local_backend, pool: [ local_container ])
+        allow(local_backend).to receive(:stop_container).with(local_container, timeout: 10)
+        allow(local_backend).to receive(:delete_container).with(local_container, force: true, v: true)
+
+        stub_backend_resources(remote_backend, pool: [ remote_container ])
+
+        job.perform
+
+        expect(local_backend).to have_received(:delete_container).with(local_container, force: true, v: true)
+        expect(remote_backend).not_to have_received(:delete_container)
+      end
     end
 
     context "with volumes" do
@@ -464,6 +515,25 @@ RSpec.describe DockerOrphanCleanupJob do
         allow(backend).to receive(:list_volumes).and_raise(Docker::Error::DockerError, "daemon error")
 
         expect { job.perform }.not_to raise_error
+      end
+
+      it "removes wrong-host orphaned pool volumes even when the entry is active on another backend" do
+        remote_entry = create(:container_pool_entry, container_host: "worker-1")
+        local_backend = build_backend(identifier: "local", remote: false)
+        remote_backend = build_backend(identifier: "worker-1", remote: true)
+        local_volume = instance_double(Docker::Volume, id: remote_entry.workspace_volume, remove: true)
+        remote_volume = instance_double(Docker::Volume, id: remote_entry.workspace_volume, remove: true)
+
+        allow(Containers).to receive(:all_backends).and_return([ local_backend, remote_backend ])
+        allow(local_backend).to receive_messages(list_containers: [], list_volumes: [ local_volume ])
+        allow(local_backend).to receive(:delete_volume).with(local_volume)
+
+        allow(remote_backend).to receive_messages(list_containers: [], list_volumes: [ remote_volume ])
+
+        job.perform
+
+        expect(local_backend).to have_received(:delete_volume).with(local_volume)
+        expect(remote_backend).not_to have_received(:delete_volume)
       end
     end
   end

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -43,6 +43,33 @@ RSpec.describe DockerOrphanCleanupJob do
   end
 
   describe "#perform" do
+    it "cleans up resources across all registered backends" do
+      local_backend = instance_double(Containers::Backends::Base, identifier: "local")
+      remote_backend = instance_double(Containers::Backends::Base, identifier: "worker-1")
+      local_container = make_container(labels: { "paid.agent_run_id" => "999999" })
+      remote_container = make_container(labels: { "paid.agent_run_id" => "888888" })
+
+      allow(Containers).to receive(:all_backends).and_return([ local_backend, remote_backend ])
+      allow(local_backend).to receive(:list_containers).with(all: true, filters: agent_filter).and_return([ local_container ])
+      allow(local_backend).to receive(:list_containers).with(all: true, filters: pool_filter).and_return([])
+      allow(local_backend).to receive(:list_containers).with(all: true, filters: service_filter).and_return([])
+      allow(local_backend).to receive(:list_volumes).and_return([])
+      allow(local_backend).to receive(:stop_container).with(local_container, timeout: 10)
+      allow(local_backend).to receive(:delete_container).with(local_container, force: true, v: true)
+
+      allow(remote_backend).to receive(:list_containers).with(all: true, filters: agent_filter).and_return([ remote_container ])
+      allow(remote_backend).to receive(:list_containers).with(all: true, filters: pool_filter).and_return([])
+      allow(remote_backend).to receive(:list_containers).with(all: true, filters: service_filter).and_return([])
+      allow(remote_backend).to receive(:list_volumes).and_return([])
+      allow(remote_backend).to receive(:stop_container).with(remote_container, timeout: 10)
+      allow(remote_backend).to receive(:delete_container).with(remote_container, force: true, v: true)
+
+      job.perform
+
+      expect(local_backend).to have_received(:delete_container).with(local_container, force: true, v: true)
+      expect(remote_backend).to have_received(:delete_container).with(remote_container, force: true, v: true)
+    end
+
     context "with agent containers" do
       before do
         stub_no_volumes

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -14,7 +14,12 @@ RSpec.describe DockerOrphanCleanupJob do
       Containers::Backends::Base,
       identifier: identifier,
       remote?: remote,
-      all_host_identifiers: [ identifier ]
+      all_host_identifiers: [ identifier ],
+      list_containers: [],
+      list_volumes: [],
+      stop_container: nil,
+      delete_container: nil,
+      delete_volume: nil
     )
   end
 

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe DockerOrphanCleanupJob do
       .and_return(containers)
   end
 
-  def make_container(labels:)
+  def make_container(labels:, id: SecureRandom.hex(32))
     instance_double(Docker::Container,
+      id: id,
       info: { "Labels" => labels },
       stop: true,
       delete: true)
@@ -269,6 +270,27 @@ RSpec.describe DockerOrphanCleanupJob do
         job.perform
 
         expect(container).not_to have_received(:delete)
+      end
+
+      it "removes stale service containers whose docker_container_id no longer matches" do
+        sc = create(:service_container, status: "running", docker_container_id: "active-container-on-remote")
+        stale_container = make_container(
+          id: "old-local-container-id",
+          labels: {
+            "paid.service_container" => "true",
+            "paid.service_container_id" => sc.id.to_s
+          }
+        )
+        stub_service_containers(stale_container)
+        allow(sc).to receive(:capacity_inflight_agent_run_count).and_return(2)
+        allow(ServiceContainer).to receive(:find_by).with(id: sc.id.to_s).and_return(sc)
+
+        job.perform
+
+        expect(stale_container).to have_received(:delete).with(force: true, v: true)
+        # DB record should NOT be cleared since it points to the active container on another backend
+        expect(sc.reload.docker_container_id).to eq("active-container-on-remote")
+        expect(sc.reload.status).to eq("running")
       end
 
       it "removes service containers with no matching DB record" do

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -398,6 +398,18 @@ RSpec.describe DockerOrphanCleanupJob do
     context "with volumes" do
       before { stub_no_containers }
 
+      it "returns a complete empty summary when no paid volumes exist" do
+        stub_no_volumes
+
+        expect(job.send(:cleanup_volumes, backend: backend)).to eq(
+          found: 0,
+          removed: 0,
+          failed: 0,
+          active: 0,
+          retained: 0
+        )
+      end
+
       it "removes volumes for completed agent runs" do
         completed_run = create(:agent_run, :completed)
         volume = instance_double(Docker::Volume, id: "paid-workspace-#{completed_run.id}", remove: true)

--- a/spec/services/containers/all_backends_spec.rb
+++ b/spec/services/containers/all_backends_spec.rb
@@ -12,19 +12,19 @@ RSpec.describe Containers, ".all_backends", :no_db do
     allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :remote, :swarm ])
     allow(Containers::Backends::Resolver).to receive(:for).with(:local).and_return(local_backend)
     allow(Containers::Backends::Resolver).to receive(:for).with(:remote).and_return(remote_backend)
+    allow(Containers::Backends::Resolver).to receive(:for).with(:swarm).and_return(swarm_backend)
   end
 
-  it "returns only the active, local, and remote backends" do
-    expect(described_class.all_backends).to eq([ local_backend, remote_backend ])
-    expect(Containers::Backends::Resolver).not_to have_received(:for).with(:swarm)
+  it "returns every registered backend once" do
+    expect(described_class.all_backends).to eq([ local_backend, remote_backend, swarm_backend ])
   end
 
   it "deduplicates the active backend when it is already local" do
     expect(described_class.all_backends.count { |backend| backend == local_backend }).to eq(1)
   end
 
-  it "returns only the active backend when no remote backend is registered" do
-    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :swarm ])
+  it "returns the active backend when no additional backends are registered" do
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local ])
 
     expect(described_class.all_backends).to eq([ local_backend ])
     expect(Containers::Backends::Resolver).not_to have_received(:for).with(:remote)

--- a/spec/services/containers/all_backends_spec.rb
+++ b/spec/services/containers/all_backends_spec.rb
@@ -3,23 +3,26 @@
 require "rails_helper"
 
 RSpec.describe Containers, ".all_backends", :no_db do
-  let(:local_backend) { instance_double(Containers::Backends::Base, identifier: "local") }
-  let(:remote_backend) { instance_double(Containers::Backends::Base, identifier: "worker-1") }
-  let(:swarm_backend) { instance_double(Containers::Backends::Base, identifier: "swarm") }
+  let(:local_backend) { instance_double(Containers::Backends::Base, identifier: "local", remote?: false) }
+  let(:remote_backend) { instance_double(Containers::Backends::Base, identifier: "worker-1", remote?: true) }
+  let(:swarm_backend) { instance_double(Containers::Backends::Base, identifier: "swarm", remote?: false) }
 
   before do
     allow(described_class).to receive(:backend).and_return(local_backend)
-    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :remote, :swarm ])
     allow(Containers::Backends::Resolver).to receive(:for).with(:local).and_return(local_backend)
     allow(Containers::Backends::Resolver).to receive(:for).with(:remote).and_return(remote_backend)
     allow(Containers::Backends::Resolver).to receive(:for).with(:swarm).and_return(swarm_backend)
   end
 
-  it "returns every registered backend once" do
-    expect(described_class.all_backends).to eq([ local_backend, remote_backend, swarm_backend ])
+  it "returns the active local backend and a configured remote backend once" do
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :remote, :swarm ])
+
+    expect(described_class.all_backends).to eq([ local_backend, remote_backend ])
   end
 
   it "deduplicates the active backend when it is already local" do
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :remote ])
+
     expect(described_class.all_backends.count { |backend| backend == local_backend }).to eq(1)
   end
 
@@ -29,5 +32,21 @@ RSpec.describe Containers, ".all_backends", :no_db do
     expect(described_class.all_backends).to eq([ local_backend ])
     expect(Containers::Backends::Resolver).not_to have_received(:for).with(:remote)
     expect(Containers::Backends::Resolver).not_to have_received(:for).with(:swarm)
+  end
+
+  it "adds the local backend when the active backend is remote" do
+    allow(described_class).to receive(:backend).and_return(remote_backend)
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :remote ])
+
+    expect(described_class.all_backends).to eq([ remote_backend, local_backend ])
+  end
+
+  it "does not fan out to other backend aliases when swarm is active" do
+    allow(described_class).to receive(:backend).and_return(swarm_backend)
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :remote, :swarm ])
+
+    expect(described_class.all_backends).to eq([ swarm_backend ])
+    expect(Containers::Backends::Resolver).not_to have_received(:for).with(:local)
+    expect(Containers::Backends::Resolver).not_to have_received(:for).with(:remote)
   end
 end

--- a/spec/services/containers/all_backends_spec.rb
+++ b/spec/services/containers/all_backends_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Containers, ".all_backends", :no_db do
+  let(:local_backend) { instance_double(Containers::Backends::Base, identifier: "local") }
+  let(:remote_backend) { instance_double(Containers::Backends::Base, identifier: "worker-1") }
+  let(:swarm_backend) { instance_double(Containers::Backends::Base, identifier: "swarm") }
+
+  before do
+    allow(described_class).to receive(:backend).and_return(local_backend)
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :remote, :swarm ])
+    allow(Containers::Backends::Resolver).to receive(:for).with(:local).and_return(local_backend)
+    allow(Containers::Backends::Resolver).to receive(:for).with(:remote).and_return(remote_backend)
+  end
+
+  it "returns only the active, local, and remote backends" do
+    expect(described_class.all_backends).to eq([ local_backend, remote_backend ])
+    expect(Containers::Backends::Resolver).not_to have_received(:for).with(:swarm)
+  end
+
+  it "deduplicates the active backend when it is already local" do
+    expect(described_class.all_backends.count { |backend| backend == local_backend }).to eq(1)
+  end
+
+  it "returns only the active backend when no remote backend is registered" do
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local, :swarm ])
+
+    expect(described_class.all_backends).to eq([ local_backend ])
+    expect(Containers::Backends::Resolver).not_to have_received(:for).with(:remote)
+    expect(Containers::Backends::Resolver).not_to have_received(:for).with(:swarm)
+  end
+end

--- a/spec/services/containers/backend_for_spec.rb
+++ b/spec/services/containers/backend_for_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Containers, ".backend_for", :no_db do
   let(:local_backend) { instance_double(Containers::Backends::LocalDocker, identifier: "local", owns_host?: false) }
 
   before do
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([])
     allow(described_class).to receive(:backend).and_return(local_backend)
   end
 
@@ -32,6 +33,16 @@ RSpec.describe Containers, ".backend_for", :no_db do
     allow(described_class).to receive(:backend).and_return(swarm_backend)
 
     expect(described_class.backend_for("worker-1")).to eq(swarm_backend)
+  end
+
+  it "routes blank legacy hosts to the local backend even when a remote backend is active" do
+    remote_backend = instance_double(Containers::Backends::Base, identifier: "remote", owns_host?: false)
+    allow(described_class).to receive(:backend).and_return(remote_backend)
+    allow(Containers::Backends::Resolver).to receive(:backend_types).and_return([ :local ])
+    allow(Containers::Backends::Resolver).to receive(:for).with(:local).and_return(local_backend)
+
+    expect(described_class.backend_for(nil)).to eq(local_backend)
+    expect(described_class.backend_for("")).to eq(local_backend)
   end
 
   it "resolves a registered backend by host name" do

--- a/spec/services/containers/backend_for_spec.rb
+++ b/spec/services/containers/backend_for_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe Containers, ".backend_for", :no_db do
     expect(described_class.backend_for("worker-1")).to eq(swarm_backend)
   end
 
+  it "keeps routing persisted remote docker hostnames back to the active backend" do
+    remote_backend = instance_double(Containers::Backends::Base, identifier: "remote", owns_host?: true)
+    allow(described_class).to receive(:backend).and_return(remote_backend)
+
+    expect(described_class.backend_for("nas.internal")).to eq(remote_backend)
+  end
+
   it "routes blank legacy hosts to the local backend even when a remote backend is active" do
     remote_backend = instance_double(Containers::Backends::Base, identifier: "remote", owns_host?: false)
     allow(described_class).to receive(:backend).and_return(remote_backend)

--- a/spec/services/containers/backends/remote_docker_spec.rb
+++ b/spec/services/containers/backends/remote_docker_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Containers::Backends::RemoteDocker, :no_db do
+  subject(:backend) do
+    described_class.new(
+      host: "worker-1.internal",
+      identifier: "worker-1",
+      tls_config: tls_config
+    )
+  end
+
+  let(:connection) { instance_double(Docker::Connection) }
+  let(:container) { instance_double(Docker::Container) }
+  let(:network) { instance_double(Docker::Network) }
+  let(:volume) { instance_double(Docker::Volume) }
+  let(:image) { instance_double(Docker::Image) }
+
+  let(:tls_config) do
+    {
+      client_cert: "/etc/paid/certs/client-cert.pem",
+      client_key: "/etc/paid/certs/client-key.pem",
+      ssl_ca_file: "/etc/paid/certs/ca.pem"
+    }
+  end
+
+  before do
+    allow(Docker::Connection).to receive(:new).and_return(connection)
+  end
+
+  it "reports a remote backend identifier" do
+    expect(backend.identifier).to eq("worker-1")
+    expect(backend).to be_remote
+  end
+
+  it "creates a tls docker connection for the remote host" do
+    backend
+
+    expect(Docker::Connection).to have_received(:new).with(
+      "tcp://worker-1.internal:2376",
+      hash_including(
+        client_cert: tls_config[:client_cert],
+        client_key: tls_config[:client_key],
+        ssl_ca_file: tls_config[:ssl_ca_file],
+        scheme: "https"
+      )
+    )
+  end
+
+  it "delegates ping through the connection" do
+    allow(Docker).to receive(:ping).with(connection).and_return("OK")
+
+    expect(backend.ping).to eq("OK")
+  end
+
+  it "delegates container operations through the remote connection" do
+    allow(Docker::Container).to receive(:create).with({ "Image" => "paid-agent:latest" }, connection).and_return(container)
+    allow(Docker::Container).to receive(:get).with("abc123", {}, connection).and_return(container)
+    allow(Docker::Container).to receive(:all).with({ all: true }, connection).and_return([ container ])
+
+    expect(backend.create_container("Image" => "paid-agent:latest")).to eq(container)
+    expect(backend.get_container("abc123")).to eq(container)
+    expect(backend.list_containers(all: true)).to eq([ container ])
+  end
+
+  it "delegates network, image, and volume access through the remote connection" do
+    allow(Docker::Network).to receive(:get).with("paid_agent", {}, connection).and_return(network)
+    allow(Docker::Network).to receive(:create).with("paid_agent", { "Driver" => "bridge" }, connection).and_return(network)
+    allow(Docker::Image).to receive(:create).with({ "fromImage" => "paid-agent:latest" }, nil, connection).and_return(image)
+    allow(Docker::Volume).to receive(:get).with("paid-workspace-1", connection).and_return(volume)
+    allow(Docker::Volume).to receive(:create).with("paid-workspace-1", { "Labels" => { "paid.managed" => "true" } }, connection).and_return(volume)
+    allow(Docker::Volume).to receive(:all).with({}, connection).and_return([ volume ])
+
+    expect(backend.get_network("paid_agent")).to eq(network)
+    expect(backend.create_network("paid_agent", "Driver" => "bridge")).to eq(network)
+    expect(backend.pull_image("fromImage" => "paid-agent:latest")).to eq(image)
+    expect(backend.get_volume("paid-workspace-1")).to eq(volume)
+    expect(backend.create_volume("paid-workspace-1", "Labels" => { "paid.managed" => "true" })).to eq(volume)
+    expect(backend.list_volumes).to eq([ volume ])
+  end
+
+  it "requires mutual tls configuration" do
+    expect {
+      described_class.new(host: "worker-1.internal", tls_config: { client_cert: "/tmp/cert.pem" })
+    }.to raise_error(ArgumentError, /REMOTE_DOCKER_KEY, REMOTE_DOCKER_CA/)
+  end
+
+  describe ".from_env" do
+    around do |example|
+      original_env = ENV.to_h.slice(
+        "REMOTE_DOCKER_HOST", "REMOTE_DOCKER_IDENTIFIER",
+        "REMOTE_DOCKER_CERT", "REMOTE_DOCKER_KEY", "REMOTE_DOCKER_CA"
+      )
+      ENV["REMOTE_DOCKER_HOST"] = "worker-2.internal:2443"
+      ENV["REMOTE_DOCKER_IDENTIFIER"] = "worker-2"
+      ENV["REMOTE_DOCKER_CERT"] = "/certs/client.pem"
+      ENV["REMOTE_DOCKER_KEY"] = "/certs/client-key.pem"
+      ENV["REMOTE_DOCKER_CA"] = "/certs/ca.pem"
+      example.run
+    ensure
+      original_env.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    end
+
+    it "builds a backend from environment configuration" do
+      backend = described_class.from_env
+
+      expect(backend.identifier).to eq("worker-2")
+      expect(backend.docker_url).to eq("tcp://worker-2.internal:2443")
+    end
+  end
+end

--- a/spec/services/containers/backends/remote_docker_spec.rb
+++ b/spec/services/containers/backends/remote_docker_spec.rb
@@ -88,9 +88,15 @@ RSpec.describe Containers::Backends::RemoteDocker, :no_db do
 
   describe ".from_env" do
     around do |example|
+      env_keys = %w[
+        REMOTE_DOCKER_HOST
+        REMOTE_DOCKER_IDENTIFIER
+        REMOTE_DOCKER_CERT
+        REMOTE_DOCKER_KEY
+        REMOTE_DOCKER_CA
+      ]
       original_env = ENV.to_h.slice(
-        "REMOTE_DOCKER_HOST", "REMOTE_DOCKER_IDENTIFIER",
-        "REMOTE_DOCKER_CERT", "REMOTE_DOCKER_KEY", "REMOTE_DOCKER_CA"
+        *env_keys
       )
       ENV["REMOTE_DOCKER_HOST"] = "worker-2.internal:2443"
       ENV["REMOTE_DOCKER_IDENTIFIER"] = "worker-2"
@@ -99,7 +105,8 @@ RSpec.describe Containers::Backends::RemoteDocker, :no_db do
       ENV["REMOTE_DOCKER_CA"] = "/certs/ca.pem"
       example.run
     ensure
-      original_env.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+      env_keys.each { |key| ENV.delete(key) }
+      original_env.each { |key, value| ENV[key] = value }
     end
 
     it "builds a backend from environment configuration" do

--- a/spec/services/containers/backends/remote_docker_spec.rb
+++ b/spec/services/containers/backends/remote_docker_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Containers::Backends::RemoteDocker, :no_db do
   it "reports a remote backend identifier" do
     expect(backend.identifier).to eq("worker-1")
     expect(backend).to be_remote
+    expect(backend.supports_host_paths?).to be(false)
   end
 
   it "creates a tls docker connection for the remote host" do

--- a/spec/services/containers/backends/remote_docker_spec.rb
+++ b/spec/services/containers/backends/remote_docker_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe Containers::Backends::RemoteDocker, :no_db do
     expect(backend.list_volumes).to eq([ volume ])
   end
 
+  it "accepts host keywords for shared volume cleanup paths" do
+    allow(Docker::Volume).to receive(:get).with("paid-workspace-1", connection).and_return(volume)
+    allow(Docker::Volume).to receive(:create)
+      .with("paid-workspace-1", { "Labels" => { "paid.managed" => "true" } }, connection)
+      .and_return(volume)
+
+    expect(backend.get_volume("paid-workspace-1", host: "worker-1")).to eq(volume)
+    expect(
+      backend.create_volume("paid-workspace-1", { "Labels" => { "paid.managed" => "true" } }, host: "worker-1")
+    ).to eq(volume)
+  end
+
   it "requires mutual tls configuration" do
     expect {
       described_class.new(host: "worker-1.internal", tls_config: { client_cert: "/tmp/cert.pem" })

--- a/spec/services/containers/backends/resolver_initializer_spec.rb
+++ b/spec/services/containers/backends/resolver_initializer_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe Containers::Backends::Resolver, :no_db do
   around do |example|
     original_backend = ENV["CONTAINER_BACKEND"]
     original_proxy_external_url = ENV["PAID_PROXY_EXTERNAL_URL"]
+    original_config_backend = Rails.application.config.x.container_backend
     example.run
   ensure
     ENV["CONTAINER_BACKEND"] = original_backend
     ENV["PAID_PROXY_EXTERNAL_URL"] = original_proxy_external_url
+    Rails.application.config.x.container_backend = original_config_backend
   end
 
   before do

--- a/spec/services/containers/backends/resolver_initializer_spec.rb
+++ b/spec/services/containers/backends/resolver_initializer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Containers::Backends::Resolver, :no_db do
+  let(:initializer_path) { Rails.root.join("config/initializers/container_backend.rb") }
+  let(:remote_backend) { instance_double(Containers::Backends::RemoteDocker, identifier: "worker-1", remote?: true) }
+  let(:local_backend) { instance_double(Containers::Backends::LocalDocker, remote?: false) }
+
+  around do |example|
+    original_backend = ENV["CONTAINER_BACKEND"]
+    original_proxy_external_url = ENV["PAID_PROXY_EXTERNAL_URL"]
+    example.run
+  ensure
+    ENV["CONTAINER_BACKEND"] = original_backend
+    ENV["PAID_PROXY_EXTERNAL_URL"] = original_proxy_external_url
+  end
+
+  before do
+    allow(described_class).to receive(:reset!)
+    allow(described_class).to receive(:register)
+    allow(Containers::Backends::LocalDocker).to receive(:new).and_return(local_backend)
+  end
+
+  def run_initializer
+    load initializer_path
+    Rails.application.reloader.prepare!
+  end
+
+  it "warns when the remote backend is active without PAID_PROXY_EXTERNAL_URL" do
+    ENV["CONTAINER_BACKEND"] = "remote"
+    ENV.delete("PAID_PROXY_EXTERNAL_URL")
+
+    allow(Containers::Backends::RemoteDocker).to receive(:from_env).and_return(remote_backend)
+    allow(described_class).to receive(:for).with(:remote).and_return(remote_backend)
+
+    expect(Rails.logger).to receive(:warn).with(
+      "Remote Docker backend is active but PAID_PROXY_EXTERNAL_URL is not set; remote containers will be unable to reach the secrets proxy"
+    )
+
+    run_initializer
+  end
+
+  it "does not warn when the remote backend has an external proxy URL" do
+    ENV["CONTAINER_BACKEND"] = "remote"
+    ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:3443"
+
+    allow(Containers::Backends::RemoteDocker).to receive(:from_env).and_return(remote_backend)
+    allow(described_class).to receive(:for).with(:remote).and_return(remote_backend)
+
+    expect(Rails.logger).not_to receive(:warn)
+
+    run_initializer
+  end
+end

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(backend.identifier).to eq("swarm")
   end
 
-  it "treats swarm as a remote backend for host-scoped routing" do
-    expect(backend.remote?).to be(true)
+  it "uses overlay DNS rather than remote proxy routing" do
+    expect(backend.remote?).to be(false)
   end
 
   it "does not advertise host path support" do

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(backend.identifier).to eq("swarm")
   end
 
+  it "treats swarm as a remote backend for host-scoped routing" do
+    expect(backend.remote?).to be(true)
+  end
+
   it "does not advertise host path support" do
     expect(backend.supports_host_paths?).to be(false)
   end

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(backend.owns_host?("other-host")).to be(false)
   end
 
+  it "includes node hostnames and backend identifier in all_host_identifiers" do
+    expect(backend.all_host_identifiers).to contain_exactly("worker-1", "swarm")
+  end
+
   it "keeps recognizing persisted node hostnames even when the node is not ready" do
     down_node = node_payload.deep_dup
     down_node["Status"]["State"] = "down"

--- a/spec/services/containers/mcp_provisioner_spec.rb
+++ b/spec/services/containers/mcp_provisioner_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Containers::McpProvisioner do
           .and_raise(Docker::Error::NotFoundError)
         allow(Docker::Container).to receive(:create).and_return(docker_container)
         allow(docker_container).to receive_messages(start: nil, json: { "State" => { "Running" => false } })
-        allow(provisioner).to receive(:tcp_port_open?).and_return(true)
+        allow(Containers::TcpHealthProbe).to receive(:open?).and_return(true)
       end
 
       it "provisions a sidecar container and returns url server spec" do
@@ -273,6 +273,26 @@ RSpec.describe Containers::McpProvisioner do
           expect(existing_container).not_to have_received(:start)
         end
       end
+
+      context "with a remote backend" do
+        let(:backend) { Containers::Backends::LocalDocker.new }
+
+        before do
+          allow(backend).to receive(:remote?).and_return(true)
+          allow(Containers).to receive(:backend).and_return(backend)
+        end
+
+        it "probes health from inside the sidecar container" do
+          provisioner.provision(agent_run)
+
+          expect(Containers::TcpHealthProbe).to have_received(:open?).with(
+            backend: backend,
+            container: docker_container,
+            host: a_string_matching(/\Apaid-mcp-/),
+            port: 8080
+          )
+        end
+      end
     end
 
     context "with mixed npx and docker_image definitions" do
@@ -304,7 +324,7 @@ RSpec.describe Containers::McpProvisioner do
           .and_raise(Docker::Error::NotFoundError)
         allow(Docker::Container).to receive(:create).and_return(docker_container)
         allow(docker_container).to receive_messages(start: nil, json: { "State" => { "Running" => false } })
-        allow(provisioner).to receive(:tcp_port_open?).and_return(true)
+        allow(Containers::TcpHealthProbe).to receive(:open?).and_return(true)
       end
 
       it "provisions both types" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe Containers::Provision do
       Containers::Backends::RemoteDocker,
       identifier: "worker-1",
       remote?: true,
+      supports_host_paths?: false,
       create_volume: mock_volume,
       create_container: mock_container,
       start_container: true,

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -852,7 +852,11 @@ RSpec.describe Containers::Provision do
 
       it "applies firewall rules after container start" do
         expect(mock_container).to receive(:start).ordered
-        expect(NetworkPolicy).to receive(:apply_firewall_rules).with(mock_container, service_destinations: []).ordered
+        expect(NetworkPolicy).to receive(:apply_firewall_rules).with(
+          mock_container,
+          service_destinations: [],
+          backend: service.backend
+        ).ordered
 
         service.provision
       end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -82,6 +82,29 @@ RSpec.describe Containers::Provision do
     FileUtils.rm_rf(worktree_path) if worktree_path && Dir.exist?(worktree_path)
   end
 
+  def stub_remote_backend_proxy_support
+    remote_backend = build_remote_backend
+    allow(remote_backend).to receive(:get_volume).and_raise(Docker::Error::NotFoundError)
+    allow(remote_backend).to receive(:get_network).with("paid_agent").and_return(mock_network)
+    allow(NetworkPolicy).to receive(:ensure_network!).with(network: "paid_agent", backend: remote_backend).and_return(mock_network)
+    allow(NetworkPolicy).to receive(:apply_firewall_rules)
+    remote_backend
+  end
+
+  def build_remote_backend
+    instance_double(
+      Containers::Backends::RemoteDocker,
+      identifier: "worker-1",
+      remote?: true,
+      create_volume: mock_volume,
+      create_container: mock_container,
+      start_container: true,
+      exec_in_container: [ [], [], 0 ],
+      delete_container: true,
+      delete_volume: true
+    )
+  end
+
   describe "constants" do
     it "defines default memory limit of 4GB" do
       expect(described_class::DEFAULTS[:memory_bytes]).to eq(4 * 1024 * 1024 * 1024)
@@ -539,6 +562,27 @@ RSpec.describe Containers::Provision do
         end
 
         service.provision
+      end
+
+      it "uses PAID_PROXY_EXTERNAL_URL when a remote backend is active" do
+        remote_backend = stub_remote_backend_proxy_support
+
+        original_proxy_external_url = ENV["PAID_PROXY_EXTERNAL_URL"]
+        ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:3443"
+
+        remote_service = described_class.new(agent_run: agent_run, backend: remote_backend)
+
+        expect(remote_backend).to receive(:create_container) do |config|
+          env = config["Env"]
+          expect(env).to include("PAID_PROXY_URL=https://proxy.example.test:3443")
+          expect(env).to include("OPENAI_BASE_URL=https://proxy.example.test:3443/api/proxy/openai")
+          expect(env).to include("GOOGLE_GEMINI_BASE_URL=https://proxy.example.test:3443/api/proxy/google")
+          mock_container
+        end
+
+        remote_service.provision
+      ensure
+        ENV["PAID_PROXY_EXTERNAL_URL"] = original_proxy_external_url
       end
 
       it "includes provider CLI env overrides from agent-harness" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -808,7 +808,10 @@ RSpec.describe Containers::Provision do
 
     context "with network integration" do
       it "ensures the agent network exists before provisioning" do
-        expect(NetworkPolicy).to receive(:ensure_network!).with(network: NetworkPolicy::NETWORK_NAME).ordered
+        expect(NetworkPolicy).to receive(:ensure_network!).with(
+          network: NetworkPolicy::NETWORK_NAME,
+          backend: service.backend
+        ).ordered
         expect(Docker::Container).to receive(:create).ordered.and_return(mock_container)
 
         service.provision
@@ -953,7 +956,10 @@ RSpec.describe Containers::Provision do
       end
 
       it "ensures the infrastructure network exists" do
-        expect(NetworkPolicy).to receive(:ensure_network!).with(network: NetworkPolicy::INFRA_NETWORK_NAME)
+        expect(NetworkPolicy).to receive(:ensure_network!).with(
+          network: NetworkPolicy::INFRA_NETWORK_NAME,
+          backend: service.backend
+        )
 
         service.provision
       end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Containers::Provision do
   def build_remote_backend_without_host_paths(container, &create_container)
     backend = instance_double(
       Containers::Backends::Base,
+      remote?: false,
       supports_host_paths?: false,
       start_container: true,
       container_host_for: "worker-1"
@@ -85,6 +86,7 @@ RSpec.describe Containers::Provision do
       identifier: "worker-1",
       remote?: true,
       supports_host_paths?: false,
+      container_host_for: "worker-1",
       create_volume: mock_volume,
       create_container: mock_container,
       start_container: true,

--- a/spec/services/containers/proxy_url_spec.rb
+++ b/spec/services/containers/proxy_url_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Containers::ProxyUrl, :no_db do
         .to eq("https://proxy.example.test:3443")
     end
 
+    it "raises when the remote backend has no external proxy URL" do
+      ENV.delete("PAID_PROXY_EXTERNAL_URL")
+
+      expect {
+        described_class.resolve(backend: remote_backend, restricted: true)
+      }.to raise_error(ArgumentError, "PAID_PROXY_EXTERNAL_URL is required when CONTAINER_BACKEND is remote")
+    end
+
     it "raises for an invalid external URL" do
       ENV["PAID_PROXY_EXTERNAL_URL"] = "not a url"
 

--- a/spec/services/containers/proxy_url_spec.rb
+++ b/spec/services/containers/proxy_url_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe Containers::ProxyUrl, :no_db do
       }.to raise_error(ArgumentError, "PAID_PROXY_EXTERNAL_URL must include scheme and host")
     end
 
+    it "raises when the external URL does not use http or https" do
+      ENV["PAID_PROXY_EXTERNAL_URL"] = "ssh://proxy.example.test:3443"
+
+      expect {
+        described_class.resolve(backend: remote_backend, restricted: true)
+      }.to raise_error(ArgumentError, "PAID_PROXY_EXTERNAL_URL must use http or https")
+    end
+
     it "raises when the external URL port is out of range" do
       ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:99999"
 

--- a/spec/services/containers/service_provisioner_spec.rb
+++ b/spec/services/containers/service_provisioner_spec.rb
@@ -669,6 +669,25 @@ RSpec.describe Containers::ServiceProvisioner do
       result = provisioner.send(:docker_healthcheck_status, sc)
       expect(result).to be_nil
     end
+
+    it "probes from inside the container when the backend is remote and no healthcheck exists" do
+      sc = create(:service_container, status: "running", docker_container_id: "remote123", name: "redis", port: 6379)
+      container = instance_double(Docker::Container)
+      backend = Containers::Backends::LocalDocker.new
+
+      allow(backend).to receive(:remote?).and_return(true)
+      allow(Containers).to receive(:backend).and_return(backend)
+      allow(Docker::Container).to receive(:get).with("remote123").and_return(container)
+      allow(Containers::TcpHealthProbe).to receive(:open?).and_return(true)
+
+      expect(provisioner.send(:tcp_port_open?, sc)).to be(true)
+      expect(Containers::TcpHealthProbe).to have_received(:open?).with(
+        backend: backend,
+        container: container,
+        host: a_string_matching(/\Apaid-svc-/),
+        port: 6379
+      )
+    end
   end
 
   describe "metrics collection scheduling" do

--- a/spec/services/containers/service_provisioner_spec.rb
+++ b/spec/services/containers/service_provisioner_spec.rb
@@ -696,6 +696,7 @@ RSpec.describe Containers::ServiceProvisioner do
       expect(Containers::TcpHealthProbe).to have_received(:open?).with(
         backend: backend,
         container: container,
+        fallback_on_missing_tools: false,
         host: a_string_matching(/\Apaid-svc-/),
         port: 6379
       )

--- a/spec/services/containers/tcp_health_probe_spec.rb
+++ b/spec/services/containers/tcp_health_probe_spec.rb
@@ -32,5 +32,21 @@ RSpec.describe Containers::TcpHealthProbe, :no_db do
 
       expect(described_class.open?(backend: backend, container: container, host: "svc-host", port: 5432)).to be(false)
     end
+
+    it "raises for an invalid remote probe port" do
+      backend = instance_double(Containers::Backends::Base, remote?: true)
+
+      expect {
+        described_class.open?(backend: backend, container: container, host: "svc-host", port: "5432;rm -rf /")
+      }.to raise_error(ArgumentError, 'Invalid probe port: "5432;rm -rf /"')
+    end
+
+    it "raises for an out-of-range remote probe port" do
+      backend = instance_double(Containers::Backends::Base, remote?: true)
+
+      expect {
+        described_class.open?(backend: backend, container: container, host: "svc-host", port: 65_536)
+      }.to raise_error(ArgumentError, "Invalid probe port: 65536")
+    end
   end
 end

--- a/spec/services/containers/tcp_health_probe_spec.rb
+++ b/spec/services/containers/tcp_health_probe_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Containers::TcpHealthProbe, :no_db do
+  describe ".open?" do
+    let(:container) { instance_double(Docker::Container) }
+
+    it "uses a local socket for local backends" do
+      backend = instance_double(Containers::Backends::Base, remote?: false)
+      socket = instance_double(BasicSocket, close: nil)
+
+      allow(Socket).to receive(:tcp).with("svc-host", 5432, connect_timeout: 1).and_return(socket)
+
+      expect(described_class.open?(backend: backend, container: container, host: "svc-host", port: 5432)).to be(true)
+    end
+
+    it "execs a probe inside the container for remote backends" do
+      backend = instance_double(Containers::Backends::Base, remote?: true)
+      allow(backend).to receive(:exec_in_container).and_return([ [], [], 0 ])
+
+      expect(described_class.open?(backend: backend, container: container, host: "svc-host", port: 5432)).to be(true)
+      expect(backend).to have_received(:exec_in_container).with(
+        container,
+        [ "sh", "-lc", a_string_including("127.0.0.1", "5432") ]
+      )
+    end
+
+    it "returns false when the remote probe fails" do
+      backend = instance_double(Containers::Backends::Base, remote?: true)
+      allow(backend).to receive(:exec_in_container).and_return([ [], [ "connection refused" ], 1 ])
+
+      expect(described_class.open?(backend: backend, container: container, host: "svc-host", port: 5432)).to be(false)
+    end
+  end
+end

--- a/spec/services/containers/tcp_health_probe_spec.rb
+++ b/spec/services/containers/tcp_health_probe_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe Containers::TcpHealthProbe, :no_db do
       expect(described_class.open?(backend: backend, container: container, host: "svc-host", port: 5432)).to be(false)
     end
 
+    it "returns true on exit 127 when fallback_on_missing_tools is true (default)" do
+      backend = instance_double(Containers::Backends::Base, remote?: true)
+      allow(backend).to receive(:exec_in_container).and_return([ [], [], 127 ])
+
+      expect(described_class.open?(backend: backend, container: container, host: "svc-host", port: 5432)).to be(true)
+    end
+
+    it "returns false on exit 127 when fallback_on_missing_tools is false" do
+      backend = instance_double(Containers::Backends::Base, remote?: true)
+      allow(backend).to receive(:exec_in_container).and_return([ [], [], 127 ])
+
+      result = described_class.open?(
+        backend: backend, container: container, host: "svc-host", port: 5432,
+        fallback_on_missing_tools: false
+      )
+      expect(result).to be(false)
+    end
+
     it "raises for an invalid remote probe port" do
       backend = instance_double(Containers::Backends::Base, remote?: true)
 

--- a/spec/services/containers/tcp_health_probe_spec.rb
+++ b/spec/services/containers/tcp_health_probe_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Containers::TcpHealthProbe, :no_db do
       expect(described_class.open?(backend: backend, container: container, host: "svc-host", port: 5432)).to be(false)
     end
 
+    it "returns false when the remote exec raises a docker transport error" do
+      backend = instance_double(Containers::Backends::Base, remote?: true)
+      allow(backend).to receive(:exec_in_container).and_raise(Docker::Error::ServerError, "transport failed")
+
+      expect(described_class.open?(backend: backend, container: container, host: "svc-host", port: 5432)).to be(false)
+    end
+
     it "raises for an invalid remote probe port" do
       backend = instance_double(Containers::Backends::Base, remote?: true)
 

--- a/spec/services/knowledge/analysis_runner_spec.rb
+++ b/spec/services/knowledge/analysis_runner_spec.rb
@@ -232,6 +232,13 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
   end
 
   describe "container configuration" do
+    it "enables TLS in generated proxy scripts when PROXY_BASE_URL is HTTPS" do
+      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+
+      expect(runner.send(:anthropic_script)).to include('http.use_ssl = uri.scheme == "https"')
+      expect(runner.send(:openai_script)).to include('http.use_ssl = uri.scheme == "https"')
+    end
+
     it "creates container with security hardening" do
       runner = described_class.new(project: project, knowledge_run: knowledge_run)
       allow(mock_container).to receive(:exec).and_return([ [ "ok" ], [ "" ], 0 ])

--- a/spec/services/knowledge/analysis_runner_spec.rb
+++ b/spec/services/knowledge/analysis_runner_spec.rb
@@ -4,6 +4,16 @@ require "rails_helper"
 
 RSpec.describe Knowledge::AnalysisRunner, :no_db do
   let(:project) { Struct.new(:id).new(42) }
+  let(:backend) do
+    instance_double(
+      Containers::Backends::Base,
+      remote?: false,
+      create_container: mock_container,
+      start_container: true,
+      stop_container: true,
+      delete_container: true
+    )
+  end
   let(:knowledge_run) do
     Struct.new(:id, :proxy_token, :persisted?, :active?, :status) do
       def ensure_proxy_token!
@@ -21,10 +31,6 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
       stop: true,
       delete: true
     )
-  end
-
-  before do
-    allow(Docker::Container).to receive(:create).and_return(mock_container)
   end
 
   describe ".available?" do
@@ -81,34 +87,35 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
 
   describe "#with_container" do
     it "provisions a container, yields, and cleans up" do
-      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: backend)
 
       runner.with_container do |r|
         expect(r).to eq(runner)
-        expect(Docker::Container).to have_received(:create)
-        expect(mock_container).to have_received(:start)
+        expect(backend).to have_received(:create_container)
+        expect(backend).to have_received(:start_container).with(mock_container)
       end
 
-      expect(mock_container).to have_received(:stop)
-      expect(mock_container).to have_received(:delete)
+      expect(backend).to have_received(:stop_container).with(mock_container, timeout: 5)
+      expect(backend).to have_received(:delete_container).with(mock_container, force: true)
     end
 
     it "cleans up container even when block raises" do
-      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: backend)
 
       expect {
         runner.with_container { raise "boom" }
       }.to raise_error(RuntimeError, "boom")
 
-      expect(mock_container).to have_received(:stop)
-      expect(mock_container).to have_received(:delete)
+      expect(backend).to have_received(:stop_container).with(mock_container, timeout: 5)
+      expect(backend).to have_received(:delete_container).with(mock_container, force: true)
     end
 
     it "raises ContainerError when Docker fails to provision" do
-      allow(Docker::Container).to receive(:create)
+      failing_backend = instance_double(Containers::Backends::Base, create_container: nil)
+      allow(failing_backend).to receive(:create_container)
         .and_raise(Docker::Error::DockerError, "no such image")
 
-      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: failing_backend)
 
       expect {
         runner.with_container { |_r| }
@@ -117,23 +124,35 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
   end
 
   describe "#call_llm" do
-    let(:runner) { described_class.new(project: project, knowledge_run: knowledge_run) }
+    let(:runner) { described_class.new(project: project, knowledge_run: knowledge_run, backend: backend) }
+    let(:remote_backend) do
+      instance_double(
+        Containers::Backends::Base,
+        remote?: true,
+        create_container: mock_container,
+        start_container: true,
+        stop_container: true,
+        delete_container: true,
+        exec_in_container: [ [ "output" ], [ "" ], 0 ]
+      )
+    end
 
     before do
       # Simulate container is provisioned
       allow(runner).to receive(:instance_variable_get).and_call_original
+      allow(backend).to receive(:exec_in_container)
       runner.send(:provision!)
     end
 
     after { runner.send(:cleanup!) }
 
     it "executes an anthropic script for claude provider" do
-      allow(mock_container).to receive(:exec).and_return([ [ '{"title":"Test"}' ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ '{"title":"Test"}' ], [ "" ], 0 ])
 
       result = runner.call_llm("Draft a decision", provider: "claude", model: "claude-sonnet-4-6")
 
       expect(result).to eq('{"title":"Test"}')
-      expect(mock_container).to have_received(:exec) do |cmd, opts|
+      expect(backend).to have_received(:exec_in_container).with(mock_container, kind_of(Array), wait: 60, Env: kind_of(Array)) do |_container, cmd, **opts|
         expect(cmd[0]).to eq("ruby")
         expect(cmd[1]).to eq("-e")
         expect(cmd[2]).to include("anthropic")
@@ -146,22 +165,22 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
     end
 
     it "executes an openai script for codex provider" do
-      allow(mock_container).to receive(:exec).and_return([ [ '{"title":"Test"}' ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ '{"title":"Test"}' ], [ "" ], 0 ])
 
       result = runner.call_llm("Draft a decision", provider: "codex")
 
       expect(result).to eq('{"title":"Test"}')
-      expect(mock_container).to have_received(:exec) do |cmd, _opts|
+      expect(backend).to have_received(:exec_in_container) do |_container, cmd, **_opts|
         expect(cmd[2]).to include("openai")
       end
     end
 
     it "uses default model when not specified" do
-      allow(mock_container).to receive(:exec).and_return([ [ "output" ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ "output" ], [ "" ], 0 ])
 
       runner.call_llm("test", provider: "claude")
 
-      expect(mock_container).to have_received(:exec) do |_cmd, opts|
+      expect(backend).to have_received(:exec_in_container) do |_container, _cmd, **opts|
         env_hash = opts[:Env].to_h { |e| e.split("=", 2) }
         expect(env_hash["LLM_MODEL"]).to eq("claude-sonnet-4-6")
       end
@@ -182,7 +201,7 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
     end
 
     it "raises ContainerError when exec returns non-zero exit code" do
-      allow(mock_container).to receive(:exec).and_return([ [ "" ], [ "Proxy error: 500" ], 1 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ "" ], [ "Proxy error: 500" ], 1 ])
 
       expect {
         runner.call_llm("test", provider: "claude")
@@ -190,26 +209,43 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
     end
 
     it "passes base64-encoded prompt in env" do
-      allow(mock_container).to receive(:exec).and_return([ [ "output" ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ "output" ], [ "" ], 0 ])
 
       runner.call_llm("Hello world", provider: "claude")
 
-      expect(mock_container).to have_received(:exec) do |_cmd, opts|
+      expect(backend).to have_received(:exec_in_container) do |_container, _cmd, **opts|
         env_hash = opts[:Env].to_h { |e| e.split("=", 2) }
         decoded = Base64.strict_decode64(env_hash["PROMPT_B64"])
         expect(decoded).to eq("Hello world")
       end
     end
+
+    it "uses the external proxy URL for remote backends" do
+      original_proxy_external_url = ENV["PAID_PROXY_EXTERNAL_URL"]
+      ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:3443"
+      remote_runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: remote_backend)
+      remote_runner.send(:provision!)
+
+      remote_runner.call_llm("test", provider: "claude")
+
+      expect(remote_backend).to have_received(:exec_in_container) do |_container, _cmd, **opts|
+        env_hash = opts[:Env].to_h { |e| e.split("=", 2) }
+        expect(env_hash["PROXY_BASE_URL"]).to eq("https://proxy.example.test:3443")
+      end
+    ensure
+      remote_runner&.send(:cleanup!)
+      ENV["PAID_PROXY_EXTERNAL_URL"] = original_proxy_external_url
+    end
   end
 
   describe "container configuration" do
     it "creates container with security hardening" do
-      runner = described_class.new(project: project, knowledge_run: knowledge_run)
-      allow(mock_container).to receive(:exec).and_return([ [ "ok" ], [ "" ], 0 ])
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: backend)
+      allow(backend).to receive(:exec_in_container).and_return([ [ "ok" ], [ "" ], 0 ])
 
       runner.with_container { |r| r.call_llm("test", provider: "claude") }
 
-      expect(Docker::Container).to have_received(:create) do |config|
+      expect(backend).to have_received(:create_container) do |config|
         expect(config["ReadonlyRootfs"]).to be true
         expect(config["CapDrop"]).to eq([ "ALL" ])
         expect(config["SecurityOpt"]).to eq([ "no-new-privileges:true" ])
@@ -223,10 +259,10 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
     end
 
     it "does not include API keys in container env" do
-      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: backend)
 
       runner.with_container do |_r|
-        expect(Docker::Container).to have_received(:create) do |config|
+        expect(backend).to have_received(:create_container) do |config|
           env_keys = config["Env"].map { |e| e.split("=", 2).first }
           expect(env_keys).not_to include("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY")
         end

--- a/spec/services/knowledge/analysis_runner_spec.rb
+++ b/spec/services/knowledge/analysis_runner_spec.rb
@@ -22,24 +22,35 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
       delete: true
     )
   end
+  let(:backend) do
+    instance_double(
+      Containers::Backends::Base,
+      remote?: false,
+      ping: "OK",
+      create_container: mock_container,
+      start_container: true,
+      stop_container: true,
+      delete_container: true,
+      exec_in_container: [ [ "output" ], [ "" ], 0 ]
+    )
+  end
 
   before do
-    allow(Docker::Container).to receive(:create).and_return(mock_container)
+    allow(Containers).to receive(:backend).and_return(backend)
   end
 
   describe ".available?" do
     it "returns true when Docker is reachable" do
-      allow(Docker).to receive(:ping).and_return("OK")
       expect(described_class.available?).to be true
     end
 
     it "returns false when Docker is unreachable" do
-      allow(Docker).to receive(:ping).and_raise(Excon::Error::Socket.new(StandardError.new("connect failed")))
+      allow(backend).to receive(:ping).and_raise(Excon::Error::Socket.new(StandardError.new("connect failed")))
       expect(described_class.available?).to be false
     end
 
     it "returns false on Docker API errors" do
-      allow(Docker).to receive(:ping).and_raise(Docker::Error::DockerError, "daemon not found")
+      allow(backend).to receive(:ping).and_raise(Docker::Error::DockerError, "daemon not found")
       expect(described_class.available?).to be false
     end
   end
@@ -85,12 +96,12 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
 
       runner.with_container do |r|
         expect(r).to eq(runner)
-        expect(Docker::Container).to have_received(:create)
-        expect(mock_container).to have_received(:start)
+        expect(backend).to have_received(:create_container)
+        expect(backend).to have_received(:start_container).with(mock_container)
       end
 
-      expect(mock_container).to have_received(:stop)
-      expect(mock_container).to have_received(:delete)
+      expect(backend).to have_received(:stop_container).with(mock_container, timeout: 5)
+      expect(backend).to have_received(:delete_container).with(mock_container, force: true)
     end
 
     it "cleans up container even when block raises" do
@@ -100,12 +111,12 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
         runner.with_container { raise "boom" }
       }.to raise_error(RuntimeError, "boom")
 
-      expect(mock_container).to have_received(:stop)
-      expect(mock_container).to have_received(:delete)
+      expect(backend).to have_received(:stop_container).with(mock_container, timeout: 5)
+      expect(backend).to have_received(:delete_container).with(mock_container, force: true)
     end
 
     it "raises ContainerError when Docker fails to provision" do
-      allow(Docker::Container).to receive(:create)
+      allow(backend).to receive(:create_container)
         .and_raise(Docker::Error::DockerError, "no such image")
 
       runner = described_class.new(project: project, knowledge_run: knowledge_run)
@@ -132,19 +143,18 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
 
     before do
       # Simulate container is provisioned
-      allow(runner).to receive(:instance_variable_get).and_call_original
       runner.send(:provision!)
     end
 
     after { runner.send(:cleanup!) }
 
     it "executes an anthropic script for claude provider" do
-      allow(mock_container).to receive(:exec).and_return([ [ '{"title":"Test"}' ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ '{"title":"Test"}' ], [ "" ], 0 ])
 
       result = runner.call_llm("Draft a decision", provider: "claude", model: "claude-sonnet-4-6")
 
       expect(result).to eq('{"title":"Test"}')
-      expect(mock_container).to have_received(:exec) do |cmd, opts|
+      expect(backend).to have_received(:exec_in_container) do |_container, cmd, **opts|
         expect(cmd[0]).to eq("ruby")
         expect(cmd[1]).to eq("-e")
         expect(cmd[2]).to include("anthropic")
@@ -157,22 +167,22 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
     end
 
     it "executes an openai script for codex provider" do
-      allow(mock_container).to receive(:exec).and_return([ [ '{"title":"Test"}' ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ '{"title":"Test"}' ], [ "" ], 0 ])
 
       result = runner.call_llm("Draft a decision", provider: "codex")
 
       expect(result).to eq('{"title":"Test"}')
-      expect(mock_container).to have_received(:exec) do |cmd, _opts|
+      expect(backend).to have_received(:exec_in_container) do |_container, cmd, **_opts|
         expect(cmd[2]).to include("openai")
       end
     end
 
     it "uses default model when not specified" do
-      allow(mock_container).to receive(:exec).and_return([ [ "output" ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ "output" ], [ "" ], 0 ])
 
       runner.call_llm("test", provider: "claude")
 
-      expect(mock_container).to have_received(:exec) do |_cmd, opts|
+      expect(backend).to have_received(:exec_in_container) do |_container, _cmd, **opts|
         env_hash = opts[:Env].to_h { |e| e.split("=", 2) }
         expect(env_hash["LLM_MODEL"]).to eq("claude-sonnet-4-6")
       end
@@ -193,7 +203,7 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
     end
 
     it "raises ContainerError when exec returns non-zero exit code" do
-      allow(mock_container).to receive(:exec).and_return([ [ "" ], [ "Proxy error: 500" ], 1 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ "" ], [ "Proxy error: 500" ], 1 ])
 
       expect {
         runner.call_llm("test", provider: "claude")
@@ -201,11 +211,11 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
     end
 
     it "passes base64-encoded prompt in env" do
-      allow(mock_container).to receive(:exec).and_return([ [ "output" ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ "output" ], [ "" ], 0 ])
 
       runner.call_llm("Hello world", provider: "claude")
 
-      expect(mock_container).to have_received(:exec) do |_cmd, opts|
+      expect(backend).to have_received(:exec_in_container) do |_container, _cmd, **opts|
         env_hash = opts[:Env].to_h { |e| e.split("=", 2) }
         decoded = Base64.strict_decode64(env_hash["PROMPT_B64"])
         expect(decoded).to eq("Hello world")
@@ -241,11 +251,11 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
 
     it "creates container with security hardening" do
       runner = described_class.new(project: project, knowledge_run: knowledge_run)
-      allow(mock_container).to receive(:exec).and_return([ [ "ok" ], [ "" ], 0 ])
+      allow(backend).to receive(:exec_in_container).and_return([ [ "ok" ], [ "" ], 0 ])
 
       runner.with_container { |r| r.call_llm("test", provider: "claude") }
 
-      expect(Docker::Container).to have_received(:create) do |config|
+      expect(backend).to have_received(:create_container) do |config|
         expect(config["ReadonlyRootfs"]).to be true
         expect(config["CapDrop"]).to eq([ "ALL" ])
         expect(config["SecurityOpt"]).to eq([ "no-new-privileges:true" ])
@@ -262,7 +272,7 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
       runner = described_class.new(project: project, knowledge_run: knowledge_run)
 
       runner.with_container do |_r|
-        expect(Docker::Container).to have_received(:create) do |config|
+        expect(backend).to have_received(:create_container) do |config|
           env_keys = config["Env"].map { |e| e.split("=", 2).first }
           expect(env_keys).not_to include("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY")
         end

--- a/spec/services/knowledge/embedding_runner_spec.rb
+++ b/spec/services/knowledge/embedding_runner_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Knowledge::EmbeddingRunner, :no_db do
   let(:project) { Struct.new(:id).new(42) }
+  let(:backend) { instance_double(Containers::Backends::Base, remote?: false) }
   let(:knowledge_run) do
     Struct.new(:id) do
       def ensure_proxy_token!
@@ -14,7 +15,7 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
 
   describe "#container_config" do
     it "bind-mounts the input directory read-only" do
-      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: backend)
       runner.instance_variable_set(:@input_dir, "/tmp/paid-embedding-runner-test")
 
       config = runner.send(:container_config)
@@ -28,7 +29,7 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
 
   describe "#generate" do
     it "cleans up the temp input directory when container execution fails" do
-      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: backend)
 
       allow(runner).to receive(:ensure_container!)
       allow(runner).to receive(:write_input_file)
@@ -47,18 +48,34 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
 
   describe "#ensure_container!" do
     it "applies firewall rules after the container starts" do
-      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: backend)
       container = instance_double(Docker::Container, start: true)
 
       allow(Dir).to receive(:mktmpdir).and_return("/tmp/paid-embedding-runner-test")
       allow(NetworkPolicy).to receive(:ensure_network!)
-      allow(Docker::Container).to receive(:create).and_return(container)
+      allow(backend).to receive(:create_container).and_return(container)
+      allow(backend).to receive(:start_container)
       allow(NetworkPolicy).to receive(:apply_firewall_rules)
 
       runner.send(:ensure_container!)
 
-      expect(NetworkPolicy).to have_received(:ensure_network!).with(network: NetworkPolicy::NETWORK_NAME)
-      expect(NetworkPolicy).to have_received(:apply_firewall_rules).with(container)
+      expect(NetworkPolicy).to have_received(:ensure_network!).with(network: NetworkPolicy::NETWORK_NAME, backend: backend)
+      expect(NetworkPolicy).to have_received(:apply_firewall_rules).with(container, backend: backend)
+    end
+  end
+
+  describe "#script_env" do
+    it "uses the external proxy URL for remote backends" do
+      original_proxy_external_url = ENV["PAID_PROXY_EXTERNAL_URL"]
+      ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:3443"
+      remote_backend = instance_double(Containers::Backends::Base, remote?: true)
+      runner = described_class.new(project: project, knowledge_run: knowledge_run, backend: remote_backend)
+
+      env = runner.send(:script_env, provider: "openai", model: "text-embedding-3-small", dimensions: 1536, timeout: 120)
+
+      expect(env["PROXY_BASE_URL"]).to eq("https://proxy.example.test:3443")
+    ensure
+      ENV["PAID_PROXY_EXTERNAL_URL"] = original_proxy_external_url
     end
   end
 end

--- a/spec/services/knowledge/embedding_runner_spec.rb
+++ b/spec/services/knowledge/embedding_runner_spec.rb
@@ -5,12 +5,28 @@ require "rails_helper"
 RSpec.describe Knowledge::EmbeddingRunner, :no_db do
   let(:project) { Struct.new(:id).new(42) }
   let(:remote_backend) { instance_double(Containers::Backends::Base, remote?: true) }
+  let(:local_backend) { instance_double(Containers::Backends::Base, supports_host_paths?: true, ping: "OK") }
   let(:knowledge_run) do
     Struct.new(:id) do
       def ensure_proxy_token!
         "proxy-token"
       end
     end.new(7)
+  end
+
+  describe ".available?" do
+    it "returns false when the backend cannot mount host paths" do
+      backend = instance_double(Containers::Backends::Base, supports_host_paths?: false)
+      allow(Containers).to receive(:backend).and_return(backend)
+
+      expect(described_class.available?).to be(false)
+    end
+
+    it "checks Docker availability when host paths are supported" do
+      allow(Containers).to receive(:backend).and_return(local_backend)
+
+      expect(described_class.available?).to be(true)
+    end
   end
 
   describe "#container_config" do
@@ -47,13 +63,25 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
   end
 
   describe "#ensure_container!" do
+    it "fails fast when the backend cannot mount host paths" do
+      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+      allow(Containers).to receive(:backend).and_return(remote_backend)
+      allow(remote_backend).to receive(:supports_host_paths?).and_return(false)
+
+      expect {
+        runner.send(:ensure_container!)
+      }.to raise_error(described_class::ContainerError, /host path support/)
+    end
+
     it "applies firewall rules after the container starts" do
       runner = described_class.new(project: project, knowledge_run: knowledge_run)
       container = instance_double(Docker::Container, start: true)
 
+      allow(Containers).to receive(:backend).and_return(local_backend)
+      allow(local_backend).to receive(:create_container).and_return(container)
+      allow(local_backend).to receive(:start_container)
       allow(Dir).to receive(:mktmpdir).and_return("/tmp/paid-embedding-runner-test")
       allow(NetworkPolicy).to receive(:ensure_network!)
-      allow(Docker::Container).to receive(:create).and_return(container)
       allow(NetworkPolicy).to receive(:apply_firewall_rules)
 
       runner.send(:ensure_container!)

--- a/spec/services/knowledge/embedding_runner_spec.rb
+++ b/spec/services/knowledge/embedding_runner_spec.rb
@@ -86,7 +86,10 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
 
       runner.send(:ensure_container!)
 
-      expect(NetworkPolicy).to have_received(:ensure_network!).with(network: NetworkPolicy::NETWORK_NAME)
+      expect(NetworkPolicy).to have_received(:ensure_network!).with(
+        network: NetworkPolicy::NETWORK_NAME,
+        backend: local_backend
+      )
       expect(NetworkPolicy).to have_received(:apply_firewall_rules).with(container, backend: Containers.backend)
     end
   end

--- a/spec/services/knowledge/embedding_runner_spec.rb
+++ b/spec/services/knowledge/embedding_runner_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
   end
 
   describe "#script_env" do
+    it "enables TLS in the generated embedding proxy script when PROXY_BASE_URL is HTTPS" do
+      runner = described_class.new(project: project, knowledge_run: knowledge_run)
+
+      expect(runner.send(:script)).to include('http.use_ssl = uri.scheme == "https"')
+    end
+
     it "uses the external proxy URL for remote backends" do
       original_proxy_external_url = ENV["PAID_PROXY_EXTERNAL_URL"]
       ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:3443"

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -284,6 +284,14 @@ RSpec.describe NetworkPolicy do
           .to raise_error(described_class::Error, /Invalid PAID_PROXY_EXTERNAL_URL/)
       end
 
+      it "raises NetworkPolicy::Error when the remote backend has no external proxy URL" do
+        remote_backend = instance_double(Containers::Backends::Base, remote?: true)
+        ENV.delete("PAID_PROXY_EXTERNAL_URL")
+
+        expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
+          .to raise_error(described_class::Error, /PAID_PROXY_EXTERNAL_URL is required/)
+      end
+
       it "raises NetworkPolicy::Error for an invalid PAID_PROXY_EXTERNAL_URL port" do
         remote_backend = instance_double(Containers::Backends::Base, remote?: true)
         ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:99999"

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe NetworkPolicy do
+RSpec.describe NetworkPolicy, :no_db do
   let(:backend) { Containers.backend }
   let(:mock_network) do
     instance_double(
@@ -297,7 +297,7 @@ RSpec.describe NetworkPolicy do
         ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:99999"
 
         expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
-          .to raise_error(described_class::Error, /Invalid proxy port/)
+          .to raise_error(described_class::Error, /PAID_PROXY_EXTERNAL_URL port must be between 1 and 65535/)
       end
 
       it "raises NetworkPolicy::Error for an unsupported PAID_PROXY_EXTERNAL_URL scheme" do

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe NetworkPolicy do
         allow(ENV).to receive(:[]).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:3443")
 
         expect(remote_backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
-          expect(cmd[2]).to include("-d proxy.example.test -p tcp --dport #{described_class::SECRETS_PROXY_PORT}")
+          expect(cmd[2]).to include("-d proxy.example.test -p tcp --dport 3443")
           [ [], [], 0 ]
         end
 
@@ -277,6 +277,15 @@ RSpec.describe NetworkPolicy do
 
         expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
           .to raise_error(described_class::Error, /Invalid PAID_PROXY_EXTERNAL_URL/)
+      end
+
+      it "raises NetworkPolicy::Error for an invalid PAID_PROXY_EXTERNAL_URL port" do
+        remote_backend = instance_double(Containers::Backends::Base, remote?: true)
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:99999")
+
+        expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
+          .to raise_error(described_class::Error, /Invalid proxy port/)
       end
     end
   end

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NetworkPolicy do
   end
 
   let(:mock_container) do
-    instance_double(Docker::Container, id: "abc123", exec: [ [], [], 0 ])
+    instance_double(Docker::Container, id: "abc123")
   end
 
   describe ".ensure_network!" do
@@ -155,11 +155,11 @@ RSpec.describe NetworkPolicy do
   describe ".apply_firewall_rules" do
     context "when rules apply successfully" do
       before do
-        allow(mock_container).to receive(:exec).and_return([ [], [], 0 ])
+        allow(backend).to receive(:exec_in_container).and_return([ [], [], 0 ])
       end
 
       it "executes a shell script via exec" do
-        expect(mock_container).to receive(:exec) do |cmd|
+        expect(backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
           expect(cmd.length).to eq(3)
           expect(cmd[0]).to eq("sh")
           expect(cmd[1]).to eq("-c")
@@ -171,7 +171,7 @@ RSpec.describe NetworkPolicy do
       end
 
       it "includes all required iptables rules in the script" do
-        expect(mock_container).to receive(:exec) do |cmd|
+        expect(backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
           script = cmd[2]
           expect(script).to include("iptables -P OUTPUT DROP")
           expect(script).to include("iptables -A OUTPUT -o lo -j ACCEPT")
@@ -186,7 +186,7 @@ RSpec.describe NetworkPolicy do
       end
 
       it "includes GitHub IP rules" do
-        expect(mock_container).to receive(:exec) do |cmd|
+        expect(backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
           script = cmd[2]
           described_class::DEFAULT_GITHUB_IPS.each do |cidr|
             expect(script).to include("-d #{cidr} -p tcp --dport 443")
@@ -201,7 +201,7 @@ RSpec.describe NetworkPolicy do
       it "accepts custom GitHub IPs" do
         custom_ips = [ "10.0.0.0/8" ]
 
-        expect(mock_container).to receive(:exec) do |cmd|
+        expect(backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
           script = cmd[2]
           expect(script).to include("-d 10.0.0.0/8 -p tcp --dport 443")
           expect(script).not_to include("140.82.112.0/20")
@@ -212,7 +212,7 @@ RSpec.describe NetworkPolicy do
       end
 
       it "accepts custom proxy host" do
-        expect(mock_container).to receive(:exec) do |cmd|
+        expect(backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
           script = cmd[2]
           expect(script).to include("-d 10.0.0.1 -p tcp --dport #{described_class::SECRETS_PROXY_PORT}")
           [ [], [], 0 ]
@@ -220,11 +220,24 @@ RSpec.describe NetworkPolicy do
 
         described_class.apply_firewall_rules(mock_container, proxy_host: "10.0.0.1")
       end
+
+      it "uses PAID_PROXY_EXTERNAL_URL for remote backends" do
+        remote_backend = instance_double(Containers::Backends::Base, remote?: true, exec_in_container: [ [], [], 0 ])
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:3443")
+
+        expect(remote_backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
+          expect(cmd[2]).to include("-d proxy.example.test -p tcp --dport #{described_class::SECRETS_PROXY_PORT}")
+          [ [], [], 0 ]
+        end
+
+        described_class.apply_firewall_rules(mock_container, backend: remote_backend)
+      end
     end
 
     context "when rules fail to apply" do
       before do
-        allow(mock_container).to receive(:exec)
+        allow(backend).to receive(:exec_in_container)
           .and_return([ [], [ "iptables: Permission denied" ], 1 ])
       end
 
@@ -255,6 +268,15 @@ RSpec.describe NetworkPolicy do
       it "raises NetworkPolicy::Error for backtick injection" do
         expect { described_class.apply_firewall_rules(mock_container, proxy_host: "`whoami`") }
           .to raise_error(described_class::Error, /Invalid proxy host/)
+      end
+
+      it "raises NetworkPolicy::Error for invalid PAID_PROXY_EXTERNAL_URL" do
+        remote_backend = instance_double(Containers::Backends::Base, remote?: true)
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("PAID_PROXY_EXTERNAL_URL").and_return("not a url")
+
+        expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
+          .to raise_error(described_class::Error, /Invalid PAID_PROXY_EXTERNAL_URL/)
       end
     end
   end

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -299,6 +299,14 @@ RSpec.describe NetworkPolicy do
         expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
           .to raise_error(described_class::Error, /Invalid proxy port/)
       end
+
+      it "raises NetworkPolicy::Error for an unsupported PAID_PROXY_EXTERNAL_URL scheme" do
+        remote_backend = instance_double(Containers::Backends::Base, remote?: true)
+        ENV["PAID_PROXY_EXTERNAL_URL"] = "ssh://proxy.example.test:3443"
+
+        expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
+          .to raise_error(described_class::Error, /must use http or https/)
+      end
     end
 
     context "with invalid service destinations" do

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -292,6 +292,26 @@ RSpec.describe NetworkPolicy do
           .to raise_error(described_class::Error, /Invalid proxy port/)
       end
     end
+
+    context "with invalid service destinations" do
+      it "raises NetworkPolicy::Error for shell metacharacters in the port" do
+        expect {
+          described_class.apply_firewall_rules(
+            mock_container,
+            service_destinations: [ { ip: "172.28.0.5", port: "5432; rm -rf /" } ]
+          )
+        }.to raise_error(described_class::Error, /Invalid service port/)
+      end
+
+      it "raises NetworkPolicy::Error for out-of-range service ports" do
+        expect {
+          described_class.apply_firewall_rules(
+            mock_container,
+            service_destinations: [ { ip: "172.28.0.5", port: 65_536 } ]
+          )
+        }.to raise_error(described_class::Error, /Invalid service port/)
+      end
+    end
   end
 
   describe ".fetch_github_ips" do

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -153,6 +153,13 @@ RSpec.describe NetworkPolicy do
   end
 
   describe ".apply_firewall_rules" do
+    around do |example|
+      original_proxy_external_url = ENV["PAID_PROXY_EXTERNAL_URL"]
+      example.run
+    ensure
+      ENV["PAID_PROXY_EXTERNAL_URL"] = original_proxy_external_url
+    end
+
     context "when rules apply successfully" do
       before do
         allow(backend).to receive(:exec_in_container).and_return([ [], [], 0 ])
@@ -223,8 +230,7 @@ RSpec.describe NetworkPolicy do
 
       it "uses PAID_PROXY_EXTERNAL_URL for remote backends" do
         remote_backend = instance_double(Containers::Backends::Base, remote?: true, exec_in_container: [ [], [], 0 ])
-        allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:3443")
+        ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:3443"
 
         expect(remote_backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
           expect(cmd[2]).to include("-d proxy.example.test -p tcp --dport 3443")
@@ -272,8 +278,7 @@ RSpec.describe NetworkPolicy do
 
       it "raises NetworkPolicy::Error for invalid PAID_PROXY_EXTERNAL_URL" do
         remote_backend = instance_double(Containers::Backends::Base, remote?: true)
-        allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with("PAID_PROXY_EXTERNAL_URL").and_return("not a url")
+        ENV["PAID_PROXY_EXTERNAL_URL"] = "not a url"
 
         expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
           .to raise_error(described_class::Error, /Invalid PAID_PROXY_EXTERNAL_URL/)
@@ -281,8 +286,7 @@ RSpec.describe NetworkPolicy do
 
       it "raises NetworkPolicy::Error for an invalid PAID_PROXY_EXTERNAL_URL port" do
         remote_backend = instance_double(Containers::Backends::Base, remote?: true)
-        allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:99999")
+        ENV["PAID_PROXY_EXTERNAL_URL"] = "https://proxy.example.test:99999"
 
         expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
           .to raise_error(described_class::Error, /Invalid proxy port/)

--- a/spec/services/network_policy_spec.rb
+++ b/spec/services/network_policy_spec.rb
@@ -223,8 +223,8 @@ RSpec.describe NetworkPolicy do
 
       it "uses PAID_PROXY_EXTERNAL_URL for remote backends" do
         remote_backend = instance_double(Containers::Backends::Base, remote?: true, exec_in_container: [ [], [], 0 ])
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:3443")
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:3443")
 
         expect(remote_backend).to receive(:exec_in_container).with(mock_container, kind_of(Array)) do |_container, cmd|
           expect(cmd[2]).to include("-d proxy.example.test -p tcp --dport 3443")
@@ -272,8 +272,8 @@ RSpec.describe NetworkPolicy do
 
       it "raises NetworkPolicy::Error for invalid PAID_PROXY_EXTERNAL_URL" do
         remote_backend = instance_double(Containers::Backends::Base, remote?: true)
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("PAID_PROXY_EXTERNAL_URL").and_return("not a url")
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("PAID_PROXY_EXTERNAL_URL").and_return("not a url")
 
         expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
           .to raise_error(described_class::Error, /Invalid PAID_PROXY_EXTERNAL_URL/)
@@ -281,8 +281,8 @@ RSpec.describe NetworkPolicy do
 
       it "raises NetworkPolicy::Error for an invalid PAID_PROXY_EXTERNAL_URL port" do
         remote_backend = instance_double(Containers::Backends::Base, remote?: true)
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:99999")
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("PAID_PROXY_EXTERNAL_URL").and_return("https://proxy.example.test:99999")
 
         expect { described_class.apply_firewall_rules(mock_container, backend: remote_backend) }
           .to raise_error(described_class::Error, /Invalid proxy port/)


### PR DESCRIPTION
## Summary

Adds a `RemoteDocker` backend so agent containers can run on a second machine (NAS, spare server, cloud VM) over TCP+mTLS, completing Phase 2 of RDR-019. Operators can now offload container execution from the Rails host without changing the workspace storage model or per-container security posture.

## Changes

- **Backend**: New `Containers::Backends::RemoteDocker` (`app/services/containers/backends/remote_docker.rb`) implementing the Phase 1 backend interface over TCP+TLS via `docker-api`'s native client-certificate support.
- **Registration**: `config/initializers/container_backend.rb` registers the remote backend from env, with `container_host` identifiers wired through to `AgentRun` and `ContainerPoolEntry` records so the pool manager routes pooled containers to the correct host.
- **Proxy routing**: `Containers::Provision#proxy_base_url` (`app/services/containers/provision.rb`) honors `PAID_PROXY_EXTERNAL_URL` when a remote backend is active, replacing the hardcoded `paid-proxy` Docker DNS name with the operator-configured routable address.
- **Network policy**: `app/services/network_policy.rb` runs iptables egress filtering over the Docker API `exec` channel so the same firewall rules apply on remote hosts.
- **Workspaces**: Volumes are created on the target host using the existing named-volume + in-container clone pattern — no storage model changes.
- **Orphan cleanup**: `app/jobs/docker_orphan_cleanup_job.rb` fans out across all registered backends so containers on both local and remote hosts are reaped.
- **Operator tooling**: `lib/tasks/remote_docker.rake` adds setup tasks for cert generation and connectivity testing; `docs/guides/remote-docker-setup.md` documents TLS, tunnel options (WireGuard, SSH, Cloudflare Tunnel, LB+mTLS), and end-to-end setup.
- **Tests**: Added `spec/services/containers/backends/remote_docker_spec.rb` and updated network policy specs.

## Design Decisions

- **Single-host scope**: This phase targets one remote Docker host; multi-worker scheduling is deferred. The pool manager uses `container_host` for routing, leaving room for future fan-out without reshaping records.
- **mTLS over the Docker API directly**: Chose `docker-api`'s native TCP+TLS client rather than an SSH-wrapped socket so network policy `exec` calls and metrics collection share the same authenticated transport.
- **Proxy hostname as the coupling point**: `PAID_PROXY_EXTERNAL_URL` is the single env var operators must set; everything that previously assumed `paid-proxy` resolves via Docker DNS now flows through this override, including firewall allow-lists.
- **No storage model change**: Reusing the named-volume + clone pattern keeps remote workspaces operationally identical to local ones, at the cost of requiring volume storage on the remote host.

## Operational Notes

- Operators must provision mTLS certs (see the rake tasks) and expose the remote Docker Engine API on TCP 2376 behind an encrypted tunnel before enabling the backend.
- `PAID_PROXY_EXTERNAL_URL` must be set to a hostname routable from the remote host; misconfiguration will surface as proxy egress failures in agent containers.
- Database-backed specs (provisioning, orphan cleanup) were not exercised in the build environment due to no Postgres; reviewers should confirm CI runs them green before merge.

---

Closes #2031