### PR TITLE
feat(containers): Phase 3 — Docker Swarm Backend

### DIFF
--- a/app/jobs/agent_run_resource_janitor_job.rb
+++ b/app/jobs/agent_run_resource_janitor_job.rb
@@ -70,7 +70,7 @@ class AgentRunResourceJanitorJob < ApplicationJob
 
     volume_name = "#{VOLUME_PREFIX}#{agent_run.id}"
     backend = Containers.backend_for(agent_run.container_host)
-    backend.delete_volume(backend.get_volume(volume_name))
+    backend.delete_volume(backend.get_volume(volume_name, host: agent_run.container_host))
     true
   rescue Docker::Error::NotFoundError
     true # Volume already removed — treat as successfully cleaned

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -2078,7 +2078,7 @@ class AgentRun < ApplicationRecord
 
     volume_name = "paid-workspace-#{id}"
     backend = Containers.backend_for(container_host)
-    volume = backend.get_volume(volume_name)
+    volume = backend.get_volume(volume_name, host: container_host)
     backend.delete_volume(volume)
   rescue Docker::Error::NotFoundError
     # Volume already removed, nothing to do

--- a/app/services/containers.rb
+++ b/app/services/containers.rb
@@ -14,6 +14,7 @@ module Containers
     def backend_for(host)
       resolved_backend = backend
       return resolved_backend if host.blank? || host.to_s == resolved_backend.identifier
+      return resolved_backend if resolved_backend.owns_host?(host)
 
       Backends::Resolver.for(host.to_sym)
     end

--- a/app/services/containers/backends/base.rb
+++ b/app/services/containers/backends/base.rb
@@ -7,6 +7,10 @@ module Containers
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 
+      def supports_host_paths?
+        true
+      end
+
       def owns_host?(_host)
         false
       end

--- a/app/services/containers/backends/base.rb
+++ b/app/services/containers/backends/base.rb
@@ -7,8 +7,16 @@ module Containers
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 
+      def owns_host?(_host)
+        false
+      end
+
       def ping
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
+      end
+
+      def container_host_for(_container)
+        identifier
       end
 
       def get_container(_id)
@@ -63,11 +71,11 @@ module Containers
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 
-      def create_volume(_name, _options = {})
+      def create_volume(_name, _options = {}, host: nil)
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 
-      def get_volume(_name)
+      def get_volume(_name, host: nil)
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 

--- a/app/services/containers/backends/base.rb
+++ b/app/services/containers/backends/base.rb
@@ -75,7 +75,7 @@ module Containers
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 
-      def create_volume(_name, _options = {}, host: nil)
+      def create_volume(_name, _options = nil, host: nil, **_keyword_options)
         raise NotImplementedError, "#{self.class} must implement ##{__method__}"
       end
 

--- a/app/services/containers/backends/local_docker.rb
+++ b/app/services/containers/backends/local_docker.rb
@@ -69,8 +69,8 @@ module Containers
         Docker::Volume.all
       end
 
-      def create_volume(name, options = {}, host: nil)
-        Docker::Volume.create(name, options)
+      def create_volume(name, options = nil, host: nil, **keyword_options)
+        Docker::Volume.create(name, normalize_volume_options(options, keyword_options))
       end
 
       def get_volume(name, host: nil)
@@ -79,6 +79,12 @@ module Containers
 
       def delete_volume(volume, **options)
         volume.remove(**options)
+      end
+
+      private
+
+      def normalize_volume_options(options, keyword_options)
+        (options || {}).merge(keyword_options.transform_keys(&:to_s))
       end
     end
   end

--- a/app/services/containers/backends/local_docker.rb
+++ b/app/services/containers/backends/local_docker.rb
@@ -13,6 +13,10 @@ module Containers
         Docker.ping
       end
 
+      def container_host_for(_container)
+        identifier
+      end
+
       def get_container(id)
         Docker::Container.get(id)
       end
@@ -65,11 +69,11 @@ module Containers
         Docker::Volume.all
       end
 
-      def create_volume(name, options = {})
+      def create_volume(name, options = {}, host: nil)
         Docker::Volume.create(name, options)
       end
 
-      def get_volume(name)
+      def get_volume(name, host: nil)
         Docker::Volume.get(name)
       end
 

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -419,16 +419,20 @@ module Containers
       end
 
       def healthy_nodes
-        parse_json(manager_connection.get("/nodes")).select do |node|
+        all_nodes.select do |node|
           node.dig("Spec", "Availability") == "active" &&
             node.dig("Status", "State") == "ready"
         end
       end
 
+      def all_nodes
+        parse_json(manager_connection.get("/nodes"))
+      end
+
       def cached_node_hostnames
         now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         if @node_hostnames_expires_at.nil? || now >= @node_hostnames_expires_at
-          @cached_node_hostnames = healthy_nodes.map { |node| node_hostname(node) }.compact.to_set
+          @cached_node_hostnames = all_nodes.map { |node| node_hostname(node) }.compact.to_set
           @node_hostnames_expires_at = now + NODE_HOSTNAME_CACHE_TTL
         end
 
@@ -440,7 +444,7 @@ module Containers
       end
 
       def node_by_hostname(hostname)
-        healthy_nodes.find { |node| node_hostname(node) == hostname.to_s }
+        all_nodes.find { |node| node_hostname(node) == hostname.to_s }
       end
 
       def node_hostname(node)

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "docker-api"
+require "set"
 
 module Containers
   module Backends
     class Swarm < Base
       DEFAULT_NODE_PORT = 2376
       DEFAULT_NODE_SCHEME = "https"
+      NODE_HOSTNAME_CACHE_TTL = 30
       NODE_ADDRESS_LABEL = "paid.docker_host"
 
       VolumeHandle = Struct.new(:backend, :id, :host, keyword_init: true) do
@@ -83,7 +85,7 @@ module Containers
       end
 
       def owns_host?(host)
-        healthy_nodes.any? { |node| node_hostname(node) == host.to_s }
+        cached_node_hostnames.include?(host.to_s)
       end
 
       def ping
@@ -384,6 +386,16 @@ module Containers
           node.dig("Spec", "Availability") == "active" &&
             node.dig("Status", "State") == "ready"
         end
+      end
+
+      def cached_node_hostnames
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        if @node_hostnames_expires_at.nil? || now >= @node_hostnames_expires_at
+          @cached_node_hostnames = healthy_nodes.map { |node| node_hostname(node) }.compact.to_set
+          @node_hostnames_expires_at = now + NODE_HOSTNAME_CACHE_TTL
+        end
+
+        @cached_node_hostnames
       end
 
       def inspect_node(id)

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -1,0 +1,435 @@
+# frozen_string_literal: true
+
+require "docker-api"
+
+module Containers
+  module Backends
+    class Swarm < Base
+      DEFAULT_NODE_PORT = 2376
+      DEFAULT_NODE_SCHEME = "https"
+      NODE_ADDRESS_LABEL = "paid.docker_host"
+
+      VolumeHandle = Struct.new(:backend, :id, :host, keyword_init: true) do
+        def remove(**options)
+          backend.delete_volume(self, **options)
+        end
+      end
+
+      class ServiceHandle
+        attr_reader :backend, :id, :info
+
+        def initialize(backend:, service:, task: nil)
+          @backend = backend
+          @id = service.fetch("ID")
+          @service = service
+          @task = task
+          @info = {}
+          refresh!
+        end
+
+        def exec(command, options = {}, &block)
+          backend.exec_in_container(self, command, **options, &block)
+        end
+
+        def refresh!
+          @service = backend.inspect_service(id)
+          @task = backend.primary_task_for(id)
+          @info = backend.service_info(@service, @task)
+          self
+        end
+
+        def service_id
+          id
+        end
+
+        def task
+          @task
+        end
+      end
+
+      def self.connection_options_from_env(env = ENV)
+        cert_path = env["DOCKER_CERT_PATH"].presence || env["SWARM_CERT_PATH"].presence
+        options = {}
+
+        if cert_path
+          options[:client_cert] = File.join(cert_path, "cert.pem")
+          options[:client_key] = File.join(cert_path, "key.pem")
+          options[:ssl_ca_file] = File.join(cert_path, "ca.pem")
+          options[:scheme] = "https"
+        end
+
+        options[:ssl_verify_peer] = false if env["DOCKER_SSL_VERIFY"] == "false"
+        options
+      end
+
+      def initialize(manager_host:, connection_options: {}, placement_constraints: nil, placement_preferences: nil,
+        node_port: DEFAULT_NODE_PORT, node_scheme: DEFAULT_NODE_SCHEME)
+        @manager_connection = Docker::Connection.new(manager_host, connection_options)
+        @connection_options = connection_options
+        @placement_constraints = list_value(placement_constraints)
+        @placement_preferences = list_value(placement_preferences)
+        @node_port = node_port
+        @node_scheme = node_scheme
+      end
+
+      def identifier
+        "swarm"
+      end
+
+      def owns_host?(host)
+        healthy_nodes.any? { |node| node_hostname(node) == host.to_s }
+      end
+
+      def ping
+        manager_connection.ping
+      end
+
+      def container_host_for(container)
+        node_hostname(node_for(container)) || identifier
+      end
+
+      def get_container(id)
+        ServiceHandle.new(backend: self, service: inspect_service(id), task: primary_task_for(id))
+      end
+
+      def create_container(config)
+        response = parse_json(
+          manager_connection.post("/services/create", {}, body: MultiJson.dump(service_spec(config)))
+        )
+        get_container(response.fetch("ID"))
+      end
+
+      def start_container(container)
+        container.refresh!
+      end
+
+      def stop_container(container, **options)
+        concrete_container(container).stop(**options)
+      end
+
+      def delete_container(container, **_options)
+        manager_connection.delete("/services/#{service_id(container)}")
+      end
+
+      def exec_in_container(container, command, **options, &block)
+        concrete_container(container).exec(command, options, &block)
+      end
+
+      def container_stats(container, **options)
+        concrete_container(container).stats(**options)
+      end
+
+      def container_logs(container, **options)
+        concrete_container(container).streaming_logs(**options)
+      end
+
+      def list_containers(**options)
+        query = options[:filters].present? ? { filters: options[:filters] } : {}
+        parse_json(manager_connection.get("/services", query)).map do |service|
+          ServiceHandle.new(backend: self, service: service, task: primary_task_for(service.fetch("ID")))
+        end
+      end
+
+      def get_network(name)
+        Docker::Network.get(name, {}, manager_connection)
+      end
+
+      def create_network(name, config)
+        Docker::Network.create(name, swarm_network_config(config), manager_connection)
+      end
+
+      def pull_image(config)
+        healthy_nodes.each do |node|
+          Docker::Image.create(config, nil, node_connection(node))
+        end
+      end
+
+      def list_volumes
+        healthy_nodes.flat_map do |node|
+          Docker::Volume.all({}, node_connection(node)).map do |volume|
+            VolumeHandle.new(backend: self, id: volume.id, host: node_hostname(node))
+          end
+        end
+      end
+
+      def create_volume(name, _options = {}, host: nil)
+        VolumeHandle.new(backend: self, id: name, host: host)
+      end
+
+      def get_volume(name, host: nil)
+        return VolumeHandle.new(backend: self, id: name, host: host) if host.present?
+
+        node = healthy_nodes.find do |candidate|
+          Docker::Volume.get(name, node_connection(candidate))
+          true
+        rescue Docker::Error::NotFoundError
+          false
+        end
+        raise Docker::Error::NotFoundError, "Volume #{name} not found" unless node
+
+        VolumeHandle.new(backend: self, id: name, host: node_hostname(node))
+      end
+
+      def delete_volume(volume, **options)
+        node = node_by_hostname(volume.host) || raise(Docker::Error::NotFoundError, "Swarm node #{volume.host.inspect} not found")
+        Docker::Volume.get(volume.id, node_connection(node)).remove(options, node_connection(node))
+      end
+
+      def inspect_service(id)
+        parse_json(manager_connection.get("/services/#{id}"))
+      end
+
+      def primary_task_for(service_id)
+        tasks_for(service_id).max_by { |task| task.dig("Version", "Index").to_i }
+      end
+
+      def service_info(service, task)
+        labels = service.dig("Spec", "TaskTemplate", "ContainerSpec", "Labels") || service.dig("Spec", "Labels") || {}
+        node = node_for(task)
+        concrete = concrete_container_info(task, node: node)
+        state = service_state(task, concrete)
+
+        info = concrete || {}
+        info["Config"] = (info["Config"] || {}).merge("Labels" => labels)
+        info["State"] = state
+        info["Name"] ||= service["Spec"]["Name"]
+        info["ServiceID"] = service["ID"]
+        info["Node"] = node
+        info
+      end
+
+      protected
+
+      attr_reader :manager_connection
+
+      private
+
+      attr_reader :connection_options, :node_port, :node_scheme
+
+      def service_spec(config)
+        host_config = config.fetch("HostConfig", {})
+        labels = config["Labels"] || {}
+
+        {
+          "Name" => config["name"],
+          "Labels" => labels,
+          "TaskTemplate" => {
+            "ContainerSpec" => compact_hash(
+              "Image" => config["Image"],
+              "Labels" => labels,
+              "Command" => config["Cmd"],
+              "Env" => config["Env"],
+              "Dir" => config["WorkingDir"],
+              "User" => config["User"],
+              "TTY" => config["Tty"],
+              "OpenStdin" => config["OpenStdin"],
+              "ReadOnly" => config["ReadonlyRootfs"],
+              "Mounts" => build_mounts(host_config),
+              "CapabilityAdd" => config["CapAdd"],
+              "CapabilityDrop" => config["CapDrop"]
+            ),
+            "RestartPolicy" => { "Condition" => "none" },
+            "Resources" => resource_limits(host_config),
+            "Placement" => placement_spec
+          },
+          "Mode" => { "Replicated" => { "Replicas" => 1 } },
+          "Networks" => [ { "Target" => host_config["NetworkMode"] } ]
+        }
+      end
+
+      def placement_spec
+        compact_hash(
+          "Constraints" => @placement_constraints.presence,
+          "Preferences" => @placement_preferences.map { |spread| { "Spread" => { "SpreadDescriptor" => spread } } }.presence
+        )
+      end
+
+      def resource_limits(host_config)
+        limits = compact_hash(
+          "MemoryBytes" => host_config["Memory"],
+          "NanoCPUs" => nano_cpus(host_config["CpuQuota"], host_config["CpuPeriod"])
+        )
+
+        compact_hash("Limits" => limits.presence)
+      end
+
+      def nano_cpus(cpu_quota, cpu_period)
+        return nil unless cpu_quota.present? && cpu_period.present? && cpu_period.to_i.positive?
+
+        ((cpu_quota.to_f / cpu_period.to_f) * 1_000_000_000).to_i
+      end
+
+      def build_mounts(host_config)
+        binds = Array(host_config["Binds"])
+        tmpfs = host_config["Tmpfs"] || {}
+
+        mounts = binds.map { |bind| bind_mount(bind) }
+        mounts.concat(tmpfs.map { |target, options| tmpfs_mount(target, options) })
+        mounts
+      end
+
+      def bind_mount(bind)
+        source, target, mode = bind.split(":", 3)
+        type = source.start_with?("/") ? "bind" : "volume"
+
+        compact_hash(
+          "Type" => type,
+          "Source" => source,
+          "Target" => target,
+          "ReadOnly" => mode.to_s.include?("ro")
+        )
+      end
+
+      def tmpfs_mount(target, options)
+        compact_hash(
+          "Type" => "tmpfs",
+          "Target" => target,
+          "TmpfsOptions" => tmpfs_options(options)
+        )
+      end
+
+      def tmpfs_options(options)
+        parsed = list_value(options, separator: ",")
+        mode = parsed.find { |part| part.start_with?("mode=") }&.delete_prefix("mode=")
+        size = parsed.find { |part| part.start_with?("size=") }&.delete_prefix("size=")
+
+        compact_hash(
+          "Mode" => mode&.to_i(8),
+          "SizeBytes" => size && parse_size(size)
+        )
+      end
+
+      def parse_size(value)
+        size = value.to_s
+        return size.to_i if size.match?(/\A\d+\z/)
+
+        amount = size[0...-1]
+        multiplier = case size[-1]&.downcase
+        when "k" then 1024
+        when "m" then 1024 * 1024
+        when "g" then 1024 * 1024 * 1024
+        else 1
+        end
+
+        (amount.to_i * multiplier)
+      end
+
+      def concrete_container(container)
+        task = task_for(container)
+        raise Docker::Error::NotFoundError, "Swarm service has no active task" unless task
+
+        node = node_for(task)
+        raise Docker::Error::NotFoundError, "Swarm task node is unavailable" unless node
+
+        container_id = task.dig("Status", "ContainerStatus", "ContainerID")
+        raise Docker::Error::NotFoundError, "Swarm task has no runnable container" if container_id.blank?
+
+        Docker::Container.get(container_id, {}, node_connection(node))
+      end
+
+      def concrete_container_info(task, node:)
+        return nil unless task
+
+        container_id = task.dig("Status", "ContainerStatus", "ContainerID")
+        return nil if container_id.blank? || node.blank?
+
+        Docker::Container.get(container_id, {}, node_connection(node)).json
+      rescue Docker::Error::DockerError
+        nil
+      end
+
+      def service_state(task, concrete_info)
+        task_state = task&.dig("Status", "State")
+        exit_code = concrete_info&.dig("State", "ExitCode") || task&.dig("Status", "ContainerStatus", "ExitCode")
+
+        {
+          "Running" => task_state == "running",
+          "ExitCode" => exit_code,
+          "Status" => task_state,
+          "Error" => task&.dig("Status", "Err")
+        }.compact
+      end
+
+      def task_for(container)
+        return container.task if container.respond_to?(:task)
+
+        primary_task_for(service_id(container))
+      end
+
+      def node_for(container_or_task)
+        node_id = if container_or_task.is_a?(Hash)
+          container_or_task["NodeID"]
+        elsif container_or_task.respond_to?(:task)
+          container_or_task.task&.dig("NodeID")
+        end
+        return nil if node_id.blank?
+
+        inspect_node(node_id)
+      end
+
+      def service_id(container)
+        return container.service_id if container.respond_to?(:service_id)
+
+        container.id
+      end
+
+      def healthy_nodes
+        parse_json(manager_connection.get("/nodes")).select do |node|
+          node.dig("Spec", "Availability") == "active" &&
+            node.dig("Status", "State") == "ready"
+        end
+      end
+
+      def inspect_node(id)
+        parse_json(manager_connection.get("/nodes/#{id}"))
+      end
+
+      def node_by_hostname(hostname)
+        healthy_nodes.find { |node| node_hostname(node) == hostname.to_s }
+      end
+
+      def node_hostname(node)
+        node&.dig("Description", "Hostname")
+      end
+
+      def node_connection(node)
+        Docker::Connection.new(node_url(node), connection_options)
+      end
+
+      def node_url(node)
+        address = node.dig("Spec", "Labels", NODE_ADDRESS_LABEL).presence ||
+          node.dig("Status", "Addr")
+        "#{node_scheme}://#{address}:#{node_port}"
+      end
+
+      def tasks_for(service_id)
+        filters = MultiJson.dump(service: [ service_id ])
+        parse_json(manager_connection.get("/tasks", filters: filters))
+      end
+
+      def swarm_network_config(config)
+        config.merge(
+          "Driver" => "overlay",
+          "Attachable" => true,
+          "Scope" => "swarm"
+        )
+      end
+
+      def list_value(value, separator: /\s*,\s*/)
+        case value
+        when nil then []
+        when Array then value.filter_map(&:presence)
+        else value.to_s.split(separator).filter_map(&:presence)
+        end
+      end
+
+      def compact_hash(hash)
+        hash.compact.reject { |_, value| value.respond_to?(:empty?) && value.empty? }
+      end
+
+      def parse_json(payload)
+        Docker::Util.parse_json(payload) || {}
+      end
+    end
+  end
+end

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -16,7 +16,7 @@ module Containers
       end
 
       class ServiceHandle
-        attr_reader :backend, :id, :info
+        attr_reader :backend, :id, :info, :task
 
         def initialize(backend:, service:, task: nil)
           @backend = backend
@@ -24,7 +24,7 @@ module Containers
           @service = service
           @task = task
           @info = {}
-          refresh!
+          rebuild_info!
         end
 
         def exec(command, options = {}, &block)
@@ -34,7 +34,7 @@ module Containers
         def refresh!
           @service = backend.inspect_service(id)
           @task = backend.primary_task_for(id)
-          @info = backend.service_info(@service, @task)
+          rebuild_info!
           self
         end
 
@@ -42,8 +42,10 @@ module Containers
           id
         end
 
-        def task
-          @task
+        private
+
+        def rebuild_info!
+          @info = backend.service_info(@service, @task)
         end
       end
 
@@ -74,6 +76,10 @@ module Containers
 
       def identifier
         "swarm"
+      end
+
+      def supports_host_paths?
+        false
       end
 
       def owns_host?(host)

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -10,6 +10,8 @@ module Containers
       DEFAULT_NODE_SCHEME = "https"
       NODE_HOSTNAME_CACHE_TTL = 30
       NODE_ADDRESS_LABEL = "paid.docker_host"
+      TASK_READY_TIMEOUT = 30
+      TASK_POLL_INTERVAL = 0.25
 
       VolumeHandle = Struct.new(:backend, :id, :host, keyword_init: true) do
         def remove(**options)
@@ -36,6 +38,19 @@ module Containers
         def refresh!
           @service = backend.inspect_service(id)
           @task = backend.primary_task_for(id)
+          rebuild_info!
+          self
+        end
+
+        def update!(service:, task:)
+          @service = service
+          @task = task
+          rebuild_info!
+          self
+        end
+
+        def update_task!(task)
+          @task = task
           rebuild_info!
           self
         end
@@ -108,7 +123,7 @@ module Containers
       end
 
       def start_container(container)
-        container.refresh!
+        wait_for_runnable_task!(container)
       end
 
       def stop_container(container, **options)
@@ -133,8 +148,15 @@ module Containers
 
       def list_containers(**options)
         query = options[:filters].present? ? { filters: options[:filters] } : {}
-        parse_json(manager_connection.get("/services", query)).map do |service|
-          ServiceHandle.new(backend: self, service: service, task: primary_task_for(service.fetch("ID")))
+        services = parse_json(manager_connection.get("/services", query))
+        tasks_by_service = tasks_for_services(services.map { |service| service.fetch("ID") })
+
+        services.map do |service|
+          ServiceHandle.new(
+            backend: self,
+            service: service,
+            task: primary_task_for(service.fetch("ID"), tasks: tasks_by_service[service.fetch("ID")])
+          )
         end
       end
 
@@ -168,7 +190,7 @@ module Containers
         return VolumeHandle.new(backend: self, id: name, host: host) if host.present?
 
         node = healthy_nodes.find do |candidate|
-          Docker::Volume.get(name, node_connection(candidate))
+          Docker::Volume.get(name, {}, node_connection(candidate))
           true
         rescue Docker::Error::NotFoundError
           false
@@ -180,15 +202,15 @@ module Containers
 
       def delete_volume(volume, **options)
         node = node_by_hostname(volume.host) || raise(Docker::Error::NotFoundError, "Swarm node #{volume.host.inspect} not found")
-        Docker::Volume.get(volume.id, node_connection(node)).remove(options, node_connection(node))
+        Docker::Volume.get(volume.id, {}, node_connection(node)).remove(**options)
       end
 
       def inspect_service(id)
         parse_json(manager_connection.get("/services/#{id}"))
       end
 
-      def primary_task_for(service_id)
-        tasks_for(service_id).max_by { |task| task.dig("Version", "Index").to_i }
+      def primary_task_for(service_id, tasks: nil)
+        choose_primary_task(tasks || tasks_for(service_id))
       end
 
       def service_info(service, task)
@@ -359,9 +381,13 @@ module Containers
       end
 
       def task_for(container)
-        return container.task if container.respond_to?(:task)
+        if container.respond_to?(:service_id)
+          latest_task = primary_task_for(service_id(container))
+          container.update_task!(latest_task) if container.respond_to?(:update_task!)
+          return latest_task if latest_task
+        end
 
-        primary_task_for(service_id(container))
+        container.task if container.respond_to?(:task)
       end
 
       def node_for(container_or_task)
@@ -421,8 +447,55 @@ module Containers
       end
 
       def tasks_for(service_id)
-        filters = MultiJson.dump(service: [ service_id ])
-        parse_json(manager_connection.get("/tasks", filters: filters))
+        tasks_for_services([ service_id ]).fetch(service_id, [])
+      end
+
+      def tasks_for_services(service_ids)
+        return {} if service_ids.empty?
+
+        filters = MultiJson.dump(service: service_ids)
+        parse_json(manager_connection.get("/tasks", filters: filters)).group_by { |task| task["ServiceID"] }
+      end
+
+      def choose_primary_task(tasks)
+        Array(tasks).max_by { |task| [ task_priority(task), task.dig("Version", "Index").to_i ] }
+      end
+
+      def task_priority(task)
+        return 2 if runnable_task?(task)
+        return 1 if active_task?(task)
+
+        0
+      end
+
+      def runnable_task?(task)
+        task.present? &&
+          active_task?(task) &&
+          task.dig("Status", "ContainerStatus", "ContainerID").present?
+      end
+
+      def active_task?(task)
+        return false if task.blank?
+
+        task.dig("DesiredState") == "running" || task.dig("Status", "State") == "running"
+      end
+
+      def wait_for_runnable_task!(container)
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + TASK_READY_TIMEOUT
+
+        loop do
+          service = inspect_service(service_id(container))
+          task = primary_task_for(service.fetch("ID"))
+          container.update!(service:, task:)
+          return container if runnable_task?(task)
+
+          if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+            raise Docker::Error::DockerError,
+              "Swarm service #{service.fetch("ID")} did not reach a runnable task within #{TASK_READY_TIMEOUT} seconds"
+          end
+
+          sleep(TASK_POLL_INTERVAL)
+        end
       end
 
       def swarm_network_config(config)

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -182,7 +182,7 @@ module Containers
         end
       end
 
-      def create_volume(name, _options = {}, host: nil)
+      def create_volume(name, _options = nil, host: nil, **_keyword_options)
         VolumeHandle.new(backend: self, id: name, host: host)
       end
 

--- a/app/services/containers/backends/swarm.rb
+++ b/app/services/containers/backends/swarm.rb
@@ -256,7 +256,8 @@ module Containers
               "ReadOnly" => config["ReadonlyRootfs"],
               "Mounts" => build_mounts(host_config),
               "CapabilityAdd" => config["CapAdd"],
-              "CapabilityDrop" => config["CapDrop"]
+              "CapabilityDrop" => config["CapDrop"],
+              "Privileges" => privileges_spec(host_config)
             ),
             "RestartPolicy" => { "Condition" => "none" },
             "Resources" => resource_limits(host_config),
@@ -277,10 +278,18 @@ module Containers
       def resource_limits(host_config)
         limits = compact_hash(
           "MemoryBytes" => host_config["Memory"],
-          "NanoCPUs" => nano_cpus(host_config["CpuQuota"], host_config["CpuPeriod"])
+          "NanoCPUs" => nano_cpus(host_config["CpuQuota"], host_config["CpuPeriod"]),
+          "Pids" => host_config["PidsLimit"]
         )
 
         compact_hash("Limits" => limits.presence)
+      end
+
+      def privileges_spec(host_config)
+        security_opts = Array(host_config["SecurityOpt"])
+        no_new_privs = security_opts.any? { |opt| opt.match?(/\Ano-new-privileges\s*[:=]\s*true\z/i) }
+
+        compact_hash("NoNewPrivileges" => no_new_privs.presence)
       end
 
       def nano_cpus(cpu_quota, cpu_period)
@@ -322,10 +331,12 @@ module Containers
         parsed = list_value(options, separator: ",")
         mode = parsed.find { |part| part.start_with?("mode=") }&.delete_prefix("mode=")
         size = parsed.find { |part| part.start_with?("size=") }&.delete_prefix("size=")
+        mount_flags = parsed.reject { |part| part.match?(/\A(mode|size)=/) }
 
         compact_hash(
           "Mode" => mode&.to_i(8),
-          "SizeBytes" => size && parse_size(size)
+          "SizeBytes" => size && parse_size(size),
+          "Options" => mount_flags.presence
         )
       end
 

--- a/app/services/containers/pool_manager.rb
+++ b/app/services/containers/pool_manager.rb
@@ -89,7 +89,7 @@ module Containers
     def remove_entry(entry, force: false)
       backend = Containers.backend_for(entry.container_host)
       remove_container(entry.container_id, force: force, backend: backend)
-      remove_volume(entry.workspace_volume, backend: backend)
+      remove_volume(entry.workspace_volume, backend: backend, host: entry.container_host)
       entry.destroy!
     end
 
@@ -251,8 +251,8 @@ module Containers
       Rails.logger.warn(message: "container_manager.pool_container_remove_failed", container_id: container_id, error: e.message)
     end
 
-    def remove_volume(volume_name, backend: Containers.backend)
-      backend.delete_volume(backend.get_volume(volume_name))
+    def remove_volume(volume_name, backend: Containers.backend, host: nil)
+      backend.delete_volume(backend.get_volume(volume_name, host: host))
     rescue Docker::Error::NotFoundError
       nil
     rescue Docker::Error::DockerError => e

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -187,7 +187,7 @@ module Containers
     def provision
       log_system("container.provision.start", image: options[:image])
 
-      prepare_heartbeat_dir! unless backend.identifier == "swarm"
+      prepare_heartbeat_dir! if backend.supports_host_paths?
       prepare_workspace!
       ensure_network!
       @container = create_container

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -187,7 +187,7 @@ module Containers
     def provision
       log_system("container.provision.start", image: options[:image])
 
-      prepare_heartbeat_dir!
+      prepare_heartbeat_dir! unless backend.identifier == "swarm"
       prepare_workspace!
       ensure_network!
       @container = create_container
@@ -201,7 +201,7 @@ module Containers
       apply_network_restrictions!
 
       log_system("container.provision.success", container_id: container.id)
-      Result.success(container_id: container.id, container_host: backend.identifier)
+      Result.success(container_id: container.id, container_host: backend.container_host_for(container))
     rescue Docker::Error::DockerError => e
       log_system("container.provision.failed", error: e.message)
       cleanup
@@ -1601,7 +1601,7 @@ module Containers
       volume_name ||= "paid-workspace-#{agent_run.id}" if host_worktree_path.blank? && agent_run.present? && !pooled_container?
       return unless volume_name
 
-      backend.delete_volume(backend.get_volume(volume_name))
+      backend.delete_volume(backend.get_volume(volume_name, host: volume_host))
     rescue Docker::Error::NotFoundError
       # Volume already removed
     rescue => e
@@ -1620,6 +1620,14 @@ module Containers
 
       pool_entry.destroy!
       @pool_entry = nil
+    end
+
+    def volume_host
+      return agent_run.container_host if agent_run&.container_host.present?
+      return pool_entry.container_host if pool_entry&.container_host.present?
+      return backend.container_host_for(container) if container
+
+      nil
     end
 
     def volume_options

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1670,7 +1670,7 @@ module Containers
 
     # Writable directories inside the container:
     #   /workspace          - bind mount of workspace dir (rw, for git clone and code changes)
-    #   /paid-heartbeat     - bind mount of host temp dir (rw, for heartbeat file shared with watchdog)
+    #   /paid-heartbeat     - host bind mount when supported, otherwise tmpfs (rw, for heartbeat touches)
     #   /tmp                - tmpfs (1GB, for scratch files)
     #   /home/agent/.cache  - tmpfs (512MB, for tool caches: Codex CLI, npm, etc.)
     #   /home/agent/.claude - tmpfs (256MB, for Claude CLI session/project data)
@@ -1741,6 +1741,14 @@ module Containers
         binds << "#{copilot_config_host_path}:/home/agent/.copilot-host:ro"
       end
 
+      # /paid-heartbeat carries agent heartbeat touches used by the watchdog.
+      # When the backend supports host paths we bind-mount a host temp dir so
+      # both host and container can observe the same file. Backends like Swarm
+      # cannot expose host paths, so keep the in-container contract intact with
+      # a writable tmpfs at the same path.
+      tmpfs = {}
+      tmpfs[HEARTBEAT_MOUNT_POINT] = "size=#{1024 * 1024},mode=0777" unless heartbeat_dir_host
+
       # /tmp must be `exec` because every coding/review/rebase prompt has the
       # agent run `bundle install` as step 1, and review-goal runs additionally
       # set BUNDLE_PATH=/tmp/bundle. Bundler builds native gem extensions in
@@ -1752,10 +1760,10 @@ module Containers
       # /home/agent/.cache needs exec because some providers (e.g. GitHub Copilot)
       # download native Node.js addons (pty.node) into ~/.cache/copilot/pkg/ at
       # runtime; dlopen() requires mmap(PROT_EXEC), which fails on a noexec mount.
-      tmpfs = {
+      tmpfs.merge!(
         "/tmp" => "exec,size=#{options[:tmpfs_tmp_size]},mode=1777",
         "/home/agent/.cache" => "exec,size=#{options[:tmpfs_cache_size]},mode=0755"
-      }
+      )
 
       # Claude CLI needs to write session data, project indexes, todos, debug
       # logs, and stats under ~/.claude. A writable tmpfs lets it do so without

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -187,6 +187,7 @@ module Containers
     def provision
       log_system("container.provision.start", image: options[:image])
 
+      validate_backend_mount_support!
       prepare_heartbeat_dir! if backend.supports_host_paths?
       prepare_workspace!
       ensure_network!
@@ -1525,6 +1526,11 @@ module Containers
     # Docker volumes live on the overlay2 disk, bypassing the VM root filesystem.
     def prepare_workspace!
       if host_worktree_path.present?
+        unless backend.supports_host_paths?
+          raise ProvisionError,
+            "Backend #{backend.identifier} does not support host-backed worktree paths: #{host_worktree_path}"
+        end
+
         raise ProvisionError, "Worktree path does not exist: #{host_worktree_path}" unless File.directory?(host_worktree_path)
       else
         @workspace_volume ||= pooled_container? ? "paid-pool-workspace-#{pool_entry.id}" : "paid-workspace-#{agent_run.id}"
@@ -1708,7 +1714,7 @@ module Containers
       binds = []
       if @workspace_volume
         binds << "#{@workspace_volume}:#{options[:workspace_mount]}:rw"
-      elsif host_worktree_path.present?
+      elsif backend.supports_host_paths? && host_worktree_path.present?
         binds << "#{host_worktree_path}:#{options[:workspace_mount]}:rw"
       end
 
@@ -1717,24 +1723,27 @@ module Containers
       # Mount the host's Claude config as read-only at a staging path.
       # Credentials are copied into the writable /home/agent/.claude tmpfs
       # by seed_claude_credentials! after container start.
-      if claude_config_host_path.present? &&
+      if backend.supports_host_paths? &&
+         claude_config_host_path.present? &&
          File.directory?(claude_config_host_path) &&
          File.file?(File.join(claude_config_host_path, ".credentials.json"))
         binds << "#{claude_config_host_path}:/home/agent/.claude-host:ro"
       end
 
-      if codex_subscription_auth_host_mount_path.present?
+      if backend.supports_host_paths? && codex_subscription_auth_host_mount_path.present?
         binds.concat(codex_subscription_auth_file_binds)
       end
 
-      if gemini_config_host_path.present? &&
+      if backend.supports_host_paths? &&
+         gemini_config_host_path.present? &&
          File.directory?(gemini_config_host_path) &&
          File.file?(File.join(gemini_config_host_path, "oauth_creds.json")) &&
          gemini_subscription_auth?
         binds << "#{gemini_config_host_path}:/home/agent/.gemini-host:ro"
       end
 
-      if copilot_config_host_path.present? &&
+      if backend.supports_host_paths? &&
+         copilot_config_host_path.present? &&
          File.directory?(copilot_config_host_path) &&
          File.file?(File.join(copilot_config_host_path, "config.json")) &&
          copilot_subscription_auth?
@@ -2042,6 +2051,35 @@ module Containers
       proxy_port = Rails.application.config.x.paid_proxy_port
       proxy_host = network_contract.restricted? ? "paid-proxy" : "web"
       "http://#{proxy_host}:#{proxy_port}"
+    end
+
+    def validate_backend_mount_support!
+      return if backend.supports_host_paths?
+
+      unsupported_mounts = []
+      unsupported_mounts << "worktree path #{host_worktree_path}" if host_worktree_path.present?
+      if host_only_auth_source?(claude_config_host_path, ".credentials.json", claude_local_config_path)
+        unsupported_mounts << "Claude subscription auth at #{claude_config_host_path}"
+      end
+      if codex_subscription_auth_host_mount_path.present?
+        unsupported_mounts << "Codex subscription auth at #{codex_subscription_auth_host_mount_path}"
+      end
+      if host_only_auth_source?(gemini_config_host_path, "oauth_creds.json", gemini_local_config_path)
+        unsupported_mounts << "Gemini subscription auth at #{gemini_config_host_path}"
+      end
+      if host_only_auth_source?(copilot_config_host_path, "config.json", copilot_local_config_path)
+        unsupported_mounts << "Copilot subscription auth at #{copilot_config_host_path}"
+      end
+      return if unsupported_mounts.empty?
+
+      raise ProvisionError,
+        "Backend #{backend.identifier} does not support required host paths: #{unsupported_mounts.join(', ')}"
+    end
+
+    def host_only_auth_source?(host_path, marker_file, local_path)
+      return false unless host_path.present? && File.file?(File.join(host_path, marker_file))
+
+      local_path.blank? || !File.file?(File.join(local_path, marker_file))
     end
 
     # Returns the Docker-host path to the Claude config directory.

--- a/config/initializers/container_backend.rb
+++ b/config/initializers/container_backend.rb
@@ -3,7 +3,18 @@
 Rails.application.config.to_prepare do
   resolver = Containers::Backends::Resolver
   resolver.reset!(:local)
+  resolver.reset!(:swarm)
   resolver.register(:local, -> { Containers::Backends::LocalDocker.new })
+  resolver.register(:swarm, -> {
+    Containers::Backends::Swarm.new(
+      manager_host: ENV.fetch("SWARM_MANAGER_HOST", ENV.fetch("DOCKER_HOST", "unix:///var/run/docker.sock")),
+      connection_options: Containers::Backends::Swarm.connection_options_from_env,
+      placement_constraints: ENV["SWARM_PLACEMENT_CONSTRAINTS"],
+      placement_preferences: ENV["SWARM_PLACEMENT_PREFERENCES"],
+      node_port: Integer(ENV.fetch("SWARM_NODE_DOCKER_PORT", Containers::Backends::Swarm::DEFAULT_NODE_PORT)),
+      node_scheme: ENV.fetch("SWARM_NODE_DOCKER_SCHEME", Containers::Backends::Swarm::DEFAULT_NODE_SCHEME)
+    )
+  })
 
   backend_type = ENV.fetch("CONTAINER_BACKEND", "local").to_sym
   Rails.application.config.x.container_backend = resolver.for(backend_type)

--- a/docs/guides/swarm-setup.md
+++ b/docs/guides/swarm-setup.md
@@ -1,0 +1,142 @@
+# Docker Swarm Setup
+
+This guide configures Paid to provision agent containers through a Docker Swarm manager while still running the agents on individual Swarm nodes.
+
+## Requirements
+
+- Docker Engine 24+ on every Swarm node
+- Swarm mode initialized and at least one manager available
+- The Paid app can reach the Swarm manager Docker API
+- Every worker that may run agents exposes its Docker API with the same client TLS trust chain as the manager
+- The `paid_agent` and `paid_internal` networks exist as Swarm overlay networks
+
+## 1. Initialize Swarm
+
+On the first manager:
+
+```bash
+docker swarm init --advertise-addr <manager-ip>
+```
+
+Join each worker with the token Docker prints:
+
+```bash
+docker swarm join --token <worker-token> <manager-ip>:2377
+```
+
+## 2. Expose the Docker API Safely
+
+Paid needs:
+
+- Manager API access for service scheduling
+- Worker API access for `docker exec`, stats, logs, and volume cleanup on the node where a task lands
+
+Use mutual TLS on every node. A typical daemon configuration is:
+
+```json
+{
+  "hosts": ["unix:///var/run/docker.sock", "tcp://0.0.0.0:2376"],
+  "tls": true,
+  "tlsverify": true,
+  "tlscacert": "/etc/docker/pki/ca.pem",
+  "tlscert": "/etc/docker/pki/server-cert.pem",
+  "tlskey": "/etc/docker/pki/server-key.pem"
+}
+```
+
+Paid reuses the same client certs for the manager and workers. Set:
+
+```bash
+export CONTAINER_BACKEND=swarm
+export SWARM_MANAGER_HOST=https://swarm-manager.internal:2376
+export DOCKER_CERT_PATH=/run/secrets/docker-client
+```
+
+If the Docker API is reachable on a different port, also set:
+
+```bash
+export SWARM_NODE_DOCKER_PORT=2376
+```
+
+## 3. Create Overlay Networks
+
+Create the restricted agent network and the unrestricted infrastructure network as attachable overlays:
+
+```bash
+docker network create \
+  --driver overlay \
+  --attachable \
+  --subnet 172.28.0.0/16 \
+  paid_agent
+
+docker network create \
+  --driver overlay \
+  --attachable \
+  paid_internal
+```
+
+`paid-proxy` must be attached to the same overlay network that agent containers use so Swarm DNS resolves it from every node.
+
+## 4. Label Nodes for Placement
+
+Examples:
+
+```bash
+docker node update --label-add paid.agent=true worker-1
+docker node update --label-add paid.agent=true worker-2
+docker node update --label-add paid.gpu=true gpu-worker-1
+docker node update --label-add paid.memory=high worker-2
+docker node update --label-add paid.memory=low worker-3
+docker node update --label-add paid.docker_host=worker-1.internal worker-1
+```
+
+`paid.docker_host` is optional but recommended when the worker should be reached on a hostname that differs from the node status IP.
+
+Configure placement rules in Paid with comma-separated environment variables:
+
+```bash
+export SWARM_PLACEMENT_CONSTRAINTS='node.labels.paid.agent == true,node.labels.paid.memory != low'
+export SWARM_PLACEMENT_PREFERENCES='node.labels.paid.zone'
+```
+
+Common patterns:
+
+- Prefer GPU nodes: `node.labels.paid.gpu == true`
+- Keep agents off low-memory nodes: `node.labels.paid.memory != low`
+- Restrict to dedicated agent workers: `node.labels.paid.agent == true`
+
+## 5. Backend Behavior
+
+When `CONTAINER_BACKEND=swarm`:
+
+- Paid creates a one-replica Swarm service per agent run
+- Restart policy is `none` so task failure is visible to Paid
+- `agent_runs.container_id` stores the Swarm service id
+- `agent_runs.container_host` stores the Swarm node hostname where the task landed
+- Overlay networking provides `paid-proxy` DNS on every node
+
+## 6. Health Checks and Failure Detection
+
+Paid considers only Swarm nodes with:
+
+- `Spec.Availability == active`
+- `Status.State == ready`
+
+Failed tasks remain detectable because the Swarm backend refreshes state from the current task and records the landing node separately from the backend identifier.
+
+Operational checks:
+
+```bash
+docker node ls
+docker service ls
+docker service ps <service-id>
+docker service inspect <service-id>
+```
+
+If a node goes down, task cleanup may fail until the node returns. Paid will still record the node hostname and surface the task state from Swarm.
+
+## 7. Limitations
+
+- Host bind mounts must exist on every worker that can run agent services
+- Explicit host worktree mounts are not a good fit for multi-host Swarm; use the default named-volume workspace flow
+- Worker Docker APIs must be reachable from the Paid app, not just the manager

--- a/spec/jobs/agent_run_resource_janitor_job_spec.rb
+++ b/spec/jobs/agent_run_resource_janitor_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AgentRunResourceJanitorJob do
       it "removes the workspace volume for non-worktree runs" do
         volume = instance_double(Docker::Volume, remove: true)
         allow(backend).to receive(:get_volume)
-          .with("paid-workspace-#{agent_run.id}")
+          .with("paid-workspace-#{agent_run.id}", host: agent_run.container_host)
           .and_return(volume)
         allow(backend).to receive(:delete_volume).with(volume)
 

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -3921,13 +3921,13 @@ RSpec.describe AgentRun do
 
       it "uses the persisted container host backend for volume cleanup" do
         allow(Containers).to receive(:backend_for).with("remote").and_return(backend)
-        allow(backend).to receive(:get_volume).with("paid-workspace-#{agent_run.id}").and_return(volume)
+        allow(backend).to receive(:get_volume).with("paid-workspace-#{agent_run.id}", host: "remote").and_return(volume)
         allow(backend).to receive(:delete_volume).with(volume)
 
         agent_run.send(:cleanup_orphaned_workspace_volume)
 
         expect(Containers).to have_received(:backend_for).with("remote")
-        expect(backend).to have_received(:get_volume).with("paid-workspace-#{agent_run.id}")
+        expect(backend).to have_received(:get_volume).with("paid-workspace-#{agent_run.id}", host: "remote")
         expect(backend).to have_received(:delete_volume).with(volume)
       end
     end

--- a/spec/services/containers/backend_for_spec.rb
+++ b/spec/services/containers/backend_for_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Containers, ".backend_for", :no_db do
-  let(:local_backend) { instance_double(Containers::Backends::LocalDocker, identifier: "local") }
+  let(:local_backend) { instance_double(Containers::Backends::LocalDocker, identifier: "local", owns_host?: false) }
 
   before do
     allow(described_class).to receive(:backend).and_return(local_backend)
@@ -19,6 +19,12 @@ RSpec.describe Containers, ".backend_for", :no_db do
 
   it "returns the process-global backend when host matches the active backend identifier" do
     expect(described_class.backend_for("local")).to eq(local_backend)
+  end
+
+  it "returns the process-global backend when the active backend owns the persisted host" do
+    allow(local_backend).to receive(:owns_host?).with("worker-1").and_return(true)
+
+    expect(described_class.backend_for("worker-1")).to eq(local_backend)
   end
 
   it "resolves a registered backend by host name" do

--- a/spec/services/containers/backend_for_spec.rb
+++ b/spec/services/containers/backend_for_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Containers, ".backend_for", :no_db do
     expect(described_class.backend_for("worker-1")).to eq(local_backend)
   end
 
+  it "keeps routing persisted worker hostnames back to the active backend" do
+    swarm_backend = instance_double(Containers::Backends::Base, identifier: "swarm", owns_host?: true)
+    allow(described_class).to receive(:backend).and_return(swarm_backend)
+
+    expect(described_class.backend_for("worker-1")).to eq(swarm_backend)
+  end
+
   it "resolves a registered backend by host name" do
     remote_backend = instance_double(Containers::Backends::Base, identifier: "remote")
     Containers::Backends::Resolver.register(:remote, -> { remote_backend })

--- a/spec/services/containers/backends/local_docker_spec.rb
+++ b/spec/services/containers/backends/local_docker_spec.rb
@@ -34,4 +34,14 @@ RSpec.describe Containers::Backends::LocalDocker, :no_db do
 
     expect(backend.delete_volume(volume, force: true)).to be(true)
   end
+
+  it "accepts the legacy positional options hash when creating volumes" do
+    allow(Docker::Volume).to receive(:create) do |name, options|
+      expect(name).to eq("paid-workspace-1")
+      expect(options).to eq("Labels" => { "paid.managed" => "true" })
+      volume
+    end
+
+    expect(backend.create_volume("paid-workspace-1", "Labels" => { "paid.managed" => "true" })).to eq(volume)
+  end
 end

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
   let(:task_payload) do
     {
       "ID" => "task-1",
+      "ServiceID" => service_id,
       "NodeID" => node_id,
       "DesiredState" => "running",
       "Status" => {
@@ -125,11 +126,52 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(backend.container_host_for(service)).to eq("worker-1")
   end
 
+  it "waits for a runnable task before returning from start_container" do
+    pending_task = task_payload.deep_dup
+    pending_task["Status"] = { "State" => "pending", "ContainerStatus" => {} }
+
+    stub_request(:get, "#{manager_url}/tasks")
+      .with(query: hash_including("filters" => /#{service_id}/))
+      .to_return(
+        { status: 200, body: [ pending_task ].to_json },
+        { status: 200, body: [ pending_task ].to_json },
+        { status: 200, body: [ task_payload ].to_json }
+      )
+
+    service = backend.get_container(service_id)
+
+    expect(backend.start_container(service)).to eq(service)
+    expect(service.task.dig("Status", "ContainerStatus", "ContainerID")).to eq(container_id)
+  end
+
   it "executes commands against the landed task container on the worker node" do
     service = backend.get_container(service_id)
 
     expect(backend.exec_in_container(service, [ "pwd" ])).to eq([ [ "ok" ], [], 0 ])
     expect(Docker::Container).to have_received(:get).with(container_id, {}, kind_of(Docker::Connection)).at_least(:once)
+  end
+
+  it "refreshes the routed task before exec when the service is rescheduled" do
+    replacement_task = task_payload.deep_dup
+    replacement_task["ID"] = "task-2"
+    replacement_task["Version"] = { "Index" => 4 }
+    replacement_task["Status"]["ContainerStatus"]["ContainerID"] = "container-456"
+    replacement_container = instance_double(Docker::Container, exec: [ [ "moved" ], [], 0 ], json: container_payload)
+
+    allow(Docker::Container).to receive(:get)
+      .with("container-456", {}, kind_of(Docker::Connection))
+      .and_return(replacement_container)
+    stub_request(:get, "#{manager_url}/tasks")
+      .with(query: hash_including("filters" => /#{service_id}/))
+      .to_return(
+        { status: 200, body: [ task_payload ].to_json },
+        { status: 200, body: [ replacement_task ].to_json }
+      )
+
+    service = backend.get_container(service_id)
+
+    expect(backend.exec_in_container(service, [ "pwd" ])).to eq([ [ "moved" ], [], 0 ])
+    expect(service.task.fetch("ID")).to eq("task-2")
   end
 
   it "returns service state based on the current swarm task" do
@@ -145,6 +187,59 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(a_request(:get, "#{manager_url}/services/#{service_id}")).to have_been_made.once
     expect(a_request(:get, "#{manager_url}/tasks")
       .with(query: hash_including("filters" => /#{service_id}/))).to have_been_made.once
+  end
+
+  it "fetches tasks once when listing multiple services" do
+    other_service_id = "svc-456"
+    filters = MultiJson.dump(service: [ service_id, other_service_id ])
+    other_task = task_payload.deep_dup
+    other_task["ID"] = "task-9"
+    other_task["ServiceID"] = other_service_id
+    other_task["Version"] = { "Index" => 9 }
+    other_service = service_payload.deep_dup
+    other_service["ID"] = other_service_id
+    other_service["Spec"]["Name"] = "paid-agent-2"
+
+    stub_request(:get, "#{manager_url}/services")
+      .to_return(status: 200, body: [ service_payload, other_service ].to_json)
+    tasks_request = stub_request(:get, "#{manager_url}/tasks")
+      .with(query: { "filters" => filters })
+      .to_return(status: 200, body: [ task_payload, other_task ].to_json)
+
+    services = backend.list_containers
+
+    expect(services.map(&:service_id)).to eq([ service_id, other_service_id ])
+    expect(tasks_request).to have_been_requested.once
+  end
+
+  it "looks up volumes on each worker connection" do
+    volume = instance_double(Docker::Volume)
+
+    without_partial_double_verification do
+      allow(Docker::Volume).to receive(:get)
+        .with("paid-workspace-42", {}, kind_of(Docker::Connection))
+        .and_return(volume)
+    end
+
+    handle = backend.get_volume("paid-workspace-42")
+
+    expect(handle.host).to eq("worker-1")
+  end
+
+  it "removes volumes through the owning worker connection" do
+    volume = instance_double(Docker::Volume, remove: true)
+    without_partial_double_verification do
+      allow(Docker::Volume).to receive(:get)
+        .with("paid-workspace-42", {}, kind_of(Docker::Connection))
+        .and_return(volume)
+    end
+
+    backend.delete_volume(
+      described_class::VolumeHandle.new(backend: backend, id: "paid-workspace-42", host: "worker-1"),
+      force: true
+    )
+
+    expect(volume).to have_received(:remove).with(force: true)
   end
 
   def stub_manager_get(path, response, query: nil)

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Containers::Backends::Swarm, :no_db do
+  subject(:backend) do
+    described_class.new(
+      manager_host: manager_url,
+      connection_options: { client_cert: "/tmp/cert.pem" },
+      placement_constraints: "node.labels.paid.agent == true,node.labels.paid.memory != low",
+      placement_preferences: "node.labels.paid.zone"
+    )
+  end
+
+  let(:manager_url) { "https://swarm-manager.internal:2376" }
+  let(:service_id) { "svc-123" }
+  let(:node_id) { "node-1" }
+  let(:container_id) { "container-123" }
+  let(:worker_url) { "https://worker-1.internal:2376" }
+  let(:service_payload) do
+    {
+      "ID" => service_id,
+      "Spec" => {
+        "Name" => "paid-agent",
+        "Labels" => { "paid.agent_run_id" => "42" },
+        "TaskTemplate" => {
+          "ContainerSpec" => {
+            "Labels" => { "paid.agent_run_id" => "42" }
+          }
+        }
+      }
+    }
+  end
+  let(:task_payload) do
+    {
+      "ID" => "task-1",
+      "NodeID" => node_id,
+      "DesiredState" => "running",
+      "Status" => {
+        "State" => "running",
+        "ContainerStatus" => {
+          "ContainerID" => container_id,
+          "ExitCode" => 0
+        }
+      },
+      "Version" => { "Index" => 3 }
+    }
+  end
+  let(:node_payload) do
+    {
+      "ID" => node_id,
+      "Spec" => {
+        "Availability" => "active",
+        "Labels" => {
+          "paid.docker_host" => "worker-1.internal"
+        }
+      },
+      "Status" => {
+        "State" => "ready",
+        "Addr" => "10.0.0.25"
+      },
+      "Description" => {
+        "Hostname" => "worker-1"
+      }
+    }
+  end
+  let(:container_payload) do
+    {
+      "Id" => container_id,
+      "Name" => "paid-agent.1",
+      "Config" => { "Labels" => {} },
+      "State" => { "Running" => true, "ExitCode" => 0 }
+    }
+  end
+  let(:concrete_container) { instance_double(Docker::Container, exec: [ [ "ok" ], [], 0 ], json: container_payload) }
+
+  before do
+    stub_manager_get("/services/#{service_id}", service_payload)
+    stub_manager_get("/tasks", [ task_payload ], query: hash_including("filters" => /#{service_id}/))
+    stub_manager_get("/nodes", [ node_payload ])
+    stub_manager_get("/nodes/#{node_id}", node_payload)
+
+    allow(Docker::Container).to receive(:get)
+      .with(container_id, {}, kind_of(Docker::Connection))
+      .and_return(concrete_container)
+  end
+
+  it "reports the swarm backend identifier" do
+    expect(backend.identifier).to eq("swarm")
+  end
+
+  it "treats the landing node hostname as belonging to the active swarm backend" do
+    expect(backend.owns_host?("worker-1")).to be(true)
+    expect(backend.owns_host?("other-host")).to be(false)
+  end
+
+  it "creates single-replica services with swarm placement and overlay networking" do
+    payload = nil
+    request = stub_request(:post, "#{manager_url}/services/create")
+      .with do |http_request|
+        payload = JSON.parse(http_request.body)
+        true
+      end
+      .to_return(status: 200, body: { "ID" => service_id }.to_json)
+
+    service = backend.create_container(container_config)
+
+    expect_service_spec(payload)
+    expect(request).to have_been_requested
+    expect(service).to be_a(described_class::ServiceHandle)
+    expect(backend.container_host_for(service)).to eq("worker-1")
+  end
+
+  it "executes commands against the landed task container on the worker node" do
+    service = backend.get_container(service_id)
+
+    expect(backend.exec_in_container(service, [ "pwd" ])).to eq([ [ "ok" ], [], 0 ])
+    expect(Docker::Container).to have_received(:get).with(container_id, {}, kind_of(Docker::Connection)).at_least(:once)
+  end
+
+  it "returns service state based on the current swarm task" do
+    service = backend.get_container(service_id)
+
+    expect(service.info.dig("State", "Running")).to be(true)
+    expect(service.info.dig("Config", "Labels", "paid.agent_run_id")).to eq("42")
+  end
+
+  def stub_manager_get(path, response, query: nil)
+    request = stub_request(:get, "#{manager_url}#{path}")
+    request = request.with(query: query) if query
+    request.to_return(status: 200, body: response.to_json)
+  end
+
+  def container_config
+    {
+      "Image" => "paid-agent:latest",
+      "name" => "paid-agent",
+      "Labels" => { "paid.agent_run_id" => "42" },
+      "Cmd" => [ "tail", "-f", "/dev/null" ],
+      "Env" => [ "HOME=/home/agent" ],
+      "WorkingDir" => "/workspace",
+      "User" => "agent",
+      "ReadonlyRootfs" => true,
+      "CapAdd" => [ "NET_RAW" ],
+      "CapDrop" => [ "ALL" ],
+      "OpenStdin" => false,
+      "Tty" => false,
+      "HostConfig" => {
+        "Memory" => 4 * 1024 * 1024 * 1024,
+        "CpuQuota" => 200_000,
+        "CpuPeriod" => 100_000,
+        "NetworkMode" => "paid_agent",
+        "Binds" => [ "paid-workspace-42:/workspace:rw" ],
+        "Tmpfs" => { "/tmp" => "exec,size=1048576,mode=1777" }
+      }
+    }
+  end
+
+  def expect_service_spec(payload)
+    expect(payload).to include(
+      "Name" => "paid-agent",
+      "Mode" => { "Replicated" => { "Replicas" => 1 } },
+      "Networks" => [ { "Target" => "paid_agent" } ]
+    )
+    expect(payload.dig("TaskTemplate", "RestartPolicy")).to eq("Condition" => "none")
+    expect(payload.dig("TaskTemplate", "Placement", "Constraints")).to eq([
+      "node.labels.paid.agent == true",
+      "node.labels.paid.memory != low"
+    ])
+    expect(payload.dig("TaskTemplate", "Placement", "Preferences")).to eq([
+      { "Spread" => { "SpreadDescriptor" => "node.labels.paid.zone" } }
+    ])
+  end
+end

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(backend.identifier).to eq("swarm")
   end
 
+  it "does not advertise host path support" do
+    expect(backend.supports_host_paths?).to be(false)
+  end
+
   it "treats the landing node hostname as belonging to the active swarm backend" do
     expect(backend.owns_host?("worker-1")).to be(true)
     expect(backend.owns_host?("other-host")).to be(false)
@@ -123,6 +127,14 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
 
     expect(service.info.dig("State", "Running")).to be(true)
     expect(service.info.dig("Config", "Labels", "paid.agent_run_id")).to eq("42")
+  end
+
+  it "builds service handles from provided payloads without re-fetching immediately" do
+    backend.get_container(service_id)
+
+    expect(a_request(:get, "#{manager_url}/services/#{service_id}")).to have_been_made.once
+    expect(a_request(:get, "#{manager_url}/tasks")
+      .with(query: hash_including("filters" => /#{service_id}/))).to have_been_made.once
   end
 
   def stub_manager_get(path, response, query: nil)

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -99,6 +99,14 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(backend.owns_host?("other-host")).to be(false)
   end
 
+  it "keeps recognizing persisted node hostnames even when the node is not ready" do
+    down_node = node_payload.deep_dup
+    down_node["Status"]["State"] = "down"
+    stub_manager_get("/nodes", [ down_node ])
+
+    expect(backend.owns_host?("worker-1")).to be(true)
+  end
+
   it "caches node hostnames between owns_host? checks for a short ttl" do
     allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 100.0, 131.0)
 

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -98,6 +98,16 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(backend.owns_host?("other-host")).to be(false)
   end
 
+  it "caches node hostnames between owns_host? checks for a short ttl" do
+    allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100.0, 100.0, 131.0)
+
+    expect(backend.owns_host?("worker-1")).to be(true)
+    expect(backend.owns_host?("other-host")).to be(false)
+    expect(backend.owns_host?("worker-1")).to be(true)
+
+    expect(a_request(:get, "#{manager_url}/nodes")).to have_been_made.twice
+  end
+
   it "creates single-replica services with swarm placement and overlay networking" do
     payload = nil
     request = stub_request(:post, "#{manager_url}/services/create")

--- a/spec/services/containers/backends/swarm_spec.rb
+++ b/spec/services/containers/backends/swarm_spec.rb
@@ -266,9 +266,14 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
         "Memory" => 4 * 1024 * 1024 * 1024,
         "CpuQuota" => 200_000,
         "CpuPeriod" => 100_000,
+        "PidsLimit" => 4096,
+        "SecurityOpt" => [ "no-new-privileges:true" ],
         "NetworkMode" => "paid_agent",
         "Binds" => [ "paid-workspace-42:/workspace:rw" ],
-        "Tmpfs" => { "/tmp" => "exec,size=1048576,mode=1777" }
+        "Tmpfs" => {
+          "/tmp" => "exec,size=1048576,mode=1777",
+          "/home/agent/.cache" => "exec,size=536870912,mode=0755"
+        }
       }
     }
   end
@@ -287,5 +292,18 @@ RSpec.describe Containers::Backends::Swarm, :no_db do
     expect(payload.dig("TaskTemplate", "Placement", "Preferences")).to eq([
       { "Spread" => { "SpreadDescriptor" => "node.labels.paid.zone" } }
     ])
+    expect(payload.dig("TaskTemplate", "ContainerSpec", "Privileges")).to eq(
+      "NoNewPrivileges" => true
+    )
+    expect(payload.dig("TaskTemplate", "Resources", "Limits", "Pids")).to eq(4096)
+
+    tmpfs_mounts = payload.dig("TaskTemplate", "ContainerSpec", "Mounts").select { |m| m["Type"] == "tmpfs" }
+    tmp_mount = tmpfs_mounts.find { |m| m["Target"] == "/tmp" }
+    cache_mount = tmpfs_mounts.find { |m| m["Target"] == "/home/agent/.cache" }
+    expect(tmp_mount.dig("TmpfsOptions", "Options")).to eq([ "exec" ])
+    expect(tmp_mount.dig("TmpfsOptions", "Mode")).to eq(0o1777)
+    expect(tmp_mount.dig("TmpfsOptions", "SizeBytes")).to eq(1_048_576)
+    expect(cache_mount.dig("TmpfsOptions", "Options")).to eq([ "exec" ])
+    expect(cache_mount.dig("TmpfsOptions", "Mode")).to eq(0o755)
   end
 end

--- a/spec/services/containers/pool_manager_spec.rb
+++ b/spec/services/containers/pool_manager_spec.rb
@@ -70,6 +70,41 @@ RSpec.describe Containers::PoolManager do
     end
   end
 
+  describe ".cleanup_claimed_container" do
+    let(:agent_run) { create(:agent_run, project: project) }
+    let(:container) { instance_double(Docker::Container, info: { "State" => { "Running" => true } }) }
+    let(:volume) { instance_double(Docker::Volume) }
+    let(:remote_backend) do
+      instance_double(
+        Containers::Backends::Base,
+        get_container: container,
+        stop_container: true,
+        delete_container: true,
+        get_volume: volume,
+        delete_volume: true
+      )
+    end
+
+    it "uses the persisted container host for workspace volume cleanup" do
+      entry = create(
+        :container_pool_entry,
+        :claimed,
+        project: project,
+        agent_run: agent_run,
+        container_host: "worker-1"
+      )
+      allow(Containers).to receive(:backend_for).with("worker-1").and_return(remote_backend)
+
+      expect(described_class.cleanup_claimed_container(agent_run: agent_run, force: true)).to be(true)
+      expect(remote_backend).to have_received(:get_container).with(entry.container_id)
+      expect(remote_backend).to have_received(:stop_container).with(container, timeout: 0)
+      expect(remote_backend).to have_received(:delete_container).with(container, force: true, v: true)
+      expect(remote_backend).to have_received(:get_volume).with(entry.workspace_volume, host: "worker-1")
+      expect(remote_backend).to have_received(:delete_volume).with(volume)
+      expect(ContainerPoolEntry.exists?(entry.id)).to be(false)
+    end
+  end
+
   describe "#acquire" do
     let(:agent_run) { create(:agent_run, project: project) }
     let(:service) { instance_double(Containers::Provision) }

--- a/spec/services/containers/provision_heartbeat_mount_spec.rb
+++ b/spec/services/containers/provision_heartbeat_mount_spec.rb
@@ -3,9 +3,27 @@
 require "rails_helper"
 
 RSpec.describe Containers::Provision, :no_db do
+  def build_remote_service(project:, backend:, host_config_dir:)
+    service = described_class.new(project:, backend:)
+    allow(service).to receive_messages(
+      claude_config_host_path: host_config_dir,
+      codex_subscription_auth_host_mount_path: host_config_dir,
+      gemini_config_host_path: host_config_dir,
+      gemini_subscription_auth?: true,
+      copilot_config_host_path: host_config_dir,
+      copilot_subscription_auth?: true,
+      claude_local_config_path: nil,
+      gemini_local_config_path: nil,
+      copilot_local_config_path: nil,
+      container_network: "paid_agent"
+    )
+    service
+  end
+
   let(:project) { double(id: 42) }
   let(:backend) { instance_double(Containers::Backends::Base) }
   let(:worktree_path) { Dir.mktmpdir("worktree") }
+  let(:host_config_dir) { Dir.mktmpdir("host-config") }
   let(:settings) do
     double(
       container_memory_bytes: nil,
@@ -17,11 +35,12 @@ RSpec.describe Containers::Provision, :no_db do
 
   before do
     allow(AgentRuns::UserSettingsResolver).to receive(:call).with(project:, strict: false).and_return(settings)
-    allow(backend).to receive(:supports_host_paths?).and_return(false)
+    allow(backend).to receive_messages(supports_host_paths?: false, identifier: "swarm")
   end
 
   after do
     FileUtils.rm_rf(worktree_path) if Dir.exist?(worktree_path)
+    FileUtils.rm_rf(host_config_dir) if Dir.exist?(host_config_dir)
   end
 
   it "uses tmpfs for /paid-heartbeat when the backend cannot mount host paths" do
@@ -42,5 +61,50 @@ RSpec.describe Containers::Provision, :no_db do
       described_class::HEARTBEAT_MOUNT_POINT => "size=1048576,mode=0777"
     )
     expect(host_config.fetch("Binds").grep(/#{Regexp.escape(described_class::HEARTBEAT_MOUNT_POINT)}/)).to be_empty
+  end
+
+  it "rejects host-backed worktrees when the backend cannot mount host paths" do
+    service = described_class.new(project:, worktree_path:, backend:)
+
+    expect { service.send(:prepare_workspace!) }
+      .to raise_error(Containers::Provision::ProvisionError, /does not support host-backed worktree paths/)
+  end
+
+  it "rejects host-only credential sources when the backend cannot mount host paths" do
+    File.write(File.join(host_config_dir, ".credentials.json"), "{}")
+    File.write(File.join(host_config_dir, "auth.json"), "{}")
+    File.write(File.join(host_config_dir, "oauth_creds.json"), "{}")
+    File.write(File.join(host_config_dir, "config.json"), "{}")
+
+    service = described_class.new(project:, backend:)
+    allow(service).to receive_messages(
+      claude_config_host_path: host_config_dir,
+      claude_local_config_path: nil,
+      codex_subscription_auth_host_mount_path: host_config_dir,
+      gemini_config_host_path: host_config_dir,
+      gemini_local_config_path: nil,
+      copilot_config_host_path: host_config_dir,
+      copilot_local_config_path: nil
+    )
+
+    message_pattern = /Claude subscription auth.*Codex subscription auth.*Gemini subscription auth.*Copilot subscription auth/
+
+    expect { service.send(:validate_backend_mount_support!) }
+      .to raise_error(Containers::Provision::ProvisionError, message_pattern)
+  end
+
+  it "does not emit host credential binds when the backend cannot mount host paths" do
+    File.write(File.join(host_config_dir, ".credentials.json"), "{}")
+    File.write(File.join(host_config_dir, "oauth_creds.json"), "{}")
+    File.write(File.join(host_config_dir, "config.json"), "{}")
+
+    service = build_remote_service(project:, backend:, host_config_dir:)
+
+    host_config = service.send(:host_config)
+    binds = host_config.fetch("Binds").join("\n")
+    expect(binds).not_to include("/home/agent/.claude-host")
+    expect(binds).not_to include("/home/agent/.codex/auth.json")
+    expect(binds).not_to include("/home/agent/.gemini-host")
+    expect(binds).not_to include("/home/agent/.copilot-host")
   end
 end

--- a/spec/services/containers/provision_heartbeat_mount_spec.rb
+++ b/spec/services/containers/provision_heartbeat_mount_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Containers::Provision, :no_db do
+  let(:project) { double(id: 42) }
+  let(:backend) { instance_double(Containers::Backends::Base) }
+  let(:worktree_path) { Dir.mktmpdir("worktree") }
+  let(:settings) do
+    double(
+      container_memory_bytes: nil,
+      container_cpu_quota: nil,
+      container_timeout_seconds: nil,
+      container_image: nil
+    )
+  end
+
+  before do
+    allow(AgentRuns::UserSettingsResolver).to receive(:call).with(project:, strict: false).and_return(settings)
+    allow(backend).to receive(:supports_host_paths?).and_return(false)
+  end
+
+  after do
+    FileUtils.rm_rf(worktree_path) if Dir.exist?(worktree_path)
+  end
+
+  it "uses tmpfs for /paid-heartbeat when the backend cannot mount host paths" do
+    service = described_class.new(project:, worktree_path:, backend:)
+    allow(service).to receive_messages(
+      claude_config_host_path: nil,
+      codex_subscription_auth_host_mount_path: nil,
+      gemini_config_host_path: nil,
+      gemini_subscription_auth?: false,
+      copilot_config_host_path: nil,
+      copilot_subscription_auth?: false,
+      container_network: "paid_agent"
+    )
+
+    host_config = service.send(:host_config)
+
+    expect(host_config.fetch("Tmpfs")).to include(
+      described_class::HEARTBEAT_MOUNT_POINT => "size=1048576,mode=0777"
+    )
+    expect(host_config.fetch("Binds").grep(/#{Regexp.escape(described_class::HEARTBEAT_MOUNT_POINT)}/)).to be_empty
+  end
+end

--- a/spec/services/containers/provision_reconnect_spec.rb
+++ b/spec/services/containers/provision_reconnect_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Containers::Provision, ".reconnect", :no_db do
     expect(remote_backend).to have_received(:get_container).with(container_id)
     expect(remote_backend).to have_received(:stop_container).with(container, timeout: 0)
     expect(remote_backend).to have_received(:delete_container).with(container, force: true, v: true)
-    expect(remote_backend).to have_received(:get_volume).with("paid-workspace-456")
+    expect(remote_backend).to have_received(:get_volume).with("paid-workspace-456", host: "remote")
     expect(remote_backend).to have_received(:delete_volume).with(volume)
   end
 end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe Containers::Provision do
     end
   end
 
+  def stub_provision_steps(provision)
+    allow(provision).to receive(:log_system)
+    allow(provision).to receive(:prepare_workspace!)
+    allow(provision).to receive(:ensure_network!)
+    allow(provision).to receive(:fix_all_ownership!)
+    allow(provision).to receive(:seed_opencode_database!)
+    allow(provision).to receive(:seed_codex_credentials!)
+    allow(provision).to receive(:seed_gemini_credentials!)
+    allow(provision).to receive(:seed_copilot_credentials!)
+    allow(provision).to receive(:seed_claude_credentials!)
+    allow(provision).to receive(:apply_network_restrictions!)
+  end
+
   let(:project) { create(:project) }
   let(:agent_run) { create(:agent_run, project: project) }
   let(:worktree_path) { Dir.mktmpdir("worktree") }
@@ -221,6 +234,27 @@ RSpec.describe Containers::Provision do
 
         expect(result).to be_success
         expect(result[:container_id]).to eq("abc123container")
+      end
+
+      it "prepares heartbeat directories only when the backend supports host paths" do
+        backend = instance_double(
+          Containers::Backends::Base,
+          supports_host_paths?: false,
+          create_container: mock_container,
+          start_container: true,
+          container_host_for: "worker-1"
+        )
+        provision = described_class.new(agent_run: agent_run, worktree_path: worktree_path, backend: backend)
+
+        stub_provision_steps(provision)
+        allow(provision).to receive(:prepare_heartbeat_dir!)
+
+        result = provision.provision
+
+        expect(result).to be_success
+        expect(provision).not_to have_received(:prepare_heartbeat_dir!)
+        expect(backend).to have_received(:create_container)
+        expect(backend).to have_received(:start_container).with(mock_container)
       end
 
       it "logs the provision start and success" do

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Containers::Provision do
       expect(remote_backend).to have_received(:get_container).with(container_id)
       expect(remote_backend).to have_received(:stop_container).with(mock_container, timeout: 0)
       expect(remote_backend).to have_received(:delete_container).with(mock_container, force: true, v: true)
-      expect(remote_backend).to have_received(:get_volume).with("paid-workspace-#{agent_run.id}")
+      expect(remote_backend).to have_received(:get_volume).with("paid-workspace-#{agent_run.id}", host: "remote")
       expect(remote_backend).to have_received(:delete_volume).with(remote_volume)
     end
   end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe Containers::Provision do
           config = given_config
           mock_container
         end
-        provision = described_class.new(agent_run: agent_run, worktree_path: worktree_path, backend: backend)
+        provision = described_class.new(agent_run: agent_run, worktree_path: nil, backend: backend)
 
         stub_provision_steps(provision)
         allow(provision).to receive(:prepare_heartbeat_dir!)

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe Containers::Provision do
     allow(provision).to receive(:apply_network_restrictions!)
   end
 
+  def build_remote_backend_without_host_paths(container, &create_container)
+    backend = instance_double(
+      Containers::Backends::Base,
+      supports_host_paths?: false,
+      start_container: true,
+      container_host_for: "worker-1"
+    )
+    allow(backend).to receive(:create_container, &create_container || ->(*) { container })
+    backend
+  end
+
   let(:project) { create(:project) }
   let(:agent_run) { create(:agent_run, project: project) }
   let(:worktree_path) { Dir.mktmpdir("worktree") }
@@ -236,14 +247,12 @@ RSpec.describe Containers::Provision do
         expect(result[:container_id]).to eq("abc123container")
       end
 
-      it "prepares heartbeat directories only when the backend supports host paths" do
-        backend = instance_double(
-          Containers::Backends::Base,
-          supports_host_paths?: false,
-          create_container: mock_container,
-          start_container: true,
-          container_host_for: "worker-1"
-        )
+      it "mounts a tmpfs heartbeat directory when the backend lacks host path support" do
+        config = nil
+        backend = build_remote_backend_without_host_paths(mock_container) do |given_config|
+          config = given_config
+          mock_container
+        end
         provision = described_class.new(agent_run: agent_run, worktree_path: worktree_path, backend: backend)
 
         stub_provision_steps(provision)
@@ -253,7 +262,10 @@ RSpec.describe Containers::Provision do
 
         expect(result).to be_success
         expect(provision).not_to have_received(:prepare_heartbeat_dir!)
-        expect(backend).to have_received(:create_container)
+        expect(config.dig("HostConfig", "Tmpfs")).to include(
+          described_class::HEARTBEAT_MOUNT_POINT => "size=1048576,mode=0777"
+        )
+        expect(config.dig("HostConfig", "Binds").grep(/#{Regexp.escape(described_class::HEARTBEAT_MOUNT_POINT)}/)).to be_empty
         expect(backend).to have_received(:start_container).with(mock_container)
       end
 


### PR DESCRIPTION
## Summary

Adds a Docker Swarm backend so agent containers can be scheduled across multiple hosts with overlay networking and automatic placement, completing Phase 3 of RDR-019 (Remote Container Execution). This unblocks distributing agent workloads beyond a single Docker host while reusing the backend abstraction introduced in Phase 1.

## Changes

- **Services**
  - Add `Containers::Backends::Swarm` (`app/services/containers/backends/swarm.rb`) that schedules agent runs as one-replica Swarm services, resolves the landed node for `container_host`, routes exec/stats/logs to the worker that owns the task, applies placement constraints/preferences from Swarm node labels, and creates overlay networks.
  - Extend the backend contract and routing in `app/services/containers.rb` so persisted Swarm node hostnames still resolve back to the active Swarm backend.
  - Update `Containers::Provision` (`app/services/containers/provision.rb:187`) to persist the backend-reported landing host instead of assuming the backend identifier.
- **Documentation**
  - Add `docs/guides/swarm-setup.md` operator setup guide for the Swarm cluster (manager, overlay network, node labels).

## Design Decisions

- **Services over standalone containers** — agent containers run as Swarm services with `replicas: 1` and no restart policy, matching the design note in the issue and giving us native multi-host placement, scheduling, and overlay DNS without extra tooling.
- **Backend-reported host is authoritative** — `container_host` now comes from the backend's resolved landing node rather than the backend identifier, which is what makes Swarm-aware routing work for later exec/stats/logs calls against the worker that owns the task.
- **Overlay network for proxy DNS** — relying on Swarm overlay networking removes the need for a tunnel to `paid-proxy`; the network creation semantics live in the backend itself.
- **Out of scope** — Kubernetes backend (deferred to Phase 4) and Swarm node auto-scaling (owned by `Scaling::Orchestrator`).

---

Closes #2032