### PR TITLE
docs(rdr): Glossary of Paid-specific terminology for consistent naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ For product overview and full local environment details, see [README.md](README.
 - [docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md)
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - [docs/AGENT_SYSTEM.md](docs/AGENT_SYSTEM.md)
+- [docs/GLOSSARY.md](docs/GLOSSARY.md) — Paid-specific terminology and naming conventions
 - [db/schema.rb](db/schema.rb)
 
 ## Before You Start

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,63 @@
+# Paid Glossary
+
+This glossary defines terms specific to the Paid platform that are not industry-standard. It serves as the canonical reference for consistent naming across the codebase, UI, documentation, and discussions.
+
+**Motivation**: PR #1950 (rename providers to runners) highlighted that ambiguous terminology causes confusion. This glossary prevents that class of problem from recurring.
+
+## Core Domain
+
+| Term | Definition |
+|------|-----------|
+| **Agent Run** | A single execution of a runner against a task (issue, PR review, etc.). Tracks lifecycle from queued to running to completed/failed. Core domain object (`AgentRun` model). |
+| **Focused Agent Run** | An agent run scoped to a single, narrow problem class (e.g., CI fix, review response) rather than all PR problems at once. See RDR-031. |
+| **Runner** | A code execution backend (e.g., Claude Code, Copilot, Aider, OpenCode, Kilocode) that performs agent work. Formerly called "Provider" in code. Renamed in #1950. NOT the same as an LLM provider. |
+| **Runner State** | The operational status record for a runner (healthy, degraded, circuit-open, etc.). Formerly `provider_states`. Renamed in #1950. |
+| **Runner Key** | The unique identifier string for a specific runner (e.g., `claude_code`, `copilot`). Formerly `provider_key`. Renamed in #1950. |
+| **Agent Harness** | The shared execution framework (`agent_harness` gem) that wraps individual runners, providing plan-only APIs, heartbeats, and lifecycle management. All LLM calls must go through this gem. |
+
+## Orchestration
+
+| Term | Definition |
+|------|-----------|
+| **Auto-Pick** | The system that automatically selects and queues GitHub issues for agent runs based on priority, labels, and project settings. Distinct from manual issue assignment. |
+| **Strategy** | A database-backed configuration (`Strategy`/`StrategyVersion` models) that defines how agent workflows execute: retry logic, decomposition rules, escalation thresholds. Evolved via A/B testing. |
+| **Configuration Bundle** | A snapshot of all tunable parameters for an agent run (model, temperature, tools, strategy) tracked for Bayesian optimization. `ConfigurationBundle` model. |
+| **Orchestration Decision** | A logged record of why the system chose a particular runner, decomposition, or retry path. Used for observability and scaling analysis. |
+| **Coordination Policy** | Rules governing how multiple concurrent agent runs interact, avoid conflicts, and escalate. Evolved via the coordination evolution workflow. |
+| **Decomposition** | Breaking a complex issue into smaller sub-tasks that can be handled by individual agent runs. Policy-based via `DecompositionService`. |
+| **Escalation** | Promoting an agent run issue to human review when confidence is low or the task exceeds agent capability. Driven by `EscalationService` with human-value prediction. |
+| **Optimizer** | The Bayesian optimization system that ranks runner/configuration candidates and balances exploration vs. exploitation. `Optimizer.ranked_candidates`. |
+
+## Infrastructure
+
+| Term | Definition |
+|------|-----------|
+| **Workspace** | The isolated filesystem environment (Docker volume or local directory) where a runner executes code changes. Container-managed via Docker or Swarm backend. |
+| **Circuit Breaker** | Per-runner failure tracking that temporarily disables a runner after repeated failures. Transitions between closed/open/half-open states on `RunnerState`. |
+| **Smoke Test / Test Agent** | A lightweight validation run that verifies a runner is functional (auth works, CLI responds). Used for health checks and onboarding. |
+| **Watchdog** | A background thread that monitors running agent containers for hangs, timeouts, and silent failures via heartbeat-based liveness detection. |
+| **Tenant** | A top-level organizational unit (GitHub org or team) that owns projects, users, runners, and settings. Multi-tenancy boundary. |
+
+## External Integrations
+
+| Term | Definition |
+|------|-----------|
+| **LLM Provider** | An upstream AI model vendor (OpenAI, Anthropic, Google, etc.) that supplies the language model a runner uses. Intentionally distinct from "Runner". Kept as `ProviderApiKey`, `LlmModel.provider`. |
+| **PR Scanner** | The subsystem that monitors open PRs for review readiness, auto-merge eligibility, and escalation triggers. Rescans on state changes. |
+| **Knowledge Base (KB)** | Project-specific context documents and business questionnaire answers injected into agent run prompts. Evolves via `KnowledgeEvolutionJob`. |
+
+## Terms Intentionally Retaining "Provider"
+
+These terms refer to LLM providers (not runners) and were intentionally kept during the #1950 rename:
+
+- `ProviderApiKey` — API key for an LLM provider
+- `LlmModel.provider` — which LLM vendor supplies a model
+- `DIRECT_OUTBOUND_API_PROVIDERS` — upstream LLM API vendors
+- `auth_provider` on `agent_runs` — LLM auth context
+- `Automation::Providers::` namespace — external SDK/integration concept
+
+## References
+
+- [#1950](https://github.com/paidplatform/paid/pull/1950) — feat(runners): rename providers to runners (phase 1)
+- [#1945](https://github.com/paidplatform/paid/issues/1945) — original issue motivating the rename
+- [RDR-031](docs/rdrs/RDR-031-focused-agent-runs.md) — Focused Agent Runs architecture

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -11,7 +11,7 @@ This glossary defines terms specific to the Paid platform that are not industry-
 | **Agent Run** | A single execution of a runner against a task (issue, PR review, etc.). Tracks lifecycle from queued to running to completed/failed. Core domain object (`AgentRun` model). |
 | **Focused Agent Run** | An agent run scoped to a single, narrow problem class (e.g., CI fix, review response) rather than all PR problems at once. See RDR-031. |
 | **Runner** | A code execution backend (e.g., Claude Code, Copilot, Aider, OpenCode, Kilocode) that performs agent work. Formerly called "Provider" in code. Renamed in #1950. NOT the same as an LLM provider. |
-| **Runner State** | The operational status record for a runner (healthy, degraded, circuit-open, etc.). Formerly `provider_states`. Renamed in #1950. |
+| **Runner State** | The operational status record for a runner (healthy, degraded, circuit-open, etc.). This remains implemented through legacy `ProviderState` / `provider_states` identifiers even though the domain concept is runner health. |
 | **Runner Key** | The unique identifier string for a specific runner (e.g., `claude_code`, `copilot`). Formerly `provider_key`. Renamed in #1950. |
 | **Agent Harness** | The shared execution framework (`agent_harness` gem) that wraps individual runners, providing plan-only APIs, heartbeats, and lifecycle management. All LLM calls must go through this gem. |
 
@@ -25,15 +25,15 @@ This glossary defines terms specific to the Paid platform that are not industry-
 | **Orchestration Decision** | A logged record of why the system chose a particular runner, decomposition, or retry path. Used for observability and scaling analysis. |
 | **Coordination Policy** | Rules governing how multiple concurrent agent runs interact, avoid conflicts, and escalate. Evolved via the coordination evolution workflow. |
 | **Decomposition** | Breaking a complex issue into smaller sub-tasks that can be handled by individual agent runs. Policy-based via `DecompositionService`. |
-| **Escalation** | Promoting an agent run issue to human review when confidence is low or the task exceeds agent capability. Driven by `EscalationService` with human-value prediction. |
-| **Optimizer** | The Bayesian optimization system that ranks runner/configuration candidates and balances exploration vs. exploitation. `Optimizer.ranked_candidates`. |
+| **Escalation** | Promoting an agent run issue to human review when confidence is low or the task exceeds agent capability. Driven by `Coordination::EscalationService` with human-value prediction. |
+| **Optimizer** | The Bayesian optimization system that ranks runner/configuration candidates and balances exploration vs. exploitation. `ConfigurationBundles::Optimizer.ranked_candidates`. |
 
 ## Infrastructure
 
 | Term | Definition |
 |------|-----------|
 | **Workspace** | The isolated filesystem environment (Docker volume or local directory) where a runner executes code changes. Container-managed via Docker or Swarm backend. |
-| **Circuit Breaker** | Per-runner failure tracking that temporarily disables a runner after repeated failures. Transitions between closed/open/half-open states on `RunnerState`. |
+| **Circuit Breaker** | Per-runner failure tracking that temporarily disables a runner after repeated failures. Transitions between closed/open/half-open states on legacy `ProviderState` records. |
 | **Smoke Test / Test Agent** | A lightweight validation run that verifies a runner is functional (auth works, CLI responds). Used for health checks and onboarding. |
 | **Watchdog** | A background thread that monitors running agent containers for hangs, timeouts, and silent failures via heartbeat-based liveness detection. |
 | **Tenant** | A top-level organizational unit (GitHub org or team) that owns projects, users, runners, and settings. Multi-tenancy boundary. |
@@ -58,6 +58,6 @@ These terms refer to LLM providers (not runners) and were intentionally kept dur
 
 ## References
 
-- [#1950](https://github.com/paidplatform/paid/pull/1950) — feat(runners): rename providers to runners (phase 1)
-- [#1945](https://github.com/paidplatform/paid/issues/1945) — original issue motivating the rename
-- [RDR-031](docs/rdrs/RDR-031-focused-agent-runs.md) — Focused Agent Runs architecture
+- [#1950](https://github.com/viamin/paid/pull/1950) — feat(runners): rename providers to runners (phase 1)
+- [#1945](https://github.com/viamin/paid/issues/1945) — original issue motivating the rename
+- [RDR-031](rdrs/RDR-031-focused-agent-runs.md) — Focused Agent Runs architecture

--- a/docs/rdrs/README.md
+++ b/docs/rdrs/README.md
@@ -188,6 +188,7 @@ Key sections:
 
 ## Related Documents
 
+- [GLOSSARY.md](../GLOSSARY.md) - Paid-specific terminology and naming conventions
 - [VISION.md](../VISION.md) - Project philosophy and principles
 - [ARCHITECTURE.md](../ARCHITECTURE.md) - System architecture overview
 - [ROADMAP.md](../ROADMAP.md) - Implementation phases


### PR DESCRIPTION
## Summary

Adds a canonical glossary of Paid-specific terminology to prevent the kind of naming ambiguity that motivated the recent `provider` → `runner` rename (#1950). The glossary documents 23 domain terms so future code, UI, docs, and discussions converge on consistent naming, especially around overloaded terms like "provider" (LLM vendor) vs. "runner" (execution backend).

## Changes

- **Documentation**
  - Added `docs/GLOSSARY.md` with 23 Paid-specific terms organized into four sections: Core Domain, Orchestration, Infrastructure, and External Integrations.
  - Included a dedicated section documenting terms that intentionally retain the word "provider" (e.g., `ProviderApiKey`, `LlmModel.provider`) to clarify the boundary between LLM vendor and execution backend concepts.
- **Discoverability**
  - Updated `CONTRIBUTING.md` to reference the glossary in the documentation list so new contributors find it during onboarding.
  - Updated `docs/rdrs/README.md` to link the glossary from the Related Documents section, anchoring it alongside architectural decision records.

## Design Decisions

- **Glossary as a standalone doc rather than inlined into `CLAUDE.md` or `ARCHITECTURE.md`** — keeps a single, scannable reference that can be linked from issues and PRs without bloating higher-traffic docs.
- **Explicit "Runner" vs. "LLM Provider" distinction** — codifies the split established in #1950 and calls out the retained `provider` identifiers so future renames don't accidentally sweep them up.
- **Grouped by concern, not alphabetized** — readers usually arrive looking for a domain area (orchestration, infra) rather than a specific letter; sectioning makes the conceptual model easier to absorb.

---

Closes #2062