### PR TITLE
fix(containers): auto-detect and link service containers when unconfigured (#2067)

### DIFF
--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -88,6 +88,21 @@ module Projects
     # to Ruby objects.
     MAX_YAML_ALIASES = 100
 
+    # Maps canonical service names to image patterns used as a fallback when
+    # no ServiceContainer exists with an exactly-matching name. Allows containers
+    # named "Screenshot Postgres" or "Dev Redis" to be matched to the
+    # "postgres" / "redis" services detected from the repo.
+    IMAGE_SERVICE_PATTERNS = {
+      "postgres" => /postgres/,
+      "redis" => /redis/,
+      "mysql" => /mysql|mariadb/,
+      "mongodb" => /mongo/,
+      "elasticsearch" => /elasticsearch|opensearch/,
+      "memcached" => /memcache/,
+      "selenium" => /selenium/,
+      "chromium" => /chromium/
+    }.freeze
+
     attr_reader :project
 
     def initialize(project:)
@@ -107,7 +122,7 @@ module Projects
 
       unique_services = detections.uniq { |d| d[:service] }
       detected_names = unique_services.map { |d| d[:service] }
-      containers = ServiceContainer.where(name: detected_names).index_by(&:name)
+      containers = matching_containers(detected_names)
 
       matched = []
       unmatched = []
@@ -129,6 +144,27 @@ module Projects
     end
 
     private
+
+    # Finds ServiceContainer records matching the given canonical service names.
+    # Tries exact name match first (e.g. name == "postgres"), then falls back
+    # to image-pattern matching so containers named "Screenshot Postgres" or
+    # "Dev Redis" are still matched to their canonical service.
+    def matching_containers(detected_names)
+      by_name = ServiceContainer.where(name: detected_names).index_by(&:name)
+      remaining = detected_names.reject { |n| by_name.key?(n) }
+      return by_name if remaining.empty?
+
+      ServiceContainer.all.each do |sc|
+        remaining.each do |service_name|
+          next if by_name.key?(service_name)
+
+          pattern = IMAGE_SERVICE_PATTERNS[service_name]
+          by_name[service_name] = sc if pattern && sc.image.match?(pattern)
+        end
+      end
+
+      by_name
+    end
 
     def fetch_file(path)
       client = project.github_token.client

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -99,8 +99,7 @@ module Projects
       "mongodb" => /mongo/,
       "elasticsearch" => /elasticsearch|opensearch/,
       "memcached" => /memcache/,
-      "selenium" => /selenium/,
-      "chromium" => /chromium/
+      "selenium" => /selenium/
     }.freeze
 
     attr_reader :project
@@ -145,16 +144,18 @@ module Projects
 
     private
 
-    # Finds ServiceContainer records matching the given canonical service names.
+    # Finds ServiceContainer records matching the given canonical service names,
+    # scoped to the project's account to prevent cross-tenant matches.
     # Tries exact name match first (e.g. name == "postgres"), then falls back
     # to image-pattern matching so containers named "Screenshot Postgres" or
     # "Dev Redis" are still matched to their canonical service.
     def matching_containers(detected_names)
-      by_name = ServiceContainer.where(name: detected_names).index_by(&:name)
+      account_scope = ServiceContainer.where(account_id: project.account_id)
+      by_name = account_scope.where(name: detected_names).index_by(&:name)
       remaining = detected_names.reject { |n| by_name.key?(n) }
       return by_name if remaining.empty?
 
-      ServiceContainer.all.each do |sc|
+      account_scope.each do |sc|
         remaining.each do |service_name|
           next if by_name.key?(service_name)
 

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -160,7 +160,7 @@ module Projects
       remaining = detected_names.reject { |n| by_name.key?(n) }
       return by_name if remaining.empty?
 
-      account_scope.each do |sc|
+      account_scope.order(:name).each do |sc|
         remaining.each do |service_name|
           next if by_name.key?(service_name)
 

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -92,7 +92,20 @@ module Projects
     # no ServiceContainer exists with an exactly-matching name. Allows containers
     # named "Screenshot Postgres" or "Dev Redis" to be matched to the
     # "postgres" / "redis" services detected from the repo.
-    IMAGE_SERVICE_PATTERNS = COMPOSE_IMAGE_PATTERNS.invert.freeze
+    #
+    # Defined explicitly (rather than derived from COMPOSE_IMAGE_PATTERNS.invert)
+    # so that adding a second regex for the same service (e.g. /\bpg\b/ for
+    # "postgres") does not silently drop entries — Hash#invert keeps only the
+    # last key when values collide.
+    IMAGE_SERVICE_PATTERNS = {
+      "postgres" => /postgres/,
+      "redis" => /redis/,
+      "mysql" => /mysql|mariadb/,
+      "mongodb" => /mongo/,
+      "elasticsearch" => /elasticsearch|opensearch/,
+      "memcached" => /memcache/,
+      "selenium" => /selenium/
+    }.freeze
 
     attr_reader :project
 

--- a/app/services/projects/detect_services.rb
+++ b/app/services/projects/detect_services.rb
@@ -92,15 +92,7 @@ module Projects
     # no ServiceContainer exists with an exactly-matching name. Allows containers
     # named "Screenshot Postgres" or "Dev Redis" to be matched to the
     # "postgres" / "redis" services detected from the repo.
-    IMAGE_SERVICE_PATTERNS = {
-      "postgres" => /postgres/,
-      "redis" => /redis/,
-      "mysql" => /mysql|mariadb/,
-      "mongodb" => /mongo/,
-      "elasticsearch" => /elasticsearch|opensearch/,
-      "memcached" => /memcache/,
-      "selenium" => /selenium/
-    }.freeze
+    IMAGE_SERVICE_PATTERNS = COMPOSE_IMAGE_PATTERNS.invert.freeze
 
     attr_reader :project
 

--- a/app/temporal/activities/provision_services_activity.rb
+++ b/app/temporal/activities/provision_services_activity.rb
@@ -48,8 +48,8 @@ module Activities
 
       added = result.apply(project)
 
+      project.service_containers.reset if result.matched.any?
       if added.any?
-        project.service_containers.reset
         logger.info(
           message: "agent_execution.service_containers_auto_linked",
           project_id: project.id,

--- a/app/temporal/activities/provision_services_activity.rb
+++ b/app/temporal/activities/provision_services_activity.rb
@@ -4,7 +4,12 @@ module Activities
   # Provisions shared service containers (PostgreSQL, Redis, etc.) needed by
   # the project. Returns environment variables for the agent container.
   #
-  # Skipped if the project has no service containers configured.
+  # When no service containers are configured for the project, attempts to
+  # auto-detect required services from the repository (Gemfile, package.json,
+  # config/database.yml, docker-compose.yml) and link matching account-level
+  # containers. This handles the common case where a project has not been
+  # through the "Detect Services" UI flow. Auto-detection is non-fatal —
+  # failures are logged and the run continues without services.
   class ProvisionServicesActivity < BaseActivity
     activity_name "ProvisionServices"
 
@@ -12,6 +17,8 @@ module Activities
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
       track_phase(agent_run_id: agent_run_id, phase_key: "provision_services", phase_group: "setup", agent_run: agent_run) do
+        auto_link_services_if_unconfigured(agent_run.project)
+
         provisioner = Containers::ServiceProvisioner.new
         env_vars = provisioner.provision(agent_run, network: Containers::Provision.network_for(agent_run: agent_run))
 
@@ -23,6 +30,48 @@ module Activities
 
         { agent_run_id: agent_run_id, service_environment: env_vars }
       end
+    end
+
+    private
+
+    # When a project has no service containers linked, attempt to auto-detect
+    # required services from the repository (Gemfile, package.json, etc.) and
+    # link any matching account-level containers. This ensures agent runs have
+    # access to services like PostgreSQL without requiring manual UI configuration.
+    #
+    # Non-fatal: failures are logged and do not block the agent run.
+    def auto_link_services_if_unconfigured(project)
+      return if project.service_containers.any?
+
+      result = Projects::DetectServices.call(project: project)
+      return if result.detected.empty?
+
+      added = result.apply(project)
+
+      if added.any?
+        project.service_containers.reset
+        logger.info(
+          message: "agent_execution.service_containers_auto_linked",
+          project_id: project.id,
+          services: added
+        )
+      end
+
+      if result.unmatched.any?
+        logger.warn(
+          message: "agent_execution.service_containers_unmatched",
+          project_id: project.id,
+          needed: result.unmatched.map { |d| d[:service] },
+          hint: "Create service containers in the account admin UI for the listed services."
+        )
+      end
+    rescue => e
+      logger.warn(
+        message: "agent_execution.auto_link_services_failed",
+        project_id: project.id,
+        error_class: e.class.name,
+        error: e.message
+      )
     end
   end
 end

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -9,15 +9,11 @@ RSpec.describe Projects::DetectServices do
 
   # Use lightweight stubs for AR models to avoid DB connections during class loading
   let(:github_token_stub) { Struct.new(:client).new(github_client) }
-  let(:project) { Struct.new(:owner, :repo, :github_token).new("test-owner", "test-repo", github_token_stub) }
+  let(:project) { Struct.new(:owner, :repo, :github_token, :account_id).new("test-owner", "test-repo", github_token_stub, 1) }
 
   let(:service_container_class) do
     Class.new do
-      def self.where(name:)
-        raise "stub me"
-      end
-
-      def self.all
+      def self.where(**_kwargs)
         raise "stub me"
       end
     end
@@ -27,8 +23,11 @@ RSpec.describe Projects::DetectServices do
     stub_const("ServiceContainer", service_container_class)
     # Default: all files return NotFound
     allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError)
-    # Default: no service containers exist
-    allow(service_container_class).to receive_messages(where: double(index_by: {}), all: [])
+    # Default: no service containers exist in this account
+    empty_scope = instance_double(ActiveRecord::Relation)
+    allow(empty_scope).to receive(:where).and_return(double(index_by: {}))
+    allow(empty_scope).to receive(:each)
+    allow(service_container_class).to receive(:where).and_return(empty_scope)
   end
 
   def stub_file(path, content)
@@ -39,21 +38,29 @@ RSpec.describe Projects::DetectServices do
       .and_return(response)
   end
 
+  # Stubs account-scoped ServiceContainer queries for named containers.
+  # Exact-name queries return all stubbed containers; the fallback scan
+  # also iterates them (matching by image pattern when names differ).
   def stub_containers(*names)
     containers_by_name = names.each_with_object({}) do |name, hash|
       hash[name] = Struct.new(:name, :image).new(name, "#{name}:latest")
     end
-    relation = double(index_by: containers_by_name)
-    allow(service_container_class).to receive_messages(where: relation, all: containers_by_name.values)
+    account_scope = instance_double(ActiveRecord::Relation)
+    allow(account_scope).to receive(:where).and_return(double(index_by: containers_by_name))
+    allow(account_scope).to receive(:each) { |&block| containers_by_name.values.each(&block) }
+    allow(service_container_class).to receive(:where).and_return(account_scope)
     containers_by_name
   end
 
+  # Stubs account-scoped ServiceContainer queries where containers have custom
+  # names but recognizable images (e.g. "My Postgres" => "postgres:16").
+  # Exact-name queries find nothing; the fallback scan iterates all containers.
   def stub_containers_by_image(containers_spec)
-    # containers_spec: { "My Postgres" => "postgres:16", "My Redis" => "redis:7" }
-    containers = containers_spec.map do |name, image|
-      Struct.new(:name, :image).new(name, image)
-    end
-    allow(service_container_class).to receive_messages(where: double(index_by: {}), all: containers)
+    containers = containers_spec.map { |name, image| Struct.new(:name, :image).new(name, image) }
+    account_scope = instance_double(ActiveRecord::Relation)
+    allow(account_scope).to receive(:where).and_return(double(index_by: {}))
+    allow(account_scope).to receive(:each) { |&block| containers.each(&block) }
+    allow(service_container_class).to receive(:where).and_return(account_scope)
     containers.index_by(&:name)
   end
 
@@ -138,7 +145,12 @@ RSpec.describe Projects::DetectServices do
       it "prefers exact name match over image-pattern match" do
         containers = stub_containers("postgres")
         image_container = Struct.new(:name, :image).new("Other Postgres", "postgres:16")
-        allow(service_container_class).to receive(:all).and_return([ containers["postgres"], image_container ])
+        # Both containers must be visible in the fallback scan; exact-name lookup
+        # still returns only the canonical "postgres" container.
+        account_scope = instance_double(ActiveRecord::Relation)
+        allow(account_scope).to receive(:where).and_return(double(index_by: { "postgres" => containers["postgres"] }))
+        allow(account_scope).to receive(:each) { |&block| [ containers["postgres"], image_container ].each(&block) }
+        allow(service_container_class).to receive(:where).and_return(account_scope)
 
         result = described_class.call(project: project)
 
@@ -154,6 +166,17 @@ RSpec.describe Projects::DetectServices do
 
         unmatched_services = result.unmatched.map { |d| d[:service] }
         expect(unmatched_services).to include("postgres", "redis")
+      end
+
+      it "scopes container lookups to the project's own account" do
+        scope = instance_double(ActiveRecord::Relation)
+        allow(scope).to receive(:where).and_return(double(index_by: {}))
+        allow(scope).to receive(:each)
+        expect(service_container_class).to receive(:where)
+          .with(hash_including(account_id: project.account_id))
+          .and_return(scope)
+
+        described_class.call(project: project)
       end
     end
 

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Projects::DetectServices do
       def self.where(name:)
         raise "stub me"
       end
+
+      def self.all
+        raise "stub me"
+      end
     end
   end
 
@@ -24,7 +28,7 @@ RSpec.describe Projects::DetectServices do
     # Default: all files return NotFound
     allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError)
     # Default: no service containers exist
-    allow(service_container_class).to receive(:where).and_return(double(index_by: {}))
+    allow(service_container_class).to receive_messages(where: double(index_by: {}), all: [])
   end
 
   def stub_file(path, content)
@@ -37,11 +41,20 @@ RSpec.describe Projects::DetectServices do
 
   def stub_containers(*names)
     containers_by_name = names.each_with_object({}) do |name, hash|
-      hash[name] = Struct.new(:name).new(name)
+      hash[name] = Struct.new(:name, :image).new(name, "#{name}:latest")
     end
     relation = double(index_by: containers_by_name)
-    allow(service_container_class).to receive(:where).and_return(relation)
+    allow(service_container_class).to receive_messages(where: relation, all: containers_by_name.values)
     containers_by_name
+  end
+
+  def stub_containers_by_image(containers_spec)
+    # containers_spec: { "My Postgres" => "postgres:16", "My Redis" => "redis:7" }
+    containers = containers_spec.map do |name, image|
+      Struct.new(:name, :image).new(name, image)
+    end
+    allow(service_container_class).to receive_messages(where: double(index_by: {}), all: containers)
+    containers.index_by(&:name)
   end
 
   describe ".call" do
@@ -101,6 +114,46 @@ RSpec.describe Projects::DetectServices do
           unmatched_services = result.unmatched.map { |d| d[:service] }
           expect(unmatched_services).to include("postgres", "redis")
         end
+      end
+    end
+
+    context "when a container exists with matching image but non-canonical name" do
+      before do
+        stub_file("Gemfile", <<~GEMFILE)
+          gem "pg"
+          gem "redis"
+        GEMFILE
+      end
+
+      it "matches postgres by image pattern when no container is named 'postgres'" do
+        stub_containers_by_image("Screenshot Postgres" => "postgres:16", "My Redis" => "redis:7-alpine")
+
+        result = described_class.call(project: project)
+
+        matched_names = result.matched.map(&:name)
+        expect(matched_names).to include("Screenshot Postgres", "My Redis")
+        expect(result.unmatched).to be_empty
+      end
+
+      it "prefers exact name match over image-pattern match" do
+        containers = stub_containers("postgres")
+        image_container = Struct.new(:name, :image).new("Other Postgres", "postgres:16")
+        allow(service_container_class).to receive(:all).and_return([ containers["postgres"], image_container ])
+
+        result = described_class.call(project: project)
+
+        matched_names = result.matched.map(&:name)
+        expect(matched_names).to include("postgres")
+        expect(matched_names).not_to include("Other Postgres")
+      end
+
+      it "reports unmatched when no container image matches" do
+        stub_containers_by_image("My MySQL" => "mysql:8")
+
+        result = described_class.call(project: project)
+
+        unmatched_services = result.unmatched.map { |d| d[:service] }
+        expect(unmatched_services).to include("postgres", "redis")
       end
     end
 

--- a/spec/services/projects/detect_services_spec.rb
+++ b/spec/services/projects/detect_services_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Projects::DetectServices do
     allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError)
     # Default: no service containers exist in this account
     empty_scope = instance_double(ActiveRecord::Relation)
-    allow(empty_scope).to receive(:where).and_return(double(index_by: {}))
+    allow(empty_scope).to receive_messages(where: double(index_by: {}), order: empty_scope)
     allow(empty_scope).to receive(:each)
     allow(service_container_class).to receive(:where).and_return(empty_scope)
   end
@@ -46,7 +46,7 @@ RSpec.describe Projects::DetectServices do
       hash[name] = Struct.new(:name, :image).new(name, "#{name}:latest")
     end
     account_scope = instance_double(ActiveRecord::Relation)
-    allow(account_scope).to receive(:where).and_return(double(index_by: containers_by_name))
+    allow(account_scope).to receive_messages(where: double(index_by: containers_by_name), order: account_scope)
     allow(account_scope).to receive(:each) { |&block| containers_by_name.values.each(&block) }
     allow(service_container_class).to receive(:where).and_return(account_scope)
     containers_by_name
@@ -58,7 +58,7 @@ RSpec.describe Projects::DetectServices do
   def stub_containers_by_image(containers_spec)
     containers = containers_spec.map { |name, image| Struct.new(:name, :image).new(name, image) }
     account_scope = instance_double(ActiveRecord::Relation)
-    allow(account_scope).to receive(:where).and_return(double(index_by: {}))
+    allow(account_scope).to receive_messages(where: double(index_by: {}), order: account_scope)
     allow(account_scope).to receive(:each) { |&block| containers.each(&block) }
     allow(service_container_class).to receive(:where).and_return(account_scope)
     containers.index_by(&:name)
@@ -148,7 +148,7 @@ RSpec.describe Projects::DetectServices do
         # Both containers must be visible in the fallback scan; exact-name lookup
         # still returns only the canonical "postgres" container.
         account_scope = instance_double(ActiveRecord::Relation)
-        allow(account_scope).to receive(:where).and_return(double(index_by: { "postgres" => containers["postgres"] }))
+        allow(account_scope).to receive_messages(where: double(index_by: { "postgres" => containers["postgres"] }), order: account_scope)
         allow(account_scope).to receive(:each) { |&block| [ containers["postgres"], image_container ].each(&block) }
         allow(service_container_class).to receive(:where).and_return(account_scope)
 
@@ -170,7 +170,7 @@ RSpec.describe Projects::DetectServices do
 
       it "scopes container lookups to the project's own account" do
         scope = instance_double(ActiveRecord::Relation)
-        allow(scope).to receive(:where).and_return(double(index_by: {}))
+        allow(scope).to receive_messages(where: double(index_by: {}), order: scope)
         allow(scope).to receive(:each)
         expect(service_container_class).to receive(:where)
           .with(hash_including(account_id: project.account_id))

--- a/spec/temporal/activities/provision_services_activity_spec.rb
+++ b/spec/temporal/activities/provision_services_activity_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe Activities::ProvisionServicesActivity do
   let(:project) { create(:project) }
   let(:agent_run) { create(:agent_run, project: project) }
 
+  before do
+    # Default: DetectServices finds nothing (prevents GitHub API calls in existing tests)
+    allow(Projects::DetectServices).to receive(:call).and_return(
+      instance_double(Projects::DetectServices::Result, detected: [], matched: [], unmatched: [], apply: [])
+    )
+  end
+
   describe "#execute" do
     it "provisions service containers and returns environment variables" do
       provisioner = instance_double(Containers::ServiceProvisioner)
@@ -56,6 +63,86 @@ RSpec.describe Activities::ProvisionServicesActivity do
       expect {
         activity.execute(agent_run_id: -1)
       }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "when the project has no service containers configured" do
+      let(:service_container) { create(:service_container, account: project.account, image: "postgres:16", name: "Dev Postgres", port: 5432) }
+      let(:detect_result) do
+        instance_double(
+          Projects::DetectServices::Result,
+          detected: [ { service: "postgres", source: "Gemfile", dependency: "pg" } ],
+          matched: [ service_container ],
+          unmatched: []
+        )
+      end
+
+      before do
+        allow(Projects::DetectServices).to receive(:call).with(project: project).and_return(detect_result)
+        allow(detect_result).to receive(:apply).with(project).and_return([ "Dev Postgres" ])
+      end
+
+      it "auto-detects and links service containers before provisioning" do
+        provisioner = instance_double(Containers::ServiceProvisioner)
+        allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+        allow(provisioner).to receive(:provision).and_return({ "DATABASE_URL" => "postgres://..." })
+        allow(Containers::Provision).to receive(:network_for).with(agent_run: agent_run).and_return(NetworkPolicy::NETWORK_NAME)
+        allow(agent_run).to receive(:service_container_ids).and_return([])
+
+        activity.execute(agent_run_id: agent_run.id)
+
+        expect(Projects::DetectServices).to have_received(:call).with(project: project)
+        expect(detect_result).to have_received(:apply).with(project)
+      end
+
+      it "skips auto-detect when the project already has service containers" do
+        create(:project_service_container, project: project, service_container: service_container)
+
+        provisioner = instance_double(Containers::ServiceProvisioner)
+        allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+        allow(provisioner).to receive(:provision).and_return({})
+        allow(Containers::Provision).to receive(:network_for).with(agent_run: agent_run).and_return(NetworkPolicy::NETWORK_NAME)
+        allow(agent_run).to receive(:service_container_ids).and_return([ service_container.id ])
+
+        activity.execute(agent_run_id: agent_run.id)
+
+        expect(Projects::DetectServices).not_to have_received(:call)
+      end
+
+      it "continues without services when auto-detect fails" do
+        allow(Projects::DetectServices).to receive(:call).and_raise(GithubClient::RateLimitError)
+
+        provisioner = instance_double(Containers::ServiceProvisioner)
+        allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+        allow(provisioner).to receive(:provision).and_return({})
+        allow(Containers::Provision).to receive(:network_for).with(agent_run: agent_run).and_return(NetworkPolicy::NETWORK_NAME)
+        allow(agent_run).to receive(:service_container_ids).and_return([])
+
+        expect { activity.execute(agent_run_id: agent_run.id) }.not_to raise_error
+      end
+
+      it "logs a warning when needed services have no matching account container" do
+        unmatched_result = instance_double(
+          Projects::DetectServices::Result,
+          detected: [ { service: "postgres", source: "Gemfile", dependency: "pg" } ],
+          matched: [],
+          unmatched: [ { service: "postgres", source: "Gemfile" } ]
+        )
+        allow(unmatched_result).to receive(:apply).with(project).and_return([])
+        allow(Projects::DetectServices).to receive(:call).and_return(unmatched_result)
+        allow(activity).to receive(:logger).and_return(Rails.logger)
+
+        provisioner = instance_double(Containers::ServiceProvisioner)
+        allow(Containers::ServiceProvisioner).to receive(:new).and_return(provisioner)
+        allow(provisioner).to receive(:provision).and_return({})
+        allow(Containers::Provision).to receive(:network_for).with(agent_run: agent_run).and_return(NetworkPolicy::NETWORK_NAME)
+        allow(agent_run).to receive(:service_container_ids).and_return([])
+
+        expect(Rails.logger).to receive(:warn).with(
+          hash_including(message: "agent_execution.service_containers_unmatched", project_id: project.id)
+        )
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- **Root cause**: PR-branch agent runs lacked `DATABASE_URL` because `project.service_containers` was empty — no `ProjectServiceContainer` join record existed, even when the account had PostgreSQL containers configured.
- **Fix 1 — Auto-detect in `ProvisionServicesActivity`**: When a project has no linked service containers, the activity now calls `Projects::DetectServices` to inspect the repo (Gemfile, package.json, docker-compose.yml, config/database.yml), applies any matched containers, and resets the AR association cache before provisioning. Failures are non-fatal: logged as a warning and the run continues without services.
- **Fix 2 — Image-pattern fallback in `DetectServices`**: Matching now falls back to image-pattern matching when no container has a canonical name match. A container named "Screenshot Postgres" with `image: postgres:16` now correctly matches the detected `"postgres"` service.

## Test plan

- [ ] `bin/rspec spec/services/projects/detect_services_spec.rb` — new contexts for image-pattern matching and preference of exact name over image match
- [ ] `bin/rspec spec/temporal/activities/provision_services_activity_spec.rb` — new contexts for auto-link behavior (detects and links, skips when already configured, handles failures gracefully, warns on unmatched)
- [ ] Manually trigger an agent run on a PR branch for a Rails project whose account has a postgres service container — verify `DATABASE_URL` is injected and the agent sees PostgreSQL

Fixes #2067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)