### PR TITLE
perf(tests): reduce record creation overhead in slow specs

### DIFF
--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -449,6 +449,7 @@ RSpec.describe AgentRun do
 
   describe ".stale_running_timeout" do
     it "falls back to the legacy timeout when healthy history is insufficient" do
+      stub_const("AgentRun::STALE_RUNNING_HEALTHY_MIN_SAMPLE_SIZE", 3)
       create_list(:agent_run, described_class::STALE_RUNNING_HEALTHY_MIN_SAMPLE_SIZE - 1,
         :completed,
         :review_goal,
@@ -460,6 +461,7 @@ RSpec.describe AgentRun do
     end
 
     it "uses no_output runs in the healthy baseline" do
+      stub_const("AgentRun::STALE_RUNNING_HEALTHY_MIN_SAMPLE_SIZE", 3)
       create_list(:agent_run, described_class::STALE_RUNNING_HEALTHY_MIN_SAMPLE_SIZE,
         :no_output,
         :review_goal,

--- a/spec/services/agent_runs/cleanup_stale_spec.rb
+++ b/spec/services/agent_runs/cleanup_stale_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe AgentRuns::CleanupStale do
     end
 
     it "uses adaptive goal-aware stale thresholds for running runs" do
+      stub_const("AgentRun::STALE_RUNNING_HEALTHY_MIN_SAMPLE_SIZE", 3)
       create_list(:agent_run, AgentRun::STALE_RUNNING_HEALTHY_MIN_SAMPLE_SIZE,
         :completed,
         :review_goal,

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -117,9 +117,7 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue)
 
-        Activities::HandleNoOutputIssueRunActivity::CLASSIFICATION_LOG_LIMIT.times do |i|
-          agent_run.log!("stdout", "progress line #{i}")
-        end
+        5.times { |i| agent_run.log!("stdout", "progress line #{i}") }
         agent_run.log!("stderr", "Free model usage limit reached. Please try again later.")
 
         result = activity.execute(agent_run_id: agent_run.id, output_present: false)


### PR DESCRIPTION
## Summary

- **Stub `STALE_RUNNING_HEALTHY_MIN_SAMPLE_SIZE` to 3** in three tests that were creating 19–20 `AgentRun` records (each with its own separate project/account) just to clear the adaptive-timeout sample threshold. The boundary conditions under test are identical with 2–3 records.
- **Reduce `CLASSIFICATION_LOG_LIMIT` log insertions from 500 → 5** in the provider-error classification test. Detecting a keyword match in recent logs doesn't require filling the 500-entry buffer — any small number of prior "noise" logs followed by the error line is sufficient.

## Affected tests (from the slowest-examples report)

| Test | Before | Expected after |
|------|--------|----------------|
| `AgentRun.stale_running_timeout` — no_output baseline | ~2.5s | <0.2s |
| `AgentRuns::CleanupStale` — adaptive goal-aware thresholds | ~3.1s | <0.2s |
| `Activities::HandleNoOutputIssueRunActivity` — classifies hidden provider output | ~3.2s | <0.2s |

Estimated ~8s off three tests without changing what they verify.

## What wasn't changed

- `worktree_spec.rb:115` — the 233s outlier was specific to seed 25069 and has no structural cause in the test code (no callbacks, no triggers, trivial update). Likely a one-off DB lock wait from an unlucky test ordering; no code change needed.
- Migration specs and system specs — inherently slow by nature.

## Test plan
- [ ] `bin/rspec spec/models/agent_run_spec.rb -e "stale_running_timeout"` — both tests pass
- [ ] `bin/rspec spec/services/agent_runs/cleanup_stale_spec.rb -e "adaptive goal-aware"` — passes
- [ ] `bin/rspec spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb -e "classifies hidden provider output"` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)