### PR TITLE
fix(providers): support pi api-key auth in paid

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -483,19 +483,7 @@ class ProvidersController < ApplicationController
   end
 
   def compatible_api_key_for_provider?(api_key:, provider_key:)
-    # OpenCode and KiloCode support multiple API key types depending on the
-    # selected api_provider, so check against all compatible service types.
-    if %w[opencode kilocode].include?(provider_key)
-      return Provider::DIRECT_OUTBOUND_SERVICE_TYPES.include?(api_key.api_service_type)
-    end
-
-    # Pi also chooses its upstream API provider per-entry, but its supported
-    # service types are narrower than the direct-outbound set above.
-    if provider_key == "pi"
-      return Provider::PI_API_PROVIDERS.values.any? { |config| config[:service_type] == api_key.api_service_type }
-    end
-
-    api_key.api_service_type == Provider.api_service_type_for(provider_key)
+    api_key.compatible_with?(provider_key)
   end
 
   def enabled_agent_provider_identifiers

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -163,7 +163,7 @@ class ProvidersController < ApplicationController
     end
     attrs = params.require(:provider).permit(
       *permitted,
-      config: { opencode: [ :api_provider, :model ], kilocode: [ :api_provider, :model ] },
+      config: { opencode: [ :api_provider, :model ], kilocode: [ :api_provider, :model ], pi: [ :api_provider, :model ] },
       tier_model_ids: LlmModel::TIERS,
       complexity_thresholds: Provider::COMPLEXITY_THRESHOLD_KEYS
     )
@@ -487,6 +487,12 @@ class ProvidersController < ApplicationController
     # selected api_provider, so check against all compatible service types.
     if %w[opencode kilocode].include?(provider_key)
       return Provider::DIRECT_OUTBOUND_SERVICE_TYPES.include?(api_key.api_service_type)
+    end
+
+    # Pi also chooses its upstream API provider per-entry, but its supported
+    # service types are narrower than the direct-outbound set above.
+    if provider_key == "pi"
+      return Provider::PI_API_PROVIDERS.values.any? { |config| config[:service_type] == api_key.api_service_type }
     end
 
     api_key.api_service_type == Provider.api_service_type_for(provider_key)

--- a/app/helpers/providers_helper.rb
+++ b/app/helpers/providers_helper.rb
@@ -49,6 +49,14 @@ module ProvidersHelper
         "If Copilot creds live elsewhere, set <code>COPILOT_HOME</code> (or Paid's legacy <code>COPILOT_CONFIG_DIR</code> override).",
         "Restart the <code>web</code> and <code>worker</code> services after changing credential mounts."
       ]
+    },
+    "pi" => {
+      summary: "Pi API-key auth is supported in Paid today:",
+      items: [
+        "API-key entries use a saved Provider API Key plus a provider-level Pi API Provider selection such as DeepSeek, OpenAI, or Anthropic.",
+        "Paid writes a request-scoped <code>~/.pi/agent/auth.json</code> inside the agent container so Pi uses the selected key deterministically.",
+        "Optional model IDs are passed through as <code>pi --model ...</code>; if left blank, Pi uses its default or previously selected model."
+      ]
     }
   }.freeze
 

--- a/app/javascript/controllers/provider_form_controller.js
+++ b/app/javascript/controllers/provider_form_controller.js
@@ -25,10 +25,10 @@ function loadProviderApiServiceType() {
 
 const PROVIDER_API_SERVICE_TYPE = loadProviderApiServiceType()
 
-// OpenCode and KiloCode support multiple upstream API providers, each with its
-// own API key type. The mapping is derived from data-service-type attributes on
-// the <option> elements rendered by the backend (Provider::DIRECT_OUTBOUND_API_PROVIDERS),
-// keeping the backend as the single source of truth.
+// OpenCode, KiloCode, and Pi support multiple upstream API providers, each
+// with its own API key type. The mapping is derived from data-service-type
+// attributes on the <option> elements rendered by the backend, keeping the
+// backend as the single source of truth.
 function loadDirectOutboundApiProviderServiceTypes() {
   const selects = document.querySelectorAll(
     "[data-provider-form-target='directOutboundApiProviderSelect']"
@@ -51,7 +51,7 @@ function loadDirectOutboundApiProviderServiceTypes() {
 }
 
 // Provider keys that use dynamic api_provider selection.
-const DYNAMIC_API_PROVIDER_KEYS = new Set(["opencode", "kilocode"])
+const DYNAMIC_API_PROVIDER_KEYS = new Set(["opencode", "kilocode", "pi"])
 
 export default class extends Controller {
   static values = {
@@ -68,6 +68,7 @@ export default class extends Controller {
     "apiKeyOption",
     "opencodeSettings",
     "kilocodeSettings",
+    "piSettings",
     "directOutboundApiProviderSelect",
     "tierSettings",
     "tierSelect",
@@ -118,6 +119,7 @@ export default class extends Controller {
     const isApiKey = this.providerApiKeyMode()
     const showOpenCodeSettings = isApiKey && providerKey === "opencode"
     const showKiloCodeSettings = isApiKey && providerKey === "kilocode"
+    const showPiSettings = isApiKey && providerKey === "pi"
 
     this.opencodeSettingsTargets.forEach((el) => {
       el.hidden = !showOpenCodeSettings
@@ -130,6 +132,13 @@ export default class extends Controller {
       el.hidden = !showKiloCodeSettings
       el.querySelectorAll("select, input").forEach((control) => {
         control.disabled = !showKiloCodeSettings
+      })
+    })
+
+    this.piSettingsTargets.forEach((el) => {
+      el.hidden = !showPiSettings
+      el.querySelectorAll("select, input").forEach((control) => {
+        control.disabled = !showPiSettings
       })
     })
 
@@ -189,7 +198,7 @@ export default class extends Controller {
   requiredApiServiceTypeFor(providerKey) {
     if (!providerKey) return null
 
-    // OpenCode and KiloCode determine their required API key type from
+    // OpenCode, KiloCode, and Pi determine their required API key type from
     // the selected api_provider dropdown.
     if (DYNAMIC_API_PROVIDER_KEYS.has(providerKey)) {
       const apiProvider = this.currentDirectOutboundApiProvider(providerKey)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -270,12 +270,6 @@ class Provider < ApplicationRecord
     PI_API_PROVIDERS.dig(pi_api_provider, :service_type)
   end
 
-  def pi_api_key_env_var
-    return nil unless provider_key == "pi"
-
-    PI_API_PROVIDERS.dig(pi_api_provider, :env_var)
-  end
-
   def aider_required_api_service_type
     return nil unless provider_key == "aider"
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -60,6 +60,22 @@ class Provider < ApplicationRecord
   AIDER_API_PROVIDER_KEYS = DIRECT_OUTBOUND_API_PROVIDERS.keys.freeze
   AIDER_DEFAULT_API_PROVIDER = "openrouter"
 
+  # Pi supports multiple upstream API-key providers selected via --provider.
+  # Keep this list aligned to providers Paid can represent as ProviderApiKey
+  # records and that Pi documents as built-in API-key auth targets.
+  PI_API_PROVIDERS = {
+    "anthropic" => { label: "Anthropic", service_type: "anthropic", env_var: "ANTHROPIC_API_KEY" },
+    "openai" => { label: "OpenAI", service_type: "openai", env_var: "OPENAI_API_KEY" },
+    "deepseek" => { label: "DeepSeek", service_type: "deepseek", env_var: "DEEPSEEK_API_KEY" },
+    "google" => { label: "Google Gemini", service_type: "google", env_var: "GEMINI_API_KEY" },
+    "mistral" => { label: "Mistral", service_type: "mistral", env_var: "MISTRAL_API_KEY" },
+    "xai" => { label: "xAI", service_type: "xai", env_var: "XAI_API_KEY" },
+    "zai" => { label: "z.ai", service_type: "zai", env_var: "ZAI_API_KEY" },
+    "openrouter" => { label: "OpenRouter", service_type: "openrouter", env_var: "OPENROUTER_API_KEY" }
+  }.freeze
+  PI_API_PROVIDER_KEYS = PI_API_PROVIDERS.keys.freeze
+  PI_DEFAULT_API_PROVIDER = "deepseek"
+
   DIRECT_OUTBOUND_MODEL_TIER_HINTS = {
     "glm-5.1" => "high",
     "glm-4.7" => "mid",
@@ -113,6 +129,7 @@ class Provider < ApplicationRecord
   validate :opencode_api_key_config_must_be_valid
   validate :kilocode_api_key_config_must_be_valid
   validate :aider_api_key_config_must_be_valid
+  validate :pi_api_key_config_must_be_valid
   validate :tier_model_ids_must_be_valid
   validate :complexity_thresholds_must_be_valid
   validate :agent_co_author_trailer_is_single_line
@@ -140,6 +157,7 @@ class Provider < ApplicationRecord
     when "opencode" then opencode_model_id
     when "kilocode" then kilocode_model_id
     when "aider" then aider_model_id
+    when "pi" then pi_model_id
     end
     label += " #{model_id}" if model_id.present?
     label += " (API Key)" if api_key?
@@ -228,6 +246,34 @@ class Provider < ApplicationRecord
     return nil unless provider_key == "aider"
 
     aider_config["model"].to_s.presence
+  end
+
+  def pi_config
+    config.is_a?(Hash) ? config.fetch("pi", {}) : {}
+  end
+
+  def pi_api_provider
+    return nil unless provider_key == "pi"
+
+    pi_config["api_provider"].presence || PI_DEFAULT_API_PROVIDER
+  end
+
+  def pi_model_id
+    return nil unless provider_key == "pi"
+
+    pi_config["model"].to_s.presence
+  end
+
+  def pi_required_api_service_type
+    return nil unless provider_key == "pi"
+
+    PI_API_PROVIDERS.dig(pi_api_provider, :service_type)
+  end
+
+  def pi_api_key_env_var
+    return nil unless provider_key == "pi"
+
+    PI_API_PROVIDERS.dig(pi_api_provider, :env_var)
   end
 
   def aider_required_api_service_type
@@ -332,12 +378,13 @@ class Provider < ApplicationRecord
 
   def agent_harness_provider_runtime
     return opencode_provider_runtime if opencode_direct_outbound?
+    return pi_provider_runtime if pi_agent_harness_runtime?
 
     nil
   end
 
   def agent_harness_runtime?
-    opencode_agent_harness_runtime? || copilot_agent_harness_runtime?
+    opencode_agent_harness_runtime? || copilot_agent_harness_runtime? || pi_agent_harness_runtime?
   end
 
   def opencode_agent_harness_runtime?
@@ -346,6 +393,12 @@ class Provider < ApplicationRecord
 
   def copilot_agent_harness_runtime?
     provider_key == "copilot"
+  end
+
+  def pi_agent_harness_runtime?
+    provider_key == "pi" &&
+      api_key? &&
+      PI_API_PROVIDER_KEYS.include?(pi_api_provider)
   end
 
   def direct_outbound_model_id
@@ -361,6 +414,7 @@ class Provider < ApplicationRecord
     when "kilocode" then kilocode_required_api_service_type
     when "opencode" then opencode_required_api_service_type
     when "aider" then aider_required_api_service_type
+    when "pi" then pi_required_api_service_type
     end
   end
 
@@ -649,6 +703,8 @@ class Provider < ApplicationRecord
       config.dig("kilocode", "model")
     when "aider"
       config.dig("aider", "model")
+    when "pi"
+      config.dig("pi", "model")
     end
   end
 
@@ -857,10 +913,20 @@ class Provider < ApplicationRecord
     end
   end
 
+  def pi_api_key_config_must_be_valid
+    return unless provider_key == "pi"
+    return unless api_key?
+
+    unless PI_API_PROVIDER_KEYS.include?(pi_api_provider)
+      errors.add(:config, "must include a supported Pi API provider")
+    end
+  end
+
   def required_api_service_type
     return opencode_required_api_service_type if provider_key == "opencode"
     return kilocode_required_api_service_type if provider_key == "kilocode"
     return aider_required_api_service_type if provider_key == "aider"
+    return pi_required_api_service_type if provider_key == "pi"
 
     self.class.api_service_type_for(provider_key)
   end
@@ -903,6 +969,19 @@ class Provider < ApplicationRecord
       metadata: {
         config: {
           "provider" => { opencode_api_provider => {} }
+        }
+      }
+    )
+  end
+
+  def pi_provider_runtime
+    AgentHarness::ProviderRuntime.new(
+      model: pi_model_id,
+      api_provider: pi_api_provider,
+      metadata: {
+        "paid_pi_auth_entry" => {
+          "provider" => pi_api_provider,
+          "api_key" => provider_api_key&.api_key.to_s
         }
       }
     )

--- a/app/models/provider_api_key.rb
+++ b/app/models/provider_api_key.rb
@@ -24,16 +24,16 @@ class ProviderApiKey < ApplicationRecord
   # Returns true when this API key's service type is compatible with the
   # given provider. Providers with a fixed service type (claude → anthropic)
   # are checked against ProviderSupport::PROVIDER_API_SERVICE_TYPE. Providers
-  # that support multiple upstream API providers (opencode, kilocode) are
-  # compatible with any service type in DIRECT_OUTBOUND_API_PROVIDERS.
-  DYNAMIC_API_PROVIDER_KEYS = %w[opencode kilocode].to_set.freeze
+  # that support multiple upstream API providers (opencode, kilocode, pi)
+  # resolve compatibility from their provider-specific service-type sets.
+  DYNAMIC_API_PROVIDER_KEYS = %w[opencode kilocode pi].to_set.freeze
 
   def compatible_with?(provider_key)
     static_type = ProviderSupport.api_service_type_for(provider_key)
     if static_type
       api_service_type == static_type
     elsif DYNAMIC_API_PROVIDER_KEYS.include?(provider_key.to_s)
-      Provider::DIRECT_OUTBOUND_SERVICE_TYPES.include?(api_service_type)
+      compatible_dynamic_service_type?(provider_key)
     else
       false
     end
@@ -57,6 +57,15 @@ class ProviderApiKey < ApplicationRecord
   end
 
   private
+
+  def compatible_dynamic_service_type?(provider_key)
+    case provider_key.to_s
+    when "pi"
+      Provider::PI_API_PROVIDERS.values.any? { |config| config[:service_type] == api_service_type }
+    else
+      Provider::DIRECT_OUTBOUND_SERVICE_TYPES.include?(api_service_type)
+    end
+  end
 
   def api_service_type_must_be_valid
     return if api_service_type.blank?

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -101,7 +101,9 @@ module AgentRuns
       return unless base_provider
       return unless provider_runnable?(base_provider)
 
-      service_type = ProviderSupport.api_service_type_for(base_provider.provider_key)
+      service_type = tenant_api_key_service_type_for(base_provider)
+      return unless service_type
+
       api_key = project.account.tenant_setting&.provider_api_key_for(service_type)
       return unless api_key
       return unless api_key.compatible_with?(base_provider.provider_key)
@@ -110,13 +112,37 @@ module AgentRuns
         provider_key: base_provider.provider_key,
         auth_type: "api_key",
         provider_api_key: api_key
-      )
+      ) do |provider|
+        provider.config = tenant_api_key_provider_config(base_provider, api_key)
+      end
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
       owner.providers.kept_only.find_by(
         provider_key: base_provider.provider_key,
         auth_type: "api_key",
         provider_api_key: api_key
       )
+    end
+
+    def tenant_api_key_service_type_for(base_provider)
+      static = ProviderSupport.api_service_type_for(base_provider.provider_key)
+      return static if static.present?
+      return base_provider.pi_required_api_service_type if base_provider.provider_key == "pi"
+
+      nil
+    end
+
+    def tenant_api_key_provider_config(base_provider, api_key)
+      return {} unless base_provider.provider_key == "pi"
+
+      config = {
+        "pi" => {
+          "api_provider" => api_key.api_service_type
+        }
+      }
+
+      model = project.account.tenant_setting&.model_preference_for("pi").to_s.presence
+      config["pi"]["model"] = model if model
+      config
     end
 
     def provider_for_id(provider_id)

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -114,6 +114,12 @@ module AgentRuns
         provider_api_key: api_key
       ) do |provider|
         provider.config = tenant_api_key_provider_config(base_provider, api_key)
+      end.tap do |provider|
+        # Config can drift between calls (e.g. tenant changes their Pi model
+        # preference in tenant_settings without rotating the API key). Sync it
+        # on every materialisation so the next agent run picks up the change.
+        fresh_config = tenant_api_key_provider_config(base_provider, api_key)
+        provider.update!(config: fresh_config) if fresh_config != provider.config
       end
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
       owner.providers.kept_only.find_by(

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -108,18 +108,18 @@ module AgentRuns
       return unless api_key
       return unless api_key.compatible_with?(base_provider.provider_key)
 
+      provider_config = tenant_api_key_provider_config(base_provider, api_key)
       owner.providers.kept_only.find_or_create_by!(
         provider_key: base_provider.provider_key,
         auth_type: "api_key",
         provider_api_key: api_key
       ) do |provider|
-        provider.config = tenant_api_key_provider_config(base_provider, api_key)
+        provider.config = provider_config
       end.tap do |provider|
         # Config can drift between calls (e.g. tenant changes their Pi model
         # preference in tenant_settings without rotating the API key). Sync it
         # on every materialisation so the next agent run picks up the change.
-        fresh_config = tenant_api_key_provider_config(base_provider, api_key)
-        provider.update!(config: fresh_config) if fresh_config != provider.config
+        provider.update!(config: provider_config) if provider_config != provider.config
       end
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
       owner.providers.kept_only.find_by(

--- a/app/views/providers/_form.html.erb
+++ b/app/views/providers/_form.html.erb
@@ -210,6 +210,43 @@
     </div>
   </div>
 
+  <% pi_settings_enabled = is_api_key && provider.provider_key == "pi" %>
+  <% pi_api_provider = provider.pi_api_provider || Provider::PI_DEFAULT_API_PROVIDER %>
+  <div data-provider-form-target="piSettings" <% unless pi_settings_enabled %>hidden<% end %>>
+    <div class="rounded-lg border border-gray-200 p-4">
+      <h3 class="text-sm font-semibold text-gray-900">Pi API Key Settings</h3>
+      <p class="mt-1 text-xs text-gray-500">Choose the upstream Pi provider to pair with this API key. Model selection is optional.</p>
+
+      <div class="mt-4">
+        <label for="provider_config_pi_api_provider" class="block text-sm font-medium text-gray-900">API Provider</label>
+        <select id="provider_config_pi_api_provider"
+                name="provider[config][pi][api_provider]"
+                <% unless pi_settings_enabled %>disabled<% end %>
+                class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                data-provider-form-target="directOutboundApiProviderSelect"
+                data-provider-key="pi"
+                data-action="change->provider-form#refreshProviderSpecificFields">
+          <% Provider::PI_API_PROVIDERS.each do |slug, cfg| %>
+            <option value="<%= slug %>" data-service-type="<%= cfg[:service_type] %>" <% if pi_api_provider == slug %>selected<% end %>><%= cfg[:label] %></option>
+          <% end %>
+        </select>
+      </div>
+
+      <div class="mt-4">
+        <label for="provider_config_pi_model" class="block text-sm font-medium text-gray-900">Model ID</label>
+        <input id="provider_config_pi_model"
+               name="provider[config][pi][model]"
+               type="text"
+               value="<%= provider.pi_model_id %>"
+               placeholder="Optional: deepseek-chat"
+               autocomplete="off"
+                <% unless pi_settings_enabled %>disabled<% end %>
+               class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+        <p class="mt-1 text-xs text-gray-500">Optional. Leave blank to let Pi use its default or previously selected model for the chosen provider.</p>
+      </div>
+    </div>
+  </div>
+
   <% tier_model_provider = Providers::DefaultTierModelIds::PROVIDER_KEY_TO_MODEL_PROVIDER[provider.provider_key.to_s] %>
   <% if tier_model_provider %>
     <% tier_models = LlmModel.active.by_provider(tier_model_provider).order(:display_name) %>

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -133,8 +133,13 @@ module PaidAgentHarnessPiRuntimePatch
   end
 end
 
-AgentHarness::Providers::Pi.prepend(PaidAgentHarnessPiRuntimePatch) unless
-  AgentHarness::Providers::Pi < PaidAgentHarnessPiRuntimePatch
+# Drop this patch once agent-harness natively materialises Pi API-key auth.
+# Adjust the version ceiling to whichever harness release ships that support.
+# TODO(#2077): remove when agent-harness >= 0.19.0 ships native Pi API-key support
+if agent_harness_version < Gem::Version.new("0.19.0")
+  AgentHarness::Providers::Pi.prepend(PaidAgentHarnessPiRuntimePatch) unless
+    AgentHarness::Providers::Pi < PaidAgentHarnessPiRuntimePatch
+end
 
 # Default agent timeout used for AgentHarness boot-time config and as a
 # fallback when per-user settings are unavailable. Runtime code should

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -64,6 +64,78 @@ if agent_harness_version == Gem::Version.new("0.17.0")
   AgentHarness::ProviderHealthCheck.singleton_class.prepend(AgentHarnessSmokeTestTimeoutPatch)
 end
 
+# Backport Pi API-key runtime support that agent-harness 0.18.1 does not yet
+# expose consistently. Pi itself supports API keys via env vars or auth.json,
+# but its harness adapter still reports oauth-only auth semantics and does not
+# materialize request-scoped auth.json content from ProviderRuntime metadata.
+#
+# Paid uses this patch to:
+# - advertise the API-key env vars that subscription runs must unset
+# - write a minimal ~/.pi/agent/auth.json for request-scoped API-key entries so
+#   Pi's own auth precedence cannot pick a stale local credential instead
+# - keep credentials off the command line (Pi supports --api-key, but that
+#   would leak raw secrets via process args/logging)
+module PaidAgentHarnessPiRuntimePatch
+  PI_API_KEY_ENV_VARS = %w[
+    ANTHROPIC_API_KEY
+    OPENAI_API_KEY
+    DEEPSEEK_API_KEY
+    GEMINI_API_KEY
+    MISTRAL_API_KEY
+    XAI_API_KEY
+    ZAI_API_KEY
+    OPENROUTER_API_KEY
+  ].freeze
+
+  def api_key_env_var_names = PI_API_KEY_ENV_VARS
+
+  def subscription_unset_vars = PI_API_KEY_ENV_VARS
+
+  protected
+
+  def build_execution_preparation(options)
+    base = super
+    runtime = options[:provider_runtime]
+    auth_entry = runtime&.metadata&.dig("paid_pi_auth_entry")
+    return base unless auth_entry.is_a?(Hash)
+
+    provider = auth_entry["provider"].to_s.strip
+    api_key = auth_entry["api_key"].to_s
+    return base if provider.empty? || api_key.empty?
+
+    auth_json = JSON.generate(
+      provider => {
+        type: "api_key",
+        key: api_key
+      }
+    )
+
+    pi_auth = AgentHarness::ExecutionPreparation.new(
+      file_writes: [
+        {
+          path: "/home/agent/.pi/agent/auth.json",
+          content: auth_json,
+          mode: 0o600
+        }
+      ]
+    )
+
+    merge_execution_preparations(base, pi_auth)
+  end
+
+  private
+
+  def merge_execution_preparations(base, extra)
+    return extra if base.nil?
+    return base if extra.nil?
+
+    AgentHarness::ExecutionPreparation.new(file_writes: base.file_writes + extra.file_writes)
+  end
+end
+
+AgentHarness::Providers::Pi.prepend(PaidAgentHarnessPiRuntimePatch) unless
+  AgentHarness::Providers::Pi < PaidAgentHarnessPiRuntimePatch
+
 # Default agent timeout used for AgentHarness boot-time config and as a
 # fallback when per-user settings are unavailable. Runtime code should
 # prefer UserSetting#agent_timeout_seconds resolved via

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -76,20 +76,13 @@ end
 # - keep credentials off the command line (Pi supports --api-key, but that
 #   would leak raw secrets via process args/logging)
 module PaidAgentHarnessPiRuntimePatch
-  PI_API_KEY_ENV_VARS = %w[
-    ANTHROPIC_API_KEY
-    OPENAI_API_KEY
-    DEEPSEEK_API_KEY
-    GEMINI_API_KEY
-    MISTRAL_API_KEY
-    XAI_API_KEY
-    ZAI_API_KEY
-    OPENROUTER_API_KEY
-  ].freeze
+  # Derived lazily via a method so that Provider (an autoloaded model) is
+  # guaranteed to be available regardless of initializer load order.
+  def pi_api_key_env_vars = Provider::PI_API_PROVIDERS.values.map { |c| c[:env_var] }.freeze
 
-  def api_key_env_var_names = PI_API_KEY_ENV_VARS
+  def api_key_env_var_names = pi_api_key_env_vars
 
-  def subscription_unset_vars = PI_API_KEY_ENV_VARS
+  def subscription_unset_vars = pi_api_key_env_vars
 
   protected
 

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -209,6 +209,18 @@ RSpec.describe ProviderSupport do
       expect(described_class.subscription_auth_unset_vars_for("gemini")).to include("GEMINI_API_KEY")
     end
 
+    it "returns the Pi API-key unset vars, including GEMINI_API_KEY" do
+      vars = described_class.subscription_auth_unset_vars_for("pi")
+
+      expect(vars).to include(
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENROUTER_API_KEY"
+      )
+    end
+
     it "returns an empty array for unknown providers" do
       expect(described_class.subscription_auth_unset_vars_for("unknown_provider")).to eq([])
     end

--- a/spec/models/provider_api_key_spec.rb
+++ b/spec/models/provider_api_key_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ProviderApiKey do
       expect(api_key.compatible_with?("unknown")).to be(false)
     end
 
-    context "with dynamic API provider keys (opencode, kilocode)" do
+    context "with dynamic API provider keys (opencode, kilocode, pi)" do
       it "returns true when service type is in DIRECT_OUTBOUND_SERVICE_TYPES" do
         Provider::DIRECT_OUTBOUND_SERVICE_TYPES.each do |service_type|
           key = build(:provider_api_key, api_service_type: service_type)
@@ -62,10 +62,22 @@ RSpec.describe ProviderApiKey do
         end
       end
 
+      it "returns true for Pi-supported service types" do
+        Provider::PI_API_PROVIDERS.each_value do |config|
+          key = build(:provider_api_key, api_service_type: config.fetch(:service_type))
+          expect(key.compatible_with?("pi")).to be(true), "expected #{config.fetch(:service_type)} to be compatible with pi"
+        end
+      end
+
       it "returns false for unsupported service types" do
         key = build(:provider_api_key, api_service_type: "google")
         expect(key.compatible_with?("opencode")).to be(false)
         expect(key.compatible_with?("kilocode")).to be(false)
+      end
+
+      it "returns false for Pi-unsupported service types" do
+        key = build(:provider_api_key, api_service_type: "inception")
+        expect(key.compatible_with?("pi")).to be(false)
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -897,6 +897,64 @@ RSpec.describe Provider do
     end
   end
 
+  describe "Pi agent-harness runtime helpers" do
+    let(:user) { create(:user) }
+    let(:api_key) { create(:provider_api_key, user: user, api_service_type: "deepseek", api_key: "sk-deepseek-secret") }
+    let(:provider) do
+      create(
+        :provider,
+        user: user,
+        provider_key: "pi",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "pi" => { "api_provider" => "deepseek", "model" => "deepseek-chat" } }
+      )
+    end
+
+    it "builds provider runtime inputs for Pi API key auth" do
+      runtime = provider.agent_harness_provider_runtime
+
+      expect(runtime.api_provider).to eq("deepseek")
+      expect(runtime.model).to eq("deepseek-chat")
+      expect(runtime.env).to eq({})
+      expect(runtime.metadata).to include(
+        "paid_pi_auth_entry" => {
+          "provider" => "deepseek",
+          "api_key" => "sk-deepseek-secret"
+        }
+      )
+    end
+
+    it "allows Pi API key entries without a model override" do
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "pi",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "pi" => { "api_provider" => "deepseek" } }
+      )
+
+      expect(provider).to be_valid
+      expect(provider.pi_model_id).to be_nil
+      expect(provider.agent_harness_provider_runtime.model).to be_nil
+    end
+
+    it "rejects unsupported Pi API provider selections" do
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "pi",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "pi" => { "api_provider" => "inception" } }
+      )
+
+      expect(provider).not_to be_valid
+      expect(provider.errors[:config]).to include("must include a supported Pi API provider")
+    end
+  end
+
   describe "#agent_harness_runtime?" do
     it "returns true for copilot providers" do
       provider = build(:provider, provider_key: "copilot")
@@ -914,6 +972,21 @@ RSpec.describe Provider do
         auth_type: "api_key",
         provider_api_key: api_key,
         config: { "opencode" => { "api_provider" => "openrouter", "model" => "test-model" } }
+      )
+
+      expect(provider.agent_harness_runtime?).to be(true)
+    end
+
+    it "returns true for pi API-key providers" do
+      user = create(:user)
+      api_key = create(:provider_api_key, user: user, api_service_type: "deepseek", api_key: "sk-test")
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "pi",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "pi" => { "api_provider" => "deepseek", "model" => "deepseek-chat" } }
       )
 
       expect(provider.agent_harness_runtime?).to be(true)

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -474,6 +474,31 @@ RSpec.describe "Providers" do
       expect(provider.opencode_model_id).to eq("moonshotai/kimi-k2-0905")
     end
 
+    it "persists nested Pi config for API-key providers" do
+      api_key = create(:provider_api_key, user: user, api_service_type: "deepseek")
+
+      post providers_path, params: {
+        provider: {
+          provider_key: "pi",
+          auth_type: "api_key",
+          provider_api_key_id: api_key.id,
+          enabled_for_agent_runs: true,
+          enabled_for_fallback: true,
+          config: {
+            pi: {
+              api_provider: "deepseek",
+              model: "deepseek-chat"
+            }
+          }
+        }
+      }
+
+      expect(response).to redirect_to(providers_path)
+      provider = user.providers.find_by!(provider_key: "pi", auth_type: "api_key")
+      expect(provider.pi_api_provider).to eq("deepseek")
+      expect(provider.pi_model_id).to eq("deepseek-chat")
+    end
+
     it "rejects kilocode API-key providers without a model id" do
       api_key = create(:provider_api_key, user: user, api_service_type: "inception")
 

--- a/spec/services/agent_runs/provider_resolver_spec.rb
+++ b/spec/services/agent_runs/provider_resolver_spec.rb
@@ -3,6 +3,23 @@
 require "rails_helper"
 
 RSpec.describe AgentRuns::ProviderResolver do
+  def create_pi_tenant_key_setup
+    account = create(:account)
+    owner = create(:user, :owner, account: account)
+    project = create(:project, account: account, created_by: owner)
+    pi_provider = create(:provider, user: owner, provider_key: "pi")
+    owner.settings.update!(default_agent_provider: pi_provider.routing_key)
+
+    api_key = create(:provider_api_key, user: owner, api_service_type: "deepseek", api_key: "sk-deepseek")
+    create(:tenant_setting, account: account,
+      provider_preferences: {
+        "api_key_ids" => { "deepseek" => api_key.id },
+        "model_preferences" => { "pi" => "deepseek-chat" }
+      })
+
+    [ project, owner, api_key ]
+  end
+
   describe ".call" do
     it "honors tenant API keys owned by another account member" do
       account = create(:account)
@@ -159,6 +176,22 @@ RSpec.describe AgentRuns::ProviderResolver do
       resolved_provider = Provider.find(provider_id)
       expect(resolved_provider.provider_key).to eq("claude")
       expect(agent_type).to eq("claude_code")
+    end
+
+    it "materializes a Pi tenant API-key provider with matching provider config" do
+      project, owner, api_key = create_pi_tenant_key_setup
+      provider_id, agent_type = described_class.call(project: project, goal: "create_pr")
+      provider = Provider.find(provider_id)
+
+      expect(agent_type).to eq("pi")
+      expect(provider).to have_attributes(
+        user: owner,
+        provider_key: "pi",
+        auth_type: "api_key",
+        provider_api_key: api_key
+      )
+      expect(provider.pi_api_provider).to eq("deepseek")
+      expect(provider.pi_model_id).to eq("deepseek-chat")
     end
 
     it "falls back to a nil provider id with the first runnable agent type when no owner providers are available" do

--- a/spec/services/providers/harness_execution_plan_spec.rb
+++ b/spec/services/providers/harness_execution_plan_spec.rb
@@ -4,6 +4,14 @@ require "rails_helper"
 require "securerandom"
 
 RSpec.describe Providers::HarnessExecutionPlan do
+  def build_user_with_account
+    create(
+      :user,
+      email: "harness-execution-plan-#{SecureRandom.hex(6)}@example.com",
+      account: create(:account, slug: "harness-execution-plan-#{SecureRandom.hex(6)}")
+    )
+  end
+
   describe ".for_provider_key" do
     let(:copilot_plan_payload) do
       {
@@ -42,11 +50,7 @@ RSpec.describe Providers::HarnessExecutionPlan do
 
   describe ".call" do
     it "builds the OpenCode execution contract through agent-harness" do
-      user = create(
-        :user,
-        email: "harness-execution-plan-#{SecureRandom.hex(6)}@example.com",
-        account: create(:account, slug: "harness-execution-plan-#{SecureRandom.hex(6)}")
-      )
+      user = build_user_with_account
       api_key = create(:provider_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret")
       provider = create(
         :provider,
@@ -67,11 +71,7 @@ RSpec.describe Providers::HarnessExecutionPlan do
     end
 
     it "writes opencode.json with provider as record, not string" do
-      user = create(
-        :user,
-        email: "harness-execution-plan-#{SecureRandom.hex(6)}@example.com",
-        account: create(:account, slug: "harness-execution-plan-#{SecureRandom.hex(6)}")
-      )
+      user = build_user_with_account
       api_key = create(:provider_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret")
       provider = create(
         :provider,
@@ -89,6 +89,31 @@ RSpec.describe Providers::HarnessExecutionPlan do
       expect(parsed["provider"]).to eq({ "openrouter" => {} })
       expect(parsed["model"]).to eq("openrouter/moonshotai/kimi-k2-0905")
       expect(parsed).not_to have_key("baseURL")
+    end
+
+    it "writes Pi auth.json for API-key providers so request-scoped credentials win" do
+      user = build_user_with_account
+      api_key = create(:provider_api_key, user: user, api_service_type: "deepseek", api_key: "sk-deepseek-secret")
+      provider = create(
+        :provider,
+        user: user,
+        provider_key: "pi",
+        auth_type: "api_key",
+        provider_api_key: api_key,
+        config: { "pi" => { "api_provider" => "deepseek", "model" => "deepseek-chat" } }
+      )
+
+      plan = described_class.call(provider: provider, prompt: "ping")
+
+      expect(plan.command).to include("pi", "--provider", "deepseek", "--model", "deepseek-chat")
+      expect(plan.preparation.file_writes.first.path).to eq("/home/agent/.pi/agent/auth.json")
+      expect(plan.preparation.file_writes.first.mode).to eq(0o600)
+      expect(JSON.parse(plan.preparation.file_writes.first.content)).to eq(
+        "deepseek" => {
+          "type" => "api_key",
+          "key" => "sk-deepseek-secret"
+        }
+      )
     end
 
     it "constructs the harness provider with external sandboxing enabled" do


### PR DESCRIPTION
## Summary
- add Pi API-key provider support in Paid, including provider-specific UI and validation
- make Pi API-key execution deterministic by materializing request-scoped Pi auth inside the container
- extend tenant API-key provider resolution so Pi can be auto-materialized from tenant defaults

## Testing
- bundle exec rspec spec/services/providers/harness_execution_plan_spec.rb spec/lib/provider_support_spec.rb spec/models/provider_spec.rb spec/models/provider_api_key_spec.rb spec/requests/providers_spec.rb spec/services/agent_runs/provider_resolver_spec.rb
- bundle exec rubocop app/models/provider.rb app/models/provider_api_key.rb app/services/agent_runs/provider_resolver.rb app/helpers/providers_helper.rb config/initializers/agent_harness.rb spec/services/providers/harness_execution_plan_spec.rb spec/lib/provider_support_spec.rb spec/models/provider_spec.rb spec/models/provider_api_key_spec.rb spec/requests/providers_spec.rb spec/services/agent_runs/provider_resolver_spec.rb