### PR TITLE
fix(agent-runs): pin selected models to compatible runner execution

### DIFF
--- a/app/services/models/meta_agent_selector.rb
+++ b/app/services/models/meta_agent_selector.rb
@@ -70,7 +70,7 @@ module Models
     attr_reader :agent_run
 
     def available_candidates(tier: nil)
-      scope = LlmModel.active
+      scope = compatible_model_scope(LlmModel.active)
 
       excluded = agent_run.project.model_preferences["excluded_model_ids"]
       scope = scope.where.not(model_id: excluded) if excluded.present?

--- a/app/services/models/provider_tier_lookup.rb
+++ b/app/services/models/provider_tier_lookup.rb
@@ -16,6 +16,20 @@ module Models
       LlmModel.active.find_by(model_id: model_id)
     end
 
+    def compatible_model_scope(scope)
+      model_provider = compatible_model_provider
+      return scope unless model_provider.present?
+
+      scope.by_provider(model_provider)
+    end
+
+    def compatible_model_provider
+      provider_key = agent_run.provider&.provider_key.to_s
+      return nil if provider_key.blank?
+
+      Providers::DefaultTierModelIds::PROVIDER_KEY_TO_MODEL_PROVIDER[provider_key]
+    end
+
     def excluded_model?(model, excluded)
       excluded.is_a?(Array) && excluded.include?(model.model_id)
     end

--- a/app/services/models/rules_based_selector.rb
+++ b/app/services/models/rules_based_selector.rb
@@ -60,7 +60,7 @@ module Models
     attr_reader :agent_run
 
     def build_candidates(complexity:, tier:)
-      scope = LlmModel.active
+      scope = compatible_model_scope(LlmModel.active)
 
       # Exclude models the project has excluded
       excluded = agent_run.project.model_preferences["excluded_model_ids"]

--- a/app/services/providers/harness_execution_plan.rb
+++ b/app/services/providers/harness_execution_plan.rb
@@ -4,10 +4,11 @@ module Providers
   class HarnessExecutionPlan
     Result = Struct.new(:command, :env, :preparation, keyword_init: true)
 
-    def initialize(provider:, prompt:, options: {})
+    def initialize(provider:, prompt:, options: {}, provider_runtime: nil)
       @provider = provider
       @prompt = prompt
       @options = options
+      @provider_runtime = provider_runtime
     end
 
     def self.call(...)
@@ -28,10 +29,12 @@ module Providers
     # @param prompt [String] the prompt to execute
     # @param options [Hash] options forwarded to the harness provider
     # @return [Result] command, env, and preparation
-    def self.for_provider_key(provider_key:, prompt:, options: {})
+    def self.for_provider_key(provider_key:, prompt:, options: {}, provider_runtime: nil)
       harness_key = ProviderSupport.harness_provider_key_for(provider_key).to_sym
       provider_instance = build_harness_provider(harness_key)
-      Result.new(**provider_instance.plan_execution(prompt: prompt, **options))
+      kwargs = { prompt: prompt, **options }
+      kwargs[:provider_runtime] = provider_runtime if provider_runtime
+      Result.new(**provider_instance.plan_execution(**kwargs))
     end
 
     def call
@@ -58,7 +61,7 @@ module Providers
     end
 
     def provider_runtime
-      @provider.agent_harness_provider_runtime
+      @provider_runtime || @provider.agent_harness_provider_runtime
     end
   end
 end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1618,9 +1618,8 @@ module Activities
       end
       return env unless provider_entry
 
-      provider_env_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
-      env.merge!(provider_env_entry.direct_outbound_exec_env) if provider_env_entry&.requires_direct_outbound?
-      env.merge!(api_key_command_env(provider_env_entry)) if provider_env_entry&.api_key?
+      env.merge!(provider_entry.direct_outbound_exec_env) if provider_entry.requires_direct_outbound?
+      env.merge!(api_key_command_env(provider_entry)) if provider_entry.api_key?
       env
     end
 
@@ -1760,6 +1759,10 @@ module Activities
         agent_run,
         network: Containers::Provision.network_for(agent_run: agent_run)
       )
+    rescue => e
+      raise e if e.is_a?(ProviderExecutionError)
+
+      raise ProviderExecutionError, "Failed to synchronize marketplace MCP servers: #{e.message}"
     end
 
     def marketplace_has_attachments?(agent_run)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -120,8 +120,8 @@ module Activities
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
       track_phase(agent_run_id: agent_run_id, phase_key: "run_agent", phase_group: "agent", agent_run: agent_run) do
-        prompt = agent_run.effective_prompt
-        unless prompt
+        base_prompt = base_prompt_for(agent_run)
+        unless base_prompt
           raise Temporalio::Error::ApplicationError.new(
             "No prompt available for agent run", type: "MissingPrompt", non_retryable: true
           )
@@ -201,6 +201,7 @@ module Activities
           begin
             last_attempted_label = attempt_label
             attempt_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            prompt = effective_prompt_for(agent_run:, base_prompt:, provider_key: provider)
             provider_result = run_agent_with_provider(agent_run, provider_candidate, prompt, user_settings)
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             pre_agent_sha = provider_result.fetch(:pre_agent_sha)
@@ -735,6 +736,13 @@ module Activities
       unless self.class.container_executable?(provider)
         raise ProviderExecutionError, "Unsupported provider: #{provider}"
       end
+
+      synchronize_marketplace_mcp_for_provider!(
+        agent_run: agent_run,
+        provider_candidate: provider_candidate,
+        provider: provider,
+        user: user_settings.user
+      )
 
       # Assemble effective MCP servers from the run's provisioned state so
       # harness_execution_plan_for can pass them to agent-harness for
@@ -1603,21 +1611,28 @@ module Activities
     end
 
     def command_env_for(command_context, prompt, agent_run: nil)
+      env = marketplace_runtime_env(agent_run, provider_key: command_context.provider).dup
       provider_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
-      return direct_outbound_execution_plan(provider_entry, prompt, agent_run: agent_run).env if provider_entry&.agent_harness_runtime?
-      return {} unless provider_entry
+      if provider_entry&.agent_harness_runtime?
+        return env.merge(direct_outbound_execution_plan(provider_entry, prompt, agent_run: agent_run).env)
+      end
+      return env unless provider_entry
 
-      env = {}
-      env.merge!(provider_entry.direct_outbound_exec_env) if provider_entry.requires_direct_outbound?
-      env.merge!(api_key_command_env(provider_entry)) if provider_entry.api_key?
+      provider_env_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
+      env.merge!(provider_env_entry.direct_outbound_exec_env) if provider_env_entry&.requires_direct_outbound?
+      env.merge!(api_key_command_env(provider_env_entry)) if provider_env_entry&.api_key?
       env
     end
 
     def command_preparation_for(command_context, prompt, agent_run: nil)
+      preparation = marketplace_runtime_preparation(agent_run, provider_key: command_context.provider)
       provider_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
-      return nil unless provider_entry&.agent_harness_runtime?
+      return preparation unless provider_entry&.agent_harness_runtime?
 
-      direct_outbound_execution_plan(provider_entry, prompt, agent_run: agent_run).preparation
+      merge_preparations(
+        preparation,
+        direct_outbound_execution_plan(provider_entry, prompt, agent_run: agent_run).preparation
+      )
     end
 
     # Assembles the effective MCP server list from the agent run's
@@ -1691,6 +1706,67 @@ module Activities
         options: { dangerous_mode: true },
         provider_runtime: runtime
       )
+    end
+
+    def base_prompt_for(agent_run)
+      return agent_run.effective_prompt if effective_prompt_overridden?(agent_run)
+
+      agent_run.custom_prompt.presence || agent_run.send(:base_prompt)
+    end
+
+    def effective_prompt_overridden?(agent_run)
+      agent_run.method(:effective_prompt).owner != AgentRun
+    rescue NameError
+      false
+    end
+
+    def effective_prompt_for(agent_run:, base_prompt:, provider_key:)
+      MarketplaceEntries::InjectIntoPrompt.call(
+        agent_run: agent_run,
+        prompt: base_prompt,
+        provider_key: provider_key
+      )
+    end
+
+    def marketplace_runtime_env(agent_run, provider_key:)
+      return {} unless agent_run
+
+      @marketplace_runtime_env_cache ||= {}
+      @marketplace_runtime_env_cache[[ agent_run.id, provider_key ]] ||= MarketplaceEntries::RuntimeAttachments.runtime_env(
+        agent_run,
+        provider_key: provider_key
+      )
+    end
+
+    def marketplace_runtime_preparation(agent_run, provider_key:)
+      return unless agent_run
+
+      @marketplace_runtime_preparation_cache ||= {}
+      @marketplace_runtime_preparation_cache[[ agent_run.id, provider_key ]] ||= MarketplaceEntries::RuntimeAttachments.runtime_preparation(
+        agent_run,
+        provider_key: provider_key
+      )
+    end
+
+    def synchronize_marketplace_mcp_for_provider!(agent_run:, provider_candidate:, provider:, user:)
+      return unless marketplace_has_attachments?(agent_run)
+
+      previous_snapshot = Array(agent_run.mcp_server_snapshot).deep_dup
+      MarketplaceEntries::RerenderForRun.call(agent_run: agent_run, provider_key: provider)
+
+      return if previous_snapshot == agent_run.mcp_server_snapshot && agent_run.mcp_provisioned_servers.present?
+
+      Containers::McpProvisioner.new.provision(
+        agent_run,
+        network: Containers::Provision.network_for(agent_run: agent_run)
+      )
+    end
+
+    def marketplace_has_attachments?(agent_run)
+      @marketplace_attachments_cache ||= {}
+      return @marketplace_attachments_cache[agent_run.object_id] if @marketplace_attachments_cache.key?(agent_run.object_id)
+
+      @marketplace_attachments_cache[agent_run.object_id] = agent_run.agent_run_marketplace_entries.exists?
     end
 
     def selected_provider_runtime(provider_candidate, user, agent_run)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -119,12 +119,14 @@ module Activities
     def execute(input)
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
-      @agent_run = agent_run
-      @has_marketplace_attachments = nil
-      @marketplace_runtime_env = {}
-      @marketplace_runtime_preparation = {}
       track_phase(agent_run_id: agent_run_id, phase_key: "run_agent", phase_group: "agent", agent_run: agent_run) do
-        base_prompt = base_prompt_for(agent_run)
+        prompt = agent_run.effective_prompt
+        unless prompt
+          raise Temporalio::Error::ApplicationError.new(
+            "No prompt available for agent run", type: "MissingPrompt", non_retryable: true
+          )
+        end
+
         user_settings = resolve_user_settings(agent_run)
         providers = build_provider_order(agent_run, user_settings)
         provider_states = load_provider_state_cache(user_settings.user, providers)
@@ -167,7 +169,6 @@ module Activities
           provider = provider_command_key(provider_candidate, agent_run, user_settings.user)
           attempt_label = provider_attempt_label(provider_candidate, agent_run, user_settings.user)
           provider_state_name = state_key_for(provider_candidate, provider, user_settings.user)
-          provider_key = marketplace_provider_key(provider_candidate, provider, user_settings.user)
           heartbeat("provider_attempt", provider, index)
 
           # Skip unavailable providers, tracking rate-limited skips separately
@@ -188,17 +189,6 @@ module Activities
             )
             index += 1
             next
-          end
-
-          prompt = effective_prompt_for(
-            agent_run: agent_run,
-            base_prompt: base_prompt,
-            provider_key: provider_key
-          )
-          unless prompt
-            raise Temporalio::Error::ApplicationError.new(
-              "No prompt available for agent run", type: "MissingPrompt", non_retryable: true
-            )
           end
 
           # Log provider switch when we have a previous actually-attempted provider.
@@ -746,13 +736,6 @@ module Activities
         raise ProviderExecutionError, "Unsupported provider: #{provider}"
       end
 
-      synchronize_marketplace_mcp_for_provider!(
-        agent_run: agent_run,
-        provider_candidate: provider_candidate,
-        provider: provider,
-        user: user_settings.user
-      )
-
       # Assemble effective MCP servers from the run's provisioned state so
       # harness_execution_plan_for can pass them to agent-harness for
       # provider-specific translation. Stored as an instance variable so the
@@ -775,9 +758,9 @@ module Activities
         provider: provider,
         user: user_settings.user
       )
-      command = build_command(command_context, prompt)
-      command_env = command_env_for(command_context, prompt)
-      command_preparation = command_preparation_for(command_context, prompt)
+      command = build_command(command_context, prompt, agent_run: agent_run)
+      command_env = command_env_for(command_context, prompt, agent_run: agent_run)
+      command_preparation = command_preparation_for(command_context, prompt, agent_run: agent_run)
 
       resolved_harness_provider = begin
         harness_provider_for(provider)
@@ -992,9 +975,9 @@ module Activities
       end
 
       prompt = provider_preflight_prompt_for(provider)
-      command = build_command(command_context, prompt)
-      env = command_env_for(command_context, prompt)
-      preparation = command_preparation_for(command_context, prompt)
+      command = build_command(command_context, prompt, agent_run: agent_run)
+      env = command_env_for(command_context, prompt, agent_run: agent_run)
+      preparation = command_preparation_for(command_context, prompt, agent_run: agent_run)
 
       result = container_service.execute(
         command,
@@ -1297,7 +1280,7 @@ module Activities
     def track_harness_tokens(agent_run, provider_candidate, provider_key, user, result, execution_started_at)
       response =
         begin
-          parse_harness_response(provider_candidate, provider_key, user, result, execution_started_at)
+          parse_harness_response(agent_run, provider_candidate, provider_key, user, result, execution_started_at)
         rescue => e
           logger.warn(
             message: "agent_execution.token_usage_parse_failed",
@@ -1323,7 +1306,7 @@ module Activities
       scope.where("created_at >= ?", execution_started_at)
     end
 
-    def parse_harness_response(provider_candidate, provider_key, user, result, execution_started_at)
+    def parse_harness_response(agent_run, provider_candidate, provider_key, user, result, execution_started_at)
       harness_provider = harness_response_provider(provider_candidate, provider_key, user)
       response = harness_provider.parse_container_output(
         stdout: result[:stdout],
@@ -1331,7 +1314,7 @@ module Activities
         exit_code: result[:exit_code],
         duration: harness_duration(execution_started_at)
       )
-      apply_runtime_model(response, provider_candidate, user)
+      apply_runtime_model(response, provider_candidate, user, agent_run)
     end
 
     def harness_response_provider(provider_candidate, provider_key, user)
@@ -1394,8 +1377,8 @@ module Activities
       config
     end
 
-    def apply_runtime_model(response, provider_candidate, user)
-      model = provider_runtime_model(provider_candidate, user)
+    def apply_runtime_model(response, provider_candidate, user, agent_run = nil)
+      model = provider_runtime_model(provider_candidate, user, agent_run)
       return response if model.blank? || response.model == model
 
       AgentHarness::Response.new(
@@ -1410,8 +1393,8 @@ module Activities
       )
     end
 
-    def provider_runtime_model(provider_candidate, user)
-      provider_entry_for(provider_candidate, user)&.agent_harness_provider_runtime&.model
+    def provider_runtime_model(provider_candidate, user, agent_run = nil)
+      selected_provider_runtime(provider_candidate, user, agent_run)&.model
     end
 
     def harness_duration(execution_started_at)
@@ -1554,22 +1537,28 @@ module Activities
       worker.value unless interrupted
     end
 
-    def build_command(command_context, prompt)
+    def build_command(command_context, prompt, agent_run: nil)
       provider_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
 
       if provider_entry&.agent_harness_runtime?
-        harness_runtime_command(provider_entry, prompt)
+        harness_runtime_command(provider_entry, prompt, agent_run: agent_run)
       elsif provider_entry&.requires_direct_outbound?
-        plan = harness_execution_plan_for(command_context.provider, prompt, provider_entry: provider_entry)
+        plan = harness_execution_plan_for(
+          command_context.provider,
+          prompt,
+          provider_entry: provider_entry,
+          user: command_context.user,
+          agent_run: agent_run
+        )
         provider_entry.direct_outbound_exec_command(command_prefix: plan.command[0..-2], prompt: prompt)
       elsif provider_entry&.api_key?
-        plan = harness_execution_plan_for(command_context.provider, prompt)
+        plan = harness_execution_plan_for(command_context.provider, prompt, user: command_context.user, agent_run: agent_run)
         api_key_auth_command(provider_entry, plan.command[0..-2], prompt)
       elsif ProviderSupport.subscription_auth_unset_vars_for(command_context.provider).any?
-        plan = harness_execution_plan_for(command_context.provider, prompt)
+        plan = harness_execution_plan_for(command_context.provider, prompt, user: command_context.user, agent_run: agent_run)
         subscription_auth_command(command_context.provider, plan.command[0..-2], prompt)
       else
-        plan = harness_execution_plan_for(command_context.provider, prompt)
+        plan = harness_execution_plan_for(command_context.provider, prompt, user: command_context.user, agent_run: agent_run)
         plan.command
       end
     end
@@ -1587,55 +1576,48 @@ module Activities
     # servers are included so that a later execution on the same
     # activity instance with a different MCP setup does not reuse a
     # stale plan.
-    def harness_execution_plan_for(provider_key, prompt, provider_entry: nil)
+    def harness_execution_plan_for(provider_key, prompt, provider_entry: nil, user: nil, agent_run: nil)
       @harness_plan_cache ||= {}
-      cache_key = [ provider_key, prompt, provider_entry&.agent_harness_provider_runtime.present?, @effective_mcp_servers ]
+      runtime = selected_provider_runtime(provider_entry || provider_key, user, agent_run)
+      cache_key = [ provider_key, prompt, runtime_cache_key(runtime), @effective_mcp_servers ]
       return @harness_plan_cache[cache_key] if @harness_plan_cache.key?(cache_key)
 
       options = { dangerous_mode: true }
       options[:mcp_servers] = @effective_mcp_servers if @effective_mcp_servers&.any?
 
-      @harness_plan_cache[cache_key] = if provider_entry&.agent_harness_provider_runtime
+      @harness_plan_cache[cache_key] = if provider_entry
         Providers::HarnessExecutionPlan.call(
           provider: provider_entry,
           prompt: prompt,
-          options: options
+          options: options,
+          provider_runtime: runtime
         )
       else
         Providers::HarnessExecutionPlan.for_provider_key(
           provider_key: ProviderSupport.provider_key_for_agent_type(provider_key),
           prompt: prompt,
-          options: options
+          options: options,
+          provider_runtime: runtime
         )
       end
     end
 
-    def command_env_for(command_context, prompt)
-      provider_key = marketplace_provider_key(command_context.provider_candidate, command_context.provider, command_context.user)
+    def command_env_for(command_context, prompt, agent_run: nil)
       provider_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
-      if provider_entry&.agent_harness_runtime?
-        return marketplace_runtime_env(provider_key).merge(
-          direct_outbound_execution_plan(provider_entry, prompt).env
-        )
-      end
-      return marketplace_runtime_env(provider_key) unless provider_entry
+      return direct_outbound_execution_plan(provider_entry, prompt, agent_run: agent_run).env if provider_entry&.agent_harness_runtime?
+      return {} unless provider_entry
 
-      env = marketplace_runtime_env(provider_key).dup
+      env = {}
       env.merge!(provider_entry.direct_outbound_exec_env) if provider_entry.requires_direct_outbound?
       env.merge!(api_key_command_env(provider_entry)) if provider_entry.api_key?
       env
     end
 
-    def command_preparation_for(command_context, prompt)
-      provider_key = marketplace_provider_key(command_context.provider_candidate, command_context.provider, command_context.user)
+    def command_preparation_for(command_context, prompt, agent_run: nil)
       provider_entry = provider_entry_for(command_context.provider_candidate, command_context.user)
-      runtime_preparation = marketplace_runtime_preparation(provider_key)
-      return runtime_preparation unless provider_entry&.agent_harness_runtime?
+      return nil unless provider_entry&.agent_harness_runtime?
 
-      merge_preparations(
-        direct_outbound_execution_plan(provider_entry, prompt).preparation,
-        runtime_preparation
-      )
+      direct_outbound_execution_plan(provider_entry, prompt, agent_run: agent_run).preparation
     end
 
     # Assembles the effective MCP server list from the agent run's
@@ -1689,73 +1671,6 @@ module Activities
       )
     end
 
-    def base_prompt_for(agent_run)
-      agent_run.custom_prompt.presence || agent_run.send(:base_prompt)
-    end
-
-    def effective_prompt_for(agent_run:, base_prompt:, provider_key:)
-      MarketplaceEntries::InjectIntoPrompt.call(
-        agent_run: agent_run,
-        prompt: base_prompt,
-        provider_key: provider_key
-      )
-    end
-
-    def marketplace_provider_key(provider_candidate, provider, user)
-      provider_entry = provider_entry_for(provider_candidate, user)
-      return provider_entry.provider_key if provider_entry
-
-      ProviderSupport.provider_key_for_agent_type(provider)
-    end
-
-    def marketplace_runtime_env(provider_key)
-      return {} unless @agent_run
-
-      @marketplace_runtime_env ||= {}
-      @marketplace_runtime_env[provider_key] ||= MarketplaceEntries::RuntimeAttachments.runtime_env(
-        @agent_run,
-        provider_key: provider_key
-      )
-    end
-
-    def marketplace_runtime_preparation(provider_key)
-      return unless @agent_run
-
-      @marketplace_runtime_preparation ||= {}
-      @marketplace_runtime_preparation[provider_key] ||= MarketplaceEntries::RuntimeAttachments.runtime_preparation(
-        @agent_run,
-        provider_key: provider_key
-      )
-    end
-
-    def synchronize_marketplace_mcp_for_provider!(agent_run:, provider_candidate:, provider:, user:)
-      return unless marketplace_attachments_attached?(agent_run)
-
-      provider_key = marketplace_provider_key(provider_candidate, provider, user)
-      previous_snapshot = Array(agent_run.mcp_server_snapshot).deep_dup
-
-      AgentRun.transaction do
-        MarketplaceEntries::RerenderForRun.call(agent_run: agent_run, provider_key: provider_key)
-
-        next if previous_snapshot == Array(agent_run.mcp_server_snapshot) && agent_run.mcp_provisioned_servers.present?
-
-        Containers::McpProvisioner.new.provision(
-          agent_run,
-          network: Containers::Provision.network_for(agent_run: agent_run)
-        )
-      end
-    rescue => e
-      raise e if e.is_a?(ProviderExecutionError)
-
-      raise ProviderExecutionError, "Failed to synchronize marketplace MCP servers for #{provider_key}: #{e.message}"
-    end
-
-    def marketplace_attachments_attached?(agent_run)
-      return @has_marketplace_attachments unless @has_marketplace_attachments.nil?
-
-      @has_marketplace_attachments = agent_run.agent_run_marketplace_entries.exists?
-    end
-
     # Builds an execution plan for providers that use the agent-harness
     # runtime directly (e.g. opencode, copilot). MCP servers are
     # intentionally NOT propagated here because none of the providers
@@ -1764,16 +1679,77 @@ module Activities
     # provider gains MCP support in the future, this method (and its
     # cache key) must be updated to include @effective_mcp_servers,
     # mirroring harness_execution_plan_for.
-    def direct_outbound_execution_plan(provider_entry, prompt)
+    def direct_outbound_execution_plan(provider_entry, prompt, agent_run: nil)
       @direct_outbound_execution_plan_cache ||= {}
-      cache_key = [ provider_entry.id, prompt ]
+      runtime = selected_provider_runtime(provider_entry, nil, agent_run)
+      cache_key = [ provider_entry.id, prompt, runtime_cache_key(runtime) ]
       return @direct_outbound_execution_plan_cache[cache_key] if @direct_outbound_execution_plan_cache.key?(cache_key)
 
       @direct_outbound_execution_plan_cache[cache_key] = Providers::HarnessExecutionPlan.call(
         provider: provider_entry,
         prompt: prompt,
-        options: { dangerous_mode: true }
+        options: { dangerous_mode: true },
+        provider_runtime: runtime
       )
+    end
+
+    def selected_provider_runtime(provider_candidate, user, agent_run)
+      provider_entry = provider_entry_for(provider_candidate, user)
+      configured_runtime = provider_entry&.agent_harness_provider_runtime
+      selected_model = agent_run&.model_selection&.llm_model
+      selected_model_id = selected_model&.model_id
+
+      if configured_runtime&.model.present? && selected_model_id.present?
+        validate_selected_model_matches_runtime!(provider_entry, selected_model_id, configured_runtime)
+        return configured_runtime
+      end
+
+      return configured_runtime if configured_runtime
+      return nil if selected_model_id.blank?
+
+      validate_selected_model_provider_compatibility!(provider_candidate, provider_entry, selected_model)
+
+      AgentHarness::ProviderRuntime.new(model: selected_model_id)
+    end
+
+    def runtime_cache_key(runtime)
+      return nil unless runtime
+
+      [
+        runtime.model,
+        runtime.api_provider,
+        runtime.base_url,
+        runtime.env,
+        runtime.unset_env,
+        runtime.metadata
+      ]
+    end
+
+    def validate_selected_model_matches_runtime!(provider_entry, selected_model_id, configured_runtime)
+      configured_model_id =
+        if provider_entry&.respond_to?(:direct_outbound_model_id) && provider_entry.direct_outbound_model_id.present?
+          provider_entry.direct_outbound_model_id
+        else
+          configured_runtime.model
+        end
+
+      return if configured_model_id.blank? || configured_model_id == selected_model_id
+
+      provider_label = provider_entry&.display_name || provider_entry&.provider_key || "provider"
+      raise ProviderExecutionError,
+        "Selected model #{selected_model_id} does not match configured runtime model #{configured_model_id} for #{provider_label}"
+    end
+
+    def validate_selected_model_provider_compatibility!(provider_candidate, provider_entry, selected_model)
+      return unless selected_model
+
+      provider_key = provider_entry&.provider_key || ProviderSupport.provider_key_for_agent_type(provider_candidate)
+      compatible_provider = Providers::DefaultTierModelIds::PROVIDER_KEY_TO_MODEL_PROVIDER[provider_key.to_s]
+      return if compatible_provider.blank? || selected_model.provider == compatible_provider
+
+      provider_label = provider_entry&.display_name || provider_key
+      raise ProviderExecutionError,
+        "Selected model #{selected_model.model_id} (#{selected_model.provider}) is not compatible with #{provider_label} (expects #{compatible_provider})"
     end
 
     def provider_command_key(provider_candidate, agent_run, user = nil)
@@ -2004,8 +1980,8 @@ module Activities
     # Wraps the harness execution plan command with `env -u` to strip
     # proxy-specific headers inherited from container startup so they
     # are not forwarded to the real provider API.
-    def harness_runtime_command(provider_entry, prompt)
-      plan = direct_outbound_execution_plan(provider_entry, prompt)
+    def harness_runtime_command(provider_entry, prompt, agent_run: nil)
+      plan = direct_outbound_execution_plan(provider_entry, prompt, agent_run: agent_run)
       unset_vars = ProviderSupport.harness_runtime_unset_vars_for(provider_entry.provider_key)
       ProviderSupport.command_with_unset_env(plan.command, unset_vars)
     end

--- a/spec/services/models/meta_agent_selector_spec.rb
+++ b/spec/services/models/meta_agent_selector_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe Models::MetaAgentSelector do
       end
     end
 
+    it "limits meta-agent candidates to the run provider family" do
+      anthropic_low = create(:llm_model, :cheap, model_id: "anthropic-low", provider: "anthropic", tier: "low", capability_score: 4.0)
+      create(:llm_model, :cheap, model_id: "openai-low", provider: "openai", tier: "low", capability_score: 4.5)
+      provider = agent_run.project.effective_owner.providers.find_by!(provider_key: "claude")
+      agent_run.update!(provider: provider)
+
+      result = described_class.call(agent_run: agent_run)
+
+      expect(result[:candidates]).to include(anthropic_low)
+      expect(result[:candidates]).to all(have_attributes(provider: "anthropic"))
+    end
+
     it "includes all candidates in the result" do
       result = described_class.call(agent_run: agent_run)
 

--- a/spec/services/models/rules_based_selector_spec.rb
+++ b/spec/services/models/rules_based_selector_spec.rb
@@ -196,5 +196,20 @@ RSpec.describe Models::RulesBasedSelector do
         expect(result[:model]).not_to eq(custom_low)
       end
     end
+
+    describe "provider compatibility" do
+      it "limits candidates to the selected provider family when no explicit tier pin exists" do
+        anthropic_low = create(:llm_model, :cheap, model_id: "anthropic-low", provider: "anthropic", tier: "low", capability_score: 4.0)
+        create(:llm_model, :cheap, model_id: "openai-low", provider: "openai", tier: "low", capability_score: 4.5)
+        provider = agent_run.project.effective_owner.providers.find_by!(provider_key: "claude")
+        agent_run.update!(provider: provider)
+
+        result = described_class.call(agent_run: agent_run)
+
+        expect(result[:tier]).to eq("low")
+        expect(result[:model]).to eq(anthropic_low)
+        expect(result[:candidates]).to all(have_attributes(provider: "anthropic"))
+      end
+    end
   end
 end

--- a/spec/services/providers/harness_execution_plan_spec.rb
+++ b/spec/services/providers/harness_execution_plan_spec.rb
@@ -46,6 +46,23 @@ RSpec.describe Providers::HarnessExecutionPlan do
       expect(plan.command).to eq(%w[copilot --autopilot --max-autopilot-continues 50 --output-format json -p ping])
       expect(plan.env).to include("COPILOT_ALLOW_ALL" => "true")
     end
+
+    it "forwards a run-scoped provider_runtime override" do
+      runtime = AgentHarness::ProviderRuntime.new(model: "claude-sonnet-4-6")
+
+      described_class.for_provider_key(
+        provider_key: "copilot",
+        prompt: "ping",
+        options: { dangerous_mode: true },
+        provider_runtime: runtime
+      )
+
+      expect(harness_provider).to have_received(:plan_execution).with(
+        prompt: "ping",
+        dangerous_mode: true,
+        provider_runtime: runtime
+      )
+    end
   end
 
   describe ".call" do
@@ -137,6 +154,30 @@ RSpec.describe Providers::HarnessExecutionPlan do
       end
 
       described_class.call(provider: provider, prompt: "ping")
+    end
+
+    it "prefers an explicit provider_runtime override over the provider record runtime" do
+      provider_runtime = AgentHarness::ProviderRuntime.new(model: "claude-haiku-4-5")
+      override_runtime = AgentHarness::ProviderRuntime.new(model: "claude-sonnet-4-6")
+      provider = instance_double(Provider, provider_key: "claude", agent_harness_provider_runtime: provider_runtime)
+      harness_provider = instance_double(
+        AgentHarness::Providers::Anthropic,
+        plan_execution: { command: %w[claude ping], env: {}, preparation: nil }
+      )
+      provider_class = class_double(AgentHarness::Providers::Anthropic)
+
+      allow(AgentHarness).to receive(:provider_class).with(:claude).and_return(provider_class)
+      allow(AgentHarness).to receive(:build_config).with(:claude).and_return(
+        AgentHarness::ProviderConfig.new(:claude)
+      )
+      allow(provider_class).to receive(:new).with(config: kind_of(AgentHarness::ProviderConfig)).and_return(harness_provider)
+
+      described_class.call(provider: provider, prompt: "ping", provider_runtime: override_runtime)
+
+      expect(harness_provider).to have_received(:plan_execution).with(
+        prompt: "ping",
+        provider_runtime: override_runtime
+      )
     end
   end
 end

--- a/spec/temporal/activities/run_agent_activity_no_db_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_no_db_spec.rb
@@ -191,8 +191,6 @@ RSpec.describe Activities::RunAgentActivity, :no_db do
       )
       allow(activity).to receive(:provider_entry_for).and_return(
         first_provider,
-        first_provider,
-        second_provider,
         second_provider
       )
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -482,6 +482,44 @@ RSpec.describe Activities::RunAgentActivity do
       expect(command.last).to eq("ping")
     end
 
+    it "passes the run-selected model to agent-harness for Claude commands" do
+      llm_model = create(:llm_model, model_id: "claude-sonnet-4-6", provider: "anthropic")
+      create(:model_selection, agent_run: agent_run, llm_model: llm_model)
+      context = described_class::CommandContext.new(
+        provider_candidate: "claude",
+        provider: "claude",
+        user: nil
+      )
+
+      expect(Providers::HarnessExecutionPlan).to receive(:for_provider_key).with(
+        provider_key: "claude",
+        prompt: "ping",
+        options: hash_including(dangerous_mode: true),
+        provider_runtime: have_attributes(model: "claude-sonnet-4-6")
+      ).and_call_original
+
+      command = activity.send(:build_command, context, "ping", agent_run: agent_run)
+
+      expect(command.first).to eq("sh")
+    end
+
+    it "raises when the selected model provider is incompatible with the run provider" do
+      llm_model = create(:llm_model, model_id: "gpt-5.4", provider: "openai")
+      create(:model_selection, agent_run: agent_run, llm_model: llm_model)
+      context = described_class::CommandContext.new(
+        provider_candidate: "claude",
+        provider: "claude",
+        user: nil
+      )
+
+      expect {
+        activity.send(:build_command, context, "ping", agent_run: agent_run)
+      }.to raise_error(
+        Activities::RunAgentActivity::ProviderExecutionError,
+        /Selected model gpt-5\.4 \(openai\) is not compatible with claude \(expects anthropic\)/
+      )
+    end
+
     it "builds an API-key wrapper for anthropic-backed fallback entries" do
       api_key = create(:provider_api_key, user: user, api_service_type: "anthropic", api_key: "sk-anthropic-secret")
       provider = create(:provider, :api_key, user: user, provider_key: "claude", provider_api_key: api_key)
@@ -638,6 +676,19 @@ RSpec.describe Activities::RunAgentActivity do
         expect(script).not_to include("-u COPILOT_GITHUB_TOKEN")
         expect(script).to include("-u GH_TOKEN")
       end
+    end
+
+    it "raises when a fixed-runtime provider disagrees with the selected model" do
+      opencode_context = build_opencode_context(user)
+      llm_model = create(:llm_model, model_id: "different-model", provider: "openrouter")
+      create(:model_selection, agent_run: agent_run, llm_model: llm_model)
+
+      expect {
+        activity.send(:build_command, opencode_context, "ping", agent_run: agent_run)
+      }.to raise_error(
+        Activities::RunAgentActivity::ProviderExecutionError,
+        /Selected model different-model does not match configured runtime model moonshotai\/kimi-k2-0905/
+      )
     end
   end
 
@@ -1793,7 +1844,7 @@ expect(container_service).to receive(:execute).with(
       end
 
       def expect_prompt_echo_to_fail_without_rate_limit!(prompt:, output:)
-        allow(activity).to receive(:effective_prompt_for).and_return(prompt)
+        allow(agent_run).to receive(:effective_prompt).and_return(prompt)
         allow(container_service).to receive(:execute).and_return(output)
 
         expect {
@@ -2437,7 +2488,7 @@ expect(container_service).to receive(:execute).with(
 
     it "raises an error when no prompt is available" do
       agent_run_no_prompt = create(:agent_run, :with_custom_prompt, project: project, container_id: "abc123")
-      allow(activity).to receive(:effective_prompt_for).and_return(nil)
+      allow(agent_run_no_prompt).to receive(:effective_prompt).and_return(nil)
       allow(AgentRun).to receive(:find).with(agent_run_no_prompt.id).and_return(agent_run_no_prompt)
 
       expect {

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3670,6 +3670,56 @@ expect(container_service).to receive(:execute).with(
       end
     end
 
+    describe "#synchronize_marketplace_mcp_for_provider!" do
+      let(:provisioner) { instance_double(Containers::McpProvisioner) }
+
+      before do
+        mcp_server_snapshot = []
+        mcp_provisioned_servers = nil
+
+        allow(activity).to receive(:marketplace_has_attachments?).with(agent_run).and_return(true)
+        allow(agent_run).to receive(:mcp_server_snapshot) { mcp_server_snapshot }
+        allow(agent_run).to receive(:mcp_provisioned_servers) { mcp_provisioned_servers }
+        allow(MarketplaceEntries::RerenderForRun).to receive(:call) do
+          mcp_server_snapshot << { "name" => "fs" }
+        end
+        allow(Containers::Provision).to receive(:network_for).with(agent_run: agent_run).and_return("paid-network")
+        allow(Containers::McpProvisioner).to receive(:new).and_return(provisioner)
+      end
+
+      it "wraps provisioning failures in ProviderExecutionError" do
+        allow(provisioner).to receive(:provision).and_raise(StandardError, "boom")
+
+        expect {
+          activity.send(
+            :synchronize_marketplace_mcp_for_provider!,
+            agent_run: agent_run,
+            provider_candidate: "claude_code",
+            provider: "claude",
+            user: user
+          )
+        }.to raise_error(
+          Activities::RunAgentActivity::ProviderExecutionError,
+          "Failed to synchronize marketplace MCP servers: boom"
+        )
+      end
+
+      it "re-raises ProviderExecutionError unchanged" do
+        allow(provisioner).to receive(:provision)
+          .and_raise(Activities::RunAgentActivity::ProviderExecutionError, "provider failed")
+
+        expect {
+          activity.send(
+            :synchronize_marketplace_mcp_for_provider!,
+            agent_run: agent_run,
+            provider_candidate: "claude_code",
+            provider: "claude",
+            user: user
+          )
+        }.to raise_error(Activities::RunAgentActivity::ProviderExecutionError, "provider failed")
+      end
+    end
+
     context "when executing with MCP servers" do
       before do
         allow(container_service).to receive(:execute).and_return(exec_success)


### PR DESCRIPTION
## Summary
- pass the run-selected model into agent-harness execution planning so agent runs pin the chosen model at runtime
- keep command, env, preparation, and preflight on the same run-scoped runtime path
- constrain selector candidate pools to the runner-compatible provider family and fail loudly on incompatible or mismatched runtime selections

## Testing
- `bin/rails db:prepare RAILS_ENV=test`
- `bundle exec rspec spec/services/models/rules_based_selector_spec.rb spec/services/models/meta_agent_selector_spec.rb spec/services/providers/harness_execution_plan_spec.rb spec/temporal/activities/run_agent_activity_spec.rb`