### PR TITLE
fix(agent-runs): classify DeepSeek 'Insufficient Balance' as provider error

### DIFF
--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -40,7 +40,10 @@ module Activities
       /not enough credits/i,
       /purchase (?:more )?credits/i,
       /buy (?:more )?credits/i,
-      /requires? more credits/i
+      /requires? more credits/i,
+      # DeepSeek wording for account-balance exhaustion. Stopgap until
+      # agent-harness ProviderSupport recognizes it upstream (#2080).
+      /insufficient balance/i
     ].freeze
 
     COMMENT_REDACTION_ONLY_PATTERNS = [

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -40,10 +40,7 @@ module Activities
       /not enough credits/i,
       /purchase (?:more )?credits/i,
       /buy (?:more )?credits/i,
-      /requires? more credits/i,
-      # DeepSeek wording for account-balance exhaustion. Stopgap until
-      # agent-harness ProviderSupport recognizes it upstream (#2080).
-      /insufficient balance/i
+      /requires? more credits/i
     ].freeze
 
     COMMENT_REDACTION_ONLY_PATTERNS = [

--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -319,9 +319,28 @@ module ProviderSupport
     []
   end
 
-  # Aggregates error_classification_patterns[category] across all supported providers.
+  # Paid-side stopgap patterns layered on top of agent-harness classification
+  # when a known provider error wording is not yet recognized upstream. Both
+  # the primary detection in `RunAgentActivity#insufficient_credits_error?`
+  # (which triggers provider fallback) and the defense-in-depth classifier in
+  # `HandleNoOutputIssueRunActivity` pick these up via
+  # `aggregated_error_classification_patterns`. Each entry should reference
+  # the upstream issue tracking its removal.
+  SUPPLEMENTARY_ERROR_CLASSIFICATION_PATTERNS = {
+    # DeepSeek wording for account-balance exhaustion. Tracked upstream in
+    # viamin/agent-harness#217; Paid cleanup tracked in #2080.
+    quota: [
+      /insufficient.?balance/i
+    ].freeze
+  }.freeze
+
+  # Aggregates error_classification_patterns[category] across all supported
+  # providers and merges Paid-side stopgap patterns from
+  # SUPPLEMENTARY_ERROR_CLASSIFICATION_PATTERNS.
   def aggregated_error_classification_patterns(category)
-    supported_provider_keys.flat_map { |key| error_classification_patterns_for(key, category) }.uniq
+    upstream = supported_provider_keys.flat_map { |key| error_classification_patterns_for(key, category) }
+    supplementary = SUPPLEMENTARY_ERROR_CLASSIFICATION_PATTERNS.fetch(category, [])
+    (upstream + supplementary).uniq
   end
 
   # Aggregates noisy_error_patterns across all supported providers.

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -441,6 +441,40 @@ RSpec.describe ProviderSupport do
     end
   end
 
+  describe ".aggregated_error_classification_patterns" do
+    context "with the :quota category" do
+      let(:patterns) { described_class.aggregated_error_classification_patterns(:quota) }
+
+      it "includes DeepSeek 'Insufficient Balance' wording (stopgap until viamin/agent-harness#217 ships)" do
+        expect(patterns.any? { |p| p.match?("Error: Insufficient Balance") }).to be(true)
+      end
+
+      it "matches the underscored API field form 'insufficient_balance'" do
+        expect(patterns.any? { |p| p.match?("insufficient_balance") }).to be(true)
+      end
+
+      it "is case-insensitive for the stopgap pattern" do
+        expect(patterns.any? { |p| p.match?("INSUFFICIENT BALANCE") }).to be(true)
+      end
+
+      it "still includes upstream harness patterns alongside the supplementary stopgaps" do
+        expect(patterns).to include(*described_class.supported_provider_keys.flat_map do |key|
+          described_class.error_classification_patterns_for(key, :quota)
+        end.uniq)
+      end
+
+      it "deduplicates patterns shared between upstream and supplementary lists" do
+        expect(patterns).to eq(patterns.uniq)
+      end
+    end
+
+    context "with an unknown category" do
+      it "returns only upstream patterns and never raises" do
+        expect { described_class.aggregated_error_classification_patterns(:no_such_category) }.not_to raise_error
+      end
+    end
+  end
+
   describe ".command_with_unset_env" do
     it "returns command unchanged when unset_vars is empty" do
       expect(described_class.command_with_unset_env("my_cmd", [])).to eq("my_cmd")

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -447,6 +447,17 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
 
         expect(result[:outcome]).to eq("provider_error")
       end
+
+      it "detects DeepSeek insufficient balance wording as a provider error" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 0)
+        agent_run.log!("stdout", "> build · deepseek-v4-pro\nError: Insufficient Balance")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("provider_error")
+      end
     end
 
     context "when output is present but agent hit infrastructure errors" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3026,6 +3026,21 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.providers_attempted.first["error_message"]).to include("credit/quota error")
       end
 
+      it "detects DeepSeek 'Insufficient Balance' as a quota error so provider fallback is triggered" do
+        deepseek_balance_failure = Containers::Provision::Result.success(
+          stdout: "> build · deepseek-v4-pro\nError: Insufficient Balance", stderr: "", exit_code: 0
+        )
+        allow(container_service).to receive(:execute).and_return(deepseek_balance_failure)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All providers exhausted/)
+
+        agent_run.reload
+        expect(agent_run.status).to eq("failed")
+        expect(agent_run.providers_attempted.first["error_message"]).to include("credit/quota error")
+      end
+
       it "does not misclassify substantial agent output as a quota error when pattern appears in test descriptions" do
         long_stdout = (1..40).map { |i| "includes test case number #{i} for the billing and rate limit patterns" }.join("\n")
         long_output_success = Containers::Provision::Result.success(


### PR DESCRIPTION
## Summary

- Closes #2072. A DeepSeek run that died with `Error: Insufficient Balance` was misclassified two ways: (1) the primary detection in `RunAgentActivity#insufficient_credits_error?` did not match, so provider fallback was never triggered; (2) the defense-in-depth classifier in `HandleNoOutputIssueRunActivity` fell through to `needs_input`, labeling the issue `paid-needs-input` and posting a "needs clarification" comment despite the agent never executing.
- Adds the stopgap pattern at the shared `ProviderSupport.aggregated_error_classification_patterns(:quota)` layer (single source of truth) so both call sites pick it up. Uses `/insufficient.?balance/i` to also cover the underscored API field form (`insufficient_balance`) and align with the codebase's `/rate.?limit/i` convention.
- Adds regression specs at both layers + a `ProviderSupport` unit spec.

## Why this is a stopgap

Per `CLAUDE.md`: "Provider-specific execution behavior belongs in `agent_harness`, not scattered across Paid." The canonical fix is to add this pattern upstream in agent-harness's provider error classification.

- Upstream issue: viamin/agent-harness#217
- Follow-up to remove this stopgap once the upstream change ships: #2080

## Test plan

- [x] `bin/rspec spec/lib/provider_support_spec.rb spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb spec/temporal/activities/run_agent_activity_spec.rb` — 348 examples, 0 failures.
- [x] `bin/rubocop` on the five changed files — no offenses.

## Review history

Initial revision only patched the defense-in-depth classifier (`HandleNoOutputIssueRunActivity::SUPPLEMENTARY_ERROR_PATTERNS`), which would have failed the run correctly but left a real UX gap: the user's configured fallback providers would not be tried, because the primary classifier in `RunAgentActivity` uses a separate (upstream-only) pattern source. Self-review caught this; the fix was centralized in `ProviderSupport` to cover both paths from one location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)