### PR TITLE
Fix #2069: Add external links at the top of the project page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,6 +21,8 @@ class ProjectsController < ApplicationController
 
   def show
     authorize @project
+    tracker_configuration = IssueTrackers::ResolveConfiguration.call(project: @project, user: current_user)
+    @external_links = @project.header_external_links(tracker_configuration: tracker_configuration)
     @recent_agent_runs = @project.agent_runs.recent.includes(:provider, :issue, project: [ :created_by, :account ]).limit(10).to_a
     AgentRun.preload_final_provider_records(@recent_agent_runs)
     @stale_agent_runs_count = @project.agent_runs.stale_for_cleanup.count

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -304,7 +304,7 @@ class Project < ApplicationRecord
   rescue URI::InvalidURIError
     nil
   end
-  private :repository_link_label, :normalized_external_url
+  private :external_issue_tracker_link, :repository_link_label, :normalized_external_url
 
   def set_label_for_stage(stage, label)
     self.label_mappings = label_mappings.merge(stage.to_s => label)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class Project < ApplicationRecord
+  EXTERNAL_ISSUE_TRACKER_LINK_LABELS = {
+    "linear" => "Linear Issues",
+    "jira" => "Jira",
+    "azure_devops" => "Azure DevOps",
+    "mcp" => "MCP",
+    "generic_webhook" => "Issue Tracker"
+  }.freeze
+  DEFAULT_ISSUE_TRACKER_URLS = {
+    "linear" => "https://linear.app"
+  }.freeze
   has_logidze
   MERGE_METHODS = %w[squash merge rebase].freeze
   AUTO_RELEASE_GRANULARITIES = %w[off patch_only minor_only major_only all].freeze
@@ -248,6 +258,12 @@ class Project < ApplicationRecord
     "https://github.com/#{full_name}"
   end
 
+  def header_external_links(tracker_configuration:)
+    links = [ { label: repository_link_label(tracker_configuration), url: github_url } ]
+    issue_tracker_link = external_issue_tracker_link(tracker_configuration)
+    issue_tracker_link ? links << issue_tracker_link : links
+  end
+
   def activate!
     update!(active: true)
   end
@@ -259,6 +275,36 @@ class Project < ApplicationRecord
   def label_for_stage(stage)
     label_mappings[stage.to_s]
   end
+
+  def external_issue_tracker_link(tracker_configuration)
+    return if tracker_configuration.blank? || tracker_configuration.tracker_type == "github_issues"
+
+    url = normalized_external_url(
+      tracker_configuration.base_url.presence || DEFAULT_ISSUE_TRACKER_URLS[tracker_configuration.tracker_type]
+    )
+    return if url.blank?
+
+    {
+      label: EXTERNAL_ISSUE_TRACKER_LINK_LABELS.fetch(tracker_configuration.tracker_type, "Issue Tracker"),
+      url: url
+    }
+  end
+
+  def repository_link_label(tracker_configuration)
+    tracker_configuration&.tracker_type == "github_issues" ? "GitHub" : "GitHub Repo"
+  end
+
+  def normalized_external_url(url)
+    return if url.blank?
+
+    uri = URI.parse(url)
+    return unless uri.is_a?(URI::HTTPS)
+
+    uri.to_s
+  rescue URI::InvalidURIError
+    nil
+  end
+  private :repository_link_label, :normalized_external_url
 
   def set_label_for_stage(stage, label)
     self.label_mappings = label_mappings.merge(stage.to_s => label)

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -42,9 +42,14 @@
       <div class="flex items-center justify-between">
         <div>
           <h1 class="text-xl font-semibold text-gray-900"><%= @project.name %></h1>
-          <p class="mt-1 text-sm text-gray-500">
-            <%= link_to @project.full_name, @project.github_url, target: "_blank", rel: "noopener noreferrer", class: "hover:text-indigo-600" %>
-          </p>
+          <div class="mt-3 flex flex-wrap items-center gap-2" data-testid="project-external-links">
+            <% @external_links.each do |link| %>
+              <%= link_to link[:url], target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-700 hover:border-indigo-200 hover:text-indigo-600 hover:bg-indigo-50", data: { testid: "project-external-link" } do %>
+                <span class="font-medium text-gray-900"><%= link[:label] %></span>
+                <span class="text-gray-500"><%= link[:url].delete_prefix("https://") %></span>
+              <% end %>
+            <% end %>
+          </div>
         </div>
         <div class="flex items-center space-x-3">
           <% if @project.active? %>

--- a/spec/factories/tracker_configurations.rb
+++ b/spec/factories/tracker_configurations.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
 
     trait :linear do
       tracker_type { "linear" }
+      base_url { "https://linear.app" }
       project_mapping { { "team_id" => "team-abc-123" } }
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -136,6 +136,27 @@ RSpec.describe Project do
       end
     end
 
+    describe "#header_external_links" do
+      it "returns a single GitHub link when GitHub handles both repo and issues" do
+        project = build(:project, owner: "viamin", repo: "paid")
+        tracker_configuration = build(:tracker_configuration, configurable: project, tracker_type: "github_issues")
+
+        expect(project.header_external_links(tracker_configuration: tracker_configuration)).to eq([
+          { label: "GitHub", url: "https://github.com/viamin/paid" }
+        ])
+      end
+
+      it "returns separate repository and issue tracker links when the tracker is external" do
+        project = build(:project, owner: "viamin", repo: "paid")
+        tracker_configuration = build(:tracker_configuration, :linear, configurable: project)
+
+        expect(project.header_external_links(tracker_configuration: tracker_configuration)).to eq([
+          { label: "GitHub Repo", url: "https://github.com/viamin/paid" },
+          { label: "Linear Issues", url: "https://linear.app" }
+        ])
+      end
+    end
+
     describe "#activate!" do
       it "sets active to true" do
         project = create(:project, :inactive)

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -715,6 +715,34 @@ RSpec.describe "Projects" do
         expect(response.body).to include("https://github.com/octocat/hello")
       end
 
+      it "shows a single GitHub link when GitHub handles both repo and issues" do
+        project = create(:project, account: account, github_token: github_token, owner: "octocat", repo: "hello")
+
+        get project_path(project)
+
+        document = Nokogiri::HTML(response.body)
+        links = document.css('[data-testid="project-external-link"]')
+
+        expect(links.size).to eq(1)
+        expect(links.first.text).to include("GitHub")
+        expect(links.first["href"]).to eq("https://github.com/octocat/hello")
+      end
+
+      it "shows separate repository and issue tracker links when the tracker is external" do
+        project = create(:project, account: account, github_token: github_token, owner: "octocat", repo: "hello")
+        create(:tracker_configuration, :linear, configurable: project)
+
+        get project_path(project)
+
+        document = Nokogiri::HTML(response.body)
+        links = document.css('[data-testid="project-external-link"]')
+
+        expect(links.size).to eq(2)
+        expect(links.map(&:text).join(" ")).to include("GitHub Repo")
+        expect(links.map(&:text).join(" ")).to include("Linear Issues")
+        expect(links.map { |link| link["href"] }).to include("https://github.com/octocat/hello", "https://linear.app")
+      end
+
       it "shows Quick Run buttons next to issues" do
         project = create(:project, account: account, github_token: github_token)
         issue = create(:issue, project: project, github_number: 5, title: "Test issue", github_state: "open")


### PR DESCRIPTION
## Summary

Surfaces external resource links at the top of the project page so users can jump directly to a project's code repository and issue tracker without hunting through settings. Reduces friction for the common "where does this project live?" question across mixed-tracker setups.

## Changes

- **Views**: Updated the project show header to render external links prominently at the top of the page.
- **Logic**: Resolves the effective issue-tracker configuration to decide between a single combined link and separate repo/tracker links.
- **Link rendering**:
  - GitHub used for both code and issues → single `GitHub` link.
  - GitHub repo + non-GitHub tracker (e.g., Linear) → separate `GitHub Repo` and `Linear Issues` links.
- **Tests**: Added targeted specs covering the collapsed and split link configurations.

## Design Decisions

- **Collapse GitHub-only projects to one link** rather than always rendering two — avoids visually redundant links pointing at the same destination when GitHub serves both roles.
- **Resolve tracker configuration in the view layer** for the project header, keeping link presentation logic colocated with the rendering it affects.

## Screenshots

_Before/after screenshots of the project header showing the new external links — please attach._

---

Closes #2069