### PR TITLE
fix(agent-runs): use conventional commit fallbacks for PR artifacts

### DIFF
--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -958,10 +958,16 @@ module Containers
     end
 
     def commit_message
-      trailer = agent_run.effective_provider_record&.agent_co_author_trailer.presence
-      return "Apply agent changes" unless trailer
+      subject = if agent_run.issue.present?
+        ConventionalCommitTitle.for_issue(agent_run.issue)
+      else
+        "chore: apply agent changes"
+      end
 
-      "Apply agent changes\n\n#{trailer}"
+      trailer = agent_run.effective_provider_record&.agent_co_author_trailer.presence
+      return subject unless trailer
+
+      "#{subject}\n\n#{trailer}"
     end
 
     def validate_branch_name!

--- a/app/services/conventional_commit_title.rb
+++ b/app/services/conventional_commit_title.rb
@@ -2,6 +2,16 @@
 
 class ConventionalCommitTitle
   CONVENTIONAL_PATTERN = /\A(?<type>feat|fix|perf|docs|refactor|ci|build|test|chore)(?<rest>(?:\([^)]+\))?!?: .+)\z/i
+  FIX_LABEL_HINTS = %w[bug bugs fix regression hotfix security dependabot].freeze
+  PREFIX_HINTS = [
+    [ "fix", /\A(?:fix|resolve|correct|prevent|repair)\b/i ],
+    [ "feat", /\A(?:add|implement|support|introduce|create|enable|allow)\b/i ],
+    [ "docs", /\A(?:docs?|document|documentation|readme)\b/i ],
+    [ "test", /\A(?:test|tests|spec|specs)\b/i ],
+    [ "ci", /\A(?:ci|workflow|github action|actions)\b/i ],
+    [ "build", /\A(?:build|bundler|rubygems|gemfile|docker(?:file| image)?)\b/i ],
+    [ "refactor", /\A(?:refactor|cleanup|clean up|simplify|rename|extract|reorganize)\b/i ]
+  ].freeze
 
   class << self
     def normalize(title)
@@ -9,6 +19,39 @@ class ConventionalCommitTitle
       return nil unless match
 
       "#{match[:type].downcase}#{match[:rest]}"
+    end
+
+    def for_issue(issue, fallback_type: "feat")
+      normalized = normalize(issue&.title)
+      return normalized if normalized
+
+      title = sanitize_subject(issue&.title)
+      return "#{fallback_type}: apply agent changes" if title.blank?
+
+      "#{infer_type(issue, title: title, fallback_type: fallback_type)}: #{title}"
+    end
+
+    private
+
+    def infer_type(issue, title:, fallback_type:)
+      labels = Array(issue&.labels).filter_map { |label| label.to_s.downcase.presence }
+      return "fix" if (labels & FIX_LABEL_HINTS).any?
+
+      PREFIX_HINTS.each do |type, pattern|
+        return type if title.match?(pattern)
+      end
+
+      fallback_type
+    end
+
+    def sanitize_subject(title)
+      title
+        .to_s
+        .strip
+        .sub(/\A(?:fix|feature)\s+#\d+:\s*/i, "")
+        .sub(/\A(?:bug|feature|chore|docs|test|refactor)\s*:\s*/i, "")
+        .gsub(/\s+/, " ")
+        .delete_suffix(".")
     end
   end
 end

--- a/app/temporal/activities/create_aggregated_pull_request_activity.rb
+++ b/app/temporal/activities/create_aggregated_pull_request_activity.rb
@@ -86,10 +86,7 @@ module Activities
 
     def pr_title(parent_issue)
       if parent_issue
-        conventional_title = ConventionalCommitTitle.normalize(parent_issue.title)
-        return conventional_title.truncate(255) if conventional_title
-
-        "Feature ##{parent_issue.github_number}: #{parent_issue.title}".truncate(255)
+        ConventionalCommitTitle.for_issue(parent_issue, fallback_type: "feat").truncate(255)
       else
         "Aggregated feature changes"
       end

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -170,10 +170,7 @@ module Activities
     def pr_title(issue)
       return "Agent changes" unless issue
 
-      conventional_title = ConventionalCommitTitle.normalize(issue.title)
-      return conventional_title.truncate(255) if conventional_title
-
-      "Fix ##{issue.github_number}: #{issue.title}".truncate(255)
+      ConventionalCommitTitle.for_issue(issue).truncate(255)
     end
 
     def build_pr_body(issue, agent_run, client: nil)

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe Containers::GitOperations do
     project.effective_owner.providers.find_by!(provider_key: "claude")
   end
 
+  def stub_auto_commit_prerequisites(status_stdout: "M  file.rb\n", staged_stdout: "file.rb\n")
+    status_result = Containers::Provision::Result.success(stdout: status_stdout, stderr: "", exit_code: 0)
+    staged_result = Containers::Provision::Result.success(stdout: staged_stdout, stderr: "", exit_code: 0)
+
+    allow(container_service).to receive(:execute)
+      .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
+      .and_return(status_result)
+
+    allow(container_service).to receive(:execute)
+      .with([ "git", "add", "-A" ], timeout: nil, stream: false)
+      .and_return(success_result)
+
+    allow(container_service).to receive(:execute)
+      .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
+      .and_return(staged_result)
+  end
+
   describe "#clone_and_setup_branch" do
     let(:head_sha) { "abc123def456789012345678901234567890abcd" }
     let(:not_a_repo_result) { Containers::Provision::Result.failure(error: "not a git repo", stdout: "", stderr: "fatal: not a git repository", exit_code: 128) }
@@ -718,6 +735,9 @@ RSpec.describe Containers::GitOperations do
 
     it "stages and commits with --no-verify when there are uncommitted changes" do
       status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
+      issue = create(:issue, project: project, title: "Add queue monitoring dashboard")
+      agent_run.update!(issue: issue)
+
       allow(container_service).to receive(:execute)
         .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
         .and_return(status_result)
@@ -732,14 +752,35 @@ RSpec.describe Containers::GitOperations do
         .and_return(staged_result)
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "commit", "--no-verify", "-m", "Apply agent changes" ], timeout: nil, stream: false)
+        .with([ "git", "commit", "--no-verify", "-m", "feat: Add queue monitoring dashboard" ], timeout: nil, stream: false)
         .and_return(success_result)
 
       expect(git_ops.commit_uncommitted_changes).to be true
     end
 
     it "appends the co-author trailer to the commit message when configured" do
+      issue = create(:issue, project: project, title: "Resolve stalled worker retries")
+      agent_run.update!(issue: issue)
+      stub_auto_commit_prerequisites
+
+      provider.update!(agent_co_author_trailer: "Co-Authored-By: Claude <noreply@anthropic.com>")
+      allow(agent_run).to receive(:effective_provider_record).and_return(provider)
+
+      expect(container_service).to receive(:execute)
+        .with(
+          [ "git", "commit", "--no-verify", "-m",
+            "fix: Resolve stalled worker retries\n\nCo-Authored-By: Claude <noreply@anthropic.com>" ],
+          timeout: nil, stream: false
+        )
+        .and_return(success_result)
+
+      expect(git_ops.commit_uncommitted_changes).to be true
+    end
+
+    it "falls back to a chore commit when there is no linked issue" do
       status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
+      agent_run.update!(issue: nil, custom_prompt: "Tidy workspace")
+
       allow(container_service).to receive(:execute)
         .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
         .and_return(status_result)
@@ -753,14 +794,8 @@ RSpec.describe Containers::GitOperations do
         .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
         .and_return(staged_result)
 
-      provider.update!(agent_co_author_trailer: "Co-Authored-By: Claude <noreply@anthropic.com>")
-
       expect(container_service).to receive(:execute)
-        .with(
-          [ "git", "commit", "--no-verify", "-m",
-            "Apply agent changes\n\nCo-Authored-By: Claude <noreply@anthropic.com>" ],
-          timeout: nil, stream: false
-        )
+        .with([ "git", "commit", "--no-verify", "-m", "chore: apply agent changes" ], timeout: nil, stream: false)
         .and_return(success_result)
 
       expect(git_ops.commit_uncommitted_changes).to be true
@@ -795,7 +830,7 @@ RSpec.describe Containers::GitOperations do
         .and_return(staged_result)
 
       allow(container_service).to receive(:execute)
-        .with([ "git", "commit", "--no-verify", "-m", "Apply agent changes" ], timeout: nil, stream: false)
+        .with([ "git", "commit", "--no-verify", "-m", ConventionalCommitTitle.for_issue(agent_run.issue) ], timeout: nil, stream: false)
         .and_return(failure_result)
 
       expect { git_ops.commit_uncommitted_changes }.to raise_error(described_class::Error, /Failed to commit/)
@@ -1007,7 +1042,7 @@ RSpec.describe Containers::GitOperations do
         .and_return(staged_result)
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "commit", "--no-verify", "-m", "Apply agent changes" ], timeout: nil, stream: false)
+        .with([ "git", "commit", "--no-verify", "-m", ConventionalCommitTitle.for_issue(agent_run.issue) ], timeout: nil, stream: false)
         .and_return(success_result)
 
       expect(git_ops.commit_uncommitted_changes).to be true
@@ -1032,7 +1067,7 @@ RSpec.describe Containers::GitOperations do
         .and_return(staged_result)
 
       expect(container_service).to receive(:execute)
-        .with([ "git", "commit", "--no-verify", "-m", "Apply agent changes" ], timeout: nil, stream: false)
+        .with([ "git", "commit", "--no-verify", "-m", ConventionalCommitTitle.for_issue(agent_run.issue) ], timeout: nil, stream: false)
         .and_return(success_result)
 
       expect(git_ops.commit_uncommitted_changes).to be true

--- a/spec/services/conventional_commit_title_spec.rb
+++ b/spec/services/conventional_commit_title_spec.rb
@@ -27,4 +27,50 @@ RSpec.describe ConventionalCommitTitle do
       expect(described_class.normalize("Add queue monitoring dashboard")).to be_nil
     end
   end
+
+  describe ".for_issue" do
+    let(:project) { create(:project) }
+
+    it "reuses conventional issue titles as-is" do
+      issue = create(:issue, project: project, title: "Feat(quality): Pause low-quality automation")
+
+      expect(described_class.for_issue(issue)).to eq("feat(quality): Pause low-quality automation")
+    end
+
+    it "infers feature commits from plain-English feature titles" do
+      issue = create(:issue, project: project, title: "Add queue monitoring dashboard")
+
+      expect(described_class.for_issue(issue)).to eq("feat: Add queue monitoring dashboard")
+    end
+
+    it "infers fix commits from plain-English fix titles" do
+      issue = create(:issue, project: project, title: "Resolve stalled worker retries")
+
+      expect(described_class.for_issue(issue)).to eq("fix: Resolve stalled worker retries")
+    end
+
+    it "prefers an explicit fix prefix over later category nouns" do
+      issue = create(:issue, project: project, title: "Fix Docker image auth failure")
+
+      expect(described_class.for_issue(issue)).to eq("fix: Fix Docker image auth failure")
+    end
+
+    it "uses fix labels as a strong hint" do
+      issue = create(:issue, project: project, title: "Worker pool tuning", labels: [ "bug" ])
+
+      expect(described_class.for_issue(issue)).to eq("fix: Worker pool tuning")
+    end
+
+    it "falls back to feat for ambiguous issue titles" do
+      issue = create(:issue, project: project, title: "Worker pool tuning")
+
+      expect(described_class.for_issue(issue)).to eq("feat: Worker pool tuning")
+    end
+
+    it "uses the provided fallback type when no heuristic matches" do
+      issue = create(:issue, project: project, title: "Worker pool tuning")
+
+      expect(described_class.for_issue(issue, fallback_type: "chore")).to eq("chore: Worker pool tuning")
+    end
+  end
 end

--- a/spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Activities::CreateAggregatedPullRequestActivity do
 
       expect(client).to have_received(:create_pull_request).with(
         anything,
-        hash_including(title: "Feature #99: Big Feature")
+        hash_including(title: "feat: Big Feature")
       )
     end
 
@@ -85,6 +85,17 @@ RSpec.describe Activities::CreateAggregatedPullRequestActivity do
       expect(client).to have_received(:create_pull_request).with(
         anything,
         hash_including(title: "feat(scaling): worker pool tuning")
+      )
+    end
+
+    it "uses fix hints when the parent issue is clearly a bug fix" do
+      parent_issue = create(:issue, project: project, github_number: 99, title: "Resolve worker pool deadlock")
+
+      activity.execute(base_input.merge(parent_issue_id: parent_issue.id))
+
+      expect(client).to have_received(:create_pull_request).with(
+        anything,
+        hash_including(title: "fix: Resolve worker pool deadlock")
       )
     end
 

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -46,11 +46,13 @@ RSpec.describe Activities::CreatePullRequestActivity do
 
   describe "#execute" do
     it "creates a pull request via the GitHub API" do
+      issue.update!(title: "Resolve auth redirect bug")
+
       expect(github_client).to receive(:create_pull_request).with(
         project.full_name,
         base: project.default_branch,
         head: agent_run.branch_name,
-        title: "Fix ##{issue.github_number}: #{issue.title}",
+        title: "fix: Resolve auth redirect bug",
         body: a_string_including("Closes ##{issue.github_number}"),
         draft: true
       ).and_return(pr_response)
@@ -80,6 +82,28 @@ RSpec.describe Activities::CreatePullRequestActivity do
       expect(github_client).to have_received(:create_pull_request).with(
         anything,
         hash_including(title: "feat(quality): automatic pause on quality threshold breach")
+      )
+    end
+
+    it "infers conventional commit titles from plain-English feature issues" do
+      issue.update!(title: "Add queue monitoring dashboard")
+
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(github_client).to have_received(:create_pull_request).with(
+        anything,
+        hash_including(title: "feat: Add queue monitoring dashboard")
+      )
+    end
+
+    it "falls back to feat for ambiguous issue titles instead of under-versioning them as fixes" do
+      issue.update!(title: "Worker pool tuning")
+
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(github_client).to have_received(:create_pull_request).with(
+        anything,
+        hash_including(title: "feat: Worker pool tuning")
       )
     end
 


### PR DESCRIPTION
## Summary

Aligns Paid's fallback commit and PR artifact generation with Conventional Commit expectations so release automation keeps working even when an issue title is not already in conventional format.

## Changes

- add `ConventionalCommitTitle.for_issue` to normalize conventional titles or infer a safe conventional subject from issue metadata
- use that helper for fallback PR titles in `CreatePullRequestActivity` and `CreateAggregatedPullRequestActivity`
- use that helper for the post-run auto-commit safety net in `Containers::GitOperations`
- add regression coverage for feature/fix inference, ambiguous titles, and co-author trailer handling

## Why

Paid was falling back to non-conventional text like `Apply agent changes` and `Fix #123: ...`, which can break repos that rely on release automation such as `release-please`.

## Testing

- `bundle exec rspec spec/services/conventional_commit_title_spec.rb spec/temporal/activities/create_pull_request_activity_spec.rb spec/temporal/activities/create_aggregated_pull_request_activity_spec.rb spec/services/containers/git_operations_spec.rb`
- In this branch worktree, the focused spec run is currently blocked because the branch-specific test database does not exist yet: `paid_test_fix_agent_runs_conventional_commit_fallbacks_0a621aff`.
- Pre-commit lint passed during `git commit`.
