### PR TITLE
fix(auto-pick): requeue eligible issues after local recovery

### DIFF
--- a/app/jobs/issues/reenqueue_eligible_job.rb
+++ b/app/jobs/issues/reenqueue_eligible_job.rb
@@ -2,7 +2,14 @@
 
 module Issues
   class ReenqueueEligibleJob < ApplicationJob
+    include GoodJob::ActiveJobExtensions::Concurrency
+
     queue_as :default
+
+    good_job_control_concurrency_with(
+      enqueue_limit: 1,
+      key: -> { "reenqueue_eligible_issue_#{arguments.first}" }
+    )
 
     def perform(issue_id)
       issue = Issue.includes(:project).find_by(id: issue_id)

--- a/app/jobs/issues/reenqueue_eligible_job.rb
+++ b/app/jobs/issues/reenqueue_eligible_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Issues
+  class ReenqueueEligibleJob < ApplicationJob
+    queue_as :default
+
+    def perform(issue_id)
+      issue = Issue.includes(:project).find_by(id: issue_id)
+      return unless issue
+      return if issue.is_pull_request?
+      return unless issue.paid_state.in?(%w[new planning failed completed])
+      return unless AutoPickProjectGate.call(issue.project)
+
+      EnqueueEligible.call(issue, project: issue.project, skip_project_gate: true)
+    rescue => e
+      Rails.logger.error(
+        message: "enqueue_eligible.issue_state_change_failed",
+        issue_id: issue_id,
+        error: e.message
+      )
+    end
+  end
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -62,6 +62,7 @@ class Issue < ApplicationRecord
   after_commit :broadcast_current_section, on: [ :create, :destroy ]
   after_update_commit :broadcast_changed_sections
   after_update_commit :enqueue_newly_unblocked_dependents, if: :github_just_closed?
+  after_update_commit :enqueue_self_if_became_auto_pick_eligible, if: :auto_pick_recheck_needed?
   after_commit :update_project_last_github_activity_at, on: [ :create, :update ]
 
   scope :by_paid_state, ->(state) { where(paid_state: state) }
@@ -561,5 +562,60 @@ class Issue < ApplicationRecord
       .includes(:project)
       .joins(:project)
       .where(id: reverse_issue_dependencies.select(:issue_id), projects: { auto_pick_enabled: true })
+  end
+
+  def auto_pick_recheck_needed?
+    return false if is_pull_request?
+    return false unless saved_change_to_paid_state?
+
+    paid_state.in?(%w[new planning failed completed])
+  end
+
+  def enqueue_self_if_became_auto_pick_eligible
+    return unless Issues::AutoPickProjectGate.call(project)
+
+    wait = auto_pick_reenqueue_delay
+    job = Issues::ReenqueueEligibleJob
+
+    if wait
+      job.set(wait: wait).perform_later(id)
+    else
+      job.perform_later(id)
+    end
+
+    Rails.logger.info(
+      message: "enqueue_eligible.issue_state_changed",
+      issue_id: id,
+      issue_number: github_number,
+      project_id: project_id,
+      paid_state: paid_state,
+      wait_seconds: wait&.to_i
+    )
+  end
+
+  def auto_pick_reenqueue_delay
+    return unless paid_state == "failed"
+
+    case [ consecutive_auto_pick_failure_count, 1 ].max
+    when 1
+      5.minutes
+    when 2
+      15.minutes
+    when 3
+      1.hour
+    else
+      4.hours
+    end
+  end
+
+  def consecutive_auto_pick_failure_count
+    statuses = agent_runs
+      .where(auto_pick: true, goal: %w[create_pr analyze_issue])
+      .finished
+      .order(created_at: :desc, id: :desc)
+      .limit(10)
+      .pluck(:status)
+
+    statuses.take_while { |status| AgentRun::FAILURE_STATUSES.include?(status) }.count
   end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -572,8 +572,6 @@ class Issue < ApplicationRecord
   end
 
   def enqueue_self_if_became_auto_pick_eligible
-    return unless Issues::AutoPickProjectGate.call(project)
-
     wait = auto_pick_reenqueue_delay
     job = Issues::ReenqueueEligibleJob
 
@@ -616,6 +614,6 @@ class Issue < ApplicationRecord
       .limit(10)
       .pluck(:status)
 
-    statuses.take_while { |status| AgentRun::FAILURE_STATUSES.include?(status) }.count
+    statuses.take_while { |status| (AgentRun::FAILURE_STATUSES + %w[no_output]).include?(status) }.count
   end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -567,6 +567,7 @@ class Issue < ApplicationRecord
   def auto_pick_recheck_needed?
     return false if is_pull_request?
     return false unless saved_change_to_paid_state?
+    return false unless project&.auto_pick_enabled?
 
     paid_state.in?(%w[new planning failed completed])
   end

--- a/spec/jobs/issues/reenqueue_eligible_job_spec.rb
+++ b/spec/jobs/issues/reenqueue_eligible_job_spec.rb
@@ -3,6 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Issues::ReenqueueEligibleJob do
+  describe "GoodJob concurrency" do
+    it "deduplicates re-enqueue work per issue" do
+      issue = build(:issue)
+      config = described_class.good_job_concurrency_config
+
+      expect(config[:enqueue_limit]).to eq(1)
+      expect(described_class.new(issue.id).good_job_concurrency_key).to eq("reenqueue_eligible_issue_#{issue.id}")
+    end
+  end
+
   describe "#perform" do
     it "rechecks an eligible issue" do
       project = create(:project, auto_pick_enabled: true)

--- a/spec/jobs/issues/reenqueue_eligible_job_spec.rb
+++ b/spec/jobs/issues/reenqueue_eligible_job_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Issues::ReenqueueEligibleJob do
+  describe "#perform" do
+    it "rechecks an eligible issue" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "failed", github_state: "open")
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      described_class.perform_now(issue.id)
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(issue, project: project, skip_project_gate: true)
+    end
+
+    it "does nothing for missing issues" do
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      described_class.perform_now(-1)
+
+      expect(Issues::EnqueueEligible).not_to have_received(:call)
+    end
+
+    it "does nothing for pull requests" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, :pull_request, project: project, paid_state: "failed", github_state: "open")
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      described_class.perform_now(issue.id)
+
+      expect(Issues::EnqueueEligible).not_to have_received(:call)
+    end
+
+    it "does nothing for intentional waiting states" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "needs_input", github_state: "open")
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      described_class.perform_now(issue.id)
+
+      expect(Issues::EnqueueEligible).not_to have_received(:call)
+    end
+
+    it "does nothing when the auto-pick project gate defers work" do
+      project = create(:project, auto_pick_enabled: true, quality_paused_at: Time.current)
+      issue = create(:issue, project: project, paid_state: "failed", github_state: "open")
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      described_class.perform_now(issue.id)
+
+      expect(Issues::EnqueueEligible).not_to have_received(:call)
+    end
+
+    it "logs and swallows enqueue errors" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "failed", github_state: "open")
+      allow(Issues::EnqueueEligible).to receive(:call).and_raise(StandardError, "transient failure")
+      allow(Rails.logger).to receive(:error)
+
+      expect { described_class.perform_now(issue.id) }.not_to raise_error
+      expect(Rails.logger).to have_received(:error).with(
+        hash_including(
+          message: "enqueue_eligible.issue_state_change_failed",
+          issue_id: issue.id,
+          error: "transient failure"
+        )
+      )
+    end
+  end
+end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -371,6 +371,20 @@ RSpec.describe Issue do
       end
     end
 
+    it "counts no_output runs toward the failure backoff streak" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
+      2.times do
+        create(:agent_run, :no_output, project: project, issue: issue, goal: "create_pr", auto_pick: true)
+      end
+
+      freeze_time do
+        expect {
+          issue.update!(paid_state: "failed")
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(15.minutes.from_now)
+      end
+    end
+
     it "does not re-enqueue intentional waiting states" do
       project = create(:project, auto_pick_enabled: true)
       issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
@@ -389,13 +403,13 @@ RSpec.describe Issue do
       }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
     end
 
-    it "does not re-enqueue when the project gate defers auto-pick" do
+    it "still enqueues recheck when the project gate defers auto-pick" do
       project = create(:project, auto_pick_enabled: true, quality_paused_at: Time.current)
       issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
 
       expect {
         issue.update!(paid_state: "failed")
-      }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+      }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id)
     end
   end
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -325,6 +325,80 @@ RSpec.describe Issue do
     end
   end
 
+  describe "after_update_commit on paid_state change" do
+    it "enqueues an immediate recheck when a non-PR issue moves back into an auto-pick eligible state" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
+      allow(Rails.logger).to receive(:info)
+
+      expect {
+        issue.update!(paid_state: "new")
+      }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id)
+
+      expect(Rails.logger).to have_received(:info).with(
+        hash_including(
+          message: "enqueue_eligible.issue_state_changed",
+          issue_id: issue.id,
+          paid_state: "new",
+          wait_seconds: nil
+        )
+      )
+    end
+
+    it "backs off failed issue retries to avoid immediate hot loops" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
+      create(:agent_run, :failed, project: project, issue: issue, goal: "create_pr", auto_pick: true)
+
+      freeze_time do
+        expect {
+          issue.update!(paid_state: "failed")
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(5.minutes.from_now)
+      end
+    end
+
+    it "increases failed issue retry backoff for consecutive failures" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
+      2.times do
+        create(:agent_run, :timeout, project: project, issue: issue, goal: "create_pr", auto_pick: true)
+      end
+
+      freeze_time do
+        expect {
+          issue.update!(paid_state: "failed")
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(15.minutes.from_now)
+      end
+    end
+
+    it "does not re-enqueue intentional waiting states" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
+
+      expect {
+        issue.update!(paid_state: "needs_input")
+      }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+    end
+
+    it "does not re-enqueue pull requests" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, :pull_request, project: project, paid_state: "in_progress", github_state: "open")
+
+      expect {
+        issue.update!(paid_state: "failed")
+      }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+    end
+
+    it "does not re-enqueue when the project gate defers auto-pick" do
+      project = create(:project, auto_pick_enabled: true, quality_paused_at: Time.current)
+      issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
+
+      expect {
+        issue.update!(paid_state: "failed")
+      }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+    end
+  end
+
   describe "instance methods" do
     describe "#github_url" do
       it "returns the GitHub issue URL for issues" do

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -403,6 +403,15 @@ RSpec.describe Issue do
       }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
     end
 
+    it "does not re-enqueue when project has auto-pick disabled" do
+      project = create(:project, auto_pick_enabled: false)
+      issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
+
+      expect {
+        issue.update!(paid_state: "failed")
+      }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+    end
+
     it "still enqueues recheck when the project gate defers auto-pick" do
       project = create(:project, auto_pick_enabled: true, quality_paused_at: Time.current)
       issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")


### PR DESCRIPTION
## Summary
- recheck auto-pick eligibility when non-PR issues transition back into retry-eligible local states
- move the re-enqueue work into a background job with guard revalidation at execution time
- add bounded backoff for repeated failed auto-pick issue runs to avoid hot retry loops

## Testing
- `bin/rspec spec/models/issue_spec.rb spec/jobs/issues/reenqueue_eligible_job_spec.rb`
