### PR TITLE
fix(agent-runs): sanitize Claude settings.json in run containers to avoid leaking interactive model defaults

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -994,11 +994,12 @@ module Containers
       # Container was already removed between running? check and stop
     end
 
-    # Copies credentials and settings from the read-only host mount into the
-    # writable ~/.claude tmpfs. Only the files Claude CLI needs for auth and
-    # configuration are copied; session/project data is created fresh each run.
+    # Copies credentials from the read-only host mount into the writable
+    # ~/.claude tmpfs. Only `.credentials.json` is needed for subscription auth;
+    # `settings.json` is intentionally excluded to prevent interactive model
+    # defaults from leaking into agent runs.
     def seed_claude_credentials!
-      source_files = %w[.credentials.json settings.json]
+      source_files = %w[.credentials.json]
       return unless claude_subscription_auth?
 
       # Prefer the source that actually contains the required credential file

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -975,6 +975,22 @@ RSpec.describe Containers::Provision do
 
         service.provision
       end
+
+      it "does not copy settings.json into the container even when present on host" do
+        File.write(File.join(claude_config_dir, "settings.json"), '{"model":"claude-sonnet-4-20250514"}')
+
+        service.provision
+
+        exec_calls = []
+        expect(mock_container).to have_received(:exec).at_least(:once) do |cmd, **_opts|
+          exec_calls << cmd
+        end
+
+        copy_commands = exec_calls.select { |cmd| cmd.is_a?(Array) && cmd.last.to_s.include?("cp ") }
+        copy_commands.each do |cmd|
+          expect(cmd.last).not_to include("settings.json")
+        end
+      end
     end
 
     context "with fallback providers" do


### PR DESCRIPTION
## Summary

Agent runs were inheriting `settings.json` from the host/devcontainer Claude CLI environment, which could leak interactive model defaults and other unrelated settings into reproducible runs. This change stops copying `settings.json` into run containers so only subscription auth (`.credentials.json`) is seeded, ensuring run behavior is driven solely by Paid's configuration and the explicit model selection from `model_selection`.

## Changes

- **Services**: Removed `settings.json` from `source_files` in `seed_claude_credentials!` (`app/services/containers/provision.rb:1001`); only `.credentials.json` is now copied into agent run containers for Claude subscription auth.
- **Tests**: Added coverage (`spec/services/containers/provision_spec.rb:979`) asserting that a host-side `settings.json` with model defaults is not propagated into the container.

## Design Decisions

- **Drop, don't sanitize** — rather than generating a minimal `settings.json`, we omit it entirely. Subscription auth only requires `.credentials.json`, so a sanitized file would add surface area without functional benefit. If run-scoped Claude settings are ever needed, they should be generated explicitly from Paid configuration rather than inherited from the host.
- **Pairs with the prior execution-side fix** — explicit model pinning from `model_selection` already guards the model dimension; this change closes the remaining input-surface gap so the container only inherits what's strictly necessary.

---

Closes #2078