### PR TITLE
feat: Add toggle switches to providers table for quick enable/disable

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -312,6 +312,7 @@ class ProvidersController < ApplicationController
         end
 
         if success
+          @provider.reload
           render turbo_stream: turbo_stream.replace(
             ActionView::RecordIdentifier.dom_id(@provider, :"#{attribute}_toggle"),
             partial: partial,

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -10,7 +10,7 @@ class ProvidersController < ApplicationController
     def circuit_open?  = circuit_state == "open"
     def circuit_half_open? = circuit_state == "half_open"
   end
-  before_action :set_provider, only: [ :edit, :update, :destroy, :test_agent ]
+  before_action :set_provider, only: [ :edit, :update, :destroy, :test_agent, :toggle_agent_runs, :toggle_fallback ]
   before_action :load_provider_options, only: [ :new, :create, :edit, :update ]
 
   def index
@@ -123,6 +123,16 @@ class ProvidersController < ApplicationController
       error_type: result.error_type,
       message: result.message
     }
+  end
+
+  def toggle_agent_runs
+    authorize @provider, :update?
+    toggle_provider_flag(:enabled_for_agent_runs, "providers/agent_runs_toggle_index")
+  end
+
+  def toggle_fallback
+    authorize @provider, :update?
+    toggle_provider_flag(:enabled_for_fallback, "providers/fallback_toggle_index")
   end
 
   def settings
@@ -281,6 +291,62 @@ class ProvidersController < ApplicationController
     if setting_fallback
       @provider.errors.add(:enabled_for_fallback, "cannot be enabled for a provider whose CLI is not installed in the agent container")
     end
+  end
+
+  def toggle_provider_flag(attribute, partial)
+    new_value = !@provider.public_send(:"#{attribute}?")
+    @provider.assign_attributes(attribute => new_value)
+
+    validate_container_executable_for_toggle(attribute)
+
+    respond_to do |format|
+      format.turbo_stream do
+        success = if @provider.errors.none?
+          Provider.transaction do
+            if @provider.save && reconcile_settings!
+              true
+            else
+              raise ActiveRecord::Rollback
+            end
+          end
+        end
+
+        if success
+          render turbo_stream: turbo_stream.replace(
+            ActionView::RecordIdentifier.dom_id(@provider, :"#{attribute}_toggle"),
+            partial: partial,
+            locals: { provider: @provider }
+          )
+        else
+          @provider.reload if @provider.persisted?
+          error_message = @provider.errors.full_messages.to_sentence.presence || "Could not update provider"
+          render turbo_stream: [
+            turbo_stream.replace(
+              ActionView::RecordIdentifier.dom_id(@provider, :"#{attribute}_toggle"),
+              partial: partial,
+              locals: { provider: @provider }
+            ),
+            turbo_stream.prepend("flash", partial: "shared/flash_alert", locals: { message: error_message })
+          ], status: :unprocessable_content
+        end
+      end
+      format.html { redirect_to providers_path }
+    end
+  end
+
+  def validate_container_executable_for_toggle(attribute)
+    return unless @provider.public_send(:"#{attribute}?")
+    return unless @provider.will_save_change_to_attribute?(attribute.to_s, to: true)
+
+    unless Provider.supported_provider_key?(@provider.provider_key)
+      @provider.errors.add(attribute, "must be disabled for an unsupported provider")
+      return
+    end
+
+    return if Provider.addable_provider_key?(@provider.provider_key)
+    return if ProviderSupport.container_executable_provider_keys.include?(@provider.provider_key)
+
+    @provider.errors.add(attribute, "cannot be enabled for a provider whose CLI is not installed in the agent container")
   end
 
   def reconcile_settings!

--- a/app/views/providers/_agent_runs_toggle_index.html.erb
+++ b/app/views/providers/_agent_runs_toggle_index.html.erb
@@ -1,0 +1,14 @@
+<%= tag.span id: dom_id(provider, :enabled_for_agent_runs_toggle) do %>
+  <% if policy(provider).update? %>
+    <%= button_to toggle_agent_runs_provider_path(provider), method: :post,
+          class: "group relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 #{provider.enabled_for_agent_runs? ? 'bg-indigo-600' : 'bg-gray-200'}",
+          form: { class: "inline" } do %>
+      <span class="sr-only">Toggle agent runs</span>
+      <span class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out <%= provider.enabled_for_agent_runs? ? 'translate-x-5' : 'translate-x-0' %>"></span>
+    <% end %>
+  <% else %>
+    <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= provider.enabled_for_agent_runs? ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600' %>">
+      <%= provider.enabled_for_agent_runs? ? "Enabled" : "Disabled" %>
+    </span>
+  <% end %>
+<% end %>

--- a/app/views/providers/_fallback_toggle_index.html.erb
+++ b/app/views/providers/_fallback_toggle_index.html.erb
@@ -1,0 +1,17 @@
+<%= tag.span id: dom_id(provider, :enabled_for_fallback_toggle) do %>
+  <% if policy(provider).update? %>
+    <%= button_to toggle_fallback_provider_path(provider), method: :post,
+          class: "group relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 #{provider.enabled_for_fallback? ? 'bg-indigo-600' : 'bg-gray-200'}",
+          form: { class: "inline" } do %>
+      <span class="sr-only">Toggle fallback</span>
+      <span class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out <%= provider.enabled_for_fallback? ? 'translate-x-5' : 'translate-x-0' %>"></span>
+    <% end %>
+    <% if provider.api_key? && provider.rate_limit_fallback? %>
+      <span class="ml-1 text-xs text-gray-500">rate-limit only</span>
+    <% end %>
+  <% else %>
+    <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= provider.enabled_for_fallback? ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600' %>">
+      <%= provider.enabled_for_fallback? ? "Enabled" : "Disabled" %>
+    </span>
+  <% end %>
+<% end %>

--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:title) { "Providers - Paid" } %>
 
 <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+  <div id="flash"></div>
   <div class="mb-6 flex items-center justify-between">
     <div>
       <h1 class="text-xl font-semibold text-gray-900">Providers</h1>
@@ -50,14 +51,8 @@
                 <span class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700">API Key</span>
               <% end %>
             </td>
-            <td class="px-4 py-3 text-sm text-gray-700"><%= provider.enabled_for_agent_runs? ? "Enabled" : "Disabled" %></td>
-            <td class="px-4 py-3 text-sm text-gray-700">
-              <% if provider.api_key? && provider.rate_limit_fallback? %>
-                <%= provider.enabled_for_fallback? ? "Enabled (rate-limit only)" : "Disabled (rate-limit only)" %>
-              <% else %>
-                <%= provider.enabled_for_fallback? ? "Enabled" : "Disabled" %>
-              <% end %>
-            </td>
+            <td class="px-4 py-3 text-sm text-gray-700"><%= render "agent_runs_toggle_index", provider: provider %></td>
+            <td class="px-4 py-3 text-sm text-gray-700"><%= render "fallback_toggle_index", provider: provider %></td>
             <% stats = @provider_stats_by_id[provider.id] %>
             <td class="px-4 py-3 text-sm text-gray-700">
               <% if stats && stats[:runs_7d] > 0 %>

--- a/app/views/shared/_flash_alert.html.erb
+++ b/app/views/shared/_flash_alert.html.erb
@@ -1,0 +1,9 @@
+<div class="mx-auto max-w-3xl px-4 py-3 sm:px-6 lg:px-8">
+  <div class="rounded-md bg-red-50 p-4">
+    <div class="flex">
+      <div class="ml-3">
+        <p class="text-sm font-medium text-red-800"><%= message %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,8 @@ Rails.application.routes.draw do
   resources :providers, except: :show do
     patch :settings, on: :collection
     post :test_agent, on: :member
+    post :toggle_agent_runs, on: :member
+    post :toggle_fallback, on: :member
   end
 
   # Service container management

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -819,4 +819,113 @@ RSpec.describe "Providers" do
       expect(Provider.with_discarded.find(provider.id)).to be_discarded
     end
   end
+
+  describe "POST /providers/:id/toggle_agent_runs" do
+    context "when not authenticated" do
+      it "redirects to sign in" do
+        provider = create(:provider, user: user, provider_key: "cursor")
+
+        post toggle_agent_runs_provider_path(provider)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "toggles agent runs from enabled to disabled" do
+        provider = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: false)
+
+        post toggle_agent_runs_provider_path(provider), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+        expect(provider.reload.enabled_for_agent_runs).to be(false)
+      end
+
+      it "toggles agent runs from disabled to enabled" do
+        provider = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: false, enabled_for_fallback: false)
+
+        post toggle_agent_runs_provider_path(provider), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+        expect(provider.reload.enabled_for_agent_runs).to be(true)
+      end
+
+      it "returns turbo stream response" do
+        provider = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: false)
+
+        post toggle_agent_runs_provider_path(provider), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        expect(response.body).to include("turbo-stream")
+      end
+
+      it "prevents toggling another user's provider" do
+        other_user = create(:user)
+        other_provider = create(:provider, user: other_user, provider_key: "cursor")
+
+        post toggle_agent_runs_provider_path(other_provider), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "prevents disabling the last provider enabled for agent runs" do
+        allow(ProviderSupport).to receive(:container_executable_provider_keys).and_return(%w[claude])
+        provider = user.providers.find_by!(provider_key: "claude")
+
+        post toggle_agent_runs_provider_path(provider), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(provider.reload.enabled_for_agent_runs).to be(true)
+      end
+
+      it "handles HTML fallback format" do
+        provider = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: false)
+
+        post toggle_agent_runs_provider_path(provider)
+
+        expect(response).to redirect_to(providers_path)
+      end
+    end
+  end
+
+  describe "POST /providers/:id/toggle_fallback" do
+    before { sign_in user }
+
+    it "toggles fallback from enabled to disabled" do
+      provider = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
+
+      post toggle_fallback_provider_path(provider), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(provider.reload.enabled_for_fallback).to be(false)
+    end
+
+    it "toggles fallback from disabled to enabled" do
+      provider = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: false)
+
+      post toggle_fallback_provider_path(provider), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(provider.reload.enabled_for_fallback).to be(true)
+    end
+
+    it "returns turbo stream response" do
+      provider = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
+
+      post toggle_fallback_provider_path(provider), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include("turbo-stream")
+    end
+
+    it "handles HTML fallback format" do
+      provider = user.providers.create!(provider_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
+
+      post toggle_fallback_provider_path(provider)
+
+      expect(response).to redirect_to(providers_path)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Eliminate the navigation friction of toggling provider availability by replacing the static "Enabled"/"Disabled" labels in the providers table with inline toggle switches that update state via Turbo Stream, keeping the providers index in sync with the edit form without a full page reload.

## Changes

- **Routes** (`config/routes.rb`): Add `toggle_agent_runs` and `toggle_fallback` POST member routes on providers.
- **Controller** (`app/controllers/providers_controller.rb`): Add `toggle_agent_runs` and `toggle_fallback` actions that delegate to a shared `toggle_provider_flag` helper. The helper toggles the boolean, validates container-executable status via `validate_container_executable_for_toggle`, and wraps the save plus settings reconciliation in a transaction so partial failures don't leave UI and persistence out of sync. Responds with Turbo Stream on success and re-renders the toggle (plus a flash alert) on failure.
- **Views**:
  - `app/views/providers/_agent_runs_toggle_index.html.erb` — toggle switch partial for the agent runs column.
  - `app/views/providers/_fallback_toggle_index.html.erb` — toggle switch partial for the fallback column, preserving the rate-limit-only label.
  - `app/views/providers/index.html.erb` — replaces text cells with the new partials and adds a `#flash` container for inline error display.
  - `app/views/shared/_flash_alert.html.erb` — reusable flash alert partial used by failed toggles.
- **Tests** (`spec/requests/providers_spec.rb`): 11 new request specs covering both toggles, Turbo Stream responses, authentication, authorization, the container-executable guard, and the HTML fallback.

## Design Decisions

- **Transactional save + reconcile** — `@provider.save` and `reconcile_settings!` run inside a single transaction. Without this, a successful save followed by a reconciliation failure would leave the provider toggled in the database while the UI reverted, producing drift between the index and edit form.
- **Mirrored container-executable guard** — Rather than reusing `validate_container_executable!` (which is wired to the edit form flow), a sibling `validate_container_executable_for_toggle` keeps the toggle path's response shape (Turbo Stream + flash) consistent with the rest of the inline UX.
- **Two narrowly-scoped endpoints** — Separate `toggle_agent_runs` and `toggle_fallback` actions, rather than one generic toggle accepting a field name, keep the surface area auditable and avoid having the controller accept a user-supplied attribute name.
- **Pattern parity with existing toggles** — The partials follow the same structure as the existing project auto-pick toggle so the index stays visually and behaviorally consistent.

## Screenshots

_Author: please attach before/after screenshots of the providers table showing the new toggle switches in both states._

---

Closes #2084