### PR TITLE
fix(agent-runs): harden codex subscription and direct-outbound preflight

### DIFF
--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -68,7 +68,7 @@ module Models
 
     def skip_model_selection?
       provider = agent_run.provider
-      provider&.provider_key == "codex" && provider.subscription?
+      provider&.provider_key == "codex" && provider&.subscription?
     end
 
     def select_model

--- a/app/services/models/select.rb
+++ b/app/services/models/select.rb
@@ -19,6 +19,11 @@ module Models
     def call
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
+      if skip_model_selection?
+        persist_decision_log(outcome: "no_selection", duration_ms: 0)
+        return nil
+      end
+
       selected = select_model
       duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
       unless selected
@@ -60,6 +65,11 @@ module Models
     end
 
     private
+
+    def skip_model_selection?
+      provider = agent_run.provider
+      provider&.provider_key == "codex" && provider.subscription?
+    end
 
     def select_model
       project = agent_run.project

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -86,6 +86,7 @@ module Activities
     DEFAULT_CREATE_PR_IDLE_TIMEOUT = 360   # 6 minutes without output = stuck
     DEFAULT_AGENT_STARTUP_TIMEOUT = 360    # 6 minutes without first output = stuck
     PREFLIGHT_TIMEOUT_SECONDS = 10
+    DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS = 30
     CHANGE_DETECTION_MAX_ATTEMPTS = 3
     CHANGE_DETECTION_RETRY_BACKOFF = 0.25
     POST_RUN_BOOKKEEPING_ERROR_TYPE = "PostRunBookkeepingFailed"
@@ -986,11 +987,12 @@ module Activities
       command = build_command(command_context, prompt, agent_run: agent_run)
       env = command_env_for(command_context, prompt, agent_run: agent_run)
       preparation = command_preparation_for(command_context, prompt, agent_run: agent_run)
+      preflight_timeout = preflight_timeout_seconds_for(command_context.provider_candidate, command_context.user)
 
       result = container_service.execute(
         command,
-        timeout: PREFLIGHT_TIMEOUT_SECONDS,
-        idle_timeout: PREFLIGHT_TIMEOUT_SECONDS,
+        timeout: preflight_timeout,
+        idle_timeout: preflight_timeout,
         env: env,
         preparation: preparation,
         abort_patterns: aggregated_abort_patterns
@@ -1041,7 +1043,8 @@ module Activities
       end
       raise_preflight_failure!(agent_run: agent_run, provider: provider, reason: reason)
     rescue Containers::Provision::TimeoutError => e
-      reason = "Timed out after #{PREFLIGHT_TIMEOUT_SECONDS}s: #{e.message}. Check proxy configuration, auth, and network policy."
+      preflight_timeout = preflight_timeout_seconds_for(command_context.provider_candidate, command_context.user)
+      reason = "Timed out after #{preflight_timeout}s: #{e.message}. Check proxy configuration, auth, and network policy."
       raise_preflight_failure!(agent_run: agent_run, provider: provider, reason: reason)
     rescue Containers::Provision::OutputAbortError => e
       reset_at = rate_limit_reset_at(provider, e.matched_output.to_s)
@@ -1069,6 +1072,13 @@ module Activities
       # Provider config unavailable — skip harness preflight and let the
       # smoke execution catch any real issues.
       nil
+    end
+
+    def preflight_timeout_seconds_for(provider_candidate, user)
+      provider_entry = provider_entry_for(provider_candidate, user)
+      return DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS if provider_entry&.requires_direct_outbound?
+
+      PREFLIGHT_TIMEOUT_SECONDS
     end
 
     # Checks if the agent run is stuck in an infinite loop by analyzing
@@ -1785,10 +1795,15 @@ module Activities
 
       return configured_runtime if configured_runtime
       return nil if selected_model_id.blank?
+      return nil if codex_subscription_auth_runtime?(provider_entry)
 
       validate_selected_model_provider_compatibility!(provider_candidate, provider_entry, selected_model)
 
       AgentHarness::ProviderRuntime.new(model: selected_model_id)
+    end
+
+    def codex_subscription_auth_runtime?(provider_entry)
+      provider_entry&.provider_key == "codex" && provider_entry&.subscription?
     end
 
     def runtime_cache_key(runtime)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1043,7 +1043,6 @@ module Activities
       end
       raise_preflight_failure!(agent_run: agent_run, provider: provider, reason: reason)
     rescue Containers::Provision::TimeoutError => e
-      preflight_timeout = preflight_timeout_seconds_for(command_context.provider_candidate, command_context.user)
       reason = "Timed out after #{preflight_timeout}s: #{e.message}. Check proxy configuration, auth, and network policy."
       raise_preflight_failure!(agent_run: agent_run, provider: provider, reason: reason)
     rescue Containers::Provision::OutputAbortError => e

--- a/spec/services/models/select_spec.rb
+++ b/spec/services/models/select_spec.rb
@@ -338,6 +338,29 @@ RSpec.describe Models::Select do
       end
     end
 
+    context "when the run uses Codex subscription auth" do
+      let(:codex_provider) { create(:provider, user: project.created_by, provider_key: "codex", auth_type: "subscription") }
+      let(:agent_run) { create(:agent_run, project: project, provider: codex_provider, agent_type: "codex") }
+
+      before do
+        create(:llm_model, :openai, model_id: "gpt-4o", tier: "mid")
+        create(:llm_model, :openai, model_id: "gpt-4o-mini", tier: "low")
+      end
+
+      it "returns nil instead of persisting an incompatible selected model" do
+        expect(described_class.call(agent_run: agent_run)).to be_nil
+        expect(agent_run.model_selection).to be_nil
+      end
+
+      it "records the no-selection outcome" do
+        described_class.call(agent_run: agent_run)
+
+        log = agent_run.agent_run_logs.where(log_type: "system").order(:id).last
+
+        expect(log.metadata).to include("type" => "model_selection_decision", "outcome" => "no_selection")
+      end
+    end
+
     context "when override model does not exist" do
       before do
         create(:llm_model)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -87,6 +87,43 @@ RSpec.describe Activities::RunAgentActivity do
     ab_test
   end
 
+  def create_opencode_provider_for(user)
+    api_key = create(:provider_api_key, user: user, api_service_type: "openrouter")
+    create(:provider, :api_key,
+      user: user,
+      provider_key: "opencode",
+      provider_api_key: api_key,
+      config: {
+        "opencode" => {
+          "model" => "moonshotai/kimi-k2",
+          "api_provider" => "openrouter"
+        }
+      })
+  end
+
+  def run_direct_outbound_preflight(activity:, agent_run:, container_service:, provider:, user:)
+    command_context = Activities::RunAgentActivity::CommandContext.new(
+      provider_candidate: provider,
+      provider: provider.provider_key,
+      user: user
+    )
+
+    allow(activity).to receive(:run_provider_preflight!).and_call_original
+    allow(activity).to receive_messages(
+      preflight_provider_instance: nil,
+      build_command: %w[echo ok],
+      command_env_for: {},
+      command_preparation_for: nil
+    )
+
+    activity.send(:run_provider_preflight!,
+      agent_run: agent_run,
+      container_service: container_service,
+      command_context: command_context,
+      provider: provider.provider_key,
+      execution_env: {})
+  end
+
   describe "#with_periodic_heartbeat" do
     let(:mock_context) { instance_double(Temporalio::Activity::Context) }
 
@@ -689,6 +726,24 @@ RSpec.describe Activities::RunAgentActivity do
         Activities::RunAgentActivity::ProviderExecutionError,
         /Selected model different-model does not match configured runtime model moonshotai\/kimi-k2-0905/
       )
+    end
+  end
+
+  describe "#selected_provider_runtime" do
+    it "ignores Paid model selection for Codex subscription-auth runs" do
+      codex_provider = create(:provider, user: user, provider_key: "codex", auth_type: "subscription")
+      runtime_issue = create(:issue, project: project)
+      run = create(:agent_run, :with_git_context,
+        project: project,
+        issue: runtime_issue,
+        agent_type: "codex",
+        provider: codex_provider,
+        container_id: "abc123")
+      create(:model_selection, agent_run: run, llm_model: create(:llm_model, :openai, model_id: "gpt-4o"))
+
+      runtime = activity.send(:selected_provider_runtime, codex_provider, nil, run)
+
+      expect(runtime).to be_nil
     end
   end
 
@@ -2057,6 +2112,27 @@ expect(container_service).to receive(:execute).with(
           hash_including(
             timeout: described_class::PREFLIGHT_TIMEOUT_SECONDS,
             idle_timeout: described_class::PREFLIGHT_TIMEOUT_SECONDS
+          )
+        )
+      end
+
+      it "uses a longer timeout for direct-outbound provider preflight" do
+        opencode_provider = create_opencode_provider_for(user)
+        allow(container_service).to receive(:execute).and_return(exec_success)
+
+        run_direct_outbound_preflight(
+          activity: activity,
+          agent_run: agent_run,
+          container_service: container_service,
+          provider: opencode_provider,
+          user: user
+        )
+
+        expect(container_service).to have_received(:execute).with(
+          %w[echo ok],
+          hash_including(
+            timeout: described_class::DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS,
+            idle_timeout: described_class::DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS
           )
         )
       end


### PR DESCRIPTION
## Summary
- avoid forcing Paid-selected OpenAI models onto Codex subscription-auth runs
- skip model selection for Codex subscription-auth runs so run metadata stays accurate
- increase direct-outbound provider smoke preflight timeout to tolerate first-run SQLite migration/bootstrap work
- add focused specs for both execution and model-selection behavior

## Why
Recent non-running agent run failures showed two recurring user-facing problems:
- Codex subscription-auth runs were failing when a selected `gpt-4o` model was injected into a Codex ChatGPT-account flow that does not support it
- direct-outbound fallback providers were timing out during short smoke preflights before first-run bootstrap completed

## Testing
- `bin/rspec spec/services/models/select_spec.rb spec/temporal/activities/run_agent_activity_spec.rb`
- `bin/rubocop app/services/models/select.rb app/temporal/activities/run_agent_activity.rb spec/services/models/select_spec.rb spec/temporal/activities/run_agent_activity_spec.rb`
