### PR TITLE
fix(providers): add missing MiniMax provider wiring

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -38,6 +38,9 @@ class Provider < ApplicationRecord
                     opencode_model_provider: "deepseek" },
     "mistral" => { label: "Mistral", base_url: "https://api.mistral.ai/v1", service_type: "mistral",
                    opencode_model_provider: "mistral" },
+    "minimax" => { label: "MiniMax", base_url: "https://api.minimax.io/anthropic", service_type: "minimax",
+                   env_var: "ANTHROPIC_API_KEY", opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic",
+                   opencode_model_provider: "anthropic" },
     "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai",
                opencode_model_provider: "xai" },
     "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai",
@@ -69,6 +72,7 @@ class Provider < ApplicationRecord
     "deepseek" => { label: "DeepSeek", service_type: "deepseek", env_var: "DEEPSEEK_API_KEY" },
     "google" => { label: "Google Gemini", service_type: "google", env_var: "GEMINI_API_KEY" },
     "mistral" => { label: "Mistral", service_type: "mistral", env_var: "MISTRAL_API_KEY" },
+    "minimax" => { label: "MiniMax", service_type: "minimax", env_var: "ANTHROPIC_API_KEY" },
     "xai" => { label: "xAI", service_type: "xai", env_var: "XAI_API_KEY" },
     "zai" => { label: "z.ai", service_type: "zai", env_var: "ZAI_API_KEY" },
     "openrouter" => { label: "OpenRouter", service_type: "openrouter", env_var: "OPENROUTER_API_KEY" }
@@ -335,10 +339,7 @@ class Provider < ApplicationRecord
   end
 
   def kilocode_api_key_env_var
-    service_type = kilocode_required_api_service_type
-    return "OPENAI_API_KEY" if service_type.blank?
-
-    "#{service_type.upcase.tr('-', '_')}_API_KEY"
+    direct_outbound_api_key_env_var(kilocode_api_provider)
   end
 
   def kilocode_runtime_env
@@ -952,7 +953,7 @@ class Provider < ApplicationRecord
 
     api_config = DIRECT_OUTBOUND_API_PROVIDERS.fetch(opencode_api_provider, DIRECT_OUTBOUND_API_PROVIDERS["openrouter"])
 
-    env_var = "#{api_config[:service_type].upcase.tr('-', '_')}_API_KEY"
+    env_var = direct_outbound_api_key_env_var(opencode_api_provider)
     env = { env_var => provider_api_key&.api_key.to_s }
     env["OPENAI_BASE_URL"] = api_config[:base_url] if api_config[:base_url]
 
@@ -979,5 +980,12 @@ class Provider < ApplicationRecord
         }
       }
     )
+  end
+
+  def direct_outbound_api_key_env_var(api_provider)
+    api_config = DIRECT_OUTBOUND_API_PROVIDERS[api_provider.to_s]
+    return "OPENAI_API_KEY" if api_config.blank?
+
+    api_config[:env_var].presence || "#{api_config[:service_type].upcase.tr('-', '_')}_API_KEY"
   end
 end

--- a/app/services/integrations/credential_catalog.rb
+++ b/app/services/integrations/credential_catalog.rb
@@ -59,6 +59,16 @@ module Integrations
       }
     }.freeze
 
+    EXTRA_LLM_PROVIDER_SERVICES = {
+      "minimax" => {
+        key: "minimax",
+        label: "MiniMax",
+        description: "Stored MiniMax API keys for account-managed credential workflows.",
+        category: :llm_provider,
+        auth_kinds: %w[api_key]
+      }
+    }.freeze
+
     module_function
 
     def provider_services
@@ -74,6 +84,7 @@ module Integrations
             auth_kinds: %w[api_key oauth_token]
           }
         end
+        .merge(EXTRA_LLM_PROVIDER_SERVICES)
         .transform_keys(&:to_s)
     end
 

--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -173,6 +173,7 @@ module ProviderSupport
     "inception" => "InceptionLabs",
     "deepseek" => "DeepSeek",
     "mistral" => "Mistral",
+    "minimax" => "MiniMax",
     "xai" => "xAI",
     "zai" => "z.ai",
     "zai_coding" => "z.ai (Coding Plan)"

--- a/spec/lib/provider_smoke_helpers_spec.rb
+++ b/spec/lib/provider_smoke_helpers_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe ProviderSmokeHelpers do
       expect(described_class.scenario_for("kilocode-zai").default_model).to eq("glm-5.1")
       expect(described_class.scenario_for("opencode-openrouter").default_model).to eq("moonshotai/kimi-k2")
       expect(described_class.scenario_for("kilocode-inception").default_model).to eq("mercury-2")
+      expect(described_class.scenario_for("opencode-minimax").default_model).to eq("MiniMax-M2.5")
+      expect(described_class.scenario_for("pi-deepseek").default_model).to eq("deepseek-chat")
+      expect(described_class.scenario_for("pi-minimax").default_model).to eq("MiniMax-M2.5")
     end
 
     it "raises a helpful error for unknown names" do
@@ -63,6 +66,34 @@ RSpec.describe ProviderSmokeHelpers do
       provider = described_class.build_direct_outbound_provider!(user: user, scenario: scenario)
 
       expect(provider.opencode_model_id).to eq("moonshotai/kimi-k2")
+    end
+
+    it "builds Pi DeepSeek providers through the shared direct-outbound path" do
+      scenario = described_class.scenario_for("pi-deepseek")
+      allow(described_class).to receive(:development_provider_info_for).with(scenario).and_return(
+        { "api_key" => "sk-deepseek-test" }
+      )
+
+      provider = described_class.build_direct_outbound_provider!(user: user, scenario: scenario)
+
+      expect(provider.provider_key).to eq("pi")
+      expect(provider.pi_api_provider).to eq("deepseek")
+      expect(provider.pi_model_id).to eq("deepseek-chat")
+      expect(provider.provider_api_key.api_service_type).to eq("deepseek")
+    end
+
+    it "builds MiniMax providers with the Anthropic env-var backed service type" do
+      scenario = described_class.scenario_for("opencode-minimax")
+      allow(described_class).to receive(:development_provider_info_for).with(scenario).and_return(
+        { "api_key" => "sk-minimax-test" }
+      )
+
+      provider = described_class.build_direct_outbound_provider!(user: user, scenario: scenario)
+
+      expect(provider.provider_key).to eq("opencode")
+      expect(provider.opencode_api_provider).to eq("minimax")
+      expect(provider.opencode_model_id).to eq("MiniMax-M2.5")
+      expect(provider.provider_api_key.api_service_type).to eq("minimax")
     end
   end
 end

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe ProviderSupport do
         "openai" => "OpenAI",
         "openrouter" => "OpenRouter",
         "google" => "Google AI",
+        "minimax" => "MiniMax",
         "zai" => "z.ai",
         "zai_coding" => "z.ai (Coding Plan)"
       )
@@ -177,6 +178,7 @@ RSpec.describe ProviderSupport do
     it "returns the human-readable label for known types" do
       expect(described_class.api_service_type_label("openrouter")).to eq("OpenRouter")
       expect(described_class.api_service_type_label("anthropic")).to eq("Anthropic")
+      expect(described_class.api_service_type_label("minimax")).to eq("MiniMax")
     end
 
     it "titleizes unknown types" do

--- a/spec/models/provider_api_key_spec.rb
+++ b/spec/models/provider_api_key_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe ProviderApiKey do
       options = described_class.api_service_type_options
 
       expect(options).to include(%w[Anthropic anthropic])
+      expect(options).to include([ "MiniMax", "minimax" ])
       expect(options).to include(%w[OpenRouter openrouter])
       expect(options).to include(%w[OpenAI openai])
       expect(options).to include([ "Google AI", "google" ])

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -612,6 +612,31 @@ RSpec.describe Provider do
       })
       expect(config["model"]).to eq("zai-coding-plan/glm-5.1")
     end
+
+    it "uses Anthropic auth env vars for MiniMax backends" do
+      minimax_key = create(:provider_api_key, user: user, api_service_type: "minimax")
+      provider.update!(
+        provider_api_key: minimax_key,
+        config: { "kilocode" => { "api_provider" => "minimax", "model" => "MiniMax-M2.5" } }
+      )
+
+      config = JSON.parse(provider.kilocode_config_json)
+      options = config.fetch("provider").fetch("anthropic").fetch("options")
+      models = config.fetch("provider").fetch("anthropic").fetch("models")
+
+      expect(options).to eq(
+        "apiKey" => "{env:ANTHROPIC_API_KEY}",
+        "baseURL" => "https://api.minimax.io/anthropic"
+      )
+      expect(models).to eq(
+        "MiniMax-M2.5" => {
+          "name" => "MiniMax-M2.5",
+          "id" => "MiniMax-M2.5",
+          "tool_call" => true
+        }
+      )
+      expect(config["model"]).to eq("anthropic/MiniMax-M2.5")
+    end
   end
 
   describe "Aider config infrastructure" do
@@ -880,6 +905,27 @@ RSpec.describe Provider do
       expect(runtime.model).to eq("zai/glm-5.1")
     end
 
+    it "uses Anthropic auth env vars for MiniMax OpenCode runtimes" do
+      minimax_key = create(:provider_api_key, user: user, api_service_type: "minimax", api_key: "sk-minimax-secret")
+      minimax_provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: minimax_key,
+        config: { "opencode" => { "api_provider" => "minimax", "model" => "MiniMax-M2.5" } }
+      )
+
+      runtime = minimax_provider.agent_harness_provider_runtime
+
+      expect(runtime.model).to eq("anthropic/MiniMax-M2.5")
+      expect(runtime.env).to include(
+        "ANTHROPIC_API_KEY" => "sk-minimax-secret",
+        "OPENAI_BASE_URL" => "https://api.minimax.io/anthropic"
+      )
+      expect(runtime.metadata[:config]["provider"]).to eq({ "minimax" => {} })
+    end
+
     it "does not enable direct outbound when the OpenCode model id is missing" do
       provider = build(
         :provider,
@@ -952,6 +998,26 @@ RSpec.describe Provider do
 
       expect(provider).not_to be_valid
       expect(provider.errors[:config]).to include("must include a supported Pi API provider")
+    end
+
+    it "accepts MiniMax as a Pi API provider" do
+      minimax_key = create(:provider_api_key, user: user, api_service_type: "minimax", api_key: "sk-minimax-secret")
+      provider = build(
+        :provider,
+        user: user,
+        provider_key: "pi",
+        auth_type: "api_key",
+        provider_api_key: minimax_key,
+        config: { "pi" => { "api_provider" => "minimax", "model" => "MiniMax-M2.5" } }
+      )
+
+      expect(provider).to be_valid
+      expect(provider.agent_harness_provider_runtime.metadata).to include(
+        "paid_pi_auth_entry" => {
+          "provider" => "minimax",
+          "api_key" => "sk-minimax-secret"
+        }
+      )
     end
   end
 

--- a/spec/requests/integration_credentials_spec.rb
+++ b/spec/requests/integration_credentials_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe "IntegrationCredentials" do
       expect(response.body).to include("GitHub Signing")
     end
 
+    it "offers MiniMax in the LLM provider credential service list" do
+      get new_integration_credential_path(category: "llm_provider")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('value="minimax"')
+      expect(response.body).to include("MiniMax")
+    end
+
     context "when user is an admin" do
       before { sign_in admin_user }
 
@@ -95,6 +103,23 @@ RSpec.describe "IntegrationCredentials" do
       expect(response).to redirect_to(integration_credential_path(credential, category: credential.category))
       expect(credential.service_key).to eq("gemini")
       expect(credential.created_by).to eq(owner_user)
+    end
+
+    it "creates MiniMax provider credentials" do
+      post integration_credentials_path, params: {
+        integration_credential: {
+          name: "MiniMax API Key",
+          service_key: "minimax",
+          category: "llm_provider",
+          auth_kind: "api_key",
+          secret: "minimax-secret"
+        }
+      }
+
+      credential = IntegrationCredential.last
+      expect(response).to redirect_to(integration_credential_path(credential, category: credential.category))
+      expect(credential.service_key).to eq("minimax")
+      expect(credential.auth_kind).to eq("api_key")
     end
 
     context "when user is an admin" do

--- a/spec/requests/provider_api_keys_spec.rb
+++ b/spec/requests/provider_api_keys_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe "ProviderApiKeys" do
         expect(response.body).to include("OpenRouter")
         expect(response.body).to include('value="anthropic"')
         expect(response.body).to include("Anthropic")
+        expect(response.body).to include('value="minimax"')
+        expect(response.body).to include("MiniMax")
       end
     end
   end

--- a/spec/support/provider_smoke_helpers.rb
+++ b/spec/support/provider_smoke_helpers.rb
@@ -40,6 +40,7 @@ module ProviderSmokeHelpers
     "inception" => "INCEPTION_API_KEY",
     "deepseek" => "DEEPSEEK_API_KEY",
     "mistral" => "MISTRAL_API_KEY",
+    "minimax" => "ANTHROPIC_API_KEY",
     "xai" => "XAI_API_KEY",
     "zai" => "ZAI_API_KEY",
     "zai_coding" => "ZAI_CODING_API_KEY"

--- a/spec/support/provider_smoke_helpers.rb
+++ b/spec/support/provider_smoke_helpers.rb
@@ -93,6 +93,15 @@ module ProviderSmokeHelpers
       default_model: "moonshotai/kimi-k2",
       label: "OpenCode with OpenRouter API key"
     ),
+    "opencode-minimax" => Scenario.new(
+      name: "opencode-minimax",
+      provider_key: "opencode",
+      auth_type: "api_key",
+      api_provider: "minimax",
+      model_env: "PAID_SMOKE_OPENCODE_MINIMAX_MODEL",
+      default_model: "MiniMax-M2.5",
+      label: "OpenCode with MiniMax API key"
+    ),
 
     "kilocode-zai" => Scenario.new(
       name: "kilocode-zai",
@@ -111,6 +120,24 @@ module ProviderSmokeHelpers
       model_env: "PAID_SMOKE_KILOCODE_INCEPTION_MODEL",
       default_model: "mercury-2",
       label: "KiloCode with Inception API key"
+    ),
+    "pi-deepseek" => Scenario.new(
+      name: "pi-deepseek",
+      provider_key: "pi",
+      auth_type: "api_key",
+      api_provider: "deepseek",
+      model_env: "PAID_SMOKE_PI_DEEPSEEK_MODEL",
+      default_model: "deepseek-chat",
+      label: "Pi with DeepSeek API key"
+    ),
+    "pi-minimax" => Scenario.new(
+      name: "pi-minimax",
+      provider_key: "pi",
+      auth_type: "api_key",
+      api_provider: "minimax",
+      model_env: "PAID_SMOKE_PI_MINIMAX_MODEL",
+      default_model: "MiniMax-M2.5",
+      label: "Pi with MiniMax API key"
     ),
     "copilot-subscription" => Scenario.new(
       name: "copilot-subscription",


### PR DESCRIPTION
## Summary
- add missing MiniMax provider wiring for OpenCode, KiloCode, and Pi API-key flows
- expose MiniMax in the provider API key and integration credential UIs
- add regression coverage for MiniMax runtime/configuration paths

## Testing
- `bundle exec rspec spec/requests/integration_credentials_spec.rb spec/lib/provider_support_spec.rb spec/models/provider_api_key_spec.rb spec/requests/provider_api_keys_spec.rb spec/models/provider_spec.rb`
- `bin/rubocop app/models/provider.rb app/services/integrations/credential_catalog.rb lib/provider_support.rb spec/lib/provider_support_spec.rb spec/models/provider_api_key_spec.rb spec/models/provider_spec.rb spec/requests/provider_api_keys_spec.rb spec/requests/integration_credentials_spec.rb spec/support/provider_smoke_helpers.rb`

## Context
Issue reference: #2072