### PR TITLE
fix(providers): cover configured minimax smoke scenarios

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -40,7 +40,7 @@ class Provider < ApplicationRecord
                    opencode_model_provider: "mistral" },
     "minimax" => { label: "MiniMax", base_url: "https://api.minimax.io/anthropic", service_type: "minimax",
                    env_var: "ANTHROPIC_API_KEY", opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic",
-                   opencode_model_provider: "anthropic" },
+                   opencode_model_provider: "minimax" },
     "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai",
                opencode_model_provider: "xai" },
     "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai",

--- a/bin/provider-smoke
+++ b/bin/provider-smoke
@@ -25,7 +25,8 @@ def usage
   USAGE
 
   ProviderSmokeHelpers::PRESETS.each do |name, scenarios|
-    puts "      #{name}: #{scenarios.join(', ')}"
+    resolved = scenarios || ProviderSmokeHelpers.expand_name(name)
+    puts "      #{name}: #{resolved.join(', ')}"
   end
 
   puts "    Scenarios:"

--- a/spec/lib/provider_smoke_helpers_spec.rb
+++ b/spec/lib/provider_smoke_helpers_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ProviderSmokeHelpers do
   describe ".scenario_names_from_env" do
     it "defaults to the current-enabled preset" do
       ENV.delete("PAID_SMOKE_SCENARIOS")
+      allow(described_class).to receive(:configured_scenario_names).and_return(%w[opencode-minimax pi-minimax])
 
       expect(described_class.scenario_names_from_env).to eq(%w[
         claude-subscription
@@ -21,13 +22,16 @@ RSpec.describe ProviderSmokeHelpers do
         kilocode-zai
         opencode-openrouter
         kilocode-inception
+        opencode-minimax
+        pi-minimax
       ])
     end
 
     it "expands preset names from the environment" do
       ENV["PAID_SMOKE_SCENARIOS"] = "current-enabled"
+      allow(described_class).to receive(:configured_scenario_names).and_return(%w[opencode-minimax])
 
-      expect(described_class.scenario_names_from_env).to eq(described_class::PRESETS.fetch("current-enabled"))
+      expect(described_class.scenario_names_from_env).to eq(described_class.current_enabled_scenario_names)
     end
 
     it "preserves duplicate scenario names for distinct matrix entries" do
@@ -58,14 +62,14 @@ RSpec.describe ProviderSmokeHelpers do
     let(:user) { create(:user, account: account, email: "provider-smoke-helpers@example.com") }
     let(:scenario) { described_class.scenario_for("opencode-openrouter") }
 
-    it "prefers the scenario default model over the development-db fallback model" do
+    it "prefers the development-db model over the scenario default model" do
       allow(described_class).to receive(:development_provider_info_for).with(scenario).and_return(
         { "model" => "moonshotai/kimi-k2-0905", "api_key" => "sk-test" }
       )
 
       provider = described_class.build_direct_outbound_provider!(user: user, scenario: scenario)
 
-      expect(provider.opencode_model_id).to eq("moonshotai/kimi-k2")
+      expect(provider.opencode_model_id).to eq("moonshotai/kimi-k2-0905")
     end
 
     it "builds Pi DeepSeek providers through the shared direct-outbound path" do
@@ -94,6 +98,29 @@ RSpec.describe ProviderSmokeHelpers do
       expect(provider.opencode_api_provider).to eq("minimax")
       expect(provider.opencode_model_id).to eq("MiniMax-M2.5")
       expect(provider.provider_api_key.api_service_type).to eq("minimax")
+    end
+  end
+
+  describe ".current_enabled_scenario_names" do
+    it "adds configured direct-outbound scenarios to the baseline preset" do
+      allow(described_class).to receive(:configured_scenario_names).and_return(%w[opencode-minimax pi-minimax])
+
+      expect(described_class.current_enabled_scenario_names).to eq(%w[
+        claude-subscription
+        codex-subscription
+        copilot-subscription
+        kilocode-zai
+        opencode-openrouter
+        kilocode-inception
+        opencode-minimax
+        pi-minimax
+      ])
+    end
+
+    it "does not duplicate scenarios already present in the baseline preset" do
+      allow(described_class).to receive(:configured_scenario_names).and_return(%w[kilocode-zai opencode-openrouter])
+
+      expect(described_class.current_enabled_scenario_names).to eq(described_class::DEFAULT_SCENARIO_NAMES)
     end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -918,7 +918,7 @@ RSpec.describe Provider do
 
       runtime = minimax_provider.agent_harness_provider_runtime
 
-      expect(runtime.model).to eq("anthropic/MiniMax-M2.5")
+      expect(runtime.model).to eq("minimax/MiniMax-M2.5")
       expect(runtime.env).to include(
         "ANTHROPIC_API_KEY" => "sk-minimax-secret",
         "OPENAI_BASE_URL" => "https://api.minimax.io/anthropic"

--- a/spec/support/provider_smoke_helpers.rb
+++ b/spec/support/provider_smoke_helpers.rb
@@ -196,7 +196,7 @@ module ProviderSmokeHelpers
     claude-diag-tool-required
   ].freeze
   PRESETS = {
-    "current-enabled" => DEFAULT_SCENARIO_NAMES,
+    "current-enabled" => nil,
     "all-scenarios" => SCENARIOS.keys,
     "claude-diagnostics" => CLAUDE_DIAGNOSTIC_SCENARIO_NAMES
   }.freeze
@@ -205,7 +205,7 @@ module ProviderSmokeHelpers
 
   def scenario_names_from_env
     configured = ENV["PAID_SMOKE_SCENARIOS"].to_s.split(",").map(&:strip).reject(&:blank?)
-    (configured.presence || DEFAULT_SCENARIO_NAMES).flat_map { |name| expand_name(name) }
+    (configured.presence || [ "current-enabled" ]).flat_map { |name| expand_name(name) }
   end
 
   def scenarios_from_env
@@ -219,7 +219,13 @@ module ProviderSmokeHelpers
   end
 
   def expand_name(name)
+    return current_enabled_scenario_names if name == "current-enabled"
+
     PRESETS.fetch(name, [ name ])
+  end
+
+  def current_enabled_scenario_names
+    DEFAULT_SCENARIO_NAMES | configured_scenario_names
   end
 
   def build_provider!(user:, scenario:)
@@ -253,8 +259,8 @@ module ProviderSmokeHelpers
 
     dev_provider = development_provider_info_for(scenario)
     model_id = ENV[scenario.model_env].to_s.strip.presence ||
-      scenario.default_model.presence ||
-      dev_provider&.fetch("model", nil).to_s.presence
+      dev_provider&.fetch("model", nil).to_s.presence ||
+      scenario.default_model.presence
     if model_id.blank?
       raise ScenarioUnavailableError, "Set #{scenario.model_env} to run #{scenario.label}"
     end
@@ -309,7 +315,7 @@ module ProviderSmokeHelpers
     return @development_provider_info_cache[scenario.name] if @development_provider_info_cache.key?(scenario.name)
 
     service_type = Provider::DIRECT_OUTBOUND_API_PROVIDERS.dig(scenario.api_provider, :service_type)
-    desired_model = ENV[scenario.model_env].to_s.strip.presence || scenario.default_model
+    desired_model = ENV[scenario.model_env].to_s.strip.presence
     payload = {
       provider_key: scenario.provider_key,
       auth_type: scenario.auth_type,
@@ -378,5 +384,61 @@ module ProviderSmokeHelpers
     @development_provider_info_cache[scenario.name] = parsed
   rescue JSON::ParserError
     nil
+  end
+
+  def configured_scenario_names
+    payload = configured_provider_payload
+    return [] unless payload.is_a?(Array)
+
+    payload.filter_map do |config|
+      scenario_for_configuration(config)
+    end.uniq
+  end
+
+  def configured_provider_payload
+    @configured_provider_payload ||= begin
+      runner_script = <<~'RUBY'
+        require "json"
+
+        result = TenantContext.with_system_access do
+          Provider.includes(:provider_api_key)
+            .where(auth_type: %w[subscription api_key])
+            .map do |provider|
+              config = provider.config.is_a?(Hash) ? provider.config.fetch(provider.provider_key, {}) : {}
+              {
+                "provider_key" => provider.provider_key,
+                "auth_type" => provider.auth_type,
+                "service_type" => provider.provider_api_key&.api_service_type,
+                "api_provider" => config["api_provider"]
+              }
+            end
+        end
+
+        puts JSON.generate(result)
+      RUBY
+
+      stdout, _stderr, status = Open3.capture3(
+        { "RAILS_ENV" => "development" },
+        "bundle", "exec", "rails", "runner", runner_script
+      )
+
+      return [] unless status.success?
+
+      JSON.parse(stdout.lines.last.to_s)
+    rescue JSON::ParserError
+      []
+    end
+  end
+
+  def scenario_for_configuration(config)
+    SCENARIOS.each_value.find do |scenario|
+      next false unless scenario.provider_key == config["provider_key"].to_s
+      next false unless scenario.auth_type == config["auth_type"].to_s
+      next true if scenario.subscription?
+
+      service_type = Provider::DIRECT_OUTBOUND_API_PROVIDERS.dig(scenario.api_provider, :service_type)
+      service_type == config["service_type"].to_s &&
+        scenario.api_provider == config["api_provider"].to_s
+    end&.name
   end
 end

--- a/spec/support/provider_smoke_helpers.rb
+++ b/spec/support/provider_smoke_helpers.rb
@@ -422,9 +422,11 @@ module ProviderSmokeHelpers
         "bundle", "exec", "rails", "runner", runner_script
       )
 
-      return [] unless status.success?
-
-      JSON.parse(stdout.lines.last.to_s)
+      if status.success?
+        JSON.parse(stdout.lines.last.to_s)
+      else
+        []
+      end
     rescue JSON::ParserError
       []
     end


### PR DESCRIPTION
## Summary
- fix OpenCode MiniMax runtime qualification so Test Agent uses a working `minimax/...` model identifier
- make `bin/provider-smoke`'s `current-enabled` preset reflect configured direct-outbound scenarios instead of a stale hard-coded list
- prefer configured provider models over canned defaults in smoke helpers so local smoke coverage matches what users actually configured

## Verification
- `bundle exec rspec spec/lib/provider_smoke_helpers_spec.rb spec/models/provider_spec.rb`
- `Providers::TestAgent.call(provider: Provider.find(26))` returned healthy for the local `Opencode MiniMax` provider

## Notes
- focused RSpec re-run inside the git worktree was blocked by the branch-scoped test DB not existing yet; the same test set passed from the main workspace before packaging this PR