### PR TITLE
chore(provider-smoke): use rspec documentation format for live output

### DIFF
--- a/bin/provider-smoke
+++ b/bin/provider-smoke
@@ -62,7 +62,14 @@ def run_rspec!(spec_paths:, scenario_names:)
     "COVERAGE" => "false",
     "PAID_SMOKE_SCENARIOS" => scenario_names.join(",")
   }
-  command = [ "bundle", "exec", "rspec", *spec_paths ]
+  command = [
+    "bundle", "exec", "rspec",
+    "--options", "/dev/null",
+    "--require", "spec_helper",
+    "--color",
+    "--format", "documentation",
+    *spec_paths
+  ]
 
   puts "Running #{Shellwords.join(command)}"
   puts "PAID_SMOKE_SCENARIOS=#{env.fetch('PAID_SMOKE_SCENARIOS')}"


### PR DESCRIPTION
## Summary
- Switches `bin/provider-smoke` to RSpec's documentation formatter so each scenario's name and pass/fail/pending status is visible in real time instead of just dots.
- Bypasses `.rspec` (`-O /dev/null`) and re-specifies only the options the smoke run needs; otherwise the project-wide `--format progress` would stack with `--format documentation` rather than be replaced.

## Test plan
- [x] `bin/provider-smoke` prints per-scenario lines (`FAILED` / `PENDING` / passing) as they run.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)