### PR TITLE
feat: OpenCode MiniMax Token Plan configuration in Paid does not match upstream OpenCode/MiniMax integration

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -38,9 +38,8 @@ class Provider < ApplicationRecord
                     opencode_model_provider: "deepseek" },
     "mistral" => { label: "Mistral", base_url: "https://api.mistral.ai/v1", service_type: "mistral",
                    opencode_model_provider: "mistral" },
-    "minimax" => { label: "MiniMax", base_url: "https://api.minimax.io/anthropic", service_type: "minimax",
-                   env_var: "ANTHROPIC_API_KEY", opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic",
-                   opencode_model_provider: "minimax" },
+    "minimax" => { label: "MiniMax", base_url: "https://api.minimax.io/anthropic/v1", service_type: "minimax",
+                   env_var: "ANTHROPIC_API_KEY", opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic" },
     "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai",
                opencode_model_provider: "xai" },
     "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai",
@@ -955,7 +954,15 @@ class Provider < ApplicationRecord
 
     env_var = direct_outbound_api_key_env_var(opencode_api_provider)
     env = { env_var => provider_api_key&.api_key.to_s }
-    env["OPENAI_BASE_URL"] = api_config[:base_url] if api_config[:base_url]
+
+    # Providers using @ai-sdk/anthropic receive their base URL through the
+    # provider config (OPENAI_BASE_URL is only read by the OpenAI-compatible SDK).
+    provider_config = {}
+    if api_config[:opencode_npm] == "@ai-sdk/anthropic" && api_config[:base_url]
+      provider_config["baseURL"] = api_config[:base_url]
+    elsif api_config[:base_url]
+      env["OPENAI_BASE_URL"] = api_config[:base_url]
+    end
 
     AgentHarness::ProviderRuntime.new(
       model: model_id,
@@ -963,7 +970,7 @@ class Provider < ApplicationRecord
       unset_env: %w[OPENAI_HEADER_X_AGENT_RUN_ID OPENAI_HEADER_X_PROXY_TOKEN],
       metadata: {
         config: {
-          "provider" => { opencode_api_provider => {} }
+          "provider" => { opencode_api_provider => provider_config }
         }
       }
     )

--- a/spec/lib/provider_smoke_helpers_spec.rb
+++ b/spec/lib/provider_smoke_helpers_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe ProviderSmokeHelpers do
       expect(described_class.scenario_for("kilocode-zai").default_model).to eq("glm-5.1")
       expect(described_class.scenario_for("opencode-openrouter").default_model).to eq("moonshotai/kimi-k2")
       expect(described_class.scenario_for("kilocode-inception").default_model).to eq("mercury-2")
-      expect(described_class.scenario_for("opencode-minimax").default_model).to eq("MiniMax-M2.5")
+      expect(described_class.scenario_for("opencode-minimax").default_model).to eq("MiniMax-M2.7")
       expect(described_class.scenario_for("pi-deepseek").default_model).to eq("deepseek-chat")
-      expect(described_class.scenario_for("pi-minimax").default_model).to eq("MiniMax-M2.5")
+      expect(described_class.scenario_for("pi-minimax").default_model).to eq("MiniMax-M2.7")
     end
 
     it "raises a helpful error for unknown names" do
@@ -96,7 +96,7 @@ RSpec.describe ProviderSmokeHelpers do
 
       expect(provider.provider_key).to eq("opencode")
       expect(provider.opencode_api_provider).to eq("minimax")
-      expect(provider.opencode_model_id).to eq("MiniMax-M2.5")
+      expect(provider.opencode_model_id).to eq("MiniMax-M2.7")
       expect(provider.provider_api_key.api_service_type).to eq("minimax")
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe Provider do
 
       expect(options).to eq(
         "apiKey" => "{env:ANTHROPIC_API_KEY}",
-        "baseURL" => "https://api.minimax.io/anthropic"
+        "baseURL" => "https://api.minimax.io/anthropic/v1"
       )
       expect(models).to eq(
         "MiniMax-M2.5" => {
@@ -913,17 +913,38 @@ RSpec.describe Provider do
         provider_key: "opencode",
         auth_type: "api_key",
         provider_api_key: minimax_key,
-        config: { "opencode" => { "api_provider" => "minimax", "model" => "MiniMax-M2.5" } }
+        config: { "opencode" => { "api_provider" => "minimax", "model" => "MiniMax-M2.7" } }
       )
 
       runtime = minimax_provider.agent_harness_provider_runtime
 
-      expect(runtime.model).to eq("minimax/MiniMax-M2.5")
-      expect(runtime.env).to include(
-        "ANTHROPIC_API_KEY" => "sk-minimax-secret",
-        "OPENAI_BASE_URL" => "https://api.minimax.io/anthropic"
+      expect(runtime.model).to eq("MiniMax-M2.7")
+      expect(runtime.env).to include("ANTHROPIC_API_KEY" => "sk-minimax-secret")
+      expect(runtime.env).not_to have_key("OPENAI_BASE_URL")
+      expect(runtime.metadata[:config]["provider"]).to eq(
+        { "minimax" => { "baseURL" => "https://api.minimax.io/anthropic/v1" } }
       )
-      expect(runtime.metadata[:config]["provider"]).to eq({ "minimax" => {} })
+    end
+
+    it "handles MiniMax-M2.7-highspeed model without provider prefix" do
+      minimax_key = create(:provider_api_key, user: user, api_service_type: "minimax", api_key: "sk-minimax-hs")
+      minimax_provider = create(
+        :provider,
+        user: user,
+        provider_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: minimax_key,
+        config: { "opencode" => { "api_provider" => "minimax", "model" => "MiniMax-M2.7-highspeed" } }
+      )
+
+      runtime = minimax_provider.agent_harness_provider_runtime
+
+      expect(runtime.model).to eq("MiniMax-M2.7-highspeed")
+      expect(runtime.env).to include("ANTHROPIC_API_KEY" => "sk-minimax-hs")
+      expect(runtime.env).not_to have_key("OPENAI_BASE_URL")
+      expect(runtime.metadata[:config]["provider"]).to eq(
+        { "minimax" => { "baseURL" => "https://api.minimax.io/anthropic/v1" } }
+      )
     end
 
     it "does not enable direct outbound when the OpenCode model id is missing" do

--- a/spec/support/provider_smoke_helpers.rb
+++ b/spec/support/provider_smoke_helpers.rb
@@ -99,8 +99,8 @@ module ProviderSmokeHelpers
       auth_type: "api_key",
       api_provider: "minimax",
       model_env: "PAID_SMOKE_OPENCODE_MINIMAX_MODEL",
-      default_model: "MiniMax-M2.5",
-      label: "OpenCode with MiniMax API key"
+      default_model: "MiniMax-M2.7",
+      label: "OpenCode with MiniMax Token Plan API key"
     ),
 
     "kilocode-zai" => Scenario.new(
@@ -136,8 +136,8 @@ module ProviderSmokeHelpers
       auth_type: "api_key",
       api_provider: "minimax",
       model_env: "PAID_SMOKE_PI_MINIMAX_MODEL",
-      default_model: "MiniMax-M2.5",
-      label: "Pi with MiniMax API key"
+      default_model: "MiniMax-M2.7",
+      label: "Pi with MiniMax Token Plan API key"
     ),
     "copilot-subscription" => Scenario.new(
       name: "copilot-subscription",


### PR DESCRIPTION
## Summary

Aligns Paid's OpenCode MiniMax integration with MiniMax's documented Token Plan contract, so a MiniMax Token Plan API key works in Paid the same way it works in native OpenCode. Previously, models were qualified as `anthropic/MiniMax-M2.7` and the base URL was incomplete, causing `ProviderModelNotFoundError` failures at preflight/runtime.

## Changes

- **Provider configuration (`app/models/provider.rb`)**:
  - Updated `DIRECT_OUTBOUND_API_PROVIDERS["minimax"]` base URL to `https://api.minimax.io/anthropic/v1` to match upstream MiniMax docs.
  - Dropped the `anthropic` model-provider qualifier so OpenCode receives bare model IDs (`MiniMax-M2.7`) rather than `anthropic/MiniMax-M2.7`.
  - Reworked `opencode_provider_runtime` to surface the base URL via provider config metadata (`baseURL`) for `@ai-sdk/anthropic`-backed providers, since `OPENAI_BASE_URL` only applies to the OpenAI-compatible SDK.

- **Specs**:
  - `spec/models/provider_spec.rb`: Updated MiniMax runtime expectations to assert bare model IDs, absence of `OPENAI_BASE_URL`, and presence of `baseURL` in provider config. Added regression coverage for `MiniMax-M2.7-highspeed`.
  - `spec/support/provider_smoke_helpers.rb`: Bumped default smoke models from `MiniMax-M2.5` to `MiniMax-M2.7` and refreshed labels to reference "Token Plan".
  - `spec/lib/provider_smoke_helpers_spec.rb`: Synced expectations with the new default model.

## Design Decisions

- **Bare model IDs over `anthropic/` qualification**: MiniMax's upstream OpenCode integration uses provider `minimax` with `npm: "@ai-sdk/anthropic"`, but the model identifier passed to the SDK is bare (`MiniMax-M2.7`). Forcing an `anthropic/` (or `minimax/`) prefix in Paid produced model-not-found errors; removing the qualifier matches the documented contract.
- **`baseURL` via provider config, not `OPENAI_BASE_URL`**: Because MiniMax uses the Anthropic-shaped SDK, the OpenAI env-var override doesn't apply. Passing `baseURL` through OpenCode's provider config metadata is the correct hook for `@ai-sdk/anthropic` and keeps Paid's direct-outbound shape consistent with how OpenCode itself wires this.
- **No change to `ANTHROPIC_API_KEY` env var**: The current OpenCode/SDK path accepts `ANTHROPIC_API_KEY` for MiniMax Token Plan keys, so no env-var rename was required.

---

Closes #2105