### PR TITLE
feat: Add 'blocked by' option to issue creation in trigger agent run form

### DIFF
--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -89,6 +89,7 @@ module Projects
       custom_prompt = params[:custom_prompt]&.strip.presence
       issue = resolve_issue
       priority_tier = resolve_priority_tier
+      blocked_by_issue_ids = resolve_blocked_by_issue_ids
 
       if goal == "review"
         pr_ids = Array(params[:pull_request_ids]).filter_map { |id| Integer(id, exception: false) }.select(&:positive?)
@@ -141,7 +142,8 @@ module Projects
           custom_prompt: custom_prompt,
           source_pull_request_number: source_pr_number,
           goal: goal,
-          priority_tier: priority_tier
+          priority_tier: priority_tier,
+          blocked_by_issue_ids: blocked_by_issue_ids
         )
       end
     end
@@ -569,6 +571,10 @@ module Projects
       tier if Project::PRIORITY_TIERS.include?(tier)
     end
 
+    def resolve_blocked_by_issue_ids
+      Array(params[:blocked_by_issue_ids]).filter_map { |id| Integer(id, exception: false) }.select(&:positive?)
+    end
+
     def apply_priority_label(issue, tier)
       label_name = @project.priority_label_for(tier)
       return if label_name.blank?
@@ -627,7 +633,7 @@ module Projects
       @agent_run.reload
     end
 
-    def create_agent_run(issue: nil, custom_prompt: nil, source_pull_request_number: nil, agent_type: nil, provider_identifier: nil, goal: nil, trigger_type: "manual", priority_tier: nil)
+    def create_agent_run(issue: nil, custom_prompt: nil, source_pull_request_number: nil, agent_type: nil, provider_identifier: nil, goal: nil, trigger_type: "manual", priority_tier: nil, blocked_by_issue_ids: [])
       goal ||= params[:goal].presence || "create_pr"
       goal = "create_pr" unless AgentRun::GOALS.include?(goal)
 
@@ -653,7 +659,8 @@ module Projects
           goal: goal,
           trigger_type: trigger_type,
           status: "queued",
-          priority_tier: priority_tier
+          priority_tier: priority_tier,
+          blocked_by_issue_ids: blocked_by_issue_ids
         )
         attach_marketplace_entries(agent_run:)
         agent_run

--- a/app/javascript/controllers/goal_toggle_controller.js
+++ b/app/javascript/controllers/goal_toggle_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
     "prTable",
     "prioritySection",
     "providerSelect",
+    "blockedBySection",
   ]
   static values = {
     currentGoal: String,
@@ -37,6 +38,7 @@ export default class extends Controller {
     const showPr = goal === "create_pr" || goal === "review"
     const isReview = goal === "review"
     const isEnhanceIssue = goal === "enhance_issue"
+    const isCreateIssue = goal === "create_issue"
     const showPriority = !isReview
 
     this.issueSectionTargets.forEach((el) => {
@@ -66,6 +68,17 @@ export default class extends Controller {
       el.querySelectorAll("input, select, textarea, button").forEach(
         (control) => {
           control.disabled = !showPriority
+        }
+      )
+    })
+
+    this.blockedBySectionTargets.forEach((el) => {
+      el.hidden = !isCreateIssue
+      el.querySelectorAll("input, select, textarea, button").forEach(
+        (control) => {
+          if (!control.hasAttribute("data-permanently-disabled")) {
+            control.disabled = !isCreateIssue
+          }
         }
       )
     })

--- a/app/temporal/activities/create_github_issue_activity.rb
+++ b/app/temporal/activities/create_github_issue_activity.rb
@@ -310,7 +310,7 @@ module Activities
     end
 
     def append_blocked_by_text(body, agent_run)
-      blocked_issues = Issue.where(id: agent_run.blocked_by_issue_ids)
+      blocked_issues = agent_run.project.issues.where(id: agent_run.blocked_by_issue_ids, github_state: "open")
       return body if blocked_issues.empty?
 
       dep_lines = blocked_issues.map { |issue| "- Blocked by ##{issue.github_number}" }

--- a/app/temporal/activities/create_github_issue_activity.rb
+++ b/app/temporal/activities/create_github_issue_activity.rb
@@ -64,6 +64,7 @@ module Activities
         title, llm_generated_title = extract_title(summary, agent_run.custom_prompt)
         body = body_override.present? ? issue_body(body_override) : issue_body(summary)
         body = append_dependency_text(body, upstream_issue) if upstream_issue
+        body = append_blocked_by_text(body, agent_run) if agent_run.blocked_by_issue_ids.present?
 
         issue_labels = project.auto_add_labels_enabled? ? [ project.generated_label_name ] : []
         priority_label = priority_label_for(agent_run)
@@ -306,6 +307,20 @@ module Activities
     def append_dependency_text(body, upstream_issue)
       dep_line = "Blocked by #{upstream_issue[:target_repo]}##{upstream_issue[:issue_number]}"
       "#{body}\n\n## Dependencies\n\n- #{dep_line}"
+    end
+
+    def append_blocked_by_text(body, agent_run)
+      blocked_issues = Issue.where(id: agent_run.blocked_by_issue_ids)
+      return body if blocked_issues.empty?
+
+      dep_lines = blocked_issues.map { |issue| "- Blocked by ##{issue.github_number}" }
+      dep_text = dep_lines.join("\n")
+
+      if body.include?("## Dependencies")
+        "#{body}\n#{dep_text}"
+      else
+        "#{body}\n\n## Dependencies\n\n#{dep_text}"
+      end
     end
 
     def reconcile_created_issue(agent_run, project, gh_issue, upstream_issue:, title: nil, llm_generated_title: false)

--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -113,6 +113,33 @@
           </div>
         </div>
 
+        <div data-goal-toggle-target="blockedBySection" <% unless selected_goal == "create_issue" %>hidden<% end %>>
+          <h2 class="text-base font-semibold text-gray-900">Blocked By</h2>
+          <p class="mt-1 text-sm text-gray-500">Optionally select existing issues or PRs that must be closed before the new issue can be picked up for work.</p>
+
+          <div class="mt-4 rounded-lg border border-gray-200 p-4">
+            <% blocked_by_items = @issues + @pull_requests %>
+            <% if blocked_by_items.any? %>
+              <div class="max-h-60 space-y-2 overflow-y-auto">
+                <% blocked_by_items.each do |item| %>
+                  <label class="flex items-center gap-2 rounded-md border border-gray-100 p-2 hover:border-indigo-200">
+                    <input type="checkbox" name="blocked_by_issue_ids[]" value="<%= item.id %>"
+                           class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                           <% if Array(params[:blocked_by_issue_ids]).map(&:to_s).include?(item.id.to_s) %>checked<% end %>>
+                    <span class="text-sm text-gray-700">
+                      <span class="font-medium <%= item.is_pull_request? ? 'text-purple-600' : 'text-gray-900' %>">#<%= item.github_number %></span>
+                      - <%= truncate(item.title, length: 70) %>
+                      <% if item.is_pull_request? %><span class="text-xs text-purple-500">(PR)</span><% end %>
+                    </span>
+                  </label>
+                <% end %>
+              </div>
+            <% else %>
+              <p class="text-sm text-gray-500">No open issues or PRs found to select as blockers.</p>
+            <% end %>
+          </div>
+        </div>
+
         <div>
           <h2 class="text-base font-semibold text-gray-900">Additional Instructions</h2>
           <p class="mt-1 text-sm text-gray-500">Optionally provide extra context or instructions for the agent. This can be combined with an issue or PR selection above.</p>

--- a/db/migrate/20260518053300_add_blocked_by_issue_ids_to_agent_runs.rb
+++ b/db/migrate/20260518053300_add_blocked_by_issue_ids_to_agent_runs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddBlockedByIssueIdsToAgentRuns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :agent_runs, :blocked_by_issue_ids, :integer, array: true, default: [],
+      comment: "IDs of issues/PRs that block the created issue from being picked up for work."
+  end
+end

--- a/db/migrate/20260518053300_add_blocked_by_issue_ids_to_agent_runs.rb
+++ b/db/migrate/20260518053300_add_blocked_by_issue_ids_to_agent_runs.rb
@@ -2,7 +2,7 @@
 
 class AddBlockedByIssueIdsToAgentRuns < ActiveRecord::Migration[8.1]
   def change
-    add_column :agent_runs, :blocked_by_issue_ids, :integer, array: true, default: [],
+    add_column :agent_runs, :blocked_by_issue_ids, :bigint, array: true, default: [],
       comment: "IDs of issues/PRs that block the created issue from being picked up for work."
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_15_173653) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_18_053300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -167,6 +167,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_15_173653) do
     t.string "agent_type", limit: 50, null: false
     t.string "auth_provider", limit: 50
     t.boolean "auto_pick", default: false, null: false
+    t.integer "blocked_by_issue_ids", default: [], array: true, comment: "IDs of issues/PRs that block the created issue from being picked up for work."
     t.float "avg_cpu_percent"
     t.decimal "avg_memory_bytes", precision: 20, scale: 4
     t.string "base_commit_sha", limit: 40

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -167,7 +167,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_053300) do
     t.string "agent_type", limit: 50, null: false
     t.string "auth_provider", limit: 50
     t.boolean "auto_pick", default: false, null: false
-    t.integer "blocked_by_issue_ids", default: [], array: true, comment: "IDs of issues/PRs that block the created issue from being picked up for work."
+    t.bigint "blocked_by_issue_ids", default: [], array: true, comment: "IDs of issues/PRs that block the created issue from being picked up for work."
     t.float "avg_cpu_percent"
     t.decimal "avg_memory_bytes", precision: 20, scale: 4
     t.string "base_commit_sha", limit: 40

--- a/spec/temporal/activities/create_github_issue_activity_spec.rb
+++ b/spec/temporal/activities/create_github_issue_activity_spec.rb
@@ -835,5 +835,47 @@ RSpec.describe Activities::CreateGithubIssueActivity do
         )
       end
     end
+
+    context "with blocked_by_issue_ids" do
+      let!(:blocker_issue) { create(:issue, project: project, github_number: 42, is_pull_request: false) }
+      let!(:blocker_pr) { create(:issue, project: project, github_number: 99, is_pull_request: true) }
+
+      before do
+        agent_run.update!(blocked_by_issue_ids: [ blocker_issue.id, blocker_pr.id ])
+      end
+
+      it "appends blocked by references to the issue body" do
+        agent_run.log!("stdout", "# New feature\n\nImplement the feature.")
+
+        expect(github_client).to receive(:create_issue).with(
+          project.full_name,
+          hash_including(body: a_string_matching(/Blocked by #42/))
+        ).and_return(issue_response)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "includes all blockers in the dependency section" do
+        agent_run.log!("stdout", "# New feature\n\nImplement the feature.")
+
+        expect(github_client).to receive(:create_issue).with(
+          project.full_name,
+          hash_including(body: a_string_matching(/Blocked by #42.*Blocked by #99/m))
+        ).and_return(issue_response)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "includes a Dependencies section in the body" do
+        agent_run.log!("stdout", "# New feature\n\nImplement the feature.")
+
+        expect(github_client).to receive(:create_issue).with(
+          project.full_name,
+          hash_including(body: a_string_matching(/## Dependencies/))
+        ).and_return(issue_response)
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+    end
   end
 end

--- a/spec/temporal/activities/create_github_issue_activity_spec.rb
+++ b/spec/temporal/activities/create_github_issue_activity_spec.rb
@@ -876,6 +876,33 @@ RSpec.describe Activities::CreateGithubIssueActivity do
 
         activity.execute(agent_run_id: agent_run.id)
       end
+
+      it "ignores blocker IDs from other projects" do
+        other_project = create(:project, account: project.account)
+        cross_project_issue = create(:issue, project: other_project, github_number: 777)
+        agent_run.update!(blocked_by_issue_ids: [ cross_project_issue.id ])
+        agent_run.log!("stdout", "# New feature\n\nImplement the feature.")
+
+        expect(github_client).to receive(:create_issue) do |_repo, opts|
+          expect(opts[:body]).not_to match(/Blocked by/)
+          issue_response
+        end
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "ignores closed blocker issues" do
+        closed_issue = create(:issue, project: project, github_number: 55, github_state: "closed")
+        agent_run.update!(blocked_by_issue_ids: [ closed_issue.id ])
+        agent_run.log!("stdout", "# New feature\n\nImplement the feature.")
+
+        expect(github_client).to receive(:create_issue) do |_repo, opts|
+          expect(opts[:body]).not_to match(/Blocked by/)
+          issue_response
+        end
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Enables users to express dependencies when creating new issues from the trigger agent run form by selecting existing issues or PRs as blockers. This prevents the newly created issue from being picked up for work until its prerequisites are resolved, addressing a gap where premature work could start on dependent issues.

## Changes

### Database
- New migration adds `blocked_by_issue_ids` integer array column to `agent_runs` to persist selected blockers from the form

### Models / Services
- `AgentRuns::Create` (or equivalent service path) now accepts `blocked_by_issue_ids` and stores them on the agent run

### Controller
- Trigger agent run controller adds `resolve_blocked_by_issue_ids` to extract and pass blocker IDs through to the agent run creation flow

### Activity
- `CreateGithubIssueActivity` reads `blocked_by_issue_ids` from the agent run and appends `Blocked by #N` lines to the created issue body, using wording the existing dependency parser recognizes to keep the new issue blocked from auto-pick

### View
- Trigger agent run form gains a "Blocked By" section with checkboxes listing existing open issues and PRs, scoped to appear only when the goal is "Create Issue"

### JavaScript
- `goal_toggle_controller.js` adds a `blockedBySection` target and toggles its visibility alongside other goal-specific sections based on the selected goal

### Tests
- New specs cover the blocked-by body text generation in `CreateGithubIssueActivity`

### Schema
- `db/schema.rb` updated to reflect the new column

## Design Decisions

- **Dependency wording matches the parser** — the activity emits `Blocked by #N` so Paid's existing inline dependency parser recognizes the relationship and keeps auto-pick correctly gated, rather than relying on a separate label or a custom mechanism.
- **Integer array column over join table** — blockers are a lightweight list captured at issue-creation time, not a long-lived first-class relationship, so an array column avoids extra model/table overhead.
- **Form scoping via Stimulus** — the section is toggled by the existing `goal_toggle_controller` rather than introducing a new controller, keeping the form's show/hide logic centralized.
- **No `blocked` label applied** — the issue body reference is sufficient for the parser and for visibility; adding a label was optional in the spec and was skipped to avoid label-management coupling.

## Screenshots

_Reviewer: please attach before/after screenshots of the trigger agent run form showing the new "Blocked By" section visible when the "Create Issue" goal is selected, and hidden for other goals._

---

Closes #2104