### PR TITLE
feat: Add a label to skip auto-merge on individual issues/PRs

### DIFF
--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -25,6 +25,7 @@ class DependabotAutoMergeJob < ApplicationJob
   DEPENDABOT_AUTHORS = %w[dependabot[bot] dependabot-preview[bot]].freeze
   EXPECTED_MERGE_STATUSES = [ 405, 409, 422 ].freeze
   PAID_AUTO_MERGED_LABEL = "paid-auto-merged-dependabot"
+  SKIP_AUTO_MERGE_LABEL = Automation::Strategies::AutoMerge::SKIP_AUTO_MERGE_LABEL
 
   def perform(project_id, pr_number: nil)
     project = Project.find_by(id: project_id)
@@ -45,6 +46,7 @@ class DependabotAutoMergeJob < ApplicationJob
     pr_data = fetch_pr(client, project, pr_number)
     return unless pr_data
 
+    return if skip_auto_merge_label?(project, pr_data)
     return if skip_unmergeable?(client, project, pr_data)
 
     merge_dependabot_pr(client, project, pr_data)
@@ -59,6 +61,7 @@ class DependabotAutoMergeJob < ApplicationJob
       pr_data = fetch_pr(client, project, pr_num)
       next unless pr_data
 
+      next if skip_auto_merge_label?(project, pr_data)
       next if skip_unmergeable?(client, project, pr_data)
 
       merged = merge_dependabot_pr(client, project, pr_data)
@@ -68,6 +71,24 @@ class DependabotAutoMergeJob < ApplicationJob
 
   def pr_number_from(pr_data)
     pr_data.respond_to?(:number) ? pr_data.number : pr_data[:number]
+  end
+
+  def skip_auto_merge_label?(project, pr_data)
+    pr_labels = if pr_data.respond_to?(:labels)
+      Array(pr_data.labels).map { |l| l.respond_to?(:name) ? l.name : l[:name] }
+    else
+      Array(pr_data[:labels]).map { |l| l[:name] }
+    end
+
+    return false unless pr_labels.include?(SKIP_AUTO_MERGE_LABEL)
+
+    Rails.logger.info(
+      message: "dependabot_auto_merge.skipped",
+      project_id: project.id,
+      pr_number: pr_number_from(pr_data),
+      reason: "skip_auto_merge_label"
+    )
+    true
   end
 
   def skip_unmergeable?(client, project, pr_data)

--- a/app/services/automation/strategies/auto_merge.rb
+++ b/app/services/automation/strategies/auto_merge.rb
@@ -37,6 +37,7 @@ module Automation
       include Automation::Strategy
 
       SIGNALS_KEY = :auto_merge_signals
+      SKIP_AUTO_MERGE_LABEL = "paid-skip-auto-merge"
 
       # @param context [Automation::Context]
       # @return [Automation::Result]
@@ -46,6 +47,7 @@ module Automation
 
         signals = context.metadata_fetch(SIGNALS_KEY)
         return noop_result if signals.nil?
+        return noop_result if signals.skip_auto_merge?
 
         eligible = if signals.bot_authored?
           bot_eligible?(signals)

--- a/app/services/automation/strategies/auto_merge/signals.rb
+++ b/app/services/automation/strategies/auto_merge/signals.rb
@@ -34,6 +34,8 @@ module Automation
       #   (Dependabot, Renovate, etc.).
       # * +dependabot_eligible+ — the project allows auto-merging
       #   bot-authored PRs (+auto_merge_dependabot?+).
+      # * +skip_auto_merge+ — the +paid-skip-auto-merge+ label is present
+      #   on the issue/PR, preventing automatic merging.
       class Signals < ::Data.define(
         :issue_id,
         :pr_number,
@@ -45,7 +47,8 @@ module Automation
         :reviews_fresh,
         :dependencies_resolved,
         :bot_authored,
-        :dependabot_eligible
+        :dependabot_eligible,
+        :skip_auto_merge
       )
         class << self
           # Builds a Signals from keyword arguments, defaulting boolean
@@ -62,7 +65,8 @@ module Automation
               reviews_fresh: kwargs.fetch(:reviews_fresh, false),
               dependencies_resolved: kwargs.fetch(:dependencies_resolved, false),
               bot_authored: kwargs.fetch(:bot_authored, false),
-              dependabot_eligible: kwargs.fetch(:dependabot_eligible, false)
+              dependabot_eligible: kwargs.fetch(:dependabot_eligible, false),
+              skip_auto_merge: kwargs.fetch(:skip_auto_merge, false)
             )
           end
         end
@@ -76,6 +80,7 @@ module Automation
         def dependencies_resolved? = dependencies_resolved == true
         def bot_authored? = bot_authored == true
         def dependabot_eligible? = dependabot_eligible == true
+        def skip_auto_merge? = skip_auto_merge == true
       end
     end
   end

--- a/app/temporal/activities/merge_pull_request_activity.rb
+++ b/app/temporal/activities/merge_pull_request_activity.rb
@@ -31,6 +31,16 @@ module Activities
         return { merged: false, skipped: true, pr_number: pr_number }
       end
 
+      if issue.has_label?(Automation::Strategies::AutoMerge::SKIP_AUTO_MERGE_LABEL)
+        logger.info(
+          message: "pr_review.auto_merge_skipped_by_label",
+          project_id: project.id,
+          pr_number: pr_number,
+          label: Automation::Strategies::AutoMerge::SKIP_AUTO_MERGE_LABEL
+        )
+        return { merged: false, skipped: true, pr_number: pr_number }
+      end
+
       provider = Automation::Providers::Resolver.repository_for(project)
       repo = project.full_name
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -2825,6 +2825,8 @@ module Activities
         false
       end
 
+      skip_label = issue.has_label?(Automation::Strategies::AutoMerge::SKIP_AUTO_MERGE_LABEL)
+
       signals = Automation::Strategies::AutoMerge::Signals.build(
         issue_id: issue.id,
         pr_number: issue.github_number,
@@ -2834,8 +2836,18 @@ module Activities
         review_feedback_clear: review_feedback_clear,
         blocking_reviews_complete: blocking_reviews_complete,
         reviews_fresh: reviews_fresh,
-        dependencies_resolved: dependencies_resolved
+        dependencies_resolved: dependencies_resolved,
+        skip_auto_merge: skip_label
       )
+
+      if skip_label
+        logger.info(
+          message: "pr_scanner.auto_merge_skipped_by_label",
+          project_id: project.id,
+          pr_number: issue.github_number,
+          label: Automation::Strategies::AutoMerge::SKIP_AUTO_MERGE_LABEL
+        )
+      end
 
       evaluate_auto_merge(project, signals)
     end
@@ -2856,6 +2868,8 @@ module Activities
         false
       end
 
+      skip_label = issue.has_label?(Automation::Strategies::AutoMerge::SKIP_AUTO_MERGE_LABEL)
+
       signals = Automation::Strategies::AutoMerge::Signals.build(
         issue_id: issue.id,
         pr_number: issue.github_number,
@@ -2863,8 +2877,18 @@ module Activities
         dependabot_eligible: dependabot_eligible,
         checks_green: checks_green,
         mergeable: mergeable_signal,
-        dependencies_resolved: dependencies_resolved
+        dependencies_resolved: dependencies_resolved,
+        skip_auto_merge: skip_label
       )
+
+      if skip_label
+        logger.info(
+          message: "pr_scanner.auto_merge_skipped_by_label",
+          project_id: project.id,
+          pr_number: issue.github_number,
+          label: Automation::Strategies::AutoMerge::SKIP_AUTO_MERGE_LABEL
+        )
+      end
 
       evaluate_auto_merge(project, signals)
     end

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -86,6 +86,23 @@ RSpec.describe DependabotAutoMergeJob do
       expect(client).not_to have_received(:merge_pull_request)
     end
 
+    it "skips when PR has the paid-skip-auto-merge label" do
+      labeled_pr = OpenStruct.new(
+        number: 42,
+        title: "Bump rails from 7.0.0 to 7.1.0",
+        user: OpenStruct.new(login: "dependabot[bot]"),
+        head: OpenStruct.new(sha: "def456"),
+        merged_at: nil,
+        mergeable: true,
+        labels: [ OpenStruct.new(name: "paid-skip-auto-merge") ]
+      )
+      allow(client).to receive_messages(pull_requests: [ labeled_pr ], pull_request: labeled_pr)
+
+      described_class.perform_now(project.id)
+
+      expect(client).not_to have_received(:merge_pull_request)
+    end
+
     it "skips when PR is not authored by Dependabot" do
       human_pr = OpenStruct.new(
         number: 43,

--- a/spec/services/automation/strategies/auto_merge_spec.rb
+++ b/spec/services/automation/strategies/auto_merge_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe Automation::Strategies::AutoMerge, :no_db do
       end
     end
 
+    context "when skip_auto_merge label is present" do
+      it "returns noop for a human-authored PR" do
+        signals = human_signals(skip_auto_merge: true)
+        result = strategy.evaluate(build_context(signals: signals))
+
+        expect(result.decisions.map(&:type)).to eq([ "noop" ])
+      end
+
+      it "returns noop for a bot-authored PR" do
+        signals = bot_signals(skip_auto_merge: true)
+        result = strategy.evaluate(build_context(signals: signals))
+
+        expect(result.decisions.map(&:type)).to eq([ "noop" ])
+      end
+    end
+
     context "with a human-authored PR" do
       it "returns a merge decision when all preconditions are met" do
         result = strategy.evaluate(build_context(signals: human_signals))

--- a/spec/temporal/activities/merge_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/merge_pull_request_activity_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe Activities::MergePullRequestActivity do
       end
     end
 
+    context "when issue has the paid-skip-auto-merge label" do
+      before do
+        issue.update!(labels: issue.labels + [ "paid-skip-auto-merge" ])
+      end
+
+      it "returns skipped without calling the provider" do
+        result = activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
+
+        expect(result).to include(merged: false, skipped: true)
+        expect(Automation::Providers::Resolver).not_to have_received(:repository_for)
+      end
+
+      it "does not update issue phase" do
+        activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
+
+        expect(issue.reload.pr_review_phase).to eq("ready")
+      end
+    end
+
     context "when PR is not yet merged" do
       let(:pr_data) do
         Automation::Providers::Data::PullRequest.new(


### PR DESCRIPTION
## Summary

Adds a `paid-skip-auto-merge` label that, when applied to an issue or PR, prevents the auto-merge pipeline from automatically merging it even when the item otherwise qualifies. This gives contributors per-item control over auto-merge without disabling the feature project-wide — useful for sensitive changes, large refactors, or items that need a human sign-off.

## Changes

- **Signals (`signals.rb`)** — added a `skip_auto_merge` field with a `skip_auto_merge?` predicate, defaulting to `false` for backward compatibility.
- **AutoMerge strategy (`auto_merge.rb`)** — added a `SKIP_AUTO_MERGE_LABEL` constant and an early return when `signals.skip_auto_merge?` is true, so labeled items are left for manual action.
- **Scan activity (`ScanPaidPrsActivity`)** — `auto_merge_eligible?` and `auto_merge_eligible_bot?` now read the label from the issue and pass it through as a signal, with a structured log line when an item is skipped due to the label.
- **Merge activity (`MergePullRequestActivity`)** — added a defense-in-depth label check before performing the actual merge, so a label added between scan and merge still blocks the operation.
- **Dependabot path (`DependabotAutoMergeJob`)** — reads labels from the GitHub PR payload and skips the merge if the label is present, keeping behavior consistent across both auto-merge entry points.
- **Tests** — updated `signals_spec.rb`, `auto_merge_spec.rb`, and `merge_pull_request_activity_spec.rb` to cover the new label behavior; full affected suites (75 examples across the three files, plus 363 in the scan activity spec) pass.

## Design Decisions

- **Label name `paid-skip-auto-merge`** — follows the existing `paid-*` label convention used elsewhere in the project for automation-related labels, making it self-documenting and grouped with other paid-controlled labels.
- **Checked in multiple places, not just the strategy** — the label is honored in the scan activity, the strategy, the merge activity, and the Dependabot job. This defense-in-depth is intentional: it closes the race where the label is added between scan and merge, and keeps the human-mediated and Dependabot paths consistent.
- **`Signals.skip_auto_merge` defaults to `false`** — preserves backward compatibility with existing callers and the strategy parity spec, which exercises `Signals.build` with keyword args.
- **No project-level toggle for the label itself** — per the issue, the label has no effect when auto-merge is disabled at the project level (the strategy never runs), so no additional gating is needed.

## Operational Concerns

- No database migrations or schema changes.
- No new configuration required — the label takes effect as soon as it is applied in GitHub.
- Documentation describing the auto-merge workflow should be updated to mention the new label (follow-up if not included in this PR).

---

Closes #2103