### PR TITLE
fix(knowledge): clean up orphaned collector docker resources

### DIFF
--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -340,22 +340,7 @@ class DockerOrphanCleanupJob < ApplicationJob
   end
 
   def collector_container_active?(container)
-    running = container.info.dig("State", "Running")
-    return false unless running
-
-    created_at = collector_container_created_at(container)
-    return true if created_at.nil?
-
-    created_at >= COLLECTOR_STALE_AFTER.ago
-  end
-
-  def collector_container_created_at(container)
-    created = container.info["Created"]
-    return if created.blank?
-
-    Time.zone.parse(created.to_s)
-  rescue ArgumentError
-    nil
+    container.info.dig("State", "Running") == true
   end
 
   def collector_volume_names_for(container)

--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -24,16 +24,21 @@ class DockerOrphanCleanupJob < ApplicationJob
 
   VOLUME_PREFIX = "paid-workspace-"
   POOL_VOLUME_PREFIX = "paid-pool-workspace-"
+  COLLECTOR_VOLUME_PREFIX = "paid-collector-"
+  COLLECTOR_CONTAINER_LABEL = "paid.resource=collector_container"
+  COLLECTOR_STALE_AFTER = 1.hour
 
   def perform
     agent_removed = 0
     pool_removed = 0
+    collector_removed = 0
     service_removed = 0
     volume_result = { found: 0, removed: 0, failed: 0, active: 0, retained: 0 }
 
     Containers.all_backends.each do |backend|
       agent_removed += cleanup_agent_containers(backend: backend)
       pool_removed += cleanup_pool_containers(backend: backend)
+      collector_removed += cleanup_collector_containers(backend: backend)
       service_removed += cleanup_service_containers(backend: backend)
       backend_volume_result = cleanup_volumes(backend: backend)
       volume_result = volume_result.merge(backend_volume_result) { |_key, old_val, new_val| old_val + new_val }
@@ -43,6 +48,7 @@ class DockerOrphanCleanupJob < ApplicationJob
       message: "container_manager.orphan_cleanup_complete",
       agent_containers_removed: agent_removed,
       pool_containers_removed: pool_removed,
+      collector_containers_removed: collector_removed,
       service_containers_removed: service_removed,
       volumes_found: volume_result[:found],
       volumes_removed: volume_result[:removed],
@@ -103,6 +109,21 @@ class DockerOrphanCleanupJob < ApplicationJob
   end
 
   # Phase 3: Remove service containers with zero in-flight capacity runs.
+  def cleanup_collector_containers(backend:)
+    containers = list_containers_by_label(COLLECTOR_CONTAINER_LABEL, backend: backend)
+    return 0 if containers.empty?
+
+    removed = 0
+    containers.each do |container|
+      next if collector_container_active?(container)
+
+      project_id = container.info.dig("Labels", "paid.project_id")
+      removed += 1 if stop_and_remove_container(container, "collector", project_id, backend: backend)
+    end
+    removed
+  end
+
+  # Phase 4: Remove service containers with zero in-flight capacity runs.
   def cleanup_service_containers(backend:)
     containers = list_containers_by_label("paid.service_container=true", backend: backend)
     return 0 if containers.empty?
@@ -136,10 +157,10 @@ class DockerOrphanCleanupJob < ApplicationJob
     removed
   end
 
-  # Phase 4: Remove orphaned workspace volumes.
+  # Phase 5: Remove orphaned workspace volumes.
   # Skips volumes for runs with an unexpired retention TTL.
   def cleanup_volumes(backend:)
-    volumes = list_paid_volumes(backend: backend)
+    volumes = list_paid_volumes(backend: backend) + list_collector_volumes(backend: backend)
     return { found: 0, removed: 0, failed: 0, active: 0, retained: 0 } if volumes.empty?
 
     numeric_agent_run_ids = volumes
@@ -162,7 +183,27 @@ class DockerOrphanCleanupJob < ApplicationJob
     active = 0
     retained = 0
     active_pool_volume_names = active_pool_volume_names_for_backend(backend)
+    active_collector_volume_names = active_collector_volume_names_for_backend(backend)
     volumes.each do |volume|
+      if volume.id.start_with?(COLLECTOR_VOLUME_PREFIX)
+        if active_collector_volume_names.include?(volume.id)
+          active += 1
+          next
+        end
+
+        unless collector_volume_stale?(volume)
+          active += 1
+          next
+        end
+
+        if remove_volume(volume, nil, backend: backend)
+          removed += 1
+        else
+          failed += 1
+        end
+        next
+      end
+
       if volume.id.start_with?(POOL_VOLUME_PREFIX)
         if active_pool_volume_names.include?(volume.id)
           active += 1
@@ -242,6 +283,17 @@ class DockerOrphanCleanupJob < ApplicationJob
     []
   end
 
+  def list_collector_volumes(backend:)
+    backend.list_volumes.select { |v| v.id.start_with?(COLLECTOR_VOLUME_PREFIX) }
+  rescue Docker::Error::DockerError => e
+    Rails.logger.error(
+      message: "container_manager.collector_volume_list_failed",
+      backend: backend.identifier,
+      error: e.message
+    )
+    []
+  end
+
   def remove_volume(volume, agent_run_id, backend:)
     backend.delete_volume(volume)
     true
@@ -284,6 +336,61 @@ class DockerOrphanCleanupJob < ApplicationJob
 
       (warm_names + warming_names + claimed_names).to_set
     end
+  end
+
+  def active_collector_volume_names_for_backend(backend)
+    @active_collector_volume_names ||= {}
+    @active_collector_volume_names[backend.identifier] ||= begin
+      list_containers_by_label(COLLECTOR_CONTAINER_LABEL, backend: backend)
+        .select { |container| collector_container_active?(container) }
+        .flat_map { |container| collector_volume_names_for(container) }
+        .to_set
+    end
+  end
+
+  def collector_container_active?(container)
+    running = container.info.dig("State", "Running")
+    return false unless running
+
+    created_at = collector_container_created_at(container)
+    return true if created_at.nil?
+
+    created_at >= COLLECTOR_STALE_AFTER.ago
+  end
+
+  def collector_container_created_at(container)
+    created = container.info["Created"]
+    return if created.blank?
+
+    Time.zone.parse(created.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def collector_volume_names_for(container)
+    Array(container.info["Mounts"]).filter_map do |mount|
+      mount["Name"] if mount["Type"] == "volume" && mount["Name"].to_s.start_with?(COLLECTOR_VOLUME_PREFIX)
+    end
+  end
+
+  def collector_volume_stale?(volume)
+    created_at = collector_volume_created_at(volume)
+    return false if created_at.nil?
+
+    created_at < COLLECTOR_STALE_AFTER.ago
+  end
+
+  def collector_volume_created_at(volume)
+    labels = volume.info["Labels"] || {}
+    labeled_time = labels["paid.created_at"]
+    return Time.zone.parse(labeled_time.to_s) if labeled_time.present?
+
+    created_at = volume.info["CreatedAt"]
+    return if created_at.blank?
+
+    Time.zone.parse(created_at.to_s)
+  rescue ArgumentError, NoMethodError
+    nil
   end
 
   def claimed_pool_entry_active?(entry)

--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -108,7 +108,7 @@ class DockerOrphanCleanupJob < ApplicationJob
     removed
   end
 
-  # Phase 3: Remove service containers with zero in-flight capacity runs.
+  # Phase 3: Remove orphaned collector containers that are stopped or stale.
   def cleanup_collector_containers(backend:)
     containers = list_containers_by_label(COLLECTOR_CONTAINER_LABEL, backend: backend)
     return 0 if containers.empty?
@@ -160,7 +160,7 @@ class DockerOrphanCleanupJob < ApplicationJob
   # Phase 5: Remove orphaned workspace volumes.
   # Skips volumes for runs with an unexpired retention TTL.
   def cleanup_volumes(backend:)
-    volumes = list_paid_volumes(backend: backend) + list_collector_volumes(backend: backend)
+    volumes = list_all_managed_volumes(backend: backend)
     return { found: 0, removed: 0, failed: 0, active: 0, retained: 0 } if volumes.empty?
 
     numeric_agent_run_ids = volumes
@@ -272,22 +272,13 @@ class DockerOrphanCleanupJob < ApplicationJob
     false
   end
 
-  def list_paid_volumes(backend:)
-    backend.list_volumes.select { |v| v.id.start_with?(VOLUME_PREFIX) || v.id.start_with?(POOL_VOLUME_PREFIX) }
+  def list_all_managed_volumes(backend:)
+    backend.list_volumes.select do |v|
+      v.id.start_with?(VOLUME_PREFIX) || v.id.start_with?(POOL_VOLUME_PREFIX) || v.id.start_with?(COLLECTOR_VOLUME_PREFIX)
+    end
   rescue Docker::Error::DockerError => e
     Rails.logger.error(
       message: "container_manager.volume_list_failed",
-      backend: backend.identifier,
-      error: e.message
-    )
-    []
-  end
-
-  def list_collector_volumes(backend:)
-    backend.list_volumes.select { |v| v.id.start_with?(COLLECTOR_VOLUME_PREFIX) }
-  rescue Docker::Error::DockerError => e
-    Rails.logger.error(
-      message: "container_manager.collector_volume_list_failed",
       backend: backend.identifier,
       error: e.message
     )
@@ -381,15 +372,16 @@ class DockerOrphanCleanupJob < ApplicationJob
   end
 
   def collector_volume_created_at(volume)
-    labels = volume.info["Labels"] || {}
+    labels = volume.info["Labels"] if volume.info.respond_to?(:[])
+    labels ||= {}
     labeled_time = labels["paid.created_at"]
     return Time.zone.parse(labeled_time.to_s) if labeled_time.present?
 
-    created_at = volume.info["CreatedAt"]
+    created_at = volume.info.respond_to?(:[]) && volume.info["CreatedAt"]
     return if created_at.blank?
 
     Time.zone.parse(created_at.to_s)
-  rescue ArgumentError, NoMethodError
+  rescue ArgumentError
     nil
   end
 

--- a/app/services/knowledge/containerized_runner.rb
+++ b/app/services/knowledge/containerized_runner.rb
@@ -254,7 +254,8 @@ module Knowledge
         "Labels" => {
           "paid.managed" => "true",
           "paid.resource" => "collector_volume",
-          "paid.project_id" => project.id.to_s
+          "paid.project_id" => project.id.to_s,
+          "paid.created_at" => Time.current.iso8601
         }
       )
     end

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe DockerOrphanCleanupJob do
   let(:job) { described_class.new }
   let(:agent_filter) { { label: [ "paid.agent_run_id" ] }.to_json }
   let(:pool_filter) { { label: [ "paid.container_pool=true" ] }.to_json }
+  let(:collector_filter) { { label: [ "paid.resource=collector_container" ] }.to_json }
   let(:service_filter) { { label: [ "paid.service_container=true" ] }.to_json }
   let(:backend) { Containers.backend }
 
@@ -49,17 +50,29 @@ RSpec.describe DockerOrphanCleanupJob do
       .and_return(containers)
   end
 
-  def make_container(labels:, id: SecureRandom.hex(32))
+  def stub_collector_containers(*containers)
+    allow(backend).to receive(:list_containers)
+      .with(all: true, filters: collector_filter)
+      .and_return(containers)
+  end
+
+  def make_container(labels:, id: SecureRandom.hex(32), running: false, created_at: Time.current, mounts: [])
     instance_double(Docker::Container,
       id: id,
-      info: { "Labels" => labels },
+      info: {
+        "Labels" => labels,
+        "State" => { "Running" => running },
+        "Created" => created_at.iso8601,
+        "Mounts" => mounts
+      },
       stop: true,
       delete: true)
   end
 
-  def stub_backend_resources(target_backend, agent: [], pool: [], service: [], volumes: [])
+  def stub_backend_resources(target_backend, agent: [], pool: [], collector: [], service: [], volumes: [])
     allow(target_backend).to receive(:list_containers).with(all: true, filters: agent_filter).and_return(agent)
     allow(target_backend).to receive(:list_containers).with(all: true, filters: pool_filter).and_return(pool)
+    allow(target_backend).to receive(:list_containers).with(all: true, filters: collector_filter).and_return(collector)
     allow(target_backend).to receive(:list_containers).with(all: true, filters: service_filter).and_return(service)
     allow(target_backend).to receive(:list_volumes).and_return(volumes)
   end
@@ -91,6 +104,7 @@ RSpec.describe DockerOrphanCleanupJob do
         stub_no_volumes
         stub_service_containers
         stub_pool_containers
+        stub_collector_containers
       end
 
       it "removes containers for finished agent runs" do
@@ -231,6 +245,7 @@ RSpec.describe DockerOrphanCleanupJob do
         stub_no_volumes
         stub_agent_containers
         stub_pool_containers
+        stub_collector_containers
       end
 
       it "removes service containers with zero in-flight capacity runs" do
@@ -320,6 +335,7 @@ RSpec.describe DockerOrphanCleanupJob do
         stub_no_volumes
         stub_agent_containers
         stub_service_containers
+        stub_collector_containers
       end
 
       it "skips fresh warming pool containers" do
@@ -404,8 +420,58 @@ RSpec.describe DockerOrphanCleanupJob do
       end
     end
 
+    context "with collector containers" do
+      before do
+        stub_no_volumes
+        stub_agent_containers
+        stub_pool_containers
+        stub_service_containers
+      end
+
+      it "removes stopped collector containers" do
+        container = make_container(
+          labels: { "paid.resource" => "collector_container", "paid.project_id" => "42" },
+          running: false
+        )
+        stub_collector_containers(container)
+
+        job.perform
+
+        expect(container).to have_received(:delete).with(force: true, v: true)
+      end
+
+      it "removes stale running collector containers" do
+        container = make_container(
+          labels: { "paid.resource" => "collector_container", "paid.project_id" => "42" },
+          running: true,
+          created_at: 2.hours.ago
+        )
+        stub_collector_containers(container)
+
+        job.perform
+
+        expect(container).to have_received(:delete).with(force: true, v: true)
+      end
+
+      it "keeps recently created running collector containers" do
+        container = make_container(
+          labels: { "paid.resource" => "collector_container", "paid.project_id" => "42" },
+          running: true,
+          created_at: 10.minutes.ago
+        )
+        stub_collector_containers(container)
+
+        job.perform
+
+        expect(container).not_to have_received(:delete)
+      end
+    end
+
     context "with volumes" do
-      before { stub_no_containers }
+      before do
+        stub_no_containers
+        stub_collector_containers
+      end
 
       it "returns a complete empty summary when no paid volumes exist" do
         stub_no_volumes
@@ -499,6 +565,55 @@ RSpec.describe DockerOrphanCleanupJob do
         job.perform
 
         expect(volume).to have_received(:remove)
+      end
+
+      it "removes stale collector volumes not mounted by active collector containers" do
+        volume = instance_double(
+          Docker::Volume,
+          id: "paid-collector-42-deadbeef",
+          info: { "Labels" => { "paid.created_at" => 2.hours.ago.iso8601 } },
+          remove: true
+        )
+        allow(backend).to receive(:list_volumes).and_return([ volume ])
+
+        job.perform
+
+        expect(volume).to have_received(:remove)
+      end
+
+      it "skips fresh collector volumes that are not mounted yet" do
+        volume = instance_double(
+          Docker::Volume,
+          id: "paid-collector-42-deadbeef",
+          info: { "Labels" => { "paid.created_at" => 5.minutes.ago.iso8601 } },
+          remove: true
+        )
+        allow(backend).to receive(:list_volumes).and_return([ volume ])
+
+        job.perform
+
+        expect(volume).not_to have_received(:remove)
+      end
+
+      it "skips collector volumes mounted by active collector containers" do
+        active_collector = make_container(
+          labels: { "paid.resource" => "collector_container", "paid.project_id" => "42" },
+          running: true,
+          created_at: 5.minutes.ago,
+          mounts: [ { "Type" => "volume", "Name" => "paid-collector-42-deadbeef" } ]
+        )
+        volume = instance_double(
+          Docker::Volume,
+          id: "paid-collector-42-deadbeef",
+          info: { "Labels" => { "paid.created_at" => 2.hours.ago.iso8601 } },
+          remove: true
+        )
+        stub_collector_containers(active_collector)
+        allow(backend).to receive(:list_volumes).and_return([ volume ])
+
+        job.perform
+
+        expect(volume).not_to have_received(:remove)
       end
 
       it "skips volumes for retained agent runs" do

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -440,24 +440,11 @@ RSpec.describe DockerOrphanCleanupJob do
         expect(container).to have_received(:delete).with(force: true, v: true)
       end
 
-      it "removes stale running collector containers" do
+      it "keeps running collector containers regardless of age" do
         container = make_container(
           labels: { "paid.resource" => "collector_container", "paid.project_id" => "42" },
           running: true,
           created_at: 2.hours.ago
-        )
-        stub_collector_containers(container)
-
-        job.perform
-
-        expect(container).to have_received(:delete).with(force: true, v: true)
-      end
-
-      it "keeps recently created running collector containers" do
-        container = make_container(
-          labels: { "paid.resource" => "collector_container", "paid.project_id" => "42" },
-          running: true,
-          created_at: 10.minutes.ago
         )
         stub_collector_containers(container)
 


### PR DESCRIPTION
## Summary
- extend `DockerOrphanCleanupJob` to reclaim orphaned knowledge collector containers and volumes
- treat collector containers as active only while running and within a conservative staleness window
- add age-aware collector volume cleanup so freshly created but not-yet-mounted volumes are not deleted in a race window

## Testing
- `bundle exec rspec spec/jobs/docker_orphan_cleanup_job_spec.rb spec/services/knowledge/containerized_runner_spec.rb`
- `bin/rubocop app/jobs/docker_orphan_cleanup_job.rb app/services/knowledge/containerized_runner.rb spec/jobs/docker_orphan_cleanup_job_spec.rb spec/services/knowledge/containerized_runner_spec.rb`