### PR TITLE
fix(agent-runs): classify terminal infra failures as errors

### DIFF
--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -80,6 +80,7 @@ module Activities
       /no space left on device/i,
       /permission requested: .*auto-rejecting/i
     ].freeze
+    PERMISSION_REQUESTED_PATTERN = /permission requested:/i
     TOOL_PERMISSION_REJECTED_PATTERN = /the user rejected permission to use this specific tool call/i
 
     def execute(input)
@@ -189,7 +190,7 @@ module Activities
 
     def auto_rejected_tool_permission_output?(text)
       text.match?(TOOL_PERMISSION_REJECTED_PATTERN) &&
-        text.match?(/permission requested:/i)
+        text.match?(PERMISSION_REQUESTED_PATTERN)
     end
 
     def classification_text_for(agent_run)

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -76,6 +76,12 @@ module Activities
       /Model not found:/i
     ].freeze
 
+    TERMINAL_INFRASTRUCTURE_ERROR_PATTERNS = [
+      /no space left on device/i,
+      /permission requested: .*auto-rejecting/i
+    ].freeze
+    TOOL_PERMISSION_REJECTED_PATTERN = /the user rejected permission to use this specific tool call/i
+
     def execute(input)
       agent_run_id = input[:agent_run_id]
       output_present = input.fetch(:output_present, false)
@@ -131,6 +137,8 @@ module Activities
     # even if RunAgentActivity failed to detect a provider error, this check
     # prevents credit/quota errors from being misclassified as recommend_close.
     def classify_outcome(agent_run, output_present, diagnostic_output)
+      return "infrastructure_error" if terminal_infrastructure_error_output?(diagnostic_output)
+
       unless output_present
         return "provider_error" if provider_error_output?(diagnostic_output)
         return "infrastructure_error" if infrastructure_error_output?(diagnostic_output)
@@ -170,6 +178,18 @@ module Activities
       return false if text.blank?
 
       INFRASTRUCTURE_ERROR_PATTERNS.any? { |pattern| text.match?(pattern) }
+    end
+
+    def terminal_infrastructure_error_output?(text)
+      return false if text.blank?
+
+      TERMINAL_INFRASTRUCTURE_ERROR_PATTERNS.any? { |pattern| text.match?(pattern) } ||
+        auto_rejected_tool_permission_output?(text)
+    end
+
+    def auto_rejected_tool_permission_output?(text)
+      text.match?(TOOL_PERMISSION_REJECTED_PATTERN) &&
+        text.match?(/permission requested:/i)
     end
 
     def classification_text_for(agent_run)

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -509,6 +509,51 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         expect(result[:outcome]).to eq("infrastructure_error")
       end
 
+      it "treats no-space-left runtime failures as infrastructure errors even after some work" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 22)
+        agent_run.log!("stdout", <<~LOG)
+          error https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz:
+          Extracting tar content of undefined failed, the file appears to be corrupt:
+          "ENOSPC: no space left on device, write"
+        LOG
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("infrastructure_error")
+        expect(agent_run.reload.status).to eq("failed")
+        expect(issue.reload.paid_state).to eq("failed")
+      end
+
+      it "treats permission auto-rejects as infrastructure errors even after some work" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 0, cost_cents: 22)
+        agent_run.log!("stderr", "! permission requested: external_directory (/home/agent/.cache/yarn/*); auto-rejecting")
+        agent_run.log!("stdout", "Error: The user rejected permission to use this specific tool call.")
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("infrastructure_error")
+        expect(agent_run.reload.status).to eq("failed")
+        expect(issue.reload.paid_state).to eq("failed")
+      end
+
+      it "does not treat a bare tool-permission rejection quote as infrastructure error" do
+        issue = create(:issue, :in_progress, project: project)
+        agent_run = create(:agent_run, :running, project: project, issue: issue,
+          iterations: 3, cost_cents: 100)
+        agent_run.log!("stdout", <<~LOG)
+          I found the prior failure note: "The user rejected permission to use this specific tool call."
+          That appears to be from an earlier run and is not needed for this issue.
+        LOG
+
+        result = activity.execute(agent_run_id: agent_run.id, output_present: true)
+
+        expect(result[:outcome]).to eq("recommend_close")
+      end
+
       it "allows recommend_close when agent has iterations > 0 despite bwrap mention" do
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue,


### PR DESCRIPTION
## Summary
- classify terminal infrastructure failures as `infrastructure_error` before `recommend_close`
- catch `ENOSPC` and permission auto-reject flows that can happen after some work/cost is recorded
- avoid false positives by requiring the tool-permission rejection text to appear with a permission-request context

## Testing
- `bundle exec rspec spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb`
- `bin/rubocop app/temporal/activities/handle_no_output_issue_run_activity.rb spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb`