### PR TITLE
fix(agent-runs): report cumulative startup idle timeout

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -118,6 +118,7 @@ module Containers
     TimeoutCheckState = Struct.new(
       :mutex, :timeout_reason_ref, :startup_timeout, :idle_timeout,
       :timeout, :started_at, :heartbeat_path, :output_received_ref, :last_activity_ref,
+      :startup_heartbeat_active_ref,
       keyword_init: true
     )
 
@@ -404,7 +405,8 @@ module Containers
         started_at: started_at,
         heartbeat_path: heartbeat_path,
         output_received_ref: -> { output_received },
-        last_activity_ref: -> { last_activity_at }
+        last_activity_ref: -> { last_activity_at },
+        startup_heartbeat_active_ref: -> { startup_heartbeat&.alive? }
       )
 
       watchdog_ctx = WatchdogContext.new(
@@ -2481,9 +2483,10 @@ module Containers
           diagnostics: timeout_diagnostics_for_state(timeout_check, output_received: false)
         )
       when :idle
+        diagnostics = timeout_diagnostics_for_state(timeout_check, output_received: true)
         raise IdleTimeoutError.new(
-          "No output received for #{timeout_check.idle_timeout} seconds",
-          diagnostics: timeout_diagnostics_for_state(timeout_check, output_received: true)
+          idle_timeout_message(timeout_check, diagnostics),
+          diagnostics: diagnostics
         )
       when :wall_clock
         elapsed_seconds = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - timeout_check.started_at)).round(1)
@@ -2542,15 +2545,16 @@ module Containers
           )
         )
       elsif output_received && tc.idle_timeout && elapsed_since_activity >= tc.idle_timeout
+        diagnostics = timeout_diagnostics_from_elapsed(
+          elapsed_since_start,
+          elapsed_since_activity,
+          output_received,
+          tc.heartbeat_path,
+          heartbeat_age
+        )
         raise IdleTimeoutError.new(
-          "No output received for #{tc.idle_timeout} seconds",
-          diagnostics: timeout_diagnostics_from_elapsed(
-            elapsed_since_start,
-            elapsed_since_activity,
-            output_received,
-            tc.heartbeat_path,
-            heartbeat_age
-          )
+          idle_timeout_message(tc, diagnostics),
+          diagnostics: diagnostics
         )
       elsif tc.timeout && elapsed_since_start >= tc.timeout && !heartbeat_fresh
         log_system("container.execute.timeout",
@@ -2568,6 +2572,22 @@ module Containers
           )
         )
       end
+    end
+
+    def idle_timeout_message(timeout_check, diagnostics)
+      if startup_grace_expired_without_output?(timeout_check)
+        elapsed = timeout_check.startup_timeout + timeout_check.idle_timeout
+        "No output received after startup grace expired (waited #{elapsed.round(1)} seconds total; " \
+          "startup grace #{timeout_check.startup_timeout} seconds, idle timeout #{timeout_check.idle_timeout} seconds)"
+      else
+        "No output received for #{timeout_check.idle_timeout} seconds"
+      end
+    end
+
+    def startup_grace_expired_without_output?(timeout_check)
+      timeout_check.startup_timeout &&
+        timeout_check.output_received_ref&.call == false &&
+        timeout_check.startup_heartbeat_active_ref&.call == false
     end
 
     def timeout_diagnostics_for_state(timeout_check, output_received:)

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -3049,7 +3049,34 @@ RSpec.describe Containers::Provision do
         }.to raise_error(described_class::IdleTimeoutError)
       end
 
-      it "allows idle timeout to fire after startup_timeout deadline elapses with no output" do
+      it "reports cumulative startup plus idle budget when startup grace expires before any output" do
+        timeout_check = described_class::TimeoutCheckState.new(
+          startup_timeout: 360,
+          idle_timeout: 360,
+          output_received_ref: -> { false },
+          startup_heartbeat_active_ref: -> { false }
+        )
+
+        message = service.send(:idle_timeout_message, timeout_check, elapsed_seconds: 720)
+
+        expect(message).to include("waited 720 seconds total")
+        expect(message).to include("startup grace 360 seconds")
+        expect(message).to include("idle timeout 360 seconds")
+        expect(message).not_to eq("No output received for 360 seconds")
+      end
+
+      it "keeps the simple idle message after output has been produced" do
+        timeout_check = described_class::TimeoutCheckState.new(
+          startup_timeout: 360,
+          idle_timeout: 360,
+          output_received_ref: -> { true },
+          startup_heartbeat_active_ref: -> { false }
+        )
+
+        expect(service.send(:idle_timeout_message, timeout_check, elapsed_seconds: 360)).to eq("No output received for 360 seconds")
+      end
+
+      it "reports total wait when idle timeout fires after silent startup grace expires" do
         host_path = service.heartbeat_host_path
         skip "startup heartbeat only active when heartbeat_host_path is set" unless host_path.present?
 
@@ -3059,8 +3086,6 @@ RSpec.describe Containers::Provision do
           [ [], [], 137 ]
         end
 
-        # startup_timeout == idle_timeout so the idle timeout fires once the
-        # startup heartbeat deadline passes and the file goes stale.
         # Total hang bound = startup_timeout + idle_timeout = 0.2 + 0.1s here.
         expect {
           service.execute(
@@ -3070,7 +3095,12 @@ RSpec.describe Containers::Provision do
             idle_timeout: 0.1,
             heartbeat_path: host_path
           )
-        }.to raise_error(described_class::IdleTimeoutError)
+        }.to raise_error(described_class::IdleTimeoutError) { |error|
+          expect(error.message).to include("No output received after startup grace expired")
+          expect(error.message).to include("startup grace 0.2 seconds")
+          expect(error.message).to include("idle timeout 0.1 seconds")
+          expect(error.message).not_to eq("No output received for 0.1 seconds")
+        }
       end
 
       it "returns nil from start_startup_heartbeat when heartbeat_host_path is absent" do


### PR DESCRIPTION
## Summary

Fixes #2122 by making startup-only idle timeout failures report the cumulative startup grace + idle budget instead of only the second idle window.

When the startup heartbeat grace expires before any output is produced, the process waits through both `startup_timeout` and `idle_timeout`. The previous message still said `No output received for 360 seconds`, which understated the real ~720s wait described in the issue.

## Changes

- Tracks whether the startup heartbeat thread is still active in `TimeoutCheckState`.
- Uses a distinct idle timeout message when no output was ever produced and startup grace has already expired.
- Keeps the existing simple idle timeout message for normal mid-run idle after output was produced.
- Adds specs for the cumulative startup+idle message and the existing post-output idle behavior.

## Verification

- `ruby -c app/services/containers/provision.rb` — pass
- `ruby -c spec/services/containers/provision_spec.rb` — pass
- `git diff --check` — pass
- Targeted extracted Ruby check for `idle_timeout_message` — pass (`targeted_message_logic_ok`)

Full `bin/rspec` could not run in this Termux environment because `bundle install` fails building native gems (`pg_query` and `temporalio`) on aarch64 Android.
