### PR TITLE
fix(agent-runs): pre-filter runner order by selected-model compatibility

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -484,7 +484,7 @@ module Activities
           selected_model = agent_run.model_selection&.llm_model
           if selected_model && runners.size == 1
             label = runner_attempt_label(runners.first, agent_run, user_settings.user)
-            reason = all_skipped_rate_limited ? "rate limited" : "unavailable"
+            reason = "rate limited"
             error_message = "No compatible runner available: #{label} is the only runner compatible with #{selected_model.model_id} and it is currently #{reason}"
             error_type = "NoCompatibleRunnerAvailable"
           end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -453,27 +453,6 @@ module Activities
         agent_run.reload
         return paused_result(agent_run_id) if agent_run.paused?
 
-        # All runners exhausted. Timeout takes precedence over rate_limited
-        # because it indicates an actual execution attempt that should trigger
-        # ProcessRunQueueJob to re-schedule work.
-        if timeout_error.present?
-          timed_out = !agent_run.finished? && agent_run.timeout!(error: timeout_error)
-          Notifications::Rules::ZeroIterationTimeout.call(scope: agent_run) if timed_out
-          # Skip queue processing when cleanup killed the run — the timeout
-          # was not a real runner issue, so there is nothing to re-schedule.
-          # (agent_run was reloaded above, so the model method sees current state)
-          ProcessRunQueueJob.perform_later if timed_out && !agent_run.cancelled_by_cleanup?
-        elsif !agent_run.finished? && (last_error == "rate_limited" || all_skipped_rate_limited)
-          runner_list = runners.any? ? runner_attempt_labels(runners, agent_run, user_settings.user).join(", ") : "none"
-          agent_run.rate_limit!(
-            error: "All runners rate limited: #{runner_list}",
-            reset_at: rate_limit_reset_at
-          )
-        elsif !agent_run.finished?
-          runner_list = runners.any? ? runner_attempt_labels(runners, agent_run, user_settings.user).join(", ") : "none"
-          agent_run.fail!(error: "All runners exhausted: #{runner_list}")
-        end
-
         error_type = "AllRunnersExhausted"
         error_message = "All runners exhausted"
 
@@ -488,6 +467,27 @@ module Activities
             error_message = "No compatible runner available: #{label} is the only runner compatible with #{selected_model.model_id} and it is currently #{reason}"
             error_type = "NoCompatibleRunnerAvailable"
           end
+        end
+
+        # All runners exhausted. Timeout takes precedence over rate_limited
+        # because it indicates an actual execution attempt that should trigger
+        # ProcessRunQueueJob to re-schedule work.
+        if timeout_error.present?
+          timed_out = !agent_run.finished? && agent_run.timeout!(error: timeout_error)
+          Notifications::Rules::ZeroIterationTimeout.call(scope: agent_run) if timed_out
+          # Skip queue processing when cleanup killed the run — the timeout
+          # was not a real runner issue, so there is nothing to re-schedule.
+          # (agent_run was reloaded above, so the model method sees current state)
+          ProcessRunQueueJob.perform_later if timed_out && !agent_run.cancelled_by_cleanup?
+        elsif !agent_run.finished? && (last_error == "rate_limited" || all_skipped_rate_limited)
+          runner_list = runners.any? ? runner_attempt_labels(runners, agent_run, user_settings.user).join(", ") : "none"
+          agent_run.rate_limit!(
+            error: error_type == "NoCompatibleRunnerAvailable" ? error_message : "All runners rate limited: #{runner_list}",
+            reset_at: rate_limit_reset_at
+          )
+        elsif !agent_run.finished?
+          runner_list = runners.any? ? runner_attempt_labels(runners, agent_run, user_settings.user).join(", ") : "none"
+          agent_run.fail!(error: "All runners exhausted: #{runner_list}")
         end
 
         raise Temporalio::Error::ApplicationError.new(

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -473,9 +473,26 @@ module Activities
           runner_list = runners.any? ? runner_attempt_labels(runners, agent_run, user_settings.user).join(", ") : "none"
           agent_run.fail!(error: "All runners exhausted: #{runner_list}")
         end
+
+        error_type = "AllRunnersExhausted"
+        error_message = "All runners exhausted"
+
+        # When the only compatible runner(s) were all rate-limited or
+        # circuit-open, surface the real cause instead of the generic
+        # "all runners exhausted" message.
+        if runners.size <= 1 && (all_skipped_rate_limited || last_error == "rate_limited")
+          selected_model = agent_run.model_selection&.llm_model
+          if selected_model && runners.size == 1
+            label = runner_attempt_label(runners.first, agent_run, user_settings.user)
+            reason = all_skipped_rate_limited ? "rate limited" : "unavailable"
+            error_message = "No compatible runner available: #{label} is the only runner compatible with #{selected_model.model_id} and it is currently #{reason}"
+            error_type = "NoCompatibleRunnerAvailable"
+          end
+        end
+
         raise Temporalio::Error::ApplicationError.new(
-          "All runners exhausted",
-          type: "AllRunnersExhausted",
+          error_message,
+          type: error_type,
           non_retryable: true
         )
       end
@@ -671,6 +688,28 @@ module Activities
         "Selected model #{selected_model.model_id} (#{selected_model.provider}) is not compatible with #{runner_label} (expects #{compatible_provider})"
     end
 
+    # Returns true when a runner candidate is structurally compatible with the
+    # selected LlmModel. Checks provider family and fixed runtime model.
+    def runner_compatible_with_model?(runner_candidate, selected_model, user)
+      runner_entry = runner_entry_for(runner_candidate, user)
+      runner_key = runner_entry&.runner_key || RunnerSupport.runner_key_for_agent_type(runner_candidate)
+
+      # 1. Provider family check — e.g. "claude" expects "anthropic"
+      compatible_provider = Runners::DefaultTierModelIds::RUNNER_KEY_TO_MODEL_PROVIDER[runner_key.to_s]
+      if compatible_provider.present? && selected_model.provider != compatible_provider
+        return false
+      end
+
+      # 2. Fixed runtime model check — direct-outbound runners have a
+      #    configured model that must match the selected model exactly.
+      fixed_model_id = runner_entry&.direct_outbound_model_id
+      if fixed_model_id.present? && fixed_model_id != selected_model.model_id
+        return false
+      end
+
+      true
+    end
+
     def paused_result(agent_run_id)
       {
         agent_run_id: agent_run_id,
@@ -744,6 +783,15 @@ module Activities
       end
       if runners.empty? && fallback_to_default_runner?(agent_run)
         runners = default_runner_candidates(agent_run, user_settings)
+      end
+
+      # Pre-filter runners that are structurally incompatible with the
+      # selected model. This avoids wasting attempts on runners that would
+      # always fail validation in selected_runner_runtime.
+      selected_model = agent_run.model_selection&.llm_model
+      if selected_model
+        compatible = runners.select { |r| runner_compatible_with_model?(r, selected_model, user_settings.user) }
+        runners = compatible if compatible.any?
       end
 
       @rate_limit_fallbacks = load_rate_limit_fallbacks(user_settings.user)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3434,6 +3434,9 @@ expect(container_service).to receive(:execute).with(
 
         agent_run.reload
         expect(agent_run.status).to eq("rate_limited")
+        expect(agent_run.error_message).to match(
+          /No compatible runner available: .* is the only runner compatible with moonshotai\/kimi-k2-0905 and it is currently rate limited/
+        )
         expect(agent_run.runners_attempted.map { |attempt| attempt["runner"] }).to eq([ kimi_runner.routing_key ])
       end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1371,6 +1371,29 @@ RSpec.describe Activities::RunAgentActivity do
 
   alias_method :create_opencode_provider_entry, :create_opencode_runner_entry
 
+  def configure_single_compatible_opencode_runner(agent_run:, user:)
+    llm_model = create(:llm_model, model_id: "moonshotai/kimi-k2-0905", provider: "openrouter")
+    create(:model_selection, agent_run: agent_run, llm_model: llm_model)
+
+    allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude codex opencode])
+
+    api_key = create(:runner_api_key, user: user, api_service_type: "openrouter")
+    kimi_runner = create_opencode_runner_entry(
+      user: user,
+      api_key: api_key,
+      name: "Kimi K2",
+      model: "moonshotai/kimi-k2-0905"
+    )
+    codex_runner = create(:runner, user: user, runner_key: "codex")
+
+    user.settings.update!(
+      fallback_enabled: true,
+      fallback_runners: [ kimi_runner.routing_key, codex_runner.routing_key ]
+    )
+
+    kimi_runner
+  end
+
   def expect_change_detection_retry_logs(logger, operation:)
     expect(logger).to have_received(:warn).with(hash_including(
       message: "agent_execution.change_detection_retry",
@@ -3395,6 +3418,23 @@ expect(container_service).to receive(:execute).with(
         agent_run.reload
         expect(agent_run.status).to eq("rate_limited")
         expect(agent_run.error_message).to include("rate limited")
+      end
+
+      it "surfaces a single compatible attempted runner as rate limited" do
+        kimi_runner = configure_single_compatible_opencode_runner(agent_run: agent_run, user: user)
+
+        allow(container_service).to receive(:execute).and_return(rate_limit_failure)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(
+          Temporalio::Error::ApplicationError,
+          /No compatible runner available: .* is the only runner compatible with moonshotai\/kimi-k2-0905 and it is currently rate limited/
+        )
+
+        agent_run.reload
+        expect(agent_run.status).to eq("rate_limited")
+        expect(agent_run.runners_attempted.map { |attempt| attempt["runner"] }).to eq([ kimi_runner.routing_key ])
       end
 
       it "classifies 'exhausted ... capacity' as a rate limit" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1148,6 +1148,84 @@ RSpec.describe Activities::RunAgentActivity do
 
       expect(runners).to eq([ "codex" ])
     end
+
+    context "with model-based pre-filtering" do
+      it "excludes runners whose provider is incompatible with the selected model" do
+        llm_model = create(:llm_model, model_id: "glm-5.1", provider: "zai_coding")
+        create(:model_selection, agent_run: agent_run, llm_model: llm_model)
+
+        api_key = create(:runner_api_key, user: user, api_service_type: "zai_coding")
+        kilocode_runner = create(
+          :runner,
+          user: user,
+          auth_type: "api_key",
+          provider_api_key: api_key,
+          runner_key: "kilocode",
+          name: "Kilocode GLM 5.1",
+          config: { "kilocode" => { "api_provider" => "zai_coding", "model" => "glm-5.1" } }
+        )
+        codex_runner = create(:runner, user: user, runner_key: "codex")
+        user.settings.update!(
+          fallback_enabled: true,
+          fallback_runners: [ kilocode_runner.routing_key, codex_runner.routing_key ]
+        )
+
+        runners = activity.send(:build_runner_order, agent_run, user.settings)
+
+        expect(runners).to include(kilocode_runner.routing_key)
+        expect(runners).not_to include(codex_runner.routing_key)
+      end
+
+      it "excludes direct-outbound runners whose fixed model differs from the selection" do
+        llm_model = create(:llm_model, model_id: "moonshotai/kimi-k2-0905", provider: "openrouter")
+        create(:model_selection, agent_run: agent_run, llm_model: llm_model)
+
+        api_key = create(:runner_api_key, user: user, api_service_type: "openrouter")
+        matching_runner = create_opencode_runner_entry(
+          user: user, api_key: api_key,
+          name: "Kimi K2", model: "moonshotai/kimi-k2-0905"
+        )
+        other_api_key = create(:runner_api_key, user: user, api_service_type: "openrouter", api_key: "sk-other")
+        mismatched_runner = create_opencode_runner_entry(
+          user: user, api_key: other_api_key,
+          name: "Deepseek", model: "deepseek-v4-pro"
+        )
+        user.settings.update!(
+          fallback_enabled: true,
+          fallback_runners: [ matching_runner.routing_key, mismatched_runner.routing_key ]
+        )
+
+        runners = activity.send(:build_runner_order, agent_run, user.settings)
+
+        expect(runners).to include(matching_runner.routing_key)
+        expect(runners).not_to include(mismatched_runner.routing_key)
+      end
+
+      it "preserves all runners when no model is selected" do
+        codex_runner = create(:runner, user: user, runner_key: "codex")
+        user.settings.update!(
+          fallback_enabled: true,
+          fallback_runners: [ codex_runner.routing_key ]
+        )
+
+        runners = activity.send(:build_runner_order, agent_run, user.settings)
+
+        expect(runners).to include("claude_code")
+        expect(runners).to include(codex_runner.routing_key)
+      end
+
+      it "keeps all runners when filtering would eliminate every candidate" do
+        # All runners are incompatible, so the filter is not applied
+        llm_model = create(:llm_model, model_id: "exotic-model-99", provider: "exotic_provider")
+        create(:model_selection, agent_run: agent_run, llm_model: llm_model)
+
+        user.settings.update!(fallback_enabled: false)
+
+        runners = activity.send(:build_runner_order, agent_run, user.settings)
+
+        expect(runners).not_to be_empty
+      end
+    end
   end
 
   def build_opencode_context(user, api_provider: "openrouter", model: "moonshotai/kimi-k2-0905", service_type: "openrouter", api_key: "sk-openrouter-secret")


### PR DESCRIPTION
## Summary

When the user-selected model has only one compatible runner and that runner is rate-limited or circuit-open, the iterator currently attempts every container-executable runner and surfaces a misleading "All runners exhausted: …" error listing structurally incompatible runners. This change pre-filters the runner order by model compatibility so the operator sees the real cause (e.g. the one compatible runner is rate-limited) instead of noise from runners that could never have served the request.

## Changes

- **`app/temporal/activities/run_agent_activity.rb`**
  - `build_runner_order` gains a model-compatibility pre-filter applied after the existing `container_executable?` check, using the agent run's selected LLM model.
  - New private `runner_compatible_with_model?` enforces two rules: provider-family match via `RUNNER_KEY_TO_MODEL_PROVIDER` (e.g. `claude→anthropic`, `codex→openai`) and, for direct-outbound runners (kilocode/opencode/aider/pi), an exact match against the runner's fixed runtime model.
  - When the only compatible runner is rate-limited or circuit-open, the error message is now `"No compatible runner available: <runner> is the only runner compatible with <model> and it is currently rate limited"` rather than the generic exhausted-list.
- **`spec/temporal/activities/run_agent_activity_spec.rb`**
  - Provider-incompatible runners are excluded (e.g. `codex` dropped for a `zai_coding` model).
  - Fixed-model mismatches are excluded (e.g. a `deepseek-v4-pro` runner dropped when `kimi-k2` is selected).
  - All runners preserved when no model is selected.
  - All runners preserved when the filter would eliminate every candidate (safety-net behavior).

## Design Decisions

- **Safety-net fallback**: if the compatibility filter would empty the candidate list, the unfiltered list is preserved rather than failing the run outright. This keeps the change strictly additive for edge cases where the compatibility metadata is incomplete or stale, at the cost of occasionally still surfacing the old generic error in those cases.
- **Reused existing mapping**: provider matching uses `Runners::DefaultTierModelIds::RUNNER_KEY_TO_MODEL_PROVIDER` rather than introducing a parallel lookup, keeping a single source of truth for runner-key → provider.
- **Pre-filter, don't relocate**: the existing in-preflight checks (`validate_selected_model_matches_runtime!`, `validate_selected_model_runner_compatibility!`) are left intact as a defense-in-depth guard; this change only prevents structurally-incompatible runners from being attempted and recorded in `runners_attempted`.

---

Closes #2121