### PR TITLE
fix(runners): Kilocode preflight consistently times out at 30s (174 runs/24h)

### DIFF
--- a/app/controllers/runners_controller.rb
+++ b/app/controllers/runners_controller.rb
@@ -174,7 +174,7 @@ class RunnersController < ApplicationController
     end
     attrs = raw_params.permit(
       *permitted,
-      config: { opencode: [ :api_provider, :model ], kilocode: [ :api_provider, :model ], aider: [ :api_provider, :model ],
+      config: { opencode: [ :api_provider, :model ], kilocode: [ :api_provider, :model, :preflight_timeout_seconds ], aider: [ :api_provider, :model ],
                 pi: [ :api_provider, :model ] },
       tier_model_ids: LlmModel::TIERS,
       complexity_thresholds: Runner::COMPLEXITY_THRESHOLD_KEYS

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -63,6 +63,7 @@ class Runner < ApplicationRecord
 
   KILOCODE_API_PROVIDER_KEYS = DIRECT_OUTBOUND_API_PROVIDERS.keys.freeze
   KILOCODE_DEFAULT_API_PROVIDER = "anthropic"
+  MIN_PREFLIGHT_TIMEOUT_SECONDS = 1
 
   AIDER_API_PROVIDER_KEYS = DIRECT_OUTBOUND_API_PROVIDERS.keys.freeze
   AIDER_DEFAULT_API_PROVIDER = "openrouter"
@@ -241,6 +242,12 @@ class Runner < ApplicationRecord
     return nil unless runner_key == "kilocode"
 
     kilocode_config["model"].to_s.presence
+  end
+
+  def kilocode_preflight_timeout_seconds
+    return nil unless runner_key == "kilocode"
+
+    Integer(kilocode_config["preflight_timeout_seconds"], exception: false)
   end
 
   def kilocode_required_api_service_type
@@ -942,6 +949,11 @@ class Runner < ApplicationRecord
 
     if kilocode_model_id.blank?
       errors.add(:config, "must include a KiloCode model id")
+    end
+
+    if kilocode_config["preflight_timeout_seconds"].present? &&
+        (kilocode_preflight_timeout_seconds.nil? || kilocode_preflight_timeout_seconds < MIN_PREFLIGHT_TIMEOUT_SECONDS)
+      errors.add(:config, "must include a KiloCode preflight timeout of at least #{MIN_PREFLIGHT_TIMEOUT_SECONDS} second")
     end
   end
 

--- a/app/models/runner_state.rb
+++ b/app/models/runner_state.rb
@@ -43,15 +43,14 @@ class RunnerState < ApplicationRecord
     with_lock do
       new_count = failure_count + 1
 
-      if new_count >= threshold && circuit_state == "closed"
-        update!(
-          failure_count: new_count,
-          circuit_state: "open",
-          circuit_opened_at: Time.current
-        )
-      else
-        update!(failure_count: new_count)
+      attrs = { failure_count: new_count }
+
+      if circuit_half_open? || (new_count >= threshold && circuit_closed?)
+        attrs[:circuit_state] = "open"
+        attrs[:circuit_opened_at] = Time.current
       end
+
+      update!(attrs)
     end
   end
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -87,6 +87,7 @@ module Activities
     DEFAULT_AGENT_STARTUP_TIMEOUT = 360    # 6 minutes without first output = stuck
     PREFLIGHT_TIMEOUT_SECONDS = 10
     DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS = 30
+    PREFLIGHT_TIMEOUT_CIRCUIT_BREAKER_THRESHOLD = 3
     CHANGE_DETECTION_MAX_ATTEMPTS = 3
     CHANGE_DETECTION_RETRY_BACKOFF = 0.25
     POST_RUN_BOOKKEEPING_ERROR_TYPE = "PostRunBookkeepingFailed"
@@ -370,6 +371,33 @@ module Activities
             # timeout should not fail the entire run when fallback runners
             # are available. Only break when max_execution_seconds is exceeded
             # (checked at the top of the loop).
+          rescue PreflightTimeoutError => e
+            last_error = "error"
+            attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
+            if cancelled_by_cleanup?(agent_run)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e)
+              break
+            end
+            record_runner_failure(
+              user_settings,
+              runner_state_name,
+              runner_states,
+              threshold: preflight_timeout_failure_threshold(user_settings)
+            )
+            agent_run.record_runner_attempt(
+              attempt_label,
+              success: false,
+              error_type: "error",
+              error_message: e.message,
+              duration_seconds: attempt_duration
+            )
+            logger.warn(
+              message: "agent_execution.preflight_timeout",
+              runner: runner,
+              agent_run_id: agent_run.id,
+              error: e.message,
+              duration_seconds: attempt_duration
+            )
           rescue RunnerAuthExpiredError => e
             last_error = "auth_expired"
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
@@ -518,6 +546,7 @@ module Activities
     end
 
     class RunnerExecutionError < StandardError; end
+    class PreflightTimeoutError < RunnerExecutionError; end
     class RunnerInfraExecutionError < RunnerExecutionError; end
     ProviderExecutionError = RunnerExecutionError
     class RunnerTimeoutError < StandardError
@@ -828,9 +857,13 @@ module Activities
     end
 
     # Records a failed runner execution.
-    def record_runner_failure(user_settings, runner_state_name, runner_states)
+    def record_runner_failure(user_settings, runner_state_name, runner_states, threshold: user_settings.circuit_breaker_failure_threshold)
       state = runner_state_for(user_settings, runner_state_name, runner_states)
-      state.record_failure!(threshold: user_settings.circuit_breaker_failure_threshold)
+      state.record_failure!(threshold: threshold)
+    end
+
+    def preflight_timeout_failure_threshold(user_settings)
+      [ user_settings.circuit_breaker_failure_threshold, PREFLIGHT_TIMEOUT_CIRCUIT_BREAKER_THRESHOLD ].min
     end
 
     # True when the agent run we're executing has already been force-timed-out
@@ -1150,6 +1183,7 @@ module Activities
       subscription_auth = runner_entry&.subscription? &&
         RunnerSupport.subscription_auth_unset_vars_for(runner_entry.runner_key).any?
       harness_provider = preflight_provider_instance(command_context)
+      harness_preflight_passed = false
       if harness_provider && !subscription_auth
         run_harness_preflight!(
           agent_run: agent_run,
@@ -1157,6 +1191,7 @@ module Activities
           runner: runner,
           execution_env: execution_env
         )
+        harness_preflight_passed = true
       end
 
       prompt = runner_preflight_prompt_for(runner)
@@ -1219,8 +1254,10 @@ module Activities
       end
       raise_preflight_failure!(agent_run: agent_run, runner: runner, reason: reason)
     rescue Containers::Provision::TimeoutError => e
-      reason = "Timed out after #{preflight_timeout}s: #{e.message}. Check proxy configuration, auth, and network policy."
-      raise_preflight_failure!(agent_run: agent_run, runner: runner, reason: reason)
+      reason = "Runner smoke preflight timed out after #{preflight_timeout}s"
+      reason += " after harness preflight passed" if harness_preflight_passed
+      reason += ". This points to the runner CLI path (container egress, proxy, auth wiring, or upstream API responsiveness). Original error: #{e.message}"
+      raise_preflight_timeout!(agent_run: agent_run, runner: runner, reason: reason)
     rescue Containers::Provision::OutputAbortError => e
       reset_at = rate_limit_reset_at(runner, e.matched_output.to_s)
       log_preflight_failure(agent_run: agent_run, runner: runner, reason: e.matched_output.to_s.truncate(200))
@@ -1241,7 +1278,7 @@ module Activities
 
       return if result[:healthy]
 
-      reason = result[:reason] || "Preflight check failed"
+      reason = "Harness preflight failed: #{result[:reason] || 'Preflight check failed'}"
       raise_preflight_failure!(agent_run: agent_run, runner: runner, reason: reason)
     rescue AgentHarness::ConfigurationError, KeyError
       # Runner config unavailable — skip harness preflight and let the
@@ -1251,6 +1288,8 @@ module Activities
 
     def preflight_timeout_seconds_for(provider_candidate, user)
       provider_entry = provider_entry_for(provider_candidate, user)
+      configured_timeout = provider_entry&.kilocode_preflight_timeout_seconds
+      return configured_timeout if configured_timeout.present?
       return DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS if provider_entry&.requires_direct_outbound?
 
       PREFLIGHT_TIMEOUT_SECONDS
@@ -1561,6 +1600,11 @@ module Activities
     def raise_preflight_failure!(agent_run:, runner:, reason:)
       log_preflight_failure(agent_run: agent_run, runner: runner, reason: reason)
       raise RunnerExecutionError, "Preflight check failed: #{reason}"
+    end
+
+    def raise_preflight_timeout!(agent_run:, runner:, reason:)
+      log_preflight_failure(agent_run: agent_run, runner: runner, reason: reason)
+      raise PreflightTimeoutError, "Preflight check failed: #{reason}"
     end
 
     def harness_response_config(harness_key, runner_candidate, user)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -387,7 +387,7 @@ module Activities
             agent_run.record_runner_attempt(
               attempt_label,
               success: false,
-              error_type: "error",
+              error_type: "preflight_timeout",
               error_message: e.message,
               duration_seconds: attempt_duration
             )

--- a/app/views/providers/_form.html.erb
+++ b/app/views/providers/_form.html.erb
@@ -207,6 +207,20 @@
                class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
         <p class="mt-1 text-xs text-gray-500">Required. The model identifier for the selected API provider.</p>
       </div>
+
+      <div class="mt-4">
+        <label for="provider_config_kilocode_preflight_timeout_seconds" class="block text-sm font-medium text-gray-900">Preflight Timeout (seconds)</label>
+        <input id="provider_config_kilocode_preflight_timeout_seconds"
+               name="provider[config][kilocode][preflight_timeout_seconds]"
+               type="number"
+               min="<%= Provider::MIN_PREFLIGHT_TIMEOUT_SECONDS %>"
+               value="<%= provider.kilocode_preflight_timeout_seconds %>"
+               placeholder="<%= Activities::RunAgentActivity::DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS %>"
+               autocomplete="off"
+                <% unless kilocode_settings_enabled %>disabled<% end %>
+               class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+        <p class="mt-1 text-xs text-gray-500">Optional. Overrides the default direct-outbound preflight timeout for this KiloCode entry only.</p>
+      </div>
     </div>
   </div>
 

--- a/app/views/runners/_form.html.erb
+++ b/app/views/runners/_form.html.erb
@@ -207,6 +207,20 @@
                class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
         <p class="mt-1 text-xs text-gray-500">Required. The model identifier for the selected API provider.</p>
       </div>
+
+      <div class="mt-4">
+        <label for="runner_config_kilocode_preflight_timeout_seconds" class="block text-sm font-medium text-gray-900">Preflight Timeout (seconds)</label>
+        <input id="runner_config_kilocode_preflight_timeout_seconds"
+               name="runner[config][kilocode][preflight_timeout_seconds]"
+               type="number"
+               min="<%= Runner::MIN_PREFLIGHT_TIMEOUT_SECONDS %>"
+               value="<%= runner.kilocode_preflight_timeout_seconds %>"
+               placeholder="<%= Activities::RunAgentActivity::DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS %>"
+               autocomplete="off"
+                <% unless kilocode_settings_enabled %>disabled<% end %>
+               class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+        <p class="mt-1 text-xs text-gray-500">Optional. Overrides the default direct-outbound preflight timeout for this KiloCode entry only.</p>
+      </div>
     </div>
   </div>
 

--- a/spec/config/runner_form_bridge_file_spec.rb
+++ b/spec/config/runner_form_bridge_file_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe RunnerFormBridgeFile, :no_db do
     expect(runner_form).to include('name="runner[config][aider][model]"')
     expect(provider_form).to include('name="provider[config][aider][api_provider]"')
     expect(provider_form).to include('name="provider[config][aider][model]"')
+    expect(runner_form).to include('name="runner[config][kilocode][preflight_timeout_seconds]"')
+    expect(provider_form).to include('name="provider[config][kilocode][preflight_timeout_seconds]"')
     expect(runner_form).to include('name="runner[config][pi][api_provider]"')
     expect(runner_form).to include('name="runner[config][pi][model]"')
     expect(provider_form).to include('name="provider[config][pi][api_provider]"')
@@ -38,6 +40,7 @@ RSpec.describe RunnerFormBridgeFile, :no_db do
   end
 
   it "permits aider config through the runners controller bridge" do
+    expect(runners_controller).to include("kilocode: [ :api_provider, :model, :preflight_timeout_seconds ]")
     expect(runners_controller).to include("aider: [ :api_provider, :model ]")
     expect(runners_controller).to include("pi: [ :api_provider, :model ]")
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -334,6 +334,17 @@ RSpec.describe Provider do
       expect(provider.errors[:config]).to include("must include a KiloCode model id")
     end
 
+    it "requires kilocode preflight timeout overrides to be positive integers" do
+      api_key = create(:provider_api_key, user: provider.user, api_service_type: "inception")
+      provider.auth_type = "api_key"
+      provider.provider_api_key = api_key
+      provider.provider_key = "kilocode"
+      provider.config = { "kilocode" => { "api_provider" => "inception", "model" => "glm-5.1", "preflight_timeout_seconds" => "0" } }
+
+      expect(provider).not_to be_valid
+      expect(provider.errors[:config]).to include("must include a KiloCode preflight timeout of at least 1 second")
+    end
+
     it "requires a model id for opencode api_key providers" do
       api_key = create(:provider_api_key, user: provider.user, api_service_type: "openrouter")
       provider.auth_type = "api_key"
@@ -598,6 +609,14 @@ RSpec.describe Provider do
       config = JSON.parse(provider.kilocode_config_json)
 
       expect(config["model"]).to eq("anthropic/claude-opus-4")
+    end
+
+    it "reads an optional per-provider preflight timeout override from config" do
+      provider.update!(
+        config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-20250514", "preflight_timeout_seconds" => "45" } }
+      )
+
+      expect(provider.kilocode_preflight_timeout_seconds).to eq(45)
     end
 
     it "uses the native zai-coding-plan provider id for z.ai coding plan backends" do

--- a/spec/models/provider_state_spec.rb
+++ b/spec/models/provider_state_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe ProviderState do
       expect(state.reload.failure_count).to eq(7)
       expect(state.circuit_state).to eq("open")
     end
+
+    it "reopens a half-open circuit on the next failure" do
+      state = create(:provider_state, :circuit_half_open, failure_count: 3, circuit_opened_at: 10.minutes.ago)
+
+      state.record_failure!(threshold: 10)
+
+      state.reload
+      expect(state.failure_count).to eq(4)
+      expect(state.circuit_state).to eq("open")
+      expect(state.circuit_opened_at).to be_within(5.seconds).of(Time.current)
+    end
   end
 
   describe "#record_success!" do

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -388,6 +388,17 @@ RSpec.describe Runner do
       expect(runner.errors[:config]).to include("must include a KiloCode model id")
     end
 
+    it "requires kilocode preflight timeout overrides to be positive integers" do
+      api_key = create(:provider_api_key, user: runner.user, api_service_type: "inception")
+      runner.auth_type = "api_key"
+      runner.provider_api_key = api_key
+      runner.runner_key = "kilocode"
+      runner.config = { "kilocode" => { "api_provider" => "inception", "model" => "glm-5.1", "preflight_timeout_seconds" => "0" } }
+
+      expect(runner).not_to be_valid
+      expect(runner.errors[:config]).to include("must include a KiloCode preflight timeout of at least 1 second")
+    end
+
     it "requires a model id for opencode api_key providers" do
       api_key = create(:provider_api_key, user: runner.user, api_service_type: "openrouter")
       runner.auth_type = "api_key"
@@ -672,6 +683,14 @@ RSpec.describe Runner do
       config = JSON.parse(runner.kilocode_config_json)
 
       expect(config["model"]).to eq("anthropic/claude-opus-4")
+    end
+
+    it "reads an optional per-runner preflight timeout override from config" do
+      runner.update!(
+        config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-20250514", "preflight_timeout_seconds" => "45" } }
+      )
+
+      expect(runner.kilocode_preflight_timeout_seconds).to eq(45)
     end
 
     it "uses the native zai-coding-plan runner id for z.ai coding plan backends" do

--- a/spec/models/runner_state_spec.rb
+++ b/spec/models/runner_state_spec.rb
@@ -95,6 +95,17 @@ RSpec.describe RunnerState do
       expect(state.reload.failure_count).to eq(7)
       expect(state.circuit_state).to eq("open")
     end
+
+    it "reopens a half-open circuit on the next failure" do
+      state = create(:runner_state, :circuit_half_open, failure_count: 3, circuit_opened_at: 10.minutes.ago)
+
+      state.record_failure!(threshold: 10)
+
+      state.reload
+      expect(state.failure_count).to eq(4)
+      expect(state.circuit_state).to eq("open")
+      expect(state.circuit_opened_at).to be_within(5.seconds).of(Time.current)
+    end
   end
 
   describe "#record_success!" do

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -6,6 +6,25 @@ require "set"
 RSpec.describe "Providers" do
   let(:user) { create(:user) }
 
+  def kilocode_provider_params(api_key_id:, model:, preflight_timeout_seconds: nil)
+    kilocode_config = {
+      api_provider: "inception",
+      model: model
+    }
+    kilocode_config[:preflight_timeout_seconds] = preflight_timeout_seconds if preflight_timeout_seconds
+
+    {
+      provider_key: "kilocode",
+      auth_type: "api_key",
+      provider_api_key_id: api_key_id,
+      enabled_for_agent_runs: true,
+      enabled_for_fallback: true,
+      config: {
+        kilocode: kilocode_config
+      }
+    }
+  end
+
   describe "GET /providers" do
     context "when not authenticated" do
       it "redirects to sign in" do
@@ -502,24 +521,27 @@ RSpec.describe "Providers" do
     it "rejects kilocode API-key providers without a model id" do
       api_key = create(:provider_api_key, user: user, api_service_type: "inception")
 
-      post providers_path, params: {
-        provider: {
-          provider_key: "kilocode",
-          auth_type: "api_key",
-          provider_api_key_id: api_key.id,
-          enabled_for_agent_runs: true,
-          enabled_for_fallback: true,
-          config: {
-            kilocode: {
-              api_provider: "inception",
-              model: ""
-            }
-          }
-        }
-      }
+      post providers_path, params: { provider: kilocode_provider_params(api_key_id: api_key.id, model: "") }
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("must include a KiloCode model id")
+    end
+
+    it "persists nested KiloCode preflight timeout config for API-key providers" do
+      api_key = create(:provider_api_key, user: user, api_service_type: "inception")
+
+      post providers_path, params: {
+        provider: kilocode_provider_params(
+          api_key_id: api_key.id,
+          model: "glm-5.1",
+          preflight_timeout_seconds: "45"
+        )
+      }
+
+      expect(response).to redirect_to(providers_path)
+      provider = user.providers.find_by!(provider_key: "kilocode", auth_type: "api_key")
+      expect(provider.kilocode_model_id).to eq("glm-5.1")
+      expect(provider.kilocode_preflight_timeout_seconds).to eq(45)
     end
 
     it "rejects opencode API-key providers without a model id" do

--- a/spec/requests/runners_spec.rb
+++ b/spec/requests/runners_spec.rb
@@ -6,6 +6,25 @@ require "set"
 RSpec.describe "Runners" do
   let(:user) { create(:user) }
 
+  def kilocode_runner_params(api_key_id:, model:, preflight_timeout_seconds: nil)
+    kilocode_config = {
+      api_provider: "inception",
+      model: model
+    }
+    kilocode_config[:preflight_timeout_seconds] = preflight_timeout_seconds if preflight_timeout_seconds
+
+    {
+      runner_key: "kilocode",
+      auth_type: "api_key",
+      provider_api_key_id: api_key_id,
+      enabled_for_agent_runs: true,
+      enabled_for_fallback: true,
+      config: {
+        kilocode: kilocode_config
+      }
+    }
+  end
+
   describe "GET /runners" do
     context "when not authenticated" do
       it "redirects to sign in" do
@@ -478,23 +497,28 @@ RSpec.describe "Runners" do
       api_key = create(:provider_api_key, user: user, api_service_type: "inception")
 
       post runners_path, params: {
-        runner: {
-          runner_key: "kilocode",
-          auth_type: "api_key",
-          provider_api_key_id: api_key.id,
-          enabled_for_agent_runs: true,
-          enabled_for_fallback: true,
-          config: {
-            kilocode: {
-              api_provider: "inception",
-              model: ""
-            }
-          }
-        }
+        runner: kilocode_runner_params(api_key_id: api_key.id, model: "")
       }
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("must include a KiloCode model id")
+    end
+
+    it "persists nested KiloCode preflight timeout config for API-key runners" do
+      api_key = create(:provider_api_key, user: user, api_service_type: "inception")
+
+      post runners_path, params: {
+        runner: kilocode_runner_params(
+          api_key_id: api_key.id,
+          model: "glm-5.1",
+          preflight_timeout_seconds: "45"
+        )
+      }
+
+      expect(response).to redirect_to(runners_path)
+      runner = user.runners.find_by!(runner_key: "kilocode", auth_type: "api_key")
+      expect(runner.kilocode_model_id).to eq("glm-5.1")
+      expect(runner.kilocode_preflight_timeout_seconds).to eq(45)
     end
 
     it "rejects opencode API-key providers without a model id" do

--- a/spec/temporal/activities/run_agent_activity_no_db_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_no_db_spec.rb
@@ -204,4 +204,34 @@ RSpec.describe Activities::RunAgentActivity, :no_db do
       expect(marketplace_env).to eq("MARKETPLACE_FLAG" => "enabled")
     end
   end
+
+  describe "#preflight_timeout_seconds_for" do
+    let(:activity) { described_class.new }
+
+    it "prefers a configured kilocode timeout override on the runner entry" do
+      runner_entry = instance_double(
+        Runner,
+        kilocode_preflight_timeout_seconds: 45,
+        requires_direct_outbound?: true
+      )
+      allow(activity).to receive(:provider_entry_for).and_return(runner_entry)
+
+      timeout = activity.send(:preflight_timeout_seconds_for, "runner:19", nil)
+
+      expect(timeout).to eq(45)
+    end
+
+    it "falls back to the direct-outbound default when no override is configured" do
+      runner_entry = instance_double(
+        Runner,
+        kilocode_preflight_timeout_seconds: nil,
+        requires_direct_outbound?: true
+      )
+      allow(activity).to receive(:provider_entry_for).and_return(runner_entry)
+
+      timeout = activity.send(:preflight_timeout_seconds_for, "runner:19", nil)
+
+      expect(timeout).to eq(described_class::DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS)
+    end
+  end
 end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -101,6 +101,32 @@ RSpec.describe Activities::RunAgentActivity do
       })
   end
 
+  def create_runner_backed_agent_run(project:, runner:)
+    create(
+      :agent_run,
+      :with_git_context,
+      project: project,
+      issue: create(:issue, project: project),
+      runner: runner,
+      container_id: "abc123"
+    )
+  end
+
+  def expect_all_runners_exhausted(activity:, agent_run:)
+    allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+
+    expect {
+      activity.execute(agent_run_id: agent_run.id)
+    }.to raise_error(Temporalio::Error::ApplicationError, /All runners exhausted/)
+  end
+
+  def trip_runner_circuit_with_preflight_timeouts(activity:, project:, runner:, attempts: 3)
+    attempts.times do
+      timed_out_run = create_runner_backed_agent_run(project: project, runner: runner)
+      expect_all_runners_exhausted(activity: activity, agent_run: timed_out_run)
+    end
+  end
+
   def run_direct_outbound_preflight(activity:, agent_run:, container_service:, provider:, user:)
     command_context = Activities::RunAgentActivity::CommandContext.new(
       runner_candidate: provider,
@@ -2254,6 +2280,32 @@ expect(container_service).to receive(:execute).with(
           hash_including(
             timeout: described_class::DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS,
             idle_timeout: described_class::DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS
+          )
+        )
+      end
+
+      it "opens the runner circuit after three consecutive preflight timeouts and skips later runs during cooldown" do
+        runner = user.runners.find_by!(runner_key: "claude")
+        user.settings.update!(circuit_breaker_failure_threshold: 10)
+        allow(activity).to receive(:run_agent_with_runner).and_raise(
+          described_class::PreflightTimeoutError,
+          "Preflight check failed: Runner smoke preflight timed out after 30s"
+        )
+
+        trip_runner_circuit_with_preflight_timeouts(activity: activity, project: project, runner: runner)
+
+        state = user.runner_states.find_by!(runner_name: runner.state_key)
+        expect(state).to be_circuit_open
+
+        skipped_run = create_runner_backed_agent_run(project: project, runner: runner)
+
+        expect(activity).not_to receive(:run_agent_with_runner)
+        expect_all_runners_exhausted(activity: activity, agent_run: skipped_run)
+
+        expect(skipped_run.reload.runners_attempted).to include(
+          hash_including(
+            "error_type" => "unavailable",
+            "error_message" => "Skipped because runner circuit is open"
           )
         )
       end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -127,6 +127,17 @@ RSpec.describe Activities::RunAgentActivity do
     end
   end
 
+  def create_open_runner_state(user:, runner:, opened_at:, failure_count: 3)
+    create(
+      :runner_state,
+      user: user,
+      runner_name: runner.state_key,
+      circuit_state: "open",
+      failure_count: failure_count,
+      circuit_opened_at: opened_at
+    )
+  end
+
   def run_direct_outbound_preflight(activity:, agent_run:, container_service:, provider:, user:)
     command_context = Activities::RunAgentActivity::CommandContext.new(
       runner_candidate: provider,
@@ -2308,6 +2319,33 @@ expect(container_service).to receive(:execute).with(
             "error_message" => "Skipped because runner circuit is open"
           )
         )
+      end
+
+      it "reopens a half-open runner circuit when the recovery preflight times out" do
+        runner = user.runners.find_by!(runner_key: "claude")
+        user.settings.update!(
+          fallback_enabled: false,
+          fallback_runners: [],
+          circuit_breaker_failure_threshold: 10,
+          circuit_breaker_timeout_seconds: 300
+        )
+        state = create_open_runner_state(user: user, runner: runner, opened_at: 10.minutes.ago)
+        allow(activity).to receive(:run_agent_with_runner).and_raise(
+          described_class::PreflightTimeoutError,
+          "Preflight check failed: Runner smoke preflight timed out after 30s"
+        )
+
+        timed_out_run = create_runner_backed_agent_run(project: project, runner: runner)
+        expect_all_runners_exhausted(activity: activity, agent_run: timed_out_run)
+
+        state.reload
+        expect(state).to be_circuit_open
+        expect(state.circuit_opened_at).to be_within(5.seconds).of(Time.current)
+
+        skipped_run = create_runner_backed_agent_run(project: project, runner: runner)
+
+        expect(activity).not_to receive(:run_agent_with_runner)
+        expect_all_runners_exhausted(activity: activity, agent_run: skipped_run)
       end
 
       it "calls harness preflight_check with the main execution env and timeout" do


### PR DESCRIPTION
## Summary

Stops Kilocode preflight timeouts (174 in the last 24h on `runner:19`) from cascading into "All runners exhausted" failures for `glm-5.1` selections. The runner now supports a per-runner preflight timeout override, opens its circuit after a small number of preflight-class failures instead of waiting for the general threshold, and produces a clearer error distinguishing runner-level smoke preflight from harness preflight.

## Changes

- **Runner model & config** (`app/models/runner.rb`): adds a `preflight_timeout_seconds` override, surfaced through runner/provider configuration.
- **Activity execution** (`app/temporal/activities/run_agent_activity.rb`): honors the per-runner override in place of the hard-coded `DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS`, classifies preflight timeouts as their own failure type, and opens the runner circuit after 3 consecutive preflight timeouts.
- **Error messaging**: rewords the timeout error so runner-level smoke preflight failures are distinguishable from harness preflight failures.
- **UI**: exposes the new override in the runner and provider edit forms (`app/views/runners/_form.html.erb`, `app/views/providers/_form.html.erb`) and accepts it through `app/controllers/runners_controller.rb`.
- **Tests**: extends specs across model, controller, request, activity, and runner form bridge to cover the new override, the dedicated preflight failure class, and the updated message.

## Design Decisions

- **Dedicated preflight-failure class with a low fixed threshold (3)** rather than reusing `circuit_breaker_failure_threshold`. The general threshold is tuned for transient run failures; preflight timeouts are reachability/auth signals where waiting longer just multiplies 30s stalls. Hardcoding 3 keeps operator config minimal while making the circuit open within ~90s of sustained breakage.
- **Per-runner timeout override instead of lowering the global cap.** Other direct-outbound runners may legitimately need the full 30s; only Kilocode has demonstrated the consistent-failure pattern, so the override lets operators tune it without affecting other providers.
- **Kept the existing `DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS` constant as the default** so behavior is unchanged for runners without an explicit override.
- Complements #2121 (compatibility pre-filter): once that lands, incompatible runners are skipped up front, and this change ensures that when the only compatible runner is broken, we fail fast with a clear message rather than re-attempting it every 30s.

## Operational Notes

- **No migration required if the override is stored in existing JSON config columns**; if a schema migration is included, it should be a nullable column with no backfill needed (existing runners fall back to the constant default).
- **Uncommitted work**: the agent reported that changes are staged but no commit object was created — the author must verify and commit before pushing. Intended commit message: `fix(runners): harden kilocode preflight timeout handling`.
- After deploy, watch the 24h count of "Preflight check failed" entries for `runner:19` — acceptance is an order-of-magnitude drop, with subsequent attempts skipped during the cool-down.

## Screenshots

_Author: please attach before/after screenshots of the runner and provider edit forms showing the new preflight timeout override field._

---

Closes #2125