### PR TITLE
fix(agent-runs): legacy "provider" JSON key in runners_attempted causes silent nil reads

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1791,7 +1791,7 @@ class AgentRun < ApplicationRecord
     return {} unless owner
 
     routing_ids = runners_attempted.filter_map do |attempt|
-      Runner.id_from_routing_key(attempt["runner"])
+      Runner.id_from_routing_key(attempt["runner"] || attempt["provider"])
     end
     return {} if routing_ids.empty?
 

--- a/app/services/notifications/rules/zero_iteration_timeout.rb
+++ b/app/services/notifications/rules/zero_iteration_timeout.rb
@@ -33,7 +33,7 @@ module Notifications
             project_id: agent_run.project_id,
             source_pull_request_number: agent_run.source_pull_request_number,
             trigger_type: agent_run.trigger_type,
-            runners_attempted: Array(agent_run.runners_attempted).map { |attempt| attempt["runner"] }.compact
+            runners_attempted: Array(agent_run.runners_attempted).map { |attempt| attempt["runner"] || attempt["provider"] }.compact
           }.compact
         }
       end

--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -530,9 +530,10 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
             </svg>
           <% end %>
-          <% attempt_runner = attempted_runners_by_routing_key[attempt["runner"]] %>
+          <% attempt_runner_key = attempt["runner"] || attempt["provider"] %>
+          <% attempt_runner = attempted_runners_by_routing_key[attempt_runner_key] %>
           <span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium <%= attempt['success'] ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %>">
-            <%= runner_display_for_identifier(attempt["runner"], runner: attempt_runner) %>
+            <%= runner_display_for_identifier(attempt_runner_key, runner: attempt_runner) %>
             <% if attempt['error_type'].present? %>
               <span class="ml-1 text-xs opacity-75">(<%= attempt['error_type'] %>)</span>
             <% end %>
@@ -543,9 +544,10 @@
       <% if attempt_failures.any? %>
         <div class="mt-3 space-y-2">
           <% attempt_failures.each do |attempt| %>
-            <% attempt_runner = attempted_runners_by_routing_key[attempt["runner"]] %>
+            <% failure_runner_key = attempt["runner"] || attempt["provider"] %>
+            <% attempt_runner = attempted_runners_by_routing_key[failure_runner_key] %>
             <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2 dark:border-amber-800 dark:bg-amber-950/50">
-              <p class="text-xs font-medium text-amber-900 dark:text-amber-100"><%= runner_display_for_identifier(attempt["runner"], runner: attempt_runner) %></p>
+              <p class="text-xs font-medium text-amber-900 dark:text-amber-100"><%= runner_display_for_identifier(failure_runner_key, runner: attempt_runner) %></p>
               <p class="mt-1 text-xs text-amber-800 dark:text-amber-200"><%= truncate(redacted_error_message(attempt["error_message"]), length: 300) %></p>
               <% if (diagnostics_summary = runner_attempt_diagnostics_summary(attempt)).present? %>
                 <p class="mt-1 text-[11px] text-amber-700 dark:text-amber-300"><%= diagnostics_summary %></p>

--- a/db/migrate/20260518210746_backfill_runners_attempted_legacy_provider_key.rb
+++ b/db/migrate/20260518210746_backfill_runners_attempted_legacy_provider_key.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class BackfillRunnersAttemptedLegacyProviderKey < ActiveRecord::Migration[8.1]
+  def up
+    safety_assured do
+      execute <<~SQL.squish
+      UPDATE agent_runs
+      SET runners_attempted = (
+        SELECT jsonb_agg(
+          CASE WHEN entry ? 'provider' AND NOT (entry ? 'runner')
+               THEN (entry - 'provider') || jsonb_build_object('runner', entry->'provider')
+               ELSE entry
+          END
+        )
+        FROM jsonb_array_elements(runners_attempted) AS entry
+      )
+      WHERE runners_attempted IS NOT NULL
+        AND runners_attempted::text LIKE '%"provider"%'
+      SQL
+    end
+  end
+
+  def down
+    # No-op: the old "provider" key was unintentional data drift, not a
+    # deliberate schema choice. Rolling back the migration would
+    # reintroduce silent nil reads in three call sites.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_18_131232) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_18_210746) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"


### PR DESCRIPTION
## Summary

Fixes silent `nil` reads in three call sites that consume `agent_runs.runners_attempted` but only look up the new `"runner"` JSON key, missing legacy entries written under the pre-rename `"provider"` key. The result was empty runner chips, broken failure-attribution panels, and incomplete notification metadata for any agent run whose history predates (or bypassed) the providers→runners rename.

## Changes

- **Database**
  - `db/migrate/20260518210746_backfill_runners_attempted_legacy_provider_key.rb` — one-shot backfill that rewrites legacy `{"provider": …}` entries in `runners_attempted` to `{"runner": …}` via `jsonb_agg` over `jsonb_array_elements`, scoped to rows containing the legacy key.
- **Models**
  - `app/models/agent_run.rb:1794` — `attempted_runners_by_routing_key` now reads `attempt["runner"] || attempt["provider"]` so legacy entries contribute to the routing-key map.
- **Services**
  - `app/services/notifications/rules/zero_iteration_timeout.rb:36` — `runners_attempted` metadata now falls back to `attempt["provider"]`, keeping the notification payload complete for legacy rows.
- **UI**
  - `app/views/agent_runs/_detail.html.erb:533-548` — runner chip and failure-attribution panel both fall back to `attempt["provider"]`.

## Design Decisions

- **Backfill + reader fallbacks (belt and suspenders).** Option 1 from the issue (backfill) is the durable fix, but the reader fallbacks are kept in place to cover any in-flight rows written by a stray code path that bypasses `AgentRun#record_runner_attempt` between deploy and migration. Fallbacks can be removed later once the schema-drift audit (#2083) confirms no remaining writers emit the legacy key.
- **Scoped UPDATE.** The migration filters with `runners_attempted::text LIKE '%"provider"%'` to avoid rewriting rows that are already clean, keeping the migration cheap on large tables.
- **No SQL-path changes needed.** `AgentRun.normalize_provider_sql` already COALESCEs both keys, so query-side consumers were unaffected.

## Operational Notes

- Run `bin/rails db:migrate` on deploy. The migration is a single SQL `UPDATE` and is safe to re-run (idempotent — it only touches rows still containing `"provider"`).
- Post-deploy verification: `SELECT count(*) FROM agent_runs WHERE runners_attempted::text LIKE '%"provider":%';` should return `0`.

## Screenshots

_Reviewer: please attach before/after screenshots of an affected agent run detail page (runner chip + failure-attribution panel) for a row that previously had legacy `"provider"` entries._

Related: #2083 (broader post-rename drift audit).

---

Closes #2126