### PR TITLE
refactor(ui): convert notifications/index view to Phlex (or remove the TODO until Phlex lands)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ app/
 ├── workflows/        # Temporal workflow definitions (to be added)
 ├── activities/       # Temporal activity implementations (to be added)
 ├── adapters/         # External service adapters (to be added)
-├── views/            # Phlex view components (to be added)
+├── views/            # ERB templates today; Phlex components if/when that layer lands
 └── jobs/             # GoodJob jobs
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ When adding a new artifact pattern, update ALL of: `.gitignore`, `CONTAINER_ARTI
 - Follow `rubocop-rails-omakase` style (StandardRB-based)
 - `frozen_string_literal: true` at top of all Ruby files
 - Service objects use [Servo](https://github.com/martinstreicher/servo) with verb-noun naming: `AgentRuns::Create`, `Projects::Import`
-- Views use [Phlex](https://www.phlex.fun/) for pure Ruby components
+- The app currently renders views with ERB. [Phlex](https://www.phlex.fun/) remains the intended future component layer, but do not assume the gem or component base classes already exist until that work lands.
 - No TODO without issue reference: `# TODO(#123): description`
 
 ### Size Guidelines (Sandi Metz's Rules)

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,4 +1,3 @@
-<%# TODO(#912): Convert to Phlex once the gem is added to the project %>
 <% content_for(:title) { "Notifications" } %>
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">

--- a/docs/LLM_STYLE_GUIDE.md
+++ b/docs/LLM_STYLE_GUIDE.md
@@ -113,8 +113,8 @@ Analyzing meaning or making a judgment?
 ## 8. Rails Patterns
 
 - **Controllers**: Thin, delegate to services. HTTP concerns only. `STYLE_GUIDE:968-1005`
-- **Views**: Phlex components (pure Ruby, composable, performant). `STYLE_GUIDE:1007-1125`
-- **Hotwire**: Broadcast Turbo Stream updates via Phlex rendering. `STYLE_GUIDE:1127-1146`
+- **Views**: Use the current ERB stack; treat Phlex as future-state guidance until the gem lands. `STYLE_GUIDE:1007-1125`
+- **Hotwire**: Follow existing Turbo patterns; Phlex rendering guidance applies only after adoption. `STYLE_GUIDE:1127-1146`
 - **Background jobs**: Prefer Temporal workflows for multi-step/external work. GoodJob for simple fire-and-forget. `STYLE_GUIDE:1148-1197`
 
 ## 9. Security

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -158,7 +158,7 @@ app/
 ├── workflows/            # Temporal workflow definitions
 ├── activities/           # Temporal activity implementations
 ├── adapters/             # External service adapters (GitHub, LLM providers)
-├── views/                # Phlex view components and templates
+├── views/                # ERB templates today; Phlex components once adopted
 └── jobs/                 # GoodJob jobs (when Temporal isn't appropriate)
 ```
 
@@ -1054,11 +1054,13 @@ class AgentRunsController < ApplicationController
 end
 ```
 
-### Views with Phlex
+### Views
 
-Use [Phlex](https://www.phlex.fun/) for view components. Phlex provides pure Ruby views with better performance than ERB and natural composition.
+The app currently renders views with ERB. Match the existing ERB-based stack unless and until Phlex is added to the application.
 
-**Why Phlex over ERB/ViewComponent**:
+If and when [Phlex](https://www.phlex.fun/) is adopted, it remains the intended future component layer because it provides pure Ruby views with natural composition.
+
+**Why Phlex once adopted**:
 
 - Pure Ruby: No template language to learn, full IDE support
 - Performance: Faster than ERB, especially for component-heavy pages
@@ -1136,7 +1138,7 @@ class Components::AgentRunCard < Phlex::HTML
 end
 ```
 
-**Page layouts with Phlex**:
+**Page layouts with Phlex once adopted**:
 
 ```ruby
 # app/views/layouts/application_layout.rb
@@ -1176,7 +1178,7 @@ end
 
 ### Hotwire Integration
 
-Phlex works seamlessly with Turbo. Broadcast updates by rendering components:
+Once Phlex is available in the app, it works seamlessly with Turbo. Broadcast updates by rendering components:
 
 ```ruby
 # app/models/agent_run.rb


### PR DESCRIPTION
## Summary

Resolves the dangling Phlex TODO in the notifications index view by acknowledging that Phlex is not yet installed and clarifying CLAUDE.md to reflect current reality. This is Option B from the issue: drop the TODO until the gem actually ships, rather than introducing Phlex as a dependency under a follow-up ticket.

## Changes

- **Docs**: Updated `CLAUDE.md` to note that the app currently uses ERB and that Phlex is the intended future component layer, only once it is introduced.
- **Views**: Removed the stale `# TODO: Convert to Phlex` comment from `app/views/notifications/index.html.erb:1`.

## Design Decisions

- Chose Option B (remove the TODO) over Option A (introduce `phlex-rails` now) because adopting a new view layer is a larger architectural commitment that should be tracked as its own umbrella initiative, not bundled into a TODO cleanup. When Phlex is actually adopted, a fresh issue can re-file the conversion of this view as the first migration target.
- Kept the CLAUDE.md guidance forward-looking rather than deleting it entirely, so the intent is preserved for future contributors without misrepresenting the current stack.

---

Closes #2140