### PR TITLE
refactor(knowledge): replace embedding Faraday client with AgentHarness.embed once agent-harness ships embedding support

### DIFF
--- a/app/services/knowledge/embedding_runner.rb
+++ b/app/services/knowledge/embedding_runner.rb
@@ -178,6 +178,11 @@ module Knowledge
         require "agent_harness"
 
         module PaidEmbeddingTransportPatch
+          PAID_TRANSPORT_ERRORS = [
+            EOFError,
+            OpenSSL::SSL::SSLError
+          ].freeze
+
           def initialize(base_url:, api_key:, model:, logger: nil, extra_headers: {}, timeout: self.class::DEFAULT_TIMEOUT)
             @paid_extra_headers = extra_headers
             @paid_timeout = timeout
@@ -197,6 +202,8 @@ module Knowledge
             handle_embedding_error_response(http_response, status_code) unless status_code == 200
 
             JSON.parse(http_response.body)
+          rescue *PAID_TRANSPORT_ERRORS => e
+            raise AgentHarness::ProviderError.new("HTTP connection error: #{e.message}", original_error: e)
           rescue JSON::ParserError => e
             raise AgentHarness::ProviderError.new(
               "Invalid JSON in embedding API response: #{e.message}",

--- a/app/services/knowledge/embedding_runner.rb
+++ b/app/services/knowledge/embedding_runner.rb
@@ -175,8 +175,47 @@ module Knowledge
     def script
       <<~'RUBY'
         require "json"
-        require "net/http"
-        require "uri"
+        require "agent_harness"
+
+        module PaidEmbeddingTransportPatch
+          def initialize(base_url:, api_key:, model:, logger: nil, extra_headers: {}, timeout: self.class::DEFAULT_TIMEOUT)
+            @paid_extra_headers = extra_headers
+            @paid_timeout = timeout
+            super(base_url:, api_key:, model:, logger:)
+          end
+
+          def embed(inputs:, model: nil, dimensions: nil)
+            uri = URI("#{@base_url}/embeddings")
+            body = {
+              input: inputs,
+              model: model || @model
+            }
+            body[:dimensions] = dimensions if dimensions
+
+            response = make_request(uri, body)
+            status_code = response.code.to_i
+            handle_error_response(response, status_code) unless status_code == 200
+
+            JSON.parse(response.body)
+          end
+
+          private
+
+          def build_http(uri)
+            http = super
+            http.read_timeout = @paid_timeout if @paid_timeout
+            http
+          end
+
+          def build_post_request(uri, body)
+            request = super
+            @paid_extra_headers.each { |key, value| request[key] = value }
+            request
+          end
+        end
+
+        AgentHarness::OpenAICompatibleTransport.prepend(PaidEmbeddingTransportPatch) unless
+          AgentHarness::OpenAICompatibleTransport < PaidEmbeddingTransportPatch
 
         proxy_url = ENV.fetch("PROXY_BASE_URL")
         run_id = ENV.fetch("KNOWLEDGE_RUN_ID")
@@ -188,29 +227,18 @@ module Knowledge
         input_path = ENV.fetch("INPUT_PATH")
 
         texts = JSON.parse(File.read(input_path))
-        uri = URI("#{proxy_url}/api/proxy/openai/v1/embeddings")
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme == "https"
-        http.open_timeout = 10
-        http.read_timeout = timeout
-
-        req = Net::HTTP::Post.new(uri.path)
-        req["Authorization"] = "Bearer paid-knowledge-run:#{run_id}:#{token}"
-        req["Content-Type"] = "application/json"
-        req["X-Paid-Knowledge-Provider"] = provider
-        req.body = {
-          input: texts,
+        transport = AgentHarness::OpenAICompatibleTransport.new(
+          base_url: "#{proxy_url}/api/proxy/openai/v1",
+          api_key: "paid-knowledge-run:#{run_id}:#{token}",
           model: model,
-          dimensions: dimensions
-        }.to_json
+          extra_headers: {
+            "X-Paid-Knowledge-Provider" => provider
+          },
+          timeout: timeout
+        )
 
-        res = http.request(req)
-        unless res.is_a?(Net::HTTPSuccess)
-          $stderr.puts("Proxy error: #{res.code} #{res.body&.slice(0, 500)}")
-          exit(1)
-        end
-
-        $stdout.print(res.body)
+        body = transport.embed(inputs: texts, model: model, dimensions: dimensions)
+        $stdout.print(JSON.generate(body))
       RUBY
     end
 

--- a/app/services/knowledge/embedding_runner.rb
+++ b/app/services/knowledge/embedding_runner.rb
@@ -192,11 +192,16 @@ module Knowledge
             }
             body[:dimensions] = dimensions if dimensions
 
-            response = make_request(uri, body)
-            status_code = response.code.to_i
-            handle_error_response(response, status_code) unless status_code == 200
+            http_response = make_request(uri, body)
+            status_code = http_response.code.to_i
+            handle_embedding_error_response(http_response, status_code) unless status_code == 200
 
-            JSON.parse(response.body)
+            JSON.parse(http_response.body)
+          rescue JSON::ParserError => e
+            raise AgentHarness::ProviderError.new(
+              "Invalid JSON in embedding API response: #{e.message}",
+              original_error: e
+            )
           end
 
           private
@@ -211,6 +216,49 @@ module Knowledge
             request = super
             @paid_extra_headers.each { |key, value| request[key] = value }
             request
+          end
+
+          def handle_embedding_error_response(http_response, status_code)
+            headers = http_response.each_header.to_h.transform_keys(&:downcase)
+            context = {
+              status: status_code,
+              headers: headers
+            }
+            message = embedding_error_message(http_response.body)
+
+            case status_code
+            when 401
+              raise AgentHarness::AuthenticationError.new(
+                "API authentication failed: #{message}",
+                provider: :openai_compatible,
+                context:
+              )
+            when 403
+              raise AgentHarness::AuthenticationError.new(
+                "API access forbidden: #{message}",
+                provider: :openai_compatible,
+                context:
+              )
+            when 429
+              raise AgentHarness::RateLimitError.new(
+                "API rate limit exceeded: #{message}",
+                provider: :openai_compatible,
+                context:
+              )
+            when 400
+              raise AgentHarness::ProviderError.new("Bad request: #{message}", context:)
+            when 500, 502, 503, 504
+              raise AgentHarness::ProviderError.new("Server error (#{status_code}): #{message}", context:)
+            else
+              raise AgentHarness::ProviderError.new("HTTP #{status_code}: #{message}", context:)
+            end
+          end
+
+          def embedding_error_message(body_string)
+            body = JSON.parse(body_string)
+            body.dig("error", "message") || body.dig("error", "type") || body_string
+          rescue JSON::ParserError
+            body_string
           end
         end
 

--- a/app/services/knowledge/embeddings/generate.rb
+++ b/app/services/knowledge/embeddings/generate.rb
@@ -8,27 +8,34 @@ module Knowledge
       COST_PER_MILLION_TOKENS = 0.13
       MAX_RETRIES = 3
       BASE_DELAY = 1.0
-      RETRYABLE_STATUSES = [ 429, 500, 502, 503, 504 ].freeze
 
       attr_reader :model, :dimensions
 
-      def initialize(model: MODEL, dimensions: DIMENSIONS, base_url:, headers: {})
+      RETRYABLE_PROVIDER_STATUSES = [ 500, 502, 503, 504 ].freeze
+      RETRYABLE_PROVIDER_ERRORS = [
+        IOError,
+        SocketError,
+        Errno::ECONNREFUSED,
+        Errno::ECONNRESET
+      ].freeze
+
+      def initialize(model: MODEL, dimensions: DIMENSIONS, base_url:, headers: {}, timeout: AgentHarness::OpenAICompatibleTransport::DEFAULT_TIMEOUT)
         @model = model
         @dimensions = dimensions
         @base_url = base_url
         @headers = headers
+        @timeout = timeout
       end
 
-      def self.call(texts:, model: MODEL, dimensions: DIMENSIONS, base_url:, headers: {})
-        new(model: model, dimensions: dimensions, base_url: base_url, headers: headers).call(texts: texts)
+      def self.call(texts:, model: MODEL, dimensions: DIMENSIONS, base_url:, headers: {}, timeout: AgentHarness::OpenAICompatibleTransport::DEFAULT_TIMEOUT)
+        new(model: model, dimensions: dimensions, base_url: base_url, headers: headers, timeout: timeout).call(texts: texts)
       end
 
       # Returns an array of Result structs with :vector and :token_count
       def call(texts:)
         return [] if texts.empty?
 
-        response = request_embeddings(texts)
-        self.class.results_from_body(parse_response(response))
+        self.class.results_from_body(request_embeddings(texts))
       end
 
       Result = Struct.new(:vector, :token_count, keyword_init: true)
@@ -53,82 +60,67 @@ module Knowledge
         retries = 0
 
         begin
-          response = connection.post(embeddings_path) do |req|
-            req.body = {
-              input: texts,
-              model: model,
-              dimensions: dimensions
-            }.to_json
-          end
+          AgentHarness.embed(
+            texts,
+            model: model,
+            dimensions: dimensions,
+            base_url: normalized_base_url,
+            api_key: api_key,
+            headers: request_headers,
+            timeout:
+          )
+        rescue AgentHarness::AuthenticationError => e
+          raise EmbeddingError, "Embedding API request failed: #{e.message}"
+        rescue AgentHarness::RateLimitError, AgentHarness::TimeoutError => e
+          retry_request(error: e, retries: retries) { |count| retries = count }
+          retry
+        rescue AgentHarness::ProviderError => e
+          raise EmbeddingError, "Embedding API request failed: #{e.message}" unless retryable_provider_error?(e)
 
-          if !response.success? && RETRYABLE_STATUSES.include?(response.status)
-            raise RetryableHTTPError, response
-          end
-
-          response
-        rescue Faraday::Error, RetryableHTTPError => e
-          retries += 1
-          if retries <= MAX_RETRIES
-            delay = retry_delay(e, retries)
-            sleep(delay)
-            retry
-          end
-          raise EmbeddingError, "Embedding API request failed after #{MAX_RETRIES} retries: #{e.message}"
+          retry_request(error: e, retries: retries) { |count| retries = count }
+          retry
         end
+      end
+
+      def retry_request(error:, retries:)
+        retries += 1
+        if retries <= MAX_RETRIES
+          sleep(retry_delay(error, retries))
+          yield(retries)
+          return
+        end
+
+        raise EmbeddingError, "Embedding API request failed after #{MAX_RETRIES} retries: #{error.message}"
       end
 
       # Respects Retry-After header when present, otherwise uses exponential backoff.
       def retry_delay(error, attempt)
-        if error.is_a?(RetryableHTTPError) && (retry_after = error.response.headers["retry-after"])
-          retry_after.to_f
-        else
-          BASE_DELAY * (2**(attempt - 1))
-        end
+        retry_after = error.context.dig(:headers, "retry-after")
+        return retry_after.to_f if retry_after.present?
+
+        BASE_DELAY * (2**(attempt - 1))
       end
 
-      # Internal error to trigger retry on retryable HTTP statuses.
-      class RetryableHTTPError < StandardError
-        attr_reader :response
+      attr_reader :base_url, :headers, :timeout
 
-        def initialize(response)
-          @response = response
-          super("HTTP #{response.status}: #{response.body}")
-        end
+      def normalized_base_url
+        base_url.to_s.sub(%r{/\z}, "")
       end
 
-      def parse_response(response)
-        unless response.success?
-          raise EmbeddingError, "Embedding API returned #{response.status}: #{response.body}"
-        end
-
-        JSON.parse(response.body)
-      rescue JSON::ParserError => e
-        raise EmbeddingError,
-          "Failed to parse embedding API response as JSON: #{e.message} (status #{response.status}, body: #{response.body})"
+      def api_key
+        headers.fetch("Authorization").to_s.sub(/\ABearer\s+/i, "")
       end
 
-      # HTTP client for the secrets-proxy-backed embedding endpoint.
-      # TODO(#1039): Replace with AgentHarness.embed once agent-harness ships embedding support.
-      def connection
-        @connection ||= Faraday.new(url: base_url) do |f|
-          f.request :retry, max: 0
-          f.headers.update(headers)
-          f.headers["Content-Type"] = "application/json"
-          f.adapter Faraday.default_adapter
-        end
+      def request_headers
+        headers.except("Authorization").compact
       end
 
-      attr_reader :base_url
+      def retryable_provider_error?(error)
+        status = error.context[:status]
+        return RETRYABLE_PROVIDER_STATUSES.include?(status) if status
 
-      def embeddings_path
-        path = URI.parse(base_url).path.to_s.sub(%r{/\z}, "")
-        path = "/v1" if path.blank?
-        "#{path}/embeddings"
-      rescue URI::InvalidURIError
-        "/v1/embeddings"
+        RETRYABLE_PROVIDER_ERRORS.any? { |klass| error.original_error.is_a?(klass) }
       end
-
-      attr_reader :headers
 
       def self.estimate_cost(token_count)
         (token_count.to_f / 1_000_000 * COST_PER_MILLION_TOKENS).round(6)

--- a/app/services/knowledge/embeddings/generate.rb
+++ b/app/services/knowledge/embeddings/generate.rb
@@ -13,7 +13,9 @@ module Knowledge
 
       RETRYABLE_PROVIDER_STATUSES = [ 500, 502, 503, 504 ].freeze
       RETRYABLE_PROVIDER_ERRORS = [
+        EOFError,
         IOError,
+        OpenSSL::SSL::SSLError,
         SocketError,
         Errno::ECONNREFUSED,
         Errno::ECONNRESET

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -139,6 +139,11 @@ end
 # behavior cleanly once the gem exposes AgentHarness.embed (or equivalent).
 # TODO(#2146): remove when agent-harness >= 0.19.0 ships native embeddings support
 module PaidAgentHarnessEmbeddingTransportPatch
+  PAID_TRANSPORT_ERRORS = [
+    EOFError,
+    OpenSSL::SSL::SSLError
+  ].freeze
+
   def initialize(base_url:, api_key:, model:, logger: nil, extra_headers: {}, timeout: self.class::DEFAULT_TIMEOUT)
     @paid_extra_headers = extra_headers
     @paid_timeout = timeout
@@ -158,6 +163,8 @@ module PaidAgentHarnessEmbeddingTransportPatch
     handle_embedding_error_response(http_response, status_code) unless status_code == 200
 
     JSON.parse(http_response.body)
+  rescue *PAID_TRANSPORT_ERRORS => e
+    raise AgentHarness::ProviderError.new("HTTP connection error: #{e.message}", original_error: e)
   rescue JSON::ParserError => e
     raise AgentHarness::ProviderError.new(
       "Invalid JSON in embedding API response: #{e.message}",

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -134,6 +134,120 @@ if agent_harness_version < Gem::Version.new("0.19.0")
     AgentHarness::Providers::Pi < PaidAgentHarnessPiRuntimePatch
 end
 
+# Backport embedding support until agent-harness ships a native public API.
+# Keep this version-gated and narrow so Paid can switch back to upstream
+# behavior cleanly once the gem exposes AgentHarness.embed (or equivalent).
+# TODO(#2146): remove when agent-harness >= 0.19.0 ships native embeddings support
+module PaidAgentHarnessEmbeddingTransportPatch
+  def initialize(base_url:, api_key:, model:, logger: nil, extra_headers: {}, timeout: self.class::DEFAULT_TIMEOUT)
+    @paid_extra_headers = extra_headers
+    @paid_timeout = timeout
+    super(base_url:, api_key:, model:, logger:)
+  end
+
+  def embed(inputs:, model: nil, dimensions: nil)
+    uri = URI("#{@base_url}/embeddings")
+    body = {
+      input: inputs,
+      model: model || @model
+    }
+    body[:dimensions] = dimensions if dimensions
+
+    http_response = make_request(uri, body)
+    status_code = http_response.code.to_i
+    handle_embedding_error_response(http_response, status_code) unless status_code == 200
+
+    JSON.parse(http_response.body)
+  rescue JSON::ParserError => e
+    raise AgentHarness::ProviderError.new(
+      "Invalid JSON in embedding API response: #{e.message}",
+      original_error: e
+    )
+  end
+
+  private
+
+  def build_http(uri)
+    http = super
+    http.read_timeout = @paid_timeout if @paid_timeout
+    http
+  end
+
+  def build_post_request(uri, body)
+    request = super
+    @paid_extra_headers.each { |key, value| request[key] = value }
+    request
+  end
+
+  def handle_embedding_error_response(http_response, status_code)
+    headers = http_response.each_header.to_h.transform_keys(&:downcase)
+    context = {
+      status: status_code,
+      headers: headers
+    }
+    message = embedding_error_message(http_response.body)
+
+    case status_code
+    when 401
+      raise AgentHarness::AuthenticationError.new(
+        "API authentication failed: #{message}",
+        provider: :openai_compatible,
+        context:
+      )
+    when 403
+      raise AgentHarness::AuthenticationError.new(
+        "API access forbidden: #{message}",
+        provider: :openai_compatible,
+        context:
+      )
+    when 429
+      raise AgentHarness::RateLimitError.new(
+        "API rate limit exceeded: #{message}",
+        provider: :openai_compatible,
+        context:
+      )
+    when 400
+      raise AgentHarness::ProviderError.new("Bad request: #{message}", context:)
+    when 500, 502, 503, 504
+      raise AgentHarness::ProviderError.new("Server error (#{status_code}): #{message}", context:)
+    else
+      raise AgentHarness::ProviderError.new("HTTP #{status_code}: #{message}", context:)
+    end
+  end
+
+  def embedding_error_message(body_string)
+    body = JSON.parse(body_string)
+    body.dig("error", "message") || body.dig("error", "type") || body_string
+  rescue JSON::ParserError
+    body_string
+  end
+end
+
+module PaidAgentHarnessEmbeddingPatch
+  def embed(inputs, model:, base_url:, api_key:, dimensions: nil, headers: {}, timeout: AgentHarness::OpenAICompatibleTransport::DEFAULT_TIMEOUT)
+    transport = AgentHarness::OpenAICompatibleTransport.new(
+      base_url: base_url,
+      api_key: api_key,
+      model: model,
+      logger: logger,
+      extra_headers: headers,
+      timeout: timeout
+    )
+
+    transport.embed(
+      inputs: Array(inputs),
+      model: model,
+      dimensions: dimensions
+    )
+  end
+end
+
+if agent_harness_version < Gem::Version.new("0.19.0") && !AgentHarness.respond_to?(:embed)
+  AgentHarness::OpenAICompatibleTransport.prepend(PaidAgentHarnessEmbeddingTransportPatch) unless
+    AgentHarness::OpenAICompatibleTransport < PaidAgentHarnessEmbeddingTransportPatch
+  AgentHarness.extend(PaidAgentHarnessEmbeddingPatch)
+end
+
 # Default agent timeout used for AgentHarness boot-time config and as a
 # fallback when per-user settings are unavailable. Runtime code should
 # prefer UserSetting#agent_timeout_seconds resolved via

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -100,6 +100,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Bundler (pinned to match Gemfile.lock)
 RUN gem install --no-document bundler:4.0.11
 
+# Install agent-harness globally so lightweight utility scripts inside the
+# agent container can use the same transport layer as the Rails app.
+# Keep this pin in sync with Gemfile.lock until the image build is wired to a
+# shared source of truth.
+RUN gem install --no-document agent-harness:0.18.2
+
 # Install ruby-maat (VCS mining tool for churn/hotspot analysis)
 # https://github.com/viamin/ruby-maat
 # Version is sourced from Gemfile.lock at build time when RUBY_MAAT_VERSION is provided

--- a/spec/services/knowledge/embedding_runner_spec.rb
+++ b/spec/services/knowledge/embedding_runner_spec.rb
@@ -95,10 +95,11 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
   end
 
   describe "#script_env" do
-    it "enables TLS in the generated embedding proxy script when PROXY_BASE_URL is HTTPS" do
+    it "uses AgentHarness transport in the generated embedding proxy script" do
       runner = described_class.new(project: project, knowledge_run: knowledge_run)
 
-      expect(runner.send(:script)).to include('http.use_ssl = uri.scheme == "https"')
+      expect(runner.send(:script)).to include('AgentHarness::OpenAICompatibleTransport.new(')
+      expect(runner.send(:script)).to include("transport.embed(inputs: texts, model: model, dimensions: dimensions)")
     end
 
     it "uses the external proxy URL for remote backends" do

--- a/spec/services/knowledge/embedding_runner_spec.rb
+++ b/spec/services/knowledge/embedding_runner_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
 
       expect(runner.send(:script)).to include('AgentHarness::OpenAICompatibleTransport.new(')
       expect(runner.send(:script)).to include("transport.embed(inputs: texts, model: model, dimensions: dimensions)")
+      expect(runner.send(:script)).to include("handle_embedding_error_response(http_response, status_code) unless status_code == 200")
     end
 
     it "uses the external proxy URL for remote backends" do

--- a/spec/services/knowledge/embedding_runner_spec.rb
+++ b/spec/services/knowledge/embedding_runner_spec.rb
@@ -101,6 +101,8 @@ RSpec.describe Knowledge::EmbeddingRunner, :no_db do
       expect(runner.send(:script)).to include('AgentHarness::OpenAICompatibleTransport.new(')
       expect(runner.send(:script)).to include("transport.embed(inputs: texts, model: model, dimensions: dimensions)")
       expect(runner.send(:script)).to include("handle_embedding_error_response(http_response, status_code) unless status_code == 200")
+      expect(runner.send(:script)).to include('OpenSSL::SSL::SSLError')
+      expect(runner.send(:script)).to include('raise AgentHarness::ProviderError.new("HTTP connection error:')
     end
 
     it "uses the external proxy URL for remote backends" do

--- a/spec/services/knowledge/embeddings/generate_spec.rb
+++ b/spec/services/knowledge/embeddings/generate_spec.rb
@@ -126,6 +126,21 @@ RSpec.describe Knowledge::Embeddings::Generate do
         .to raise_error(Knowledge::Embeddings::EmbeddingError, /after 3 retries/)
     end
 
+    it "retries when the shim wraps TLS transport failures as provider errors" do
+      allow(AgentHarness).to receive(:embed).and_raise(
+        AgentHarness::ProviderError.new(
+          "HTTP connection error: tls handshake failed",
+          original_error: OpenSSL::SSL::SSLError.new("tls handshake failed")
+        )
+      )
+
+      generator = described_class.new(base_url: base_url, headers: headers)
+      allow(generator).to receive(:sleep)
+
+      expect { generator.call(texts: texts) }
+        .to raise_error(Knowledge::Embeddings::EmbeddingError, /after 3 retries/)
+    end
+
     it "raises EmbeddingError on invalid embedding response JSON" do
       allow(AgentHarness).to receive(:embed).and_raise(
         AgentHarness::ProviderError.new(

--- a/spec/services/knowledge/embeddings/generate_spec.rb
+++ b/spec/services/knowledge/embeddings/generate_spec.rb
@@ -15,22 +15,17 @@ RSpec.describe Knowledge::Embeddings::Generate do
 
   let(:success_response_body) do
     {
-      data: [
-        { index: 0, embedding: vector },
-        { index: 1, embedding: vector }
+      "data" => [
+        { "index" => 0, "embedding" => vector },
+        { "index" => 1, "embedding" => vector }
       ],
-      usage: { total_tokens: 10 }
-    }.to_json
+      "usage" => { "total_tokens" => 10 }
+    }
   end
 
   describe ".call" do
     before do
-      stub_request(:post, "https://proxy.openai.test/api/proxy/openai/v1/embeddings")
-        .with(
-          body: { input: texts, model: "text-embedding-3-large", dimensions: 3072 }.to_json,
-          headers: headers.merge("Content-Type" => "application/json")
-        )
-        .to_return(status: 200, body: success_response_body, headers: { "Content-Type" => "application/json" })
+      allow(AgentHarness).to receive(:embed).and_return(success_response_body)
     end
 
     it "returns embedding results for each text" do
@@ -47,27 +42,41 @@ RSpec.describe Knowledge::Embeddings::Generate do
 
     it "sorts results by index" do
       reversed_body = {
-        data: [
-          { index: 1, embedding: Array.new(3072, 0.2) },
-          { index: 0, embedding: Array.new(3072, 0.1) }
+        "data" => [
+          { "index" => 1, "embedding" => Array.new(3072, 0.2) },
+          { "index" => 0, "embedding" => Array.new(3072, 0.1) }
         ],
-        usage: { total_tokens: 10 }
-      }.to_json
+        "usage" => { "total_tokens" => 10 }
+      }
 
-      stub_request(:post, "https://proxy.openai.test/api/proxy/openai/v1/embeddings")
-        .to_return(status: 200, body: reversed_body, headers: { "Content-Type" => "application/json" })
+      allow(AgentHarness).to receive(:embed).and_return(reversed_body)
 
       results = described_class.call(texts: texts, base_url: base_url, headers: headers)
 
       expect(results.first.vector.first).to eq(0.1)
       expect(results.last.vector.first).to eq(0.2)
     end
+
+    it "passes proxy credentials through AgentHarness.embed" do
+      described_class.call(texts: texts, base_url: base_url, headers: headers)
+
+      expect(AgentHarness).to have_received(:embed).with(
+        texts,
+        model: "text-embedding-3-large",
+        dimensions: 3072,
+        base_url: base_url,
+        api_key: "paid-knowledge-run:99:token",
+        headers: { "X-Paid-Knowledge-Provider" => "openrouter" },
+        timeout: AgentHarness::OpenAICompatibleTransport::DEFAULT_TIMEOUT
+      )
+    end
   end
 
   describe "error handling" do
     it "retries on retryable HTTP statuses and raises after max retries" do
-      stub_request(:post, "https://proxy.openai.test/api/proxy/openai/v1/embeddings")
-        .to_return(status: 500, body: "Internal Server Error")
+      allow(AgentHarness).to receive(:embed).and_raise(
+        AgentHarness::ProviderError.new("Server error (500): Internal Server Error", context: { status: 500 })
+      )
 
       generator = described_class.new(base_url: base_url, headers: headers)
       allow(generator).to receive(:sleep)
@@ -77,9 +86,16 @@ RSpec.describe Knowledge::Embeddings::Generate do
     end
 
     it "respects Retry-After header on 429 responses" do
-      stub_request(:post, "https://proxy.openai.test/api/proxy/openai/v1/embeddings")
-        .to_return(status: 429, body: "Rate limited", headers: { "Retry-After" => "2.5" })
-        .then.to_return(status: 200, body: success_response_body, headers: { "Content-Type" => "application/json" })
+      calls = 0
+      allow(AgentHarness).to receive(:embed) do
+        calls += 1
+        raise AgentHarness::RateLimitError.new(
+          "API rate limit exceeded: Rate limited",
+          context: { headers: { "retry-after" => "2.5" } }
+        ) if calls == 1
+
+        success_response_body
+      end
 
       generator = described_class.new(base_url: base_url, headers: headers)
       allow(generator).to receive(:sleep)
@@ -90,16 +106,18 @@ RSpec.describe Knowledge::Embeddings::Generate do
     end
 
     it "raises EmbeddingError on non-retryable HTTP failures" do
-      stub_request(:post, "https://proxy.openai.test/api/proxy/openai/v1/embeddings")
-        .to_return(status: 400, body: "Bad Request")
+      allow(AgentHarness).to receive(:embed).and_raise(
+        AgentHarness::ProviderError.new("Bad request: Bad Request", context: { status: 400 })
+      )
 
       expect { described_class.call(texts: texts, base_url: base_url, headers: headers) }
-        .to raise_error(Knowledge::Embeddings::EmbeddingError, /400/)
+        .to raise_error(Knowledge::Embeddings::EmbeddingError, /Bad request/)
     end
 
-    it "retries on Faraday errors and raises after max retries" do
-      stub_request(:post, "https://proxy.openai.test/api/proxy/openai/v1/embeddings")
-        .to_raise(Faraday::ConnectionFailed.new("connection failed"))
+    it "retries on transport errors and raises after max retries" do
+      allow(AgentHarness).to receive(:embed).and_raise(
+        AgentHarness::ProviderError.new("HTTP connection error: connection failed", original_error: IOError.new("connection failed"))
+      )
 
       generator = described_class.new(base_url: base_url, headers: headers)
       allow(generator).to receive(:sleep)
@@ -108,27 +126,36 @@ RSpec.describe Knowledge::Embeddings::Generate do
         .to raise_error(Knowledge::Embeddings::EmbeddingError, /after 3 retries/)
     end
 
-    it "raises EmbeddingError on non-JSON response body" do
-      stub_request(:post, "https://proxy.openai.test/api/proxy/openai/v1/embeddings")
-        .to_return(status: 200, body: "<html>Error</html>", headers: { "Content-Type" => "text/html" })
+    it "raises EmbeddingError on invalid embedding response JSON" do
+      allow(AgentHarness).to receive(:embed).and_raise(
+        AgentHarness::ProviderError.new(
+          "Invalid JSON in embedding API response: unexpected token at '<html>Error</html>'",
+          original_error: JSON::ParserError.new("unexpected token at '<html>Error</html>'")
+        )
+      )
 
       expect { described_class.call(texts: texts, base_url: base_url, headers: headers) }
-        .to raise_error(Knowledge::Embeddings::EmbeddingError, /Failed to parse embedding API response/)
+        .to raise_error(Knowledge::Embeddings::EmbeddingError, /Invalid JSON/)
     end
 
     it "supports arbitrary OpenAI-compatible proxy base URLs" do
-      stub_request(:post, "https://proxy.openai.test/custom/v1/embeddings")
-        .with(headers: headers)
-        .to_return(status: 200, body: success_response_body, headers: { "Content-Type" => "application/json" })
+      allow(AgentHarness).to receive(:embed).and_return(success_response_body)
 
-      results = described_class.call(
+      described_class.call(
         texts: texts,
         base_url: "https://proxy.openai.test/custom/v1",
         headers: headers
       )
 
-      expect(results.size).to eq(2)
-      expect(results.first.vector).to eq(vector)
+      expect(AgentHarness).to have_received(:embed).with(
+        texts,
+        model: "text-embedding-3-large",
+        dimensions: 3072,
+        base_url: "https://proxy.openai.test/custom/v1",
+        api_key: "paid-knowledge-run:99:token",
+        headers: { "X-Paid-Knowledge-Provider" => "openrouter" },
+        timeout: AgentHarness::OpenAICompatibleTransport::DEFAULT_TIMEOUT
+      )
     end
   end
 


### PR DESCRIPTION
## Summary

Routes knowledge embedding generation through `agent_harness` instead of a direct Faraday client, aligning with the CLAUDE.md rule that all LLM calls must flow through the unified agent-harness interface and removing Paid's direct coupling to the secrets-proxy embedding endpoint.

## Changes

- **Services**: `app/services/knowledge/embeddings/generate.rb` now calls `AgentHarness.embed` and handles `AgentHarness` errors for retries instead of issuing raw HTTP POSTs and parsing Faraday responses.
- **Container runner**: `app/services/knowledge/embedding_runner.rb` no longer performs `Net::HTTP` POSTs to the embedding endpoint from the container-side script — it goes through the same `agent_harness` path.
- **Initializer**: Added `config/initializers/agent_harness.rb`, a version-gated compatibility shim that exposes `AgentHarness.embed` on top of the existing OpenAI-compatible transport until the upstream gem ships a native embedding API.
- **Specs**: Updated `spec/services/knowledge/embeddings/generate_spec.rb` and `spec/services/knowledge/embedding_runner_spec.rb` to stub `AgentHarness` instead of Faraday.
- **Cleanup**: Removed the TODO referenced in the issue.

## Design Decisions

- **Compatibility shim vs. waiting for upstream**: The released `agent-harness` gem in this repo still lacks a native embedding API. Rather than continue using Faraday until upstream ships, a small version-gated shim in `config/initializers/agent_harness.rb` provides `AgentHarness.embed` today, so the service code matches the long-term shape and the shim can be deleted once upstream lands. This keeps Paid free of provider-specific HTTP details per CLAUDE.md's "provider-specific execution behavior belongs in `agent_harness`" guidance.
- **Error handling**: Retry and error classification now key off `AgentHarness` error types rather than Faraday status codes, so future provider/transport changes upstream propagate cleanly.

## Operational Notes

- No migrations or infrastructure changes. The secrets-proxy embedding endpoint is still reachable; this PR only changes how Paid calls it.
- Once upstream `agent-harness` ships a native `embed` API, the shim in `config/initializers/agent_harness.rb` should be removed and the gem bumped.

---

Closes #2146