### PR TITLE
feat(accounts): Phase 5.2 — User-Facing Account Administration

### DIFF
--- a/app/controllers/account_lifecycles_controller.rb
+++ b/app/controllers/account_lifecycles_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AccountLifecyclesController < ApplicationController
+  def update
+    authorize current_account, :destroy?
+
+    Accounts::TransitionLifecycle.call(
+      account: current_account,
+      actor: current_user,
+      transition: lifecycle_params[:transition]
+    )
+
+    redirect_to account_path, notice: "Account lifecycle updated."
+  rescue Accounts::AdministrationError, Account::InvalidTransitionError => e
+    redirect_to account_path, alert: e.message
+  end
+
+  private
+
+  def lifecycle_params
+    params.permit(:transition)
+  end
+end

--- a/app/controllers/account_lifecycles_controller.rb
+++ b/app/controllers/account_lifecycles_controller.rb
@@ -20,4 +20,8 @@ class AccountLifecyclesController < ApplicationController
   def lifecycle_params
     params.permit(:transition)
   end
+
+  def allow_suspended_account_write?
+    current_account.suspended? && lifecycle_params[:transition].in?(%w[reactivate deactivate])
+  end
 end

--- a/app/controllers/account_lifecycles_controller.rb
+++ b/app/controllers/account_lifecycles_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccountLifecyclesController < ApplicationController
+  include AccountAdministrationPage
+
   def update
     authorize current_account, :destroy?
 
@@ -13,6 +15,8 @@ class AccountLifecyclesController < ApplicationController
     redirect_to account_path, notice: "Account lifecycle updated."
   rescue Accounts::AdministrationError, Account::InvalidTransitionError => e
     redirect_to account_path, alert: e.message
+  rescue ActiveRecord::RecordInvalid
+    render_account_administration_error
   end
 
   private

--- a/app/controllers/account_memberships_controller.rb
+++ b/app/controllers/account_memberships_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class AccountMembershipsController < ApplicationController
+  before_action :set_membership, only: [ :update, :destroy ]
+
+  def create
+    authorize current_account, :update?
+
+    Accounts::InviteMember.call(
+      account: current_account,
+      actor: current_user,
+      **invitation_params.to_h.symbolize_keys
+    )
+
+    redirect_to account_path, notice: "Invitation sent."
+  rescue Accounts::AdministrationError => e
+    redirect_to account_path, alert: e.message
+  end
+
+  def update
+    authorize current_account, :update?
+
+    Accounts::UpdateMembership.call(
+      account: current_account,
+      membership: @membership,
+      actor: current_user,
+      role: membership_params[:role]
+    )
+
+    redirect_to account_path, notice: "Membership updated."
+  rescue Accounts::AdministrationError => e
+    redirect_to account_path, alert: e.message
+  end
+
+  def destroy
+    authorize current_account, :update?
+
+    Accounts::RemoveMembership.call(
+      account: current_account,
+      membership: @membership,
+      actor: current_user
+    )
+
+    redirect_to account_path, notice: "Membership removed."
+  rescue Accounts::AdministrationError => e
+    redirect_to account_path, alert: e.message
+  end
+
+  private
+
+  def set_membership
+    @membership = current_account.account_memberships.includes(:user).find(params[:id])
+  end
+
+  def invitation_params
+    params.require(:invitation).permit(:email, :name, :role)
+  end
+
+  def membership_params
+    params.require(:account_membership).permit(:role)
+  end
+end

--- a/app/controllers/account_memberships_controller.rb
+++ b/app/controllers/account_memberships_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccountMembershipsController < ApplicationController
+  include AccountAdministrationPage
+
   before_action :set_membership, only: [ :update, :destroy ]
 
   def create
@@ -15,6 +17,8 @@ class AccountMembershipsController < ApplicationController
     redirect_to account_path, notice: "Invitation sent."
   rescue Accounts::AdministrationError => e
     redirect_to account_path, alert: e.message
+  rescue ActiveRecord::RecordInvalid
+    render_account_administration_error
   end
 
   def update
@@ -30,6 +34,8 @@ class AccountMembershipsController < ApplicationController
     redirect_to account_path, notice: "Membership updated."
   rescue Accounts::AdministrationError => e
     redirect_to account_path, alert: e.message
+  rescue ActiveRecord::RecordInvalid
+    render_account_administration_error
   end
 
   def destroy
@@ -44,6 +50,8 @@ class AccountMembershipsController < ApplicationController
     redirect_to account_path, notice: "Membership removed."
   rescue Accounts::AdministrationError => e
     redirect_to account_path, alert: e.message
+  rescue ActiveRecord::RecordInvalid
+    render_account_administration_error
   end
 
   private

--- a/app/controllers/account_memberships_controller.rb
+++ b/app/controllers/account_memberships_controller.rb
@@ -53,10 +53,18 @@ class AccountMembershipsController < ApplicationController
   end
 
   def invitation_params
-    params.require(:invitation).permit(:email, :name, :role)
+    invitation = params.require(:invitation)
+
+    {
+      email: invitation[:email],
+      name: invitation[:name],
+      role: invitation[:role]
+    }
   end
 
   def membership_params
-    params.require(:account_membership).permit(:role)
+    membership = params.require(:account_membership)
+
+    { role: membership[:role] }
   end
 end

--- a/app/controllers/account_ownership_transfers_controller.rb
+++ b/app/controllers/account_ownership_transfers_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AccountOwnershipTransfersController < ApplicationController
+  def create
+    authorize current_account, :destroy?
+
+    membership = current_account.account_memberships.includes(:user).find(params[:membership_id])
+
+    Accounts::TransferOwnership.call(
+      account: current_account,
+      new_owner_membership: membership,
+      actor: current_user
+    )
+
+    redirect_to account_path, notice: "Ownership transferred."
+  rescue Accounts::AdministrationError => e
+    redirect_to account_path, alert: e.message
+  end
+end

--- a/app/controllers/account_ownership_transfers_controller.rb
+++ b/app/controllers/account_ownership_transfers_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccountOwnershipTransfersController < ApplicationController
+  include AccountAdministrationPage
+
   def create
     authorize current_account, :destroy?
 
@@ -15,5 +17,7 @@ class AccountOwnershipTransfersController < ApplicationController
     redirect_to account_path, notice: "Ownership transferred."
   rescue Accounts::AdministrationError => e
     redirect_to account_path, alert: e.message
+  rescue ActiveRecord::RecordInvalid
+    render_account_administration_error
   end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class AccountsController < ApplicationController
+  before_action :set_account_context
+
+  def show
+    authorize current_account
+  end
+
+  def update
+    authorize current_account, :update?
+
+    if current_account.update(account_params)
+      Accounts::RecordActivity.call(
+        account: current_account,
+        actor: current_user,
+        action: "account.updated",
+        subject: current_account,
+        metadata: { changed_fields: current_account.saved_changes.except("updated_at").keys }
+      )
+
+      redirect_to account_path, notice: "Account settings updated."
+    else
+      render :show, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def set_account_context
+    @tenant_setting = current_account.tenant_setting!
+    @memberships = current_account.account_memberships.includes(:user).order(role: :desc, created_at: :asc)
+    @active_plan = current_account.billing_plans.active.order(created_at: :desc).first
+    @current_billing_period = current_account.billing_periods.order(starts_at: :desc).first
+    @recent_invoices = current_account.billing_invoices.order(created_at: :desc).limit(5)
+    @recent_activity = current_account.account_activity_events.includes(:actor).recent.limit(20)
+    @billing_visible = BillingPolicy.new(current_user, current_account).billing?
+  end
+
+  def account_params
+    params.require(:account).permit(:name, :default_max_tokens_per_run)
+  end
+end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -15,13 +15,15 @@ class AccountsController < ApplicationController
     ActiveRecord::Base.transaction do
       current_account.update!(account_params)
 
-      Accounts::RecordActivity.call(
-        account: current_account,
-        actor: current_user,
-        action: "account.updated",
-        subject: current_account,
-        metadata: { changed_fields: current_account.saved_changes.except("updated_at").keys }
-      )
+      if current_account.saved_changes.except("updated_at").any?
+        Accounts::RecordActivity.call(
+          account: current_account,
+          actor: current_user,
+          action: "account.updated",
+          subject: current_account,
+          metadata: { changed_fields: current_account.saved_changes.except("updated_at").keys }
+        )
+      end
     end
 
     redirect_to account_path, notice: "Account settings updated."

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class AccountsController < ApplicationController
-  before_action :set_account_context
+  include AccountAdministrationPage
+
+  before_action :load_account_administration_page
 
   def show
     authorize current_account
@@ -28,17 +30,6 @@ class AccountsController < ApplicationController
   end
 
   private
-
-  def set_account_context
-    @tenant_setting = current_account.tenant_setting!
-    @memberships = current_account.account_memberships.includes(:user).order(role: :desc, created_at: :asc)
-    @projects_count = current_account.projects.count
-    @active_plan = current_account.billing_plans.active.order(created_at: :desc).first
-    @current_billing_period = current_account.billing_periods.order(starts_at: :desc).first
-    @recent_invoices = current_account.billing_invoices.order(created_at: :desc).limit(5)
-    @recent_activity = current_account.account_activity_events.includes(:actor).recent.limit(20)
-    @billing_visible = BillingPolicy.new(current_user, current_account).billing?
-  end
 
   def account_params
     params.require(:account).permit(:name, :default_max_tokens_per_run)

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -30,6 +30,7 @@ class AccountsController < ApplicationController
   def set_account_context
     @tenant_setting = current_account.tenant_setting!
     @memberships = current_account.account_memberships.includes(:user).order(role: :desc, created_at: :asc)
+    @projects_count = current_account.projects.count
     @active_plan = current_account.billing_plans.active.order(created_at: :desc).first
     @current_billing_period = current_account.billing_periods.order(starts_at: :desc).first
     @recent_invoices = current_account.billing_invoices.order(created_at: :desc).limit(5)

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -10,7 +10,9 @@ class AccountsController < ApplicationController
   def update
     authorize current_account, :update?
 
-    if current_account.update(account_params)
+    ActiveRecord::Base.transaction do
+      current_account.update!(account_params)
+
       Accounts::RecordActivity.call(
         account: current_account,
         actor: current_user,
@@ -18,11 +20,11 @@ class AccountsController < ApplicationController
         subject: current_account,
         metadata: { changed_fields: current_account.saved_changes.except("updated_at").keys }
       )
-
-      redirect_to account_path, notice: "Account settings updated."
-    else
-      render :show, status: :unprocessable_content
     end
+
+    redirect_to account_path, notice: "Account settings updated."
+  rescue ActiveRecord::RecordInvalid
+    render :show, status: :unprocessable_content
   end
 
   private

--- a/app/controllers/concerns/account_administration_page.rb
+++ b/app/controllers/concerns/account_administration_page.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module AccountAdministrationPage
+  extend ActiveSupport::Concern
+
+  private
+
+  def load_account_administration_page
+    @tenant_setting = current_account.tenant_setting!
+    @memberships = current_account.account_memberships.includes(:user).order(role: :desc, created_at: :asc)
+    @projects_count = current_account.projects.count
+    @active_plan = current_account.billing_plans.active.order(created_at: :desc).first
+    @current_billing_period = current_account.billing_periods.order(starts_at: :desc).first
+    @recent_invoices = current_account.billing_invoices.order(created_at: :desc).limit(5)
+    @recent_activity = current_account.account_activity_events.includes(:actor).recent.limit(20)
+    @billing_visible = BillingPolicy.new(current_user, current_account).billing?
+  end
+
+  def render_account_administration_error(message = "Something went wrong. Please try again.")
+    load_account_administration_page
+    flash.now[:alert] = message
+    render "accounts/show", status: :unprocessable_content
+  end
+end

--- a/app/controllers/concerns/tenant_enforcement.rb
+++ b/app/controllers/concerns/tenant_enforcement.rb
@@ -19,7 +19,7 @@ module TenantEnforcement
 
     if current_account.deactivated?
       handle_deactivated_account
-    elsif current_account.suspended? && mutating_request?
+    elsif current_account.suspended? && mutating_request? && !allow_suspended_account_write?
       handle_suspended_account
     end
   end
@@ -82,5 +82,9 @@ module TenantEnforcement
 
   def skip_tenant_enforcement?
     devise_controller?
+  end
+
+  def allow_suspended_account_write?
+    false
   end
 end

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -15,13 +15,16 @@ class TenantConfigurationsController < ApplicationController
       @tenant_setting.update!(tenant_setting_params)
       update_feature_flag_rollouts! if feature_flag_rollout_params.present?
 
-      Accounts::RecordActivity.call(
-        account: current_account,
-        actor: current_user,
-        action: "tenant_configuration.updated",
-        subject: @tenant_setting,
-        metadata: { changed_fields: @tenant_setting.saved_changes.except("updated_at").keys }
-      )
+      if @tenant_setting.saved_changes.except("updated_at").any? ||
+          (feature_flag_rollout_params.present? && changed_feature_flag_rollouts.any?)
+        Accounts::RecordActivity.call(
+          account: current_account,
+          actor: current_user,
+          action: "tenant_configuration.updated",
+          subject: @tenant_setting,
+          metadata: { changed_fields: @tenant_setting.saved_changes.except("updated_at").keys }
+        )
+      end
     end
 
     redirect_to edit_tenant_configuration_path, notice: "Tenant configuration saved successfully."

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -14,6 +14,14 @@ class TenantConfigurationsController < ApplicationController
     ActiveRecord::Base.transaction do
       @tenant_setting.update!(tenant_setting_params)
       update_feature_flag_rollouts! if feature_flag_rollout_params.present?
+
+      Accounts::RecordActivity.call(
+        account: current_account,
+        actor: current_user,
+        action: "tenant_configuration.updated",
+        subject: @tenant_setting,
+        metadata: { changed_fields: @tenant_setting.saved_changes.except("updated_at").keys }
+      )
     end
 
     redirect_to edit_tenant_configuration_path, notice: "Tenant configuration saved successfully."

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -10,6 +10,7 @@ class Account < ApplicationRecord
 
   has_many :users, dependent: :destroy
   has_many :account_memberships, dependent: :destroy
+  has_many :account_activity_events, dependent: :destroy
   has_many :members, through: :account_memberships, source: :user
   has_many :provider_api_keys, through: :users
   has_many :projects, dependent: :destroy
@@ -140,6 +141,14 @@ class Account < ApplicationRecord
   def fallback_owner_id
     account_memberships.where(role: :owner).order(:id).pick(:user_id) ||
       users.order(:id).pick(:id)
+  end
+
+  def primary_owner_membership
+    account_memberships.where(role: :owner).order(:id).first
+  end
+
+  def primary_owner
+    primary_owner_membership&.user
   end
 
   private

--- a/app/models/account_activity_event.rb
+++ b/app/models/account_activity_event.rb
@@ -18,13 +18,13 @@ class AccountActivityEvent < ApplicationRecord
     when "account.updated"
       "Updated account settings"
     when "membership.invited"
-      "Invited #{metadata.fetch('email')} as #{metadata.fetch('role').humanize.downcase}"
+      "Invited #{metadata_value('email')} as #{humanized_metadata_value('role')}"
     when "membership.role_changed"
-      "Changed #{metadata.fetch('email')} from #{metadata.fetch('from_role').humanize.downcase} to #{metadata.fetch('to_role').humanize.downcase}"
+      "Changed #{metadata_value('email')} from #{humanized_metadata_value('from_role')} to #{humanized_metadata_value('to_role')}"
     when "membership.removed"
-      "Removed #{metadata.fetch('email')} from the account"
+      "Removed #{metadata_value('email')} from the account"
     when "ownership.transferred"
-      "Transferred ownership to #{metadata.fetch('to_email')}"
+      "Transferred ownership to #{metadata_value('to_email')}"
     when "lifecycle.suspended"
       "Suspended the account"
     when "lifecycle.reactivated"
@@ -41,11 +41,21 @@ class AccountActivityEvent < ApplicationRecord
   def detail_lines
     case action
     when "account.updated", "tenant_configuration.updated"
-      Array(metadata["changed_fields"]).map { |field| "#{field.humanize} changed" }
+      Array(metadata.to_h["changed_fields"]).map { |field| "#{field.humanize} changed" }
     when "ownership.transferred"
-      [ "Previous owner: #{metadata['from_email']}" ]
+      [ "Previous owner: #{metadata_value('from_email')}" ]
     else
       []
     end
+  end
+
+  private
+
+  def metadata_value(key)
+    metadata.to_h[key] || "unknown"
+  end
+
+  def humanized_metadata_value(key)
+    metadata_value(key).to_s.humanize.downcase
   end
 end

--- a/app/models/account_activity_event.rb
+++ b/app/models/account_activity_event.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class AccountActivityEvent < ApplicationRecord
+  belongs_to :account
+  belongs_to :actor, class_name: "User", optional: true, inverse_of: :account_activity_events
+  belongs_to :subject, polymorphic: true, optional: true
+
+  validates :action, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+
+  def actor_label
+    actor&.email || "System"
+  end
+
+  def description
+    case action
+    when "account.updated"
+      "Updated account settings"
+    when "membership.invited"
+      "Invited #{metadata.fetch('email')} as #{metadata.fetch('role').humanize.downcase}"
+    when "membership.role_changed"
+      "Changed #{metadata.fetch('email')} from #{metadata.fetch('from_role').humanize.downcase} to #{metadata.fetch('to_role').humanize.downcase}"
+    when "membership.removed"
+      "Removed #{metadata.fetch('email')} from the account"
+    when "ownership.transferred"
+      "Transferred ownership to #{metadata.fetch('to_email')}"
+    when "lifecycle.suspended"
+      "Suspended the account"
+    when "lifecycle.reactivated"
+      "Reactivated the account"
+    when "lifecycle.deactivated"
+      "Deactivated the account"
+    when "tenant_configuration.updated"
+      "Updated tenant configuration"
+    else
+      action.humanize
+    end
+  end
+
+  def detail_lines
+    case action
+    when "account.updated", "tenant_configuration.updated"
+      Array(metadata["changed_fields"]).map { |field| "#{field.humanize} changed" }
+    when "ownership.transferred"
+      [ "Previous owner: #{metadata['from_email']}" ]
+    else
+      []
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,7 +109,13 @@ class User < ApplicationRecord
     return false unless membership
     return false unless normalize_role(role, resource) == membership.role
 
-    membership.destroy
+    case resource
+    when Account
+      revoke_account_access!(resource)
+    else
+      membership.destroy
+    end
+
     true
   end
 
@@ -165,6 +171,28 @@ class User < ApplicationRecord
 
   def operator?
     OperatorConsole::Access.allowed?(self)
+  end
+
+  def revoke_account_access!(account)
+    with_lock do
+      membership = account_memberships.find_by(account: account)
+      return false unless membership
+
+      if account_id == account.id
+        successor_membership = account_memberships.where.not(id: membership.id).order(:id).first
+
+        if successor_membership
+          update!(account: successor_membership.account)
+          membership.destroy!
+        else
+          destroy!
+        end
+      else
+        membership.destroy!
+      end
+    end
+
+    true
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   has_many :runners, dependent: :destroy
   has_many :providers, class_name: "Provider", dependent: :destroy
   has_many :provider_api_keys, dependent: :destroy
+  has_many :account_activity_events, foreign_key: :actor_id, dependent: :nullify, inverse_of: :actor
   has_many :pre_commit_requirements, dependent: :destroy
   has_many :initiated_agent_runs, class_name: "AgentRun", foreign_key: :initiating_user_id, dependent: :nullify, inverse_of: :initiating_user
   has_one :tracker_configuration, as: :configurable, dependent: :destroy

--- a/app/services/accounts/administration_error.rb
+++ b/app/services/accounts/administration_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Accounts
+  class AdministrationError < StandardError; end
+end

--- a/app/services/accounts/invite_member.rb
+++ b/app/services/accounts/invite_member.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Accounts
+  class InviteMember
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, actor:, email:, role:, name: nil)
+      @account = account
+      @actor = actor
+      @email = email.to_s.strip.downcase
+      @role = role.to_s
+      @name = name.to_s.strip.presence
+    end
+
+    def call
+      raise AdministrationError, "Email is required." if email.blank?
+      raise AdministrationError, "Role is invalid." unless AccountMembership.roles.key?(role)
+      raise AdministrationError, "Only owners can invite another owner." if role == "owner" && !actor.has_role?(:owner, account)
+
+      existing_user = TenantContext.with_system_access do
+        User.find_by(email: email)
+      end
+      raise AdministrationError, "That email is already used by another account." if existing_user.present? && existing_user.account_id != account.id
+
+      membership = nil
+
+      ActiveRecord::Base.transaction do
+        user = existing_user || create_user!
+        membership = account.account_memberships.find_or_initialize_by(user: user)
+        raise AdministrationError, "That user is already a member of this account." if membership.persisted?
+
+        membership.role = role
+        membership.save!
+        user.send_reset_password_instructions if existing_user.nil?
+
+        Accounts::RecordActivity.call(
+          account: account,
+          actor: actor,
+          action: "membership.invited",
+          subject: membership,
+          metadata: { email: user.email, role: membership.role }
+        )
+      end
+
+      membership
+    end
+
+    private
+
+    attr_reader :account, :actor, :email, :role, :name
+
+    def create_user!
+      password = SecureRandom.base58(24)
+
+      account.users.create!(
+        email: email,
+        name: name,
+        password: password,
+        password_confirmation: password
+      )
+    end
+  end
+end

--- a/app/services/accounts/invite_member.rb
+++ b/app/services/accounts/invite_member.rb
@@ -17,7 +17,7 @@ module Accounts
     def call
       raise AdministrationError, "Email is required." if email.blank?
       raise AdministrationError, "Role is invalid." unless AccountMembership.roles.key?(role)
-      raise AdministrationError, "Only owners can invite another owner." if role == "owner" && !actor.has_role?(:owner, account)
+      raise AdministrationError, "Use ownership transfer to assign the owner role." if role == "owner"
 
       existing_user = TenantContext.with_system_access do
         User.find_by(email: email)

--- a/app/services/accounts/invite_member.rb
+++ b/app/services/accounts/invite_member.rb
@@ -22,6 +22,9 @@ module Accounts
       existing_user = TenantContext.with_system_access do
         User.find_by(email: email)
       end
+      if existing_user.present? && existing_user.account_id != account.id
+        raise AdministrationError, "That user already belongs to another account. Cross-account invites are not supported yet."
+      end
 
       membership = nil
       user = nil

--- a/app/services/accounts/invite_member.rb
+++ b/app/services/accounts/invite_member.rb
@@ -22,7 +22,6 @@ module Accounts
       existing_user = TenantContext.with_system_access do
         User.find_by(email: email)
       end
-      raise AdministrationError, "That email is already used by another account." if existing_user.present? && existing_user.account_id != account.id
 
       membership = nil
       user = nil

--- a/app/services/accounts/invite_member.rb
+++ b/app/services/accounts/invite_member.rb
@@ -25,6 +25,7 @@ module Accounts
       raise AdministrationError, "That email is already used by another account." if existing_user.present? && existing_user.account_id != account.id
 
       membership = nil
+      user = nil
 
       ActiveRecord::Base.transaction do
         user = existing_user || create_user!
@@ -33,7 +34,6 @@ module Accounts
 
         membership.role = role
         membership.save!
-        user.send_reset_password_instructions if existing_user.nil?
 
         Accounts::RecordActivity.call(
           account: account,
@@ -43,6 +43,8 @@ module Accounts
           metadata: { email: user.email, role: membership.role }
         )
       end
+
+      user.send_reset_password_instructions if existing_user.nil?
 
       membership
     end

--- a/app/services/accounts/record_activity.rb
+++ b/app/services/accounts/record_activity.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Accounts
+  class RecordActivity
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, action:, actor: nil, subject: nil, metadata: {})
+      @account = account
+      @action = action
+      @actor = actor
+      @subject = subject
+      @metadata = metadata
+    end
+
+    def call
+      account.account_activity_events.create!(
+        action: action,
+        actor: actor,
+        subject: subject,
+        metadata: metadata
+      )
+    end
+
+    private
+
+    attr_reader :account, :action, :actor, :subject, :metadata
+  end
+end

--- a/app/services/accounts/remove_membership.rb
+++ b/app/services/accounts/remove_membership.rb
@@ -17,14 +17,17 @@ module Accounts
       raise AdministrationError, "Transfer ownership before removing an owner." if membership.owner?
 
       email = membership.user.email
-      membership.destroy!
 
-      Accounts::RecordActivity.call(
-        account: account,
-        actor: actor,
-        action: "membership.removed",
-        metadata: { email: email }
-      )
+      ActiveRecord::Base.transaction do
+        membership.destroy!
+
+        Accounts::RecordActivity.call(
+          account: account,
+          actor: actor,
+          action: "membership.removed",
+          metadata: { email: email }
+        )
+      end
     end
 
     private

--- a/app/services/accounts/remove_membership.rb
+++ b/app/services/accounts/remove_membership.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Accounts
+  class RemoveMembership
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, membership:, actor:)
+      @account = account
+      @membership = membership
+      @actor = actor
+    end
+
+    def call
+      raise AdministrationError, "Membership does not belong to this account." unless membership.account_id == account.id
+      raise AdministrationError, "Transfer ownership before removing an owner." if membership.owner?
+
+      email = membership.user.email
+      membership.destroy!
+
+      Accounts::RecordActivity.call(
+        account: account,
+        actor: actor,
+        action: "membership.removed",
+        metadata: { email: email }
+      )
+    end
+
+    private
+
+    attr_reader :account, :membership, :actor
+  end
+end

--- a/app/services/accounts/remove_membership.rb
+++ b/app/services/accounts/remove_membership.rb
@@ -19,7 +19,7 @@ module Accounts
       email = membership.user.email
 
       ActiveRecord::Base.transaction do
-        membership.destroy!
+        membership.user.revoke_account_access!(account)
 
         Accounts::RecordActivity.call(
           account: account,

--- a/app/services/accounts/transfer_ownership.rb
+++ b/app/services/accounts/transfer_ownership.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Accounts
+  class TransferOwnership
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, new_owner_membership:, actor:)
+      @account = account
+      @new_owner_membership = new_owner_membership
+      @actor = actor
+    end
+
+    def call
+      current_owner = account.account_memberships.find_by!(user: actor)
+
+      raise AdministrationError, "Only an owner can transfer ownership." unless current_owner.owner?
+      raise AdministrationError, "Membership does not belong to this account." unless new_owner_membership.account_id == account.id
+      raise AdministrationError, "Select a different member." if new_owner_membership.user_id == actor.id
+
+      ActiveRecord::Base.transaction do
+        account.account_memberships.where(role: :owner).find_each do |membership|
+          membership.update!(role: :admin)
+        end
+
+        new_owner_membership.update!(role: :owner)
+
+        Accounts::RecordActivity.call(
+          account: account,
+          actor: actor,
+          action: "ownership.transferred",
+          subject: new_owner_membership,
+          metadata: {
+            from_email: actor.email,
+            to_email: new_owner_membership.user.email
+          }
+        )
+      end
+    end
+
+    private
+
+    attr_reader :account, :new_owner_membership, :actor
+  end
+end

--- a/app/services/accounts/transfer_ownership.rb
+++ b/app/services/accounts/transfer_ownership.rb
@@ -14,6 +14,7 @@ module Accounts
 
     def call
       current_owner = account.account_memberships.find_by!(user: actor)
+      new_owner = new_owner_membership.user
 
       raise AdministrationError, "Only an owner can transfer ownership." unless current_owner.owner?
       raise AdministrationError, "Membership does not belong to this account." unless new_owner_membership.account_id == account.id
@@ -25,6 +26,7 @@ module Accounts
         end
 
         new_owner_membership.update!(role: :owner)
+        new_owner.update!(account: account) if new_owner.account_id != account.id
 
         Accounts::RecordActivity.call(
           account: account,

--- a/app/services/accounts/transition_lifecycle.rb
+++ b/app/services/accounts/transition_lifecycle.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Accounts
+  class TransitionLifecycle
+    TRANSITIONS = {
+      "suspend" => :suspend!,
+      "reactivate" => :reactivate!,
+      "deactivate" => :deactivate!
+    }.freeze
+    ACTIVITY_ACTIONS = {
+      "suspend" => "lifecycle.suspended",
+      "reactivate" => "lifecycle.reactivated",
+      "deactivate" => "lifecycle.deactivated"
+    }.freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, actor:, transition:)
+      @account = account
+      @actor = actor
+      @transition = transition.to_s
+    end
+
+    def call
+      method_name = TRANSITIONS[transition]
+      raise AdministrationError, "Unsupported lifecycle transition." unless method_name
+
+      account.public_send(method_name)
+
+      Accounts::RecordActivity.call(
+        account: account,
+        actor: actor,
+        action: ACTIVITY_ACTIONS.fetch(transition),
+        subject: account
+      )
+    end
+
+    private
+
+    attr_reader :account, :actor, :transition
+  end
+end

--- a/app/services/accounts/transition_lifecycle.rb
+++ b/app/services/accounts/transition_lifecycle.rb
@@ -27,14 +27,16 @@ module Accounts
       method_name = TRANSITIONS[transition]
       raise AdministrationError, "Unsupported lifecycle transition." unless method_name
 
-      account.public_send(method_name)
+      ActiveRecord::Base.transaction do
+        account.public_send(method_name)
 
-      Accounts::RecordActivity.call(
-        account: account,
-        actor: actor,
-        action: ACTIVITY_ACTIONS.fetch(transition),
-        subject: account
-      )
+        Accounts::RecordActivity.call(
+          account: account,
+          actor: actor,
+          action: ACTIVITY_ACTIONS.fetch(transition),
+          subject: account
+        )
+      end
     end
 
     private

--- a/app/services/accounts/update_membership.rb
+++ b/app/services/accounts/update_membership.rb
@@ -22,19 +22,21 @@ module Accounts
       previous_role = membership.role
       return membership if previous_role == role
 
-      membership.update!(role: role)
+      ActiveRecord::Base.transaction do
+        membership.update!(role: role)
 
-      Accounts::RecordActivity.call(
-        account: account,
-        actor: actor,
-        action: "membership.role_changed",
-        subject: membership,
-        metadata: {
-          email: membership.user.email,
-          from_role: previous_role,
-          to_role: membership.role
-        }
-      )
+        Accounts::RecordActivity.call(
+          account: account,
+          actor: actor,
+          action: "membership.role_changed",
+          subject: membership,
+          metadata: {
+            email: membership.user.email,
+            from_role: previous_role,
+            to_role: membership.role
+          }
+        )
+      end
 
       membership
     end

--- a/app/services/accounts/update_membership.rb
+++ b/app/services/accounts/update_membership.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Accounts
+  class UpdateMembership
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, membership:, actor:, role:)
+      @account = account
+      @membership = membership
+      @actor = actor
+      @role = role.to_s
+    end
+
+    def call
+      raise AdministrationError, "Membership does not belong to this account." unless membership.account_id == account.id
+      raise AdministrationError, "Role is invalid." unless AccountMembership.roles.key?(role)
+      raise AdministrationError, "Use ownership transfer to assign the owner role." if role == "owner"
+      raise AdministrationError, "Use ownership transfer to change the current owner." if membership.owner?
+
+      previous_role = membership.role
+      return membership if previous_role == role
+
+      membership.update!(role: role)
+
+      Accounts::RecordActivity.call(
+        account: account,
+        actor: actor,
+        action: "membership.role_changed",
+        subject: membership,
+        metadata: {
+          email: membership.user.email,
+          from_role: previous_role,
+          to_role: membership.role
+        }
+      )
+
+      membership
+    end
+
+    private
+
+    attr_reader :account, :membership, :actor, :role
+  end
+end

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -30,6 +30,7 @@ module Screenshots
       mcp_server_definitions
       onboarding
       user_settings
+      account
       quality_dashboard
       chat_sessions
       ab_tests
@@ -73,6 +74,7 @@ module Screenshots
       provider_api_key_show: Target.new(slug: "provider_api_key_show", path_builder: ->(seed_data) { "/provider_api_keys/#{seed_data.fetch(:provider_api_key).id}" }, requires_auth: true),
       provider_api_key_edit: Target.new(slug: "provider_api_key_edit", path_builder: ->(seed_data) { "/provider_api_keys/#{seed_data.fetch(:provider_api_key).id}/edit" }, requires_auth: true),
       user_settings: Target.new(slug: "user_settings", path_builder: "/user_settings/edit", requires_auth: true),
+      account: Target.new(slug: "account", path_builder: "/account", requires_auth: true),
       tenant_configuration: Target.new(slug: "tenant_configuration", path_builder: "/tenant_configuration/edit", requires_auth: true),
       providers: Target.new(slug: "providers", path_builder: "/runners", requires_auth: true),
       providers_new: Target.new(slug: "providers_new", path_builder: "/runners/new?form_variant=subscription", requires_auth: true),
@@ -197,6 +199,10 @@ module Screenshots
       "notifications_controller.rb" => [ :notifications ],
       "onboarding_controller.rb" => [ :onboarding ],
       "user_settings_controller.rb" => [ :user_settings ],
+      "accounts_controller.rb" => [ :account ],
+      "account_memberships_controller.rb" => [ :account ],
+      "account_ownership_transfers_controller.rb" => [ :account ],
+      "account_lifecycles_controller.rb" => [ :account ],
       "tenant_configurations_controller.rb" => [ :tenant_configuration ],
       "service_containers_controller.rb" => %i[service_containers service_container_new service_container_show service_container_edit],
       "mcp_server_definitions_controller.rb" => %i[mcp_server_definitions mcp_server_definition_new mcp_server_definition_show mcp_server_definition_edit],
@@ -319,6 +325,7 @@ module Screenshots
       when /\Agithub_tokens\// then rest_resource_targets(relative_path, "github_tokens", index: :github_tokens, new: :github_token_new, show: :github_token_show, edit: :github_token_show)
       when /\Alinear_tokens\// then rest_resource_targets(relative_path, "linear_tokens", index: :linear_tokens, new: :linear_token_new, show: :linear_token_show, edit: :linear_token_show)
       when /\Auser_settings\// then [ :user_settings ]
+      when /\Aaccounts\// then [ :account ]
       when /\Atenant_configurations\// then [ :tenant_configuration ]
       when /\Aprovider_api_keys\// then rest_resource_targets(relative_path, "provider_api_keys", index: :provider_api_keys, new: :provider_api_key_new, show: :provider_api_key_show, edit: :provider_api_key_edit)
       when /\Aproviders\// then providers_targets(relative_path.delete_prefix("providers/"))

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -277,7 +277,7 @@
         <section class="rounded-3xl border border-red-200 bg-white p-6 shadow-sm dark:border-red-900 dark:bg-gray-800">
           <div>
             <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Lifecycle</h2>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Owner-only actions for pausing, reactivating, or permanently winding down the account.</p>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Owner-only actions for pausing or permanently winding down the account, plus reactivation while the account is still suspended.</p>
           </div>
 
           <div class="mt-6 space-y-3">
@@ -287,7 +287,9 @@
               <%= button_to "Reactivate account", account_lifecycle_path(transition: :reactivate), method: :patch, class: "w-full rounded-2xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white hover:bg-emerald-500", form: { data: { turbo_confirm: "Reactivate this account?" } } %>
               <%= button_to "Deactivate account", account_lifecycle_path(transition: :deactivate), method: :patch, class: "w-full rounded-2xl bg-red-600 px-4 py-3 text-sm font-semibold text-white hover:bg-red-500", form: { data: { turbo_confirm: "Deactivate this account? This should only be used when you are ready to shut it down." } } %>
             <% else %>
-              <%= button_to "Reactivate account", account_lifecycle_path(transition: :reactivate), method: :patch, class: "w-full rounded-2xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white hover:bg-emerald-500", form: { data: { turbo_confirm: "Reactivate this account?" } } %>
+              <div class="rounded-2xl border border-dashed border-red-300 px-4 py-4 text-sm text-red-700 dark:border-red-800 dark:text-red-200">
+                Deactivated accounts are signed out immediately. Contact support to restore access.
+              </div>
             <% end %>
           </div>
         </section>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,0 +1,331 @@
+<% content_for :title, "Account" %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <div>
+      <p class="text-sm font-medium uppercase tracking-[0.2em] text-amber-700 dark:text-amber-300">Account Administration</p>
+      <h1 class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= current_account.name %></h1>
+      <p class="mt-2 max-w-3xl text-sm text-gray-600 dark:text-gray-300">
+        Manage your team, account profile, quota visibility, billing state, and lifecycle without using the operator console.
+      </p>
+    </div>
+
+    <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div class="rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Status</p>
+        <p class="mt-1 text-sm font-semibold text-gray-900 dark:text-white"><%= current_account.status.humanize %></p>
+      </div>
+      <div class="rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Plan</p>
+        <p class="mt-1 text-sm font-semibold text-gray-900 dark:text-white"><%= current_account.plan.humanize %></p>
+      </div>
+      <div class="rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Members</p>
+        <p class="mt-1 text-sm font-semibold text-gray-900 dark:text-white"><%= @memberships.size %></p>
+      </div>
+      <div class="rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Projects</p>
+        <p class="mt-1 text-sm font-semibold text-gray-900 dark:text-white"><%= current_account.projects.count %></p>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-8 grid gap-8 xl:grid-cols-[minmax(0,1.7fr)_minmax(320px,0.9fr)]">
+    <div class="space-y-8">
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Profile</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Core account identity and defaults used across the product.</p>
+          </div>
+          <% if current_account.primary_owner %>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Owner: <span class="font-medium text-gray-900 dark:text-white"><%= current_account.primary_owner.email %></span></p>
+          <% end %>
+        </div>
+
+        <% if current_account.errors.any? %>
+          <div class="mt-4 rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-800 dark:bg-red-950/40 dark:text-red-200">
+            <%= current_account.errors.full_messages.to_sentence %>
+          </div>
+        <% end %>
+
+        <%= form_with model: current_account, url: account_path, method: :patch, class: "mt-6 grid gap-4 md:grid-cols-2" do |form| %>
+          <div class="md:col-span-2">
+            <%= form.label :name, "Account name", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+            <%= form.text_field :name, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+          </div>
+          <div>
+            <%= label_tag :account_slug, "Slug", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+            <%= text_field_tag :account_slug, current_account.slug, disabled: true, class: "mt-1 block w-full rounded-xl border-gray-300 bg-gray-50 text-sm text-gray-500 shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-gray-400" %>
+          </div>
+          <div>
+            <%= form.label :default_max_tokens_per_run, "Default max tokens per run", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+            <%= form.number_field :default_max_tokens_per_run, min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+          </div>
+          <div>
+            <%= label_tag :account_trial_ends_at, "Trial ends", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+            <%= text_field_tag :account_trial_ends_at, current_account.trial_ends_at&.to_date || "N/A", disabled: true, class: "mt-1 block w-full rounded-xl border-gray-300 bg-gray-50 text-sm text-gray-500 shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-gray-400" %>
+          </div>
+          <div>
+            <%= label_tag :account_scheduler_paused, "Scheduler", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+            <%= text_field_tag :account_scheduler_paused, current_account.scheduler_paused? ? "Paused" : "Running", disabled: true, class: "mt-1 block w-full rounded-xl border-gray-300 bg-gray-50 text-sm text-gray-500 shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-gray-400" %>
+          </div>
+          <% if policy(current_account).update? %>
+            <div class="md:col-span-2 flex justify-end">
+              <%= form.submit "Save profile", class: "rounded-full bg-amber-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-amber-500" %>
+            </div>
+          <% end %>
+        <% end %>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Team</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Invite users, adjust roles, remove access, or transfer ownership.</p>
+          </div>
+          <% if policy(current_account).update? %>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Owners and admins can manage team access.</p>
+          <% end %>
+        </div>
+
+        <% if policy(current_account).update? %>
+          <%= form_with url: account_memberships_path, method: :post, class: "mt-6 grid gap-4 rounded-2xl border border-dashed border-amber-300 bg-amber-50/70 p-4 dark:border-amber-700 dark:bg-amber-950/20 md:grid-cols-4" do %>
+            <div class="md:col-span-2">
+              <%= label_tag "invitation_email", "Email", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+              <%= email_field_tag "invitation[email]", nil, required: true, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+            </div>
+            <div>
+              <%= label_tag "invitation_name", "Name", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+              <%= text_field_tag "invitation[name]", nil, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+            </div>
+            <div>
+              <%= label_tag "invitation_role", "Role", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+              <%= select_tag "invitation[role]", options_for_select(AccountMembership.roles.keys.reject { |role| role == "owner" }.map { |role| [role.humanize, role] }, "member"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+            </div>
+            <div class="md:col-span-4 flex justify-end">
+              <%= submit_tag "Send invitation", class: "rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-gray-700 dark:bg-amber-500 dark:text-gray-900 dark:hover:bg-amber-400" %>
+            </div>
+          <% end %>
+        <% end %>
+
+        <div class="mt-6 overflow-hidden rounded-2xl border border-gray-200 dark:border-gray-700">
+          <table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900/60">
+              <tr>
+                <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">User</th>
+                <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Role</th>
+                <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Joined</th>
+                <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+              <% @memberships.each do |membership| %>
+                <tr>
+                  <td class="px-4 py-4">
+                    <div class="font-medium text-gray-900 dark:text-white"><%= membership.user.name.presence || membership.user.email %></div>
+                    <div class="text-gray-500 dark:text-gray-400"><%= membership.user.email %></div>
+                  </td>
+                  <td class="px-4 py-4">
+                    <% if policy(current_account).update? && !membership.owner? %>
+                      <%= form_with model: membership, url: account_membership_path(membership), method: :patch, class: "flex items-center gap-2" do |form| %>
+                        <%= form.select :role, options_for_select(AccountMembership.roles.keys.reject { |role| role == "owner" }.map { |role| [role.humanize, role] }, membership.role), {}, class: "rounded-full border-gray-300 text-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+                        <%= form.submit "Update", class: "rounded-full border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
+                      <% end %>
+                    <% else %>
+                      <span class="inline-flex rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700 dark:bg-gray-900 dark:text-gray-200"><%= membership.role.humanize %></span>
+                    <% end %>
+                  </td>
+                  <td class="px-4 py-4 text-gray-500 dark:text-gray-400"><%= membership.created_at.to_date %></td>
+                  <td class="px-4 py-4">
+                    <div class="flex flex-wrap gap-2">
+                      <% if policy(current_account).destroy? && !membership.owner? %>
+                        <%= button_to "Transfer ownership", account_ownership_transfer_path(membership_id: membership.id), method: :post, class: "rounded-full border border-amber-300 px-3 py-1.5 text-xs font-semibold text-amber-800 hover:bg-amber-50 dark:border-amber-600 dark:text-amber-300 dark:hover:bg-amber-950/30", form: { data: { turbo_confirm: "Transfer ownership to #{membership.user.email}?" } } %>
+                      <% end %>
+
+                      <% if policy(current_account).update? && !membership.owner? %>
+                        <%= button_to "Remove", account_membership_path(membership), method: :delete, class: "rounded-full border border-red-300 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-300 dark:hover:bg-red-950/30", form: { data: { turbo_confirm: "Remove #{membership.user.email} from the account?" } } %>
+                      <% end %>
+                    </div>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Tenant Limits and Usage</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Current capacity, active usage, and the enforced defaults applied to this account.</p>
+          </div>
+          <% if policy(current_account).update? %>
+            <%= link_to "Edit tenant configuration", edit_tenant_configuration_path, class: "text-sm font-semibold text-amber-700 hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-200" %>
+          <% end %>
+        </div>
+
+        <div class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Users</p>
+            <p class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white"><%= @memberships.size %></p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Limit: <%= @tenant_setting.max_users || "Unlimited" %></p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Projects</p>
+            <p class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white"><%= current_account.projects.count %></p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Limit: <%= @tenant_setting.max_projects || "Unlimited" %></p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Concurrent runs</p>
+            <p class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white"><%= @tenant_setting.effective_guardrails["max_concurrent_runs"] %></p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Hard cap: <%= @tenant_setting.max_concurrent_runs || "Inherited" %></p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Max tokens / run</p>
+            <p class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white"><%= number_with_delimiter(@tenant_setting.effective_guardrails["max_tokens_per_run"]) %></p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Account default: <%= number_with_delimiter(current_account.default_max_tokens_per_run) %></p>
+          </div>
+        </div>
+
+        <dl class="mt-6 grid gap-4 rounded-2xl border border-gray-200 p-4 text-sm dark:border-gray-700 sm:grid-cols-2">
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Monthly cost ceiling</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= number_to_currency((@tenant_setting.max_monthly_cost_cents || 0) / 100.0) %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Default goal</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= @tenant_setting.effective_agent_settings["default_goal"].to_s.humanize %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Auto-continue</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= @tenant_setting.effective_agent_settings["auto_continue"] ? "Enabled" : "Disabled" %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Marketplace auto-attach</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= @tenant_setting.marketplace_auto_attach_required? ? "Required" : "Optional" %></dd>
+          </div>
+        </dl>
+      </section>
+
+      <% if @billing_visible %>
+        <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Billing</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Current plan, recent usage, invoices, and payment status.</p>
+          </div>
+
+          <div class="mt-6 grid gap-4 lg:grid-cols-3">
+            <div class="rounded-2xl bg-emerald-50 p-4 dark:bg-emerald-950/20">
+              <p class="text-xs uppercase tracking-wide text-emerald-700 dark:text-emerald-300">Active plan</p>
+              <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-white"><%= @active_plan&.name || "No active plan" %></p>
+              <% if @active_plan %>
+                <p class="text-sm text-gray-600 dark:text-gray-300"><%= @active_plan.billing_model.humanize %> • <%= @active_plan.period_type.humanize %></p>
+              <% end %>
+            </div>
+            <div class="rounded-2xl bg-sky-50 p-4 dark:bg-sky-950/20">
+              <p class="text-xs uppercase tracking-wide text-sky-700 dark:text-sky-300">Current usage</p>
+              <% if @current_billing_period %>
+                <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-white"><%= number_to_currency(@current_billing_period.total_cost_cents / 100.0) %></p>
+                <p class="text-sm text-gray-600 dark:text-gray-300"><%= number_with_delimiter(@current_billing_period.total_runs) %> runs • <%= number_with_delimiter(@current_billing_period.total_tokens) %> tokens</p>
+              <% else %>
+                <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-white">No period yet</p>
+              <% end %>
+            </div>
+            <div class="rounded-2xl bg-violet-50 p-4 dark:bg-violet-950/20">
+              <p class="text-xs uppercase tracking-wide text-violet-700 dark:text-violet-300">Payment state</p>
+              <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-white"><%= @recent_invoices.first&.status&.humanize || "No invoices" %></p>
+              <p class="text-sm text-gray-600 dark:text-gray-300">Most recent invoice status</p>
+            </div>
+          </div>
+
+          <div class="mt-6 overflow-hidden rounded-2xl border border-gray-200 dark:border-gray-700">
+            <table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+              <thead class="bg-gray-50 dark:bg-gray-900/60">
+                <tr>
+                  <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Invoice</th>
+                  <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Status</th>
+                  <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Issued</th>
+                  <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Total</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+                <% if @recent_invoices.any? %>
+                  <% @recent_invoices.each do |invoice| %>
+                    <tr>
+                      <td class="px-4 py-4 font-medium text-gray-900 dark:text-white"><%= invoice.external_id.presence || "Invoice ##{invoice.id}" %></td>
+                      <td class="px-4 py-4 text-gray-600 dark:text-gray-300"><%= invoice.status.humanize %></td>
+                      <td class="px-4 py-4 text-gray-600 dark:text-gray-300"><%= invoice.issued_at&.to_date || "Draft" %></td>
+                      <td class="px-4 py-4 text-gray-600 dark:text-gray-300"><%= number_to_currency(invoice.total_cents / 100.0) %></td>
+                    </tr>
+                  <% end %>
+                <% else %>
+                  <tr>
+                    <td colspan="4" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No invoices yet.</td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      <% end %>
+    </div>
+
+    <div class="space-y-8">
+      <% if policy(current_account).destroy? %>
+        <section class="rounded-3xl border border-red-200 bg-white p-6 shadow-sm dark:border-red-900 dark:bg-gray-800">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Lifecycle</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Owner-only actions for pausing, reactivating, or permanently winding down the account.</p>
+          </div>
+
+          <div class="mt-6 space-y-3">
+            <% if current_account.active? %>
+              <%= button_to "Suspend account", account_lifecycle_path(transition: :suspend), method: :patch, class: "w-full rounded-2xl bg-amber-600 px-4 py-3 text-sm font-semibold text-white hover:bg-amber-500", form: { data: { turbo_confirm: "Suspend this account?" } } %>
+            <% elsif current_account.suspended? %>
+              <%= button_to "Reactivate account", account_lifecycle_path(transition: :reactivate), method: :patch, class: "w-full rounded-2xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white hover:bg-emerald-500", form: { data: { turbo_confirm: "Reactivate this account?" } } %>
+              <%= button_to "Deactivate account", account_lifecycle_path(transition: :deactivate), method: :patch, class: "w-full rounded-2xl bg-red-600 px-4 py-3 text-sm font-semibold text-white hover:bg-red-500", form: { data: { turbo_confirm: "Deactivate this account? This should only be used when you are ready to shut it down." } } %>
+            <% else %>
+              <%= button_to "Reactivate account", account_lifecycle_path(transition: :reactivate), method: :patch, class: "w-full rounded-2xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white hover:bg-emerald-500", form: { data: { turbo_confirm: "Reactivate this account?" } } %>
+            <% end %>
+          </div>
+        </section>
+      <% end %>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Activity Trail</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Recent account-administration changes with actor and time.</p>
+        </div>
+
+        <div class="mt-6 space-y-4">
+          <% if @recent_activity.any? %>
+            <% @recent_activity.each do |event| %>
+              <article class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+                <div class="flex items-start justify-between gap-4">
+                  <div>
+                    <p class="font-medium text-gray-900 dark:text-white"><%= event.description %></p>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400"><%= event.actor_label %> • <%= time_ago_in_words(event.created_at) %> ago</p>
+                  </div>
+                  <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600 dark:bg-gray-900 dark:text-gray-300"><%= event.action %></span>
+                </div>
+                <% if event.detail_lines.any? %>
+                  <div class="mt-3 space-y-1 text-sm text-gray-600 dark:text-gray-300">
+                    <% event.detail_lines.each do |line| %>
+                      <p><%= line %></p>
+                    <% end %>
+                  </div>
+                <% end %>
+              </article>
+            <% end %>
+          <% else %>
+            <div class="rounded-2xl border border-dashed border-gray-300 px-4 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+              No account administration activity yet.
+            </div>
+          <% end %>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -25,7 +25,7 @@
       </div>
       <div class="rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
         <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Projects</p>
-        <p class="mt-1 text-sm font-semibold text-gray-900 dark:text-white"><%= current_account.projects.count %></p>
+        <p class="mt-1 text-sm font-semibold text-gray-900 dark:text-white"><%= @projects_count %></p>
       </div>
     </div>
   </div>
@@ -174,7 +174,7 @@
           </div>
           <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
             <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Projects</p>
-            <p class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white"><%= current_account.projects.count %></p>
+            <p class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white"><%= @projects_count %></p>
             <p class="text-sm text-gray-500 dark:text-gray-400">Limit: <%= @tenant_setting.max_projects || "Unlimited" %></p>
           </div>
           <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,6 +83,7 @@
               <%= link_to "Quality", quality_dashboard_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <%= link_to "Knowledge", knowledge_search_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <%= link_to "Integrations", integrations_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
+              <%= link_to "Account", account_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <%= link_to "Runners", runners_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white", data: { nav_section: "runners" } %>
               <% if policy(current_account).update? %>
                 <%= link_to "Tenant", edit_tenant_configuration_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
@@ -140,6 +141,7 @@
             <%= link_to "Quality", quality_dashboard_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <%= link_to "Knowledge", knowledge_search_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <%= link_to "Integrations", integrations_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+            <%= link_to "Account", account_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <%= link_to "Runners", runners_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <% if policy(current_account).update? %>
               <%= link_to "Tenant", edit_tenant_configuration_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,12 @@ Rails.application.routes.draw do
   # User settings (singleton resource — one per user)
   resource :user_settings, only: [ :edit, :update ]
 
+  # Customer-facing account administration
+  resource :account, only: [ :show, :update ]
+  resources :account_memberships, only: [ :create, :update, :destroy ]
+  resource :account_ownership_transfer, only: [ :create ]
+  resource :account_lifecycle, only: [ :update ]
+
   # Account tenant configuration
   resource :tenant_configuration, only: [ :edit, :update ]
 

--- a/db/migrate/20260519134704_create_account_activity_events.rb
+++ b/db/migrate/20260519134704_create_account_activity_events.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateAccountActivityEvents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :account_activity_events do |t|
+      t.references :account, null: false, foreign_key: true, comment: "Account whose administration history this event belongs to."
+      t.bigint :actor_id, comment: "User who performed the action, when available."
+      t.string :action, null: false, comment: "Stable action key for the account administration event."
+      t.string :subject_type, comment: "Polymorphic subject type affected by the action."
+      t.bigint :subject_id
+      t.jsonb :metadata, null: false, default: {}, comment: "Structured event details for UI rendering and audits."
+
+      t.timestamps
+    end
+
+    add_foreign_key :account_activity_events, :users, column: :actor_id, validate: false
+    add_index :account_activity_events, [ :account_id, :created_at ]
+    add_index :account_activity_events, [ :subject_type, :subject_id ]
+  end
+end

--- a/db/migrate/20260519134704_create_account_activity_events.rb
+++ b/db/migrate/20260519134704_create_account_activity_events.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CreateAccountActivityEvents < ActiveRecord::Migration[8.1]
-  def change
+  def up
     create_table :account_activity_events do |t|
       t.references :account, null: false, foreign_key: true, index: false,
         comment: "Account whose administration history this event belongs to."
@@ -18,5 +18,13 @@ class CreateAccountActivityEvents < ActiveRecord::Migration[8.1]
     add_index :account_activity_events, :actor_id
     add_index :account_activity_events, [ :account_id, :created_at ]
     add_index :account_activity_events, [ :subject_type, :subject_id ]
+  end
+
+  def down
+    remove_index :account_activity_events, [ :subject_type, :subject_id ], if_exists: true
+    remove_index :account_activity_events, [ :account_id, :created_at ], if_exists: true
+    remove_index :account_activity_events, :actor_id, if_exists: true
+    remove_foreign_key :account_activity_events, column: :actor_id if foreign_key_exists?(:account_activity_events, column: :actor_id)
+    drop_table :account_activity_events, if_exists: true
   end
 end

--- a/db/migrate/20260519134704_create_account_activity_events.rb
+++ b/db/migrate/20260519134704_create_account_activity_events.rb
@@ -3,7 +3,8 @@
 class CreateAccountActivityEvents < ActiveRecord::Migration[8.1]
   def change
     create_table :account_activity_events do |t|
-      t.references :account, null: false, foreign_key: true, comment: "Account whose administration history this event belongs to."
+      t.references :account, null: false, foreign_key: true, index: false,
+        comment: "Account whose administration history this event belongs to."
       t.bigint :actor_id, comment: "User who performed the action, when available."
       t.string :action, null: false, comment: "Stable action key for the account administration event."
       t.string :subject_type, comment: "Polymorphic subject type affected by the action."
@@ -14,6 +15,7 @@ class CreateAccountActivityEvents < ActiveRecord::Migration[8.1]
     end
 
     add_foreign_key :account_activity_events, :users, column: :actor_id, validate: false
+    add_index :account_activity_events, :actor_id
     add_index :account_activity_events, [ :account_id, :created_at ]
     add_index :account_activity_events, [ :subject_type, :subject_id ]
   end

--- a/db/migrate/20260519134704_create_account_activity_events.rb
+++ b/db/migrate/20260519134704_create_account_activity_events.rb
@@ -18,9 +18,21 @@ class CreateAccountActivityEvents < ActiveRecord::Migration[8.1]
     add_index :account_activity_events, :actor_id
     add_index :account_activity_events, [ :account_id, :created_at ]
     add_index :account_activity_events, [ :subject_type, :subject_id ]
+
+    execute <<~SQL
+      ALTER TABLE account_activity_events ENABLE ROW LEVEL SECURITY;
+      ALTER TABLE account_activity_events FORCE ROW LEVEL SECURITY;
+      CREATE POLICY tenant_isolation ON account_activity_events
+        USING (account_id = paid_current_account_id())
+        WITH CHECK (account_id = paid_current_account_id());
+    SQL
   end
 
   def down
+    return unless table_exists?(:account_activity_events)
+
+    execute "DROP POLICY IF EXISTS tenant_isolation ON account_activity_events"
+    execute "ALTER TABLE account_activity_events NO FORCE ROW LEVEL SECURITY"
     remove_index :account_activity_events, [ :subject_type, :subject_id ], if_exists: true
     remove_index :account_activity_events, [ :account_id, :created_at ], if_exists: true
     remove_index :account_activity_events, :actor_id, if_exists: true

--- a/db/migrate/20260519135640_validate_account_activity_events_actor_foreign_key.rb
+++ b/db/migrate/20260519135640_validate_account_activity_events_actor_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateAccountActivityEventsActorForeignKey < ActiveRecord::Migration[8.1]
+  def change
+    validate_foreign_key :account_activity_events, :users, column: :actor_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_030522) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_19_135640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -66,6 +66,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_030522) do
     t.index ["prompt_id"], name: "index_ab_tests_one_running_per_prompt", unique: true, where: "((status)::text = 'running'::text)"
     t.index ["status"], name: "index_ab_tests_on_status"
     t.index ["winner_variant_id"], name: "index_ab_tests_on_winner_variant_id"
+  end
+
+  create_table "account_activity_events", force: :cascade do |t|
+    t.bigint "account_id", null: false, comment: "Account whose administration history this event belongs to."
+    t.string "action", null: false, comment: "Stable action key for the account administration event."
+    t.bigint "actor_id", comment: "User who performed the action, when available."
+    t.datetime "created_at", null: false
+    t.jsonb "metadata", default: {}, null: false, comment: "Structured event details for UI rendering and audits."
+    t.bigint "subject_id"
+    t.string "subject_type", comment: "Polymorphic subject type affected by the action."
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "created_at"], name: "index_account_activity_events_on_account_id_and_created_at"
+    t.index ["account_id"], name: "index_account_activity_events_on_account_id"
+    t.index ["subject_type", "subject_id"], name: "index_account_activity_events_on_subject_type_and_subject_id"
   end
 
   create_table "account_memberships", force: :cascade do |t|
@@ -2288,6 +2302,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_030522) do
   add_foreign_key "ab_tests", "ab_test_variants", column: "winner_variant_id", on_delete: :nullify
   add_foreign_key "ab_tests", "prompt_versions", column: "control_version_id", on_delete: :restrict
   add_foreign_key "ab_tests", "prompts", on_delete: :cascade
+  add_foreign_key "account_activity_events", "accounts"
+  add_foreign_key "account_activity_events", "users", column: "actor_id"
   add_foreign_key "account_memberships", "accounts"
   add_foreign_key "account_memberships", "users"
   add_foreign_key "agent_coordination_signals", "agent_runs", column: "source_agent_run_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_135640) do
     t.string "subject_type", comment: "Polymorphic subject type affected by the action."
     t.datetime "updated_at", null: false
     t.index ["account_id", "created_at"], name: "index_account_activity_events_on_account_id_and_created_at"
-    t.index ["account_id"], name: "index_account_activity_events_on_account_id"
+    t.index ["actor_id"], name: "index_account_activity_events_on_actor_id"
     t.index ["subject_type", "subject_id"], name: "index_account_activity_events_on_subject_type_and_subject_id"
   end
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tailwindcss": "4.3.0"
   },
   "resolutions": {
+    "brace-expansion": "5.0.6",
     "minimatch": ">=10.2.3"
   }
 }

--- a/spec/migrations/create_account_activity_events_dbless_spec.rb
+++ b/spec/migrations/create_account_activity_events_dbless_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260519134704_create_account_activity_events")
+
+RSpec.describe CreateAccountActivityEvents, :no_db do
+  let(:migration) { described_class.new }
+  let(:table_definition_class) do
+    stub_const("SpecTableDefinition", Class.new do
+      def references(*) = nil
+      def bigint(*) = nil
+      def string(*) = nil
+      def jsonb(*) = nil
+      def timestamps(*) = nil
+    end)
+  end
+  let(:table) { instance_double(table_definition_class) }
+
+  before do
+    allow(migration).to receive(:create_table).and_yield(table)
+    allow(migration).to receive(:add_foreign_key)
+    allow(migration).to receive(:add_index)
+    allow(table).to receive_messages(
+      references: nil,
+      bigint: nil,
+      string: nil,
+      jsonb: nil,
+      timestamps: nil
+    )
+  end
+
+  it "creates the intended index and foreign key shape" do
+    migration.change
+
+    expect(table).to have_received(:references).with(
+      :account,
+      null: false,
+      foreign_key: true,
+      index: false,
+      comment: "Account whose administration history this event belongs to."
+    )
+    expect(migration).to have_received(:add_foreign_key)
+      .with(:account_activity_events, :users, column: :actor_id, validate: false)
+    expect(migration).to have_received(:add_index).with(:account_activity_events, :actor_id)
+    expect(migration).to have_received(:add_index).with(:account_activity_events, [ :account_id, :created_at ])
+    expect(migration).to have_received(:add_index).with(:account_activity_events, [ :subject_type, :subject_id ])
+    expect(migration).not_to have_received(:add_index).with(:account_activity_events, :account_id)
+  end
+end

--- a/spec/migrations/create_account_activity_events_dbless_spec.rb
+++ b/spec/migrations/create_account_activity_events_dbless_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe CreateAccountActivityEvents, :no_db do
     allow(migration).to receive(:create_table).and_yield(table)
     allow(migration).to receive(:add_foreign_key)
     allow(migration).to receive(:add_index)
+    allow(migration).to receive(:execute)
     allow(table).to receive_messages(
       references: nil,
       bigint: nil,
@@ -45,5 +46,17 @@ RSpec.describe CreateAccountActivityEvents, :no_db do
     expect(migration).to have_received(:add_index).with(:account_activity_events, [ :account_id, :created_at ])
     expect(migration).to have_received(:add_index).with(:account_activity_events, [ :subject_type, :subject_id ])
     expect(migration).not_to have_received(:add_index).with(:account_activity_events, :account_id)
+  end
+
+  it "enables forced tenant RLS for account activity events" do
+    recorded_sql = []
+    allow(migration).to receive(:execute) { |sql| recorded_sql << sql }
+
+    migration.up
+
+    expect(recorded_sql.join("\n")).to include("ALTER TABLE account_activity_events ENABLE ROW LEVEL SECURITY;")
+    expect(recorded_sql.join("\n")).to include("ALTER TABLE account_activity_events FORCE ROW LEVEL SECURITY;")
+    expect(recorded_sql.join("\n")).to include("CREATE POLICY tenant_isolation ON account_activity_events")
+    expect(recorded_sql.join("\n")).to include("account_id = paid_current_account_id()")
   end
 end

--- a/spec/migrations/create_account_activity_events_dbless_spec.rb
+++ b/spec/migrations/create_account_activity_events_dbless_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CreateAccountActivityEvents, :no_db do
   end
 
   it "creates the intended index and foreign key shape" do
-    migration.change
+    migration.up
 
     expect(table).to have_received(:references).with(
       :account,

--- a/spec/models/account_activity_event_spec.rb
+++ b/spec/models/account_activity_event_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AccountActivityEvent do
+  describe "#description" do
+    it "renders a human-friendly invitation message" do
+      event = described_class.new(action: "membership.invited", metadata: {
+        "email" => "person@example.com",
+        "role" => "admin"
+      })
+
+      expect(event.description).to eq("Invited person@example.com as admin")
+    end
+  end
+end

--- a/spec/models/account_activity_event_spec.rb
+++ b/spec/models/account_activity_event_spec.rb
@@ -12,5 +12,11 @@ RSpec.describe AccountActivityEvent do
 
       expect(event.description).to eq("Invited person@example.com as admin")
     end
+
+    it "falls back to unknown values when metadata is missing" do
+      event = described_class.new(action: "membership.role_changed", metadata: {})
+
+      expect(event.description).to eq("Changed unknown from unknown to unknown")
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -171,6 +171,29 @@ RSpec.describe User do
         expect(result).to be false
         expect(user.has_role?(:admin, account)).to be true
       end
+
+      it "destroys the user when removing their last account role" do
+        account = create(:account)
+        user = create(:user, :admin, account: account)
+
+        expect {
+          user.remove_role(:admin, account)
+        }.to change(described_class, :count).by(-1)
+          .and change(AccountMembership, :count).by(-1)
+      end
+
+      it "switches the user's current account when another membership remains" do
+        primary_account = create(:account)
+        user = create(:user, :admin, account: primary_account)
+        secondary_account = create(:account)
+        secondary_membership = create(:account_membership, :member, user: user, account: secondary_account)
+
+        user.remove_role(:admin, primary_account)
+
+        expect(user.reload.account).to eq(secondary_account)
+        expect(user.account_membership_for(primary_account)).to be_nil
+        expect(user.account_membership_for(secondary_account)).to eq(secondary_membership)
+      end
     end
 
     describe "#role_on" do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe "Accounts" do
       expect(account.account_activity_events.recent.first.action).to eq("membership.invited")
     end
 
-    it "rejects inviting an email that belongs to another account" do
-      create(:user, email: "shared@example.com")
+    it "invites an existing user from another account without creating a duplicate user" do
+      existing_user = create(:user, :member, email: "shared@example.com")
 
       expect do
         post account_memberships_path, params: {
@@ -118,10 +118,15 @@ RSpec.describe "Accounts" do
             role: "member"
           }
         }
-      end.not_to change(AccountMembership, :count)
+      end.to change(AccountMembership, :count).by(1)
+        .and change(AccountActivityEvent, :count).by(1)
 
       expect(response).to redirect_to(account_path)
-      expect(flash[:alert]).to include("another account")
+      membership = account.account_memberships.find_by!(user: existing_user)
+      expect(membership.role).to eq("member")
+      expect(User.find_by!(email: "shared@example.com")).to eq(existing_user)
+      expect(existing_user.reload.account).not_to eq(account)
+      expect(ActionMailer::Base.deliveries).to be_empty
     end
 
     it "does not send reset instructions when the invite transaction rolls back" do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -124,6 +124,22 @@ RSpec.describe "Accounts" do
       expect(flash[:alert]).to include("another account")
     end
 
+    it "does not send reset instructions when the invite transaction rolls back" do
+      allow(Accounts::RecordActivity).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(AccountActivityEvent.new))
+
+      expect do
+        post account_memberships_path, params: {
+          invitation: {
+            email: "rolled-back@example.com",
+            role: "member"
+          }
+        }
+      end.not_to change(ActionMailer::Base.deliveries, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(User.find_by(email: "rolled-back@example.com")).to be_nil
+    end
+
     it "refuses to invite an owner via the membership flow" do
       expect do
         post account_memberships_path, params: {
@@ -216,6 +232,30 @@ RSpec.describe "Accounts" do
 
       expect(response).to redirect_to(root_path)
       expect(account.reload).to be_active
+    end
+
+    it "reactivates a suspended account and records activity" do
+      account.suspend!
+
+      expect do
+        patch account_lifecycle_path, params: { transition: "reactivate" }
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      expect(account.reload).to be_active
+      expect(account.account_activity_events.recent.first.action).to eq("lifecycle.reactivated")
+    end
+
+    it "deactivates a suspended account and records activity" do
+      account.suspend!
+
+      expect do
+        patch account_lifecycle_path, params: { transition: "deactivate" }
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      expect(account.reload).to be_deactivated
+      expect(account.account_activity_events.recent.first.action).to eq("lifecycle.deactivated")
     end
   end
 end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -2,6 +2,8 @@
 
 require "rails_helper"
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.describe "Accounts" do
   let(:account) { create(:account, name: "Acme") }
   let(:owner) { create(:user, :owner, account: account) }
@@ -108,7 +110,7 @@ RSpec.describe "Accounts" do
       expect(account.account_activity_events.recent.first.action).to eq("membership.invited")
     end
 
-    it "invites an existing user from another account without creating a duplicate user" do
+    it "rejects inviting an existing user from another account" do
       existing_user = create(:user, :member, email: "shared@example.com")
 
       expect do
@@ -118,12 +120,12 @@ RSpec.describe "Accounts" do
             role: "member"
           }
         }
-      end.to change(AccountMembership, :count).by(1)
-        .and change(AccountActivityEvent, :count).by(1)
+      end.to not_change(AccountMembership, :count)
+        .and not_change(AccountActivityEvent, :count)
 
       expect(response).to redirect_to(account_path)
-      membership = account.account_memberships.find_by!(user: existing_user)
-      expect(membership.role).to eq("member")
+      expect(flash[:alert]).to include("Cross-account invites are not supported yet")
+      expect(account.account_memberships.find_by(user: existing_user)).to be_nil
       expect(User.find_by!(email: "shared@example.com")).to eq(existing_user)
       expect(existing_user.reload.account).not_to eq(account)
       expect(ActionMailer::Base.deliveries).to be_empty
@@ -318,6 +320,15 @@ RSpec.describe "Accounts" do
       expect(response).to redirect_to(account_path)
       expect(account.reload).to be_deactivated
       expect(account.account_activity_events.recent.first.action).to eq("lifecycle.deactivated")
+    end
+
+    it "does not render a self-service reactivation button for deactivated accounts" do
+      account.suspend!
+      account.deactivate!
+
+      get account_path
+
+      expect(response).to redirect_to(new_user_session_path)
     end
   end
 end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -201,11 +201,26 @@ RSpec.describe "Accounts" do
 
       expect do
         delete account_membership_path(membership)
-      end.to change(AccountMembership, :count).by(-1)
+      end.to change(User, :count).by(-1)
+        .and change(AccountMembership, :count).by(-1)
         .and change(AccountActivityEvent, :count).by(1)
 
       expect(response).to redirect_to(account_path)
       expect(account.account_activity_events.recent.first.action).to eq("membership.removed")
+    end
+
+    it "switches the removed user to another account when they still have one" do
+      membership = create(:account_membership, :viewer, account: account, user: create(:user, account: account))
+      secondary_account = create(:account)
+      create(:account_membership, :member, user: membership.user, account: secondary_account)
+
+      expect do
+        delete account_membership_path(membership)
+      end.to change(AccountMembership, :count).by(-1)
+        .and change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      expect(membership.user.reload.account).to eq(secondary_account)
     end
 
     it "rolls back the removal when activity recording fails" do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Accounts" do
+  let(:account) { create(:account, name: "Acme") }
+  let(:owner) { create(:user, :owner, account: account) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+    sign_in owner
+  end
+
+  describe "GET /account" do
+    it "renders the account administration page" do
+      create(:user, :member, account: account)
+      create(:billing_plan, :per_run, account: account, name: "Growth")
+      period = create(:billing_period, :with_usage, account: account)
+      create(:billing_invoice, :issued, account: account, billing_period: period, total_cents: 7800)
+
+      get account_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Account Administration")
+      expect(response.body).to include("Team")
+      expect(response.body).to include("Tenant Limits and Usage")
+      expect(response.body).to include("Billing")
+      expect(response.body).to include("Activity Trail")
+    end
+
+    it "allows a viewer to read the page" do
+      viewer = create(:user, :viewer, account: account)
+      sign_out owner
+      sign_in viewer
+
+      get account_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Account Administration")
+    end
+  end
+
+  describe "PATCH /account" do
+    it "updates editable account settings and records activity" do
+      expect do
+        patch account_path, params: {
+          account: {
+            name: "Acme Labs",
+            default_max_tokens_per_run: 200_000
+          }
+        }
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      expect(account.reload.name).to eq("Acme Labs")
+      expect(account.default_max_tokens_per_run).to eq(200_000)
+
+      event = account.account_activity_events.recent.first
+      expect(event.action).to eq("account.updated")
+      expect(event.metadata["changed_fields"]).to include("name", "default_max_tokens_per_run")
+    end
+
+    it "rejects viewers" do
+      viewer = create(:user, :viewer, account: account)
+      sign_out owner
+      sign_in viewer
+
+      patch account_path, params: { account: { name: "Blocked" } }
+
+      expect(response).to redirect_to(root_path)
+      expect(account.reload.name).to eq("Acme")
+    end
+  end
+
+  describe "POST /account_memberships" do
+    it "invites a user, creates a membership, sends reset instructions, and records activity" do
+      expect do
+        post account_memberships_path, params: {
+          invitation: {
+            email: "new-user@example.com",
+            name: "New User",
+            role: "admin"
+          }
+        }
+      end.to change(User, :count).by(1)
+        .and change(AccountMembership, :count).by(1)
+        .and change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      membership = account.account_memberships.includes(:user).find_by!(user: { email: "new-user@example.com" })
+      expect(membership.role).to eq("admin")
+      expect(ActionMailer::Base.deliveries.last.to).to eq([ "new-user@example.com" ])
+      expect(account.account_activity_events.recent.first.action).to eq("membership.invited")
+    end
+
+    it "rejects inviting an email that belongs to another account" do
+      create(:user, email: "shared@example.com")
+
+      expect do
+        post account_memberships_path, params: {
+          invitation: {
+            email: "shared@example.com",
+            role: "member"
+          }
+        }
+      end.not_to change(AccountMembership, :count)
+
+      expect(response).to redirect_to(account_path)
+      expect(flash[:alert]).to include("another account")
+    end
+  end
+
+  describe "PATCH /account_memberships/:id" do
+    it "changes a non-owner role and records activity" do
+      membership = create(:account_membership, :member, account: account, user: create(:user, account: account))
+
+      expect do
+        patch account_membership_path(membership), params: {
+          account_membership: { role: "admin" }
+        }
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      expect(membership.reload.role).to eq("admin")
+      expect(account.account_activity_events.recent.first.action).to eq("membership.role_changed")
+    end
+
+    it "refuses to assign owner via role change" do
+      membership = create(:account_membership, :member, account: account, user: create(:user, account: account))
+
+      patch account_membership_path(membership), params: {
+        account_membership: { role: "owner" }
+      }
+
+      expect(response).to redirect_to(account_path)
+      expect(flash[:alert]).to include("ownership transfer")
+      expect(membership.reload.role).to eq("member")
+    end
+  end
+
+  describe "DELETE /account_memberships/:id" do
+    it "removes a non-owner membership and records activity" do
+      membership = create(:account_membership, :viewer, account: account, user: create(:user, account: account))
+
+      expect do
+        delete account_membership_path(membership)
+      end.to change(AccountMembership, :count).by(-1)
+        .and change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      expect(account.account_activity_events.recent.first.action).to eq("membership.removed")
+    end
+  end
+
+  describe "POST /account_ownership_transfer" do
+    it "transfers ownership and records activity" do
+      membership = create(:account_membership, :admin, account: account, user: create(:user, account: account))
+
+      expect do
+        post account_ownership_transfer_path, params: { membership_id: membership.id }
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      expect(membership.reload.role).to eq("owner")
+      expect(owner.account_membership_for(account).reload.role).to eq("admin")
+      expect(account.account_activity_events.recent.first.action).to eq("ownership.transferred")
+    end
+  end
+
+  describe "PATCH /account_lifecycle" do
+    it "suspends the account and records activity" do
+      expect do
+        patch account_lifecycle_path, params: { transition: "suspend" }
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_path)
+      expect(account.reload).to be_suspended
+      expect(account.account_activity_events.recent.first.action).to eq("lifecycle.suspended")
+    end
+
+    it "rejects admins" do
+      admin = create(:user, :admin, account: account)
+      sign_out owner
+      sign_in admin
+
+      patch account_lifecycle_path, params: { transition: "suspend" }
+
+      expect(response).to redirect_to(root_path)
+      expect(account.reload).to be_active
+    end
+  end
+end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe "Accounts" do
       expect(event.metadata["changed_fields"]).to include("name", "default_max_tokens_per_run")
     end
 
+    it "rolls back the account update when activity recording fails" do
+      allow(Accounts::RecordActivity).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(AccountActivityEvent.new))
+
+      expect do
+        patch account_path, params: {
+          account: {
+            name: "Acme Labs"
+          }
+        }
+      end.not_to change(AccountActivityEvent, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(account.reload.name).to eq("Acme")
+    end
+
     it "rejects viewers" do
       viewer = create(:user, :viewer, account: account)
       sign_out owner

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -170,6 +170,18 @@ RSpec.describe "Accounts" do
       expect(account.account_activity_events.recent.first.action).to eq("membership.role_changed")
     end
 
+    it "rolls back the role change when activity recording fails" do
+      membership = create(:account_membership, :member, account: account, user: create(:user, account: account))
+      allow(Accounts::RecordActivity).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(AccountActivityEvent.new))
+
+      patch account_membership_path(membership), params: {
+        account_membership: { role: "admin" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(membership.reload.role).to eq("member")
+    end
+
     it "refuses to assign owner via role change" do
       membership = create(:account_membership, :member, account: account, user: create(:user, account: account))
 
@@ -195,6 +207,16 @@ RSpec.describe "Accounts" do
       expect(response).to redirect_to(account_path)
       expect(account.account_activity_events.recent.first.action).to eq("membership.removed")
     end
+
+    it "rolls back the removal when activity recording fails" do
+      membership = create(:account_membership, :viewer, account: account, user: create(:user, account: account))
+      allow(Accounts::RecordActivity).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(AccountActivityEvent.new))
+
+      delete account_membership_path(membership)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(membership.reload).to be_present
+    end
   end
 
   describe "POST /account_ownership_transfer" do
@@ -210,6 +232,17 @@ RSpec.describe "Accounts" do
       expect(owner.account_membership_for(account).reload.role).to eq("admin")
       expect(account.account_activity_events.recent.first.action).to eq("ownership.transferred")
     end
+
+    it "rolls back the transfer when activity recording fails" do
+      membership = create(:account_membership, :admin, account: account, user: create(:user, account: account))
+      allow(Accounts::RecordActivity).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(AccountActivityEvent.new))
+
+      post account_ownership_transfer_path, params: { membership_id: membership.id }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(membership.reload.role).to eq("admin")
+      expect(owner.account_membership_for(account).reload.role).to eq("owner")
+    end
   end
 
   describe "PATCH /account_lifecycle" do
@@ -221,6 +254,15 @@ RSpec.describe "Accounts" do
       expect(response).to redirect_to(account_path)
       expect(account.reload).to be_suspended
       expect(account.account_activity_events.recent.first.action).to eq("lifecycle.suspended")
+    end
+
+    it "rolls back the transition when activity recording fails" do
+      allow(Accounts::RecordActivity).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(AccountActivityEvent.new))
+
+      patch account_lifecycle_path, params: { transition: "suspend" }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(account.reload).to be_active
     end
 
     it "rejects admins" do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -108,6 +108,20 @@ RSpec.describe "Accounts" do
       expect(response).to redirect_to(account_path)
       expect(flash[:alert]).to include("another account")
     end
+
+    it "refuses to invite an owner via the membership flow" do
+      expect do
+        post account_memberships_path, params: {
+          invitation: {
+            email: "new-owner@example.com",
+            role: "owner"
+          }
+        }
+      end.not_to change(AccountMembership, :count)
+
+      expect(response).to redirect_to(account_path)
+      expect(flash[:alert]).to include("ownership transfer")
+    end
   end
 
   describe "PATCH /account_memberships/:id" do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -255,6 +255,25 @@ RSpec.describe "Accounts" do
       expect(account.account_activity_events.recent.first.action).to eq("ownership.transferred")
     end
 
+    it "switches the new owner's active account when they belong to another account" do
+      secondary_account = create(:account)
+      transferee = create(:user, :admin, account: secondary_account)
+      membership = create(:account_membership, :admin, account: account, user: transferee)
+
+      post account_ownership_transfer_path, params: { membership_id: membership.id }
+
+      expect(response).to redirect_to(account_path)
+      expect(transferee.reload.account).to eq(account)
+
+      sign_out owner
+      sign_in transferee
+
+      get account_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Account Administration")
+    end
+
     it "rolls back the transfer when activity recording fails" do
       membership = create(:account_membership, :admin, account: account, user: create(:user, account: account))
       allow(Accounts::RecordActivity).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(AccountActivityEvent.new))

--- a/spec/requests/tenant_configurations_spec.rb
+++ b/spec/requests/tenant_configurations_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe "TenantConfigurations" do
       expect(setting.features["explicit_pr_automation_decisions"]).to be(true)
     end
 
+    it "records account activity when tenant configuration changes" do
+      api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
+
+      expect do
+        patch tenant_configuration_path, params: tenant_configuration_params(api_key)
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(account.account_activity_events.recent.first.action).to eq("tenant_configuration.updated")
+    end
+
     it "updates the tenant marketplace auto-attach override" do
       api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
 

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       expect(targets.map(&:slug)).to eq([ "dashboard" ])
     end
 
+    it "maps account administration controllers to the account page target" do
+      targets = described_class.call(changed_files: [ "app/controllers/accounts_controller.rb" ])
+
+      expect(targets.map(&:slug)).to eq([ "account" ])
+    end
+
     it "maps marketplace entry controllers to representative marketplace routes" do
       targets = described_class.call(changed_files: [ "app/controllers/marketplace_entries_controller.rb" ])
 
@@ -222,6 +228,12 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       targets = described_class.call(changed_files: [ "app/views/projects/_issues.html.erb" ])
 
       expect(targets.map(&:slug)).to eq([ "project_show" ])
+    end
+
+    it "maps the account administration view to the account page target" do
+      targets = described_class.call(changed_files: [ "app/views/accounts/show.html.erb" ])
+
+      expect(targets.map(&:slug)).to eq([ "account" ])
     end
 
     it "maps the clarifying-questions wizard view to its screenshot target" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,10 +658,10 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+brace-expansion@5.0.6, brace-expansion@^5.0.5:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Summary

Delivers Phase 5.2 of the accounts initiative: a native, customer-facing account administration surface so account owners and admins can manage profile, membership, ownership, tenant settings, lifecycle, and billing visibility without relying on the internal Avo console. Adds a persistent activity trail so account-management changes are auditable from the product UI.

## Changes

**Database**
- New `account_activity_events` table with two migrations: `20260519134704_create_account_activity_events.rb` creates the table and indexes; `20260519135640_validate_account_activity_events_actor_foreign_key.rb` validates the actor FK after backfill.

**Models / Services**
- New `AccountActivityEvent` model records who did what on an account (covered by `spec/models/account_activity_event_spec.rb`).
- New `Accounts::*` Servo services encapsulate profile updates, invitations, membership role changes/removals, ownership transfer, and lifecycle actions, each emitting an activity event.
- `TenantConfigurations` updates now also write account activity events so tenant/quota changes appear in the audit trail.

**Routing / Controllers / Views**
- `config/routes.rb` exposes the new `/account` surface.
- `app/controllers/accounts_controller.rb` handles the admin actions and renders the new UI.
- `app/views/accounts/show.html.erb` presents profile editing, invitations, membership list (with role changes and removals), ownership transfer, lifecycle actions, tenant settings/quota visibility, billing visibility, and the activity trail.

## Design Decisions

- **Native UI, not Avo** — Avo is intentionally kept as an internal backoffice; the customer-facing admin surface is a first-class product UI per the Phase 5.2 deliverables.
- **Activity trail as a dedicated table** — Rather than reusing `logidze` history (which is per-table diff data), a purpose-built `AccountActivityEvent` model gives a unified, user-presentable audit feed across profile, membership, lifecycle, and tenant-config changes.
- **FK validation split into a second migration** — Standard pattern for adding a validated FK without a long lock on existing rows.
- **Services emit events, not controllers** — Activity events are written inside the `Accounts::*` Servo services (and from tenant-config updates) so any future caller automatically produces the audit record.

## Operational Notes

- Two migrations to run; the second only validates the FK added in the first, so deploy order matters but no backfill job is required.
- No new env vars or infrastructure changes.

## Screenshots

_Author: please attach before/after screenshots of the new `/account` page (profile, membership, ownership transfer, tenant/quota, billing, and activity trail sections)._

## Follow-ups

- The commit was not created on this branch because the pre-commit hook runs the full suite and an unrelated pre-existing failure in `spec/migrations/create_strategies_and_strategy_versions_spec.rb:58` blocks it. That failure should be resolved (or scoped out) separately before merging.

---

Closes #2012