### PR TITLE
feat(model-catalog): integrate ruby-llm registry as primary source for SeedKnownModels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,9 @@ gem "aws-sdk-s3", require: false
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
 gem "agent-harness", "~> 0.18.2"
 
+# Runtime model registry for canonical model metadata, pricing, and capabilities.
+gem "ruby_llm", "~> 1.15"
+
 # Code analysis tool for VCS mining (churn/hotspot analysis) [https://github.com/viamin/ruby-maat]
 # Defer loading — invoked as CLI binary, not via Ruby API.
 gem "ruby-maat", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    event_stream_parser (1.0.0)
     excon (1.4.2)
       logger
     factory_bot (6.5.6)
@@ -194,6 +195,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -307,6 +310,7 @@ GEM
       prism (~> 1.5)
     msgpack (1.8.0)
     multi_json (1.20.1)
+    multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.4)
@@ -503,6 +507,17 @@ GEM
       rexml (~> 3.2)
       rover-df (~> 0.3)
     ruby-progressbar (1.13.0)
+    ruby_llm (1.15.0)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1)
+      ruby_llm-schema (~> 0)
+      zeitwerk (~> 2)
+    ruby_llm-schema (0.3.1)
     ruby_parser (3.22.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -660,6 +675,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubocop-rspec
   ruby-maat
+  ruby_llm (~> 1.15)
   shoulda-matchers
   simplecov
   solid_cable
@@ -710,6 +726,7 @@ CHECKSUMS
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   chartkick (5.2.1) sha256=2848d7de87189f30f28d077eb0bbdebc8a1f0f6f81de1ded95008fe564369949
@@ -733,11 +750,13 @@ CHECKSUMS
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
+  event_stream_parser (1.0.0) sha256=a2683bab70126286f8184dc88f7968ffc4028f813161fb073ec90d171f7de3c8
   excon (1.4.2) sha256=32d8d8eda619717d9b8043b4675e096fb5c2139b080e2ad3b267f88c545aaa35
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
   faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
   faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   fasterer (0.11.0) sha256=9c38b77583584f3339a729eb077fd8f2856a317abe747528f6563d7c23e9dda8
@@ -784,6 +803,7 @@ CHECKSUMS
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   multi_json (1.20.1) sha256=2f3934e805cc45ef91b551a1f89d0e9191abd06a5e04a2ef09a6a036c452ca6d
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
@@ -861,6 +881,8 @@ CHECKSUMS
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   ruby-maat (1.2.0) sha256=558797d7e1267126a56fbfc9db2d29002a5e5d2bc330b8a45ba106c0771ff844
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby_llm (1.15.0) sha256=ca207465bca1cca007010a79fce500d4012b1fbe188b025040cd37b884fb98af
+  ruby_llm-schema (0.3.1) sha256=bfec093db924f8995e598c338147507e71b4dedfeb59de2de3ebf7985938d3d4
   ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23
   sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/app/services/models/seed_known_models.rb
+++ b/app/services/models/seed_known_models.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 module Models
-  # Seeds LlmModel records from a hardcoded snapshot of known models.
-  # Pricing and capabilities are static — this does not pull from an
-  # external registry at runtime.
-  # TODO(#139): Integrate with ruby-llm registry as the primary source,
-  # falling back to KNOWN_MODELS when the registry is unavailable.
+  # Seeds LlmModel records from the RubyLLM registry, falling back to the
+  # app snapshot for app-owned defaults and registry failures.
   class SeedKnownModels
+    REGISTRY_PROVIDER_ALIASES = {
+      "gemini" => "google"
+    }.freeze
+    TOOL_CAPABILITIES = %w[function_calling tools].freeze
+    JSON_OUTPUT_CAPABILITIES = %w[structured_output json_output].freeze
+
     KNOWN_MODELS = [
       {
         model_id: "claude-sonnet-4-6",
@@ -112,18 +115,114 @@ module Models
 
     def call
       synced = 0
-      KNOWN_MODELS.each do |attrs|
-        model = LlmModel.find_or_initialize_by(model_id: attrs[:model_id])
-        model.assign_attributes(attrs)
+      registry_models = registry_models_by_id
+
+      KNOWN_MODELS.each do |snapshot_attrs|
+        model = LlmModel.find_or_initialize_by(model_id: snapshot_attrs[:model_id])
+        model.assign_attributes(merged_attributes(snapshot_attrs, registry_models))
+        model.tier ||= snapshot_attrs[:tier]
         model.save!
         synced += 1
       end
 
-      # Clear cached pricing so TokenUsageTracker picks up updated costs.
       TokenUsageTracker.clear_model_cache!
-
       Rails.logger.info(message: "model_registry.seed_completed", models_synced: synced)
       synced
+    end
+
+    private
+
+    def merged_attributes(snapshot_attrs, registry_models)
+      snapshot_attrs.except(:tier).merge(registry_attributes_for(snapshot_attrs, registry_models)).compact
+    end
+
+    def registry_attributes_for(snapshot_attrs, registry_models)
+      registry_model = registry_model_for(snapshot_attrs, registry_models)
+      return {} unless registry_model
+
+      capabilities = Array(registry_model.capabilities).map(&:to_s)
+
+      {
+        display_name: registry_model.name,
+        provider: normalized_provider(registry_model.provider),
+        family: registry_model.family,
+        context_window: registry_model.context_window,
+        max_output_tokens: registry_model.max_output_tokens,
+        input_cost_per_million: pricing_for(registry_model, :input_per_million),
+        output_cost_per_million: pricing_for(registry_model, :output_per_million),
+        supports_vision: supports_vision?(registry_model, capabilities),
+        supports_tools: supports_tools?(capabilities),
+        supports_json_output: supports_json_output?(capabilities)
+      }
+    end
+
+    def registry_model_for(snapshot_attrs, registry_models)
+      provider_models = registry_models[snapshot_attrs[:model_id]]
+      return unless provider_models
+
+      provider_models[normalized_provider(snapshot_attrs[:provider])] || provider_models.values.first
+    end
+
+    def registry_models_by_id
+      models = fetch_registry_models
+      return {} unless models
+
+      models.each_with_object({}) do |model, index|
+        next if model.id.blank?
+
+        index[model.id] ||= {}
+        index[model.id][normalized_provider(model.provider)] ||= model
+      end
+    end
+
+    def fetch_registry_models
+      require "ruby_llm"
+
+      models = Array(RubyLLM.models.all)
+      return models if models.any?
+
+      log_registry_fallback(reason: "empty_registry")
+      nil
+    rescue LoadError, StandardError => e
+      log_registry_fallback(
+        reason: "registry_unavailable",
+        error_class: e.class.name,
+        error_message: e.message
+      )
+      nil
+    end
+
+    def log_registry_fallback(reason:, error_class: nil, error_message: nil)
+      Rails.logger.warn(
+        message: "model_registry.registry_fallback",
+        registry: "ruby_llm",
+        reason: reason,
+        fallback: "known_models",
+        error_class: error_class,
+        error_message: error_message
+      )
+    end
+
+    def normalized_provider(provider)
+      REGISTRY_PROVIDER_ALIASES.fetch(provider.to_s, provider.to_s)
+    end
+
+    def pricing_for(model, field)
+      model.pricing.to_h.dig(:text_tokens, :standard, field)
+    end
+
+    def supports_vision?(model, capabilities)
+      return true if capabilities.include?("vision")
+
+      model.modalities.to_h.fetch(:input, []).intersect?(%w[image video pdf])
+    end
+
+    def supports_tools?(capabilities)
+      (capabilities & TOOL_CAPABILITIES).any?
+    end
+
+    def supports_json_output?(capabilities)
+      (capabilities & JSON_OUTPUT_CAPABILITIES).any?
     end
   end
 end

--- a/app/services/models/seed_known_models.rb
+++ b/app/services/models/seed_known_models.rb
@@ -178,6 +178,7 @@ module Models
     def fetch_registry_models
       require "ruby_llm"
 
+      RubyLLM.models.refresh!
       models = Array(RubyLLM.models.all)
       return models if models.any?
 

--- a/app/services/models/seed_known_models.rb
+++ b/app/services/models/seed_known_models.rb
@@ -133,7 +133,7 @@ module Models
     private
 
     def merged_attributes(snapshot_attrs, registry_models)
-      snapshot_attrs.except(:tier).merge(registry_attributes_for(snapshot_attrs, registry_models)).compact
+      snapshot_attrs.except(:tier).merge(registry_attributes_for(snapshot_attrs, registry_models).compact)
     end
 
     def registry_attributes_for(snapshot_attrs, registry_models)

--- a/spec/services/models/seed_known_models_spec.rb
+++ b/spec/services/models/seed_known_models_spec.rb
@@ -38,6 +38,26 @@ RSpec.describe Models::SeedKnownModels do
       expect(model.supports_vision).to be(false)
     end
 
+    it "preserves snapshot values when registry metadata is missing" do
+      registry_models.replace([
+        registry_model(
+          id: "gpt-4o",
+          name: "GPT-4o (Registry)",
+          provider: "openai",
+          family: "gpt-4.1",
+          pricing: {}
+        )
+      ])
+
+      described_class.call
+
+      model = LlmModel.find_by!(model_id: "gpt-4o")
+      expect(model.display_name).to eq("GPT-4o (Registry)")
+      expect(model.family).to eq("gpt-4.1")
+      expect(model.input_cost_per_million).to eq(2.50)
+      expect(model.output_cost_per_million).to eq(10.0)
+    end
+
     it "falls back to the snapshot when the registry misses a known model" do
       registry_models.replace([
         registry_model(id: "other-model", provider: "openai")

--- a/spec/services/models/seed_known_models_spec.rb
+++ b/spec/services/models/seed_known_models_spec.rb
@@ -9,10 +9,17 @@ RSpec.describe Models::SeedKnownModels do
 
     before do
       allow(RubyLLM).to receive(:models).and_return(registry)
+      allow(registry).to receive(:refresh!).and_return(true)
     end
 
     it "creates model records from known models" do
       expect { described_class.call }.to change(LlmModel, :count).by(described_class::KNOWN_MODELS.size)
+    end
+
+    it "refreshes the registry before reading models" do
+      described_class.call
+
+      expect(registry).to have_received(:refresh!).once
     end
 
     it "updates existing models on re-sync" do
@@ -72,7 +79,7 @@ RSpec.describe Models::SeedKnownModels do
     end
 
     it "falls back cleanly with a single structured warning when the registry is unavailable" do
-      allow(RubyLLM).to receive(:models).and_raise(Faraday::ConnectionFailed.new("registry down"))
+      allow(registry).to receive(:refresh!).and_raise(Faraday::ConnectionFailed.new("registry down"))
       allow(Rails.logger).to receive(:warn)
 
       described_class.call

--- a/spec/services/models/seed_known_models_spec.rb
+++ b/spec/services/models/seed_known_models_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 RSpec.describe Models::SeedKnownModels do
   describe ".call" do
+    let(:registry) { instance_double(RubyLLM::Models, all: registry_models) }
+    let(:registry_models) { [] }
+
+    before do
+      allow(RubyLLM).to receive(:models).and_return(registry)
+    end
+
     it "creates model records from known models" do
       expect { described_class.call }.to change(LlmModel, :count).by(described_class::KNOWN_MODELS.size)
     end
@@ -14,14 +21,52 @@ RSpec.describe Models::SeedKnownModels do
       expect { described_class.call }.not_to change(LlmModel, :count)
     end
 
-    it "sets correct attributes for Claude Sonnet" do
+    it "uses registry metadata when a known model is present" do
+      registry_models.replace([ gpt_4o_registry_model ])
+
       described_class.call
 
-      model = LlmModel.find_by(model_id: "claude-sonnet-4-6")
-      expect(model).to be_present
-      expect(model.provider).to eq("anthropic")
+      model = LlmModel.find_by!(model_id: "gpt-4o")
+      expect(model.display_name).to eq("GPT-4o (Registry)")
+      expect(model.family).to eq("gpt-4.1")
+      expect(model.context_window).to eq(256_000)
+      expect(model.max_output_tokens).to eq(32_768)
+      expect(model.input_cost_per_million).to eq(9.99)
+      expect(model.output_cost_per_million).to eq(19.99)
+      expect(model.supports_tools).to be(true)
+      expect(model.supports_json_output).to be(true)
+      expect(model.supports_vision).to be(false)
+    end
+
+    it "falls back to the snapshot when the registry misses a known model" do
+      registry_models.replace([
+        registry_model(id: "other-model", provider: "openai")
+      ])
+
+      described_class.call
+
+      model = LlmModel.find_by!(model_id: "claude-sonnet-4-6")
+      expect(model.display_name).to eq("Claude Sonnet 4.6")
       expect(model.input_cost_per_million).to eq(3.0)
-      expect(model.capability_score).to eq(9.0)
+      expect(model.supports_vision).to be(true)
+    end
+
+    it "falls back cleanly with a single structured warning when the registry is unavailable" do
+      allow(RubyLLM).to receive(:models).and_raise(Faraday::ConnectionFailed.new("registry down"))
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.call
+
+      expect(Rails.logger).to have_received(:warn).once.with(
+        hash_including(
+          message: "model_registry.registry_fallback",
+          registry: "ruby_llm",
+          reason: "registry_unavailable",
+          fallback: "known_models",
+          error_class: "Faraday::ConnectionFailed",
+          error_message: "registry down"
+        )
+      )
     end
 
     it "assigns tier to seeded models" do
@@ -48,5 +93,55 @@ RSpec.describe Models::SeedKnownModels do
 
       expect(existing.reload.tier).to eq("high")
     end
+
+    it "does not overwrite an existing non-nil tier" do
+      existing = LlmModel.create!(
+        model_id: "claude-opus-4-6",
+        display_name: "Outdated",
+        provider: "anthropic",
+        category: "coding",
+        tier: "mid"
+      )
+
+      described_class.call
+
+      expect(existing.reload.tier).to eq("mid")
+    end
+  end
+
+  def registry_model(id:, name: id, provider:, family: "test-family", context_window: 123_456,
+    max_output_tokens: 4_096, capabilities: [], pricing: {}, modalities: {})
+    RubyLLM::Model::Info.new(
+      id: id,
+      name: name,
+      provider: provider,
+      family: family,
+      context_window: context_window,
+      max_output_tokens: max_output_tokens,
+      capabilities: capabilities,
+      pricing: pricing,
+      modalities: modalities,
+      metadata: {}
+    )
+  end
+
+  def gpt_4o_registry_model
+    registry_model(
+      id: "gpt-4o",
+      name: "GPT-4o (Registry)",
+      provider: "openai",
+      family: "gpt-4.1",
+      context_window: 256_000,
+      max_output_tokens: 32_768,
+      capabilities: %w[function_calling structured_output],
+      pricing: {
+        text_tokens: {
+          standard: {
+            input_per_million: 9.99,
+            output_per_million: 19.99
+          }
+        }
+      }
+    )
   end
 end


### PR DESCRIPTION
## Summary

Integrates the `ruby-llm` registry as the primary source for `Models::SeedKnownModels` so pricing and capabilities reflect upstream model metadata at seed time, while preserving the hardcoded snapshot as a safety net. Resolves the TODO at `app/services/models/seed_known_models.rb:7` (follow-up to #139).

## Changes

- **Dependencies**: Added `ruby_llm` to the bundle.
- **Services**: `Models::SeedKnownModels` now queries the `ruby-llm` registry first and merges registry metadata over `KNOWN_MODELS` per `model_id`. Registry misses and failures fall back to the hardcoded snapshot, with a single structured warning log on registry-down. The TODO at line 7 is removed.
- **Reconciliation**: Pricing and capability drift is applied idempotently to existing `LlmModel` records. Non-nil `tier` values are preserved; missing tiers are still backfilled from the snapshot.
- **Specs**: Covers registry-hit, registry-miss, and registry-down paths for the seeder.

## Design Decisions

- **Registry-first with snapshot fallback**: Treats `ruby-llm` as authoritative for shared fields (pricing, capabilities) while keeping `KNOWN_MODELS` as the resilience layer. A registry outage degrades to the previous behavior rather than failing the seed.
- **Tier preservation**: Provider-specific tier fields are app-managed, not registry-managed, so existing non-nil values are left untouched to avoid clobbering operator configuration. Missing tiers fall back to snapshot values.
- **Single structured warning**: Registry failures emit one log line rather than per-model noise, keeping the fallback path observable without flooding logs.

---

Closes #2142