### PR TITLE
fix(agent-runs): preserve ContainerNotProvisioned error on first attempt

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -940,7 +940,23 @@ module Activities
     #
     # @return [Hash] The pre-agent SHA and whether output was present
     def run_agent_with_runner(agent_run, runner_candidate, prompt, user_settings)
-      container_service = reconnect_container(agent_run)
+      container_service = begin
+        reconnect_container(agent_run)
+      rescue Temporalio::Error::ApplicationError => e
+        # When a prior runner attempt has already recorded a failure on this
+        # run, a secondary ContainerNotProvisioned (e.g. because the earlier
+        # failure cleared container_id) would otherwise overwrite the real
+        # root cause at the top level. Wrap it as RunnerExecutionError so the
+        # per-runner rescue records the attempt and the loop surfaces
+        # AllRunnersExhausted, leaving the original failure visible in
+        # runners_attempted. On a first attempt with no prior history, let
+        # the precise ContainerNotProvisioned propagate so the user-visible
+        # error names the actual problem.
+        if e.type == "ContainerNotProvisioned" && agent_run.runners_attempted.present?
+          raise RunnerExecutionError, e.message
+        end
+        raise
+      end
 
       unless container_service.container_running?
         container_exit_info = container_exit_diagnostics(container_service)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2765,6 +2765,33 @@ expect(container_service).to receive(:execute).with(
           activity.execute(agent_run_id: run_no_container.id)
         }.to raise_error(Temporalio::Error::ApplicationError, /No container provisioned/)
       end
+
+      it "wraps ContainerNotProvisioned as RunnerExecutionError when a prior runner attempt is already recorded" do
+        other_issue = create(:issue, project: project)
+        prior_attempt = {
+          "runner" => "claude_code",
+          "success" => false,
+          "error_type" => "error",
+          "error_message" => "prior runner failure (real root cause)"
+        }
+        run_no_container = create(
+          :agent_run, :with_git_context,
+          project: project,
+          issue: other_issue,
+          container_id: nil,
+          runners_attempted: [ prior_attempt ]
+        )
+        allow(AgentRun).to receive(:find).with(run_no_container.id).and_return(run_no_container)
+
+        expect {
+          activity.execute(agent_run_id: run_no_container.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /All runners exhausted/)
+
+        # The prior failure remains the first entry so the real root cause is preserved
+        # even though the run now surfaces AllRunnersExhausted at the activity boundary.
+        expect(run_no_container.reload.runners_attempted.first)
+          .to include("error_message" => "prior runner failure (real root cause)")
+      end
     end
 
     it "raises an error when no prompt is available" do


### PR DESCRIPTION
## Summary

- Restores the `ContainerNotProvisioned` → `RunnerExecutionError` wrap in `run_agent_with_runner` (dropped during the providers→runners rename in #1950, originally added in #2077).
- Gates the wrap on `agent_run.runners_attempted.present?` so the precise `ContainerNotProvisioned` error still propagates when there's no prior runner attempt to preserve.

## Why

#2077 added the wrap to fix a real bug: when a prior runner attempt failed and cleared `container_id`, the next attempt's `reconnect_container` raised `ContainerNotProvisioned` and overwrote the original failure as the top-level Temporal activity error.

The unconditional wrap, however, regressed the first-attempt case: a fresh run with no container ever provisioned now surfaced `"All runners exhausted"` instead of the more specific `"No container provisioned"`, forcing operators to drill into `runners_attempted` to find the actual cause.

Then during the providers→runners rename refactor (#1950), the rescue block was dropped entirely while restructuring `run_agent_with_provider` into `run_agent_with_runner`, regressing the original #2077 fix on main.

This change restores the wrap and applies the gate in one go.

## Behavior

| Scenario | Before this PR | After this PR |
| --- | --- | --- |
| Fresh run, container_id nil, no prior attempts | `ContainerNotProvisioned` propagates (currently on main) | `ContainerNotProvisioned` propagates (unchanged) |
| Prior runner attempt recorded, container_id cleared | `ContainerNotProvisioned` propagates and masks the real cause | Wrapped as `RunnerExecutionError`; loop records attempt; surfaces `AllRunnersExhausted` with original failure visible in `runners_attempted` |

## Test plan

- [x] `bin/rspec spec/temporal/activities/run_agent_activity_spec.rb` — all 226 specs pass
- [x] Existing `"when no container is provisioned"` spec still asserts raw `ContainerNotProvisioned` propagation
- [x] New regression spec `"wraps ContainerNotProvisioned as RunnerExecutionError when a prior runner attempt is already recorded"` covers the wrap path

🤖 Generated with [Claude Code](https://claude.com/claude-code)