### PR TITLE
perf(scaling): switch QueueMonitor to client.count_workflows once the Ruby Temporal SDK exposes it

### DIFF
--- a/app/services/scaling/queue_monitor.rb
+++ b/app/services/scaling/queue_monitor.rb
@@ -176,11 +176,7 @@ module Scaling
       client = Paid.temporal_client
       sanitized_queue = task_queue.gsub("\\", "\\\\\\\\").gsub("'", "\\\\'")
       query = "TaskQueue = '#{sanitized_queue}' AND ExecutionStatus = 'Running'"
-      # TODO(#725): Switch to client.count_workflows(query) when the Ruby Temporal SDK
-      # exposes CountWorkflowExecutions. list_workflows is O(n) and will degrade at scale.
-      count = 0
-      client.list_workflows(query).each { |_wf| count += 1 }
-      count
+      client.count_workflows(query).count
     rescue => e
       Rails.logger.warn(
         message: "scaling.queue_monitor.temporal_count_failed",

--- a/spec/services/scaling/queue_monitor_spec.rb
+++ b/spec/services/scaling/queue_monitor_spec.rb
@@ -134,6 +134,65 @@ RSpec.describe Scaling::QueueMonitor do
       temporal_depths = result.queue_depths.select { |d| d.type == :temporal }
       expect(temporal_depths).to be_empty
     end
+
+    it "uses Temporal count_workflows to measure queue depth" do
+      temporal_client = instance_double(Temporalio::Client)
+      allow(Paid).to receive(:temporal_client).and_return(temporal_client)
+      allow(temporal_client).to receive(:count_workflows).and_return(
+        instance_double(Temporalio::Client::WorkflowExecutionCount, count: 3)
+      )
+
+      result = described_class.call
+
+      temporal_depths = result.queue_depths.select { |d| d.type == :temporal }
+      expect(temporal_depths.map(&:depth)).to eq([ 3, 3 ])
+      expect(temporal_client).to have_received(:count_workflows).with(
+        "TaskQueue = '#{Paid.poll_task_queue}' AND ExecutionStatus = 'Running'"
+      )
+      expect(temporal_client).to have_received(:count_workflows).with(
+        "TaskQueue = '#{Paid.agent_task_queue}' AND ExecutionStatus = 'Running'"
+      )
+    end
+
+    it "falls back to zero when Temporal count_workflows fails" do
+      temporal_client = instance_double(Temporalio::Client)
+      allow(Paid).to receive(:temporal_client).and_return(temporal_client)
+      allow(temporal_client).to receive(:count_workflows).and_raise(StandardError, "count failed")
+
+      result = described_class.call
+
+      temporal_depths = result.queue_depths.select { |d| d.type == :temporal }
+      expect(temporal_depths.map(&:depth)).to eq([ 0, 0 ])
+    end
+  end
+
+  describe "#fetch_temporal_queue_depth" do
+    subject(:fetch_temporal_queue_depth) { monitor.send(:fetch_temporal_queue_depth, task_queue) }
+
+    let(:monitor) { described_class.new }
+    let(:temporal_client) { instance_double(Temporalio::Client) }
+    let(:count_result) { instance_double(Temporalio::Client::WorkflowExecutionCount, count: 7) }
+
+    before do
+      allow(Paid).to receive(:temporal_client).and_return(temporal_client)
+    end
+
+    {
+      "plain-task-queue" => "TaskQueue = 'plain-task-queue' AND ExecutionStatus = 'Running'",
+      "queue'with quote" => "TaskQueue = 'queue\\'with quote' AND ExecutionStatus = 'Running'",
+      "queue\\with\\slashes" => "TaskQueue = 'queue\\\\with\\\\slashes' AND ExecutionStatus = 'Running'"
+    }.each do |task_queue_name, expected_query|
+      context "when task queue is #{task_queue_name.inspect}" do
+        let(:task_queue) { task_queue_name }
+
+        it "uses the same escaped query with Temporal count_workflows" do
+          allow(temporal_client).to receive(:count_workflows).with(expected_query).and_return(count_result)
+
+          expect(fetch_temporal_queue_depth).to eq(7)
+          expect(temporal_client).to have_received(:count_workflows).with(expected_query)
+        end
+      end
+    end
   end
 
   describe ".cached_for_account" do


### PR DESCRIPTION
## Summary

Updated `Scaling::QueueMonitor` to use `client.count_workflows(query).count` in [app/services/scaling/queue_monitor.rb](/workspace/app/services/scaling/queue_monitor.rb:175), which removes the O(n) workflow enumeration and drops the stale TODO. I also added coverage in [spec/services/scaling/queue_monitor_spec.rb](/workspace/spec/services/scaling/queue_monitor_spec.rb:137) for the success path, the count-error fallback to zero, and representative escaped query strings to preserve behavior parity.

Validation passed:
- `bundle exec rails db:prepare`
- `bundle exec rubocop`
- `bundle exec rspec`
- pre-commit hook reran staged lint and full `rspec` successfully

The suite still has the existing `7 pending` examples, but there were `0 failures`. Commit: `9a705bb` (`perf(scaling): use Temporal count_workflows in queue monitor`). Worktree is clean.

---

Closes #2145