### PR TITLE
feat(knowledge): implement AST-aware chunking for semantic code search (file-level fallback today)

### DIFF
--- a/app/services/knowledge/collectors/tree_sitter_collector.rb
+++ b/app/services/knowledge/collectors/tree_sitter_collector.rb
@@ -312,7 +312,7 @@ module Knowledge
             absolute_path: path,
             relative_path: relative,
             language: language,
-            content: File.read(path)
+            content: (File.size(path) <= 512_000) ? File.read(path) : nil
           }
         rescue Errno::ENOENT, Errno::EACCES
           nil

--- a/app/services/knowledge/collectors/tree_sitter_collector.rb
+++ b/app/services/knowledge/collectors/tree_sitter_collector.rb
@@ -9,7 +9,30 @@ module Knowledge
     class TreeSitterCollector < BaseCollector
       include Concerns::AstGrepRunner
 
+      IGNORED_PATH_SEGMENTS = %w[
+        .git
+        node_modules
+        vendor
+        tmp
+        log
+        storage
+        coverage
+      ].freeze
+
       LANGUAGE_CONFIG = {
+        javascript: {
+          extensions: %w[.js .jsx],
+          lang: "JavaScript",
+          patterns: {
+            class_extends: {
+              pattern: "class $NAME extends $PARENT { $$$BODY }", element: "class"
+            },
+            class_plain: { pattern: "class $NAME", element: "class" },
+            function_def: {
+              pattern: "function $NAME($$$PARAMS) { $$$BODY }", element: "function"
+            }
+          }
+        },
         ruby: {
           extensions: %w[.rb],
           lang: "Ruby",
@@ -62,16 +85,23 @@ module Knowledge
         }
       }.freeze
 
+      FILE_LEVEL_FALLBACKS = {
+        shell: %w[.sh],
+        sql: %w[.sql],
+        lua: %w[.lua]
+      }.freeze
+
       def collect
-        artifacts = []
-        LANGUAGE_CONFIG.each do |language, config|
-          artifacts.concat(collect_language(language, config))
-        end
-        deduplicate_by_content(artifacts).sort_by do |artifact|
+        ast_artifacts = collect_ast_artifacts
+        fallback_artifacts = collect_file_fallback_artifacts(
+          existing_paths: ast_artifacts.map { |artifact| artifact[:scope_path] }.to_set
+        )
+
+        deduplicate_by_content(ast_artifacts + fallback_artifacts).sort_by do |artifact|
           metadata = artifact[:metadata] || {}
           [
             artifact[:scope_path].to_s,
-            metadata[:line].to_i,
+            metadata[:start_line].to_i.nonzero? || metadata[:line].to_i,
             metadata[:element_type].to_s,
             metadata[:name].to_s,
             artifact[:identifier].to_s
@@ -88,6 +118,12 @@ module Knowledge
       end
 
       private
+
+      def collect_ast_artifacts
+        LANGUAGE_CONFIG.each_with_object([]) do |(language, config), artifacts|
+          artifacts.concat(collect_language(language, config))
+        end
+      end
 
       def collect_language(language, config)
         results = []
@@ -189,7 +225,9 @@ module Knowledge
           language: result[:language].to_s,
           element_type: result[:element_type],
           name: result[:name],
+          chunking_strategy: "ast",
           line: result[:line],
+          start_line: result[:line],
           end_line: result[:end_line],
           line_count: result[:line_count],
           naming_style: result[:naming_style]
@@ -207,11 +245,97 @@ module Knowledge
             {
               chunk_type: "definition",
               content: result[:text],
-              scope_tags: [ result[:language].to_s, result[:element_type] ],
+              scope_tags: [ result[:language].to_s, result[:element_type], "ast" ],
               sequence: 0
             }
           ]
         }
+      end
+
+      def collect_file_fallback_artifacts(existing_paths:)
+        repo_files.filter_map do |repo_file|
+          next if existing_paths.include?(repo_file[:relative_path])
+
+          language = fallback_language_for(repo_file[:relative_path])
+          next unless language
+
+          build_file_artifact(repo_file, language)
+        end
+      end
+
+      def build_file_artifact(repo_file, language)
+        line_count = repo_file[:content].lines.count
+
+        {
+          artifact_type: "structure",
+          scope_path: repo_file[:relative_path],
+          identifier: "#{repo_file[:relative_path]}::file",
+          content: repo_file[:content],
+          metadata: {
+            language: language.to_s,
+            element_type: "file",
+            name: File.basename(repo_file[:relative_path]),
+            chunking_strategy: "file_fallback",
+            line: 1,
+            start_line: 1,
+            end_line: line_count,
+            line_count: line_count,
+            naming_style: "other"
+          },
+          chunks: [
+            {
+              chunk_type: "definition",
+              content: repo_file[:content],
+              scope_tags: [ language.to_s, "file", "file_fallback" ],
+              sequence: 0
+            }
+          ]
+        }
+      end
+
+      def repo_files
+        root = host_repo_path || scan_path
+        return [] if root.blank?
+
+        Dir.glob(File.join(root, "**", "*")).filter_map do |path|
+          next unless File.file?(path)
+
+          relative = relative_path(path)
+          next if ignored_path?(relative)
+          next unless text_file?(path)
+
+          {
+            absolute_path: path,
+            relative_path: relative,
+            content: File.read(path)
+          }
+        rescue Errno::ENOENT, Errno::EACCES
+          nil
+        end
+      end
+
+      def ignored_path?(relative_path)
+        relative_path.split(File::SEPARATOR).any? { |segment| IGNORED_PATH_SEGMENTS.include?(segment) }
+      end
+
+      def text_file?(path)
+        !File.binread(path, 1024).include?("\x00")
+      rescue EOFError
+        true
+      end
+
+      def fallback_language_for(relative_path)
+        extension = File.extname(relative_path)
+
+        LANGUAGE_CONFIG.each do |language, config|
+          return language if config[:extensions].include?(extension)
+        end
+
+        FILE_LEVEL_FALLBACKS.each do |language, extensions|
+          return language if extensions.include?(extension)
+        end
+
+        nil
       end
 
       # Prevent content_hash collisions within a single collector run.

--- a/app/services/knowledge/collectors/tree_sitter_collector.rb
+++ b/app/services/knowledge/collectors/tree_sitter_collector.rb
@@ -300,8 +300,16 @@ module Knowledge
         root = host_repo_path || scan_path
         return [] if root.blank?
 
-        Dir.glob(File.join(root, "**", "*")).filter_map do |path|
-          next unless File.file?(path)
+        require "find"
+
+        root_basename = File.basename(root)
+        results = []
+        Find.find(root) do |path|
+          if File.directory?(path)
+            basename = File.basename(path)
+            Find.prune if basename != root_basename && IGNORED_PATH_SEGMENTS.include?(basename)
+            next
+          end
 
           relative = relative_path(path)
           next if ignored_path?(relative)
@@ -311,15 +319,17 @@ module Knowledge
           next unless text_file?(path)
           next if File.size(path) > MAX_FALLBACK_FILE_BYTES
 
-          {
+          results << {
             absolute_path: path,
             relative_path: relative,
             language: language,
             content: File.read(path)
           }
         rescue Errno::ENOENT, Errno::EACCES
-          nil
+          next
         end
+
+        results
       end
 
       def ignored_path?(relative_path)

--- a/app/services/knowledge/collectors/tree_sitter_collector.rb
+++ b/app/services/knowledge/collectors/tree_sitter_collector.rb
@@ -91,6 +91,8 @@ module Knowledge
         lua: %w[.lua]
       }.freeze
 
+      MAX_FALLBACK_FILE_BYTES = 512_000
+
       def collect
         ast_artifacts = collect_ast_artifacts
         fallback_artifacts = collect_file_fallback_artifacts(
@@ -307,12 +309,13 @@ module Knowledge
           language = fallback_language_for(relative)
           next unless language
           next unless text_file?(path)
+          next if File.size(path) > MAX_FALLBACK_FILE_BYTES
 
           {
             absolute_path: path,
             relative_path: relative,
             language: language,
-            content: (File.size(path) <= 512_000) ? File.read(path) : nil
+            content: File.read(path)
           }
         rescue Errno::ENOENT, Errno::EACCES
           nil

--- a/app/services/knowledge/collectors/tree_sitter_collector.rb
+++ b/app/services/knowledge/collectors/tree_sitter_collector.rb
@@ -255,11 +255,7 @@ module Knowledge
       def collect_file_fallback_artifacts(existing_paths:)
         repo_files.filter_map do |repo_file|
           next if existing_paths.include?(repo_file[:relative_path])
-
-          language = fallback_language_for(repo_file[:relative_path])
-          next unless language
-
-          build_file_artifact(repo_file, language)
+          build_file_artifact(repo_file, repo_file[:language])
         end
       end
 
@@ -302,11 +298,14 @@ module Knowledge
 
           relative = relative_path(path)
           next if ignored_path?(relative)
+          language = fallback_language_for(relative)
+          next unless language
           next unless text_file?(path)
 
           {
             absolute_path: path,
             relative_path: relative,
+            language: language,
             content: File.read(path)
           }
         rescue Errno::ENOENT, Errno::EACCES

--- a/app/services/knowledge/collectors/tree_sitter_collector.rb
+++ b/app/services/knowledge/collectors/tree_sitter_collector.rb
@@ -259,8 +259,7 @@ module Knowledge
       end
 
       def collect_file_fallback_artifacts(existing_paths:)
-        repo_files.filter_map do |repo_file|
-          next if existing_paths.include?(repo_file[:relative_path])
+        repo_files(exclude_paths: existing_paths).map do |repo_file|
           build_file_artifact(repo_file, repo_file[:language])
         end
       end
@@ -295,7 +294,7 @@ module Knowledge
         }
       end
 
-      def repo_files
+      def repo_files(exclude_paths: Set.new)
         root = host_repo_path || scan_path
         return [] if root.blank?
 
@@ -304,6 +303,7 @@ module Knowledge
 
           relative = relative_path(path)
           next if ignored_path?(relative)
+          next if exclude_paths.include?(relative)
           language = fallback_language_for(relative)
           next unless language
           next unless text_file?(path)

--- a/app/services/knowledge/collectors/tree_sitter_collector.rb
+++ b/app/services/knowledge/collectors/tree_sitter_collector.rb
@@ -147,8 +147,8 @@ module Knowledge
         return nil if name.nil? || name.empty?
 
         text = match["text"].to_s
-        line = match.dig("range", "start", "line")
-        end_line = match.dig("range", "end", "line")
+        line = one_indexed_line(match.dig("range", "start", "line"))
+        end_line = one_indexed_line(match.dig("range", "end", "line"))
 
         {
           file_path: file_path,
@@ -163,6 +163,12 @@ module Knowledge
           params: extract_params(match),
           naming_style: detect_naming_style(name)
         }
+      end
+
+      def one_indexed_line(line)
+        return nil if line.nil?
+
+        line.to_i + 1
       end
 
       def extract_meta_var(match, var_name)

--- a/app/services/knowledge/search/exact.rb
+++ b/app/services/knowledge/search/exact.rb
@@ -3,6 +3,8 @@
 module Knowledge
   class Search
     class Exact
+      include LineRangeHelpers
+
       attr_reader :project, :query, :artifact_type, :limit
 
       def initialize(project:, query:, artifact_type: nil, limit: 20)
@@ -88,14 +90,6 @@ module Knowledge
           commit_sha: version.commit_sha,
           committed_at: version.committed_at&.iso8601
         }
-      end
-
-      def start_line_for(artifact)
-        artifact.metadata["start_line"] || artifact.metadata["line"]
-      end
-
-      def end_line_for(artifact)
-        artifact.metadata["end_line"]
       end
     end
   end

--- a/app/services/knowledge/search/exact.rb
+++ b/app/services/knowledge/search/exact.rb
@@ -72,6 +72,8 @@ module Knowledge
           source: "exact",
           project_version: version_info(version),
           scope_tags: chunk.scope_tags || [],
+          start_line: start_line_for(artifact),
+          end_line: end_line_for(artifact),
           collector_run_id: artifact.collector_run_id,
           status: artifact.status,
           link_count: chunk.outgoing_links.size + chunk.incoming_links.size,
@@ -86,6 +88,14 @@ module Knowledge
           commit_sha: version.commit_sha,
           committed_at: version.committed_at&.iso8601
         }
+      end
+
+      def start_line_for(artifact)
+        artifact.metadata["start_line"] || artifact.metadata["line"]
+      end
+
+      def end_line_for(artifact)
+        artifact.metadata["end_line"]
       end
     end
   end

--- a/app/services/knowledge/search/line_range_helpers.rb
+++ b/app/services/knowledge/search/line_range_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Knowledge
+  class Search
+    module LineRangeHelpers
+      private
+
+      def start_line_for(artifact)
+        artifact.metadata["start_line"] || artifact.metadata["line"]
+      end
+
+      def end_line_for(artifact)
+        artifact.metadata["end_line"]
+      end
+    end
+  end
+end

--- a/app/services/knowledge/search/semantic.rb
+++ b/app/services/knowledge/search/semantic.rb
@@ -3,6 +3,8 @@
 module Knowledge
   class Search
     class Semantic
+      include LineRangeHelpers
+
       attr_reader :project, :query, :artifact_type, :limit
 
       def initialize(project:, query:, artifact_type: nil, limit: 20)
@@ -151,15 +153,6 @@ module Knowledge
           committed_at: version.committed_at&.iso8601
         }
       end
-
-      def start_line_for(artifact)
-        artifact.metadata["start_line"] || artifact.metadata["line"]
-      end
-
-      def end_line_for(artifact)
-        artifact.metadata["end_line"]
-      end
-
       def generate_query_embedding
         generator = Knowledge::Embeddings::ProxyGenerator.new(project: project, containerize: false)
         results = generator.call(texts: [ query ])

--- a/app/services/knowledge/search/semantic.rb
+++ b/app/services/knowledge/search/semantic.rb
@@ -134,6 +134,8 @@ module Knowledge
           source: "semantic",
           project_version: version_info(version),
           scope_tags: chunk.scope_tags || [],
+          start_line: start_line_for(artifact),
+          end_line: end_line_for(artifact),
           collector_run_id: artifact.collector_run_id,
           status: artifact.status,
           link_count: chunk.outgoing_links.size + chunk.incoming_links.size,
@@ -148,6 +150,14 @@ module Knowledge
           commit_sha: version.commit_sha,
           committed_at: version.committed_at&.iso8601
         }
+      end
+
+      def start_line_for(artifact)
+        artifact.metadata["start_line"] || artifact.metadata["line"]
+      end
+
+      def end_line_for(artifact)
+        artifact.metadata["end_line"]
       end
 
       def generate_query_embedding

--- a/app/services/knowledge/search/semantic.rb
+++ b/app/services/knowledge/search/semantic.rb
@@ -153,6 +153,7 @@ module Knowledge
           committed_at: version.committed_at&.iso8601
         }
       end
+
       def generate_query_embedding
         generator = Knowledge::Embeddings::ProxyGenerator.new(project: project, containerize: false)
         results = generator.call(texts: [ query ])

--- a/app/views/knowledge/search/_results.html.erb
+++ b/app/views/knowledge/search/_results.html.erb
@@ -39,7 +39,9 @@
             <% end %>
             <% if result[:scope_path].present? %>
               <div class="mt-2 text-xs text-gray-400">
-                <code><%= result[:scope_path] %></code>
+                <code>
+                  <%= result[:scope_path] %><% if result[:start_line].present? %>:<%= result[:start_line] %><% if result[:end_line].present? && result[:end_line] != result[:start_line] %>-<%= result[:end_line] %><% end %><% end %>
+                </code>
               </div>
             <% end %>
           </div>

--- a/docs/rdrs/RDR-018-semantic-code-search.md
+++ b/docs/rdrs/RDR-018-semantic-code-search.md
@@ -423,13 +423,17 @@ module SemanticSearch
     end
 
     # Splits a source file into semantic chunks (function/class/module level).
-    # Falls back to file-level chunking when AST parsing is unavailable.
+    # Live implementation note: chunking now happens in
+    # Knowledge::Collectors::TreeSitterCollector, not
+    # app/services/knowledge/embeddings/generate.rb.
+    # It emits AST definition artifacts for supported languages and
+    # file-level fallback artifacts for unsupported files or when AST
+    # parsing is unavailable.
     def chunk_file(file_path)
       content = File.read(file_path)
       language = detect_language(file_path)
 
-      # TODO(#66): Implement AST-aware chunking via tree-sitter for
-      # function/class-level granularity. For now, chunk at file level.
+      # Historical pseudo-code only. See the collector for the live behavior.
       [{
         path: file_path, id: file_path, type: "file",
         content: content, language: language,

--- a/spec/fixtures/knowledge/sample.lua
+++ b/spec/fixtures/knowledge/sample.lua
@@ -1,0 +1,5 @@
+local Greeter = {}
+
+function Greeter.hello(name)
+  return "hello " .. name
+end

--- a/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
+++ b/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
@@ -121,6 +121,14 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
             expect(m[:metadata][:line_count]).to be >= 1
           end
         end
+
+        it "preserves line ranges for deep-linking" do
+          greet = ruby_artifacts.find { |a| a[:metadata][:name] == "greet" }
+
+          expect(greet[:metadata][:start_line]).to eq(8)
+          expect(greet[:metadata][:end_line]).to eq(10)
+          expect(greet[:metadata][:chunking_strategy]).to eq("ast")
+        end
       end
 
       context "with TypeScript files" do
@@ -215,6 +223,29 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
         end
       end
 
+      context "with unsupported source files" do
+        let(:fallback_artifact) { artifacts.find { |a| a[:scope_path] == "sample.lua" } }
+
+        it "falls back to file-level chunking" do
+          expect(fallback_artifact).to include(
+            artifact_type: "structure",
+            identifier: "sample.lua::file"
+          )
+          expect(fallback_artifact[:metadata]).to include(
+            language: "lua",
+            element_type: "file",
+            chunking_strategy: "file_fallback",
+            start_line: 1
+          )
+          expect(fallback_artifact[:chunks]).to contain_exactly(
+            hash_including(
+              chunk_type: "definition",
+              scope_tags: [ "lua", "file", "file_fallback" ]
+            )
+          )
+        end
+      end
+
       it "deduplicates overlapping patterns" do
         # When both "class $NAME" and "class $NAME < $PARENT" match,
         # only the more specific one should be kept
@@ -230,8 +261,14 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
         )
       end
 
-      it "returns an empty array" do
-        expect(collector.collect).to eq([])
+      it "returns file-level fallback artifacts" do
+        expect(collector.collect).to include(
+          hash_including(
+            scope_path: "sample.rb",
+            identifier: "sample.rb::file",
+            metadata: hash_including(chunking_strategy: "file_fallback")
+          )
+        )
       end
     end
 
@@ -240,8 +277,14 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
         allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
       end
 
-      it "returns an empty array" do
-        expect(collector.collect).to eq([])
+      it "returns file-level fallback artifacts" do
+        expect(collector.collect).to include(
+          hash_including(
+            scope_path: "sample.ts",
+            identifier: "sample.ts::file",
+            metadata: hash_including(chunking_strategy: "file_fallback")
+          )
+        )
       end
     end
   end

--- a/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
+++ b/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
         it "preserves line ranges for deep-linking" do
           greet = ruby_artifacts.find { |a| a[:metadata][:name] == "greet" }
 
-          expect(greet[:metadata][:start_line]).to eq(8)
-          expect(greet[:metadata][:end_line]).to eq(10)
+          expect(greet[:metadata][:start_line]).to eq(9)
+          expect(greet[:metadata][:end_line]).to eq(11)
           expect(greet[:metadata][:chunking_strategy]).to eq("ast")
         end
       end

--- a/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
+++ b/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
@@ -329,6 +329,19 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
           hash_including(relative_path: "sample.lua", language: :lua)
         )
       end
+
+      it "skips oversized supported source files instead of building nil-content artifacts" do
+        rb_path = File.join(fixture_path, "sample.rb")
+
+        allow(Dir).to receive(:glob).and_return([ rb_path ])
+        allow(File).to receive(:file?).with(rb_path).and_return(true)
+        allow(File).to receive(:size).with(rb_path)
+          .and_return(described_class::MAX_FALLBACK_FILE_BYTES + 1)
+        allow(File).to receive(:read).with(rb_path).and_call_original
+
+        expect(collector.collect).to eq([])
+        expect(File).not_to have_received(:read).with(rb_path)
+      end
     end
   end
 end

--- a/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
+++ b/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
@@ -286,6 +286,26 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
           )
         )
       end
+
+      it "skips reading files whose extensions cannot produce fallback artifacts" do
+        txt_path = File.join(fixture_path, "notes.txt")
+        rb_path = File.join(fixture_path, "sample.rb")
+
+        allow(Dir).to receive(:glob).and_return([ txt_path, rb_path ])
+        allow(File).to receive(:file?).with(txt_path).and_return(true)
+        allow(File).to receive(:file?).with(rb_path).and_return(true)
+        allow(File).to receive(:binread).with(rb_path, 1024).and_call_original
+        allow(File).to receive(:read).with(rb_path).and_call_original
+        allow(File).to receive(:binread).with(txt_path, 1024).and_call_original
+        allow(File).to receive(:read).with(txt_path).and_call_original
+
+        collector.collect
+
+        expect(File).not_to have_received(:binread).with(txt_path, 1024)
+        expect(File).not_to have_received(:read).with(txt_path)
+        expect(File).to have_received(:binread).with(rb_path, 1024)
+        expect(File).to have_received(:read).with(rb_path)
+      end
     end
   end
 end

--- a/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
+++ b/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
@@ -291,9 +291,9 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
         txt_path = File.join(fixture_path, "notes.txt")
         rb_path = File.join(fixture_path, "sample.rb")
 
-        allow(Dir).to receive(:glob).and_return([ txt_path, rb_path ])
-        allow(File).to receive(:file?).with(txt_path).and_return(true)
-        allow(File).to receive(:file?).with(rb_path).and_return(true)
+        allow(Find).to receive(:find).with(fixture_path).and_yield(txt_path).and_yield(rb_path)
+        allow(File).to receive(:directory?).with(txt_path).and_return(false)
+        allow(File).to receive(:directory?).with(rb_path).and_return(false)
         allow(File).to receive(:binread).with(rb_path, 1024).and_call_original
         allow(File).to receive(:read).with(rb_path).and_call_original
         allow(File).to receive(:binread).with(txt_path, 1024).and_call_original
@@ -311,9 +311,9 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
         rb_path = File.join(fixture_path, "sample.rb")
         lua_path = File.join(fixture_path, "sample.lua")
 
-        allow(Dir).to receive(:glob).and_return([ rb_path, lua_path ])
-        allow(File).to receive(:file?).with(rb_path).and_return(true)
-        allow(File).to receive(:file?).with(lua_path).and_return(true)
+        allow(Find).to receive(:find).with(fixture_path).and_yield(rb_path).and_yield(lua_path)
+        allow(File).to receive(:directory?).with(rb_path).and_return(false)
+        allow(File).to receive(:directory?).with(lua_path).and_return(false)
         allow(File).to receive(:binread).with(lua_path, 1024).and_call_original
         allow(File).to receive(:read).with(lua_path).and_call_original
         allow(File).to receive(:binread).with(rb_path, 1024).and_call_original
@@ -333,14 +333,38 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
       it "skips oversized supported source files instead of building nil-content artifacts" do
         rb_path = File.join(fixture_path, "sample.rb")
 
-        allow(Dir).to receive(:glob).and_return([ rb_path ])
-        allow(File).to receive(:file?).with(rb_path).and_return(true)
+        allow(Find).to receive(:find).with(fixture_path).and_yield(rb_path)
+        allow(File).to receive(:directory?).with(rb_path).and_return(false)
         allow(File).to receive(:size).with(rb_path)
           .and_return(described_class::MAX_FALLBACK_FILE_BYTES + 1)
         allow(File).to receive(:read).with(rb_path).and_call_original
 
         expect(collector.collect).to eq([])
         expect(File).not_to have_received(:read).with(rb_path)
+      end
+
+      it "prunes ignored directories before visiting their files" do
+        ignored_dir = File.join(fixture_path, "node_modules")
+        ignored_file = File.join(ignored_dir, "ignored.js")
+        root_basename = File.basename(fixture_path)
+
+        allow(Find).to receive(:find).with(fixture_path)
+          .and_yield(fixture_path)
+          .and_yield(ignored_dir)
+          .and_yield(ignored_file)
+        allow(File).to receive(:directory?).with(fixture_path).and_return(true)
+        allow(File).to receive(:directory?).with(ignored_dir).and_return(true)
+        allow(File).to receive(:directory?).with(ignored_file).and_return(false)
+        allow(File).to receive(:basename).and_call_original
+        allow(File).to receive(:basename).with(fixture_path).and_return(root_basename)
+        allow(File).to receive(:basename).with(ignored_dir).and_return("node_modules")
+        allow(Find).to receive(:prune)
+        allow(File).to receive(:binread).with(ignored_file, 1024).and_call_original
+
+        collector.send(:repo_files)
+
+        expect(Find).to have_received(:prune)
+        expect(File).not_to have_received(:binread).with(ignored_file, 1024)
       end
     end
   end

--- a/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
+++ b/spec/services/knowledge/collectors/tree_sitter_collector_spec.rb
@@ -306,6 +306,29 @@ RSpec.describe Knowledge::Collectors::TreeSitterCollector, :no_db do
         expect(File).to have_received(:binread).with(rb_path, 1024)
         expect(File).to have_received(:read).with(rb_path)
       end
+
+      it "skips reading files already covered by AST artifacts" do
+        rb_path = File.join(fixture_path, "sample.rb")
+        lua_path = File.join(fixture_path, "sample.lua")
+
+        allow(Dir).to receive(:glob).and_return([ rb_path, lua_path ])
+        allow(File).to receive(:file?).with(rb_path).and_return(true)
+        allow(File).to receive(:file?).with(lua_path).and_return(true)
+        allow(File).to receive(:binread).with(lua_path, 1024).and_call_original
+        allow(File).to receive(:read).with(lua_path).and_call_original
+        allow(File).to receive(:binread).with(rb_path, 1024).and_call_original
+        allow(File).to receive(:read).with(rb_path).and_call_original
+
+        repo_files = collector.send(:repo_files, exclude_paths: Set["sample.rb"])
+
+        expect(File).not_to have_received(:binread).with(rb_path, 1024)
+        expect(File).not_to have_received(:read).with(rb_path)
+        expect(File).to have_received(:binread).with(lua_path, 1024)
+        expect(File).to have_received(:read).with(lua_path)
+        expect(repo_files).to contain_exactly(
+          hash_including(relative_path: "sample.lua", language: :lua)
+        )
+      end
     end
   end
 end

--- a/spec/services/knowledge/search/exact_spec.rb
+++ b/spec/services/knowledge/search/exact_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Knowledge::Search::Exact do
       artifact_type: "route",
       identifier: "POST /api/users",
       content: "POST /api/users → api/users#create",
-      scope_path: "config/routes.rb")
+      scope_path: "config/routes.rb",
+      metadata: { line: 4, start_line: 4, end_line: 9 })
   end
 
   let!(:route_chunk) do
@@ -77,6 +78,7 @@ RSpec.describe Knowledge::Search::Exact do
       results = described_class.call(project: project, query: "POST /api/users")
 
       expect(results.first).to have_key(:scope_tags)
+      expect(results.first).to include(start_line: 4, end_line: 9)
     end
 
     it "includes internal scoring fields" do

--- a/spec/services/knowledge/search/semantic_spec.rb
+++ b/spec/services/knowledge/search/semantic_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Knowledge::Search::Semantic do
       artifact_type: "route",
       identifier: "GET /api/users",
       content: "GET /api/users → api/users#index",
-      scope_path: "config/routes.rb")
+      scope_path: "config/routes.rb",
+      metadata: { line: 12, start_line: 12, end_line: 18 })
   end
 
   before do
@@ -48,6 +49,7 @@ RSpec.describe Knowledge::Search::Semantic do
         results = described_class.call(project: project, query: "lists all users")
 
         expect(results.first).to have_key(:scope_tags)
+        expect(results.first).to include(start_line: 12, end_line: 18)
         expect(results.first).to have_key(:link_count)
         expect(results.first).to have_key(:created_at)
       end


### PR DESCRIPTION
## Summary

Implemented on the live path in [`app/services/knowledge/collectors/tree_sitter_collector.rb`](/workspace/app/services/knowledge/collectors/tree_sitter_collector.rb): supported files now emit AST definition artifacts with preserved `start_line`/`end_line`, JavaScript support was added alongside the existing Ruby/TS coverage, and unsupported or parser-unavailable source files fall back to one file-level artifact. Search results now carry those line ranges through [`app/services/knowledge/search/semantic.rb`](/workspace/app/services/knowledge/search/semantic.rb), [`app/services/knowledge/search/exact.rb`](/workspace/app/services/knowledge/search/exact.rb), and the search UI in [`app/views/knowledge/search/_results.html.erb`](/workspace/app/views/knowledge/search/_results.html.erb). I also reconciled the stale RDR pseudo-code in [`docs/rdrs/RDR-018-semantic-code-search.md`](/workspace/docs/rdrs/RDR-018-semantic-code-search.md) so it points at the collector-based implementation instead of the embedding transport.

Verification is complete: `bundle exec rubocop` passed, and `bundle exec rspec` passed with `13611 examples, 0 failures, 7 pending` (the same existing pending specs around Qdrant availability and the runner/provider migration rewrite). The branch is clean and committed as `cd8f2a9` with message `feat(knowledge): add AST-aware code chunk fallbacks`.

---

Closes #2147