### PR TITLE
feat(integrations): consume llm_provider IntegrationCredential records from agent runtime and provider test flows

### DIFF
--- a/app/controllers/api/secrets_proxy_controller.rb
+++ b/app/controllers/api/secrets_proxy_controller.rb
@@ -182,7 +182,12 @@ module Api
         return nil
       end
 
-      runner_entry.provider_api_key.api_key
+      api_key = runner_entry.effective_api_secret
+      return api_key if api_key.present?
+
+      log_error("secrets_proxy.missing_runner_credential", "No active runner credential configured for #{provider}")
+      render json: { error: "API key not configured for #{provider}" }, status: :service_unavailable
+      nil
     end
 
     def agent_run_runner_entry(provider)
@@ -192,11 +197,12 @@ module Api
       runner_entries = @agent_run.project.effective_owner
         &.runners
         &.api_key
-        &.joins(:provider_api_key)
       return unless runner_entries
 
-      available_runner_entries(runner_entries)
-        .find_by(id: provider_id, provider_api_keys: { api_service_type: provider.to_s })
+      entry = available_runner_entries(runner_entries).find_by(id: provider_id)
+      return if entry.blank? || !entry.proxy_route_compatible?(provider)
+
+      entry
     end
 
     def knowledge_run_api_key(provider)

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -801,7 +801,8 @@ class Runner < ApplicationRecord
     return unless subscription?
     return if provider_api_key_id.blank? && integration_credential_id.blank?
 
-    errors.add(:provider_api_key, "must not be set for subscription authentication")
+    credential_error_attribute = provider_api_key_id.present? ? :provider_api_key : :integration_credential
+    errors.add(credential_error_attribute, "must not be set for subscription authentication")
   end
 
   def api_key_must_be_compatible

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -93,6 +93,7 @@ class Runner < ApplicationRecord
 
   belongs_to :user
   belongs_to :provider_api_key, optional: true
+  belongs_to :integration_credential, optional: true
 
   has_many :chat_sessions, dependent: :nullify
 
@@ -134,6 +135,7 @@ class Runner < ApplicationRecord
   validate :subscription_auth_must_not_have_api_key
   validate :api_key_must_be_compatible
   validate :api_key_must_belong_to_same_account
+  validate :integration_credential_must_be_active
   validate :subscription_must_have_standard_fallback_role
   validate :api_key_entry_must_be_unique
   validate :opencode_api_key_config_must_be_valid
@@ -157,6 +159,21 @@ class Runner < ApplicationRecord
 
   def rate_limit_fallback?
     fallback_role == "rate_limit_fallback"
+  end
+
+  def effective_api_secret
+    return provider_api_key&.api_key.to_s.presence if provider_api_key.present?
+    return unless active_integration_credential?
+
+    integration_credential.secret.to_s.presence
+  end
+
+  def active_integration_credential?
+    integration_credential&.category == "llm_provider" && integration_credential&.active?
+  end
+
+  def proxy_route_compatible?(provider)
+    required_api_service_type == provider.to_s
   end
 
   def display_name
@@ -366,7 +383,7 @@ class Runner < ApplicationRecord
   end
 
   def kilocode_runtime_env
-    api_key = provider_api_key&.api_key.to_s
+    api_key = effective_api_secret.to_s
     return {} if api_key.blank?
 
     { kilocode_api_key_env_var => api_key }
@@ -775,42 +792,57 @@ class Runner < ApplicationRecord
 
   def api_key_auth_requires_provider_api_key
     return unless api_key?
-    return if provider_api_key.present?
+    return if provider_api_key.present? || integration_credential.present?
 
     errors.add(:provider_api_key, "is required for API key authentication")
   end
 
   def subscription_auth_must_not_have_api_key
     return unless subscription?
-    return if provider_api_key_id.blank?
+    return if provider_api_key_id.blank? && integration_credential_id.blank?
 
     errors.add(:provider_api_key, "must not be set for subscription authentication")
   end
 
   def api_key_must_be_compatible
     return unless api_key?
-    return if provider_api_key_id.blank?
-    return unless provider_api_key
+    return if provider_api_key_id.blank? && integration_credential_id.blank?
 
     required_service = required_api_service_type
 
     if required_service.nil?
-      errors.add(:provider_api_key, "is not supported for this runner; use subscription authentication instead")
+      credential_error_attribute = provider_api_key.present? ? :provider_api_key : :integration_credential
+      errors.add(credential_error_attribute, "is not supported for this runner; use subscription authentication instead")
       return
     end
 
-    return if provider_api_key.api_service_type == required_service
+    if provider_api_key.present?
+      return if provider_api_key.api_service_type == required_service
 
-    errors.add(:provider_api_key, "must be an API key for #{RunnerSupport.api_service_type_label(required_service)}")
+      errors.add(:provider_api_key, "must be an API key for #{RunnerSupport.api_service_type_label(required_service)}")
+      return
+    end
+
+    return if integration_credential.present? &&
+      integration_credential.category == "llm_provider" &&
+      integration_credential.service_key == runner_key
+
+    errors.add(:integration_credential, "must match this runner")
   end
 
   def api_key_must_belong_to_same_account
     return unless api_key?
-    return if provider_api_key_id.blank?
-    return unless provider_api_key
-    return if provider_api_key.user&.account_id == user&.account_id
+    if provider_api_key.present?
+      return if provider_api_key.user&.account_id == user&.account_id
 
-    errors.add(:provider_api_key, "must belong to the same account")
+      errors.add(:provider_api_key, "must belong to the same account")
+      return
+    end
+
+    return unless integration_credential.present?
+    return if integration_credential.account_id == user&.account_id
+
+    errors.add(:integration_credential, "must belong to the same account")
   end
 
   def subscription_must_have_standard_fallback_role
@@ -827,11 +859,20 @@ class Runner < ApplicationRecord
     normalized_name = name.to_s
     duplicate = user.runners.kept_only.api_key.where(
       runner_key: runner_key,
-      provider_api_key_id: provider_api_key_id
+      provider_api_key_id: provider_api_key_id,
+      integration_credential_id: integration_credential_id
     ).where.not(id: id).where("COALESCE(name, '') = ?", normalized_name).exists?
     return unless duplicate
 
     errors.add(:runner_key, "already has an entry with this API key")
+  end
+
+  def integration_credential_must_be_active
+    return unless api_key?
+    return unless integration_credential.present?
+    return if integration_credential.active?
+
+    errors.add(:integration_credential, "must be active")
   end
 
   def opencode_api_key_config_must_be_valid
@@ -995,6 +1036,7 @@ class Runner < ApplicationRecord
 
     self.class.api_service_type_for(runner_key)
   end
+  public :required_api_service_type
 
   def opencode_direct_outbound?
     runner_key == "opencode" &&
@@ -1031,7 +1073,7 @@ class Runner < ApplicationRecord
     api_config = DIRECT_OUTBOUND_API_PROVIDERS.fetch(opencode_api_provider, DIRECT_OUTBOUND_API_PROVIDERS["openrouter"])
 
     env_var = direct_outbound_api_key_env_var(opencode_api_provider)
-    env = { env_var => provider_api_key&.api_key.to_s }
+    env = { env_var => effective_api_secret.to_s }
 
     # Providers using @ai-sdk/anthropic receive their base URL through the
     # provider config (OPENAI_BASE_URL is only read by the OpenAI-compatible SDK).
@@ -1061,7 +1103,7 @@ class Runner < ApplicationRecord
       metadata: {
         "paid_pi_auth_entry" => {
           "provider" => pi_api_provider,
-          "api_key" => provider_api_key&.api_key.to_s
+          "api_key" => effective_api_secret.to_s
         }
       }
     )

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -48,10 +48,10 @@ module AgentRuns
       configured_provider = configured_runner_from_raw_settings(settings)
       base_provider = runnable_runner(selected_provider) || runnable_runner(configured_provider)
       fallback_provider = Provider.first_enabled_for_owner(owner) || Provider.ensure_default_for(owner)
-      tenant_api_key_runner(base_provider, owner) ||
+      account_managed_runner(base_provider, owner) ||
         base_provider ||
-        tenant_api_key_runner(configured_provider, owner) ||
-        tenant_api_key_runner(fallback_provider, owner) ||
+        account_managed_runner(configured_provider, owner) ||
+        account_managed_runner(fallback_provider, owner) ||
         fallback_provider
     end
 
@@ -77,22 +77,20 @@ module AgentRuns
       provider
     end
 
-    def tenant_api_key_runner(base_provider, owner)
+    def account_managed_runner(base_provider, owner)
       return unless base_provider
       return unless runner_runnable?(base_provider)
 
-      service_type = tenant_api_key_service_type_for(base_provider)
-      return unless service_type
+      credential = resolve_account_credential(base_provider)
+      return unless credential.present?
+      return if credential.provider_api_key? && !credential.provider_api_key.compatible_with?(base_provider.provider_key)
 
-      api_key = project.account.tenant_setting&.provider_api_key_for(service_type)
-      return unless api_key
-      return unless api_key.compatible_with?(base_provider.provider_key)
-
-      provider_config = tenant_api_key_provider_config(base_provider, api_key)
+      provider_config = account_managed_provider_config(base_provider, credential)
       owner.providers.kept_only.find_or_create_by!(
         provider_key: base_provider.provider_key,
         auth_type: "api_key",
-        provider_api_key: api_key
+        provider_api_key: credential.provider_api_key,
+        integration_credential: credential.integration_credential
       ) do |provider|
         provider.config = provider_config
       end.tap do |provider|
@@ -103,11 +101,12 @@ module AgentRuns
       owner.providers.kept_only.find_by(
         provider_key: base_provider.provider_key,
         auth_type: "api_key",
-        provider_api_key: api_key
+        provider_api_key: credential&.provider_api_key,
+        integration_credential: credential&.integration_credential
       )
     end
 
-    def tenant_api_key_service_type_for(base_provider)
+    def account_credential_service_type_for(base_provider)
       static = ProviderSupport.api_service_type_for(base_provider.provider_key)
       return static if static.present?
       return base_provider.pi_required_api_service_type if base_provider.provider_key == "pi"
@@ -115,12 +114,12 @@ module AgentRuns
       nil
     end
 
-    def tenant_api_key_provider_config(base_provider, api_key)
+    def account_managed_provider_config(base_provider, credential)
       return {} unless base_provider.provider_key == "pi"
 
       config = {
         "pi" => {
-          "api_provider" => api_key.api_service_type
+          "api_provider" => credential.provider_api_key&.api_service_type || account_credential_service_type_for(base_provider)
         }
       }
 

--- a/app/services/agent_runs/runner_resolver.rb
+++ b/app/services/agent_runs/runner_resolver.rb
@@ -68,10 +68,10 @@ module AgentRuns
       configured_runner = configured_runner_from_raw_settings(settings)
       base_runner = runnable_runner(selected_runner) || runnable_runner(configured_runner)
       fallback_runner = Runner.first_enabled_for_owner(owner) || Runner.ensure_default_for(owner)
-      tenant_api_key_runner(base_runner, owner) ||
+      account_managed_runner(base_runner, owner) ||
         base_runner ||
-        tenant_api_key_runner(configured_runner, owner) ||
-        tenant_api_key_runner(fallback_runner, owner) ||
+        account_managed_runner(configured_runner, owner) ||
+        account_managed_runner(fallback_runner, owner) ||
         fallback_runner
     end
 
@@ -97,36 +97,44 @@ module AgentRuns
       runner
     end
 
-    def tenant_api_key_runner(base_runner, owner)
+    def account_managed_runner(base_runner, owner)
       return unless base_runner
       return unless runner_runnable?(base_runner)
 
-      service_type = tenant_api_key_service_type_for(base_runner)
-      return unless service_type
-
-      api_key = project.account.tenant_setting&.provider_api_key_for(service_type)
-      return unless api_key
-      return unless api_key.compatible_with?(base_runner.runner_key)
+      credential = resolve_account_credential(base_runner)
+      return unless credential.present?
+      return if credential.provider_api_key? && !credential.provider_api_key.compatible_with?(base_runner.runner_key)
 
       owner.runners.kept_only.find_or_create_by!(
         runner_key: base_runner.runner_key,
         auth_type: "api_key",
-        provider_api_key: api_key
+        provider_api_key: credential.provider_api_key,
+        integration_credential: credential.integration_credential
       ) do |runner|
-        runner.config = tenant_api_key_runner_config(base_runner, api_key)
+        runner.config = account_managed_runner_config(base_runner, credential)
       end.tap do |runner|
-        config = tenant_api_key_runner_config(base_runner, api_key)
+        config = account_managed_runner_config(base_runner, credential)
         runner.update!(config: config) if config != runner.config
       end
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
       owner.runners.kept_only.find_by(
         runner_key: base_runner.runner_key,
         auth_type: "api_key",
-        provider_api_key: api_key
+        provider_api_key: credential&.provider_api_key,
+        integration_credential: credential&.integration_credential
       )
     end
 
-    def tenant_api_key_service_type_for(base_runner)
+    def resolve_account_credential(base_runner)
+      LlmCredentials::AccountResolver.call(
+        account: project.account,
+        runner_key: base_runner.runner_key,
+        api_service_type: account_credential_service_type_for(base_runner),
+        tenant_setting: project.account.tenant_setting
+      )
+    end
+
+    def account_credential_service_type_for(base_runner)
       return base_runner.aider_required_api_service_type if base_runner.runner_key == "aider"
       return base_runner.pi_required_api_service_type if base_runner.runner_key == "pi"
 
@@ -136,19 +144,21 @@ module AgentRuns
       nil
     end
 
-    def tenant_api_key_runner_config(base_runner, api_key)
+    def account_managed_runner_config(base_runner, credential)
+      api_service_type = credential.provider_api_key&.api_service_type || account_credential_service_type_for(base_runner)
+
       case base_runner.runner_key
       when "aider"
         {
           "aider" => {
-            "api_provider" => api_key.api_service_type,
+            "api_provider" => api_service_type,
             "model" => base_runner.aider_model_id
           }.compact
         }
       when "pi"
         config = {
           "pi" => {
-            "api_provider" => api_key.api_service_type
+            "api_provider" => api_service_type
           }
         }
 

--- a/app/services/integrations/credential_catalog.rb
+++ b/app/services/integrations/credential_catalog.rb
@@ -13,7 +13,7 @@ module Integrations
       },
       llm_provider: {
         label: "LLM Providers",
-        description: "API keys and OAuth tokens stored in Paid for provider integrations and future runtime wiring."
+        description: "API keys and OAuth tokens stored in Paid for provider integrations and account-level runtime fallback."
       },
       signing: {
         label: "Signing",
@@ -79,7 +79,7 @@ module Integrations
             label: ::Runner.display_name(runner_key),
             description: "Stored #{::Runner.display_name(runner_key)} " \
               "credentials for API-key or OAuth-based access. " \
-              "Runtime use will be wired in a follow-up.",
+              "Active records can back account-level runtime execution.",
             category: :llm_provider,
             auth_kinds: %w[api_key oauth_token]
           }

--- a/app/services/llm_credentials/account_resolver.rb
+++ b/app/services/llm_credentials/account_resolver.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module LlmCredentials
+  class AccountResolver
+    Result = Data.define(:provider_api_key, :integration_credential) do
+      def present?
+        provider_api_key.present? || integration_credential.present?
+      end
+
+      def provider_api_key?
+        provider_api_key.present?
+      end
+
+      def integration_credential?
+        integration_credential.present?
+      end
+
+      def api_secret
+        provider_api_key&.api_key.to_s.presence || integration_credential&.secret.to_s.presence
+      end
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, runner_key:, api_service_type: nil, tenant_setting: nil)
+      @account = account
+      @runner_key = runner_key
+      @api_service_type = api_service_type
+      @tenant_setting = tenant_setting
+    end
+
+    def call
+      provider_api_key = resolve_provider_api_key
+      return Result.new(provider_api_key:, integration_credential: nil) if provider_api_key.present?
+
+      Result.new(provider_api_key: nil, integration_credential: resolve_integration_credential)
+    end
+
+    private
+
+    attr_reader :account, :runner_key, :api_service_type, :tenant_setting
+
+    def resolve_provider_api_key
+      return if api_service_type.blank?
+
+      tenant_setting&.provider_api_key_for(api_service_type)
+    end
+
+    def resolve_integration_credential
+      return if account.blank? || runner_key.blank?
+
+      account.integration_credentials.active
+        .for_category(:llm_provider)
+        .for_service(runner_key)
+        .order(created_at: :desc, id: :desc)
+        .first
+    end
+  end
+end

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -187,13 +187,13 @@ module Providers
     private
 
     def validate!
-      unless ProviderSupport.supported_provider_key?(provider.provider_key)
-        raise UnsupportedProviderError, "Unknown provider: #{provider.provider_key}"
+      unless ProviderSupport.supported_provider_key?(effective_provider.provider_key)
+        raise UnsupportedProviderError, "Unknown provider: #{effective_provider.provider_key}"
       end
 
-      unless ProviderSupport.container_executable_provider_key?(provider.provider_key)
+      unless ProviderSupport.container_executable_provider_key?(effective_provider.provider_key)
         raise NotContainerExecutableError,
-          "Provider #{provider.provider_key} is not installed in the agent container"
+          "Provider #{effective_provider.provider_key} is not installed in the agent container"
       end
 
       return if harness_health_check_supported? && !@diagnostic_prompt
@@ -375,18 +375,18 @@ module Providers
       return kilocode_provider_runtime if kilocode_direct_outbound?
       return subscription_provider_runtime if subscription_provider_runtime?
 
-      provider.agent_harness_provider_runtime
+      effective_provider.agent_harness_provider_runtime
     end
 
     def subscription_provider_runtime?
-      provider.subscription? &&
-        ProviderSupport.subscription_auth_unset_vars_for(provider.provider_key).any?
+      effective_provider.subscription? &&
+        ProviderSupport.subscription_auth_unset_vars_for(effective_provider.provider_key).any?
     end
 
     def subscription_provider_runtime
-      unset_vars = ProviderSupport.subscription_auth_unset_vars_for(provider.provider_key)
+      unset_vars = ProviderSupport.subscription_auth_unset_vars_for(effective_provider.provider_key)
 
-      if provider.provider_key == "copilot"
+      if effective_provider.provider_key == "copilot"
         unset_vars.delete("COPILOT_GITHUB_TOKEN")
       end
 
@@ -400,11 +400,11 @@ module Providers
     # key from environment variables. This runtime passes the API key through
     # the env var referenced by the generated config.
     def kilocode_provider_runtime
-      AgentHarness::ProviderRuntime.new(env: provider.kilocode_runtime_env)
+      AgentHarness::ProviderRuntime.new(env: effective_provider.kilocode_runtime_env)
     end
 
     def kilocode_direct_outbound?
-      provider.provider_key == "kilocode" && provider.requires_direct_outbound?
+      effective_provider.provider_key == "kilocode" && effective_provider.requires_direct_outbound?
     end
 
     # Writes the kilocode config file into the container before the smoke test.
@@ -414,7 +414,7 @@ module Providers
     # provision.rb ensure block), which removes the config before the
     # subsequent smoke test runs.
     def prepare_kilocode_config!(run)
-      config_json = provider.kilocode_config_json
+      config_json = effective_provider.kilocode_config_json
       run.execute_in_container(
         [ "sh", "-c",
           "mkdir -p /home/agent/.config/kilo && " \
@@ -434,10 +434,10 @@ module Providers
         result = AgentRun.insert_all!(
           [ {
             project_id: test_project.id,
-            initiating_user_id: provider.user_id,
-            provider_id: provider.id,
-            runner_id: provider.id,
-            agent_type: Provider.agent_type_for(provider.provider_key),
+            initiating_user_id: effective_provider.user_id,
+            provider_id: effective_provider.id,
+            runner_id: effective_provider.id,
+            agent_type: Provider.agent_type_for(effective_provider.provider_key),
             status: "queued",
             temporal_workflow_id: AgentRun::CLAIMED_SENTINEL,
             goal: "create_pr",
@@ -455,18 +455,18 @@ module Providers
     end
 
     def test_project
-      @test_project ||= provider.user.created_projects.active.order(:id).first ||
-        provider.user.member_projects.active.order(:id).first
+      @test_project ||= effective_provider.user.created_projects.active.order(:id).first ||
+        effective_provider.user.member_projects.active.order(:id).first
     end
 
     def harness_health_check_supported?
-      return false if provider.subscription?
-      api_key_name = ProviderSupport.proxy_health_check_api_key_for(provider.provider_key)
+      return false if effective_provider.subscription?
+      api_key_name = ProviderSupport.proxy_health_check_api_key_for(effective_provider.provider_key)
       !!(api_key_name && proxy_api_key_configured?(api_key_name))
     end
 
     def harness_provider_name
-      ProviderSupport.harness_provider_key_for(provider.provider_key).to_sym
+      ProviderSupport.harness_provider_key_for(effective_provider.provider_key).to_sym
     end
 
     def proxy_api_key_configured?(provider_name)
@@ -484,7 +484,7 @@ module Providers
 
     def clear_provider_state_if_healthy!
       provider_state_names.each do |provider_name|
-        provider.user.provider_states.find_by(provider_name: provider_name)&.record_success!
+        effective_provider.user.provider_states.find_by(provider_name: provider_name)&.record_success!
       end
     end
 
@@ -492,21 +492,68 @@ module Providers
       reset_at = rate_limit_reset_at(message)
 
       provider_state_names.each do |provider_name|
-        provider.user.provider_states.find_or_create_by!(provider_name: provider_name).mark_rate_limited!(reset_at: reset_at)
+        effective_provider.user.provider_states.find_or_create_by!(provider_name: provider_name).mark_rate_limited!(reset_at: reset_at)
       end
     rescue ActiveRecord::RecordNotUnique
       provider_state_names.each do |provider_name|
-        provider.user.provider_states.find_by!(provider_name: provider_name).mark_rate_limited!(reset_at: reset_at)
+        effective_provider.user.provider_states.find_by!(provider_name: provider_name).mark_rate_limited!(reset_at: reset_at)
       end
     end
 
     def provider_state_names
-      names = [ provider.state_key ]
-      if provider.subscription? || provider.state_key == provider.provider_key
-        names << provider.provider_key
+      names = [ effective_provider.state_key ]
+      if effective_provider.subscription? || effective_provider.state_key == effective_provider.provider_key
+        names << effective_provider.provider_key
       end
 
       names.uniq
+    end
+
+    def effective_provider
+      @effective_provider ||= materialize_account_provider || provider
+    end
+
+    def materialize_account_provider
+      return if provider.api_key?
+
+      credential = LlmCredentials::AccountResolver.call(
+        account: provider.user.account,
+        runner_key: provider.provider_key,
+        api_service_type: provider.required_api_service_type,
+        tenant_setting: provider.user.account.tenant_setting
+      )
+      return unless credential.present?
+
+      provider.user.providers.kept_only.find_or_create_by!(
+        provider_key: provider.provider_key,
+        auth_type: "api_key",
+        provider_api_key: credential.provider_api_key,
+        integration_credential: credential.integration_credential
+      ) do |record|
+        record.config = account_managed_provider_config(credential)
+        record.enabled_for_agent_runs = provider.enabled_for_agent_runs
+        record.enabled_for_fallback = provider.enabled_for_fallback
+        record.fallback_role = provider.fallback_role
+      end.tap do |record|
+        config = account_managed_provider_config(credential)
+        record.update!(config: config) if config != record.config
+      end
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+      provider.user.providers.kept_only.find_by(
+        provider_key: provider.provider_key,
+        auth_type: "api_key",
+        provider_api_key: credential&.provider_api_key,
+        integration_credential: credential&.integration_credential
+      )
+    end
+
+    def account_managed_provider_config(credential)
+      return provider.config unless provider.provider_key == "pi"
+
+      provider.config.deep_dup.tap do |config|
+        config["pi"] ||= {}
+        config["pi"]["api_provider"] = credential.provider_api_key&.api_service_type || provider.required_api_service_type
+      end
     end
 
     def rate_limit_reset_at(message)

--- a/app/views/integration_credentials/index.html.erb
+++ b/app/views/integration_credentials/index.html.erb
@@ -21,7 +21,7 @@
   <% if provider_credentials_view %>
     <div class="mt-6 rounded-md border border-amber-200 bg-amber-50 p-4">
       <p class="text-sm text-amber-800">
-        Provider credentials saved here are account-managed records only for now. Agent runtime and provider test flows do not consume them yet.
+        Provider credentials saved here are account-managed records. Paid uses active records as an account-level fallback when no user-scoped provider API key is selected.
       </p>
     </div>
   <% end %>

--- a/db/migrate/20260520150012_add_integration_credential_to_runners.rb
+++ b/db/migrate/20260520150012_add_integration_credential_to_runners.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIntegrationCredentialToRunners < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :runners, :integration_credential, null: true, index: { algorithm: :concurrently }
+    add_foreign_key :runners, :integration_credentials, on_delete: :restrict, validate: false
+    validate_foreign_key :runners, :integration_credentials
+  end
+end

--- a/db/migrate/20260520150804_update_runner_credential_constraints.rb
+++ b/db/migrate/20260520150804_update_runner_credential_constraints.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UpdateRunnerCredentialConstraints < ActiveRecord::Migration[8.1]
+  def change
+    remove_check_constraint :runners, name: "runners_api_key_requires_key"
+    remove_check_constraint :runners, name: "runners_subscription_invariants"
+
+    add_check_constraint :runners,
+      "auth_type::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL OR integration_credential_id IS NOT NULL OR discarded_at IS NOT NULL",
+      name: "runners_api_key_requires_key",
+      validate: false
+    add_check_constraint :runners,
+      "auth_type::text <> 'subscription'::text OR (provider_api_key_id IS NULL AND integration_credential_id IS NULL AND fallback_role::text = 'standard'::text)",
+      name: "runners_subscription_invariants",
+      validate: false
+  end
+end

--- a/db/migrate/20260520150840_validate_runner_credential_constraints.rb
+++ b/db/migrate/20260520150840_validate_runner_credential_constraints.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ValidateRunnerCredentialConstraints < ActiveRecord::Migration[8.1]
+  def change
+    validate_check_constraint :runners, name: "runners_api_key_requires_key"
+    validate_check_constraint :runners, name: "runners_subscription_invariants"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_135640) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_20_150840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1876,6 +1876,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_135640) do
     t.boolean "enabled_for_agent_runs", default: true, null: false
     t.boolean "enabled_for_fallback", default: true, null: false
     t.string "fallback_role", limit: 30, default: "standard", null: false
+    t.bigint "integration_credential_id"
     t.jsonb "log_data"
     t.string "name", limit: 100, default: "", null: false
     t.bigint "provider_api_key_id"
@@ -1887,6 +1888,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_135640) do
     t.integer "weight", default: 1, null: false
     t.index ["auth_type"], name: "index_runners_on_auth_type"
     t.index ["discarded_at"], name: "index_runners_on_discarded_at"
+    t.index ["integration_credential_id"], name: "index_runners_on_integration_credential_id"
     t.index ["provider_api_key_id"], name: "index_runners_on_provider_api_key_id"
     t.index ["tier_model_ids"], name: "index_runners_on_tier_model_ids", using: :gin
     t.index ["user_id", "provider_key", "provider_api_key_id", "name"], name: "idx_providers_unique_api_key", unique: true, where: "(((auth_type)::text = 'api_key'::text) AND (discarded_at IS NULL))"
@@ -1894,8 +1896,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_135640) do
     t.index ["user_id", "runner_key", "provider_api_key_id", "name"], name: "idx_runners_unique_api_key", unique: true, where: "(((auth_type)::text = 'api_key'::text) AND (discarded_at IS NULL))"
     t.index ["user_id", "runner_key"], name: "idx_runners_unique_subscription", unique: true, where: "(((auth_type)::text = 'subscription'::text) AND (discarded_at IS NULL))"
     t.index ["user_id"], name: "index_runners_on_user_id"
-    t.check_constraint "auth_type::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL OR discarded_at IS NOT NULL", name: "runners_api_key_requires_key"
-    t.check_constraint "auth_type::text <> 'subscription'::text OR provider_api_key_id IS NULL AND fallback_role::text = 'standard'::text", name: "runners_subscription_invariants"
+    t.check_constraint "auth_type::text <> 'api_key'::text OR provider_api_key_id IS NOT NULL OR integration_credential_id IS NOT NULL OR discarded_at IS NOT NULL", name: "runners_api_key_requires_key"
+    t.check_constraint "auth_type::text <> 'subscription'::text OR provider_api_key_id IS NULL AND integration_credential_id IS NULL AND fallback_role::text = 'standard'::text", name: "runners_subscription_invariants"
     t.check_constraint "weight >= 1", name: "runners_weight_positive"
   end
 
@@ -2491,6 +2493,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_135640) do
   add_foreign_key "quality_thresholds", "accounts"
   add_foreign_key "quality_thresholds", "projects"
   add_foreign_key "runner_states", "users", on_delete: :cascade
+  add_foreign_key "runners", "integration_credentials", on_delete: :restrict
   add_foreign_key "runners", "provider_api_keys", on_delete: :restrict
   add_foreign_key "runners", "users", on_delete: :cascade
   add_foreign_key "scaling_experiment_assignments", "issues", on_delete: :nullify

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -254,6 +254,15 @@ RSpec.describe Provider do
       expect(provider.errors[:provider_api_key]).to include("must not be set for subscription authentication")
     end
 
+    it "rejects integration_credential for subscription auth type" do
+      credential = create(:integration_credential, account: provider.user.account, created_by: provider.user, category: "llm_provider")
+      provider.auth_type = "subscription"
+      provider.integration_credential = credential
+
+      expect(provider).not_to be_valid
+      expect(provider.errors[:integration_credential]).to include("must not be set for subscription authentication")
+    end
+
     it "prevents duplicate subscription entries for the same user and provider_key" do
       user = create(:user)
       create(:provider, user: user, provider_key: "cursor", auth_type: "subscription")

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Provider do
   describe "associations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:provider_api_key).optional }
+    it { is_expected.to belong_to(:integration_credential).optional }
   end
 
   describe "validations" do

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -308,6 +308,15 @@ RSpec.describe Runner do
       expect(runner.errors[:provider_api_key]).to include("must not be set for subscription authentication")
     end
 
+    it "rejects integration_credential for subscription auth type" do
+      credential = create(:integration_credential, account: runner.user.account, created_by: runner.user, category: "llm_provider")
+      runner.auth_type = "subscription"
+      runner.integration_credential = credential
+
+      expect(runner).not_to be_valid
+      expect(runner.errors[:integration_credential]).to include("must not be set for subscription authentication")
+    end
+
     it "prevents duplicate subscription entries for the same user and runner_key" do
       user = create(:user)
       create(:runner, user: user, runner_key: "cursor", auth_type: "subscription")

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Runner do
   describe "associations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:provider_api_key).optional }
+    it { is_expected.to belong_to(:integration_credential).optional }
   end
 
   describe "validations" do

--- a/spec/requests/api/secrets_proxy_spec.rb
+++ b/spec/requests/api/secrets_proxy_spec.rb
@@ -108,6 +108,28 @@ RSpec.describe "Api::SecretsProxy" do
           .with(headers: { "x-api-key" => "sk-stored-anthropic-key" })
       end
 
+      it "uses the run owner's active integration credential when a runner id header is present" do
+        credential = create(
+          :integration_credential,
+          account: project.account,
+          created_by: project.effective_owner,
+          service_key: "claude",
+          secret: "sk-account-anthropic-key"
+        )
+        runner = create(:runner, :api_key, user: project.effective_owner, runner_key: "claude",
+          provider_api_key: nil, integration_credential: credential)
+
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: valid_headers.merge(
+            "X-Paid-Provider-Id" => runner.id.to_s,
+            "x-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+          )
+
+        expect(WebMock).to have_requested(:post, target_url)
+          .with(headers: { "x-api-key" => "sk-account-anthropic-key" })
+      end
+
       it "uses a fallback-only runner API key when a runner id header is present" do
         runner = create_anthropic_api_key_provider(
           :rate_limit_fallback,
@@ -157,6 +179,23 @@ RSpec.describe "Api::SecretsProxy" do
           )
 
         expect(response).to have_http_status(:forbidden)
+        expect(WebMock).not_to have_requested(:post, target_url)
+      end
+
+      it "rejects revoked integration credentials" do
+        credential = create(:integration_credential, account: project.account, created_by: project.effective_owner, service_key: "claude")
+        runner = create(:runner, :api_key, user: project.effective_owner, runner_key: "claude",
+          provider_api_key: nil, integration_credential: credential)
+        credential.revoke!
+
+        post "/api/proxy/anthropic/v1/messages",
+          params: { model: "claude-3-5-sonnet-20241022" }.to_json,
+          headers: valid_headers.merge(
+            "X-Paid-Provider-Id" => runner.id.to_s,
+            "x-api-key" => "paid-run:#{agent_run.id}:#{agent_run.proxy_token}"
+          )
+
+        expect(response).to have_http_status(:service_unavailable)
         expect(WebMock).not_to have_requested(:post, target_url)
       end
 

--- a/spec/services/agent_runs/runner_resolver_spec.rb
+++ b/spec/services/agent_runs/runner_resolver_spec.rb
@@ -182,6 +182,70 @@ RSpec.describe AgentRuns::RunnerResolver do
       )
     end
 
+    it "falls back to an account integration credential when no tenant API key is selected" do
+      account = create(:account)
+      owner = create(:user, :owner, account: account)
+      project = create(:project, account: account, created_by: owner)
+      credential = create(:integration_credential, account: account, created_by: owner, service_key: "claude")
+
+      runner_id, agent_type = described_class.call(project: project, goal: "create_pr")
+      runner = Runner.find(runner_id)
+
+      expect(agent_type).to eq("claude_code")
+      expect(runner).to have_attributes(
+        user: owner,
+        runner_key: "claude",
+        auth_type: "api_key",
+        provider_api_key: nil,
+        integration_credential: credential
+      )
+    end
+
+    it "prefers the tenant-selected ProviderApiKey over an account integration credential" do
+      account = create(:account)
+      owner = create(:user, :owner, account: account)
+      project = create(:project, account: account, created_by: owner)
+      api_key = create(:provider_api_key, user: owner, api_service_type: "anthropic")
+      create(:integration_credential, account: account, created_by: owner, service_key: "claude")
+      create(:tenant_setting, account: account,
+        runner_preferences: { "api_key_ids" => { "anthropic" => api_key.id } })
+
+      runner_id, = described_class.call(project: project, goal: "create_pr")
+      runner = Runner.find(runner_id)
+
+      expect(runner.provider_api_key).to eq(api_key)
+      expect(runner.integration_credential).to be_nil
+    end
+
+    it "ignores revoked and expired integration credentials" do
+      account = create(:account)
+      owner = create(:user, :owner, account: account)
+      project = create(:project, account: account, created_by: owner)
+      create(:integration_credential, :revoked, account: account, created_by: owner, service_key: "claude")
+      create(:integration_credential, :expired, account: account, created_by: owner, service_key: "claude")
+
+      runner_id, agent_type = described_class.call(project: project, goal: "create_pr")
+      runner = Runner.find(runner_id)
+
+      expect(agent_type).to eq("claude_code")
+      expect(runner.auth_type).to eq("subscription")
+      expect(runner.integration_credential).to be_nil
+    end
+
+    it "does not use integration credentials from another account" do
+      project = create(:project)
+      other_account = create(:account)
+      other_owner = create(:user, :owner, account: other_account)
+      create(:integration_credential, account: other_account, created_by: other_owner, service_key: "claude")
+
+      runner_id, agent_type = described_class.call(project: project, goal: "create_pr")
+      runner = Runner.find(runner_id)
+
+      expect(agent_type).to eq("claude_code")
+      expect(runner.auth_type).to eq("subscription")
+      expect(runner.integration_credential).to be_nil
+    end
+
     it "falls back to a nil runner id with the first runnable agent type when no owner runners are available" do
       allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[codex])
 

--- a/spec/services/providers/test_agent_spec.rb
+++ b/spec/services/providers/test_agent_spec.rb
@@ -257,6 +257,35 @@ RSpec.describe Providers::TestAgent do
       end
     end
 
+    context "when an account integration credential exists for the provider" do
+      let(:credential) do
+        create(:integration_credential, account: account, created_by: user, service_key: "claude", secret: "sk-account-claude")
+      end
+      let(:provider_record) do
+        user.providers.find_or_create_by!(provider_key: "claude").tap do |record|
+          record.update!(enabled_for_agent_runs: true, enabled_for_fallback: false)
+        end
+      end
+
+      before do
+        credential
+        allow(ProviderSupport).to receive_messages(supported_provider_key?: true,
+          container_executable_provider_key?: true, harness_provider_key_for: "claude")
+        stub_container_smoke_test(
+          name: :claude, status: "ok", message: "Smoke test passed", latency_ms: 42, error_category: nil, check: :smoke_test
+        )
+      end
+
+      it "materializes an API-key provider backed by the integration credential" do
+        result = described_class.call(provider: provider)
+        materialized = user.providers.find_by!(provider_key: "claude", auth_type: "api_key")
+
+        expect(result).to be_success
+        expect(materialized.integration_credential).to eq(credential)
+        expect(materialized.provider_api_key).to be_nil
+      end
+    end
+
     context "when agent-harness returns a binary-encoded failure message" do
       let(:api_key_record) { create(:provider_api_key, user: user, api_service_type: "openai") }
       let(:provider_record) { create(:provider, :api_key, user: user, provider_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: api_key_record) }


### PR DESCRIPTION
## Summary

Implemented additive precedence: user-scoped `ProviderApiKey` still wins, and active account-scoped `IntegrationCredential` (`category: "llm_provider"`) is now the fallback for runtime and provider test flows.

The change is committed as `d8fe337` with message `feat(integrations): consume llm provider integration credentials`.

Verification:
- `bundle exec rubocop` passed
- `PAID_SKIP_DATABASE_RUNTIME_ROLE_GUARD=true bundle exec rspec` passed with `13618 examples, 0 failures, 7 pending`

One environment note: `bin/rails db:prepare` did not succeed in this shell because the development DB task path was trying to connect via a local Postgres socket despite `DATABASE_URL` being present. I migrated the test DB successfully and ran the full suite there, so the code and tests are green, but `db:prepare` itself remains blocked by that environment-specific connection behavior.

---

Closes #2151