### PR TITLE
refactor(feature-flags): remove :focused_runs flag once focused agent runs are the default

### DIFF
--- a/app/services/feature_flags.rb
+++ b/app/services/feature_flags.rb
@@ -14,13 +14,6 @@ class FeatureFlags
       intent: "Stage the PR automation decision refactor for the #1077 bug class behind an explicit gate.",
       rollout_plan: "Enable per project/repo during validation, monitor the new decision path, then promote to the default rollout.",
       cleanup_criteria: "Remove after the explicit-decision path is the only implementation and the legacy branch is deleted."
-    ),
-    focused_agent_runs: Definition.new(
-      name: :focused_agent_runs,
-      owner: "agent-runs",
-      intent: "Stage focused agent runs so PR follow-ups can target a single highest-priority problem instead of a blended prompt.",
-      rollout_plan: "Enable per project during validation of focus resolution and prompt plumbing, then expand once follow-up prompt scoping lands.",
-      cleanup_criteria: "Remove after focused agent runs are the default behavior and the general-only fallback path is deleted."
     )
   }.freeze
 
@@ -101,10 +94,6 @@ class FeatureFlags
 
     def explicit_pr_automation_decisions?(project: nil)
       enabled?(:explicit_pr_automation_decisions, project:)
-    end
-
-    def focused_agent_runs?(project: nil)
-      enabled?(:focused_agent_runs, project:)
     end
 
     def flipper

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -924,9 +924,7 @@ module Activities
       FOCUS_PRIORITY.find { |focus| candidate_focuses.include?(focus) } || "general"
     end
 
-    def focus_for(project, triggers)
-      return "general" unless FeatureFlags.focused_agent_runs?(project:)
-
+    def focus_for(_project, triggers)
       resolve_focus(triggers)
     end
 

--- a/spec/services/feature_flags_spec.rb
+++ b/spec/services/feature_flags_spec.rb
@@ -17,13 +17,6 @@ RSpec.describe FeatureFlags do
       expect(definition.intent).to include("#1077")
     end
 
-    it "returns metadata for focused agent runs" do
-      definition = described_class.definition(:focused_agent_runs)
-
-      expect(definition.owner).to eq("agent-runs")
-      expect(definition.intent).to include("focused agent runs")
-    end
-
     it "raises for unknown flags" do
       expect {
         described_class.definition(:missing_flag)
@@ -65,16 +58,6 @@ RSpec.describe FeatureFlags do
       described_class.enable!(:explicit_pr_automation_decisions, project:)
 
       expect(described_class.enabled?(:explicit_pr_automation_decisions, project:)).to be(true)
-    end
-  end
-
-  describe ".focused_agent_runs?" do
-    it "returns the focused-agent-runs state for a project" do
-      expect(described_class.focused_agent_runs?(project:)).to be(false)
-
-      described_class.enable!(:focused_agent_runs, project:)
-
-      expect(described_class.focused_agent_runs?(project:)).to be(true)
     end
   end
 
@@ -148,8 +131,7 @@ RSpec.describe FeatureFlags do
       described_class.enable!(:explicit_pr_automation_decisions, project:)
 
       expect(described_class.snapshot(project:)).to eq(
-        explicit_pr_automation_decisions: true,
-        focused_agent_runs: false
+        explicit_pr_automation_decisions: true
       )
     end
   end

--- a/spec/temporal/activities/load_feature_flags_activity_spec.rb
+++ b/spec/temporal/activities/load_feature_flags_activity_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe Activities::LoadFeatureFlagsActivity do
 
       expect(activity.execute(project_id: project.id)).to eq(
         flags: {
-          explicit_pr_automation_decisions: true,
-          focused_agent_runs: false
+          explicit_pr_automation_decisions: true
         },
         project_missing: false
       )

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(result[:automation_results]).to contain_exactly(
           {
             decisions: [
-              { type: "queue_create_pr_run", issue_id: pr_issue.id, source_pull_request_number: 42, focus: "general" },
+              { type: "queue_create_pr_run", issue_id: pr_issue.id, source_pull_request_number: 42, focus: "ci_fix" },
               { type: "record_pr_followup", issue_id: pr_issue.id, labels_to_remove: [], expected_followup_count: 0 }
             ]
           }
@@ -554,15 +554,17 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         expect(result[:prs_to_trigger].first[:labels_to_remove]).to eq([])
       end
-
-      it "defaults focus to general when focused agent runs are disabled" do
-        result = activity.execute(project_id: project.id)
-
-        expect(result[:prs_to_trigger].first[:focus]).to eq("general")
-      end
     end
 
-    context "when focused agent runs are enabled" do
+    it "resolves review feedback focus for review triggers" do
+      expect(activity.send(:resolve_focus, [ { type: "review_threads" } ])).to eq("review_feedback")
+    end
+
+    it "resolves general focus when no trigger maps to a specific focus" do
+      expect(activity.send(:resolve_focus, [ { type: "owner_approved" } ])).to eq("general")
+    end
+
+    context "when focused follow-up triggers are present" do
       let(:pr_issue) do
         create(:issue, :pull_request,
           project: project,
@@ -572,7 +574,6 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
 
       before do
-        FeatureFlags.enable!(:focused_agent_runs, project:)
         project.update!(pr_action_labels: [ "needs-docs" ], auto_fix_merge_conflicts: true)
         pr_issue
         allow(github_client).to receive_messages(
@@ -596,14 +597,6 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         result = activity.execute(project_id: project.id)
 
         expect(result[:prs_to_trigger].first[:focus]).to eq("merge_conflict")
-      end
-
-      it "resolves review feedback focus for review triggers" do
-        expect(activity.send(:resolve_focus, [ { type: "review_threads" } ])).to eq("review_feedback")
-      end
-
-      it "resolves general focus when no trigger maps to a specific focus" do
-        expect(activity.send(:resolve_focus, [ { type: "owner_approved" } ])).to eq("general")
       end
     end
 


### PR DESCRIPTION
## Summary

Removed the focused-runs rollout gate and committed it as `eaeb20e` (`refactor(feature-flags): remove focused agent runs flag`).

Focused runs are now unconditional in the scanner path: the only production fallback to `"general"` was [app/temporal/activities/scan_paid_prs_activity.rb](/workspace/app/temporal/activities/scan_paid_prs_activity.rb:927), and that gate is gone. I also removed the `:focused_agent_runs` definition/API from [app/services/feature_flags.rb](/workspace/app/services/feature_flags.rb:6) and updated the affected specs in [spec/services/feature_flags_spec.rb](/workspace/spec/services/feature_flags_spec.rb:10), [spec/temporal/activities/load_feature_flags_activity_spec.rb](/workspace/spec/temporal/activities/load_feature_flags_activity_spec.rb:18), and [spec/temporal/activities/scan_paid_prs_activity_spec.rb](/workspace/spec/temporal/activities/scan_paid_prs_activity_spec.rb:196) to reflect focused behavior as the default.

Verification passed:
`bundle exec rubocop`
`bundle exec rspec`
`git commit` hook lint/tests

The full suite still reports the repo’s existing 7 pending examples, but there were 0 failures. Working tree is clean.

---

Closes #2149