### PR TITLE
fix: Auto-pick allowlist filter is case-sensitive in SQL but case-insensitive in model helper

### DIFF
--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -187,7 +187,10 @@ module Automation
               .where.not(id: Issue.open_pull_request_parent_issue_ids(project: project).distinct)
 
             trusted_usernames = Array(project.allowed_github_usernames).presence
-            base = base.where(github_creator_login: trusted_usernames) if trusted_usernames
+            if trusted_usernames
+              downcased = trusted_usernames.map(&:downcase)
+              base = base.where("LOWER(issues.github_creator_login) IN (?)", downcased)
+            end
 
             project.effective_auto_pick_skip_labels.reduce(base) do |scope, label|
               scope.where.not("labels @> ?::jsonb", [ label ].to_json)

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -190,6 +190,24 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
       expect(described_class.eligible_scope(project).pluck(:labels)).to include([ "planning" ])
     end
+
+    it "matches allowlist entries case-insensitively against github_creator_login" do
+      project.update!(allowed_github_usernames: [ "Viamin" ])
+      issue = create(:issue, project: project, github_creator_login: "viamin")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(issue.id)
+    end
+
+    it "excludes issues whose creator is not in the allowlist regardless of case" do
+      project.update!(allowed_github_usernames: [ "Viamin" ])
+      create(:issue, project: project, github_creator_login: "otheruser")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to be_empty
+    end
   end
 
   describe ".eligible_issue_ids" do


### PR DESCRIPTION
## Summary

Fixes a case-sensitivity mismatch in the auto-pick trusted-creator allowlist that caused legitimate candidate issues to be silently dropped. `Project#trusted_github_user?` compares case-insensitively, but `DefaultCandidateSource`'s SQL filter compiled to `WHERE github_creator_login IN (...)`, which Postgres evaluates case-sensitively — so an allowlist entry differing only in case (e.g. `"Viamin"` vs `"viamin"`) produced zero candidates with no log line.

## Changes

- **Services**: `app/services/automation/strategies/auto_pick/default_candidate_source.rb` — replaced the case-sensitive `where(github_creator_login: trusted_usernames)` with `where("LOWER(issues.github_creator_login) IN (?)", trusted_usernames.map(&:downcase))` so the SQL filter matches the model helper's behavior.
- **Tests**: `spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb` — added two regression specs covering the mixed-case allowlist scenario (`"Viamin"` matching `"viamin"`) and confirming non-matching creators are still excluded.

## Design Decisions

- **Picked the SQL-side fix over normalizing on write.** Normalizing `allowed_github_usernames` on write and `github_creator_login` on sync would require a data backfill and changes to the sync path; making the SQL filter case-insensitive is a localized fix that aligns with the existing `Project#trusted_github_user?` semantics already shipping in production.
- **No functional index added.** The allowlist filter runs against an already narrowed candidate set in auto-pick, not a hot OLTP path. If profiling later shows this is a hotspot, a `LOWER(github_creator_login)` functional index can be added without further code changes.

---

Closes #2177