### PR TITLE
refactor(temporal): remove #872 rate-limit-budget patch guard once pre-v872 workflows have continued-as-new

### DIFF
--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -187,17 +187,20 @@ module Workflows
     # sufficient budget remains. Issue detection (FetchIssues + DetectLabels)
     # is prioritized as core work; PR scanning, security alerts, and knowledge
     # staleness checks are skipped when budget is low.
+    # TODO(#872): Remove patch guard after all pre-v872 workflows have continued-as-new
     def maybe_run_non_critical_activities(project_id)
-      rate_limit = run_activity(Activities::CheckRateLimitActivity,
-        { project_id: project_id }, timeout: 10)
+      if Temporalio::Workflow.patched("add-rate-limit-budget-v1")
+        rate_limit = run_activity(Activities::CheckRateLimitActivity,
+          { project_id: project_id }, timeout: 10)
 
-      if rate_limit[:rate_limit_low]
-        Temporalio::Workflow.logger.info(
-          message: "poll.non_critical_skipped_budget_low",
-          project_id: project_id,
-          rate_limit_remaining: rate_limit[:rate_limit_remaining]
-        )
-        return nil
+        if rate_limit[:rate_limit_low]
+          Temporalio::Workflow.logger.info(
+            message: "poll.non_critical_skipped_budget_low",
+            project_id: project_id,
+            rate_limit_remaining: rate_limit[:rate_limit_remaining]
+          )
+          return nil
+        end
       end
 
       scan_result = maybe_scan_paid_prs(project_id)

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -187,20 +187,17 @@ module Workflows
     # sufficient budget remains. Issue detection (FetchIssues + DetectLabels)
     # is prioritized as core work; PR scanning, security alerts, and knowledge
     # staleness checks are skipped when budget is low.
-    # TODO(#872): Remove patch guard after all pre-v872 workflows have continued-as-new
     def maybe_run_non_critical_activities(project_id)
-      if Temporalio::Workflow.patched("add-rate-limit-budget-v1")
-        rate_limit = run_activity(Activities::CheckRateLimitActivity,
-          { project_id: project_id }, timeout: 10)
+      rate_limit = run_activity(Activities::CheckRateLimitActivity,
+        { project_id: project_id }, timeout: 10)
 
-        if rate_limit[:rate_limit_low]
-          Temporalio::Workflow.logger.info(
-            message: "poll.non_critical_skipped_budget_low",
-            project_id: project_id,
-            rate_limit_remaining: rate_limit[:rate_limit_remaining]
-          )
-          return nil
-        end
+      if rate_limit[:rate_limit_low]
+        Temporalio::Workflow.logger.info(
+          message: "poll.non_critical_skipped_budget_low",
+          project_id: project_id,
+          rate_limit_remaining: rate_limit[:rate_limit_remaining]
+        )
+        return nil
       end
 
       scan_result = maybe_scan_paid_prs(project_id)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -165,8 +165,11 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     let(:workflow) { described_class.new }
 
     before do
-      allow(Temporalio::Workflow).to receive(:patched).and_return(true)
       allow(workflow).to receive(:run_activity).and_return({})
+      allow(workflow).to receive(:maybe_scan_code_scanning_alerts)
+      allow(workflow).to receive(:maybe_check_knowledge_staleness)
+      allow(workflow).to receive(:maybe_evaluate_auto_release)
+      allow(workflow).to receive(:maybe_evaluate_dependabot_auto_merge)
     end
 
     it "skips non-critical activities when rate limit is low" do
@@ -202,20 +205,6 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
       workflow.send(:maybe_run_non_critical_activities, 1)
 
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120)
-    end
-
-    it "skips rate limit check but still runs non-critical activities when patch guard returns false (pre-v872 workflows)" do
-      allow(Temporalio::Workflow).to receive(:patched).with("add-rate-limit-budget-v1").and_return(false)
-      allow(workflow).to receive(:run_activity)
-        .with(Activities::ScanPaidPrsActivity, anything, timeout: anything)
-        .and_return({ prs_to_trigger: [] })
-
-      workflow.send(:maybe_run_non_critical_activities, 1)
-
-      expect(workflow).not_to have_received(:run_activity)
-        .with(Activities::CheckRateLimitActivity, anything, timeout: anything)
       expect(workflow).to have_received(:run_activity)
         .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120)
     end
@@ -292,8 +281,6 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     let(:workflow) { described_class.new }
 
     before do
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("add-rate-limit-budget-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with(anything).and_return(true)
     end
@@ -1862,8 +1849,6 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive(:continue_as_new_suggested).and_return(false)
       allow(Temporalio::Workflow).to receive(:patched).and_call_original
       allow(Temporalio::Workflow).to receive(:patched)
-        .with("add-rate-limit-budget-v1").and_return(false)
-      allow(Temporalio::Workflow).to receive(:patched)
         .with("add-auto-release-poll-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("add-dependabot-auto-merge-poll-v1").and_return(false)
@@ -1879,6 +1864,10 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with("batch-evaluate-issues-v1").and_return(true)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("notification-rules-v1").and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-auto-release-poll-v1").and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-dependabot-auto-merge-poll-v1").and_return(false)
       allow(workflow).to receive(:interruptible_sleep)
       allow(workflow).to receive(:with_jitter) { |base| base }
       allow(workflow).to receive(:run_activity)
@@ -1893,6 +1882,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(workflow).to receive(:run_activity)
         .with(Activities::CheckKnowledgeStalenessActivity, { project_id: project_id }, timeout: 30)
         .and_return({})
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::CheckRateLimitActivity, { project_id: project_id }, timeout: 10)
+        .and_return({ rate_limit_remaining: 500, rate_limit_low: false })
       allow(workflow).to receive(:run_activity)
         .with(Activities::LoadFeatureFlagsActivity, { project_id: project_id }, timeout: 10)
         .and_return(flags: { explicit_pr_automation_decisions: false }, project_missing: false)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -210,16 +210,19 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120)
     end
 
-    it "skips the rate limit check for pre-v872 workflows" do
+    it "runs the rate limit check unconditionally even when patch returns false" do
       allow(Temporalio::Workflow).to receive(:patched).with("add-rate-limit-budget-v1").and_return(false)
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::CheckRateLimitActivity, anything, timeout: anything)
+        .and_return({ rate_limit_remaining: 500, rate_limit_low: false })
       allow(workflow).to receive(:run_activity)
         .with(Activities::ScanPaidPrsActivity, anything, timeout: anything)
         .and_return({ prs_to_trigger: [] })
 
       workflow.send(:maybe_run_non_critical_activities, 1)
 
-      expect(workflow).not_to have_received(:run_activity)
-        .with(Activities::CheckRateLimitActivity, anything, timeout: anything)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::CheckRateLimitActivity, { project_id: 1 }, timeout: 10)
       expect(workflow).to have_received(:run_activity)
         .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120)
     end

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -1864,10 +1864,6 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with("batch-evaluate-issues-v1").and_return(true)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("notification-rules-v1").and_return(false)
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("add-auto-release-poll-v1").and_return(false)
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("add-dependabot-auto-merge-poll-v1").and_return(false)
       allow(workflow).to receive(:interruptible_sleep)
       allow(workflow).to receive(:with_jitter) { |base| base }
       allow(workflow).to receive(:run_activity)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -1842,6 +1842,9 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
     def stub_initial_sync(trigger_result:)
       allow(workflow).to receive(:run_activity)
+        .with(Activities::CheckRateLimitActivity, { project_id: project_id }, timeout: 10)
+        .and_return({ rate_limit_remaining: 500, rate_limit_low: false })
+      allow(workflow).to receive(:run_activity)
         .with(Activities::FetchIssuesActivity, { project_id: project_id }, timeout: 60)
         .and_return(
           { issues: [ { id: 10 } ], project_id: project_id },
@@ -1866,8 +1869,6 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     before do
       allow(Temporalio::Workflow).to receive(:continue_as_new_suggested).and_return(false)
       allow(Temporalio::Workflow).to receive(:patched).and_call_original
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("add-rate-limit-budget-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("add-auto-release-poll-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -165,6 +165,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
     let(:workflow) { described_class.new }
 
     before do
+      allow(Temporalio::Workflow).to receive(:patched).and_return(true)
       allow(workflow).to receive(:run_activity).and_return({})
       allow(workflow).to receive(:maybe_scan_code_scanning_alerts)
       allow(workflow).to receive(:maybe_check_knowledge_staleness)
@@ -205,6 +206,20 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
       workflow.send(:maybe_run_non_critical_activities, 1)
 
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120)
+    end
+
+    it "skips the rate limit check for pre-v872 workflows" do
+      allow(Temporalio::Workflow).to receive(:patched).with("add-rate-limit-budget-v1").and_return(false)
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::ScanPaidPrsActivity, anything, timeout: anything)
+        .and_return({ prs_to_trigger: [] })
+
+      workflow.send(:maybe_run_non_critical_activities, 1)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::CheckRateLimitActivity, anything, timeout: anything)
       expect(workflow).to have_received(:run_activity)
         .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120)
     end
@@ -1849,6 +1864,8 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive(:continue_as_new_suggested).and_return(false)
       allow(Temporalio::Workflow).to receive(:patched).and_call_original
       allow(Temporalio::Workflow).to receive(:patched)
+        .with("add-rate-limit-budget-v1").and_return(false)
+      allow(Temporalio::Workflow).to receive(:patched)
         .with("add-auto-release-poll-v1").and_return(false)
       allow(Temporalio::Workflow).to receive(:patched)
         .with("add-dependabot-auto-merge-poll-v1").and_return(false)
@@ -1878,9 +1895,6 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(workflow).to receive(:run_activity)
         .with(Activities::CheckKnowledgeStalenessActivity, { project_id: project_id }, timeout: 30)
         .and_return({})
-      allow(workflow).to receive(:run_activity)
-        .with(Activities::CheckRateLimitActivity, { project_id: project_id }, timeout: 10)
-        .and_return({ rate_limit_remaining: 500, rate_limit_low: false })
       allow(workflow).to receive(:run_activity)
         .with(Activities::LoadFeatureFlagsActivity, { project_id: project_id }, timeout: 10)
         .and_return(flags: { explicit_pr_automation_decisions: false }, project_missing: false)


### PR DESCRIPTION
## Summary

Removes the `add-rate-limit-budget-v1` patch guard from `GitHubPollWorkflow`, making the rate-limit budget check unconditional. The guard was introduced in #872 (~1.4 months ago) to safely roll out the budget coordination feature across long-running poll workflows; with sufficient time elapsed for pre-v872 workflows to continue-as-new, the guard is no longer needed and is removed per the follow-up plan.

## Changes

- **Workflow**: In `app/temporal/workflows/git_hub_poll_workflow.rb`, removed the `if Temporalio::Workflow.patched(:"add-rate-limit-budget-v1")` wrapper and its accompanying TODO in `#maybe_run_non_critical_activities`. `CheckRateLimitActivity` now runs unconditionally.
- **Tests**: Updated `spec/temporal/workflows/git_hub_poll_workflow_spec.rb` to drop the pre-v872 guard expectations and add unconditional rate-limit stubs to the existing initial-sync examples.

## Design Decisions

- **Verification gap**: The issue calls for confirming the oldest still-running `GitHubPollWorkflow` has continued-as-new past the #872 deploy. This was not verifiable from the dev environment (no running `WorkflowState` rows locally and no Temporal endpoint configured). Reviewers/operators should confirm against the production Temporal cluster before merging — if any pre-v872 execution is still active, deploying this change will cause it to fail non-determinism checks until it continues-as-new.
- **Unconditional inline**: Followed the acceptance criteria literally — the budget check is inlined unconditionally rather than introducing a new patch level, since the goal is to retire the patch entirely.

## Operational Notes

- No migration or infrastructure changes.
- Before merging, verify in the production Temporal UI that no `GitHubPollWorkflow` execution started before the #872 deploy is still active. If one is, either wait for continue-as-new or terminate/restart it.

---

Closes #2136