### PR TITLE
feat: tracking(temporal): define and apply a sunset policy for Temporalio::Workflow.patched(...) guards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ Use `WORKLOG.md` as persistent working memory across context compactions:
 
 - `docs/ARCHITECTURE.md` - System design and technology stack
 - `docs/AGENT_SYSTEM.md` - Temporal workflows and container management
+- `docs/PATCH_GUARDS.md` - Temporal patch guard registry, sunset policy, and sweep workflow
 - `docs/LLM_STYLE_GUIDE.md` - **Read this first** — concise coding rules for AI assistants (with line refs to full guide)
 - `docs/STYLE_GUIDE.md` - Detailed coding standards, rationale, and examples
 - `db/schema.rb` - Canonical database schema with table and column comments

--- a/app/jobs/temporal_patch_guard_sweep_job.rb
+++ b/app/jobs/temporal_patch_guard_sweep_job.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class TemporalPatchGuardSweepJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :maintenance
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: "temporal_patch_guard_sweep"
+  )
+
+  def perform
+    report = TemporalPatchGuards::Sweep.new.call
+
+    Rails.logger.info(
+      message: "temporal.patch_guard_sweep.completed",
+      workflow_count: report.workflow_summaries.size,
+      eligible_guard_count: report.eligible_guards.size,
+      workflows: report.workflow_summaries
+    )
+
+    return if report.eligible_guards.empty?
+
+    Rails.logger.warn(
+      message: "temporal.patch_guard_sweep.eligible_guards",
+      eligible_guard_names: report.eligible_guards.map(&:name),
+      eligible_workflow_types: report.eligible_guards.map(&:workflow_type).uniq,
+      policy_path: "docs/PATCH_GUARDS.md"
+    )
+  rescue => e
+    Rails.logger.error(
+      message: "temporal.patch_guard_sweep.failed",
+      error_class: e.class.name,
+      error: e.message
+    )
+    raise
+  end
+end

--- a/app/services/temporal_patch_guards/registry.rb
+++ b/app/services/temporal_patch_guards/registry.rb
@@ -6,7 +6,7 @@ require "yaml"
 module TemporalPatchGuards
   Entry = Data.define(:name, :workflow_type, :introduced_on) do
     def sunset_at
-      introduced_on.next_day.beginning_of_day.utc
+      introduced_on.next_day.to_time(:utc)
     end
   end
 

--- a/app/services/temporal_patch_guards/registry.rb
+++ b/app/services/temporal_patch_guards/registry.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "date"
+require "yaml"
+
+module TemporalPatchGuards
+  Entry = Data.define(:name, :workflow_type, :introduced_on) do
+    def sunset_at
+      introduced_on.next_day.beginning_of_day.utc
+    end
+  end
+
+  class Registry
+    METADATA_PATH = Rails.root.join("config/temporal_patch_guards.yml")
+
+    class << self
+      def entries
+        load_entries.freeze
+      end
+
+      def workflow_types
+        entries.map(&:workflow_type).uniq
+      end
+
+      private
+
+      def load_entries
+        data = YAML.safe_load(METADATA_PATH.read, aliases: false) || {}
+
+        data.fetch("workflows", {}).flat_map do |workflow_type, guards|
+          guards.map do |guard_name, metadata|
+            Entry.new(
+              name: guard_name,
+              workflow_type: workflow_type,
+              introduced_on: Date.iso8601(metadata.fetch("introduced_on"))
+            )
+          end
+        end.sort_by { |entry| [ entry.workflow_type, entry.introduced_on, entry.name ] }
+      end
+    end
+  end
+end

--- a/app/services/temporal_patch_guards/sweep.rb
+++ b/app/services/temporal_patch_guards/sweep.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module TemporalPatchGuards
+  GuardStatus = Data.define(:entry, :oldest_running_start_time, :eligible) do
+    delegate :introduced_on, :name, :sunset_at, :workflow_type, to: :entry
+  end
+
+  Report = Data.define(:statuses) do
+    def eligible_guards
+      statuses.select(&:eligible)
+    end
+
+    def workflow_summaries
+      statuses.group_by(&:workflow_type).map do |workflow_type, workflow_statuses|
+        {
+          workflow_type: workflow_type,
+          oldest_running_start_time: workflow_statuses.first.oldest_running_start_time,
+          eligible_guard_names: workflow_statuses.select(&:eligible).map(&:name),
+          tracked_guard_names: workflow_statuses.map(&:name)
+        }
+      end.sort_by { |summary| summary[:workflow_type] }
+    end
+
+    def to_text
+      workflow_summaries.map do |summary|
+        oldest = summary[:oldest_running_start_time]&.utc&.iso8601 || "none"
+        eligible = summary[:eligible_guard_names].presence || [ "none" ]
+        tracked = summary[:tracked_guard_names].join(", ")
+        <<~TEXT.chomp
+          #{summary[:workflow_type]}
+            oldest_running_start_time: #{oldest}
+            tracked_guards: #{tracked}
+            eligible_guards: #{eligible.join(", ")}
+        TEXT
+      end.join("\n")
+    end
+  end
+
+  class Sweep
+    def initialize(client: Paid.temporal_client, entries: Registry.entries)
+      @client = client
+      @entries = entries
+    end
+
+    def call
+      oldest_running_by_workflow = @entries.map(&:workflow_type).uniq.index_with do |workflow_type|
+        oldest_running_start_time_for(workflow_type)
+      end
+
+      statuses = @entries.map do |entry|
+        oldest_running_start_time = oldest_running_by_workflow.fetch(entry.workflow_type)
+        GuardStatus.new(
+          entry: entry,
+          oldest_running_start_time: oldest_running_start_time,
+          eligible: oldest_running_start_time.nil? || oldest_running_start_time >= entry.sunset_at
+        )
+      end
+
+      Report.new(statuses:)
+    end
+
+    private
+
+    def oldest_running_start_time_for(workflow_type)
+      @client.list_workflows(running_workflow_query(workflow_type))
+        .min_by(&:start_time)
+        &.start_time
+    end
+
+    def running_workflow_query(workflow_type)
+      sanitized_workflow_type = workflow_type.gsub("\\", "\\\\\\\\").gsub("'", "\\\\'")
+      "WorkflowType = '#{sanitized_workflow_type}' AND ExecutionStatus = 'Running'"
+    end
+  end
+end

--- a/app/services/temporal_patch_guards/sweep.rb
+++ b/app/services/temporal_patch_guards/sweep.rb
@@ -52,7 +52,7 @@ module TemporalPatchGuards
         GuardStatus.new(
           entry: entry,
           oldest_running_start_time: oldest_running_start_time,
-          eligible: oldest_running_start_time.nil? || oldest_running_start_time >= entry.sunset_at
+          eligible: oldest_running_start_time.nil? || oldest_running_start_time > entry.sunset_at
         )
       end
 

--- a/app/services/temporal_patch_guards/sweep.rb
+++ b/app/services/temporal_patch_guards/sweep.rb
@@ -52,7 +52,7 @@ module TemporalPatchGuards
         GuardStatus.new(
           entry: entry,
           oldest_running_start_time: oldest_running_start_time,
-          eligible: oldest_running_start_time.nil? || oldest_running_start_time > entry.sunset_at
+          eligible: oldest_running_start_time.nil? || oldest_running_start_time >= entry.sunset_at
         )
       end
 

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -116,19 +116,17 @@ module Workflows
       workflow_error = nil
 
       begin
-        if Temporalio::Workflow.patched("agent-execution-quality-gate-v1")
-          gate_result = check_quality_gate(
-            project_id: project_id,
-            issue_id: issue_id,
-            agent_run_id: agent_run_id,
-            source_pull_request_number: source_pull_request_number
-          )
-          unless gate_result.fetch(:allowed, true)
-            run_activity(Activities::MarkAgentRunFailedActivity,
-              { agent_run_id: agent_run_id, error: quality_gate_error(gate_result) }, timeout: 30)
+        gate_result = check_quality_gate(
+          project_id: project_id,
+          issue_id: issue_id,
+          agent_run_id: agent_run_id,
+          source_pull_request_number: source_pull_request_number
+        )
+        unless gate_result.fetch(:allowed, true)
+          run_activity(Activities::MarkAgentRunFailedActivity,
+            { agent_run_id: agent_run_id, error: quality_gate_error(gate_result) }, timeout: 30)
 
-            return { success: false, quality_gate_blocked: true, agent_run_id: agent_run_id }
-          end
+          return { success: false, quality_gate_blocked: true, agent_run_id: agent_run_id }
         end
 
         if goal == "enhance_issue"
@@ -162,10 +160,8 @@ module Workflows
         # Always run unconditionally — returns empty lists when no MCP servers
         # are configured. Must run before container provisioning so sidecar
         # URLs are available when the agent starts.
-        if Temporalio::Workflow.patched("provision_mcp_servers_v1")
-          run_activity(Activities::ProvisionMcpServersActivity,
-            { agent_run_id: agent_run_id }, timeout: 120)
-        end
+        run_activity(Activities::ProvisionMcpServersActivity,
+          { agent_run_id: agent_run_id }, timeout: 120)
 
         # Step 2: Provision container (with empty workspace directory)
         run_activity(Activities::ProvisionContainerActivity,
@@ -178,9 +174,7 @@ module Workflows
         # effectively pausing the workflow until credentials are available.
         skip_clone = goal.in?(%w[create_issue enhance_issue analyze_issue]) && source_pull_request_number.blank?
         unless skip_clone
-          if Temporalio::Workflow.patched("check_proxy_health_before_clone")
-            ensure_proxy_healthy(agent_run_id)
-          end
+          ensure_proxy_healthy(agent_run_id)
         end
 
         # Step 3: Clone repo and create branch inside the container.
@@ -289,9 +283,7 @@ module Workflows
           # Step 5: Push branch (inside container)
           # Re-check proxy health before push — the agent may have run for
           # a long time and the proxy could have gone down in the meantime.
-          if Temporalio::Workflow.patched("check_proxy_health_before_push")
-            ensure_proxy_healthy(agent_run_id)
-          end
+          ensure_proxy_healthy(agent_run_id)
 
           run_activity(Activities::PushBranchActivity,
             { agent_run_id: agent_run_id }, timeout: 60)
@@ -438,20 +430,18 @@ module Workflows
             end
           end
 
-          if Temporalio::Workflow.patched("provision_mcp_servers_v1")
-            begin
-              run_activity(Activities::CleanupMcpServersActivity,
-                { agent_run_id: agent_run_id },
-                start_to_close_timeout: 120, schedule_to_close_timeout: 300,
-                retry_policy: CLEANUP_RETRY_POLICY)
-            rescue => e
-              Temporalio::Workflow.logger.warn(
-                message: "agent_execution.cleanup_mcp_servers_failed",
-                agent_run_id: agent_run_id,
-                error_class: e.class.name,
-                error: e.message
-              )
-            end
+          begin
+            run_activity(Activities::CleanupMcpServersActivity,
+              { agent_run_id: agent_run_id },
+              start_to_close_timeout: 120, schedule_to_close_timeout: 300,
+              retry_policy: CLEANUP_RETRY_POLICY)
+          rescue => e
+            Temporalio::Workflow.logger.warn(
+              message: "agent_execution.cleanup_mcp_servers_failed",
+              agent_run_id: agent_run_id,
+              error_class: e.class.name,
+              error: e.message
+            )
           end
 
           begin
@@ -558,22 +548,11 @@ module Workflows
     # when :reviewers is not supplied, so the workflow does not need to know
     # which bot is enabled.
     #
-    # The :reviewers argument is gated behind a workflow patch so that
-    # in-flight AgentExecutionWorkflow executions started before this
-    # deployment — whose history recorded the old `reviewers: [copilot]`
-    # payload — can replay without a non-determinism error. Histories
-    # captured after the patch use the new project-resolved form.
     def request_review_bot_review(project_id, pr_number)
       return unless pr_number
 
-      input = if Temporalio::Workflow.patched("request_review_resolve_reviewer_from_project")
-        { project_id: project_id, pr_number: pr_number }
-      else
-        { project_id: project_id, pr_number: pr_number,
-          reviewers: [ Activities::RequestReviewActivity::COPILOT_LOGIN ] }
-      end
-
-      run_activity(Activities::RequestReviewActivity, input, timeout: 60)
+      run_activity(Activities::RequestReviewActivity,
+        { project_id: project_id, pr_number: pr_number }, timeout: 60)
     rescue Temporalio::Error::CanceledError
       raise
     rescue => e
@@ -586,32 +565,18 @@ module Workflows
     end
 
     def resolve_followup_review_threads_after_push(agent_run_id, pr_run_without_prompt, pr_prompt_result)
-      if Temporalio::Workflow.patched("resolve_review_threads_with_prompt_thread_ids")
-        return unless pr_run_without_prompt && pr_prompt_result[:review_thread_ids].present?
+      return unless pr_run_without_prompt && pr_prompt_result[:review_thread_ids].present?
 
-        resolve_review_threads(agent_run_id, thread_ids: pr_prompt_result[:review_thread_ids])
-      else
-        return unless pr_run_without_prompt
-
-        resolve_review_threads(agent_run_id)
-      end
+      resolve_review_threads(agent_run_id, thread_ids: pr_prompt_result[:review_thread_ids])
     end
 
     def resolve_no_change_followup_review_threads(agent_run_id, source_pull_request_number, pr_run_without_prompt, pr_prompt_result, agent_result)
-      if Temporalio::Workflow.patched("resolve_review_threads_with_prompt_thread_ids")
-        return unless source_pull_request_number && pr_run_without_prompt &&
-          pr_prompt_result[:includes_review_threads] &&
-          pr_prompt_result[:review_thread_ids].present? &&
-          agent_result[:review_threads_already_addressed]
+      return unless source_pull_request_number && pr_run_without_prompt &&
+        pr_prompt_result[:includes_review_threads] &&
+        pr_prompt_result[:review_thread_ids].present? &&
+        agent_result[:review_threads_already_addressed]
 
-        resolve_review_threads(agent_run_id, thread_ids: pr_prompt_result[:review_thread_ids])
-      else
-        return unless source_pull_request_number && pr_run_without_prompt &&
-          pr_prompt_result[:includes_review_threads] &&
-          agent_result[:review_threads_already_addressed]
-
-        resolve_review_threads(agent_run_id)
-      end
+      resolve_review_threads(agent_run_id, thread_ids: pr_prompt_result[:review_thread_ids])
     end
 
     def resolve_review_threads(agent_run_id, thread_ids: nil)

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -189,6 +189,11 @@ Rails.application.configure do
       cron: "*/15 * * * *",
       class: "AgentRunPatternDetectorJob",
       description: "Detect goal-level failure patterns in agent runs and notify"
+    },
+    temporal_patch_guard_sweep: {
+      cron: "0 4 1 */3 *",
+      class: "TemporalPatchGuardSweepJob",
+      description: "Audit Temporal workflow patch guards against oldest running executions (quarterly)"
     }
   }
 end

--- a/config/temporal_patch_guards.yml
+++ b/config/temporal_patch_guards.yml
@@ -6,8 +6,6 @@ workflows:
   Workflows::GitHubPollWorkflow:
     add-dev-environment-update-v1:
       introduced_on: "2026-03-25"
-    add-rate-limit-budget-v1:
-      introduced_on: "2026-04-07"
     escalation-reason-payload-v1:
       introduced_on: "2026-04-11"
     queue-agent-run-goal-v1:

--- a/config/temporal_patch_guards.yml
+++ b/config/temporal_patch_guards.yml
@@ -1,0 +1,32 @@
+# Temporal workflow patch guards that still require sunset tracking.
+#
+# See docs/PATCH_GUARDS.md for the policy, sweep workflow, and the rules for
+# adding new guards.
+workflows:
+  Workflows::GitHubPollWorkflow:
+    add-dev-environment-update-v1:
+      introduced_on: "2026-03-25"
+    add-rate-limit-budget-v1:
+      introduced_on: "2026-04-07"
+    escalation-reason-payload-v1:
+      introduced_on: "2026-04-11"
+    queue-agent-run-goal-v1:
+      introduced_on: "2026-04-13"
+    queue-paid-agent-review-run-v1:
+      introduced_on: "2026-04-13"
+    pause-followup-during-review-v1:
+      introduced_on: "2026-04-15"
+    batch-evaluate-issues-v1:
+      introduced_on: "2026-04-17"
+    pause-review-bot-followup-during-review-v1:
+      introduced_on: "2026-04-20"
+    github-poll-quality-gate-v1:
+      introduced_on: "2026-04-21"
+    add-auto-release-poll-v1:
+      introduced_on: "2026-04-25"
+    notification-rules-v1:
+      introduced_on: "2026-04-25"
+    add-dependabot-auto-merge-poll-v1:
+      introduced_on: "2026-04-27"
+    feature-orchestration-start-v1:
+      introduced_on: "2026-05-05"

--- a/docs/PATCH_GUARDS.md
+++ b/docs/PATCH_GUARDS.md
@@ -1,0 +1,46 @@
+# Temporal Patch Guard Policy
+
+`Temporalio::Workflow.patched(...)` is a temporary compatibility tool, not a permanent control flow primitive.
+
+## Required Metadata
+
+Every live patch guard in `app/temporal/workflows/` must have an entry in [`config/temporal_patch_guards.yml`](../config/temporal_patch_guards.yml).
+
+Each entry records:
+
+- `workflow_type`: the workflow class whose history carries the guard
+- `introduced_on`: the UTC calendar date when the guard first landed
+
+The registry is CI-checked by `spec/services/temporal_patch_guards/registry_spec.rb`. A new guard without registry coverage should fail CI. If sunset coverage cannot land in the same PR, add a `TODO(#issue)` comment beside the guard and open a tracking issue before merging.
+
+## Sunset Rule
+
+A guard becomes removable when the oldest still-running execution for that workflow type started after the guard’s introduction date.
+
+The automated sweep stores only a date, not a deployment timestamp, so it evaluates removal conservatively:
+
+- `introduced_on` is treated as expiring at the next UTC midnight
+- a guard is sweep-eligible when `oldest_running_start_time >= introduced_on + 1 day`
+- if there are no running executions for that workflow type, all tracked guards for that workflow type are eligible
+
+## Sweep Process
+
+Use either:
+
+- `bin/rails temporal:patch_guards:sweep`
+- `TemporalPatchGuardSweepJob`, scheduled quarterly through GoodJob cron
+
+The sweep queries Temporal visibility for the oldest running execution per tracked workflow type and logs any eligible guard names for cleanup.
+
+## Initial Sweep
+
+Issue #2150 removed the expired `AgentExecutionWorkflow` guards:
+
+- `agent-execution-quality-gate-v1`
+- `provision_mcp_servers_v1`
+- `check_proxy_health_before_clone`
+- `check_proxy_health_before_push`
+- `request_review_resolve_reviewer_from_project`
+- `resolve_review_threads_with_prompt_thread_ids`
+
+Those removals were safe without a live Temporal query because `AgentExecutionWorkflow` is runtime-bounded by `max_execution_seconds <= 86_400`, so workflows started before those April-May 2026 introductions could not still be running on May 21, 2026.

--- a/docs/PATCH_GUARDS.md
+++ b/docs/PATCH_GUARDS.md
@@ -15,7 +15,7 @@ The registry is CI-checked by `spec/services/temporal_patch_guards/registry_spec
 
 ## Sunset Rule
 
-A guard becomes removable when the oldest still-running execution for that workflow type started after the guard’s introduction date.
+A guard becomes removable when the oldest still-running execution for that workflow type started no earlier than the guard’s sunset boundary.
 
 The automated sweep stores only a date, not a deployment timestamp, so it evaluates removal conservatively:
 

--- a/lib/tasks/temporal_patch_guards.rake
+++ b/lib/tasks/temporal_patch_guards.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :temporal do
+  namespace :patch_guards do
+    desc "Audit Temporal workflow patch guards against the oldest running executions"
+    task sweep: :environment do
+      report = TemporalPatchGuards::Sweep.new.call
+      puts report.to_text
+    end
+  end
+end

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe ApplicationJob, :no_db do
         ScreenshotCleanupJob
         ServiceContainerReconciliationJob
         StaleRunDetectorJob
+        TemporalPatchGuardSweepJob
         WorktreeOrphanCleanupJob
       ],
       metrics: %w[

--- a/spec/jobs/temporal_patch_guard_sweep_job_spec.rb
+++ b/spec/jobs/temporal_patch_guard_sweep_job_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TemporalPatchGuardSweepJob do
+  describe "#perform" do
+    let(:sweep) { instance_double(TemporalPatchGuards::Sweep) }
+    let(:report) do
+      instance_double(
+        TemporalPatchGuards::Report,
+        workflow_summaries: [ { workflow_type: "Workflows::GitHubPollWorkflow", eligible_guard_names: [ "guard-a" ] } ],
+        eligible_guards: [ instance_double(TemporalPatchGuards::GuardStatus, name: "guard-a", workflow_type: "Workflows::GitHubPollWorkflow") ]
+      )
+    end
+
+    before do
+      allow(TemporalPatchGuards::Sweep).to receive(:new).and_return(sweep)
+      allow(sweep).to receive(:call).and_return(report)
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it "logs a warning when eligible guards are found" do
+      described_class.perform_now
+
+      expect(Rails.logger).to have_received(:warn).with(
+        hash_including(
+          message: "temporal.patch_guard_sweep.eligible_guards",
+          eligible_guard_names: [ "guard-a" ]
+        )
+      )
+    end
+
+    it "re-raises sweep failures after logging" do
+      allow(sweep).to receive(:call).and_raise(StandardError, "Temporal unavailable")
+
+      expect {
+        described_class.perform_now
+      }.to raise_error(StandardError, "Temporal unavailable")
+
+      expect(Rails.logger).to have_received(:error).with(
+        hash_including(
+          message: "temporal.patch_guard_sweep.failed",
+          error: "Temporal unavailable"
+        )
+      )
+    end
+  end
+end

--- a/spec/services/temporal_patch_guards/registry_spec.rb
+++ b/spec/services/temporal_patch_guards/registry_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TemporalPatchGuards::Registry do
+  describe ".entries" do
+    it "tracks every Temporal patch guard still present in workflow code" do
+      workflow_guards = Dir.glob(Rails.root.join("app/temporal/workflows/*.rb")).flat_map do |path|
+        content = File.read(path)
+        workflow_name = content[/class\s+(\w+)\s+<\s+BaseWorkflow/, 1]
+        next [] unless workflow_name
+
+        content.scan(/Temporalio::Workflow\.patched\("([^"]+)"\)/).flatten.map do |guard_name|
+          [ "Workflows::#{workflow_name}", guard_name ]
+        end
+      end.uniq.sort
+
+      registry_guards = described_class.entries.map { |entry| [ entry.workflow_type, entry.name ] }.sort
+
+      expect(registry_guards).to eq(workflow_guards)
+    end
+
+    it "parses ISO dates for every entry" do
+      expect(described_class.entries).to all(have_attributes(introduced_on: be_a(Date)))
+    end
+  end
+end

--- a/spec/services/temporal_patch_guards/registry_spec.rb
+++ b/spec/services/temporal_patch_guards/registry_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe TemporalPatchGuards::Registry do
       expect(described_class.entries).to all(have_attributes(introduced_on: be_a(Date)))
     end
   end
+
+  describe TemporalPatchGuards::Entry do
+    describe "#sunset_at" do
+      it "returns the next UTC midnight regardless of the Rails time zone" do
+        Time.use_zone("Eastern Time (US & Canada)") do
+          entry = described_class.new(
+            name: "guard-a",
+            workflow_type: "Workflows::GitHubPollWorkflow",
+            introduced_on: Date.new(2026, 4, 20)
+          )
+
+          expect(entry.sunset_at).to eq(Time.utc(2026, 4, 21))
+        end
+      end
+    end
+  end
 end

--- a/spec/services/temporal_patch_guards/sweep_spec.rb
+++ b/spec/services/temporal_patch_guards/sweep_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TemporalPatchGuards::Sweep do
+  let(:client) { instance_double(Temporalio::Client) }
+
+  describe "#call" do
+    it "marks a guard eligible when no workflow of that type is still running" do
+      entry = TemporalPatchGuards::Entry.new(
+        name: "guard-a",
+        workflow_type: "Workflows::GitHubPollWorkflow",
+        introduced_on: Date.new(2026, 4, 7)
+      )
+      allow(client).to receive(:list_workflows)
+        .with("WorkflowType = 'Workflows::GitHubPollWorkflow' AND ExecutionStatus = 'Running'")
+        .and_return([])
+
+      report = described_class.new(client:, entries: [ entry ]).call
+
+      expect(report.eligible_guards.map(&:name)).to eq([ "guard-a" ])
+    end
+
+    it "keeps a guard in place when the oldest running workflow chain predates its sunset" do
+      entry = TemporalPatchGuards::Entry.new(
+        name: "guard-a",
+        workflow_type: "Workflows::GitHubPollWorkflow",
+        introduced_on: Date.new(2026, 4, 7)
+      )
+      older_run = instance_double(Temporalio::Client::WorkflowExecution, start_time: Time.utc(2026, 4, 7, 12))
+      allow(client).to receive(:list_workflows)
+        .with("WorkflowType = 'Workflows::GitHubPollWorkflow' AND ExecutionStatus = 'Running'")
+        .and_return([ older_run ])
+
+      report = described_class.new(client:, entries: [ entry ]).call
+
+      expect(report.eligible_guards).to be_empty
+    end
+
+    it "queries each workflow type once and uses the oldest running start time for all of its guards" do
+      entries = [
+        TemporalPatchGuards::Entry.new(
+          name: "guard-a",
+          workflow_type: "Workflows::GitHubPollWorkflow",
+          introduced_on: Date.new(2026, 4, 7)
+        ),
+        TemporalPatchGuards::Entry.new(
+          name: "guard-b",
+          workflow_type: "Workflows::GitHubPollWorkflow",
+          introduced_on: Date.new(2026, 4, 20)
+        )
+      ]
+      older_run = instance_double(Temporalio::Client::WorkflowExecution, start_time: Time.utc(2026, 4, 15))
+      newer_run = instance_double(Temporalio::Client::WorkflowExecution, start_time: Time.utc(2026, 4, 22))
+      allow(client).to receive(:list_workflows)
+        .with("WorkflowType = 'Workflows::GitHubPollWorkflow' AND ExecutionStatus = 'Running'")
+        .once
+        .and_return([ newer_run, older_run ])
+
+      report = described_class.new(client:, entries:).call
+
+      expect(report.eligible_guards.map(&:name)).to eq([ "guard-a" ])
+    end
+  end
+end

--- a/spec/services/temporal_patch_guards/sweep_spec.rb
+++ b/spec/services/temporal_patch_guards/sweep_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe TemporalPatchGuards::Sweep do
       expect(report.eligible_guards).to be_empty
     end
 
-    it "keeps a guard in place when the oldest running workflow started at the sunset boundary" do
+    it "marks a guard eligible when the oldest running workflow started at the sunset boundary" do
       entry = entry_class.new(
         name: "guard-a",
         workflow_type: "Workflows::GitHubPollWorkflow",
@@ -59,7 +59,7 @@ RSpec.describe TemporalPatchGuards::Sweep do
 
       report = described_class.new(client:, entries: [ entry ]).call
 
-      expect(report.eligible_guards).to be_empty
+      expect(report.eligible_guards.map(&:name)).to eq([ "guard-a" ])
     end
 
     it "queries each workflow type once and uses the oldest running start time for all of its guards" do

--- a/spec/services/temporal_patch_guards/sweep_spec.rb
+++ b/spec/services/temporal_patch_guards/sweep_spec.rb
@@ -3,11 +3,20 @@
 require "rails_helper"
 
 RSpec.describe TemporalPatchGuards::Sweep do
-  let(:client) { instance_double(Temporalio::Client) }
+  let(:client_class) do
+    Class.new do
+      def list_workflows(_query); end
+    end
+  end
+  let(:workflow_execution_class) do
+    Struct.new(:start_time)
+  end
+  let(:client) { instance_double(client_class) }
+  let(:entry_class) { TemporalPatchGuards::Registry.entries.first.class }
 
   describe "#call" do
     it "marks a guard eligible when no workflow of that type is still running" do
-      entry = TemporalPatchGuards::Entry.new(
+      entry = entry_class.new(
         name: "guard-a",
         workflow_type: "Workflows::GitHubPollWorkflow",
         introduced_on: Date.new(2026, 4, 7)
@@ -22,12 +31,12 @@ RSpec.describe TemporalPatchGuards::Sweep do
     end
 
     it "keeps a guard in place when the oldest running workflow chain predates its sunset" do
-      entry = TemporalPatchGuards::Entry.new(
+      entry = entry_class.new(
         name: "guard-a",
         workflow_type: "Workflows::GitHubPollWorkflow",
         introduced_on: Date.new(2026, 4, 7)
       )
-      older_run = instance_double(Temporalio::Client::WorkflowExecution, start_time: Time.utc(2026, 4, 7, 12))
+      older_run = instance_double(workflow_execution_class, start_time: Time.utc(2026, 4, 7, 12))
       allow(client).to receive(:list_workflows)
         .with("WorkflowType = 'Workflows::GitHubPollWorkflow' AND ExecutionStatus = 'Running'")
         .and_return([ older_run ])
@@ -37,21 +46,37 @@ RSpec.describe TemporalPatchGuards::Sweep do
       expect(report.eligible_guards).to be_empty
     end
 
+    it "keeps a guard in place when the oldest running workflow started at the sunset boundary" do
+      entry = entry_class.new(
+        name: "guard-a",
+        workflow_type: "Workflows::GitHubPollWorkflow",
+        introduced_on: Date.new(2026, 4, 7)
+      )
+      boundary_run = instance_double(workflow_execution_class, start_time: Time.utc(2026, 4, 8))
+      allow(client).to receive(:list_workflows)
+        .with("WorkflowType = 'Workflows::GitHubPollWorkflow' AND ExecutionStatus = 'Running'")
+        .and_return([ boundary_run ])
+
+      report = described_class.new(client:, entries: [ entry ]).call
+
+      expect(report.eligible_guards).to be_empty
+    end
+
     it "queries each workflow type once and uses the oldest running start time for all of its guards" do
       entries = [
-        TemporalPatchGuards::Entry.new(
+        entry_class.new(
           name: "guard-a",
           workflow_type: "Workflows::GitHubPollWorkflow",
           introduced_on: Date.new(2026, 4, 7)
         ),
-        TemporalPatchGuards::Entry.new(
+        entry_class.new(
           name: "guard-b",
           workflow_type: "Workflows::GitHubPollWorkflow",
           introduced_on: Date.new(2026, 4, 20)
         )
       ]
-      older_run = instance_double(Temporalio::Client::WorkflowExecution, start_time: Time.utc(2026, 4, 15))
-      newer_run = instance_double(Temporalio::Client::WorkflowExecution, start_time: Time.utc(2026, 4, 22))
+      older_run = instance_double(workflow_execution_class, start_time: Time.utc(2026, 4, 15))
+      newer_run = instance_double(workflow_execution_class, start_time: Time.utc(2026, 4, 22))
       allow(client).to receive(:list_workflows)
         .with("WorkflowType = 'Workflows::GitHubPollWorkflow' AND ExecutionStatus = 'Running'")
         .once

--- a/spec/system/worker_pool_load_spec.rb
+++ b/spec/system/worker_pool_load_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe "Worker pool load behavior" do
       DockerOrphanCleanupJob => "maintenance",
       StaleRunDetectorJob => "maintenance",
       PollWorkflowHealthCheckJob => "maintenance",
+      TemporalPatchGuardSweepJob => "maintenance",
       WorktreeOrphanCleanupJob => "maintenance",
       AgentRunResourceJanitorJob => "maintenance",
       ServiceContainerReconciliationJob => "maintenance",

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -337,6 +337,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::CheckQualityGateActivity"
           { allowed: false, reason: "quality_gate_breached", breaches: [ { metric: "composite_score" } ] }
         when "Activities::MarkAgentRunFailedActivity",
+          "Activities::CleanupMcpServersActivity",
           "Activities::CleanupContainerActivity",
           "Activities::CleanupServicesActivity",
           "Activities::CleanupWorktreeActivity",
@@ -367,29 +368,6 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
       expect(workflow).to have_received(:run_activity)
         .with(Activities::CreateAgentRunActivity, hash_excluding(:agent_type), timeout: 30)
-    end
-
-    it "skips quality gate activity before the Temporal patch" do
-      allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger, patched: false)
-      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
-        case activity_class.name
-        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42 }
-        when "Activities::EnhanceIssueActivity" then { agent_run_id: 42, success: true }
-        when "Activities::CleanupContainerActivity",
-          "Activities::CleanupServicesActivity",
-          "Activities::CleanupWorktreeActivity",
-          "Activities::EnqueueJanitorActivity"
-          {}
-        else
-          raise "unexpected activity #{activity_class.name}"
-        end
-      end
-
-      result = workflow.execute(input.merge(goal: "enhance_issue"))
-
-      expect(result).to eq(success: true, agent_run_id: 42)
-      expect(workflow).not_to have_received(:run_activity)
-        .with(Activities::CheckQualityGateActivity, anything, any_args)
     end
   end
 
@@ -652,28 +630,6 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       end
     end
 
-    def stub_existing_pr_followup_legacy_prompt_result
-      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
-        case activity_class.name
-        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, runner_attempt_count: 1 }
-        when "Activities::ProvisionServicesActivity" then {}
-        when "Activities::ProvisionContainerActivity" then {}
-        when "Activities::CloneRepoActivity" then {}
-        when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
-        when "Activities::PreparePrPromptActivity" then {}
-        when "Activities::RunAgentActivity" then { success: true, has_changes: true }
-        when "Activities::PushBranchActivity" then {}
-        when "Activities::ResolveReviewThreadsActivity" then {}
-        when "Activities::CompleteExistingPrRunActivity" then { pr_review_phase: "ready" }
-        when "Activities::RequestReviewActivity" then {}
-        when "Activities::CleanupContainerActivity" then {}
-        when "Activities::CleanupServicesActivity" then {}
-        when "Activities::CleanupWorktreeActivity" then {}
-        else {}
-        end
-      end
-    end
-
     def stub_existing_pr_followup_with_focus(expected_focus)
       allow(workflow).to receive(:run_activity) do |activity_class, input, **_opts|
         case activity_class.name
@@ -776,25 +732,6 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         .with(Activities::DraftDecisionRecordActivity, any_args)
     end
 
-    it "emits the pre-patch activity input shape when the workflow patch is not set" do
-      # Regression: in-flight workflows whose history recorded the old
-      # `reviewers: [copilot]` payload must replay without a
-      # non-determinism error. When the patch flag is false the workflow
-      # must reproduce the legacy input shape exactly.
-      allow(Temporalio::Workflow).to receive(:patched).and_return(true)
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("request_review_resolve_reviewer_from_project").and_return(false)
-      stub_existing_pr_followup(pr_review_phase: "ready")
-
-      workflow.execute(input)
-
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::RequestReviewActivity,
-          { project_id: 1, pr_number: 42,
-            reviewers: [ Activities::RequestReviewActivity::COPILOT_LOGIN ] },
-          timeout: 60)
-    end
-
     it "passes prompt-captured review thread ids when resolving after pushing commits" do
       stub_existing_pr_followup(pr_review_phase: "ready")
 
@@ -813,20 +750,6 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::ResolveReviewThreadsActivity, anything, timeout: anything)
-    end
-
-    it "replays the legacy resolve activity after pushing commits when the workflow patch is not set" do
-      allow(Temporalio::Workflow).to receive(:patched).and_return(true)
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("resolve_review_threads_with_prompt_thread_ids").and_return(false)
-      stub_existing_pr_followup_legacy_prompt_result
-
-      workflow.execute(input)
-
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::ResolveReviewThreadsActivity,
-          { agent_run_id: 42 },
-          timeout: 60)
     end
   end
 
@@ -889,27 +812,6 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
         when "Activities::PreparePrPromptActivity" then { includes_review_threads: true, review_thread_ids: [] }
         when "Activities::RunAgentActivity" then { success: true, has_changes: false, review_threads_already_addressed: true }
-        when "Activities::MarkAgentRunCompleteActivity" then {}
-        when "Activities::RequestReviewActivity" then {}
-        when "Activities::CleanupContainerActivity" then {}
-        when "Activities::CleanupServicesActivity" then {}
-        when "Activities::CleanupWorktreeActivity" then {}
-        else {}
-        end
-      end
-    end
-
-    def stub_no_changes_followup_legacy_prompt_result
-      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
-        case activity_class.name
-        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, runner_attempt_count: 1 }
-        when "Activities::ProvisionServicesActivity" then {}
-        when "Activities::ProvisionContainerActivity" then {}
-        when "Activities::CloneRepoActivity" then {}
-        when "Activities::RebaseBranchActivity" then { rebase_succeeded: true }
-        when "Activities::PreparePrPromptActivity" then { includes_review_threads: true }
-        when "Activities::RunAgentActivity" then { success: true, has_changes: false, review_threads_already_addressed: true }
-        when "Activities::ResolveReviewThreadsActivity" then {}
         when "Activities::MarkAgentRunCompleteActivity" then {}
         when "Activities::RequestReviewActivity" then {}
         when "Activities::CleanupContainerActivity" then {}
@@ -993,20 +895,6 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::ResolveReviewThreadsActivity, anything, timeout: anything)
-    end
-
-    it "replays the legacy resolve activity on a no-change PR follow-up when the workflow patch is not set" do
-      allow(Temporalio::Workflow).to receive(:patched).and_return(true)
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("resolve_review_threads_with_prompt_thread_ids").and_return(false)
-      stub_no_changes_followup_legacy_prompt_result
-
-      workflow.execute(input)
-
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::ResolveReviewThreadsActivity,
-          { agent_run_id: 42 },
-          timeout: 60)
     end
 
     it "pushes an automatic rebase even when the agent makes no additional changes" do
@@ -1124,20 +1012,6 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
           retry_policy: described_class::NO_RETRY)
     end
 
-    it "emits the pre-patch activity input shape for new PR when the workflow patch is not set" do
-      allow(Temporalio::Workflow).to receive(:patched)
-        .with("request_review_resolve_reviewer_from_project").and_return(false)
-      stub_new_pr_creation
-
-      workflow.execute(input)
-
-      expect(workflow).to have_received(:run_activity)
-        .with(Activities::RequestReviewActivity,
-          { project_id: 1, pr_number: 99,
-            reviewers: [ Activities::RequestReviewActivity::COPILOT_LOGIN ] },
-          timeout: 60)
-    end
-
     it "does not request a review-bot review when the agent produces no changes" do
       allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
         case activity_class.name
@@ -1217,6 +1091,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       workflow.execute(input)
 
       [
+        Activities::CleanupMcpServersActivity,
         Activities::CleanupContainerActivity,
         Activities::CleanupServicesActivity,
         Activities::CleanupWorktreeActivity
@@ -1262,7 +1137,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
 
       expect { workflow.execute(input) }.to raise_error(Temporalio::Error::ApplicationError)
 
-      skipped = [ Activities::CleanupContainerActivity, Activities::CleanupServicesActivity,
+      skipped = [ Activities::CleanupMcpServersActivity, Activities::CleanupContainerActivity, Activities::CleanupServicesActivity,
                   Activities::CleanupWorktreeActivity, Activities::EnqueueJanitorActivity ]
       expect(called_activities & skipped).to be_empty
     end

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -210,8 +210,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
         .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120)
     end
 
-    it "runs the rate limit check unconditionally even when patch returns false" do
-      allow(Temporalio::Workflow).to receive(:patched).with("add-rate-limit-budget-v1").and_return(false)
+    it "runs the rate limit check before the non-critical activities" do
       allow(workflow).to receive(:run_activity)
         .with(Activities::CheckRateLimitActivity, anything, timeout: anything)
         .and_return({ rate_limit_remaining: 500, rate_limit_low: false })


### PR DESCRIPTION
## Summary

Establishes a sunset policy for `Temporalio::Workflow.patched(...)` guards so they can be retired safely instead of accumulating indefinitely. Introduces a CI-checked registry that tracks every guard's introduction date, a quarterly sweep that surfaces eligible removals, and performs an initial cleanup of expired guards in `AgentExecutionWorkflow`.

## Changes

- **Policy & documentation**
  - Add `docs/PATCH_GUARDS.md` describing the sunset rule, registration requirements, and sweep cadence.
  - Reference the new policy from `CLAUDE.md` so contributors discover it before adding new guards.
- **Registry & enforcement**
  - Add `config/temporal_patch_guards.yml` as the single source of truth for guard metadata (name, workflow, introduction date).
  - Add specs that fail if a `Temporalio::Workflow.patched(...)` call in `app/temporal/workflows/` is missing from the registry.
- **Sweep automation**
  - Add a rake task / job that queries Temporal for the oldest running execution per workflow type and flags guards whose introduction date precedes it.
  - Wire the sweep to run on a quarterly cadence.
- **Initial sweep cleanup**
  - Remove expired guards from `app/temporal/workflows/agent_execution_workflow.rb` and update the corresponding workflow specs.
  - Remaining tracked guards (the long-lived `GitHubPollWorkflow` ones) are now covered by the registry.

## Design Decisions

- **YAML registry over inline comments**: a centralized registry is machine-readable, lets the sweep job operate without parsing source, and makes coverage enforceable in CI. Inline `TODO(#NNNN)` markers were inconsistent and easy to forget.
- **Sunset rule keyed on oldest running workflow `start_time`**: removing a guard is only safe once no in-flight workflow predates it, so the rule queries live Temporal state rather than relying on a fixed TTL.
- **Initial sweep limited to clearly expired `AgentExecutionWorkflow` guards**: avoids bundling broader cleanup with the policy rollout; the long-lived `GitHubPollWorkflow` guards stay in place and are tracked for future sweeps.

## Operational Notes

- New scheduled sweep task runs quarterly — confirm the cron/Temporal schedule registration deploys with this change.
- No database migrations. Adding a new patch guard now requires a matching entry in `config/temporal_patch_guards.yml` or specs will fail.

---

Closes #2150