### PR TITLE
feat(planning): split decomposition-plan tasks covering too many components into smaller per-layer tasks

### DIFF
--- a/app/services/decomposition_plan/generate.rb
+++ b/app/services/decomposition_plan/generate.rb
@@ -33,6 +33,12 @@ module DecompositionPlan
     MAX_DESCRIPTION_LENGTH = 5000
     MAX_TITLE_LENGTH = 255
     MAX_TASKS = 20
+    MAX_COMPONENTS_PER_TASK = {
+      "model" => 3,
+      "service" => 3,
+      "controller" => 2,
+      "view" => 2
+    }.freeze
 
     attr_reader :title, :description, :sub_components, :max_tasks, :layer_order
 
@@ -71,15 +77,17 @@ module DecompositionPlan
     private
 
     def build_tasks
-      grouped = group_components_by_layer
-      tasks = []
-
-      grouped.each do |layer, components|
-        tasks << build_task_for_layer(layer, components)
-      end
+      layer_tasks = build_layer_tasks
+      tasks = layer_tasks.map { |task| build_task_for_layer(task[:layer], task[:components]) }
 
       tasks = [ build_single_task ] if tasks.empty?
       tasks
+    end
+
+    def build_layer_tasks
+      split_oversized_layer_tasks(group_components_by_layer.map do |layer, components|
+        { layer: layer, components: components }
+      end)
     end
 
     def group_components_by_layer
@@ -93,6 +101,42 @@ module DecompositionPlan
       end
 
       grouped
+    end
+
+    def split_oversized_layer_tasks(tasks)
+      remaining_capacity = [ max_tasks - tasks.size, 0 ].max
+
+      tasks.flat_map do |task|
+        split_task_count = split_task_count_for(task)
+        extra_tasks_needed = split_task_count - 1
+
+        if extra_tasks_needed.positive? && extra_tasks_needed <= remaining_capacity
+          remaining_capacity -= extra_tasks_needed
+          split_task(task)
+        else
+          [ task ]
+        end
+      end
+    end
+
+    def split_task_count_for(task)
+      threshold = component_threshold_for(task[:layer])
+      return 1 unless threshold
+
+      (task[:components].size.to_f / threshold).ceil
+    end
+
+    def split_task(task)
+      threshold = component_threshold_for(task[:layer])
+      return [ task ] unless threshold
+
+      task[:components].each_slice(threshold).map do |components|
+        task.merge(components: components)
+      end
+    end
+
+    def component_threshold_for(layer)
+      MAX_COMPONENTS_PER_TASK[layer]
     end
 
     def classify_component(component)
@@ -226,9 +270,6 @@ module DecompositionPlan
     def layer_rank_for(layer)
       layer_order.fetch(layer, DEFAULT_LAYER_ORDER.size)
     end
-
-    # TODO(#453): Split tasks covering too many components into smaller tasks
-    # within the same layer when we have room under MAX_TASKS.
 
     # Attempt to fix DAG issues by removing problematic dependency edges.
     def repair_dag(tasks)

--- a/spec/services/decomposition_plan/generate_spec.rb
+++ b/spec/services/decomposition_plan/generate_spec.rb
@@ -269,6 +269,61 @@ RSpec.describe DecompositionPlan::Generate, :no_db do
         expect(result.tasks.map { |task| task[:scope] }).to eq(%w[view controller service model])
       end
     end
+
+    context "when a layer touches too many components" do
+      let(:title) { "Notification orchestration" }
+      let(:description) { "Add storage, business logic, and endpoints for notifications." }
+      let(:service_threshold) { described_class::MAX_COMPONENTS_PER_TASK.fetch("service") }
+      let(:sub_components) do
+        [ "database" ] +
+          Array.new(service_threshold + 1) { |index| "custom_service_component_#{index}" } +
+          [ "api endpoints" ]
+      end
+
+      it "splits the oversized layer into multiple same-scope tasks" do
+        service_tasks = result.tasks.select { |task| task[:scope] == "service" }
+
+        expect(service_tasks.size).to eq(2)
+        expect(result.tasks.map { |task| task[:scope] }).to eq(%w[model service service controller])
+      end
+
+      it "preserves layer ordering and dependency edges after splitting" do
+        model_task = result.tasks.find { |task| task[:scope] == "model" }
+        service_tasks = result.tasks.select { |task| task[:scope] == "service" }
+        controller_task = result.tasks.find { |task| task[:scope] == "controller" }
+
+        expect(service_tasks.map { |task| task[:deps] }).to all(eq([ model_task[:index] ]))
+        expect(controller_task[:index]).to be > service_tasks.last[:index]
+        expect(controller_task[:deps]).to eq(service_tasks.map { |task| task[:index] })
+      end
+    end
+
+    context "when splitting would exceed max_tasks" do
+      subject(:result) do
+        described_class.call(
+          title: title,
+          description: description,
+          sub_components: sub_components,
+          max_tasks: 4
+        )
+      end
+
+      let(:title) { "Notification orchestration" }
+      let(:description) { "Add storage, business logic, and endpoints for notifications." }
+      let(:service_threshold) { described_class::MAX_COMPONENTS_PER_TASK.fetch("service") }
+      let(:sub_components) do
+        [ "database" ] +
+          Array.new(service_threshold + 1) { |index| "custom_service_component_#{index}" } +
+          [ "api endpoints", "views" ]
+      end
+
+      it "keeps the oversized layer as a single task" do
+        service_tasks = result.tasks.select { |task| task[:scope] == "service" }
+
+        expect(result.task_count).to eq(4)
+        expect(service_tasks.size).to eq(1)
+      end
+    end
   end
 
   describe "immutability" do


### PR DESCRIPTION
## Summary

Multi-component tasks produced by `DecompositionPlan::Generate` were hard to implement and review, leading to sprawling PRs. This change splits oversized same-layer tasks into smaller per-layer tasks when the resulting count stays under `MAX_TASKS`, making generated plans more reviewable and easier to execute.

## Changes

- **Services**: Added `MAX_COMPONENTS_PER_TASK` with explicit per-layer thresholds in `app/services/decomposition_plan/generate.rb`; introduced splitting logic that divides oversized tasks within the same layer while preserving layer ordering and dependency edges via the existing index assignment flow. Removed the TODO at the former line 230.
- **Specs**: Extended `spec/services/decomposition_plan/generate_spec.rb` to cover the split happening, splitting being skipped when the plan is at `MAX_TASKS`, and dependency/layer ordering being preserved after a split.

## Design Decisions

- **Per-layer thresholds, not a single global constant**: Different architectural layers tolerate different component counts before a task becomes unwieldy, so `MAX_COMPONENTS_PER_TASK` is defined as a per-layer mapping rather than a flat number.
- **Capacity-bounded splitting**: Splits only run when the resulting task count remains under `MAX_TASKS`. When the plan is already saturated, oversized tasks are left intact rather than dropping work or violating the cap.
- **Reuses existing index assignment**: Layer ordering and dependency edges are preserved by routing split tasks through the same index assignment path the generator already uses, avoiding a parallel ordering implementation.

---

Closes #2141