### PR TITLE
fix(agent-runs): resume analyze-issue followups

### DIFF
--- a/app/jobs/analyze_issue_followup_backfill_job.rb
+++ b/app/jobs/analyze_issue_followup_backfill_job.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# One-time backfill for issues stranded in paid_state="analyzed" before
+# analyze_issue workflows started enqueueing their own follow-up runs.
+#
+# Without this pass, legacy analyzed issues can remain stuck indefinitely:
+# they are no longer eligible for auto-pick, and unchanged issues are not
+# revisited by incremental sync.
+class AnalyzeIssueFollowupBackfillJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :maintenance
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: "analyze_issue_followup_backfill"
+  )
+
+  CACHE_NAMESPACE = "analyze_issue_followup_backfill/v1"
+
+  def perform
+    return if completed?
+
+    processed = 0
+
+    eligible_projects.find_each do |project|
+      next if project_backfilled?(project.id)
+      next unless Issues::AutoPickProjectGate.call(project)
+
+      backfill_project(project)
+      mark_project_backfilled(project.id)
+      processed += 1
+    rescue => e
+      Rails.logger.error(
+        message: "analyze_issue_followup_backfill.project_failed",
+        project_id: project.id,
+        error: e.message
+      )
+    end
+
+    remaining = remaining_project_ids
+    mark_completed if remaining.empty?
+
+    Rails.logger.info(
+      message: "analyze_issue_followup_backfill.completed",
+      processed_projects: processed,
+      remaining_projects: remaining.size
+    )
+  end
+
+  private
+
+  def backfill_project(project)
+    analyzed_issues_for(project).find_each do |issue|
+      analysis_run = latest_completed_analysis_run_for(issue)
+      next unless analysis_run
+
+      followup_goal = followup_goal_for(analysis_run)
+      next unless followup_goal
+
+      Activities::CreateFollowupRunActivity.new.execute(
+        agent_run_id: analysis_run.id,
+        goal: followup_goal
+      )
+    end
+  end
+
+  def analyzed_issues_for(project)
+    project.issues
+      .where(github_state: "open", is_pull_request: false, paid_state: "analyzed")
+      .where.not(
+        id: project.agent_runs
+          .where(status: AgentRun::UNFINISHED_STATUSES)
+          .where.not(issue_id: nil)
+          .select(:issue_id)
+      )
+  end
+
+  def latest_completed_analysis_run_for(issue)
+    issue.agent_runs
+      .where(goal: "analyze_issue", status: "completed")
+      .order(completed_at: :desc, id: :desc)
+      .first
+  end
+
+  def followup_goal_for(agent_run)
+    payload = parse_analysis_payload(agent_run)
+    return unless payload&.key?("sufficient_context") || payload&.key?(:sufficient_context)
+
+    sufficient_context = payload["sufficient_context"]
+    sufficient_context = payload[:sufficient_context] if sufficient_context.nil?
+    sufficient_context ? "create_pr" : "enhance_issue"
+  rescue JSON::ParserError => e
+    Rails.logger.warn(
+      message: "analyze_issue_followup_backfill.invalid_payload",
+      agent_run_id: agent_run.id,
+      error: e.message
+    )
+    nil
+  end
+
+  def parse_analysis_payload(agent_run)
+    raw = agent_run.agent_run_logs.stdout.recent.limit(1).pick(:content)
+    return if raw.blank?
+
+    JSON.parse(raw)
+  end
+
+  def completed?
+    Rails.cache.read(completed_cache_key) == true
+  end
+
+  def mark_completed
+    Rails.cache.write(completed_cache_key, true)
+  end
+
+  def project_backfilled?(project_id)
+    Rails.cache.read(project_cache_key(project_id)) == true
+  end
+
+  def mark_project_backfilled(project_id)
+    Rails.cache.write(project_cache_key(project_id), true)
+  end
+
+  def remaining_project_ids
+    eligible_projects.each_with_object([]) do |project, remaining|
+      next if project_backfilled?(project.id)
+
+      remaining << project.id
+    end
+  end
+
+  def eligible_projects
+    Project.active.where(auto_pick_enabled: true, auto_enhance_enabled: true)
+  end
+
+  def completed_cache_key
+    "#{CACHE_NAMESPACE}/completed"
+  end
+
+  def project_cache_key(project_id)
+    "#{CACHE_NAMESPACE}/projects/#{project_id}"
+  end
+end

--- a/app/temporal/activities/create_followup_run_activity.rb
+++ b/app/temporal/activities/create_followup_run_activity.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Activities
+  class CreateFollowupRunActivity < BaseActivity
+    activity_name "CreateFollowupRun"
+
+    def execute(input)
+      agent_run = AgentRun.find(input.fetch(:agent_run_id))
+      goal = input.fetch(:goal)
+
+      result = track_phase(
+        agent_run_id: agent_run.id,
+        phase_key: "create_followup_run",
+        phase_group: "post",
+        agent_run: agent_run,
+        metadata: { goal: goal }
+      ) do
+        QueueAgentRunActivity.new.execute(queue_input(agent_run, goal))
+      end
+
+      {
+        agent_run_id: agent_run.id,
+        followup_agent_run_id: result[:agent_run_id],
+        goal: goal,
+        queued: result.fetch(:queued, false),
+        duplicate: result.fetch(:duplicate, false),
+        cross_goal: result.fetch(:cross_goal, false)
+      }
+    end
+
+    private
+
+    def queue_input(agent_run, goal)
+      {
+        project_id: agent_run.project_id,
+        issue_id: agent_run.issue_id,
+        goal: goal,
+        auto_pick: true,
+        initiating_user_id: agent_run.initiating_user_id,
+        runner_id: agent_run.runner_id
+      }.compact
+    end
+  end
+end

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -13,6 +13,7 @@ module Activities
       source_pull_request_number = input[:source_pull_request_number]
       goal = input[:goal]
       focus = input[:focus] || "general"
+      auto_pick = input.fetch(:auto_pick, false)
       count_toward_draft_review_round = input.fetch(:count_toward_draft_review_round, false)
       expected_draft_review_count = input[:expected_draft_review_count]
 
@@ -53,6 +54,7 @@ module Activities
             source_pull_request_number: source_pull_request_number,
             goal: goal,
             focus: focus,
+            auto_pick: auto_pick,
             count_toward_draft_review_round: count_toward_draft_review_round,
             expected_draft_review_count: expected_draft_review_count,
             status: "queued"

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -145,6 +145,19 @@ module Workflows
             start_to_close_timeout: issue_goal_timeout_seconds,
             retry_policy: NO_RETRY)
 
+          unless result.is_a?(Hash) && result.key?(:sufficient_context)
+            raise Temporalio::Error::ApplicationError.new(
+              "AnalyzeIssueActivity returned an invalid result payload",
+              type: "AnalyzeIssueInvalidResult",
+              non_retryable: true
+            )
+          end
+
+          followup_goal = result[:sufficient_context] ? "create_pr" : "enhance_issue"
+          run_activity(Activities::CreateFollowupRunActivity,
+            { agent_run_id: agent_run_id, goal: followup_goal },
+            timeout: 30)
+
           agent_step_succeeded = true
           return { success: true, agent_run_id: agent_run_id, **result.slice(:sufficient_context) }
         end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -117,6 +117,11 @@ Rails.application.configure do
       class: "AutoPickQueueBackfillJob",
       description: "Backfill eager auto-pick queue seeding for already-enabled projects"
     },
+    analyze_issue_followup_backfill: {
+      cron: "15 * * * *",
+      class: "AnalyzeIssueFollowupBackfillJob",
+      description: "Backfill follow-up runs for legacy analyzed issues"
+    },
     service_container_reconciliation: {
       cron: "*/5 * * * *",
       class: "ServiceContainerReconciliationJob",

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ApplicationJob, :no_db do
         RetryTimedOutIssueGoalJob
       ],
       maintenance: %w[
+        AnalyzeIssueFollowupBackfillJob
         AutoPickQueueBackfillJob
         AgentRunPatternDetectorJob
         AgentRunResourceJanitorJob

--- a/spec/jobs/analyze_issue_followup_backfill_job_spec.rb
+++ b/spec/jobs/analyze_issue_followup_backfill_job_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AnalyzeIssueFollowupBackfillJob do
+  describe "#perform" do
+    let(:project) do
+      create(:project, auto_pick_enabled: true, auto_enhance_enabled: true)
+    end
+    let(:issue) do
+      create(:issue, project: project, paid_state: "analyzed", github_state: "open", is_pull_request: false)
+    end
+    let!(:runner) { create(:runner, user: project.created_by) }
+
+    before do
+      Rails.cache.clear
+    end
+
+    it "queues a create_pr follow-up for analyzed issues with sufficient context" do
+      analysis_run = create(:agent_run, :analyze_issue_goal, :completed, project: project, issue: issue, runner: runner)
+      analysis_run.log!("stdout", { sufficient_context: true, reasoning: "ready", missing_context_areas: [] }.to_json)
+
+      expect {
+        described_class.perform_now
+      }.to change {
+        project.agent_runs.where(goal: "create_pr", status: "queued").count
+      }.by(1)
+    end
+
+    it "queues an enhance_issue follow-up for analyzed issues without sufficient context" do
+      analysis_run = create(:agent_run, :analyze_issue_goal, :completed, project: project, issue: issue, runner: runner)
+      analysis_run.log!("stdout", { sufficient_context: false, reasoning: "needs details", missing_context_areas: [ "acceptance criteria" ] }.to_json)
+
+      expect {
+        described_class.perform_now
+      }.to change {
+        project.agent_runs.where(goal: "enhance_issue", status: "queued").count
+      }.by(1)
+    end
+
+    it "skips issues without a parseable analysis payload" do
+      analysis_run = create(:agent_run, :analyze_issue_goal, :completed, project: project, issue: issue, runner: runner)
+      analysis_run.log!("stdout", "not json")
+
+      expect {
+        described_class.perform_now
+      }.not_to change {
+        project.agent_runs.where(status: "queued").count
+      }
+    end
+  end
+end

--- a/spec/temporal/activities/create_followup_run_activity_spec.rb
+++ b/spec/temporal/activities/create_followup_run_activity_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Activities::CreateFollowupRunActivity do
+  describe "#execute" do
+    let(:activity) { described_class.new }
+    let(:project) { create(:project) }
+    let(:issue) { create(:issue, project: project) }
+    let(:runner) { create(:runner, user: project.created_by) }
+    let(:initiating_user) { create(:user, account: project.account) }
+    let(:analysis_run) do
+      create(:agent_run, :analyze_issue_goal, :completed,
+        project: project,
+        issue: issue,
+        runner: runner,
+        initiating_user: initiating_user)
+    end
+
+    it "queues an auto-pick follow-up run using the analysis run context" do
+      result = activity.execute(agent_run_id: analysis_run.id, goal: "create_pr")
+      followup = AgentRun.find(result[:followup_agent_run_id])
+
+      expect(result).to eq(
+        agent_run_id: analysis_run.id,
+        followup_agent_run_id: followup.id,
+        goal: "create_pr",
+        queued: true,
+        duplicate: false,
+        cross_goal: false
+      )
+      expect(followup.goal).to eq("create_pr")
+      expect(followup.status).to eq("queued")
+      expect(followup.auto_pick).to be(true)
+      expect(followup.runner).to eq(runner)
+      expect(followup.initiating_user).to eq(initiating_user)
+    end
+
+    it "reuses an existing unfinished run for the same issue even when the goal differs" do
+      existing = create(:agent_run, project: project, issue: issue, goal: "enhance_issue", status: "queued")
+
+      result = activity.execute(agent_run_id: analysis_run.id, goal: "create_pr")
+
+      expect(result).to eq(
+        agent_run_id: analysis_run.id,
+        followup_agent_run_id: existing.id,
+        goal: "create_pr",
+        queued: false,
+        duplicate: true,
+        cross_goal: true
+      )
+      expect(
+        AgentRun.where(project: project, issue: issue, status: AgentRun::UNFINISHED_STATUSES).count
+      ).to eq(1)
+    end
+  end
+end

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -256,12 +256,20 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger, patched: true)
     end
 
-    it "runs AnalyzeIssueActivity without provisioning or running an agent container" do
+    def expect_analyze_issue_followup(goal:)
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::CreateFollowupRunActivity, { agent_run_id: 42, goal: goal },
+          timeout: 30)
+    end
+
+    it "runs AnalyzeIssueActivity and queues a create_pr follow-up when context is sufficient" do
       allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
         case activity_class.name
         when "Activities::CreateAgentRunActivity" then { agent_run_id: 42 }
         when "Activities::AnalyzeIssueActivity"
           { agent_run_id: 42, sufficient_context: true }
+        when "Activities::CreateFollowupRunActivity"
+          { agent_run_id: 42, followup_agent_run_id: 43, goal: "create_pr" }
         else {}
         end
       end
@@ -272,10 +280,28 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       expect(workflow).to have_received(:run_activity)
         .with(Activities::AnalyzeIssueActivity, { agent_run_id: 42 },
           start_to_close_timeout: anything, retry_policy: described_class::NO_RETRY)
+      expect_analyze_issue_followup(goal: "create_pr")
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::ProvisionContainerActivity, anything, any_args)
       expect(workflow).not_to have_received(:run_activity)
         .with(Activities::RunAgentActivity, anything, any_args)
+    end
+
+    it "queues an enhance_issue follow-up when context is insufficient" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42 }
+        when "Activities::AnalyzeIssueActivity"
+          { agent_run_id: 42, sufficient_context: false }
+        when "Activities::CreateFollowupRunActivity"
+          { agent_run_id: 42, followup_agent_run_id: 43, goal: "enhance_issue" }
+        else {}
+        end
+      end
+
+      workflow.execute(input)
+
+      expect_analyze_issue_followup(goal: "enhance_issue")
     end
 
     it "uses the issue-goal timeout for AnalyzeIssueActivity" do
@@ -289,11 +315,36 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::AnalyzeIssueActivity"
           expect(opts[:start_to_close_timeout]).to eq(180)
           { agent_run_id: 42, sufficient_context: true }
+        when "Activities::CreateFollowupRunActivity"
+          { agent_run_id: 42, followup_agent_run_id: 43, goal: "create_pr" }
         else {}
         end
       end
 
       workflow.execute(input)
+    end
+
+    it "fails loudly when AnalyzeIssueActivity returns an invalid payload" do
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42 }
+        when "Activities::AnalyzeIssueActivity" then {}
+        when "Activities::MarkAgentRunFailedActivity",
+          "Activities::CleanupContainerActivity",
+          "Activities::CleanupServicesActivity",
+          "Activities::CleanupWorktreeActivity",
+          "Activities::EnqueueJanitorActivity"
+          {}
+        else {}
+        end
+      end
+
+      expect {
+        workflow.execute(input)
+      }.to raise_error(Temporalio::Error::ApplicationError, /AnalyzeIssueActivity returned an invalid result payload/)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::CreateFollowupRunActivity, anything, any_args)
     end
   end
 


### PR DESCRIPTION
## Summary
- enqueue follow-up runs after `analyze_issue` instead of stopping at `paid_state = analyzed`
- route follow-ups through the normal queueing path so duplicate protection and `auto_pick` metadata stay consistent
- add a maintenance backfill for legacy analyzed issues that were already stranded before the workflow fix

Closes #2191
Closes #2192

## Testing
- targeted workflow/activity/job specs passed in the original workspace before branch packaging
- pre-commit lint checks passed during commit
- branch-worktree spec rerun hit branch-specific missing test DB setup, not a code failure