### PR TITLE
fix(pr-scanner): reduce premature PR escalation

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -23,7 +23,9 @@ module Activities
     MIN_COMMENT_LENGTH = 20
     CI_ACTION_DISPATCH_GRACE_PERIOD = 2.minutes
     DEFAULT_CONSECUTIVE_UNSUCCESSFUL_PR_RUNS = 3
-    NO_PROGRESS_ESCALATION_WINDOW = 1.hour
+    # Give the system multiple poll cycles and follow-up runs to recover
+    # before escalating a PR solely for lack of progress.
+    NO_PROGRESS_ESCALATION_WINDOW = 3.hours
     # Floor for re-scanning a PR even when GitHub's `updated_at` has not
     # advanced. `updated_at` does not bump for check-run state changes,
     # unanswered bot review requests, or review-goal retry timers — without
@@ -355,7 +357,6 @@ module Activities
       retry_needed = review_goal_retry_needed?(project, issue, progress_state:)
 
       if !explicit_pr_decisions &&
-          retry_needed &&
           review_goal_retry_limit_reached?(project, issue, progress_state:) &&
           no_progress_stuck?(project, issue, progress_state) &&
           review_goal_retry_limit_requires_escalation?(project, issue, progress_state:) &&
@@ -1169,26 +1170,38 @@ module Activities
       streak = progress_state.consecutive_unsuccessful_automatic_runs
 
       if progress_state.latest_unsuccessful_review?
-        "No meaningful progress for #{NO_PROGRESS_ESCALATION_WINDOW / 1.minute} minutes after " \
+        "No meaningful progress for #{no_progress_escalation_window_label} after " \
           "#{streak} consecutive unsuccessful automatic runs; latest run was review"
       elsif issue.draft_phase?
-        "No meaningful progress for #{NO_PROGRESS_ESCALATION_WINDOW / 1.minute} minutes after " \
+        "No meaningful progress for #{no_progress_escalation_window_label} after " \
           "#{streak} consecutive unsuccessful automatic runs in the current PR cycle"
       else
-        "No meaningful progress for #{NO_PROGRESS_ESCALATION_WINDOW / 1.minute} minutes after " \
+        "No meaningful progress for #{no_progress_escalation_window_label} after " \
           "#{streak} consecutive unsuccessful automatic runs"
       end
     end
 
     def operational_failure_reason
-      "No meaningful progress for #{NO_PROGRESS_ESCALATION_WINDOW / 1.minute} minutes after " \
+      "No meaningful progress for #{no_progress_escalation_window_label} after " \
         "#{MAX_CONSECUTIVE_OPERATIONAL_FAILURES} consecutive provider/infrastructure failures"
     end
 
     def review_goal_retry_escalation_reason(project, issue, progress_state: nil)
       "Review-goal retry budget exhausted with no meaningful progress for " \
-        "#{NO_PROGRESS_ESCALATION_WINDOW / 1.minute} minutes " \
+        "#{no_progress_escalation_window_label} " \
         "(#{review_goal_consecutive_failure_count(project, issue, progress_state:)} consecutive failures)"
+    end
+
+    def no_progress_escalation_window_label
+      seconds = NO_PROGRESS_ESCALATION_WINDOW.to_i
+
+      if (seconds % 1.hour).zero?
+        hours = seconds / 1.hour
+        "#{hours} #{'hour'.pluralize(hours)}"
+      else
+        minutes = seconds / 1.minute
+        "#{minutes} #{'minute'.pluralize(minutes)}"
+      end
     end
 
     def review_goal_retry_trigger?(project, issue, progress_state:, explicit_pr_decisions:)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -193,9 +193,7 @@ module Activities
       reason = if op_breaker
         operational_failure_reason
       elsif no_progress_stuck && retry_escalation
-        "Review-goal retry budget exhausted with no meaningful progress for " \
-          "#{NO_PROGRESS_ESCALATION_WINDOW / 1.minute} minutes " \
-          "(#{review_goal_consecutive_failure_count(project, issue, progress_state:)} consecutive failures)"
+        review_goal_retry_escalation_reason(project, issue, progress_state:)
       elsif no_progress_stuck && failure_limit
         failure_streak_reason(project, issue, progress_state)
       end
@@ -1893,9 +1891,10 @@ module Activities
     # Returns [] when the retry limit is reached so no more review-goal runs
     # are queued (#1002). Callers separately decide whether that exhaustion
     # should escalate the PR or let another enabled bot continue review gating.
-    def check_paid_agent_review_status(project, issue)
+    def check_paid_agent_review_status(project, issue, progress_state: nil)
       return [] unless issue
 
+      progress_state ||= pr_progress_state(project, issue)
       current_cycle_review_runs = attempted_automatic_review_runs(project, issue)
       unfinished_run = current_cycle_review_run_in_progress(project, issue)
 
@@ -1905,14 +1904,14 @@ module Activities
                  active_run: true } ]
       end
 
-      return [] if review_goal_retry_limit_reached?(project, issue)
+      return [] if review_goal_retry_limit_reached?(project, issue, progress_state:)
 
       # When a review-goal retry is already being emitted as an explicit
       # review_goal_retry trigger, suppress the sidecar-only pending trigger
       # for mixed-bot projects so the remaining bot can keep gating the PR.
       # Paid-agent-only projects still need paid_agent_review_pending to block
       # draft exit until the retried review is posted.
-      return [] if review_goal_retry_needed?(project, issue) && !paid_agent_sole_review_method?(project)
+      return [] if review_goal_retry_needed?(project, issue, progress_state:) && !paid_agent_sole_review_method?(project)
 
       # Count all finished review attempts (including failed/timed-out) toward
       # the max_review_rounds limit, but exclude retried runs because retry
@@ -1933,10 +1932,10 @@ module Activities
       # even when the last finished review attempt post-dates the last create_pr.
       # However, when the run already posted a review on the PR, the feedback is
       # visible — retrying would post a duplicate review on every scan cycle.
-      latest_finished_run = latest_finished_automatic_review_run(project, issue)
+      latest_finished_run = latest_finished_automatic_review_run(project, issue, progress_state:)
       if latest_finished_run&.status&.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES) &&
           latest_finished_run.review_posted_at.blank?
-        failed_count = review_goal_consecutive_failure_count(project, issue)
+        failed_count = review_goal_consecutive_failure_count(project, issue, progress_state:)
         max_retries = review_goal_max_retries(project)
         return [ { type: "paid_agent_review_pending",
                  details: "Retrying unsuccessful review-goal run (attempt #{failed_count + 1}/#{max_retries})" } ]

--- a/spec/services/automation/strategies/auto_continue_review_retry_no_db_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_review_retry_no_db_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Automation::Strategies::AutoContinue, :no_db do
   end
 
   it "escalates once the review-goal retry path itself requires escalation" do
-    reason = "Review-goal retry budget exhausted with no meaningful progress for 60 minutes (3 consecutive failures)"
+    reason = "Review-goal retry budget exhausted with no meaningful progress for 3 hours (3 consecutive failures)"
     context = Automation::Context.build(
       record: pull_request,
       project: project,
@@ -130,7 +130,7 @@ RSpec.describe Automation::Strategies::AutoContinue, :no_db do
   end
 
   it "escalates even when the unified failure streak signal remains soft" do
-    reason = "Review-goal retry budget exhausted with no meaningful progress for 60 minutes"
+    reason = "Review-goal retry budget exhausted with no meaningful progress for 3 hours"
     context = Automation::Context.build(
       record: pull_request,
       project: project,

--- a/spec/services/automation/strategies/auto_continue_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Automation::Strategies::AutoContinue do
           lifecycle: base_lifecycle.merge(
             operational_failure_breaker: true,
             no_progress_stuck: true,
-            escalation_reason: "No meaningful progress for 60 minutes after 3 consecutive provider/infrastructure failures"
+            escalation_reason: "No meaningful progress for 3 hours after 3 consecutive provider/infrastructure failures"
           )
         )
 
@@ -121,7 +121,7 @@ RSpec.describe Automation::Strategies::AutoContinue do
           issue_id: pull_request.id,
           pr_number: 42,
           owner_reviewer_login: "alice",
-          reason: "No meaningful progress for 60 minutes after 3 consecutive provider/infrastructure failures"
+          reason: "No meaningful progress for 3 hours after 3 consecutive provider/infrastructure failures"
         )
       end
     end

--- a/spec/services/coordination/escalation_service_spec.rb
+++ b/spec/services/coordination/escalation_service_spec.rb
@@ -121,18 +121,18 @@ RSpec.describe Coordination::EscalationService do
       result = call_service(
         no_progress_stuck: true,
         operational_failure_breaker: true,
-        escalation_reason: "No meaningful progress for 60 minutes after 3 consecutive provider/infrastructure failures"
+        escalation_reason: "No meaningful progress for 3 hours after 3 consecutive provider/infrastructure failures"
       )
 
       expect(result).to be_escalate
-      expect(result.reason).to eq("No meaningful progress for 60 minutes after 3 consecutive provider/infrastructure failures")
+      expect(result.reason).to eq("No meaningful progress for 3 hours after 3 consecutive provider/infrastructure failures")
       expect_logged_decision(
         OrchestrationDecision.last,
         status: "applied",
         inputs: explicit_trigger_decision_inputs,
         outputs: {
           "decision" => "escalate",
-          "reason" => "No meaningful progress for 60 minutes after 3 consecutive provider/infrastructure failures",
+          "reason" => "No meaningful progress for 3 hours after 3 consecutive provider/infrastructure failures",
           "explicit_trigger" => "no_progress_stuck",
           "policy_source" => "defaults"
         }

--- a/spec/services/notifications/rules/pr_followup_limit_reached_spec.rb
+++ b/spec/services/notifications/rules/pr_followup_limit_reached_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
         consecutive_operational_failures: 0,
         last_meaningful_progress_at: nil,
         latest_automatic_run_at: nil,
-        latest_unsuccessful_run_at: 2.hours.ago,
+        latest_unsuccessful_run_at: 4.hours.ago,
         latest_unsuccessful_run_goal: "create_pr",
         latest_unsuccessful_run_status: "failed"
       )
@@ -50,7 +50,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
           consecutive_operational_failures: 0,
           last_meaningful_progress_at: nil,
           latest_automatic_run_at: nil,
-          latest_unsuccessful_run_at: 2.hours.ago,
+          latest_unsuccessful_run_at: 4.hours.ago,
           latest_unsuccessful_run_goal: "create_pr",
           latest_unsuccessful_run_status: "failed"
         )
@@ -155,7 +155,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
         consecutive_operational_failures: 0,
         last_meaningful_progress_at: nil,
         latest_automatic_run_at: nil,
-        latest_unsuccessful_run_at: 2.hours.ago,
+        latest_unsuccessful_run_at: 4.hours.ago,
         latest_unsuccessful_run_goal: "create_pr",
         latest_unsuccessful_run_status: "failed"
       )
@@ -183,7 +183,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
         consecutive_operational_failures: 0,
         last_meaningful_progress_at: nil,
         latest_automatic_run_at: nil,
-        latest_unsuccessful_run_at: 2.hours.ago,
+        latest_unsuccessful_run_at: 4.hours.ago,
         latest_unsuccessful_run_goal: "create_pr",
         latest_unsuccessful_run_status: "failed"
       )

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -69,13 +69,17 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
   def create_stale_review_runs!(issue, statuses:, trigger_type: "automatic")
     Array(statuses).each_with_index do |status, index|
-      timestamp = (90 + ((Array(statuses).size - index) * 5)).minutes.ago
+      timestamp = (
+        Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW +
+        ((Array(statuses).size - index + 1) * 5).minutes
+      ).ago
       create(:agent_run,
         project: project,
         issue: issue,
         source_pull_request_number: issue.github_number,
         goal: "review",
         status: status,
+        result_commit_sha: nil,
         trigger_type: trigger_type,
         created_at: timestamp,
         updated_at: timestamp,
@@ -1401,7 +1405,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           draft_review_count: 0)
         create(:agent_run, :running,
           project: project, source_pull_request_number: 42, goal: "review")
-        stub_github_for_pr(draft: true, reviews: [])
+        stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
       end
 
       it "does not skip the PR" do
@@ -1443,13 +1447,13 @@ RSpec.describe Activities::ScanPaidPrsActivity do
               project: project,
               goal: "create_pr",
               source_pull_request_number: 42,
-              created_at: 90.minutes.ago,
-              updated_at: 90.minutes.ago,
-              completed_at: 90.minutes.ago)
+              created_at: 4.hours.ago,
+              updated_at: 4.hours.ago,
+              completed_at: 4.hours.ago)
           end
           stub_github_for_pr(
             checks: [ { name: "ci", conclusion: "failure" } ],
-            head_committed_at: 3.hours.ago
+            head_committed_at: 5.hours.ago
           )
         end
 
@@ -1475,12 +1479,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
               goal: "create_pr",
               source_pull_request_number: 42,
               base_commit_sha: "abc123",
-              created_at: 90.minutes.ago,
-              updated_at: 90.minutes.ago,
-              completed_at: 90.minutes.ago)
+              created_at: 4.hours.ago,
+              updated_at: 4.hours.ago,
+              completed_at: 4.hours.ago)
           end
           stub_github_for_pr(
-            head_committed_at: 3.hours.ago,
+            head_committed_at: 5.hours.ago,
             checks: [ { name: "ci", conclusion: "success" } ],
             reviews: default_clean_copilot_review + [
               { id: 1, user_login: "viamin", state: "CHANGES_REQUESTED", body: "", submitted_at: Time.current }
@@ -1511,14 +1515,14 @@ RSpec.describe Activities::ScanPaidPrsActivity do
               project: project,
               goal: "create_pr",
               source_pull_request_number: 42,
-              created_at: 90.minutes.ago,
-              updated_at: 90.minutes.ago,
-              completed_at: 90.minutes.ago)
+              created_at: 4.hours.ago,
+              updated_at: 4.hours.ago,
+              completed_at: 4.hours.ago)
           end
           stub_github_for_pr(
             author_login: "dependabot[bot]",
             checks: [ { name: "ci", conclusion: "failure" } ],
-            head_committed_at: 3.hours.ago
+            head_committed_at: 5.hours.ago
           )
         end
 
@@ -4763,7 +4767,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         project.update!(max_draft_review_rounds: 3)
         stub_github_for_pr(
           draft: true,
-          head_committed_at: 4.hours.ago,
+          head_committed_at: 5.hours.ago,
           review_threads: [
             { id: "thread_1", is_resolved: false,
              comments: [ { body: "Fix this", path: "app/model.rb", line: 10, author: "viamin" } ] }
@@ -4779,6 +4783,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           trigger_type: trigger_type,
           goal: goal,
           status: status,
+          result_commit_sha: nil,
           iterations: iterations,
           created_at: created_at,
           updated_at: created_at,
@@ -4787,7 +4792,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "escalates after 3 consecutive unsuccessful draft runs once the PR is stuck past the no-progress window" do
         3.times do |i|
-          create_draft_run(status: "no_output", iterations: 0, created_at: 2.hours.ago - i.minutes)
+          create_draft_run(status: "no_output", iterations: 0, created_at: 4.hours.ago - i.minutes)
         end
 
         result = activity.execute(project_id: project.id)
@@ -4795,7 +4800,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(result[:prs_to_trigger].size).to eq(1)
         trigger = result[:prs_to_trigger].first
         expect(trigger[:triggers].first[:type]).to eq("escalate_to_owner")
-        expect(trigger[:triggers].first[:details]).to include("No meaningful progress for 60 minutes after")
+        expect(trigger[:triggers].first[:details]).to include("No meaningful progress for 3 hours after")
       end
 
       it "does not escalate immediately after 3 consecutive failures when progress might still resume" do
@@ -5008,7 +5013,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
 
       before do
-        stub_github_for_pr(review_threads: [], reviews: [], checks: [], head_committed_at: 4.hours.ago)
+        stub_github_for_pr(review_threads: [], reviews: [], checks: [], head_committed_at: 5.hours.ago)
       end
 
       def create_followup_run(status:, error_message: nil, created_at: Time.current)
@@ -5019,6 +5024,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           trigger_type: "automatic",
           goal: "create_pr",
           status: status,
+          result_commit_sha: nil,
           error_message: error_message,
           started_at: created_at - 5.minutes,
           completed_at: created_at,
@@ -5030,7 +5036,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           create_followup_run(
             status: "failed",
             error_message: "All providers exhausted: claude_code, codex",
-            created_at: 2.hours.ago - i.minutes
+            created_at: 4.hours.ago - i.minutes
           )
         end
 
@@ -5039,7 +5045,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(result[:prs_to_trigger].size).to eq(1)
         trigger = result[:prs_to_trigger].first
         expect(trigger[:triggers].first[:type]).to eq("escalate_to_owner")
-        expect(trigger[:triggers].first[:details]).to include("No meaningful progress for 60 minutes after")
+        expect(trigger[:triggers].first[:details]).to include("No meaningful progress for 3 hours after")
       end
 
       it "escalates after 3 consecutive timeout failures" do
@@ -5047,7 +5053,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           create_followup_run(
             status: "timeout",
             error_message: "wall_clock_timeout: exceeded 30 minutes",
-            created_at: 2.hours.ago - i.minutes
+            created_at: 4.hours.ago - i.minutes
           )
         end
 
@@ -5056,13 +5062,13 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(result[:prs_to_trigger].size).to eq(1)
         trigger = result[:prs_to_trigger].first
         expect(trigger[:triggers].first[:type]).to eq("escalate_to_owner")
-        expect(trigger[:triggers].first[:details]).to include("No meaningful progress for 60 minutes after")
+        expect(trigger[:triggers].first[:details]).to include("No meaningful progress for 3 hours after")
       end
 
       it "escalates after 3 consecutive mixed operational failures" do
-        create_followup_run(status: "timeout", error_message: "wall_clock_timeout", created_at: 2.hours.ago)
-        create_followup_run(status: "rate_limited", error_message: "All providers rate limited", created_at: 2.hours.ago - 1.minute)
-        create_followup_run(status: "failed", error_message: "All providers exhausted: claude_code", created_at: 2.hours.ago - 2.minutes)
+        create_followup_run(status: "timeout", error_message: "wall_clock_timeout", created_at: 4.hours.ago)
+        create_followup_run(status: "rate_limited", error_message: "All providers rate limited", created_at: 4.hours.ago - 1.minute)
+        create_followup_run(status: "failed", error_message: "All providers exhausted: claude_code", created_at: 4.hours.ago - 2.minutes)
 
         result = activity.execute(project_id: project.id)
 
@@ -5118,7 +5124,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         triggers = result[:prs_to_trigger]
         escalation_triggers = triggers.select do |t|
-          t[:triggers].any? { |tr| tr[:details]&.include?("No meaningful progress for 60 minutes after") }
+          t[:triggers].any? { |tr| tr[:details]&.include?("No meaningful progress for 3 hours after") }
         end
         expect(escalation_triggers).to be_empty
       end
@@ -7159,9 +7165,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           project: project,
           goal: "create_pr",
           source_pull_request_number: 42,
-          completed_at: 90.minutes.ago,
-          updated_at: 90.minutes.ago,
-          created_at: 90.minutes.ago)
+          completed_at: 4.hours.ago,
+          updated_at: 4.hours.ago,
+          created_at: 4.hours.ago)
 
         result = activity.execute(project_id: project.id)
 
@@ -7362,7 +7368,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       before do
         enable_paid_agent_review!
         pr_issue
-        stub_github_for_pr(draft: true, reviews: [])
+        stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
       end
 
       it "emits review_goal_retry when most recent review-goal run failed" do
@@ -7502,7 +7508,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       it "escalates at retry limit in ready phase when PR is not draft" do
         pr_issue.update!(pr_review_phase: "ready", review_goal_retry_count: 3)
         create_stale_review_runs!(pr_issue, statuses: %w[failed failed failed])
-        stub_github_for_pr(draft: false, reviews: [])
+        stub_github_for_pr(draft: false, reviews: [], head_committed_at: 5.hours.ago)
 
         result = activity.execute(project_id: project.id)
 
@@ -7663,7 +7669,6 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         triggered_types = (result[:prs_to_trigger] || []).flat_map { |t| t[:triggers].map { |tr| tr[:type] } }
         expect(triggered_types).not_to include("escalate_to_owner")
-        expect(triggered_types).to include("review_goal_retry")
         expect(triggered_types).to include("review_bot_review_pending")
         expect(triggered_types).not_to include("paid_agent_review_pending")
       end
@@ -7767,7 +7772,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         })
         pr_issue
         create_stale_review_runs!(pr_issue, statuses: %w[failed failed failed])
-        stub_github_for_pr(reviews: [], checks: [ { name: "rspec", conclusion: "success" } ])
+        stub_github_for_pr(reviews: [], checks: [ { name: "rspec", conclusion: "success" } ], head_committed_at: 5.hours.ago)
       end
 
       it "escalates at retry limit because manual review cannot recover paid_agent" do
@@ -7799,7 +7804,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         })
         pr_issue
         create_stale_review_runs!(pr_issue, statuses: %w[failed failed failed])
-        stub_github_for_pr(reviews: [], checks: [ { name: "rspec", conclusion: "success" } ])
+        stub_github_for_pr(reviews: [], checks: [ { name: "rspec", conclusion: "success" } ], head_committed_at: 5.hours.ago)
       end
 
       it "escalates at retry limit because ci_action cannot recover paid_agent" do
@@ -7819,7 +7824,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         labels: [ "paid-generated", "paid-automation" ],
         pr_review_phase: "draft",
         draft_review_count: 0)
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "blocks draft exit with a paid_agent_review_pending trigger (no ready_for_owner)" do
@@ -7847,7 +7852,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         "enabled" => false,
         "methods" => { "paid_agent" => { "enabled" => true } }
       })
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "does not emit a paid_agent_review_pending trigger" do
@@ -8269,7 +8274,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     before do
       enable_paid_agent_review!(project, max_review_rounds: 3)
       create_stale_review_runs!(retry_limit_issue, statuses: %w[failed failed failed])
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "escalates to owner instead of retrying" do
@@ -8311,6 +8316,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       trigger = result[:prs_to_trigger].first
       trigger_types = trigger[:triggers].map { |t| t[:type] }
+      expect(trigger_types).to include("review_goal_retry")
       expect(trigger_types).to include("paid_agent_review_pending")
       expect(trigger_types).not_to include("escalate_to_owner")
     end
@@ -8387,7 +8393,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     before do
       enable_paid_agent_review!(project, max_review_rounds: 1)
       create_stale_review_runs!(low_rounds_issue, statuses: [ "failed" ])
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "caps default retry limit to max_review_rounds and escalates" do
@@ -8413,7 +8419,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     before do
       enable_paid_agent_review!(project)
       create_stale_review_runs!(ready_retry_issue, statuses: %w[failed failed failed])
-      stub_github_for_pr
+      stub_github_for_pr(reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "escalates to owner because the PR is still ready (not draft)" do
@@ -8567,7 +8573,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         goal: "review",
         started_at: 1.hour.ago,
         completed_at: 1.hour.ago)
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "retries instead of escalating because the breaker resets for the new cycle" do
@@ -8609,7 +8615,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         goal: "review",
         started_at: 1.hour.ago,
         completed_at: 1.hour.ago)
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "retries the review instead of escalating on the unified PR streak" do
@@ -8656,7 +8662,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         goal: "review",
         started_at: 1.hour.ago,
         completed_at: 1.hour.ago)
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "retries instead of escalating because the breaker resets after a successful review" do
@@ -8695,7 +8701,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         source_pull_request_number: 42,
         goal: "review", status: "completed",
         completed_at: 1.hour.ago)
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "does not retry when a completed review exists after the last create_pr run" do
@@ -8729,7 +8735,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         }
       })
       create_stale_review_runs!(custom_retries_issue, statuses: [ "failed" ])
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "escalates after custom retry limit" do
@@ -8820,7 +8826,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     before do
       enable_paid_agent_review!(project, max_review_rounds: 3)
       create_stale_review_runs!(no_output_retry_limit_issue, statuses: %w[no_output no_output no_output])
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "escalates instead of getting stuck behind the rounds cap" do
@@ -9110,7 +9116,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         }
       })
       create_stale_review_runs!(manual_retry_issue, statuses: %w[failed failed failed])
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "escalates because paid_agent is the sole bot and manual cannot recover failed review-goal runs" do
@@ -9147,7 +9153,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         }
       })
       create_stale_review_runs!(ci_retry_issue, statuses: %w[failed failed failed])
-      stub_github_for_pr(draft: true, reviews: [])
+      stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
     it "escalates because paid_agent is the sole bot and ci_action cannot recover failed review-goal runs" do

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -8565,6 +8565,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         project: project, issue: new_cycle_issue,
         source_pull_request_number: 42,
         goal: "create_pr",
+        result_commit_sha: "abc123",
         started_at: 90.minutes.ago,
         completed_at: 90.minutes.ago)
       create(:agent_run, :failed,


### PR DESCRIPTION
## Summary
- extend the no-progress PR escalation window from 1 hour to 3 hours
- keep stale paid-agent draft PRs from slipping through to `ready_for_owner` after retry exhaustion
- update scanner specs to model truly stale runs without accidentally resetting on newer head commits
- make escalation reasons say `3 hours` instead of `180 minutes`

## Testing
- `bundle exec rspec spec/services/automation/strategies/auto_continue_review_retry_no_db_spec.rb spec/services/automation/strategies/auto_continue_spec.rb spec/services/coordination/escalation_service_spec.rb`
- `bundle exec rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb:8278 spec/temporal/activities/scan_paid_prs_activity_spec.rb:8399 spec/temporal/activities/scan_paid_prs_activity_spec.rb:8741 spec/temporal/activities/scan_paid_prs_activity_spec.rb:8832 spec/temporal/activities/scan_paid_prs_activity_spec.rb:9122 spec/temporal/activities/scan_paid_prs_activity_spec.rb:9159`
- `bundle exec rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb:4789 spec/temporal/activities/scan_paid_prs_activity_spec.rb:5031 spec/temporal/activities/scan_paid_prs_activity_spec.rb:7449 spec/temporal/activities/scan_paid_prs_activity_spec.rb:7656`
