### PR TITLE
fix(auto-pick): Sidekiq-style exponential backoff for failed-run re-enqueue

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -592,27 +592,30 @@ class Issue < ApplicationRecord
     )
   end
 
+  # Sidekiq's retry curve: (n ** 4) + 15 + jitter seconds, where n is the
+  # zero-indexed retry attempt (n=0 is the first retry, after the first
+  # failure). Lenient on the first few retries (~20s, ~26s, ~46s, ~2m, ~5m)
+  # then grows quickly (~11m, ~22m, ~41m at n=5-7) and keeps growing — at
+  # n=24 the delay is ~3.8 days, at n=49 it's ~72 days. See
+  # https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry.
   def auto_pick_reenqueue_delay
     return unless paid_state == "failed"
 
-    case [ consecutive_auto_pick_failure_count, 1 ].max
-    when 1
-      5.minutes
-    when 2
-      15.minutes
-    when 3
-      1.hour
-    else
-      4.hours
-    end
+    n = [ consecutive_auto_pick_failure_count - 1, 0 ].max
+    ((n**4) + 15 + (rand(10) * (n + 1))).seconds
   end
 
+  # Counts the most recent consecutive failed/no_output auto-pick runs.
+  # Bounded at 50 so the retry curve can keep growing past the ~2-hour
+  # mark (n=10 produces ~3h, n=49 produces ~72 days) without scanning
+  # an unbounded number of historical runs. A 51st consecutive failure
+  # is treated the same as the 50th.
   def consecutive_auto_pick_failure_count
     statuses = agent_runs
       .where(auto_pick: true, goal: %w[create_pr analyze_issue])
       .finished
       .order(created_at: :desc, id: :desc)
-      .limit(10)
+      .limit(50)
       .pluck(:status)
 
     statuses.take_while { |status| (AgentRun::FAILURE_STATUSES + %w[no_output]).include?(status) }.count

--- a/docs/rdrs/RDR-032-eager-queue-seeding.md
+++ b/docs/rdrs/RDR-032-eager-queue-seeding.md
@@ -366,3 +366,88 @@ Use `INSERT ... ON CONFLICT DO NOTHING` for bulk seeding. **Rejected** per desig
 - Existing queued auto-pick runs continue to be processed
 - `ProcessRunQueueJob` dequeue loop works with both old and new queued runs
 - `max_auto_pick_open_prs` column presence does not cause errors (soft deprecate)
+
+## Amendment A: Sidekiq-style retry backoff for failed runs
+
+**Date**: 2026-05-21
+
+### Motivation
+
+The post-failure re-enqueue hook (`Issue#enqueue_self_if_became_auto_pick_eligible`) shipped alongside the eager-seeding work to keep an issue moving through the queue after a run finishes in `failed` state. The initial backoff curve was a coarse four-tier ladder:
+
+| Consecutive failures | Delay |
+|---|---|
+| 1 | 5 minutes |
+| 2 | 15 minutes |
+| 3 | 1 hour |
+| 4+ | 4 hours |
+
+Two problems with this curve in practice:
+
+1. **First-failure penalty is large relative to the cost of a retry.** A single failure parks an issue for 5 minutes before the next attempt — long enough that the issue is invisible on the dashboard's upcoming-queue view, even though the agent that just finished could pick another run instantly.
+2. **The curve plateaus at 4 hours forever.** A persistently broken issue is retried every 4 hours indefinitely. There is no graceful decay toward "don't try this again any time soon."
+
+Observed effect on `viamin/paid` (2026-05-21): three eligible issues (#2181, #2137, #2148) each had three consecutive timeouts during the day. Under the four-tier ladder each one was sitting in a 1-hour or 4-hour wait window, so the dashboard showed an empty upcoming queue despite three issues being eligible.
+
+### Decision
+
+Adopt Sidekiq's exponential backoff formula from
+[Sidekiq Wiki — Error Handling](https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry):
+
+```
+delay_seconds = (n ** 4) + 15 + (rand(10) * (n + 1))
+```
+
+Where `n` is the zero-indexed retry attempt: `n=0` is the first retry (scheduled after the first failure), `n=1` is the second retry, and so on. Implementation maps `n = [consecutive_auto_pick_failure_count - 1, 0].max`.
+
+| Retry attempt (`n`) | Delay range | Approx midpoint |
+|---|---|---|
+| 0 | 15–24 s | ~20 s |
+| 1 | 16–34 s | ~26 s |
+| 2 | 31–60 s | ~46 s |
+| 3 | 96–135 s | ~2 min |
+| 5 | 640–699 s | ~11 min |
+| 7 | 2 416–2 495 s | ~41 min |
+| 10 | 10 015–10 124 s | ~2 h 50 min |
+| 24 | ~331 776 s | ~3 d 20 h |
+| 49 (saturation) | ~5 764 800 s | ~66 d 17 h |
+
+Properties this gives us:
+
+- **First retries are nearly free.** The first three retries fire in well under a minute, so transient failures (network blip, race with sync) resolve quickly without burning a queue slot for minutes.
+- **Curve keeps growing well past 4 hours.** A persistently broken issue's retries taper out — by the 10th consecutive failure it's only attempted every ~3 hours; by the 25th, every ~4 days — so it stops consuming queue churn on its own without any human intervention to silence it.
+- **Saturates, doesn't grow unbounded.** `consecutive_auto_pick_failure_count` is bounded at 50 (any further consecutive failures are treated as the 50th), capping the maximum delay at ~72 days. This keeps the query that computes the count predictably small without meaningfully shortening real-world retry horizons.
+- **Jitter prevents thundering herd.** A burst of correlated failures (e.g., GitHub outage) does not all retry at exactly the same wall-clock instant.
+
+### Implementation
+
+Replace `Issue#auto_pick_reenqueue_delay` (`app/models/issue.rb`):
+
+```ruby
+def auto_pick_reenqueue_delay
+  return unless paid_state == "failed"
+
+  n = consecutive_auto_pick_failure_count
+  ((n**4) + 15 + (rand(10) * (n + 1))).seconds
+end
+```
+
+The `paid_state == "failed"` guard is preserved so that re-enqueues following a successful state transition (e.g., `analyzed → new`) remain immediate.
+
+### Trade-offs
+
+**Positive**
+
+- Matches established prior art (Sidekiq's curve has been battle-tested across many Rails apps).
+- Removes the artificial 4-hour ceiling: chronically failing issues taper out naturally instead of cycling every 4 h forever.
+- Aligns the dashboard's "upcoming queue" view with reality: after a single failure the issue is back in the queue within seconds, visible to the operator.
+
+**Negative**
+
+- Slightly more queue churn for issues that fail and recover quickly (3 retries in the first ~2 minutes instead of 1 retry in 5 minutes). Acceptable because each retry still consumes a `max_concurrent_runs` slot, capping the actual blast radius.
+- Removes the previous coarse signal "this issue is in the 4-hour bucket" that some operators may have been reading off the queue. Replace with structured logging on `enqueue_eligible.issue_state_changed` (`wait_seconds` already included).
+
+### Validation
+
+- Existing specs in `spec/models/issue_spec.rb` covering `enqueue_self_if_became_auto_pick_eligible` updated to assert the new delays with `rand` stubbed to a deterministic value.
+- No production migration required — the delay is computed at re-enqueue time, so existing scheduled `ReenqueueEligibleJob` entries keep their previously-computed delays and new enqueues use the new formula.

--- a/docs/rdrs/RDR-032-eager-queue-seeding.md
+++ b/docs/rdrs/RDR-032-eager-queue-seeding.md
@@ -427,7 +427,7 @@ Replace `Issue#auto_pick_reenqueue_delay` (`app/models/issue.rb`):
 def auto_pick_reenqueue_delay
   return unless paid_state == "failed"
 
-  n = consecutive_auto_pick_failure_count
+  n = [ consecutive_auto_pick_failure_count - 1, 0 ].max
   ((n**4) + 15 + (rand(10) * (n + 1))).seconds
 end
 ```

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -345,29 +345,33 @@ RSpec.describe Issue do
       )
     end
 
-    it "backs off failed issue retries to avoid immediate hot loops" do
+    it "applies a short Sidekiq-style backoff after the first failure" do
       project = create(:project, auto_pick_enabled: true)
       issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
       create(:agent_run, :failed, project: project, issue: issue, goal: "create_pr", auto_pick: true)
+      allow(issue).to receive(:rand).with(10).and_return(0)
 
+      # n = max(1 - 1, 0) = 0; delay = 0^4 + 15 + 0 * 1 = 15 seconds.
       freeze_time do
         expect {
           issue.update!(paid_state: "failed")
-        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(5.minutes.from_now)
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(15.seconds.from_now)
       end
     end
 
-    it "increases failed issue retry backoff for consecutive failures" do
+    it "grows the backoff polynomially across consecutive failures" do
       project = create(:project, auto_pick_enabled: true)
       issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
       2.times do
         create(:agent_run, :timeout, project: project, issue: issue, goal: "create_pr", auto_pick: true)
       end
+      allow(issue).to receive(:rand).with(10).and_return(0)
 
+      # n = max(2 - 1, 0) = 1; delay = 1^4 + 15 + 0 * 2 = 16 seconds.
       freeze_time do
         expect {
           issue.update!(paid_state: "failed")
-        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(15.minutes.from_now)
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(16.seconds.from_now)
       end
     end
 
@@ -377,11 +381,12 @@ RSpec.describe Issue do
       2.times do
         create(:agent_run, :no_output, project: project, issue: issue, goal: "create_pr", auto_pick: true)
       end
+      allow(issue).to receive(:rand).with(10).and_return(0)
 
       freeze_time do
         expect {
           issue.update!(paid_state: "failed")
-        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(15.minutes.from_now)
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id).at(16.seconds.from_now)
       end
     end
 


### PR DESCRIPTION
## Summary

- Replace `Issue#auto_pick_reenqueue_delay`'s 4-tier ladder (5m / 15m / 1h / 4h, plateaued forever) with [Sidekiq's exponential backoff formula](https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry): `(n ** 4) + 15 + (rand(10) * (n + 1))` seconds, zero-indexed against the retry attempt.
- Raise the `consecutive_auto_pick_failure_count` cap from 10 to 50 so the curve keeps growing past ~2 hours and tapers naturally for chronically broken issues (instead of cycling forever every 4 hours).
- Amend RDR-032 with the motivation, formula, full delay table, and trade-offs.

## Motivation

Observed on viamin/paid 2026-05-21: three eligible issues (#2181, #2137, #2148) had three consecutive timeouts during the day and were each sitting in a 1-to-4-hour wait window, so the dashboard's upcoming-queue view showed empty even though three issues were eligible. The 4-tier ladder is too aggressive at the first failure (5 minutes is forever when an agent slot is sitting idle) and stops growing exactly when it should keep stretching.

## Delay curve

| Retry attempt (`n`) | Old ladder | New (midpoint) |
|---|---|---|
| 0 (1st retry) | 5 min | ~20 s |
| 1 (2nd retry) | 15 min | ~26 s |
| 2 (3rd retry) | 1 h | ~46 s |
| 3 (4th retry) | 4 h | ~2 min |
| 5 (6th retry) | 4 h | ~11 min |
| 7 (8th retry) | 4 h | ~41 min |
| 10 (11th retry) | 4 h | ~3 h |
| 24 (25th retry) | 4 h | ~4 days |
| 49 (saturation) | 4 h | ~72 days |

## Test plan

- [x] `spec/models/issue_spec.rb` — three existing specs updated to assert the new deterministic delays (`rand` stubbed to 0) and renamed to reflect the new shape; all three pass locally.
- [ ] RuboCop / Markdown lint pass via pre-commit (already green on commit).
- [ ] CI green.

## Notes

- No data migration needed — delay is computed at re-enqueue time, so any already-scheduled `ReenqueueEligibleJob` entries keep their previously-computed delays and new enqueues use the new formula.
- Conceptually independent of #2194 (analyze-issue follow-ups). Either can land first.
- RDR-032 is still `Draft`; this amendment doesn't flip it. Whoever takes the broader eager-seeding work to `Final` can flip the status header then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)