### PR TITLE
Reject untrusted create_pr issue queueing

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1694,7 +1694,11 @@ class AgentRun < ApplicationRecord
   # @return [String, nil] The built prompt, or nil if no issue is attached
   def prompt_for_issue
     return nil unless issue
-    return nil unless issue.trusted?
+    unless issue.trusted?
+      raise Prompts::BuildForIssue::UntrustedIssueError,
+        "Cannot build prompt for issue ##{issue.github_number} " \
+        "from untrusted user: #{issue.github_creator_login}"
+    end
 
     Prompts::BuildForIssue.call(issue: issue, project: project, github_client: project.github_token&.client, agent_run: self)
   end

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -4,6 +4,8 @@ module Activities
   class QueueAgentRunActivity < BaseActivity
     activity_name "QueueAgentRun"
 
+    TRUSTED_ISSUE_GOALS = %w[create_pr].freeze
+
     def execute(input)
       project_id = input[:project_id]
       issue_id = input[:issue_id]
@@ -20,6 +22,9 @@ module Activities
       project = Project.find(project_id)
       goal ||= project.account.tenant_setting&.default_goal || "create_pr"
       issue = issue_id ? Issue.find(issue_id) : nil
+      untrusted_result = skip_untrusted_issue(project: project, issue: issue, goal: goal)
+      return untrusted_result if untrusted_result
+
       respect_requested = input.key?(:agent_type) || input.key?(:runner_id)
       provider_id, agent_type = resolve_runner_selection(
         project: project,
@@ -118,6 +123,20 @@ module Activities
     end
 
     private
+
+    def skip_untrusted_issue(project:, issue:, goal:)
+      return unless issue.present? && TRUSTED_ISSUE_GOALS.include?(goal) && issue.untrusted?
+
+      logger.info(
+        message: "queue_agent_run.untrusted_issue_skipped",
+        project_id: project.id,
+        issue_id: issue.id,
+        github_creator_login: issue.github_creator_login,
+        goal: goal
+      )
+
+      { queued: false, skipped: true, reason: "untrusted_issue", goal: goal }
+    end
 
     def resolve_runner_selection(project:, requested_agent_type:, requested_runner_id:, goal:, agent_type_provided:, runner_id_provided:)
       AgentRuns::RunnerResolver.call(

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -122,7 +122,7 @@ module Activities
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
       track_phase(agent_run_id: agent_run_id, phase_key: "run_agent", phase_group: "agent", agent_run: agent_run) do
-        prompt = agent_run.effective_prompt
+        prompt = effective_prompt_for_run(agent_run)
         unless prompt
           raise Temporalio::Error::ApplicationError.new(
             "No prompt available for agent run", type: "MissingPrompt", non_retryable: true
@@ -747,6 +747,14 @@ module Activities
         has_changes: false,
         output_present: false
       }
+    end
+
+    def effective_prompt_for_run(agent_run)
+      agent_run.effective_prompt
+    rescue Prompts::BuildForIssue::UntrustedIssueError => e
+      raise Temporalio::Error::ApplicationError.new(
+        e.message, type: "UntrustedIssue", non_retryable: true
+      )
     end
 
     # Resolves user settings for the agent run by finding the appropriate user.

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -1414,12 +1414,18 @@ RSpec.describe AgentRun do
         expect(prompt).to include("#5")
       end
 
-      it "returns nil when issue is from an untrusted user" do
+      it "raises UntrustedIssueError when issue is from an untrusted user" do
         project = create(:project, allowed_github_usernames: [ "viamin" ])
-        issue = create(:issue, project: project, title: "Malicious", github_number: 666, github_creator_login: "attacker")
+        issue = create(:issue,
+          project: project,
+          title: "Malicious",
+          github_number: 666,
+          github_creator_login: "attacker")
         agent_run = build(:agent_run, project: project, issue: issue)
 
-        expect(agent_run.prompt_for_issue).to be_nil
+        expect {
+          agent_run.prompt_for_issue
+        }.to raise_error(Prompts::BuildForIssue::UntrustedIssueError, /#666.*attacker/)
       end
     end
 

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -238,6 +238,20 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.custom_prompt).to eq("Do something")
     end
 
+    it "skips untrusted create_pr issues without creating an agent run" do
+      project.update!(allowed_github_usernames: [ "viamin" ])
+      untrusted_issue = create(:issue,
+        project: project,
+        github_creator_login: "dependabot[bot]",
+        github_number: 3622)
+
+      result = activity.execute(project_id: project.id, issue_id: untrusted_issue.id, goal: "create_pr")
+
+      expect(result).to include(queued: false, skipped: true, reason: "untrusted_issue", goal: "create_pr")
+      expect(AgentRun.where(project: project, issue: untrusted_issue)).to be_empty
+      expect(ProcessRunQueueJob).not_to have_been_enqueued
+    end
+
     context "when a duplicate run exists" do
       it "returns existing run when a queued run exists for the same issue" do
         existing = create(:agent_run, :queued, project: project, issue: issue)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2804,6 +2804,20 @@ expect(container_service).to receive(:execute).with(
       }.to raise_error(Temporalio::Error::ApplicationError, /No prompt available/)
     end
 
+    it "raises a clear non-retryable error when issue prompt building rejects an untrusted issue" do
+      agent_run = create(:agent_run, :with_custom_prompt, project: project, container_id: "abc123")
+      allow(agent_run).to receive(:effective_prompt)
+        .and_raise(Prompts::BuildForIssue::UntrustedIssueError, "Cannot build prompt for issue #3622")
+      allow(AgentRun).to receive(:find).with(agent_run.id).and_return(agent_run)
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError) { |error|
+        expect(error.type).to eq("UntrustedIssue")
+        expect(error.non_retryable).to be(true)
+      }
+    end
+
     it "raises ActiveRecord::RecordNotFound for invalid agent_run_id" do
       allow(AgentRun).to receive(:find).and_call_original
 


### PR DESCRIPTION
## Summary
- Reject untrusted `create_pr` issue queueing in `QueueAgentRunActivity` before an `AgentRun` is created.
- Return a structured skipped result and log `queue_agent_run.untrusted_issue_skipped` with project, issue, creator, and goal context.
- Convert untrusted issue prompt-building failures into a non-retryable `UntrustedIssue` application error instead of surfacing the generic missing-prompt error.
- Add regression coverage for queue-time skipping, prompt-builder failure, and the AgentRun prompt guard.

## Verification
- `git diff --check`
- Attempted local RSpec/RuboCop, but this Windows worker does not have Ruby/Bundler installed and Docker Desktop is not running, so full Rails checks need to run in GitHub CI.

Resolves #2193

## Payment
If this issue is eligible for paid-managed compensation, preferred payout is PayPal: https://paypal.me/Jeremytsangchina
Backup: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`