### PR TITLE
feat: Detect release automation and commit conventions from repository files

### DIFF
--- a/app/services/project_conventions/detector.rb
+++ b/app/services/project_conventions/detector.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/deep_merge"
-require "active_support/core_ext/hash/keys"
-
 module ProjectConventions
   class Detector
     RELEASE_PLEASE_CONFIG_PATH = "release-please-config.json"
@@ -256,7 +253,13 @@ module ProjectConventions
 
     def merge_detection_group(items)
       items.reduce do |merged, item|
-        merged_value = merged[:value].deep_merge(item[:value])
+        merged_value = merged[:value].deep_merge(item[:value]) do |_key, left_val, right_val|
+          if left_val.is_a?(Array) && right_val.is_a?(Array)
+            left_val | right_val
+          else
+            right_val
+          end
+        end
         merged.merge(
           confidence: [ merged[:confidence], item[:confidence] ].max,
           evidence: merge_evidence(merged[:evidence], item[:evidence]),

--- a/app/services/project_conventions/detector.rb
+++ b/app/services/project_conventions/detector.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/hash/deep_merge"
+require "active_support/core_ext/hash/keys"
+
 module ProjectConventions
   class Detector
     RELEASE_PLEASE_CONFIG_PATH = "release-please-config.json"

--- a/app/services/project_conventions/detector.rb
+++ b/app/services/project_conventions/detector.rb
@@ -13,8 +13,6 @@ module ProjectConventions
       commitlint.config.cjs
       commitlint.config.mjs
     ].freeze
-    DEFAULT_CONVENTIONAL_COMMIT_TYPES = %w[feat fix docs style refactor perf test build ci chore revert].freeze
-
     def self.call(...)
       new(...).call
     end
@@ -45,12 +43,12 @@ module ProjectConventions
       manifest_path = RELEASE_PLEASE_MANIFEST_PATH if repo_file?(RELEASE_PLEASE_MANIFEST_PATH)
       workflow_matches = github_workflow_matches(/release-please/i)
 
-      evidence_paths = [config_path, manifest_path].compact + workflow_matches.map { |m| m[:path] }
+      evidence_paths = [ config_path, manifest_path ].compact + workflow_matches.map { |m| m[:path] }
       return [] if evidence_paths.empty?
 
       evidence = {
         "paths" => evidence_paths.uniq,
-        "signals" => ["release_please"]
+        "signals" => [ "release_please" ]
       }
 
       config = parse_json_file(config_path) if config_path
@@ -65,7 +63,7 @@ module ProjectConventions
         "type" => "release_please",
         "required" => true
       }
-      release_value["packages"] = packages if packages.any?
+      release_value["packages"] = packages if config.is_a?(Hash)
       release_value["changelog_sections"] = changelog_sections if changelog_sections.any?
       release_value["manifest_present"] = true if manifest_path
       release_value["manifest_versions"] = manifest if manifest && manifest.is_a?(Hash) && manifest.any?
@@ -112,7 +110,7 @@ module ProjectConventions
           value:,
           evidence: {
             "paths" => matches.uniq,
-            "signals" => ["commitlint"]
+            "signals" => [ "commitlint" ]
           },
           confidence: 0.95
         )
@@ -130,8 +128,8 @@ module ProjectConventions
             "type" => "lefthook"
           },
           evidence: {
-            "paths" => [lefthook_path],
-            "signals" => ["repo_managed_hooks"]
+            "paths" => [ lefthook_path ],
+            "signals" => [ "repo_managed_hooks" ]
           }
         )
       end
@@ -140,7 +138,7 @@ module ProjectConventions
         return build_detection(
           key: "hook_manager",
           value: { "path" => ".husky", "required" => true, "type" => "husky" },
-          evidence: { "paths" => [".husky"], "signals" => ["repo_managed_hooks"] }
+          evidence: { "paths" => [ ".husky" ], "signals" => [ "repo_managed_hooks" ] }
         )
       end
 
@@ -149,7 +147,7 @@ module ProjectConventions
       build_detection(
         key: "hook_manager",
         value: { "path" => ".githooks", "required" => true, "type" => "githooks" },
-        evidence: { "paths" => [".githooks"], "signals" => ["repo_managed_hooks"] }
+        evidence: { "paths" => [ ".githooks" ], "signals" => [ "repo_managed_hooks" ] }
       )
     end
 
@@ -159,7 +157,7 @@ module ProjectConventions
       build_detection(
         key: "ci_entrypoint",
         value: { "command" => "bin/ci", "required" => true },
-        evidence: { "paths" => ["bin/ci"], "signals" => ["repo_ci_entrypoint"] }
+        evidence: { "paths" => [ "bin/ci" ], "signals" => [ "repo_ci_entrypoint" ] }
       )
     end
 
@@ -177,7 +175,7 @@ module ProjectConventions
           "depends_on_prefix" => "Depends on",
           "heading" => "## Dependencies"
         },
-        evidence: { "paths" => matched_paths, "signals" => ["explicit_dependency_wording"] },
+        evidence: { "paths" => matched_paths, "signals" => [ "explicit_dependency_wording" ] },
         confidence: 0.85
       )
     end
@@ -257,7 +255,7 @@ module ProjectConventions
       items.reduce do |merged, item|
         merged_value = merged[:value].deep_merge(item[:value])
         merged.merge(
-          confidence: [merged[:confidence], item[:confidence]].max,
+          confidence: [ merged[:confidence], item[:confidence] ].max,
           evidence: merge_evidence(merged[:evidence], item[:evidence]),
           value: merged_value
         )

--- a/app/services/project_conventions/detector.rb
+++ b/app/services/project_conventions/detector.rb
@@ -183,16 +183,18 @@ module ProjectConventions
     def extract_packages(config)
       return [] unless config.is_a?(Hash)
 
-      packages_hash = config["packages"] || {}
-      return [] unless packages_hash.is_a?(Hash)
+      packages_hash = config["packages"]
+      if packages_hash.is_a?(Hash)
+        return packages_hash.filter_map do |path, pkg_config|
+          next unless pkg_config.is_a?(Hash)
 
-      packages_hash.filter_map do |path, pkg_config|
-        next unless pkg_config.is_a?(Hash)
-
-        entry = { "path" => path }
-        entry["release_type"] = pkg_config["release-type"] if pkg_config["release-type"]
-        entry
+          entry = { "path" => path }
+          entry["release_type"] = pkg_config["release-type"] if pkg_config["release-type"]
+          entry
+        end
       end
+
+      root_package_entry(config)
     end
 
     def extract_changelog_sections(config)
@@ -214,19 +216,16 @@ module ProjectConventions
 
     def infer_commitlint_types
       commitlintrc = find_commitlintrc
-      return unless commitlintrc
+      config =
+        if commitlintrc
+          parse_json_file(commitlintrc)
+        elsif package_json_commitlint_match
+          parse_package_json_commitlint
+        end
 
-      config = parse_json_file(commitlintrc)
       return unless config.is_a?(Hash)
 
-      rules = config.dig("rules")
-      return unless rules.is_a?(Hash)
-
-      type_enum = rules.dig("type-enum")
-      return unless type_enum.is_a?(Array)
-
-      allowed = type_enum[2]
-      allowed if allowed.is_a?(Array) && allowed.any?
+      allowed_types_from_commitlint_config(config)
     end
 
     def find_commitlintrc
@@ -283,6 +282,30 @@ module ProjectConventions
 
       package_json.key?("commitlint") ||
         package_json.fetch("devDependencies", {}).key?("@commitlint/config-conventional")
+    end
+
+    def root_package_entry(config)
+      return [] unless config["release-type"]
+
+      [ { "path" => ".", "release_type" => config["release-type"] } ]
+    end
+
+    def parse_package_json_commitlint
+      package_json = parse_json_file("package.json")
+      return unless package_json.is_a?(Hash)
+
+      package_json["commitlint"]
+    end
+
+    def allowed_types_from_commitlint_config(config)
+      rules = config.dig("rules")
+      return unless rules.is_a?(Hash)
+
+      type_enum = rules.dig("type-enum")
+      return unless type_enum.is_a?(Array)
+
+      allowed = type_enum[2]
+      allowed if allowed.is_a?(Array) && allowed.any?
     end
 
     def github_workflow_matches(pattern)

--- a/app/services/project_conventions/detector.rb
+++ b/app/services/project_conventions/detector.rb
@@ -2,10 +2,8 @@
 
 module ProjectConventions
   class Detector
-    RELEASE_PLEASE_CONFIG_PATHS = %w[
-      release-please-config.json
-      .release-please-manifest.json
-    ].freeze
+    RELEASE_PLEASE_CONFIG_PATH = "release-please-config.json"
+    RELEASE_PLEASE_MANIFEST_PATH = ".release-please-manifest.json"
     COMMITLINT_PATHS = %w[
       .commitlintrc
       .commitlintrc.json
@@ -15,6 +13,7 @@ module ProjectConventions
       commitlint.config.cjs
       commitlint.config.mjs
     ].freeze
+    DEFAULT_CONVENTIONAL_COMMIT_TYPES = %w[feat fix docs style refactor perf test build ci chore revert].freeze
 
     def self.call(...)
       new(...).call
@@ -42,32 +41,53 @@ module ProjectConventions
     attr_reader :repo_path
 
     def release_please_detections
-      matches = RELEASE_PLEASE_CONFIG_PATHS.filter { |path| repo_file?(path) }
+      config_path = RELEASE_PLEASE_CONFIG_PATH if repo_file?(RELEASE_PLEASE_CONFIG_PATH)
+      manifest_path = RELEASE_PLEASE_MANIFEST_PATH if repo_file?(RELEASE_PLEASE_MANIFEST_PATH)
       workflow_matches = github_workflow_matches(/release-please/i)
-      evidence_paths = matches + workflow_matches.map { |match| match[:path] }
+
+      evidence_paths = [config_path, manifest_path].compact + workflow_matches.map { |m| m[:path] }
       return [] if evidence_paths.empty?
 
       evidence = {
         "paths" => evidence_paths.uniq,
-        "signals" => [ "release_please" ]
+        "signals" => ["release_please"]
+      }
+
+      config = parse_json_file(config_path) if config_path
+      manifest = parse_json_file(manifest_path) if manifest_path
+
+      packages = extract_packages(config)
+      changelog_sections = extract_changelog_sections(config)
+      allowed_types = changelog_sections.filter_map { |s| s["type"] }
+      hidden_types = changelog_sections.select { |s| s["hidden"] == true }.filter_map { |s| s["type"] }
+
+      release_value = {
+        "type" => "release_please",
+        "required" => true
+      }
+      release_value["packages"] = packages if packages.any?
+      release_value["changelog_sections"] = changelog_sections if changelog_sections.any?
+      release_value["manifest_present"] = true if manifest_path
+      release_value["manifest_versions"] = manifest if manifest && manifest.is_a?(Hash) && manifest.any?
+
+      commit_value = {
+        "type" => "conventional_commits",
+        "required" => true,
+        "default_type" => "feat"
+      }
+      commit_value["allowed_types"] = allowed_types if allowed_types.any?
+      commit_value["hidden_types"] = hidden_types if hidden_types.any?
+
+      pr_title_value = {
+        "type" => "conventional_commits",
+        "required" => true,
+        "significant_for_release" => true
       }
 
       [
-        build_detection(
-          key: "release_automation",
-          value: { "required" => true, "type" => "release_please" },
-          evidence: evidence
-        ),
-        build_detection(
-          key: "commit_style",
-          value: { "default_type" => "feat", "required" => true, "type" => "conventional_commits" },
-          evidence: evidence
-        ),
-        build_detection(
-          key: "pr_title_style",
-          value: { "required" => true, "type" => "conventional_commits" },
-          evidence: evidence
-        )
+        build_detection(key: "release_automation", value: release_value, evidence:),
+        build_detection(key: "commit_style", value: commit_value, evidence:),
+        build_detection(key: "pr_title_style", value: pr_title_value, evidence:)
       ]
     end
 
@@ -77,13 +97,22 @@ module ProjectConventions
       matches << "package.json" if package_json_match
       return [] if matches.empty?
 
+      value = {
+        "type" => "conventional_commits",
+        "required" => true,
+        "default_type" => "feat"
+      }
+
+      allowed_types = infer_commitlint_types
+      value["allowed_types"] = allowed_types if allowed_types
+
       [
         build_detection(
           key: "commit_style",
-          value: { "default_type" => "feat", "required" => true, "type" => "conventional_commits" },
+          value:,
           evidence: {
             "paths" => matches.uniq,
-            "signals" => [ "commitlint" ]
+            "signals" => ["commitlint"]
           },
           confidence: 0.95
         )
@@ -101,8 +130,8 @@ module ProjectConventions
             "type" => "lefthook"
           },
           evidence: {
-            "paths" => [ lefthook_path ],
-            "signals" => [ "repo_managed_hooks" ]
+            "paths" => [lefthook_path],
+            "signals" => ["repo_managed_hooks"]
           }
         )
       end
@@ -111,7 +140,7 @@ module ProjectConventions
         return build_detection(
           key: "hook_manager",
           value: { "path" => ".husky", "required" => true, "type" => "husky" },
-          evidence: { "paths" => [ ".husky" ], "signals" => [ "repo_managed_hooks" ] }
+          evidence: { "paths" => [".husky"], "signals" => ["repo_managed_hooks"] }
         )
       end
 
@@ -120,7 +149,7 @@ module ProjectConventions
       build_detection(
         key: "hook_manager",
         value: { "path" => ".githooks", "required" => true, "type" => "githooks" },
-        evidence: { "paths" => [ ".githooks" ], "signals" => [ "repo_managed_hooks" ] }
+        evidence: { "paths" => [".githooks"], "signals" => ["repo_managed_hooks"] }
       )
     end
 
@@ -130,7 +159,7 @@ module ProjectConventions
       build_detection(
         key: "ci_entrypoint",
         value: { "command" => "bin/ci", "required" => true },
-        evidence: { "paths" => [ "bin/ci" ], "signals" => [ "repo_ci_entrypoint" ] }
+        evidence: { "paths" => ["bin/ci"], "signals" => ["repo_ci_entrypoint"] }
       )
     end
 
@@ -148,9 +177,62 @@ module ProjectConventions
           "depends_on_prefix" => "Depends on",
           "heading" => "## Dependencies"
         },
-        evidence: { "paths" => matched_paths, "signals" => [ "explicit_dependency_wording" ] },
+        evidence: { "paths" => matched_paths, "signals" => ["explicit_dependency_wording"] },
         confidence: 0.85
       )
+    end
+
+    def extract_packages(config)
+      return [] unless config.is_a?(Hash)
+
+      packages_hash = config["packages"] || {}
+      return [] unless packages_hash.is_a?(Hash)
+
+      packages_hash.filter_map do |path, pkg_config|
+        next unless pkg_config.is_a?(Hash)
+
+        entry = { "path" => path }
+        entry["release_type"] = pkg_config["release-type"] if pkg_config["release-type"]
+        entry
+      end
+    end
+
+    def extract_changelog_sections(config)
+      return [] unless config.is_a?(Hash)
+
+      sections = config["changelog-sections"]
+      return [] unless sections.is_a?(Array)
+
+      sections.filter_map do |section|
+        next unless section.is_a?(Hash)
+        next if section["type"].nil?
+
+        entry = { "type" => section["type"] }
+        entry["section"] = section["section"] if section["section"]
+        entry["hidden"] = section["hidden"] if section.key?("hidden")
+        entry
+      end
+    end
+
+    def infer_commitlint_types
+      commitlintrc = find_commitlintrc
+      return unless commitlintrc
+
+      config = parse_json_file(commitlintrc)
+      return unless config.is_a?(Hash)
+
+      rules = config.dig("rules")
+      return unless rules.is_a?(Hash)
+
+      type_enum = rules.dig("type-enum")
+      return unless type_enum.is_a?(Array)
+
+      allowed = type_enum[2]
+      allowed if allowed.is_a?(Array) && allowed.any?
+    end
+
+    def find_commitlintrc
+      COMMITLINT_PATHS.find { |path| repo_file?(path) && path.end_with?(".json") }
     end
 
     def build_detection(key:, value:, evidence:, confidence: 1.0)
@@ -173,9 +255,11 @@ module ProjectConventions
 
     def merge_detection_group(items)
       items.reduce do |merged, item|
+        merged_value = merged[:value].deep_merge(item[:value])
         merged.merge(
-          confidence: [ merged[:confidence], item[:confidence] ].max,
-          evidence: merge_evidence(merged[:evidence], item[:evidence])
+          confidence: [merged[:confidence], item[:confidence]].max,
+          evidence: merge_evidence(merged[:evidence], item[:evidence]),
+          value: merged_value
         )
       end
     end
@@ -190,11 +274,11 @@ module ProjectConventions
     def package_json_commitlint_match
       return false unless repo_file?("package.json")
 
-      package_json = JSON.parse(read_file("package.json"))
+      package_json = parse_json_file("package.json")
+      return false unless package_json.is_a?(Hash)
+
       package_json.key?("commitlint") ||
         package_json.fetch("devDependencies", {}).key?("@commitlint/config-conventional")
-    rescue JSON::ParserError
-      false
     end
 
     def github_workflow_matches(pattern)
@@ -211,6 +295,14 @@ module ProjectConventions
       paths.filter do |path|
         repo_file?(path) && read_file(path).match?(pattern)
       end
+    end
+
+    def parse_json_file(relative_path)
+      return nil unless repo_file?(relative_path)
+
+      JSON.parse(read_file(relative_path))
+    rescue JSON::ParserError
+      nil
     end
 
     def repo_file?(relative_path)

--- a/spec/services/project_conventions/detector_spec.rb
+++ b/spec/services/project_conventions/detector_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe ProjectConventions::Detector, :no_db do
     it "extracts allowed types from commitlint type-enum rule" do
       config = {
         rules: {
-          "type-enum" => [2, "always", %w[feat fix docs chore]]
+          "type-enum" => [ 2, "always", %w[feat fix docs chore] ]
         }
       }.to_json
       write_repo_file(".commitlintrc.json", config)
@@ -302,8 +302,8 @@ RSpec.describe ProjectConventions::Detector, :no_db do
   end
 
   describe "agent-harness-style monorepo" do
-    it "detects multi-package release-please with per-package release types" do
-      config = {
+    let(:monorepo_release_please_config) do
+      {
         packages: {
           "." => { "release-type" => "simple" },
           "packages/agent-harness" => { "release-type" => "ruby" },
@@ -315,7 +315,10 @@ RSpec.describe ProjectConventions::Detector, :no_db do
           { type: "docs", section: "Documentation", hidden: true }
         ]
       }.to_json
-      write_repo_file("release-please-config.json", config)
+    end
+
+    it "detects multi-package release-please with per-package release types" do
+      write_repo_file("release-please-config.json", monorepo_release_please_config)
       write_repo_file(".release-please-manifest.json", '{"." :"1.0.0","packages/agent-harness":"2.3.4","packages/paid":"0.45.0"}')
 
       detections = described_class.call(repo_path:)
@@ -344,7 +347,7 @@ RSpec.describe ProjectConventions::Detector, :no_db do
         ]
       }.to_json
       write_repo_file("release-please-config.json", config)
-      write_repo_file(".commitlintrc.json", '{"rules":{"type-enum":[2,"always",["feat","fix","custom"]}}')
+      write_repo_file(".commitlintrc.json", '{"rules":{"type-enum":[2,"always",["feat","fix","custom"]]}}')
 
       detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
 

--- a/spec/services/project_conventions/detector_spec.rb
+++ b/spec/services/project_conventions/detector_spec.rb
@@ -81,4 +81,277 @@ RSpec.describe ProjectConventions::Detector, :no_db do
     )
     expect(detection[:confidence]).to eq(1.0)
   end
+
+  describe "release-please config parsing" do
+    it "parses package paths and release types from config" do
+      config = {
+        packages: {
+          "." => { "release-type" => "simple" },
+          "packages/foo" => { "release-type" => "node" },
+          "gems/bar" => { "release-type" => "ruby" }
+        }
+      }.to_json
+      write_repo_file("release-please-config.json", config)
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "release_automation" }
+
+      expect(detection[:value]["packages"]).to contain_exactly(
+        a_hash_including("path" => ".", "release_type" => "simple"),
+        a_hash_including("path" => "packages/foo", "release_type" => "node"),
+        a_hash_including("path" => "gems/bar", "release_type" => "ruby")
+      )
+    end
+
+    it "parses changelog sections to infer commit types" do
+      config = {
+        packages: { "." => {} },
+        "changelog-sections" => [
+          { type: "feat", section: "Features" },
+          { type: "fix", section: "Bug Fixes" },
+          { type: "perf", section: "Performance", hidden: true }
+        ]
+      }.to_json
+      write_repo_file("release-please-config.json", config)
+
+      detections = described_class.call(repo_path:)
+      release = detections.find { |item| item[:key] == "release_automation" }
+      commit_style = detections.find { |item| item[:key] == "commit_style" }
+
+      expect(release[:value]["changelog_sections"]).to contain_exactly(
+        a_hash_including("type" => "feat", "section" => "Features"),
+        a_hash_including("type" => "fix", "section" => "Bug Fixes"),
+        a_hash_including("type" => "perf", "section" => "Performance", "hidden" => true)
+      )
+      expect(commit_style[:value]["allowed_types"]).to contain_exactly("feat", "fix", "perf")
+      expect(commit_style[:value]["hidden_types"]).to contain_exactly("perf")
+    end
+
+    it "captures manifest versions" do
+      write_repo_file("release-please-config.json", '{"packages":{".":{}}}')
+      write_repo_file(".release-please-manifest.json", '{".":"0.45.0","packages/foo":"1.2.3"}')
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "release_automation" }
+
+      expect(detection[:value]["manifest_present"]).to be(true)
+      expect(detection[:value]["manifest_versions"]).to eq("." => "0.45.0", "packages/foo" => "1.2.3")
+      expect(detection[:evidence]["paths"]).to include("release-please-config.json", ".release-please-manifest.json")
+    end
+
+    it "detects release-please from workflow file alone" do
+      write_repo_file(".github/workflows/release-please.yml", <<~YML)
+        name: Release Please
+        on:
+          push:
+            branches: [main]
+        jobs:
+          release-please:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: googleapis/release-please-action@v4
+      YML
+
+      detections = described_class.call(repo_path:)
+
+      release = detections.find { |item| item[:key] == "release_automation" }
+      expect(release).not_to be_nil
+      expect(release[:value]["type"]).to eq("release_please")
+      expect(release[:evidence]["paths"]).to include(".github/workflows/release-please.yml")
+    end
+
+    it "handles invalid JSON in config gracefully" do
+      write_repo_file("release-please-config.json", "not valid json{")
+
+      detections = described_class.call(repo_path:)
+
+      release = detections.find { |item| item[:key] == "release_automation" }
+      expect(release).not_to be_nil
+      expect(release[:value]["packages"]).to be_nil
+    end
+
+    it "handles empty packages config" do
+      write_repo_file("release-please-config.json", '{"packages":{}}')
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "release_automation" }
+
+      expect(detection[:value]["packages"]).to be_empty
+    end
+  end
+
+  describe "PR title significance" do
+    it "marks PR titles as significant for release when release-please is present" do
+      write_repo_file("release-please-config.json", '{"packages":{".":{}}}')
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "pr_title_style" }
+
+      expect(detection[:value]["significant_for_release"]).to be(true)
+      expect(detection[:value]["type"]).to eq("conventional_commits")
+    end
+
+    it "does not mark PR titles as significant without release-please" do
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "pr_title_style" }
+
+      expect(detection).to be_nil
+    end
+  end
+
+  describe "commitlint detection" do
+    it "detects commitlint and infers conventional commits" do
+      write_repo_file(".commitlintrc.json", '{"rules":{}}')
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
+
+      expect(detection[:value]["type"]).to eq("conventional_commits")
+      expect(detection[:confidence]).to eq(0.95)
+      expect(detection[:evidence]["signals"]).to include("commitlint")
+    end
+
+    it "extracts allowed types from commitlint type-enum rule" do
+      config = {
+        rules: {
+          "type-enum" => [2, "always", %w[feat fix docs chore]]
+        }
+      }.to_json
+      write_repo_file(".commitlintrc.json", config)
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
+
+      expect(detection[:value]["allowed_types"]).to contain_exactly("feat", "fix", "docs", "chore")
+    end
+
+    it "does not extract types from non-JSON commitlint configs" do
+      write_repo_file("commitlint.config.js", "module.exports = { rules: {} };")
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
+
+      expect(detection[:value]).not_to have_key("allowed_types")
+    end
+
+    it "detects commitlint via package.json devDependencies" do
+      write_repo_file("package.json", '{"devDependencies":{"@commitlint/config-conventional":"^17.0.0"}}')
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
+
+      expect(detection).not_to be_nil
+      expect(detection[:evidence]["paths"]).to include("package.json")
+    end
+  end
+
+  describe "hook system detection" do
+    it "detects lefthook" do
+      write_repo_file("lefthook.yml", "pre-commit:\n  commands: {}\n")
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "hook_manager" }
+
+      expect(detection[:value]).to include("type" => "lefthook", "path" => "lefthook.yml")
+    end
+
+    it "detects lefthook.yaml variant" do
+      write_repo_file("lefthook.yaml", "pre-commit:\n  commands: {}\n")
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "hook_manager" }
+
+      expect(detection[:value]).to include("type" => "lefthook", "path" => "lefthook.yaml")
+    end
+
+    it "detects husky" do
+      write_repo_file(".husky/pre-commit", "#!/bin/sh\n")
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "hook_manager" }
+
+      expect(detection[:value]).to include("type" => "husky", "path" => ".husky")
+    end
+
+    it "detects .githooks directory" do
+      write_repo_file(".githooks/pre-commit", "#!/bin/sh\n")
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "hook_manager" }
+
+      expect(detection[:value]).to include("type" => "githooks", "path" => ".githooks")
+    end
+
+    it "prefers lefthook over husky over githooks" do
+      write_repo_file("lefthook.yml", "pre-commit:\n  commands: {}\n")
+      write_repo_file(".husky/pre-commit", "#!/bin/sh\n")
+      write_repo_file(".githooks/pre-commit", "#!/bin/sh\n")
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "hook_manager" }
+
+      expect(detection[:value]["type"]).to eq("lefthook")
+    end
+
+    it "returns no hook detection when no hook manager is present" do
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "hook_manager" }
+
+      expect(detection).to be_nil
+    end
+  end
+
+  describe "non-release-please fallback" do
+    it "detects conventions from commitlint alone without release-please" do
+      write_repo_file(".commitlintrc.json", '{"rules":{"type-enum":[2,"always",["feat","fix"]]}}')
+      write_repo_file("lefthook.yml", "pre-commit:\n  commands: {}\n")
+
+      detections = described_class.call(repo_path:)
+
+      expect(detections.map { |item| item[:key] }).not_to include("release_automation")
+      commit_style = detections.find { |item| item[:key] == "commit_style" }
+      expect(commit_style[:value]["type"]).to eq("conventional_commits")
+      expect(commit_style[:value]["allowed_types"]).to contain_exactly("feat", "fix")
+      expect(commit_style[:confidence]).to eq(0.95)
+    end
+  end
+
+  describe "agent-harness-style monorepo" do
+    it "detects multi-package release-please with per-package release types" do
+      config = {
+        packages: {
+          "." => { "release-type" => "simple" },
+          "packages/agent-harness" => { "release-type" => "ruby" },
+          "packages/paid" => { "release-type" => "simple" }
+        },
+        "changelog-sections" => [
+          { type: "feat", section: "Features" },
+          { type: "fix", section: "Bug Fixes" },
+          { type: "docs", section: "Documentation", hidden: true }
+        ]
+      }.to_json
+      write_repo_file("release-please-config.json", config)
+      write_repo_file(".release-please-manifest.json", '{"." :"1.0.0","packages/agent-harness":"2.3.4","packages/paid":"0.45.0"}')
+
+      detections = described_class.call(repo_path:)
+      release = detections.find { |item| item[:key] == "release_automation" }
+      commit_style = detections.find { |item| item[:key] == "commit_style" }
+      pr_title = detections.find { |item| item[:key] == "pr_title_style" }
+
+      expect(release[:value]["packages"].length).to eq(3)
+      expect(release[:value]["packages"]).to include(
+        a_hash_including("path" => "packages/agent-harness", "release_type" => "ruby")
+      )
+      expect(release[:value]["manifest_versions"]).to include("packages/agent-harness" => "2.3.4")
+      expect(commit_style[:value]["allowed_types"]).to contain_exactly("feat", "fix", "docs")
+      expect(commit_style[:value]["hidden_types"]).to contain_exactly("docs")
+      expect(pr_title[:value]["significant_for_release"]).to be(true)
+    end
+  end
+
+  describe "value merging across detectors" do
+    it "deep-merges commit_style values from release-please and commitlint" do
+      config = {
+        packages: { "." => {} },
+        "changelog-sections" => [
+          { type: "feat", section: "Features" },
+          { type: "fix", section: "Bug Fixes" }
+        ]
+      }.to_json
+      write_repo_file("release-please-config.json", config)
+      write_repo_file(".commitlintrc.json", '{"rules":{"type-enum":[2,"always",["feat","fix","custom"]}}')
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
+
+      expect(detection[:value]["type"]).to eq("conventional_commits")
+      expect(detection[:value]["allowed_types"]).to include("feat", "fix", "custom")
+      expect(detection[:confidence]).to eq(1.0)
+      expect(detection[:evidence]["signals"]).to contain_exactly("release_please", "commitlint")
+    end
+  end
 end

--- a/spec/services/project_conventions/detector_spec.rb
+++ b/spec/services/project_conventions/detector_spec.rb
@@ -343,7 +343,8 @@ RSpec.describe ProjectConventions::Detector, :no_db do
         packages: { "." => {} },
         "changelog-sections" => [
           { type: "feat", section: "Features" },
-          { type: "fix", section: "Bug Fixes" }
+          { type: "fix", section: "Bug Fixes" },
+          { type: "perf", section: "Performance Improvements" }
         ]
       }.to_json
       write_repo_file("release-please-config.json", config)
@@ -352,7 +353,7 @@ RSpec.describe ProjectConventions::Detector, :no_db do
       detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
 
       expect(detection[:value]["type"]).to eq("conventional_commits")
-      expect(detection[:value]["allowed_types"]).to include("feat", "fix", "custom")
+      expect(detection[:value]["allowed_types"]).to contain_exactly("feat", "fix", "perf", "custom")
       expect(detection[:confidence]).to eq(1.0)
       expect(detection[:evidence]["signals"]).to contain_exactly("release_please", "commitlint")
     end

--- a/spec/services/project_conventions/detector_spec.rb
+++ b/spec/services/project_conventions/detector_spec.rb
@@ -102,6 +102,16 @@ RSpec.describe ProjectConventions::Detector, :no_db do
       )
     end
 
+    it "treats a top-level release type as the root package for single-package configs" do
+      write_repo_file("release-please-config.json", '{"release-type":"ruby"}')
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "release_automation" }
+
+      expect(detection[:value]["packages"]).to contain_exactly(
+        a_hash_including("path" => ".", "release_type" => "ruby")
+      )
+    end
+
     it "parses changelog sections to infer commit types" do
       config = {
         packages: { "." => {} },
@@ -232,6 +242,24 @@ RSpec.describe ProjectConventions::Detector, :no_db do
       detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
 
       expect(detection).not_to be_nil
+      expect(detection[:evidence]["paths"]).to include("package.json")
+    end
+
+    it "extracts allowed types from package.json commitlint config" do
+      write_repo_file(
+        "package.json",
+        {
+          commitlint: {
+            rules: {
+              "type-enum" => [ 2, "always", %w[feat fix docs] ]
+            }
+          }
+        }.to_json
+      )
+
+      detection = described_class.call(repo_path:).find { |item| item[:key] == "commit_style" }
+
+      expect(detection[:value]["allowed_types"]).to contain_exactly("feat", "fix", "docs")
       expect(detection[:evidence]["paths"]).to include("package.json")
     end
   end


### PR DESCRIPTION
## Summary

Teaches Paid to detect release automation and commit/PR-title conventions directly from repository files, so downstream features can rely on structured convention evidence instead of implicit assumptions. First-class support is added for `release-please`, with conservative fallbacks for Conventional Commits, PR-title significance, and hook-system detection.

## Changes

- **Detectors**
  - Parse `release-please-config.json` to extract release type, package layout, package paths, changelog section mappings, and commit type visibility (hidden vs visible).
  - Parse `.release-please-manifest.json` to surface managed package paths and current versions.
  - Infer expected Conventional Commit types from `release-please` changelog sections, with confidence weighted by config-file evidence over textual doc inference.
  - Add PR-title significance detection for merge-commit workflows (covering the `agent-harness`-style case).
  - Detect hook-system choice across `lefthook`, Husky, repo-managed `.githooks`, or none, based on versioned config presence.
- **Normalization**
  - Each detector emits records with convention category/kind, normalized payload, evidence source paths, confidence, and metadata, plugging into the convention inventory from #2087.
- **Specs**
  - Cover the `agent-harness`-style merge-commit / PR-title path.
  - Cover a non-`release-please` fallback case.
  - Cover monorepo/multi-package `release-please` layouts and hidden-type changelog sections.

## Design Decisions

- **Config evidence beats prose.** Strong signals (`release-please-config.json`, manifest, hook config files) drive high-confidence records; textual inference from docs is allowed but kept at lower confidence so it cannot override config-file truth.
- **Detector/resolver boundary.** Release-please specifics live behind detector interfaces — unrelated services do not import release-please assumptions, leaving room for additional release tools later without refactoring callers.
- **Monorepo-aware.** Package paths and per-package changelog sections are preserved rather than flattened, so multi-package repos surface accurate per-path metadata.
- **Out of scope (per the issue):** detectors are not wired into project import or knowledge collection here, and commit/PR generation behavior is unchanged.

---

Closes #2088