### PR TITLE
feat: Run convention detection during project import and knowledge collection

### DIFF
--- a/app/jobs/enqueue_knowledge_collection_job.rb
+++ b/app/jobs/enqueue_knowledge_collection_job.rb
@@ -32,6 +32,8 @@ class EnqueueKnowledgeCollectionJob < ApplicationJob
       commit_sha: commit_sha,
       branch: project.default_branch
     )
+  rescue WorktreeService::Error, Errno::ENOENT
+    raise
   rescue StandardError => e
     Rails.logger.error(
       message: "knowledge.import_convention_detection_failed",

--- a/app/jobs/enqueue_knowledge_collection_job.rb
+++ b/app/jobs/enqueue_knowledge_collection_job.rb
@@ -15,11 +15,29 @@ class EnqueueKnowledgeCollectionJob < ApplicationJob
     commit_sha = worktree_service.current_commit_sha
 
     project.update!(knowledge_status: "collecting") if project.knowledge_status.in?(%w[pending stale])
+    detect_import_conventions(project, commit_sha)
 
     RunCollectorsJob.perform_later(
       project.id,
       commit_sha,
       branch: project.default_branch
+    )
+  end
+
+  private
+
+  def detect_import_conventions(project, commit_sha)
+    ProjectConventions::DetectForImport.call(
+      project: project,
+      commit_sha: commit_sha,
+      branch: project.default_branch
+    )
+  rescue StandardError => e
+    Rails.logger.error(
+      message: "knowledge.import_convention_detection_failed",
+      project_id: project.id,
+      commit_sha: commit_sha,
+      error: e.message
     )
   end
 end

--- a/app/jobs/enqueue_knowledge_collection_job.rb
+++ b/app/jobs/enqueue_knowledge_collection_job.rb
@@ -15,7 +15,7 @@ class EnqueueKnowledgeCollectionJob < ApplicationJob
     commit_sha = worktree_service.current_commit_sha
 
     project.update!(knowledge_status: "collecting") if project.knowledge_status.in?(%w[pending stale])
-    detect_import_conventions(project, commit_sha) unless project.project_convention_detections.exists?
+    detect_import_conventions(project, commit_sha)
 
     RunCollectorsJob.perform_later(
       project.id,

--- a/app/jobs/enqueue_knowledge_collection_job.rb
+++ b/app/jobs/enqueue_knowledge_collection_job.rb
@@ -15,7 +15,7 @@ class EnqueueKnowledgeCollectionJob < ApplicationJob
     commit_sha = worktree_service.current_commit_sha
 
     project.update!(knowledge_status: "collecting") if project.knowledge_status.in?(%w[pending stale])
-    detect_import_conventions(project, commit_sha)
+    detect_import_conventions(project, commit_sha) unless project.project_convention_detections.exists?
 
     RunCollectorsJob.perform_later(
       project.id,

--- a/app/services/knowledge/collector_runner.rb
+++ b/app/services/knowledge/collector_runner.rb
@@ -182,14 +182,16 @@ module Knowledge
       @collector_classes ||= begin
         requested_types = Array(options[:collector_types]).map(&:to_s).uniq
         registry = self.class.registry
-        return registry if requested_types.empty?
+        if requested_types.empty?
+          registry
+        else
+          missing_types = requested_types - registry.keys
+          if missing_types.any?
+            raise ArgumentError, "Unknown collector types: #{missing_types.join(', ')}"
+          end
 
-        missing_types = requested_types - registry.keys
-        if missing_types.any?
-          raise ArgumentError, "Unknown collector types: #{missing_types.join(', ')}"
+          registry.slice(*requested_types)
         end
-
-        registry.slice(*requested_types)
       end
     end
 

--- a/app/services/knowledge/collector_runner.rb
+++ b/app/services/knowledge/collector_runner.rb
@@ -35,7 +35,7 @@ module Knowledge
       project_version = resolve_project_version
       results = run_collectors(project_version)
 
-      if should_mark_stale_artifacts?(results)
+      if should_mark_stale_artifacts?(results) && full_collection_run?
         mark_stale_artifacts(project_version, preserved_collector_types(results))
       end
 
@@ -179,7 +179,23 @@ module Knowledge
     end
 
     def collector_classes
-      self.class.registry
+      @collector_classes ||= begin
+        requested_types = Array(options[:collector_types]).map(&:to_s).uniq
+        registry = self.class.registry
+        return registry if requested_types.empty?
+
+        missing_types = requested_types - registry.keys
+        if missing_types.any?
+          raise ArgumentError, "Unknown collector types: #{missing_types.join(', ')}"
+        end
+
+        registry.slice(*requested_types)
+      end
+    end
+
+    def full_collection_run?
+      requested_types = Array(options[:collector_types]).map(&:to_s).uniq
+      requested_types.empty? || requested_types.sort == self.class.registry.keys.sort
     end
 
     def skipped_artifacts_count(collector_type:, preserve_existing_artifacts:)

--- a/app/services/project_conventions/detect_for_import.rb
+++ b/app/services/project_conventions/detect_for_import.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ProjectConventions
+  class DetectForImport
+    IMPORT_COLLECTOR_TYPES = [ "project_conventions" ].freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, commit_sha:, branch:)
+      @project = project
+      @commit_sha = commit_sha
+      @branch = branch
+    end
+
+    def call
+      worktree_service.with_temporary_checkout(commit_sha) do |checkout_path|
+        Knowledge::CollectorRunner.call(
+          project: project,
+          commit_sha: commit_sha,
+          branch: branch,
+          options: {
+            collector_types: IMPORT_COLLECTOR_TYPES,
+            scan_path: checkout_path
+          }
+        )
+      end
+    end
+
+    private
+
+    attr_reader :project, :commit_sha, :branch
+
+    def worktree_service
+      @worktree_service ||= WorktreeService.new(project)
+    end
+  end
+end

--- a/app/services/worktree_service.rb
+++ b/app/services/worktree_service.rb
@@ -280,6 +280,36 @@ class WorktreeService
     end
   end
 
+  # Creates a short-lived detached worktree for read-only maintenance or
+  # analysis against an exact commit SHA.
+  #
+  # @param ref [String] Commit SHA or other git rev to check out
+  # @yieldparam worktree_path [String] Path to the temporary worktree
+  # @return [Object] the block result
+  def with_temporary_checkout(ref)
+    ensure_cloned
+
+    temp_path = File.join(worktrees_path, "paid-checkout-#{SecureRandom.hex(6)}")
+
+    @mutex.synchronize do
+      FileUtils.mkdir_p(worktrees_path)
+      run_git(
+        "worktree", "add", "--detach", temp_path, ref,
+        chdir: project_repo_path
+      )
+    end
+
+    yield temp_path
+  ensure
+    @mutex.synchronize do
+      if defined?(temp_path) && temp_path.present? && Dir.exist?(temp_path)
+        run_git("worktree", "remove", temp_path, "--force", chdir: project_repo_path, raise_on_error: false)
+      end
+
+      run_git("worktree", "prune", chdir: project_repo_path, raise_on_error: false)
+    end
+  end
+
   private
 
   def project_repo_path

--- a/app/services/worktree_service.rb
+++ b/app/services/worktree_service.rb
@@ -21,6 +21,7 @@ class WorktreeService
 
   DEFAULT_WORKSPACE_ROOT = "/var/paid/workspaces"
   FETCH_REFSPEC = "+refs/heads/*:refs/remotes/origin/*"
+  STALE_WORKTREE_GLOBS = %w[paid-agent-* paid-checkout-* paid-conflict-*].freeze
 
   def self.workspace_root
     Rails.application.config.x.workspace_root || DEFAULT_WORKSPACE_ROOT
@@ -231,15 +232,17 @@ class WorktreeService
   def cleanup_stale_worktrees(older_than: 24.hours)
     return unless Dir.exist?(worktrees_path)
 
-    Dir.glob(File.join(worktrees_path, "paid-agent-*")).each do |path|
-      next unless File.directory?(path)
-      next unless File.mtime(path) < older_than.ago
+    STALE_WORKTREE_GLOBS.each do |glob|
+      Dir.glob(File.join(worktrees_path, glob)).each do |path|
+        next unless File.directory?(path)
+        next unless File.mtime(path) < older_than.ago
 
-      run_git(
-        "worktree", "remove", path, "--force",
-        chdir: project_repo_path,
-        raise_on_error: false
-      )
+        run_git(
+          "worktree", "remove", path, "--force",
+          chdir: project_repo_path,
+          raise_on_error: false
+        )
+      end
     end
 
     run_git("worktree", "prune", chdir: project_repo_path, raise_on_error: false)

--- a/spec/jobs/enqueue_knowledge_collection_job_spec.rb
+++ b/spec/jobs/enqueue_knowledge_collection_job_spec.rb
@@ -84,6 +84,18 @@ RSpec.describe EnqueueKnowledgeCollectionJob do
       )
     end
 
+    it "re-raises import convention checkout errors for retry_on to handle" do
+      allow(ProjectConventions::DetectForImport).to receive(:call).and_raise(WorktreeService::Error, "checkout failed")
+
+      expect { described_class.new.perform(project.id) }.to raise_error(WorktreeService::Error, "checkout failed")
+    end
+
+    it "re-raises missing checkout errors for retry_on to handle" do
+      allow(ProjectConventions::DetectForImport).to receive(:call).and_raise(Errno::ENOENT, "No such file or directory")
+
+      expect { described_class.new.perform(project.id) }.to raise_error(Errno::ENOENT)
+    end
+
     it "raises WorktreeService::Error for retry_on to handle" do
       allow(worktree_service).to receive(:ensure_cloned).and_raise(WorktreeService::Error, "not cloned")
 

--- a/spec/jobs/enqueue_knowledge_collection_job_spec.rb
+++ b/spec/jobs/enqueue_knowledge_collection_job_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe EnqueueKnowledgeCollectionJob do
       )
     end
 
+    it "skips import-time convention detection after conventions already exist" do
+      create(:project_convention_detection, project: project)
+
+      described_class.new.perform(project.id)
+
+      expect(ProjectConventions::DetectForImport).not_to have_received(:call)
+    end
+
     it "uses the project default_branch" do
       project.update!(default_branch: "develop")
 

--- a/spec/jobs/enqueue_knowledge_collection_job_spec.rb
+++ b/spec/jobs/enqueue_knowledge_collection_job_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe EnqueueKnowledgeCollectionJob do
     allow(WorktreeService).to receive(:new).with(project).and_return(worktree_service)
     allow(worktree_service).to receive(:ensure_cloned)
     allow(worktree_service).to receive(:current_commit_sha).and_return(commit_sha)
+    allow(ProjectConventions::DetectForImport).to receive(:call)
   end
 
   describe "#perform" do
@@ -32,6 +33,16 @@ RSpec.describe EnqueueKnowledgeCollectionJob do
       }.to have_enqueued_job(RunCollectorsJob).with(project.id, commit_sha, branch: "main")
     end
 
+    it "runs import-time convention detection before enqueuing full collection" do
+      described_class.new.perform(project.id)
+
+      expect(ProjectConventions::DetectForImport).to have_received(:call).with(
+        project: project,
+        commit_sha: commit_sha,
+        branch: "main"
+      )
+    end
+
     it "uses the project default_branch" do
       project.update!(default_branch: "develop")
 
@@ -46,6 +57,23 @@ RSpec.describe EnqueueKnowledgeCollectionJob do
       described_class.new.perform(project.id)
 
       expect(project.reload.knowledge_status).to eq("ready")
+    end
+
+    it "logs and continues when import convention detection fails" do
+      allow(ProjectConventions::DetectForImport).to receive(:call).and_raise(StandardError, "boom")
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        described_class.new.perform(project.id)
+      }.to have_enqueued_job(RunCollectorsJob).with(project.id, commit_sha, branch: "main")
+
+      expect(Rails.logger).to have_received(:error).with(
+        hash_including(
+          message: "knowledge.import_convention_detection_failed",
+          project_id: project.id,
+          commit_sha: commit_sha
+        )
+      )
     end
 
     it "raises WorktreeService::Error for retry_on to handle" do

--- a/spec/jobs/enqueue_knowledge_collection_job_spec.rb
+++ b/spec/jobs/enqueue_knowledge_collection_job_spec.rb
@@ -43,12 +43,20 @@ RSpec.describe EnqueueKnowledgeCollectionJob do
       )
     end
 
-    it "skips import-time convention detection after conventions already exist" do
-      create(:project_convention_detection, project: project)
+    it "still runs import-time convention detection when older conventions already exist" do
+      create(
+        :project_convention_detection,
+        project: project,
+        project_version: create(:project_version, project: project, commit_sha: "b" * 40)
+      )
 
       described_class.new.perform(project.id)
 
-      expect(ProjectConventions::DetectForImport).not_to have_received(:call)
+      expect(ProjectConventions::DetectForImport).to have_received(:call).with(
+        project: project,
+        commit_sha: commit_sha,
+        branch: "main"
+      )
     end
 
     it "uses the project default_branch" do

--- a/spec/services/knowledge/collector_runner_spec.rb
+++ b/spec/services/knowledge/collector_runner_spec.rb
@@ -393,6 +393,13 @@ RSpec.describe Knowledge::CollectorRunner do
         expect(CollectorRun.pluck(:collector_type)).to contain_exactly("test_collector")
       end
 
+      it "memoizes the full collector registry for repeated access" do
+        runner = described_class.new(project: project, commit_sha: commit_sha)
+
+        first_registry = runner.send(:collector_classes)
+        expect(runner.send(:collector_classes)).to be(first_registry)
+      end
+
       it "does not stale artifacts from non-selected collectors" do
         old_sha = "b" * 40
         new_sha = "c" * 40

--- a/spec/services/knowledge/collector_runner_spec.rb
+++ b/spec/services/knowledge/collector_runner_spec.rb
@@ -351,5 +351,67 @@ RSpec.describe Knowledge::CollectorRunner do
         expect(extra.reload.status).to eq("active")
       end
     end
+
+    context "when running a subset of collectors" do
+      let(:other_collector_class) do
+        Class.new(Knowledge::BaseCollector) do
+          def collect
+            [
+              {
+                artifact_type: "other_artifact",
+                scope_path: "README.md",
+                identifier: "readme",
+                content: "docs",
+                metadata: {},
+                chunks: []
+              }
+            ]
+          end
+
+          def collector_type
+            "other_collector"
+          end
+        end
+      end
+
+      before do
+        described_class.reset_registry!
+        described_class.register("test_collector", test_collector_class)
+        described_class.register("other_collector", other_collector_class)
+      end
+
+      it "runs only the requested collector types" do
+        result = described_class.call(
+          project: project,
+          commit_sha: commit_sha,
+          options: { collector_types: [ "test_collector" ] }
+        )
+
+        expect(result[:results]).to contain_exactly(
+          hash_including(collector_type: "test_collector", status: "completed")
+        )
+        expect(CollectorRun.pluck(:collector_type)).to contain_exactly("test_collector")
+      end
+
+      it "does not stale artifacts from non-selected collectors" do
+        old_sha = "b" * 40
+        new_sha = "c" * 40
+
+        described_class.call(project: project, commit_sha: old_sha, committed_at: 2.hours.ago)
+
+        old_version = ProjectVersion.find_by!(project:, commit_sha: old_sha)
+        other_run = CollectorRun.find_by!(project_version: old_version, collector_type: "other_collector")
+        other_artifact = KnowledgeArtifact.find_by!(collector_run: other_run, identifier: "readme")
+
+        described_class.call(
+          project: project,
+          commit_sha: new_sha,
+          committed_at: 1.hour.ago,
+          options: { collector_types: [ "test_collector" ] }
+        )
+
+        expect(other_artifact.reload.status).to eq("active")
+      end
+    end
   end
 end

--- a/spec/services/knowledge/collectors/project_conventions_collector_spec.rb
+++ b/spec/services/knowledge/collectors/project_conventions_collector_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe Knowledge::Collectors::ProjectConventionsCollector do
     fixture_path.join("bin/ci").write("#!/usr/bin/env bash\nbundle exec rspec\n")
   end
 
+  def build_collector(version:, run:, path:)
+    described_class.new(
+      project: project,
+      project_version: version,
+      collector_run: run,
+      options: { scan_path: path.to_s }
+    )
+  end
+
   it "stores convention artifacts and syncs first-class detections" do
     artifacts = collector.collect
 
@@ -65,5 +74,30 @@ RSpec.describe Knowledge::Collectors::ProjectConventionsCollector do
     artifact = collector.collect.find { |item| item[:identifier] == "hook_manager" }
 
     expect(artifact.dig(:metadata, :category)).to eq("hook_system")
+  end
+
+  it "refreshes detections per project version when repository conventions change" do
+    collector.collect
+    second_project_version = create(:project_version, project: project)
+    second_collector_run = create(:collector_run, project_version: second_project_version, collector_type: "project_conventions")
+    second_fixture_path = build_husky_fixture
+
+    build_collector(version: second_project_version, run: second_collector_run, path: second_fixture_path).collect
+
+    first_detection = project.project_convention_detections.find_by!(project_version: project_version, key: "hook_manager")
+    second_detection = project.project_convention_detections.find_by!(project_version: second_project_version, key: "hook_manager")
+
+    expect(first_detection.value).to include("type" => "lefthook")
+    expect(second_detection.value).to include("type" => "husky")
+  ensure
+    FileUtils.rm_rf(second_fixture_path) if defined?(second_fixture_path)
+  end
+
+  def build_husky_fixture
+    Pathname(Dir.mktmpdir).tap do |path|
+      path.join(".husky").mkpath
+      path.join("bin").mkpath
+      path.join("bin/ci").write("#!/usr/bin/env bash\nbundle exec rspec\n")
+    end
   end
 end

--- a/spec/services/project_conventions/detect_for_import_spec.rb
+++ b/spec/services/project_conventions/detect_for_import_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectConventions::DetectForImport do
+  let(:project) { create(:project) }
+  let(:commit_sha) { "a" * 40 }
+  let(:branch) { "main" }
+  let(:worktree_service) { instance_double(WorktreeService) }
+
+  before do
+    allow(WorktreeService).to receive(:new).with(project).and_return(worktree_service)
+    Knowledge::CollectorRunner.reset_registry!
+    Knowledge::CollectorRunner.register("project_conventions", Knowledge::Collectors::ProjectConventionsCollector)
+  end
+
+  after do
+    Knowledge::CollectorRunner.reset_registry!
+  end
+
+  it "runs the project conventions collector against a temporary checkout" do
+    Dir.mktmpdir do |dir|
+      Pathname(dir).join("release-please-config.json").write('{"packages":{".":{}}}')
+      Pathname(dir).join("bin").mkpath
+      Pathname(dir).join("bin/ci").write("#!/usr/bin/env bash\nbundle exec rspec\n")
+
+      allow(worktree_service).to receive(:with_temporary_checkout).with(commit_sha).and_yield(dir)
+
+      result = described_class.call(project:, commit_sha:, branch:)
+
+      expect(result[:results]).to contain_exactly(
+        hash_including(collector_type: "project_conventions", status: "completed")
+      )
+
+      detection = project.project_convention_detections.find_by!(key: "commit_style")
+      expect(detection.project_version.commit_sha).to eq(commit_sha)
+      expect(detection.value).to include("type" => "conventional_commits")
+    end
+  end
+end

--- a/spec/services/worktree_service_spec.rb
+++ b/spec/services/worktree_service_spec.rb
@@ -518,27 +518,52 @@ RSpec.describe WorktreeService do
 
     context "when stale worktrees exist" do
       let(:stale_dir) { File.join(worktrees_path, "paid-agent-stale") }
+      let(:stale_checkout_dir) { File.join(worktrees_path, "paid-checkout-stale") }
+      let(:stale_conflict_dir) { File.join(worktrees_path, "paid-conflict-stale") }
       let(:fresh_dir) { File.join(worktrees_path, "paid-agent-fresh") }
 
       before do
         FileUtils.mkdir_p(stale_dir)
+        FileUtils.mkdir_p(stale_checkout_dir)
+        FileUtils.mkdir_p(stale_conflict_dir)
         FileUtils.mkdir_p(fresh_dir)
         FileUtils.touch(stale_dir, mtime: 25.hours.ago.to_time)
+        FileUtils.touch(stale_checkout_dir, mtime: 25.hours.ago.to_time)
+        FileUtils.touch(stale_conflict_dir, mtime: 25.hours.ago.to_time)
       end
 
-      it "removes stale worktrees" do
-        expect(service).to receive(:run_git).with(
+      it "removes stale agent worktrees" do
+        allow(service).to receive(:run_git)
+
+        service.cleanup_stale_worktrees
+
+        expect(service).to have_received(:run_git).with(
           "worktree", "remove", stale_dir, "--force",
           chdir: repo_path,
           raise_on_error: false
         )
-        expect(service).to receive(:run_git).with(
+      end
+
+      it "removes stale temporary checkout worktrees" do
+        allow(service).to receive(:run_git)
+
+        service.cleanup_stale_worktrees
+
+        expect(service).to have_received(:run_git).with(
+          "worktree", "remove", stale_checkout_dir, "--force",
+          chdir: repo_path,
+          raise_on_error: false
+        )
+        expect(service).to have_received(:run_git).with(
+          "worktree", "remove", stale_conflict_dir, "--force",
+          chdir: repo_path,
+          raise_on_error: false
+        )
+        expect(service).to have_received(:run_git).with(
           "worktree", "prune",
           chdir: repo_path,
           raise_on_error: false
         )
-
-        service.cleanup_stale_worktrees
       end
 
       it "does not remove fresh worktrees" do

--- a/spec/services/worktree_service_spec.rb
+++ b/spec/services/worktree_service_spec.rb
@@ -580,6 +580,120 @@ RSpec.describe WorktreeService do
     end
   end
 
+  describe "#with_temporary_worktree" do
+    let(:branch_name) { "feature/test-branch" }
+    let(:temp_branch) { "paid-conflict/branch123" }
+    let(:temp_path) { File.join(worktrees_path, "paid-conflict-path456") }
+
+    before do
+      allow(service).to receive(:ensure_cloned)
+      FileUtils.mkdir_p(repo_path)
+      FileUtils.mkdir_p(worktrees_path)
+      allow(SecureRandom).to receive(:hex).and_return("branch123", "path456")
+      allow(Dir).to receive(:exist?).and_call_original
+      allow(Dir).to receive(:exist?).with(temp_path).and_return(true)
+    end
+
+    def expect_temporary_worktree_cleanup(temp_branch:, temp_path:)
+      expect(service).to receive(:run_git).ordered.with(
+        "worktree", "remove", temp_path, "--force",
+        chdir: repo_path,
+        raise_on_error: false
+      )
+      expect(service).to receive(:run_git).ordered.with(
+        "branch", "-D", temp_branch,
+        chdir: repo_path,
+        raise_on_error: false
+      )
+      expect(service).to receive(:run_git).ordered.with(
+        "worktree", "prune",
+        chdir: repo_path,
+        raise_on_error: false
+      )
+    end
+
+    it "creates, yields, and removes the temporary worktree on success" do
+      expect(service).to receive(:run_git).ordered.with(
+        "worktree", "add", "--force", "-B", temp_branch, temp_path, "origin/#{branch_name}",
+        chdir: repo_path
+      )
+      expect_temporary_worktree_cleanup(temp_branch:, temp_path:)
+
+      result = service.with_temporary_worktree(branch_name) do |path|
+        expect(path).to eq(temp_path)
+        :ok
+      end
+
+      expect(result).to eq(:ok)
+    end
+
+    it "removes the temporary worktree on error" do
+      expect(service).to receive(:run_git).ordered.with(
+        "worktree", "add", "--force", "-B", temp_branch, temp_path, "origin/#{branch_name}",
+        chdir: repo_path
+      )
+      expect_temporary_worktree_cleanup(temp_branch:, temp_path:)
+
+      expect do
+        service.with_temporary_worktree(branch_name) { |_path| raise "boom" }
+      end.to raise_error("boom")
+    end
+  end
+
+  describe "#with_temporary_checkout" do
+    let(:ref) { "a" * 40 }
+    let(:temp_path) { File.join(worktrees_path, "paid-checkout-checkout123") }
+
+    before do
+      allow(service).to receive(:ensure_cloned)
+      FileUtils.mkdir_p(repo_path)
+      FileUtils.mkdir_p(worktrees_path)
+      allow(SecureRandom).to receive(:hex).and_return("checkout123")
+      allow(Dir).to receive(:exist?).and_call_original
+      allow(Dir).to receive(:exist?).with(temp_path).and_return(true)
+    end
+
+    def expect_temporary_checkout_cleanup(temp_path:)
+      expect(service).to receive(:run_git).ordered.with(
+        "worktree", "remove", temp_path, "--force",
+        chdir: repo_path,
+        raise_on_error: false
+      )
+      expect(service).to receive(:run_git).ordered.with(
+        "worktree", "prune",
+        chdir: repo_path,
+        raise_on_error: false
+      )
+    end
+
+    it "creates, yields, and removes the temporary checkout on success" do
+      expect(service).to receive(:run_git).ordered.with(
+        "worktree", "add", "--detach", temp_path, ref,
+        chdir: repo_path
+      )
+      expect_temporary_checkout_cleanup(temp_path:)
+
+      result = service.with_temporary_checkout(ref) do |path|
+        expect(path).to eq(temp_path)
+        :ok
+      end
+
+      expect(result).to eq(:ok)
+    end
+
+    it "removes the temporary checkout on error" do
+      expect(service).to receive(:run_git).ordered.with(
+        "worktree", "add", "--detach", temp_path, ref,
+        chdir: repo_path
+      )
+      expect_temporary_checkout_cleanup(temp_path:)
+
+      expect do
+        service.with_temporary_checkout(ref) { |_path| raise "boom" }
+      end.to raise_error("boom")
+    end
+  end
+
   describe "error classes" do
     describe "CloneError" do
       it "is a subclass of Error" do


### PR DESCRIPTION
## Summary

Wires project convention detection into the project import flow so newly imported repositories have convention context available before the first agent run, instead of waiting for the full knowledge collection cycle to complete.

## Changes

- **Services**: Added `ProjectConventions::DetectForImport`, a lightweight flow that runs the existing `project_conventions` collector against a temporary detached checkout during project onboarding, ahead of the full knowledge collection job.
- **Knowledge pipeline**: Extended `Knowledge::CollectorRunner` to accept a selected collector subset and skip stale-artifact marking when running a partial set, so the fast import-time pass stays focused and doesn't corrupt broader knowledge state.
- **Import flow**: Project import now triggers the focused convention detection pass before enqueuing the standard knowledge collection job.

## Design Decisions

- **Reused the existing `project_conventions` collector** rather than building a parallel detection pipeline, keeping import-time and refresh-time detection on the same code path.
- **Detached temporary checkout** isolates the import-time pass from any in-flight worktrees and avoids contaminating the longer-running collection state.
- **Partial-run mode skips stale-artifact marking** because a focused subset should not invalidate artifacts produced by collectors it didn't run — this preserves the contract that only full runs reconcile the knowledge graph.
- **Import-time pass is intentionally narrow** to avoid making every project import slow; deeper heuristic analysis remains the responsibility of the regular knowledge collection job, which refreshes conventions against the collected revision.

---

Closes #2089