### PR TITLE
fix(agent-runs): show duration for setup-time failures

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,18 +78,28 @@ module ApplicationHelper
   end
 
   def agent_run_display_duration_seconds(agent_run)
-    return agent_run.duration_seconds if agent_run.duration_seconds.present?
-    if agent_run.paused_at.present? && agent_run.started_at.present?
-      return [ (agent_run.paused_at - agent_run.started_at).to_i, 0 ].max
+    duration_seconds = agent_run.respond_to?(:duration_seconds) ? agent_run.duration_seconds : nil
+    return duration_seconds if duration_seconds.present?
+
+    started_at = agent_run.respond_to?(:started_at) ? agent_run.started_at : nil
+    paused_at = agent_run.respond_to?(:paused_at) ? agent_run.paused_at : nil
+    if paused_at.present? && started_at.present?
+      return [ (paused_at - started_at).to_i, 0 ].max
     end
-    return agent_run.duration if agent_run.running?
 
-    return nil unless agent_run.completed_at.present?
+    if agent_run.respond_to?(:running?) && agent_run.running?
+      duration = agent_run.respond_to?(:duration) ? agent_run.duration : nil
+      return duration if duration.present?
+    end
 
-    start_time = agent_run.started_at || agent_run.created_at
+    completed_at = agent_run.respond_to?(:completed_at) ? agent_run.completed_at : nil
+    return nil unless completed_at.present?
+
+    created_at = agent_run.respond_to?(:created_at) ? agent_run.created_at : nil
+    start_time = started_at || created_at
     return nil unless start_time.present?
 
-    [ (agent_run.completed_at - start_time).to_i, 0 ].max
+    [ (completed_at - start_time).to_i, 0 ].max
   end
 
   AGENT_RUN_PRIORITY_STYLES = {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -77,6 +77,21 @@ module ApplicationHelper
     )
   end
 
+  def agent_run_display_duration_seconds(agent_run)
+    return agent_run.duration_seconds if agent_run.duration_seconds.present?
+    if agent_run.paused_at.present? && agent_run.started_at.present?
+      return [ (agent_run.paused_at - agent_run.started_at).to_i, 0 ].max
+    end
+    return agent_run.duration if agent_run.running?
+
+    return nil unless agent_run.completed_at.present?
+
+    start_time = agent_run.started_at || agent_run.created_at
+    return nil unless start_time.present?
+
+    [ (agent_run.completed_at - start_time).to_i, 0 ].max
+  end
+
   AGENT_RUN_PRIORITY_STYLES = {
     label_p1: { bg: "bg-red-100", text: "text-red-700" },
     manual: { bg: "bg-sky-100", text: "text-sky-700" },

--- a/app/views/agent_runs/_detail.html.erb
+++ b/app/views/agent_runs/_detail.html.erb
@@ -58,11 +58,7 @@
       <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6 dark:bg-gray-800">
         <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400">Duration</dt>
         <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
-          <% elapsed = if agent_run.duration_seconds.present?
-               agent_run.duration_seconds
-             elsif agent_run.running? && agent_run.started_at.present?
-               (Time.current - agent_run.started_at).to_i
-             end %>
+          <% elapsed = agent_run_display_duration_seconds(agent_run) %>
           <% if elapsed %>
             <%= elapsed %>s
           <% else %>

--- a/app/views/agent_runs/_index_table.html.erb
+++ b/app/views/agent_runs/_index_table.html.erb
@@ -62,10 +62,9 @@
                     <%= agent_run_context_display(run) %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    <% if run.duration_seconds.present? %>
-                      <%= run.duration_seconds %>s
-                    <% elsif run.running? && run.started_at.present? %>
-                      <%= (Time.current - run.started_at).to_i %>s
+                    <% elapsed = agent_run_display_duration_seconds(run) %>
+                    <% if elapsed %>
+                      <%= elapsed %>s
                     <% else %>
                       <span class="text-gray-400">-</span>
                     <% end %>

--- a/app/views/agent_runs/_table.html.erb
+++ b/app/views/agent_runs/_table.html.erb
@@ -31,10 +31,9 @@
                       <%= agent_run_context_display(run) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      <% if run.duration_seconds.present? %>
-                        <%= run.duration_seconds %>s
-                      <% elsif run.running? && run.started_at.present? %>
-                        <%= (Time.current - run.started_at).to_i %>s
+                      <% elapsed = agent_run_display_duration_seconds(run) %>
+                      <% if elapsed %>
+                        <%= elapsed %>s
                       <% else %>
                         <span class="text-gray-400">-</span>
                       <% end %>

--- a/app/views/projects/_agent_run.html.erb
+++ b/app/views/projects/_agent_run.html.erb
@@ -25,11 +25,7 @@
     <%= agent_run_runner_display(agent_run) %>
   </td>
   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-    <% elapsed = if agent_run.duration_seconds.present?
-         agent_run.duration_seconds
-       elsif agent_run.running? && agent_run.started_at.present?
-         (Time.current - agent_run.started_at).to_i
-       end %>
+    <% elapsed = agent_run_display_duration_seconds(agent_run) %>
     <% if elapsed %>
       <%= elapsed %>s
     <% else %>

--- a/app/views/projects/agent_runs/_table.html.erb
+++ b/app/views/projects/agent_runs/_table.html.erb
@@ -31,10 +31,9 @@
                       <%= agent_run_runner_display(run) %>
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                      <% if run.duration_seconds.present? %>
-                        <%= run.duration_seconds %>s
-                      <% elsif run.running? && run.started_at.present? %>
-                        <%= (Time.current - run.started_at).to_i %>s
+                      <% elapsed = agent_run_display_duration_seconds(run) %>
+                      <% if elapsed %>
+                        <%= elapsed %>s
                       <% else %>
                         <span class="text-gray-400">-</span>
                       <% end %>

--- a/spec/helpers/application_helper_agent_run_runner_spec.rb
+++ b/spec/helpers/application_helper_agent_run_runner_spec.rb
@@ -85,5 +85,28 @@ RSpec.describe ApplicationHelper, :db do
 
       expect(helper.agent_run_display_duration_seconds(run)).to eq(45)
     end
+
+    it "returns the live duration for running runs" do
+      run = Struct.new(:duration_seconds, :started_at, :paused_at, :completed_at, :created_at, :duration, keyword_init: true) do
+        def running? = true
+      end.new(
+        duration_seconds: nil,
+        started_at: Time.current - 12.seconds,
+        paused_at: nil,
+        completed_at: nil,
+        created_at: Time.current - 20.seconds,
+        duration: 12
+      )
+
+      expect(helper.agent_run_display_duration_seconds(run)).to eq(12)
+    end
+
+    it "returns nil for lightweight run objects that omit optional timestamp methods" do
+      run = Struct.new(:duration_seconds, keyword_init: true) do
+        def running? = false
+      end.new(duration_seconds: nil)
+
+      expect(helper.agent_run_display_duration_seconds(run)).to be_nil
+    end
   end
 end

--- a/spec/helpers/application_helper_agent_run_runner_spec.rb
+++ b/spec/helpers/application_helper_agent_run_runner_spec.rb
@@ -42,4 +42,48 @@ RSpec.describe ApplicationHelper, :db do
       expect(helper.agent_run_runner_display(run)).to eq("Api")
     end
   end
+
+  describe "#agent_run_display_duration_seconds" do
+    let(:account) { create(:account) }
+    let(:user) { create(:user, account: account) }
+    let(:project) { create(:project, account: account, created_by: user) }
+
+    it "returns the persisted duration when present" do
+      run = create(:agent_run,
+        project: project,
+        status: "failed",
+        created_at: 5.minutes.ago,
+        started_at: 4.minutes.ago,
+        completed_at: 2.minutes.ago,
+        duration_seconds: 120)
+
+      expect(helper.agent_run_display_duration_seconds(run)).to eq(120)
+    end
+
+    it "falls back to created-to-completed time for terminal runs that failed before start" do
+      completed_at = Time.current
+      run = create(:agent_run,
+        project: project,
+        status: "failed",
+        created_at: completed_at - 36.seconds,
+        started_at: nil,
+        completed_at: completed_at,
+        duration_seconds: nil)
+
+      expect(helper.agent_run_display_duration_seconds(run)).to eq(36)
+    end
+
+    it "uses started-to-paused time for paused runs without a persisted duration" do
+      paused_at = Time.current
+      run = create(:agent_run,
+        :paused,
+        project: project,
+        created_at: paused_at - 90.seconds,
+        started_at: paused_at - 45.seconds,
+        paused_at: paused_at,
+        duration_seconds: nil)
+
+      expect(helper.agent_run_display_duration_seconds(run)).to eq(45)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- add a shared helper for agent run duration display
- show duration for pre-start terminal runs using created_at -> completed_at
- show duration for paused runs using started_at -> paused_at
- reuse the helper across the detail page and both agent run tables

## Testing
- bin/rspec spec/helpers/application_helper_agent_run_runner_spec.rb

## Notes
- The focused helper spec passed in the original workspace.
- The clean packaging worktree needed bundle install before the pre-commit hook could run, but the commit hook passed once those gems were installed.