### PR TITLE
fix(good-job): enqueue analyze followup backfill on boot

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -225,5 +225,6 @@ Rails.application.config.after_initialize do
 
   "DockerOrphanCleanupJob".constantize.perform_later
   "AutoPickQueueBackfillJob".constantize.perform_later
+  "AnalyzeIssueFollowupBackfillJob".constantize.perform_later
   "PoolReplenishmentJob".constantize.perform_later if "Containers::PoolManager".constantize.enabled?
 end


### PR DESCRIPTION
## Summary
Adds `AnalyzeIssueFollowupBackfillJob` to the existing startup backfill enqueues so the legacy analyzed-issue catch-up path still runs after boot even when an in-process GoodJob scheduler has not been restarted since the cron entry was introduced.

## Root Cause
The running Rails/GoodJob process was started before the `analyze_issue_followup_backfill` cron entry was added, so that scheduler instance never loaded the new cron definition. As a result, projects like `HuntHelper/hunthelper` still have open issues stranded in `paid_state = "analyzed"` with completed `analyze_issue` runs but no follow-up `create_pr` or `enhance_issue` run.

## Change
- enqueue `AnalyzeIssueFollowupBackfillJob` during boot alongside the existing startup backfills

## Notes
- This is a defense-in-depth fix for future boots.
- The currently running process still needs a restart, or the backfill job needs to be triggered manually, to unstick already-stranded analyzed issues.