### PR TITLE
feat: Apply resolved project conventions to Paid-created commits, PRs, and issues

### DIFF
--- a/app/services/conventional_commit_title.rb
+++ b/app/services/conventional_commit_title.rb
@@ -22,17 +22,26 @@ class ConventionalCommitTitle
     end
 
     def for_issue(issue, fallback_type: nil, project: issue&.project, style_key: "commit_style")
-      style = style_for(project, style_key)
+      style_entry = style_entry_for(project, style_key)
+      style = style_entry.fetch(:value)
       return plain_title_for(issue, style) if style["type"] == "plain"
 
-      normalized = normalize(issue&.title)
+      normalized = normalized_title_for(issue, style, style_entry:, style_key:)
       return normalized if normalized
 
       title = sanitize_subject(issue&.title)
-      fallback_type ||= style["default_type"] || "feat"
+      fallback_type = normalized_fallback_type(style, fallback_type: fallback_type)
       return "#{fallback_type}: apply agent changes" if title.blank?
 
-      "#{infer_type(issue, title: title, fallback_type: fallback_type)}: #{title}"
+      inferred_type = infer_type(issue, title: title, fallback_type: fallback_type)
+      inferred_type = enforce_allowed_type(
+        inferred_type,
+        original_title: issue&.title,
+        style: style,
+        style_entry: style_entry,
+        style_key: style_key
+      )
+      "#{inferred_type}: #{title}"
     end
 
     private
@@ -44,21 +53,56 @@ class ConventionalCommitTitle
       style["fallback_subject"].presence || "Apply agent changes"
     end
 
-    def style_for(project, style_key)
-      return default_style(style_key) unless project
+    def style_entry_for(project, style_key)
+      return default_style_entry(style_key) unless project
 
-      ProjectConventions::Resolve.call(project:, key: style_key).fetch(:value)
+      ProjectConventions::AutomationProfile.for(project:).convention(style_key)
+    end
+
+    def default_style_entry(style_key)
+      value = ProjectConventions::Catalog.default_for(style_key)
+
+      {
+        key: style_key,
+        value: value,
+        enabled: value.present?,
+        source: value.present? ? "default" : "unset"
+      }
     rescue ActiveRecord::ActiveRecordError => e
       Rails.logger.warn(
         message: "conventional_commit_title.style_lookup_failed",
         key: style_key,
         error: e.message
       )
-      default_style(style_key)
+
+      {
+        key: style_key,
+        value: ProjectConventions::Catalog.default_for(style_key),
+        enabled: true,
+        source: "default"
+      }
     end
 
-    def default_style(style_key)
-      ProjectConventions::Catalog.default_for(style_key)
+    def normalized_title_for(issue, style, style_entry:, style_key:)
+      normalized = normalize(issue&.title)
+      return unless normalized
+
+      type = normalized[CONVENTIONAL_PATTERN, :type]&.downcase
+      type = enforce_allowed_type(type, original_title: issue&.title, style:, style_entry:, style_key:) if type
+      return normalized if type == normalized[CONVENTIONAL_PATTERN, :type]&.downcase
+
+      title = sanitize_subject(issue&.title)
+      return if title.blank?
+
+      "#{type}: #{title}"
+    end
+
+    def normalized_fallback_type(style, fallback_type:)
+      preferred = fallback_type.presence || style["default_type"].presence || "feat"
+      allowed_types = Array(style["allowed_types"]).filter_map(&:presence)
+      return preferred if allowed_types.empty? || allowed_types.include?(preferred)
+
+      allowed_types.first
     end
 
     def infer_type(issue, title:, fallback_type:)
@@ -70,6 +114,25 @@ class ConventionalCommitTitle
       end
 
       fallback_type
+    end
+
+    def enforce_allowed_type(type, original_title:, style:, style_entry:, style_key:)
+      allowed_types = Array(style["allowed_types"]).filter_map(&:presence)
+      return type if type.blank? || allowed_types.empty? || allowed_types.include?(type)
+
+      Rails.logger.warn(
+        message: "conventional_commit_title.disallowed_type",
+        key: style_key,
+        source: style_entry[:source],
+        required: style.fetch("required", false),
+        disallowed_type: type,
+        allowed_types: allowed_types,
+        title: original_title.to_s
+      )
+
+      return type unless style.fetch("required", false)
+
+      normalized_fallback_type(style, fallback_type: type)
     end
 
     def sanitize_subject(title)

--- a/app/services/project_conventions/automation_profile.rb
+++ b/app/services/project_conventions/automation_profile.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module ProjectConventions
+  class AutomationProfile
+    RELEVANT_KEYS = %w[commit_style pr_title_style issue_dependency_format release_automation].freeze
+
+    def self.for(project:)
+      new(project: project)
+    end
+
+    attr_reader :project
+
+    def initialize(project:)
+      @project = project
+    end
+
+    def convention(key)
+      conventions.fetch(key.to_s) { default_entry(key) }
+    end
+
+    def value(key)
+      convention(key).fetch(:value)
+    end
+
+    def required?(key)
+      entry = convention(key)
+      entry[:enabled] && entry.fetch(:value, {}).fetch("required", false) == true
+    end
+
+    def significant_for_release?(key = "pr_title_style")
+      convention(key).fetch(:value, {}).fetch("significant_for_release", false) == true
+    end
+
+    def allowed_types(key)
+      Array(value(key)["allowed_types"]).filter_map(&:presence)
+    end
+
+    private
+
+    def conventions
+      @conventions ||= resolved_profile.fetch(:conventions)
+    end
+
+    def resolved_profile
+      return { conventions: RELEVANT_KEYS.index_with { |key| default_entry(key) } } unless resolvable_project?
+
+      @resolved_profile ||= Resolve.profile(project:)
+    rescue ActiveRecord::ActiveRecordError => e
+      Rails.logger.warn(
+        message: "project_conventions.automation_profile_lookup_failed",
+        project_id: project&.id,
+        error: e.message
+      )
+
+      {
+        conventions: RELEVANT_KEYS.index_with { |key| default_entry(key) }
+      }
+    end
+
+    def resolvable_project?
+      project.respond_to?(:project_convention_detections) &&
+        project.respond_to?(:project_convention_overrides)
+    end
+
+    def default_entry(key)
+      value = Catalog.default_for(key)
+
+      {
+        key: key.to_s,
+        category: Catalog.category_for(key),
+        value: value,
+        source: value.present? ? "default" : "unset",
+        enabled: value.present?
+      }
+    end
+  end
+end

--- a/app/services/project_conventions/inject_into_prompt.rb
+++ b/app/services/project_conventions/inject_into_prompt.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module ProjectConventions
+  class InjectIntoPrompt
+    SECTION_HEADING = "## Repository Automation Conventions"
+
+    def self.call(...)
+      new(...).call
+    end
+
+    attr_reader :prompt, :project
+
+    def initialize(prompt:, project:)
+      @prompt = prompt.to_s
+      @project = project
+    end
+
+    def call
+      return prompt if prompt.include?(SECTION_HEADING)
+
+      section = build_section
+      return prompt if section.blank?
+
+      "#{prompt.rstrip}\n\n#{section}\n"
+    end
+
+    private
+
+    def build_section
+      profile = AutomationProfile.for(project:)
+      lines = [
+        SECTION_HEADING,
+        "",
+        "Treat required items as hard requirements. Treat guidance items as preferred defaults unless the user explicitly overrides them.",
+        "",
+        commit_line(profile),
+        pr_line(profile),
+        dependency_line(profile)
+      ].compact
+
+      lines.join("\n")
+    end
+
+    def commit_line(profile)
+      style = profile.value("commit_style")
+      strength = profile.required?("commit_style") ? "Required" : "Guidance"
+
+      if style["type"] == "plain"
+        fallback = style["fallback_subject"].presence || "Apply agent changes"
+        "- Commit subjects: #{strength}. Use plain subjects. Fallback subject: `#{fallback}`."
+      else
+        allowed_types = profile.allowed_types("commit_style")
+        allowed_text = allowed_types.any? ? " Allowed types: `#{allowed_types.join("`, `")}`." : ""
+        default_type = style["default_type"].presence || "feat"
+        "- Commit subjects: #{strength}. Use conventional commits with default type `#{default_type}`.#{allowed_text}"
+      end
+    end
+
+    def pr_line(profile)
+      style = profile.value("pr_title_style")
+      strength = profile.required?("pr_title_style") ? "Required" : "Guidance"
+      release_text = profile.significant_for_release? ? " Merged PR titles affect release automation." : ""
+
+      if style["type"] == "plain"
+        fallback = style["fallback_subject"].presence || "Agent changes"
+        "- PR titles: #{strength}. Use plain titles. Fallback title: `#{fallback}`.#{release_text}"
+      else
+        allowed_types = profile.allowed_types("pr_title_style")
+        allowed_text = allowed_types.any? ? " Allowed types: `#{allowed_types.join("`, `")}`." : ""
+        default_type = style["default_type"].presence || "feat"
+        "- PR titles: #{strength}. Use conventional commits with default type `#{default_type}`.#{allowed_text}#{release_text}"
+      end
+    end
+
+    def dependency_line(profile)
+      format = profile.value("issue_dependency_format")
+      strength = profile.required?("issue_dependency_format") ? "Required" : "Guidance"
+
+      "- Issue and comment dependencies: #{strength}. Use heading `#{format["heading"]}` and explicit lines like `#{format["depends_on_prefix"]} #123` and `#{format["blocked_by_prefix"]} owner/repo#123`."
+    end
+  end
+end

--- a/app/services/project_conventions/issue_dependencies.rb
+++ b/app/services/project_conventions/issue_dependencies.rb
@@ -17,13 +17,7 @@ module ProjectConventions
     end
 
     def convention_value(project, resolved: nil)
-      resolved || Resolve.call(project:, key: "issue_dependency_format").fetch(:value)
-    rescue ActiveRecord::ActiveRecordError => e
-      Rails.logger.warn(
-        message: "issue_dependencies.convention_lookup_failed",
-        error: e.message
-      )
-      Catalog.default_for("issue_dependency_format")
+      resolved || AutomationProfile.for(project:).value("issue_dependency_format")
     end
   end
 end

--- a/app/services/prompts/build_for_issue.rb
+++ b/app/services/prompts/build_for_issue.rb
@@ -108,7 +108,8 @@ module Prompts
       ].compact.join("\n\n")
 
       with_knowledge = inject_knowledge_context(base_prompt)
-      StyleGuides::InjectIntoPrompt.call(prompt: with_knowledge, project: project)
+      with_style_guides = StyleGuides::InjectIntoPrompt.call(prompt: with_knowledge, project: project)
+      ProjectConventions::InjectIntoPrompt.call(prompt: with_style_guides, project: project)
     end
 
     # Fetches and formats trusted issue comments as a prompt section.

--- a/app/services/prompts/build_for_pr.rb
+++ b/app/services/prompts/build_for_pr.rb
@@ -110,7 +110,8 @@ module Prompts
       sections << service_environment_section
       base_prompt = sections.join("\n").delete("\x00")
 
-      StyleGuides::InjectIntoPrompt.call(prompt: base_prompt, project: project)
+      with_style_guides = StyleGuides::InjectIntoPrompt.call(prompt: base_prompt, project: project)
+      ProjectConventions::InjectIntoPrompt.call(prompt: with_style_guides, project: project)
     end
 
     private

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -69,6 +69,7 @@ module Activities
             ),
             Prompts::BuildForIssue.service_environment_section_for(project: project)
           ].reject(&:blank?).join("\n\n")
+          custom_prompt = ProjectConventions::InjectIntoPrompt.call(prompt: custom_prompt, project: project)
         end
       end
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -2905,7 +2905,8 @@ module Activities
         Prompts::Render.interpolate(fallback_template, variables)
       end
 
-      append_missing_issue_goal_runtime_instructions(rendered, slug, variables)
+      prompt = append_missing_issue_goal_runtime_instructions(rendered, slug, variables)
+      ProjectConventions::InjectIntoPrompt.call(prompt: prompt, project: agent_run.project)
     end
 
     def maybe_assign_ab_test_variant(agent_run, slug, rendered, vars)

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe Containers::GitOperations do
     receive_email.ordered if ordered
   end
 
+  def stub_successful_auto_commit_with_issue(issue)
+    status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
+    agent_run.update!(issue: issue)
+
+    allow(container_service).to receive(:execute)
+      .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
+      .and_return(status_result)
+    allow(container_service).to receive(:execute)
+      .with([ "git", "add", "-A" ], timeout: nil, stream: false)
+      .and_return(success_result)
+    allow(container_service).to receive(:execute)
+      .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
+      .and_return(Containers::Provision::Result.success(stdout: "file.rb\n", stderr: "", exit_code: 0))
+  end
+
   describe "#clone_and_setup_branch" do
     let(:head_sha) { "abc123def456789012345678901234567890abcd" }
     let(:not_a_repo_result) { Containers::Provision::Result.failure(error: "not a git repo", stdout: "", stderr: "fatal: not a git repository", exit_code: 128) }
@@ -883,26 +898,35 @@ RSpec.describe Containers::GitOperations do
     end
 
     it "uses the resolved plain commit style when the project overrides away from conventional commits" do
-      status_result = Containers::Provision::Result.success(stdout: "M  file.rb\n", stderr: "", exit_code: 0)
       issue = create(:issue, project: project, title: "Tidy workspace")
       create(:project_convention_override,
         project: project,
         key: "commit_style",
         value: { "type" => "plain", "fallback_subject" => "Apply Paid changes" })
-      agent_run.update!(issue: issue)
-
-      allow(container_service).to receive(:execute)
-        .with([ "git", "status", "--porcelain" ], timeout: nil, stream: false)
-        .and_return(status_result)
-      allow(container_service).to receive(:execute)
-        .with([ "git", "add", "-A" ], timeout: nil, stream: false)
-        .and_return(success_result)
-      allow(container_service).to receive(:execute)
-        .with([ "git", "diff", "--cached", "--name-only", "--diff-filter=d" ], timeout: nil, stream: false)
-        .and_return(Containers::Provision::Result.success(stdout: "file.rb\n", stderr: "", exit_code: 0))
+      stub_successful_auto_commit_with_issue(issue)
 
       expect(container_service).to receive(:execute)
         .with([ "git", "commit", "--no-verify", "-m", "Tidy workspace" ], timeout: nil, stream: false)
+        .and_return(success_result)
+
+      expect(git_ops.commit_uncommitted_changes).to be true
+    end
+
+    it "enforces allowed conventional commit types for the auto-commit safety net" do
+      issue = create(:issue, project: project, title: "docs: Update architecture guide")
+      create(:project_convention_override,
+        project: project,
+        key: "commit_style",
+        value: {
+          "type" => "conventional_commits",
+          "required" => true,
+          "default_type" => "feat",
+          "allowed_types" => %w[feat fix]
+        })
+      stub_successful_auto_commit_with_issue(issue)
+
+      expect(container_service).to receive(:execute)
+        .with([ "git", "commit", "--no-verify", "-m", "feat: Update architecture guide" ], timeout: nil, stream: false)
         .and_return(success_result)
 
       expect(git_ops.commit_uncommitted_changes).to be true

--- a/spec/services/conventional_commit_title_spec.rb
+++ b/spec/services/conventional_commit_title_spec.rb
@@ -92,18 +92,47 @@ RSpec.describe ConventionalCommitTitle do
       expect(described_class.for_issue(nil, project: project)).to eq("Apply Paid changes")
     end
 
+    it "enforces allowed types when the repo requires conventional commits" do
+      create(:project_convention_override,
+        project: project,
+        key: "commit_style",
+        value: {
+          "type" => "conventional_commits",
+          "required" => true,
+          "default_type" => "feat",
+          "allowed_types" => %w[feat fix]
+        })
+      issue = create(:issue, project: project, title: "docs: Update architecture guide")
+
+      expect(described_class.for_issue(issue, project: project)).to eq("feat: Update architecture guide")
+    end
+
+    it "preserves disallowed types as guidance when the repo does not require them" do
+      create(:project_convention_override,
+        project: project,
+        key: "commit_style",
+        value: {
+          "type" => "conventional_commits",
+          "required" => false,
+          "allowed_types" => %w[feat fix]
+        })
+      issue = create(:issue, project: project, title: "docs: Update architecture guide")
+
+      expect(described_class.for_issue(issue, project: project)).to eq("docs: Update architecture guide")
+    end
+
     it "logs and falls back to defaults when convention lookup hits an Active Record error" do
       issue = create(:issue, project: project, title: "Worker pool tuning")
       error = ActiveRecord::ConnectionNotEstablished.new("database unavailable")
 
-      allow(ProjectConventions::Resolve).to receive(:call).and_raise(error)
+      allow(ProjectConventions::Resolve).to receive(:profile).and_raise(error)
       allow(Rails.logger).to receive(:warn)
 
       expect(described_class.for_issue(issue, project: project)).to eq("feat: Worker pool tuning")
       expect(Rails.logger).to have_received(:warn).with(
         hash_including(
-          message: "conventional_commit_title.style_lookup_failed",
-          key: "commit_style",
+          message: "project_conventions.automation_profile_lookup_failed",
+          project_id: project.id,
           error: "database unavailable"
         )
       )

--- a/spec/services/project_conventions/inject_into_prompt_spec.rb
+++ b/spec/services/project_conventions/inject_into_prompt_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectConventions::InjectIntoPrompt do
+  let(:project) { create(:project) }
+
+  def configure_release_sensitive_conventions(project)
+    create(:project_convention_detection,
+      project: project,
+      key: "pr_title_style",
+      value: {
+        "type" => "conventional_commits",
+        "required" => true,
+        "default_type" => "feat",
+        "significant_for_release" => true
+      })
+    create(:project_convention_override,
+      project: project,
+      key: "issue_dependency_format",
+      value: {
+        "depends_on_prefix" => "Requires",
+        "blocked_by_prefix" => "Awaits",
+        "heading" => "## Blockers"
+      })
+  end
+
+  it "appends convention guidance for repository automation artifacts" do
+    configure_release_sensitive_conventions(project)
+
+    prompt = described_class.call(prompt: "Implement the issue.", project: project)
+
+    expect(prompt).to include("## Repository Automation Conventions")
+    expect(prompt).to include("PR titles: Required. Use conventional commits")
+    expect(prompt).to include("Merged PR titles affect release automation")
+    expect(prompt).to include("`Requires #123`")
+    expect(prompt).to include("`Awaits owner/repo#123`")
+  end
+
+  it "does not append the section more than once" do
+    prompt = described_class.call(
+      prompt: "Implement the issue.\n\n## Repository Automation Conventions\n\nExisting guidance.",
+      project: project
+    )
+
+    expect(prompt.scan("## Repository Automation Conventions").size).to eq(1)
+  end
+end

--- a/spec/services/project_conventions/issue_dependencies_spec.rb
+++ b/spec/services/project_conventions/issue_dependencies_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ProjectConventions::IssueDependencies do
   it "falls back to defaults when convention lookup hits an Active Record error" do
     error = ActiveRecord::StatementInvalid.new("db unavailable")
 
-    allow(ProjectConventions::Resolve).to receive(:call).and_raise(error)
+    allow(ProjectConventions::Resolve).to receive(:profile).and_raise(error)
     allow(Rails.logger).to receive(:warn)
 
     expect(described_class.depends_on_line(project: first_project, github_number: 12)).to eq("Depends on #12")
@@ -60,7 +60,8 @@ RSpec.describe ProjectConventions::IssueDependencies do
       .to eq("Blocked by acme/repo#34")
     expect(described_class.heading(project: first_project)).to eq("## Dependencies")
     expect(Rails.logger).to have_received(:warn).with(
-      message: "issue_dependencies.convention_lookup_failed",
+      message: "project_conventions.automation_profile_lookup_failed",
+      project_id: first_project.id,
       error: "db unavailable"
     ).at_least(:once)
   end

--- a/spec/services/prompts/build_for_issue_spec.rb
+++ b/spec/services/prompts/build_for_issue_spec.rb
@@ -87,6 +87,15 @@ RSpec.describe Prompts::BuildForIssue do
       expect(prompt).to include("bundle exec rubocop")
     end
 
+    it "includes repository automation conventions guidance" do
+      prompt = described_class.call(issue: issue, project: project)
+
+      expect(prompt).to include("## Repository Automation Conventions")
+      expect(prompt).to include("Commit subjects: Guidance")
+      expect(prompt).to include("PR titles: Guidance")
+      expect(prompt).to include("Depends on #123")
+    end
+
     context "when project responds to detected_language" do
       let(:project_with_language) do
         OpenStruct.new(

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -158,6 +158,13 @@ RSpec.describe Prompts::BuildForPr do
       expect(prompt).to include("bundle exec rspec")
     end
 
+    it "includes repository automation conventions guidance" do
+      expect(prompt).to include("## Repository Automation Conventions")
+      expect(prompt).to include("Commit subjects:")
+      expect(prompt).to include("PR titles:")
+      expect(prompt).to include("Issue and comment dependencies:")
+    end
+
     it "omits merge conflicts section when rebase succeeded" do
       expect(prompt).not_to include("Merge Conflicts")
     end

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -122,6 +122,27 @@ RSpec.describe Activities::CreatePullRequestActivity do
       )
     end
 
+    it "enforces allowed PR title types for release-sensitive repos" do
+      create(:project_convention_override,
+        project: project,
+        key: "pr_title_style",
+        value: {
+          "type" => "conventional_commits",
+          "required" => true,
+          "default_type" => "feat",
+          "allowed_types" => %w[feat fix],
+          "significant_for_release" => true
+        })
+      issue.update!(title: "docs: Update release notes")
+
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(github_client).to have_received(:create_pull_request).with(
+        anything,
+        hash_including(title: "feat: Update release notes")
+      )
+    end
+
     it "checks for an existing PR before creating a new one" do
       activity.execute(agent_run_id: agent_run.id)
 


### PR DESCRIPTION
## Summary

Apply resolved project conventions to Paid-created commits, PRs, issues, and agent prompts so generated artifacts match each repo's workflows (release automation triggers, semver-correct PR titles, parseable dependency wording) instead of being technically valid but wrong for the target. Convention semantics are centralized in a single automation profile so artifact services don't each re-implement the logic.

## Changes

- **Conventions core**
  - New automation profile / injector that exposes the resolved convention set to artifact-creation paths with a required-vs-guidance distinction.
  - Centralized semantics so commit, PR, and issue paths share one source of truth.
- **Commit generation**
  - Default and fallback commit subjects are normalized through the profile.
  - Auto-commit safety net after agent runs respects required conventions; weaker conventions only warn.
- **PR creation**
  - PR title generation and normalization use the resolved profile.
  - Release-sensitive title handling for repos where merged PR titles drive release automation.
- **Issues and comments**
  - Paid-created dependency references use explicit wording (`Depends on …` / `Blocked by …`) so Paid's own dependency parser stays reliable across repos.
- **Agent prompts**
  - Artifact conventions injected into prompt/context so agents follow them on the first pass, before any fallback normalization.
- **User overrides**
  - Intentional user overrides are preserved over detected repo behavior.

## Design Decisions

- **Required vs. guidance split:** strong conventions (e.g., Conventional Commits in a release-please repo) are enforced; weaker signals only guide or warn, to avoid aggressive rewrites that change semantic meaning.
- **Single profile, many consumers:** convention logic lives in one injector consumed by commit, PR, issue, and prompt paths — no duplication across artifact services.
- **Prompt-first, normalize-second:** agents are told the rules up front; fallback normalization is a safety net, not the primary mechanism.
- **Low-confidence safe defaults:** when detection confidence is low, defaults plus warnings are preferred over rewriting text that could mislead reviewers or release tooling.

## Operational Notes

- No migrations or infrastructure changes.
- `bin/rails db:prepare` was not run successfully in the implementation shell due to a missing PostgreSQL connection from `DATABASE_URL`; reviewers should confirm DB state is unchanged (no migrations were added by this change).

---

Closes #2090