### PR TITLE
fix: Reject create_pr runs for untrusted issues at queue time (root cause of "No prompt available")

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1694,7 +1694,6 @@ class AgentRun < ApplicationRecord
   # @return [String, nil] The built prompt, or nil if no issue is attached
   def prompt_for_issue
     return nil unless issue
-    return nil unless issue.trusted?
 
     Prompts::BuildForIssue.call(issue: issue, project: project, github_client: project.github_token&.client, agent_run: self)
   end

--- a/app/services/orchestration_strategies/defaults.rb
+++ b/app/services/orchestration_strategies/defaults.rb
@@ -196,21 +196,8 @@ module OrchestrationStrategies
         ],
         "planning_outcomes" => planning_mappings[:success] + planning_mappings[:failure].values,
         "parallelization_outcomes" => parallelization_mappings[:success] + parallelization_mappings[:failure].values,
-        "known_failure_types" => %w[
-          AllProvidersExhausted
-          AgentExecutionFailed
-          IssueDraftInvalid
-          McpProvisioningFailed
-          MissingPrompt
-          MissingUser
-          ContainerNotProvisioned
-          ProxyUnavailable
-          RateLimit
-        ],
-        "known_failure_classes" => %w[
-          GithubClient::RateLimitError
-          GithubClient::AuthenticationError
-        ]
+        "known_failure_types" => Workflows::AgentExecutionWorkflow::KNOWN_FAILURE_TYPES,
+        "known_failure_classes" => Workflows::AgentExecutionWorkflow::KNOWN_FAILURE_CLASSES
       }
     end
 

--- a/app/temporal/activities/create_followup_run_activity.rb
+++ b/app/temporal/activities/create_followup_run_activity.rb
@@ -18,7 +18,7 @@ module Activities
         QueueAgentRunActivity.new.execute(queue_input(agent_run, goal))
       end
 
-      {
+      response = {
         agent_run_id: agent_run.id,
         followup_agent_run_id: result[:agent_run_id],
         goal: goal,
@@ -26,6 +26,9 @@ module Activities
         duplicate: result.fetch(:duplicate, false),
         cross_goal: result.fetch(:cross_goal, false)
       }
+      response[:skipped] = true if result[:skipped]
+      response[:reason] = result[:reason] if result[:reason]
+      response
     end
 
     private

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -3,6 +3,7 @@
 module Activities
   class QueueAgentRunActivity < BaseActivity
     activity_name "QueueAgentRun"
+    GOALS_REQUIRING_TRUSTED_ISSUE = %w[create_pr].freeze
 
     def execute(input)
       project_id = input[:project_id]
@@ -20,6 +21,17 @@ module Activities
       project = Project.find(project_id)
       goal ||= project.account.tenant_setting&.default_goal || "create_pr"
       issue = issue_id ? Issue.find(issue_id) : nil
+      if issue_requires_trust?(goal) && issue&.untrusted?
+        logger.info(
+          message: "queue_agent_run.untrusted_issue_skipped",
+          project_id: project.id,
+          issue_id: issue.id,
+          github_creator_login: issue.github_creator_login,
+          goal: goal
+        )
+        return { queued: false, skipped: true, reason: "untrusted_issue" }
+      end
+
       respect_requested = input.key?(:agent_type) || input.key?(:runner_id)
       provider_id, agent_type = resolve_runner_selection(
         project: project,
@@ -128,6 +140,10 @@ module Activities
         respect_requested: runner_id_provided || agent_type_provided,
         logger: logger
       )
+    end
+
+    def issue_requires_trust?(goal)
+      GOALS_REQUIRING_TRUSTED_ISSUE.include?(goal)
     end
 
     # Returns nil for custom-prompt-only runs (no issue or PR) intentionally:

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -122,7 +122,16 @@ module Activities
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
       track_phase(agent_run_id: agent_run_id, phase_key: "run_agent", phase_group: "agent", agent_run: agent_run) do
-        prompt = agent_run.effective_prompt
+        prompt = begin
+          agent_run.effective_prompt
+        rescue Prompts::BuildForIssue::UntrustedIssueError => error
+          raise Temporalio::Error::ApplicationError.new(
+            error.message,
+            type: "UntrustedIssue",
+            non_retryable: true
+          )
+        end
+
         unless prompt
           raise Temporalio::Error::ApplicationError.new(
             "No prompt available for agent run", type: "MissingPrompt", non_retryable: true

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -62,6 +62,7 @@ module Workflows
       ContainerNotProvisioned
       ProxyUnavailable
       RateLimit
+      UntrustedIssue
     ].freeze
 
     # Non-ApplicationError exception classes that represent expected/recoverable

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -1414,12 +1414,14 @@ RSpec.describe AgentRun do
         expect(prompt).to include("#5")
       end
 
-      it "returns nil when issue is from an untrusted user" do
+      it "raises when issue is from an untrusted user" do
         project = create(:project, allowed_github_usernames: [ "viamin" ])
         issue = create(:issue, project: project, title: "Malicious", github_number: 666, github_creator_login: "attacker")
         agent_run = build(:agent_run, project: project, issue: issue)
 
-        expect(agent_run.prompt_for_issue).to be_nil
+        expect {
+          agent_run.prompt_for_issue
+        }.to raise_error(Prompts::BuildForIssue::UntrustedIssueError, /attacker/)
       end
     end
 

--- a/spec/temporal/activities/create_followup_run_activity_spec.rb
+++ b/spec/temporal/activities/create_followup_run_activity_spec.rb
@@ -53,5 +53,23 @@ RSpec.describe Activities::CreateFollowupRunActivity do
         AgentRun.where(project: project, issue: issue, status: AgentRun::UNFINISHED_STATUSES).count
       ).to eq(1)
     end
+
+    it "returns a skipped result when the follow-up create_pr target issue is untrusted" do
+      issue.update!(github_creator_login: "dependabot[bot]")
+
+      result = activity.execute(agent_run_id: analysis_run.id, goal: "create_pr")
+
+      expect(result).to eq(
+        agent_run_id: analysis_run.id,
+        followup_agent_run_id: nil,
+        goal: "create_pr",
+        queued: false,
+        skipped: true,
+        reason: "untrusted_issue",
+        duplicate: false,
+        cross_goal: false
+      )
+      expect(AgentRun.where(project: project, issue: issue, goal: "create_pr")).to be_empty
+    end
   end
 end

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -238,6 +238,16 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.custom_prompt).to eq("Do something")
     end
 
+    it "skips create_pr runs for untrusted issues" do
+      untrusted_issue = create(:issue, project: project, github_creator_login: "dependabot[bot]")
+
+      result = activity.execute(project_id: project.id, issue_id: untrusted_issue.id, goal: "create_pr")
+
+      expect(result).to eq(queued: false, skipped: true, reason: "untrusted_issue")
+      expect(AgentRun.where(project: project, issue: untrusted_issue)).to be_empty
+      expect(ProcessRunQueueJob).not_to have_been_enqueued
+    end
+
     context "when a duplicate run exists" do
       it "returns existing run when a queued run exists for the same issue" do
         existing = create(:agent_run, :queued, project: project, issue: issue)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2804,6 +2804,18 @@ expect(container_service).to receive(:execute).with(
       }.to raise_error(Temporalio::Error::ApplicationError, /No prompt available/)
     end
 
+    it "raises UntrustedIssue when prompt building rejects an untrusted issue" do
+      allow(agent_run).to receive(:effective_prompt)
+        .and_raise(Prompts::BuildForIssue::UntrustedIssueError, "Issue #1 creator 'attacker' is not trusted")
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError) { |error|
+        expect(error.message).to include("Issue #1 creator 'attacker' is not trusted")
+        expect(error.type).to eq("UntrustedIssue")
+      }
+    end
+
     it "raises ActiveRecord::RecordNotFound for invalid agent_run_id" do
       allow(AgentRun).to receive(:find).and_call_original
 


### PR DESCRIPTION
## Summary

Reject `create_pr` agent runs for untrusted issue creators at queue time instead of letting them silently fail 8+ minutes later inside `RunAgentActivity` with a misleading "No prompt available" error. This stops bot-filed issues (honeybadger, dependabot, etc.) from burning runner slots and budget on runs that cannot possibly succeed.

## Changes

- **Queue-time guard (`Activities::QueueAgentRunActivity`)**: Skip untrusted `create_pr` issues before creating an `AgentRun`, log `queue_agent_run.untrusted_issue_skipped` with project/issue/creator/goal context, and return `{ skipped: true, reason: "untrusted_issue" }` so callers can act on the result.
- **Defense-in-depth (`AgentRun#prompt_for_issue`)**: Let `Prompts::BuildForIssue::UntrustedIssueError` propagate instead of silently returning nil.
- **Clearer Temporal failure (`Activities::RunAgentActivity`)**: Translate `UntrustedIssueError` into a non-retryable `UntrustedIssue` application error, distinct from the existing `MissingPrompt` failure.
- **Follow-up runs & orchestration defaults**: Reference the workflow's known failure constants so configuration stays in sync as new failure types are added.

## Design Decisions

- **Guard scoped to `create_pr`**: `analyze_issue` and `enhance_issue` only post comments, so they remain permitted for untrusted issues. Only goals that mutate the repo require trusted creators.
- **Choke point is `QueueAgentRunActivity`, not individual callers**: `DefaultCandidateSource` already filters at auto-pick selection, but the older `GitHubPollWorkflow#queue_create_pr_run` path and the new `CreateFollowupRunActivity` both funnel through `QueueAgentRunActivity` — guarding here covers current and future callers without duplicating checks.
- **Skip vs. raise at queue time**: Returning a `skipped` result (rather than raising) lets the workflow treat untrusted issues as a normal non-event and avoids polluting Temporal failure metrics with expected skips.
- **Case-sensitivity mismatch in the allowlist is out of scope**: Tracked separately in #2177; this PR addresses only the silent-failure path.

## Related

- Root cause of "No prompt available for agent run" errors on bot-filed issues.
- Companion to #2177 (allowlist case-sensitivity).

---

Closes #2193