### PR TITLE
fix(auto-pick): stop parking issues as recommend_close on zero-iteration runs

### DIFF
--- a/app/services/issues/upsert_from_github.rb
+++ b/app/services/issues/upsert_from_github.rb
@@ -1,24 +1,32 @@
 # frozen_string_literal: true
 
 module Issues
+  # Label used to surface the recommend_close recommendation on GitHub.
+  # Mirrors HandleNoOutputIssueRunActivity::PAID_RECOMMEND_CLOSE_LABEL but
+  # duplicated here to avoid a temporal-activity dependency on this service.
+  RECOMMEND_CLOSE_LABEL = "paid-recommend-close"
+
   class UpsertFromGithub
     def self.call(project:, github_issue:, body: github_issue.body)
       issue = project.issues.find_or_initialize_by(github_issue_id: github_issue.id)
       was_open = issue.github_state == "open"
+      previous_labels = Array(issue.labels)
 
+      new_labels = extract_labels(github_issue)
       issue.update!(
         github_number: github_issue.number,
         title: github_issue.title,
         body: body,
         github_creator_login: github_issue.user&.login || "unknown",
         github_state: github_issue.state,
-        labels: extract_labels(github_issue),
+        labels: new_labels,
         is_pull_request: pull_request_payload(github_issue).present?,
         github_created_at: github_issue.created_at,
         github_updated_at: github_issue.updated_at
       )
 
       deliver_completion_notifications(issue, github_issue: github_issue, was_open: was_open)
+      maybe_clear_recommend_close(issue, project: project, previous_labels: previous_labels, new_labels: new_labels)
       issue
     end
 
@@ -46,5 +54,30 @@ module Issues
       github_issue.respond_to?(:state_reason) && github_issue.state_reason == "completed"
     end
     private_class_method :closed_as_completed?
+
+    # When a user removes the recommend-close label from an issue that Paid
+    # had parked in paid_state=recommend_close, treat that as an explicit
+    # "I disagree, work on this again" signal. Reset paid_state to new — the
+    # Issue model's auto_pick_recheck_needed? callback handles re-enqueueing
+    # when paid_state transitions to an eligible value. We do not act on
+    # label *additions* — only Paid itself should add the recommend-close
+    # label as part of its classification.
+    def self.maybe_clear_recommend_close(issue, project:, previous_labels:, new_labels:)
+      return if issue.is_pull_request?
+      return unless issue.paid_state == "recommend_close"
+
+      label = project.label_for_stage("recommend_close") || RECOMMEND_CLOSE_LABEL
+      return unless previous_labels.include?(label)
+      return if new_labels.include?(label)
+
+      issue.update!(paid_state: "new")
+      Rails.logger.info(
+        message: "recommend_close.label_removed_reset",
+        issue_id: issue.id,
+        project_id: project.id,
+        github_number: issue.github_number
+      )
+    end
+    private_class_method :maybe_clear_recommend_close
   end
 end

--- a/app/temporal/activities/handle_no_output_issue_run_activity.rb
+++ b/app/temporal/activities/handle_no_output_issue_run_activity.rb
@@ -147,13 +147,14 @@ module Activities
         return "needs_input"
       end
 
-      # Guard: if the agent produced output but shows no evidence of having
-      # actually run (zero iterations AND zero cost), the "output" is likely
-      # a provider-level error (e.g. credit exhaustion) or trivial CLI
-      # boilerplate rather than a real agent response. Confirm by checking
-      # the output for error patterns; if neither matches, classify as
-      # needs_input since the agent did not perform meaningful work.
-      if agent_run.iterations.to_i.zero? && agent_run.cost_cents.to_i.zero?
+      # Guard: if the agent produced output but did zero iterations, the
+      # "output" is likely a provider-level error, trivial CLI boilerplate,
+      # or an agent that read the prompt then gave up without doing real
+      # work. Cost-cents alone is not evidence of work — reading the
+      # prompt incurs a few cents. Recommend-close requires real iterations
+      # so users are not left with issues parked on transient agent failures.
+      # Confirm provider/infrastructure errors against output patterns first.
+      if agent_run.iterations.to_i.zero?
         return "provider_error" if provider_error_output?(diagnostic_output)
         return "infrastructure_error" if infrastructure_error_output?(diagnostic_output)
 

--- a/lib/tasks/issues.rake
+++ b/lib/tasks/issues.rake
@@ -32,7 +32,6 @@ namespace :issues do
         next if dry_run
 
         issue.update!(paid_state: "new")
-        Issues::ReenqueueEligibleJob.perform_later(issue.id) if issue.project.auto_pick_enabled?
       end
 
       puts dry_run ? "Dry run only. Re-run with DRY_RUN=false to apply." : "Done."

--- a/lib/tasks/issues.rake
+++ b/lib/tasks/issues.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+namespace :issues do
+  desc "Reset paid_state for issues parked in recommend_close by the false-positive classifier (iterations=0 + cost>0). Use DRY_RUN=false to apply."
+  task reset_false_positive_recommend_close: :environment do
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+    candidates = []
+
+    # Goal allowlist mirrors the workflow path that routes through
+    # HandleNoOutputIssueRunActivity: any issue-based run with no source
+    # PR can reach the classifier. analyze_issue takes a different path
+    # (paid_state: "analyzed") and never sets recommend_close, but listing
+    # both create_pr and enhance_issue here avoids missing future goals
+    # added to the no-output classifier path.
+    classifier_goals = %w[create_pr enhance_issue]
+
+    TenantContext.with_system_access do
+      Issue.where(paid_state: "recommend_close", is_pull_request: false, github_state: "open").find_each do |issue|
+        last = issue.agent_runs
+          .where(goal: classifier_goals, status: "completed")
+          .order(created_at: :desc)
+          .first
+        next unless last
+        next unless last.iterations.to_i.zero?
+
+        candidates << [ issue, last ]
+      end
+
+      puts "Found #{candidates.size} issue(s) with iterations=0 recommend_close runs (DRY_RUN=#{dry_run})"
+      candidates.each do |issue, run|
+        puts "  ##{issue.github_number} project=#{issue.project.full_name} run=#{run.id} iterations=#{run.iterations} cost_cents=#{run.cost_cents}"
+        next if dry_run
+
+        issue.update!(paid_state: "new")
+        Issues::ReenqueueEligibleJob.perform_later(issue.id) if issue.project.auto_pick_enabled?
+      end
+
+      puts dry_run ? "Dry run only. Re-run with DRY_RUN=false to apply." : "Done."
+    end
+  end
+end

--- a/spec/services/issues/upsert_from_github_spec.rb
+++ b/spec/services/issues/upsert_from_github_spec.rb
@@ -117,5 +117,80 @@ RSpec.describe Issues::UpsertFromGithub do
         described_class.call(project: project, github_issue: github_issue)
       }.not_to change(Notification, :count)
     end
+
+    describe "recommend_close label removal reset" do
+      let(:project) { create(:project, auto_pick_enabled: true) }
+      let(:github_issue) do
+        OpenStruct.new(
+          id: 9000,
+          number: 7,
+          title: "Re-evaluate me",
+          body: "body",
+          state: "open",
+          labels: [ OpenStruct.new(name: "P1") ],
+          pull_request: nil,
+          state_reason: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: Time.zone.parse("2026-05-18 00:00:00 UTC"),
+          updated_at: Time.zone.parse("2026-05-20 00:00:00 UTC")
+        )
+      end
+
+      it "resets paid_state to new and re-enqueues when the recommend_close label is removed" do
+        create(:issue, project: project, github_issue_id: 9000, github_number: 7,
+          paid_state: "recommend_close", labels: [ "P1", "paid-recommend-close" ])
+
+        expect {
+          described_class.call(project: project, github_issue: github_issue)
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob)
+
+        expect(project.issues.find_by(github_issue_id: 9000).paid_state).to eq("new")
+      end
+
+      it "does not reset when the label is still present" do
+        create(:issue, project: project, github_issue_id: 9000, github_number: 7,
+          paid_state: "recommend_close", labels: [ "P1", "paid-recommend-close" ])
+        github_issue.labels = [ OpenStruct.new(name: "P1"), OpenStruct.new(name: "paid-recommend-close") ]
+
+        expect {
+          described_class.call(project: project, github_issue: github_issue)
+        }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+
+        expect(project.issues.find_by(github_issue_id: 9000).paid_state).to eq("recommend_close")
+      end
+
+      it "does not reset when paid_state is not recommend_close" do
+        create(:issue, project: project, github_issue_id: 9000, github_number: 7,
+          paid_state: "new", labels: [ "P1", "paid-recommend-close" ])
+
+        expect {
+          described_class.call(project: project, github_issue: github_issue)
+        }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+      end
+
+      it "uses the project-configured recommend_close label override" do
+        project.update!(label_mappings: { "recommend_close" => "needs-review" })
+        create(:issue, project: project, github_issue_id: 9000, github_number: 7,
+          paid_state: "recommend_close", labels: [ "P1", "needs-review" ])
+
+        expect {
+          described_class.call(project: project, github_issue: github_issue)
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob)
+
+        expect(project.issues.find_by(github_issue_id: 9000).paid_state).to eq("new")
+      end
+
+      it "clears state but does not enqueue when auto_pick is disabled" do
+        project.update!(auto_pick_enabled: false)
+        create(:issue, project: project, github_issue_id: 9000, github_number: 7,
+          paid_state: "recommend_close", labels: [ "P1", "paid-recommend-close" ])
+
+        expect {
+          described_class.call(project: project, github_issue: github_issue)
+        }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+
+        expect(project.issues.find_by(github_issue_id: 9000).paid_state).to eq("new")
+      end
+    end
   end
 end

--- a/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
+++ b/spec/temporal/activities/handle_no_output_issue_run_activity_spec.rb
@@ -379,15 +379,16 @@ RSpec.describe Activities::HandleNoOutputIssueRunActivity do
         expect(result[:outcome]).to eq("recommend_close")
       end
 
-      it "allows recommend_close when agent has cost_cents > 0" do
+      it "classifies as needs_input when iterations is zero even with cost > 0" do
         issue = create(:issue, :in_progress, project: project)
         agent_run = create(:agent_run, :running, project: project, issue: issue,
           iterations: 0, cost_cents: 50)
-        agent_run.log!("stdout", "This issue appears resolved already")
+        agent_run.log!("stdout", "OK.")
 
         result = activity.execute(agent_run_id: agent_run.id, output_present: true)
 
-        expect(result[:outcome]).to eq("recommend_close")
+        expect(result[:outcome]).to eq("needs_input")
+        expect(issue.reload.paid_state).to eq("needs_input")
       end
 
       it "detects quota exceeded errors" do


### PR DESCRIPTION
## Summary

Four of six open P1 issues on `viamin/paid` (#1897, #2026, #2057, #2117) were stranded in `paid_state=recommend_close` — invisible to the scheduler — because the no-output classifier in `HandleNoOutputIssueRunActivity` was routing zero-iteration runs to `recommend_close` whenever they incurred even a few cents of prompt-reading cost. A few cents is not evidence of real work.

Three coordinated fixes:

- **Tighten the classifier** (`handle_no_output_issue_run_activity.rb:156`) — `recommend_close` now requires `iterations > 0`. Zero-iteration runs route to `needs_input` (with provider/infrastructure-error overrides applied first).
- **Add a label-removed reset hook** (`upsert_from_github.rb`) — when a GitHub sync observes `paid-recommend-close` was removed from an issue still in `paid_state=recommend_close`, transition `paid_state` back to `new`. The existing `Issue#auto_pick_recheck_needed?` model callback re-enqueues. This turns the label into the user's "I disagree, work on this again" signal, which is how the label was already being used in practice but with no listener.
- **One-shot backfill** (`rake issues:reset_false_positive_recommend_close`) — defaults to `DRY_RUN=true`. Dry-run against the production-equivalent dev DB matches exactly the 4 stranded P1s; no collateral.

## Why now

In production, the four stranded P1s had completed runs with `iterations=0` and `cost_cents` between 3 and 34. For #1897 the agent literally noted "the work is already done." For #2026/#2057 it said "OK." — clearly giving-up signals, not "this should be closed" judgments. The user had manually removed `paid-recommend-close` from each issue 2–6 days ago expecting Paid to retry; nothing in Paid noticed.

## Test plan

- [x] Classifier spec covers the new `iterations=0 + cost>0` → `needs_input` path
- [x] Five new specs cover the label-removed hook (positive, negative, label still present, project override, auto-pick disabled)
- [x] Full upsert + classifier + adjacent specs (569 examples) pass
- [x] Backfill dry-run identifies exactly the 4 stranded P1s

## Followups (out of scope)

- `paid-needs-input` does not have a symmetric label-removed hook. False-positives shifted from `recommend_close` to `needs_input` are still parked. Different semantics (needs_input = "provide info" not "push back") makes the symmetric hook potentially loop-prone — worth separate UX discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)