### PR TITLE
feat: Add symmetric label-removed hook for paid-needs-input

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -51,6 +51,9 @@ module Activities
         enhance_issue_rechecks = enhance_issue_result[:rechecks]
         sync_changed ||= enhance_issue_result[:changed]
 
+        needs_input_changed = detect_needs_input_label_removals(project, synced_issues)
+        sync_changed ||= needs_input_changed
+
         closed_count = close_stale_issues(project, github_issues, truncated: truncated, incremental: incremental)
         sync_changed ||= closed_count.positive?
 
@@ -394,6 +397,31 @@ module Activities
           paid_state: "needs_input"
         )
       end
+    end
+
+    def detect_needs_input_label_removals(project, synced_issues)
+      needs_input_label = project.label_for_stage("needs_input") ||
+        Activities::HandleNoOutputIssueRunActivity::PAID_NEEDS_INPUT_LABEL
+      changed = false
+
+      synced_issues.each do |issue_data|
+        next unless Array(issue_data[:removed_labels]).include?(needs_input_label)
+
+        issue = project.issues.find(issue_data[:id])
+        next if issue.is_pull_request? || issue.github_state == "closed" || issue.paid_state != "needs_input"
+
+        issue.update!(paid_state: "new")
+        changed = true
+
+        logger.info(
+          message: "github_sync.needs_input_label_removed",
+          project_id: project.id,
+          issue_id: issue.id,
+          issue_number: issue.github_number
+        )
+      end
+
+      changed
     end
 
     # Parses dependency and parent/child relationships from issue comments.

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -546,6 +546,92 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
     end
 
+    context "when the paid-needs-input label is removed" do
+      let(:project) do
+        create(:project,
+          label_mappings: { "build" => "paid-build" },
+          enhance_issue_needs_input_label_name: "paid-enhance-needs-input",
+          auto_pick_enabled: true)
+      end
+
+      let!(:issue) do
+        create(:issue,
+          project: project,
+          github_issue_id: 9301,
+          github_number: 93,
+          paid_state: "needs_input",
+          labels: [ "paid-needs-input", "paid-build" ])
+      end
+
+      let(:github_issue) do
+        OpenStruct.new(
+          id: issue.github_issue_id,
+          number: issue.github_number,
+          title: issue.title,
+          body: issue.body,
+          state: "open",
+          labels: [ OpenStruct.new(name: "paid-build") ],
+          pull_request: nil,
+          user: OpenStruct.new(login: "viamin"),
+          created_at: issue.github_created_at,
+          updated_at: Time.current
+        )
+      end
+
+      before do
+        stub_issues_by_label(nil => [ github_issue ])
+      end
+
+      it "transitions paid_state to new" do
+        activity.execute(project_id: project.id)
+
+        expect(issue.reload.paid_state).to eq("new")
+      end
+
+      it "enqueues auto-pick recheck after transitioning to new" do
+        expect {
+          activity.execute(project_id: project.id)
+        }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id)
+
+        expect(issue.reload.paid_state).to eq("new")
+      end
+
+      it "does not transition when issue is closed" do
+        github_issue.state = "closed"
+
+        activity.execute(project_id: project.id)
+
+        expect(issue.reload.paid_state).to eq("needs_input")
+      end
+
+      it "does not transition when issue is a pull request" do
+        github_issue.pull_request = OpenStruct.new(html_url: "https://github.com/owner/repo/pull/93")
+
+        activity.execute(project_id: project.id)
+
+        expect(issue.reload.paid_state).to eq("needs_input")
+      end
+
+      it "does not transition when paid_state is not needs_input" do
+        issue.update!(paid_state: "failed")
+
+        activity.execute(project_id: project.id)
+
+        expect(issue.reload.paid_state).to eq("failed")
+      end
+
+      it "does not transition when the label is still present" do
+        github_issue.labels = [
+          OpenStruct.new(name: "paid-needs-input"),
+          OpenStruct.new(name: "paid-build")
+        ]
+
+        activity.execute(project_id: project.id)
+
+        expect(issue.reload.paid_state).to eq("needs_input")
+      end
+    end
+
     context "when rate limited" do
       before do
         allow(github_client).to receive(:issues).and_raise(


### PR DESCRIPTION
## Summary

Adds a symmetric label-removed hook for `paid-needs-input` so users can signal "I disagree, retry this" by removing the label, mirroring the existing behavior for `paid-recommend-close` (#2215). Without this, false-positive issues routed to `needs_input` after the #2215 classifier change remain stranded indefinitely with no user-driven recovery path.

## Changes

- **Activities** (`app/temporal/activities/fetch_issues_activity.rb`): Added `detect_needs_input_label_removals`, invoked during GitHub issue sync. When `paid-needs-input` appears in `removed_labels` for an open, non-PR issue in `paid_state=needs_input`, it transitions `paid_state` back to `new`. The existing `Issue#auto_pick_recheck_needed?` callback then re-enqueues auto-pick. The lookup uses `project.label_for_stage("needs_input")` to honor custom label mappings, falling back to the `PAID_NEEDS_INPUT_LABEL` constant.
- **Specs** (`spec/temporal/activities/fetch_issues_activity_spec.rb`): 6 new tests covering the basic transition, auto-pick re-enqueue, and guard clauses for closed issues, PRs, mismatched `paid_state`, and label-still-present cases.

## Design Decisions

- **Unconditional transition (option 3 from the issue).** Treating the user's label removal as the signal — same semantics as `recommend_close` — keeps the two hooks symmetric and the implementation minimal. Options 1 (gate on new body/comment activity) and 2 (cooldown / retry cap) were considered to bound tight-loop risk where `needs_input` was caused by a real information gap; rejected because the immediate re-run will simply re-park the issue with the same blocker, which is recoverable and visible, not destructive. If loop churn shows up in practice, a cooldown can be layered on later without changing the entry point.
- **Guard clauses up front.** Closed/PR/wrong-state issues are filtered before the transition to keep the hook scoped narrowly and avoid touching records outside its concern.

---

Closes #2217