### PR TITLE
fix(devcontainer): seed valid JSON in opencode auth.json initializer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,7 @@
   },
   // Ensure host paths that are bind-mounted as files (not directories) exist before
   // Docker creates them as directories. See: https://github.com/moby/moby/issues/26702
-  "initializeCommand": "mkdir -p ~/.config/opencode && touch ~/.config/opencode/auth.json",
+  "initializeCommand": "mkdir -p ~/.config/opencode && { [ -s ~/.config/opencode/auth.json ] || echo '{}' > ~/.config/opencode/auth.json; }",
   "mounts": [
     // Git configuration
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",


### PR DESCRIPTION
## Summary

- `.devcontainer/devcontainer.json`'s `initializeCommand` ran `touch ~/.config/opencode/auth.json`, creating an empty file on the host that is then bind-mounted into the container.
- opencode's provider loader does `JSON.parse` on `auth.json`; an empty file throws `SyntaxError: JSON Parse error: Expected ']'`, which surfaces as failures in both `config.providers` and `provider.list`.
- The `touch` exists only to satisfy the moby/26702 workaround (so Docker doesn't create the bind target as a directory). Replaced with `[ -s … ] || echo '{}' > …` so the file is valid JSON when first created, while existing host credentials are left untouched.

## Test plan

- [ ] Rebuild the devcontainer on a host where `~/.config/opencode/auth.json` does not exist and confirm opencode no longer errors on `provider.list` / `config.providers`.
- [ ] Rebuild on a host where `~/.config/opencode/auth.json` already contains real provider auth and confirm the file is not overwritten.