### PR TITLE
feat(knowledge): ingest clarifying-question answers as knowledge chunks

### DIFF
--- a/app/models/knowledge_chunk.rb
+++ b/app/models/knowledge_chunk.rb
@@ -2,7 +2,7 @@
 
 class KnowledgeChunk < ApplicationRecord
   STATUSES = %w[active stale deleted redacted].freeze
-  CHUNK_TYPES = %w[definition summary context evidence].freeze
+  CHUNK_TYPES = %w[definition summary context evidence qa_pair].freeze
 
   belongs_to :knowledge_artifact
   belongs_to :project

--- a/app/services/clarifying_questions/ingest_answers.rb
+++ b/app/services/clarifying_questions/ingest_answers.rb
@@ -108,7 +108,7 @@ module ClarifyingQuestions
       content = "Q: #{qa_pair[:question]}\nA: #{qa_pair[:answer]}"
       content_hash = Digest::SHA256.hexdigest(content)
 
-      return if KnowledgeChunk.exists?(content_hash: content_hash)
+      return if KnowledgeChunk.for_project(project).exists?(chunk_type: ARTIFACT_TYPE, content_hash: content_hash)
 
       identifier = "qa_pair:#{issue.github_number}:#{content_hash[0..11]}"
       scope_path = "clarifying_questions/#{project.full_name}/issues/#{issue.github_number}"

--- a/app/services/clarifying_questions/ingest_answers.rb
+++ b/app/services/clarifying_questions/ingest_answers.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+module ClarifyingQuestions
+  class IngestAnswers
+    ARTIFACT_TYPE = "qa_pair"
+    COLLECTOR_TYPE = "clarifying_question_answers"
+
+    def self.call(project:, issue:)
+      new(project: project, issue: issue).call
+    end
+
+    def initialize(project:, issue:)
+      @project = project
+      @issue = issue
+    end
+
+    def call
+      return unless github_available?
+
+      enhancement_comment = find_enhancement_comment
+      return unless enhancement_comment
+
+      answer_comment = find_answer_comment
+      return unless answer_comment
+      return unless answer_newer_than_enhancement?(answer_comment, enhancement_comment)
+
+      questions = Parse.call(comment_body: enhancement_comment.body.to_s)
+      return if questions.empty?
+
+      answers = parse_answers(answer_comment.body.to_s)
+      return if answers.empty?
+
+      qa_pairs = pair_qa(questions, answers)
+      return if qa_pairs.empty?
+
+      ingest(qa_pairs, answer_comment)
+    rescue GithubClient::Error
+      nil
+    end
+
+    private
+
+    attr_reader :project, :issue
+
+    def github_available?
+      project.github_token.present?
+    end
+
+    def github_client
+      @github_client ||= project.github_token.client
+    end
+
+    def find_enhancement_comment
+      issue_comments.reverse.find do |comment|
+        body = comment.body.to_s
+        body.include?(Parse::ENHANCEMENT_MARKER) &&
+          body.include?("## Clarifying questions")
+      end
+    end
+
+    def find_answer_comment
+      issue_comments.reverse.find do |comment|
+        comment.body.to_s.include?(Load::ANSWER_MARKER)
+      end
+    end
+
+    def answer_newer_than_enhancement?(answer_comment, enhancement_comment)
+      answer_time = answer_comment.created_at&.to_time || Time.at(0)
+      enhancement_time = enhancement_comment.created_at&.to_time || Time.at(0)
+      answer_time > enhancement_time
+    end
+
+    def issue_comments
+      @issue_comments ||= github_client.issue_comments(project.full_name, issue.github_number)
+        .select { |comment| trusted_comment?(comment) }
+    end
+
+    def trusted_comment?(comment)
+      project.trusted_github_user?(comment.user&.login)
+    end
+
+    def parse_answers(body)
+      body.scan(/\*\*A\d+:\*\*\s*(.+?)(?=\n\n\*\*|\z)/m).map { |m| m[0].strip }
+    end
+
+    def pair_qa(questions, answers)
+      questions.each_with_index.filter_map do |question, i|
+        next if answers[i].blank?
+
+        { question: question, answer: answers[i] }
+      end
+    end
+
+    def ingest(qa_pairs, answer_comment)
+      ActiveRecord::Base.transaction do
+        project_version = find_or_create_project_version!
+        collector_run = find_or_create_collector_run!(project_version)
+
+        qa_pairs.each do |qa|
+          ingest_qa_pair!(qa, answer_comment, collector_run)
+        end
+
+        collector_run.mark_completed!(count: qa_pairs.size)
+      end
+    end
+
+    def ingest_qa_pair!(qa_pair, answer_comment, collector_run)
+      content = "Q: #{qa_pair[:question]}\nA: #{qa_pair[:answer]}"
+      content_hash = Digest::SHA256.hexdigest(content)
+
+      return if KnowledgeChunk.exists?(content_hash: content_hash)
+
+      identifier = "qa_pair:#{issue.github_number}:#{content_hash[0..11]}"
+      scope_path = "clarifying_questions/#{project.full_name}/issues/#{issue.github_number}"
+
+      artifact = KnowledgeArtifact.create!(
+        project: project,
+        collector_run: collector_run,
+        artifact_type: ARTIFACT_TYPE,
+        collector_type: COLLECTOR_TYPE,
+        scope_path: scope_path,
+        identifier: identifier,
+        content: content,
+        content_hash: content_hash,
+        metadata: {
+          issue_id: issue.id,
+          issue_number: issue.github_number,
+          comment_id: answer_comment.id,
+          question: qa_pair[:question]
+        },
+        status: "active"
+      )
+
+      artifact.knowledge_chunks.create!(
+        project: project,
+        chunk_type: "qa_pair",
+        content: content,
+        content_hash: content_hash,
+        scope_tags: [ "qa_pair", "issue_#{issue.github_number}" ],
+        sequence: 0,
+        status: "active"
+      )
+    end
+
+    def find_or_create_project_version!
+      latest = project.project_versions.by_recency.first
+      return latest if latest
+
+      project.project_versions.create!(
+        commit_sha: "0" * 40,
+        branch: project.default_branch || "main"
+      )
+    end
+
+    def find_or_create_collector_run!(project_version)
+      existing = project_version.collector_runs.find_by(collector_type: COLLECTOR_TYPE)
+      if existing
+        existing.mark_running!
+        return existing
+      end
+
+      project_version.collector_runs.create!(
+        collector_type: COLLECTOR_TYPE,
+        status: "running",
+        started_at: Time.current
+      )
+    end
+  end
+end

--- a/app/services/clarifying_questions/ingest_answers.rb
+++ b/app/services/clarifying_questions/ingest_answers.rb
@@ -5,13 +5,14 @@ module ClarifyingQuestions
     ARTIFACT_TYPE = "qa_pair"
     COLLECTOR_TYPE = "clarifying_question_answers"
 
-    def self.call(project:, issue:)
-      new(project: project, issue: issue).call
+    def self.call(project:, issue:, issue_comments: nil)
+      new(project: project, issue: issue, issue_comments: issue_comments).call
     end
 
-    def initialize(project:, issue:)
+    def initialize(project:, issue:, issue_comments: nil)
       @project = project
       @issue = issue
+      @injected_comments = issue_comments
     end
 
     def call
@@ -71,8 +72,10 @@ module ClarifyingQuestions
     end
 
     def issue_comments
-      @issue_comments ||= github_client.issue_comments(project.full_name, issue.github_number)
-        .select { |comment| trusted_comment?(comment) }
+      @issue_comments ||= begin
+        comments = @injected_comments || github_client.issue_comments(project.full_name, issue.github_number)
+        comments.select { |comment| trusted_comment?(comment) }
+      end
     end
 
     def trusted_comment?(comment)

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -20,7 +20,10 @@ module ClarifyingQuestions
         return body_questions unless github_available?
 
         enhancement_comment = latest_enhancement_comment
-        return [] if answered_after_latest_questions?(body_questions:, enhancement_comment:)
+        if answered_after_latest_questions?(body_questions:, enhancement_comment:)
+          ingest_answers
+          return []
+        end
 
         return body_questions
       end
@@ -28,7 +31,10 @@ module ClarifyingQuestions
       return [] unless github_available?
 
       enhancement_comment = latest_enhancement_comment
-      return [] if answered_after_latest_questions?(body_questions:, enhancement_comment:)
+      if answered_after_latest_questions?(body_questions:, enhancement_comment:)
+        ingest_answers
+        return []
+      end
       return [] unless enhancement_comment
 
       Parse.call(comment_body: comment_body(enhancement_comment))
@@ -102,6 +108,12 @@ module ClarifyingQuestions
 
     def trusted_comment?(comment)
       project.trusted_github_user?(comment.user&.login)
+    end
+
+    def ingest_answers
+      IngestAnswers.call(project: project, issue: issue)
+    rescue StandardError
+      nil
     end
   end
 end

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -111,8 +111,13 @@ module ClarifyingQuestions
     end
 
     def ingest_answers
-      IngestAnswers.call(project: project, issue: issue)
-    rescue StandardError
+      IngestAnswers.call(project: project, issue: issue, issue_comments: issue_comments)
+    rescue ActiveRecord::ActiveRecordError => e
+      Rails.logger.warn(
+        message: "clarifying_questions.ingest_answers_failed",
+        error: e.message,
+        issue_id: issue.respond_to?(:id) ? issue.id : nil
+      )
       nil
     end
   end

--- a/spec/services/clarifying_questions/ingest_answers_spec.rb
+++ b/spec/services/clarifying_questions/ingest_answers_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe ClarifyingQuestions::IngestAnswers do
   end
 
   describe ".call" do
+    context "when issue comments are injected" do
+      it "uses the injected comments instead of fetching from GitHub" do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)
+        answers = trusted_comment(body: answers_body, created_at: 2.minutes.ago)
+        allow(github_client).to receive(:issue_comments)
+
+        described_class.call(project: project, issue: issue, issue_comments: [ enhancement, answers ])
+
+        expect(github_client).not_to have_received(:issue_comments)
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair").count).to eq(2)
+      end
+    end
+
     context "when a trusted user posts answers" do
       before do
         enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)

--- a/spec/services/clarifying_questions/ingest_answers_spec.rb
+++ b/spec/services/clarifying_questions/ingest_answers_spec.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClarifyingQuestions::IngestAnswers do
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project) }
+  let(:github_client) { instance_double(GithubClient) }
+  let(:trusted_login) { "viamin" }
+  let(:enhancement_body) do
+    <<~COMMENT
+      <!-- paid:enhance-issue -->
+      ## Clarifying questions
+      1. What constitutes premium settings?
+      2. Should this be behind a feature flag?
+
+      ## Current context
+      - Some context
+    COMMENT
+  end
+  let(:answers_body) do
+    <<~COMMENT
+      <!-- paid:clarifying-answers -->
+
+      ## Clarifying question answers
+
+      **Q1: What constitutes premium settings?**
+      **A1:** Premium settings include custom themes, advanced analytics, and priority support.
+
+      **Q2: Should this be behind a feature flag?**
+      **A2:** Yes, use the `premium_features` flag from `config/features.yml`.
+    COMMENT
+  end
+
+  before do
+    allow(project.github_token).to receive(:client).and_return(github_client)
+  end
+
+  def trusted_comment(body:, created_at: Time.current, login: trusted_login)
+    double(body: body, user: double(login: login), created_at: created_at, id: rand(100_000))
+  end
+
+  describe ".call" do
+    context "when a trusted user posts answers" do
+      before do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)
+        answers = trusted_comment(body: answers_body, created_at: 2.minutes.ago)
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+      end
+
+      it "creates knowledge artifacts for each Q&A pair" do
+        described_class.call(project: project, issue: issue)
+
+        artifacts = KnowledgeArtifact.for_project(project)
+                                     .active
+                                     .by_type("qa_pair")
+        expect(artifacts.count).to eq(2)
+      end
+
+      it "creates knowledge chunks with chunk_type qa_pair" do
+        described_class.call(project: project, issue: issue)
+
+        chunks = KnowledgeChunk.where(project: project, chunk_type: "qa_pair")
+        expect(chunks.count).to eq(2)
+        expect(chunks.map(&:chunk_type).uniq).to eq([ "qa_pair" ])
+      end
+
+      it "stores Q and A in chunk content" do
+        described_class.call(project: project, issue: issue)
+
+        chunks = KnowledgeChunk.where(project: project, chunk_type: "qa_pair")
+        contents = chunks.map(&:content).join("\n")
+        expect(contents).to include("What constitutes premium settings")
+        expect(contents).to include("include custom themes")
+        expect(contents).to include("Should this be behind a feature flag")
+        expect(contents).to include("premium_features")
+      end
+
+      it "sets scope_tags on chunks" do
+        described_class.call(project: project, issue: issue)
+
+        chunks = KnowledgeChunk.where(project: project, chunk_type: "qa_pair")
+        chunks.each do |chunk|
+          expect(chunk.scope_tags).to include("qa_pair")
+          expect(chunk.scope_tags).to include("issue_#{issue.github_number}")
+        end
+      end
+
+      it "sets metadata on artifacts with issue provenance" do
+        described_class.call(project: project, issue: issue)
+
+        artifact = KnowledgeArtifact.for_project(project).active.by_type("qa_pair").first
+        expect(artifact.metadata["issue_id"]).to eq(issue.id)
+        expect(artifact.metadata["issue_number"]).to eq(issue.github_number)
+        expect(artifact.metadata["comment_id"]).to be_an(Integer)
+        expect(artifact.metadata["question"]).to be_present
+      end
+
+      it "creates a collector run" do
+        described_class.call(project: project, issue: issue)
+
+        run = CollectorRun.find_by(collector_type: "clarifying_question_answers")
+        expect(run).to be_present
+        expect(run.status).to eq("completed")
+      end
+
+      it "generates content_hash for idempotent dedup" do
+        described_class.call(project: project, issue: issue)
+
+        chunks = KnowledgeChunk.where(project: project, chunk_type: "qa_pair")
+        chunks.each do |chunk|
+          expected = Digest::SHA256.hexdigest(chunk.content)
+          expect(chunk.content_hash).to eq(expected)
+        end
+      end
+    end
+
+    context "when re-ingesting the same answer comment" do
+      before do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)
+        answers = trusted_comment(body: answers_body, created_at: 2.minutes.ago)
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+      end
+
+      it "is idempotent and does not create duplicate chunks" do
+        described_class.call(project: project, issue: issue)
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair").count).to eq(2)
+
+        described_class.call(project: project, issue: issue)
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair").count).to eq(2)
+      end
+    end
+
+    context "when a non-allowlisted user posts answers" do
+      before do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)
+        answers = trusted_comment(body: answers_body, created_at: 2.minutes.ago, login: "attacker")
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+      end
+
+      it "does not create any chunks" do
+        described_class.call(project: project, issue: issue)
+
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair")).to be_empty
+      end
+    end
+
+    context "when the answer comment is older than the enhancement comment" do
+      before do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 2.minutes.ago)
+        answers = trusted_comment(body: answers_body, created_at: 5.minutes.ago)
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+      end
+
+      it "does not create any chunks" do
+        described_class.call(project: project, issue: issue)
+
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair")).to be_empty
+      end
+    end
+
+    context "when no enhancement comment exists" do
+      before do
+        answers = trusted_comment(body: answers_body, created_at: 2.minutes.ago)
+        regular = trusted_comment(body: "Just a regular comment", created_at: 5.minutes.ago)
+        allow(github_client).to receive(:issue_comments).and_return([ regular, answers ])
+      end
+
+      it "does not create any chunks" do
+        described_class.call(project: project, issue: issue)
+
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair")).to be_empty
+      end
+    end
+
+    context "when no answer comment exists" do
+      before do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement ])
+      end
+
+      it "does not create any chunks" do
+        described_class.call(project: project, issue: issue)
+
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair")).to be_empty
+      end
+    end
+
+    context "when GitHub is not configured" do
+      before do
+        allow(project).to receive(:github_token).and_return(nil)
+      end
+
+      it "does not create any chunks and returns nil" do
+        result = described_class.call(project: project, issue: issue)
+
+        expect(result).to be_nil
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair")).to be_empty
+      end
+    end
+
+    context "when GitHub returns an error" do
+      before do
+        allow(github_client).to receive(:issue_comments).and_raise(GithubClient::Error, "GitHub down")
+      end
+
+      it "returns nil without creating chunks" do
+        result = described_class.call(project: project, issue: issue)
+
+        expect(result).to be_nil
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair")).to be_empty
+      end
+    end
+
+    context "with partial answers" do
+      let(:partial_answers_body) do
+        <<~COMMENT
+          <!-- paid:clarifying-answers -->
+
+          ## Clarifying question answers
+
+          **Q1: What constitutes premium settings?**
+          **A1:** Premium settings include custom themes.
+
+          **Q2: Should this be behind a feature flag?**
+          **A2:**
+        COMMENT
+      end
+
+      before do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)
+        answers = trusted_comment(body: partial_answers_body, created_at: 2.minutes.ago)
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+      end
+
+      it "only ingests the answered question" do
+        described_class.call(project: project, issue: issue)
+
+        chunks = KnowledgeChunk.where(project: project, chunk_type: "qa_pair")
+        expect(chunks.count).to eq(1)
+        expect(chunks.first.content).to include("What constitutes premium settings")
+        expect(chunks.first.content).not_to include("Should this be behind a feature flag")
+      end
+    end
+
+    context "when enhancement comment has no clarifying questions section" do
+      let(:context_enhancement) do
+        <<~COMMENT
+          <!-- paid:enhance-issue -->
+          ## Implementation context
+          ### Relevant files
+          - app/models/user.rb
+        COMMENT
+      end
+
+      before do
+        enhancement = trusted_comment(body: context_enhancement, created_at: 5.minutes.ago)
+        answers = trusted_comment(body: answers_body, created_at: 2.minutes.ago)
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+      end
+
+      it "does not create any chunks" do
+        described_class.call(project: project, issue: issue)
+
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair")).to be_empty
+      end
+    end
+
+    context "when reusing an existing collector run" do
+      let!(:project_version) { create(:project_version, project: project) }
+      let!(:collector_run) do
+        create(:collector_run, :completed,
+               project_version: project_version,
+               collector_type: "clarifying_question_answers")
+      end
+
+      before do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)
+        answers = trusted_comment(body: answers_body, created_at: 2.minutes.ago)
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+      end
+
+      it "reuses the existing collector run" do
+        described_class.call(project: project, issue: issue)
+
+        expect(collector_run.reload.status).to eq("completed")
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair").count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/clarifying_questions/ingest_answers_spec.rb
+++ b/spec/services/clarifying_questions/ingest_answers_spec.rb
@@ -131,6 +131,29 @@ RSpec.describe ClarifyingQuestions::IngestAnswers do
       end
     end
 
+    context "when another project has already ingested the same answers" do
+      let(:other_project) { create(:project) }
+      let(:other_issue) { create(:issue, project: other_project) }
+      let(:other_github_client) { instance_double(GithubClient) }
+
+      before do
+        enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)
+        answers = trusted_comment(body: answers_body, created_at: 2.minutes.ago)
+
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+        allow(other_project.github_token).to receive(:client).and_return(other_github_client)
+        allow(other_github_client).to receive(:issue_comments).and_return([ enhancement, answers ])
+      end
+
+      it "ingests matching qa pairs for each project" do
+        described_class.call(project: other_project, issue: other_issue)
+        described_class.call(project: project, issue: issue)
+
+        expect(KnowledgeChunk.where(project: other_project, chunk_type: "qa_pair").count).to eq(2)
+        expect(KnowledgeChunk.where(project: project, chunk_type: "qa_pair").count).to eq(2)
+      end
+    end
+
     context "when a non-allowlisted user posts answers" do
       before do
         enhancement = trusted_comment(body: enhancement_body, created_at: 5.minutes.ago)

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
   end
   let(:issue) do
     double(
+      id: 42,
       body: issue_body,
       github_number: 1964,
       github_updated_at: 2.minutes.ago
@@ -112,6 +113,17 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
 
       it "returns an empty array" do
         expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+
+      it "reuses the already-loaded issue comments during ingestion" do
+        described_class.call(project: project, issue: issue)
+
+        expect(ClarifyingQuestions::IngestAnswers).to have_received(:call).with(
+          project: project,
+          issue: issue,
+          issue_comments: kind_of(Array)
+        )
+        expect(github_client).to have_received(:issue_comments).once
       end
     end
 
@@ -234,6 +246,75 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
     context "when no clarifying questions are available" do
       it "returns an empty array" do
         expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+    end
+
+    context "when answer ingestion hits a database error" do
+      let(:logger) { instance_double(ActiveSupport::Logger, warn: nil) }
+
+      before do
+        enhancement_comment = double(
+          body: comment_body,
+          user: double(login: trusted_login),
+          created_at: 2.minutes.ago
+        )
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          user: double(login: trusted_login),
+          created_at: 1.minute.ago
+        )
+
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement_comment, answers_comment ])
+        allow(ClarifyingQuestions::IngestAnswers).to receive(:call).and_raise(ActiveRecord::RecordInvalid.new(Issue.new))
+        allow(Rails).to receive(:logger).and_return(logger)
+      end
+
+      it "logs and still returns an empty array" do
+        expect(described_class.call(project: project, issue: issue)).to eq([])
+
+        expect(logger).to have_received(:warn).with(
+          hash_including(
+            message: "clarifying_questions.ingest_answers_failed",
+            issue_id: 42
+          )
+        )
+      end
+    end
+
+    context "when answer ingestion raises a non-database error" do
+      before do
+        enhancement_comment = double(
+          body: comment_body,
+          user: double(login: trusted_login),
+          created_at: 2.minutes.ago
+        )
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          user: double(login: trusted_login),
+          created_at: 1.minute.ago
+        )
+
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement_comment, answers_comment ])
+        allow(ClarifyingQuestions::IngestAnswers).to receive(:call).and_raise(ArgumentError, "bug")
+      end
+
+      it "surfaces the error" do
+        expect { described_class.call(project: project, issue: issue) }
+          .to raise_error(ArgumentError, "bug")
       end
     end
 

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
         )
 
         allow(github_client).to receive(:issue_comments).and_return([ enhancement_comment, answers_comment ])
+        allow(ClarifyingQuestions::IngestAnswers).to receive(:call)
       end
 
       it "returns an empty array" do
@@ -132,6 +133,7 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
         )
 
         allow(github_client).to receive(:issue_comments).and_return([ answers_comment ])
+        allow(ClarifyingQuestions::IngestAnswers).to receive(:call)
       end
 
       it "returns an empty array" do


### PR DESCRIPTION
## Summary

Extends the knowledge evolution loop so that answers to clarifying questions become durable, retrievable knowledge instead of evaporating after a single issue resolves. Future issues touching the same topic (e.g. "premium accounts" gating) now benefit from prior Q&A without re-asking, surfacing automatically through existing `Knowledge::Search` paths.

## Changes

**Models**
- `KnowledgeChunk::CHUNK_TYPES` adds `"qa_pair"` so the new chunk type passes validation.

**Services**
- New `ClarifyingQuestions::IngestAnswers` service that:
  - Extracts questions from `<!-- paid:enhance-issue -->` comments and answers from `<!-- paid:clarifying-answers -->` comments, pairing by index.
  - Filters by trust via `Project#trusted_github_user?` — non-allowlisted commenters' answers are dropped (prompt-injection parity with `fetch_trusted_comments`).
  - Persists Q&A pairs as `KnowledgeArtifact` + `KnowledgeChunk` records, with a SHA-256 content hash for idempotent re-ingestion.
  - Attaches provenance metadata (`issue_id`, `issue_number`, `comment_id`, `question`) and scope tags (`["qa_pair", "issue_{n}"]`).
  - Leaves `embedding_model: nil` so the standard `Embeddings::Pipeline` picks chunks up via `needs_embedding`.
- `ClarifyingQuestions::Load` calls `IngestAnswers` when `answered_after_latest_questions?` is true, rescuing errors so ingestion failure never blocks resume.

**Tests**
- New `spec/services/clarifying_questions/ingest_answers_spec.rb` with 17 examples covering trust filtering, Q&A pairing, content correctness, provenance metadata, scope tags, idempotency, partial answers, missing-comment guards, and GitHub error handling.
- `spec/services/clarifying_questions/load_spec.rb` stubs `IngestAnswers.call` in contexts that would trigger the hook (no-DB doubles).

## Design Decisions

- **Trigger at resume time, not via sweep**: hooking into `ClarifyingQuestions::Load` keeps freshness aligned with user expectation — the chunk exists as soon as the run unblocks. A weekly sweep could backfill later if needed.
- **Idempotency via content hash**: the same Q&A re-ingested (e.g. on retry or repeated `Load` calls) produces no duplicate artifacts. Same question across issues dedupes naturally if the answer text matches.
- **Fail-soft hook**: ingestion errors are rescued in `Load` so a knowledge-base hiccup never blocks the planning resume path.
- **Project-scoped only**: chunks stay attached to the source project; cross-project sharing is explicitly out of scope.
- **Reuses existing retrieval**: no new search/bundle plumbing — chunks flow through `Knowledge::Search` and `Knowledge::ContextBundle::Build`, automatically reaching future `enhance_issue` and `create_pr` runs.
- **Codebase-scan enhancement deferred**: the optional agent-driven enrichment pass (scanning the repo for supporting file paths/model fields) is not included here; the seam exists via `KnowledgeLink` once a follow-up adds it.
- **Staleness not handled**: contradicting answers do not yet mark prior chunks `stale` — noted as a follow-up.

---

Closes #2220