### PR TITLE
feat(auto-pick): backfill missing dependency issues automatically

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -84,6 +84,7 @@ class ApplicationJob < ActiveJob::Base
     [
       AutoReleaseEvaluationJob,
       DependabotAutoMergeJob,
+      DependencyBackfillJob,
       EmbedChunksJob,
       EnqueueKnowledgeCollectionJob,
       PoolReplenishmentJob,

--- a/app/jobs/dependency_backfill_job.rb
+++ b/app/jobs/dependency_backfill_job.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Backfills GitHub issues that are referenced in dependency trees or tracker
+# bodies but are missing from the local database. Without this, closed issues
+# that were never synced can cause tracker-blocked and dependency-blocked issues
+# to remain stuck indefinitely — the sync pipeline only fetches open issues
+# during initial sync and only fetches updates after its watermark during
+# incremental sync, so closed issues that predate the watermark are invisible.
+class DependencyBackfillJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :maintenance
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: -> { "dependency_backfill/#{arguments.first}" }
+  )
+
+  MAX_ISSUES_PER_JOB = 25
+
+  def perform(project_id, issue_numbers)
+    project = Project.find_by(id: project_id)
+    return unless project
+
+    client = project.github_token.client
+    backfilled_ids = []
+
+    issue_numbers.take(MAX_ISSUES_PER_JOB).each do |number|
+      next if project.issues.exists?(github_number: number)
+
+      github_issue = client.issue(project.full_name, number)
+      record = Issues::UpsertFromGithub.call(project: project, github_issue: github_issue)
+      backfilled_ids << record.id
+    rescue GithubClient::NotFoundError
+      Rails.logger.warn(
+        message: "dependency_backfill.issue_not_found",
+        project_id: project_id,
+        github_number: number
+      )
+    rescue => e
+      Rails.logger.warn(
+        message: "dependency_backfill.issue_failed",
+        project_id: project_id,
+        github_number: number,
+        error: e.message
+      )
+    end
+
+    backfilled_ids
+  end
+end

--- a/app/jobs/dependency_backfill_job.rb
+++ b/app/jobs/dependency_backfill_job.rb
@@ -27,9 +27,11 @@ class DependencyBackfillJob < ApplicationJob
 
     client = project.github_token.client
     backfilled_ids = []
+    issue_numbers = issue_numbers.take(MAX_ISSUES_PER_JOB)
+    existing_numbers = project.issues.where(github_number: issue_numbers).pluck(:github_number).to_set
 
-    issue_numbers.take(MAX_ISSUES_PER_JOB).each do |number|
-      next if project.issues.exists?(github_number: number)
+    issue_numbers.each do |number|
+      next if existing_numbers.include?(number)
 
       github_issue = client.issue(project.full_name, number)
       record = Issues::UpsertFromGithub.call(project: project, github_issue: github_issue)
@@ -47,6 +49,7 @@ class DependencyBackfillJob < ApplicationJob
         message: "dependency_backfill.issue_failed",
         project_id: project_id,
         github_number: number,
+        error_class: e.class.name,
         error: e.message
       )
     end

--- a/app/jobs/dependency_backfill_job.rb
+++ b/app/jobs/dependency_backfill_job.rb
@@ -17,6 +17,8 @@ class DependencyBackfillJob < ApplicationJob
     key: -> { "dependency_backfill/#{arguments.first}" }
   )
 
+  retry_on GithubClient::RateLimitError, wait: :polynomially_longer, attempts: 3
+
   MAX_ISSUES_PER_JOB = 25
 
   def perform(project_id, issue_numbers)
@@ -32,6 +34,8 @@ class DependencyBackfillJob < ApplicationJob
       github_issue = client.issue(project.full_name, number)
       record = Issues::UpsertFromGithub.call(project: project, github_issue: github_issue)
       backfilled_ids << record.id
+    rescue GithubClient::RateLimitError
+      raise # let GoodJob retry after rate-limit resets
     rescue GithubClient::NotFoundError
       Rails.logger.warn(
         message: "dependency_backfill.issue_not_found",

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -164,6 +164,9 @@ module Automation
               github_number: all_referenced_numbers
             ).pluck(:github_number, :github_state).to_h
 
+            unknown_numbers = all_referenced_numbers.reject { |num| referenced_states.key?(num) }
+            DependencyBackfillJob.perform_later(project.id, unknown_numbers) if unknown_numbers.any?
+
             blocked_with_refs = with_refs.filter_map do |issue_id, refs|
               issue_id if refs.any? do |num|
                 state = referenced_states[num]

--- a/app/services/issues/parse_dependencies.rb
+++ b/app/services/issues/parse_dependencies.rb
@@ -326,6 +326,9 @@ module Issues
         .where(github_number: referenced_numbers)
         .index_by(&:github_number)
 
+      missing_numbers = referenced_numbers.reject { |number| project_issues.key?(number) }
+      DependencyBackfillJob.perform_later(issue.project_id, missing_numbers) if missing_numbers.any?
+
       adj = adjacency || IssueDependency.account_adjacency(issue.project.account)
 
       referenced_numbers.each do |number|

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ApplicationJob, :no_db do
         AutoPickQueueBackfillJob
         AgentRunPatternDetectorJob
         AgentRunResourceJanitorJob
+        DependencyBackfillJob
         DockerOrphanCleanupJob
         GithubTokenHealthCheckJob
         KnowledgeAuditRetentionJob

--- a/spec/jobs/dependency_backfill_job_spec.rb
+++ b/spec/jobs/dependency_backfill_job_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+RSpec.describe DependencyBackfillJob do
+  let(:project) { create(:project) }
+  let(:account) { project.account }
+  let(:github_client) { instance_double(GithubClient) }
+
+  around do |example|
+    TenantContext.with(account) { example.run }
+  end
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(github_client)
+  end
+
+  def github_issue(number, state: "closed")
+    OpenStruct.new(
+      id: 99_000 + number,
+      number: number,
+      title: "Issue #{number}",
+      body: "body",
+      state: state,
+      labels: [],
+      pull_request: nil,
+      user: OpenStruct.new(login: "dev"),
+      created_at: 2.days.ago,
+      updated_at: 5.minutes.ago
+    )
+  end
+
+  describe "#perform" do
+    it "fetches missing issues from GitHub and upserts them" do
+      allow(github_client).to receive(:issue).with(project.full_name, 42).and_return(github_issue(42))
+
+      expect {
+        described_class.perform_now(project.id, [ 42 ])
+      }.to change { project.issues.where(github_number: 42).count }.by(1)
+
+      issue = project.issues.find_by(github_number: 42)
+      expect(issue.github_state).to eq("closed")
+    end
+
+    it "skips issues that already exist in the database" do
+      create(:issue, project: project, github_number: 42, github_state: "closed")
+
+      expect(github_client).not_to receive(:issue)
+
+      described_class.perform_now(project.id, [ 42 ])
+    end
+
+    it "handles GithubClient::NotFoundError gracefully" do
+      allow(github_client).to receive(:issue).with(project.full_name, 999)
+        .and_raise(GithubClient::NotFoundError, "Not Found")
+
+      expect {
+        described_class.perform_now(project.id, [ 999 ])
+      }.not_to raise_error
+    end
+
+    it "does nothing when the project does not exist" do
+      expect {
+        described_class.perform_now(-1, [ 42 ])
+      }.not_to raise_error
+    end
+
+    it "does not reevaluate dependents when no issues were backfilled" do
+      create(:issue, project: project, github_number: 42, github_state: "closed")
+
+      expect(Issues::EnqueueEligible).not_to receive(:call)
+
+      described_class.perform_now(project.id, [ 42 ])
+    end
+  end
+end

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -227,6 +227,38 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
     end
   end
 
+  describe ".tracker_ids_blocked_by_open_references" do
+    it "enqueues DependencyBackfillJob for referenced issues not in the database" do
+      tracker = create(:issue, project: project, github_number: 1, title: "Tracker",
+        body: "## Completion Criteria\n- [ ] #99\n- [ ] #100")
+      _closed_ref = create(:issue, project: project, github_number: 100,
+        github_state: "closed", is_pull_request: false)
+
+      scope = Issue.where(id: tracker.id)
+
+      allow(DependencyBackfillJob).to receive(:perform_later)
+
+      described_class.tracker_ids_blocked_by_open_references(scope, project)
+
+      expect(DependencyBackfillJob).to have_received(:perform_later).with(project.id, [ 99 ])
+    end
+
+    it "does not enqueue backfill when all referenced issues exist in the database" do
+      tracker = create(:issue, project: project, github_number: 1, title: "Tracker",
+        body: "## Completion Criteria\n- [ ] #100")
+      _closed_ref = create(:issue, project: project, github_number: 100,
+        github_state: "closed", is_pull_request: false)
+
+      scope = Issue.where(id: tracker.id)
+
+      allow(DependencyBackfillJob).to receive(:perform_later)
+
+      described_class.tracker_ids_blocked_by_open_references(scope, project)
+
+      expect(DependencyBackfillJob).not_to have_received(:perform_later)
+    end
+  end
+
   describe "interface compliance" do
     it "responds to every method declared by the CandidateSource interface" do
       %i[eligible_issue_ids eligible_scope next_candidate].each do |method_name|

--- a/spec/services/issues/parse_dependencies_spec.rb
+++ b/spec/services/issues/parse_dependencies_spec.rb
@@ -890,4 +890,27 @@ RSpec.describe Issues::ParseDependencies do
       end
     end
   end
+
+  describe "missing issue backfill" do
+    it "enqueues DependencyBackfillJob when a local dependency references an issue not in the database" do
+      issue = create(:issue, project: project, body: "Depends on #99999")
+
+      allow(DependencyBackfillJob).to receive(:perform_later)
+
+      described_class.call(issue: issue)
+
+      expect(DependencyBackfillJob).to have_received(:perform_later).with(project.id, [ 99999 ])
+    end
+
+    it "does not enqueue backfill when all local dependencies exist in the database" do
+      dep = create(:issue, project: project, github_number: 100)
+      issue = create(:issue, project: project, body: "Depends on ##{dep.github_number}")
+
+      allow(DependencyBackfillJob).to receive(:perform_later)
+
+      described_class.call(issue: issue)
+
+      expect(DependencyBackfillJob).not_to have_received(:perform_later)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Issues referenced in dependency trees or tracker bodies that don't exist in the local database cause auto-pick eligibility to get permanently stuck. This happens because:

- Initial GitHub sync fetches only `state: "open"` issues — any issue already closed at that point is invisible
- Incremental syncs use a `since` watermark, so closed issues predating the watermark are never fetched
- Hourly reconciliation only backfills **open** issues
- The webhook handler doesn't handle `issues` events

Example: issue #1782 (a tracker/umbrella issue) was blocked because 3 of its 5 body-referenced sub-issues (#1753, #1760, #1767) were not in the local DB. All 5 were closed on GitHub, but only #1774 and #1781 had been synced.

## Solution

Add `DependencyBackfillJob` that fetches missing issues from GitHub and upserts them. Trigger it from two points:

1. **Tracker reference check** (`DefaultCandidateSource.tracker_ids_blocked_by_open_references`) — when the tracker blocker finds body-referenced issue numbers missing from the DB, it enqueues a backfill
2. **Dependency parser** (`ParseDependencies#sync_local_deps`) — when a `#N` dependency reference points to an issue not in the DB, it enqueues a backfill so the dependency can be resolved on the next sync cycle

## Changes

- New `DependencyBackfillJob` (per-project concurrency, handles 404s gracefully, caps at 25 issues per run)
- Trigger in tracker check for unknown body references
- Trigger in dependency parser for missing local deps
- Added to `ApplicationJob` tenant context resolution
- Tests for job, tracker trigger, and parser trigger

## Manual fix applied

Also backfilled issues #1753, #1760, #1767 into the local DB via Rails runner, unblocking issue #1782.
