### PR TITLE
feat(auto-pick): add periodic eligibility sweep for missed issues

### DIFF
--- a/app/jobs/auto_pick_eligibility_sweep_job.rb
+++ b/app/jobs/auto_pick_eligibility_sweep_job.rb
@@ -57,7 +57,7 @@ class AutoPickEligibilitySweepJob < ApplicationJob
   private
 
   def eligible_projects
-    Project.active.where(auto_pick_enabled: true).includes(:account)
+    Project.active.where(auto_pick_enabled: true).includes(:account, :created_by)
   end
 
   def batch_resolve_owners(scope)

--- a/app/jobs/auto_pick_eligibility_sweep_job.rb
+++ b/app/jobs/auto_pick_eligibility_sweep_job.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Periodic sweep that re-evaluates all open issues for auto-pick eligibility.
+#
+# The auto-pick queue is primarily event-driven (GitHub sync callbacks, paid_state
+# transitions, dependency resolution). This sweep closes the gap for issues that
+# became eligible between sync cycles — for example, when a runner was temporarily
+# unavailable, a transient error caused a silent skip, or an issue was backfilled
+# by reconcile_open_issues without being added to the eligible list.
+#
+# Runs every 15 minutes via GoodJob cron. Each invocation calls
+# {Issues::BulkEnqueueEligible} for every active project with auto-pick enabled,
+# which internally filters to only eligible issues and skips those that already
+# have an active agent run.
+#
+# Concurrency is limited to a single invocation to avoid stacking sweeps when
+# the queue is large or the DB is slow.
+class AutoPickEligibilitySweepJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :maintenance
+
+  good_job_control_concurrency_with(
+    total_limit: 1,
+    enqueue_limit: 1,
+    key: "auto_pick_eligibility_sweep"
+  )
+
+  def perform
+    processed = 0
+    enqueued = 0
+
+    eligible_projects.find_each do |project|
+      next unless Issues::AutoPickProjectGate.call(project)
+
+      runs = Issues::BulkEnqueueEligible.call(project: project, skip_project_gate: true)
+      processed += 1
+      enqueued += runs.count(&:previously_new_record?)
+    rescue => e
+      Rails.logger.error(
+        message: "auto_pick_eligibility_sweep.project_failed",
+        project_id: project.id,
+        error: e.message
+      )
+    end
+
+    Rails.logger.info(
+      message: "auto_pick_eligibility_sweep.completed",
+      processed_projects: processed,
+      enqueued_runs: enqueued
+    )
+  end
+
+  private
+
+  def eligible_projects
+    Project.active.where(auto_pick_enabled: true).includes(:account, :created_by)
+  end
+end

--- a/app/jobs/auto_pick_eligibility_sweep_job.rb
+++ b/app/jobs/auto_pick_eligibility_sweep_job.rb
@@ -30,8 +30,11 @@ class AutoPickEligibilitySweepJob < ApplicationJob
     processed = 0
     enqueued = 0
 
-    eligible_projects.find_each do |project|
-      next unless Issues::AutoPickProjectGate.call(project)
+    scope = eligible_projects
+    owners_by_project = batch_resolve_owners(scope)
+
+    scope.find_each do |project|
+      next unless Issues::AutoPickProjectGate.call(project, owner: owners_by_project[project.id])
 
       runs = Issues::BulkEnqueueEligible.call(project: project, skip_project_gate: true)
       processed += 1
@@ -54,6 +57,20 @@ class AutoPickEligibilitySweepJob < ApplicationJob
   private
 
   def eligible_projects
-    Project.active.where(auto_pick_enabled: true).includes(:account, :created_by)
+    Project.active.where(auto_pick_enabled: true).includes(:account)
+  end
+
+  def batch_resolve_owners(scope)
+    rows = scope.select(:id, :account_id, :created_by_id).to_a
+    account_ids = rows.map(&:account_id).compact.uniq
+    fallback_by_account = Account.batch_fallback_owner_ids(account_ids)
+
+    owner_ids = rows.filter_map { |p| p.created_by_id || fallback_by_account[p.account_id] }.uniq
+    users_by_id = User.where(id: owner_ids).index_by(&:id)
+
+    rows.each_with_object({}) do |p, memo|
+      uid = p.created_by_id || fallback_by_account[p.account_id]
+      memo[p.id] = users_by_id[uid] if uid
+    end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -143,6 +143,26 @@ class Account < ApplicationRecord
       users.order(:id).pick(:id)
   end
 
+  def self.batch_fallback_owner_ids(account_ids)
+    account_ids = account_ids.compact.uniq
+    return {} if account_ids.empty?
+
+    owner_ids = AccountMembership.where(account_id: account_ids, role: :owner)
+      .order(:account_id, :id)
+      .pluck(:account_id, :user_id)
+      .each_with_object({}) { |(aid, uid), memo| memo[aid] ||= uid }
+
+    missing = account_ids - owner_ids.keys
+    return owner_ids if missing.empty?
+
+    User.where(account_id: missing)
+      .order(:account_id, :id)
+      .pluck(:account_id, :id)
+      .each { |aid, uid| owner_ids[aid] ||= uid }
+
+    owner_ids
+  end
+
   def primary_owner_membership
     account_memberships.where(role: :owner).order(:id).first
   end

--- a/app/services/issues/auto_pick_project_gate.rb
+++ b/app/services/issues/auto_pick_project_gate.rb
@@ -2,12 +2,13 @@
 
 module Issues
   class AutoPickProjectGate
-    def self.call(project)
-      new(project).call
+    def self.call(project, owner: nil)
+      new(project, owner: owner).call
     end
 
-    def initialize(project)
+    def initialize(project, owner: nil)
       @project = project
+      @preresolved_owner = owner
     end
 
     def call
@@ -22,10 +23,10 @@ module Issues
 
     private
 
-    attr_reader :project
+    attr_reader :project, :preresolved_owner
 
     def owner
-      @owner ||= project.effective_owner
+      @owner ||= preresolved_owner || project.effective_owner
     end
   end
 end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -117,6 +117,11 @@ Rails.application.configure do
       class: "AutoPickQueueBackfillJob",
       description: "Backfill eager auto-pick queue seeding for already-enabled projects"
     },
+    auto_pick_eligibility_sweep: {
+      cron: "*/15 * * * *",
+      class: "AutoPickEligibilitySweepJob",
+      description: "Periodic re-evaluation of all open issues for auto-pick eligibility"
+    },
     analyze_issue_followup_backfill: {
       cron: "15 * * * *",
       class: "AnalyzeIssueFollowupBackfillJob",

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ApplicationJob, :no_db do
       ],
       maintenance: %w[
         AnalyzeIssueFollowupBackfillJob
+        AutoPickEligibilitySweepJob
         AutoPickQueueBackfillJob
         AgentRunPatternDetectorJob
         AgentRunResourceJanitorJob

--- a/spec/config/good_job_configuration_spec.rb
+++ b/spec/config/good_job_configuration_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe GoodJob, :no_db do
       expected_jobs = %i[
         worktree_cleanup poll_workflow_health_check stale_run_detector
         docker_orphan_cleanup recover_missing_pull_request_labels models_sync
-        ab_test_analysis process_run_queue auto_pick_queue_backfill service_container_reconciliation screenshot_cleanup
+        ab_test_analysis process_run_queue auto_pick_queue_backfill
+        auto_pick_eligibility_sweep service_container_reconciliation screenshot_cleanup
         knowledge_audit_retention delayed_human_feedback notifications_check_runner_quotas
         agent_run_pattern_detector
       ]

--- a/spec/jobs/auto_pick_eligibility_sweep_job_spec.rb
+++ b/spec/jobs/auto_pick_eligibility_sweep_job_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AutoPickEligibilitySweepJob, :no_db do
+  def stub_projects(*projects)
+    active_relation = instance_double(ActiveRecord::Relation)
+    where_relation = instance_double(ActiveRecord::Relation)
+    includes_relation = instance_double(ActiveRecord::Relation)
+
+    allow(Project).to receive(:active).and_return(active_relation)
+    allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(where_relation)
+    allow(where_relation).to receive(:includes).with(:account, :created_by).and_return(includes_relation)
+    allow(includes_relation).to receive(:find_each) do |&block|
+      projects.each { |p| block.call(p) }
+    end
+  end
+
+  before do
+    stub_const("Project", Class.new do
+      attr_reader :id
+
+      def initialize(id)
+        @id = id
+      end
+
+      def self.active; end
+      def self.where(*); end
+    end)
+  end
+
+  it "bulk enqueues eligible issues for each runnable project" do
+    project = Project.new(101)
+
+    stub_projects(project)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
+    allow(Issues::BulkEnqueueEligible).to receive(:call).and_return([])
+
+    described_class.perform_now
+
+    expect(Issues::BulkEnqueueEligible).to have_received(:call).with(
+      project: project,
+      skip_project_gate: true
+    )
+  end
+
+  it "skips projects that do not pass the gate" do
+    project = Project.new(202)
+
+    stub_projects(project)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
+    allow(Issues::BulkEnqueueEligible).to receive(:call)
+
+    described_class.perform_now
+
+    expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
+  end
+
+  it "continues processing remaining projects after a failure" do
+    failing_project = Project.new(303)
+    healthy_project = Project.new(404)
+
+    stub_projects(failing_project, healthy_project)
+    allow(Issues::AutoPickProjectGate).to receive(:call).and_return(true)
+    allow(Issues::BulkEnqueueEligible).to receive(:call) do |kwargs|
+      raise "queue unavailable" if kwargs[:project].id == 303
+
+      []
+    end
+
+    described_class.perform_now
+
+    expect(Issues::BulkEnqueueEligible).to have_received(:call).twice
+  end
+
+  it "runs on every invocation unlike the one-time backfill" do
+    project = Project.new(505)
+
+    stub_projects(project)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
+    allow(Issues::BulkEnqueueEligible).to receive(:call).and_return([])
+
+    described_class.perform_now
+    described_class.perform_now
+
+    expect(Issues::BulkEnqueueEligible).to have_received(:call).twice.with(
+      project: project,
+      skip_project_gate: true
+    )
+  end
+end

--- a/spec/jobs/auto_pick_eligibility_sweep_job_spec.rb
+++ b/spec/jobs/auto_pick_eligibility_sweep_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AutoPickEligibilitySweepJob, :no_db do
 
     allow(Project).to receive(:active).and_return(active_relation)
     allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(where_relation)
-    allow(where_relation).to receive(:includes).with(:account).and_return(includes_relation)
+    allow(where_relation).to receive(:includes).with(:account, :created_by).and_return(includes_relation)
     allow(includes_relation).to receive(:select).with(:id, :account_id, :created_by_id).and_return(select_relation)
     allow(select_relation).to receive(:to_a).and_return(projects)
     allow(includes_relation).to receive(:find_each) do |&block|

--- a/spec/jobs/auto_pick_eligibility_sweep_job_spec.rb
+++ b/spec/jobs/auto_pick_eligibility_sweep_job_spec.rb
@@ -7,10 +7,13 @@ RSpec.describe AutoPickEligibilitySweepJob, :no_db do
     active_relation = instance_double(ActiveRecord::Relation)
     where_relation = instance_double(ActiveRecord::Relation)
     includes_relation = instance_double(ActiveRecord::Relation)
+    select_relation = instance_double(ActiveRecord::Relation)
 
     allow(Project).to receive(:active).and_return(active_relation)
     allow(active_relation).to receive(:where).with(auto_pick_enabled: true).and_return(where_relation)
-    allow(where_relation).to receive(:includes).with(:account, :created_by).and_return(includes_relation)
+    allow(where_relation).to receive(:includes).with(:account).and_return(includes_relation)
+    allow(includes_relation).to receive(:select).with(:id, :account_id, :created_by_id).and_return(select_relation)
+    allow(select_relation).to receive(:to_a).and_return(projects)
     allow(includes_relation).to receive(:find_each) do |&block|
       projects.each { |p| block.call(p) }
     end
@@ -18,22 +21,29 @@ RSpec.describe AutoPickEligibilitySweepJob, :no_db do
 
   before do
     stub_const("Project", Class.new do
-      attr_reader :id
+      attr_reader :id, :account_id, :created_by_id
 
       def initialize(id)
         @id = id
+        @account_id = nil
+        @created_by_id = nil
       end
 
       def self.active; end
       def self.where(*); end
     end)
+
+    allow(Account).to receive(:batch_fallback_owner_ids).and_return({})
+    user_relation = instance_double(ActiveRecord::Relation)
+    allow(User).to receive(:where).and_return(user_relation)
+    allow(user_relation).to receive(:index_by).and_return({})
   end
 
   it "bulk enqueues eligible issues for each runnable project" do
     project = Project.new(101)
 
     stub_projects(project)
-    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project, hash_including(:owner)).and_return(true)
     allow(Issues::BulkEnqueueEligible).to receive(:call).and_return([])
 
     described_class.perform_now
@@ -48,7 +58,7 @@ RSpec.describe AutoPickEligibilitySweepJob, :no_db do
     project = Project.new(202)
 
     stub_projects(project)
-    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project, hash_including(:owner)).and_return(false)
     allow(Issues::BulkEnqueueEligible).to receive(:call)
 
     described_class.perform_now
@@ -77,7 +87,7 @@ RSpec.describe AutoPickEligibilitySweepJob, :no_db do
     project = Project.new(505)
 
     stub_projects(project)
-    allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
+    allow(Issues::AutoPickProjectGate).to receive(:call).with(project, hash_including(:owner)).and_return(true)
     allow(Issues::BulkEnqueueEligible).to receive(:call).and_return([])
 
     described_class.perform_now

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -163,6 +163,38 @@ RSpec.describe Account do
     end
   end
 
+  describe ".batch_fallback_owner_ids" do
+    it "prefers the first owner membership for each account" do
+      account = create(:account)
+      non_owner = create(:user, account: account)
+      non_owner.add_role(:member, account)
+      first_owner = create(:user, account: account)
+      first_owner.add_role(:owner, account)
+      second_owner = create(:user, account: account)
+      second_owner.add_role(:owner, account)
+
+      expect(described_class.batch_fallback_owner_ids([ account.id ])).to eq(account.id => first_owner.id)
+    end
+
+    it "falls back to the first account user when no owner membership exists" do
+      account = create(:account)
+      first_user = create(:user, account: account)
+      first_user.add_role(:member, account)
+      create(:user, account: account)
+
+      expect(described_class.batch_fallback_owner_ids([ account.id ])).to eq(account.id => first_user.id)
+    end
+
+    it "returns only accounts that resolve to an owner" do
+      account_with_owner = create(:account)
+      owner = create(:user, account: account_with_owner)
+      unresolved_account = create(:account)
+
+      expect(described_class.batch_fallback_owner_ids([ account_with_owner.id, unresolved_account.id ]))
+        .to eq(account_with_owner.id => owner.id)
+    end
+  end
+
   describe "dependent billing records" do
     it "destroys invoices, periods, and plans with the account" do
       account = create(:account)

--- a/spec/system/worker_pool_load_spec.rb
+++ b/spec/system/worker_pool_load_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe "Worker pool load behavior" do
       DiagnoseErrorJob => "default",
       HumanFeedbackCollectionJob => "default",
       GithubTokenValidationJob => "default",
+      AutoPickEligibilitySweepJob => "maintenance",
       AutoPickQueueBackfillJob => "maintenance",
       DockerOrphanCleanupJob => "maintenance",
       StaleRunDetectorJob => "maintenance",
@@ -135,6 +136,7 @@ RSpec.describe "Worker pool load behavior" do
   describe "GoodJob concurrency controls" do
     # Jobs with global singleton concurrency (only one instance system-wide)
     [
+      AutoPickEligibilitySweepJob,
       AutoPickQueueBackfillJob,
       DockerOrphanCleanupJob,
       RecoverMissingPullRequestLabelsJob,


### PR DESCRIPTION
## Problem

Open, unblocked P1 issues were not being added to the auto-pick queue. The root cause is that the auto-pick system has **no periodic mechanism** to re-evaluate all open issues for eligibility. It relies entirely on event-driven triggers:

- **Path A**: GitHub incremental sync — only processes issues updated since last sync
- **Path B**: `paid_state` transition callback — only fires on specific state changes
- **Path C**: Dependency resolution callback — only fires when a blocker closes
- **Path D**: Auto-pick first enabled — one-time event

If an issue was missed during its evaluation window (runner unavailable, transient error, reconciliation backfill without eligibility check), it sits eligible but unevaluated indefinitely.

## Fix

Add `AutoPickEligibilitySweepJob` — a periodic cron job (every 15 min) that calls `BulkEnqueueEligible` for all active projects with auto-pick enabled.

- Eager-loads `account` and `created_by` to avoid N+1 queries when checking `AutoPickProjectGate`
- Idempotent — `BulkEnqueueEligible` already filters to issues without active runs and uses `find_or_create_by!` for race safety
- Concurrency-limited to prevent stacking
- Runs on the `:maintenance` queue to avoid interfering with user-facing work

## Follow-up Issues

| # | Title |
|---|-------|
| #2229 | Retry enqueue when no runner is available |
| #2230 | Backfilled issues from reconciliation not evaluated for auto-pick |
| #2231 | `paid_state=analyzed` is a dead end for re-enqueue |
| #2232 | Recoverable completed check is too narrow |
| #2233 | Priority label matching is case-sensitive |