### PR TITLE
feat(agent-runs): retry enqueue when no runner is available

### DIFF
--- a/app/jobs/issues/reenqueue_eligible_job.rb
+++ b/app/jobs/issues/reenqueue_eligible_job.rb
@@ -6,23 +6,48 @@ module Issues
 
     queue_as :default
 
+    NO_RUNNER_RETRY_BASE_DELAY = 30.seconds
+    NO_RUNNER_RETRY_MAX_DELAY = 1.minute
+    MAX_NO_RUNNER_RETRIES = 3
+
     good_job_control_concurrency_with(
       enqueue_limit: 1,
       key: -> { "reenqueue_eligible_issue_#{arguments.first}" }
     )
 
-    def perform(issue_id)
+    def self.schedule_no_runner_retry(issue_id, no_runner_retry_count:)
+      return if no_runner_retry_count >= MAX_NO_RUNNER_RETRIES
+
+      next_retry_count = no_runner_retry_count + 1
+      wait = no_runner_retry_delay(next_retry_count)
+
+      set(wait: wait).perform_later(issue_id, no_runner_retry_count: next_retry_count)
+
+      { retry_count: next_retry_count, wait: wait }
+    end
+
+    def self.no_runner_retry_delay(retry_count)
+      [ NO_RUNNER_RETRY_BASE_DELAY * (2**(retry_count - 1)), NO_RUNNER_RETRY_MAX_DELAY ].min
+    end
+
+    def perform(issue_id, no_runner_retry_count: 0)
       issue = Issue.includes(:project).find_by(id: issue_id)
       return unless issue
       return if issue.is_pull_request?
       return unless issue.paid_state.in?(%w[new planning failed completed])
       return unless AutoPickProjectGate.call(issue.project)
 
-      EnqueueEligible.call(issue, project: issue.project, skip_project_gate: true)
+      EnqueueEligible.call(
+        issue,
+        project: issue.project,
+        skip_project_gate: true,
+        no_runner_retry_count: no_runner_retry_count
+      )
     rescue => e
       Rails.logger.error(
         message: "enqueue_eligible.issue_state_change_failed",
         issue_id: issue_id,
+        no_runner_retry_count: no_runner_retry_count,
         error: e.message
       )
     end

--- a/app/jobs/issues/reenqueue_eligible_job.rb
+++ b/app/jobs/issues/reenqueue_eligible_job.rb
@@ -27,7 +27,9 @@ module Issues
     end
 
     def self.no_runner_retry_delay(retry_count)
-      [ NO_RUNNER_RETRY_BASE_DELAY * (2**(retry_count - 1)), NO_RUNNER_RETRY_MAX_DELAY ].min
+      base_delay_multiplier = retry_count.positive? ? 2**(retry_count - 1) : 1
+
+      [ NO_RUNNER_RETRY_BASE_DELAY * base_delay_multiplier, NO_RUNNER_RETRY_MAX_DELAY ].min
     end
 
     def perform(issue_id, no_runner_retry_count: 0)

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -6,10 +6,11 @@ module Issues
       new(...).call
     end
 
-    def initialize(issue, project:, skip_project_gate: false)
+    def initialize(issue, project:, skip_project_gate: false, no_runner_retry_count: 0)
       @issue = issue
       @project = project
       @skip_project_gate = skip_project_gate
+      @no_runner_retry_count = no_runner_retry_count
     end
 
     def call
@@ -26,7 +27,8 @@ module Issues
       goal = seeded_goal
       runner = resolve_runner(goal)
       unless runner
-        log_no_runner
+        retry_schedule = schedule_no_runner_retry
+        log_no_runner(retry_schedule)
         return nil
       end
 
@@ -62,7 +64,7 @@ module Issues
     private
 
     attr_reader :issue, :project
-    attr_reader :skip_project_gate
+    attr_reader :skip_project_gate, :no_runner_retry_count
 
     def eligible?
       Automation::Strategies::AutoPick::DefaultCandidateSource
@@ -100,8 +102,21 @@ module Issues
       Rails.logger.info(log_context("enqueue_eligible.project_deferred"))
     end
 
-    def log_no_runner
-      Rails.logger.warn(log_context("enqueue_eligible.no_runner"))
+    def schedule_no_runner_retry
+      Issues::ReenqueueEligibleJob.schedule_no_runner_retry(issue.id, no_runner_retry_count: no_runner_retry_count)
+    end
+
+    def log_no_runner(retry_schedule)
+      Rails.logger.warn(
+        log_context(
+          "enqueue_eligible.no_runner",
+          no_runner_retry_count: no_runner_retry_count,
+          no_runner_retry_scheduled: retry_schedule.present?,
+          next_no_runner_retry_count: retry_schedule&.fetch(:retry_count, nil),
+          wait_seconds: retry_schedule&.fetch(:wait, nil)&.to_i,
+          retries_exhausted: retry_schedule.blank?
+        )
+      )
     end
 
     def log_context(message, extra = {})

--- a/spec/jobs/issues/reenqueue_eligible_job_spec.rb
+++ b/spec/jobs/issues/reenqueue_eligible_job_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe Issues::ReenqueueEligibleJob do
     end
   end
 
+  describe ".no_runner_retry_delay" do
+    it "uses the base delay when retry_count is zero" do
+      expect(described_class.no_runner_retry_delay(0)).to eq(30.seconds)
+    end
+  end
+
   describe "GoodJob concurrency" do
     it "deduplicates re-enqueue work per issue" do
       issue = build(:issue)

--- a/spec/jobs/issues/reenqueue_eligible_job_spec.rb
+++ b/spec/jobs/issues/reenqueue_eligible_job_spec.rb
@@ -3,6 +3,44 @@
 require "rails_helper"
 
 RSpec.describe Issues::ReenqueueEligibleJob do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    clear_performed_jobs
+    example.run
+  ensure
+    clear_enqueued_jobs
+    clear_performed_jobs
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
+  describe ".schedule_no_runner_retry" do
+    it "enqueues a short delayed retry with the next retry count" do
+      freeze_time do
+        expect {
+          described_class.schedule_no_runner_retry(42, no_runner_retry_count: 0)
+        }.to have_enqueued_job(described_class).with(42, no_runner_retry_count: 1).at(30.seconds.from_now)
+      end
+    end
+
+    it "caps the no-runner backoff at one minute" do
+      freeze_time do
+        expect {
+          described_class.schedule_no_runner_retry(42, no_runner_retry_count: 2)
+        }.to have_enqueued_job(described_class).with(42, no_runner_retry_count: 3).at(1.minute.from_now)
+      end
+    end
+
+    it "stops scheduling once the retry cap is reached" do
+      expect {
+        described_class.schedule_no_runner_retry(42, no_runner_retry_count: described_class::MAX_NO_RUNNER_RETRIES)
+      }.not_to have_enqueued_job(described_class)
+    end
+  end
+
   describe "GoodJob concurrency" do
     it "deduplicates re-enqueue work per issue" do
       issue = build(:issue)
@@ -21,7 +59,27 @@ RSpec.describe Issues::ReenqueueEligibleJob do
 
       described_class.perform_now(issue.id)
 
-      expect(Issues::EnqueueEligible).to have_received(:call).with(issue, project: project, skip_project_gate: true)
+      expect(Issues::EnqueueEligible).to have_received(:call).with(
+        issue,
+        project: project,
+        skip_project_gate: true,
+        no_runner_retry_count: 0
+      )
+    end
+
+    it "forwards the current no-runner retry count" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "failed", github_state: "open")
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      described_class.perform_now(issue.id, no_runner_retry_count: 2)
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(
+        issue,
+        project: project,
+        skip_project_gate: true,
+        no_runner_retry_count: 2
+      )
     end
 
     it "does nothing for missing issues" do
@@ -68,11 +126,12 @@ RSpec.describe Issues::ReenqueueEligibleJob do
       allow(Issues::EnqueueEligible).to receive(:call).and_raise(StandardError, "transient failure")
       allow(Rails.logger).to receive(:error)
 
-      expect { described_class.perform_now(issue.id) }.not_to raise_error
+      expect { described_class.perform_now(issue.id, no_runner_retry_count: 2) }.not_to raise_error
       expect(Rails.logger).to have_received(:error).with(
         hash_including(
           message: "enqueue_eligible.issue_state_change_failed",
           issue_id: issue.id,
+          no_runner_retry_count: 2,
           error: "transient failure"
         )
       )

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -3,6 +3,20 @@
 require "rails_helper"
 
 RSpec.describe Issues::EnqueueEligible, :no_db do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    clear_performed_jobs
+    example.run
+  ensure
+    clear_enqueued_jobs
+    clear_performed_jobs
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
   def project_class
     @project_class ||= Struct.new(:id) do
       def auto_enhance_enabled? = false
@@ -136,11 +150,48 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(service).to receive(:resolve_runner).with("create_pr").and_return(nil)
     allow(Rails.logger).to receive(:warn)
 
-    result = service.call
+    freeze_time do
+      expect {
+        result = service.call
+        expect(result).to be_nil
+      }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id, no_runner_retry_count: 1).at(30.seconds.from_now)
+    end
 
-    expect(result).to be_nil
     expect(Rails.logger).to have_received(:warn).with(
-      hash_including(message: "enqueue_eligible.no_runner", issue_id: issue.id, project_id: project.id)
+      hash_including(
+        message: "enqueue_eligible.no_runner",
+        issue_id: issue.id,
+        project_id: project.id,
+        no_runner_retry_count: 0,
+        no_runner_retry_scheduled: true,
+        next_no_runner_retry_count: 1,
+        wait_seconds: 30,
+        retries_exhausted: false
+      )
+    )
+  end
+
+  it "does not schedule another retry after the no-runner retry cap" do
+    capped_service = described_class.new(
+      issue,
+      project: project,
+      no_runner_retry_count: Issues::ReenqueueEligibleJob::MAX_NO_RUNNER_RETRIES
+    )
+    allow(capped_service).to receive(:resolve_runner).with("create_pr").and_return(nil)
+    allow(Rails.logger).to receive(:warn)
+
+    expect {
+      expect(capped_service.call).to be_nil
+    }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
+
+    expect(Rails.logger).to have_received(:warn).with(
+      hash_including(
+        message: "enqueue_eligible.no_runner",
+        issue_id: issue.id,
+        no_runner_retry_count: Issues::ReenqueueEligibleJob::MAX_NO_RUNNER_RETRIES,
+        no_runner_retry_scheduled: false,
+        retries_exhausted: true
+      )
     )
   end
 


### PR DESCRIPTION
## Summary

Prevents eligible P1 issues from stalling in the queue when a runner is temporarily unavailable. Previously, `Issues::EnqueueEligible` silently skipped issues with only a log warning when `AgentRuns::RunnerResolver` returned nil, leaving them unevaluated until the next GitHub sync cycle (or up to 15 minutes for the `AutoPickEligibilitySweepJob`).

## Changes

- **Services**: `Issues::EnqueueEligible` now schedules a delayed `Issues::ReenqueueEligibleJob` retry when runner resolution returns `nil`, and logs whether a retry was scheduled or the cap was exhausted.
- **Jobs**: `Issues::ReenqueueEligibleJob` carries a `no_runner_retry_count`, applies a bounded 30s/60s backoff capped at 3 retries, and forwards the count back into the service.
- **Tests**: Added coverage in `spec/services/issues/enqueue_eligible_spec.rb` and `spec/jobs/issues/reenqueue_eligible_job_spec.rb` for the retry scheduling, backoff progression, and retry-cap exhaustion.

## Design Decisions

- **Bounded retries (max 3, 30s/60s backoff)**: Caps retries to avoid infinite loops for projects with no runner configured at all, while still recovering quickly from transient unavailability (capacity, brief outages).
- **Reused `Issues::ReenqueueEligibleJob` rather than a new job**: Threads `no_runner_retry_count` through the existing job to keep the retry surface area small, instead of introducing a parallel retry job.
- **Complements rather than replaces `AutoPickEligibilitySweepJob`**: The 15-minute sweep remains a safety net; the targeted retry collapses recovery time from up to 15 minutes to ≤90 seconds for the common transient-runner case.

---

Closes #2229