### PR TITLE
fix(auto-pick): recoverable completed check is too narrow

### DIFF
--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -69,10 +69,11 @@ module Automation
               project: project,
               status: "completed",
               trigger_type: "automatic",
-              goal: "create_pr",
               auto_pick: true,
               pull_request_number: nil
-            ).where.not(issue_id: nil).select(:issue_id)
+            ).where.not(issue_id: nil)
+              .where.not(goal: "analyze_issue")
+              .select(:issue_id)
 
             pr_produced_issue_ids = AgentRun.where(
               project: project, status: "completed", goal: "create_pr"

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
       expect(scope.pluck(:id)).to contain_exactly(issue.id)
     end
 
+    it "includes completed issues when an auto-pick follow-up run completed without a PR" do
+      issue = create(:issue, project: project, paid_state: "completed")
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "enhance_issue", auto_pick: true, pull_request_number: nil, pull_request_url: nil)
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(issue.id)
+    end
+
     it "excludes completed issues that had a PR-producing run" do
       issue = create(:issue, project: project, paid_state: "completed")
       create(:agent_run, :completed, :automatic, project: project, issue: issue,
@@ -97,7 +107,7 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
       expect(scope.pluck(:id)).to contain_exactly(issue.id)
     end
 
-    it "excludes completed issues whose completed run was not an auto-pick create_pr run" do
+    it "excludes completed issues whose completed run was not a recoverable auto-pick run" do
       manual_issue = create(:issue, project: project, paid_state: "completed", github_number: 50)
       analyze_issue = create(:issue, project: project, paid_state: "completed", github_number: 51)
 


### PR DESCRIPTION
## Summary

Broadens the auto-pick recovery path so issues left at `paid_state: "completed"` without a PR are re-enqueued regardless of which goal the prior run used. Previously the recovery scope only matched `goal: "create_pr"`, which silently stranded issues whose last automatic run was an `enhance_issue` follow-up.

## Changes

- **Services**: Update `eligible_scope` in `app/services/automation/strategies/auto_pick/default_candidate_source.rb` to match any completed automatic auto-pick run with no PR, excluding only `analyze_issue` (which never produces a PR by design).
- **Tests**: Add regression coverage in `spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb` for an auto-pick `enhance_issue` follow-up run, and update the existing exclusion example to reflect the broader rule.

## Design Decisions

- **Exclude `analyze_issue` explicitly rather than enumerate PR-producing goals.** An allowlist would silently drop any future goal that legitimately produces a PR; a denylist of goals that never produce a PR fails open toward recovery, which matches the intent of the recovery path.
- **Recovery remains scoped to `auto_pick: true` automatic runs.** Manual or non-auto-pick runs are out of scope for this queue and continue to be filtered out.

---

Closes #2232