### PR TITLE
fix(auto-pick): priority label matching is case-sensitive

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -808,8 +808,8 @@ class AgentRun < ApplicationRecord
 
   # When a run has both an associated issue AND a source PR, labels from
   # both records are considered (highest configured tier wins). Label
-  # name matching is case-sensitive on both the Ruby and SQL sides; an
-  # issue tagged "p1" will not match a configured tier of "P1".
+  # name matching is case-insensitive on both the Ruby and SQL sides, so
+  # an issue tagged "p1" still matches a configured tier of "P1".
   def compute_label_priority_tier
     return nil unless project
 
@@ -822,7 +822,7 @@ class AgentRun < ApplicationRecord
     Project::PRIORITY_TIERS.find do |tier|
       label_name = project.priority_label_for(tier)
       next false if label_name.blank?
-      label_sources.any? { |labels| labels.include?(label_name) }
+      label_sources.any? { |labels| labels.any? { |label| label.casecmp?(label_name) } }
     end
   end
   private :compute_label_priority_tier
@@ -954,17 +954,29 @@ class AgentRun < ApplicationRecord
   # correlated subqueries. Reads per-project label names from
   # `projects.priority_labels` jsonb, falling back to literal tier keys
   # (P1/P2/P3) when the project's mapping is empty so behavior matches
-  # Project#effective_priority_labels. Element matching is case-sensitive.
+  # Project#effective_priority_labels. Element matching is case-insensitive.
   #
   # NOTE: This SQL contains no interpolated values — the tier names are
   # hardcoded literals — so it is not a SQL injection vector.
   QUEUE_PRIORITY_CASE_SQL = <<~SQL.squish.freeze
     CASE
       WHEN trigger_type = 'manual' THEN 0
-      WHEN issue_labels.labels @> jsonb_build_array(COALESCE(NULLIF(p.priority_labels->>'P1', ''), 'P1')) THEN 1
-      WHEN issue_labels.labels @> jsonb_build_array(COALESCE(NULLIF(p.priority_labels->>'P2', ''), 'P2')) THEN 2
+      WHEN EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements_text(issue_labels.labels) AS label(value)
+        WHERE LOWER(label.value) = LOWER(COALESCE(NULLIF(p.priority_labels->>'P1', ''), 'P1'))
+      ) THEN 1
+      WHEN EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements_text(issue_labels.labels) AS label(value)
+        WHERE LOWER(label.value) = LOWER(COALESCE(NULLIF(p.priority_labels->>'P2', ''), 'P2'))
+      ) THEN 2
       WHEN trigger_type = 'automatic' AND source_pull_request_number IS NOT NULL THEN 3
-      WHEN issue_labels.labels @> jsonb_build_array(COALESCE(NULLIF(p.priority_labels->>'P3', ''), 'P3')) THEN 4
+      WHEN EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements_text(issue_labels.labels) AS label(value)
+        WHERE LOWER(label.value) = LOWER(COALESCE(NULLIF(p.priority_labels->>'P3', ''), 'P3'))
+      ) THEN 4
       ELSE 5
     END
   SQL

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -221,7 +221,6 @@ module Automation
           # P3/unlabeled, and P3 beats unlabeled.
           def priority_label_order_node(project)
             effective = project.effective_priority_labels
-            issues = Issue.arel_table
             priority_case = Arel::Nodes::Case.new
             configured_tiers = 0
 
@@ -230,11 +229,13 @@ module Automation
               next if label_name.blank?
 
               configured_tiers += 1
-              condition = Arel::Nodes::InfixOperation.new(
-                "@>",
-                issues[:labels],
-                Arel::Nodes::NamedFunction.new("jsonb_build_array", [ Arel::Nodes.build_quoted(label_name) ])
-              )
+              condition = Arel.sql(<<~SQL.squish)
+                EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements_text(issues.labels) AS label(value)
+                  WHERE LOWER(label.value) = LOWER(#{Issue.connection.quote(label_name)})
+                )
+              SQL
               priority_case.when(condition).then(index + 1)
             end
 

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2278,6 +2278,12 @@ RSpec.describe AgentRun do
       expect(run.queue_priority_tier).to eq(:label_p1)
     end
 
+    it "matches configured priority labels case-insensitively" do
+      run = queued_run_with_issue_labels([ "CRITICAL" ], trigger_type: "automatic")
+
+      expect(run.queue_priority_tier).to eq(:label_p1)
+    end
+
     it "ranks manual above P1 within the same project" do
       p1 = queued_run_with_issue_labels([ "critical" ], trigger_type: "automatic", created_at: 2.minutes.ago)
       manual = create(:agent_run, :queued, project: project, trigger_type: "manual", created_at: 1.minute.ago)
@@ -2304,6 +2310,15 @@ RSpec.describe AgentRun do
 
       ordered = described_class.queued_with_priority.order(described_class::QUEUE_ORDER).to_a
       expect(ordered).to eq([ auto_continue, p3, auto_pick ])
+    end
+
+    it "orders queued runs by priority labels case-insensitively" do
+      auto_pick = create(:agent_run, :queued, project: project, trigger_type: "automatic", created_at: 3.minutes.ago)
+      p1 = queued_run_with_issue_labels([ "CRITICAL" ], trigger_type: "automatic", created_at: 2.minutes.ago)
+      p2 = queued_run_with_issue_labels([ "HIGH" ], trigger_type: "automatic", created_at: 1.minute.ago)
+
+      ordered = described_class.queued_with_priority.order(described_class::QUEUE_ORDER).to_a
+      expect(ordered).to eq([ p1, p2, auto_pick ])
     end
 
     it "picks the highest priority when multiple labels are present" do

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
       expect(described_class.next_candidate(project)).to eq(p1)
     end
 
+    it "matches configured priority labels case-insensitively" do
+      project.update!(priority_labels: { "P1" => "P1", "P2" => "P2", "P3" => "P3" })
+      _p3 = create(:issue, project: project, github_number: 1, labels: [ "p3" ])
+      p1 = create(:issue, project: project, github_number: 2, labels: [ "p1" ])
+
+      expect(described_class.next_candidate(project)).to eq(p1)
+    end
+
     it "prefers runnable dependency-tree roots over standalone issues" do
       _standalone = create(:issue, project: project, github_number: 1, github_state: "open")
       blocker = create(:issue, project: project, github_number: 2, github_state: "open")


### PR DESCRIPTION
## Summary

Priority labels configured on a project (e.g. `P1`) failed to match GitHub issue labels with different casing (e.g. `p1`), causing high-priority issues to be ranked as lowest-priority (rank 4) and starved behind older low-priority work. This change makes priority-label matching case-insensitive across both the auto-pick candidate ordering and the queue dispatch ordering, so labels are compared by canonical case at the SQL layer.

## Changes

- **Services**: Updated `Automation::Strategies::AutoPick::DefaultCandidateSource#priority_label_order_node` to compare labels case-insensitively instead of using case-sensitive `jsonb` containment via `@>` with `jsonb_build_array`.
- **Models**: Aligned `AgentRun::QUEUE_ORDER` to apply the same case-insensitive comparison so dispatch ordering matches candidate selection, and updated the Ruby-side `queue_priority_tier` logic so UI/reporting agrees with queue behavior.
- **Tests**: Added regressions in `spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb` and `spec/models/agent_run_spec.rb` covering label-case mismatches.

## Design Decisions

- Chose the localized SQL-layer normalization (option 1 from the issue) over normalizing labels on sync or backfilling the DB. It fixes the immediate priority-starvation symptom without touching the label storage format or requiring a migration, and keeps the change reviewable. A broader canonicalization on sync remains viable as future work if more label comparisons need the same treatment.
- Kept the fix in both the candidate source and `AgentRun::QUEUE_ORDER` so the two ordering paths stay consistent — divergence between them would reintroduce the same class of bug for in-flight runs.

---

Closes #2233