### PR TITLE
feat(policy): Phase 6.3 — Policy, Risk & Approval Controls

### DIFF
--- a/app/models/coordination_policy.rb
+++ b/app/models/coordination_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoordinationPolicy < ApplicationRecord
-  POLICY_TYPES = %w[decomposition recovery escalation lifecycle_state].freeze
+  POLICY_TYPES = %w[decomposition recovery escalation lifecycle_state execution].freeze
   STATUSES = %w[draft active archived].freeze
 
   belongs_to :account

--- a/app/services/policy_controls/context_matcher.rb
+++ b/app/services/policy_controls/context_matcher.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module PolicyControls
+  class ContextMatcher
+    def self.matches?(conditions:, context:)
+      new(conditions:, context:).matches?
+    end
+
+    def initialize(conditions:, context:)
+      @conditions = normalize_hash(conditions)
+      @context = normalize_hash(context)
+    end
+
+    def matches?
+      return true if conditions.empty?
+
+      conditions.all? do |key, expected|
+        match_condition?(key, expected)
+      end
+    end
+
+    private
+
+    attr_reader :conditions, :context
+
+    def match_condition?(key, expected)
+      case key
+      when "risk_score_gte"
+        numeric_context("risk_score") >= expected.to_f
+      when "risk_score_lte"
+        numeric_context("risk_score") <= expected.to_f
+      when "issue_labels_any"
+        overlap?(array_context("issue_labels"), Array(expected))
+      when "issue_labels_all"
+        subset?(Array(expected), array_context("issue_labels"))
+      when "change_surface_any"
+        overlap?(array_context("change_surface"), Array(expected))
+      when "change_surface_all"
+        subset?(Array(expected), array_context("change_surface"))
+      else
+        value_matches?(expected, context[key])
+      end
+    end
+
+    def numeric_context(key)
+      context[key].to_f
+    end
+
+    def array_context(key)
+      Array(context[key]).map(&:to_s)
+    end
+
+    def overlap?(actual, expected)
+      actual.intersection(expected.map(&:to_s)).any?
+    end
+
+    def subset?(expected, actual)
+      expected.map(&:to_s).all? { |value| actual.include?(value) }
+    end
+
+    def value_matches?(expected, actual)
+      case expected
+      when Hash
+        actual.is_a?(Hash) && self.class.matches?(conditions: expected, context: actual)
+      when Array
+        return true if expected.map(&:to_s).include?("any")
+
+        actual_values = actual.is_a?(Array) ? actual.map(&:to_s) : [ actual.to_s ]
+        expected.map(&:to_s).any? { |value| actual_values.include?(value) }
+      when nil, "any"
+        true
+      when true, false
+        ActiveModel::Type::Boolean.new.cast(actual) == expected
+      else
+        actual.to_s == expected.to_s
+      end
+    end
+
+    def normalize_hash(value)
+      return {} unless value.is_a?(Hash)
+
+      value.deep_stringify_keys
+    end
+  end
+end

--- a/app/services/policy_controls/evaluate.rb
+++ b/app/services/policy_controls/evaluate.rb
@@ -325,7 +325,8 @@ module PolicyControls
     end
 
     def tier_index(tier)
-      LlmModel::TIERS.index(tier.to_s) || -1
+      idx = LlmModel::TIERS.index(tier.to_s)
+      idx.nil? ? -1 : idx
     end
 
     def normalize_hash(value)

--- a/app/services/policy_controls/evaluate.rb
+++ b/app/services/policy_controls/evaluate.rb
@@ -1,0 +1,337 @@
+# frozen_string_literal: true
+
+module PolicyControls
+  class Evaluate
+    POLICY_TYPE = "execution"
+    POLICY_KEY = "agent_execution"
+    SERVICE_CONTAINER_MODE_ALLOW_ATTACHED = "allow_attached"
+    SERVICE_CONTAINER_MODE_ALLOWLIST = "allowlist"
+    SERVICE_CONTAINER_MODE_NONE = "none"
+
+    Result = Data.define(
+      :allowed,
+      :paused,
+      :reason,
+      :sanitized_prompt,
+      :risk_score,
+      :violations,
+      :approval,
+      :classification,
+      :redaction,
+      :controls,
+      :context,
+      :policy_metadata,
+      :matched_environment_controls,
+      :matched_risk_rules,
+      :matched_approval_rules,
+      :simulation
+    ) do
+      def to_h
+        {
+          "allowed" => allowed,
+          "paused" => paused,
+          "reason" => reason,
+          "risk_score" => risk_score,
+          "violations" => violations,
+          "approval" => approval,
+          "classification" => classification,
+          "redaction" => redaction,
+          "controls" => controls,
+          "context" => context,
+          "policy_metadata" => policy_metadata,
+          "matched_environment_controls" => matched_environment_controls,
+          "matched_risk_rules" => matched_risk_rules,
+          "matched_approval_rules" => matched_approval_rules,
+          "simulation" => simulation
+        }
+      end
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, issue: nil, goal: nil, runner: nil, model: nil, prompt: nil,
+      target_branch: nil, service_containers: nil, context: {}, rules: nil, simulation: false)
+      @project = project
+      @issue = issue
+      @goal = goal
+      @runner = runner
+      @model = model
+      @prompt = prompt.to_s
+      @target_branch = target_branch
+      @service_containers = Array(service_containers)
+      @context = normalize_hash(context)
+      @rules_override = normalize_hash(rules)
+      @simulation = simulation
+    end
+
+    def call
+      merged_rules = policy_rules
+      base_context = build_context
+      environment_result = apply_environment_controls(base_context, merged_rules)
+      redaction_result = evaluate_redaction(environment_result[:controls])
+      evaluation_context = environment_result[:context].merge(redaction_context(redaction_result))
+      risk_result = evaluate_risk(evaluation_context, merged_rules)
+      approval_result = evaluate_approval(
+        evaluation_context.merge("risk_score" => risk_result[:score]),
+        merged_rules
+      )
+      violations = evaluate_violations(
+        controls: environment_result[:controls],
+        fully_redacted: redaction_result[:details]["fully_redacted"]
+      )
+      allowed = violations.empty?
+      paused = !allowed || approval_result["required"] == true
+
+      Result.new(
+        allowed: allowed,
+        paused: paused,
+        reason: pause_reason(violations, approval_result),
+        sanitized_prompt: redaction_result[:sanitized_prompt],
+        risk_score: risk_result[:score],
+        violations: violations,
+        approval: approval_result,
+        classification: redaction_result[:classification],
+        redaction: redaction_result[:details],
+        controls: environment_result[:controls],
+        context: evaluation_context,
+        policy_metadata: policy_metadata,
+        matched_environment_controls: environment_result[:matched],
+        matched_risk_rules: risk_result[:matched],
+        matched_approval_rules: approval_result["matched_rules"],
+        simulation: simulation
+      )
+    end
+
+    private
+
+    attr_reader :project, :issue, :goal, :runner, :model, :prompt, :target_branch, :service_containers, :context, :rules_override, :simulation
+
+    def policy_rules
+      return rules_override if rules_override.present?
+      return {} unless policy_version
+
+      normalize_hash(policy_version.rules).deep_merge(normalize_hash(policy_version.parameters))
+    end
+
+    def policy_metadata
+      {
+        "source" => rules_override.present? ? "simulation" : "coordination_policy",
+        "policy_key" => POLICY_KEY,
+        "coordination_policy_id" => policy_record&.id,
+        "coordination_policy_version_id" => policy_version&.id,
+        "coordination_policy_version" => policy_version&.version
+      }
+    end
+
+    def policy_record
+      @policy_record ||= CoordinationPolicy
+        .active
+        .by_type(POLICY_TYPE)
+        .where(account: project.account, policy_key: POLICY_KEY)
+        .where(project_id: [ nil, project.id ])
+        .includes(:current_version)
+        .order(Arel.sql("CASE WHEN project_id IS NOT NULL THEN 0 ELSE 1 END"), id: :desc)
+        .find { |candidate| candidate.current_version.present? }
+    end
+
+    def policy_version
+      policy_record&.current_version
+    end
+
+    def build_context
+      {
+        "repo" => project.full_name,
+        "branch" => target_branch.presence || project.default_branch,
+        "goal" => goal.to_s.presence,
+        "issue_labels" => Array(issue&.labels).map(&:to_s),
+        "change_surface" => Array(context["change_surface"]).map(&:to_s),
+        "regulated" => ActiveModel::Type::Boolean.new.cast(context["regulated"]),
+        "runner_key" => runner&.runner_key,
+        "direct_outbound" => runner&.requires_direct_outbound? == true,
+        "model_id" => model&.model_id,
+        "model_tier" => model&.tier
+      }.compact.merge(context)
+    end
+
+    def apply_environment_controls(base_context, rules)
+      controls = normalize_hash(rules["controls"])
+      matched = Array(rules["environment_controls"]).filter_map do |rule|
+        normalized_rule = normalize_hash(rule)
+        next unless ContextMatcher.matches?(conditions: normalized_rule["conditions"], context: base_context)
+
+        controls = controls.deep_merge(normalize_hash(normalized_rule["controls"]))
+        normalized_rule["environment"] || normalized_rule["name"] || "unnamed"
+      end
+
+      resolved_context = matched.empty? ? base_context : base_context.merge("environment" => matched.last)
+      { controls:, context: resolved_context, matched: matched }
+    end
+
+    def evaluate_redaction(controls)
+      redaction_controls = normalize_hash(controls["prompt_redaction"])
+      return empty_redaction(prompt) unless redaction_controls["enabled"] == true
+
+      redaction = Knowledge::Redaction::Redactor.call(text: prompt)
+      {
+        sanitized_prompt: redaction.clean_text,
+        classification: classify_redaction(redaction, redaction_controls),
+        details: {
+          "enabled" => true,
+          "redacted" => redaction.redacted?,
+          "fully_redacted" => redaction.fully_redacted?,
+          "match_types" => redaction.redactions.map(&:pattern).map(&:to_s).uniq
+        }
+      }
+    end
+
+    def empty_redaction(text)
+      {
+        sanitized_prompt: text,
+        classification: [],
+        details: {
+          "enabled" => false,
+          "redacted" => false,
+          "fully_redacted" => false,
+          "match_types" => []
+        }
+      }
+    end
+
+    def classify_redaction(redaction, controls)
+      return [] unless controls["classify"] == true
+
+      labels = redaction.redactions.map(&:pattern).map { |pattern| "contains:#{pattern}" }.uniq
+      labels << "fully_redacted" if redaction.fully_redacted?
+      labels
+    end
+
+    def redaction_context(redaction_result)
+      {
+        "classification" => redaction_result[:classification],
+        "fully_redacted" => redaction_result[:details]["fully_redacted"]
+      }
+    end
+
+    def evaluate_risk(evaluation_context, rules)
+      matched = Array(rules["risk_rules"]).filter_map do |rule|
+        normalized_rule = normalize_hash(rule)
+        next unless ContextMatcher.matches?(conditions: normalized_rule["conditions"], context: evaluation_context)
+
+        normalized_rule.slice("name", "score", "labels")
+      end
+
+      score = matched.map { |rule| rule["score"].to_i }.max || 0
+      { score:, matched: matched }
+    end
+
+    def evaluate_approval(evaluation_context, rules)
+      matched = Array(rules["approval_rules"]).filter_map do |rule|
+        normalized_rule = normalize_hash(rule)
+        next unless ContextMatcher.matches?(conditions: normalized_rule["conditions"], context: evaluation_context)
+
+        workflow = normalize_hash(normalized_rule["workflow"])
+        next if workflow.empty?
+
+        normalized_rule.merge("workflow" => workflow)
+      end
+
+      required = matched.any? { |rule| rule.dig("workflow", "required") == true }
+      approvers = matched.flat_map { |rule| Array(rule.dig("workflow", "approvers")) }.map(&:to_s).uniq
+      reason = matched.filter_map { |rule| rule.dig("workflow", "reason").presence }.first
+
+      {
+        "required" => required,
+        "approvers" => approvers,
+        "reason" => reason,
+        "matched_rules" => matched.map { |rule| rule["name"] || rule.dig("workflow", "reason") || "approval_rule" }
+      }
+    end
+
+    def evaluate_violations(controls:, fully_redacted:)
+      violations = []
+      violations << "runner_not_allowed" if runner_disallowed?(controls)
+      violations << "model_not_allowed" if model_disallowed?(controls)
+      violations << "model_tier_exceeds_maximum" if model_tier_disallowed?(controls)
+      violations << "network_access_not_allowed" if network_disallowed?(controls)
+      violations << "service_container_not_allowed" if service_container_disallowed?(controls)
+      violations << "prompt_fully_redacted" if prompt_blocked?(controls, fully_redacted)
+      violations
+    end
+
+    def runner_disallowed?(controls)
+      allowlist = Array(controls["runner_allowlist"]).map(&:to_s)
+      return false if allowlist.empty?
+      return false unless runner
+
+      !allowlist.include?(runner.runner_key.to_s)
+    end
+
+    def model_disallowed?(controls)
+      allowlist = Array(controls["model_allowlist"]).map(&:to_s)
+      return false if allowlist.empty?
+      return false unless model
+
+      !allowlist.include?(model.model_id.to_s)
+    end
+
+    def model_tier_disallowed?(controls)
+      max_tier = controls["max_model_tier"].to_s
+      return false if max_tier.blank? || model&.tier.blank?
+
+      tier_index(model.tier) > tier_index(max_tier)
+    end
+
+    def network_disallowed?(controls)
+      return false unless runner&.requires_direct_outbound?
+
+      controls["network_access"].to_s == "restricted"
+    end
+
+    def service_container_disallowed?(controls)
+      restrictions = normalize_hash(controls["service_containers"])
+      mode = restrictions["mode"].to_s
+      return false if mode.blank? || service_containers.empty?
+
+      case mode
+      when SERVICE_CONTAINER_MODE_NONE
+        true
+      when SERVICE_CONTAINER_MODE_ALLOW_ATTACHED
+        false
+      when SERVICE_CONTAINER_MODE_ALLOWLIST
+        allowlist = Array(restrictions["allowlist"]).map(&:to_s)
+        service_containers.any? do |container|
+          !allowlist.include?(container.name.to_s) && !allowlist.include?(container.id.to_s)
+        end
+      else
+        false
+      end
+    end
+
+    def prompt_blocked?(controls, fully_redacted)
+      redaction_controls = normalize_hash(controls["prompt_redaction"])
+      return false unless redaction_controls["enabled"] == true
+      return false unless redaction_controls["block_fully_redacted"] == true
+
+      fully_redacted == true
+    end
+
+    def pause_reason(violations, approval_result)
+      return "Policy approval required: #{approval_result["reason"] || "matched approval workflow"}" if violations.empty? && approval_result["required"] == true
+      return "Policy blocked execution: #{violations.join(', ')}" if violations.any?
+
+      nil
+    end
+
+    def tier_index(tier)
+      LlmModel::TIERS.index(tier.to_s) || -1
+    end
+
+    def normalize_hash(value)
+      return {} unless value.is_a?(Hash)
+
+      value.deep_stringify_keys
+    end
+  end
+end

--- a/app/temporal/activities/create_agent_run_activity.rb
+++ b/app/temporal/activities/create_agent_run_activity.rb
@@ -122,6 +122,7 @@ module Activities
         # tracking and audit). Non-fatal — runs proceed with default pricing
         # if no LlmModel records exist yet.
         select_model(agent_run)
+        policy_evaluation = apply_policy_controls(agent_run)
         assign_configuration_bundle(agent_run)
 
         log_scope_analysis(agent_run, scope_result)
@@ -135,7 +136,7 @@ module Activities
           prompt_version_id: prompt_version&.id
         )
 
-        {
+        result = {
           agent_run_id: agent_run.id,
           focus: agent_run.focus,
           runner_attempt_count: runner_attempt_count_for(agent_run, user_settings),
@@ -148,6 +149,8 @@ module Activities
             sub_components: scope_result.sub_components
           } : nil
         }
+        result[:paused] = true if policy_evaluation.paused
+        result
       end
     end
 
@@ -251,6 +254,7 @@ module Activities
         force: false,
         account_auto_attach_required: marketplace_auto_attach_required?(agent_run.project)
       )
+      policy_evaluation = apply_policy_controls(agent_run)
       assign_configuration_bundle(agent_run)
 
       logger.info(
@@ -266,7 +270,8 @@ module Activities
         runner_attempt_count: runner_attempt_count_for(agent_run, user_settings),
         agent_timeout_seconds: user_settings&.agent_timeout_seconds || AGENT_TIMEOUT_DEFAULT,
         issue_goal_timeout_seconds: user_settings&.issue_goal_timeout_seconds || Activities::RunAgentActivity::DEFAULT_ISSUE_GOAL_TIMEOUT,
-        max_execution_seconds: effective_max_execution_seconds(agent_run.project, user_settings)
+        max_execution_seconds: effective_max_execution_seconds(agent_run.project, user_settings),
+        paused: policy_evaluation.paused
       }
     end
 
@@ -367,6 +372,47 @@ module Activities
 
     def assign_configuration_bundle(agent_run)
       ConfigurationBundles::AssignToRun.call(agent_run: agent_run)
+    end
+
+    def apply_policy_controls(agent_run)
+      evaluation = PolicyControls::Evaluate.call(
+        project: agent_run.project,
+        issue: agent_run.issue,
+        goal: agent_run.goal,
+        runner: agent_run.runner,
+        model: agent_run.model_selection&.llm_model,
+        prompt: agent_run.custom_prompt,
+        target_branch: agent_run.project.default_branch,
+        service_containers: agent_run.project.service_containers
+      )
+
+      attributes = {
+        guardrail_context: agent_run.guardrail_context.to_h.merge(
+          "policy_controls" => evaluation.to_h
+        )
+      }
+      if agent_run.custom_prompt.present? || evaluation.sanitized_prompt.present?
+        attributes[:custom_prompt] = evaluation.sanitized_prompt if evaluation.sanitized_prompt != agent_run.custom_prompt
+      end
+
+      if evaluation.paused
+        attributes[:status] = "paused"
+        attributes[:paused_at] = Time.current
+        attributes[:error_message] = evaluation.reason
+      end
+
+      agent_run.update!(attributes)
+
+      return evaluation unless evaluation.paused
+
+      logger.info(
+        message: "agent_execution.policy_controls_paused",
+        agent_run_id: agent_run.id,
+        project_id: agent_run.project_id,
+        reason: evaluation.reason,
+        risk_score: evaluation.risk_score
+      )
+      evaluation
     end
 
     def resolve_user_settings(project)

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -113,6 +113,10 @@ module Workflows
       )
       max_execution_seconds = agent_run_result[:max_execution_seconds]
 
+      if agent_run_result[:paused]
+        return { success: false, paused: true, agent_run_id: agent_run_id }
+      end
+
       agent_step_succeeded = false
       workflow_error = nil
 

--- a/spec/models/coordination_policy_spec.rb
+++ b/spec/models/coordination_policy_spec.rb
@@ -106,6 +106,12 @@ RSpec.describe CoordinationPolicy do
       expect(coordination_policy).not_to be_valid
       expect(coordination_policy.errors[:metadata]).to include("must be a JSON object")
     end
+
+    it "accepts execution policies for runtime governance controls" do
+      coordination_policy.policy_type = "execution"
+
+      expect(coordination_policy).to be_valid
+    end
   end
 
   describe "#create_version!" do

--- a/spec/services/policy_controls/context_matcher_spec.rb
+++ b/spec/services/policy_controls/context_matcher_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PolicyControls::ContextMatcher do
+  describe ".matches?" do
+    it "matches empty conditions" do
+      expect(match({}, {})).to be(true)
+    end
+
+    it "supports numeric risk score comparisons with missing context values" do
+      expect(match({ "risk_score_gte" => 0 }, {})).to be(true)
+      expect(match({ "risk_score_gte" => 1 }, {})).to be(false)
+      expect(match({ "risk_score_lte" => 0 }, {})).to be(true)
+    end
+
+    it "supports issue label and change surface list conditions" do
+      context = {
+        "issue_labels" => [ "bug", :security ],
+        "change_surface" => [ "api", "db" ]
+      }
+
+      aggregate_failures do
+        expect(match({ "issue_labels_any" => [ "security" ] }, context)).to be(true)
+        expect(match({ "issue_labels_all" => [ "bug", "security" ] }, context)).to be(true)
+        expect(match({ "issue_labels_all" => [] }, context)).to be(true)
+        expect(match({ "change_surface_any" => [ "db" ] }, context)).to be(true)
+        expect(match({ "change_surface_all" => [ "api", "db" ] }, context)).to be(true)
+        expect(match({ "change_surface_all" => [] }, context)).to be(true)
+      end
+    end
+
+    it "handles nil and wildcard values" do
+      aggregate_failures do
+        expect(match({ "runner_key" => nil }, {})).to be(true)
+        expect(match({ "runner_key" => "any" }, {})).to be(true)
+        expect(match({ "runner_key" => [ "any" ] }, {})).to be(true)
+        expect(match({ "runner_key" => [ "codex" ] }, {})).to be(false)
+      end
+    end
+
+    it "casts boolean values from non-boolean context inputs" do
+      aggregate_failures do
+        expect(match({ "regulated" => true }, { "regulated" => "1" })).to be(true)
+        expect(match({ "regulated" => false }, { "regulated" => "false" })).to be(true)
+        expect(match({ "regulated" => false }, { "regulated" => "0" })).to be(true)
+      end
+    end
+
+    it "supports nested hash matching" do
+      expect(
+        match(
+          { "service_containers" => { "redis" => true } },
+          { "service_containers" => { "redis" => "1", "postgres" => false } }
+        )
+      ).to be(true)
+    end
+
+    it "matches array expectations against scalar context values" do
+      expect(match({ "environment" => [ "production", "staging" ] }, { "environment" => :production })).to be(true)
+    end
+  end
+
+  def match(conditions, context)
+    described_class.matches?(conditions: conditions, context: context)
+  end
+end

--- a/spec/services/policy_controls/evaluate_spec.rb
+++ b/spec/services/policy_controls/evaluate_spec.rb
@@ -91,6 +91,17 @@ RSpec.describe PolicyControls::Evaluate do
       expect(result.reason).to eq("Policy approval required: Owner approval required")
       expect(result.approval["matched_rules"]).to eq([ "risk_gate" ])
     end
+
+    it "does not block the lowest allowed tier when the maximum tier is low" do
+      result = evaluate(
+        model: create(:llm_model, :openai, model_id: "gpt-5.4-nano", tier: "low"),
+        rules: { "controls" => { "max_model_tier" => "low" } },
+        simulation: true
+      )
+
+      expect(result.violations).to be_empty
+      expect(result.allowed).to be(true)
+    end
   end
 
   def evaluate(**overrides)

--- a/spec/services/policy_controls/evaluate_spec.rb
+++ b/spec/services/policy_controls/evaluate_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PolicyControls::Evaluate do
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project, labels: [ "type:bug", "surface:schema" ]) }
+  let(:runner) { create(:runner, user: project.created_by, runner_key: "codex") }
+  let(:model) { create(:llm_model, :openai, model_id: "gpt-5.4", tier: "high") }
+  let(:simulation_rules) do
+    {
+      "controls" => {
+        "runner_allowlist" => [ "codex" ],
+        "max_model_tier" => "mid",
+        "prompt_redaction" => { "enabled" => true, "classify" => true, "block_fully_redacted" => true }
+      },
+      "risk_rules" => [
+        { "name" => "schema_changes", "conditions" => { "change_surface_any" => [ "schema" ] }, "score" => 90 }
+      ],
+      "approval_rules" => [
+        {
+          "name" => "high_risk",
+          "conditions" => { "risk_score_gte" => 80 },
+          "workflow" => { "required" => true, "reason" => "Security review required", "approvers" => [ "security" ] }
+        }
+      ]
+    }
+  end
+
+  describe ".call" do
+    it "uses simulation rules without requiring a persisted policy" do
+      result = evaluate(prompt: "api_key=abcdefghijklmnopqrstuvwx123456", context: { "change_surface" => [ "schema" ] }, simulation: true, rules: simulation_rules)
+
+      expect(result.paused).to be(true)
+      expect(result.allowed).to be(false)
+      expect(result.violations).to include("model_tier_exceeds_maximum")
+      expect(result.risk_score).to eq(90)
+      expect(result.approval["required"]).to be(true)
+      expect(result.approval["approvers"]).to eq([ "security" ])
+      expect(result.sanitized_prompt).to include("[REDACTED:")
+      expect(result.classification).to include(a_string_starting_with("contains:"))
+      expect(result.policy_metadata["source"]).to eq("simulation")
+    end
+
+    it "applies environment-specific controls from the active execution policy" do
+      direct_outbound_runner = pi_direct_outbound_runner
+      policy = create_execution_policy(
+        "controls" => { "service_containers" => { "mode" => "allow_attached" } },
+        "environment_controls" => [
+          {
+            "name" => "production",
+            "conditions" => { "branch" => "main" },
+            "controls" => {
+              "network_access" => "restricted",
+              "max_model_tier" => "mid"
+            }
+          }
+        ]
+      )
+
+      result = evaluate(runner: direct_outbound_runner, prompt: "Ship it")
+
+      expect(result.matched_environment_controls).to eq([ "production" ])
+      expect(result.context["environment"]).to eq("production")
+      expect(result.controls["network_access"]).to eq("restricted")
+      expect(result.violations).to include("network_access_not_allowed", "model_tier_exceeds_maximum")
+      expect(result.policy_metadata["coordination_policy_id"]).to eq(policy.id)
+    end
+
+    it "requires approval for matched approval workflows without introducing hard violations" do
+      create_execution_policy(
+        "controls" => { "runner_allowlist" => [ "codex" ] },
+        "risk_rules" => [
+          { "name" => "bugfix", "conditions" => { "issue_labels_any" => [ "type:bug" ] }, "score" => 75 }
+        ],
+        "approval_rules" => [
+          {
+            "name" => "risk_gate",
+            "conditions" => { "risk_score_gte" => 70 },
+            "workflow" => { "required" => true, "reason" => "Owner approval required", "approvers" => [ "repo_owner" ] }
+          }
+        ]
+      )
+
+      low_tier_model = create(:llm_model, :openai, model_id: "gpt-5.4-mini", tier: "mid")
+      result = evaluate(model: low_tier_model, prompt: "Implement the fix")
+
+      expect(result.allowed).to be(true)
+      expect(result.paused).to be(true)
+      expect(result.violations).to be_empty
+      expect(result.reason).to eq("Policy approval required: Owner approval required")
+      expect(result.approval["matched_rules"]).to eq([ "risk_gate" ])
+    end
+  end
+
+  def evaluate(**overrides)
+    described_class.call(**{
+      project: project,
+      issue: issue,
+      goal: "create_pr",
+      runner: runner,
+      model: model,
+      prompt: "Implement the fix"
+    }.merge(overrides))
+  end
+
+  def create_execution_policy(rules)
+    create(:coordination_policy,
+      :active,
+      account: project.account,
+      project: project,
+      policy_type: "execution",
+      policy_key: "agent_execution").tap do |policy|
+      policy.current_version.update!(rules: rules)
+    end
+  end
+
+  def pi_direct_outbound_runner
+    create(
+      :runner,
+      user: project.created_by,
+      runner_key: "pi",
+      auth_type: "api_key",
+      provider_api_key: create(:provider_api_key, user: project.created_by, api_service_type: "anthropic"),
+      config: { "pi" => { "api_provider" => "anthropic", "model" => "claude-3-7-sonnet" } }
+    )
+  end
+end

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -527,6 +527,65 @@ RSpec.describe Activities::CreateAgentRunActivity do
       expect(issue.reload.paid_state).to eq("in_progress")
     end
 
+    it "pauses the run when execution policy approval is required" do
+      create_execution_policy(
+        "controls" => { "runner_allowlist" => [ "claude" ] },
+        "risk_rules" => [
+          { "name" => "bugfix", "conditions" => { "issue_labels_any" => [ "bug" ] }, "score" => 80 }
+        ],
+        "approval_rules" => [
+          {
+            "name" => "owner_review",
+            "conditions" => { "risk_score_gte" => 80 },
+            "workflow" => { "required" => true, "reason" => "Owner approval required", "approvers" => [ "repo_owner" ] }
+          }
+        ]
+      )
+      issue.update!(labels: [ "bug" ])
+
+      result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(result[:paused]).to be(true)
+      expect(agent_run.status).to eq("paused")
+      expect(agent_run.error_message).to eq("Policy approval required: Owner approval required")
+      expect(agent_run.guardrail_context.dig("policy_controls", "approval", "required")).to be(true)
+    end
+
+    it "redacts the custom prompt before persistence when prompt redaction is enabled" do
+      create_execution_policy(
+        "controls" => {
+          "prompt_redaction" => {
+            "enabled" => true,
+            "classify" => true,
+            "block_fully_redacted" => false
+          }
+        }
+      )
+
+      result = activity.execute(
+        project_id: project.id,
+        issue_id: issue.id,
+        custom_prompt: "api_key=abcdefghijklmnopqrstuvwx123456"
+      )
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.custom_prompt).to include("[REDACTED:")
+      expect(agent_run.guardrail_context.dig("policy_controls", "classification")).not_to be_empty
+      expect(agent_run.status).to eq("queued")
+    end
+
+    def create_execution_policy(rules)
+      create(:coordination_policy,
+        :active,
+        account: project.account,
+        project: project,
+        policy_type: "execution",
+        policy_key: "agent_execution").tap do |policy|
+        policy.current_version.update!(rules: rules)
+      end
+    end
+
     it "records a failed phase when later side effects raise" do
       allow(Issue).to receive(:find).with(issue.id).and_return(issue)
       allow(issue).to receive(:update!).and_raise(StandardError, "issue update failed")

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -1302,6 +1302,23 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
       expect(called_activities).not_to include(Activities::MarkAgentRunFailedActivity)
     end
 
+    it "short-circuits when create-agent-run pauses before execution starts" do
+      called_activities = []
+      allow(workflow).to receive(:run_activity) do |activity_class, _input, **_opts|
+        called_activities << activity_class
+        case activity_class.name
+        when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, paused: true }
+        else
+          raise "unexpected activity #{activity_class.name}"
+        end
+      end
+
+      result = workflow.execute(input)
+
+      expect(result).to include(success: false, paused: true, agent_run_id: 42)
+      expect(called_activities).to eq([ Activities::CreateAgentRunActivity ])
+    end
+
     it "falls back to cleanup when RetainContainerActivity fails" do
       called_activities = []
       stub_post_agent_failure(called_activities, retain_error: StandardError.new("DB write failed"))


### PR DESCRIPTION
## Summary

Implements Phase 6.3 enterprise policy controls so customers can encode SDLC and AI-risk policies that bound runner/model choice, restrict network and service-container access, and gate high-risk work through approval workflows before agent execution starts. The runtime path reuses the existing `coordination_policies` store via a new `execution` policy type rather than introducing a parallel policy table.

## Changes

- **Models / data**: Extend `CoordinationPolicy` to accept an `execution` policy type; persist policy decisions on `agent_runs.guardrail_context["policy_controls"]` (no new table or migration).
- **Services**: Add `app/services/policy_controls/` with an evaluator that enforces runner allowlists, model allowlists, max capability tier, network/service-container restrictions, environment overlays, prompt redaction/classification, approval rules, and simulation mode driven by explicit rules input.
- **Temporal**: `CreateAgentRunActivity` now evaluates policy before execution and pauses the run when a rule blocks or gates it; `AgentExecutionWorkflow` short-circuits immediately when creation returns a paused run.
- **Tests**: Focused specs for the evaluator, `CoordinationPolicy`, the create-run activity, and the execution workflow.

## Design Decisions

- **Reuse `coordination_policies` instead of a new policy store** — adding an `execution` policy type kept the surface small and avoided a parallel admin/UI for a second policy table.
- **Enforce at run creation, not mid-execution** — gating in `CreateAgentRunActivity` (with workflow short-circuit on paused runs) keeps blocked work out of containers entirely rather than tearing down a running agent.
- **Persist full decision under `guardrail_context["policy_controls"]`** — gives operators and approval UIs the matched rules and rationale without a separate audit table; piggybacks on existing guardrail context plumbing.
- **Simulation via explicit rules input** — the evaluator accepts a proposed ruleset so simulation runs against real run inputs without touching stored policies.

## Operational Notes

- No database migration; the change is additive on existing `coordination_policies` and `agent_runs.guardrail_context`.
- Repo-wide `bundle exec rspec` was not run to green due to a pre-existing PostgreSQL deadlock flake in `spec/temporal/activities/fetch_issues_activity_spec.rb:1167` (passes in isolation). Targeted specs for the changed paths all pass. Reviewers/CI should confirm the full suite.

---

Closes #2226