### PR TITLE
fix(auto-pick): recover issues when produced PR was closed without merging

### DIFF
--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -54,6 +54,7 @@ module Automation
             AND closed_prs.github_number = agent_runs.pull_request_number
             AND closed_prs.is_pull_request = TRUE
             AND closed_prs.github_state = 'closed'
+            AND (closed_prs.pr_review_phase IS NULL OR closed_prs.pr_review_phase != 'merged')
         SQL
 
         class << self

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -54,7 +54,7 @@ module Automation
             AND closed_prs.github_number = agent_runs.pull_request_number
             AND closed_prs.is_pull_request = TRUE
             AND closed_prs.github_state = 'closed'
-            AND (closed_prs.pr_review_phase IS NULL OR closed_prs.pr_review_phase != 'merged')
+            AND closed_prs.pr_review_phase IS DISTINCT FROM 'merged'
         SQL
 
         class << self

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -48,6 +48,14 @@ module Automation
           "%meta%issue%"
         ].freeze
 
+        CLOSED_PR_CORRELATED_SUBQUERY = <<~SQL.squish.freeze
+          SELECT 1 FROM issues closed_prs
+          WHERE closed_prs.project_id = agent_runs.project_id
+            AND closed_prs.github_number = agent_runs.pull_request_number
+            AND closed_prs.is_pull_request = TRUE
+            AND closed_prs.github_state = 'closed'
+        SQL
+
         class << self
           def eligible_issue_ids(displayed_issues)
             return Set.new if displayed_issues.empty?
@@ -69,15 +77,19 @@ module Automation
               project: project,
               status: "completed",
               trigger_type: "automatic",
-              auto_pick: true,
-              pull_request_number: nil
+              auto_pick: true
             ).where.not(issue_id: nil)
               .where.not(goal: "analyze_issue")
+              .where(
+                "agent_runs.pull_request_number IS NULL OR EXISTS (#{CLOSED_PR_CORRELATED_SUBQUERY})"
+              )
               .select(:issue_id)
 
             pr_produced_issue_ids = AgentRun.where(
               project: project, status: "completed", goal: "create_pr"
-            ).where.not(pull_request_number: nil).where.not(issue_id: nil).select(:issue_id)
+            ).where.not(pull_request_number: nil).where.not(issue_id: nil)
+              .where("NOT EXISTS (#{CLOSED_PR_CORRELATED_SUBQUERY})")
+              .select(:issue_id)
 
             scope = scope.or(
               base.where(paid_state: "completed", id: recoverable_completed_issue_ids)

--- a/app/temporal/activities/create_github_issue_activity.rb
+++ b/app/temporal/activities/create_github_issue_activity.rb
@@ -317,7 +317,9 @@ module Activities
     end
 
     def append_blocked_by_text(body, agent_run, project:, resolved: nil)
-      blocked_issues = agent_run.project.issues.where(id: agent_run.blocked_by_issue_ids, github_state: "open")
+      blocked_issues = agent_run.project.issues
+        .where(id: agent_run.blocked_by_issue_ids, github_state: "open")
+        .order(:github_number)
       return body if blocked_issues.empty?
 
       resolved ||= ProjectConventions::IssueDependencies.convention_value(project)

--- a/app/temporal/activities/create_github_issue_activity.rb
+++ b/app/temporal/activities/create_github_issue_activity.rb
@@ -319,7 +319,6 @@ module Activities
     def append_blocked_by_text(body, agent_run, project:, resolved: nil)
       blocked_issues = agent_run.project.issues
         .where(id: agent_run.blocked_by_issue_ids, github_state: "open")
-        .order(:github_number)
       return body if blocked_issues.empty?
 
       resolved ||= ProjectConventions::IssueDependencies.convention_value(project)

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -691,7 +691,7 @@ module Activities
 
       backfilled_count = backfill_open_pull_requests(project, client, open_pr_numbers)
       dependency_changed = open_pr_numbers.any? && resolve_external_dependencies(project, open_pr_numbers)
-      closed_count = close_stale_pull_requests(project, open_pr_numbers)
+      closed_count = close_stale_pull_requests(project, open_pr_numbers, client: client)
 
       {
         changed: backfilled_count.positive? || dependency_changed || closed_count.positive?,
@@ -746,7 +746,7 @@ module Activities
       missing_numbers.size
     end
 
-    def close_stale_pull_requests(project, open_pr_numbers)
+    def close_stale_pull_requests(project, open_pr_numbers, client:)
       stale_prs = project.issues
         .pull_requests_only
         .where(github_state: "open", source: Issue::GITHUB_SOURCE)
@@ -755,15 +755,59 @@ module Activities
       count = stale_prs.count
       return 0 if count.zero?
 
-      stale_prs.update_all(github_state: "closed", updated_at: Time.current)
+      merged_numbers, unmerged_numbers = partition_by_merge_status(
+        client, project.full_name, stale_prs.pluck(:github_number)
+      )
+
+      if merged_numbers.any?
+        project.issues
+          .pull_requests_only
+          .where(project_id: project.id, github_number: merged_numbers)
+          .update_all(github_state: "closed", pr_review_phase: "merged", updated_at: Time.current)
+      end
+
+      if unmerged_numbers.any?
+        project.issues
+          .pull_requests_only
+          .where(project_id: project.id, github_number: unmerged_numbers)
+          .update_all(github_state: "closed", updated_at: Time.current)
+      end
 
       logger.info(
         message: "github_sync.closed_stale_pull_requests",
         project_id: project.id,
-        count: count
+        count: count,
+        merged_count: merged_numbers.size
       )
 
       count
+    end
+
+    def partition_by_merge_status(client, repo_full_name, pr_numbers)
+      merged_numbers = []
+      unmerged_numbers = []
+
+      pr_numbers.each do |number|
+        github_pr = client.pull_request(repo_full_name, number)
+        if github_pr.merged_at.present? || github_pr.merged == true
+          merged_numbers << number
+        else
+          unmerged_numbers << number
+        end
+      rescue GithubClient::RateLimitError
+        raise
+      rescue => e
+        logger.warn(
+          message: "github_sync.stale_pr_merge_check_failed",
+          repo: repo_full_name,
+          pr_number: number,
+          error_class: e.class.name,
+          error: e.message
+        )
+        unmerged_numbers << number
+      end
+
+      [ merged_numbers, unmerged_numbers ]
     end
 
     # Mirrors reconcile_open_pull_requests for issues. Fetches all open issue

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -755,7 +755,7 @@ module Activities
       count = stale_prs.count
       return 0 if count.zero?
 
-      merged_numbers, unmerged_numbers = partition_by_merge_status(
+      merged_numbers, unmerged_numbers, unknown_numbers = partition_by_merge_status(
         client, project.full_name, stale_prs.pluck(:github_number)
       )
 
@@ -773,19 +773,23 @@ module Activities
           .update_all(github_state: "closed", updated_at: Time.current)
       end
 
+      closed_numbers = merged_numbers.size + unmerged_numbers.size
+
       logger.info(
         message: "github_sync.closed_stale_pull_requests",
         project_id: project.id,
-        count: count,
-        merged_count: merged_numbers.size
+        count: closed_numbers,
+        merged_count: merged_numbers.size,
+        unknown_count: unknown_numbers.size
       )
 
-      count
+      closed_numbers
     end
 
     def partition_by_merge_status(client, repo_full_name, pr_numbers)
       merged_numbers = []
       unmerged_numbers = []
+      unknown_numbers = []
 
       pr_numbers.each do |number|
         github_pr = client.pull_request(repo_full_name, number)
@@ -804,10 +808,10 @@ module Activities
           error_class: e.class.name,
           error: e.message
         )
-        unmerged_numbers << number
+        unknown_numbers << number
       end
 
-      [ merged_numbers, unmerged_numbers ]
+      [ merged_numbers, unmerged_numbers, unknown_numbers ]
     end
 
     # Mirrors reconcile_open_pull_requests for issues. Fetches all open issue

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -93,10 +93,46 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
       expect(scope.pluck(:id)).to contain_exactly(issue.id)
     end
 
-    it "excludes completed issues that had a PR-producing run" do
+    it "excludes completed issues when the produced PR has not been synced yet" do
       issue = create(:issue, project: project, paid_state: "completed")
       create(:agent_run, :completed, :automatic, project: project, issue: issue,
         goal: "create_pr", auto_pick: true, pull_request_number: 42, pull_request_url: "https://example.test/pr/42")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to be_empty
+    end
+
+    it "excludes completed issues when the produced PR is still open" do
+      issue = create(:issue, project: project, paid_state: "completed")
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "create_pr", auto_pick: true, pull_request_number: 42, pull_request_url: "https://example.test/pr/42")
+      create(:issue, project: project, github_number: 42, is_pull_request: true, github_state: "open")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to be_empty
+    end
+
+    it "recovers completed issues when the produced PR was closed without merging" do
+      issue = create(:issue, project: project, paid_state: "completed")
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "create_pr", auto_pick: true, pull_request_number: 42, pull_request_url: "https://example.test/pr/42")
+      create(:issue, project: project, github_number: 42, is_pull_request: true, github_state: "closed")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(issue.id)
+    end
+
+    it "blocks recovery when one PR is closed but another is still open" do
+      issue = create(:issue, project: project, paid_state: "completed")
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "create_pr", auto_pick: true, pull_request_number: 10, pull_request_url: "https://example.test/pr/10")
+      create(:issue, project: project, github_number: 10, is_pull_request: true, github_state: "closed")
+      create(:agent_run, :completed, project: project, issue: issue,
+        goal: "create_pr", pull_request_number: 11, pull_request_url: "https://example.test/pr/11")
+      create(:issue, project: project, github_number: 11, is_pull_request: true, github_state: "open")
 
       scope = described_class.eligible_scope(project)
 

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -125,6 +125,17 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
       expect(scope.pluck(:id)).to contain_exactly(issue.id)
     end
 
+    it "does not recover completed issues when the produced PR was merged" do
+      issue = create(:issue, project: project, paid_state: "completed")
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "create_pr", auto_pick: true, pull_request_number: 42, pull_request_url: "https://example.test/pr/42")
+      create(:issue, :pull_request, :closed, project: project, github_number: 42, pr_review_phase: "merged")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to be_empty
+    end
+
     it "blocks recovery when one PR is closed but another is still open" do
       issue = create(:issue, project: project, paid_state: "completed")
       create(:agent_run, :completed, :automatic, project: project, issue: issue,

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -11,8 +11,13 @@ RSpec.describe Activities::FetchIssuesActivity do
 
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
-    allow(github_client).to receive_messages(issue_comments: [], recent_issue_comments: [], "rate_limit_remaining!": 100)
-    allow(github_client).to receive(:pull_requests).and_return([])
+    allow(github_client).to receive_messages(
+      issue_comments: [],
+      recent_issue_comments: [],
+      "rate_limit_remaining!": 100,
+      pull_requests: [],
+      pull_request: OpenStruct.new(merged_at: nil, merged: false)
+    )
     allow(github_client).to receive(:add_comment)
   end
 
@@ -1612,11 +1617,33 @@ RSpec.describe Activities::FetchIssuesActivity do
         allow(github_client).to receive(:pull_requests).and_return([
           OpenStruct.new(number: open_pr.github_number)
         ])
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, stale_pr.github_number)
+          .and_return(OpenStruct.new(merged_at: nil, merged: false))
 
         activity.execute(project_id: project.id)
 
         expect(stale_pr.reload.github_state).to eq("closed")
+        expect(stale_pr.reload.pr_review_phase).to eq("ready")
         expect(open_pr.reload.github_state).to eq("open")
+      end
+
+      it "stamps pr_review_phase as merged when stale-closing a merged PR" do
+        stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5000,
+                          github_number: 50, github_state: "open", pr_review_phase: "ready")
+
+        allow(github_client).to receive_messages(
+          pull_requests: [],
+          pull_request: OpenStruct.new(merged_at: nil, merged: false)
+        )
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, stale_pr.github_number)
+          .and_return(OpenStruct.new(merged_at: 1.hour.ago, merged: true))
+
+        activity.execute(project_id: project.id)
+
+        expect(stale_pr.reload.github_state).to eq("closed")
+        expect(stale_pr.reload.pr_review_phase).to eq("merged")
       end
 
       it "backfills open pull requests missing from the local cache" do

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -1646,6 +1646,31 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(stale_pr.reload.pr_review_phase).to eq("merged")
       end
 
+      it "leaves stale pull requests open when GitHub merge-status lookup fails" do
+        stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5000,
+                          github_number: 50, github_state: "open", pr_review_phase: "ready")
+
+        allow(github_client).to receive_messages(pull_requests: [])
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, stale_pr.github_number)
+          .and_raise(StandardError, "temporary outage")
+        allow(Rails.logger).to receive(:warn)
+
+        activity.execute(project_id: project.id)
+
+        expect(stale_pr.reload.github_state).to eq("open")
+        expect(stale_pr.reload.pr_review_phase).to eq("ready")
+        expect(Rails.logger).to have_received(:warn).with(
+          hash_including(
+            message: "github_sync.stale_pr_merge_check_failed",
+            repo: project.full_name,
+            pr_number: stale_pr.github_number,
+            error_class: "StandardError",
+            error: "temporary outage"
+          )
+        )
+      end
+
       it "backfills open pull requests missing from the local cache" do
         allow(github_client).to receive(:pull_requests).and_return([
           OpenStruct.new(number: 52)


### PR DESCRIPTION
## Summary

When an auto-pick run created a PR that was later closed without merging, the parent issue got permanently stuck in `completed` state and could never be re-picked.

## Root Cause

The recovery logic in `DefaultCandidateSource.eligible_scope` had two problems:

1. `recoverable_completed_issue_ids` only matched runs with `pull_request_number: nil` — a run that produced a closed PR was excluded
2. `pr_produced_issue_ids` matched any run that ever produced a PR, regardless of whether the PR was still open or had been closed without merging

## Fix

Check the actual PR state in the `issues` table:

- `recoverable_completed_issue_ids` now includes runs where the produced PR has a corresponding Issue record with `github_state = "closed"`
- `pr_produced_issue_ids` now only blocks when the PR is open or unsynced (conservative: unknown PR state blocks recovery, same as tracker references)
- Both queries share a `CLOSED_PR_CORRELATED_SUBQUERY` constant to prevent drift

## Test Plan

- [x] New test: excludes when PR is still open
- [x] New test: recovers when PR was closed without merging
- [x] New test: blocks recovery when one PR is closed but another is still open
- [x] All 31 existing DefaultCandidateSource specs pass
- [x] All 19 EnqueueEligible / BulkEnqueueEligible specs pass
- [x] Lint clean