### PR TITLE
feat: Allow users to choose which runners are eligible for chat sessions

### DIFF
--- a/app/controllers/runners_controller.rb
+++ b/app/controllers/runners_controller.rb
@@ -168,7 +168,7 @@ class RunnersController < ApplicationController
 
   def runner_params
     raw_params = params[resource_param_key] || params.fetch(:runner)
-    permitted = [ :enabled_for_agent_runs, :enabled_for_fallback, :name, :fallback_role, :agent_co_author_trailer, :weight ]
+    permitted = [ :enabled_for_agent_runs, :enabled_for_chat, :enabled_for_fallback, :name, :fallback_role, :agent_co_author_trailer, :weight ]
     if action_name == "create"
       permitted.push(:runner_key, :provider_key, :auth_type, :provider_api_key_id)
     end
@@ -345,6 +345,9 @@ class RunnersController < ApplicationController
       if @runner.enabled_for_agent_runs
         @runner.errors.add(:enabled_for_agent_runs, "must be disabled for an unsupported #{resource_noun}")
       end
+      if @runner.enabled_for_chat
+        @runner.errors.add(:enabled_for_chat, "must be disabled for an unsupported #{resource_noun}")
+      end
       if @runner.enabled_for_fallback
         @runner.errors.add(:enabled_for_fallback, "must be disabled for an unsupported #{resource_noun}")
       end
@@ -354,10 +357,14 @@ class RunnersController < ApplicationController
     return if resource_addable_key?(@runner.runner_key)
 
     setting_agent_runs = @runner.enabled_for_agent_runs && (@runner.new_record? || @runner.will_save_change_to_attribute?("enabled_for_agent_runs", to: true))
+    setting_chat = @runner.enabled_for_chat && (@runner.new_record? || @runner.will_save_change_to_attribute?("enabled_for_chat", to: true))
     setting_fallback = @runner.enabled_for_fallback && (@runner.new_record? || @runner.will_save_change_to_attribute?("enabled_for_fallback", to: true))
 
     if setting_agent_runs
       @runner.errors.add(:enabled_for_agent_runs, "cannot be enabled for a #{resource_noun} whose CLI is not installed in the agent container")
+    end
+    if setting_chat
+      @runner.errors.add(:enabled_for_chat, "cannot be enabled for a #{resource_noun} whose CLI is not installed in the agent container")
     end
     if setting_fallback
       @runner.errors.add(:enabled_for_fallback, "cannot be enabled for a #{resource_noun} whose CLI is not installed in the agent container")

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -99,6 +99,7 @@ class Runner < ApplicationRecord
 
   scope :kept_only, -> { kept }
   scope :for_agent_runs, -> { where(enabled_for_agent_runs: true) }
+  scope :for_chat, -> { where(enabled_for_chat: true) }
   scope :for_fallback, -> { where(enabled_for_fallback: true) }
   scope :ordered, -> { order(:runner_key, :auth_type, :name, :id) }
   scope :subscription, -> { where(auth_type: "subscription") }
@@ -507,6 +508,13 @@ class Runner < ApplicationRecord
 
     executable_keys = RunnerSupport.container_executable_runner_keys
     owner.runners.kept_only.for_agent_runs.where(runner_key: executable_keys).ordered.first
+  end
+
+  def self.first_chat_enabled_for_owner(owner)
+    return unless owner
+
+    executable_keys = RunnerSupport.container_executable_runner_keys
+    owner.runners.kept_only.for_chat.where(runner_key: executable_keys).ordered.first
   end
 
   def self.display_name_for(runner_key)

--- a/app/services/chat_sessions/create.rb
+++ b/app/services/chat_sessions/create.rb
@@ -89,6 +89,7 @@ module ChatSessions
           unless runner.user&.account_id == account.id
             raise ArgumentError, "runner must belong to the same account"
           end
+          raise ArgumentError, "runner must be enabled for chat" unless runner.enabled_for_chat?
         end
       else
         default_runner_for_user
@@ -105,7 +106,7 @@ module ChatSessions
     end
 
     def default_runner_for_user
-      Runner.first_enabled_for_owner(user)
+      Runner.first_chat_enabled_for_owner(user)
     end
   end
 end

--- a/app/views/runners/_form.html.erb
+++ b/app/views/runners/_form.html.erb
@@ -355,6 +355,11 @@
     </div>
 
     <div class="flex items-center">
+      <%= form.check_box :enabled_for_chat, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+      <%= form.label :enabled_for_chat, "Enable for chat sessions", class: "ml-3 block text-sm font-medium text-gray-900" %>
+    </div>
+
+    <div class="flex items-center">
       <%= form.check_box :enabled_for_fallback, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
       <%= form.label :enabled_for_fallback, "Allow as fallback runner", class: "ml-3 block text-sm font-medium text-gray-900" %>
     </div>

--- a/app/views/runners/index.html.erb
+++ b/app/views/runners/index.html.erb
@@ -4,7 +4,7 @@
   <div class="mb-6 flex items-center justify-between">
     <div>
       <h1 class="text-xl font-semibold text-gray-900">Runners</h1>
-      <p class="mt-1 text-sm text-gray-500">Configure runners available for agent runs and fallback routing.</p>
+      <p class="mt-1 text-sm text-gray-500">Configure runners available for agent runs, chat sessions, and fallback routing.</p>
     </div>
     <% if @addable_runner_options.any? %>
       <%= link_to "Add Runner", new_runner_path, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
@@ -25,6 +25,7 @@
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Runner</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Auth</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Agent Runs</th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Chat</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Fallback</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Usage (7d)</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Fallback Rate</th>
@@ -51,6 +52,7 @@
               <% end %>
             </td>
             <td class="px-4 py-3 text-sm text-gray-700"><%= runner.enabled_for_agent_runs? ? "Enabled" : "Disabled" %></td>
+            <td class="px-4 py-3 text-sm text-gray-700"><%= runner.enabled_for_chat? ? "Enabled" : "Disabled" %></td>
             <td class="px-4 py-3 text-sm text-gray-700">
               <% if runner.api_key? && runner.rate_limit_fallback? %>
                 <%= runner.enabled_for_fallback? ? "Enabled (rate-limit only)" : "Disabled (rate-limit only)" %>

--- a/db/migrate/20260523232320_add_enabled_for_chat_to_runners.rb
+++ b/db/migrate/20260523232320_add_enabled_for_chat_to_runners.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddEnabledForChatToRunners < ActiveRecord::Migration[8.1]
+  def change
+    add_column :runners, :enabled_for_chat, :boolean, default: true, null: false,
+      comment: "Whether the runner is eligible to back interactive chat sessions."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_23_041806) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_23_232320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1902,6 +1902,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_23_041806) do
     t.datetime "created_at", null: false
     t.datetime "discarded_at", comment: "Soft-delete timestamp so historical provider names remain available for filters and run history."
     t.boolean "enabled_for_agent_runs", default: true, null: false
+    t.boolean "enabled_for_chat", default: true, null: false, comment: "Whether the runner is eligible to back interactive chat sessions."
     t.boolean "enabled_for_fallback", default: true, null: false
     t.string "fallback_role", limit: 30, default: "standard", null: false
     t.bigint "integration_credential_id"

--- a/spec/factories/runners.rb
+++ b/spec/factories/runners.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     runner_key { "cursor" }
     auth_type { "subscription" }
     enabled_for_agent_runs { true }
+    enabled_for_chat { true }
     enabled_for_fallback { true }
     fallback_role { "standard" }
     config { {} }

--- a/spec/requests/runners_spec.rb
+++ b/spec/requests/runners_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe "Runners" do
         expect(response.body).to include("The active automated runner is excluded automatically for each run")
       end
 
+      it "shows the chat eligibility column" do
+        get runners_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Chat")
+      end
+
       it "renders collapsed auth instructions for every supported runner" do
         get runners_path
 
@@ -400,10 +407,10 @@ RSpec.describe "Runners" do
       allow(RunnerSupport).to receive(:addable_runner_key?).and_call_original
       allow(RunnerSupport).to receive(:addable_runner_key?).with("cursor").and_return(true)
 
-      post runners_path, params: { runner: { runner_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true } }
+      post runners_path, params: { runner: { runner_key: "cursor", enabled_for_agent_runs: true, enabled_for_chat: false, enabled_for_fallback: true } }
 
       expect(response).to redirect_to(runners_path)
-      expect(user.runners.find_by(runner_key: "cursor")).to be_present
+      expect(user.runners.find_by(runner_key: "cursor")).to have_attributes(enabled_for_chat: false)
     end
 
     it "handles an empty run-runner list during settings reconciliation" do
@@ -595,10 +602,11 @@ RSpec.describe "Runners" do
     it "updates runner flags" do
       runner = user.runners.create!(runner_key: "cursor")
 
-      patch runner_path(runner), params: { runner: { enabled_for_agent_runs: false } }
+      patch runner_path(runner), params: { runner: { enabled_for_agent_runs: false, enabled_for_chat: false } }
 
       expect(response).to redirect_to(runners_path)
       expect(runner.reload.enabled_for_agent_runs).to be(false)
+      expect(runner.reload.enabled_for_chat).to be(false)
     end
 
     it "persists the agent_co_author_trailer on update" do
@@ -666,6 +674,18 @@ RSpec.describe "Runners" do
       allow(RunnerSupport).to receive(:supported_runner_key?).with("cursor").and_return(false)
 
       patch runner_path(runner), params: { runner: { enabled_for_fallback: true } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("must be disabled for an unsupported runner")
+    end
+
+    it "rejects enabling chat on a runner that has become unsupported" do
+      runner = user.runners.create!(runner_key: "cursor", enabled_for_chat: false)
+
+      allow(RunnerSupport).to receive(:supported_runner_key?).and_call_original
+      allow(RunnerSupport).to receive(:supported_runner_key?).with("cursor").and_return(false)
+
+      patch runner_path(runner), params: { runner: { enabled_for_chat: true } }
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("must be disabled for an unsupported runner")

--- a/spec/services/chat_sessions/create_spec.rb
+++ b/spec/services/chat_sessions/create_spec.rb
@@ -61,6 +61,17 @@ RSpec.describe ChatSessions::Create do
       expect(session.model).to eq("gpt-4o")
     end
 
+    it "defaults to the first chat-eligible runner" do
+      non_chat_runner = user.runners.find_by!(runner_key: "claude")
+      non_chat_runner.update!(enabled_for_chat: false)
+      chat_runner = create(:runner, user: user, runner_key: "cursor", enabled_for_chat: true)
+
+      session = described_class.call(account: account, user: user)
+
+      expect(session.runner).to eq(chat_runner)
+      expect(session.runner).not_to eq(non_chat_runner)
+    end
+
     it "accepts provider_id as a legacy alias for runner_id" do
       runner = create(:runner, user: user)
       session = described_class.call(
@@ -80,6 +91,14 @@ RSpec.describe ChatSessions::Create do
       expect {
         described_class.call(account: account, user: user, runner_id: runner.id)
       }.to raise_error(ArgumentError, /same account/)
+    end
+
+    it "raises when the selected runner is not enabled for chat" do
+      runner = create(:runner, user: user, enabled_for_chat: false)
+
+      expect {
+        described_class.call(account: account, user: user, runner_id: runner.id)
+      }.to raise_error(ArgumentError, /enabled for chat/)
     end
 
     it "creates a workspace mode session" do


### PR DESCRIPTION
## Summary

Adds chat runner eligibility so users can control which runners are available for chat sessions, mirroring the existing agent-run and fallback eligibility controls. This closes the inconsistency where chat sessions ignored user runner preferences.

## Changes

- **Database**: New migration adds an `enabled_for_chat` flag to runners, defaulting to `true` so existing runners stay chat-eligible after deploy.
- **Models**: Runner exposes the new `enabled_for_chat` attribute alongside the existing eligibility flags.
- **Services**: Chat session runner selection now filters to `enabled_for_chat` runners and explicitly rejects a chosen runner that is not chat-eligible.
- **UI**: Runner settings form surfaces the chat eligibility toggle next to the agent-run and fallback toggles, following the same pattern.

## Design Decisions

- **Default to `true` on migration** to preserve current behavior — all enabled runners remain chat-eligible until an operator opts a runner out, satisfying the acceptance criterion that existing chat behavior is unchanged.
- **Explicit rejection** when a caller passes a non-chat-eligible runner, rather than silently falling back, so misconfigurations surface loudly instead of routing chat to an unintended runner.

## Operational Notes

- Requires running the migration on deploy; no backfill is needed because the column defaults to `true`.

## Screenshots

_Please attach before/after screenshots of the runner settings UI showing the new chat eligibility toggle alongside the existing controls._

---

Closes #2117