### PR TITLE
fix: upgrade agent-harness once --disallowedTools CLI compat fix lands upstream

### DIFF
--- a/spec/services/runners/harness_execution_plan_spec.rb
+++ b/spec/services/runners/harness_execution_plan_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe Runners::HarnessExecutionPlan do
       expect(plan.command).to eq(%w[copilot --autopilot --max-autopilot-continues 50 --output-format json -p ping])
       expect(plan.env).to include("COPILOT_ALLOW_ALL" => "true")
     end
+
+    it "keeps the prompt positional when Claude tools are disabled" do
+      allow(AgentHarness).to receive(:provider_class).and_call_original
+      allow(AgentHarness).to receive(:build_config).and_call_original
+
+      plan = described_class.for_runner_key(
+        runner_key: "claude",
+        prompt: "Say hello",
+        options: { tools: :none }
+      )
+
+      disallowed_tools_flag = plan.command.find { |part| part.start_with?("--disallowedTools=") }
+
+      expect(disallowed_tools_flag).to start_with("--disallowedTools=Agent,Bash,")
+      expect(plan.command).not_to include("--disallowedTools")
+      expect(plan.command.last).to eq("Say hello")
+    end
   end
 
   describe ".call" do


### PR DESCRIPTION
## Summary

Lock in the upstream `agent-harness` fix for Claude CLI v2.1.92+ `--disallowedTools` handling so the regression that broke all `tools: :none` LLM calls cannot silently return. The upstream patch (viamin/agent-harness#212) already shipped in `agent-harness 0.18.1` and this repo is on `0.18.2`, so no dependency bump is required — this PR adds a regression spec that guards the expected CLI flag shape.

## Changes

- **Tests**: Added `spec/services/runners/harness_execution_plan_spec.rb` asserting Paid's harness execution plan emits a single comma-joined `--disallowedTools=tool1,tool2,...` flag and preserves the prompt as the final positional argument.

## Design Decisions

- **No Gemfile change needed**: Verified the installed `agent-harness 0.18.2` already contains the fixed `flags = ["--disallowedTools=#{tool_names.join(",")}"]` implementation, so the local gem patch described in the issue is no longer load-bearing and the lockfile is already past the affected version.
- **Regression spec over integration test**: Rather than exercising every one of the 13 affected callers, the spec pins the contract at the execution-plan layer — the single point where the CLI flag shape is decided — so any future upstream regression that reintroduces varargs `--disallowedTools` fails loudly here.
- **Manual `enhance_issue` end-to-end run not performed**: The available environment supports tests but not a clean app/worker manual run; reviewers wanting that validation should trigger it against a test issue post-merge.

---

Closes #1897