### PR TITLE
docs(style-guides): note divergence between human docs and seeded DB guides

### DIFF
--- a/docs/LLM_STYLE_GUIDE.md
+++ b/docs/LLM_STYLE_GUIDE.md
@@ -1,7 +1,6 @@
 # Paid LLM Style Cheat Sheet
 
 > Concise rules for AI coding assistants working on Paid. Use this as the quick reference for generation. For rationale and examples, see `STYLE_GUIDE.md`.
-
 > **Note:** Some of the guidance in this document is also seeded as global `StyleGuide` records in [`db/seeds/style_guides.rb`](../db/seeds/style_guides.rb). The DB-backed guides are what reach agent prompts via `StyleGuides::InjectIntoPrompt`; this document is a human reference. Edits intended to reach agents must update the seed file or be made through the StyleGuide admin UI (`/admin/resources/style_guides`). The two surfaces may drift over time — that is acceptable as long as contributors know both exist.
 
 ## 1. Core Architecture

--- a/docs/LLM_STYLE_GUIDE.md
+++ b/docs/LLM_STYLE_GUIDE.md
@@ -2,6 +2,8 @@
 
 > Concise rules for AI coding assistants working on Paid. Use this as the quick reference for generation. For rationale and examples, see `STYLE_GUIDE.md`.
 
+> **Note:** Some of the guidance in this document is also seeded as global `StyleGuide` records in [`db/seeds/style_guides.rb`](../db/seeds/style_guides.rb). The DB-backed guides are what reach agent prompts via `StyleGuides::InjectIntoPrompt`; this document is a human reference. Edits intended to reach agents must update the seed file or be made through the StyleGuide admin UI (`/admin/resources/style_guides`). The two surfaces may drift over time — that is acceptable as long as contributors know both exist.
+
 ## 1. Core Architecture
 
 - **ZFC**: Meaning/decisions -> AI. Mechanical/structural -> code. Never hard-code semantic analysis. `STYLE_GUIDE:11-94`

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -4,6 +4,8 @@ This style guide establishes coding standards, architectural patterns, and best 
 
 The guide emphasizes detailed reasoning for each decision. Understanding *why* a pattern exists is as important as knowing the pattern itself—it enables developers to make good judgment calls in novel situations.
 
+> **Note:** Some of the guidance in this document is also seeded as global `StyleGuide` records in [`db/seeds/style_guides.rb`](../db/seeds/style_guides.rb). The DB-backed guides are what reach agent prompts via `StyleGuides::InjectIntoPrompt`; this document is a human reference. Edits intended to reach agents must update the seed file or be made through the StyleGuide admin UI (`/admin/resources/style_guides`). The two surfaces may drift over time — that is acceptable as long as contributors know both exist.
+
 ---
 
 ## Core Architectural Principles


### PR DESCRIPTION
## Summary

Adds a note near the top of `docs/STYLE_GUIDE.md` and `docs/LLM_STYLE_GUIDE.md` clarifying that some of their content is also seeded as global `StyleGuide` records in the database, and that the DB-backed guides — not the docs — are what reach agent prompts. This prevents contributors from updating only one surface and assuming agents will pick up the change.

## Changes

- **docs/STYLE_GUIDE.md**: Added a short paragraph near the top noting the parallel DB-backed `StyleGuide` records, linking to `db/seeds/style_guides.rb` and the StyleGuide admin route, and explaining that edits intended to reach agents must update the seed (or go through the admin UI).
- **docs/LLM_STYLE_GUIDE.md**: Added the equivalent note in the same location, with the same links and guidance.

## Design Decisions

- **Accept drift between the two surfaces** rather than trying to keep them in lockstep. The issue explicitly calls this out as acceptable as long as contributors know both exist; mechanically syncing them would add maintenance burden without clear benefit, since the docs serve human readers and the seeds serve agents.
- **Documentation-only change** — no code, schema, or seed modifications. The seeds and admin UI already exist from PR #2249; this PR only closes the discoverability gap.

---

Closes #2255