### PR TITLE
fix(github-sync): backfilled issues from reconciliation not evaluated for auto-pick

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -62,7 +62,12 @@ module Activities
           stale_pr_count = stale_pr_result[:closed_count]
           sync_changed ||= stale_pr_result[:changed]
 
-          stale_issue_result = reconcile_open_issues(project, client)
+          stale_issue_result = reconcile_open_issues(
+            project,
+            client,
+            eager_queue_enabled: eager_queue_enabled,
+            eligible_issues: eligible_issues
+          )
           stale_issue_count = stale_issue_result[:closed_count]
           sync_changed ||= stale_issue_result[:changed]
         end
@@ -765,7 +770,7 @@ module Activities
     # numbers from GitHub and closes locally-open issues not in that set.
     # Gated by ISSUE_RECONCILIATION_INTERVAL (default 1 hour) to limit API
     # cost, since issue counts can be much larger than PR counts.
-    def reconcile_open_issues(project, client)
+    def reconcile_open_issues(project, client, eager_queue_enabled: false, eligible_issues: nil)
       return { changed: false, closed_count: 0 } unless issue_reconciliation_due?(project)
 
       open_numbers, truncated = fetch_open_issue_numbers(client, project.full_name)
@@ -780,7 +785,13 @@ module Activities
         return { changed: false, closed_count: 0 }
       end
 
-      backfilled_count = backfill_open_issues(project, client, open_numbers)
+      backfilled_count = backfill_open_issues(
+        project,
+        client,
+        open_numbers,
+        eager_queue_enabled: eager_queue_enabled,
+        eligible_issues: eligible_issues
+      )
 
       stale = project.issues
         .where(github_state: "open", is_pull_request: false, source: Issue::GITHUB_SOURCE)
@@ -803,7 +814,7 @@ module Activities
       }
     end
 
-    def backfill_open_issues(project, client, open_issue_numbers)
+    def backfill_open_issues(project, client, open_issue_numbers, eager_queue_enabled: false, eligible_issues: nil)
       return 0 if open_issue_numbers.empty?
 
       existing_open_numbers = project.issues
@@ -815,7 +826,12 @@ module Activities
 
       missing_numbers.each do |number|
         github_issue = client.issue(project.full_name, number)
-        sync_issue(project, github_issue)
+        sync_issue(
+          project,
+          github_issue,
+          eager_queue_enabled: eager_queue_enabled,
+          eligible_issues: eligible_issues
+        )
       end
 
       missing_numbers.size

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -1892,6 +1892,31 @@ RSpec.describe Activities::FetchIssuesActivity do
           expect(issue.is_pull_request).to be false
         end
 
+        it "eagerly enqueues backfilled issues during incremental sync when auto-pick is enabled" do
+          project.update!(auto_pick_enabled: true)
+          allow(Issues::EnqueueEligible).to receive(:call)
+
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(
+            project.full_name,
+            hash_including(state: "open")
+          ).and_return([
+            OpenStruct.new(number: 52, pull_request: nil)
+          ])
+          allow(github_client).to receive(:issue).with(project.full_name, 52).and_return(
+            github_issue(52, id: 6002, title: "Recovered issue")
+          )
+
+          activity.execute(project_id: project.id)
+
+          synced_issue = project.issues.find_by!(github_issue_id: 6002)
+          expect(Issues::EnqueueEligible).to have_received(:call).with(
+            synced_issue,
+            project: project,
+            skip_project_gate: true
+          )
+        end
+
         it "refreshes the project show page when issue reconciliation only backfills a missing issue" do
           create_synced_issue_from_github(project, updated_issue, relationships_parsed_at: updated_issue.updated_at)
 


### PR DESCRIPTION
## Summary

Backfilled issues discovered during reconciliation are now evaluated for auto-pick in the same incremental sync cycle, instead of waiting up to 15 minutes for the periodic eligibility sweep. This closes a gap where P1 issues that existed on GitHub but were missing locally would remain unevaluated at `paid_state: "new"` after being synced.

## Changes

- **Activities**: Threaded `eager_queue_enabled` and `eligible_issues` through `reconcile_open_issues` into `backfill_open_issues` in `app/temporal/activities/fetch_issues_activity.rb`, so `sync_issue` receives the same eligibility-tracking context used by the main incremental sync path.
- **Tests**: Added a regression spec in `spec/temporal/activities/fetch_issues_activity_spec.rb` covering the incremental auto-pick case for a reconciliation-backfilled issue.

## Design Decisions

- Kept the fix surgical — passed the existing parameters through the call chain rather than restructuring reconciliation or introducing a separate post-sync eligibility pass. The candidate list already exists for this purpose; backfill just wasn't contributing to it.
- Relies on the existing `AutoPickEligibilitySweepJob` as a backstop, so issues discovered outside an incremental sync window remain covered.

---

Closes #2230