### PR TITLE
feat(agent-runs): RDR-034 phase 0 — loosen runner fallback model filter (tactical)

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1824,7 +1824,8 @@ class AgentRun < ApplicationRecord
   # @param runner [String] The runner name
   # @param success [Boolean] Whether the attempt succeeded
   # @param error_type [String, nil] Type of error if failed (e.g., "rate_limited", "error")
-  def record_runner_attempt(runner, success:, error_type: nil, error_message: nil, duration_seconds: nil, diagnostics: nil)
+  def record_runner_attempt(runner, success:, error_type: nil, error_message: nil, duration_seconds: nil,
+                            diagnostics: nil, resolved_model_id: nil, resolved_provider_id: nil)
     attempt = {
       "runner" => runner,
       "success" => success,
@@ -1835,6 +1836,8 @@ class AgentRun < ApplicationRecord
     attempt["error_message"] = sanitized_error_message if sanitized_error_message.present?
     attempt["duration_seconds"] = duration_seconds if duration_seconds.present?
     attempt["diagnostics"] = sanitize_runner_attempt_diagnostics(diagnostics) if diagnostics.present?
+    attempt["resolved_model_id"] = resolved_model_id if resolved_model_id.present?
+    attempt["resolved_provider_id"] = resolved_provider_id if resolved_provider_id.present?
 
     self.runners_attempted = (runners_attempted || []) + [ attempt ]
     save!

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -180,6 +180,7 @@ module Activities
           runner = runner_command_key(runner_candidate, agent_run, user_settings.user)
           attempt_label = runner_attempt_label(runner_candidate, agent_run, user_settings.user)
           runner_state_name = state_key_for(runner_candidate, runner, user_settings.user)
+          resolved_run_info = resolved_model_info_for(runner_candidate, agent_run, user_settings.user)
           heartbeat("runner_attempt", runner, index)
 
           # Skip unavailable runners, tracking rate-limited skips separately
@@ -196,7 +197,8 @@ module Activities
               attempt_label,
               success: false,
               error_type: error_type,
-              error_message: error_message
+              error_message: error_message,
+              **resolved_run_info
             )
             index += 1
             next
@@ -219,7 +221,8 @@ module Activities
             # Success - heartbeat and record final runner
             heartbeat("runner_completed", runner)
             record_runner_success(user_settings, runner_state_name, runner_states)
-            agent_run.record_runner_attempt(attempt_label, success: true, duration_seconds: attempt_duration)
+            agent_run.record_runner_attempt(attempt_label, success: true, duration_seconds: attempt_duration,
+              **resolved_run_info)
             # Persist the routing key so multiple entries sharing the same
             # runner_key (e.g. several OpenCode API-key entries with
             # different models) remain distinguishable in UI and retry logic.
@@ -288,7 +291,8 @@ module Activities
               success: false,
               error_type: "rate_limited",
               error_message: e.message,
-              duration_seconds: attempt_duration
+              duration_seconds: attempt_duration,
+              **resolved_run_info
             )
             logger.info(message: "agent_execution.rate_limited", runner: runner, agent_run_id: agent_run.id, duration_seconds: attempt_duration)
             if container_unavailable_for_fallback?(agent_run)
@@ -325,7 +329,8 @@ module Activities
               success: false,
               error_type: "infinite_loop",
               error_message: e.message,
-              duration_seconds: attempt_duration
+              duration_seconds: attempt_duration,
+              **resolved_run_info
             )
             logger.warn(message: "agent_execution.infinite_loop_detected", agent_run_id: agent_run.id, reason: e.message, duration_seconds: attempt_duration)
 
@@ -359,7 +364,8 @@ module Activities
               error_type: "timeout",
               error_message: e.message,
               duration_seconds: attempt_duration,
-              diagnostics: e.diagnostics
+              diagnostics: e.diagnostics,
+              **resolved_run_info
             )
             logger.warn(message: "agent_execution.runner_timeout", runner: runner, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
             if container_unavailable_for_fallback?(agent_run)
@@ -398,7 +404,8 @@ module Activities
               success: false,
               error_type: "preflight_timeout",
               error_message: e.message,
-              duration_seconds: attempt_duration
+              duration_seconds: attempt_duration,
+              **resolved_run_info
             )
             logger.warn(
               message: "agent_execution.preflight_timeout",
@@ -417,7 +424,8 @@ module Activities
               success: false,
               error_type: "auth_expired",
               error_message: e.message,
-              duration_seconds: attempt_duration
+              duration_seconds: attempt_duration,
+              **resolved_run_info
             )
             logger.warn(message: "agent_execution.auth_expired", runner: runner, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
             break
@@ -433,7 +441,8 @@ module Activities
               success: false,
               error_type: "error",
               error_message: e.message,
-              duration_seconds: attempt_duration
+              duration_seconds: attempt_duration,
+              **resolved_run_info
             )
             logger.warn(
               message: "agent_execution.runner_infra_failure",
@@ -455,7 +464,8 @@ module Activities
               success: false,
               error_type: "error",
               error_message: e.message,
-              duration_seconds: attempt_duration
+              duration_seconds: attempt_duration,
+              **resolved_run_info
             )
             logger.warn(message: "agent_execution.runner_failed", runner: runner, agent_run_id: agent_run.id, error: e.message, duration_seconds: attempt_duration)
 
@@ -727,25 +737,45 @@ module Activities
     end
 
     # Returns true when a runner candidate is structurally compatible with the
-    # selected LlmModel. Checks provider family and fixed runtime model.
+    # selected LlmModel. Checks only the provider family; direct-outbound
+    # runners (kilocode, opencode, pi) are always compatible because they
+    # use their own configured model and are not in the provider-family map.
+    #
+    # TODO(RDR-034): replace with tier-based filter in Phase 2 — the
+    #   provider-family check will be replaced by runner_supports_tier?
+    #   once tier_models columns and ResolveTierModel are in place.
     def runner_compatible_with_model?(runner_candidate, selected_model, user)
       runner_entry = runner_entry_for(runner_candidate, user)
       runner_key = runner_entry&.runner_key || RunnerSupport.runner_key_for_agent_type(runner_candidate)
 
-      # 1. Provider family check — e.g. "claude" expects "anthropic"
+      # Provider family check — e.g. "claude" expects "anthropic".
+      # Direct-outbound runners (kilocode, opencode, pi, aider) are not in
+      # the RUNNER_KEY_TO_MODEL_PROVIDER map, so this check is a no-op for
+      # them — they are always compatible because they bring their own model.
       compatible_provider = Runners::DefaultTierModelIds::RUNNER_KEY_TO_MODEL_PROVIDER[runner_key.to_s]
       if compatible_provider.present? && selected_model.provider != compatible_provider
         return false
       end
 
-      # 2. Fixed runtime model check — direct-outbound runners have a
-      #    configured model that must match the selected model exactly.
-      fixed_model_id = runner_entry&.direct_outbound_model_id
-      if fixed_model_id.present? && fixed_model_id != selected_model.model_id
-        return false
-      end
-
       true
+    end
+
+    # Returns the model and provider that a runner candidate will actually
+    # use at execution time. For direct-outbound runners (kilocode, opencode,
+    # pi, aider) this is the runner's configured model; for subscription
+    # runners it falls back to the selected model from the agent run.
+    #
+    # Used to populate resolved_model_id / resolved_provider_id on
+    # runners_attempted entries so analytics can see what actually ran.
+    def resolved_model_info_for(runner_candidate, agent_run, user)
+      runner_entry = runner_entry_for(runner_candidate, user)
+      model_id = runner_entry&.direct_outbound_model_id || agent_run&.model_selection&.llm_model&.model_id
+      provider_id = runner_entry&.id
+
+      result = {}
+      result[:resolved_model_id] = model_id if model_id.present?
+      result[:resolved_provider_id] = provider_id if provider_id.present?
+      result
     end
 
     def paused_result(agent_run_id)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -320,7 +320,7 @@ module Activities
             last_error = "infinite_loop"
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             if cancelled_by_cleanup?(agent_run)
-              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e, resolved_run_info: resolved_run_info)
               break
             end
             record_runner_failure(user_settings, runner_state_name, runner_states)
@@ -354,7 +354,7 @@ module Activities
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             timeout_error ||= e.message
             if cancelled_by_cleanup?(agent_run)
-              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e, resolved_run_info: resolved_run_info)
               break
             end
             record_runner_failure(user_settings, runner_state_name, runner_states)
@@ -390,7 +390,7 @@ module Activities
             last_error = "error"
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             if cancelled_by_cleanup?(agent_run)
-              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e, resolved_run_info: resolved_run_info)
               break
             end
             record_runner_failure(
@@ -433,7 +433,7 @@ module Activities
             last_error = "error"
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             if cancelled_by_cleanup?(agent_run)
-              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e, resolved_run_info: resolved_run_info)
               break
             end
             agent_run.record_runner_attempt(
@@ -455,7 +455,7 @@ module Activities
             last_error = "error"
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
             if cancelled_by_cleanup?(agent_run)
-              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e)
+              record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, e, resolved_run_info: resolved_run_info)
               break
             end
             record_runner_failure(user_settings, runner_state_name, runner_states)
@@ -920,8 +920,8 @@ module Activities
     # records the attempt with a distinct error_type so the UI can show what
     # happened, but skips both record_runner_failure and the standard warn
     # log (which would imply a real runner problem).
-    def record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, error)
-      agent_run.record_runner_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup")
+    def record_cleanup_cancelled_attempt(agent_run, attempt_label, runner, error, resolved_run_info: {})
+      agent_run.record_runner_attempt(attempt_label, success: false, error_type: "cancelled_by_cleanup", **resolved_run_info)
       logger.info(
         message: "agent_execution.cancelled_by_cleanup",
         runner: runner,

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -718,6 +718,10 @@ module Activities
         end
 
       return if configured_model_id.blank? || configured_model_id == selected_model_id
+      # TODO(RDR-034): replace with tier-based runtime resolution in Phase 2.
+      # Tactical Phase 0 keeps direct-outbound runners on their configured
+      # runtime even when the meta-agent selected a different primary model.
+      return if runner_entry&.respond_to?(:requires_direct_outbound?) && runner_entry.requires_direct_outbound?
 
       runner_label = runner_entry&.display_name || runner_entry&.runner_key || "runner"
       raise RunnerExecutionError,

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1213,29 +1213,33 @@ RSpec.describe Activities::RunAgentActivity do
         expect(runners).not_to include(codex_runner.routing_key)
       end
 
-      it "excludes direct-outbound runners whose fixed model differs from the selection" do
-        llm_model = create(:llm_model, model_id: "moonshotai/kimi-k2-0905", provider: "openrouter")
+      it "includes direct-outbound runners even when their fixed model differs from the selection" do
+        # TODO(RDR-034): replace with tier-based filter in Phase 2.
+        # Phase 0 loosens the model-compatibility filter so direct-outbound
+        # fallback runners (kilocode, opencode, pi) are never excluded by
+        # model mismatch — they bring their own configured model.
+        llm_model = create(:llm_model, model_id: "claude-sonnet-4-6", provider: "anthropic")
         create(:model_selection, agent_run: agent_run, llm_model: llm_model)
 
         api_key = create(:runner_api_key, user: user, api_service_type: "openrouter")
-        matching_runner = create_opencode_runner_entry(
+        mismatched_runner = create_opencode_runner_entry(
           user: user, api_key: api_key,
           name: "Kimi K2", model: "moonshotai/kimi-k2-0905"
         )
-        other_api_key = create(:runner_api_key, user: user, api_service_type: "openrouter", api_key: "sk-other")
-        mismatched_runner = create_opencode_runner_entry(
-          user: user, api_key: other_api_key,
-          name: "Deepseek", model: "deepseek-v4-pro"
-        )
+        codex_runner = create(:runner, user: user, runner_key: "codex")
         user.settings.update!(
           fallback_enabled: true,
-          fallback_runners: [ matching_runner.routing_key, mismatched_runner.routing_key ]
+          fallback_runners: [ mismatched_runner.routing_key, codex_runner.routing_key ]
         )
 
         runners = activity.send(:build_runner_order, agent_run, user.settings)
 
-        expect(runners).to include(matching_runner.routing_key)
-        expect(runners).not_to include(mismatched_runner.routing_key)
+        # Direct-outbound runner with a different model from the selection
+        # should NOT be filtered out (Phase 0 tactical fix).
+        expect(runners).to include(mismatched_runner.routing_key)
+        # Codex should still be filtered out because of provider-family
+        # mismatch (codex expects openai, selected model is anthropic).
+        expect(runners).not_to include(codex_runner.routing_key)
       end
 
       it "preserves all runners when no model is selected" do
@@ -2750,6 +2754,72 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.runners_attempted).to contain_exactly(
           hash_including("runner" => "claude_code", "success" => false, "error_type" => "timeout"),
           hash_including("runner" => "cursor", "success" => true)
+        )
+        expect(agent_run.runner_switches).to eq(1)
+      end
+    end
+
+    context "when primary preflight times out and direct-outbound fallback succeeds with a different model" do
+      let(:opencode_runner) do
+        api_key = create(:runner_api_key, user: user, api_service_type: "openrouter")
+        create_opencode_runner_entry(
+          user: user, api_key: api_key,
+          name: "Kimi K2", model: "moonshotai/kimi-k2-0905"
+        )
+      end
+
+      before do
+        llm_model = create(:llm_model, model_id: "claude-sonnet-4-6", provider: "anthropic")
+        create(:model_selection, agent_run: agent_run, llm_model: llm_model)
+
+        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude opencode])
+
+        user.settings.update!(
+          fallback_enabled: true,
+          fallback_runners: [ opencode_runner.routing_key ]
+        )
+
+        allow(git_ops).to receive_messages(
+          head_sha: "pre_agent_sha_abc123",
+          commit_uncommitted_changes: false,
+          has_changes_since?: false
+        )
+
+        call_count = 0
+        allow(activity).to receive(:run_agent_with_runner) do
+          call_count += 1
+          if call_count == 1
+            raise described_class::PreflightTimeoutError,
+              "Preflight check failed: Runner smoke preflight timed out after 30s"
+          else
+            { pre_agent_sha: "pre_agent_sha_abc123", output_present: true }
+          end
+        end
+
+        allow(activity).to receive(:run_runner_preflight!).and_call_original
+        allow(activity).to receive(:run_harness_preflight!)
+      end
+
+      it "falls back to the direct-outbound runner and records resolved model info" do
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        agent_run.reload
+        expect(result).to include(success: true)
+        expect(result[:final_runner]).to eq(opencode_runner.routing_key)
+
+        expect(agent_run.runners_attempted).to contain_exactly(
+          hash_including(
+            "runner" => "claude_code",
+            "success" => false,
+            "error_type" => "preflight_timeout",
+            "resolved_model_id" => "claude-sonnet-4-6"
+          ),
+          hash_including(
+            "runner" => opencode_runner.routing_key,
+            "success" => true,
+            "resolved_model_id" => "moonshotai/kimi-k2-0905",
+            "resolved_provider_id" => opencode_runner.id
+          )
         )
         expect(agent_run.runner_switches).to eq(1)
       end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -752,17 +752,16 @@ RSpec.describe Activities::RunAgentActivity do
       end
     end
 
-    it "raises when a fixed-runtime provider disagrees with the selected model" do
+    it "keeps the configured runtime when a direct-outbound runner disagrees with the selected model" do
       opencode_context = build_opencode_context(user)
       llm_model = create(:llm_model, model_id: "different-model", provider: "openrouter")
       create(:model_selection, agent_run: agent_run, llm_model: llm_model)
 
-      expect {
-        activity.send(:build_command, opencode_context, "ping", agent_run: agent_run)
-      }.to raise_error(
-        Activities::RunAgentActivity::RunnerExecutionError,
-        /Selected model different-model does not match configured runtime model moonshotai\/kimi-k2-0905/
-      )
+      command = activity.send(:build_command, opencode_context, "ping", agent_run: agent_run)
+      preparation = activity.send(:command_preparation_for, opencode_context, "ping")
+
+      expect(command).to eq([ "env", "-u", "OPENAI_HEADER_X_AGENT_RUN_ID", "-u", "OPENAI_HEADER_X_PROXY_TOKEN", "opencode", "run", "ping" ])
+      expect(preparation.file_writes.first.content).to include("\"model\": \"openrouter/moonshotai/kimi-k2-0905\"")
     end
   end
 
@@ -781,6 +780,15 @@ RSpec.describe Activities::RunAgentActivity do
       runtime = activity.send(:selected_runner_runtime, codex_provider, nil, run)
 
       expect(runtime).to be_nil
+    end
+
+    it "keeps the configured runtime for direct-outbound runners with a different selected model" do
+      opencode_context = build_opencode_context(user)
+      create(:model_selection, agent_run: agent_run, llm_model: create(:llm_model, model_id: "different-model", provider: "openrouter"))
+
+      runtime = activity.send(:selected_runner_runtime, opencode_context.runner_candidate, user, agent_run)
+
+      expect(runtime).to have_attributes(model: "openrouter/moonshotai/kimi-k2-0905", api_provider: nil)
     end
   end
 
@@ -1319,6 +1327,33 @@ RSpec.describe Activities::RunAgentActivity do
     expect(result[:success]).to be true
     expect(result[:final_runner]).to eq(opencode_runner.routing_key)
     expect(agent_run.reload.final_runner).to eq(opencode_runner.routing_key)
+  end
+
+  def expect_opencode_runtime_execute_calls(execute_calls)
+    expect(execute_calls.length).to eq(3)
+    expect(execute_calls.second.first[0..6]).to eq([ "env", "-u", "OPENAI_HEADER_X_AGENT_RUN_ID", "-u", "OPENAI_HEADER_X_PROXY_TOKEN", "opencode", "run" ])
+    expect(execute_calls.third.first[0..6]).to eq([ "env", "-u", "OPENAI_HEADER_X_AGENT_RUN_ID", "-u", "OPENAI_HEADER_X_PROXY_TOKEN", "opencode", "run" ])
+    expect(execute_calls.second.second[:env]).to include("OPENAI_BASE_URL" => "https://openrouter.ai/api/v1")
+    expect(execute_calls.third.second[:env]).to include("OPENAI_BASE_URL" => "https://openrouter.ai/api/v1")
+    expect(execute_calls.second.second[:preparation].file_writes.first.content).to include("\"model\": \"openrouter/moonshotai/kimi-k2-0905\"")
+    expect(execute_calls.third.second[:preparation].file_writes.first.content).to include("\"model\": \"openrouter/moonshotai/kimi-k2-0905\"")
+  end
+
+  def expect_resolved_model_attempts(agent_run, opencode_runner)
+    expect(agent_run.runners_attempted).to contain_exactly(
+      hash_including(
+        "runner" => "claude_code",
+        "success" => false,
+        "error_type" => "preflight_timeout",
+        "resolved_model_id" => "claude-sonnet-4-6"
+      ),
+      hash_including(
+        "runner" => opencode_runner.routing_key,
+        "success" => true,
+        "resolved_model_id" => "moonshotai/kimi-k2-0905",
+        "resolved_provider_id" => opencode_runner.id
+      )
+    )
   end
 
   def expect_timeout_fallback_recovery(agent_run)
@@ -2785,42 +2820,27 @@ expect(container_service).to receive(:execute).with(
           has_changes_since?: false
         )
 
-        call_count = 0
-        allow(activity).to receive(:run_agent_with_runner) do
-          call_count += 1
-          if call_count == 1
-            raise described_class::PreflightTimeoutError,
-              "Preflight check failed: Runner smoke preflight timed out after 30s"
-          else
-            { pre_agent_sha: "pre_agent_sha_abc123", output_present: true }
-          end
-        end
-
         allow(activity).to receive(:run_runner_preflight!).and_call_original
         allow(activity).to receive(:run_harness_preflight!)
       end
 
       it "falls back to the direct-outbound runner and records resolved model info" do
+        call_count = 0
+        execute_calls = []
+        allow(container_service).to receive(:execute) do |command, **opts|
+          call_count += 1
+          execute_calls << [ command, opts ]
+
+          call_count == 1 ? raise(Containers::Provision::TimeoutError, "execution timed out") : exec_success
+        end
+
         result = activity.execute(agent_run_id: agent_run.id)
 
         agent_run.reload
         expect(result).to include(success: true)
         expect(result[:final_runner]).to eq(opencode_runner.routing_key)
-
-        expect(agent_run.runners_attempted).to contain_exactly(
-          hash_including(
-            "runner" => "claude_code",
-            "success" => false,
-            "error_type" => "preflight_timeout",
-            "resolved_model_id" => "claude-sonnet-4-6"
-          ),
-          hash_including(
-            "runner" => opencode_runner.routing_key,
-            "success" => true,
-            "resolved_model_id" => "moonshotai/kimi-k2-0905",
-            "resolved_provider_id" => opencode_runner.id
-          )
-        )
+        expect_opencode_runtime_execute_calls(execute_calls)
+        expect_resolved_model_attempts(agent_run, opencode_runner)
         expect(agent_run.runner_switches).to eq(1)
       end
     end


### PR DESCRIPTION
## Summary

Restores fallback runner behavior when the meta-agent selects a model that only the primary runner can execute natively. Previously, `runner_compatible_with_model?` filtered out direct-outbound fallback runners whose configured model differed from the selected model, causing runs to fail with "All runners exhausted" when the primary runner's preflight timed out (e.g., agent run 19487). This is the tactical Phase 0 fix from RDR-034; the full tier-based design lands in later phases.

## Changes

**Runner compatibility filter** (`app/temporal/activities/run_agent_activity.rb`)
- Removed the `direct_outbound_model_id` mismatch rejection from `runner_compatible_with_model?`, so direct-outbound fallback runners (kilocode, opencode, pi, aider) are no longer excluded when the selected model differs from their configured model
- Preserved the provider-family check for non-direct-outbound runners (e.g., codex)
- Marked the loosened branch with `# TODO(RDR-034): replace with tier-based filter in Phase 2`

**Resolved model tracking** (`app/temporal/activities/run_agent_activity.rb`, `app/models/agent_run.rb`)
- Added `resolved_model_info_for` helper to compute the model and provider a runner will actually use at execution time
- Extended `record_runner_attempt` to accept optional `resolved_model_id:` and `resolved_provider_id:` kwargs
- Updated all `record_runner_attempt` call sites in the runner loop to include resolved model info
- Propagated `resolved_run_info` through `record_cleanup_cancelled_attempt` across all 5 rescue blocks so cancelled/errored attempts also carry correct resolved ids

**Tests** (`spec/temporal/activities/run_agent_activity_spec.rb`)
- Updated existing compatibility test to verify direct-outbound runners with mismatched models are now included
- Added integration spec: primary preflight times out → direct-outbound fallback succeeds with a different model → `runners_attempted` entries carry correct `resolved_model_id` and `resolved_provider_id`

## Design Decisions

- **No new columns or migrations**: `resolved_model_id` and `resolved_provider_id` are stored in the existing `runners_attempted` JSONB array entries, keeping this change purely application-level
- **Analytics inconsistency accepted**: `model_selections.llm_model_id` continues to pin the primary's selected model even when a fallback runner executes with a different model — this is a known trade-off documented in the issue and will be addressed in later RDR-034 phases
- **Provider-family check preserved**: Non-direct-outbound runners like codex still get filtered by provider family, since they genuinely cannot execute arbitrary models

---

Closes #2235