### PR TITLE
refactor(pr-review): remove legacy phase-specific breaker/reset plumbing and simplify stuck-state recovery

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -254,29 +254,12 @@ class Issue < ApplicationRecord
     pr_review_phase == "merged"
   end
 
-  def reset_review_goal_retry_breaker!
-    reset_at = Time.current
-
-    update!(
-      pr_review_phase: "ready",
-      review_goal_retry_count: 0,
-      review_goal_retry_reset_at: reset_at,
-      operational_failure_reset_at: reset_at
-    )
-  end
-
   def dismiss_escalation!(draft:)
-    reset_at = Time.current
     attrs = {
       labels: labels - %w[paid-escalated paid-dismiss-escalation],
       pr_review_phase: draft ? "restarted" : "ready",
-      pr_followup_count: 0,
-      review_goal_retry_count: 0,
-      review_goal_retry_reset_at: reset_at,
-      operational_failure_reset_at: reset_at,
       ci_retry_requested_at: nil
     }
-    attrs[:draft_review_count] = 0 if draft
 
     update!(attrs)
   end

--- a/app/services/automation/strategies/auto_continue.rb
+++ b/app/services/automation/strategies/auto_continue.rb
@@ -79,12 +79,6 @@ module Automation
       private
 
       def check_lifecycle_gates(context:, signals:)
-        # Escalation dismissal must win before any breaker can re-escalate
-        # the PR in the same cycle after the owner removes the label.
-        if signals.escalation_dismissed
-          return dismiss_escalation_result(signals)
-        end
-
         # Operational failure breaker — provider/infrastructure bursts only
         # escalate once the PR has also gone stale without meaningful
         # progress for too long.
@@ -151,16 +145,6 @@ module Automation
           )
         ])
       end
-
-      def dismiss_escalation_result(signals)
-        Result.new(decisions: [
-          Decision.dismiss_escalation(
-            issue_id: signals.issue_id,
-            draft: signals.draft
-          )
-        ])
-      end
-
       def delegate_to_auto_review(context)
         auto_review_strategy(context).evaluate(context)
       end

--- a/app/services/automation/strategies/auto_continue/signals.rb
+++ b/app/services/automation/strategies/auto_continue/signals.rb
@@ -21,15 +21,11 @@ module Automation
         :no_progress_stuck,
         :failure_streak_limit_reached,
         :review_goal_retry_limit_requires_escalation,
-        :escalation_dismissed,
         :owner_reviewer_login,
         :escalation_reason,
         :consecutive_unsuccessful_automatic_runs,
         :consecutive_operational_failures,
         :last_meaningful_progress_at,
-        :draft_review_count,
-        :review_goal_retry_count,
-        :pr_followup_count,
         :draft,
         :scan
       )
@@ -49,15 +45,11 @@ module Automation
               no_progress_stuck: value_for(lifecycle, :no_progress_stuck) == true,
               failure_streak_limit_reached: value_for(lifecycle, :failure_streak_limit_reached) == true,
               review_goal_retry_limit_requires_escalation: value_for(lifecycle, :review_goal_retry_limit_requires_escalation) == true,
-              escalation_dismissed: value_for(lifecycle, :escalation_dismissed) == true,
               owner_reviewer_login: value_for(lifecycle, :owner_reviewer_login),
               escalation_reason: value_for(lifecycle, :escalation_reason),
               consecutive_unsuccessful_automatic_runs: value_for(lifecycle, :consecutive_unsuccessful_automatic_runs).to_i,
               consecutive_operational_failures: value_for(lifecycle, :consecutive_operational_failures).to_i,
               last_meaningful_progress_at: value_for(lifecycle, :last_meaningful_progress_at),
-              draft_review_count: value_for(lifecycle, :draft_review_count).to_i,
-              review_goal_retry_count: value_for(lifecycle, :review_goal_retry_count).to_i,
-              pr_followup_count: value_for(lifecycle, :pr_followup_count).to_i,
               draft: value_for(lifecycle, :draft) == true,
               scan: value_for(metadata, :scan)
             )

--- a/app/services/coordination/escalation_service.rb
+++ b/app/services/coordination/escalation_service.rb
@@ -144,8 +144,6 @@ module Coordination
     end
 
     def auto_resolve_trigger?(policy)
-      return true if signals["escalation_dismissed"] == true
-
       trigger_types.any? { |type| policy["auto_resolve_trigger_types"].include?(type) }
     end
 

--- a/app/services/notifications/rules/stalled_draft_pr.rb
+++ b/app/services/notifications/rules/stalled_draft_pr.rb
@@ -6,7 +6,6 @@ module Notifications
       SOURCE = "stalled_draft_pr"
       NO_PROGRESS_ESCALATION_WINDOW = Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW
       ERROR_THRESHOLD = 10
-      STALL_THRESHOLD = 6.hours
 
       private
 

--- a/app/services/notifications/rules/stalled_draft_pr.rb
+++ b/app/services/notifications/rules/stalled_draft_pr.rb
@@ -4,8 +4,7 @@ module Notifications
   module Rules
     class StalledDraftPr < Rule
       SOURCE = "stalled_draft_pr"
-      FAILURE_STATUSES = %w[timeout failed cancelled auth_expired rate_limited].freeze
-      FAILURE_THRESHOLD = 3
+      NO_PROGRESS_ESCALATION_WINDOW = Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW
       ERROR_THRESHOLD = 10
       STALL_THRESHOLD = 6.hours
 
@@ -22,77 +21,63 @@ module Notifications
         return false unless issue.github_state == "open"
         return false unless issue.pr_review_phase.in?(%w[draft restarted])
         return false if issue.auto_continue_paused?
+        return false unless synced_with_latest_pr_state?(issue)
 
-        consecutive_failures(issue) >= FAILURE_THRESHOLD || stalled_duration(issue) >= STALL_THRESHOLD
+        progress_state_for(issue).stuck?(limit: issue.project.max_draft_review_rounds,
+          stale_after: NO_PROGRESS_ESCALATION_WINDOW)
       end
 
       def build(issue)
-        latest_run = latest_draft_followup_run(issue)
-        failures = consecutive_failures(issue)
+        progress_state = progress_state_for(issue)
+        failures = progress_state.consecutive_unsuccessful_automatic_runs
 
         {
           severity: failures >= ERROR_THRESHOLD ? :error : :warning,
-          title: "PR ##{issue.github_number} stuck in draft for #{human_duration(stall_since(issue))}",
-          description: description_for(issue, latest_run, failures),
+          title: "PR ##{issue.github_number} stuck in #{issue.pr_review_phase} for #{human_duration(stall_since(issue))}",
+          description: description_for(issue, progress_state, failures),
           nav_section: "projects",
           action_url: project_path(issue.project),
           metadata: {
             consecutive_failures: failures,
-            latest_run_id: latest_run&.id,
-            earliest_failure_at: earliest_failure_at(issue)&.iso8601
+            latest_unsuccessful_run_at: progress_state.latest_unsuccessful_run_at&.iso8601,
+            latest_unsuccessful_run_goal: progress_state.latest_unsuccessful_run_goal,
+            latest_unsuccessful_run_status: progress_state.latest_unsuccessful_run_status
           }.compact
         }
       end
 
-      def description_for(issue, latest_run, failures)
+      def description_for(issue, progress_state, failures)
         parts = []
-        parts << "#{failures} consecutive failed draft follow-ups" if failures.positive?
-        parts << "latest error: #{latest_run.error_message}" if latest_run&.error_message.present?
-        parts << "latest run: #{project_agent_run_path(issue.project, latest_run)}" if latest_run
+        parts << "#{failures} consecutive unsuccessful automatic PR runs" if failures.positive?
+        if progress_state.latest_unsuccessful_run_goal.present? && progress_state.latest_unsuccessful_run_status.present?
+          parts << "latest run: #{progress_state.latest_unsuccessful_run_goal} #{progress_state.latest_unsuccessful_run_status}"
+        end
         parts.join(". ")
       end
 
-      def stalled_duration(issue)
-        since = stall_since(issue)
-        return 0 unless since
-
-        Time.current - since
-      end
-
       def stall_since(issue)
-        last_progress_run(issue)&.completed_at || earliest_failure_at(issue) || issue.github_updated_at || issue.created_at
+        progress_state = progress_state_for(issue)
+        progress_state.last_meaningful_progress_at || progress_state.latest_unsuccessful_run_at || issue.github_updated_at || issue.created_at
       end
 
-      def earliest_failure_at(issue)
-        failure_streak(issue).last&.created_at
+      def resolve_candidates(scope)
+        Array(scope).select do |issue|
+          issue.github_state != "open" ||
+            !issue.pr_review_phase.in?(%w[draft restarted]) ||
+            synced_with_latest_pr_state?(issue)
+        end
       end
 
-      def consecutive_failures(issue)
-        failure_streak(issue).size
+      def synced_with_latest_pr_state?(issue)
+        return false if issue.last_pr_scan_at.blank?
+        return true if issue.github_updated_at.blank?
+
+        issue.last_pr_scan_at >= issue.github_updated_at
       end
 
-      def failure_streak(issue)
-        @failure_streaks ||= {}
-        @failure_streaks[issue.id] ||= draft_followup_runs(issue).take_while { |run| FAILURE_STATUSES.include?(run.status) }
-      end
-
-      def latest_draft_followup_run(issue)
-        draft_followup_runs(issue).first
-      end
-
-      def last_progress_run(issue)
-        draft_followup_runs(issue).find { |run| run.status.in?(%w[completed no_output]) }
-      end
-
-      def draft_followup_runs(issue)
-        @draft_followup_runs ||= {}
-        @draft_followup_runs[issue.id] ||= issue.project.agent_runs
-          .where(source_pull_request_number: issue.github_number, trigger_type: "automatic", goal: "create_pr")
-          .where(count_toward_draft_review_round: true)
-          .finished
-          .order(created_at: :desc)
-          .limit(ERROR_THRESHOLD)
-          .to_a
+      def progress_state_for(issue)
+        @progress_states ||= {}
+        @progress_states[issue.id] ||= issue.pr_progress_state
       end
     end
   end

--- a/app/temporal/activities/dismiss_escalation_activity.rb
+++ b/app/temporal/activities/dismiss_escalation_activity.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 module Activities
-  # Resets an escalated PR back into an automation-managed phase after the
-  # owner dismisses escalation by removing the paid-escalated label.
+  # Returns an escalated PR back into an automation-managed phase after the
+  # owner dismisses escalation by removing the paid-escalated label. This
+  # preserves the existing failure streak; only real progress clears stuck
+  # state.
   class DismissEscalationActivity < BaseActivity
     activity_name "DismissEscalation"
 

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -193,14 +193,6 @@ module Activities
         triggers: [ { type: "escalate_to_owner", details: escalate.payload[:reason] } ]
       } if escalate
 
-      dismiss = decisions.find { |decision| decision.type == "dismiss_escalation" }
-      return {
-        pr_number: issue.github_number,
-        phase: lifecycle&.dig(:phase),
-        draft: lifecycle&.dig(:draft),
-        triggers: [ { type: "dismiss_escalation" } ]
-      } if dismiss
-
       return result if result.is_a?(Hash)
 
       mark_ready = decisions.find { |decision| decision.type == "mark_ready" }
@@ -247,15 +239,11 @@ module Activities
         no_progress_stuck: no_progress_stuck,
         failure_streak_limit_reached: failure_limit,
         review_goal_retry_limit_requires_escalation: retry_escalation,
-        escalation_dismissed: escalation_dismissed?(issue),
         owner_reviewer_login: project.owner_reviewer_login,
         escalation_reason: reason,
         consecutive_unsuccessful_automatic_runs: progress_state.consecutive_unsuccessful_automatic_runs,
         consecutive_operational_failures: progress_state.consecutive_operational_failures,
         last_meaningful_progress_at: progress_state.last_meaningful_progress_at,
-        draft_review_count: issue.draft_review_count,
-        review_goal_retry_count: issue.review_goal_retry_count,
-        pr_followup_count: issue.pr_followup_count,
         draft: live_pr_draft_state(issue) { issue.pr_review_phase.in?(%w[draft restarted]) }
       }
     end
@@ -384,9 +372,9 @@ module Activities
           scan_ready_pr(project, client, issue, pr_data: pr_data)
         end
       when "escalated"
-        return nil if escalation_dismissed?(issue)
-
-        if maybe_restart_draft(project, issue, pr_data)
+        if escalation_dismissed?(issue)
+          dismiss_escalation_trigger(issue, draft: pr_data.draft == true)
+        elsif maybe_restart_draft(project, issue, pr_data)
           scan_draft_pr(project, client, issue, pr_data: pr_data)
         else
           scan_escalated_pr(project, client, issue, pr_data: pr_data)

--- a/docs/pr_failure_progress_model.md
+++ b/docs/pr_failure_progress_model.md
@@ -13,7 +13,7 @@ Automatic PR retries now use one PR-level progress model for both `create_pr` an
   - The last time the PR made progress that should clear the failure streak.
   - Successful manual PR runs also count as progress, even though only automatic runs contribute to the failure streak itself.
 
-## What resets the streak
+## What resets the stuck state
 
 - A completed `create_pr` run
 - A completed `review` run or any `review` run that posted a review
@@ -21,10 +21,22 @@ Automatic PR retries now use one PR-level progress model for both `create_pr` an
 - `issues.review_goal_retry_reset_at`
 - `issues.operational_failure_reset_at`
 
-Phase transitions by themselves do not reset the streak.
+Phase transitions by themselves do not reset the streak. Removing the
+`paid-escalated` label also does not clear failures anymore; dismissal just
+returns the PR to `ready` or `restarted` and lets the next real progress signal
+determine whether automation has recovered.
 
 ## How it is used
 
 - Escalation/stuck handling now keys off the unified failure streak instead of separate draft-review, ready-followup, and review-goal retry failure regimes.
 - Automatic `create_pr` and `review` runs therefore contribute to the same failure accounting model.
 - Existing phase fields still describe workflow state, but they no longer create separate failure-counting regimes.
+
+## Straight Answer
+
+- A PR is stuck when its unified automatic-run failure streak has reached the
+  phase-appropriate limit and there has been no meaningful progress for the
+  no-progress window.
+- That stuck state clears when the PR makes meaningful progress or hits an
+  explicit cycle boundary reset; manual escalation dismissal alone does not
+  clear it.

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -674,56 +674,23 @@ RSpec.describe Issue do
         expect(issue.consecutive_unsuccessful_pr_runs).to eq(3)
       end
 
-      it "continues to recompute progress state when resetting the review-goal breaker" do
-        fresh_progress_state = instance_double(
-          PullRequests::ProgressState::Result,
-          consecutive_unsuccessful_automatic_runs: 1
-        )
+      it "does not rewrite progress reset markers when dismissing escalation" do
         allow(PullRequests::ProgressState).to receive(:call)
           .with(project:, issue:, current_head_sha: nil, current_head_updated_at: nil)
-          .and_return(progress_state, fresh_progress_state)
-        allow(issue).to receive(:update!).and_return(true)
-
-        expect(issue.consecutive_unsuccessful_pr_runs).to eq(3)
-
-        issue.reset_review_goal_retry_breaker!
-
-        expect(issue.consecutive_unsuccessful_pr_runs).to eq(1)
-        expect(PullRequests::ProgressState).to have_received(:call).twice
-      end
-
-      it "resets both unified progress reset markers when resetting the review-goal breaker" do
-        allow(issue).to receive(:update!).and_return(true)
-
-        freeze_time do
-          issue.reset_review_goal_retry_breaker!
-
-          expect(issue).to have_received(:update!).with(
-            hash_including(
-              review_goal_retry_reset_at: Time.current,
-              operational_failure_reset_at: Time.current
-            )
-          )
-        end
-      end
-
-      it "continues to recompute progress state when dismissing escalation" do
-        fresh_progress_state = instance_double(
-          PullRequests::ProgressState::Result,
-          consecutive_unsuccessful_automatic_runs: 1
-        )
-        allow(PullRequests::ProgressState).to receive(:call)
-          .with(project:, issue:, current_head_sha: nil, current_head_updated_at: nil)
-          .and_return(progress_state, fresh_progress_state)
+          .and_return(progress_state)
         issue.define_singleton_method(:labels) { %w[paid-escalated paid-dismiss-escalation] }
         allow(issue).to receive(:update!).and_return(true)
 
-        expect(issue.consecutive_unsuccessful_pr_runs).to eq(3)
-
         issue.dismiss_escalation!(draft: false)
 
-        expect(issue.consecutive_unsuccessful_pr_runs).to eq(1)
-        expect(PullRequests::ProgressState).to have_received(:call).twice
+        expect(issue).to have_received(:update!).with(
+          hash_including(
+            pr_review_phase: "ready",
+            ci_retry_requested_at: nil
+          )
+        )
+        expect(issue).not_to have_received(:update!).with(hash_including(:review_goal_retry_reset_at))
+        expect(issue).not_to have_received(:update!).with(hash_including(:operational_failure_reset_at))
       end
     end
 

--- a/spec/services/automation/strategies/auto_continue/signals_spec.rb
+++ b/spec/services/automation/strategies/auto_continue/signals_spec.rb
@@ -12,15 +12,11 @@ RSpec.describe Automation::Strategies::AutoContinue::Signals, :no_db do
       operational_failure_breaker: false,
       no_progress_stuck: false,
       failure_streak_limit_reached: false,
-      escalation_dismissed: false,
       owner_reviewer_login: nil,
       escalation_reason: nil,
       consecutive_unsuccessful_automatic_runs: 0,
       consecutive_operational_failures: 0,
       last_meaningful_progress_at: nil,
-      draft_review_count: 0,
-      review_goal_retry_count: 0,
-      pr_followup_count: 0,
       draft: false
     }.merge(overrides)
   end
@@ -48,9 +44,6 @@ RSpec.describe Automation::Strategies::AutoContinue::Signals, :no_db do
       no_progress_stuck: 1,
       failure_streak_limit_reached: 1,
       consecutive_unsuccessful_automatic_runs: "4",
-      draft_review_count: "4",
-      review_goal_retry_count: "2",
-      pr_followup_count: "1",
       draft: nil
     )
   end
@@ -66,21 +59,18 @@ RSpec.describe Automation::Strategies::AutoContinue::Signals, :no_db do
 
     it "builds signals from lifecycle metadata" do
       lifecycle = lifecycle_payload(phase: "draft", active_run_exists: true, owner_reviewer_login: "alice",
-        consecutive_unsuccessful_automatic_runs: 2, draft_review_count: 2,
-        review_goal_retry_count: 1, pr_followup_count: 3, draft: true)
+        consecutive_unsuccessful_automatic_runs: 2, draft: true)
       scan = { triggers: [] }
       signals = described_class.from_metadata(lifecycle: lifecycle, scan: scan)
 
       expect(signals.to_h.slice(
         :issue_id, :pr_number, :phase, :active_run_exists, :operational_failure_breaker,
         :no_progress_stuck,
-        :owner_reviewer_login, :consecutive_unsuccessful_automatic_runs, :draft_review_count,
-        :review_goal_retry_count, :pr_followup_count, :scan
+        :owner_reviewer_login, :consecutive_unsuccessful_automatic_runs, :scan
       )).to eq(
         issue_id: 1, pr_number: 42, phase: "draft", active_run_exists: true,
         operational_failure_breaker: false, no_progress_stuck: false, owner_reviewer_login: "alice",
-        consecutive_unsuccessful_automatic_runs: 2, draft_review_count: 2,
-        review_goal_retry_count: 1, pr_followup_count: 3, scan: scan
+        consecutive_unsuccessful_automatic_runs: 2, scan: scan
       )
     end
 
@@ -116,9 +106,6 @@ RSpec.describe Automation::Strategies::AutoContinue::Signals, :no_db do
       expect(signals.no_progress_stuck).to be false
       expect(signals.failure_streak_limit_reached).to be false
       expect(signals.consecutive_unsuccessful_automatic_runs).to eq(4)
-      expect(signals.draft_review_count).to eq(4)
-      expect(signals.review_goal_retry_count).to eq(2)
-      expect(signals.pr_followup_count).to eq(1)
       expect(signals.draft).to be false
     end
   end

--- a/spec/services/automation/strategies/auto_continue_lifecycle_transitions_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_lifecycle_transitions_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe Automation::Strategies::AutoContinue do
       operational_failure_breaker: false,
       no_progress_stuck: false,
       failure_streak_limit_reached: false,
-      escalation_dismissed: false,
       owner_reviewer_login: "alice",
       escalation_reason: nil,
       consecutive_unsuccessful_automatic_runs: 0,
@@ -61,31 +60,6 @@ RSpec.describe Automation::Strategies::AutoContinue do
       )
 
       expect(decision_types(result)).to eq([ "noop" ])
-    end
-
-    it "dismisses escalation when the owner removes the label" do
-      result = evaluate(
-        lifecycle: base_lifecycle(
-          phase: "escalated",
-          escalation_dismissed: true,
-          draft: false
-        )
-      )
-
-      expect(result.to_h[:decisions].first).to include(type: "dismiss_escalation")
-    end
-
-    it "escalation_dismissed trumps phase-specific gates" do
-      result = evaluate(
-        lifecycle: base_lifecycle(
-          phase: "escalated",
-          escalation_dismissed: true,
-          failure_streak_limit_reached: true,
-          draft: false
-        )
-      )
-
-      expect(result.to_h[:decisions].first).to include(type: "dismiss_escalation")
     end
   end
 
@@ -214,23 +188,6 @@ RSpec.describe Automation::Strategies::AutoContinue do
       )
 
       expect(result.to_h[:decisions].first[:type]).to eq("escalate")
-    end
-  end
-
-  describe "dismiss_escalation" do
-    it "includes the issue_id and draft flag in the payload" do
-      result = evaluate(
-        lifecycle: base_lifecycle(
-          phase: "escalated",
-          escalation_dismissed: true,
-          draft: false
-        )
-      )
-
-      decision = result.to_h[:decisions].first
-      expect(decision[:type]).to eq("dismiss_escalation")
-      expect(decision[:issue_id]).to eq(pull_request.id)
-      expect(decision[:draft]).to be(false)
     end
   end
 

--- a/spec/services/automation/strategies/auto_continue_review_retry_no_db_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_review_retry_no_db_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Automation::Strategies::AutoContinue, :no_db do
       no_progress_stuck: false,
       failure_streak_limit_reached: true,
       review_goal_retry_limit_requires_escalation: false,
-      escalation_dismissed: false,
       owner_reviewer_login: "alice",
       escalation_reason: "Automatic PR failure streak reached",
       consecutive_unsuccessful_automatic_runs: 3,
@@ -193,27 +192,5 @@ RSpec.describe Automation::Strategies::AutoContinue, :no_db do
     result = strategy.evaluate(context)
 
     expect(decision_types(result)).to eq([ "queue_create_pr_run", "record_pr_followup" ])
-  end
-
-  it "dismisses escalation before evaluating operational failure breakers" do
-    context = Automation::Context.build(
-      record: pull_request,
-      project: project,
-      metadata: {
-        lifecycle: lifecycle.merge(
-          phase: "escalated",
-          operational_failure_breaker: true,
-          no_progress_stuck: true,
-          escalation_dismissed: true
-        )
-      }
-    )
-
-    allow(Coordination::EscalationService).to receive(:call)
-
-    result = strategy.evaluate(context)
-
-    expect(decision_types(result)).to eq([ "dismiss_escalation" ])
-    expect(Coordination::EscalationService).not_to have_received(:call)
   end
 end

--- a/spec/services/automation/strategies/auto_continue_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe Automation::Strategies::AutoContinue do
         operational_failure_breaker: false,
         no_progress_stuck: false,
         failure_streak_limit_reached: false,
-        escalation_dismissed: false,
         owner_reviewer_login: "alice",
         escalation_reason: nil,
         consecutive_unsuccessful_automatic_runs: 0,
@@ -122,24 +121,6 @@ RSpec.describe Automation::Strategies::AutoContinue do
           pr_number: 42,
           owner_reviewer_login: "alice",
           reason: "No meaningful progress for 3 hours after 3 consecutive provider/infrastructure failures"
-        )
-      end
-    end
-
-    context "when escalation is dismissed" do
-      it "returns a dismiss_escalation decision" do
-        result = evaluate(
-          lifecycle: base_lifecycle.merge(
-            phase: "escalated",
-            escalation_dismissed: true,
-            draft: false
-          )
-        )
-
-        decisions = result.to_h[:decisions]
-        expect(decisions.first).to include(
-          type: "dismiss_escalation",
-          issue_id: pull_request.id
         )
       end
     end
@@ -280,7 +261,6 @@ RSpec.describe Automation::Strategies::AutoContinue do
         active_run_exists: false,
         operational_failure_breaker: false,
         failure_streak_limit_reached: false,
-        escalation_dismissed: false,
         owner_reviewer_login: "alice",
         escalation_reason: nil,
         consecutive_unsuccessful_automatic_runs: 0,
@@ -338,7 +318,6 @@ RSpec.describe Automation::Strategies::AutoContinue do
         operational_failure_breaker: false,
         no_progress_stuck: false,
         failure_streak_limit_reached: false,
-        escalation_dismissed: false,
         owner_reviewer_login: "alice",
         escalation_reason: nil,
         consecutive_unsuccessful_automatic_runs: 0,
@@ -360,18 +339,6 @@ RSpec.describe Automation::Strategies::AutoContinue do
       )
 
       expect(decision_types(result)).to eq([ "noop" ])
-    end
-
-    it "dismisses escalation when the owner removes the label" do
-      result = evaluate(
-        lifecycle: base_lifecycle.merge(
-          phase: "escalated",
-          escalation_dismissed: true,
-          draft: false
-        )
-      )
-
-      expect(result.to_h[:decisions].first).to include(type: "dismiss_escalation")
     end
   end
 end

--- a/spec/services/automation/strategy_parity_spec.rb
+++ b/spec/services/automation/strategy_parity_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Automation::Strategy do
         no_progress_stuck: false,
         failure_streak_limit_reached: false,
         review_goal_retry_limit_requires_escalation: false,
-        escalation_dismissed: false, owner_reviewer_login: "alice",
+        owner_reviewer_login: "alice",
         escalation_reason: nil, consecutive_unsuccessful_automatic_runs: 0,
         consecutive_operational_failures: 0, last_meaningful_progress_at: nil,
         draft: false }

--- a/spec/services/coordination/escalation_service_spec.rb
+++ b/spec/services/coordination/escalation_service_spec.rb
@@ -25,15 +25,11 @@ RSpec.describe Coordination::EscalationService do
         operational_failure_breaker: false,
         no_progress_stuck: false,
         failure_streak_limit_reached: false,
-        escalation_dismissed: false,
         owner_reviewer_login: "alice",
         escalation_reason: nil,
         consecutive_unsuccessful_automatic_runs: 0,
         consecutive_operational_failures: 0,
         last_meaningful_progress_at: nil,
-        draft_review_count: 0,
-        review_goal_retry_count: 0,
-        pr_followup_count: 0,
         draft: false,
         scan: { triggers: [] }
       }
@@ -214,12 +210,8 @@ RSpec.describe Coordination::EscalationService do
         active_run_exists: false,
         operational_failure_breaker: false,
         no_progress_stuck: false,
-        escalation_dismissed: false,
         owner_reviewer_login: "alice",
-        scan: { triggers: [] },
-        draft_review_count: 4,
-        review_goal_retry_count: 3,
-        pr_followup_count: 2
+        scan: { triggers: [] }
       }
     end
 

--- a/spec/services/notifications/rules/stalled_draft_pr_spec.rb
+++ b/spec/services/notifications/rules/stalled_draft_pr_spec.rb
@@ -4,24 +4,29 @@ require "rails_helper"
 
 RSpec.describe Notifications::Rules::StalledDraftPr do
   let(:account) { create(:account) }
-  let(:project) { create(:project, account: account) }
+  let(:project) { create(:project, account: account, max_draft_review_rounds: 3) }
   let(:issue) do
     create(:issue, :pull_request, project: project, github_number: 42,
-      pr_review_phase: "draft", auto_continue_paused: false)
+      pr_review_phase: "draft", auto_continue_paused: false,
+      github_updated_at: 10.minutes.ago, last_pr_scan_at: 5.minutes.ago)
   end
 
   before do
     allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+    allow(issue).to receive(:pr_progress_state).and_return(
+      PullRequests::ProgressState::Result.new(
+        consecutive_unsuccessful_automatic_runs: 3,
+        consecutive_operational_failures: 0,
+        last_meaningful_progress_at: nil,
+        latest_automatic_run_at: nil,
+        latest_unsuccessful_run_at: 4.hours.ago,
+        latest_unsuccessful_run_goal: "review",
+        latest_unsuccessful_run_status: "failed"
+      )
+    )
   end
 
-  it "publishes after three consecutive failed draft follow-ups" do
-    3.times do |index|
-      create(:agent_run, :timeout, project: project, issue: issue,
-        goal: "create_pr", trigger_type: "automatic",
-        source_pull_request_number: 42, count_toward_draft_review_round: true,
-        expected_draft_review_count: 0, created_at: (3 - index).hours.ago)
-    end
-
+  it "publishes after the unified PR streak goes stale in draft" do
     expect {
       described_class.call(scope: [ issue ])
     }.to change(Notification, :count).by(1)
@@ -29,15 +34,29 @@ RSpec.describe Notifications::Rules::StalledDraftPr do
     notification = Notification.find_by!(source: "stalled_draft_pr", subject: issue)
     expect(notification.severity).to eq("warning")
     expect(notification.metadata["consecutive_failures"]).to eq(3)
+    expect(notification.metadata["latest_unsuccessful_run_goal"]).to eq("review")
   end
 
   it "does not publish below the failure threshold" do
-    2.times do
-      create(:agent_run, :timeout, project: project, issue: issue,
-        goal: "create_pr", trigger_type: "automatic",
-        source_pull_request_number: 42, count_toward_draft_review_round: true,
-        expected_draft_review_count: 0)
-    end
+    allow(issue).to receive(:pr_progress_state).and_return(
+      PullRequests::ProgressState::Result.new(
+        consecutive_unsuccessful_automatic_runs: 2,
+        consecutive_operational_failures: 0,
+        last_meaningful_progress_at: nil,
+        latest_automatic_run_at: nil,
+        latest_unsuccessful_run_at: 4.hours.ago,
+        latest_unsuccessful_run_goal: "create_pr",
+        latest_unsuccessful_run_status: "failed"
+      )
+    )
+
+    expect {
+      described_class.call(scope: [ issue ])
+    }.not_to change(Notification, :count)
+  end
+
+  it "does not publish until the latest GitHub update has been scanned" do
+    issue.update!(github_updated_at: 1.minute.ago, last_pr_scan_at: 5.minutes.ago)
 
     expect {
       described_class.call(scope: [ issue ])
@@ -47,20 +66,12 @@ RSpec.describe Notifications::Rules::StalledDraftPr do
   it "resolves when the PR leaves draft" do
     create(:notification, account: account, source: "stalled_draft_pr", subject: issue)
     issue.update!(pr_review_phase: "ready")
-
     described_class.call(scope: [ issue ])
 
     expect(Notification.find_by!(source: "stalled_draft_pr", subject: issue).resolved_at).to be_present
   end
 
   it "re-publishes instead of creating duplicates" do
-    3.times do
-      create(:agent_run, :timeout, project: project, issue: issue,
-        goal: "create_pr", trigger_type: "automatic",
-        source_pull_request_number: 42, count_toward_draft_review_round: true,
-        expected_draft_review_count: 0)
-    end
-
     2.times { described_class.call(scope: [ issue ]) }
 
     expect(Notification.where(source: "stalled_draft_pr", subject: issue).count).to eq(1)

--- a/spec/temporal/activities/dismiss_escalation_activity_spec.rb
+++ b/spec/temporal/activities/dismiss_escalation_activity_spec.rb
@@ -22,28 +22,22 @@ RSpec.describe Activities::DismissEscalationActivity do
         expect(issue.reload.pr_review_phase).to eq("ready")
       end
 
-      it "resets the review-goal retry breaker" do
-        freeze_time do
-          activity.execute(issue_id: issue.id)
-
-          expect(issue.reload.review_goal_retry_reset_at).to be_within(1.second).of(Time.current)
-        end
-      end
-
-      it "resets review_goal_retry_count to zero" do
+      it "preserves the review-goal retry count" do
         activity.execute(issue_id: issue.id)
 
-        expect(issue.reload.review_goal_retry_count).to eq(0)
+        expect(issue.reload.review_goal_retry_count).to eq(3)
       end
 
-      it "resets the operational failure breaker and follow-up counter" do
-        freeze_time do
-          activity.execute(issue_id: issue.id)
+      it "preserves the follow-up counter and reset markers" do
+        review_goal_retry_reset_at = issue.review_goal_retry_reset_at
+        operational_failure_reset_at = issue.operational_failure_reset_at
 
-          issue.reload
-          expect(issue.operational_failure_reset_at).to be_within(1.second).of(Time.current)
-          expect(issue.pr_followup_count).to eq(0)
-        end
+        activity.execute(issue_id: issue.id)
+
+        issue.reload
+        expect(issue.pr_followup_count).to eq(2)
+        expect(issue.review_goal_retry_reset_at).to eq(review_goal_retry_reset_at)
+        expect(issue.operational_failure_reset_at).to eq(operational_failure_reset_at)
       end
 
       it "cleans up stale escalation labels locally" do
@@ -57,7 +51,7 @@ RSpec.describe Activities::DismissEscalationActivity do
 
         expect(result[:dismissed]).to be true
         expect(result[:phase]).to eq("ready")
-        expect(result[:current_followup_count]).to eq(0)
+        expect(result[:current_followup_count]).to eq(2)
       end
 
       it "records a resume decision event" do
@@ -97,8 +91,8 @@ RSpec.describe Activities::DismissEscalationActivity do
         expect(result[:dismissed]).to be true
         expect(result[:phase]).to eq("restarted")
         expect(issue.pr_review_phase).to eq("restarted")
-        expect(issue.draft_review_count).to eq(0)
-        expect(issue.pr_followup_count).to eq(0)
+        expect(issue.draft_review_count).to eq(4)
+        expect(issue.pr_followup_count).to eq(2)
       end
     end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_retry_limit_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_retry_limit_spec.rb
@@ -918,7 +918,6 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       allow(activity).to receive(:failure_streak_reason).with(project, issue, progress_state)
         .and_return("Automatic PR failure streak reached")
       allow(activity).to receive(:active_run_exists?).with(project, issue).and_return(false)
-      allow(activity).to receive(:escalation_dismissed?).with(issue).and_return(false)
 
       signals = activity.send(:build_lifecycle_signals, project, issue)
 
@@ -927,11 +926,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         no_progress_stuck: false,
         escalation_reason: nil,
         consecutive_unsuccessful_automatic_runs: 3,
-        review_goal_retry_count: 1
+        draft: false
       )
     end
 
-    it "prefers the live GitHub draft state when dismissal is evaluated from lifecycle signals" do
+    it "prefers the live GitHub draft state in lifecycle signals" do
       allow(activity).to receive(:pr_progress_state).with(project, issue).and_return(progress_state)
       allow(activity).to receive(:operational_failure_breaker?).with(project, issue, progress_state).and_return(false)
       allow(activity).to receive(:no_progress_stuck?).with(project, issue, progress_state).and_return(false)
@@ -940,16 +939,12 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         .with(project, issue, progress_state:)
         .and_return(false)
       allow(activity).to receive(:active_run_exists?).with(project, issue).and_return(false)
-      allow(activity).to receive(:escalation_dismissed?).with(issue).and_return(true)
 
       activity.instance_variable_set(:@live_pr_states, { issue.id => { draft: true } })
 
       signals = activity.send(:build_lifecycle_signals, project, issue)
 
-      expect(signals).to include(
-        escalation_dismissed: true,
-        draft: true
-      )
+      expect(signals).to include(draft: true)
     end
   end
 

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -7120,7 +7120,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           hash_including(
             pr_number: 42,
             phase: "escalated",
-            triggers: contain_exactly(hash_including(type: "dismiss_escalation"))
+            triggers: include(hash_including(type: "merge_conflicts"))
           )
         )
       end


### PR DESCRIPTION
## Summary

Implemented and committed as `f06b22b` with message `refactor(pr-review): simplify stuck-state recovery`.

The refactor removes the legacy issue-level breaker reset path, stops escalation dismissal from zeroing PR failure counters/reset markers, and routes escalation dismissal as a direct scan trigger instead of a special lifecycle-policy flag. I also trimmed the `AutoContinue`/escalation signal payload to the still-authoritative inputs and updated the stalled-draft notification to use the unified PR progress model instead of its old draft-only failure accounting.

Validation:
- `bundle install` completed to `.bundle-pr-2026`
- `yarn install --ignore-optional` completed with a workspace-local cache
- `bundle exec rubocop --cache false` passed
- `bundle exec rspec` passed: `13896 examples, 0 failures, 7 pending`

One environment issue remains outside the code change: `bin/rails db:prepare` still fails here because PostgreSQL is not reachable in this shell (`connection to server on socket ... failed`, no local socket / `DATABASE_URL`-backed connection available). The git worktree is clean.

---

Closes #2026