### PR TITLE
test(style-guides): assert seeded guides reach create_pr agent prompts

### DIFF
--- a/spec/services/prompts/build_for_issue_spec.rb
+++ b/spec/services/prompts/build_for_issue_spec.rb
@@ -473,6 +473,33 @@ RSpec.describe Prompts::BuildForIssue do
       end
     end
 
+    context "when a global style guide exists" do
+      let(:real_project) { create(:project, allowed_github_usernames: [ "viamin" ]) }
+      let(:real_issue) do
+        create(:issue,
+          project: real_project,
+          title: "Fix login redirect",
+          github_number: 42,
+          body: "Users are redirected to the wrong page after login.",
+          github_creator_login: "viamin")
+      end
+
+      before do
+        create(:style_guide,
+          :global,
+          name: "Seeded Ruby Guide",
+          raw_content: "Prefer small methods.",
+          compressed_content: nil)
+      end
+
+      it "appends the style guide section using raw_content" do
+        prompt = described_class.call(issue: real_issue, project: real_project)
+
+        expect(prompt).to include("# Style Guide")
+        expect(prompt).to include("Seeded Ruby Guide")
+      end
+    end
+
     context "when issue body is nil" do
       let(:issue) do
         OpenStruct.new(

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -188,6 +188,27 @@ RSpec.describe Prompts::BuildForPr do
     it "omits issue requirements section when no issue" do
       expect(prompt).not_to include("Issue Requirements")
     end
+
+    it "appends global style guides using raw_content" do
+      pr_issue = create(:issue, :pull_request, project: project, github_number: 42)
+
+      create(:style_guide,
+        :global,
+        name: "Seeded Ruby Guide",
+        raw_content: "Prefer small methods.",
+        compressed_content: nil)
+
+      rendered_prompt = described_class.call(
+        project: project,
+        pr_number: 42,
+        github_client: github_client,
+        rebase_succeeded: true,
+        issue: pr_issue
+      )
+
+      expect(rendered_prompt).to include("# Style Guide")
+      expect(rendered_prompt).to include("Seeded Ruby Guide")
+    end
   end
 
   describe "#includes_review_threads?" do


### PR DESCRIPTION
## Summary

Added the regression coverage in [spec/services/prompts/build_for_issue_spec.rb](/workspace/spec/services/prompts/build_for_issue_spec.rb) and [spec/services/prompts/build_for_pr_spec.rb](/workspace/spec/services/prompts/build_for_pr_spec.rb). The new examples seed a global `StyleGuide` with `raw_content` only, call both prompt builders, and assert the rendered prompt includes `# Style Guide` plus the seeded guide name. The PR-side spec explicitly exercises the continuation path with a PR `Issue` record.

Verification passed with `bundle exec rubocop` and `bundle exec rspec` under the repo’s required DB env. The full suite finished with `13914 examples, 0 failures, 7 pending` (existing pending specs only). Commit: `be12f3c` (`test(style-guides): assert guides reach prompt builders`).

---

Closes #2252