### PR TITLE
feat(admin): style guide compression state visibility and recompress action

### DIFF
--- a/app/avo/actions/recompress_style_guides.rb
+++ b/app/avo/actions/recompress_style_guides.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Avo::Actions::RecompressStyleGuides < Avo::BaseAction
+  self.name = "Recompress Style Guides"
+
+  def handle(query:, current_user:, **)
+    return error("Select at least one style guide.") if query.empty?
+
+    query.each do |style_guide|
+      StyleGuides::EnqueueCompression.call(
+        style_guide: style_guide,
+        initiated_by: current_user,
+        source: "operator_console"
+      )
+    end
+
+    succeed(success_message(query.count))
+  end
+
+  private
+
+  def success_message(count)
+    noun = "style guide".pluralize(count)
+    "Queued recompression for #{count} #{noun}."
+  end
+end

--- a/app/avo/resources/style_guide.rb
+++ b/app/avo/resources/style_guide.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Avo::Resources::StyleGuide < Avo::BaseResource
+  self.title = :name
+  self.model_class = ::StyleGuide
+  self.authorization_policy = ::OperatorConsole::StyleGuidePolicy
+
+  def fields
+    field :id, as: :id
+    field :name, as: :text, sortable: true
+    field :account_id, as: :number
+    field :project_id, as: :number
+    field :language, as: :text, sortable: true
+    field :active, as: :boolean, sortable: true
+    field :compression_state, as: :badge, sortable: false, options: {
+      success: "Compressed",
+      warning: "Stale",
+      danger: "Failed"
+    } do
+      record.compression_state.to_s.humanize
+    end
+    field :compressed_at, as: :date_time, readonly: true do
+      record.last_compressed_at
+    end
+    field :created_at, as: :date_time, readonly: true
+    field :updated_at, as: :date_time, readonly: true
+  end
+
+  def actions
+    action Avo::Actions::RecompressStyleGuides
+  end
+end

--- a/app/controllers/style_guides_controller.rb
+++ b/app/controllers/style_guides_controller.rb
@@ -64,7 +64,11 @@ class StyleGuidesController < ApplicationController
   def compress
     authorize @style_guide, :compress?
 
-    StyleGuideCompressionJob.perform_later(@style_guide.id)
+    StyleGuides::EnqueueCompression.call(
+      style_guide: @style_guide,
+      initiated_by: current_user,
+      source: "style_guides_controller"
+    )
     redirect_to @style_guide, notice: "Style guide compression has been queued and will complete shortly."
   end
 

--- a/app/models/style_guide.rb
+++ b/app/models/style_guide.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require "digest"
+
 class StyleGuide < ApplicationRecord
   has_logidze
   LANGUAGES = %w[ruby javascript typescript python go rust].freeze
+  COMPRESSION_FAILED_THRESHOLD = 15.minutes
 
   belongs_to :account, optional: true
   belongs_to :project, optional: true
@@ -51,6 +54,28 @@ class StyleGuide < ApplicationRecord
     compressed_content.present?
   end
 
+  def compression_current?
+    return false if compressed_content.blank?
+
+    raw_content_digest = compression_metadata["raw_content_sha256"]
+    raw_content_digest.blank? || raw_content_digest == current_raw_content_sha256
+  end
+
+  def compression_state(now: Time.current)
+    return :compressed if compression_current?
+    return :failed if compression_failed?(now: now)
+
+    :stale
+  end
+
+  def raw_content_written_at
+    parse_metadata_time(compression_metadata["raw_content_updated_at"]) || updated_at || created_at || Time.current
+  end
+
+  def last_compressed_at
+    parse_metadata_time(compression_metadata["compressed_at"])
+  end
+
   # Resolves applicable style guides for a given project, using inheritance:
   # project > account > global. Returns applicable style guides deduplicated
   # by name with most-specific-wins ordering.
@@ -95,6 +120,22 @@ class StyleGuide < ApplicationRecord
 
   private
 
+  def current_raw_content_sha256
+    Digest::SHA256.hexdigest(raw_content.to_s)
+  end
+
+  def compression_failed?(now:)
+    compressed_content.blank? && raw_content_written_at <= now - COMPRESSION_FAILED_THRESHOLD
+  end
+
+  def parse_metadata_time(value)
+    return if value.blank?
+
+    Time.zone.parse(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+
   def truncate_to_byte_limit(text, max_bytes)
     truncated = +""
     text.each_char do |char|
@@ -113,7 +154,7 @@ class StyleGuide < ApplicationRecord
 
   def clear_compression
     self.compressed_content = nil
-    self.compression_metadata = {}
+    self.compression_metadata = { "raw_content_updated_at" => Time.current.iso8601 }
   end
 
   def set_account_from_project

--- a/app/policies/operator_console/style_guide_policy.rb
+++ b/app/policies/operator_console/style_guide_policy.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module OperatorConsole
+  class StyleGuidePolicy < BasePolicy
+  end
+end

--- a/app/services/style_guides/compress.rb
+++ b/app/services/style_guides/compress.rb
@@ -102,11 +102,14 @@ module StyleGuides
     def build_metadata(compressed)
       raw_bytes = style_guide.raw_content.bytesize
       compressed_bytes = compressed.bytesize
+      raw_content_written_at = style_guide.raw_content_written_at
 
       meta = {
         "compressed_at" => Time.current.iso8601,
         "model" => DEFAULT_MODEL,
         "raw_length" => raw_bytes,
+        "raw_content_sha256" => Digest::SHA256.hexdigest(style_guide.raw_content),
+        "raw_content_updated_at" => raw_content_written_at.iso8601,
         "compressed_length" => compressed_bytes,
         "compression_ratio" => (compressed_bytes.to_f / raw_bytes).round(2)
       }

--- a/app/services/style_guides/enqueue_compression.rb
+++ b/app/services/style_guides/enqueue_compression.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module StyleGuides
+  class EnqueueCompression
+    attr_reader :style_guide, :initiated_by, :source
+
+    def initialize(style_guide:, initiated_by: nil, source:)
+      @style_guide = style_guide
+      @initiated_by = initiated_by
+      @source = source
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      StyleGuideCompressionJob.perform_later(style_guide.id)
+
+      Rails.logger.info(
+        message: "style_guides.compression_enqueued",
+        style_guide_id: style_guide.id,
+        account_id: style_guide.account_id,
+        project_id: style_guide.project_id,
+        source: source,
+        actor_user_id: initiated_by&.id,
+        actor_user_email: initiated_by&.email
+      )
+    end
+  end
+end

--- a/spec/lib/avo/actions/recompress_style_guides_spec.rb
+++ b/spec/lib/avo/actions/recompress_style_guides_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::Actions::RecompressStyleGuides do
+  include ActiveJob::TestHelper
+
+  let(:current_user) { Struct.new(:id, :email).new(7, "operator@example.com") }
+  let(:logger) { instance_double(ActiveSupport::Logger, info: true) }
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    allow(Rails).to receive(:logger).and_return(logger)
+  end
+
+  it "enqueues recompression for a single style guide and logs it" do
+    style_guide = create(:style_guide, :global)
+
+    action = described_class.new.handle(query: [ style_guide ], fields: {}, current_user:, resource: nil)
+
+    expect(action.response[:messages]).to include(
+      hash_including(type: :success, body: "Queued recompression for 1 style guide.")
+    )
+    expect(enqueued_jobs.last).to include(
+      job: StyleGuideCompressionJob,
+      args: [ style_guide.id ]
+    )
+    expect(logger).to have_received(:info).with(hash_including(
+      message: "style_guides.compression_enqueued",
+      style_guide_id: style_guide.id,
+      source: "operator_console",
+      actor_user_id: current_user.id,
+      actor_user_email: current_user.email
+    ))
+  end
+
+  it "supports bulk recompression" do
+    style_guides = create_list(:style_guide, 2, :global)
+
+    action = described_class.new.handle(query: style_guides, fields: {}, current_user:, resource: nil)
+
+    expect(action.response[:messages]).to include(
+      hash_including(type: :success, body: "Queued recompression for 2 style guides.")
+    )
+    expect(enqueued_jobs.last(2).map { |job| job[:args].first }).to match_array(style_guides.map(&:id))
+  end
+end

--- a/spec/lib/avo/resources/style_guide_spec.rb
+++ b/spec/lib/avo/resources/style_guide_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::Resources::StyleGuide, :no_db do
+  it "registers the expected style guide fields" do
+    resource = described_class.new(view: :show).detect_fields
+
+    expect(described_class.model_class).to eq(StyleGuide)
+    expect(described_class.authorization_policy).to eq(OperatorConsole::StyleGuidePolicy)
+    expect(resource.get_field_definitions.map(&:id)).to include(
+      :name,
+      :account_id,
+      :project_id,
+      :language,
+      :active,
+      :compression_state,
+      :compressed_at
+    )
+  end
+
+  it "attaches the recompress action to the resource" do
+    file, line = described_class.instance_method(:actions).source_location
+    source = File.readlines(file)[(line - 1), 4].join
+
+    expect(source).to include("action Avo::Actions::RecompressStyleGuides")
+  end
+end

--- a/spec/models/style_guide_spec.rb
+++ b/spec/models/style_guide_spec.rb
@@ -151,6 +151,32 @@ RSpec.describe StyleGuide do
       end
     end
 
+    describe "#compression_state" do
+      it "returns compressed when compressed content matches the current raw content" do
+        guide = build(:style_guide, :global, :compressed)
+
+        expect(guide.compression_state).to eq(:compressed)
+      end
+
+      it "returns stale when compression is missing within the grace period" do
+        guide = build(:style_guide, :global, compressed_content: nil, compression_metadata: {})
+        allow(guide).to receive(:updated_at).and_return(5.minutes.ago)
+
+        expect(guide.compression_state).to eq(:stale)
+      end
+
+      it "returns failed when compression is still missing after the grace period" do
+        guide = build(
+          :style_guide,
+          :global,
+          compressed_content: nil,
+          compression_metadata: { "raw_content_updated_at" => 20.minutes.ago.iso8601 }
+        )
+
+        expect(guide.compression_state).to eq(:failed)
+      end
+    end
+
     describe "#content_for_prompt" do
       it "returns compressed content when available" do
         guide = build(:style_guide, :global, :compressed)
@@ -188,7 +214,7 @@ RSpec.describe StyleGuide do
 
         guide.update!(raw_content: "Updated content")
         expect(guide.compressed_content).to be_nil
-        expect(guide.compression_metadata).to eq({})
+        expect(guide.compression_metadata).to include("raw_content_updated_at" => be_present)
       end
 
       it "does not clear compressed content when other attributes change" do

--- a/spec/services/style_guides/compress_spec.rb
+++ b/spec/services/style_guides/compress_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe StyleGuides::Compress do
       style_guide.reload
       expect(style_guide.compression_metadata).to include(
         "compressed_at" => be_present,
+        "raw_content_sha256" => Digest::SHA256.hexdigest(style_guide.raw_content),
+        "raw_content_updated_at" => be_present,
         "raw_length" => style_guide.raw_content.bytesize,
         "compressed_length" => 48,
         "compression_ratio" => be_a(Float)


### PR DESCRIPTION
## Summary

Implemented the admin visibility and recompress flow for style guides. Avo now has a `StyleGuide` resource with a compression-state badge (`Compressed`, `Stale`, `Failed`) and a bulk-capable `Recompress Style Guides` action. The state logic lives on `StyleGuide`, successful compressions now persist raw-content fingerprint/timestamp metadata, and recompression enqueueing goes through a shared helper that logs `style_guides.compression_enqueued` and still routes execution through `StyleGuideCompressionJob`, so the existing `style_guides.compression_failed` rescue/log path remains the one that handles `AgentHarness` outages.

Verification passed with `bundle exec rubocop`, `bundle exec rspec` (`13,919` examples, `0` failures, `7` existing pendings), and the commit hook reran lint/tests successfully. Commit created: `36ed826` with message `feat(admin): show style guide compression state`. The branch is clean.

---

Closes #2253