### PR TITLE
fix(agent-runs): paid_state=analyzed is a dead end for re-enqueue

### DIFF
--- a/app/jobs/issues/reenqueue_eligible_job.rb
+++ b/app/jobs/issues/reenqueue_eligible_job.rb
@@ -36,7 +36,7 @@ module Issues
       issue = Issue.includes(:project).find_by(id: issue_id)
       return unless issue
       return if issue.is_pull_request?
-      return unless issue.paid_state.in?(%w[new planning failed completed])
+      return unless issue.paid_state.in?(%w[new planning failed completed analyzed])
       return unless AutoPickProjectGate.call(issue.project)
 
       EnqueueEligible.call(

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -569,7 +569,7 @@ class Issue < ApplicationRecord
     return false unless saved_change_to_paid_state?
     return false unless project&.auto_pick_enabled?
 
-    paid_state.in?(%w[new planning failed completed])
+    paid_state.in?(%w[new planning failed completed analyzed])
   end
 
   def enqueue_self_if_became_auto_pick_eligible

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -72,7 +72,7 @@ module Automation
           def eligible_scope(project)
             base = without_open_non_pr_subissues(base_scope(project))
 
-            scope = base.where(paid_state: %w[new planning failed])
+            scope = base.where(paid_state: %w[new planning failed analyzed])
 
             recoverable_completed_issue_ids = AgentRun.where(
               project: project,

--- a/spec/jobs/issues/reenqueue_eligible_job_spec.rb
+++ b/spec/jobs/issues/reenqueue_eligible_job_spec.rb
@@ -88,6 +88,21 @@ RSpec.describe Issues::ReenqueueEligibleJob do
       )
     end
 
+    it "rechecks analyzed issues" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "analyzed", github_state: "open")
+      allow(Issues::EnqueueEligible).to receive(:call)
+
+      described_class.perform_now(issue.id)
+
+      expect(Issues::EnqueueEligible).to have_received(:call).with(
+        issue,
+        project: project,
+        skip_project_gate: true,
+        no_runner_retry_count: 0
+      )
+    end
+
     it "does nothing for missing issues" do
       allow(Issues::EnqueueEligible).to receive(:call)
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -459,6 +459,15 @@ RSpec.describe Issue do
       }.not_to have_enqueued_job(Issues::ReenqueueEligibleJob)
     end
 
+    it "re-enqueues analyzed issues so failed follow-up creation can recover" do
+      project = create(:project, auto_pick_enabled: true)
+      issue = create(:issue, project: project, paid_state: "in_progress", github_state: "open")
+
+      expect {
+        issue.update!(paid_state: "analyzed")
+      }.to have_enqueued_job(Issues::ReenqueueEligibleJob).with(issue.id)
+    end
+
     it "does not re-enqueue pull requests" do
       project = create(:project, auto_pick_enabled: true)
       issue = create(:issue, :pull_request, project: project, paid_state: "in_progress", github_state: "open")

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
       expect(scope.pluck(:id)).to contain_exactly(eligible.id)
     end
 
+    it "includes analyzed issues without requiring a follow-up backfill sweep" do
+      issue = create(:issue, project: project, paid_state: "analyzed")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to contain_exactly(issue.id)
+    end
+
     it "includes completed issues with no PR-producing run (infrastructure failure recovery)" do
       issue = create(:issue, project: project, paid_state: "completed")
       create(:agent_run, :completed, :automatic, project: project, issue: issue,


### PR DESCRIPTION
## Summary

Updated the re-enqueue path so issues in `paid_state: "analyzed"` are no longer stranded. The fix adds `"analyzed"` to the paid-state checks in [app/models/issue.rb](/workspace/app/models/issue.rb), [app/jobs/issues/reenqueue_eligible_job.rb](/workspace/app/jobs/issues/reenqueue_eligible_job.rb), and [app/services/automation/strategies/auto_pick/default_candidate_source.rb](/workspace/app/services/automation/strategies/auto_pick/default_candidate_source.rb). I also added regression coverage in [spec/models/issue_spec.rb](/workspace/spec/models/issue_spec.rb), [spec/jobs/issues/reenqueue_eligible_job_spec.rb](/workspace/spec/jobs/issues/reenqueue_eligible_job_spec.rb), and [spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb](/workspace/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb).

Validation passed with `bundle exec rubocop` and `bundle exec rspec` across the full repo. `bin/rails db:prepare` also succeeded once Rails was given the expected `DB_*` env vars for this workspace’s Postgres host. The commit is `dabfb53` with message `fix(agent-runs): re-enqueue analyzed issues`, and the worktree is clean.

---

Closes #2231