### PR TITLE
feat(style-guides): filter StyleGuide.resolve_for by project language

### DIFF
--- a/app/models/style_guide.rb
+++ b/app/models/style_guide.rb
@@ -58,6 +58,7 @@ class StyleGuide < ApplicationRecord
   # @param project [Project] The project context
   # @return [ActiveRecord::Relation] Style guides ordered by specificity
   def self.resolve_for(project)
+    detected_language = Prompts::LanguageCommands.detected_language(project)
     specificity_order = Arel.sql(
       "CASE WHEN project_id IS NOT NULL THEN 0 WHEN account_id IS NOT NULL THEN 1 ELSE 2 END"
     )
@@ -69,6 +70,7 @@ class StyleGuide < ApplicationRecord
         project_id: project.id,
         account_id: project.account_id
       )
+      .where(language: [ nil, detected_language ])
       .select("DISTINCT ON (name) id")
       .order(Arel.sql("name"), specificity_order)
 

--- a/spec/models/style_guide_spec.rb
+++ b/spec/models/style_guide_spec.rb
@@ -257,5 +257,52 @@ RSpec.describe StyleGuide do
       expect(names.count("Ruby Guide")).to eq(1)
       expect(result.find { |g| g.name == "Ruby Guide" }).to eq(account_guide)
     end
+
+    it "includes language-agnostic guides for every project" do
+      global = create(:style_guide, :global, language: nil)
+      project.define_singleton_method(:detected_language) { "python" }
+
+      result = described_class.resolve_for(project)
+
+      expect(result).to include(global)
+    end
+
+    it "includes guides matching the detected project language" do
+      ruby_guide = create(:style_guide, :global, language: "ruby")
+      project.define_singleton_method(:detected_language) { "ruby" }
+
+      result = described_class.resolve_for(project)
+
+      expect(result).to include(ruby_guide)
+    end
+
+    it "excludes guides that do not match the detected project language" do
+      create(:style_guide, :global, language: "ruby")
+      project.define_singleton_method(:detected_language) { "python" }
+
+      result = described_class.resolve_for(project)
+
+      expect(result).to be_empty
+    end
+
+    it "falls through to a less-specific matching guide when a more-specific guide mismatches language" do
+      global = create(:style_guide, :global, name: "Team Guide", language: nil)
+      create(:style_guide, account: account, project: nil, name: "Team Guide", language: "ruby")
+      project.define_singleton_method(:detected_language) { "python" }
+
+      result = described_class.resolve_for(project)
+
+      expect(result).to eq([ global ])
+    end
+
+    it "keeps the most specific applicable guide when multiple languages match" do
+      create(:style_guide, :global, name: "Team Guide", language: nil)
+      account_guide = create(:style_guide, account: account, project: nil, name: "Team Guide", language: "ruby")
+      project.define_singleton_method(:detected_language) { "ruby" }
+
+      result = described_class.resolve_for(project)
+
+      expect(result).to eq([ account_guide ])
+    end
   end
 end


### PR DESCRIPTION
## Summary

Updated `StyleGuide.resolve_for` to filter guides by project language before deduping by name and scope, so only `language: nil` guides or guides matching `Prompts::LanguageCommands.detected_language(project)` are considered. That preserves precedence correctly: a more-specific matching guide still wins, and a mismatching override no longer blocks a less-specific applicable guide.

Expanded [spec/models/style_guide_spec.rb](/workspace/spec/models/style_guide_spec.rb) to cover nil-language inclusion, matching-language inclusion, mismatching-language exclusion, mismatching override fallthrough, and matching-language precedence. The model change is in [app/models/style_guide.rb](/workspace/app/models/style_guide.rb).

Verification passed with:
- `bundle exec rubocop`
- `bundle exec rspec` (`13909 examples, 0 failures, 7 pending`)

Commit: `7e38a39`  
Message: `feat(style-guides): filter resolve_for by project language`

---

Closes #2250